### PR TITLE
test(nextly): assert the logged hook error, not just its phase

### DIFF
--- a/packages/nextly/src/domains/webhooks/__tests__/outbox-capture.integration.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/outbox-capture.integration.test.ts
@@ -59,6 +59,23 @@ function envelopeOf(row: EventRow): WebhookEvent {
   ) as WebhookEvent;
 }
 
+/**
+ * The error the registry logged alongside its phase line.
+ *
+ * `console.error` is called with the phase line AND the normalized exception,
+ * so an assertion that reads only the first argument cannot tell a logged
+ * failure from a logged label. `normalizeHookError` wraps an untyped throw, so
+ * the thrown text arrives as the wrapper's `cause` rather than its message; a
+ * typed throw arrives as itself, carrying its `logContext`. All three are
+ * rendered so a test can name the original failure whichever way it was thrown.
+ */
+function loggedFailure(spy: { mock: { calls: unknown[][] } }): string {
+  const error = spy.mock.calls[0]?.[1];
+  const cause = (error as { cause?: unknown } | undefined)?.cause;
+  const context = (error as { logContext?: unknown } | undefined)?.logContext;
+  return `${String(error)} ${String(cause ?? "")} ${JSON.stringify(context ?? {})}`;
+}
+
 async function events(handle: TestNextly): Promise<EventRow[]> {
   return handle.adapter.select<EventRow>("nextly_events");
 }
@@ -140,6 +157,10 @@ describe("webhook outbox capture (integration)", () => {
     // let a regression that swallows the hook error entirely still pass.
     expect(logged).toHaveBeenCalled();
     expect(String(logged.mock.calls[0][0])).toContain("afterCreate");
+    // The exception, not only the phase line: an implementation that logged
+    // the label and dropped the error would satisfy the assertion above while
+    // losing the operator's only diagnostic for a write reported successful.
+    expect(loggedFailure(logged)).toContain("afterCreate observer failed");
 
     const rows = await events(current);
     expect(rows).toHaveLength(1);
@@ -188,6 +209,10 @@ describe("webhook outbox capture (integration)", () => {
     // clean run while every item's side effect quietly broke.
     expect(logged).toHaveBeenCalled();
     expect(String(logged.mock.calls[0][0])).toContain("afterDelete");
+    // The exception, not only the phase line: an implementation that logged
+    // the label and dropped the error would satisfy the assertion above while
+    // losing the operator's only diagnostic for a write reported successful.
+    expect(loggedFailure(logged)).toContain("afterDelete observer failed");
 
     const rows = await events(current);
     expect(rows.map(r => r.type).sort()).toEqual([

--- a/packages/nextly/src/domains/webhooks/__tests__/singles-outbox.integration.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/singles-outbox.integration.test.ts
@@ -760,6 +760,12 @@ describe("webhook outbox capture — singles (integration)", () => {
     // The single trace the failure leaves, given the operation reports success.
     expect(logged).toHaveBeenCalled();
     expect(String(logged.mock.calls[0][0])).toContain("afterUpdate");
+    // The exception, not only the phase line. This hook throws a typed error
+    // carrying its reason, and that reason is what an operator has to go on.
+    const loggedError = logged.mock.calls[0][1] as {
+      logContext?: Record<string, unknown>;
+    };
+    expect(loggedError?.logContext?.reason).toBe("afterUpdate-observer-failed");
 
     const rows = (await events(current)).filter(
       r => r.type === "single.updated"


### PR DESCRIPTION
Rebuilt on top of `main` now that #462 has merged. This is only what #462 did
not cover, and it is 31 added lines across two test files — no runtime change.

## What #462 already did, and this does not repeat

The contract flip (`success` false→true, `successCount` 0→1, `eventRecorded`
unchanged), the rewritten comments, and `vi.restoreAllMocks()` in `afterEach`.
All good, all left alone.

## The gap

Both PRs asserted the failure is still observable, like this:

```ts
expect(logged).toHaveBeenCalled();
expect(String(logged.mock.calls[0][0])).toContain("afterCreate");
```

The registry logs `console.error(phaseLine, normalized)` — the exception is the
**second** argument. So that assertion checks a label was printed, not that the
failure was in it. An implementation that logged `Hook "afterCreate" failed` and
dropped the error passes it, while losing the only diagnostic an operator gets
for a write that now reports success.

That matters more here than usual precisely because of #447: `success: true` is
the answer the caller receives, so the log is the whole safety net.

## What this adds

Each of the three cases now names the original failure.

The two collection cases go through a small helper, because the thrown value
does not arrive intact: `normalizeHookError` wraps an untyped throw, so the
thrown text lands on the wrapper's `cause` rather than its message. The helper
renders the error, its cause and its `logContext` so the assertion holds however
the hook threw. The singles case asserts `logContext.reason` directly, since that
hook throws a typed error carrying it.

## Verification

Dropping `normalized` from the `console.error` call in `HookRegistry.execute`
fails all three:

```
expected 'undefined  {}' to contain 'afterCreate observer failed'
expected 'undefined  {}' to contain 'afterDelete observer failed'
expected undefined to be 'afterUpdate-observer-failed'
```

Under that same probe **every phase-line assertion from #462 passes unchanged**,
which is the control: it shows the added lines carry the coverage rather than
duplicating what is already there.

- Runtime untouched: `git diff packages/nextly/src/hooks/hook-registry.ts` empty.
- `src/domains/webhooks/`: 200 passed, 0 failed.
- `pnpm run check-types` clean.
- No changeset — test-only.
