### PR TITLE
test(nextly): pass the required wasStatus arg in companion-transition tests

### DIFF
--- a/packages/nextly/src/domains/i18n/migration/__tests__/companion-transition.integration.test.ts
+++ b/packages/nextly/src/domains/i18n/migration/__tests__/companion-transition.integration.test.ts
@@ -86,6 +86,7 @@ describe("buildCompanionTransitionStatements — enable", () => {
       dialect: "sqlite",
       defaultLocale: "en",
       status: false,
+      wasStatus: false,
       wasLocalized: false,
       isLocalized: true,
       oldFields: FIELDS,
@@ -123,6 +124,7 @@ describe("buildCompanionTransitionStatements — enable", () => {
       dialect: "sqlite",
       defaultLocale: "en",
       status: false,
+      wasStatus: false,
       wasLocalized: false,
       isLocalized: true,
       oldFields: FIELDS,
@@ -167,6 +169,7 @@ describe("buildCompanionTransitionStatements — enable", () => {
       dialect: "sqlite",
       defaultLocale: "en",
       status: false,
+      wasStatus: false,
       wasLocalized: false,
       isLocalized: true,
       oldFields: [...FIELDS, SUB_TITLE_FIELD],
@@ -197,6 +200,7 @@ describe("buildCompanionTransitionStatements — enable", () => {
       dialect: "sqlite",
       defaultLocale: "en",
       status: false,
+      wasStatus: false,
       wasLocalized: false,
       isLocalized: true,
       oldFields: [...FIELDS, { name: "gallery", type: "component" as const }],
@@ -224,6 +228,7 @@ describe("buildCompanionTransitionStatements — disable", () => {
       dialect: "sqlite",
       defaultLocale: "en",
       status: false,
+      wasStatus: false,
       wasLocalized: false,
       isLocalized: true,
       oldFields: FIELDS,
@@ -245,6 +250,7 @@ describe("buildCompanionTransitionStatements — disable", () => {
       dialect: "sqlite",
       defaultLocale: "en",
       status: false,
+      wasStatus: false,
       wasLocalized: true,
       isLocalized: false,
       oldFields: FIELDS,
@@ -312,7 +318,17 @@ describe("buildCompanionTransitionStatements — disable", () => {
  * can only say the statement was emitted, which is true of a copy that never runs.
  */
 describe("buildCompanionTransitionStatements — disable with Draft/Published", () => {
-  const withStatus = (over: Record<string, unknown>) => ({
+  const withStatus = (
+    over: Omit<
+      Parameters<typeof buildCompanionTransitionStatements>[0],
+      | "slug"
+      | "tableName"
+      | "dialect"
+      | "defaultLocale"
+      | "oldFields"
+      | "newFields"
+    >
+  ) => ({
     slug: "hero",
     tableName: "single_hero",
     dialect: "sqlite" as const,
@@ -333,6 +349,7 @@ describe("buildCompanionTransitionStatements — disable with Draft/Published", 
     const enable = buildCompanionTransitionStatements(
       withStatus({
         status: true,
+        wasStatus: true,
         wasLocalized: false,
         isLocalized: true,
         companionExists: false,
@@ -375,6 +392,7 @@ describe("buildCompanionTransitionStatements — disable with Draft/Published", 
     const enable = buildCompanionTransitionStatements(
       withStatus({
         status: true,
+        wasStatus: true,
         wasLocalized: false,
         isLocalized: true,
         companionExists: false,
@@ -406,6 +424,7 @@ describe("buildCompanionTransitionStatements — disable with Draft/Published", 
     const enable = buildCompanionTransitionStatements(
       withStatus({
         status: false,
+        wasStatus: false,
         wasLocalized: false,
         isLocalized: true,
         companionExists: false,

--- a/packages/nextly/src/domains/i18n/migration/transition-plans.test.ts
+++ b/packages/nextly/src/domains/i18n/migration/transition-plans.test.ts
@@ -18,6 +18,7 @@ const disable = {
   dialect: "postgresql" as const,
   defaultLocale: "en",
   status: false,
+  wasStatus: false,
   wasLocalized: true,
   isLocalized: false,
   oldFields: [{ name: "title", type: "text", localized: true }],


### PR DESCRIPTION
## What
Fixes 16 `tsc` errors in `companion-transition.integration.test.ts` and `transition-plans.test.ts` that break the **Typecheck** CI step on `main`. Test-only.

## Why
#452 made `wasStatus` a **required** field on `CompanionTransitionArgs` (deliberately — its doc says "REQUIRED rather than optional, and that is the point... which is exactly how this went wrong once already"), but its test call sites weren't updated. So `tsc -p tsconfig.tests.json` fails, and every branch cut from main inherits red typecheck. `341890fa1`→`#450` typechecked clean; the regression landed with #452.

## Fixes
- **`withStatus` helper** was typed `over: Record<string, unknown>`, widening every field to `unknown` (so even the call sites that *did* pass `wasStatus` failed). Retyped against `Parameters<typeof buildCompanionTransitionStatements>[0]` so it tracks the real arg type.
- Supplied `wasStatus` at each call site with the "before" publishing state the scenario means (`false` for the enable fixtures / no-status disable; the disable-with-status cases already carried it).

## Verification
- `pnpm --filter nextly check-types` → **green** (0 errors, was 16).
- `companion-transition.integration.test.ts` (8) + `transition-plans.test.ts` (4) pass at runtime — confirming the `wasStatus` values are semantically correct (a wrong value changes `restoreStatus` and would fail the assertions).

Test-only, so no changeset.

> Note: this is the **second** i18n PR to land a `tsc -p tsconfig.tests.json` regression on main (after #429, fixed in #453). The root cause is that the "Lint / Typecheck / Test / Build" check isn't gating merges — recommend making it a required status check so this stops recurring.