### PR TITLE
feat(admin): draft/publish editing UX for the entry editor

### DIFF
--- a/.changeset/draft-publish-editing-ux.md
+++ b/.changeset/draft-publish-editing-ux.md
@@ -1,0 +1,27 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+Editing a published entry on a drafts-enabled collection now works as a proper draft and publish flow.
+
+When a collection has drafts enabled, editing a published entry saves your changes as a pending working draft instead of overwriting what is live. The editor shows a "Changed" status while a draft is pending, a Publish button promotes it to the live document, and a confirmed "Discard draft" action throws the pending edits away and restores the published version. The read API also surfaces the working draft to a trusted editor through `?draft=true`.

--- a/packages/admin/src/components/features/entries/EntryForm/DiscardDraftConfirmDialog.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/DiscardDraftConfirmDialog.tsx
@@ -32,8 +32,9 @@ export interface DiscardDraftConfirmDialogProps {
   /** Display name for the entry. Falls back to "this entry" when empty. */
   entryLabel?: string | null;
   /** Confirm callback. The dialog does not close itself on confirm — the caller
-   *  closes it on success/error so the loading state stays visible meanwhile. */
-  onConfirm: () => void;
+   *  closes it once the discard settles so the loading state stays visible
+   *  meanwhile. May be async; its promise is awaited by the caller. */
+  onConfirm: () => void | Promise<void>;
   /** Whether the discard mutation is in flight. */
   isLoading?: boolean;
 }
@@ -60,7 +61,13 @@ export function DiscardDraftConfirmDialog({
         <AlertDialogFooter>
           <AlertDialogCancel disabled={isLoading}>Cancel</AlertDialogCancel>
           <AlertDialogAction
-            onClick={onConfirm}
+            // Prevent Radix from auto-closing on click: the caller keeps the
+            // dialog open until the discard settles so this button's in-flight
+            // spinner and the disabled controls are actually visible meanwhile.
+            onClick={event => {
+              event.preventDefault();
+              void onConfirm();
+            }}
             disabled={isLoading}
             className="bg-destructive-solid text-destructive-foreground hover:bg-destructive-700"
           >

--- a/packages/admin/src/components/features/entries/EntryForm/DiscardDraftConfirmDialog.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/DiscardDraftConfirmDialog.tsx
@@ -1,0 +1,80 @@
+/**
+ * Discard Draft Confirm Dialog
+ *
+ * Two-step confirm before throwing away a published entry's pending working
+ * draft (the draft/published split). Unlike "Discard changes", which only drops
+ * unsaved edits from the current session, this deletes edits already saved as a
+ * working draft, so the confirm guards a genuinely destructive, irreversible
+ * action. The live published row is untouched either way. Built on the same
+ * AlertDialog primitives as UnpublishConfirmDialog.
+ *
+ * @module components/features/entries/EntryForm/DiscardDraftConfirmDialog
+ */
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@nextlyhq/ui";
+
+import { Loader2 } from "@admin/components/icons";
+
+export interface DiscardDraftConfirmDialogProps {
+  /** Whether the dialog is open. */
+  open: boolean;
+  /** Open-state change handler — fires on ESC, click-outside, Cancel. */
+  onOpenChange: (open: boolean) => void;
+  /** Display name for the entry. Falls back to "this entry" when empty. */
+  entryLabel?: string | null;
+  /** Confirm callback. The dialog does not close itself on confirm — the caller
+   *  closes it on success/error so the loading state stays visible meanwhile. */
+  onConfirm: () => void;
+  /** Whether the discard mutation is in flight. */
+  isLoading?: boolean;
+}
+
+export function DiscardDraftConfirmDialog({
+  open,
+  onOpenChange,
+  entryLabel,
+  onConfirm,
+  isLoading = false,
+}: DiscardDraftConfirmDialogProps) {
+  const label = entryLabel?.trim() || "this entry";
+
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Discard draft for {label}?</AlertDialogTitle>
+          <AlertDialogDescription>
+            This permanently deletes the unpublished changes and restores the
+            editor to the published version. The published version stays live.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={isLoading}>Cancel</AlertDialogCancel>
+          <AlertDialogAction
+            onClick={onConfirm}
+            disabled={isLoading}
+            className="bg-destructive-solid text-destructive-foreground hover:bg-destructive-700"
+          >
+            {isLoading ? (
+              <>
+                <Loader2 className="h-4 w-4 animate-spin" />
+                Discarding...
+              </>
+            ) : (
+              "Discard draft"
+            )}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/packages/admin/src/components/features/entries/EntryForm/EntryForm.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/EntryForm.tsx
@@ -50,9 +50,9 @@ import { PublicUrlChangeNotice } from "./PublicUrlChangeNotice";
 import {
   useEntryForm,
   getCollectionFields,
+  resolveDefaultSaveIntent,
   type EntryFormCollection,
   type EntryData,
-  type EntryFormIntent,
   type EntryFormMode,
 } from "./useEntryForm";
 import { useRailCollapsed } from "./useRailCollapsed";
@@ -334,14 +334,14 @@ export function EntryForm({
   // (status-less), on a non-drafts collection it re-asserts published, and any
   // other editing state saves a draft. Create mode and non-status collections
   // keep the intent-less single-Save behavior.
-  const keyboardSaveIntent: EntryFormIntent | undefined =
-    mode === "edit" && hasStatus
-      ? (entry?.status as string | undefined) === "published"
-        ? collection.draftsEnabled === true
-          ? "save-working-draft"
-          : "save-changes"
-        : "save-draft"
-      : undefined;
+  const keyboardSaveIntent = resolveDefaultSaveIntent({
+    mode,
+    hasStatus,
+    // The ACTIVE locale's status, not the main row's — the same effective status
+    // the header's submit buttons use, so a keyboard save and a button save agree.
+    effectiveStatus: effectiveEntryStatus(entry, locale, defaultLocale),
+    draftsEnabled: collection.draftsEnabled === true,
+  });
 
   // Only enable shortcuts in standalone mode (not embedded modals)
   useEntryFormShortcuts({
@@ -479,7 +479,8 @@ export function EntryForm({
                   // affordances. Reading the main row instead would show "Published" beside a
                   // Publish button whenever a translation lags its default language.
                   status={
-                    effectiveEntryStatus(entry, locale, defaultLocale) ?? "draft"
+                    effectiveEntryStatus(entry, locale, defaultLocale) ??
+                    "draft"
                   }
                   hasWorkingDraft={
                     (entry as { _isWorkingDraft?: boolean } | null | undefined)

--- a/packages/admin/src/components/features/entries/EntryForm/EntryForm.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/EntryForm.tsx
@@ -52,6 +52,7 @@ import {
   getCollectionFields,
   type EntryFormCollection,
   type EntryData,
+  type EntryFormIntent,
   type EntryFormMode,
 } from "./useEntryForm";
 import { useRailCollapsed } from "./useRailCollapsed";
@@ -191,6 +192,7 @@ export function EntryForm({
     form,
     handleSubmit,
     handleDelete,
+    handleDiscardWorkingDraft,
     handleCancel,
     isSubmitting,
     isDirty,
@@ -326,10 +328,25 @@ export function EntryForm({
   // Keyboard Shortcuts (standalone mode only)
   // ---------------------------------------------------------------------------
 
+  // Route Cmd/Ctrl+S to the same intent the primary Save button uses for this
+  // document's state, so a keyboard save and a button save behave identically:
+  // on a drafts collection a published entry stores a working draft
+  // (status-less), on a non-drafts collection it re-asserts published, and any
+  // other editing state saves a draft. Create mode and non-status collections
+  // keep the intent-less single-Save behavior.
+  const keyboardSaveIntent: EntryFormIntent | undefined =
+    mode === "edit" && hasStatus
+      ? (entry?.status as string | undefined) === "published"
+        ? collection.draftsEnabled === true
+          ? "save-working-draft"
+          : "save-changes"
+        : "save-draft"
+      : undefined;
+
   // Only enable shortcuts in standalone mode (not embedded modals)
   useEntryFormShortcuts({
     onSave: () => {
-      void handleSubmit();
+      void handleSubmit(undefined, keyboardSaveIntent);
     },
     onCancel: handleCancel,
     isDirty,
@@ -451,6 +468,7 @@ export function EntryForm({
                   }}
                   onCancel={handleCancel}
                   onDelete={handleDelete}
+                  onDiscardWorkingDraft={handleDiscardWorkingDraft}
                   isRailCollapsed={railCollapsed}
                   onToggleRail={mode === "edit" ? toggleRail : undefined}
                 />

--- a/packages/admin/src/components/features/entries/EntryForm/EntryForm.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/EntryForm.tsx
@@ -461,8 +461,11 @@ export function EntryForm({
                   // affordances. Reading the main row instead would show "Published" beside a
                   // Publish button whenever a translation lags its default language.
                   status={
-                    effectiveEntryStatus(entry, locale, defaultLocale) ??
-                    "draft"
+                    effectiveEntryStatus(entry, locale, defaultLocale) ?? "draft"
+                  }
+                  hasWorkingDraft={
+                    (entry as { _isWorkingDraft?: boolean } | null | undefined)
+                      ?._isWorkingDraft === true
                   }
                   isRailCollapsed={railCollapsed}
                   hasPublicAddress={hasPublicAddress}

--- a/packages/admin/src/components/features/entries/EntryForm/EntryForm.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/EntryForm.tsx
@@ -418,6 +418,7 @@ export function EntryForm({
                   mode={mode}
                   titleField={titleField}
                   hasStatus={hasStatus}
+                  draftsEnabled={collection.draftsEnabled === true}
                   isSubmitting={isSubmitting}
                   isDirty={isDirty}
                   entry={entry}
@@ -441,6 +442,9 @@ export function EntryForm({
                   }}
                   onSaveChanges={() => {
                     void handleSubmit(undefined, "save-changes");
+                  }}
+                  onSaveWorkingDraft={() => {
+                    void handleSubmit(undefined, "save-working-draft");
                   }}
                   onUnpublish={() => {
                     void handleSubmit(undefined, "unpublish");

--- a/packages/admin/src/components/features/entries/EntryForm/EntryForm.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/EntryForm.tsx
@@ -78,6 +78,13 @@ export interface EntryFormProps {
   onCancel?: () => void;
   /** Active content locale (i18n M7) — saves target this language. */
   locale?: string;
+  /**
+   * Whether the parent read this entry with the working-draft overlay (`draft`).
+   * Forwarded to the update so its optimistic cache key matches the query on
+   * screen. Omit for the full-page editor (it reads the overlay for a drafts
+   * collection); an embedded editor reading the live row passes `false`.
+   */
+  readDraft?: boolean;
   /** Called when the user switches the active content language (i18n M7). */
   onLocaleChange?: (locale: string) => void;
   /**
@@ -183,6 +190,7 @@ export function EntryForm({
   onDelete,
   onCancel,
   locale,
+  readDraft,
   onLocaleChange,
   sourceValues,
   embedded = false,
@@ -201,6 +209,7 @@ export function EntryForm({
     entry,
     mode,
     locale,
+    readDraft,
     onSuccess: data => {
       onSuccess?.(data);
     },

--- a/packages/admin/src/components/features/entries/EntryForm/EntryMetaStrip.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/EntryMetaStrip.tsx
@@ -22,6 +22,10 @@ export interface EntryMetaStripProps {
   hasStatus: boolean;
   /** Current entry status ("draft" | "published" | other). Used for the pill. */
   status?: string | null;
+  /** Whether a pending working draft exists over a published entry
+   *  (draft/published split). When true the pill reads "Changed" instead of
+   *  "Published", mirroring the Document panel. Defaults to false. */
+  hasWorkingDraft?: boolean;
   /** Whether the rail is currently collapsed. Pill only renders when true,
    *  since DocumentPanel takes over that role when the rail is expanded. */
   isRailCollapsed: boolean;
@@ -39,6 +43,7 @@ export function EntryMetaStrip({
   slugField,
   hasStatus,
   status,
+  hasWorkingDraft = false,
   isRailCollapsed,
   lockSlug = false,
   hasPublicAddress = false,
@@ -50,7 +55,9 @@ export function EntryMetaStrip({
 
   return (
     <div className="px-6 py-2 border-b border-border flex items-center gap-3 text-xs text-muted-foreground">
-      {showStatusPill && <StatusPill status={status} />}
+      {showStatusPill && (
+        <StatusPill status={status} hasWorkingDraft={hasWorkingDraft} />
+      )}
       {showSlug && (
         <SlugInlineEditor
           slugField={slugField}
@@ -62,21 +69,34 @@ export function EntryMetaStrip({
   );
 }
 
-function StatusPill({ status }: { status: string }) {
+function StatusPill({
+  status,
+  hasWorkingDraft,
+}: {
+  status: string;
+  hasWorkingDraft: boolean;
+}) {
   const isPublished = status === "published";
+  // A published entry with a pending working draft is Payload's "Changed"
+  // state — the live row stays published while newer edits wait to be promoted.
+  const isChanged = isPublished && hasWorkingDraft;
   return (
     <span
       className={cn(
         "px-1.5 py-0.5 text-xs font-bold tracking-[0.1em] uppercase rounded shrink-0",
         // Why: Mobeen's request — neutral admin palette, not saturated. Use
         // muted bg + foreground/muted-foreground to blend with the rest of
-        // the chrome instead of standing out as candy-colour AI styling.
-        isPublished
-          ? "bg-muted text-foreground"
-          : "bg-muted text-muted-foreground"
+        // the chrome instead of standing out as candy-colour AI styling. The
+        // Changed state reuses the muted amber `warning` token (both modes) to
+        // match the Document panel's pending-changes pill.
+        isChanged
+          ? "bg-warning-100 text-warning-800 dark:bg-warning-950/40 dark:text-warning-200"
+          : isPublished
+            ? "bg-muted text-foreground"
+            : "bg-muted text-muted-foreground"
       )}
     >
-      {isPublished ? "Published" : "Draft"}
+      {isChanged ? "Changed" : isPublished ? "Published" : "Draft"}
     </span>
   );
 }

--- a/packages/admin/src/components/features/entries/EntryForm/EntrySystemHeader.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/EntrySystemHeader.tsx
@@ -105,7 +105,7 @@ export interface EntrySystemHeaderProps {
   /** Discard-working-draft handler (draft/published split). Throws away the
    *  pending working draft and reverts the editor to the live published row.
    *  Shown as a confirmed menu action for a Changed document. */
-  onDiscardWorkingDraft?: () => void;
+  onDiscardWorkingDraft?: () => void | Promise<void>;
   /** Discard / Cancel handler. */
   onCancel?: () => void;
   /** Delete handler (edit mode only). */
@@ -283,11 +283,15 @@ export function EntrySystemHeader({
     draftsEnabled &&
     (entry as { _isWorkingDraft?: boolean } | null | undefined)
       ?._isWorkingDraft === true;
-  // The "Discard draft" revert is offered only for a Changed document (a pending
-  // working draft over a published row) and only to a caller who may update it —
-  // the server gates the discard on update access.
-  const showDiscardDraft =
-    hasWorkingDraft && !!onDiscardWorkingDraft && canUpdateDocument;
+  // The "Discard draft" revert is offered for a Changed document (a pending
+  // working draft over a published row). The server authorizes it as an update,
+  // and the working-draft split is code-first only, so update can be granted by a
+  // collection `access.update` rule that the flat `update-{slug}` permission does
+  // not list. Gating on that permission here would hide Discard from an editor who
+  // can create and keep saving the very draft this reverts, so it is not gated on
+  // it — the sibling Save affordances are not either, and the endpoint refuses if
+  // the caller truly may not update.
+  const showDiscardDraft = hasWorkingDraft && !!onDiscardWorkingDraft;
   const entryLabel =
     typeof entry?.title === "string" && entry.title.trim().length > 0
       ? entry.title
@@ -581,9 +585,13 @@ export function EntrySystemHeader({
         open={discardDraftOpen}
         onOpenChange={setDiscardDraftOpen}
         entryLabel={entryLabel}
-        onConfirm={() => {
+        onConfirm={async () => {
+          // Keep the dialog open (and its in-flight spinner visible) while the
+          // discard runs, then close once it settles. Closing first — as this
+          // did — hid the progress state and dropped the retry context on a slow
+          // or failed request.
+          await onDiscardWorkingDraft?.();
           setDiscardDraftOpen(false);
-          onDiscardWorkingDraft?.();
         }}
         isLoading={isSubmitting}
       />

--- a/packages/admin/src/components/features/entries/EntryForm/EntrySystemHeader.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/EntrySystemHeader.tsx
@@ -587,11 +587,16 @@ export function EntrySystemHeader({
         entryLabel={entryLabel}
         onConfirm={async () => {
           // Keep the dialog open (and its in-flight spinner visible) while the
-          // discard runs, then close once it settles. Closing first — as this
-          // did — hid the progress state and dropped the retry context on a slow
-          // or failed request.
-          await onDiscardWorkingDraft?.();
-          setDiscardDraftOpen(false);
+          // discard runs, then close only once it SUCCEEDS. Closing first — as
+          // this did — hid the progress state; closing on failure too would drop
+          // the retry context. A rejection leaves the dialog open; its error was
+          // already surfaced by the mutation's onError toast.
+          try {
+            await onDiscardWorkingDraft?.();
+            setDiscardDraftOpen(false);
+          } catch {
+            // Stay open for a retry.
+          }
         }}
         isLoading={isSubmitting}
       />

--- a/packages/admin/src/components/features/entries/EntryForm/EntrySystemHeader.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/EntrySystemHeader.tsx
@@ -55,6 +55,11 @@ export interface EntrySystemHeaderProps {
   /** Whether the collection has the Draft/Published feature enabled.
    *  Splits the primary submit into Save Draft + Publish/Update. */
   hasStatus: boolean;
+  /** Whether the working-draft split is enabled (drafts on a versioned
+   *  collection). When `true`, editing a PUBLISHED entry saves a pending
+   *  working draft (live row untouched) instead of re-publishing, and a
+   *  separate Publish promotes it. */
+  draftsEnabled?: boolean;
   /** Whether the form is currently submitting. Disables buttons + spinner. */
   isSubmitting?: boolean;
   /** Whether the form has validation errors. Disables submit. */
@@ -84,9 +89,14 @@ export interface EntrySystemHeaderProps {
    *  Used in create mode and when promoting a draft to published. */
   onPublish?: () => void;
   /** Save changes handler — routed through useEntryForm.handleSubmit('save-changes').
-   *  Used when editing a published entry; submits dirty fields with
-   *  status="published" so the lifecycle stays the same. */
+   *  Used when editing a published entry on a NON-drafts collection; submits
+   *  dirty fields with status="published" so the lifecycle stays the same. */
   onSaveChanges?: () => void;
+  /** Save working draft handler — routed through
+   *  useEntryForm.handleSubmit('save-working-draft'). Used when editing a
+   *  published entry on a drafts-enabled collection: stores a pending working
+   *  draft (status-less) instead of writing the live row. */
+  onSaveWorkingDraft?: () => void;
   /** Unpublish handler — routed through useEntryForm.handleSubmit('unpublish').
    *  Fires only after the user confirms the modal. Sends `{ status: "draft" }`
    *  with no other field changes (matches Payload's Unpublish pattern). */
@@ -157,6 +167,7 @@ export function EntrySystemHeader({
   mode,
   titleField,
   hasStatus,
+  draftsEnabled = false,
   isSubmitting = false,
   isInvalid = false,
   isDirty = false,
@@ -168,6 +179,7 @@ export function EntrySystemHeader({
   onSaveDraft,
   onPublish,
   onSaveChanges,
+  onSaveWorkingDraft,
   onUnpublish,
   onCancel,
   onDelete,
@@ -257,6 +269,13 @@ export function EntrySystemHeader({
   // which ask the same question and must not answer it differently.
   const effectiveStatus = effectiveEntryStatus(entry, locale, defaultLocale);
   const isPublishedEdit = mode === "edit" && effectiveStatus === "published";
+  // A drafts-enabled published entry that has a pending working draft: the
+  // server flags the overlay read with `_isWorkingDraft`. This is Payload's
+  // "Changed" state — Publish promotes it and the status pill reflects it.
+  const hasWorkingDraft =
+    draftsEnabled &&
+    (entry as { _isWorkingDraft?: boolean } | null | undefined)
+      ?._isWorkingDraft === true;
   const entryLabel =
     typeof entry?.title === "string" && entry.title.trim().length > 0
       ? entry.title
@@ -318,15 +337,41 @@ export function EntrySystemHeader({
               variant="outline"
               size="sm"
               disabled={isSubmitting || isInvalid || !isDirty}
-              onClick={onSaveChanges}
-              data-status="save-changes"
+              // On a drafts-enabled collection a save on a published entry
+              // stores a working draft (live untouched); otherwise it re-asserts
+              // published, keeping the lifecycle unchanged.
+              onClick={draftsEnabled ? onSaveWorkingDraft : onSaveChanges}
+              data-status={
+                draftsEnabled ? "save-working-draft" : "save-changes"
+              }
             >
               {isSubmitting && <Loader2 className="h-3.5 w-3.5 animate-spin" />}
-              Save changes
+              {draftsEnabled ? "Save" : "Save changes"}
             </Button>
+            {/* Promote the pending working draft to live. Shown only when one
+                exists — a fully-published entry has nothing to promote. */}
+            {hasWorkingDraft && canPublishDocument && (
+              <Button
+                type="button"
+                size="sm"
+                disabled={isSubmitting || isInvalid}
+                onClick={onPublish}
+                data-status="published"
+              >
+                {isSubmitting ? (
+                  <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                ) : (
+                  <Globe className="h-3.5 w-3.5" />
+                )}
+                Publish
+              </Button>
+            )}
             {canUnpublishDocument && (
               <Button
                 type="button"
+                // Keep Publish the sole primary action when a draft is pending;
+                // otherwise Unpublish stays the primary (published-only) action.
+                variant={hasWorkingDraft ? "outline" : "default"}
                 size="sm"
                 disabled={isSubmitting}
                 onClick={() => setUnpublishOpen(true)}

--- a/packages/admin/src/components/features/entries/EntryForm/EntrySystemHeader.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/EntrySystemHeader.tsx
@@ -33,6 +33,7 @@ import { cn } from "@admin/lib/utils";
 import { useEntryLocale } from "../EntryLocaleContext";
 import { LanguageSwitcher } from "../LanguageSwitcher";
 
+import { DiscardDraftConfirmDialog } from "./DiscardDraftConfirmDialog";
 import { effectiveEntryStatus } from "./entry-address";
 import { ShowJSONDialog } from "./ShowJSONDialog";
 import { UnpublishConfirmDialog } from "./UnpublishConfirmDialog";
@@ -101,6 +102,10 @@ export interface EntrySystemHeaderProps {
    *  Fires only after the user confirms the modal. Sends `{ status: "draft" }`
    *  with no other field changes (matches Payload's Unpublish pattern). */
   onUnpublish?: () => void;
+  /** Discard-working-draft handler (draft/published split). Throws away the
+   *  pending working draft and reverts the editor to the live published row.
+   *  Shown as a confirmed menu action for a Changed document. */
+  onDiscardWorkingDraft?: () => void;
   /** Discard / Cancel handler. */
   onCancel?: () => void;
   /** Delete handler (edit mode only). */
@@ -181,6 +186,7 @@ export function EntrySystemHeader({
   onSaveChanges,
   onSaveWorkingDraft,
   onUnpublish,
+  onDiscardWorkingDraft,
   onCancel,
   onDelete,
   onDuplicate,
@@ -202,6 +208,7 @@ export function EntrySystemHeader({
   const { defaultLocale } = useLocalization();
   const inputRef = useRef<HTMLInputElement>(null);
   const [unpublishOpen, setUnpublishOpen] = useState(false);
+  const [discardDraftOpen, setDiscardDraftOpen] = useState(false);
   const [historyOpen, setHistoryOpen] = useState(false);
 
   // Both collections and singles authorize a document write as `update-{slug}`.
@@ -276,6 +283,11 @@ export function EntrySystemHeader({
     draftsEnabled &&
     (entry as { _isWorkingDraft?: boolean } | null | undefined)
       ?._isWorkingDraft === true;
+  // The "Discard draft" revert is offered only for a Changed document (a pending
+  // working draft over a published row) and only to a caller who may update it —
+  // the server gates the discard on update access.
+  const showDiscardDraft =
+    hasWorkingDraft && !!onDiscardWorkingDraft && canUpdateDocument;
   const entryLabel =
     typeof entry?.title === "string" && entry.title.trim().length > 0
       ? entry.title
@@ -452,6 +464,15 @@ export function EntrySystemHeader({
               </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end">
+              {showDiscardDraft && (
+                <DropdownMenuItem
+                  onClick={() => setDiscardDraftOpen(true)}
+                  disabled={isSubmitting}
+                >
+                  <RotateCcw className="h-3.5 w-3.5" />
+                  Discard draft
+                </DropdownMenuItem>
+              )}
               {isDirty && onCancel && (
                 <DropdownMenuItem onClick={onCancel} disabled={isSubmitting}>
                   <RotateCcw className="h-3.5 w-3.5" />
@@ -460,7 +481,9 @@ export function EntrySystemHeader({
               )}
               {onDuplicate && (
                 <>
-                  {isDirty && onCancel && <DropdownMenuSeparator />}
+                  {(showDiscardDraft || (isDirty && onCancel)) && (
+                    <DropdownMenuSeparator />
+                  )}
                   <DropdownMenuItem
                     onClick={onDuplicate}
                     disabled={isSubmitting}
@@ -547,6 +570,20 @@ export function EntrySystemHeader({
         onConfirm={() => {
           setUnpublishOpen(false);
           onUnpublish?.();
+        }}
+        isLoading={isSubmitting}
+      />
+
+      {/* Discarding a working draft deletes saved-but-unpublished edits, so it
+          is confirmed like Unpublish. Mounted at the root for the same reason:
+          it must survive whichever button-matrix branch rendered. */}
+      <DiscardDraftConfirmDialog
+        open={discardDraftOpen}
+        onOpenChange={setDiscardDraftOpen}
+        entryLabel={entryLabel}
+        onConfirm={() => {
+          setDiscardDraftOpen(false);
+          onDiscardWorkingDraft?.();
         }}
         isLoading={isSubmitting}
       />

--- a/packages/admin/src/components/features/entries/EntryForm/__tests__/DiscardDraftConfirmDialog.test.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/__tests__/DiscardDraftConfirmDialog.test.tsx
@@ -76,6 +76,26 @@ describe("DiscardDraftConfirmDialog", () => {
     expect(onConfirm).toHaveBeenCalledOnce();
   });
 
+  it("does not auto-close on confirm, so the caller controls when it closes", async () => {
+    // Radix AlertDialogAction closes the dialog on click by default; the action
+    // prevents that so the caller can keep it open (spinner visible) until the
+    // discard settles. `onOpenChange` firing here would be that auto-close.
+    const onOpenChange = vi.fn();
+    const onConfirm = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <DiscardDraftConfirmDialog
+        open
+        onOpenChange={onOpenChange}
+        entryLabel="Live post"
+        onConfirm={onConfirm}
+      />
+    );
+    await user.click(screen.getByRole("button", { name: /^Discard draft$/ }));
+    expect(onConfirm).toHaveBeenCalledOnce();
+    expect(onOpenChange).not.toHaveBeenCalled();
+  });
+
   it("disables both buttons while loading and renders the loading label", () => {
     render(
       <DiscardDraftConfirmDialog

--- a/packages/admin/src/components/features/entries/EntryForm/__tests__/DiscardDraftConfirmDialog.test.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/__tests__/DiscardDraftConfirmDialog.test.tsx
@@ -1,0 +1,92 @@
+/**
+ * Pins the confirm copy + confirm/cancel wiring. The dialog is a presentational
+ * wrapper around shadcn AlertDialog; the actual discard mutation lives in the
+ * parent's onConfirm callback. Discarding deletes saved-but-unpublished edits,
+ * so — unlike "Discard changes" — it is gated behind this confirm.
+ */
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi } from "vitest";
+
+import { render, screen } from "@admin/__tests__/utils";
+
+import { DiscardDraftConfirmDialog } from "../DiscardDraftConfirmDialog";
+
+describe("DiscardDraftConfirmDialog", () => {
+  it("renders the title with the provided entryLabel", () => {
+    render(
+      <DiscardDraftConfirmDialog
+        open
+        onOpenChange={vi.fn()}
+        entryLabel="Hello world"
+        onConfirm={vi.fn()}
+      />
+    );
+    expect(
+      screen.getByRole("alertdialog", {
+        name: /Discard draft for Hello world\?/,
+      })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/permanently deletes the unpublished changes/i)
+    ).toBeInTheDocument();
+  });
+
+  it("falls back to 'this entry' when entryLabel is empty/null/whitespace", () => {
+    const { rerender } = render(
+      <DiscardDraftConfirmDialog
+        open
+        onOpenChange={vi.fn()}
+        entryLabel={null}
+        onConfirm={vi.fn()}
+      />
+    );
+    expect(
+      screen.getByRole("alertdialog", {
+        name: /Discard draft for this entry\?/,
+      })
+    ).toBeInTheDocument();
+
+    rerender(
+      <DiscardDraftConfirmDialog
+        open
+        onOpenChange={vi.fn()}
+        entryLabel="   "
+        onConfirm={vi.fn()}
+      />
+    );
+    expect(
+      screen.getByRole("alertdialog", {
+        name: /Discard draft for this entry\?/,
+      })
+    ).toBeInTheDocument();
+  });
+
+  it("fires onConfirm when the user clicks Discard draft", async () => {
+    const onConfirm = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <DiscardDraftConfirmDialog
+        open
+        onOpenChange={vi.fn()}
+        entryLabel="Live post"
+        onConfirm={onConfirm}
+      />
+    );
+    await user.click(screen.getByRole("button", { name: /^Discard draft$/ }));
+    expect(onConfirm).toHaveBeenCalledOnce();
+  });
+
+  it("disables both buttons while loading and renders the loading label", () => {
+    render(
+      <DiscardDraftConfirmDialog
+        open
+        onOpenChange={vi.fn()}
+        entryLabel="Post"
+        onConfirm={vi.fn()}
+        isLoading
+      />
+    );
+    expect(screen.getByRole("button", { name: /^Cancel$/ })).toBeDisabled();
+    expect(screen.getByRole("button", { name: /Discarding/i })).toBeDisabled();
+  });
+});

--- a/packages/admin/src/components/features/entries/EntryForm/__tests__/EntryMetaStrip.status-pill.test.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/__tests__/EntryMetaStrip.status-pill.test.tsx
@@ -1,0 +1,48 @@
+/**
+ * The collapsed-rail status pill mirrors the Document panel's lifecycle state
+ * when the rail is hidden. It carries Draft / Published and the working-draft
+ * "Changed" state; local-dirty "Modified" stays a Document-panel-only affordance.
+ */
+import { describe, it, expect } from "vitest";
+
+import { render, screen } from "@admin/__tests__/utils";
+
+import { EntryMetaStrip } from "../EntryMetaStrip";
+
+describe("EntryMetaStrip — status pill", () => {
+  it("shows Published for a published entry when the rail is collapsed", () => {
+    render(<EntryMetaStrip hasStatus status="published" isRailCollapsed />);
+    expect(screen.getByText("Published")).toBeInTheDocument();
+  });
+
+  it("shows Draft for a draft entry when the rail is collapsed", () => {
+    render(<EntryMetaStrip hasStatus status="draft" isRailCollapsed />);
+    expect(screen.getByText("Draft")).toBeInTheDocument();
+  });
+
+  it("shows Changed when a published entry has a pending working draft", () => {
+    render(
+      <EntryMetaStrip
+        hasStatus
+        status="published"
+        isRailCollapsed
+        hasWorkingDraft
+      />
+    );
+    expect(screen.getByText("Changed")).toBeInTheDocument();
+    expect(screen.queryByText("Published")).not.toBeInTheDocument();
+  });
+
+  it("hides the pill while the rail is expanded (Document panel owns it)", () => {
+    render(
+      <EntryMetaStrip
+        hasStatus
+        status="published"
+        isRailCollapsed={false}
+        hasWorkingDraft
+      />
+    );
+    expect(screen.queryByText("Changed")).not.toBeInTheDocument();
+    expect(screen.queryByText("Published")).not.toBeInTheDocument();
+  });
+});

--- a/packages/admin/src/components/features/entries/EntryForm/__tests__/EntrySystemHeader.status-matrix.test.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/__tests__/EntrySystemHeader.status-matrix.test.tsx
@@ -7,6 +7,7 @@
  *  - !hasStatus → single Save / Create button
  *
  */
+import userEvent from "@testing-library/user-event";
 import { useForm, FormProvider } from "react-hook-form";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
@@ -41,6 +42,7 @@ interface HarnessProps {
     _isWorkingDraft?: boolean;
   } | null;
   isDirty?: boolean;
+  onDiscardWorkingDraft?: () => void;
 }
 
 function Harness({
@@ -49,6 +51,7 @@ function Harness({
   draftsEnabled = false,
   entry = null,
   isDirty = false,
+  onDiscardWorkingDraft,
 }: HarnessProps) {
   const methods = useForm({ defaultValues: { title: entry?.title ?? "" } });
   return (
@@ -65,6 +68,7 @@ function Harness({
         onSaveChanges={vi.fn()}
         onSaveWorkingDraft={vi.fn()}
         onUnpublish={vi.fn()}
+        onDiscardWorkingDraft={onDiscardWorkingDraft ?? vi.fn()}
       />
     </FormProvider>
   );
@@ -210,6 +214,58 @@ describe("EntrySystemHeader — drafts-enabled working-draft matrix", () => {
     expect(
       screen.getByRole("button", { name: /^unpublish$/i })
     ).toBeInTheDocument();
+  });
+});
+
+describe("EntrySystemHeader — discard working draft menu", () => {
+  it("offers Discard draft in the More menu for a Changed document", async () => {
+    const user = userEvent.setup();
+    render(
+      <Harness
+        mode="edit"
+        draftsEnabled
+        entry={{ id: "x", status: "published", _isWorkingDraft: true }}
+      />
+    );
+
+    await user.click(screen.getByRole("button", { name: /more actions/i }));
+    expect(
+      screen.getByRole("menuitem", { name: /discard draft/i })
+    ).toBeInTheDocument();
+  });
+
+  it("hides Discard draft when there is no pending working draft", async () => {
+    const user = userEvent.setup();
+    render(
+      <Harness
+        mode="edit"
+        draftsEnabled
+        entry={{ id: "x", status: "published" }}
+      />
+    );
+
+    await user.click(screen.getByRole("button", { name: /more actions/i }));
+    expect(
+      screen.queryByRole("menuitem", { name: /discard draft/i })
+    ).not.toBeInTheDocument();
+  });
+
+  it("hides Discard draft when the caller cannot update the document", async () => {
+    // The server gates the discard on update access, so the affordance is too.
+    canFor.mockImplementation((slug: string) => slug !== "update-posts");
+    const user = userEvent.setup();
+    render(
+      <Harness
+        mode="edit"
+        draftsEnabled
+        entry={{ id: "x", status: "published", _isWorkingDraft: true }}
+      />
+    );
+
+    await user.click(screen.getByRole("button", { name: /more actions/i }));
+    expect(
+      screen.queryByRole("menuitem", { name: /discard draft/i })
+    ).not.toBeInTheDocument();
   });
 });
 

--- a/packages/admin/src/components/features/entries/EntryForm/__tests__/EntrySystemHeader.status-matrix.test.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/__tests__/EntrySystemHeader.status-matrix.test.tsx
@@ -42,7 +42,7 @@ interface HarnessProps {
     _isWorkingDraft?: boolean;
   } | null;
   isDirty?: boolean;
-  onDiscardWorkingDraft?: () => void;
+  onDiscardWorkingDraft?: () => void | Promise<void>;
 }
 
 function Harness({
@@ -269,6 +269,32 @@ describe("EntrySystemHeader — discard working draft menu", () => {
     await user.click(screen.getByRole("button", { name: /more actions/i }));
     expect(
       screen.getByRole("menuitem", { name: /discard draft/i })
+    ).toBeInTheDocument();
+  });
+
+  it("keeps the confirm dialog open when the discard fails, for a retry", async () => {
+    // The discard handler rejects on failure, and the header closes the dialog
+    // only on success — so a failed destructive request keeps its confirmation
+    // (and the error toast from the mutation explains what went wrong).
+    const onDiscardWorkingDraft = vi.fn().mockRejectedValue(new Error("nope"));
+    const user = userEvent.setup();
+    render(
+      <Harness
+        mode="edit"
+        draftsEnabled
+        entry={{ id: "x", status: "published", _isWorkingDraft: true }}
+        onDiscardWorkingDraft={onDiscardWorkingDraft}
+      />
+    );
+
+    await user.click(screen.getByRole("button", { name: /more actions/i }));
+    await user.click(screen.getByRole("menuitem", { name: /discard draft/i }));
+    await user.click(screen.getByRole("button", { name: /^Discard draft$/ }));
+
+    expect(onDiscardWorkingDraft).toHaveBeenCalledOnce();
+    // Still open: the rejection was caught and the dialog was not closed.
+    expect(
+      await screen.findByRole("alertdialog", { name: /discard draft for/i })
     ).toBeInTheDocument();
   });
 });

--- a/packages/admin/src/components/features/entries/EntryForm/__tests__/EntrySystemHeader.status-matrix.test.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/__tests__/EntrySystemHeader.status-matrix.test.tsx
@@ -32,11 +32,13 @@ beforeEach(() => {
 interface HarnessProps {
   mode: "create" | "edit";
   hasStatus?: boolean;
+  draftsEnabled?: boolean;
   entry?: {
     id: string;
     status?: string;
     title?: string;
     slug?: string;
+    _isWorkingDraft?: boolean;
   } | null;
   isDirty?: boolean;
 }
@@ -44,6 +46,7 @@ interface HarnessProps {
 function Harness({
   mode,
   hasStatus = true,
+  draftsEnabled = false,
   entry = null,
   isDirty = false,
 }: HarnessProps) {
@@ -53,12 +56,14 @@ function Harness({
       <EntrySystemHeader
         mode={mode}
         hasStatus={hasStatus}
+        draftsEnabled={draftsEnabled}
         isDirty={isDirty}
         entry={entry}
         collectionSlug="posts"
         onSaveDraft={vi.fn()}
         onPublish={vi.fn()}
         onSaveChanges={vi.fn()}
+        onSaveWorkingDraft={vi.fn()}
         onUnpublish={vi.fn()}
       />
     </FormProvider>
@@ -156,6 +161,55 @@ describe("EntrySystemHeader — button matrix", () => {
     expect(
       screen.queryByRole("button", { name: /^unpublish$/i })
     ).not.toBeInTheDocument();
+  });
+});
+
+describe("EntrySystemHeader — drafts-enabled working-draft matrix", () => {
+  it("published + drafts on, no pending draft → Save (not Save changes), Unpublish, no Publish", () => {
+    render(
+      <Harness
+        mode="edit"
+        draftsEnabled
+        entry={{ id: "x", status: "published", title: "Live" }}
+        isDirty
+      />
+    );
+    // The primary save on a drafts collection stores a working draft, so it
+    // reads "Save" rather than "Save changes"; nothing is pending to promote.
+    expect(screen.getByRole("button", { name: /^save$/i })).toBeEnabled();
+    expect(
+      screen.queryByRole("button", { name: /^save changes$/i })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /^publish$/i })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /^unpublish$/i })
+    ).toBeInTheDocument();
+  });
+
+  it("published + drafts on + pending working draft → Save + Publish + Unpublish", () => {
+    render(
+      <Harness
+        mode="edit"
+        draftsEnabled
+        entry={{
+          id: "x",
+          status: "published",
+          title: "Live",
+          _isWorkingDraft: true,
+        }}
+      />
+    );
+    // A pending working draft can be promoted, so Publish appears alongside the
+    // status-less Save and the Unpublish action.
+    expect(screen.getByRole("button", { name: /^save$/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /^publish$/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /^unpublish$/i })
+    ).toBeInTheDocument();
   });
 });
 

--- a/packages/admin/src/components/features/entries/EntryForm/__tests__/EntrySystemHeader.status-matrix.test.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/__tests__/EntrySystemHeader.status-matrix.test.tsx
@@ -250,8 +250,12 @@ describe("EntrySystemHeader — discard working draft menu", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("hides Discard draft when the caller cannot update the document", async () => {
-    // The server gates the discard on update access, so the affordance is too.
+  it("keeps Discard draft without the flat update permission, since a code-first rule may grant it", async () => {
+    // The working-draft split is code-first only, so update can be granted by a
+    // collection `access.update` rule the flat `update-posts` permission does not
+    // list. Gating on that permission would hide Discard from an editor who can
+    // save the very draft it reverts; the server authorizes the discard as an
+    // update, and the sibling Save affordances are not gated on it either.
     canFor.mockImplementation((slug: string) => slug !== "update-posts");
     const user = userEvent.setup();
     render(
@@ -264,8 +268,8 @@ describe("EntrySystemHeader — discard working draft menu", () => {
 
     await user.click(screen.getByRole("button", { name: /more actions/i }));
     expect(
-      screen.queryByRole("menuitem", { name: /discard draft/i })
-    ).not.toBeInTheDocument();
+      screen.getByRole("menuitem", { name: /discard draft/i })
+    ).toBeInTheDocument();
   });
 });
 

--- a/packages/admin/src/components/features/entries/EntryForm/__tests__/useEntryForm.intent.test.ts
+++ b/packages/admin/src/components/features/entries/EntryForm/__tests__/useEntryForm.intent.test.ts
@@ -52,6 +52,15 @@ describe("mapIntentToPayload", () => {
     expect(mapIntentToPayload(RAW, undefined)).toEqual(RAW);
   });
 
+  it("save-working-draft → passes rawData through without a status", () => {
+    // Why: a status-less save on a drafts-enabled published entry is exactly
+    // what tells the server to store a pending working draft and leave the
+    // live row untouched. Injecting any status would re-write the live row.
+    const result = mapIntentToPayload(RAW, "save-working-draft");
+    expect(result).toEqual(RAW);
+    expect(result).not.toHaveProperty("status");
+  });
+
   it("does not mutate the input rawData object", () => {
     const input = { ...RAW };
     mapIntentToPayload(input, "publish");

--- a/packages/admin/src/components/features/entries/EntryForm/__tests__/useEntryForm.intent.test.ts
+++ b/packages/admin/src/components/features/entries/EntryForm/__tests__/useEntryForm.intent.test.ts
@@ -7,7 +7,11 @@
  */
 import { describe, it, expect } from "vitest";
 
-import { mapIntentToPayload, passwordFieldNames } from "../useEntryForm";
+import {
+  mapIntentToPayload,
+  passwordFieldNames,
+  resolveDefaultSaveIntent,
+} from "../useEntryForm";
 
 const RAW = { title: "Hello", body: "Body content", customField: 42 };
 
@@ -134,5 +138,60 @@ describe("passwordFieldNames", () => {
       },
     ] as unknown as Parameters<typeof passwordFieldNames>[0];
     expect(passwordFieldNames(fields)).toEqual(new Set());
+  });
+});
+
+describe("resolveDefaultSaveIntent", () => {
+  const base = { mode: "edit" as const, hasStatus: true, draftsEnabled: true };
+
+  it("published + drafts on → save-working-draft", () => {
+    expect(
+      resolveDefaultSaveIntent({ ...base, effectiveStatus: "published" })
+    ).toBe("save-working-draft");
+  });
+
+  it("published + drafts off → save-changes", () => {
+    expect(
+      resolveDefaultSaveIntent({
+        ...base,
+        draftsEnabled: false,
+        effectiveStatus: "published",
+      })
+    ).toBe("save-changes");
+  });
+
+  it("draft → save-draft", () => {
+    expect(
+      resolveDefaultSaveIntent({ ...base, effectiveStatus: "draft" })
+    ).toBe("save-draft");
+  });
+
+  it("an unpublished translation (no active-locale status) saves a draft, not save-changes", () => {
+    // The core of the fix: on a non-default locale the main row may be published
+    // while this translation is not, so effectiveStatus is undefined. Keying off
+    // it saves a draft rather than re-publishing the wrong language.
+    expect(
+      resolveDefaultSaveIntent({ ...base, effectiveStatus: undefined })
+    ).toBe("save-draft");
+  });
+
+  it("non-status collection → no lifecycle intent", () => {
+    expect(
+      resolveDefaultSaveIntent({
+        ...base,
+        hasStatus: false,
+        effectiveStatus: "published",
+      })
+    ).toBeUndefined();
+  });
+
+  it("create mode → no lifecycle intent", () => {
+    expect(
+      resolveDefaultSaveIntent({
+        ...base,
+        mode: "create",
+        effectiveStatus: undefined,
+      })
+    ).toBeUndefined();
   });
 });

--- a/packages/admin/src/components/features/entries/EntryForm/panels/DocumentPanel.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/panels/DocumentPanel.tsx
@@ -38,15 +38,23 @@ export interface DocumentPanelProps {
 }
 
 /**
- * Derive the displayed pill state from the persisted status + form dirty.
- * "Modified" only applies to published entries with local changes; drafts
- * stay drafts regardless of dirty (drafts are inherently work-in-progress).
+ * Derive the displayed pill state from the persisted status, the form dirty
+ * flag, and whether a working draft is pending.
+ *
+ * - "Changed" — a published entry with a persisted working draft waiting to be
+ *   promoted (Payload's model). This is the authoritative divergence from live,
+ *   so it wins over "Modified": the enabled Save button already signals any
+ *   extra unsaved local edits.
+ * - "Modified" — a published entry with local edits not yet saved. Drafts never
+ *   show Modified (they are inherently work-in-progress).
  */
-export type PillState = "draft" | "modified" | "published";
+export type PillState = "draft" | "modified" | "changed" | "published";
 export function pillStateFromForm(
   status: string | undefined,
-  isDirty: boolean
+  isDirty: boolean,
+  hasWorkingDraft = false
 ): PillState {
+  if (status === "published" && hasWorkingDraft) return "changed";
   if (status === "published" && isDirty) return "modified";
   return status === "published" ? "published" : "draft";
 }
@@ -80,7 +88,16 @@ export function DocumentPanel({
   // Hide entirely on create — nothing to show until the entry exists.
   if (isCreate) return null;
 
-  const pill = pillStateFromForm(entry?.status as string | undefined, isDirty);
+  // A published entry whose overlay read carried `_isWorkingDraft` has a pending
+  // working draft (draft/published split) — surfaced as the "Changed" state.
+  const hasWorkingDraft =
+    (entry as { _isWorkingDraft?: boolean } | null | undefined)
+      ?._isWorkingDraft === true;
+  const pill = pillStateFromForm(
+    entry?.status as string | undefined,
+    isDirty,
+    hasWorkingDraft
+  );
 
   // i18n M7: per-language translation-status pills (spec §10). Present only when the entry was
   // fetched with `?translation-status=1` on a localized collection; inert otherwise.
@@ -151,18 +168,24 @@ function RowIcon({ icon: Icon }: { icon: typeof Hash }) {
 function StatusRow({ state }: { state: PillState }) {
   // Why: heavier pill than the meta-strip variant — matched padding and
   // font weight so the lifecycle state reads as the most important row.
-  // The Modified state uses amber-50/foreground (light) and amber-200
-  // text on a transparent bg (dark) — distinct from Draft (neutral) and
-  // Published (foreground/background). Avoids saturated AI-style hues.
+  // Both pending states use the muted amber `warning` token (light + dark) —
+  // distinct from Draft (neutral) and Published (foreground/background), and
+  // avoiding saturated AI-style hues. "Modified" flags unsaved local edits;
+  // "Changed" flags a persisted working draft pending publish. They share the
+  // colour because both mean "diverges from what's live"; the label says which,
+  // and pillStateFromForm guarantees they never render at once.
   const PILL_CLASS: Record<PillState, string> = {
     draft: "bg-muted text-muted-foreground border border-border",
     modified:
+      "bg-warning-100 text-warning-800 border border-warning-200 dark:bg-warning-950/40 dark:text-warning-200 dark:border-warning-900",
+    changed:
       "bg-warning-100 text-warning-800 border border-warning-200 dark:bg-warning-950/40 dark:text-warning-200 dark:border-warning-900",
     published: "bg-foreground text-background",
   };
   const PILL_LABEL: Record<PillState, string> = {
     draft: "Draft",
     modified: "Modified",
+    changed: "Changed",
     published: "Published",
   };
   return (

--- a/packages/admin/src/components/features/entries/EntryForm/panels/__tests__/DocumentPanel.test.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/panels/__tests__/DocumentPanel.test.tsx
@@ -167,6 +167,33 @@ describe("DocumentPanel", () => {
     expect(screen.getByText("Draft")).toBeInTheDocument();
     expect(screen.queryByText("Modified")).not.toBeInTheDocument();
   });
+
+  it("renders the Changed pill when a published entry has a pending working draft", () => {
+    // The server flags an overlay read with `_isWorkingDraft` while keeping the
+    // status at the live parent's "published"; that pairing is "Changed".
+    render(
+      <DocumentPanel
+        mode="edit"
+        entry={{ id: "x", status: "published", _isWorkingDraft: true }}
+        hasStatus
+      />
+    );
+    expect(screen.getByText("Changed")).toBeInTheDocument();
+    expect(screen.queryByText("Published")).not.toBeInTheDocument();
+  });
+
+  it("shows Changed (not Modified) when a working draft exists and the form is dirty", () => {
+    render(
+      <DocumentPanel
+        mode="edit"
+        entry={{ id: "x", status: "published", _isWorkingDraft: true }}
+        hasStatus
+        isDirty
+      />
+    );
+    expect(screen.getByText("Changed")).toBeInTheDocument();
+    expect(screen.queryByText("Modified")).not.toBeInTheDocument();
+  });
 });
 
 describe("pillStateFromForm", () => {
@@ -186,5 +213,27 @@ describe("pillStateFromForm", () => {
   it("returns 'draft' when status is undefined", () => {
     expect(pillStateFromForm(undefined, false)).toBe("draft");
     expect(pillStateFromForm(undefined, true)).toBe("draft");
+  });
+
+  it("returns 'changed' when published with a pending working draft", () => {
+    // A persisted working draft over a published row is the "Changed"
+    // lifecycle state (Payload's model): live is published, edits pend.
+    expect(pillStateFromForm("published", false, true)).toBe("changed");
+  });
+
+  it("prefers 'changed' over 'modified' when a working draft also has local edits", () => {
+    // The persisted working draft is the authoritative divergence; the enabled
+    // Save button already signals the extra unsaved edits, so 'changed' wins.
+    expect(pillStateFromForm("published", true, true)).toBe("changed");
+  });
+
+  it("stays 'draft' for a draft entry even if a working-draft flag is passed", () => {
+    // The working-draft overlay only ever applies to a published parent, so a
+    // draft-status entry is a plain draft, never 'changed'.
+    expect(pillStateFromForm("draft", false, true)).toBe("draft");
+  });
+
+  it("defaults hasWorkingDraft to false so a clean published entry is 'published'", () => {
+    expect(pillStateFromForm("published", false)).toBe("published");
   });
 });

--- a/packages/admin/src/components/features/entries/EntryForm/useEntryForm.ts
+++ b/packages/admin/src/components/features/entries/EntryForm/useEntryForm.ts
@@ -305,9 +305,9 @@ export interface UseEntryFormReturn {
   /** Handle entry deletion (edit mode only) */
   handleDelete: () => void;
   /** Discard the pending working draft (draft/published split), reverting the
-   *  editor to the live published row. No-op outside edit mode. Resolves when the
-   *  discard settles, so the confirm dialog can stay open (showing its progress)
-   *  until then. */
+   *  editor to the live published row. No-op outside edit mode. Resolves once the
+   *  discard succeeds and REJECTS if it fails, so the confirm dialog can show its
+   *  progress until then and stay open for a retry on failure. */
   handleDiscardWorkingDraft: () => Promise<void>;
   /** Handle form cancellation */
   handleCancel: () => void;
@@ -770,6 +770,10 @@ export function useEntryForm({
     } catch (error) {
       console.error("Discard working draft error:", error);
       onError?.(error);
+      // Rethrow after surfacing the error so the confirm dialog, which awaits
+      // this, stays open on failure and keeps its retry context rather than
+      // closing as it does on success.
+      throw error;
     }
   }, [mode, entry?.id, discardMutation, form, fields, onError]);
 

--- a/packages/admin/src/components/features/entries/EntryForm/useEntryForm.ts
+++ b/packages/admin/src/components/features/entries/EntryForm/useEntryForm.ts
@@ -19,6 +19,7 @@ import { z } from "zod";
 
 import { useCreateEntry } from "@admin/hooks/queries/useCreateEntry";
 import { useDeleteEntry } from "@admin/hooks/queries/useDeleteEntry";
+import { useDiscardWorkingDraft } from "@admin/hooks/queries/useDiscardWorkingDraft";
 import { useUpdateEntry } from "@admin/hooks/queries/useUpdateEntry";
 import { generateClientSchema } from "@admin/lib/field-validation";
 import type { EntryValue } from "@admin/types/collection";
@@ -268,6 +269,9 @@ export interface UseEntryFormReturn {
   ) => Promise<void>;
   /** Handle entry deletion (edit mode only) */
   handleDelete: () => void;
+  /** Discard the pending working draft (draft/published split), reverting the
+   *  editor to the live published row. No-op outside edit mode. */
+  handleDiscardWorkingDraft: () => void;
   /** Handle form cancellation */
   handleCancel: () => void;
   /** Whether form is currently submitting */
@@ -631,6 +635,11 @@ export function useEntryForm({
     showToast: true,
   });
 
+  const discardMutation = useDiscardWorkingDraft({
+    collectionSlug: collection.name,
+    entryId: entry?.id ?? "",
+  });
+
   // Singular label for UI
   const singularLabel = getSingularLabel(collection);
 
@@ -704,6 +713,23 @@ export function useEntryForm({
     }
   }, [mode, entry?.id, deleteMutation, onDelete, onError]);
 
+  // Discard handler (draft/published split). Throws away the pending working
+  // draft and resets the editor to the live published values the discard
+  // returns; the hook also invalidates the entry so the cache refetches the
+  // same row. A no-op outside edit mode or before the entry exists.
+  const handleDiscardWorkingDraft = useCallback(async () => {
+    if (mode !== "edit" || !entry?.id) {
+      return;
+    }
+    try {
+      const result = await discardMutation.mutateAsync();
+      form.reset(getDefaultValues(fields, result.item));
+    } catch (error) {
+      console.error("Discard working draft error:", error);
+      onError?.(error);
+    }
+  }, [mode, entry?.id, discardMutation, form, fields, onError]);
+
   // Cancel handler
   const handleCancel = useCallback(() => {
     onCancel?.();
@@ -715,8 +741,14 @@ export function useEntryForm({
     handleDelete: () => {
       void handleDelete();
     },
+    handleDiscardWorkingDraft: () => {
+      void handleDiscardWorkingDraft();
+    },
     handleCancel,
-    isSubmitting: createMutation.isPending || updateMutation.isPending,
+    isSubmitting:
+      createMutation.isPending ||
+      updateMutation.isPending ||
+      discardMutation.isPending,
     isDeleting: deleteMutation.isPending,
     isDirty: form.formState.isDirty,
     mode,

--- a/packages/admin/src/components/features/entries/EntryForm/useEntryForm.ts
+++ b/packages/admin/src/components/features/entries/EntryForm/useEntryForm.ts
@@ -254,6 +254,31 @@ export function mapIntentToPayload(
 }
 
 /**
+ * The submit intent a plain save (the keyboard Cmd/Ctrl+S shortcut) uses for an
+ * editor in a given lifecycle state, mirroring the primary Save button.
+ *
+ * `effectiveStatus` is the ACTIVE locale's status (from `effectiveEntryStatus`),
+ * not the main row's: on a non-default language the main row carries the default
+ * language's lifecycle, so keying the shortcut off it could publish or unpublish
+ * the wrong translation. A published document stores a working draft on a drafts
+ * collection or re-asserts published otherwise; any other state saves a draft; a
+ * non-status collection has no lifecycle intent (its single Save button submits
+ * without one).
+ */
+export function resolveDefaultSaveIntent(args: {
+  mode: EntryFormMode;
+  hasStatus: boolean;
+  effectiveStatus: string | undefined;
+  draftsEnabled: boolean;
+}): EntryFormIntent | undefined {
+  if (args.mode !== "edit" || !args.hasStatus) return undefined;
+  if (args.effectiveStatus === "published") {
+    return args.draftsEnabled ? "save-working-draft" : "save-changes";
+  }
+  return "save-draft";
+}
+
+/**
  * Return type for useEntryForm hook
  */
 export interface UseEntryFormReturn {
@@ -621,6 +646,10 @@ export function useEntryForm({
     setError: form.setError,
     // i18n M7: route the save to the active content language.
     locale,
+    // Match the editor's read mode so the optimistic update keys onto the same
+    // cached document the form is showing (the entry page reads with this same
+    // `draft` flag when the working-draft split is enabled).
+    draft: collection.draftsEnabled === true,
   });
 
   // Password fields submit "" to mean "keep the stored hash", so they are

--- a/packages/admin/src/components/features/entries/EntryForm/useEntryForm.ts
+++ b/packages/admin/src/components/features/entries/EntryForm/useEntryForm.ts
@@ -92,6 +92,14 @@ export interface EntryFormCollection {
    * Backed by the `dynamic_collections.localized` boolean column.
    */
   localized?: boolean;
+  /**
+   * Whether the draft/published working-draft split is enabled (drafts on a
+   * versioned collection). When `true` on a `status` collection, saving an
+   * already-published entry stores a pending working draft instead of writing
+   * the live row; a separate Publish promotes it. Read-only, derived
+   * server-side — only code-first collections enable it.
+   */
+  draftsEnabled?: boolean;
 }
 
 /**
@@ -149,6 +157,7 @@ export interface UseEntryFormOptions {
 export type EntryFormIntent =
   | "save-draft"
   | "publish"
+  | "save-working-draft"
   | "save-changes"
   | "unpublish";
 
@@ -228,6 +237,12 @@ export function mapIntentToPayload(
       return { ...data, status: "draft" };
     case "publish":
       return { ...data, status: "published" };
+    case "save-working-draft":
+      // A status-less save on a drafts-enabled, already-published entry: the
+      // server stores the pending edit as a working draft and leaves the live
+      // row untouched (draft/published split). Omitting `status` is exactly
+      // what triggers that; a later Publish promotes the draft to live.
+      return data;
     case "save-changes":
       return { ...data, status: "published" };
     case "unpublish":

--- a/packages/admin/src/components/features/entries/EntryForm/useEntryForm.ts
+++ b/packages/admin/src/components/features/entries/EntryForm/useEntryForm.ts
@@ -142,6 +142,16 @@ export interface UseEntryFormOptions {
   onCancel?: () => void;
   /** Active content locale (i18n M7) — the update targets this language's values. */
   locale?: string;
+  /**
+   * Whether the entry was READ with the working-draft overlay (`draft`), so the
+   * update's optimistic cache key matches the query the form is showing. The
+   * full-page editor reads the overlay for a drafts collection; an embedded
+   * editor (relationship quick-edit) reads the live row, so it must say so here
+   * or its optimistic update, rollback, and `cancelQueries` would target a
+   * different `detailScoped` key than the one on screen. Defaults to the
+   * collection's split when unset — the full-page editor's read mode.
+   */
+  readDraft?: boolean;
 }
 
 /**
@@ -295,8 +305,10 @@ export interface UseEntryFormReturn {
   /** Handle entry deletion (edit mode only) */
   handleDelete: () => void;
   /** Discard the pending working draft (draft/published split), reverting the
-   *  editor to the live published row. No-op outside edit mode. */
-  handleDiscardWorkingDraft: () => void;
+   *  editor to the live published row. No-op outside edit mode. Resolves when the
+   *  discard settles, so the confirm dialog can stay open (showing its progress)
+   *  until then. */
+  handleDiscardWorkingDraft: () => Promise<void>;
   /** Handle form cancellation */
   handleCancel: () => void;
   /** Whether form is currently submitting */
@@ -578,6 +590,7 @@ export function useEntryForm({
   onDelete,
   onCancel,
   locale,
+  readDraft,
 }: UseEntryFormOptions): UseEntryFormReturn {
   // Get fields from collection (supports both old and new API formats)
   const fields = getCollectionFields(collection);
@@ -646,10 +659,11 @@ export function useEntryForm({
     setError: form.setError,
     // i18n M7: route the save to the active content language.
     locale,
-    // Match the editor's read mode so the optimistic update keys onto the same
-    // cached document the form is showing (the entry page reads with this same
-    // `draft` flag when the working-draft split is enabled).
-    draft: collection.draftsEnabled === true,
+    // Match the editor's read mode so the optimistic update, rollback, and
+    // cancelQueries key onto the same cached document the form is showing. The
+    // caller passes how it read the entry; absent that, assume the full-page
+    // editor's mode (the working-draft overlay for a drafts collection).
+    draft: readDraft ?? collection.draftsEnabled === true,
   });
 
   // Password fields submit "" to mean "keep the stored hash", so they are
@@ -770,9 +784,9 @@ export function useEntryForm({
     handleDelete: () => {
       void handleDelete();
     },
-    handleDiscardWorkingDraft: () => {
-      void handleDiscardWorkingDraft();
-    },
+    // Returned as a promise (not fire-and-forget) so the confirm dialog can
+    // await the discard and keep its loading state visible until it settles.
+    handleDiscardWorkingDraft: () => handleDiscardWorkingDraft(),
     handleCancel,
     isSubmitting:
       createMutation.isPending ||

--- a/packages/admin/src/components/features/entries/fields/relational/RelationshipQuickEdit.tsx
+++ b/packages/admin/src/components/features/entries/fields/relational/RelationshipQuickEdit.tsx
@@ -122,6 +122,16 @@ function ModalContent({
   // are still drafts.
   const { enabled: localizationEnabled } = useLocalization();
 
+  // Read the pending working draft in place of the live row when the related
+  // collection has the draft/published split, exactly as the full-page editor
+  // does. Reading the live row here instead would clobber the sidecar on save:
+  // the embedded form submits with no intent, so every live-loaded field is sent
+  // and the server merges those older live values over the saved draft. Showing
+  // and saving onto the draft keeps quick-edit consistent and non-destructive.
+  const draftsEnabled =
+    (collection as { draftsEnabled?: boolean } | undefined)?.draftsEnabled ===
+    true;
+
   const {
     data: entry,
     isLoading: isLoadingEntry,
@@ -131,6 +141,7 @@ function ModalContent({
     entryId,
     enabled: !!collectionSlug && !!entryId,
     translationStatus: localizationEnabled,
+    draft: draftsEnabled,
   });
 
   const isLoading = isLoadingCollection || isLoadingEntry;
@@ -193,9 +204,9 @@ function ModalContent({
       entry={entry}
       mode="edit"
       embedded
-      // This modal reads the live row (no working-draft overlay), so the update
-      // keys its optimistic cache onto that same query rather than the drafts one.
-      readDraft={false}
+      // Match the working-draft overlay this modal reads with, so the update keys
+      // its optimistic cache onto the same query the form is showing.
+      readDraft={draftsEnabled}
       onSuccess={updatedEntry => onUpdate(updatedEntry)}
       onCancel={onCancel}
     />

--- a/packages/admin/src/components/features/entries/fields/relational/RelationshipQuickEdit.tsx
+++ b/packages/admin/src/components/features/entries/fields/relational/RelationshipQuickEdit.tsx
@@ -193,6 +193,9 @@ function ModalContent({
       entry={entry}
       mode="edit"
       embedded
+      // This modal reads the live row (no working-draft overlay), so the update
+      // keys its optimistic cache onto that same query rather than the drafts one.
+      readDraft={false}
       onSuccess={updatedEntry => onUpdate(updatedEntry)}
       onCancel={onCancel}
     />

--- a/packages/admin/src/hooks/queries/__tests__/useDiscardWorkingDraft.test.tsx
+++ b/packages/admin/src/hooks/queries/__tests__/useDiscardWorkingDraft.test.tsx
@@ -1,0 +1,90 @@
+/**
+ * Discarding a working draft removes the sidecar and returns the live row. The
+ * cache consequence worth pinning: the entry DETAIL must be invalidated so the
+ * editor (which reads with `?draft=1`) refetches the now-published document,
+ * while list/count caches stay untouched because the live row never changed.
+ */
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { discardSpy, toastSuccessSpy, toastErrorSpy } = vi.hoisted(() => ({
+  discardSpy: vi.fn(),
+  toastSuccessSpy: vi.fn(),
+  toastErrorSpy: vi.fn(),
+}));
+
+vi.mock("@admin/services/versionApi", () => ({
+  versionApi: { discardWorkingDraft: discardSpy },
+}));
+
+vi.mock("@admin/components/ui", () => ({
+  toast: { success: toastSuccessSpy, error: toastErrorSpy },
+}));
+
+import { entryKeys } from "@admin/services/entryApi";
+
+import { useDiscardWorkingDraft } from "../useDiscardWorkingDraft";
+
+function makeWrapper(client: QueryClient) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={client}>{children}</QueryClientProvider>
+    );
+  };
+}
+
+function makeClient() {
+  return new QueryClient({
+    defaultOptions: { mutations: { retry: false } },
+  });
+}
+
+describe("useDiscardWorkingDraft", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("calls the collection-scoped endpoint, invalidates the detail, and toasts on success", async () => {
+    const client = makeClient();
+    const invalidateSpy = vi.spyOn(client, "invalidateQueries");
+    discardSpy.mockResolvedValue({
+      message: "Working draft discarded.",
+      item: { id: "e1", status: "published" },
+    });
+
+    const { result } = renderHook(
+      () => useDiscardWorkingDraft({ collectionSlug: "posts", entryId: "e1" }),
+      { wrapper: makeWrapper(client) }
+    );
+
+    await result.current.mutateAsync();
+
+    expect(discardSpy).toHaveBeenCalledWith({
+      kind: "collection",
+      slug: "posts",
+      entryId: "e1",
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: entryKeys.detail("posts", "e1"),
+    });
+    expect(toastSuccessSpy).toHaveBeenCalledWith("Working draft discarded");
+  });
+
+  it("toasts the error and does not invalidate on failure", async () => {
+    const client = makeClient();
+    const invalidateSpy = vi.spyOn(client, "invalidateQueries");
+    discardSpy.mockRejectedValue(new Error("nope"));
+
+    const { result } = renderHook(
+      () => useDiscardWorkingDraft({ collectionSlug: "posts", entryId: "e1" }),
+      { wrapper: makeWrapper(client) }
+    );
+
+    await expect(result.current.mutateAsync()).rejects.toThrow("nope");
+
+    expect(invalidateSpy).not.toHaveBeenCalled();
+    expect(toastErrorSpy).toHaveBeenCalledWith(
+      "Failed to discard working draft: nope"
+    );
+  });
+});

--- a/packages/admin/src/hooks/queries/__tests__/useDiscardWorkingDraft.test.tsx
+++ b/packages/admin/src/hooks/queries/__tests__/useDiscardWorkingDraft.test.tsx
@@ -87,4 +87,39 @@ describe("useDiscardWorkingDraft", () => {
       "Failed to discard working draft: nope"
     );
   });
+
+  it("seeds the returned live row into the detail cache and clears the draft flag", async () => {
+    const client = makeClient();
+    // What the editor read: the pending working draft (Changed state).
+    const key = entryKeys.detailScoped("posts", "e1", {
+      locale: undefined,
+      fallbackLocale: undefined,
+      translationStatus: false,
+      draft: true,
+    });
+    client.setQueryData(key, {
+      id: "e1",
+      status: "published",
+      title: "draft-title",
+      _isWorkingDraft: true,
+    });
+    discardSpy.mockResolvedValue({
+      message: "Working draft discarded.",
+      item: { id: "e1", status: "published", title: "live-title" },
+    });
+
+    const { result } = renderHook(
+      () => useDiscardWorkingDraft({ collectionSlug: "posts", entryId: "e1" }),
+      { wrapper: makeWrapper(client) }
+    );
+
+    await result.current.mutateAsync();
+
+    // The live row replaced the draft and Changed cleared, without waiting on a
+    // refetch — so a slow/failed refetch or a remount cannot restore the draft.
+    expect(client.getQueryData(key)).toMatchObject({
+      title: "live-title",
+      _isWorkingDraft: false,
+    });
+  });
 });

--- a/packages/admin/src/hooks/queries/__tests__/useUpdateEntry.test.tsx
+++ b/packages/admin/src/hooks/queries/__tests__/useUpdateEntry.test.tsx
@@ -86,4 +86,46 @@ describe("useUpdateEntry", () => {
       title: "new",
     });
   });
+
+  it("clears a stale _isWorkingDraft when the response omits it (publish)", async () => {
+    const client = makeClient();
+    const key = entryKeys.detailScoped("posts", "e1", {
+      locale: undefined,
+      fallbackLocale: undefined,
+      translationStatus: false,
+      draft: true,
+    });
+    // Cached as a pending working draft (Changed state on screen).
+    client.setQueryData(key, {
+      id: "e1",
+      status: "draft",
+      title: "old",
+      _isWorkingDraft: true,
+    });
+    // Publishing returns the live document WITHOUT the synthetic flag.
+    updateSpy.mockResolvedValue({
+      id: "e1",
+      status: "published",
+      title: "new",
+    });
+
+    const { result } = renderHook(
+      () =>
+        useUpdateEntry({
+          collectionSlug: "posts",
+          entryId: "e1",
+          draft: true,
+          showToast: false,
+        }),
+      { wrapper: makeWrapper(client) }
+    );
+
+    await result.current.mutateAsync({ status: "published" });
+
+    // The stale `true` did not survive the spread — Changed clears at once.
+    expect(client.getQueryData(key)).toMatchObject({
+      _isWorkingDraft: false,
+      status: "published",
+    });
+  });
 });

--- a/packages/admin/src/hooks/queries/__tests__/useUpdateEntry.test.tsx
+++ b/packages/admin/src/hooks/queries/__tests__/useUpdateEntry.test.tsx
@@ -1,0 +1,89 @@
+/**
+ * A status-less "save working draft" returns `_isWorkingDraft` from the server,
+ * but the optimistic merge only writes the status-less PAYLOAD (which carries no
+ * such flag). This pins that the mutation seeds the server RESPONSE into the same
+ * detail query the editor reads, so the Changed state and Publish/Discard
+ * controls appear at once rather than only after the invalidation's refetch —
+ * which may be slow or fail.
+ */
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { updateSpy } = vi.hoisted(() => ({ updateSpy: vi.fn() }));
+
+vi.mock("@admin/services/entryApi", async importOriginal => {
+  const actual =
+    await importOriginal<typeof import("@admin/services/entryApi")>();
+  return { ...actual, entryApi: { ...actual.entryApi, update: updateSpy } };
+});
+
+vi.mock("@admin/hooks/useLocalization", () => ({
+  useLocalization: () => ({ enabled: false }),
+}));
+
+vi.mock("@admin/components/ui", () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+import { entryKeys } from "@admin/services/entryApi";
+
+import { useUpdateEntry } from "../useUpdateEntry";
+
+function makeWrapper(client: QueryClient) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={client}>{children}</QueryClientProvider>
+    );
+  };
+}
+
+function makeClient() {
+  return new QueryClient({
+    defaultOptions: { mutations: { retry: false } },
+  });
+}
+
+describe("useUpdateEntry", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("seeds the server response into the detail query the editor reads", async () => {
+    const client = makeClient();
+    // The key the editor reads a drafts entry with (working-draft overlay).
+    const key = entryKeys.detailScoped("posts", "e1", {
+      locale: undefined,
+      fallbackLocale: undefined,
+      translationStatus: false,
+      draft: true,
+    });
+    // Cached without the flag, as the status-less optimistic merge leaves it.
+    client.setQueryData(key, { id: "e1", status: "published", title: "old" });
+    // The server's response to a status-less save DOES carry the flag.
+    updateSpy.mockResolvedValue({
+      id: "e1",
+      status: "published",
+      title: "new",
+      _isWorkingDraft: true,
+    });
+
+    const { result } = renderHook(
+      () =>
+        useUpdateEntry({
+          collectionSlug: "posts",
+          entryId: "e1",
+          draft: true,
+          showToast: false,
+        }),
+      { wrapper: makeWrapper(client) }
+    );
+
+    await result.current.mutateAsync({ title: "new" });
+
+    // The editor's cached entry now carries the flag without waiting on a refetch.
+    expect(client.getQueryData(key)).toMatchObject({
+      _isWorkingDraft: true,
+      title: "new",
+    });
+  });
+});

--- a/packages/admin/src/hooks/queries/useDiscardWorkingDraft.ts
+++ b/packages/admin/src/hooks/queries/useDiscardWorkingDraft.ts
@@ -1,0 +1,78 @@
+"use client";
+
+/**
+ * useDiscardWorkingDraft Hook
+ *
+ * TanStack Query mutation for discarding a published entry's pending working
+ * draft (the draft/published split). It calls the discard endpoint, then
+ * invalidates the entry detail so the editor refetches the live published row.
+ *
+ * The list and count caches are intentionally left alone: discarding never
+ * touches the live row, so its representation in those views is unchanged.
+ *
+ * @see services/versionApi.ts - discardWorkingDraft fetcher
+ * @see hooks/queries/useDeleteEntry.ts - reference mutation pattern
+ */
+
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import { toast } from "@admin/components/ui";
+import { entryKeys } from "@admin/services/entryApi";
+import {
+  versionApi,
+  type DiscardWorkingDraftResponse,
+} from "@admin/services/versionApi";
+
+export interface UseDiscardWorkingDraftOptions {
+  /** The collection slug/name containing the entry. */
+  collectionSlug: string;
+  /** The entry whose working draft is being discarded. */
+  entryId: string;
+  /** Callback fired on a successful discard, with the live published document. */
+  onSuccess?: (data: DiscardWorkingDraftResponse) => void;
+  /** Callback fired on error. */
+  onError?: (error: Error) => void;
+  /** Whether to show toast notifications (default: true). */
+  showToast?: boolean;
+}
+
+export function useDiscardWorkingDraft({
+  collectionSlug,
+  entryId,
+  onSuccess,
+  onError,
+  showToast = true,
+}: UseDiscardWorkingDraftOptions) {
+  const queryClient = useQueryClient();
+
+  return useMutation<DiscardWorkingDraftResponse, Error, void>({
+    mutationFn: () =>
+      versionApi.discardWorkingDraft({
+        kind: "collection",
+        slug: collectionSlug,
+        entryId,
+      }),
+
+    onSuccess: data => {
+      // The editor reads with `?draft=1`; with the sidecar gone the server has
+      // no draft to overlay, so refetching the detail returns the live row.
+      void queryClient.invalidateQueries({
+        queryKey: entryKeys.detail(collectionSlug, entryId),
+      });
+
+      if (showToast) {
+        toast.success("Working draft discarded");
+      }
+
+      onSuccess?.(data);
+    },
+
+    onError: (error: Error) => {
+      if (showToast) {
+        toast.error(`Failed to discard working draft: ${error.message}`);
+      }
+
+      onError?.(error);
+    },
+  });
+}

--- a/packages/admin/src/hooks/queries/useDiscardWorkingDraft.ts
+++ b/packages/admin/src/hooks/queries/useDiscardWorkingDraft.ts
@@ -54,8 +54,21 @@ export function useDiscardWorkingDraft({
       }),
 
     onSuccess: data => {
+      // Seed the authoritative live row the discard returned into every scoped
+      // variant of this entry's detail cache BEFORE invalidating. Otherwise the
+      // cache keeps the now-deleted working draft (and `_isWorkingDraft: true`)
+      // until the refetch lands: a slow or failed refetch would leave the editor
+      // showing Changed, and a remount could briefly restore the discarded
+      // values. `_isWorkingDraft` is cleared explicitly — the live item omits it,
+      // so a plain spread would let the stale `true` survive.
+      queryClient.setQueriesData<Record<string, unknown>>(
+        { queryKey: entryKeys.detail(collectionSlug, entryId) },
+        old => (old ? { ...old, ...data.item, _isWorkingDraft: false } : old)
+      );
+
       // The editor reads with `?draft=1`; with the sidecar gone the server has
-      // no draft to overlay, so refetching the detail returns the live row.
+      // no draft to overlay, so refetching the detail reconciles with the live
+      // row. List/count caches are left alone — the live row never changed.
       void queryClient.invalidateQueries({
         queryKey: entryKeys.detail(collectionSlug, entryId),
       });

--- a/packages/admin/src/hooks/queries/useEntry.ts
+++ b/packages/admin/src/hooks/queries/useEntry.ts
@@ -177,6 +177,12 @@ export function useEntry<T = Entry>({
             locale: locale ?? null,
             fallbackLocale: fallbackLocale ?? null,
             translationStatus: translationStatus ?? false,
+            // Part of the cache identity: the editor learns `draftsEnabled` only
+            // after the schema loads, flipping `draft` false -> true on a cold
+            // load. Without it in the key the stale-time would keep serving the
+            // live row, hiding an existing working draft (and the Changed /
+            // Publish / Discard affordances) until a manual refetch.
+            draft: draft ?? false,
           },
         ]
       : entryKeys.detailsByCollection(collectionSlug),

--- a/packages/admin/src/hooks/queries/useEntry.ts
+++ b/packages/admin/src/hooks/queries/useEntry.ts
@@ -170,21 +170,19 @@ export function useEntry<T = Entry>({
   return useQuery<T, Error>({
     // i18n M7: locale is part of the cache identity — switching languages must refetch the
     // entry (the localized field values differ per locale), not serve the previous language.
+    // The cache identity is built through the shared `detailScoped` helper so the
+    // mutation hook's optimistic-update key stays in lockstep with this read key.
+    // `draft` is part of it: the editor learns `draftsEnabled` only after the
+    // schema loads, flipping `draft` false -> true on a cold load, and without it
+    // in the key the stale-time would keep serving the live row and hide an
+    // existing working draft (and the Changed / Publish / Discard affordances).
     queryKey: entryId
-      ? [
-          ...entryKeys.detail(collectionSlug, entryId),
-          {
-            locale: locale ?? null,
-            fallbackLocale: fallbackLocale ?? null,
-            translationStatus: translationStatus ?? false,
-            // Part of the cache identity: the editor learns `draftsEnabled` only
-            // after the schema loads, flipping `draft` false -> true on a cold
-            // load. Without it in the key the stale-time would keep serving the
-            // live row, hiding an existing working draft (and the Changed /
-            // Publish / Discard affordances) until a manual refetch.
-            draft: draft ?? false,
-          },
-        ]
+      ? entryKeys.detailScoped(collectionSlug, entryId, {
+          locale,
+          fallbackLocale,
+          translationStatus,
+          draft,
+        })
       : entryKeys.detailsByCollection(collectionSlug),
     queryFn: async () => {
       // Safety check: This shouldn't execute due to `enabled` flag,

--- a/packages/admin/src/hooks/queries/useUpdateEntry.ts
+++ b/packages/admin/src/hooks/queries/useUpdateEntry.ts
@@ -90,6 +90,12 @@ export interface UseUpdateEntryOptions<
   locale?: string;
   /** Fallback locale when a translation is missing. */
   fallbackLocale?: string;
+  /**
+   * Whether the editor reads in draft (working-draft overlay) mode. Part of the
+   * cache identity: it must match the useEntry read key so the optimistic write,
+   * rollback, and query cancellation target the query the editor is showing.
+   */
+  draft?: boolean;
 }
 
 /**
@@ -218,25 +224,23 @@ export function useUpdateEntry<
   setError,
   locale,
   fallbackLocale,
+  draft,
 }: UseUpdateEntryOptions<T, TFieldValues>) {
   const queryClient = useQueryClient();
   const { enabled: localizationEnabled } = useLocalization();
 
-  // the optimistic cache is keyed by locale so the update touches the
-  // currently-viewed language's cached entry — not the default-language one. The key MUST
-  // match useEntry's exactly (React Query hashes the object), so it mirrors the same
-  // `translationStatus` and `fallbackLocale` dimensions the entry editor passes to useEntry:
-  // a localized editor requests `translationStatus` and `fallbackLocale: "none"`. Omitting
-  // them (as before) meant the key never matched and the optimistic write / rollback silently
-  // no-oped.
-  const localeKey = [
-    ...entryKeys.detail(collectionSlug, entryId),
-    {
-      locale: locale ?? null,
-      fallbackLocale: localizationEnabled ? "none" : (fallbackLocale ?? null),
-      translationStatus: localizationEnabled,
-    },
-  ] as const;
+  // The optimistic cache is keyed by the same per-view dimensions useEntry reads
+  // with, built through the shared `detailScoped` helper so the two can never
+  // drift (React Query hashes the object; any mismatch silently no-ops the
+  // optimistic write, rollback, and cancellation). A localized editor reads with
+  // `translationStatus` on and `fallbackLocale: "none"`, and draft mode follows
+  // the collection's working-draft split.
+  const localeKey = entryKeys.detailScoped(collectionSlug, entryId, {
+    locale,
+    fallbackLocale: localizationEnabled ? "none" : fallbackLocale,
+    translationStatus: localizationEnabled,
+    draft,
+  });
 
   return useMutation<T, Error, UpdateEntryPayload, UpdateContext<T>>({
     mutationFn: async (data: UpdateEntryPayload) => {

--- a/packages/admin/src/hooks/queries/useUpdateEntry.ts
+++ b/packages/admin/src/hooks/queries/useUpdateEntry.ts
@@ -316,9 +316,19 @@ export function useUpdateEntry<
       // Keyed by the same `localeKey` the read uses; merged over the cached entry
       // so any view-only fields the response omits survive.
       if (optimistic) {
-        queryClient.setQueryData<T>(localeKey, old =>
-          old ? { ...old, ...data } : data
-        );
+        queryClient.setQueryData<T>(localeKey, old => {
+          const merged = old ? { ...old, ...data } : data;
+          // `_isWorkingDraft` is a synthetic flag the server sets only on a
+          // working-draft overlay read; a publish/unpublish response returns the
+          // live document WITHOUT it. Derive it from this response so a stale
+          // cached `true` cannot survive the spread and keep the Changed state
+          // (and Publish/Discard controls) on screen after the sidecar is gone.
+          return {
+            ...merged,
+            _isWorkingDraft:
+              (data as { _isWorkingDraft?: boolean })._isWorkingDraft === true,
+          };
+        });
       }
 
       // Invalidate entry list queries for this collection

--- a/packages/admin/src/hooks/queries/useUpdateEntry.ts
+++ b/packages/admin/src/hooks/queries/useUpdateEntry.ts
@@ -306,6 +306,21 @@ export function useUpdateEntry<
 
     // On success, invalidate queries to ensure fresh data
     onSuccess: data => {
+      // Write the server's response into the detail cache the editor reads, so
+      // fields it derives server-side are shown at once rather than only after
+      // the invalidation below refetches (which may be slow or fail). The
+      // working-draft split is why this matters: a status-less save returns
+      // `_isWorkingDraft`, and without seeding it here the optimistic merge (of
+      // the status-less payload, which carries no such flag) leaves the editor's
+      // Changed state and Publish/Discard controls hidden until a refetch lands.
+      // Keyed by the same `localeKey` the read uses; merged over the cached entry
+      // so any view-only fields the response omits survive.
+      if (optimistic) {
+        queryClient.setQueryData<T>(localeKey, old =>
+          old ? { ...old, ...data } : data
+        );
+      }
+
       // Invalidate entry list queries for this collection
       void queryClient.invalidateQueries({
         queryKey: entryKeys.listsByCollection(collectionSlug),

--- a/packages/admin/src/pages/dashboard/entries/[slug]/[id]/index.tsx
+++ b/packages/admin/src/pages/dashboard/entries/[slug]/[id]/index.tsx
@@ -247,6 +247,11 @@ export default function EditEntryPage({
     collectionSlug: slug || "",
     entryId: id,
     depth: 2,
+    // Load the pending working draft in place of the live row when the
+    // collection has the draft/published split enabled, so the editor shows and
+    // saves onto the unpublished edits. Inert for non-drafts collections (the
+    // server only overlays a draft it actually has).
+    draft: collection?.draftsEnabled === true,
     locale,
     // Edit the ACTUAL per-locale values — disable fallback so an untranslated field
     // shows empty (not the default-language text, which a save would otherwise persist

--- a/packages/admin/src/services/__tests__/entryKeys.detail-scoped.test.ts
+++ b/packages/admin/src/services/__tests__/entryKeys.detail-scoped.test.ts
@@ -1,0 +1,62 @@
+/**
+ * The entry read hook (useEntry) and the mutation hook (useUpdateEntry) build
+ * their detail cache key through `entryKeys.detailScoped`. React Query hashes the
+ * key object, so if the two ever diverged the optimistic write, rollback, and
+ * query cancellation would silently target a query the editor is not reading.
+ * These pin the contract: the key carries every read dimension (including draft
+ * mode), normalises absent values, and is stable for equal inputs.
+ */
+import { describe, it, expect } from "vitest";
+
+import { entryKeys } from "../entryApi";
+
+describe("entryKeys.detailScoped", () => {
+  it("carries the collection, id, and every read dimension including draft", () => {
+    expect(
+      entryKeys.detailScoped("posts", "e1", {
+        locale: "de",
+        fallbackLocale: "none",
+        translationStatus: true,
+        draft: true,
+      })
+    ).toEqual([
+      ...entryKeys.detail("posts", "e1"),
+      {
+        locale: "de",
+        fallbackLocale: "none",
+        translationStatus: true,
+        draft: true,
+      },
+    ]);
+  });
+
+  it("normalises absent dimensions to null / false", () => {
+    expect(entryKeys.detailScoped("posts", "e1", {})).toEqual([
+      ...entryKeys.detail("posts", "e1"),
+      {
+        locale: null,
+        fallbackLocale: null,
+        translationStatus: false,
+        draft: false,
+      },
+    ]);
+  });
+
+  it("produces equal keys for equal inputs (read and write hooks match)", () => {
+    const params = {
+      locale: "en",
+      fallbackLocale: "none" as const,
+      translationStatus: true,
+      draft: true,
+    };
+    expect(entryKeys.detailScoped("posts", "e1", params)).toEqual(
+      entryKeys.detailScoped("posts", "e1", params)
+    );
+  });
+
+  it("distinguishes draft mode from live mode", () => {
+    const live = entryKeys.detailScoped("posts", "e1", { draft: false });
+    const draft = entryKeys.detailScoped("posts", "e1", { draft: true });
+    expect(live).not.toEqual(draft);
+  });
+});

--- a/packages/admin/src/services/__tests__/versionApi.test.ts
+++ b/packages/admin/src/services/__tests__/versionApi.test.ts
@@ -6,10 +6,13 @@
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
-const { getSpy } = vi.hoisted(() => ({ getSpy: vi.fn() }));
+const { getSpy, delSpy } = vi.hoisted(() => ({
+  getSpy: vi.fn(),
+  delSpy: vi.fn(),
+}));
 
 vi.mock("@admin/lib/api/protectedApi", () => ({
-  protectedApi: { get: getSpy },
+  protectedApi: { get: getSpy, delete: delSpy },
 }));
 
 import { versionApi } from "../versionApi";
@@ -84,5 +87,20 @@ describe("versionApi.get", () => {
     await versionApi.get(single, 2);
 
     expect(getSpy).toHaveBeenCalledWith("/singles/settings/versions/2");
+  });
+});
+
+describe("versionApi.discardWorkingDraft", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    delSpy.mockResolvedValue({ message: "Working draft discarded.", item: {} });
+  });
+
+  it("DELETEs the working-draft sidecar under the collection entry", async () => {
+    await versionApi.discardWorkingDraft(collection);
+
+    expect(delSpy).toHaveBeenCalledWith(
+      "/collections/posts/entries/e1/versions/working-draft"
+    );
   });
 });

--- a/packages/admin/src/services/entryApi.ts
+++ b/packages/admin/src/services/entryApi.ts
@@ -172,6 +172,36 @@ export const entryKeys = {
   detail: (collectionSlug: string, id: string) =>
     [...entryKeys.detailsByCollection(collectionSlug), id] as const,
 
+  /**
+   * The FULL detail cache identity, including the per-view read dimensions that
+   * change which document the server returns: content locale, fallback locale,
+   * the translation-status overview flag, and draft mode (the working-draft
+   * overlay). The read hook (useEntry) and the mutation hook (useUpdateEntry)
+   * MUST build the key through this one function — React Query hashes the object,
+   * so any divergence makes the optimistic write, rollback, and cancelQueries
+   * silently target a query the editor is not reading. Values are null/false
+   * normalised here so callers cannot drift on `undefined` vs `null`.
+   */
+  detailScoped: (
+    collectionSlug: string,
+    id: string,
+    params: {
+      locale?: string | null;
+      fallbackLocale?: string | null;
+      translationStatus?: boolean;
+      draft?: boolean;
+    }
+  ) =>
+    [
+      ...entryKeys.detail(collectionSlug, id),
+      {
+        locale: params.locale ?? null,
+        fallbackLocale: params.fallbackLocale ?? null,
+        translationStatus: params.translationStatus ?? false,
+        draft: params.draft ?? false,
+      },
+    ] as const,
+
   /** Key for count queries */
   counts: () => [...entryKeys.all, "count"] as const,
 

--- a/packages/admin/src/services/versionApi.ts
+++ b/packages/admin/src/services/versionApi.ts
@@ -114,6 +114,12 @@ export interface SetVersionLabelResponse {
   item: VersionMeta;
 }
 
+/** What a discard reports back: the live published document, now authoritative. */
+export interface DiscardWorkingDraftResponse {
+  message: string;
+  item: Record<string, unknown>;
+}
+
 export const versionApi = {
   list: (
     scope: VersionScope,
@@ -166,6 +172,21 @@ export const versionApi = {
     protectedApi.patch<SetVersionLabelResponse>(
       `${basePath(scope)}/${versionNo}`,
       { label }
+    ),
+
+  /**
+   * Discard a collection entry's pending working draft (draft/published split),
+   * reverting the editor to the live published row. A DELETE on the sidecar
+   * sub-resource; the response carries the live published document.
+   *
+   * Collection-only: the split gives a published document a separate draft head,
+   * which a Single — one row, no published/draft pair — never has.
+   */
+  discardWorkingDraft: (
+    scope: Extract<VersionScope, { kind: "collection" }>
+  ): Promise<DiscardWorkingDraftResponse> =>
+    protectedApi.delete<DiscardWorkingDraftResponse>(
+      `${basePath(scope)}/working-draft`
     ),
 
   /**

--- a/packages/admin/src/types/collection.ts
+++ b/packages/admin/src/types/collection.ts
@@ -253,6 +253,14 @@ export interface Collection {
    */
   status?: boolean;
   /**
+   * Whether the draft/published working-draft split is enabled (drafts on a
+   * versioned collection). Derived server-side; read-only. When true on a
+   * `status` collection, saving a published entry stores a pending working
+   * draft instead of writing live. Only code-first collections enable it — the
+   * Schema Builder always resolves drafts off.
+   */
+  draftsEnabled?: boolean;
+  /**
    * Resolved cache-revalidation config, or null/absent when revalidation is on
    * with no override. The server normalizes the Schema Builder's on/off switch
    * into this shape (off → `{ disable: true }`), so reads carry the object while
@@ -353,6 +361,10 @@ export interface CreateCollectionPayload {
   /** Durable versions kept per document. `false` = unlimited, a number = keep
    *  that many, undefined = the default (50). Ignored when `versions` is off. */
   versionsMaxPerDoc?: number | false;
+  /** Whether the draft/published working-draft split is enabled (drafts on a
+   *  versioned collection). Derived server-side; read-only. Only code-first
+   *  collections enable it — the Schema Builder always resolves drafts off. */
+  draftsEnabled?: boolean;
   /** Whether writes bust cache tags. Default true; false opts the collection out. */
   revalidate?: boolean;
   /** Whether writes are recorded to the webhook outbox. Default true; false

--- a/packages/nextly/src/api/collections-schema-detail.ts
+++ b/packages/nextly/src/api/collections-schema-detail.ts
@@ -42,6 +42,7 @@ import { getHandlerConfig } from "../route-handler/auth-handler";
 import type { CollectionRegistryService } from "../services/collections/collection-registry-service";
 import type { FieldGroupRegistryService } from "../services/field-groups/field-group-registry-service";
 import { requireBuilderEnabled } from "../shared/builder-access";
+import { hasPasswordField } from "../shared/lib/password-fields";
 import { simplePluralize } from "../shared/lib/pluralization";
 
 import { assertValidFieldsPayload } from "./fields-payload";
@@ -117,15 +118,26 @@ export const GET = withErrorHandler(
       config?.plugins ?? []
     );
 
-    // Derived flag: whether the draft/published working-draft split is enabled
-    // (drafts on a versioned collection). The full versions config is passed
-    // through above, but the admin editor reads this simple boolean to decide
-    // whether a "Save" stores a working draft instead of writing the live row.
-    // Builder collections always resolve drafts off; only code-first ones enable
-    // it, so this is derived from the resolved config rather than assumed.
+    // Derived flag: whether the draft/published working-draft split will actually
+    // run for this collection. The admin editor reads it to decide whether a
+    // "Save" stores a working draft or writes the live row, so it MUST match the
+    // server's own `splitEnabled` gate (collection-mutation-service): a mismatch
+    // makes the editor present a status-less save as a pending draft while the
+    // server writes it live. The split needs the status + drafts lifecycle and is
+    // off for a localized document and for a reachable password field (top-level,
+    // in a group, or in a component), which cannot ride safely in a draft
+    // snapshot. Builder collections always resolve drafts off, so this is derived
+    // from the resolved config, never assumed. (An ineligible component — one that
+    // is localized or fails to resolve — also disables the split server-side; that
+    // resolution-state parity is a follow-up needing a shared eligibility helper.)
     const draftsEnabled =
+      (collection as { status?: boolean }).status === true &&
       (collection.versions as { drafts?: { enabled?: boolean } } | null)?.drafts
-        ?.enabled === true;
+        ?.enabled === true &&
+      (collection as { localized?: boolean }).localized !== true &&
+      !hasPasswordField(
+        enrichedFields as unknown as Parameters<typeof hasPasswordField>[0]
+      );
 
     return respondDoc({
       ...(collectionWithViews as unknown as typeof collection),

--- a/packages/nextly/src/api/collections-schema-detail.ts
+++ b/packages/nextly/src/api/collections-schema-detail.ts
@@ -29,6 +29,7 @@ import {
   coerceBuilderMaxPerDoc,
   resolveBuilderVersions,
 } from "../domains/versions/builder-versions";
+import { schemaDraftsEnabled } from "../domains/versions/draft-split-eligibility";
 import { resolveBuilderWebhooks } from "../domains/webhooks/builder-webhooks";
 import { NextlyError } from "../errors/nextly-error";
 import { getCachedNextly } from "../init";
@@ -42,7 +43,6 @@ import { getHandlerConfig } from "../route-handler/auth-handler";
 import type { CollectionRegistryService } from "../services/collections/collection-registry-service";
 import type { FieldGroupRegistryService } from "../services/field-groups/field-group-registry-service";
 import { requireBuilderEnabled } from "../shared/builder-access";
-import { hasPasswordField } from "../shared/lib/password-fields";
 import { simplePluralize } from "../shared/lib/pluralization";
 
 import { assertValidFieldsPayload } from "./fields-payload";
@@ -120,24 +120,27 @@ export const GET = withErrorHandler(
 
     // Derived flag: whether the draft/published working-draft split will actually
     // run for this collection. The admin editor reads it to decide whether a
-    // "Save" stores a working draft or writes the live row, so it MUST match the
-    // server's own `splitEnabled` gate (collection-mutation-service): a mismatch
-    // makes the editor present a status-less save as a pending draft while the
-    // server writes it live. The split needs the status + drafts lifecycle and is
-    // off for a localized document and for a reachable password field (top-level,
-    // in a group, or in a component), which cannot ride safely in a draft
-    // snapshot. Builder collections always resolve drafts off, so this is derived
-    // from the resolved config, never assumed. (An ineligible component — one that
-    // is localized or fails to resolve — also disables the split server-side; that
-    // resolution-state parity is a follow-up needing a shared eligibility helper.)
-    const draftsEnabled =
-      (collection as { status?: boolean }).status === true &&
-      (collection.versions as { drafts?: { enabled?: boolean } } | null)?.drafts
-        ?.enabled === true &&
-      (collection as { localized?: boolean }).localized !== true &&
-      !hasPasswordField(
-        enrichedFields as unknown as Parameters<typeof hasPasswordField>[0]
-      );
+    // "Save" stores a working draft or writes the live row, so it is derived from
+    // the SAME shared predicate the mutation service gates on — a mismatch would
+    // make the editor present a status-less save as a pending draft while the
+    // server writes it live. Resolution runs over the ORIGINAL fields (not the
+    // enriched ones, which drop the component localized/resolved markers), and a
+    // registry failure leaves the split off rather than failing the read.
+    let draftsEnabled = false;
+    try {
+      draftsEnabled = await schemaDraftsEnabled({
+        status: (collection as { status?: boolean }).status,
+        versions: collection.versions,
+        localized: (collection as { localized?: boolean }).localized,
+        fields: collection.fields,
+      });
+    } catch (eligibilityError) {
+      getNextlyLogger().warn({
+        kind: "collection-drafts-eligibility-failed",
+        slug,
+        err: String(eligibilityError),
+      });
+    }
 
     return respondDoc({
       ...(collectionWithViews as unknown as typeof collection),

--- a/packages/nextly/src/api/collections-schema-detail.ts
+++ b/packages/nextly/src/api/collections-schema-detail.ts
@@ -117,9 +117,20 @@ export const GET = withErrorHandler(
       config?.plugins ?? []
     );
 
+    // Derived flag: whether the draft/published working-draft split is enabled
+    // (drafts on a versioned collection). The full versions config is passed
+    // through above, but the admin editor reads this simple boolean to decide
+    // whether a "Save" stores a working draft instead of writing the live row.
+    // Builder collections always resolve drafts off; only code-first ones enable
+    // it, so this is derived from the resolved config rather than assumed.
+    const draftsEnabled =
+      (collection.versions as { drafts?: { enabled?: boolean } } | null)?.drafts
+        ?.enabled === true;
+
     return respondDoc({
       ...(collectionWithViews as unknown as typeof collection),
       fields: enrichedFields,
+      draftsEnabled,
     } as unknown as typeof collection);
   }
 );

--- a/packages/nextly/src/api/collections-schema-detail.ts
+++ b/packages/nextly/src/api/collections-schema-detail.ts
@@ -124,23 +124,20 @@ export const GET = withErrorHandler(
     // the SAME shared predicate the mutation service gates on — a mismatch would
     // make the editor present a status-less save as a pending draft while the
     // server writes it live. Resolution runs over the ORIGINAL fields (not the
-    // enriched ones, which drop the component localized/resolved markers), and a
-    // registry failure leaves the split off rather than failing the read.
-    let draftsEnabled = false;
-    try {
-      draftsEnabled = await schemaDraftsEnabled({
-        status: (collection as { status?: boolean }).status,
-        versions: collection.versions,
-        localized: (collection as { localized?: boolean }).localized,
-        fields: collection.fields,
-      });
-    } catch (eligibilityError) {
-      getNextlyLogger().warn({
-        kind: "collection-drafts-eligibility-failed",
-        slug,
-        err: String(eligibilityError),
-      });
-    }
+    // enriched ones, which drop the component localized/resolved markers).
+    //
+    // A resolution failure is propagated, not defaulted to false: for a
+    // drafts-configured collection false is the destructive answer — the admin
+    // would send an explicit published save that overwrites the live row instead
+    // of storing a working draft — so this independently exported GET fails
+    // closed and is retryable, matching the dispatcher path and the fail-closed
+    // resolveComponentSchemas it calls into.
+    const draftsEnabled = await schemaDraftsEnabled({
+      status: (collection as { status?: boolean }).status,
+      versions: collection.versions,
+      localized: (collection as { localized?: boolean }).localized,
+      fields: collection.fields,
+    });
 
     return respondDoc({
       ...(collectionWithViews as unknown as typeof collection),

--- a/packages/nextly/src/dispatcher/handlers/__tests__/discard-working-draft-access.test.ts
+++ b/packages/nextly/src/dispatcher/handlers/__tests__/discard-working-draft-access.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Discard is authorized as an update, so like restore the read permission that
+ * guards history is re-established on the way in, and then the document's own
+ * update rule is enforced before the sidecar is removed. These pin that gate
+ * chain and the identity it judges; the decisions themselves live in the access
+ * modules' own tests.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { discardSpy, readableSpy, updatableSpy, canReadSpy } = vi.hoisted(
+  () => ({
+    discardSpy: vi.fn(),
+    readableSpy: vi.fn(),
+    updatableSpy: vi.fn(),
+    canReadSpy: vi.fn(),
+  })
+);
+
+vi.mock("../../../domains/versions/discard-working-draft", () => ({
+  discardWorkingDraft: discardSpy,
+}));
+
+vi.mock("../../../api/versions-access", () => ({
+  assertVersionDocumentReadable: readableSpy,
+  assertVersionDocumentUpdatable: updatableSpy,
+}));
+
+vi.mock("../../../auth/entity-read-access", () => ({
+  canReadEntity: canReadSpy,
+}));
+
+import { discardWorkingDraftForDocument } from "../versions-methods";
+
+const baseParams = {
+  collectionName: "posts",
+  entryId: "e1",
+  _authenticatedUserId: "u1",
+  _authenticatedUserRoles: JSON.stringify(["editor"]),
+};
+
+const argsFor = (params: Record<string, string>) => ({
+  scopeKind: "collection" as const,
+  slug: "posts",
+  entryId: "e1",
+  user: { id: "u1", roles: ["editor"] },
+  params,
+});
+
+describe("discardWorkingDraftForDocument — the gate chain", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    canReadSpy.mockResolvedValue(true);
+    readableSpy.mockResolvedValue(undefined);
+    updatableSpy.mockResolvedValue(undefined);
+    discardSpy.mockResolvedValue({
+      id: "e1",
+      title: "live",
+      status: "published",
+    });
+  });
+
+  it("discards and returns the live document when read and update are allowed", async () => {
+    await expect(
+      discardWorkingDraftForDocument(argsFor(baseParams))
+    ).resolves.toMatchObject({ title: "live", status: "published" });
+    expect(discardSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ slug: "posts", entryId: "e1" })
+    );
+  });
+
+  it("refuses as not-found when the caller may not read the entity, without discarding", async () => {
+    canReadSpy.mockResolvedValue(false);
+
+    await expect(
+      discardWorkingDraftForDocument(argsFor(baseParams))
+    ).rejects.toMatchObject({ code: "NOT_FOUND" });
+    expect(discardSpy).not.toHaveBeenCalled();
+  });
+
+  it("still applies the per-document read gate after the coarse one", async () => {
+    // Coarse permission is not enough on its own: an owner-only rule is decided
+    // per document, and a refusal there is a 404 like the coarse gate.
+    readableSpy.mockRejectedValue(
+      Object.assign(new Error("not readable"), { code: "NOT_FOUND" })
+    );
+
+    await expect(
+      discardWorkingDraftForDocument(argsFor(baseParams))
+    ).rejects.toMatchObject({ code: "NOT_FOUND" });
+    expect(discardSpy).not.toHaveBeenCalled();
+  });
+
+  it("refuses as forbidden when the caller may read but not update, without discarding", async () => {
+    // Read is established first, so an update refusal is an honest 403 rather
+    // than a 404 that would conceal a document the caller has proven they see.
+    updatableSpy.mockRejectedValue(
+      Object.assign(new Error("not updatable"), { code: "FORBIDDEN" })
+    );
+
+    await expect(
+      discardWorkingDraftForDocument(argsFor(baseParams))
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
+    expect(discardSpy).not.toHaveBeenCalled();
+  });
+
+  it("forwards the API-key scope to the discard so the re-read is judged on its own grant", async () => {
+    await discardWorkingDraftForDocument(
+      argsFor({
+        ...baseParams,
+        _authenticatedActorType: "apiKey",
+        _authenticatedPermissions: JSON.stringify([
+          "read-posts",
+          "update-posts",
+        ]),
+      })
+    );
+
+    expect(discardSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        authenticatedScope: {
+          actorType: "apiKey",
+          permissions: ["read-posts", "update-posts"],
+        },
+      })
+    );
+  });
+});

--- a/packages/nextly/src/dispatcher/handlers/__tests__/versions-dispatch.test.ts
+++ b/packages/nextly/src/dispatcher/handlers/__tests__/versions-dispatch.test.ts
@@ -41,6 +41,7 @@ describe("version methods are registered", () => {
     // being registered for authorization, which decides whether it is
     // permitted as a read or as a write.
     expect(Object.keys(COLLECTION_VERSION_METHODS).sort()).toEqual([
+      "discardWorkingDraft",
       "getEntryVersion",
       "getEntryVersionDiff",
       "listEntryVersions",
@@ -152,6 +153,18 @@ describe("version methods reach the router", () => {
       method: "setEntryVersionLabel",
       path: ["collections", "posts", "entries", "e1", "versions", "2"],
       verb: "PATCH",
+    },
+    {
+      method: "discardWorkingDraft",
+      path: [
+        "collections",
+        "posts",
+        "entries",
+        "e1",
+        "versions",
+        "working-draft",
+      ],
+      verb: "DELETE",
     },
     {
       method: "listSingleVersions",

--- a/packages/nextly/src/dispatcher/handlers/collection-dispatcher.ts
+++ b/packages/nextly/src/dispatcher/handlers/collection-dispatcher.ts
@@ -115,6 +115,7 @@ import type { MethodHandler, Params } from "../types";
 // all three entity kinds, so a stale UI save is rejected before any DDL runs.
 import { assertSchemaVersionMatch } from "./schema-version-guard";
 import {
+  discardWorkingDraftForDocument,
   getVersionDiffForDocument,
   getVersionForDocument,
   restoreVersionForDocument,
@@ -214,6 +215,18 @@ export const COLLECTION_VERSION_METHODS: Record<
         params: p,
       });
       return respondAction("Version restored.", result);
+    },
+  },
+  discardWorkingDraft: {
+    execute: async (_svc, p) => {
+      const item = await discardWorkingDraftForDocument({
+        scopeKind: "collection",
+        slug: String(p.collectionName ?? ""),
+        entryId: String(p.entryId ?? ""),
+        user: userFromParams(p),
+        params: p,
+      });
+      return respondMutation("Working draft discarded.", item);
     },
   },
   getEntryVersion: {

--- a/packages/nextly/src/dispatcher/handlers/versions-methods.ts
+++ b/packages/nextly/src/dispatcher/handlers/versions-methods.ts
@@ -31,6 +31,7 @@ import {
   type VersionMetaWithAuthor,
 } from "../../domains/versions/author-hydration";
 import type { VersionDiff } from "../../domains/versions/diff";
+import { discardWorkingDraft } from "../../domains/versions/discard-working-draft";
 import { restoreVersion } from "../../domains/versions/restore-version";
 import type { VersionRow } from "../../domains/versions/versions-repository";
 import { NextlyError } from "../../errors/nextly-error";
@@ -532,5 +533,68 @@ export async function restoreVersionForDocument(
     // The publish gate a restore-to-published triggers must judge the key's own
     // scope, not the owner's RBAC.
     authenticatedScope: readAuthenticatedScope(args.params),
+  });
+}
+
+/**
+ * Discard a collection entry's pending working draft (draft/published split),
+ * reverting the editor to the live published row.
+ *
+ * The sidecar is deleted; the document's durable history is never touched, so
+ * this reverts unpublished edits rather than writing a version. It is authorized
+ * as an update — a caller who may not update the document may not throw away its
+ * pending edits either — after read access is established, so a caller who cannot
+ * see the document gets a 404 rather than a 403 that would confirm it exists.
+ *
+ * Returns the published document as a plain read would, so the editor can reset
+ * to the live values without a second request. A no-op that still returns the
+ * live row when no working draft exists.
+ */
+export async function discardWorkingDraftForDocument(
+  args: VersionMethodArgs & { params: Params }
+): Promise<unknown> {
+  const caller = readAccessCallerFromParams(args.params, args.user);
+
+  // Read gate first: the route authorized this as an update, not a read, so a
+  // caller who cannot read the document is refused here — as "not found" so the
+  // refusal does not confirm it exists. Mirrors restoreVersionForDocument.
+  if (!(await canReadEntity(args.slug, caller))) {
+    throw NextlyError.notFound({
+      logContext: {
+        reason: "discard-working-draft-read-denied",
+        scopeKind: args.scopeKind,
+        scopeSlug: args.slug,
+        entryId: args.entryId,
+        userId: args.user.id,
+      },
+    });
+  }
+
+  const authenticatedScope = readAuthenticatedScope(args.params);
+
+  // Per-document read (404 when the row is gone or hidden by an owner-only rule)
+  // then the update gate (403): the coarse update-<slug> permission ran at the
+  // route, but a per-document rule can still refuse THIS document, and discarding
+  // its pending edits owes the same rules as any other update to it.
+  await assertVersionDocumentReadable(
+    args.scopeKind,
+    args.slug,
+    args.entryId,
+    args.user,
+    authenticatedScope
+  );
+  await assertVersionDocumentUpdatable(
+    args.scopeKind,
+    args.slug,
+    args.entryId,
+    args.user,
+    authenticatedScope
+  );
+
+  return discardWorkingDraft({
+    slug: args.slug,
+    entryId: args.entryId,
+    user: args.user,
+    authenticatedScope,
   });
 }

--- a/packages/nextly/src/domains/collections/services/__tests__/draft-published-split.integration.test.ts
+++ b/packages/nextly/src/domains/collections/services/__tests__/draft-published-split.integration.test.ts
@@ -213,6 +213,57 @@ describe("draft/published split — updateEntry (integration)", () => {
     );
   });
 
+  it("flags the working draft with _isWorkingDraft on the save response and the draft read, but never the live row", async () => {
+    // The editor UI derives a "Changed / unpublished edits" state from this flag
+    // rather than from `status` (which the overlay keeps at the live parent's
+    // published value).
+    const entries = await boot();
+    const ctx = { collectionName: COLLECTION, overrideAccess: true };
+
+    await entries.createEntry(ctx, { title: "live", status: "published" });
+    const [row] = await handle!.adapter.select<LiveRow>(TABLE);
+    const id = row.id;
+
+    // A status-less save stores a working draft — its response carries the flag.
+    const saveRes = await entries.updateEntry(
+      { ...ctx, entryId: id },
+      { title: "edited-in-draft" }
+    );
+    expect(
+      (saveRes.data as { _isWorkingDraft?: boolean })._isWorkingDraft
+    ).toBe(true);
+
+    // The trusted draft-view read carries the flag.
+    const draftRead = await entries.getEntry({
+      ...ctx,
+      entryId: id,
+      includeWorkingDraft: true,
+    });
+    expect(
+      (draftRead.data as { _isWorkingDraft?: boolean })._isWorkingDraft
+    ).toBe(true);
+
+    // The published-view read returns the live row, which must NOT be flagged.
+    const publishedRead = await entries.getEntry({
+      ...ctx,
+      entryId: id,
+      status: "published",
+    });
+    expect(
+      (publishedRead.data as { _isWorkingDraft?: boolean })._isWorkingDraft
+    ).toBeUndefined();
+
+    // A publish promotes the draft to the live row; that live-write response is
+    // NOT a working draft, so it must not be flagged.
+    const publishRes = await entries.updateEntry(
+      { ...ctx, entryId: id },
+      { status: "published" }
+    );
+    expect(
+      (publishRes.data as { _isWorkingDraft?: boolean })._isWorkingDraft
+    ).toBeUndefined();
+  });
+
   it("makes the working draft reachable through the Direct API findByID draft option", async () => {
     // End-to-end reachability: the split engine's read overlay is dormant unless
     // a caller-facing surface forwards the opt-in. This drives the full

--- a/packages/nextly/src/domains/collections/services/__tests__/draft-published-split.integration.test.ts
+++ b/packages/nextly/src/domains/collections/services/__tests__/draft-published-split.integration.test.ts
@@ -19,6 +19,7 @@ import {
   createTestNextly,
   type TestNextly,
 } from "../../../../plugins/test-nextly";
+import { discardWorkingDraftForDocument } from "../../../../dispatcher/handlers/versions-methods";
 import type { CollectionsHandler } from "../../../../services/collections-handler";
 import type { CollectionEntryService } from "../../../../services/collections/collection-entry-service";
 
@@ -407,6 +408,113 @@ describe("draft/published split — updateEntry (integration)", () => {
     });
     expect(readerRead.success).toBe(true);
     expect((readerRead.data as { title?: string }).title).toBe("live");
+  });
+});
+
+// Discarding a pending working draft throws away the unpublished edits and
+// reverts the editor to the live published row. It is authorized as an update
+// of the document — a caller who may not update it may not discard its pending
+// edits — and it never touches the durable history.
+describe("draft/published split — discard working draft (integration)", () => {
+  it("removes the sidecar and returns the live published row for an editor who may update", async () => {
+    handle = await createTestNextly({
+      collections: [
+        defineCollection({
+          slug: COLLECTION,
+          status: true,
+          versions: { drafts: true },
+          access: { read: () => true, update: () => true },
+          fields: [text({ name: "title" }), text({ name: "body" })],
+        }),
+      ],
+    });
+    const entries = handle
+      .getService("collectionsHandler")
+      .getEntryService() as CollectionEntryService;
+    const trusted = { collectionName: COLLECTION, overrideAccess: true };
+
+    await entries.createEntry(trusted, { title: "live", status: "published" });
+    const [row] = await handle.adapter.select<LiveRow>(TABLE);
+    const id = row.id;
+    // A status-less edit stores a working draft over the published row.
+    await entries.updateEntry(
+      { ...trusted, entryId: id },
+      { title: "edited-in-draft" }
+    );
+    expect(await workingDraftCount(id)).toBe(1);
+
+    const discarded = await discardWorkingDraftForDocument({
+      scopeKind: "collection",
+      slug: COLLECTION,
+      entryId: id,
+      user: { id: "editor-1" },
+      params: {
+        collectionName: COLLECTION,
+        entryId: id,
+        _authenticatedUserId: "editor-1",
+      },
+    });
+
+    // The sidecar is gone...
+    expect(await workingDraftCount(id)).toBe(0);
+    // ...and the response is the live published row, not the discarded edit.
+    expect((discarded as { title?: string }).title).toBe("live");
+    expect((discarded as { status?: string }).status).toBe("published");
+    // The live row itself was never touched.
+    const [liveAfter] = await handle.adapter.select<LiveRow>(TABLE);
+    expect(liveAfter.title).toBe("live");
+    expect(liveAfter.status).toBe("published");
+  });
+
+  it("refuses to discard for a caller who may not read the document, leaving the sidecar", async () => {
+    // Reads are denied for this caller. Discard is authorized as an update, but
+    // it re-establishes read first and refuses as not-found so the response does
+    // not confirm the document exists — and the pending draft is left intact.
+    // (The update-gate refusal, a 403 for a reader who may see but not edit the
+    // document, is pinned at the handler in discard-working-draft-access.test.)
+    handle = await createTestNextly({
+      collections: [
+        defineCollection({
+          slug: COLLECTION,
+          status: true,
+          versions: { drafts: true },
+          access: { read: () => false },
+          fields: [text({ name: "title" }), text({ name: "body" })],
+        }),
+      ],
+    });
+    const entries = handle
+      .getService("collectionsHandler")
+      .getEntryService() as CollectionEntryService;
+
+    await entries.createEntry(
+      { collectionName: COLLECTION, overrideAccess: true },
+      { title: "live", status: "published" }
+    );
+    const [row] = await handle.adapter.select<LiveRow>(TABLE);
+    const id = row.id;
+    await entries.updateEntry(
+      { collectionName: COLLECTION, entryId: id, overrideAccess: true },
+      { title: "edited-in-draft" }
+    );
+    expect(await workingDraftCount(id)).toBe(1);
+
+    await expect(
+      discardWorkingDraftForDocument({
+        scopeKind: "collection",
+        slug: COLLECTION,
+        entryId: id,
+        user: { id: "reader-1" },
+        params: {
+          collectionName: COLLECTION,
+          entryId: id,
+          _authenticatedUserId: "reader-1",
+        },
+      })
+    ).rejects.toMatchObject({ code: "NOT_FOUND" });
+
+    // The pending draft survives a refused discard.
+    expect(await workingDraftCount(id)).toBe(1);
   });
 });
 

--- a/packages/nextly/src/domains/collections/services/__tests__/draft-published-split.integration.test.ts
+++ b/packages/nextly/src/domains/collections/services/__tests__/draft-published-split.integration.test.ts
@@ -2173,3 +2173,71 @@ describe("draft/published split — schema and component eligibility (integratio
     expect(await workingDraftCount(id)).toBe(0);
   });
 });
+
+// The admin editor fetches a collection's schema through the dispatcher path
+// (CollectionsHandler.getCollection). It must carry `draftsEnabled` derived from
+// the SAME eligibility the mutation service gates on, or the editor would present
+// a status-less save as a pending draft while the server writes the live row.
+describe("draft/published split — schema draftsEnabled flag (integration)", () => {
+  async function draftsEnabledFor(
+    collection: ReturnType<typeof defineCollection>
+  ): Promise<boolean | undefined> {
+    handle = await createTestNextly({ collections: [collection] });
+    const res = await handle
+      .getService("collectionsHandler")
+      .getCollection({ collectionName: COLLECTION });
+    return (res.data as { draftsEnabled?: boolean } | null)?.draftsEnabled;
+  }
+
+  it("is true for an eligible drafts collection", async () => {
+    expect(
+      await draftsEnabledFor(
+        defineCollection({
+          slug: COLLECTION,
+          status: true,
+          versions: { drafts: true },
+          fields: [text({ name: "title" }), text({ name: "body" })],
+        })
+      )
+    ).toBe(true);
+  });
+
+  it("is false without the drafts lifecycle", async () => {
+    expect(
+      await draftsEnabledFor(
+        defineCollection({
+          slug: COLLECTION,
+          status: true,
+          fields: [text({ name: "title" })],
+        })
+      )
+    ).toBe(false);
+  });
+
+  it("is false for a localized collection", async () => {
+    expect(
+      await draftsEnabledFor(
+        defineCollection({
+          slug: COLLECTION,
+          status: true,
+          localized: true,
+          versions: { drafts: true },
+          fields: [text({ name: "title" })],
+        })
+      )
+    ).toBe(false);
+  });
+
+  it("is false for a collection with a reachable password field", async () => {
+    expect(
+      await draftsEnabledFor(
+        defineCollection({
+          slug: COLLECTION,
+          status: true,
+          versions: { drafts: true },
+          fields: [text({ name: "title" }), password({ name: "secret" })],
+        })
+      )
+    ).toBe(false);
+  });
+});

--- a/packages/nextly/src/domains/collections/services/__tests__/draft-published-split.integration.test.ts
+++ b/packages/nextly/src/domains/collections/services/__tests__/draft-published-split.integration.test.ts
@@ -516,6 +516,45 @@ describe("draft/published split — discard working draft (integration)", () => 
     // The pending draft survives a refused discard.
     expect(await workingDraftCount(id)).toBe(1);
   });
+
+  it("removes the sidecar through the handler's locked discard, leaving the live row untouched", async () => {
+    // The handler-level method the discard endpoint calls once it has authorized
+    // read and update: it deletes the sidecar under the parent-row lock (a no-op
+    // lock on SQLite, which serializes writers) and takes no user of its own.
+    handle = await createTestNextly({
+      collections: [
+        defineCollection({
+          slug: COLLECTION,
+          status: true,
+          versions: { drafts: true },
+          access: { read: () => true, update: () => true },
+          fields: [text({ name: "title" })],
+        }),
+      ],
+    });
+    const handler = handle.getService("collectionsHandler");
+    const entries = handler.getEntryService() as CollectionEntryService;
+    const trusted = { collectionName: COLLECTION, overrideAccess: true };
+
+    await entries.createEntry(trusted, { title: "live", status: "published" });
+    const [row] = await handle.adapter.select<LiveRow>(TABLE);
+    const id = row.id;
+    await entries.updateEntry(
+      { ...trusted, entryId: id },
+      { title: "edited-in-draft" }
+    );
+    expect(await workingDraftCount(id)).toBe(1);
+
+    await handler.discardWorkingDraft({
+      collectionName: COLLECTION,
+      entryId: id,
+    });
+
+    expect(await workingDraftCount(id)).toBe(0);
+    const [liveAfter] = await handle.adapter.select<LiveRow>(TABLE);
+    expect(liveAfter.title).toBe("live");
+    expect(liveAfter.status).toBe("published");
+  });
 });
 
 // Publishing a document that has a pending working draft must apply the draft's

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -1458,6 +1458,46 @@ export class CollectionMutationService extends BaseService {
     });
   }
 
+  /**
+   * Remove a document's pending working-draft sidecar under the same parent-row
+   * lock a draft save takes.
+   *
+   * A status-less save upserts the working draft while holding the parent row's
+   * lock (see the working-draft branch of updateEntry). Discarding has to take
+   * the same lock: without it, a save that commits between a discard's
+   * authorization checks and its delete would have its brand-new draft removed,
+   * and both requests would report success, silently losing that edit. Running
+   * the delete inside a transaction that locks the parent row serializes it with
+   * those saves. The lock is a no-op where row locking is unavailable (SQLite,
+   * which already serializes writers).
+   *
+   * Authorization is the caller's concern: the discard handler establishes read
+   * and update on the document before this runs. Deleting when no working draft
+   * exists is a no-op, not an error.
+   */
+  async discardWorkingDraft(params: {
+    collectionName: string;
+    entryId: string;
+  }): Promise<void> {
+    const collection = await this.collectionService.getCollection(
+      params.collectionName
+    );
+    const tableName = this.resolveTableName(collection, params.collectionName);
+    await this.adapter.transaction(async tx => {
+      // Serialize with concurrent draft-save upserts, which lock this same parent
+      // row before writing the sidecar.
+      await tx.lockRow(tableName, params.entryId);
+      await new VersionsRepository(tx).deleteWorkingDraft(
+        {
+          scopeKind: "collection",
+          scopeSlug: params.collectionName,
+          entryId: params.entryId,
+        },
+        null
+      );
+    });
+  }
+
   private async readCompanionSlugsAllLocales(
     db: CompanionReadDb,
     collectionName: string,

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -6239,6 +6239,16 @@ export class CollectionMutationService extends BaseService {
         params.collectionName
       );
 
+      // Signal that this save stored a pending working draft rather than writing
+      // the live row (draft/published split): the caller edited a published,
+      // drafts-enabled document without naming a status. The response reflects the
+      // draft, but its `status` stays the live parent's value, so an editor UI
+      // needs an explicit flag to show an "unpublished changes" state. Mirrors the
+      // read overlay's `_isWorkingDraft`.
+      if (workingDraftDocument) {
+        responseEntry._isWorkingDraft = true;
+      }
+
       return {
         success: true,
         statusCode: 200,

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -100,6 +100,7 @@ import {
 } from "../../i18n/runtime/companion-readiness";
 import { assembleDocument } from "../../versions/assemble-document";
 import { captureInTx } from "../../versions/capture-in-tx";
+import { isDraftSplitEligible } from "../../versions/draft-split-eligibility";
 import {
   buildRestorePayload,
   type ComponentSchemas,
@@ -4756,42 +4757,21 @@ export class CollectionMutationService extends BaseService {
         !hasPasswordField(fields)
           ? await resolveComponentSchemas(fields as unknown as FieldConfig[])
           : null;
-      // A localized component stores its values per locale, but a working draft
-      // is keyed under one unlocalized slot, so a draft saved under one locale
-      // would be promoted under another and misfile the translation into the
-      // wrong companion. A component whose schema cannot be resolved is treated
-      // the same way: it could itself be localized, and promoting a draft while
-      // it stays unresolvable drops the component subtree (the restore filter
-      // cannot see inside a schema it cannot load) before the sidecar is deleted,
-      // silently losing the pending edit. Until per-locale drafts exist, either
-      // kind of component makes the collection ineligible for the split,
-      // alongside a localized document.
-      const hasIneligibleComponent = splitComponentSchemas
-        ? [...splitComponentSchemas.values()].some(
-            schema => schema.localized || !schema.resolved
-          )
-        : false;
-      // A password field cannot ride safely in a working draft: the snapshot
-      // strips passwords so no plaintext credential is stored at rest, and the
-      // promote filter drops any field whose subtree holds one, so a draft can
-      // neither carry a password change nor preserve an ordinary edit made
-      // alongside a password in the same component. Until drafts persist password
-      // changes through a secure path, a collection with a reachable password
-      // field (top-level or inside a reachable component) is excluded from the
-      // split and edits the live row directly, exactly as before the split.
-      const hasReachablePassword =
-        hasPasswordField(fields) ||
-        (splitComponentSchemas
-          ? [...splitComponentSchemas.values()].some(schema =>
-              hasPasswordField(schema.fields)
-            )
-          : false);
-      const splitEnabled =
-        collectionHasStatus &&
-        versionsConfig?.drafts?.enabled === true &&
-        !documentLocalized &&
-        !hasIneligibleComponent &&
-        !hasReachablePassword;
+      // Eligibility is decided by the shared predicate so the admin's
+      // `draftsEnabled` flag (surfaced on the schema read) can never disagree
+      // with whether a status-less update here actually stores a working draft.
+      // A localized document or component, an unresolved component, or a
+      // reachable password field all rule it out — a localized component would
+      // misfile a promoted draft into the wrong companion, an unresolved one
+      // drops its subtree on promote, and a password cannot ride a draft
+      // snapshot. See isDraftSplitEligible.
+      const splitEnabled = isDraftSplitEligible({
+        collectionHasStatus,
+        draftsVersioningEnabled: versionsConfig?.drafts?.enabled === true,
+        documentLocalized,
+        fields: fields as unknown as FieldConfig[],
+        componentSchemas: splitComponentSchemas,
+      });
       // No status named ⇒ neither the main row nor the write-locale companion
       // `_status` is being set (matches the transition guard's own build gate at
       // `transitionNextStatus !== undefined`).

--- a/packages/nextly/src/domains/collections/services/collection-query-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-query-service.ts
@@ -2868,6 +2868,15 @@ export class CollectionQueryService extends BaseService {
       // nothing downstream can re-expose the creator's user id.
       stripSystemOwnerField(finalData);
 
+      // Signal that the returned document is the pending working draft, not the
+      // live row (draft/published split). The overlay keeps the draft's `status`
+      // at the live parent's value, so an editor UI needs an explicit flag to show
+      // an "unpublished changes" state. Set only when a draft was actually
+      // surfaced; mirrors the synthetic `_translations` read-response convention.
+      if (draftOverlaid) {
+        finalData._isWorkingDraft = true;
+      }
+
       return {
         success: true,
         statusCode: 200,

--- a/packages/nextly/src/domains/versions/__tests__/discard-working-draft.test.ts
+++ b/packages/nextly/src/domains/versions/__tests__/discard-working-draft.test.ts
@@ -4,10 +4,13 @@
  *
  * - the removal goes through the collections handler's LOCKED discard (which
  *   serializes with concurrent draft saves), never the lock-less
- *   versions-service delete; and
- * - a failed re-read is propagated as the error it carries rather than reported
- *   as a successful discard of an empty document (the live row may be deleted
- *   concurrently, or an after-read hook or database call may throw).
+ *   versions-service delete;
+ * - the live row is read BEFORE the sidecar is deleted, so a read failure (a
+ *   concurrent delete, or an after-read hook or database error) surfaces with
+ *   NOTHING removed — the draft survives for a retry, and the discard is never
+ *   reported as a failure after its deletion already happened; and
+ * - a failed read is propagated as the error it carries rather than reported as
+ *   a successful discard of an empty document.
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
@@ -48,7 +51,7 @@ describe("discardWorkingDraft", () => {
     discardSpy.mockResolvedValue(undefined);
   });
 
-  it("removes the sidecar through the locked handler, not the lock-less versions-service delete", async () => {
+  it("reads the live row, then removes the sidecar through the locked handler, not the lock-less versions-service delete", async () => {
     getEntrySpy.mockResolvedValue({
       success: true,
       data: { id: "e1", title: "live", status: "published" },
@@ -63,12 +66,19 @@ describe("discardWorkingDraft", () => {
       entryId: "e1",
     });
     expect(unlockedDeleteSpy).not.toHaveBeenCalled();
+    // The live read precedes the deletion, so a read failure can leave the draft
+    // intact (pinned by the next case).
+    expect(getEntrySpy.mock.invocationCallOrder[0]).toBeLessThan(
+      discardSpy.mock.invocationCallOrder[0]
+    );
   });
 
-  it("throws the envelope's error when the re-read fails, so the discard is not reported as a success", async () => {
-    // The sidecar delete succeeds, but the live row was deleted concurrently, so
-    // the re-read is a 404 failure envelope. Returning its null `data` would
-    // answer HTTP 200 with an empty item and reset the editor to blank fields.
+  it("throws the read failure BEFORE deleting, leaving the pending draft intact", async () => {
+    // The live-row read runs first; when it fails (a concurrent delete, or a
+    // failing after-read hook), nothing has been removed yet, so the discard has
+    // no side effect and is not reported as a failure after the deletion already
+    // happened. Returning the failure envelope's null `data` would instead answer
+    // HTTP 200 with an empty item and reset the editor to blank fields.
     getEntrySpy.mockResolvedValue({
       success: false,
       statusCode: 404,
@@ -80,8 +90,8 @@ describe("discardWorkingDraft", () => {
     await expect(discardWorkingDraft(args)).rejects.toMatchObject({
       code: "NOT_FOUND",
     });
-    // The removal still happened — the failure is only in reading back.
-    expect(discardSpy).toHaveBeenCalledTimes(1);
+    // Nothing was deleted — the read failed first.
+    expect(discardSpy).not.toHaveBeenCalled();
   });
 
   it("rebuilds the error from the status when the failure envelope carries no code", async () => {

--- a/packages/nextly/src/domains/versions/__tests__/discard-working-draft.test.ts
+++ b/packages/nextly/src/domains/versions/__tests__/discard-working-draft.test.ts
@@ -1,24 +1,32 @@
 /**
  * Discarding a working draft removes the sidecar and then re-reads the live
- * published row to hand back to the editor. That re-read runs the full pipeline
- * and can fail — the row may be deleted concurrently, or an after-read hook or
- * database call may throw — in which case the service answers a failure envelope
- * with `data: null`. These pin that the failure is propagated as the error it
- * carries rather than reported as a successful discard of an empty document.
+ * published row to hand back to the editor. These pin two things:
+ *
+ * - the removal goes through the collections handler's LOCKED discard (which
+ *   serializes with concurrent draft saves), never the lock-less
+ *   versions-service delete; and
+ * - a failed re-read is propagated as the error it carries rather than reported
+ *   as a successful discard of an empty document (the live row may be deleted
+ *   concurrently, or an after-read hook or database call may throw).
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
-const { deleteWorkingDraftSpy, getEntrySpy } = vi.hoisted(() => ({
-  deleteWorkingDraftSpy: vi.fn(),
+const { discardSpy, getEntrySpy, unlockedDeleteSpy } = vi.hoisted(() => ({
+  discardSpy: vi.fn(),
   getEntrySpy: vi.fn(),
+  unlockedDeleteSpy: vi.fn(),
 }));
 
 vi.mock("../../../di", () => ({
   getService: vi.fn((name: string) => {
-    if (name === "versionsService") {
-      return { deleteWorkingDraft: deleteWorkingDraftSpy };
+    if (name === "collectionsHandler") {
+      return { discardWorkingDraft: discardSpy, getEntry: getEntrySpy };
     }
-    if (name === "collectionsHandler") return { getEntry: getEntrySpy };
+    // The lock-less path the discard must no longer take; wired so the test can
+    // assert it is never called.
+    if (name === "versionsService") {
+      return { deleteWorkingDraft: unlockedDeleteSpy };
+    }
     return {};
   }),
 }));
@@ -34,13 +42,13 @@ const args = {
   user,
 };
 
-describe("discardWorkingDraft — propagating a failed post-discard read", () => {
+describe("discardWorkingDraft", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    deleteWorkingDraftSpy.mockResolvedValue(undefined);
+    discardSpy.mockResolvedValue(undefined);
   });
 
-  it("removes the null-locale sidecar then returns the live document on a successful re-read", async () => {
+  it("removes the sidecar through the locked handler, not the lock-less versions-service delete", async () => {
     getEntrySpy.mockResolvedValue({
       success: true,
       data: { id: "e1", title: "live", status: "published" },
@@ -50,10 +58,11 @@ describe("discardWorkingDraft — propagating a failed post-discard read", () =>
       title: "live",
       status: "published",
     });
-    expect(deleteWorkingDraftSpy).toHaveBeenCalledWith(
-      { scopeKind: "collection", scopeSlug: "posts", entryId: "e1" },
-      null
-    );
+    expect(discardSpy).toHaveBeenCalledWith({
+      collectionName: "posts",
+      entryId: "e1",
+    });
+    expect(unlockedDeleteSpy).not.toHaveBeenCalled();
   });
 
   it("throws the envelope's error when the re-read fails, so the discard is not reported as a success", async () => {
@@ -72,7 +81,7 @@ describe("discardWorkingDraft — propagating a failed post-discard read", () =>
       code: "NOT_FOUND",
     });
     // The removal still happened — the failure is only in reading back.
-    expect(deleteWorkingDraftSpy).toHaveBeenCalledTimes(1);
+    expect(discardSpy).toHaveBeenCalledTimes(1);
   });
 
   it("rebuilds the error from the status when the failure envelope carries no code", async () => {

--- a/packages/nextly/src/domains/versions/__tests__/discard-working-draft.test.ts
+++ b/packages/nextly/src/domains/versions/__tests__/discard-working-draft.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Discarding a working draft removes the sidecar and then re-reads the live
+ * published row to hand back to the editor. That re-read runs the full pipeline
+ * and can fail — the row may be deleted concurrently, or an after-read hook or
+ * database call may throw — in which case the service answers a failure envelope
+ * with `data: null`. These pin that the failure is propagated as the error it
+ * carries rather than reported as a successful discard of an empty document.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { deleteWorkingDraftSpy, getEntrySpy } = vi.hoisted(() => ({
+  deleteWorkingDraftSpy: vi.fn(),
+  getEntrySpy: vi.fn(),
+}));
+
+vi.mock("../../../di", () => ({
+  getService: vi.fn((name: string) => {
+    if (name === "versionsService") {
+      return { deleteWorkingDraft: deleteWorkingDraftSpy };
+    }
+    if (name === "collectionsHandler") return { getEntry: getEntrySpy };
+    return {};
+  }),
+}));
+
+import type { UserContext } from "../../singles/types";
+import { discardWorkingDraft } from "../discard-working-draft";
+
+const user = { id: "u1", roles: ["editor"] } as unknown as UserContext;
+
+const args = {
+  slug: "posts",
+  entryId: "e1",
+  user,
+};
+
+describe("discardWorkingDraft — propagating a failed post-discard read", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    deleteWorkingDraftSpy.mockResolvedValue(undefined);
+  });
+
+  it("removes the null-locale sidecar then returns the live document on a successful re-read", async () => {
+    getEntrySpy.mockResolvedValue({
+      success: true,
+      data: { id: "e1", title: "live", status: "published" },
+    });
+
+    await expect(discardWorkingDraft(args)).resolves.toMatchObject({
+      title: "live",
+      status: "published",
+    });
+    expect(deleteWorkingDraftSpy).toHaveBeenCalledWith(
+      { scopeKind: "collection", scopeSlug: "posts", entryId: "e1" },
+      null
+    );
+  });
+
+  it("throws the envelope's error when the re-read fails, so the discard is not reported as a success", async () => {
+    // The sidecar delete succeeds, but the live row was deleted concurrently, so
+    // the re-read is a 404 failure envelope. Returning its null `data` would
+    // answer HTTP 200 with an empty item and reset the editor to blank fields.
+    getEntrySpy.mockResolvedValue({
+      success: false,
+      statusCode: 404,
+      code: "NOT_FOUND",
+      message: "Entry not found.",
+      data: null,
+    });
+
+    await expect(discardWorkingDraft(args)).rejects.toMatchObject({
+      code: "NOT_FOUND",
+    });
+    // The removal still happened — the failure is only in reading back.
+    expect(deleteWorkingDraftSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("rebuilds the error from the status when the failure envelope carries no code", async () => {
+    getEntrySpy.mockResolvedValue({
+      success: false,
+      statusCode: 404,
+      message: "Entry not found.",
+      data: null,
+    });
+
+    await expect(discardWorkingDraft(args)).rejects.toMatchObject({
+      code: "NOT_FOUND",
+    });
+  });
+});

--- a/packages/nextly/src/domains/versions/__tests__/draft-split-eligibility.test.ts
+++ b/packages/nextly/src/domains/versions/__tests__/draft-split-eligibility.test.ts
@@ -1,0 +1,130 @@
+/**
+ * The draft-split eligibility predicate is the single source of truth shared by
+ * the mutation service (whether a status-less update stores a working draft) and
+ * the schema-read paths (the admin's `draftsEnabled`). These pin every
+ * disqualifier so the two can never present a status-less save as a draft while
+ * the server writes the live row.
+ */
+import { describe, it, expect } from "vitest";
+
+import type { FieldConfig } from "../../../collections/fields/types";
+import {
+  isDraftSplitEligible,
+  type DraftSplitEligibilityInput,
+} from "../draft-split-eligibility";
+import type { ComponentSchemas } from "../restore-snapshot";
+
+const textFields = [
+  { name: "title", type: "text" },
+] as unknown as FieldConfig[];
+const passwordFields = [
+  { name: "secret", type: "password" },
+] as unknown as FieldConfig[];
+
+const components = (
+  info: Partial<{
+    fields: FieldConfig[];
+    localized: boolean;
+    resolved: boolean;
+  }>
+): ComponentSchemas =>
+  new Map([
+    [
+      "hero",
+      {
+        fields: info.fields ?? textFields,
+        localized: info.localized ?? false,
+        resolved: info.resolved ?? true,
+      },
+    ],
+  ]);
+
+const base: DraftSplitEligibilityInput = {
+  collectionHasStatus: true,
+  draftsVersioningEnabled: true,
+  documentLocalized: false,
+  fields: textFields,
+  componentSchemas: new Map(),
+};
+
+describe("isDraftSplitEligible", () => {
+  it("is eligible when the lifecycle is on and nothing disqualifies", () => {
+    expect(isDraftSplitEligible(base)).toBe(true);
+  });
+
+  it("requires the Draft/Published lifecycle", () => {
+    expect(isDraftSplitEligible({ ...base, collectionHasStatus: false })).toBe(
+      false
+    );
+  });
+
+  it("requires drafts-enabled versioning", () => {
+    expect(
+      isDraftSplitEligible({ ...base, draftsVersioningEnabled: false })
+    ).toBe(false);
+  });
+
+  it("is off for a localized document", () => {
+    expect(isDraftSplitEligible({ ...base, documentLocalized: true })).toBe(
+      false
+    );
+  });
+
+  it("is off for a top-level (or grouped) password field", () => {
+    expect(isDraftSplitEligible({ ...base, fields: passwordFields })).toBe(
+      false
+    );
+  });
+
+  it("is off for a password inside a reachable component", () => {
+    expect(
+      isDraftSplitEligible({
+        ...base,
+        componentSchemas: components({ fields: passwordFields }),
+      })
+    ).toBe(false);
+  });
+
+  it("is off for a localized component", () => {
+    expect(
+      isDraftSplitEligible({
+        ...base,
+        componentSchemas: components({ localized: true }),
+      })
+    ).toBe(false);
+  });
+
+  it("is off for an unresolved component", () => {
+    expect(
+      isDraftSplitEligible({
+        ...base,
+        componentSchemas: components({ resolved: false }),
+      })
+    ).toBe(false);
+  });
+
+  it("stays eligible with an ordinary resolved, non-localized component", () => {
+    expect(
+      isDraftSplitEligible({ ...base, componentSchemas: components({}) })
+    ).toBe(true);
+  });
+
+  it("treats a null component map as no components when the cheap checks pass", () => {
+    // The mutation service skips component resolution when a cheaper disqualifier
+    // already forces false; a null map must not itself flip an otherwise-eligible
+    // collection, since the cheap checks run first.
+    expect(isDraftSplitEligible({ ...base, componentSchemas: null })).toBe(
+      true
+    );
+  });
+
+  it("still fails a cheap disqualifier even with a null component map", () => {
+    expect(
+      isDraftSplitEligible({
+        ...base,
+        collectionHasStatus: false,
+        componentSchemas: null,
+      })
+    ).toBe(false);
+  });
+});

--- a/packages/nextly/src/domains/versions/__tests__/schema-drafts-enabled.test.ts
+++ b/packages/nextly/src/domains/versions/__tests__/schema-drafts-enabled.test.ts
@@ -1,0 +1,97 @@
+/**
+ * `schemaDraftsEnabled` resolves the admin's `draftsEnabled` flag from the same
+ * eligibility predicate the write path gates on. When a drafts-configured
+ * collection embeds components, it must resolve their schemas from the registry,
+ * and a lookup failure there is PROPAGATED rather than swallowed into `false`:
+ * false is the destructive answer (the admin would send an explicit published
+ * save that overwrites the live row instead of storing a working draft), so an
+ * unknown verdict has to fail closed and be retried. These pin that contract and
+ * the cheap-path short-circuits that avoid touching the registry at all.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { getComponentBySlugSpy } = vi.hoisted(() => ({
+  getComponentBySlugSpy: vi.fn(),
+}));
+
+vi.mock("../../../di", () => ({
+  getService: vi.fn((name: string) => {
+    if (name === "fieldGroupRegistryService") {
+      return { getComponentBySlug: getComponentBySlugSpy };
+    }
+    return {};
+  }),
+}));
+
+import type { FieldConfig } from "../../../collections/fields/types";
+import { schemaDraftsEnabled } from "../draft-split-eligibility";
+
+const draftsCollection = (fields: FieldConfig[]) => ({
+  status: true,
+  versions: { drafts: { enabled: true } },
+  localized: false,
+  fields,
+});
+
+const componentFields = [
+  { name: "hero", type: "fieldGroup", component: "hero" },
+] as unknown as FieldConfig[];
+
+const plainFields = [
+  { name: "title", type: "text" },
+] as unknown as FieldConfig[];
+
+describe("schemaDraftsEnabled", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("propagates a component lookup failure instead of defaulting to false", async () => {
+    getComponentBySlugSpy.mockRejectedValue(new Error("registry unavailable"));
+
+    await expect(
+      schemaDraftsEnabled(draftsCollection(componentFields))
+    ).rejects.toThrow();
+  });
+
+  it("is true for a drafts collection whose component resolves clean and non-localized", async () => {
+    getComponentBySlugSpy.mockResolvedValue({
+      fields: [{ name: "heading", type: "text" }],
+      localized: false,
+    });
+
+    await expect(
+      schemaDraftsEnabled(draftsCollection(componentFields))
+    ).resolves.toBe(true);
+  });
+
+  it("is false for a localized component without failing", async () => {
+    getComponentBySlugSpy.mockResolvedValue({
+      fields: [{ name: "heading", type: "text" }],
+      localized: true,
+    });
+
+    await expect(
+      schemaDraftsEnabled(draftsCollection(componentFields))
+    ).resolves.toBe(false);
+  });
+
+  it("never touches the registry when the collection has no components", async () => {
+    await expect(
+      schemaDraftsEnabled(draftsCollection(plainFields))
+    ).resolves.toBe(true);
+    expect(getComponentBySlugSpy).not.toHaveBeenCalled();
+  });
+
+  it("never touches the registry when the drafts lifecycle is off", async () => {
+    await expect(
+      schemaDraftsEnabled({
+        status: true,
+        versions: null,
+        localized: false,
+        fields: componentFields,
+      })
+    ).resolves.toBe(false);
+    expect(getComponentBySlugSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/nextly/src/domains/versions/discard-working-draft.ts
+++ b/packages/nextly/src/domains/versions/discard-working-draft.ts
@@ -1,0 +1,64 @@
+/**
+ * Discarding a document's pending working draft.
+ *
+ * The draft/published split stores a status-less edit of a published document
+ * as a working-draft sidecar in `nextly_versions`. Discarding removes that
+ * sidecar and hands back the live published row, so the editor resets to what
+ * is public. Durable history is never touched — this reverts unpublished edits,
+ * it does not rewrite a version.
+ *
+ * Authorization is the caller's concern: the dispatcher handler establishes
+ * read and update on the document before calling in here, so this module only
+ * performs the removal and the re-read.
+ *
+ * @module domains/versions/discard-working-draft
+ */
+
+import type { AuthenticatedScope } from "../../auth/authenticated-scope";
+import { getService } from "../../di";
+import type { UserContext } from "../singles/types";
+
+export interface DiscardWorkingDraftArgs {
+  /** Collection slug. The split is a collection feature, so there is no Single
+   *  variant: a Single has a single row, not a published/draft pair. */
+  slug: string;
+  entryId: string;
+  user: UserContext;
+  /**
+   * The caller's authenticated scope, forwarded to the re-read so a scoped API
+   * key is judged on its OWN read grant rather than the key owner's roles.
+   */
+  authenticatedScope?: AuthenticatedScope;
+}
+
+/**
+ * Remove the working-draft sidecar for a published collection entry and return
+ * the live published document as a plain read would shape it. A no-op that
+ * still returns the live row when no working draft exists.
+ */
+export async function discardWorkingDraft(
+  args: DiscardWorkingDraftArgs
+): Promise<unknown> {
+  // Remove the sidecar. The split stores the working draft under the null
+  // locale key (it applies only to non-localized collections), so that is the
+  // one to clear. Deleting when none exists is a no-op, not an error.
+  await getService("versionsService").deleteWorkingDraft(
+    { scopeKind: "collection", scopeSlug: args.slug, entryId: args.entryId },
+    null
+  );
+
+  // Re-read the now-authoritative published row through the full read pipeline
+  // (hooks, redaction, field-level access), without the working-draft overlay,
+  // so the response is the live document the editor resets to.
+  const result = await getService("collectionsHandler").getEntry({
+    collectionName: args.slug,
+    entryId: args.entryId,
+    user: args.user,
+    // Read and update were established by the caller; skip only the redundant
+    // coarse RBAC re-check while the document's own rules still run in getEntry.
+    routeAuthorized: true,
+    authenticatedScope: args.authenticatedScope,
+    status: "all",
+  });
+  return result.data;
+}

--- a/packages/nextly/src/domains/versions/discard-working-draft.ts
+++ b/packages/nextly/src/domains/versions/discard-working-draft.ts
@@ -40,21 +40,15 @@ export interface DiscardWorkingDraftArgs {
 export async function discardWorkingDraft(
   args: DiscardWorkingDraftArgs
 ): Promise<unknown> {
-  // Remove the sidecar through the collections handler, which deletes it under
-  // the same parent-row lock a draft save takes: a save committing between this
-  // request's authorization checks and the delete would otherwise have its
-  // brand-new draft removed with both requests reporting success. The split
-  // stores the working draft under the null locale key (it applies only to
-  // non-localized collections). Deleting when none exists is a no-op, not an
-  // error.
-  await getService("collectionsHandler").discardWorkingDraft({
-    collectionName: args.slug,
-    entryId: args.entryId,
-  });
-
-  // Re-read the now-authoritative published row through the full read pipeline
-  // (hooks, redaction, field-level access), without the working-draft overlay,
-  // so the response is the live document the editor resets to.
+  // Read the live published row FIRST, through the full read pipeline (hooks,
+  // redaction, field-level access) and WITHOUT the working-draft overlay, so it
+  // is the live document the editor resets to. The delete below never touches
+  // the live row — it only clears the sidecar — so this pre-read is the same
+  // document a post-delete read would return. Reading first is what makes the
+  // discard effectively atomic: a read failure surfaces before anything is
+  // removed, leaving the pending draft intact rather than deleting it and then
+  // reporting a failure the admin treats as a no-op (which would keep the stale
+  // draft on screen and let a later Publish push its values straight to live).
   const result = await getService("collectionsHandler").getEntry({
     collectionName: args.slug,
     entryId: args.entryId,
@@ -66,11 +60,10 @@ export async function discardWorkingDraft(
     status: "all",
   });
 
-  // The sidecar removal succeeded, but the re-read can still fail — the live row
-  // may have been deleted concurrently, or an after-read hook or database call
-  // may throw. Returning the failure envelope's null `data` as-is would answer
-  // HTTP 200 and reset the editor from an empty item; rebuild the error the
-  // envelope carries so the caller gets the real status and code instead.
+  // A failed read (a concurrent delete, or an after-read hook or database error)
+  // is propagated as the error it carries rather than returned as a successful
+  // discard of an empty document — and because nothing has been deleted yet, the
+  // draft is left intact for a retry.
   if (!result.success) {
     throw errorFromServiceEnvelope({
       statusCode: result.statusCode,
@@ -81,5 +74,18 @@ export async function discardWorkingDraft(
       errors: result.errors,
     });
   }
+
+  // Now remove the sidecar through the collections handler, which deletes it
+  // under the same parent-row lock a draft save takes: a save committing between
+  // this request's authorization checks and the delete would otherwise have its
+  // brand-new draft removed with both requests reporting success. The split
+  // stores the working draft under the null locale key (it applies only to
+  // non-localized collections). Deleting when none exists is a no-op, not an
+  // error.
+  await getService("collectionsHandler").discardWorkingDraft({
+    collectionName: args.slug,
+    entryId: args.entryId,
+  });
+
   return result.data;
 }

--- a/packages/nextly/src/domains/versions/discard-working-draft.ts
+++ b/packages/nextly/src/domains/versions/discard-working-draft.ts
@@ -16,6 +16,7 @@
 
 import type { AuthenticatedScope } from "../../auth/authenticated-scope";
 import { getService } from "../../di";
+import { errorFromServiceEnvelope } from "../../errors/from-service-envelope";
 import type { UserContext } from "../singles/types";
 
 export interface DiscardWorkingDraftArgs {
@@ -60,5 +61,21 @@ export async function discardWorkingDraft(
     authenticatedScope: args.authenticatedScope,
     status: "all",
   });
+
+  // The sidecar removal succeeded, but the re-read can still fail — the live row
+  // may have been deleted concurrently, or an after-read hook or database call
+  // may throw. Returning the failure envelope's null `data` as-is would answer
+  // HTTP 200 and reset the editor from an empty item; rebuild the error the
+  // envelope carries so the caller gets the real status and code instead.
+  if (!result.success) {
+    throw errorFromServiceEnvelope({
+      statusCode: result.statusCode,
+      code: result.code,
+      message: result.message,
+      messageKey: result.messageKey,
+      publicData: result.publicData,
+      errors: result.errors,
+    });
+  }
   return result.data;
 }

--- a/packages/nextly/src/domains/versions/discard-working-draft.ts
+++ b/packages/nextly/src/domains/versions/discard-working-draft.ts
@@ -40,13 +40,17 @@ export interface DiscardWorkingDraftArgs {
 export async function discardWorkingDraft(
   args: DiscardWorkingDraftArgs
 ): Promise<unknown> {
-  // Remove the sidecar. The split stores the working draft under the null
-  // locale key (it applies only to non-localized collections), so that is the
-  // one to clear. Deleting when none exists is a no-op, not an error.
-  await getService("versionsService").deleteWorkingDraft(
-    { scopeKind: "collection", scopeSlug: args.slug, entryId: args.entryId },
-    null
-  );
+  // Remove the sidecar through the collections handler, which deletes it under
+  // the same parent-row lock a draft save takes: a save committing between this
+  // request's authorization checks and the delete would otherwise have its
+  // brand-new draft removed with both requests reporting success. The split
+  // stores the working draft under the null locale key (it applies only to
+  // non-localized collections). Deleting when none exists is a no-op, not an
+  // error.
+  await getService("collectionsHandler").discardWorkingDraft({
+    collectionName: args.slug,
+    entryId: args.entryId,
+  });
 
   // Re-read the now-authoritative published row through the full read pipeline
   // (hooks, redaction, field-level access), without the working-draft overlay,

--- a/packages/nextly/src/domains/versions/draft-split-eligibility.ts
+++ b/packages/nextly/src/domains/versions/draft-split-eligibility.ts
@@ -1,0 +1,125 @@
+/**
+ * Whether the draft/published working-draft split will run for a collection.
+ *
+ * This is the single source of truth for the split's eligibility. The mutation
+ * service gates a status-less update on it (whether to store a working draft
+ * instead of writing the live row), and the schema-read paths expose it to the
+ * admin as `draftsEnabled` so the editor offers the matching affordances. Any
+ * divergence would make the editor present a status-less save as a pending draft
+ * while the server writes the live row (or the reverse), so all three call sites
+ * MUST derive it here.
+ *
+ * The split needs the Draft/Published lifecycle and drafts-enabled versioning,
+ * and is off for a localized document and for a reachable password field
+ * (top-level, in a group, or in a component) — a password cannot ride safely in
+ * a draft snapshot. It is also off when any reachable component is localized or
+ * fails to resolve, since the draft snapshot cannot represent those faithfully.
+ *
+ * Component analysis is left to the caller (via `resolveComponentSchemas`) so
+ * this stays a pure, synchronous, DI-free predicate that is trivially testable.
+ *
+ * @module domains/versions/draft-split-eligibility
+ */
+
+import type { FieldConfig } from "../../collections/fields/types";
+import { hasPasswordField } from "../../shared/lib/password-fields";
+
+import type { ComponentSchemas } from "./restore-snapshot";
+import { resolveComponentSchemas } from "./restore-version";
+
+export interface DraftSplitEligibilityInput {
+  /** `collection.status === true` — the Draft/Published lifecycle is enabled. */
+  collectionHasStatus: boolean;
+  /** `collection.versions?.drafts?.enabled === true`. */
+  draftsVersioningEnabled: boolean;
+  /** `collection.localized === true` — the split is off for localized documents. */
+  documentLocalized: boolean;
+  /** The collection's top-level fields, for the reachable-password check. */
+  fields: FieldConfig[];
+  /**
+   * The collection's reachable component schemas, from
+   * `resolveComponentSchemas(fields)`. May be `null` when a caller skipped
+   * resolution because a cheaper disqualifier already forces the result false
+   * (the mutation service's optimization); the cheap checks below run first, so
+   * a `null` map is never reached while still eligible.
+   */
+  componentSchemas: ComponentSchemas | null;
+}
+
+/**
+ * Whether a status-less update stores a working draft (the live row untouched)
+ * rather than writing the live row directly.
+ */
+export function isDraftSplitEligible(
+  input: DraftSplitEligibilityInput
+): boolean {
+  if (
+    !input.collectionHasStatus ||
+    !input.draftsVersioningEnabled ||
+    input.documentLocalized
+  ) {
+    return false;
+  }
+  // A reachable password field disqualifies the whole collection: the snapshot
+  // strips passwords and the promote filter drops any subtree holding one, so a
+  // draft could neither carry a password change nor preserve an edit made
+  // alongside it.
+  if (hasPasswordField(input.fields)) {
+    return false;
+  }
+  const schemas = input.componentSchemas
+    ? [...input.componentSchemas.values()]
+    : [];
+  // A localized or unresolved component cannot be represented faithfully in a
+  // draft snapshot; a component holding a password is disqualified for the same
+  // reason as a top-level one.
+  if (schemas.some(schema => schema.localized || !schema.resolved)) {
+    return false;
+  }
+  if (schemas.some(schema => hasPasswordField(schema.fields))) {
+    return false;
+  }
+  return true;
+}
+
+/** The collection shape the schema-read paths carry, for {@link schemaDraftsEnabled}. */
+export interface SchemaEligibilityCollection {
+  status?: boolean;
+  versions?: { drafts?: { enabled?: boolean } } | null;
+  localized?: boolean;
+  /** Top-level fields, in their ORIGINAL (un-enriched) form — the enriched shape
+   *  drops the localized/resolved markers component eligibility needs. */
+  fields: FieldConfig[];
+}
+
+/**
+ * Resolve `draftsEnabled` for a schema-read response (the admin editor's flag),
+ * from the same predicate the mutation service gates on.
+ *
+ * Component schemas are resolved from the registry here (async), but only once
+ * the cheap disqualifiers pass — mirroring the mutation service, so a collection
+ * the split can never take (localized, no drafts, top-level password) never pays
+ * for a registry read. The caller owns error handling: a registry failure should
+ * leave the flag off rather than fail the read.
+ */
+export async function schemaDraftsEnabled(
+  collection: SchemaEligibilityCollection
+): Promise<boolean> {
+  const collectionHasStatus = collection.status === true;
+  const draftsVersioningEnabled = collection.versions?.drafts?.enabled === true;
+  const documentLocalized = collection.localized === true;
+  const componentSchemas =
+    collectionHasStatus &&
+    draftsVersioningEnabled &&
+    !documentLocalized &&
+    !hasPasswordField(collection.fields)
+      ? await resolveComponentSchemas(collection.fields)
+      : null;
+  return isDraftSplitEligible({
+    collectionHasStatus,
+    draftsVersioningEnabled,
+    documentLocalized,
+    fields: collection.fields,
+    componentSchemas,
+  });
+}

--- a/packages/nextly/src/domains/versions/versions-service.ts
+++ b/packages/nextly/src/domains/versions/versions-service.ts
@@ -89,4 +89,20 @@ export class VersionsService {
     }
     return row;
   }
+
+  /**
+   * Discard a document's pending working draft in one locale, returning the
+   * number of rows removed (0 when none exists).
+   *
+   * The working draft is the status-less sidecar the draft/published split
+   * writes for edits to a published document. Removing it reverts the editor to
+   * the live published row; history is untouched, which is why this discards
+   * unpublished edits rather than rewriting a version.
+   */
+  async deleteWorkingDraft(
+    ref: VersionRef,
+    locale: string | null
+  ): Promise<number> {
+    return this.repo.deleteWorkingDraft(ref, locale);
+  }
 }

--- a/packages/nextly/src/route-handler/__tests__/route-parser.versions.test.ts
+++ b/packages/nextly/src/route-handler/__tests__/route-parser.versions.test.ts
@@ -137,6 +137,35 @@ describe("version routes", () => {
     expect(parsed.method).toBeUndefined();
   });
 
+  it("parses discarding a collection entry's working draft as a write", () => {
+    const parsed = parseRestRoute(
+      ["collections", "posts", "entries", "e1", "versions", "working-draft"],
+      "DELETE"
+    );
+
+    expect(parsed).toMatchObject({
+      service: "collections",
+      method: "discardWorkingDraft",
+      // Discarding rewrites what the editor sees (it reverts the document to its
+      // live published row), so it resolves to update-{slug}, not read-{slug}.
+      operation: "update",
+      routeParams: { collectionName: "posts", entryId: "e1" },
+    });
+    // `working-draft` is a named sub-resource, never captured as a version number.
+    expect(parsed.routeParams?.versionNo).toBeUndefined();
+  });
+
+  it("does not discard a working draft on a POST", () => {
+    // Only DELETE discards; a create-verb on the same path owns no route and
+    // must not fall through to an entry write.
+    expect(
+      parseRestRoute(
+        ["collections", "posts", "entries", "e1", "versions", "working-draft"],
+        "POST"
+      ).method
+    ).toBeUndefined();
+  });
+
   it("still matches the entry itself when no segments trail", () => {
     // The guard must not cost the entry routes their own paths.
     expect(

--- a/packages/nextly/src/route-handler/route-parser.ts
+++ b/packages/nextly/src/route-handler/route-parser.ts
@@ -829,6 +829,26 @@ function parseCollectionEntryVersionRoutes(
     };
   }
 
+  // `versions/working-draft` DELETE discards the pending working draft
+  // (draft/published split), reverting the document to its live published row.
+  // `working-draft` is a named sub-resource, never a version number, so it can
+  // never collide with `versions/{versionNo}`. Authorized as an update: it
+  // changes what the editor sees, not the document's history.
+  if (
+    additionalParams.length === 2 &&
+    additionalParams[1] === "working-draft" &&
+    httpMethod === "DELETE"
+  ) {
+    routeParams.collectionName = id;
+    routeParams.entryId = subId;
+    return {
+      service: "collections",
+      operation: "update",
+      method: "discardWorkingDraft",
+      routeParams,
+    };
+  }
+
   if (
     // Only `versions` or `versions/{versionNo}`; anything deeper is not a
     // route this owns and must not be silently truncated to one that is.

--- a/packages/nextly/src/routeHandler.ts
+++ b/packages/nextly/src/routeHandler.ts
@@ -522,6 +522,10 @@ const COLLECTION_ENTRY_METHODS = new Set([
   // Naming a version writes history rather than the document, but it is still
   // a write and resolves to the same permission.
   "setEntryVersionLabel",
+  // Discarding the working draft reverts the document to its live row; the
+  // route parser marks it an `update` operation, so it resolves to the
+  // `update-{slug}` permission rather than a definition mutation's manage-settings.
+  "discardWorkingDraft",
 ]);
 
 /** Single document methods (read/update content, not schema definitions). */

--- a/packages/nextly/src/services/collections-handler.ts
+++ b/packages/nextly/src/services/collections-handler.ts
@@ -417,27 +417,24 @@ export class CollectionsHandler {
       // actually fetches through, and it derives the flag from the SAME predicate
       // the mutation service gates on, so the editor can never present a
       // status-less save as a pending draft while the server writes the live row.
-      // Best-effort: a component-registry failure leaves the split off rather than
-      // failing the schema read.
-      try {
-        data.draftsEnabled = await schemaDraftsEnabled({
-          status: data.status as boolean | undefined,
-          versions: data.versions as
-            | { drafts?: { enabled?: boolean } }
-            | null
-            | undefined,
-          localized: data.localized as boolean | undefined,
-          fields: originalFields,
-        });
-      } catch (eligibilityError) {
-        console.error(
-          "[CollectionsHandler.getCollection] Failed to resolve draftsEnabled:",
-          eligibilityError instanceof Error
-            ? eligibilityError.message
-            : String(eligibilityError)
-        );
-        data.draftsEnabled = false;
-      }
+      //
+      // A failure to resolve component eligibility is propagated, not defaulted
+      // to false: the only path that throws is a drafts-configured collection
+      // whose components could not be resolved (a transient registry/database
+      // error), and false is the DESTRUCTIVE answer there — the admin would send
+      // an explicit published save that overwrites the live row instead of the
+      // status-less save that stores a working draft. Failing the read keeps the
+      // editor from acting on an unknown verdict; it is retryable, and mirrors
+      // resolveComponentSchemas, which is fail-closed for the same reason.
+      data.draftsEnabled = await schemaDraftsEnabled({
+        status: data.status as boolean | undefined,
+        versions: data.versions as
+          | { drafts?: { enabled?: boolean } }
+          | null
+          | undefined,
+        localized: data.localized as boolean | undefined,
+        fields: originalFields,
+      });
     }
 
     return result;
@@ -660,6 +657,19 @@ export class CollectionsHandler {
     authenticatedScope?: AuthenticatedScope;
   }) {
     return this.entryService.getEntry(params);
+  }
+
+  /**
+   * Remove a document's pending working-draft sidecar under the same parent-row
+   * lock a draft save takes. Serializing the discard with concurrent draft saves
+   * keeps it from deleting a draft another editor committed after this request's
+   * authorization checks. The discard handler authorizes read and update first.
+   */
+  async discardWorkingDraft(params: {
+    collectionName: string;
+    entryId: string;
+  }): Promise<void> {
+    return this.entryService.discardWorkingDraft(params);
   }
 
   /**

--- a/packages/nextly/src/services/collections-handler.ts
+++ b/packages/nextly/src/services/collections-handler.ts
@@ -6,11 +6,13 @@ import { getHookRegistry } from "@nextly/hooks/hook-registry";
 
 import type { AuthenticatedScope } from "../auth/authenticated-scope";
 import type { RequestActor } from "../auth/request-actor";
+import type { FieldConfig } from "../collections/fields/types";
 import { container } from "../di/container";
 import type { PermissionSeedService } from "../domains/auth/services/permission-seed-service";
 import type { RBACAccessControlService } from "../domains/auth/services/rbac-access-control-service";
 import { DynamicCollectionService } from "../domains/dynamic-collections";
 import type { SanitizedLocalizationConfig } from "../domains/i18n/config/types";
+import { schemaDraftsEnabled } from "../domains/versions/draft-split-eligibility";
 import type { WebhookFastDrainScheduler } from "../domains/webhooks/after-drain";
 import type { ResolvedWebhookRetentionConfig } from "../domains/webhooks/retention-config";
 import { MetaRetentionGate } from "../domains/webhooks/retention-gate";
@@ -378,6 +380,10 @@ export class CollectionsHandler {
     // form rendering works without extra API calls per component.
     const data = result.data as Record<string, unknown> | null;
     if (result.success && data?.fields) {
+      // The ORIGINAL fields, captured before enrichment replaces them: the
+      // working-draft eligibility below needs the un-enriched shape (the enriched
+      // one drops the component localized/resolved markers it inspects).
+      const originalFields = data.fields as unknown as FieldConfig[];
       try {
         const hasComponentRegistry = container.has("fieldGroupRegistryService");
         if (hasComponentRegistry) {
@@ -403,6 +409,34 @@ export class CollectionsHandler {
             ? enrichError.message
             : String(enrichError)
         );
+      }
+
+      // Surface whether the draft/published working-draft split will run for this
+      // collection so the admin editor offers the matching Save / Publish /
+      // Discard affordances. This is the dispatcher path the built-in admin
+      // actually fetches through, and it derives the flag from the SAME predicate
+      // the mutation service gates on, so the editor can never present a
+      // status-less save as a pending draft while the server writes the live row.
+      // Best-effort: a component-registry failure leaves the split off rather than
+      // failing the schema read.
+      try {
+        data.draftsEnabled = await schemaDraftsEnabled({
+          status: data.status as boolean | undefined,
+          versions: data.versions as
+            | { drafts?: { enabled?: boolean } }
+            | null
+            | undefined,
+          localized: data.localized as boolean | undefined,
+          fields: originalFields,
+        });
+      } catch (eligibilityError) {
+        console.error(
+          "[CollectionsHandler.getCollection] Failed to resolve draftsEnabled:",
+          eligibilityError instanceof Error
+            ? eligibilityError.message
+            : String(eligibilityError)
+        );
+        data.draftsEnabled = false;
       }
     }
 

--- a/packages/nextly/src/services/collections/collection-entry-service.ts
+++ b/packages/nextly/src/services/collections/collection-entry-service.ts
@@ -571,6 +571,19 @@ export class CollectionEntryService extends BaseService {
     return this.mutationService.warmLocalizedReadiness(collectionName);
   }
 
+  /**
+   * Remove a document's pending working-draft sidecar under the same parent-row
+   * lock a draft save takes, so a discard cannot delete a draft that a
+   * concurrent save committed after the discard's checks. The discard handler
+   * has already authorized read and update on the document.
+   */
+  async discardWorkingDraft(params: {
+    collectionName: string;
+    entryId: string;
+  }): Promise<void> {
+    return this.mutationService.discardWorkingDraft(params);
+  }
+
   async createEntryInTransaction(
     tx: TransactionContext,
     params: { collectionName: string; user?: UserContext },


### PR DESCRIPTION
## What

Turns the merged draft/published split engine into a usable editor experience. On a drafts-enabled collection, editing a **published** entry now saves a pending **working draft** instead of overwriting what is live, and the editor exposes the full Draft / Published / Changed lifecycle (aligned to Payload as the industry reference).

## Why

The working-draft engine landed in #428 and became reachable via `?draft=true` in #451, but nothing in the admin drove it: editing a published entry always re-asserted `status: "published"`, so a working draft was never created. This is the admin half of that work.

## Changes

**Server (`nextly`)**
- `getEntry` / `updateEntry` flag an overlaid read and a status-less save with a synthetic `_isWorkingDraft` (mirrors the `_translations` convention; never touches the user's `status`).
- New `DELETE /collections/{slug}/entries/{id}/versions/working-draft` discards the pending draft and returns the live published row. Authorized as an update: read is re-established (404 when denied), then the document's own update rule runs (403 when denied), before the sidecar is removed. History is never touched. Implemented as a small `discardWorkingDraft` domain fn + a gate-only dispatcher handler, mirroring `restoreVersion`.
- `VersionsService.deleteWorkingDraft` exposes the repository op through the public surface.
- The collection schema GET now returns a derived `draftsEnabled` boolean (only code-first `versions.drafts` collections enable the split; the Schema Builder always resolves `drafts: false`).

**Admin (`@nextlyhq/admin`)**
- A published, drafts-enabled entry: **Save** stores a working draft (status-less), **Publish** promotes it, and a confirmed **Discard draft** action (More menu, gated on update access) reverts to the published version.
- The status pill shows **Changed** (published + pending draft) in both the Document panel and the collapsed-rail meta strip, using the muted amber `warning` token in light and dark.
- The editor loads with `?draft=1` so it shows and saves onto the working draft; discard invalidates the entry so it refetches the live row.
- Keyboard save (Cmd/Ctrl+S) mirrors the primary Save button per lifecycle state.

## Testing

- Server: route-parser cases, an adversarial gate-chain unit test for the discard handler, the dispatch registry/reachability cross-checks, and two integration cases (real sidecar delete + live re-read; refusal leaves the sidecar) across the draft-split suite. TDD throughout (red -> implement -> green).
- Admin: `pillStateFromForm` / DocumentPanel / EntryMetaStrip "Changed" states, the header button matrix incl. the drafts branch, the discard menu gating (incl. update-permission), the confirm dialog, the `versionApi` URL, and the `useDiscardWorkingDraft` invalidation/toast.
- `check-types` and `lint` green for both packages; one changeset (all fixed-group packages, patch).

## Notes

Deferred to a follow-up (documented): a batched `_hasWorkingDraft` existence probe so the entries LIST can show a "Changed" column. The editor does not need it.
