### PR TITLE
feat(nextly): give field-group validators the write's request

### DIFF
--- a/.changeset/field-group-request-and-manifest-check.md
+++ b/.changeset/field-group-request-and-manifest-check.md
@@ -1,0 +1,27 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+Field validators inside a field group now receive the write's request context, so a plugin field type whose rule depends on `req.user` behaves the same nested in a field group as it does at the top level. Previously that rule saw an empty context and accepted every value.
+
+Adds `nextly generate:manifest`, which emits the block manifest on its own, and `--check`, which writes nothing and fails when the committed manifest no longer matches the config. The manifest also publishes its own schema, and generation now refuses to write a document that schema would reject.

--- a/packages/nextly/package.json
+++ b/packages/nextly/package.json
@@ -197,6 +197,7 @@
     "@nextlyhq/adapter-mysql": "workspace:*",
     "@nextlyhq/adapter-postgres": "workspace:*",
     "@nextlyhq/adapter-sqlite": "workspace:*",
+    "@nextlyhq/blocks-engine": "workspace:*",
     "@nextlyhq/eslint-config": "workspace:*",
     "@nextlyhq/telemetry": "workspace:*",
     "@nextlyhq/tsconfig": "workspace:*",

--- a/packages/nextly/src/cli/commands/__tests__/generate-manifest.test.ts
+++ b/packages/nextly/src/cli/commands/__tests__/generate-manifest.test.ts
@@ -1,0 +1,167 @@
+/**
+ * Settling the block manifest on disk, and reporting when it is stale.
+ *
+ * The pair under test is what both `generate:types` and `generate:manifest`
+ * call, so these cases are the whole of the contract for where the file lives,
+ * when it is written, and when it is removed.
+ *
+ * `--check` exists because a committed manifest that no longer matches the
+ * config breaks nothing at runtime — the app reads its registry, not the file —
+ * so the only thing that can notice is a build step that compares them.
+ */
+import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { PAGE_BUILDER_PLUGIN } from "../../../plugins/codegen/block-manifest";
+import {
+  definePlugin,
+  type PluginDefinition,
+} from "../../../plugins/plugin-context";
+import {
+  applyBlockManifestState,
+  describeManifestDrift,
+  readBlockManifestState,
+} from "../generate-manifest";
+
+const TYPES_OUTPUT = "src/generated/nextly-types.ts";
+const MANIFEST_REL = "src/generated/blocks.manifest.json";
+
+const dirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    dirs.splice(0).map(dir => rm(dir, { recursive: true, force: true }))
+  );
+});
+
+async function workspace(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "nextly-manifest-"));
+  dirs.push(dir);
+  return dir;
+}
+
+function consumer(): PluginDefinition {
+  return definePlugin({
+    name: PAGE_BUILDER_PLUGIN,
+    version: "1.0.0",
+    nextly: ">=0.0.0",
+  });
+}
+
+function declaring(blocks: unknown[]): PluginDefinition {
+  return definePlugin({
+    name: "@acme/blocks",
+    version: "1.0.0",
+    nextly: ">=0.0.0",
+    contributes: { declarations: { [PAGE_BUILDER_PLUGIN]: { blocks } } },
+  });
+}
+
+function block(name: string) {
+  return {
+    name,
+    version: 1,
+    description: `The ${name} block.`,
+    example: { props: {} },
+    render: () => null,
+  };
+}
+
+const WITH_BLOCKS = [consumer(), declaring([block("acme/hero")])];
+
+describe("settling the manifest on disk", () => {
+  it("writes it beside the generated types", async () => {
+    const cwd = await workspace();
+
+    const state = await readBlockManifestState(WITH_BLOCKS, TYPES_OUTPUT, cwd);
+    expect(await applyBlockManifestState(state)).toBe(true);
+
+    const written = JSON.parse(
+      await readFile(join(cwd, MANIFEST_REL), "utf-8")
+    );
+    expect(written.blocks.map((b: { name: string }) => b.name)).toEqual([
+      "acme/hero",
+    ]);
+  });
+
+  it("reports no change on a second run", async () => {
+    // Not cosmetic: a generator that rewrites an identical file touches its
+    // mtime on every run, which is enough to invalidate a build cache.
+    const cwd = await workspace();
+    await applyBlockManifestState(
+      await readBlockManifestState(WITH_BLOCKS, TYPES_OUTPUT, cwd)
+    );
+
+    const second = await readBlockManifestState(WITH_BLOCKS, TYPES_OUTPUT, cwd);
+    expect(await applyBlockManifestState(second)).toBe(false);
+  });
+
+  it("removes a manifest left behind when the last block plugin goes", async () => {
+    // The state that matters most: the file still reads as current, and
+    // advertises blocks nothing can render.
+    const cwd = await workspace();
+    await applyBlockManifestState(
+      await readBlockManifestState(WITH_BLOCKS, TYPES_OUTPUT, cwd)
+    );
+
+    const after = await readBlockManifestState([consumer()], TYPES_OUTPUT, cwd);
+    expect(await applyBlockManifestState(after)).toBe(true);
+    await expect(readFile(join(cwd, MANIFEST_REL), "utf-8")).rejects.toThrow();
+  });
+
+  it("does nothing when there is neither a manifest nor a file", async () => {
+    const cwd = await workspace();
+
+    const state = await readBlockManifestState([consumer()], TYPES_OUTPUT, cwd);
+    expect(state.expected).toBeNull();
+    expect(state.actual).toBeNull();
+    expect(await applyBlockManifestState(state)).toBe(false);
+  });
+
+  it("refuses a types output that would collide with the manifest", async () => {
+    // The cleanup branch deletes by name, so this is the difference between
+    // removing a stale artifact and deleting the file the user asked for.
+    const cwd = await workspace();
+
+    await expect(
+      readBlockManifestState(WITH_BLOCKS, "src/blocks.manifest.json", cwd)
+    ).rejects.toMatchObject({ code: "VALIDATION_ERROR" });
+  });
+});
+
+describe("reporting drift", () => {
+  it("names a manifest that is missing", async () => {
+    const cwd = await workspace();
+
+    const state = await readBlockManifestState(WITH_BLOCKS, TYPES_OUTPUT, cwd);
+    expect(describeManifestDrift(state)).toMatch(/is missing/);
+  });
+
+  it("names a manifest that should not exist at all", async () => {
+    const cwd = await workspace();
+    await mkdir(join(cwd, "src/generated"), { recursive: true });
+    await writeFile(join(cwd, MANIFEST_REL), "{}\n", "utf-8");
+
+    const state = await readBlockManifestState([consumer()], TYPES_OUTPUT, cwd);
+    expect(describeManifestDrift(state)).toMatch(/declares no blocks/);
+  });
+
+  it("names a manifest whose contents have drifted", async () => {
+    const cwd = await workspace();
+    await applyBlockManifestState(
+      await readBlockManifestState(WITH_BLOCKS, TYPES_OUTPUT, cwd)
+    );
+
+    const state = await readBlockManifestState(
+      [consumer(), declaring([block("acme/pricing")])],
+      TYPES_OUTPUT,
+      cwd
+    );
+    expect(state.expected).not.toBeNull();
+    expect(state.actual).not.toBeNull();
+    expect(describeManifestDrift(state)).toMatch(/does not match this config/);
+  });
+});

--- a/packages/nextly/src/cli/commands/__tests__/generate-manifest.test.ts
+++ b/packages/nextly/src/cli/commands/__tests__/generate-manifest.test.ts
@@ -130,6 +130,18 @@ describe("settling the manifest on disk", () => {
       readBlockManifestState(WITH_BLOCKS, "src/blocks.manifest.json", cwd)
     ).rejects.toMatchObject({ code: "VALIDATION_ERROR" });
   });
+
+  it("surfaces a manifest path that exists but cannot be read", async () => {
+    // Reading unreadable as absent is what makes it dangerous: with no blocks
+    // expected, "nothing there" compares equal to "there should be nothing",
+    // so the removal is skipped and a check reports the tree clean.
+    const cwd = await workspace();
+    await mkdir(join(cwd, MANIFEST_REL), { recursive: true });
+
+    await expect(
+      readBlockManifestState([consumer()], TYPES_OUTPUT, cwd)
+    ).rejects.toMatchObject({ code: "INVALID_INPUT" });
+  });
 });
 
 describe("reporting drift", () => {

--- a/packages/nextly/src/cli/commands/generate-manifest.ts
+++ b/packages/nextly/src/cli/commands/generate-manifest.ts
@@ -39,7 +39,7 @@ import { resolve, dirname, join } from "node:path";
 
 import type { Command } from "commander";
 
-import { describeError } from "../../errors/index";
+import { describeError, NextlyError } from "../../errors/index";
 import {
   assertManifestPathIsFree,
   BLOCK_MANIFEST_FILENAME,
@@ -114,14 +114,33 @@ export function describeManifestDrift(state: BlockManifestState): string {
   return `${state.path} does not match this config.`;
 }
 
+/**
+ * The manifest on disk, or `null` only when there is genuinely no file.
+ *
+ * Absent and unreadable are NOT the same answer. Reading a permission error or
+ * a directory as "no file" makes an existing stale manifest compare equal to
+ * "there should be none", so the write command skips the removal it owes and
+ * `--check` reports the tree clean while the stale file sits there. Anything
+ * that is not a missing file is surfaced.
+ */
 async function read(path: string): Promise<string | null> {
   try {
     return await readFile(path, "utf-8");
-  } catch {
-    // Absent and unreadable are the same answer to the only question asked
-    // here: there is nothing on disk to compare against.
-    return null;
+  } catch (error) {
+    if (isMissingFile(error)) return null;
+    throw NextlyError.invalidInput({
+      message: `The block manifest at ${path} could not be read: ${error instanceof Error ? error.message : String(error)}`,
+    });
   }
+}
+
+/** A filesystem error meaning the path holds nothing, rather than something unreadable. */
+function isMissingFile(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    (error as { code?: unknown }).code === "ENOENT"
+  );
 }
 
 interface GenerateManifestOptions {

--- a/packages/nextly/src/cli/commands/generate-manifest.ts
+++ b/packages/nextly/src/cli/commands/generate-manifest.ts
@@ -1,0 +1,226 @@
+/**
+ * Generate Manifest Command
+ *
+ * Implements `nextly generate:manifest`, which emits the block manifest on its
+ * own, and `--check`, which emits nothing and reports whether the file on disk
+ * is what this config would produce.
+ *
+ * The manifest is also written by `generate:types`, because an app generating
+ * its types should not have to remember a second command. This exists for the
+ * two cases that one cannot serve:
+ *
+ * - **CI.** A committed manifest that no longer matches the config is a lie
+ *   told to every reader of the repository, and nothing else notices — the app
+ *   still boots, because the runtime reads the registry rather than the file.
+ *   `--check` is what turns that into a failing build.
+ * - **Cost.** Generating types walks every collection, single, component and
+ *   user field and writes a Zod schema per collection. The manifest needs the
+ *   plugin list and nothing else, so a check that only cares about blocks
+ *   should not pay for the rest.
+ *
+ * Both paths settle the file through the same pair of functions below, so the
+ * command that checks and the command that writes cannot disagree about what
+ * belongs on disk.
+ *
+ * @module cli/commands/generate-manifest
+ *
+ * @example
+ * ```bash
+ * # Write the manifest
+ * nextly generate:manifest
+ *
+ * # Fail if the committed manifest is stale (CI)
+ * nextly generate:manifest --check
+ * ```
+ */
+
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { resolve, dirname, join } from "node:path";
+
+import type { Command } from "commander";
+
+import { describeError } from "../../errors/index";
+import {
+  assertManifestPathIsFree,
+  BLOCK_MANIFEST_FILENAME,
+  buildBlockManifestArtifact,
+} from "../../plugins/codegen/block-manifest";
+import type { PluginDefinition } from "../../plugins/plugin-context";
+import { createContext, type CommandContext } from "../program";
+import { loadConfig } from "../utils/config-loader";
+
+/**
+ * What generation would leave on disk, next to what is there now.
+ *
+ * `null` on either side means "no manifest", which is a state in its own right
+ * rather than a missing value: an app with no block plugins must have no file,
+ * and a leftover from a previous run advertises blocks it cannot render.
+ */
+export interface BlockManifestState {
+  /** Absolute path the manifest occupies, whether or not it exists. */
+  path: string;
+  /** What this config would write, or `null` to write nothing. */
+  expected: string | null;
+  /** What is on disk now, or `null` when absent. */
+  actual: string | null;
+}
+
+/**
+ * Resolve both sides without touching disk beyond reading.
+ *
+ * The path collision is refused here rather than at each caller, because the
+ * apply step below DELETES by that name: a types output called
+ * `blocks.manifest.json` would be removed by the cleanup branch.
+ */
+export async function readBlockManifestState(
+  plugins: readonly PluginDefinition[],
+  typesOutputPath: string,
+  cwd: string
+): Promise<BlockManifestState> {
+  assertManifestPathIsFree(typesOutputPath);
+  const artifact = buildBlockManifestArtifact(plugins, typesOutputPath);
+  const path = resolve(
+    cwd,
+    artifact?.path ?? join(dirname(typesOutputPath), BLOCK_MANIFEST_FILENAME)
+  );
+  return { path, expected: artifact?.code ?? null, actual: await read(path) };
+}
+
+/**
+ * Make disk agree with `expected`. Returns whether anything changed, so a
+ * caller can report "already current" rather than implying it rewrote a file.
+ */
+export async function applyBlockManifestState(
+  state: BlockManifestState
+): Promise<boolean> {
+  if (state.expected === state.actual) return false;
+  if (state.expected === null) {
+    await rm(state.path, { force: true });
+    return true;
+  }
+  await mkdir(dirname(state.path), { recursive: true });
+  await writeFile(state.path, state.expected, "utf-8");
+  return true;
+}
+
+/** A one-line account of a mismatch, for a CI log read without the diff. */
+export function describeManifestDrift(state: BlockManifestState): string {
+  if (state.actual === null) {
+    return `${state.path} is missing; this config generates one.`;
+  }
+  if (state.expected === null) {
+    return `${state.path} exists, but this config declares no blocks. Remove it.`;
+  }
+  return `${state.path} does not match this config.`;
+}
+
+async function read(path: string): Promise<string | null> {
+  try {
+    return await readFile(path, "utf-8");
+  } catch {
+    // Absent and unreadable are the same answer to the only question asked
+    // here: there is nothing on disk to compare against.
+    return null;
+  }
+}
+
+interface GenerateManifestOptions {
+  output?: string;
+  check?: boolean;
+  config?: string;
+  verbose?: boolean;
+  quiet?: boolean;
+  cwd?: string;
+}
+
+export async function runGenerateManifest(
+  options: GenerateManifestOptions,
+  context: CommandContext
+): Promise<void> {
+  const { logger } = context;
+
+  logger.header(options.check ? "Check Block Manifest" : "Generate Manifest");
+
+  const configResult = await loadConfig({
+    configPath: options.config,
+    cwd: options.cwd,
+    debug: options.verbose,
+  });
+
+  const cwd = options.cwd ?? process.cwd();
+  const state = await readBlockManifestState(
+    configResult.config.plugins ?? [],
+    options.output ?? configResult.config.typescript.outputFile,
+    cwd
+  );
+
+  if (options.check) {
+    if (state.expected === state.actual) {
+      logger.success(
+        state.expected === null
+          ? "No blocks are declared, and no manifest is committed."
+          : `Block manifest is current: ${state.path}`
+      );
+      return;
+    }
+    logger.error(describeManifestDrift(state));
+    logger.info("Run `nextly generate:manifest` and commit the result.");
+    process.exit(1);
+  }
+
+  const changed = await applyBlockManifestState(state);
+  if (state.expected === null) {
+    logger.success(
+      changed
+        ? `No blocks are declared; removed ${state.path}`
+        : "No blocks are declared, and no manifest exists."
+    );
+    return;
+  }
+  logger.success(
+    changed
+      ? `Written block manifest → ${state.path}`
+      : `Block manifest already current: ${state.path}`
+  );
+}
+
+/**
+ * Register the generate:manifest command with the program
+ *
+ * @param program - Commander program instance
+ */
+export function registerGenerateManifestCommand(program: Command): void {
+  program
+    .command("generate:manifest")
+    .description(
+      "Generate the block manifest from plugin declarations, or check it is current"
+    )
+    .option(
+      "-o, --output <path>",
+      "Types output path the manifest is written beside"
+    )
+    .option(
+      "--check",
+      "Write nothing; exit non-zero if the committed manifest is stale"
+    )
+    .action(async (cmdOptions: GenerateManifestOptions, cmd: Command) => {
+      const globalOpts = cmd.optsWithGlobals();
+      const context = createContext(globalOpts);
+
+      try {
+        await runGenerateManifest(
+          {
+            ...cmdOptions,
+            config: globalOpts.config,
+            verbose: globalOpts.verbose,
+            quiet: globalOpts.quiet,
+            cwd: globalOpts.cwd,
+          },
+          context
+        );
+      } catch (error) {
+        context.logger.error(describeError(error));
+        process.exit(1);
+      }
+    });
+}

--- a/packages/nextly/src/cli/commands/generate-types.ts
+++ b/packages/nextly/src/cli/commands/generate-types.ts
@@ -41,11 +41,6 @@ import { describeError } from "../../errors/index";
 // Reserved-option refusals are reported through the canonical error shape, so
 // the CLI renders them like any other declaration failure.
 import type { FieldGroupConfig } from "../../field-groups/config/types";
-import {
-  assertManifestPathIsFree,
-  BLOCK_MANIFEST_FILENAME,
-  buildBlockManifestArtifact,
-} from "../../plugins/codegen/block-manifest";
 import { collectCodegenNames } from "../../plugins/codegen/collect-codegen-names";
 import {
   buildImportMapArtifact,
@@ -64,6 +59,11 @@ import type { UserFieldConfig } from "../../users/config/types";
 import { createContext, type CommandContext } from "../program";
 import { loadConfig, type LoadConfigResult } from "../utils/config-loader";
 import { formatDuration, formatCount } from "../utils/logger";
+
+import {
+  applyBlockManifestState,
+  readBlockManifestState,
+} from "./generate-manifest";
 
 // ============================================================================
 // Types
@@ -189,34 +189,21 @@ export async function runGenerateTypes(
   // reaches zero on every count the moment that plugin is removed, and that is
   // exactly when its manifest most needs deleting. The path is recorded and
   // reported on the result further down, where that object exists.
-  const manifestCwd = options.cwd ?? process.cwd();
-  const manifestOutputPath =
-    options.output ?? configResult.config.typescript.outputFile;
-  // Checked before either branch: the cleanup path deletes by name, so a
-  // collision here would remove the types output rather than a stale manifest.
-  assertManifestPathIsFree(manifestOutputPath);
-  const blockManifest = buildBlockManifestArtifact(
+  // Settled through the same pair `generate:manifest` uses, so the command that
+  // writes the file and the command that checks it cannot disagree about what
+  // belongs on disk. `expected === null` is expressed by REMOVING any previous
+  // manifest: writing nothing would leave the last run's file still advertising
+  // blocks the app no longer has.
+  const manifestState = await readBlockManifestState(
     configResult.config.plugins ?? [],
-    manifestOutputPath
+    options.output ?? configResult.config.typescript.outputFile,
+    options.cwd ?? process.cwd()
   );
-  let writtenManifestPath: string | undefined;
-  if (blockManifest) {
-    writtenManifestPath = resolve(manifestCwd, blockManifest.path);
-    await ensureDir(dirname(writtenManifestPath));
-    await writeFile(writtenManifestPath, blockManifest.code, "utf-8");
+  await applyBlockManifestState(manifestState);
+  const writtenManifestPath =
+    manifestState.expected === null ? undefined : manifestState.path;
+  if (writtenManifestPath) {
     logger.debug(`Written block manifest to: ${writtenManifestPath}`);
-  } else {
-    // No manifest for this config, expressed by removing any previous one.
-    // Writing nothing would leave the last run's file on disk still
-    // advertising blocks the app no longer has -- worse than never having
-    // generated it, because it reads as current.
-    await rm(
-      resolve(
-        manifestCwd,
-        join(dirname(manifestOutputPath), BLOCK_MANIFEST_FILENAME)
-      ),
-      { force: true }
-    );
   }
 
   if (

--- a/packages/nextly/src/cli/program.ts
+++ b/packages/nextly/src/cli/program.ts
@@ -17,6 +17,7 @@ import { registerAddCommand } from "./commands/add";
 import { registerBuildCommand } from "./commands/build";
 // What: import the renamed one-shot sync command.
 import { registerDbSyncCommand } from "./commands/db-sync";
+import { registerGenerateManifestCommand } from "./commands/generate-manifest";
 import { registerGenerateTypesCommand } from "./commands/generate-types";
 import { registerI18nRestoreCommand } from "./commands/i18n-restore";
 import { registerInitCommand } from "./commands/init";
@@ -140,6 +141,7 @@ export function createProgram(): Command {
 ${pc.bold("Examples:")}
   ${pc.gray("$")} next dev                      ${pc.gray("# Start the dev server (Nextly boots in-process)")}
   ${pc.gray("$")} nextly generate:types         ${pc.gray("# Generate TypeScript types")}
+  ${pc.gray("$")} nextly generate:manifest --check ${pc.gray("# Fail if the committed block manifest is stale")}
   ${pc.gray("$")} nextly migrate                ${pc.gray("# Run pending migrations")}
   ${pc.gray("$")} nextly migrate:status         ${pc.gray("# Show migration status")}
 
@@ -204,6 +206,9 @@ function registerCommands(program: Command): void {
   // Type generation commands
   registerGenerateTypesCommand(program);
   registerGenerateSchemaCommand(program);
+  // The manifest is also written by generate:types; this stands alone so CI can
+  // check it is current without paying for type and Zod generation.
+  registerGenerateManifestCommand(program);
 
   // Migration commands. F11 was forward-only; SP-2 adds single-step rollback.
   registerMigrateCommand(program); // Imported from ./commands/migrate.js

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -2863,6 +2863,10 @@ export class CollectionMutationService extends BaseService {
             // i18n: thread the write locale so an embedded localized component writes
             // translatable fields to its companion within the same transaction.
             locale: params.locale,
+            // A component instance is validated by its own pass inside the field-group
+            // service, so the request has to travel with it for a field rule nested in
+            // a field group to see the same `user` a top-level field rule sees.
+            req: params.user ? { user: params.user } : {},
           });
         }
 
@@ -5407,6 +5411,10 @@ export class CollectionMutationService extends BaseService {
                 // i18n: thread the write locale so an embedded localized component writes
                 // translatable fields to its companion within the same transaction.
                 locale: params.locale,
+                // A component instance is validated by its own pass inside the field-group
+                // service, so the request has to travel with it for a field rule nested in
+                // a field group to see the same `user` a top-level field rule sees.
+                req: params.user ? { user: params.user } : {},
               }
             );
           }

--- a/packages/nextly/src/domains/field-groups/__tests__/field-group-validation-request.integration.test.ts
+++ b/packages/nextly/src/domains/field-groups/__tests__/field-group-validation-request.integration.test.ts
@@ -1,0 +1,185 @@
+/**
+ * The parent write carries its request into a field group's validators.
+ *
+ * The service-level cases prove the value travels once it is handed over; this
+ * proves the entity write paths hand it over at all. Each of them builds the
+ * request itself, so each is a place the forwarding can be missing
+ * independently of the others — a collection create, a collection update, and
+ * a single update.
+ */
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  defineCollection,
+  defineFieldGroup,
+  defineSingle,
+  fieldGroup,
+  pluginField,
+  text,
+} from "../../../config";
+import type { PluginFieldValidateArgs } from "../../../plugins/contributions";
+import { definePlugin } from "../../../plugins/plugin-context";
+import {
+  createTestNextly,
+  type TestNextly,
+} from "../../../plugins/test-nextly";
+
+/** The signed-in caller a write is attributed to. */
+const USER = { id: "u1", email: "editor@example.com" };
+
+let current: TestNextly | undefined;
+
+afterEach(async () => {
+  await current?.destroy();
+  current = undefined;
+});
+
+/**
+ * A plugin field type whose rule depends on who is writing — the capability
+ * that silently did nothing inside a field group, because it fails OPEN: with
+ * no user in scope the safe-looking answer is to accept.
+ */
+const ownerOnlyPlugin = definePlugin({
+  name: "@test/owner-only",
+  version: "1.0.0",
+  nextly: ">=0.0.0",
+  contributes: {
+    fieldTypes: [
+      {
+        type: "owner-only",
+        storage: "text",
+        component: "@test/owner-only/admin#OwnerOnlyInput",
+        validate: (_value: unknown, args: PluginFieldValidateArgs) =>
+          args.req.user ? true : "Only a signed-in user may set a badge",
+      },
+    ],
+  },
+});
+
+async function boot(): Promise<TestNextly> {
+  return createTestNextly({
+    plugins: [ownerOnlyPlugin],
+    fieldGroups: [
+      defineFieldGroup({
+        slug: "badged",
+        fields: [pluginField({ name: "badge", type: "owner-only" })],
+      }),
+    ],
+    collections: [
+      defineCollection({
+        slug: "pages",
+        fields: [
+          text({ name: "title" }),
+          fieldGroup({ name: "badge", component: "badged" }),
+        ],
+      }),
+    ],
+    singles: [
+      defineSingle({
+        slug: "landing",
+        fields: [
+          text({ name: "headline" }),
+          fieldGroup({ name: "badge", component: "badged" }),
+        ],
+      }),
+    ],
+  });
+}
+
+describe("a field group's validators and the parent write's request", () => {
+  it("a collection create forwards its user", async () => {
+    current = await boot();
+
+    const created = await current.nextly.create({
+      collection: "pages",
+      data: { title: "About", badge: { badge: "gold" } },
+      user: USER,
+      overrideAccess: true,
+    });
+
+    expect((created.item as { title?: string }).title).toBe("About");
+  });
+
+  it("refuses the same create when nobody is signed in", async () => {
+    // The control: without it a passing case above could be a validator that
+    // never ran rather than one that was given the user.
+    //
+    // Matched on the message rather than the code: a refusal raised inside a
+    // collection write's transaction is reclassified on the way out of the
+    // callback, so the code and the issue list do not survive that boundary.
+    // The single case below asserts the full issue, on the path that keeps it.
+    current = await boot();
+
+    await expect(
+      current.nextly.create({
+        collection: "pages",
+        data: { title: "About", badge: { badge: "gold" } },
+        overrideAccess: true,
+      })
+    ).rejects.toThrow(/Validation failed/);
+  });
+
+  it("a collection update forwards its user", async () => {
+    current = await boot();
+
+    const created = await current.nextly.create({
+      collection: "pages",
+      data: { title: "About", badge: { badge: "gold" } },
+      user: USER,
+      overrideAccess: true,
+    });
+
+    const updated = await current.nextly.update({
+      collection: "pages",
+      id: (created.item as { id: string }).id,
+      data: { badge: { badge: "silver" } },
+      user: USER,
+      overrideAccess: true,
+    });
+
+    expect((updated.item as { id?: string }).id).toBe(
+      (created.item as { id: string }).id
+    );
+  });
+
+  it("a single update forwards its user", async () => {
+    current = await boot();
+
+    const updated = await current.nextly.updateSingle({
+      slug: "landing",
+      data: { headline: "Hello", badge: { badge: "gold" } },
+      user: USER,
+      overrideAccess: true,
+    });
+
+    expect((updated as { headline?: string }).headline).toBe("Hello");
+  });
+
+  it("refuses the same single update when nobody is signed in", async () => {
+    // The single path hands the refusal back intact, so this is where the
+    // validator's own issue can be read: the field it is about and the code
+    // the client keys its handling on, not just a sentence.
+    current = await boot();
+
+    const error = await current.nextly
+      .updateSingle({
+        slug: "landing",
+        data: { headline: "Hello", badge: { badge: "gold" } },
+        overrideAccess: true,
+      })
+      .catch((e: unknown) => e);
+
+    expect(error).toMatchObject({
+      code: "VALIDATION_ERROR",
+      publicData: {
+        errors: [
+          {
+            path: "badge",
+            code: "CUSTOM",
+            message: "Only a signed-in user may set a badge.",
+          },
+        ],
+      },
+    });
+  });
+});

--- a/packages/nextly/src/domains/field-groups/__tests__/field-group-validation-request.test.ts
+++ b/packages/nextly/src/domains/field-groups/__tests__/field-group-validation-request.test.ts
@@ -1,0 +1,266 @@
+/**
+ * A field validator nested in a field group sees the write's request context.
+ *
+ * A component instance is validated by its own pass, in this service, against
+ * the component's own field set — the parent entry's validation never descends
+ * into it. That pass used to run with no request at all, so a plugin field
+ * type's `validate` was handed an empty `req` and a rule reading `req.user`
+ * could not tell an authenticated write from an anonymous one. It failed OPEN:
+ * the value was accepted, so nothing surfaced.
+ *
+ * Every shape a field group can take has its own save method and its own
+ * pooled/transactional pair, which is why each is exercised rather than one
+ * standing in for the rest.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { AuthorableFieldConfig } from "../../../collections/fields/types/plugin-field";
+import { fieldGroup, pluginField } from "../../../config";
+import { FieldGroupDataService } from "../../../services/field-groups/field-group-data-service";
+import {
+  clearFieldTypes,
+  registerFieldType,
+} from "../../schema/field-types/field-type-registry";
+
+import {
+  createSilentLogger,
+  createMockAdapter,
+  createMockTxContext,
+  createMockComponentRegistry,
+  createMockRelationshipService,
+} from "./field-group-test-helpers";
+
+/** The signed-in caller a write is attributed to. */
+const USER = { id: "u1", email: "editor@example.com" };
+
+/** Every `req` the field type's validator was handed, in call order. */
+let seen: Record<string, unknown>[] = [];
+
+/**
+ * A plugin field type whose rule depends on who is writing — the capability
+ * that silently did nothing inside a field group. It records what it was given
+ * so a test can assert on the context itself, not only on the verdict.
+ */
+function registerOwnerOnly(): void {
+  registerFieldType({
+    type: "owner-only",
+    storage: "text",
+    component: "@acme/owner/admin#OwnerOnlyInput",
+    validate: (_value, args) => {
+      seen.push(args.req);
+      return args.req.user ? true : "Only a signed-in user may set a badge";
+    },
+  });
+}
+
+type Ctx = {
+  service: FieldGroupDataService;
+  adapter: ReturnType<typeof createMockAdapter>;
+  registry: ReturnType<typeof createMockComponentRegistry>;
+};
+
+function createCtx(): Ctx {
+  const adapter = createMockAdapter();
+  const registry = createMockComponentRegistry();
+  const service = new FieldGroupDataService(
+    adapter as unknown as ConstructorParameters<
+      typeof FieldGroupDataService
+    >[0],
+    createSilentLogger(),
+    registry as unknown as ConstructorParameters<
+      typeof FieldGroupDataService
+    >[2],
+    createMockRelationshipService() as unknown as ConstructorParameters<
+      typeof FieldGroupDataService
+    >[3]
+  );
+  return { service, adapter, registry };
+}
+
+/** A component holding one field of the request-dependent type. */
+const BADGED_FIELDS: AuthorableFieldConfig[] = [
+  pluginField({ name: "badge", type: "owner-only" }),
+];
+
+const badgeField = fieldGroup({ name: "badge", component: "badged" });
+
+const badgeListField = fieldGroup({
+  name: "badges",
+  component: "badged",
+  repeatable: true,
+});
+
+const badgeZoneField = fieldGroup({
+  name: "zone",
+  components: ["badged", "alsoBadged"],
+  repeatable: true,
+});
+
+let ctx: Ctx;
+
+beforeEach(() => {
+  seen = [];
+  registerOwnerOnly();
+  ctx = createCtx();
+  ctx.registry.registerComponent("badged", {
+    slug: "badged",
+    tableName: "comp_badged",
+    fields: BADGED_FIELDS,
+  });
+  ctx.registry.registerComponent("alsoBadged", {
+    slug: "alsoBadged",
+    tableName: "comp_also_badged",
+    fields: BADGED_FIELDS,
+  });
+});
+
+afterEach(() => {
+  clearFieldTypes();
+});
+
+/** A transaction context whose reads return no existing instances. */
+function emptyTx() {
+  return createMockTxContext({ select: vi.fn().mockResolvedValue([]) });
+}
+
+type TxParam = Parameters<
+  FieldGroupDataService["saveComponentDataInTransaction"]
+>[0];
+
+describe("request context reaching a field group's validators", () => {
+  it("forwards the request to a single component's validator", async () => {
+    await ctx.service.saveComponentData({
+      parentId: "entry-1",
+      parentTable: "dc_pages",
+      fields: [badgeField],
+      data: { badge: { badge: "gold" } },
+      req: { user: USER },
+    });
+
+    expect(seen).toEqual([{ user: USER }]);
+    expect(ctx.adapter.insert).toHaveBeenCalledTimes(1);
+  });
+
+  it("refuses the same write when there is no request behind it", async () => {
+    // The control for every case here: it proves the validator runs at all, so
+    // a passing case above cannot be a validator that was never reached.
+    await expect(
+      ctx.service.saveComponentData({
+        parentId: "entry-1",
+        parentTable: "dc_pages",
+        fields: [badgeField],
+        data: { badge: { badge: "gold" } },
+      })
+    ).rejects.toMatchObject({ code: "VALIDATION_ERROR" });
+
+    expect(seen).toEqual([{}]);
+    expect(ctx.adapter.insert).not.toHaveBeenCalled();
+  });
+
+  it("reports the refusal against the field, not as a bare message", async () => {
+    // The write path wraps issues in an envelope, so the caller's own error
+    // handling reads the path and code rather than parsing a sentence.
+    const error = await ctx.service
+      .saveComponentData({
+        parentId: "entry-1",
+        parentTable: "dc_pages",
+        fields: [badgeField],
+        data: { badge: { badge: "gold" } },
+      })
+      .catch((e: unknown) => e);
+
+    expect(error).toMatchObject({
+      code: "VALIDATION_ERROR",
+      publicData: {
+        errors: [
+          {
+            path: "badge",
+            code: "CUSTOM",
+            message: "Only a signed-in user may set a badge.",
+          },
+        ],
+      },
+    });
+  });
+
+  it("forwards the request inside a transaction", async () => {
+    const tx = emptyTx();
+
+    await ctx.service.saveComponentDataInTransaction(tx as unknown as TxParam, {
+      parentId: "entry-1",
+      parentTable: "dc_pages",
+      fields: [badgeField],
+      data: { badge: { badge: "gold" } },
+      req: { user: USER },
+    });
+
+    expect(seen).toEqual([{ user: USER }]);
+    expect(tx.insert).toHaveBeenCalledTimes(1);
+  });
+
+  it("forwards it to every instance of a repeatable field group", async () => {
+    await ctx.service.saveComponentData({
+      parentId: "entry-1",
+      parentTable: "dc_pages",
+      fields: [badgeListField],
+      data: { badges: [{ badge: "gold" }, { badge: "silver" }] },
+      req: { user: USER },
+    });
+
+    expect(seen).toEqual([{ user: USER }, { user: USER }]);
+    expect(ctx.adapter.insert).toHaveBeenCalledTimes(2);
+  });
+
+  it("forwards it to a repeatable field group inside a transaction", async () => {
+    const tx = emptyTx();
+
+    await ctx.service.saveComponentDataInTransaction(tx as unknown as TxParam, {
+      parentId: "entry-1",
+      parentTable: "dc_pages",
+      fields: [badgeListField],
+      data: { badges: [{ badge: "gold" }, { badge: "silver" }] },
+      req: { user: USER },
+    });
+
+    expect(seen).toEqual([{ user: USER }, { user: USER }]);
+    expect(tx.insert).toHaveBeenCalledTimes(2);
+  });
+
+  it("forwards it across the component types of a dynamic zone", async () => {
+    await ctx.service.saveComponentData({
+      parentId: "entry-1",
+      parentTable: "dc_pages",
+      fields: [badgeZoneField],
+      data: {
+        zone: [
+          { _componentType: "badged", badge: "gold" },
+          { _componentType: "alsoBadged", badge: "silver" },
+        ],
+      },
+      req: { user: USER },
+    });
+
+    expect(seen).toEqual([{ user: USER }, { user: USER }]);
+    expect(ctx.adapter.insert).toHaveBeenCalledTimes(2);
+  });
+
+  it("forwards it across a dynamic zone inside a transaction", async () => {
+    const tx = emptyTx();
+
+    await ctx.service.saveComponentDataInTransaction(tx as unknown as TxParam, {
+      parentId: "entry-1",
+      parentTable: "dc_pages",
+      fields: [badgeZoneField],
+      data: {
+        zone: [
+          { _componentType: "badged", badge: "gold" },
+          { _componentType: "alsoBadged", badge: "silver" },
+        ],
+      },
+      req: { user: USER },
+    });
+
+    expect(seen).toEqual([{ user: USER }, { user: USER }]);
+    expect(tx.insert).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/nextly/src/domains/field-groups/services/field-group-mutation-service.ts
+++ b/packages/nextly/src/domains/field-groups/services/field-group-mutation-service.ts
@@ -68,6 +68,20 @@ export interface SaveComponentDataParams {
    * (shared fields still go to the main comp_ row). Threaded from the parent entity's write.
    */
   locale?: string;
+
+  /**
+   * The parent write's request context, forwarded to the field validators that run on each
+   * component instance. Carries `user` when the write is authenticated.
+   *
+   * A component instance is validated by its own pass, in its own service, against its own
+   * field set — the parent entry's validation never reaches inside it. Without this the
+   * instance pass runs with an empty context, so a field rule that reads `req.user` cannot
+   * tell an authenticated write from an anonymous one and accepts both.
+   *
+   * The whole record rather than a bare `user`: it is what the validator receives, so
+   * anything else the parent write puts on its request travels with it.
+   */
+  req?: Record<string, unknown>;
 }
 
 /**
@@ -322,7 +336,7 @@ export class FieldGroupMutationService extends BaseService {
    * Save component data for all component fields of a parent entry.
    */
   async saveComponentData(params: SaveComponentDataParams): Promise<void> {
-    const { parentId, parentTable, fields, data, locale } = params;
+    const { parentId, parentTable, fields, data, locale, req } = params;
 
     for (const field of fields) {
       if (!isFieldGroupField(field)) continue;
@@ -351,6 +365,7 @@ export class FieldGroupMutationService extends BaseService {
           field,
           data: fieldData,
           locale,
+          req,
         });
       } else if (field.component) {
         if (field.repeatable) {
@@ -361,6 +376,7 @@ export class FieldGroupMutationService extends BaseService {
             componentSlug: field.component,
             data: fieldData,
             locale,
+            req,
           });
         } else {
           await this.saveSingleComponent({
@@ -370,6 +386,7 @@ export class FieldGroupMutationService extends BaseService {
             componentSlug: field.component,
             data: fieldData as ComponentInstanceData,
             locale,
+            req,
           });
         }
       }
@@ -484,7 +501,7 @@ export class FieldGroupMutationService extends BaseService {
     tx: TransactionContext,
     params: SaveComponentDataParams
   ): Promise<void> {
-    const { parentId, parentTable, fields, data, locale } = params;
+    const { parentId, parentTable, fields, data, locale, req } = params;
 
     for (const field of fields) {
       if (!isFieldGroupField(field)) continue;
@@ -513,6 +530,7 @@ export class FieldGroupMutationService extends BaseService {
           field,
           data: fieldData,
           locale,
+          req,
         });
       } else if (field.component) {
         if (field.repeatable) {
@@ -523,6 +541,7 @@ export class FieldGroupMutationService extends BaseService {
             componentSlug: field.component,
             data: fieldData,
             locale,
+            req,
           });
         } else {
           await this.saveSingleComponentInTx(tx, {
@@ -532,6 +551,7 @@ export class FieldGroupMutationService extends BaseService {
             componentSlug: field.component,
             data: fieldData as ComponentInstanceData,
             locale,
+            req,
           });
         }
       }
@@ -582,9 +602,17 @@ export class FieldGroupMutationService extends BaseService {
     componentSlug: string;
     data: ComponentInstanceData;
     locale?: string;
+    req?: Record<string, unknown>;
   }): Promise<void> {
-    const { parentId, parentTable, fieldName, componentSlug, data, locale } =
-      params;
+    const {
+      parentId,
+      parentTable,
+      fieldName,
+      componentSlug,
+      data,
+      locale,
+      req,
+    } = params;
 
     try {
       const componentMeta =
@@ -605,7 +633,8 @@ export class FieldGroupMutationService extends BaseService {
       await this.prepareInstanceForWrite(
         data,
         componentFields,
-        existing.length > 0 ? "update" : "create"
+        existing.length > 0 ? "update" : "create",
+        req
       );
 
       // i18n: split translatable values out of the main comp_ write — they live on the
@@ -684,10 +713,18 @@ export class FieldGroupMutationService extends BaseService {
       componentSlug: string;
       data: ComponentInstanceData;
       locale?: string;
+      req?: Record<string, unknown>;
     }
   ): Promise<void> {
-    const { parentId, parentTable, fieldName, componentSlug, data, locale } =
-      params;
+    const {
+      parentId,
+      parentTable,
+      fieldName,
+      componentSlug,
+      data,
+      locale,
+      req,
+    } = params;
 
     try {
       const componentMeta =
@@ -709,7 +746,8 @@ export class FieldGroupMutationService extends BaseService {
       await this.prepareInstanceForWrite(
         data,
         componentFields,
-        existing.length > 0 ? "update" : "create"
+        existing.length > 0 ? "update" : "create",
+        req
       );
 
       // i18n: split translatable values out of the main comp_ write (companion-owned).
@@ -775,9 +813,17 @@ export class FieldGroupMutationService extends BaseService {
     componentSlug: string;
     data: unknown;
     locale?: string;
+    req?: Record<string, unknown>;
   }): Promise<void> {
-    const { parentId, parentTable, fieldName, componentSlug, data, locale } =
-      params;
+    const {
+      parentId,
+      parentTable,
+      fieldName,
+      componentSlug,
+      data,
+      locale,
+      req,
+    } = params;
 
     if (!Array.isArray(data)) {
       this.logger.warn("Repeatable component data is not an array", {
@@ -818,7 +864,8 @@ export class FieldGroupMutationService extends BaseService {
         await this.prepareInstanceForWrite(
           instance,
           componentFields,
-          instanceId && existingMap.has(instanceId) ? "update" : "create"
+          instanceId && existingMap.has(instanceId) ? "update" : "create",
+          req
         );
 
         if (instanceId && existingMap.has(instanceId)) {
@@ -890,10 +937,18 @@ export class FieldGroupMutationService extends BaseService {
       componentSlug: string;
       data: unknown;
       locale?: string;
+      req?: Record<string, unknown>;
     }
   ): Promise<void> {
-    const { parentId, parentTable, fieldName, componentSlug, data, locale } =
-      params;
+    const {
+      parentId,
+      parentTable,
+      fieldName,
+      componentSlug,
+      data,
+      locale,
+      req,
+    } = params;
 
     if (!Array.isArray(data)) {
       this.logger.warn("Repeatable component data is not an array", {
@@ -937,7 +992,8 @@ export class FieldGroupMutationService extends BaseService {
         await this.prepareInstanceForWrite(
           instance,
           componentFields,
-          instanceId && existingMap.has(instanceId) ? "update" : "create"
+          instanceId && existingMap.has(instanceId) ? "update" : "create",
+          req
         );
 
         if (instanceId && existingMap.has(instanceId)) {
@@ -1010,8 +1066,10 @@ export class FieldGroupMutationService extends BaseService {
     field: FieldGroupFieldConfig;
     data: unknown;
     locale?: string;
+    req?: Record<string, unknown>;
   }): Promise<void> {
-    const { parentId, parentTable, fieldName, field, data, locale } = params;
+    const { parentId, parentTable, fieldName, field, data, locale, req } =
+      params;
     const allowedSlugs = field.components ?? [];
 
     // Shared with the pre-transaction check, so the two cannot disagree about which
@@ -1105,7 +1163,8 @@ export class FieldGroupMutationService extends BaseService {
         await this.prepareInstanceForWrite(
           instance,
           componentFields,
-          instanceId && globalExistingMap.has(instanceId) ? "update" : "create"
+          instanceId && globalExistingMap.has(instanceId) ? "update" : "create",
+          req
         );
 
         if (instanceId && globalExistingMap.has(instanceId)) {
@@ -1182,9 +1241,11 @@ export class FieldGroupMutationService extends BaseService {
       field: FieldGroupFieldConfig;
       data: unknown;
       locale?: string;
+      req?: Record<string, unknown>;
     }
   ): Promise<void> {
-    const { parentId, parentTable, fieldName, field, data, locale } = params;
+    const { parentId, parentTable, fieldName, field, data, locale, req } =
+      params;
     const allowedSlugs = field.components ?? [];
 
     // Shared with the pre-transaction check, so the two cannot disagree about which
@@ -1264,7 +1325,8 @@ export class FieldGroupMutationService extends BaseService {
         await this.prepareInstanceForWrite(
           instance,
           componentFields,
-          instanceId && globalExistingMap.has(instanceId) ? "update" : "create"
+          instanceId && globalExistingMap.has(instanceId) ? "update" : "create",
+          req
         );
 
         if (instanceId && globalExistingMap.has(instanceId)) {
@@ -1487,11 +1549,18 @@ export class FieldGroupMutationService extends BaseService {
    * matching the parent entry pipeline. `mode` is "update" for an instance
    * that already exists (so a write-only password left empty keeps the stored
    * hash) and "create" for a new one.
+   *
+   * `req` is the parent write's request context. It reaches the field
+   * validators unchanged, so a rule on a component field sees the same `user`
+   * a rule on a top-level field would. Defaults to an empty record: a caller
+   * with no request (an internal write, a seed) supplies no context, which is
+   * what an unauthenticated write looks like anyway.
    */
   private async prepareInstanceForWrite(
     instance: ComponentInstanceData,
     componentFields: FieldConfig[],
-    mode: "create" | "update"
+    mode: "create" | "update",
+    req: Record<string, unknown> = {}
   ): Promise<void> {
     // A component instance must be a plain object. A primitive (e.g. a bare
     // string sent for a non-repeatable component field) would make the field
@@ -1517,7 +1586,10 @@ export class FieldGroupMutationService extends BaseService {
     // reference left populated here is stored there as a snapshot of the row.
     normalizeRelationshipFields(instance, componentFields);
 
-    const issues = await validateEntryData(instance, componentFields, { mode });
+    const issues = await validateEntryData(instance, componentFields, {
+      mode,
+      req,
+    });
     if (issues.length > 0) {
       throw NextlyError.validation({ errors: issues });
     }

--- a/packages/nextly/src/domains/singles/services/single-mutation-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-mutation-service.ts
@@ -1592,6 +1592,11 @@ export class SingleMutationService extends BaseService {
                   fields: fieldConfigs,
                   data: attemptComponentData,
                   locale: options.locale,
+                  // A component instance is validated by its own pass inside the
+                  // field-group service, so the request has to travel with it for a
+                  // field rule nested in a field group to see the same `user` a
+                  // top-level field rule sees.
+                  req: options.user ? { user: options.user } : {},
                 }
               );
             }

--- a/packages/nextly/src/index.ts
+++ b/packages/nextly/src/index.ts
@@ -368,6 +368,20 @@ export {
   type ValidationIssue,
 } from "./plugins/validate-field-values";
 
+// The block manifest's published contract. Exported from the package root
+// because a schema nothing can import promises nothing: the file is read by an
+// editor build, a docs page or an agent, and none of them can reach an internal
+// module through the export map.
+export {
+  BLOCK_MANIFEST_FILENAME,
+  BLOCK_MANIFEST_VERSION,
+  blockManifestJsonSchema,
+  blockManifestSchema,
+  blockManifestEntrySchema,
+  type BlockManifest,
+  type BlockManifestEntry,
+} from "./plugins/codegen/block-manifest";
+
 // Plugin System - Types and helpers for creating plugins
 export {
   AdminPlacement,

--- a/packages/nextly/src/plugins/codegen/__tests__/block-manifest-engine-parity.test.ts
+++ b/packages/nextly/src/plugins/codegen/__tests__/block-manifest-engine-parity.test.ts
@@ -1,0 +1,24 @@
+/**
+ * The manifest's version bound and the engine's are the same number.
+ *
+ * Generation refuses what registration refuses, so the bound has to be stated
+ * where generation runs. Core states it rather than importing it: reading it
+ * from the engine would make every app that installs core carry the block
+ * engine so codegen can read one integer, and it points the dependency the
+ * wrong way, since the plugin layer builds on core and not the reverse.
+ *
+ * Restating a value is only safe if it cannot quietly diverge. This is what
+ * makes that true — raising the engine's bound without raising core's fails
+ * here, rather than shipping a generator that refuses a block the engine
+ * accepts. The engine is a development dependency for this file alone.
+ */
+import { MAX_BLOCK_VERSION } from "@nextlyhq/blocks-engine";
+import { describe, expect, it } from "vitest";
+
+import { MAX_DECLARED_BLOCK_VERSION } from "../block-manifest";
+
+describe("the manifest's block-version bound", () => {
+  it("is the bound the engine enforces at registration", () => {
+    expect(MAX_DECLARED_BLOCK_VERSION).toBe(MAX_BLOCK_VERSION);
+  });
+});

--- a/packages/nextly/src/plugins/codegen/__tests__/block-manifest-engine-parity.test.ts
+++ b/packages/nextly/src/plugins/codegen/__tests__/block-manifest-engine-parity.test.ts
@@ -1,24 +1,111 @@
 /**
- * The manifest's version bound and the engine's are the same number.
+ * Generation and registration agree about what they refuse.
  *
- * Generation refuses what registration refuses, so the bound has to be stated
- * where generation runs. Core states it rather than importing it: reading it
- * from the engine would make every app that installs core carry the block
- * engine so codegen can read one integer, and it points the dependency the
- * wrong way, since the plugin layer builds on core and not the reverse.
+ * The rules have to be stated where generation runs, and core states them
+ * rather than importing them: reading them from the engine would make every
+ * app that installs core carry the block engine so codegen can read a bound
+ * and walk a map, and it points the dependency the wrong way, since the plugin
+ * layer builds on core and not the reverse.
  *
- * Restating a value is only safe if it cannot quietly diverge. This is what
- * makes that true — raising the engine's bound without raising core's fails
- * here, rather than shipping a generator that refuses a block the engine
- * accepts. The engine is a development dependency for this file alone.
+ * Restating a rule is only safe if it cannot quietly diverge. These are what
+ * make that true — moving one side without the other fails here, rather than
+ * shipping a generator that reports a tree clean for an app that will not
+ * start. The engine is a development dependency for this file alone.
  */
-import { MAX_BLOCK_VERSION } from "@nextlyhq/blocks-engine";
+import { findMigrationGaps, MAX_BLOCK_VERSION } from "@nextlyhq/blocks-engine";
 import { describe, expect, it } from "vitest";
 
-import { MAX_DECLARED_BLOCK_VERSION } from "../block-manifest";
+import { definePlugin, type PluginDefinition } from "../../plugin-context";
+import {
+  buildBlockManifest,
+  MAX_DECLARED_BLOCK_VERSION,
+  PAGE_BUILDER_PLUGIN,
+} from "../block-manifest";
 
 describe("the manifest's block-version bound", () => {
   it("is the bound the engine enforces at registration", () => {
     expect(MAX_DECLARED_BLOCK_VERSION).toBe(MAX_BLOCK_VERSION);
   });
+});
+
+function consumer(): PluginDefinition {
+  return definePlugin({
+    name: PAGE_BUILDER_PLUGIN,
+    version: "1.0.0",
+    nextly: ">=0.0.0",
+  });
+}
+
+function declaring(blocks: unknown[]): PluginDefinition {
+  return definePlugin({
+    name: "@acme/blocks",
+    version: "1.0.0",
+    nextly: ">=0.0.0",
+    contributes: { declarations: { [PAGE_BUILDER_PLUGIN]: { blocks } } },
+  });
+}
+
+const step = () => ({});
+
+const MIGRATION_CASES: { label: string; version: number; migrate?: unknown }[] =
+  [
+    { label: "version 1 needing no steps", version: 1 },
+    { label: "version 1 with a stray step", version: 1, migrate: { 1: step } },
+    { label: "version 2 with no map at all", version: 2 },
+    { label: "version 2 with its one step", version: 2, migrate: { 1: step } },
+    {
+      label: "version 3 missing the first step",
+      version: 3,
+      migrate: { 2: step },
+    },
+    {
+      label: "version 3 missing the second step",
+      version: 3,
+      migrate: { 1: step },
+    },
+    {
+      label: "version 3 fully covered",
+      version: 3,
+      migrate: { 1: step, 2: step },
+    },
+    {
+      label: "version 3 whose step is not a function",
+      version: 3,
+      migrate: { 1: step, 2: "nope" },
+    },
+  ];
+
+describe("the manifest's migration-gap rule", () => {
+  it.each(MIGRATION_CASES)(
+    "reaches the same verdict as the engine for $label",
+    ({ version, migrate }) => {
+      const engineRefuses =
+        findMigrationGaps(
+          1,
+          version,
+          migrate as Parameters<typeof findMigrationGaps>[2]
+        ).length > 0;
+
+      let generationRefuses = false;
+      try {
+        buildBlockManifest([
+          consumer(),
+          declaring([
+            {
+              name: "acme/hero",
+              version,
+              description: "A hero.",
+              example: { props: {} },
+              migrate,
+              render: () => null,
+            },
+          ]),
+        ]);
+      } catch {
+        generationRefuses = true;
+      }
+
+      expect(generationRefuses).toBe(engineRefuses);
+    }
+  );
 });

--- a/packages/nextly/src/plugins/codegen/__tests__/block-manifest-engine-parity.test.ts
+++ b/packages/nextly/src/plugins/codegen/__tests__/block-manifest-engine-parity.test.ts
@@ -3,17 +3,32 @@
  *
  * The rules have to be stated where generation runs, and core states them
  * rather than importing them: reading them from the engine would make every
- * app that installs core carry the block engine so codegen can read a bound
- * and walk a map, and it points the dependency the wrong way, since the plugin
- * layer builds on core and not the reverse.
+ * app that installs core carry the block engine so codegen can read a bound,
+ * match a name and walk a map, and it points the dependency the wrong way,
+ * since the plugin layer builds on core and not the reverse.
  *
- * Restating a rule is only safe if it cannot quietly diverge. These are what
- * make that true — moving one side without the other fails here, rather than
- * shipping a generator that reports a tree clean for an app that will not
- * start. The engine is a development dependency for this file alone.
+ * Restating a rule is only safe if it cannot quietly diverge. This file is what
+ * makes that true. Rather than checking each restated rule against its
+ * counterpart, it asks the engine itself — `registerBlocks` runs the whole
+ * registration validator — and requires the two to reach the same verdict on
+ * the same declaration. A rule tightened or loosened on either side, including
+ * one nobody thought to mirror, shows up here.
+ *
+ * `supports` is the one thing deliberately absent from the table: the engine
+ * checks those keys against capabilities registered at runtime, which
+ * generation cannot know without booting, so parity there is not achievable
+ * rather than merely unimplemented.
+ *
+ * The engine is a development dependency for this file alone; nothing imports
+ * it at runtime.
  */
-import { findMigrationGaps, MAX_BLOCK_VERSION } from "@nextlyhq/blocks-engine";
-import { describe, expect, it } from "vitest";
+import {
+  clearBlocks,
+  COMPONENT_INSTANCE_TYPE,
+  registerBlocks,
+  MAX_BLOCK_VERSION,
+} from "@nextlyhq/blocks-engine";
+import { afterEach, describe, expect, it } from "vitest";
 
 import { definePlugin, type PluginDefinition } from "../../plugin-context";
 import {
@@ -21,6 +36,10 @@ import {
   MAX_DECLARED_BLOCK_VERSION,
   PAGE_BUILDER_PLUGIN,
 } from "../block-manifest";
+
+afterEach(() => {
+  clearBlocks();
+});
 
 describe("the manifest's block-version bound", () => {
   it("is the bound the engine enforces at registration", () => {
@@ -47,65 +66,110 @@ function declaring(blocks: unknown[]): PluginDefinition {
 
 const step = () => ({});
 
-const MIGRATION_CASES: { label: string; version: number; migrate?: unknown }[] =
-  [
-    { label: "version 1 needing no steps", version: 1 },
-    { label: "version 1 with a stray step", version: 1, migrate: { 1: step } },
-    { label: "version 2 with no map at all", version: 2 },
-    { label: "version 2 with its one step", version: 2, migrate: { 1: step } },
-    {
-      label: "version 3 missing the first step",
-      version: 3,
-      migrate: { 2: step },
-    },
-    {
-      label: "version 3 missing the second step",
-      version: 3,
-      migrate: { 1: step },
-    },
-    {
-      label: "version 3 fully covered",
-      version: 3,
-      migrate: { 1: step, 2: step },
-    },
-    {
-      label: "version 3 whose step is not a function",
-      version: 3,
-      migrate: { 1: step, 2: "nope" },
-    },
-  ];
+/** A declaration the engine accepts, for a case to vary one thing from. */
+function valid(overrides: Record<string, unknown> = {}) {
+  return {
+    name: "acme/hero",
+    version: 1,
+    description: "A hero.",
+    example: { props: {} },
+    render: () => null,
+    ...overrides,
+  };
+}
 
-describe("the manifest's migration-gap rule", () => {
-  it.each(MIGRATION_CASES)(
-    "reaches the same verdict as the engine for $label",
-    ({ version, migrate }) => {
-      const engineRefuses =
-        findMigrationGaps(
-          1,
-          version,
-          migrate as Parameters<typeof findMigrationGaps>[2]
-        ).length > 0;
+const CASES: { label: string; definition: Record<string, unknown> }[] = [
+  { label: "an ordinary block", definition: valid() },
+  {
+    label: "a hyphenated namespace and name",
+    definition: valid({ name: "my-co/call-to-action" }),
+  },
+  { label: "a name with no namespace", definition: valid({ name: "Hero" }) },
+  {
+    label: "a name in the wrong case",
+    definition: valid({ name: "Acme/Hero" }),
+  },
+  { label: "a name with two slashes", definition: valid({ name: "a/b/c" }) },
+  {
+    label: "a name with a trailing hyphen",
+    definition: valid({ name: "acme/hero-" }),
+  },
+  { label: "an empty namespace", definition: valid({ name: "/hero" }) },
+  {
+    label: "the reserved component-instance name",
+    definition: valid({ name: COMPONENT_INSTANCE_TYPE }),
+  },
+  { label: "a fractional version", definition: valid({ version: 1.5 }) },
+  { label: "a version of zero", definition: valid({ version: 0 }) },
+  {
+    label: "a version past the bound",
+    definition: valid({ version: MAX_BLOCK_VERSION + 1 }),
+  },
+  {
+    label: "a version at the bound, fully migrated",
+    definition: valid({ version: 2, migrate: { 1: step } }),
+  },
+  {
+    label: "version 2 with no migration map",
+    definition: valid({ version: 2 }),
+  },
+  {
+    label: "version 3 missing its first step",
+    definition: valid({ version: 3, migrate: { 2: step } }),
+  },
+  {
+    label: "version 3 fully covered",
+    definition: valid({ version: 3, migrate: { 1: step, 2: step } }),
+  },
+  {
+    label: "a step that is not a function",
+    definition: valid({ version: 2, migrate: { 1: "nope" } }),
+  },
+  { label: "a blank description", definition: valid({ description: "   " }) },
+  {
+    label: "no description at all",
+    definition: valid({ description: undefined }),
+  },
+  {
+    label: "an example whose props are an array",
+    definition: valid({ example: { props: [] } }),
+  },
+  { label: "an example with no props", definition: valid({ example: {} }) },
+];
 
-      let generationRefuses = false;
-      try {
-        buildBlockManifest([
-          consumer(),
-          declaring([
-            {
-              name: "acme/hero",
-              version,
-              description: "A hero.",
-              example: { props: {} },
-              migrate,
-              render: () => null,
-            },
-          ]),
-        ]);
-      } catch {
-        generationRefuses = true;
-      }
+/**
+ * Whether the engine refuses this definition at registration.
+ *
+ * The table is mostly definitions the engine SHOULD refuse, so it cannot
+ * satisfy the definition type — that is the point. Handing the registrar what
+ * a plugin might actually declare, rather than only what type-checks, is the
+ * whole of what makes this an oracle.
+ */
+function engineRefuses(definition: Record<string, unknown>): boolean {
+  try {
+    registerBlocks([definition] as unknown as Parameters<
+      typeof registerBlocks
+    >[0]);
+    return false;
+  } catch {
+    return true;
+  } finally {
+    clearBlocks();
+  }
+}
 
-      expect(generationRefuses).toBe(engineRefuses);
-    }
-  );
+/** Whether generation refuses the same definition as a declaration. */
+function generationRefuses(definition: Record<string, unknown>): boolean {
+  try {
+    buildBlockManifest([consumer(), declaring([definition])]);
+    return false;
+  } catch {
+    return true;
+  }
+}
+
+describe("what generation refuses", () => {
+  it.each(CASES)("matches the engine for $label", ({ definition }) => {
+    expect(generationRefuses(definition)).toBe(engineRefuses(definition));
+  });
 });

--- a/packages/nextly/src/plugins/codegen/__tests__/block-manifest-engine-parity.test.ts
+++ b/packages/nextly/src/plugins/codegen/__tests__/block-manifest-engine-parity.test.ts
@@ -135,6 +135,26 @@ const CASES: { label: string; definition: Record<string, unknown> }[] = [
     definition: valid({ example: { props: [] } }),
   },
   { label: "an example with no props", definition: valid({ example: {} }) },
+  // The two the engine requires that never reach the manifest. A table whose
+  // every row carries a render function cannot notice a missing render check,
+  // which is how these went unmirrored in the first place.
+  { label: "no render function", definition: valid({ render: undefined }) },
+  {
+    label: "a render that is not a function",
+    definition: valid({ render: "./hero.js" }),
+  },
+  {
+    label: "defaultProps that are a plain record",
+    definition: valid({ defaultProps: { heading: "Hi" } }),
+  },
+  {
+    label: "defaultProps that are an array",
+    definition: valid({ defaultProps: [] }),
+  },
+  {
+    label: "defaultProps that are a primitive",
+    definition: valid({ defaultProps: "none" }),
+  },
 ];
 
 /**

--- a/packages/nextly/src/plugins/codegen/__tests__/block-manifest-schema.test.ts
+++ b/packages/nextly/src/plugins/codegen/__tests__/block-manifest-schema.test.ts
@@ -14,6 +14,7 @@ import {
   blockManifestJsonSchema,
   blockManifestSchema,
   buildBlockManifest,
+  buildBlockManifestArtifact,
   PAGE_BUILDER_PLUGIN,
 } from "../block-manifest";
 
@@ -118,10 +119,14 @@ describe("the manifest schema", () => {
       "an example with no props at all",
       { name: "n", version: 1, description: "d", example: {} },
     ],
+    [
+      "a block with no example, which the emitter can never produce",
+      { name: "n", version: 1, description: "d", example: undefined },
+    ],
   ])("refuses %s", (_label, partial) => {
     const result = blockManifestSchema.safeParse({
       manifestVersion: BLOCK_MANIFEST_VERSION,
-      blocks: [{ ...partial, source: "@acme/x" }],
+      blocks: [{ example: { props: {} }, ...partial, source: "@acme/x" }],
     });
 
     expect(result.success).toBe(false);
@@ -131,6 +136,18 @@ describe("the manifest schema", () => {
     expect(blockManifestSchema.safeParse({ blocks: [] }).success).toBe(false);
     expect(
       blockManifestSchema.safeParse({ manifestVersion: 0, blocks: [] }).success
+    ).toBe(false);
+  });
+
+  it("refuses a version of the document this schema was not written for", () => {
+    // The field exists so a reader can tell whether it understands the file.
+    // Accepting a version this schema does not describe answers that question
+    // wrong, and a consumer trusting it would read a future format as this one.
+    expect(
+      blockManifestSchema.safeParse({
+        manifestVersion: BLOCK_MANIFEST_VERSION + 1,
+        blocks: [],
+      }).success
     ).toBe(false);
   });
 });
@@ -223,6 +240,72 @@ describe("the emitter's obligation to the schema", () => {
   });
 });
 
+describe("rendering the manifest as a file", () => {
+  /** The first structured issue of a thrown validation error. */
+  function issueOf(run: () => unknown): { code?: string; message?: string } {
+    try {
+      run();
+    } catch (error) {
+      const issues = (
+        error as {
+          publicData?: { errors?: { code?: string; message?: string }[] };
+        }
+      )?.publicData?.errors;
+      return issues?.[0] ?? {};
+    }
+    return {};
+  }
+
+  function artifactOf(props: Record<string, unknown>) {
+    return () =>
+      buildBlockManifestArtifact(
+        [
+          consumer(),
+          declaring("@acme/pricing", [block("acme/hero", { props })]),
+        ],
+        "src/generated/nextly-types.ts"
+      );
+  }
+
+  it.each([
+    ["a bigint", { count: 10n }],
+    [
+      "a cycle",
+      (() => {
+        const cyclic: Record<string, unknown> = {};
+        cyclic.self = cyclic;
+        return { shape: cyclic };
+      })(),
+    ],
+  ])("refuses %s, which JSON cannot represent", (_label, props) => {
+    // Whatever a plugin puts in `props` reaches `JSON.stringify` untouched, and
+    // these make it throw. A raw TypeError leaving the package says nothing
+    // about which declaration to go and fix.
+    expect(issueOf(artifactOf(props))).toMatchObject({
+      code: "INVALID_BLOCK_DECLARATION",
+    });
+    expect(issueOf(artifactOf(props)).message).toMatch(/JSON cannot represent/);
+  });
+
+  it("writes a file that satisfies the schema after JSON has had its way", () => {
+    // A function and an `undefined` are dropped by serialization rather than
+    // refused, as `render` already is. What must hold is that the TEXT still
+    // satisfies the published contract, since the text is what anyone reads.
+    const artifact = artifactOf({
+      keep: 1,
+      drop: undefined,
+      alsoDrop: () => null,
+    })();
+
+    const parsed: unknown = JSON.parse(artifact?.code ?? "null");
+    expect(blockManifestSchema.safeParse(parsed).success).toBe(true);
+    expect(
+      (parsed as { blocks: { props: Record<string, unknown> }[] }).blocks[0]
+        .props
+    ).toEqual({ keep: 1 });
+  });
+});
+
 describe("the published JSON Schema", () => {
   it("describes the same document the emitter writes", () => {
     // Pinned rather than merely smoke-tested: this is the contract an outside
@@ -297,15 +380,15 @@ describe("the published JSON Schema", () => {
                 "version",
                 "description",
                 "source",
+                "example",
               ],
               "type": "object",
             },
             "type": "array",
           },
           "manifestVersion": {
-            "exclusiveMinimum": 0,
-            "maximum": 9007199254740991,
-            "type": "integer",
+            "const": 1,
+            "type": "number",
           },
         },
         "required": [

--- a/packages/nextly/src/plugins/codegen/__tests__/block-manifest-schema.test.ts
+++ b/packages/nextly/src/plugins/codegen/__tests__/block-manifest-schema.test.ts
@@ -1,0 +1,235 @@
+/**
+ * The manifest's published contract, and the emitter's obligation to it.
+ *
+ * The file is read by things that never import Nextly, so the shape it promises
+ * has to exist as data rather than only as a TypeScript interface. These cases
+ * hold the two halves together: the emitter's output satisfies the schema, and
+ * the JSON Schema handed to outside readers describes that same shape.
+ */
+import { describe, expect, it } from "vitest";
+
+import { definePlugin, type PluginDefinition } from "../../plugin-context";
+import {
+  BLOCK_MANIFEST_VERSION,
+  blockManifestJsonSchema,
+  blockManifestSchema,
+  buildBlockManifest,
+  PAGE_BUILDER_PLUGIN,
+} from "../block-manifest";
+
+function block(name: string, extra: Record<string, unknown> = {}) {
+  return {
+    name,
+    version: 1,
+    description: `The ${name} block.`,
+    example: { props: {} },
+    render: () => null,
+    ...extra,
+  };
+}
+
+function consumer(): PluginDefinition {
+  return definePlugin({
+    name: PAGE_BUILDER_PLUGIN,
+    version: "1.0.0",
+    nextly: ">=0.0.0",
+  });
+}
+
+function declaring(name: string, blocks: unknown[]): PluginDefinition {
+  return definePlugin({
+    name,
+    version: "1.0.0",
+    nextly: ">=0.0.0",
+    contributes: { declarations: { [PAGE_BUILDER_PLUGIN]: { blocks } } },
+  });
+}
+
+describe("the manifest schema", () => {
+  it("accepts what the emitter produces, with every optional part present", () => {
+    const manifest = buildBlockManifest([
+      consumer(),
+      declaring("@acme/pricing", [
+        block("acme/pricing-table", {
+          props: { tiers: { type: "array" } },
+          supports: { spacing: true },
+          slots: { footer: {} },
+        }),
+      ]),
+    ]);
+
+    expect(blockManifestSchema.safeParse(manifest).success).toBe(true);
+  });
+
+  it("accepts a manifest with no blocks", () => {
+    // The shape an app with the page builder but no block plugins produces.
+    expect(
+      blockManifestSchema.safeParse({
+        manifestVersion: BLOCK_MANIFEST_VERSION,
+        blocks: [],
+      }).success
+    ).toBe(true);
+  });
+
+  it("refuses an entry carrying a key the contract does not mention", () => {
+    // Strictness is what makes the published schema a promise rather than a
+    // description: a key added to the emitter and not to the schema fails here
+    // instead of appearing in a file whose own schema rejects it.
+    const result = blockManifestSchema.safeParse({
+      manifestVersion: BLOCK_MANIFEST_VERSION,
+      blocks: [
+        {
+          name: "acme/hero",
+          version: 1,
+          description: "A hero.",
+          source: "@acme/hero",
+          renderer: "./hero.js",
+        },
+      ],
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it.each([
+    ["a nameless block", { name: "", version: 1, description: "d" }],
+    ["a block with no description", { name: "n", version: 1, description: "" }],
+    ["a non-numeric version", { name: "n", version: "1", description: "d" }],
+  ])("refuses %s", (_label, partial) => {
+    const result = blockManifestSchema.safeParse({
+      manifestVersion: BLOCK_MANIFEST_VERSION,
+      blocks: [{ ...partial, source: "@acme/x" }],
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it("refuses a document whose manifestVersion is missing or not a version", () => {
+    expect(blockManifestSchema.safeParse({ blocks: [] }).success).toBe(false);
+    expect(
+      blockManifestSchema.safeParse({ manifestVersion: 0, blocks: [] }).success
+    ).toBe(false);
+  });
+});
+
+describe("the emitter's obligation to the schema", () => {
+  /**
+   * The first structured issue of a thrown validation error. Asserted on
+   * instead of the message, which is deliberately generic — what identifies the
+   * failure is the issue's own code and path.
+   */
+  function issueOf(run: () => unknown): { code?: string; path?: string } {
+    try {
+      run();
+    } catch (error) {
+      const issues = (
+        error as {
+          publicData?: { errors?: { code?: string; path?: string }[] };
+        }
+      )?.publicData?.errors;
+      return issues?.[0] ?? {};
+    }
+    return {};
+  }
+
+  it.each([
+    ["NaN", Number.NaN],
+    ["Infinity", Number.POSITIVE_INFINITY],
+  ])("refuses a version of %s, which JSON cannot carry", (_label, version) => {
+    // `typeof NaN === "number"`, so the per-declaration check reads it as a
+    // version. It survives to `JSON.stringify`, which writes it as `null` — a
+    // manifest that parses as JSON and is wrong. The schema is what catches the
+    // gap between "is a number" and "is a number a reader can be handed".
+    expect(
+      issueOf(() =>
+        buildBlockManifest([
+          consumer(),
+          declaring("@acme/pricing", [block("acme/hero", { version })]),
+        ])
+      )
+      // Not the message: its tail is zod's wording, which a zod upgrade may
+      // reword without anything about this refusal having changed.
+    ).toMatchObject({
+      code: "MANIFEST_SCHEMA_MISMATCH",
+      path: "blocks.manifest.json.blocks.0.version",
+    });
+  });
+});
+
+describe("the published JSON Schema", () => {
+  it("describes the same document the emitter writes", () => {
+    // Pinned rather than merely smoke-tested: this is the contract an outside
+    // reader validates against, so a change to it is a change to what Nextly
+    // promises, and has to be visible in a diff.
+    expect(blockManifestJsonSchema()).toMatchInlineSnapshot(`
+      {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "additionalProperties": false,
+        "properties": {
+          "blocks": {
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "description": {
+                  "minLength": 1,
+                  "type": "string",
+                },
+                "example": {},
+                "name": {
+                  "minLength": 1,
+                  "type": "string",
+                },
+                "props": {
+                  "additionalProperties": {},
+                  "propertyNames": {
+                    "type": "string",
+                  },
+                  "type": "object",
+                },
+                "slots": {
+                  "additionalProperties": {},
+                  "propertyNames": {
+                    "type": "string",
+                  },
+                  "type": "object",
+                },
+                "source": {
+                  "minLength": 1,
+                  "type": "string",
+                },
+                "supports": {
+                  "additionalProperties": {},
+                  "propertyNames": {
+                    "type": "string",
+                  },
+                  "type": "object",
+                },
+                "version": {
+                  "type": "number",
+                },
+              },
+              "required": [
+                "name",
+                "version",
+                "description",
+                "source",
+              ],
+              "type": "object",
+            },
+            "type": "array",
+          },
+          "manifestVersion": {
+            "exclusiveMinimum": 0,
+            "maximum": 9007199254740991,
+            "type": "integer",
+          },
+        },
+        "required": [
+          "manifestVersion",
+          "blocks",
+        ],
+        "type": "object",
+      }
+    `);
+  });
+});

--- a/packages/nextly/src/plugins/codegen/__tests__/block-manifest-schema.test.ts
+++ b/packages/nextly/src/plugins/codegen/__tests__/block-manifest-schema.test.ts
@@ -95,6 +95,29 @@ describe("the manifest schema", () => {
     ["a nameless block", { name: "", version: 1, description: "d" }],
     ["a block with no description", { name: "n", version: 1, description: "" }],
     ["a non-numeric version", { name: "n", version: "1", description: "d" }],
+    // The rest are what the block engine refuses at registration. Generation
+    // accepting them would report success, and delete the previous manifest,
+    // for an app that cannot start.
+    [
+      "a fractional version, which has no migration step",
+      { name: "n", version: 1.5, description: "d" },
+    ],
+    [
+      "a version below 1, with nothing to migrate from",
+      { name: "n", version: 0, description: "d" },
+    ],
+    [
+      "a description of nothing but whitespace",
+      { name: "n", version: 1, description: "   " },
+    ],
+    [
+      "an example whose props are an array, which no node can hold",
+      { name: "n", version: 1, description: "d", example: { props: [] } },
+    ],
+    [
+      "an example with no props at all",
+      { name: "n", version: 1, description: "d", example: {} },
+    ],
   ])("refuses %s", (_label, partial) => {
     const result = blockManifestSchema.safeParse({
       manifestVersion: BLOCK_MANIFEST_VERSION,
@@ -135,23 +158,67 @@ describe("the emitter's obligation to the schema", () => {
   it.each([
     ["NaN", Number.NaN],
     ["Infinity", Number.POSITIVE_INFINITY],
-  ])("refuses a version of %s, which JSON cannot carry", (_label, version) => {
-    // `typeof NaN === "number"`, so the per-declaration check reads it as a
-    // version. It survives to `JSON.stringify`, which writes it as `null` — a
-    // manifest that parses as JSON and is wrong. The schema is what catches the
-    // gap between "is a number" and "is a number a reader can be handed".
+    ["a fraction", 1.5],
+    ["zero", 0],
+    ["a negative", -1],
+  ])(
+    "refuses a version of %s, which the per-declaration check reads as a number",
+    (_label, version) => {
+      // `typeof NaN === "number"`, and so is 1.5 and -1, so the declaration
+      // check lets all of them through. NaN even survives to `JSON.stringify`,
+      // which writes it as `null` — a manifest that parses as JSON and is
+      // wrong. The schema is the gap between "is a number" and "is a version".
+      expect(
+        issueOf(() =>
+          buildBlockManifest([
+            consumer(),
+            declaring("@acme/pricing", [block("acme/hero", { version })]),
+          ])
+        )
+        // Not the message: its tail is zod's wording, which a zod upgrade may
+        // reword without anything about this refusal having changed.
+      ).toMatchObject({
+        code: "MANIFEST_SCHEMA_MISMATCH",
+        path: "blocks.manifest.json.blocks.0.version",
+      });
+    }
+  );
+
+  it("refuses a description of nothing but whitespace", () => {
+    // The per-declaration check measures length, so spaces pass it; the engine
+    // trims before checking, and a blank description renders as an empty
+    // palette entry — the thing requiring one exists to prevent.
     expect(
       issueOf(() =>
         buildBlockManifest([
           consumer(),
-          declaring("@acme/pricing", [block("acme/hero", { version })]),
+          declaring("@acme/pricing", [
+            block("acme/hero", { description: "   " }),
+          ]),
         ])
       )
-      // Not the message: its tail is zod's wording, which a zod upgrade may
-      // reword without anything about this refusal having changed.
     ).toMatchObject({
       code: "MANIFEST_SCHEMA_MISMATCH",
-      path: "blocks.manifest.json.blocks.0.version",
+      path: "blocks.manifest.json.blocks.0.description",
+    });
+  });
+
+  it("refuses an example whose props are not a key/value map", () => {
+    // The per-declaration check requires the example to be an object and says
+    // nothing about its props. A stored node's props are a map, so an
+    // array-shaped example describes a node that could never be valid.
+    expect(
+      issueOf(() =>
+        buildBlockManifest([
+          consumer(),
+          declaring("@acme/pricing", [
+            block("acme/hero", { example: { props: [] } }),
+          ]),
+        ])
+      )
+    ).toMatchObject({
+      code: "MANIFEST_SCHEMA_MISMATCH",
+      path: "blocks.manifest.json.blocks.0.example.props",
     });
   });
 });
@@ -171,10 +238,25 @@ describe("the published JSON Schema", () => {
               "additionalProperties": false,
               "properties": {
                 "description": {
-                  "minLength": 1,
+                  "pattern": "\\S",
                   "type": "string",
                 },
-                "example": {},
+                "example": {
+                  "additionalProperties": {},
+                  "properties": {
+                    "props": {
+                      "additionalProperties": {},
+                      "propertyNames": {
+                        "type": "string",
+                      },
+                      "type": "object",
+                    },
+                  },
+                  "required": [
+                    "props",
+                  ],
+                  "type": "object",
+                },
                 "name": {
                   "minLength": 1,
                   "type": "string",
@@ -205,7 +287,9 @@ describe("the published JSON Schema", () => {
                   "type": "object",
                 },
                 "version": {
-                  "type": "number",
+                  "exclusiveMinimum": 0,
+                  "maximum": 9007199254740991,
+                  "type": "integer",
                 },
               },
               "required": [

--- a/packages/nextly/src/plugins/codegen/__tests__/block-manifest-schema.test.ts
+++ b/packages/nextly/src/plugins/codegen/__tests__/block-manifest-schema.test.ts
@@ -148,6 +148,47 @@ describe("the manifest schema", () => {
     ).toBe(false);
   });
 
+  it("refuses a name the engine reserves, not merely a misshapen one", () => {
+    // The reserved name satisfies the slug shape, so a pattern alone lets it
+    // through. It has to be refused by the SCHEMA and not only by the
+    // declaration pass: an externally produced or hand-edited manifest is
+    // judged by the published contract, and would otherwise be accepted while
+    // describing a block that can never register.
+    const result = blockManifestSchema.safeParse({
+      manifestVersion: BLOCK_MANIFEST_VERSION,
+      blocks: [
+        {
+          name: "nextly/component-instance",
+          version: 1,
+          description: "A block.",
+          source: "@acme/x",
+          example: { props: {} },
+        },
+      ],
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it("still accepts an ordinary name in the same namespace", () => {
+    // The exclusion is one name, not the namespace: over-reaching would refuse
+    // manifests the engine registers without complaint.
+    expect(
+      blockManifestSchema.safeParse({
+        manifestVersion: BLOCK_MANIFEST_VERSION,
+        blocks: [
+          {
+            name: "nextly/component-instances",
+            version: 1,
+            description: "A block.",
+            source: "@acme/x",
+            example: { props: {} },
+          },
+        ],
+      }).success
+    ).toBe(true);
+  });
+
   it("refuses a version of the document this schema was not written for", () => {
     // The field exists so a reader can tell whether it understands the file.
     // Accepting a version this schema does not describe answers that question
@@ -351,7 +392,7 @@ describe("the published JSON Schema", () => {
                   "type": "object",
                 },
                 "name": {
-                  "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*\\/[a-z0-9]+(?:-[a-z0-9]+)*$",
+                  "pattern": "^(?!(?:nextly\\/component-instance)$)[a-z0-9]+(?:-[a-z0-9]+)*\\/[a-z0-9]+(?:-[a-z0-9]+)*$",
                   "type": "string",
                 },
                 "props": {

--- a/packages/nextly/src/plugins/codegen/__tests__/block-manifest-schema.test.ts
+++ b/packages/nextly/src/plugins/codegen/__tests__/block-manifest-schema.test.ts
@@ -11,6 +11,7 @@ import { describe, expect, it } from "vitest";
 import { definePlugin, type PluginDefinition } from "../../plugin-context";
 import {
   BLOCK_MANIFEST_VERSION,
+  MAX_DECLARED_BLOCK_VERSION,
   blockManifestJsonSchema,
   blockManifestSchema,
   buildBlockManifest,
@@ -123,6 +124,14 @@ describe("the manifest schema", () => {
       "a block with no example, which the emitter can never produce",
       { name: "n", version: 1, description: "d", example: undefined },
     ],
+    [
+      "a version above what migration can chain back from",
+      {
+        name: "n",
+        version: MAX_DECLARED_BLOCK_VERSION + 1,
+        description: "d",
+      },
+    ],
   ])("refuses %s", (_label, partial) => {
     const result = blockManifestSchema.safeParse({
       manifestVersion: BLOCK_MANIFEST_VERSION,
@@ -178,6 +187,7 @@ describe("the emitter's obligation to the schema", () => {
     ["a fraction", 1.5],
     ["zero", 0],
     ["a negative", -1],
+    ["one past the engine's bound", MAX_DECLARED_BLOCK_VERSION + 1],
   ])(
     "refuses a version of %s, which the per-declaration check reads as a number",
     (_label, version) => {
@@ -371,7 +381,7 @@ describe("the published JSON Schema", () => {
                 },
                 "version": {
                   "exclusiveMinimum": 0,
-                  "maximum": 9007199254740991,
+                  "maximum": 1001,
                   "type": "integer",
                 },
               },

--- a/packages/nextly/src/plugins/codegen/__tests__/block-manifest-schema.test.ts
+++ b/packages/nextly/src/plugins/codegen/__tests__/block-manifest-schema.test.ts
@@ -351,7 +351,7 @@ describe("the published JSON Schema", () => {
                   "type": "object",
                 },
                 "name": {
-                  "minLength": 1,
+                  "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*\\/[a-z0-9]+(?:-[a-z0-9]+)*$",
                   "type": "string",
                 },
                 "props": {

--- a/packages/nextly/src/plugins/codegen/__tests__/block-manifest.test.ts
+++ b/packages/nextly/src/plugins/codegen/__tests__/block-manifest.test.ts
@@ -192,6 +192,22 @@ describe("buildBlockManifest rejects what boot would reject", () => {
     expect(message).toContain("index 0");
   });
 
+  it("refuses a version whose migration chain has a hole", () => {
+    // A version above 1 says stored nodes exist at older versions. Without the
+    // step between, registration refuses the block and those nodes could never
+    // be upgraded, so a manifest describing it would describe an app that does
+    // not start.
+    const message = issueOf(() =>
+      buildBlockManifest([
+        consumer(),
+        declaring("@acme/a", [{ ...block("acme/one"), version: 2 }]),
+      ])
+    );
+
+    expect(message).toContain("acme/one");
+    expect(message).toContain("no migration from version 1");
+  });
+
   it("refuses a block with no name", () => {
     const message = issueOf(() =>
       buildBlockManifest([consumer(), declaring("@acme/a", [{ version: 1 }])])
@@ -252,6 +268,18 @@ describe("assertManifestPathIsFree", () => {
     // manifest, and with none the cleanup deletes the types output.
     expect(() =>
       assertManifestPathIsFree(`/app/src/${BLOCK_MANIFEST_FILENAME}`)
+    ).toThrow();
+  });
+
+  it("refuses one that differs only in case", () => {
+    // The default filesystem on macOS and Windows is case-insensitive, so this
+    // IS the manifest there — and the cleanup branch would delete it. Matching
+    // case-sensitively would have guarded Linux alone while the delete landed
+    // on the two platforms most users are on.
+    expect(() =>
+      assertManifestPathIsFree(
+        `/app/src/${BLOCK_MANIFEST_FILENAME.toUpperCase()}`
+      )
     ).toThrow();
   });
 

--- a/packages/nextly/src/plugins/codegen/block-manifest.ts
+++ b/packages/nextly/src/plugins/codegen/block-manifest.ts
@@ -21,6 +21,8 @@
 
 import { join, dirname, basename } from "node:path";
 
+import { z } from "zod";
+
 import { NextlyError } from "../../errors";
 import { collectDeclarations } from "../declarations";
 import type { PluginDefinition } from "../plugin-context";
@@ -43,28 +45,69 @@ export const PAGE_BUILDER_PLUGIN = "@nextlyhq/plugin-page-builder";
  */
 export const BLOCK_MANIFEST_VERSION = 1;
 
-/** One block, as the manifest states it. */
-export interface BlockManifestEntry {
-  name: string;
-  /** The block's own schema version, stamped onto every node of its type. */
-  version: number;
-  description: string;
-  /** The plugin that declared it, so a reader knows what to install. */
-  source: string;
-  /** A worked instance, for previews and few-shot prompting. */
-  example?: unknown;
-  /** Prop schemas keyed by prop name. */
-  props?: Record<string, unknown>;
-  /** Style capabilities the block opts into. */
-  supports?: Record<string, unknown>;
-  /** Named child regions, for container blocks. */
-  slots?: Record<string, unknown>;
-}
+/**
+ * One block, as the manifest states it.
+ *
+ * Strict, and not optionally so: the JSON Schema derived from this object
+ * carries `additionalProperties: false` whether or not `.strict()` is written
+ * here. Without it the two sides disagree — an unknown key would be quietly
+ * dropped by the emitter's own check and REJECTED by the schema handed to
+ * outside readers, so a manifest Nextly wrote would fail the contract Nextly
+ * published for it. Strict makes both refuse, which is also what makes a key
+ * added to the emitter and not to the schema a decision someone made rather
+ * than a diff nobody noticed.
+ *
+ * `props`, `supports` and `slots` stay open, because their contents belong to
+ * the block rather than to the manifest: core has no vocabulary for them and
+ * would only be guessing at what a plugin may put there.
+ */
+export const blockManifestEntrySchema = z
+  .object({
+    name: z.string().min(1),
+    /** The block's own schema version, stamped onto every node of its type. */
+    version: z.number(),
+    description: z.string().min(1),
+    /** The plugin that declared it, so a reader knows what to install. */
+    source: z.string().min(1),
+    /** A worked instance, for previews and few-shot prompting. */
+    example: z.unknown().optional(),
+    /** Prop schemas keyed by prop name. */
+    props: z.record(z.string(), z.unknown()).optional(),
+    /** Style capabilities the block opts into. */
+    supports: z.record(z.string(), z.unknown()).optional(),
+    /** Named child regions, for container blocks. */
+    slots: z.record(z.string(), z.unknown()).optional(),
+  })
+  .strict();
 
 /** The emitted document. */
-export interface BlockManifest {
-  manifestVersion: number;
-  blocks: BlockManifestEntry[];
+export const blockManifestSchema = z
+  .object({
+    manifestVersion: z.number().int().positive(),
+    blocks: z.array(blockManifestEntrySchema),
+  })
+  .strict();
+
+/**
+ * The types are DERIVED from the schema rather than declared beside it, so the
+ * shape a TypeScript consumer sees and the shape a JSON consumer validates
+ * against cannot describe different files.
+ */
+export type BlockManifestEntry = z.infer<typeof blockManifestEntrySchema>;
+export type BlockManifest = z.infer<typeof blockManifestSchema>;
+
+/**
+ * The manifest's contract in a form that needs neither zod nor this package.
+ *
+ * A manifest is read by things that never import Nextly — an editor build, a
+ * docs page, an agent handed the file on its own — and until now they had only
+ * a TypeScript interface, which a JSON consumer cannot check anything against.
+ *
+ * Derived from the schema above, so publishing it cannot drift from what the
+ * emitter actually writes.
+ */
+export function blockManifestJsonSchema(): Record<string, unknown> {
+  return z.toJSONSchema(blockManifestSchema);
 }
 
 /**
@@ -103,7 +146,39 @@ export function buildBlockManifest(
     }
   }
   blocks.sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
-  return { manifestVersion: BLOCK_MANIFEST_VERSION, blocks };
+  return assertMatchesSchema({
+    manifestVersion: BLOCK_MANIFEST_VERSION,
+    blocks,
+  });
+}
+
+/**
+ * Hold the assembled document to the contract the manifest publishes.
+ *
+ * The per-block checks above read a DECLARATION, addressing whoever wrote it.
+ * This reads the DOCUMENT, and its audience is whoever changed the emitter: it
+ * is what stops a manifest being written that the schema shipped alongside it
+ * would reject, which is the one failure a reader has no way to recover from.
+ *
+ * Refusing rather than warning, for the reason the whole module refuses: this
+ * runs on a path that DELETES the previous manifest when it finds no blocks, so
+ * an emitter defect must stop generation rather than be written over the last
+ * good file.
+ */
+function assertMatchesSchema(manifest: unknown): BlockManifest {
+  const parsed = blockManifestSchema.safeParse(manifest);
+  if (parsed.success) return parsed.data;
+  const [issue] = parsed.error.issues;
+  const at = issue.path.length > 0 ? issue.path.join(".") : "(root)";
+  throw NextlyError.validation({
+    errors: [
+      {
+        path: `${BLOCK_MANIFEST_FILENAME}.${at}`,
+        code: "MANIFEST_SCHEMA_MISMATCH",
+        message: `The block manifest does not satisfy the schema published for it: ${issue.message}`,
+      },
+    ],
+  });
 }
 
 /**

--- a/packages/nextly/src/plugins/codegen/block-manifest.ts
+++ b/packages/nextly/src/plugins/codegen/block-manifest.ts
@@ -61,6 +61,28 @@ export const BLOCK_MANIFEST_VERSION = 1;
 export const MAX_DECLARED_BLOCK_VERSION = 1001;
 
 /**
+ * The shape of a block name: two slug segments joined by a slash, the second
+ * naming the block and the first the namespace that owns it.
+ *
+ * Namespacing is what keeps names collision-free across plugins nobody
+ * coordinates, which is also why the registry treats them as global.
+ *
+ * Restated from the engine for the reason {@link MAX_DECLARED_BLOCK_VERSION}
+ * is, and held to its behaviour by the same parity test.
+ */
+export const BLOCK_NAME_PATTERN =
+  /^[a-z0-9]+(?:-[a-z0-9]+)*\/[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
+/**
+ * Names the engine keeps for itself. A document node of this type is a
+ * component instance rather than a block, so a block answering to it would
+ * shadow the one type the renderer resolves without the registry.
+ */
+export const RESERVED_BLOCK_NAMES: readonly string[] = [
+  "nextly/component-instance",
+];
+
+/**
  * One block, as the manifest states it.
  *
  * Strict, and not optionally so: the JSON Schema derived from this object
@@ -88,7 +110,12 @@ export const MAX_DECLARED_BLOCK_VERSION = 1001;
  */
 export const blockManifestEntrySchema = z
   .object({
-    name: z.string().min(1),
+    /**
+     * Carries the namespaced-slug pattern so the published JSON Schema states
+     * it too, rather than leaving an outside reader to discover the rule by
+     * having a name rejected somewhere else.
+     */
+    name: z.string().regex(BLOCK_NAME_PATTERN),
     /**
      * The block's own schema version, stamped onto every node of its type.
      *
@@ -418,6 +445,16 @@ function declaredBlocks(value: unknown, source: string): DeclaredBlock[] {
     if (typeof definition.name !== "string" || definition.name.length === 0) {
       throw invalidDeclaration(
         `Plugin "${source}" declared a block at index ${index} with no name.`
+      );
+    }
+    if (!BLOCK_NAME_PATTERN.test(definition.name)) {
+      throw invalidDeclaration(
+        `Plugin "${source}" declared a block named "${definition.name}" at index ${index}; a block name is a namespaced slug like "core/heading".`
+      );
+    }
+    if (RESERVED_BLOCK_NAMES.includes(definition.name)) {
+      throw invalidDeclaration(
+        `Plugin "${source}" declared a block named "${definition.name}", which the engine reserves and no block may answer to.`
       );
     }
     if (typeof definition.version !== "number") {

--- a/packages/nextly/src/plugins/codegen/block-manifest.ts
+++ b/packages/nextly/src/plugins/codegen/block-manifest.ts
@@ -127,11 +127,18 @@ export type BlockManifestEntry = z.infer<typeof blockManifestEntrySchema>;
 export type BlockManifest = z.infer<typeof blockManifestSchema>;
 
 /**
- * The manifest's contract in a form that needs neither zod nor this package.
+ * The manifest's contract as plain JSON Schema, for a reader that has the
+ * package but not zod, and no interest in either.
  *
- * A manifest is read by things that never import Nextly — an editor build, a
- * docs page, an agent handed the file on its own — and until now they had only
- * a TypeScript interface, which a JSON consumer cannot check anything against.
+ * A manifest is consumed by things that are not the app — an editor build, a
+ * docs page, a generator handed the file — and a TypeScript interface gives a
+ * JSON consumer nothing to check against. This does, in a form any JSON Schema
+ * validator understands.
+ *
+ * Re-exported from the package root, because a contract reachable only through
+ * an internal module is not published: the export map admits no deep import.
+ * Something holding the file with no package installed is still unserved; that
+ * wants a hosted copy, which is a docs concern rather than an emitter one.
  *
  * Derived from the schema above, so publishing it cannot drift from what the
  * emitter actually writes.

--- a/packages/nextly/src/plugins/codegen/block-manifest.ts
+++ b/packages/nextly/src/plugins/codegen/block-manifest.ts
@@ -93,14 +93,17 @@ export const blockManifestEntrySchema = z
     /** The plugin that declared it, so a reader knows what to install. */
     source: z.string().min(1),
     /**
-     * A worked instance, for previews and few-shot prompting. Its `props` are a
-     * key/value map because that is what a stored node's props are; an
-     * array-shaped example could never become a valid node.
+     * A worked instance, for previews and few-shot prompting.
+     *
+     * Required, because both the declaration pass and the engine require one:
+     * making it optional here would accept a hand-edited or externally produced
+     * manifest the app itself would refuse, and hand every consumer an absence
+     * to handle that the emitter can never produce.
+     *
+     * Its `props` are a key/value map because that is what a stored node's
+     * props are; an array-shaped example could never become a valid node.
      */
-    example: z
-      .object({ props: z.record(z.string(), z.unknown()) })
-      .loose()
-      .optional(),
+    example: z.object({ props: z.record(z.string(), z.unknown()) }).loose(),
     /** Prop schemas keyed by prop name. */
     props: z.record(z.string(), z.unknown()).optional(),
     /** Style capabilities the block opts into. */
@@ -113,7 +116,14 @@ export const blockManifestEntrySchema = z
 /** The emitted document. */
 export const blockManifestSchema = z
   .object({
-    manifestVersion: z.number().int().positive(),
+    /**
+     * Pinned to the one version this schema describes, not to any version.
+     * The field exists so a reader can tell whether it understands the file at
+     * all; a schema accepting a version it was not written for answers that
+     * question wrong, and a consumer trusting it would process a future format
+     * as though it were this one.
+     */
+    manifestVersion: z.literal(BLOCK_MANIFEST_VERSION),
     blocks: z.array(blockManifestEntrySchema),
   })
   .strict();
@@ -270,10 +280,41 @@ export function buildBlockManifestArtifact(
   if (manifest.blocks.length === 0) return null;
   return {
     path: join(dirname(typesOutputPath), BLOCK_MANIFEST_FILENAME),
+    code: serialize(manifest),
+  };
+}
+
+/**
+ * Render the manifest as the text that will be written.
+ *
+ * `props`, `supports`, `slots` and an example's props carry whatever a plugin
+ * put there, and not every JavaScript value survives the trip into a JSON file.
+ * Two things can go wrong, and they fail differently:
+ *
+ * A `bigint` or a cycle makes `JSON.stringify` throw, and a raw `TypeError`
+ * leaving this package tells whoever ran generation nothing about which
+ * declaration to go and fix.
+ *
+ * A function, a symbol or an `undefined` is dropped instead — silently, and by
+ * design: the manifest already drops `render` and `resolve` for the same
+ * reason. What must not survive that is a FILE that no longer satisfies the
+ * schema published for it, so the rendered text is parsed back and judged
+ * again. The check is on the artifact rather than on the object it came from,
+ * because the artifact is what anyone else will read.
+ */
+function serialize(manifest: BlockManifest): string {
+  let code: string;
+  try {
     // Trailing newline so the file is well-formed for line-based tooling and
     // does not show a no-newline marker in every diff.
-    code: `${JSON.stringify(manifest, null, 2)}\n`,
-  };
+    code = `${JSON.stringify(manifest, null, 2)}\n`;
+  } catch (error) {
+    throw invalidDeclaration(
+      `A declared block holds a value JSON cannot represent, so the manifest cannot be written: ${error instanceof Error ? error.message : String(error)}`
+    );
+  }
+  assertMatchesSchema(JSON.parse(code));
+  return code;
 }
 
 /**
@@ -403,8 +444,11 @@ function toEntry(block: DeclaredBlock, source: string): BlockManifestDraft {
     version: block.version,
     description: block.description,
     source,
+    // Unconditional: the declaration pass has already refused a block without
+    // an example, so a guard here would be a branch that never runs and a
+    // manifest entry the schema now requires it to have.
+    example: block.example,
   };
-  if (block.example !== undefined) entry.example = block.example;
   if (isRecord(block.props)) entry.props = block.props;
   if (isRecord(block.supports)) entry.supports = block.supports;
   if (isRecord(block.slots)) entry.slots = block.slots;

--- a/packages/nextly/src/plugins/codegen/block-manifest.ts
+++ b/packages/nextly/src/plugins/codegen/block-manifest.ts
@@ -276,7 +276,14 @@ export function assertManifestPathIsFree(typesOutputPath: string): void {
   // manifest is written and then overwritten by the types; with none, the
   // cleanup deletes the types output the user asked for. Both are silent, and
   // one destroys work, so the collision is refused before either happens.
-  if (basename(typesOutputPath) === BLOCK_MANIFEST_FILENAME) {
+  //
+  // Compared without regard to case, because on macOS and Windows the default
+  // filesystem is case-insensitive: `BLOCKS.MANIFEST.JSON` is the same file
+  // there, and a case-sensitive comparison would protect Linux alone while the
+  // delete still landed everywhere else. On a case-sensitive filesystem this
+  // refuses a name that would in fact have been distinct, which costs a user
+  // nothing beyond picking a less confusing one.
+  if (basename(typesOutputPath).toLowerCase() === BLOCK_MANIFEST_FILENAME) {
     throw NextlyError.validation({
       errors: [
         {
@@ -418,6 +425,12 @@ function declaredBlocks(value: unknown, source: string): DeclaredBlock[] {
         `Block "${definition.name}" from "${source}" has no numeric version.`
       );
     }
+    const gaps = missingMigrationSteps(definition.version, definition.migrate);
+    if (gaps.length > 0) {
+      throw invalidDeclaration(
+        `Block "${definition.name}" from "${source}" is at version ${definition.version} but has no migration from version${gaps.length > 1 ? "s" : ""} ${gaps.join(", ")}. Add the missing step(s) so stored blocks can be upgraded.`
+      );
+    }
     if (
       typeof definition.description !== "string" ||
       definition.description.length === 0
@@ -470,6 +483,34 @@ function toEntry(block: DeclaredBlock, source: string): BlockManifestDraft {
   if (isRecord(block.supports)) entry.supports = block.supports;
   if (isRecord(block.slots)) entry.slots = block.slots;
   return entry;
+}
+
+/**
+ * The versions between 1 and this block's own that no migration step covers.
+ *
+ * A version above 1 says stored nodes exist at older versions, so every step
+ * between has to be there or those nodes could never be upgraded. Registration
+ * refuses a declaration with a gap, and the map is functions — which never
+ * reach the manifest — so this is judged from the declaration or not at all.
+ *
+ * Only for a version already in range. An out-of-range one is refused by the
+ * schema a moment later, and walking up to it first would mean counting to
+ * whatever number was declared.
+ */
+function missingMigrationSteps(version: number, map: unknown): number[] {
+  if (
+    !Number.isInteger(version) ||
+    version <= 1 ||
+    version > MAX_DECLARED_BLOCK_VERSION
+  ) {
+    return [];
+  }
+  const steps = isRecord(map) ? map : undefined;
+  const gaps: number[] = [];
+  for (let step = 1; step < version; step++) {
+    if (typeof steps?.[String(step)] !== "function") gaps.push(step);
+  }
+  return gaps;
 }
 
 /** A short, safe description of a bad value, for an error a human reads. */

--- a/packages/nextly/src/plugins/codegen/block-manifest.ts
+++ b/packages/nextly/src/plugins/codegen/block-manifest.ts
@@ -46,6 +46,21 @@ export const PAGE_BUILDER_PLUGIN = "@nextlyhq/plugin-page-builder";
 export const BLOCK_MANIFEST_VERSION = 1;
 
 /**
+ * The highest version a declared block may carry.
+ *
+ * The same bound the block engine enforces at registration, restated rather
+ * than imported: reading it from `@nextlyhq/blocks-engine` would make every
+ * app that installs core carry the block engine so that code generation can
+ * read one integer, and it points the dependency the wrong way — the plugin
+ * layer builds on core, not the reverse.
+ *
+ * Restating a value is only safe if it cannot quietly diverge, so a test holds
+ * this equal to the engine's own constant. The engine is a development
+ * dependency here for that test alone; nothing imports it at runtime.
+ */
+export const MAX_DECLARED_BLOCK_VERSION = 1001;
+
+/**
  * One block, as the manifest states it.
  *
  * Strict, and not optionally so: the JSON Schema derived from this object
@@ -77,13 +92,15 @@ export const blockManifestEntrySchema = z
     /**
      * The block's own schema version, stamped onto every node of its type.
      *
-     * A whole number from 1: the engine counts migration steps between
-     * versions, so a fraction has no step to chain and a value below 1 has
-     * nothing to migrate from. `.int()` also excludes `NaN` and `Infinity`,
-     * which `typeof` reads as numbers and `JSON.stringify` writes as `null` —
-     * a manifest that parses as JSON and is wrong.
+     * A whole number from 1 to {@link MAX_DECLARED_BLOCK_VERSION}: the engine
+     * counts migration steps between versions, so a fraction has no step to
+     * chain, a value below 1 has nothing to migrate from, and one above the
+     * bound could never chain back to its oldest stored nodes. `.int()` also
+     * excludes `NaN` and `Infinity`, which `typeof` reads as numbers and
+     * `JSON.stringify` writes as `null` — a manifest that parses as JSON and
+     * is wrong.
      */
-    version: z.number().int().positive(),
+    version: z.number().int().positive().max(MAX_DECLARED_BLOCK_VERSION),
     /**
      * Required to be non-blank rather than merely non-empty: the engine trims
      * before checking, and a description of spaces renders as an empty palette

--- a/packages/nextly/src/plugins/codegen/block-manifest.ts
+++ b/packages/nextly/src/plugins/codegen/block-manifest.ts
@@ -61,19 +61,6 @@ export const BLOCK_MANIFEST_VERSION = 1;
 export const MAX_DECLARED_BLOCK_VERSION = 1001;
 
 /**
- * The shape of a block name: two slug segments joined by a slash, the second
- * naming the block and the first the namespace that owns it.
- *
- * Namespacing is what keeps names collision-free across plugins nobody
- * coordinates, which is also why the registry treats them as global.
- *
- * Restated from the engine for the reason {@link MAX_DECLARED_BLOCK_VERSION}
- * is, and held to its behaviour by the same parity test.
- */
-export const BLOCK_NAME_PATTERN =
-  /^[a-z0-9]+(?:-[a-z0-9]+)*\/[a-z0-9]+(?:-[a-z0-9]+)*$/;
-
-/**
  * Names the engine keeps for itself. A document node of this type is a
  * component instance rather than a block, so a block answering to it would
  * shadow the one type the renderer resolves without the registry.
@@ -81,6 +68,43 @@ export const BLOCK_NAME_PATTERN =
 export const RESERVED_BLOCK_NAMES: readonly string[] = [
   "nextly/component-instance",
 ];
+
+/** Two slug segments joined by a slash: the namespace, then the block. */
+const BLOCK_NAME_BODY = "[a-z0-9]+(?:-[a-z0-9]+)*\\/[a-z0-9]+(?:-[a-z0-9]+)*";
+
+/**
+ * The shape of a block name, the second segment naming the block and the first
+ * the namespace that owns it.
+ *
+ * Namespacing is what keeps names collision-free across plugins nobody
+ * coordinates, which is also why the registry treats them as global.
+ *
+ * Restated from the engine for the reason {@link MAX_DECLARED_BLOCK_VERSION}
+ * is, and held to its behaviour by the same parity test.
+ */
+export const BLOCK_NAME_PATTERN = new RegExp(`^${BLOCK_NAME_BODY}$`);
+
+/**
+ * The same shape with the reserved names excluded, which is what the manifest
+ * schema carries.
+ *
+ * Expressed as a pattern rather than as a `refine`, because a refinement is an
+ * arbitrary function and `z.toJSONSchema` silently drops it: the zod schema
+ * would refuse a reserved name while the JSON Schema published beside it
+ * accepted one. A lookahead survives the translation, so both sides say the
+ * same thing — the property `.strict()` exists to preserve on the object.
+ *
+ * Built from the list above rather than written out, so adding a reserved name
+ * cannot leave the pattern behind.
+ */
+const DECLARABLE_BLOCK_NAME_PATTERN = new RegExp(
+  `^(?!(?:${RESERVED_BLOCK_NAMES.map(escapeForPattern).join("|")})$)${BLOCK_NAME_BODY}$`
+);
+
+/** Render a literal harmless inside a pattern built by concatenation. */
+function escapeForPattern(literal: string): string {
+  return literal.replace(/[.*+?^${}()|[\]\\/]/g, "\\$&");
+}
 
 /**
  * One block, as the manifest states it.
@@ -111,11 +135,11 @@ export const RESERVED_BLOCK_NAMES: readonly string[] = [
 export const blockManifestEntrySchema = z
   .object({
     /**
-     * Carries the namespaced-slug pattern so the published JSON Schema states
-     * it too, rather than leaving an outside reader to discover the rule by
-     * having a name rejected somewhere else.
+     * Carries the whole naming rule — shape and reserved names — so the
+     * published JSON Schema states it too, rather than leaving an outside
+     * reader to discover it by having a manifest rejected somewhere else.
      */
-    name: z.string().regex(BLOCK_NAME_PATTERN),
+    name: z.string().regex(DECLARABLE_BLOCK_NAME_PATTERN),
     /**
      * The block's own schema version, stamped onto every node of its type.
      *

--- a/packages/nextly/src/plugins/codegen/block-manifest.ts
+++ b/packages/nextly/src/plugins/codegen/block-manifest.ts
@@ -489,6 +489,24 @@ function declaredBlocks(value: unknown, source: string): DeclaredBlock[] {
         `Block "${definition.name}" from "${source}" has no example. Every block needs a worked instance, for previews and for generating content.`
       );
     }
+    // The last two the engine requires that the manifest never carries: a
+    // node's props are a key/value map, so defaults shaped otherwise could not
+    // seed one, and a block with nothing to draw with cannot render a page.
+    // Both are judged from the declaration or not at all — one is a function,
+    // and the other is dropped along with everything else JSON cannot hold.
+    if (
+      definition.defaultProps !== undefined &&
+      !isRecord(definition.defaultProps)
+    ) {
+      throw invalidDeclaration(
+        `Block "${definition.name}" from "${source}" declares defaultProps that are not a plain object.`
+      );
+    }
+    if (typeof definition.render !== "function") {
+      throw invalidDeclaration(
+        `Block "${definition.name}" from "${source}" declares no render function.`
+      );
+    }
     // Rebuilt with the name spelled out so the checked type carries what was
     // just proved about it; returning `definition` would hand the caller a
     // record whose `name` is `unknown` again, and it sorts and dedupes on it.

--- a/packages/nextly/src/plugins/codegen/block-manifest.ts
+++ b/packages/nextly/src/plugins/codegen/block-manifest.ts
@@ -60,17 +60,47 @@ export const BLOCK_MANIFEST_VERSION = 1;
  * `props`, `supports` and `slots` stay open, because their contents belong to
  * the block rather than to the manifest: core has no vocabulary for them and
  * would only be guessing at what a plugin may put there.
+ *
+ * The per-field rules mirror what the block engine enforces at registration,
+ * because a manifest generated for a configuration that cannot boot is worse
+ * than no manifest — generation DELETES the previous file, so it would trade a
+ * good artifact for a description of an app that does not start.
+ *
+ * Mirrored only where the rule is a shape rather than a value. The engine's
+ * upper version bound and its block-name pattern are values it may move, and a
+ * copy of them here that fell BEHIND would refuse a block the engine accepts,
+ * blocking generation for a valid app. Those two stay the engine's to enforce.
  */
 export const blockManifestEntrySchema = z
   .object({
     name: z.string().min(1),
-    /** The block's own schema version, stamped onto every node of its type. */
-    version: z.number(),
-    description: z.string().min(1),
+    /**
+     * The block's own schema version, stamped onto every node of its type.
+     *
+     * A whole number from 1: the engine counts migration steps between
+     * versions, so a fraction has no step to chain and a value below 1 has
+     * nothing to migrate from. `.int()` also excludes `NaN` and `Infinity`,
+     * which `typeof` reads as numbers and `JSON.stringify` writes as `null` —
+     * a manifest that parses as JSON and is wrong.
+     */
+    version: z.number().int().positive(),
+    /**
+     * Required to be non-blank rather than merely non-empty: the engine trims
+     * before checking, and a description of spaces renders as an empty palette
+     * entry, which is the thing requiring one was meant to prevent.
+     */
+    description: z.string().regex(/\S/),
     /** The plugin that declared it, so a reader knows what to install. */
     source: z.string().min(1),
-    /** A worked instance, for previews and few-shot prompting. */
-    example: z.unknown().optional(),
+    /**
+     * A worked instance, for previews and few-shot prompting. Its `props` are a
+     * key/value map because that is what a stored node's props are; an
+     * array-shaped example could never become a valid node.
+     */
+    example: z
+      .object({ props: z.record(z.string(), z.unknown()) })
+      .loose()
+      .optional(),
     /** Prop schemas keyed by prop name. */
     props: z.record(z.string(), z.unknown()).optional(),
     /** Style capabilities the block opts into. */
@@ -111,6 +141,20 @@ export function blockManifestJsonSchema(): Record<string, unknown> {
 }
 
 /**
+ * A block as the emitter assembles it, before the schema judges it.
+ *
+ * Only `name` is narrowed, because sorting and the duplicate check read it and
+ * the per-declaration pass has already established it is a non-empty string.
+ * Everything else stays exactly as declared: coercing it here would mean
+ * deciding what is acceptable in two places, and the schema is the one whose
+ * answer is published.
+ */
+interface BlockManifestDraft {
+  name: string;
+  [key: string]: unknown;
+}
+
+/**
  * Build the manifest from what plugins declared.
  *
  * Blocks are sorted by name so the emitted file is stable: an artifact that
@@ -121,13 +165,13 @@ export function blockManifestJsonSchema(): Record<string, unknown> {
 export function buildBlockManifest(
   plugins: readonly PluginDefinition[]
 ): BlockManifest {
-  const blocks: BlockManifestEntry[] = [];
+  const blocks: BlockManifestDraft[] = [];
   // Nothing can register when the consumer is absent or disabled: a disabled
   // plugin runs no `init` and contributes no services, so the registry these
   // declarations would fill never exists. Listing them anyway would tell
   // tooling the app has blocks it cannot render.
   if (!isConsumerActive(plugins, PAGE_BUILDER_PLUGIN)) {
-    return { manifestVersion: BLOCK_MANIFEST_VERSION, blocks };
+    return { manifestVersion: BLOCK_MANIFEST_VERSION, blocks: [] };
   }
   // Where each name came from, so a collision names both plugins rather than
   // just the one that lost.
@@ -272,10 +316,13 @@ function isConsumerActive(
  * A declaration carrying no `blocks` key at all is not an error: another
  * version of the page builder may read keys this one does not.
  */
-function declaredBlocks(
-  value: unknown,
-  source: string
-): Record<string, unknown>[] {
+interface DeclaredBlock {
+  /** Checked here, so the caller need not re-establish it to sort or dedupe. */
+  name: string;
+  [key: string]: unknown;
+}
+
+function declaredBlocks(value: unknown, source: string): DeclaredBlock[] {
   if (typeof value !== "object" || value === null || Array.isArray(value)) {
     return [];
   }
@@ -327,7 +374,10 @@ function declaredBlocks(
         `Block "${definition.name}" from "${source}" has no example. Every block needs a worked instance, for previews and for generating content.`
       );
     }
-    return definition;
+    // Rebuilt with the name spelled out so the checked type carries what was
+    // just proved about it; returning `definition` would hand the caller a
+    // record whose `name` is `unknown` again, and it sorts and dedupes on it.
+    return { ...definition, name: definition.name };
   });
 }
 
@@ -340,14 +390,11 @@ function declaredBlocks(
  * holds, copied rather than reshaped, so the file and the definition cannot
  * drift into different vocabularies.
  */
-function toEntry(
-  block: Record<string, unknown>,
-  source: string
-): BlockManifestEntry {
-  const entry: BlockManifestEntry = {
-    name: typeof block.name === "string" ? block.name : "",
-    version: typeof block.version === "number" ? block.version : 0,
-    description: typeof block.description === "string" ? block.description : "",
+function toEntry(block: DeclaredBlock, source: string): BlockManifestDraft {
+  const entry: BlockManifestDraft = {
+    name: block.name,
+    version: block.version,
+    description: block.description,
     source,
   };
   if (block.example !== undefined) entry.example = block.example;

--- a/packages/nextly/src/plugins/contributions.ts
+++ b/packages/nextly/src/plugins/contributions.ts
@@ -354,9 +354,14 @@ export interface PluginFieldValidateArgs {
    */
   data: Record<string, unknown>;
   /**
-   * Request context; carries `user` when the write is authenticated. Empty
-   * for a field inside a component instance, whose write path does not
-   * forward the parent's request.
+   * Request context; carries `user` when the write is authenticated. The
+   * parent write's request, forwarded unchanged, including to a field nested
+   * inside a component instance — which is validated by its own pass, in its
+   * own service, so the context has to be carried there rather than being in
+   * scope already.
+   *
+   * Empty for a write with no request behind it: an internal write, a seed,
+   * or an unauthenticated one.
    */
   req: Record<string, unknown>;
   /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -961,6 +961,9 @@ importers:
       '@nextlyhq/adapter-sqlite':
         specifier: workspace:*
         version: link:../adapter-sqlite
+      '@nextlyhq/blocks-engine':
+        specifier: workspace:*
+        version: link:../blocks-engine
       '@nextlyhq/eslint-config':
         specifier: workspace:*
         version: link:../eslint-config


### PR DESCRIPTION
Two things, both about a gap between what something promises and what it actually does. Tasks 099 and the last two PR-9 items, in one PR as requested.

## 1. A field group's validators had no request

`field-group-mutation-service.ts` validated a component instance with `validateEntryData(instance, componentFields, { mode })` — no `req` at all. A component instance is validated by its own pass, in its own service, against its own field set; the parent entry's validation never descends into it. So a plugin field type whose `validate` reads `req.user` could not tell an authenticated write from an anonymous one.

It failed **open**: the value was accepted, so nothing surfaced. Core's own doc comment on `PluginFieldValidateArgs.req` documented this as expected behaviour.

`req` now travels on `SaveComponentDataParams` alongside `locale`, through all six save methods (single / repeatable / dynamic-zone, each pooled and in-transaction) into `prepareInstanceForWrite`. The whole record rather than a bare `user`, because that is what `validateEntryData` takes and what the collection paths already build.

**Three external call sites forward it**, not two: collection create (`:2858`), collection update (`:5400`), and `single-mutation-service.ts:1587`. The task file had traced only the collection pair.

Each site was stub-verified on its own — remove `req` from one and exactly the test for that path fails.

## 2. `nextly generate:manifest`, and a schema the manifest is held to

`generate:types` already writes the block manifest. This adds the command on its own, plus `--check`, which writes nothing and exits non-zero when the committed manifest no longer matches the config.

Why it needs to exist: a stale manifest breaks nothing at runtime, because the app reads its registry rather than the file. Nothing notices except a build step that compares them. `--check` is that step, and it skips type and Zod generation, which the manifest does not need.

Both commands settle the file through one pair of functions, so the command that writes and the command that checks cannot disagree about what belongs on disk.

The manifest also now states its shape as a schema rather than only a TypeScript interface, with `blockManifestJsonSchema()` for readers that never import Nextly, and the emitter is parsed through it before anything is written.

**One thing this caught, worth knowing:** `z.toJSONSchema` emits `additionalProperties: false` whether or not the object is `.strict()`. Without `.strict()` the two sides disagree — the emitter would quietly drop an unknown key while the published schema rejects it, so a manifest Nextly wrote would fail the contract Nextly published for it.

It also closes a real input gap: `typeof NaN === "number"`, so a block declared with `version: NaN` passed the per-declaration check and reached `JSON.stringify`, which writes it as `null`. That is a manifest that parses as JSON and is wrong. Covered for `NaN` and `Infinity`.

## Filed, not fixed

**[task 101](tasks/left-tasks/101-collection-write-reclassifies-field-group-refusals.md) — a collection write turns a field-group refusal into a 500.** Found while building the tests here; pre-existing and unrelated. Measured on SQLite with a plain `required` text field inside a field group, no plugin types involved:

| Write | Code the caller sees | `publicData.errors` |
|---|---|---|
| `nextly.create` (collection) | `INTERNAL_ERROR` | `undefined` |
| `nextly.update` (collection) | `INTERNAL_ERROR` | `undefined` |
| `nextly.updateSingle` | `VALIDATION_ERROR` | the full issue list |

Singles are right; collections are not. A user leaving a required field blank inside a field group gets HTTP 500 and nothing the admin form can use to mark the field. It is the transaction boundary rewrapping the error, not the field-group service — the same rewrap `assertLocalizedFieldGroupsWritable`'s own comment describes dodging.

Not fixed here because changing how a collection write's transaction classifies errors is a core write-path change with its own blast radius, and it is not what either task asked for. The integration test matches on the message for the collection case and says why in a comment; the single case asserts the full issue, on the path that keeps it.

## Verification

- **Unit baseline held**: 37 failed files / 400 failed tests, exactly the documented baseline, none of them mine.
- **Every new test stub-verified**: disable the code it covers, confirm THAT test fails and no other. Done per call site and per save method — stubbing only the dynamic-zone transactional path fails exactly one test.
- **`generate:manifest` smoke-tested end to end** against the playground with the built CLI: `--check` passes on a clean tree, fails with exit 1 and a named path on a planted stale manifest, and the write form removes it.
- `check-types` and `lint` clean. The 16 `check-types` errors under `src/domains/i18n/migration/` are **pre-existing on main** — `wasStatus` became required in `reconcile-companion.ts` and two test files were not updated. Both files are byte-identical to main here.

## Known-failing, not from this PR

The three webhook outbox tests from #447 ([task 100](tasks/left-tasks/100-outbox-tests-assert-pre-447-hook-contract.md)) still fail on all dialects.
