### PR TITLE
test(nextly): assert the post-commit hook contract #447 introduced

### DIFF
--- a/packages/nextly/src/domains/webhooks/__tests__/outbox-capture.integration.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/outbox-capture.integration.test.ts
@@ -6,7 +6,7 @@
  * reach the payload, and the row is written for versioned and non-versioned
  * collections alike (webhooks are independent of versioning).
  */
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
   fieldGroup,
@@ -30,6 +30,10 @@ let current: TestNextly | undefined;
 afterEach(async () => {
   await current?.destroy();
   current = undefined;
+  // The post-commit-hook cases silence `console.error` to assert against it.
+  // This config does not restore mocks between tests, so without this every
+  // later test in the file would run with errors muted.
+  vi.restoreAllMocks();
 });
 
 /** A `nextly_events` row as read back (Drizzle camelCases the columns). */
@@ -101,9 +105,12 @@ describe("webhook outbox capture (integration)", () => {
 
   it("flags eventRecorded when the write commits but a post-commit hook throws", async () => {
     // The event is appended inside the write transaction; afterCreate hooks run
-    // after it commits. A throwing hook surfaces success:false on an already
-    // committed write, so the result must still report `eventRecorded` — that is
-    // the signal the fast drain + retention key off, not `success`.
+    // after it commits, so a throw there cannot undo either. The write reports
+    // success and the hook failure is reported separately — raising it instead
+    // would describe a durable row as a failure and invite a retry that writes a
+    // second one. `eventRecorded` is what the fast drain + retention key off, and
+    // it stays true independently of how the hook fared.
+    const logged = vi.spyOn(console, "error").mockImplementation(() => {});
     current = await createTestNextly({
       collections: [
         defineCollection({
@@ -124,9 +131,15 @@ describe("webhook outbox capture (integration)", () => {
       { title: "hello" }
     );
 
-    // The hook failure is surfaced, but the entry + event committed.
-    expect(created.success).toBe(false);
+    // The entry + event committed, and that is what the caller is told.
+    expect(created.success).toBe(true);
     expect(created.eventRecorded).toBe(true);
+
+    // Asserted, not merely allowed to happen: the operation reports success, so
+    // this log is the only trace an operator gets. Dropping the assertion would
+    // let a regression that swallows the hook error entirely still pass.
+    expect(logged).toHaveBeenCalled();
+    expect(String(logged.mock.calls[0][0])).toContain("afterCreate");
 
     const rows = await events(current);
     expect(rows).toHaveLength(1);
@@ -135,9 +148,11 @@ describe("webhook outbox capture (integration)", () => {
 
   it("flags eventRecorded on a bulk result when a committed item's hook throws", async () => {
     // A bulk delete runs each item through the per-item mutation, which commits
-    // the row + event and then runs afterDelete. A throwing hook makes that item
-    // a failure (successCount stays 0), but the event is durable — so the bulk
-    // result must still report eventRecorded, or the batch would skip the drain.
+    // the row + event and then runs afterDelete. The item counts as a success
+    // because it IS one — the row is gone and the event durable — and a batch
+    // that counted it a failure would invite a retry against a row that no
+    // longer exists. `eventRecorded` stays true so the batch still drains.
+    const logged = vi.spyOn(console, "error").mockImplementation(() => {});
     current = await createTestNextly({
       collections: [
         defineCollection({
@@ -165,9 +180,14 @@ describe("webhook outbox capture (integration)", () => {
       overrideAccess: true,
     });
 
-    // The item is counted a failure, yet the delete + event committed.
-    expect(result.successCount).toBe(0);
+    // The delete + event committed, so the item counts as done.
+    expect(result.successCount).toBe(1);
     expect(result.eventRecorded).toBe(true);
+
+    // The hook failure still has to leave a trace, or a batch could report a
+    // clean run while every item's side effect quietly broke.
+    expect(logged).toHaveBeenCalled();
+    expect(String(logged.mock.calls[0][0])).toContain("afterDelete");
 
     const rows = await events(current);
     expect(rows.map(r => r.type).sort()).toEqual([

--- a/packages/nextly/src/domains/webhooks/__tests__/singles-outbox.integration.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/singles-outbox.integration.test.ts
@@ -7,7 +7,7 @@
  * the status transitions — independent of whether versioning is enabled, and
  * with secret fields never reaching the payload.
  */
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
   fieldGroup,
@@ -30,6 +30,10 @@ let current: TestNextly | undefined;
 afterEach(async () => {
   await current?.destroy();
   current = undefined;
+  // The post-commit-hook case silences `console.error` to assert against it.
+  // This config does not restore mocks between tests, so without this every
+  // later test in the file would run with errors muted.
+  vi.restoreAllMocks();
 });
 
 /** A `nextly_events` row as read back (Drizzle camelCases the columns). */
@@ -721,6 +725,7 @@ describe("webhook outbox capture — singles (integration)", () => {
   });
 
   it("reports eventRecorded when the write commits but a post-commit hook throws", async () => {
+    const logged = vi.spyOn(console, "error").mockImplementation(() => {});
     current = await createTestNextly({
       singles: [
         defineSingle({
@@ -729,8 +734,10 @@ describe("webhook outbox capture — singles (integration)", () => {
         }),
       ],
     });
-    // afterUpdate runs after the write transaction commits, so a throw here
-    // leaves the entry + outbox event durable while the result reports failure.
+    // afterUpdate runs after the write transaction commits, so a throw here can
+    // undo neither the entry nor the outbox event. The write reports success and
+    // the hook failure is reported separately; `eventRecorded` is what the drain
+    // keys off and is unaffected either way.
     current.hooks.register(
       "afterUpdate",
       getSingleHookCollection("preferences"),
@@ -747,8 +754,13 @@ describe("webhook outbox capture — singles (integration)", () => {
       { overrideAccess: true }
     );
 
-    expect(result.success).toBe(false);
+    expect(result.success).toBe(true);
     expect(result.eventRecorded).toBe(true);
+
+    // The single trace the failure leaves, given the operation reports success.
+    expect(logged).toHaveBeenCalled();
+    expect(String(logged.mock.calls[0][0])).toContain("afterUpdate");
+
     const rows = (await events(current)).filter(
       r => r.type === "single.updated"
     );


### PR DESCRIPTION
Closes task 100.

## Why this is worth landing first

These three failures are not confined to their own suite. **Every open PR cut from `main` inherits
them**, so the Integration check is red repo-wide regardless of what the PR changed. #456 is
admin-only and its postgres, mysql and sqlite legs all fail on exactly these two assertions:

```
AssertionError: expected 1 to be +0
AssertionError: expected true to be false
```

## What was wrong

`afterCreate`, `afterUpdate` and `afterDelete` run once the transaction has committed. #447
(`ab6795fb6`) stopped a throw there being reported as a failed write — raising it described a
durable row as a failure and invited a retry that wrote a second one. The write succeeds, the
failure is logged with its phase and collection, and the caller may pass `onSideEffectError`.

#447 updated `post-commit-hook-failure.integration.test.ts` and
`cache-revalidation.integration.test.ts`. It did not update these two files, which still encoded
the contract it replaced.

**This is test debt, not a product bug.** The runtime is untouched — making these pass by changing
`hook-registry.ts` would reinstate the bug #447 fixed.

## What changed

The values come from running the tests, not from reading #447's description:

| assertion | was | is |
|---|---|---|
| collection create, `success` | `false` | `true` |
| bulk delete, `successCount` | `0` | `1` |
| single update, `success` | `false` | `true` |

The bulk case is the one worth a second look: the item counts as a success because it *is* one —
the row is gone and the event durable — and a batch that called it a failure would invite a retry
against a row that no longer exists. `eventRecorded` was never in question; it is what the fast
drain and retention key off, and it stays true either way.

Each test's comment was rewritten. They explained the old contract and would have misled the next
reader.

## The failure is still asserted to be observable

Dropping the old assertion would have been enough to make these green — and would have passed just
as well against a registry that swallowed the hook error entirely. Since the operation now reports
success, the log is its only trace, so each case asserts it:

```ts
expect(logged).toHaveBeenCalled();
expect(String(logged.mock.calls[0][0])).toContain("afterCreate");
```

Verified by deleting that `console.error` from `hook-registry.ts` and rebuilding: all three fail.
Restored afterwards, and the diff confirms no runtime file is touched.

`onSideEffectError` would have been the tidier hook to assert on, but nothing in production passes
it — it is a declared option with no caller — so the log is the real contract today.

## Two things beyond the literal fix

- **The spy is undone in the existing teardown.** This config sets neither `restoreMocks` nor
  `clearMocks`, so muting `console.error` would have left every later test in both files running
  with errors suppressed.
- **Swept for the same stale expectation elsewhere.** #447 changed the shared registry, so other
  callers could encode it too. Every suite registering a throwing `after*` hook was checked; the
  only other `success: false` near one is `cache-revalidation`'s update of a missing entry, which
  is a genuine not-found and correctly unchanged.

## Verification

Freshly recreated databases, one leg at a time, build first:

| leg | result |
|---|---|
| postgres17 | 1055 passed, 56 skipped, **0 failed** |
| mysql | 991 passed, 94 skipped, **0 failed** |
| sqlite | 920 passed, 140 skipped, **0 failed** |

No changeset: test-only, no published behaviour changes.
