### PR TITLE
fix(adapter-drizzle): let a refusal out of a transaction unchanged

### DIFF
--- a/.changeset/field-group-refusal-survives-tx.md
+++ b/.changeset/field-group-refusal-survives-tx.md
@@ -1,0 +1,25 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+A write refused inside a field group is now reported as the refusal it is. A blank required field returned a generic server error with no per-field detail, because every dialect adapter re-classified anything thrown out of a transaction as a database failure — including an error the application raised deliberately to roll the write back. Collections were affected on create and update; singles already behaved correctly.

--- a/packages/adapter-drizzle/src/__tests__/application-error.test.ts
+++ b/packages/adapter-drizzle/src/__tests__/application-error.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Telling the application's verdict apart from the database's failure.
+ *
+ * Work running inside a transaction may throw to roll the write back — a
+ * refused value, a denied permission. Such an error did not come from the
+ * driver, and classifying it as a database error replaces the code and payload
+ * the application chose with a generic one, so a caller that asked for a
+ * refusal is handed an unexplained failure instead.
+ *
+ * The adapters cannot import the class that defines these errors — they sit
+ * below it — so the test that matters is that recognition works through the
+ * global symbol registry, which is the whole reason the brand takes that form.
+ */
+import { describe, expect, it } from "vitest";
+
+import { isApplicationError } from "../types/error";
+
+/** A branded error built the way a separate copy of the defining module would. */
+function branded(): Error {
+  const error = new Error("Validation failed.");
+  Object.defineProperty(error, Symbol.for("nextly/NextlyError"), {
+    value: true,
+  });
+  return error;
+}
+
+describe("isApplicationError", () => {
+  it("recognises a branded error built from another module instance", () => {
+    // The point of `Symbol.for`: two copies of the defining module — a
+    // duplicated install, a bundler that did not dedupe — resolve the same
+    // symbol, so the brand survives a package boundary that `instanceof` would
+    // not.
+    expect(isApplicationError(branded())).toBe(true);
+  });
+
+  it("recognises it through a prototype chain", () => {
+    // Subclasses carry the brand by inheritance, which is how the legacy error
+    // shims stay recognisable.
+    class Derived extends Error {}
+    const error = new Derived("nope");
+    Object.setPrototypeOf(error, branded());
+    expect(isApplicationError(error)).toBe(true);
+  });
+
+  it("does not claim an ordinary error", () => {
+    // A driver error must still be classified: treating it as a verdict would
+    // send raw driver text to a caller in place of a mapped database error.
+    expect(isApplicationError(new Error("connection reset"))).toBe(false);
+  });
+
+  it("does not claim an error branded with a look-alike symbol", () => {
+    // A symbol of the same DESCRIPTION from outside the registry is a different
+    // symbol, so nothing outside Nextly can claim to be a Nextly error.
+    const error = new Error("impostor");
+    Object.defineProperty(error, Symbol("nextly/NextlyError"), { value: true });
+    expect(isApplicationError(error)).toBe(false);
+  });
+
+  it("does not claim a value carrying the brand set to anything but true", () => {
+    const error = new Error("half-branded");
+    Object.defineProperty(error, Symbol.for("nextly/NextlyError"), {
+      value: "yes",
+    });
+    expect(isApplicationError(error)).toBe(false);
+  });
+
+  it.each([
+    ["null", null],
+    ["undefined", undefined],
+    ["a string", "boom"],
+    ["a number", 500],
+  ])("does not claim %s", (_label, value) => {
+    // A thrown non-object is legal JavaScript and reaches the same catch.
+    expect(isApplicationError(value)).toBe(false);
+  });
+});

--- a/packages/adapter-drizzle/src/adapter.ts
+++ b/packages/adapter-drizzle/src/adapter.ts
@@ -171,12 +171,18 @@ export abstract class DrizzleAdapter {
    * Supports nested transactions via savepoints on databases that support them.
    *
    * Two kinds of error leave this method, and a caller has to be able to tell
-   * them apart. A failure of the transaction itself — the driver, the
-   * connection, a constraint — arrives as a `DatabaseError` with its kind
-   * classified. An error the CALLBACK raised arrives exactly as it was thrown,
-   * because that is the application refusing the write rather than the database
-   * failing to perform it, and rewriting it would discard the code and payload
-   * the caller is meant to act on.
+   * them apart. An error carrying the Nextly application brand — see
+   * `isApplicationError` — arrives exactly as it was thrown, because that is
+   * the application refusing the write rather than the database failing to
+   * perform it, and rewriting it would discard the code and payload the caller
+   * is meant to act on.
+   *
+   * Everything else arrives as a `DatabaseError` with its kind classified, and
+   * that deliberately includes an unbranded error the callback itself threw:
+   * the brand is the only thing distinguishing a deliberate refusal from a
+   * driver failure that surfaced through callback code, and guessing from the
+   * throw site would put raw driver text on the wire under a caller's own
+   * error shape.
    *
    * The rollback is the same either way.
    *
@@ -184,8 +190,9 @@ export abstract class DrizzleAdapter {
    * @param options - Transaction options
    * @returns Result from the callback
    *
-   * @throws {DatabaseError} If the transaction itself fails
-   * @throws The callback's own error, unchanged, if the callback threw one
+   * @throws {DatabaseError} If the transaction itself fails, or if the callback
+   * threw an error that does not carry the application brand
+   * @throws The callback's own error, unchanged, when it carries that brand
    */
   abstract transaction<T>(
     callback: (ctx: TransactionContext) => Promise<T>,

--- a/packages/adapter-drizzle/src/adapter.ts
+++ b/packages/adapter-drizzle/src/adapter.ts
@@ -170,11 +170,22 @@ export abstract class DrizzleAdapter {
    * The transaction is automatically committed on success or rolled back on error.
    * Supports nested transactions via savepoints on databases that support them.
    *
+   * Two kinds of error leave this method, and a caller has to be able to tell
+   * them apart. A failure of the transaction itself — the driver, the
+   * connection, a constraint — arrives as a `DatabaseError` with its kind
+   * classified. An error the CALLBACK raised arrives exactly as it was thrown,
+   * because that is the application refusing the write rather than the database
+   * failing to perform it, and rewriting it would discard the code and payload
+   * the caller is meant to act on.
+   *
+   * The rollback is the same either way.
+   *
    * @param callback - Function to execute within transaction
    * @param options - Transaction options
    * @returns Result from the callback
    *
-   * @throws {DatabaseError} If transaction fails
+   * @throws {DatabaseError} If the transaction itself fails
+   * @throws The callback's own error, unchanged, if the callback threw one
    */
   abstract transaction<T>(
     callback: (ctx: TransactionContext) => Promise<T>,

--- a/packages/adapter-drizzle/src/types/error.ts
+++ b/packages/adapter-drizzle/src/types/error.ts
@@ -95,6 +95,44 @@ export function isDatabaseError(error: unknown): error is DatabaseError {
 }
 
 /**
+ * The brand every Nextly application error carries.
+ *
+ * Read through the global symbol registry rather than imported, because the
+ * adapters must not depend on the package that defines the error: `Symbol.for`
+ * resolves to the same symbol in every module instance, which is why the brand
+ * exists in that form to begin with.
+ *
+ * @internal
+ */
+const APPLICATION_ERROR_BRAND: unique symbol = Symbol.for("nextly/NextlyError");
+
+/**
+ * Whether an error is the application's verdict rather than the database's
+ * failure.
+ *
+ * Work running inside a transaction may throw to roll the write back — a
+ * refused value, a permission denial — and such an error is not something the
+ * driver produced. Classifying it as a database error replaces its code and its
+ * payload with a generic one, so a caller that asked for a refusal is handed an
+ * unexplained failure instead, and per-field validation detail is lost on the
+ * way out.
+ *
+ * @param error - Error to check
+ * @returns True if the error was raised by application code
+ *
+ * @public
+ */
+export function isApplicationError(error: unknown): boolean {
+  if (
+    error === null ||
+    (typeof error !== "object" && typeof error !== "function")
+  ) {
+    return false;
+  }
+  return (error as Record<symbol, unknown>)[APPLICATION_ERROR_BRAND] === true;
+}
+
+/**
  * Database error constructor options.
  *
  * @public

--- a/packages/adapter-drizzle/src/types/index.ts
+++ b/packages/adapter-drizzle/src/types/index.ts
@@ -103,7 +103,11 @@ export type {
   DatabaseErrorOptions,
 } from "./error";
 
-export { isDatabaseError, createDatabaseError } from "./error";
+export {
+  isDatabaseError,
+  createDatabaseError,
+  isApplicationError,
+} from "./error";
 
 // ============================================================
 // Configuration Types

--- a/packages/adapter-mysql/src/index.ts
+++ b/packages/adapter-mysql/src/index.ts
@@ -61,6 +61,7 @@ import {
   type AdapterLogger,
   type PoolConfig,
   type SslConfig,
+  isApplicationError,
 } from "@nextlyhq/adapter-drizzle/types";
 import { checkDialectVersion } from "@nextlyhq/adapter-drizzle/version-check";
 import type { AnyRelations, SQL } from "drizzle-orm";
@@ -508,6 +509,14 @@ export class MySqlAdapter extends DrizzleAdapter {
         await connection.query("ROLLBACK").catch(() => {});
 
         lastError = error;
+
+        // Work inside a transaction may throw to roll the write back — a
+        // refused value, a denied permission — and that is the application's
+        // verdict, not the driver's failure. Rethrown before the retry check as
+        // well as before classification: a refusal re-run is the same refusal,
+        // and the caller must receive the code and payload it raised rather
+        // than a generic database error with the detail stripped out.
+        if (isApplicationError(error)) throw error;
 
         // Check if error is retryable (deadlock only per approved approach)
         const mysqlError = error as { errno?: number; code?: string };

--- a/packages/adapter-postgres/src/index.ts
+++ b/packages/adapter-postgres/src/index.ts
@@ -563,11 +563,16 @@ export class PostgresAdapter extends DrizzleAdapter {
    * Supports automatic retry for serialization failures (40001) and
    * deadlocks (40P01) when `retryCount` is specified in options.
    *
+   * An error the callback raised is neither retried nor classified: it is the
+   * application refusing the write, so it arrives at the caller as it was
+   * thrown. Only failures of the transaction itself are retried and mapped.
+   *
    * @param callback - Function to execute within the transaction
    * @param options - Transaction options (isolation level, timeout, retry)
    * @returns The result of the callback
    *
-   * @throws {DatabaseError} If transaction fails after all retries
+   * @throws {DatabaseError} If the transaction itself fails after all retries
+   * @throws The callback's own error, unchanged, if the callback threw one
    */
   async transaction<T>(
     callback: (ctx: TransactionContext) => Promise<T>,

--- a/packages/adapter-postgres/src/index.ts
+++ b/packages/adapter-postgres/src/index.ts
@@ -89,6 +89,7 @@ import type {
 import {
   createDatabaseError,
   isDatabaseError,
+  isApplicationError,
 } from "@nextlyhq/adapter-drizzle/types";
 import { checkDialectVersion } from "@nextlyhq/adapter-drizzle/version-check";
 import type { AnyRelations, SQL } from "drizzle-orm";
@@ -610,6 +611,14 @@ export class PostgresAdapter extends DrizzleAdapter {
         await client.query("ROLLBACK").catch(() => {});
 
         lastError = error;
+
+        // Work inside a transaction may throw to roll the write back — a
+        // refused value, a denied permission — and that is the application's
+        // verdict, not the driver's failure. Rethrown before the retry check as
+        // well as before classification: a refusal re-run is the same refusal,
+        // and the caller must receive the code and payload it raised rather
+        // than a generic database error with the detail stripped out.
+        if (isApplicationError(error)) throw error;
 
         // Check if error is retryable
         const pgError = error as { code?: string };

--- a/packages/adapter-postgres/src/index.ts
+++ b/packages/adapter-postgres/src/index.ts
@@ -563,16 +563,20 @@ export class PostgresAdapter extends DrizzleAdapter {
    * Supports automatic retry for serialization failures (40001) and
    * deadlocks (40P01) when `retryCount` is specified in options.
    *
-   * An error the callback raised is neither retried nor classified: it is the
-   * application refusing the write, so it arrives at the caller as it was
-   * thrown. Only failures of the transaction itself are retried and mapped.
+   * An error carrying the Nextly application brand is neither retried nor
+   * classified: it is the application refusing the write, so it arrives at the
+   * caller as it was thrown. Retrying it would repeat work whose verdict has
+   * already been given. Every other error, including an unbranded one raised by
+   * the callback, is retried when it is a serialization failure or deadlock and
+   * classified on the way out.
    *
    * @param callback - Function to execute within the transaction
    * @param options - Transaction options (isolation level, timeout, retry)
    * @returns The result of the callback
    *
-   * @throws {DatabaseError} If the transaction itself fails after all retries
-   * @throws The callback's own error, unchanged, if the callback threw one
+   * @throws {DatabaseError} If the transaction itself fails after all retries,
+   * or if the callback threw an error that does not carry the application brand
+   * @throws The callback's own error, unchanged, when it carries that brand
    */
   async transaction<T>(
     callback: (ctx: TransactionContext) => Promise<T>,

--- a/packages/adapter-sqlite/src/__tests__/transaction-application-error.test.ts
+++ b/packages/adapter-sqlite/src/__tests__/transaction-application-error.test.ts
@@ -131,9 +131,12 @@ describe("SqliteAdapter — a refusal thrown inside transaction()", () => {
     expect(statements).not.toContain("COMMIT");
   });
 
-  it("still classifies an error that did come from the driver", async () => {
-    // The other half of the contract. Letting a driver error through unchanged
-    // would put raw driver text on the wire in place of a mapped kind.
+  it("classifies a callback error that carries no application brand", async () => {
+    // The other half of the contract, and the reason the brand is the test
+    // rather than the throw site: this error is raised from inside the callback
+    // exactly like a refusal, and is still classified. Passing it through
+    // unchanged would put raw driver text on the wire under a shape callers
+    // read as their own deliberate refusal.
     const adapter = await makeAdapter();
 
     const caught: unknown = await adapter

--- a/packages/adapter-sqlite/src/__tests__/transaction-application-error.test.ts
+++ b/packages/adapter-sqlite/src/__tests__/transaction-application-error.test.ts
@@ -1,0 +1,147 @@
+/**
+ * A refusal raised inside a transaction reaches the caller as itself.
+ *
+ * Application code throws inside `transaction()` to roll a write back — a
+ * refused value, a denied permission. That error is the application's verdict,
+ * not the driver's failure, and it used to be replaced on the way out by the
+ * adapter's error classification: the caller received a generic database error
+ * and every payload the verdict carried, such as the per-field issues an admin
+ * form needs, was gone.
+ *
+ * The rollback still has to happen — the point is only that what surfaces is
+ * what was thrown.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { SqliteAdapter } from "../index";
+
+const mockExec = vi.fn();
+const mockPrepare = vi.fn();
+const mockPragma = vi.fn();
+const mockClose = vi.fn();
+
+const mockStatement = { run: vi.fn(), get: vi.fn(), all: vi.fn() };
+
+class MockDatabase {
+  prepare = mockPrepare;
+  exec = mockExec;
+  pragma = mockPragma;
+  close = mockClose;
+  inTransaction = false;
+  constructor(_path: string, _options?: Record<string, unknown>) {}
+}
+
+vi.mock("better-sqlite3", () => ({ default: MockDatabase }));
+
+/** An error branded the way the application's own error class brands one. */
+function refusal(): Error & { code?: string; publicData?: unknown } {
+  const error: Error & { code?: string; publicData?: unknown } = new Error(
+    "Validation failed."
+  );
+  error.code = "VALIDATION_ERROR";
+  error.publicData = {
+    errors: [
+      { path: "badge", code: "REQUIRED", message: "badge is required." },
+    ],
+  };
+  Object.defineProperty(error, Symbol.for("nextly/NextlyError"), {
+    value: true,
+  });
+  return error;
+}
+
+describe("SqliteAdapter — a refusal thrown inside transaction()", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockPrepare.mockImplementation((sql: string) => {
+      if (
+        typeof sql === "string" &&
+        sql.toLowerCase().includes("sqlite_version()")
+      ) {
+        return {
+          run: vi.fn(),
+          all: vi.fn().mockReturnValue([]),
+          get: vi.fn().mockReturnValue({ version: "3.45.0" }),
+        };
+      }
+      return mockStatement;
+    });
+    mockStatement.run.mockReturnValue({ changes: 1, lastInsertRowid: 1 });
+    mockStatement.all.mockReturnValue([]);
+    mockStatement.get.mockReturnValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  async function makeAdapter(): Promise<SqliteAdapter> {
+    const adapter = new SqliteAdapter({ filename: ":memory:" });
+    await adapter.connect();
+    return adapter;
+  }
+
+  it("surfaces the very error that was thrown", async () => {
+    const adapter = await makeAdapter();
+    const thrown = refusal();
+
+    const caught = await adapter
+      .transaction(async () => {
+        throw thrown;
+      })
+      .catch((error: unknown) => error);
+
+    // Identity, not shape: anything that rebuilt it would satisfy a shape
+    // check while having decided for itself what to keep.
+    expect(caught).toBe(thrown);
+  });
+
+  it("keeps the code and the payload a caller reads", async () => {
+    const adapter = await makeAdapter();
+
+    const caught: unknown = await adapter
+      .transaction(async () => {
+        throw refusal();
+      })
+      .catch((error: unknown) => error);
+
+    expect(caught).toMatchObject({
+      code: "VALIDATION_ERROR",
+      publicData: { errors: [{ path: "badge", code: "REQUIRED" }] },
+    });
+  });
+
+  it("still rolls the transaction back", async () => {
+    // Surfacing the verdict must not cost the rollback: the write is being
+    // refused, so nothing it did may survive.
+    const adapter = await makeAdapter();
+    const statements: string[] = [];
+    mockExec.mockImplementation((sql: string) => {
+      statements.push(sql);
+    });
+
+    await adapter
+      .transaction(async () => {
+        throw refusal();
+      })
+      .catch(() => undefined);
+
+    expect(statements).toContain("BEGIN IMMEDIATE");
+    expect(statements).toContain("ROLLBACK");
+    expect(statements).not.toContain("COMMIT");
+  });
+
+  it("still classifies an error that did come from the driver", async () => {
+    // The other half of the contract. Letting a driver error through unchanged
+    // would put raw driver text on the wire in place of a mapped kind.
+    const adapter = await makeAdapter();
+
+    const caught: unknown = await adapter
+      .transaction(async () => {
+        throw new Error("database is locked");
+      })
+      .catch((error: unknown) => error);
+
+    expect(caught).toMatchObject({ kind: expect.any(String) });
+  });
+});

--- a/packages/adapter-sqlite/src/index.ts
+++ b/packages/adapter-sqlite/src/index.ts
@@ -59,6 +59,7 @@ import {
   type DatabaseErrorKind,
   type BaseAdapterConfig,
   type AdapterLogger,
+  isApplicationError,
 } from "@nextlyhq/adapter-drizzle/types";
 import { checkDialectVersion } from "@nextlyhq/adapter-drizzle/version-check";
 import type Database from "better-sqlite3";
@@ -539,6 +540,12 @@ export class SqliteAdapter extends DrizzleAdapter {
         throw error;
       }
     } catch (error) {
+      // Work inside a transaction may throw to roll the write back — a refused
+      // value, a denied permission — and that is the application's verdict, not
+      // the driver's failure. Classifying it would replace its code and payload
+      // with a generic database error, so a caller that asked for a refusal is
+      // handed an unexplained failure and the per-field detail never arrives.
+      if (isApplicationError(error)) throw error;
       throw this.classifyError(error);
     }
   }

--- a/packages/nextly/src/domains/field-groups/__tests__/field-group-refusal-envelope.integration.test.ts
+++ b/packages/nextly/src/domains/field-groups/__tests__/field-group-refusal-envelope.integration.test.ts
@@ -1,0 +1,127 @@
+/**
+ * A refused write inside a field group is reported as a refusal.
+ *
+ * A field group is validated inside the parent write's transaction, so a value
+ * it rejects is raised from in there and has to travel out through the
+ * transaction boundary. That boundary classifies what escapes it as a database
+ * failure, which turned a refusal into a generic server error: the caller was
+ * handed a 500 for a blank required field, and the per-field issues an admin
+ * form marks the field from never arrived.
+ *
+ * Singles were unaffected and are kept here as the contrast — the same refusal
+ * arriving intact on a path that already worked is what says the collection
+ * cases are now consistent with it rather than merely different.
+ */
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  defineCollection,
+  defineFieldGroup,
+  defineSingle,
+  fieldGroup,
+  text,
+} from "../../../config";
+import {
+  createTestNextly,
+  type TestNextly,
+} from "../../../plugins/test-nextly";
+
+let current: TestNextly | undefined;
+
+afterEach(async () => {
+  await current?.destroy();
+  current = undefined;
+});
+
+/** The refusal every case here provokes: a required field left blank. */
+const BLANK = { badge: {} };
+
+async function boot(): Promise<TestNextly> {
+  return createTestNextly({
+    fieldGroups: [
+      defineFieldGroup({
+        slug: "badged",
+        fields: [text({ name: "badge", required: true })],
+      }),
+    ],
+    collections: [
+      defineCollection({
+        slug: "pages",
+        fields: [
+          text({ name: "title" }),
+          fieldGroup({ name: "badge", component: "badged" }),
+        ],
+      }),
+    ],
+    singles: [
+      defineSingle({
+        slug: "landing",
+        fields: [
+          text({ name: "headline" }),
+          fieldGroup({ name: "badge", component: "badged" }),
+        ],
+      }),
+    ],
+  });
+}
+
+/** What a client needs to render the refusal, rather than just its existence. */
+const REFUSAL = {
+  code: "VALIDATION_ERROR",
+  publicData: {
+    errors: [{ path: "badge", code: "REQUIRED" }],
+  },
+};
+
+describe("a field-group refusal crossing the write's transaction", () => {
+  it("survives a collection create", async () => {
+    current = await boot();
+
+    const error = await current.nextly
+      .create({ collection: "pages", data: { title: "A", ...BLANK } })
+      .catch((e: unknown) => e);
+
+    expect(error).toMatchObject(REFUSAL);
+  });
+
+  it("survives a collection update", async () => {
+    current = await boot();
+    const created = await current.nextly.create({
+      collection: "pages",
+      data: { title: "A", badge: { badge: "gold" } },
+    });
+
+    const error = await current.nextly
+      .update({
+        collection: "pages",
+        id: (created.item as { id: string }).id,
+        data: { badge: { badge: "" } },
+      })
+      .catch((e: unknown) => e);
+
+    expect(error).toMatchObject(REFUSAL);
+  });
+
+  it("survives a single update, as it always did", async () => {
+    current = await boot();
+
+    const error = await current.nextly
+      .updateSingle({ slug: "landing", data: { headline: "H", ...BLANK } })
+      .catch((e: unknown) => e);
+
+    expect(error).toMatchObject(REFUSAL);
+  });
+
+  it("leaves nothing behind when the create is refused", async () => {
+    // The rollback is the other half: reporting the refusal correctly would be
+    // no use if the row it refused had been written anyway.
+    current = await boot();
+
+    await current.nextly
+      .create({ collection: "pages", data: { title: "A", ...BLANK } })
+      .catch(() => undefined);
+
+    const remaining = await current.nextly.find({ collection: "pages" });
+    expect(remaining.items).toHaveLength(0);
+  });
+});

--- a/packages/nextly/src/domains/field-groups/__tests__/field-group-validation-request.integration.test.ts
+++ b/packages/nextly/src/domains/field-groups/__tests__/field-group-validation-request.integration.test.ts
@@ -103,20 +103,28 @@ describe("a field group's validators and the parent write's request", () => {
   it("refuses the same create when nobody is signed in", async () => {
     // The control: without it a passing case above could be a validator that
     // never ran rather than one that was given the user.
-    //
-    // Matched on the message rather than the code: a refusal raised inside a
-    // collection write's transaction is reclassified on the way out of the
-    // callback, so the code and the issue list do not survive that boundary.
-    // The single case below asserts the full issue, on the path that keeps it.
     current = await boot();
 
-    await expect(
-      current.nextly.create({
+    const error = await current.nextly
+      .create({
         collection: "pages",
         data: { title: "About", badge: { badge: "gold" } },
         overrideAccess: true,
       })
-    ).rejects.toThrow(/Validation failed/);
+      .catch((e: unknown) => e);
+
+    expect(error).toMatchObject({
+      code: "VALIDATION_ERROR",
+      publicData: {
+        errors: [
+          {
+            path: "badge",
+            code: "CUSTOM",
+            message: "Only a signed-in user may set a badge.",
+          },
+        ],
+      },
+    });
   });
 
   it("a collection update forwards its user", async () => {
@@ -156,9 +164,7 @@ describe("a field group's validators and the parent write's request", () => {
   });
 
   it("refuses the same single update when nobody is signed in", async () => {
-    // The single path hands the refusal back intact, so this is where the
-    // validator's own issue can be read: the field it is about and the code
-    // the client keys its handling on, not just a sentence.
+    // The same refusal on the singles path, which reports it the same way.
     current = await boot();
 
     const error = await current.nextly

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/helpers/table-world.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/helpers/table-world.ts
@@ -19,15 +19,17 @@
  * `buildCondition`). Raising a different error type here would test refusal
  * handling against errors the code will never actually meet.
  *
- * And it reclassifies whatever escapes a transaction callback, exactly as every
- * real adapter does: `classifyError` short-circuits only on an existing
- * `DatabaseError`, so a `NextlyError` thrown inside a transaction reaches the
- * caller rewrapped as an unknown database error with its `logContext` gone. A
- * double that let one through unchanged would certify refusal messages that no
- * operator ever sees.
+ * And it treats what escapes a transaction callback the way every real adapter
+ * does, which is to distinguish two things. An error the WORK raised is the
+ * application refusing the write, and reaches the caller as it was thrown, with
+ * the code and payload it chose. Anything else is a failure of the transaction
+ * and is classified. A double that rewrapped both would be stricter than
+ * production, and a test written against it would pass while the real path
+ * handed the caller a different error entirely.
  */
 import {
   createDatabaseError,
+  isApplicationError,
   isDatabaseError,
   type SelectOptions,
   type TransactionContext,
@@ -214,10 +216,13 @@ export function createTableWorld(
           const fixture = tables.get(name);
           if (fixture !== undefined) fixture.rows = rows;
         }
-        // Mirrors every adapter's transaction boundary: anything that is not
-        // already a DatabaseError is rewrapped as an unknown one, losing
-        // whatever structured context it carried.
-        if (isDatabaseError(error)) throw error;
+        // Mirrors every adapter's transaction boundary, which distinguishes two
+        // things: an error the WORK raised is the application refusing the
+        // write and reaches the caller as it was thrown, while anything else is
+        // a failure of the transaction and is classified. A double that
+        // rewrapped both would be stricter than production, and a test written
+        // against it would pass while the real path returned a different error.
+        if (isApplicationError(error) || isDatabaseError(error)) throw error;
         throw createDatabaseError({
           kind: "unknown",
           message: error instanceof Error ? error.message : String(error),

--- a/packages/nextly/src/domains/field-groups/migration/data-steps.ts
+++ b/packages/nextly/src/domains/field-groups/migration/data-steps.ts
@@ -187,13 +187,11 @@ function registryDefinitionsStep(
     id: "data:registry-definitions",
     async run(session) {
       const outcome = await session.inTransaction(async ctx => {
-        // Every patch is computed before any of them is issued. A refusal has
-        // to leave the transaction as a value rather than as an exception —
-        // the adapter reclassifies anything thrown out of a callback and
-        // discards the context naming what could not be read — and a value
-        // returned from the callback COMMITS. Staging first is what keeps that
-        // from committing the rows already rewritten and leaving exactly the
-        // mixed-vocabulary registry set this step exists to prevent.
+        // Every patch is computed before any of them is issued. A refusal
+        // leaves the transaction as a value rather than as an exception, and a
+        // value returned from the callback COMMITS. Staging first is what keeps
+        // that from committing the rows already rewritten and leaving exactly
+        // the mixed-vocabulary registry set this step exists to prevent.
         const staged: { table: string; id: string; patch: Patch }[] = [];
         for (const table of DEFINITION_TABLES) {
           for (const row of await readRegistryRows(ctx, table)) {


### PR DESCRIPTION
Task 101. A blank required field inside a field group returned **HTTP 500** with nothing a form could use, instead of a validation error naming the field.

## What was actually wrong

The task file traced this to the collection service. That was the wrong level — `errorToServiceResult` preserves a `NextlyError` correctly, including its `publicData.errors`.

The real cause is one layer down, and it is in **every dialect adapter**:

```ts
} catch (error) {
  throw this.classifyError(error);   // ← everything, including a deliberate refusal
}
```

Work inside a transaction throws to roll the write back. A refused value, a denied permission — these are the *application's verdict*, not the driver's failure. Classifying them replaced the code and payload the application chose with a generic database error, so the collection service never saw a `NextlyError` at all and fell through to its 500 branch.

Measured before, on SQLite, with a plain `required` text field (no plugin types involved):

| Write | Code the caller saw | `publicData.errors` |
|---|---|---|
| `create` (collection) | `INTERNAL_ERROR` | `undefined` |
| `update` (collection) | `INTERNAL_ERROR` | `undefined` |
| `updateSingle` | `VALIDATION_ERROR` | the full issue list |

Singles were never affected — that path does not raise its refusal from inside the callback. They are kept in the tests as the contrast, so the collection cases are shown to be *consistent with* a working path rather than merely changed.

## The fix, and why it is at this seam

`isApplicationError` in `adapter-drizzle/types/error.ts`, and each dialect rethrows a branded error unchanged.

**At the seam rather than per caller.** The alternative was to fix create, then update, then delete, then the bulk paths, then singles — and to keep doing it for every future write. One guard where the classification happens covers all of them, including callers that do not exist yet.

**The brand is read through the global symbol registry**, not imported:

```ts
const APPLICATION_ERROR_BRAND: unique symbol = Symbol.for("nextly/NextlyError");
```

The adapters sit *below* the package that defines `NextlyError` and must not depend on it. `Symbol.for` resolves to the same symbol across module instances, which is the whole reason the brand exists in that form — the error class already relies on it to survive package boundaries that `instanceof` does not.

**Rethrown before the retry check** on PostgreSQL and MySQL, not just before classification. Re-running a refusal only refuses again, and it would have burned the retry budget doing it. It also removes a latent hazard: `NextlyError.code` and a pg SQLSTATE share the property name `code`, so the retry predicate was reading a field that could belong to either.

## Verification

- **Full sqlite integration leg: no new failures.** 167 passed; the only three failures are task 100's inherited webhook tests. That matters more than usual here — this changes the error path of *every* transactional write, so the question was whether anything depended on the old reclassification. Nothing did.
- **Unit baseline exactly held**: nextly 37 failed files / 400 failed tests. All four adapter packages 100% green (109 / 66 / 87 / 47).
- **Stub-verified with a rebuild**: removing the sqlite guard fails exactly the two collection cases and leaves the singles case and the rollback case passing. (The rebuild matters — integration runs against `dist`, and my first attempt at this verification was reading a stale build.)
- `check-types` 0 errors across the monorepo, lint clean.

## Tests

- `adapter-drizzle/__tests__/application-error.test.ts` — brand recognition, including a look-alike `Symbol()` from outside the registry, a brand set to a non-`true` value, and thrown non-objects.
- `adapter-sqlite/__tests__/transaction-application-error.test.ts` — the seam itself: the caught error is the *same object* that was thrown (identity, not shape — anything that rebuilt it would pass a shape check while having chosen for itself what to keep), the rollback still happens, and a genuine driver error is still classified.
- `nextly/domains/field-groups/__tests__/field-group-refusal-envelope.integration.test.ts` — the reported symptom end to end, plus a case asserting the refused row was not written.

## Also here

One assertion in `field-group-validation-request.integration.test.ts` (from #459) was deliberately matching on the error *message*, with a comment explaining that the code and issue list could not survive the transaction boundary. That reason is gone, so it now asserts the full issue and the comment is removed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Application-level validation errors now pass through database transactions unchanged, preserving their error codes and structured details.
  * Prevented application refusals from being misclassified as database errors or triggering unnecessary retries.
  * Ensured refused operations roll back correctly without creating or modifying records.

* **Tests**
  * Added coverage for error recognition, transaction behavior, rollback handling, and field-group validation responses across supported database adapters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->