### PR TITLE
test(nextly): pass the now-required wasStatus in i18n transition tests

### DIFF
--- a/packages/nextly/src/domains/i18n/migration/__tests__/companion-transition.integration.test.ts
+++ b/packages/nextly/src/domains/i18n/migration/__tests__/companion-transition.integration.test.ts
@@ -12,7 +12,10 @@ import { NextlyError } from "../../../../errors";
 import { getI18nArchiveDdl } from "../../../../schemas/nextly-i18n-archive/ddl";
 import { ddlType } from "../ddl-types";
 import { fieldToLocalizedColumnSpec } from "../field-to-column-spec";
-import { buildCompanionTransitionStatements } from "../reconcile-companion";
+import {
+  type CompanionTransitionArgs,
+  buildCompanionTransitionStatements,
+} from "../reconcile-companion";
 
 let sqlite: Database.Database;
 
@@ -66,6 +69,10 @@ const FIELDS = [
   { name: "views", type: "number" as const },
 ];
 
+/** The main table above has no `status` column, so every case built on it says `wasStatus: false`.
+ *  The Draft/Published cases further down add the column and set their own value. */
+const NO_STATUS_HISTORY = { status: false, wasStatus: false } as const;
+
 beforeEach(() => {
   sqlite = new Database(":memory:");
   createMainTable();
@@ -85,7 +92,7 @@ describe("buildCompanionTransitionStatements — enable", () => {
       tableName: "single_hero",
       dialect: "sqlite",
       defaultLocale: "en",
-      status: false,
+      ...NO_STATUS_HISTORY,
       wasLocalized: false,
       isLocalized: true,
       oldFields: FIELDS,
@@ -122,7 +129,7 @@ describe("buildCompanionTransitionStatements — enable", () => {
       tableName: "single_hero",
       dialect: "sqlite",
       defaultLocale: "en",
-      status: false,
+      ...NO_STATUS_HISTORY,
       wasLocalized: false,
       isLocalized: true,
       oldFields: FIELDS,
@@ -166,7 +173,7 @@ describe("buildCompanionTransitionStatements — enable", () => {
       tableName: "single_hero",
       dialect: "sqlite",
       defaultLocale: "en",
-      status: false,
+      ...NO_STATUS_HISTORY,
       wasLocalized: false,
       isLocalized: true,
       oldFields: [...FIELDS, SUB_TITLE_FIELD],
@@ -196,7 +203,7 @@ describe("buildCompanionTransitionStatements — enable", () => {
       tableName: "single_hero",
       dialect: "sqlite",
       defaultLocale: "en",
-      status: false,
+      ...NO_STATUS_HISTORY,
       wasLocalized: false,
       isLocalized: true,
       oldFields: [...FIELDS, { name: "gallery", type: "component" as const }],
@@ -223,7 +230,7 @@ describe("buildCompanionTransitionStatements — disable", () => {
       tableName: "single_hero",
       dialect: "sqlite",
       defaultLocale: "en",
-      status: false,
+      ...NO_STATUS_HISTORY,
       wasLocalized: false,
       isLocalized: true,
       oldFields: FIELDS,
@@ -244,7 +251,7 @@ describe("buildCompanionTransitionStatements — disable", () => {
       tableName: "single_hero",
       dialect: "sqlite",
       defaultLocale: "en",
-      status: false,
+      ...NO_STATUS_HISTORY,
       wasLocalized: true,
       isLocalized: false,
       oldFields: FIELDS,
@@ -312,7 +319,21 @@ describe("buildCompanionTransitionStatements — disable", () => {
  * can only say the statement was emitted, which is true of a copy that never runs.
  */
 describe("buildCompanionTransitionStatements — disable with Draft/Published", () => {
-  const withStatus = (over: Record<string, unknown>) => ({
+  // Typed as the exact slice of the arguments these cases vary, not `Record<string, unknown>`.
+  // A `Record` spread erases what it contributes, so the result satisfied no required field and
+  // the helper could not tell a caller it had left one out — the failure mode these cases exist
+  // to catch, hidden in the fixture that sets them up.
+  type StatusCase = Pick<
+    CompanionTransitionArgs,
+    | "status"
+    | "wasStatus"
+    | "wasLocalized"
+    | "isLocalized"
+    | "companionExists"
+    | "companionHasStatus"
+  >;
+
+  const withStatus = (over: StatusCase): CompanionTransitionArgs => ({
     slug: "hero",
     tableName: "single_hero",
     dialect: "sqlite" as const,
@@ -333,6 +354,8 @@ describe("buildCompanionTransitionStatements — disable with Draft/Published", 
     const enable = buildCompanionTransitionStatements(
       withStatus({
         status: true,
+        // Main was given `status` just above, so it carried one before this save.
+        wasStatus: true,
         wasLocalized: false,
         isLocalized: true,
         companionExists: false,
@@ -375,6 +398,8 @@ describe("buildCompanionTransitionStatements — disable with Draft/Published", 
     const enable = buildCompanionTransitionStatements(
       withStatus({
         status: true,
+        // Draft/Published is on across this enable, so the entity already had `status`.
+        wasStatus: true,
         wasLocalized: false,
         isLocalized: true,
         companionExists: false,
@@ -405,7 +430,7 @@ describe("buildCompanionTransitionStatements — disable with Draft/Published", 
     // companion transition before the shared ALTER, so a copy here would fail the migration.
     const enable = buildCompanionTransitionStatements(
       withStatus({
-        status: false,
+        ...NO_STATUS_HISTORY,
         wasLocalized: false,
         isLocalized: true,
         companionExists: false,

--- a/packages/nextly/src/domains/i18n/migration/transition-plans.test.ts
+++ b/packages/nextly/src/domains/i18n/migration/transition-plans.test.ts
@@ -18,6 +18,10 @@ const disable = {
   dialect: "postgresql" as const,
   defaultLocale: "en",
   status: false,
+  // This entity has no Draft/Published lifecycle on either side of the save, so it carried no
+  // `status` beforehand either. The restore that `wasStatus` gates is inert here, which is what
+  // keeps these cases about the retained-column question they exist to ask.
+  wasStatus: false,
   wasLocalized: true,
   isLocalized: false,
   oldFields: [{ name: "title", type: "text", localized: true }],


### PR DESCRIPTION
## Why

`check-types` is failing on `main`. #452 made `wasStatus` a required field of
`CompanionTransitionArgs` without updating the two suites that construct those arguments by hand,
and #453 had shortly before started type-checking test files via `tsconfig.tests.json`. Neither
change is wrong; they landed 14 minutes apart and the combination is red.

Every branch cut from `main` inherits the failure, so this is worth landing on its own rather than
riding along with feature work.

```
src/domains/i18n/migration/__tests__/companion-transition.integration.test.ts(83,53):
  error TS2345: Property 'wasStatus' is missing in type '{ ... }'
  but required in type 'CompanionTransitionArgs'.
```

16 errors across two files. Reproduced locally on `main`; both `tsc --noEmit` and
`tsc --noEmit -p tsconfig.tests.json` are clean with this change.

## What

**The values are the ones each case means, not whatever silences the checker.** `wasStatus` asks
whether main carried `status` and the companion `_status` *before* this save. The main table both
suites build has no `status` column, so those cases say `false` — hoisted into a shared
`NO_STATUS_HISTORY` constant so the reason is stated once. The Draft/Published cases that do
`ALTER TABLE ... ADD COLUMN "status"` say `true`.

**One real gap in the fixture, not just missing arguments.** `withStatus` typed its overrides as
`Record<string, unknown>`. Spreading that type contributes nothing the checker can track, so the
result satisfied *no* required field — which is why all six of its call sites reported all five
fields missing rather than just `wasStatus`. It now takes the exact slice of
`CompanionTransitionArgs` these cases vary, so an omitted argument is reported at the call site
that omitted it.

## Verification

- `tsc --noEmit` and `tsc --noEmit -p tsconfig.tests.json` in `packages/nextly`: both clean.
- `transition-plans.test.ts` 4 passed; `companion-transition.integration.test.ts` 8 passed.
- No product code touched, so no changeset.
