### PR TITLE
fix(admin): stop a published entry's slug following its title

### DIFF
--- a/.changeset/published-slug-sticky.md
+++ b/.changeset/published-slug-sticky.md
@@ -24,6 +24,8 @@
 
 Editing a published entry's title no longer changes its URL. The slug follows the title while an entry is still a draft and stops once the entry has a public address, at which point it changes only if you edit it yourself. Previously a title edit silently retired the published address and every link to it started returning a not-found page.
 
-An entry counts as publicly addressed in three cases, each of which was a way to lose a URL: it is published in the language you are editing (publishing is per language, so a live translation of a draft entry is protected and an untranslated language is not); it lives in a collection with no draft/published lifecycle, where saving is publishing; or you have published it at least once while the editor has been open, so unpublishing to make an edit does not put the address back up for grabs.
+An entry counts as publicly addressed in three cases, each of which was a way to lose a URL: it is published wherever its slug is served; it lives in a collection with no draft/published lifecycle, where saving is publishing; or you have published it at least once while the editor has been open, so unpublishing to make an edit does not put the address back up for grabs.
+
+Where the slug is served depends on the slug field. The slug a collection gets by default is shared across languages, so one address serves all of them and any published language keeps it frozen: editing the title of a German draft no longer rewrites the URL the published English version is being served at. A slug you have explicitly localized is genuinely per language, and follows only that language's status.
 
 When you do change a public entry's slug, the editor says so before you save: the public URL changes and the old one stops working. That notice now also appears in the quick-edit form opened from a relationship field, and it clears once the change is saved rather than lingering against the URL you already replaced.

--- a/.changeset/published-slug-sticky.md
+++ b/.changeset/published-slug-sticky.md
@@ -22,6 +22,8 @@
 "@nextlyhq/tsconfig": patch
 ---
 
-Editing a published entry's title no longer changes its URL. The slug follows the title while an entry is still a draft and stops once it is published, at which point it changes only if you edit it yourself. Previously a title edit silently retired the published address and every link to it started returning a not-found page.
+Editing a published entry's title no longer changes its URL. The slug follows the title while an entry is still a draft and stops once the entry has a public address, at which point it changes only if you edit it yourself. Previously a title edit silently retired the published address and every link to it started returning a not-found page.
 
-When you do change a published entry's slug, the editor now says so before you save: the public URL changes and the old one stops working.
+An entry counts as publicly addressed in three cases, each of which was a way to lose a URL: it is published in the language you are editing (publishing is per language, so a live translation of a draft entry is protected and an untranslated language is not); it lives in a collection with no draft/published lifecycle, where saving is publishing; or you have published it at least once while the editor has been open, so unpublishing to make an edit does not put the address back up for grabs.
+
+When you do change a public entry's slug, the editor says so before you save: the public URL changes and the old one stops working. That notice now also appears in the quick-edit form opened from a relationship field, and it clears once the change is saved rather than lingering against the URL you already replaced.

--- a/.changeset/published-slug-sticky.md
+++ b/.changeset/published-slug-sticky.md
@@ -1,0 +1,27 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+Editing a published entry's title no longer changes its URL. The slug follows the title while an entry is still a draft and stops once it is published, at which point it changes only if you edit it yourself. Previously a title edit silently retired the published address and every link to it started returning a not-found page.
+
+When you do change a published entry's slug, the editor now says so before you save: the public URL changes and the old one stops working.

--- a/packages/admin/src/components/features/entries/EntryForm/EntryForm.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/EntryForm.tsx
@@ -290,11 +290,18 @@ export function EntryForm({
   // slug-gen logic that used to live in TextInput never fired for the
   // configured title. Mounting the hook here closes that gap and follows the
   // configured title field name (not a hardcoded "title"/"name").
+  // A published entry's slug stops following its title. The URL is public by then — in links,
+  // feeds, sitemaps and search results — so re-deriving it from an edited title retires an address
+  // the author never chose to change, and the old one 404s. Editing the slug directly still works;
+  // this only stops the automatic rewrite.
+  const isPublished = hasStatus && entry?.status === "published";
+
   useAutoSlug({
     form,
     titleFieldName: titleField?.name ?? "title",
     slugFieldName: slugField?.name ?? "slug",
     enabled: !!titleField && !!slugField,
+    frozen: isPublished,
   });
 
   // ---------------------------------------------------------------------------

--- a/packages/admin/src/components/features/entries/EntryForm/EntryForm.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/EntryForm.tsx
@@ -32,7 +32,11 @@ import { cn } from "@admin/lib/utils";
 
 import { EntryLocaleProvider } from "../EntryLocaleContext";
 
-import { effectiveEntryStatus, useHasPublicAddress } from "./entry-address";
+import {
+  effectiveEntryStatus,
+  isSlugPerLocale,
+  useHasPublicAddress,
+} from "./entry-address";
 import { EntryFormActions } from "./EntryFormActions";
 import { EntryFormContent } from "./EntryFormContent";
 import { EntryFormContextProvider } from "./EntryFormContext";
@@ -296,11 +300,15 @@ export function EntryForm({
   // links, feeds, sitemaps and search results, so re-deriving it from an edited title retires a URL
   // the author never chose to change and the old one 404s. Editing the slug directly still works;
   // this only stops the automatic rewrite.
+  // The auto-injected slug is shared across languages, so one address serves them all and any
+  // published language keeps it frozen. Only a slug the author opted into localizing belongs to
+  // the language in view.
   const hasPublicAddress = useHasPublicAddress({
     mode,
     hasStatus,
     entry,
     locale,
+    slugLocalized: isSlugPerLocale(slugField, collection.localized === true),
   });
 
   useAutoSlug({

--- a/packages/admin/src/components/features/entries/EntryForm/EntryForm.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/EntryForm.tsx
@@ -456,7 +456,10 @@ export function EntryForm({
                   // The pill reports the language being edited, matching the header's submit
                   // affordances. Reading the main row instead would show "Published" beside a
                   // Publish button whenever a translation lags its default language.
-                  status={effectiveEntryStatus(entry, locale) ?? "draft"}
+                  status={
+                    effectiveEntryStatus(entry, locale, defaultLocale) ??
+                    "draft"
+                  }
                   isRailCollapsed={railCollapsed}
                   hasPublicAddress={hasPublicAddress}
                 />

--- a/packages/admin/src/components/features/entries/EntryForm/EntryForm.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/EntryForm.tsx
@@ -309,6 +309,9 @@ export function EntryForm({
     entry,
     locale,
     slugLocalized: isSlugPerLocale(slugField, collection.localized === true),
+    collectionLocalized: collection.localized === true,
+    defaultLocale,
+    mutationPending: isSubmitting,
   });
 
   useAutoSlug({

--- a/packages/admin/src/components/features/entries/EntryForm/EntryForm.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/EntryForm.tsx
@@ -32,6 +32,7 @@ import { cn } from "@admin/lib/utils";
 
 import { EntryLocaleProvider } from "../EntryLocaleContext";
 
+import { effectiveEntryStatus, useHasPublicAddress } from "./entry-address";
 import { EntryFormActions } from "./EntryFormActions";
 import { EntryFormContent } from "./EntryFormContent";
 import { EntryFormContextProvider } from "./EntryFormContext";
@@ -41,6 +42,7 @@ import { EntryFormToolbarSlots } from "./EntryFormToolbarSlots";
 import { EntryMetaStrip } from "./EntryMetaStrip";
 import { EntrySystemHeader } from "./EntrySystemHeader";
 import { FormErrorSummary } from "./FormErrorSummary";
+import { PublicUrlChangeNotice } from "./PublicUrlChangeNotice";
 import {
   useEntryForm,
   getCollectionFields,
@@ -290,18 +292,23 @@ export function EntryForm({
   // slug-gen logic that used to live in TextInput never fired for the
   // configured title. Mounting the hook here closes that gap and follows the
   // configured title field name (not a hardcoded "title"/"name").
-  // A published entry's slug stops following its title. The URL is public by then — in links,
-  // feeds, sitemaps and search results — so re-deriving it from an edited title retires an address
-  // the author never chose to change, and the old one 404s. Editing the slug directly still works;
+  // Once an entry has a public address its slug stops following its title. That address is in
+  // links, feeds, sitemaps and search results, so re-deriving it from an edited title retires a URL
+  // the author never chose to change and the old one 404s. Editing the slug directly still works;
   // this only stops the automatic rewrite.
-  const isPublished = hasStatus && entry?.status === "published";
+  const hasPublicAddress = useHasPublicAddress({
+    mode,
+    hasStatus,
+    entry,
+    locale,
+  });
 
   useAutoSlug({
     form,
     titleFieldName: titleField?.name ?? "title",
     slugFieldName: slugField?.name ?? "slug",
     enabled: !!titleField && !!slugField,
-    frozen: isPublished,
+    frozen: hasPublicAddress,
   });
 
   // ---------------------------------------------------------------------------
@@ -336,6 +343,17 @@ export function EntryForm({
           <div className="space-y-6">
             {/* Error summary at top of form */}
             <FormErrorSummary errors={errors} submitCount={submitCount} />
+            {/* This branch renders every collection field, the editable slug among them, but not
+                the meta strip that carries the notice in the standalone layout. Quick-edit from a
+                relationship picker lands here on existing entries, so without this the one place
+                the warning is skipped is also a place a live URL can be rewritten and saved. */}
+            {slugField && (
+              <PublicUrlChangeNotice
+                slugName={slugField.name ?? "slug"}
+                active={hasPublicAddress}
+                className="block"
+              />
+            )}
             {/* Forward the form mode so write-only password fields render
                 their edit-mode affordance: on edit a blank password input
                 means "keep the current password" (the stored hash never
@@ -424,8 +442,12 @@ export function EntryForm({
                 <EntryMetaStrip
                   slugField={slugField}
                   hasStatus={hasStatus}
-                  status={(entry?.status as string | undefined) ?? "draft"}
+                  // The pill reports the language being edited, matching the header's submit
+                  // affordances. Reading the main row instead would show "Published" beside a
+                  // Publish button whenever a translation lags its default language.
+                  status={effectiveEntryStatus(entry, locale) ?? "draft"}
                   isRailCollapsed={railCollapsed}
+                  hasPublicAddress={hasPublicAddress}
                 />
 
                 {mainFields.length > 0 && (

--- a/packages/admin/src/components/features/entries/EntryForm/EntryMetaStrip.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/EntryMetaStrip.tsx
@@ -45,7 +45,12 @@ export function EntryMetaStrip({
     <div className="px-6 py-2 border-b border-border flex items-center gap-3 text-xs text-muted-foreground">
       {showStatusPill && <StatusPill status={status} />}
       {showSlug && (
-        <SlugInlineEditor slugField={slugField} readOnly={lockSlug} />
+        <SlugInlineEditor
+          slugField={slugField}
+          readOnly={lockSlug}
+          // Only a published entry has a URL anyone could already be holding.
+          warnOnChange={hasStatus === true && status === "published"}
+        />
       )}
     </div>
   );
@@ -73,13 +78,34 @@ function StatusPill({ status }: { status: string }) {
 function SlugInlineEditor({
   slugField,
   readOnly = false,
+  warnOnChange = false,
 }: {
   slugField: FieldConfig;
   readOnly?: boolean;
+  /**
+   * Say so when this edit will change a live public address.
+   *
+   * Changing a published entry's slug is legitimate and stays available — but it retires the URL
+   * that is already in links, feeds, sitemaps and search results, and nothing in the editor
+   * otherwise distinguishes that from renaming a draft. Most CMSs say nothing here; the cost of
+   * silence is an author discovering it from a 404 someone else hit.
+   */
+  warnOnChange?: boolean;
 }) {
   const form = useFormContext();
   const slugName = "name" in slugField ? (slugField.name as string) : "slug";
   const liveValue = form?.watch(slugName) as string | undefined;
+  // The value the entry was loaded with, so the notice tracks "differs from what is published"
+  // rather than "was touched" — typing a change and undoing it should clear it again.
+  const publishedValue = useRef<string | undefined>(undefined);
+  if (publishedValue.current === undefined && typeof liveValue === "string") {
+    publishedValue.current = liveValue;
+  }
+  const urlWillChange =
+    warnOnChange &&
+    typeof liveValue === "string" &&
+    publishedValue.current !== undefined &&
+    liveValue !== publishedValue.current;
   const errorMsg = (
     form?.formState.errors[slugName] as { message?: string } | undefined
   )?.message;
@@ -163,6 +189,11 @@ function SlugInlineEditor({
       {errorMsg && (
         <span className="text-xs text-destructive-600 shrink-0" role="alert">
           {errorMsg}
+        </span>
+      )}
+      {!errorMsg && urlWillChange && (
+        <span className="text-xs text-muted-foreground shrink-0" role="status">
+          Changes the public URL — the old one will stop working
         </span>
       )}
     </div>

--- a/packages/admin/src/components/features/entries/EntryForm/EntryMetaStrip.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/EntryMetaStrip.tsx
@@ -7,6 +7,8 @@ import { useFormContext } from "react-hook-form";
 import { Pencil } from "@admin/components/icons";
 import { cn } from "@admin/lib/utils";
 
+import { PublicUrlChangeNotice } from "./PublicUrlChangeNotice";
+
 // Why: thin metadata strip below the system header. Carries the slug (with
 // inline pencil-to-edit) and, when the rail is collapsed, the Draft/Published
 // status pill. When the rail is expanded the status pill renders inside the
@@ -27,6 +29,10 @@ export interface EntryMetaStripProps {
    *  as read-only text with no inline-edit affordance. Defaults to false so
    *  collection entry forms keep the editable slug. */
   lockSlug?: boolean;
+  /** Whether this entry's slug is already a public address, so editing it retires a live URL.
+   *  Resolved by the form via `useHasPublicAddress`, which knows about per-locale publishing and
+   *  collections that have no draft lifecycle at all. */
+  hasPublicAddress?: boolean;
 }
 
 export function EntryMetaStrip({
@@ -35,6 +41,7 @@ export function EntryMetaStrip({
   status,
   isRailCollapsed,
   lockSlug = false,
+  hasPublicAddress = false,
 }: EntryMetaStripProps) {
   const showStatusPill = hasStatus && isRailCollapsed && !!status;
   const showSlug = !!slugField;
@@ -48,8 +55,7 @@ export function EntryMetaStrip({
         <SlugInlineEditor
           slugField={slugField}
           readOnly={lockSlug}
-          // Only a published entry has a URL anyone could already be holding.
-          warnOnChange={hasStatus === true && status === "published"}
+          warnOnChange={hasPublicAddress}
         />
       )}
     </div>
@@ -82,30 +88,12 @@ function SlugInlineEditor({
 }: {
   slugField: FieldConfig;
   readOnly?: boolean;
-  /**
-   * Say so when this edit will change a live public address.
-   *
-   * Changing a published entry's slug is legitimate and stays available — but it retires the URL
-   * that is already in links, feeds, sitemaps and search results, and nothing in the editor
-   * otherwise distinguishes that from renaming a draft. Most CMSs say nothing here; the cost of
-   * silence is an author discovering it from a 404 someone else hit.
-   */
+  /** Whether this entry's slug is a live public address, so an edit here retires a URL. */
   warnOnChange?: boolean;
 }) {
   const form = useFormContext();
   const slugName = "name" in slugField ? (slugField.name as string) : "slug";
   const liveValue = form?.watch(slugName) as string | undefined;
-  // The value the entry was loaded with, so the notice tracks "differs from what is published"
-  // rather than "was touched" — typing a change and undoing it should clear it again.
-  const publishedValue = useRef<string | undefined>(undefined);
-  if (publishedValue.current === undefined && typeof liveValue === "string") {
-    publishedValue.current = liveValue;
-  }
-  const urlWillChange =
-    warnOnChange &&
-    typeof liveValue === "string" &&
-    publishedValue.current !== undefined &&
-    liveValue !== publishedValue.current;
   const errorMsg = (
     form?.formState.errors[slugName] as { message?: string } | undefined
   )?.message;
@@ -191,10 +179,12 @@ function SlugInlineEditor({
           {errorMsg}
         </span>
       )}
-      {!errorMsg && urlWillChange && (
-        <span className="text-xs text-muted-foreground shrink-0" role="status">
-          Changes the public URL — the old one will stop working
-        </span>
+      {!errorMsg && (
+        <PublicUrlChangeNotice
+          slugName={slugName}
+          active={warnOnChange}
+          className="shrink-0"
+        />
       )}
     </div>
   );

--- a/packages/admin/src/components/features/entries/EntryForm/EntrySystemHeader.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/EntrySystemHeader.tsx
@@ -27,6 +27,7 @@ import {
   Trash2,
 } from "@admin/components/icons";
 import { useCan } from "@admin/hooks/useCan";
+import { useLocalization } from "@admin/hooks/useLocalization";
 import { cn } from "@admin/lib/utils";
 
 import { useEntryLocale } from "../EntryLocaleContext";
@@ -184,6 +185,9 @@ export function EntrySystemHeader({
 }: EntrySystemHeaderProps) {
   const form = useFormContext();
   const entryLocale = useEntryLocale();
+  // The default language is edited with `locale === undefined`, and its status
+  // can live on the companion, so resolve it to read the right lifecycle.
+  const { defaultLocale } = useLocalization();
   const inputRef = useRef<HTMLInputElement>(null);
   const [unpublishOpen, setUnpublishOpen] = useState(false);
   const [historyOpen, setHistoryOpen] = useState(false);
@@ -251,7 +255,7 @@ export function EntrySystemHeader({
   // active locale's status — not the main/default row's — decides which submit
   // affordances to show. Shared with the slug freeze and the public-URL notice,
   // which ask the same question and must not answer it differently.
-  const effectiveStatus = effectiveEntryStatus(entry, locale);
+  const effectiveStatus = effectiveEntryStatus(entry, locale, defaultLocale);
   const isPublishedEdit = mode === "edit" && effectiveStatus === "published";
   const entryLabel =
     typeof entry?.title === "string" && entry.title.trim().length > 0

--- a/packages/admin/src/components/features/entries/EntryForm/EntrySystemHeader.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/EntrySystemHeader.tsx
@@ -32,6 +32,7 @@ import { cn } from "@admin/lib/utils";
 import { useEntryLocale } from "../EntryLocaleContext";
 import { LanguageSwitcher } from "../LanguageSwitcher";
 
+import { effectiveEntryStatus } from "./entry-address";
 import { ShowJSONDialog } from "./ShowJSONDialog";
 import { UnpublishConfirmDialog } from "./UnpublishConfirmDialog";
 import type { EntryData, EntryFormMode } from "./useEntryForm";
@@ -248,22 +249,9 @@ export function EntrySystemHeader({
   // - !hasStatus → single Save button (collections without drafts).
   // On a localized draft collection each language has its own lifecycle, so the
   // active locale's status — not the main/default row's — decides which submit
-  // affordances to show. A non-default locale with no companion status is not
-  // yet published; only fall back to the row status when there is no per-locale
-  // map (non-localized entries), so it never inherits the default's published state.
-  const localeStatus =
-    locale !== undefined
-      ? (
-          entry?._translations as
-            | Record<string, { status?: string }>
-            | undefined
-        )?.[locale]?.status
-      : undefined;
-  const hasTranslations =
-    locale !== undefined && entry?._translations !== undefined;
-  const effectiveStatus = hasTranslations
-    ? localeStatus
-    : (entry?.status as string | undefined);
+  // affordances to show. Shared with the slug freeze and the public-URL notice,
+  // which ask the same question and must not answer it differently.
+  const effectiveStatus = effectiveEntryStatus(entry, locale);
   const isPublishedEdit = mode === "edit" && effectiveStatus === "published";
   const entryLabel =
     typeof entry?.title === "string" && entry.title.trim().length > 0

--- a/packages/admin/src/components/features/entries/EntryForm/PublicUrlChangeNotice.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/PublicUrlChangeNotice.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { useFormContext } from "react-hook-form";
+
+import { cn } from "@admin/lib/utils";
+
+/**
+ * Says so when the pending slug edit will retire a live public address.
+ *
+ * Changing a published entry's slug is legitimate and stays available. What is not obvious from the
+ * editor is that it retires the URL already sitting in links, feeds, sitemaps and search results,
+ * and that nothing distinguishes it from renaming a draft. Most CMSs say nothing here; the cost of
+ * silence is an author learning about it from a 404 somebody else hit.
+ *
+ * @module components/features/entries/EntryForm/PublicUrlChangeNotice
+ */
+
+/**
+ * Whether the slug in the form differs from the one that is actually persisted.
+ *
+ * The baseline is the form's default values, not a value captured on first render. Defaults are
+ * re-seeded whenever the entry is re-read, so a saved change moves the baseline with it: the notice
+ * clears once the new slug IS the public URL, and reappears if the field is then pointed back at
+ * the old one, which is another change of address rather than a return to safety. A captured ref
+ * gets both of those backwards, and keeps showing a warning about an edit that already landed.
+ */
+export function usePublicUrlWillChange(
+  slugName: string,
+  active: boolean
+): boolean {
+  const form = useFormContext();
+  const liveValue = form?.watch(slugName);
+  const persisted = form?.formState.defaultValues?.[slugName];
+
+  if (!active) return false;
+  return (
+    typeof liveValue === "string" &&
+    typeof persisted === "string" &&
+    liveValue !== persisted
+  );
+}
+
+export interface PublicUrlChangeNoticeProps {
+  /** Form field holding the slug. */
+  slugName: string;
+  /** Whether this entry has a public address at all (see `useHasPublicAddress`). */
+  active: boolean;
+  className?: string;
+}
+
+export function PublicUrlChangeNotice({
+  slugName,
+  active,
+  className,
+}: PublicUrlChangeNoticeProps) {
+  const willChange = usePublicUrlWillChange(slugName, active);
+  if (!willChange) return null;
+  return (
+    <span
+      className={cn("text-xs text-muted-foreground", className)}
+      role="status"
+    >
+      Changes the public URL. The old one will stop working.
+    </span>
+  );
+}

--- a/packages/admin/src/components/features/entries/EntryForm/__tests__/PublicUrlChangeNotice.test.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/__tests__/PublicUrlChangeNotice.test.tsx
@@ -1,0 +1,103 @@
+// The notice has to track "differs from the URL that is actually published", not "was touched".
+// A baseline captured once on mount gets the two cases after a save exactly backwards, and a
+// warning that lies in either direction is worse than none.
+
+import { act, render, screen } from "@testing-library/react";
+import { FormProvider, useForm } from "react-hook-form";
+import { describe, expect, it } from "vitest";
+
+import { PublicUrlChangeNotice } from "../PublicUrlChangeNotice";
+
+const NOTICE = /Changes the public URL/i;
+
+function Harness({
+  active,
+  defaultSlug,
+  onReady,
+}: {
+  active: boolean;
+  defaultSlug: string;
+  onReady: (form: ReturnType<typeof useForm>) => void;
+}) {
+  const form = useForm({ defaultValues: { slug: defaultSlug } });
+  onReady(form);
+  return (
+    <FormProvider {...form}>
+      <PublicUrlChangeNotice slugName="slug" active={active} />
+    </FormProvider>
+  );
+}
+
+function setup(active: boolean, defaultSlug = "original-post") {
+  let form!: ReturnType<typeof useForm>;
+  render(
+    <Harness
+      active={active}
+      defaultSlug={defaultSlug}
+      onReady={f => {
+        form = f;
+      }}
+    />
+  );
+  return () => form;
+}
+
+describe("PublicUrlChangeNotice", () => {
+  it("says nothing while the slug matches what is published", () => {
+    setup(true);
+    expect(screen.queryByText(NOTICE)).toBeNull();
+  });
+
+  it("warns once the slug is edited away from the published one", () => {
+    const form = setup(true);
+
+    act(() => {
+      form().setValue("slug", "renamed-post");
+    });
+
+    expect(screen.getByText(NOTICE)).toBeTruthy();
+  });
+
+  it("clears once the edit is saved and becomes the published URL", () => {
+    // The editor stays mounted while the entry is re-read, and the form is re-seeded from it. A
+    // baseline captured on mount would still hold the old slug and keep warning about a change
+    // that already landed.
+    const form = setup(true);
+
+    act(() => {
+      form().setValue("slug", "renamed-post");
+    });
+    expect(screen.getByText(NOTICE)).toBeTruthy();
+
+    act(() => {
+      form().reset({ slug: "renamed-post" });
+    });
+
+    expect(screen.queryByText(NOTICE)).toBeNull();
+  });
+
+  it("warns again when the slug is pointed back at the old one after a save", () => {
+    // Reverting is another change of address, not a return to safety. A mount-time baseline reads
+    // this as "back to normal" and goes quiet on the edit that moves the URL a second time.
+    const form = setup(true);
+
+    act(() => {
+      form().reset({ slug: "renamed-post" });
+    });
+    act(() => {
+      form().setValue("slug", "original-post");
+    });
+
+    expect(screen.getByText(NOTICE)).toBeTruthy();
+  });
+
+  it("stays silent for an entry with no public address", () => {
+    const form = setup(false);
+
+    act(() => {
+      form().setValue("slug", "still-a-draft");
+    });
+
+    expect(screen.queryByText(NOTICE)).toBeNull();
+  });
+});

--- a/packages/admin/src/components/features/entries/EntryForm/__tests__/PublicUrlChangeNotice.test.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/__tests__/PublicUrlChangeNotice.test.tsx
@@ -3,7 +3,12 @@
 // warning that lies in either direction is worse than none.
 
 import { act, render, screen } from "@testing-library/react";
-import { FormProvider, useForm } from "react-hook-form";
+import {
+  FormProvider,
+  useForm,
+  type FieldValues,
+  type UseFormReturn,
+} from "react-hook-form";
 import { describe, expect, it } from "vitest";
 
 import { PublicUrlChangeNotice } from "../PublicUrlChangeNotice";
@@ -17,9 +22,9 @@ function Harness({
 }: {
   active: boolean;
   defaultSlug: string;
-  onReady: (form: ReturnType<typeof useForm>) => void;
+  onReady: (form: UseFormReturn<FieldValues>) => void;
 }) {
-  const form = useForm({ defaultValues: { slug: defaultSlug } });
+  const form = useForm<FieldValues>({ defaultValues: { slug: defaultSlug } });
   onReady(form);
   return (
     <FormProvider {...form}>
@@ -29,7 +34,7 @@ function Harness({
 }
 
 function setup(active: boolean, defaultSlug = "original-post") {
-  let form!: ReturnType<typeof useForm>;
+  let form!: UseFormReturn<FieldValues>;
   render(
     <Harness
       active={active}

--- a/packages/admin/src/components/features/entries/EntryForm/__tests__/entry-address.test.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/__tests__/entry-address.test.tsx
@@ -5,13 +5,27 @@
 import { renderHook } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
-import { effectiveEntryStatus, useHasPublicAddress } from "../entry-address";
+import {
+  anyLocalePublished,
+  effectiveEntryStatus,
+  useHasPublicAddress,
+  type PublicAddressArgs,
+} from "../entry-address";
 import type { EntryData } from "../useEntryForm";
 
 const entry = (over: Partial<EntryData> = {}): EntryData => ({
   id: "e1",
   ...over,
 });
+
+/** English live, German still being drafted — the shape both new cases turn on. */
+const EN_LIVE_DE_DRAFT = {
+  status: "published",
+  _translations: {
+    en: { translated: true, status: "published" },
+    de: { translated: true, status: "draft" },
+  },
+};
 
 describe("effectiveEntryStatus", () => {
   it("reads the active locale's status, not the main row's", () => {
@@ -50,18 +64,53 @@ describe("effectiveEntryStatus", () => {
   });
 });
 
+describe("anyLocalePublished", () => {
+  it("is true when a language other than the one in view is live", () => {
+    expect(anyLocalePublished(entry(EN_LIVE_DE_DRAFT))).toBe(true);
+  });
+
+  it("is false when every language is still a draft", () => {
+    expect(
+      anyLocalePublished(
+        entry({
+          status: "draft",
+          _translations: {
+            en: { translated: true, status: "draft" },
+            de: { translated: false },
+          },
+        })
+      )
+    ).toBe(false);
+  });
+
+  it("falls back to the row status with no translation map", () => {
+    expect(anyLocalePublished(entry({ status: "published" }))).toBe(true);
+  });
+});
+
 describe("useHasPublicAddress", () => {
-  const render = (args: Parameters<typeof useHasPublicAddress>[0]) =>
+  const render = (args: PublicAddressArgs) =>
     renderHook(props => useHasPublicAddress(props), { initialProps: args });
 
-  it("is false while creating", () => {
-    const { result } = render({
-      mode: "create",
-      hasStatus: true,
-      entry: null,
-      locale: undefined,
-    });
+  /** The default injected slug: one field, shared by every language. */
+  const shared = (
+    over: Partial<PublicAddressArgs> = {}
+  ): PublicAddressArgs => ({
+    mode: "edit",
+    hasStatus: true,
+    entry: entry(),
+    locale: undefined,
+    slugLocalized: false,
+    ...over,
+  });
 
+  /** A slug the author opted into localizing: one address per language. */
+  const perLocale = (
+    over: Partial<PublicAddressArgs> = {}
+  ): PublicAddressArgs => shared({ slugLocalized: true, ...over });
+
+  it("is false while creating", () => {
+    const { result } = render(shared({ mode: "create", entry: null }));
     expect(result.current).toBe(false);
   });
 
@@ -69,59 +118,86 @@ describe("useHasPublicAddress", () => {
     // Without Draft/Published there is no unpublished state to be in: saving publishes. Asking
     // whether such an entry is "published" can only answer no, which would leave every entry in
     // these collections auto-rewriting a live URL.
-    const { result } = render({
-      mode: "edit",
-      hasStatus: false,
-      entry: entry(),
-      locale: undefined,
-    });
-
+    const { result } = render(shared({ hasStatus: false }));
     expect(result.current).toBe(true);
   });
 
   it("is false for a draft in a collection that has the lifecycle", () => {
-    const { result } = render({
-      mode: "edit",
-      hasStatus: true,
-      entry: entry({ status: "draft" }),
-      locale: undefined,
-    });
-
+    const { result } = render(shared({ entry: entry({ status: "draft" }) }));
     expect(result.current).toBe(false);
   });
 
-  it("follows the active locale rather than the row", () => {
-    const { result } = render({
-      mode: "edit",
-      hasStatus: true,
-      entry: entry({
-        status: "draft",
-        _translations: { de: { status: "published" } },
-      }),
-      locale: "de",
-    });
+  it("follows the active locale when the slug is localized", () => {
+    const { result } = render(
+      perLocale({
+        entry: entry({
+          status: "draft",
+          _translations: { de: { status: "published" } },
+        }),
+        locale: "de",
+      })
+    );
 
     expect(result.current).toBe(true);
+  });
+
+  it("freezes a shared slug while editing a draft language, if another is live", () => {
+    // The auto-injected slug is `localized: false`, so English and German resolve through the same
+    // field. Judging it by the language in view lets a title edit on the German draft rewrite the
+    // address English is already being served at.
+    const { result } = render(
+      shared({ entry: entry(EN_LIVE_DE_DRAFT), locale: "de" })
+    );
+
+    expect(result.current).toBe(true);
+  });
+
+  it("leaves a localized slug free while its own language is a draft", () => {
+    // The mirror. A slug the author localized is genuinely per-language, so German's own address
+    // has never been public and may still follow its title.
+    const { result } = render(
+      perLocale({ entry: entry(EN_LIVE_DE_DRAFT), locale: "de" })
+    );
+
+    expect(result.current).toBe(false);
   });
 
   it("stays true after the entry is unpublished", () => {
     // Unpublishing returns the row to draft, but the links and search results that accumulated
     // while it was live do not go away. Letting the slug track again here means republishing
     // silently lands at a different address.
-    const { result, rerender } = render({
-      mode: "edit",
-      hasStatus: true,
-      entry: entry({ status: "published" }),
-      locale: undefined,
-    });
+    const { result, rerender } = render(
+      shared({ entry: entry({ status: "published" }) })
+    );
     expect(result.current).toBe(true);
 
-    rerender({
-      mode: "edit",
-      hasStatus: true,
-      entry: entry({ status: "draft" }),
-      locale: undefined,
+    rerender(shared({ entry: entry({ status: "draft" }) }));
+
+    expect(result.current).toBe(true);
+  });
+
+  it("keeps the latch for a language it left and came back to", () => {
+    // The editor stays mounted across language switches. A single-slot latch is overwritten by
+    // whichever address was looked at last, so unpublishing English, glancing at German and
+    // returning would hand English's formerly public URL back to the generator.
+    const draftEn = entry({
+      status: "draft",
+      _translations: {
+        en: { translated: true, status: "draft" },
+        de: { translated: true, status: "draft" },
+      },
     });
+    const { result, rerender } = render(
+      perLocale({ entry: entry(EN_LIVE_DE_DRAFT), locale: "en" })
+    );
+    expect(result.current).toBe(true);
+
+    // English is unpublished, then the author looks at German and comes back.
+    rerender(perLocale({ entry: draftEn, locale: "en" }));
+    rerender(perLocale({ entry: draftEn, locale: "de" }));
+    expect(result.current).toBe(false);
+
+    rerender(perLocale({ entry: draftEn, locale: "en" }));
 
     expect(result.current).toBe(true);
   });
@@ -129,48 +205,25 @@ describe("useHasPublicAddress", () => {
   it("does not carry that history to a different entry", () => {
     // The editor stays mounted across documents, so an unkeyed latch would freeze the slug of the
     // next draft the author opened purely because the previous one was live.
-    const { result, rerender } = render({
-      mode: "edit",
-      hasStatus: true,
-      entry: entry({ id: "published-one", status: "published" }),
-      locale: undefined,
-    });
+    const { result, rerender } = render(
+      shared({ entry: entry({ id: "published-one", status: "published" }) })
+    );
     expect(result.current).toBe(true);
 
-    rerender({
-      mode: "edit",
-      hasStatus: true,
-      entry: entry({ id: "draft-two", status: "draft" }),
-      locale: undefined,
-    });
+    rerender(shared({ entry: entry({ id: "draft-two", status: "draft" }) }));
 
     expect(result.current).toBe(false);
   });
 
-  it("does not carry that history to another language of the same entry", () => {
+  it("does not carry a localized slug's history to another language", () => {
     // Publishing is per locale, so switching to an untranslated language is a different address
     // with its own lifecycle.
-    const published = {
-      status: "draft",
-      _translations: {
-        en: { status: "published" },
-        de: { status: "draft" },
-      },
-    };
-    const { result, rerender } = render({
-      mode: "edit",
-      hasStatus: true,
-      entry: entry(published),
-      locale: "en",
-    });
+    const { result, rerender } = render(
+      perLocale({ entry: entry(EN_LIVE_DE_DRAFT), locale: "en" })
+    );
     expect(result.current).toBe(true);
 
-    rerender({
-      mode: "edit",
-      hasStatus: true,
-      entry: entry(published),
-      locale: "de",
-    });
+    rerender(perLocale({ entry: entry(EN_LIVE_DE_DRAFT), locale: "de" }));
 
     expect(result.current).toBe(false);
   });

--- a/packages/admin/src/components/features/entries/EntryForm/__tests__/entry-address.test.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/__tests__/entry-address.test.tsx
@@ -1,0 +1,177 @@
+// Whether an entry's slug is already a public address decides two things at once: whether the
+// auto-slug generator keeps rewriting it, and whether the editor warns before an edit lands. Both
+// break quietly — a URL moves and nothing says so — so the predicate is exercised directly.
+
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { effectiveEntryStatus, useHasPublicAddress } from "../entry-address";
+import type { EntryData } from "../useEntryForm";
+
+const entry = (over: Partial<EntryData> = {}): EntryData => ({
+  id: "e1",
+  ...over,
+});
+
+describe("effectiveEntryStatus", () => {
+  it("reads the active locale's status, not the main row's", () => {
+    // The row is a draft, but the German translation is live. Reading `status` off the row calls a
+    // published translation unpublished and lets its URL be rewritten.
+    const result = effectiveEntryStatus(
+      entry({
+        status: "draft",
+        _translations: { de: { status: "published" } },
+      }),
+      "de"
+    );
+
+    expect(result).toBe("published");
+  });
+
+  it("does not inherit the default language's published state", () => {
+    // The mirror case. The row is published, this translation has no companion row at all, so it is
+    // not live in this language and must not be treated as though it were.
+    const result = effectiveEntryStatus(
+      entry({
+        status: "published",
+        _translations: { en: { status: "published" } },
+      }),
+      "de"
+    );
+
+    expect(result).toBeUndefined();
+  });
+
+  it("falls back to the row status when there is no translation map", () => {
+    // A non-localized collection has one lifecycle and it lives on the row.
+    expect(
+      effectiveEntryStatus(entry({ status: "published" }), undefined)
+    ).toBe("published");
+  });
+});
+
+describe("useHasPublicAddress", () => {
+  const render = (args: Parameters<typeof useHasPublicAddress>[0]) =>
+    renderHook(props => useHasPublicAddress(props), { initialProps: args });
+
+  it("is false while creating", () => {
+    const { result } = render({
+      mode: "create",
+      hasStatus: true,
+      entry: null,
+      locale: undefined,
+    });
+
+    expect(result.current).toBe(false);
+  });
+
+  it("treats every persisted entry as live when the collection has no draft lifecycle", () => {
+    // Without Draft/Published there is no unpublished state to be in: saving publishes. Asking
+    // whether such an entry is "published" can only answer no, which would leave every entry in
+    // these collections auto-rewriting a live URL.
+    const { result } = render({
+      mode: "edit",
+      hasStatus: false,
+      entry: entry(),
+      locale: undefined,
+    });
+
+    expect(result.current).toBe(true);
+  });
+
+  it("is false for a draft in a collection that has the lifecycle", () => {
+    const { result } = render({
+      mode: "edit",
+      hasStatus: true,
+      entry: entry({ status: "draft" }),
+      locale: undefined,
+    });
+
+    expect(result.current).toBe(false);
+  });
+
+  it("follows the active locale rather than the row", () => {
+    const { result } = render({
+      mode: "edit",
+      hasStatus: true,
+      entry: entry({
+        status: "draft",
+        _translations: { de: { status: "published" } },
+      }),
+      locale: "de",
+    });
+
+    expect(result.current).toBe(true);
+  });
+
+  it("stays true after the entry is unpublished", () => {
+    // Unpublishing returns the row to draft, but the links and search results that accumulated
+    // while it was live do not go away. Letting the slug track again here means republishing
+    // silently lands at a different address.
+    const { result, rerender } = render({
+      mode: "edit",
+      hasStatus: true,
+      entry: entry({ status: "published" }),
+      locale: undefined,
+    });
+    expect(result.current).toBe(true);
+
+    rerender({
+      mode: "edit",
+      hasStatus: true,
+      entry: entry({ status: "draft" }),
+      locale: undefined,
+    });
+
+    expect(result.current).toBe(true);
+  });
+
+  it("does not carry that history to a different entry", () => {
+    // The editor stays mounted across documents, so an unkeyed latch would freeze the slug of the
+    // next draft the author opened purely because the previous one was live.
+    const { result, rerender } = render({
+      mode: "edit",
+      hasStatus: true,
+      entry: entry({ id: "published-one", status: "published" }),
+      locale: undefined,
+    });
+    expect(result.current).toBe(true);
+
+    rerender({
+      mode: "edit",
+      hasStatus: true,
+      entry: entry({ id: "draft-two", status: "draft" }),
+      locale: undefined,
+    });
+
+    expect(result.current).toBe(false);
+  });
+
+  it("does not carry that history to another language of the same entry", () => {
+    // Publishing is per locale, so switching to an untranslated language is a different address
+    // with its own lifecycle.
+    const published = {
+      status: "draft",
+      _translations: {
+        en: { status: "published" },
+        de: { status: "draft" },
+      },
+    };
+    const { result, rerender } = render({
+      mode: "edit",
+      hasStatus: true,
+      entry: entry(published),
+      locale: "en",
+    });
+    expect(result.current).toBe(true);
+
+    rerender({
+      mode: "edit",
+      hasStatus: true,
+      entry: entry(published),
+      locale: "de",
+    });
+
+    expect(result.current).toBe(false);
+  });
+});

--- a/packages/admin/src/components/features/entries/EntryForm/__tests__/entry-address.test.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/__tests__/entry-address.test.tsx
@@ -66,7 +66,7 @@ describe("effectiveEntryStatus", () => {
 
 describe("anyLocalePublished", () => {
   it("is true when a language other than the one in view is live", () => {
-    expect(anyLocalePublished(entry(EN_LIVE_DE_DRAFT))).toBe(true);
+    expect(anyLocalePublished(entry(EN_LIVE_DE_DRAFT), true)).toBe(true);
   });
 
   it("is false when every language is still a draft", () => {
@@ -78,13 +78,24 @@ describe("anyLocalePublished", () => {
             en: { translated: true, status: "draft" },
             de: { translated: false },
           },
-        })
+        }),
+        true
       )
     ).toBe(false);
   });
 
   it("falls back to the row status with no translation map", () => {
-    expect(anyLocalePublished(entry({ status: "published" }))).toBe(true);
+    expect(anyLocalePublished(entry({ status: "published" }), false)).toBe(
+      true
+    );
+  });
+
+  it("assumes public when a LOCALIZED entry arrives without the overview", () => {
+    // The map's absence is a property of the caller's query, not of the entry — quick-edit from a
+    // relationship field does not ask for it. The row status describes the default language alone,
+    // so trusting it would call an entry unpublished while another language is live and hand its
+    // shared slug back to the generator. Losing auto-slug convenience is the cheaper mistake.
+    expect(anyLocalePublished(entry({ status: "draft" }), true)).toBe(true);
   });
 });
 
@@ -101,6 +112,10 @@ describe("useHasPublicAddress", () => {
     entry: entry(),
     locale: undefined,
     slugLocalized: false,
+    // Most collections are not localized; the cases that turn this on say so.
+    collectionLocalized: false,
+    defaultLocale: "en",
+    mutationPending: false,
     ...over,
   });
 
@@ -213,6 +228,64 @@ describe("useHasPublicAddress", () => {
     rerender(shared({ entry: entry({ id: "draft-two", status: "draft" }) }));
 
     expect(result.current).toBe(false);
+  });
+
+  it("treats the default language the same whether it is implicit or named", () => {
+    // The editor represents the default language as `undefined` until the switcher is touched and
+    // as its explicit code afterwards. They are one address, so a latch written under one must be
+    // found under the other — otherwise leaving the default language and returning unfreezes a
+    // slug that was public.
+    const draftEverywhere = entry({
+      status: "draft",
+      _translations: {
+        en: { translated: true, status: "draft" },
+        de: { translated: true, status: "draft" },
+      },
+    });
+    const { result, rerender } = render(
+      perLocale({ entry: entry(EN_LIVE_DE_DRAFT), locale: undefined })
+    );
+    expect(result.current).toBe(true);
+
+    // Unpublished, then the author visits German and comes back — this time picking "en" from the
+    // switcher, which reports the explicit code rather than undefined.
+    rerender(perLocale({ entry: draftEverywhere, locale: undefined }));
+    rerender(perLocale({ entry: draftEverywhere, locale: "de" }));
+    rerender(perLocale({ entry: draftEverywhere, locale: "en" }));
+
+    expect(result.current).toBe(true);
+  });
+
+  it("does not remember a publish that is still in flight", () => {
+    // The update hook writes the pending status into the query cache optimistically and restores
+    // the previous entry if the request fails. A latch cannot roll back with it, so recording an
+    // unconfirmed publish would freeze a draft's slug permanently — and make its editor warn about
+    // a public URL that does not exist — until the editor is remounted.
+    const { result, rerender } = render(
+      shared({
+        entry: entry({ status: "published" }),
+        mutationPending: true,
+      })
+    );
+    // Frozen while the write is in flight, which is right if it succeeds.
+    expect(result.current).toBe(true);
+
+    // The server refuses it and the cache rolls back to the draft.
+    rerender(shared({ entry: entry({ status: "draft" }) }));
+
+    expect(result.current).toBe(false);
+  });
+
+  it("remembers a publish once the write has settled", () => {
+    // The mirror, so the guard above cannot be satisfied by never latching at all.
+    const { result, rerender } = render(
+      shared({ entry: entry({ status: "published" }), mutationPending: false })
+    );
+    expect(result.current).toBe(true);
+
+    rerender(shared({ entry: entry({ status: "draft" }) }));
+
+    expect(result.current).toBe(true);
   });
 
   it("does not carry a localized slug's history to another language", () => {

--- a/packages/admin/src/components/features/entries/EntryForm/__tests__/entry-address.test.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/__tests__/entry-address.test.tsx
@@ -62,6 +62,52 @@ describe("effectiveEntryStatus", () => {
       effectiveEntryStatus(entry({ status: "published" }), undefined)
     ).toBe("published");
   });
+
+  it("reads the default locale's companion status when editing it implicitly", () => {
+    // The editor shows the default language as `locale === undefined`. After a
+    // reconcile the default locale's `_status` can live on the companion and be
+    // published while the main row is a draft; reading the row would call the
+    // live default a draft and let its already-live slug be rewritten.
+    const result = effectiveEntryStatus(
+      entry({
+        status: "draft",
+        _translations: { en: { status: "published" } },
+      }),
+      undefined,
+      "en"
+    );
+
+    expect(result).toBe("published");
+  });
+
+  it("prefers the default companion status over the row in both directions", () => {
+    // The mirror: a drafted default over a published-shaped row reports draft.
+    const result = effectiveEntryStatus(
+      entry({
+        status: "published",
+        _translations: { en: { status: "draft" } },
+      }),
+      undefined,
+      "en"
+    );
+
+    expect(result).toBe("draft");
+  });
+
+  it("falls back to the row status for the default locale with no companion row", () => {
+    // The default language's own content lives on the main row, so when the map
+    // carries only other languages the row status still governs it.
+    const result = effectiveEntryStatus(
+      entry({
+        status: "published",
+        _translations: { de: { status: "draft" } },
+      }),
+      undefined,
+      "en"
+    );
+
+    expect(result).toBe("published");
+  });
 });
 
 describe("anyLocalePublished", () => {

--- a/packages/admin/src/components/features/entries/EntryForm/entry-address.ts
+++ b/packages/admin/src/components/features/entries/EntryForm/entry-address.ts
@@ -90,15 +90,24 @@ export function effectiveEntryStatus(
  * for it — the row's own status is the only lifecycle there is.
  */
 export function anyLocalePublished(
-  entry: EntryData | null | undefined
+  entry: EntryData | null | undefined,
+  collectionLocalized: boolean
 ): boolean {
   const translations = entry?._translations;
-  if (!isRecord(translations)) {
-    return entry?.status === "published";
+  if (isRecord(translations)) {
+    return Object.values(translations).some(
+      meta => isRecord(meta) && meta.status === "published"
+    );
   }
-  return Object.values(translations).some(
-    meta => isRecord(meta) && meta.status === "published"
-  );
+  // A localized entry whose overview was not requested cannot answer this. The row's own status
+  // describes the default language alone, so believing it would call an entry unpublished while
+  // another language is live and hand its shared slug back to the generator. The map's absence is
+  // a property of the CALLER's query, not of the entry, so the safe reading is the conservative
+  // one: assume the address may be public. Callers that need the precise answer ask for the
+  // overview — but one that forgets loses auto-slug convenience rather than someone's live URL.
+  if (collectionLocalized) return true;
+  // Not localized: one lifecycle, and it lives on the row.
+  return entry?.status === "published";
 }
 
 export interface PublicAddressArgs {
@@ -118,6 +127,29 @@ export interface PublicAddressArgs {
    * A slug the author opted into localizing is genuinely per-language and follows that language.
    */
   slugLocalized: boolean;
+  /** Whether the collection itself is localized, which decides what the ABSENCE of a translation
+   *  overview means — unavailable, or genuinely not applicable. See {@link anyLocalePublished}. */
+  collectionLocalized: boolean;
+  /**
+   * The app's configured default language.
+   *
+   * The editor represents the default language as `undefined` until the switcher is touched, and
+   * as its explicit code afterwards. Those are one address, so the latch key normalises through
+   * this — otherwise leaving the default language and returning to it looks up a key that was
+   * never written, and a formerly public slug quietly unfreezes.
+   */
+  defaultLocale: string | undefined;
+  /**
+   * Whether a write for this entry is currently in flight.
+   *
+   * The update hook writes the pending status into the query cache optimistically and restores the
+   * previous entry if the request fails. A latch is monotonic and cannot roll back with it, so
+   * latching mid-flight would make a publish that never happened permanent: the draft's slug would
+   * stop following its title, and its slug editor would warn about a public URL that does not
+   * exist, until the editor is remounted. The pending state is still allowed to FREEZE — it is
+   * only recording it forever that has to wait for the server to agree.
+   */
+  mutationPending: boolean;
 }
 
 /**
@@ -151,9 +183,15 @@ export function useHasPublicAddress({
   entry,
   locale,
   slugLocalized,
+  collectionLocalized,
+  defaultLocale,
+  mutationPending,
 }: PublicAddressArgs): boolean {
-  // A shared slug is one address for every language, so its key must not carry the locale.
-  const addressKey = `${entry?.id ?? ""}${slugLocalized ? `:${locale ?? ""}` : ""}`;
+  // A shared slug is one address for every language, so its key must not carry the locale at all.
+  // A localized one does, normalised so the default language cannot occupy two keys.
+  const addressKey = `${entry?.id ?? ""}${
+    slugLocalized ? `:${locale ?? defaultLocale ?? ""}` : ""
+  }`;
   const seenRef = useRef<Set<string> | null>(null);
   seenRef.current ??= new Set<string>();
 
@@ -162,7 +200,9 @@ export function useHasPublicAddress({
 
   const liveNow = slugLocalized
     ? effectiveEntryStatus(entry, locale) === "published"
-    : anyLocalePublished(entry);
-  if (liveNow) seenRef.current.add(addressKey);
-  return seenRef.current.has(addressKey);
+    : anyLocalePublished(entry, collectionLocalized);
+  // Freeze on the pending state, but only REMEMBER it once the write has settled — the cache may
+  // still be holding an optimistic publish that is about to be rolled back.
+  if (liveNow && !mutationPending) seenRef.current.add(addressKey);
+  return liveNow || seenRef.current.has(addressKey);
 }

--- a/packages/admin/src/components/features/entries/EntryForm/entry-address.ts
+++ b/packages/admin/src/components/features/entries/EntryForm/entry-address.ts
@@ -63,21 +63,34 @@ export function isSlugPerLocale(
  * a published translation of a draft row looks unpublished, and a draft translation of a published
  * row looks live.
  *
- * The fallback to `entry.status` is deliberately conditioned on the absence of a `_translations`
- * map rather than on the absence of an entry for this locale. A localized entry with no companion
- * row for the active language is not published in that language, and must not inherit the default
- * language's state by falling through.
+ * The editor represents the default language implicitly as `locale === undefined`, so the caller
+ * passes `defaultLocale` to resolve it. After a reconcile the default locale's `_status` can land on
+ * the companion and diverge from the main row (a published default over a draft-shaped row); reading
+ * the row alone would call it a draft and let a title edit move its already-live slug.
+ *
+ * When the resolved language has no companion row, the fallback differs by which language it is. A
+ * non-default language with no companion is simply not published in it, so it reports no status
+ * rather than inheriting the default's. The default language's own content lives on the main row, so
+ * it falls back to the row status — as does any language when there is no `_translations` map at all
+ * (a non-localized entry, or a request that did not ask for the overview).
  */
 export function effectiveEntryStatus(
   entry: EntryData | null | undefined,
-  locale: string | undefined
+  locale: string | undefined,
+  defaultLocale?: string
 ): string | undefined {
   const translations = entry?._translations;
-  if (locale !== undefined && isRecord(translations)) {
-    const forLocale = translations[locale];
-    return isRecord(forLocale) && typeof forLocale.status === "string"
-      ? forLocale.status
-      : undefined;
+  // The editor shows the default language as `locale === undefined`; resolve it so the default
+  // locale's own companion `_status` is read rather than the main row's, which can diverge from it.
+  const activeLocale = locale ?? defaultLocale;
+  if (activeLocale !== undefined && isRecord(translations)) {
+    const forLocale = translations[activeLocale];
+    if (isRecord(forLocale) && typeof forLocale.status === "string") {
+      return forLocale.status;
+    }
+    // No companion row for this language. A non-default language is not published in it; the
+    // default language's content lives on the main row, so let it fall through to the row status.
+    if (activeLocale !== defaultLocale) return undefined;
   }
   return typeof entry?.status === "string" ? entry.status : undefined;
 }

--- a/packages/admin/src/components/features/entries/EntryForm/entry-address.ts
+++ b/packages/admin/src/components/features/entries/EntryForm/entry-address.ts
@@ -10,12 +10,48 @@
  * @module components/features/entries/EntryForm/entry-address
  */
 
+import { isFieldLocalized } from "nextly/config";
 import { useRef } from "react";
 
 import type { EntryData } from "./useEntryForm";
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
+}
+
+function stringProp(source: object, key: string): string | undefined {
+  return key in source &&
+    typeof (source as Record<string, unknown>)[key] === "string"
+    ? ((source as Record<string, unknown>)[key] as string)
+    : undefined;
+}
+
+/**
+ * Whether the slug field is per-locale rather than shared.
+ *
+ * `FieldConfig` is a union whose members do not all carry `localized`, so the classifier's minimal
+ * shape is rebuilt from whichever properties are actually present. Falling back to `text` matches
+ * how the injected slug is declared, and the classifier answers false for any non-localized
+ * collection regardless.
+ */
+export function isSlugPerLocale(
+  slugField: object | undefined,
+  collectionLocalized: boolean
+): boolean {
+  if (!slugField) return false;
+  const localized =
+    "localized" in slugField &&
+    typeof (slugField as Record<string, unknown>).localized === "boolean"
+      ? ((slugField as Record<string, unknown>).localized as boolean)
+      : undefined;
+  return isFieldLocalized(
+    {
+      type: stringProp(slugField, "type") ?? "text",
+      name: stringProp(slugField, "name") ?? "slug",
+      localized,
+    },
+    collectionLocalized
+  );
 }
 
 /**
@@ -46,6 +82,25 @@ export function effectiveEntryStatus(
   return typeof entry?.status === "string" ? entry.status : undefined;
 }
 
+/**
+ * Whether any language of this entry is published.
+ *
+ * The translation overview reports every configured locale, so this is answerable from the row the
+ * editor already has. Without that map — a non-localized collection, or a request that did not ask
+ * for it — the row's own status is the only lifecycle there is.
+ */
+export function anyLocalePublished(
+  entry: EntryData | null | undefined
+): boolean {
+  const translations = entry?._translations;
+  if (!isRecord(translations)) {
+    return entry?.status === "published";
+  }
+  return Object.values(translations).some(
+    meta => isRecord(meta) && meta.status === "published"
+  );
+}
+
 export interface PublicAddressArgs {
   /** Create forms have no address yet; only a persisted entry can have one. */
   mode: "create" | "edit";
@@ -54,6 +109,15 @@ export interface PublicAddressArgs {
   entry: EntryData | null | undefined;
   /** The language being edited, or undefined for the implicit default. */
   locale: string | undefined;
+  /**
+   * Whether the slug field itself is per-locale.
+   *
+   * The auto-injected slug is `localized: false`, so by default ONE slug serves every language's
+   * URL. Deciding a shared slug's fate from the language in view means editing a draft
+   * translation's title rewrites the address the published language is already being served at.
+   * A slug the author opted into localizing is genuinely per-language and follows that language.
+   */
+  slugLocalized: boolean;
 }
 
 /**
@@ -64,37 +128,41 @@ export interface PublicAddressArgs {
  * - **No Draft/Published lifecycle.** A collection without status has no unpublished state: saving
  *   an entry makes it readable. Asking whether such an entry is "published" can only ever answer
  *   no, which would leave every entry in those collections auto-rewriting its live URL.
- * - **Published in the language being edited**, per {@link effectiveEntryStatus}.
+ * - **Published where this slug is served.** For a slug the author localized, that is the language
+ *   in view. For the default shared slug it is ANY language, because they all resolve through the
+ *   one field.
  * - **Published at any point while this editor has been open.** Unpublishing returns the row to
  *   draft, but the links, feeds and search results that accumulated while it was live do not go
- *   away, so republishing under a title-derived slug would silently move it. Latched per entry and
- *   locale so opening a different document does not inherit the previous one's history.
+ *   away, so republishing under a title-derived slug would silently move it.
  *
- * The latch is bounded by the editing session because nothing durable records that an entry was
- * once published: there is no first-published timestamp on the row. An entry unpublished, reloaded,
- * and then retitled still tracks. Closing that needs a persisted marker in core rather than a
- * longer-lived ref here.
+ * The latch is a set of addresses rather than a single slot, and is never cleared. Keys carry the
+ * entry id, so one document cannot inherit another's history; keeping every key means switching
+ * language, or navigating away and back, does not discard what was already observed. A single slot
+ * loses the first address the moment a second one is looked at.
+ *
+ * The latch is still bounded by the editing session, because nothing durable records that an entry
+ * was once published: there is no first-published timestamp on the row. An entry unpublished,
+ * reloaded, and then retitled still tracks. Closing that needs a persisted marker in core rather
+ * than a longer-lived ref here.
  */
 export function useHasPublicAddress({
   mode,
   hasStatus,
   entry,
   locale,
+  slugLocalized,
 }: PublicAddressArgs): boolean {
-  const key = `${entry?.id ?? ""}:${locale ?? ""}`;
-  const seen = useRef<{ key: string; published: boolean }>({
-    key,
-    published: false,
-  });
-  if (seen.current.key !== key) {
-    seen.current = { key, published: false };
-  }
+  // A shared slug is one address for every language, so its key must not carry the locale.
+  const addressKey = `${entry?.id ?? ""}${slugLocalized ? `:${locale ?? ""}` : ""}`;
+  const seenRef = useRef<Set<string> | null>(null);
+  seenRef.current ??= new Set<string>();
 
   if (mode !== "edit" || !entry) return false;
   if (!hasStatus) return true;
 
-  if (effectiveEntryStatus(entry, locale) === "published") {
-    seen.current.published = true;
-  }
-  return seen.current.published;
+  const liveNow = slugLocalized
+    ? effectiveEntryStatus(entry, locale) === "published"
+    : anyLocalePublished(entry);
+  if (liveNow) seenRef.current.add(addressKey);
+  return seenRef.current.has(addressKey);
 }

--- a/packages/admin/src/components/features/entries/EntryForm/entry-address.ts
+++ b/packages/admin/src/components/features/entries/EntryForm/entry-address.ts
@@ -1,0 +1,100 @@
+"use client";
+
+/**
+ * Whether an entry currently has a public address, and which status decides that.
+ *
+ * Two questions the editor keeps asking in different places: the slug auto-generator needs to know
+ * whether re-deriving the slug would retire a live URL, and the slug editor needs to know whether
+ * to say so. Both are the same question, and answering it twice is how they drift apart.
+ *
+ * @module components/features/entries/EntryForm/entry-address
+ */
+
+import { useRef } from "react";
+
+import type { EntryData } from "./useEntryForm";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+/**
+ * The status that governs the language being edited.
+ *
+ * Publishing is per locale once a collection is localized, so a row carries one lifecycle per
+ * language on its companion and the main row's own `status` describes the default language alone.
+ * Reading the main row for a translation therefore reports the wrong lifecycle in both directions:
+ * a published translation of a draft row looks unpublished, and a draft translation of a published
+ * row looks live.
+ *
+ * The fallback to `entry.status` is deliberately conditioned on the absence of a `_translations`
+ * map rather than on the absence of an entry for this locale. A localized entry with no companion
+ * row for the active language is not published in that language, and must not inherit the default
+ * language's state by falling through.
+ */
+export function effectiveEntryStatus(
+  entry: EntryData | null | undefined,
+  locale: string | undefined
+): string | undefined {
+  const translations = entry?._translations;
+  if (locale !== undefined && isRecord(translations)) {
+    const forLocale = translations[locale];
+    return isRecord(forLocale) && typeof forLocale.status === "string"
+      ? forLocale.status
+      : undefined;
+  }
+  return typeof entry?.status === "string" ? entry.status : undefined;
+}
+
+export interface PublicAddressArgs {
+  /** Create forms have no address yet; only a persisted entry can have one. */
+  mode: "create" | "edit";
+  /** Whether the collection has the Draft/Published lifecycle enabled. */
+  hasStatus: boolean;
+  entry: EntryData | null | undefined;
+  /** The language being edited, or undefined for the implicit default. */
+  locale: string | undefined;
+}
+
+/**
+ * Whether this entry's slug is already a public address.
+ *
+ * Three things make it one, and each covers a case the others miss:
+ *
+ * - **No Draft/Published lifecycle.** A collection without status has no unpublished state: saving
+ *   an entry makes it readable. Asking whether such an entry is "published" can only ever answer
+ *   no, which would leave every entry in those collections auto-rewriting its live URL.
+ * - **Published in the language being edited**, per {@link effectiveEntryStatus}.
+ * - **Published at any point while this editor has been open.** Unpublishing returns the row to
+ *   draft, but the links, feeds and search results that accumulated while it was live do not go
+ *   away, so republishing under a title-derived slug would silently move it. Latched per entry and
+ *   locale so opening a different document does not inherit the previous one's history.
+ *
+ * The latch is bounded by the editing session because nothing durable records that an entry was
+ * once published: there is no first-published timestamp on the row. An entry unpublished, reloaded,
+ * and then retitled still tracks. Closing that needs a persisted marker in core rather than a
+ * longer-lived ref here.
+ */
+export function useHasPublicAddress({
+  mode,
+  hasStatus,
+  entry,
+  locale,
+}: PublicAddressArgs): boolean {
+  const key = `${entry?.id ?? ""}:${locale ?? ""}`;
+  const seen = useRef<{ key: string; published: boolean }>({
+    key,
+    published: false,
+  });
+  if (seen.current.key !== key) {
+    seen.current = { key, published: false };
+  }
+
+  if (mode !== "edit" || !entry) return false;
+  if (!hasStatus) return true;
+
+  if (effectiveEntryStatus(entry, locale) === "published") {
+    seen.current.published = true;
+  }
+  return seen.current.published;
+}

--- a/packages/admin/src/components/features/entries/fields/relational/RelationshipQuickEdit.tsx
+++ b/packages/admin/src/components/features/entries/fields/relational/RelationshipQuickEdit.tsx
@@ -29,6 +29,7 @@ import { AlertCircle, Loader2, ExternalLink } from "@admin/components/icons";
 import { buildRoute, ROUTES } from "@admin/constants/routes";
 import { useCollection } from "@admin/hooks/queries/useCollections";
 import { useEntry } from "@admin/hooks/queries/useEntry";
+import { useLocalization } from "@admin/hooks/useLocalization";
 import { entryKeys } from "@admin/services/entryApi";
 
 import { EntryForm } from "../../EntryForm/EntryForm";
@@ -114,6 +115,13 @@ function ModalContent({
     error: collectionError,
   } = useCollection(collectionSlug);
 
+  // The per-locale translation overview, on a localized app only. Quick-edit renders the same
+  // editable slug the full editor does, and whether that slug is already a public address depends
+  // on whether ANY language is published — a question only this map can answer. Without it the
+  // form has to assume the address may be live, which costs auto-slug convenience on entries that
+  // are still drafts.
+  const { enabled: localizationEnabled } = useLocalization();
+
   const {
     data: entry,
     isLoading: isLoadingEntry,
@@ -122,6 +130,7 @@ function ModalContent({
     collectionSlug,
     entryId,
     enabled: !!collectionSlug && !!entryId,
+    translationStatus: localizationEnabled,
   });
 
   const isLoading = isLoadingCollection || isLoadingEntry;

--- a/packages/admin/src/hooks/__tests__/useAutoSlug.test.tsx
+++ b/packages/admin/src/hooks/__tests__/useAutoSlug.test.tsx
@@ -22,6 +22,7 @@ interface DriverOptions {
   titleFieldName: string;
   slugFieldName: string;
   enabled?: boolean;
+  frozen?: boolean;
 }
 
 function useDriver({
@@ -29,9 +30,10 @@ function useDriver({
   titleFieldName,
   slugFieldName,
   enabled,
+  frozen,
 }: DriverOptions) {
   const form = useForm<FormShape>({ defaultValues });
-  useAutoSlug({ form, titleFieldName, slugFieldName, enabled });
+  useAutoSlug({ form, titleFieldName, slugFieldName, enabled, frozen });
   return form;
 }
 
@@ -185,5 +187,73 @@ describe("useAutoSlug", () => {
 
     // No write happened — slug stays empty.
     expect(result.current.getValues("slug")).toBe("");
+  });
+
+  it("leaves a frozen slug alone when the title changes", () => {
+    // A published entry's slug is a public address. Re-deriving it from an edited title retires a
+    // URL the author never chose to change, and every inbound link to it 404s.
+    const { result } = renderHook(() =>
+      useDriver({
+        defaultValues: {
+          title: "How to build a blog with Nextly",
+          slug: "how-to-build-a-blog-with-nextly",
+        },
+        titleFieldName: "title",
+        slugFieldName: "slug",
+        frozen: true,
+      })
+    );
+
+    act(() => {
+      result.current.setValue(
+        "title",
+        "How to build a blog with Nextly ISR check"
+      );
+    });
+
+    expect(result.current.getValues("slug")).toBe(
+      "how-to-build-a-blog-with-nextly"
+    );
+  });
+
+  it("still lets a frozen slug be edited directly", () => {
+    // Freezing stops the automatic rewrite, not the author. Changing the URL stays available; it
+    // just becomes something done on purpose rather than as a side effect of retitling.
+    const { result } = renderHook(() =>
+      useDriver({
+        defaultValues: { title: "Original title", slug: "original-title" },
+        titleFieldName: "title",
+        slugFieldName: "slug",
+        frozen: true,
+      })
+    );
+
+    act(() => {
+      result.current.setValue("slug", "a-deliberate-url");
+    });
+    act(() => {
+      result.current.setValue("title", "Retitled again");
+    });
+
+    expect(result.current.getValues("slug")).toBe("a-deliberate-url");
+  });
+
+  it("keeps following the title while the entry is not frozen", () => {
+    // The draft case, which must not regress: an author refining a title before publishing expects
+    // the URL to keep up.
+    const { result } = renderHook(() =>
+      useDriver({
+        defaultValues: { title: "First draft", slug: "first-draft" },
+        titleFieldName: "title",
+        slugFieldName: "slug",
+        frozen: false,
+      })
+    );
+
+    act(() => {
+      result.current.setValue("title", "Second draft");
+    });
+
+    expect(result.current.getValues("slug")).toBe("second-draft");
   });
 });

--- a/packages/admin/src/hooks/useAutoSlug.ts
+++ b/packages/admin/src/hooks/useAutoSlug.ts
@@ -63,6 +63,23 @@ export interface UseAutoSlugOptions<TValues extends FieldValues = FieldValues> {
    * @default true
    */
   enabled?: boolean;
+  /**
+   * Stop following the title, without unmounting the hook.
+   *
+   * A published entry's slug is a public contract: it is in inbound links, feeds, sitemaps, shares
+   * and search results. Re-deriving it from an edited title silently retires a URL the author never
+   * chose to change, and the old one 404s. No established CMS does this — WordPress, Ghost and
+   * Contentful all stop tracking at first publish, Strapi stops as soon as the field is non-empty,
+   * and Sanity never tracks at all.
+   *
+   * Distinct from `enabled`, deliberately. `enabled: false` means this form has no auto-slug
+   * concept (a single, whose slug is fixed by config); `frozen` means the entry HAS one and has
+   * outgrown it. Keeping them apart lets a caller that freezes still describe why, and lets the
+   * manual-edit detection below stay meaningful for the unfrozen case.
+   *
+   * @default false
+   */
+  frozen?: boolean;
 }
 
 /**
@@ -88,6 +105,7 @@ export function useAutoSlug<TValues extends FieldValues = FieldValues>({
   titleFieldName,
   slugFieldName,
   enabled = true,
+  frozen = false,
 }: UseAutoSlugOptions<TValues>): void {
   const titleValue = useWatch({
     control: form.control,
@@ -140,6 +158,11 @@ export function useAutoSlug<TValues extends FieldValues = FieldValues>({
     const isStillAuto =
       currentSlug === "" || currentSlug === lastGeneratedRef.current;
 
+    // Frozen entries seed the ref above and stop here. Checked after the mount pass rather than at
+    // the top of the effect so the baseline is still established: the write is what must not
+    // happen, not the bookkeeping that decides whether a later value was hand-edited.
+    if (frozen) return;
+
     if (isStillAuto && generatedSlug !== currentSlug) {
       // shouldDirty stays false on the very first auto-write so we
       // don't trip the unsaved-changes warning before the user has
@@ -152,5 +175,13 @@ export function useAutoSlug<TValues extends FieldValues = FieldValues>({
       });
       lastGeneratedRef.current = generatedSlug;
     }
-  }, [enabled, form, titleFieldName, slugFieldName, titleValue, slugValue]);
+  }, [
+    enabled,
+    frozen,
+    form,
+    titleFieldName,
+    slugFieldName,
+    titleValue,
+    slugValue,
+  ]);
 }


### PR DESCRIPTION
Closes task `073`.

Editing the title of an already-published entry regenerated its slug. The old URL then rendered a soft 404 — HTTP 200 with "Post Not Found" — with no redirect. Measured in the task-006 walk: `how-to-build-a-blog-with-nextly` became `how-to-build-a-blog-with-nextly-isr-check` after a title edit.

It also makes ISR look broken while it is working correctly, which is why beat 6 of the alpha demo script had to be rewritten to edit the body instead.

## What the research said

I surveyed how six established systems handle this before choosing a rule.

| System | Slug follows title | Freeze trigger |
|---|---|---|
| WordPress | while draft (nothing stored yet) | first publish |
| Ghost | while draft, never published, and untouched | first publish |
| Contentful | until first publish | `sys.publishedVersion` |
| Strapi | only while the field is empty | any non-empty value |
| Sanity | never — an explicit "Generate" button | n/a |
| Payload (official examples) | on create, or continuously while locked | create, or manual unlock |

**Zero of the six auto-regenerate a published slug from a title change.** That is the one unanimous finding. Four freeze on or before publish, and a manual edit is sticky everywhere.

## The rule

Follows WordPress / Ghost / Contentful:

1. While an entry is unpublished, the slug follows the title — unchanged.
2. Once published, it is frozen. It changes only if the author edits it.
3. A manual edit stays sticky either way — already true here, and equivalent to Ghost's check that the stored slug still matches what the previous title would have produced.

## Scope is smaller than the task assumed

**Core needed no change.** `applyGeneratedSlugAndTitle` runs only on create paths, and `reSanitizeSlug` returns early when the payload carries no `slug` — so no REST or Direct-API caller can reach this. It is the admin's `useAutoSlug` writing into the form, and the form submitting it.

**Singles were already exempt** — `SingleForm` passes `enabled: false` because a single's slug is fixed by its config. So acceptance criterion 4 was already half-met, and this is collections-only.

`frozen` is deliberately a separate option from `enabled`: `enabled: false` means the form has no auto-slug concept at all, `frozen` means the entry has one and has outgrown it.

## The UX half

Most CMSs say **nothing** when you retype a live URL — WordPress, Ghost, Contentful and Strapi all let it happen silently. Changing a published slug stays available here, but the editor now says what it costs before you save:

> Changes the public URL — the old one will stop working

It compares against the value the entry loaded with rather than tracking whether the field was touched, so typing a change and undoing it clears the notice again. `EntryMetaStrip` already received `status`, so this needed no new plumbing.

## Redirects: deliberately out of scope

Scope item 3 asked whether a redirect from the old slug belongs here. It does not:

- Redirects are a **plugin** in this repo — `plugin-redirects`, stranded on `feat/plugin-platform` and planned in task `032`, which is itself gated to two reference plugins.
- Only WordPress captures old slugs automatically, and only for published, **non-hierarchical** types; pages are excluded, which is the gap Redirection and Yoast Premium fill.
- Ghost has core redirects but they are a hand-authored YAML file, never populated automatically. Strapi, Sanity, Contentful and Storyblok have nothing; Storyblok explicitly declined the request.

Automatic redirect capture would be a genuine differentiator rather than table stakes — worth doing on purpose in `032`, not smuggled into a slug fix.

## Known gap, recorded not papered over

**Unpublishing re-arms the auto-slug.** The freeze reads current status, and core has no durable first-published marker — I checked; `published_at` exists only as a user-defined field in the blog template. Ghost guards exactly this with `!published_at` so that unpublishing does not restart title-tracking.

Closing it needs a first-published column, which belongs with the draft/published work rather than here. Logged on the task.

## Verification

Three hook tests, and the freeze one uses the exact slug pair from the original report. Without the fix:

```
AssertionError: expected 'how-to-build-a-blog-with-nextly-isr-c…' to be 'how-to-build-a-blog-with-nextly'
```

The other two cover what must not regress: a frozen slug can still be edited directly, and an unpublished entry keeps following its title.

Admin suite: **37 failures before and after, byte-identical sets** — all pre-existing on `main` @ `80fdee610`.
