### PR TITLE
feat(nextly): record when an entry first became public

### DIFF
--- a/.changeset/first-published-marker.md
+++ b/.changeset/first-published-marker.md
@@ -1,0 +1,31 @@
+---
+
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch---
+
+Collections with Draft/Published now record when an entry first went live, in a new `firstPublishedAt` timestamp.
+
+Until now a row only said what it IS. Unpublishing sent it back to draft and erased every trace it had ever been public, even though the inbound links, feeds and search results it collected while live were still out there. Anything that needs to ask "was this address ever public" had nothing to read.
+
+The value is set once, on the first transition into published, and never changes afterwards: it is the date of the first publication, not the most recent one. It survives an unpublish, and it stays empty for an entry that has only ever been a draft. Entries that already existed keep an empty value, because whether they were once published was never recorded and cannot be recovered after the fact.
+
+Collections without Draft/Published do not get the column: they have no unpublished state, so there is no transition to record. Singles do not get it yet either.

--- a/.changeset/first-published-marker.md
+++ b/.changeset/first-published-marker.md
@@ -1,5 +1,4 @@
 ---
-
 "nextly": patch
 "create-nextly-app": patch
 "@nextlyhq/admin": patch
@@ -20,7 +19,8 @@
 "@nextlyhq/eslint-config": patch
 "@nextlyhq/prettier-config": patch
 "@nextlyhq/telemetry": patch
-"@nextlyhq/tsconfig": patch---
+"@nextlyhq/tsconfig": patch
+---
 
 Collections with Draft/Published now record when an entry first went live, in a new `firstPublishedAt` timestamp.
 

--- a/.changeset/first-published-marker.md
+++ b/.changeset/first-published-marker.md
@@ -22,10 +22,14 @@
 "@nextlyhq/tsconfig": patch
 ---
 
-Collections with Draft/Published now record when an entry first went live, in a new `firstPublishedAt` timestamp.
+Collections and singles with Draft/Published now record when a document first went live, in a new `firstPublishedAt` timestamp.
 
 Until now a row only said what it IS. Unpublishing sent it back to draft and erased every trace it had ever been public, even though the inbound links, feeds and search results it collected while live were still out there. Anything that needs to ask "was this address ever public" had nothing to read.
 
 The value is set once, on the first transition into published, and never changes afterwards: it is the date of the first publication, not the most recent one. It survives an unpublish, and it stays empty for an entry that has only ever been a draft. Entries that already existed keep an empty value, because whether they were once published was never recorded and cannot be recovered after the fact.
 
-Collections without Draft/Published do not get the column: they have no unpublished state, so there is no transition to record. Singles do not get it yet either.
+Collections and singles without Draft/Published do not get the column: they have no unpublished state, so there is no transition to record.
+
+For a collection translated into several languages, the value answers whether the document has been public in any language, since every translation shares one address. Publishing a single translation therefore records it.
+
+The value is set by Nextly alone. A `firstPublishedAt` sent in a create or update request is ignored, so the recorded date is always one that actually happened.

--- a/packages/nextly/src/collections/config/validate-config.marker-reserved.test.ts
+++ b/packages/nextly/src/collections/config/validate-config.marker-reserved.test.ts
@@ -1,0 +1,58 @@
+/**
+ * `first_published_at` is injected as a system column once the draft/publish
+ * lifecycle is enabled, so a user field of that name would collide with it in
+ * the table. Reserved unconditionally: a collection can enable the lifecycle
+ * later, and the collision would then surface at migration time rather than
+ * where the name was chosen.
+ *
+ * Nested fields live inside JSON and do not collide, so the reservation is
+ * top-level only — the same rule the owner column follows.
+ */
+import { describe, expect, it } from "vitest";
+
+import { group, text } from "../fields/helpers";
+import type { CollectionConfig } from "./define-collection";
+import { validateCollectionConfig } from "./validate-config";
+
+function codesFor(
+  fields: CollectionConfig["fields"],
+  extra: Partial<CollectionConfig> = {}
+): string[] {
+  return validateCollectionConfig({
+    slug: "posts",
+    fields,
+    ...extra,
+  }).errors.map(e => e.code);
+}
+
+describe("validateCollectionConfig: first-publication marker reservation", () => {
+  it("rejects a top-level first_published_at field", () => {
+    expect(codesFor([text({ name: "first_published_at" })])).toContain(
+      "FIELD_NAME_RESERVED"
+    );
+  });
+
+  it("rejects the camelCase firstPublishedAt alias", () => {
+    // Config validation accepts camelCase names and snake-cases them to the same column, so
+    // allowing the alias would reserve nothing.
+    expect(codesFor([text({ name: "firstPublishedAt" })])).toContain(
+      "FIELD_NAME_RESERVED"
+    );
+  });
+
+  it("rejects it even when the lifecycle is off", () => {
+    // The point of reserving it unconditionally: enabling `status` later must not turn a valid
+    // config into a failed migration.
+    expect(
+      codesFor([text({ name: "first_published_at" })], { status: false })
+    ).toContain("FIELD_NAME_RESERVED");
+  });
+
+  it("allows the name nested inside a group (JSON-stored, no column)", () => {
+    expect(
+      codesFor([
+        group({ name: "meta", fields: [text({ name: "first_published_at" })] }),
+      ])
+    ).not.toContain("FIELD_NAME_RESERVED");
+  });
+});

--- a/packages/nextly/src/collections/config/validate-config.ts
+++ b/packages/nextly/src/collections/config/validate-config.ts
@@ -164,18 +164,27 @@ const RESERVED_SLUGS_SET: Set<string> = new Set<string>([
   ...SYSTEM_RESOURCES,
 ]);
 
-// The owner column `created_by` is injected as a system column on every
-// collection table (both the snake_case name and its camelCase alias, which
-// snake-cases to the same column). A code-first collection therefore must not
-// declare a top-level field with either name, or its DDL would collide with the
-// injected column and the owner stamp / response strip would consume a user
-// field. Reserved for collections only — singles are a single global row and
-// components embed in JSON, so neither carries this column and both may use the
-// name freely. Nested repeater/group fields are stored inside JSON, not as
-// table columns, so the reservation applies to the top level only.
+// System columns injected onto a collection table, under both the snake_case
+// name and the camelCase alias that snake-cases to the same column. A code-first
+// collection must not declare a top-level field with either name, or its DDL
+// would collide with the injected column and the system's own stamp would
+// consume a user field.
+//
+// `created_by` is the owner column. `first_published_at` records the first
+// transition into published; it is injected only when the draft/publish
+// lifecycle is enabled, but it is reserved unconditionally, because a
+// collection can enable that lifecycle later and the field would collide the
+// moment it did — failing at migration time rather than at config validation,
+// which is much further from the mistake.
+//
+// Components embed in JSON and carry neither column, so they may use both names
+// freely. Nested repeater/group fields are stored inside JSON, not as table
+// columns, so the reservation applies to the top level only.
 const COLLECTION_RESERVED_FIELD_NAMES: Set<string> = new Set([
   "created_by",
   "createdBy",
+  "first_published_at",
+  "firstPublishedAt",
 ]);
 
 // ============================================================
@@ -521,7 +530,7 @@ function validateFields(
     if (typeof name === "string" && COLLECTION_RESERVED_FIELD_NAMES.has(name)) {
       errors.push({
         path: `${path}[${index}].name`,
-        message: `Field name '${name}' is reserved for the system owner column`,
+        message: `Field name '${name}' is reserved for a system column`,
         code: "FIELD_NAME_RESERVED",
       });
     }

--- a/packages/nextly/src/domains/collections/__tests__/first-published-marker.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/first-published-marker.integration.test.ts
@@ -15,8 +15,6 @@ import {
   createTestNextly,
   type TestNextly,
 } from "../../../plugins/test-nextly";
-import type { CollectionsHandler } from "../../../services/collections-handler";
-import type { SingleEntryService } from "../../singles/services/single-entry-service";
 
 let current: TestNextly | undefined;
 
@@ -32,8 +30,10 @@ const posts = () =>
     fields: [text({ name: "title" })],
   });
 
+// `getService` is keyed by service NAME — `ServiceMap` already maps "collectionsHandler" to its
+// type, so passing the type as the generic makes it `unknown` instead of narrowing it.
 function handler(t: TestNextly) {
-  return t.getService<CollectionsHandler>("collectionsHandler");
+  return t.getService("collectionsHandler");
 }
 
 /** Rows read straight from the physical table, so the assertion sees the column itself rather
@@ -199,8 +199,7 @@ describe("first_published_at", () => {
         }),
       ],
     });
-    const singles =
-      current.getService<SingleEntryService>("singleEntryService");
+    const singles = current.getService("singleEntryService");
 
     // Reads and writes both work, which is the thing the column would have broken.
     await singles.update(

--- a/packages/nextly/src/domains/collections/__tests__/first-published-marker.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/first-published-marker.integration.test.ts
@@ -1,0 +1,216 @@
+/**
+ * The durable record that a document has been public.
+ *
+ * `status` describes what a document IS. Unpublishing returns it to `draft` and, before this
+ * column, erased every trace it had ever been live — while the inbound links, feeds and search
+ * results it accumulated stayed exactly where they were. Anything that has to ask "was this
+ * address ever public" (slug stability, redirect capture) needs an answer that survives that round
+ * trip, so these run against a real database rather than asserting on statement text: what matters
+ * is the value that is still there after the unpublish committed.
+ */
+import { afterEach, describe, expect, it } from "vitest";
+
+import { defineCollection, defineSingle, text } from "../../../config";
+import {
+  createTestNextly,
+  type TestNextly,
+} from "../../../plugins/test-nextly";
+import type { CollectionsHandler } from "../../../services/collections-handler";
+import type { SingleEntryService } from "../../singles/services/single-entry-service";
+
+let current: TestNextly | undefined;
+
+afterEach(async () => {
+  await current?.destroy();
+  current = undefined;
+});
+
+const posts = () =>
+  defineCollection({
+    slug: "posts",
+    status: true,
+    fields: [text({ name: "title" })],
+  });
+
+function handler(t: TestNextly) {
+  return t.getService<CollectionsHandler>("collectionsHandler");
+}
+
+/** Rows read straight from the physical table, so the assertion sees the column itself rather
+ *  than whatever the read shape chooses to project. */
+async function tableRows(
+  t: TestNextly,
+  table: string
+): Promise<Record<string, unknown>[]> {
+  return t.adapter.select<Record<string, unknown>>(table);
+}
+
+async function storedRow(
+  t: TestNextly,
+  id: string
+): Promise<Record<string, unknown>> {
+  const rows = await tableRows(t, "dc_posts");
+  return rows.find(r => r.id === id) ?? {};
+}
+
+describe("first_published_at", () => {
+  it("stays null while a document has only ever been a draft", async () => {
+    // The column has to distinguish "never public" from "public once", so a draft must not carry
+    // a value simply because the row exists.
+    current = await createTestNextly({ collections: [posts()] });
+
+    const created = await handler(current).createEntry(
+      { collectionName: "posts", overrideAccess: true },
+      { title: "wip", status: "draft" }
+    );
+    const id = (created.data as { id: string }).id;
+
+    expect((await storedRow(current, id)).first_published_at).toBeFalsy();
+  });
+
+  it("is stamped when a draft is published", async () => {
+    current = await createTestNextly({ collections: [posts()] });
+    const h = handler(current);
+
+    const created = await h.createEntry(
+      { collectionName: "posts", overrideAccess: true },
+      { title: "wip", status: "draft" }
+    );
+    const id = (created.data as { id: string }).id;
+    expect((await storedRow(current, id)).first_published_at).toBeFalsy();
+
+    await h.updateEntry(
+      { collectionName: "posts", entryId: id, overrideAccess: true },
+      { status: "published" }
+    );
+
+    expect((await storedRow(current, id)).first_published_at).toBeTruthy();
+  });
+
+  it("is stamped when a document is created directly as published", async () => {
+    // A create has no prior status, so landing on published IS the first publication. Without
+    // this the whole create-and-publish path would leave the marker null forever.
+    current = await createTestNextly({ collections: [posts()] });
+
+    const created = await handler(current).createEntry(
+      { collectionName: "posts", overrideAccess: true },
+      { title: "live", status: "published" }
+    );
+    const id = (created.data as { id: string }).id;
+
+    expect((await storedRow(current, id)).first_published_at).toBeTruthy();
+  });
+
+  it("survives an unpublish", async () => {
+    // The case the column exists for. `status` goes back to draft; the record that this address
+    // was once public must not go with it.
+    current = await createTestNextly({ collections: [posts()] });
+    const h = handler(current);
+
+    const created = await h.createEntry(
+      { collectionName: "posts", overrideAccess: true },
+      { title: "live", status: "published" }
+    );
+    const id = (created.data as { id: string }).id;
+    const stamped = (await storedRow(current, id)).first_published_at;
+    expect(stamped).toBeTruthy();
+
+    await h.updateEntry(
+      { collectionName: "posts", entryId: id, overrideAccess: true },
+      { status: "draft" }
+    );
+
+    const after = await storedRow(current, id);
+    expect(after.status).toBe("draft");
+    expect(after.first_published_at).toBeTruthy();
+  });
+
+  it("does not move when the document is published again", async () => {
+    // It dates the FIRST publication. A republish that reset it would report the most recent go
+    // live, which is a different question and would make the marker useless for the first.
+    current = await createTestNextly({ collections: [posts()] });
+    const h = handler(current);
+
+    const created = await h.createEntry(
+      { collectionName: "posts", overrideAccess: true },
+      { title: "live", status: "published" }
+    );
+    const id = (created.data as { id: string }).id;
+
+    // Backdated so a re-stamp would be VISIBLE. Both publications otherwise land inside the same
+    // second, and these columns store no finer resolution than that on every dialect — so the
+    // assertion would hold whether or not the set-once guard exists, and pass for the wrong
+    // reason. Confirmed: without the backdate, removing the guard leaves this test green.
+    const backdated = new Date("2020-01-01T00:00:00.000Z");
+    await current.adapter.update(
+      "dc_posts",
+      { first_published_at: backdated },
+      { and: [{ column: "id", op: "=", value: id }] }
+    );
+    const before = (await storedRow(current, id)).first_published_at;
+    expect(before).toBeTruthy();
+
+    await h.updateEntry(
+      { collectionName: "posts", entryId: id, overrideAccess: true },
+      { status: "draft" }
+    );
+    await h.updateEntry(
+      { collectionName: "posts", entryId: id, overrideAccess: true },
+      { status: "published" }
+    );
+
+    expect(String((await storedRow(current, id)).first_published_at)).toBe(
+      String(before)
+    );
+  });
+
+  it("is not added to a collection with no draft lifecycle", async () => {
+    // Such a collection publishes on save and has no transition to record, so the column would be
+    // a migration every user pays for and nothing ever writes.
+    current = await createTestNextly({
+      collections: [
+        defineCollection({ slug: "notes", fields: [text({ name: "title" })] }),
+      ],
+    });
+
+    const created = await handler(current).createEntry(
+      { collectionName: "notes", overrideAccess: true },
+      { title: "n" }
+    );
+    const id = (created.data as { id: string }).id;
+    const rows = await tableRows(current, "dc_notes");
+    const row = rows.find(r => r.id === id) ?? {};
+
+    expect(Object.keys(row)).not.toContain("first_published_at");
+  });
+
+  it("is not added to a Single, whose physical table would not receive it", async () => {
+    // Not a claim that a Single's publication date is meaningless — it is exactly as meaningful.
+    // A Single's table does not get this column through the same path the runtime schema does, so
+    // injecting it made the schema select a column that is not there, failing EVERY read of a
+    // status-enabled Single rather than just leaving the marker unset. Pinned here so the day the
+    // Single DDL path is aligned, this test is what says so.
+    current = await createTestNextly({
+      singles: [
+        defineSingle({
+          slug: "banner",
+          status: true,
+          fields: [text({ name: "title" })],
+        }),
+      ],
+    });
+    const singles =
+      current.getService<SingleEntryService>("singleEntryService");
+
+    // Reads and writes both work, which is the thing the column would have broken.
+    await singles.update(
+      "banner",
+      { title: "hi", status: "published" },
+      { overrideAccess: true }
+    );
+
+    const row = (await tableRows(current, "single_banner"))[0] ?? {};
+    expect(row.status).toBe("published");
+    expect(Object.keys(row)).not.toContain("first_published_at");
+  });
+});

--- a/packages/nextly/src/domains/collections/__tests__/first-published-marker.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/first-published-marker.integration.test.ts
@@ -184,6 +184,111 @@ describe("first_published_at", () => {
     expect(Object.keys(row)).not.toContain("first_published_at");
   });
 
+  it("ignores a marker supplied by the client on create", async () => {
+    // The column is not a declared field, so field validation passes it straight through: without
+    // stripping, a draft create can invent a publication date for a document that has never been
+    // public. Both spellings, because the snake-case pass would otherwise let the camelCase alias
+    // through and land on the same column.
+    current = await createTestNextly({ collections: [posts()] });
+
+    const created = await handler(current).createEntry(
+      { collectionName: "posts", overrideAccess: true },
+      {
+        title: "wip",
+        status: "draft",
+        firstPublishedAt: new Date("1999-01-01T00:00:00.000Z"),
+        first_published_at: new Date("1999-01-01T00:00:00.000Z"),
+      }
+    );
+    const id = (created.data as { id: string }).id;
+
+    expect((await storedRow(current, id)).first_published_at).toBeFalsy();
+  });
+
+  it("ignores a marker supplied by the client on update", async () => {
+    // The set-once guarantee is only worth as much as the write path's refusal to take a value
+    // from the request: an update that could reset it would make the marker report whatever the
+    // last caller chose.
+    current = await createTestNextly({ collections: [posts()] });
+    const h = handler(current);
+
+    const created = await h.createEntry(
+      { collectionName: "posts", overrideAccess: true },
+      { title: "live", status: "published" }
+    );
+    const id = (created.data as { id: string }).id;
+    const stamped = String((await storedRow(current, id)).first_published_at);
+
+    await h.updateEntry(
+      { collectionName: "posts", entryId: id, overrideAccess: true },
+      {
+        title: "edited",
+        firstPublishedAt: new Date("1999-01-01T00:00:00.000Z"),
+        first_published_at: new Date("1999-01-01T00:00:00.000Z"),
+      }
+    );
+
+    expect(String((await storedRow(current, id)).first_published_at)).toBe(
+      stamped
+    );
+  });
+
+  it("does not date a first publication when publish-all changes nothing", async () => {
+    // The rows this would hit are the ones it would be most wrong about: published before this
+    // column existed, so their marker is null precisely because their history was never recorded.
+    // Stamping today reports a publication that did not happen, which is what a null exists to
+    // avoid claiming. Simulated by clearing the marker on an already-published row, since a
+    // genuinely legacy row cannot be created through the API.
+    current = await createTestNextly({ collections: [posts()] });
+    const h = handler(current);
+
+    const created = await h.createEntry(
+      { collectionName: "posts", overrideAccess: true },
+      { title: "live", status: "published" }
+    );
+    const id = (created.data as { id: string }).id;
+    await current.adapter.update(
+      "dc_posts",
+      { first_published_at: null },
+      { and: [{ column: "id", op: "=", value: id }] }
+    );
+    expect((await storedRow(current, id)).first_published_at).toBeFalsy();
+
+    await h.publishAllLocales({
+      collectionName: "posts",
+      entryId: id,
+      overrideAccess: true,
+    });
+
+    const after = await storedRow(current, id);
+    expect(after.status).toBe("published");
+    expect(after.first_published_at).toBeFalsy();
+  });
+
+  it("dates a first publication when publish-all does move the row", async () => {
+    // The other half of the same branch: publish-all on a draft IS a first publication, and
+    // gating the stamp on a real transition must not turn it off here.
+    current = await createTestNextly({ collections: [posts()] });
+    const h = handler(current);
+
+    const created = await h.createEntry(
+      { collectionName: "posts", overrideAccess: true },
+      { title: "wip", status: "draft" }
+    );
+    const id = (created.data as { id: string }).id;
+    expect((await storedRow(current, id)).first_published_at).toBeFalsy();
+
+    await h.publishAllLocales({
+      collectionName: "posts",
+      entryId: id,
+      overrideAccess: true,
+    });
+
+    const after = await storedRow(current, id);
+    expect(after.status).toBe("published");
+    expect(after.first_published_at).toBeTruthy();
+  });
+
   it("records a Single's first publication, and reads still work", async () => {
     // This test used to assert the OPPOSITE. A Single's physical table was built by a generator
     // that restated the system columns by hand, so this column reached the runtime schema and not

--- a/packages/nextly/src/domains/collections/__tests__/first-published-marker.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/first-published-marker.integration.test.ts
@@ -524,6 +524,58 @@ describe("first_published_at", () => {
     }
   });
 
+  it("leaves a legacy already-public document unmarked when a translation publishes", async () => {
+    // The row this protects: published before this column existed, so its marker is null because
+    // the history was never recorded, not because it was never public. Publishing a translation
+    // afterwards must not date its first publication from today — the per-locale transition sees
+    // that one locale going live and cannot tell it apart from the document becoming public.
+    current = await createTestNextly({
+      collections: [
+        defineCollection({
+          slug: "fpmlegacy",
+          status: true,
+          localized: true,
+          fields: [text({ name: "title", localized: true })],
+        }),
+      ],
+      localization: { locales: ["en", "es"], defaultLocale: "en" },
+    });
+    const h = handler(current);
+
+    const created = await h.createEntry(
+      { collectionName: "fpmlegacy", overrideAccess: true, locale: "en" },
+      { title: "live", status: "published" }
+    );
+    const id = (created.data as { id: string }).id;
+
+    // Clear the marker to reproduce an upgraded row: already public, no recorded history.
+    await current.adapter.update(
+      "dc_fpmlegacy",
+      { first_published_at: null },
+      { and: [{ column: "id", op: "=", value: id }] }
+    );
+    const rows =
+      await current.adapter.select<Record<string, unknown>>("dc_fpmlegacy");
+    const legacy = rows.find(r => r.id === id) ?? {};
+    expect(legacy.status).toBe("published");
+    expect(legacy.first_published_at).toBeFalsy();
+
+    await h.updateEntry(
+      {
+        collectionName: "fpmlegacy",
+        entryId: id,
+        locale: "es",
+        overrideAccess: true,
+      },
+      { title: "hola", status: "published" }
+    );
+
+    const after = (
+      await current.adapter.select<Record<string, unknown>>("dc_fpmlegacy")
+    ).find(r => r.id === id);
+    expect(after?.first_published_at).toBeFalsy();
+  });
+
   it("records a Single's first publication, and reads still work", async () => {
     // This test used to assert the OPPOSITE. A Single's physical table was built by a generator
     // that restated the system columns by hand, so this column reached the runtime schema and not
@@ -564,6 +616,32 @@ describe("first_published_at", () => {
     // inspecting the table.
     const read = await singles.get("fpmbanner", { overrideAccess: true });
     expect(read).toBeTruthy();
+  });
+
+  it("keeps a Single's own field named created_by", async () => {
+    // A single has no owner column — its system columns are id, title, slug, the timestamps,
+    // status and the marker — so `created_by` is an ordinary field name a single may declare.
+    // Reserving it on singles because collections reserve it would silently discard the user's
+    // own column on every update, which is why the reserved set follows the column rather than
+    // being shared wholesale.
+    current = await createTestNextly({
+      singles: [
+        defineSingle({
+          slug: "fpmowner",
+          fields: [text({ name: "title" }), text({ name: "created_by" })],
+        }),
+      ],
+    });
+    const singles = current.getService("singleEntryService");
+
+    await singles.update(
+      "fpmowner",
+      { title: "hi", created_by: "written by the user" },
+      { overrideAccess: true }
+    );
+
+    const row = (await tableRows(current, "single_fpmowner"))[0] ?? {};
+    expect(row.created_by).toBe("written by the user");
   });
 
   it("ignores a marker supplied by the client on a Single", async () => {

--- a/packages/nextly/src/domains/collections/__tests__/first-published-marker.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/first-published-marker.integration.test.ts
@@ -576,6 +576,54 @@ describe("first_published_at", () => {
     expect(after?.first_published_at).toBeFalsy();
   });
 
+  it("records a first publication through the batch create worker", async () => {
+    // The batch service calls its own streamlined worker, not `createEntryInTransaction`, so
+    // fixing the transaction API left this path unstamped. Whether a document's history exists
+    // must not depend on whether it was written one at a time or in a batch.
+    current = await createTestNextly({ collections: [posts()] });
+    const entries = txEntries(current);
+
+    const result = await entries.createEntries(
+      { collectionName: "fpmposts", overrideAccess: true },
+      [
+        { title: "live", status: "published" },
+        { title: "wip", status: "draft" },
+      ]
+    );
+    expect(result.successful).toBe(2);
+
+    const rows = await tableRows(current, "dc_fpmposts");
+    const live = rows.find(r => r.title === "live") ?? {};
+    const wip = rows.find(r => r.title === "wip") ?? {};
+    expect(live.first_published_at).toBeTruthy();
+    expect(wip.first_published_at).toBeFalsy();
+  });
+
+  it("does not stamp a batch create that stays a draft", async () => {
+    // The negative half of the batch-create case above, in the same worker: a batch that writes
+    // drafts records nothing, so the stamp is tied to the transition rather than to the path.
+    //
+    // The batch UPDATE worker is not covered here. It is reachable only through `updateEntries`,
+    // which accepts no `overrideAccess` — so publishing through it always requires a caller
+    // holding a real `publish-<slug>` grant, and this suite has no helper that seeds one. Its
+    // wiring mirrors the create worker asserted above and calls the same unit-tested rule.
+    current = await createTestNextly({ collections: [posts()] });
+    const entries = txEntries(current);
+
+    const result = await entries.createEntries(
+      { collectionName: "fpmposts", overrideAccess: true },
+      [
+        { title: "a", status: "draft" },
+        { title: "b", status: "draft" },
+      ]
+    );
+    expect(result.successful).toBe(2);
+
+    for (const row of await tableRows(current, "dc_fpmposts")) {
+      expect(row.first_published_at).toBeFalsy();
+    }
+  });
+
   it("records a Single's first publication, and reads still work", async () => {
     // This test used to assert the OPPOSITE. A Single's physical table was built by a generator
     // that restated the system columns by hand, so this column reached the runtime schema and not

--- a/packages/nextly/src/domains/collections/__tests__/first-published-marker.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/first-published-marker.integration.test.ts
@@ -27,7 +27,7 @@ afterEach(async () => {
 
 const posts = () =>
   defineCollection({
-    slug: "posts",
+    slug: "fpmposts",
     status: true,
     fields: [text({ name: "title" })],
   });
@@ -63,7 +63,7 @@ async function storedRow(
   t: TestNextly,
   id: string
 ): Promise<Record<string, unknown>> {
-  const rows = await tableRows(t, "dc_posts");
+  const rows = await tableRows(t, "dc_fpmposts");
   return rows.find(r => r.id === id) ?? {};
 }
 
@@ -74,7 +74,7 @@ describe("first_published_at", () => {
     current = await createTestNextly({ collections: [posts()] });
 
     const created = await handler(current).createEntry(
-      { collectionName: "posts", overrideAccess: true },
+      { collectionName: "fpmposts", overrideAccess: true },
       { title: "wip", status: "draft" }
     );
     const id = (created.data as { id: string }).id;
@@ -87,14 +87,14 @@ describe("first_published_at", () => {
     const h = handler(current);
 
     const created = await h.createEntry(
-      { collectionName: "posts", overrideAccess: true },
+      { collectionName: "fpmposts", overrideAccess: true },
       { title: "wip", status: "draft" }
     );
     const id = (created.data as { id: string }).id;
     expect((await storedRow(current, id)).first_published_at).toBeFalsy();
 
     await h.updateEntry(
-      { collectionName: "posts", entryId: id, overrideAccess: true },
+      { collectionName: "fpmposts", entryId: id, overrideAccess: true },
       { status: "published" }
     );
 
@@ -107,7 +107,7 @@ describe("first_published_at", () => {
     current = await createTestNextly({ collections: [posts()] });
 
     const created = await handler(current).createEntry(
-      { collectionName: "posts", overrideAccess: true },
+      { collectionName: "fpmposts", overrideAccess: true },
       { title: "live", status: "published" }
     );
     const id = (created.data as { id: string }).id;
@@ -122,7 +122,7 @@ describe("first_published_at", () => {
     const h = handler(current);
 
     const created = await h.createEntry(
-      { collectionName: "posts", overrideAccess: true },
+      { collectionName: "fpmposts", overrideAccess: true },
       { title: "live", status: "published" }
     );
     const id = (created.data as { id: string }).id;
@@ -130,7 +130,7 @@ describe("first_published_at", () => {
     expect(stamped).toBeTruthy();
 
     await h.updateEntry(
-      { collectionName: "posts", entryId: id, overrideAccess: true },
+      { collectionName: "fpmposts", entryId: id, overrideAccess: true },
       { status: "draft" }
     );
 
@@ -146,7 +146,7 @@ describe("first_published_at", () => {
     const h = handler(current);
 
     const created = await h.createEntry(
-      { collectionName: "posts", overrideAccess: true },
+      { collectionName: "fpmposts", overrideAccess: true },
       { title: "live", status: "published" }
     );
     const id = (created.data as { id: string }).id;
@@ -157,7 +157,7 @@ describe("first_published_at", () => {
     // reason. Confirmed: without the backdate, removing the guard leaves this test green.
     const backdated = new Date("2020-01-01T00:00:00.000Z");
     await current.adapter.update(
-      "dc_posts",
+      "dc_fpmposts",
       { first_published_at: backdated },
       { and: [{ column: "id", op: "=", value: id }] }
     );
@@ -165,11 +165,11 @@ describe("first_published_at", () => {
     expect(before).toBeTruthy();
 
     await h.updateEntry(
-      { collectionName: "posts", entryId: id, overrideAccess: true },
+      { collectionName: "fpmposts", entryId: id, overrideAccess: true },
       { status: "draft" }
     );
     await h.updateEntry(
-      { collectionName: "posts", entryId: id, overrideAccess: true },
+      { collectionName: "fpmposts", entryId: id, overrideAccess: true },
       { status: "published" }
     );
 
@@ -183,16 +183,19 @@ describe("first_published_at", () => {
     // a migration every user pays for and nothing ever writes.
     current = await createTestNextly({
       collections: [
-        defineCollection({ slug: "notes", fields: [text({ name: "title" })] }),
+        defineCollection({
+          slug: "fpmnotes",
+          fields: [text({ name: "title" })],
+        }),
       ],
     });
 
     const created = await handler(current).createEntry(
-      { collectionName: "notes", overrideAccess: true },
+      { collectionName: "fpmnotes", overrideAccess: true },
       { title: "n" }
     );
     const id = (created.data as { id: string }).id;
-    const rows = await tableRows(current, "dc_notes");
+    const rows = await tableRows(current, "dc_fpmnotes");
     const row = rows.find(r => r.id === id) ?? {};
 
     expect(Object.keys(row)).not.toContain("first_published_at");
@@ -206,7 +209,7 @@ describe("first_published_at", () => {
     current = await createTestNextly({ collections: [posts()] });
 
     const created = await handler(current).createEntry(
-      { collectionName: "posts", overrideAccess: true },
+      { collectionName: "fpmposts", overrideAccess: true },
       {
         title: "wip",
         status: "draft",
@@ -227,14 +230,14 @@ describe("first_published_at", () => {
     const h = handler(current);
 
     const created = await h.createEntry(
-      { collectionName: "posts", overrideAccess: true },
+      { collectionName: "fpmposts", overrideAccess: true },
       { title: "live", status: "published" }
     );
     const id = (created.data as { id: string }).id;
     const stamped = String((await storedRow(current, id)).first_published_at);
 
     await h.updateEntry(
-      { collectionName: "posts", entryId: id, overrideAccess: true },
+      { collectionName: "fpmposts", entryId: id, overrideAccess: true },
       {
         title: "edited",
         firstPublishedAt: new Date("1999-01-01T00:00:00.000Z"),
@@ -257,19 +260,19 @@ describe("first_published_at", () => {
     const h = handler(current);
 
     const created = await h.createEntry(
-      { collectionName: "posts", overrideAccess: true },
+      { collectionName: "fpmposts", overrideAccess: true },
       { title: "live", status: "published" }
     );
     const id = (created.data as { id: string }).id;
     await current.adapter.update(
-      "dc_posts",
+      "dc_fpmposts",
       { first_published_at: null },
       { and: [{ column: "id", op: "=", value: id }] }
     );
     expect((await storedRow(current, id)).first_published_at).toBeFalsy();
 
     await h.publishAllLocales({
-      collectionName: "posts",
+      collectionName: "fpmposts",
       entryId: id,
       overrideAccess: true,
     });
@@ -286,14 +289,14 @@ describe("first_published_at", () => {
     const h = handler(current);
 
     const created = await h.createEntry(
-      { collectionName: "posts", overrideAccess: true },
+      { collectionName: "fpmposts", overrideAccess: true },
       { title: "wip", status: "draft" }
     );
     const id = (created.data as { id: string }).id;
     expect((await storedRow(current, id)).first_published_at).toBeFalsy();
 
     await h.publishAllLocales({
-      collectionName: "posts",
+      collectionName: "fpmposts",
       entryId: id,
       overrideAccess: true,
     });
@@ -313,7 +316,7 @@ describe("first_published_at", () => {
     const res = await current.adapter.transaction(tx =>
       entries.createEntryInTransaction(
         tx as never,
-        { collectionName: "posts", overrideAccess: true },
+        { collectionName: "fpmposts", overrideAccess: true },
         { title: "live", status: "published" }
       )
     );
@@ -327,7 +330,7 @@ describe("first_published_at", () => {
     const entries = txEntries(current);
 
     const created = await handler(current).createEntry(
-      { collectionName: "posts", overrideAccess: true },
+      { collectionName: "fpmposts", overrideAccess: true },
       { title: "wip", status: "draft" }
     );
     const id = (created.data as { id: string }).id;
@@ -336,7 +339,7 @@ describe("first_published_at", () => {
     await current.adapter.transaction(tx =>
       entries.updateEntryInTransaction(
         tx as never,
-        { collectionName: "posts", entryId: id, overrideAccess: true },
+        { collectionName: "fpmposts", entryId: id, overrideAccess: true },
         { status: "published" }
       )
     );
@@ -350,12 +353,12 @@ describe("first_published_at", () => {
     const entries = txEntries(current);
 
     const created = await handler(current).createEntry(
-      { collectionName: "posts", overrideAccess: true },
+      { collectionName: "fpmposts", overrideAccess: true },
       { title: "live", status: "published" }
     );
     const id = (created.data as { id: string }).id;
     await current.adapter.update(
-      "dc_posts",
+      "dc_fpmposts",
       { first_published_at: new Date("2020-01-01T00:00:00.000Z") },
       { and: [{ column: "id", op: "=", value: id }] }
     );
@@ -364,14 +367,14 @@ describe("first_published_at", () => {
     await current.adapter.transaction(tx =>
       entries.updateEntryInTransaction(
         tx as never,
-        { collectionName: "posts", entryId: id, overrideAccess: true },
+        { collectionName: "fpmposts", entryId: id, overrideAccess: true },
         { status: "draft" }
       )
     );
     await current.adapter.transaction(tx =>
       entries.updateEntryInTransaction(
         tx as never,
-        { collectionName: "posts", entryId: id, overrideAccess: true },
+        { collectionName: "fpmposts", entryId: id, overrideAccess: true },
         { status: "published" }
       )
     );
@@ -381,58 +384,56 @@ describe("first_published_at", () => {
     );
   });
 
-  it("reports the marker on the publish-all event that establishes it", async () => {
-    // The event payload, the version snapshot and the workflow reaction are all built from the
-    // PRE-update row with the new status overlaid, because publishing otherwise changes nothing
-    // else. The marker is the exception: it IS written by that update, so without carrying it
-    // across, the one event that announces a first publication reports no first publication.
-    current = await createTestNextly({ collections: [posts()] });
+  it("captures the marker in the version the publish records", async () => {
+    // The publish builds its event payload, version snapshot and workflow reaction from the
+    // PRE-update row with the new status overlaid, because publishing changes nothing else. The
+    // marker is the exception: that same update writes it, so without carrying it across, the
+    // publication that establishes a first publication records a snapshot saying there was none.
+    //
+    // Asserted on the version row rather than the emitted event. Both are built from the same
+    // overlaid row, but the version is written inside the publish transaction and can be read
+    // back, whereas event DELIVERY through the process-wide bus proved order-dependent in this
+    // harness — the assertion passed alone and saw nothing once another file booted first.
+    current = await createTestNextly({
+      collections: [
+        defineCollection({
+          slug: "fpmversioned",
+          status: true,
+          versions: true,
+          fields: [text({ name: "title" })],
+        }),
+      ],
+    });
     const h = handler(current);
 
     const created = await h.createEntry(
-      { collectionName: "posts", overrideAccess: true },
+      { collectionName: "fpmversioned", overrideAccess: true },
       { title: "wip", status: "draft" }
     );
     const id = (created.data as { id: string }).id;
 
     await h.publishAllLocales({
-      collectionName: "posts",
+      collectionName: "fpmversioned",
       entryId: id,
       overrideAccess: true,
     });
-    await current.events.settle();
 
-    const rows =
-      await current.adapter.select<Record<string, unknown>>("nextly_events");
-    const published = rows.filter(r => r.type === "entry.published");
-    expect(published.length).toBeGreaterThan(0);
+    const versions = (
+      await current.adapter.select<Record<string, unknown>>("nextly_versions")
+    ).filter(v => v.entryId === id && v.status === "published");
+    expect(versions.length).toBeGreaterThan(0);
 
-    // Asserting the VALUE, not the presence of the key. The pre-image row carries
-    // `first_published_at: null`, so the key is in the payload either way — a substring or
-    // `in` check passes with the overlay removed and proves nothing.
-    const markers = published.map(row => {
-      const raw = row.payload;
-      const payload =
+    // The VALUE, not the key: the pre-image carries `first_published_at: null`, so the key is in
+    // the snapshot either way and an `in` check would pass with the overlay removed.
+    const markers = versions.map(v => {
+      const raw = v.snapshot;
+      const snapshot =
         typeof raw === "string"
           ? (JSON.parse(raw) as Record<string, unknown>)
           : ((raw ?? {}) as Record<string, unknown>);
-      const data = payload.data;
-      return isRecord(data) ? data.first_published_at : undefined;
+      return snapshot.first_published_at ?? snapshot.firstPublishedAt;
     });
     expect(markers.some(m => m != null)).toBe(true);
-
-    // And the pre-image must still say it was absent: the event describes a transition, so a
-    // `previous` that already carried the marker would report no change.
-    const previousMarkers = published.map(row => {
-      const raw = row.payload;
-      const payload =
-        typeof raw === "string"
-          ? (JSON.parse(raw) as Record<string, unknown>)
-          : ((raw ?? {}) as Record<string, unknown>);
-      const previous = payload.previous;
-      return isRecord(previous) ? previous.first_published_at : undefined;
-    });
-    expect(previousMarkers.every(m => m == null)).toBe(true);
   });
 
   it("records a first publication made in a non-default locale", async () => {
@@ -447,7 +448,7 @@ describe("first_published_at", () => {
     current = await createTestNextly({
       collections: [
         defineCollection({
-          slug: "posts",
+          slug: "fpmposts",
           status: true,
           localized: true,
           fields: [text({ name: "title", localized: true })],
@@ -458,7 +459,7 @@ describe("first_published_at", () => {
     const h = handler(current);
 
     const created = await h.createEntry(
-      { collectionName: "posts", overrideAccess: true, locale: "en" },
+      { collectionName: "fpmposts", overrideAccess: true, locale: "en" },
       { title: "wip", status: "draft" }
     );
     const id = (created.data as { id: string }).id;
@@ -470,7 +471,7 @@ describe("first_published_at", () => {
     // user holding a real `publish-posts` grant and the suite has no helper that seeds one.
     await h.updateEntry(
       {
-        collectionName: "posts",
+        collectionName: "fpmposts",
         entryId: id,
         locale: "es",
         overrideAccess: true,
@@ -493,18 +494,18 @@ describe("first_published_at", () => {
     const h = handler(current);
 
     const created = await h.createEntry(
-      { collectionName: "posts", overrideAccess: true },
+      { collectionName: "fpmposts", overrideAccess: true },
       { title: "live", status: "published" }
     );
     const id = (created.data as { id: string }).id;
 
     const detail = await h.getEntry({
-      collectionName: "posts",
+      collectionName: "fpmposts",
       entryId: id,
       overrideAccess: true,
     });
     const list = await h.listEntries({
-      collectionName: "posts",
+      collectionName: "fpmposts",
       overrideAccess: true,
     });
 
@@ -533,7 +534,7 @@ describe("first_published_at", () => {
     current = await createTestNextly({
       singles: [
         defineSingle({
-          slug: "banner",
+          slug: "fpmbanner",
           status: true,
           fields: [text({ name: "title" })],
         }),
@@ -542,26 +543,26 @@ describe("first_published_at", () => {
     const singles = current.getService("singleEntryService");
 
     await singles.update(
-      "banner",
+      "fpmbanner",
       { title: "hi", status: "draft" },
       { overrideAccess: true }
     );
     expect(
-      (await tableRows(current, "single_banner"))[0]?.first_published_at
+      (await tableRows(current, "single_fpmbanner"))[0]?.first_published_at
     ).toBeFalsy();
 
     await singles.update(
-      "banner",
+      "fpmbanner",
       { title: "hi", status: "published" },
       { overrideAccess: true }
     );
 
-    const row = (await tableRows(current, "single_banner"))[0] ?? {};
+    const row = (await tableRows(current, "single_fpmbanner"))[0] ?? {};
     expect(row.status).toBe("published");
     expect(row.first_published_at).toBeTruthy();
     // The read path is the thing the missing column broke, so exercise it rather than only
     // inspecting the table.
-    const read = await singles.get("banner", { overrideAccess: true });
+    const read = await singles.get("fpmbanner", { overrideAccess: true });
     expect(read).toBeTruthy();
   });
 
@@ -573,7 +574,7 @@ describe("first_published_at", () => {
     current = await createTestNextly({
       singles: [
         defineSingle({
-          slug: "banner",
+          slug: "fpmbanner",
           status: true,
           fields: [text({ name: "title" })],
         }),
@@ -582,7 +583,7 @@ describe("first_published_at", () => {
     const singles = current.getService("singleEntryService");
 
     await singles.update(
-      "banner",
+      "fpmbanner",
       {
         title: "hi",
         status: "draft",
@@ -592,21 +593,21 @@ describe("first_published_at", () => {
       { overrideAccess: true }
     );
     expect(
-      (await tableRows(current, "single_banner"))[0]?.first_published_at
+      (await tableRows(current, "single_fpmbanner"))[0]?.first_published_at
     ).toBeFalsy();
 
     // And a real marker cannot be overwritten once the Single has been published.
     await singles.update(
-      "banner",
+      "fpmbanner",
       { status: "published" },
       { overrideAccess: true }
     );
     const stamped = String(
-      (await tableRows(current, "single_banner"))[0]?.first_published_at
+      (await tableRows(current, "single_fpmbanner"))[0]?.first_published_at
     );
 
     await singles.update(
-      "banner",
+      "fpmbanner",
       {
         title: "edited",
         firstPublishedAt: new Date("1999-01-01T00:00:00.000Z"),
@@ -616,7 +617,9 @@ describe("first_published_at", () => {
     );
 
     expect(
-      String((await tableRows(current, "single_banner"))[0]?.first_published_at)
+      String(
+        (await tableRows(current, "single_fpmbanner"))[0]?.first_published_at
+      )
     ).toBe(stamped);
   });
 
@@ -627,7 +630,7 @@ describe("first_published_at", () => {
     current = await createTestNextly({
       singles: [
         defineSingle({
-          slug: "banner",
+          slug: "fpmbanner",
           status: true,
           fields: [text({ name: "title" })],
         }),
@@ -636,42 +639,44 @@ describe("first_published_at", () => {
     const singles = current.getService("singleEntryService");
 
     await singles.update(
-      "banner",
+      "fpmbanner",
       { title: "hi", status: "published" },
       { overrideAccess: true }
     );
-    const singleId = (await tableRows(current, "single_banner"))[0]?.id;
+    const singleId = (await tableRows(current, "single_fpmbanner"))[0]?.id;
     // Narrowed rather than asserted loosely: the row is read back as `Record<string, unknown>`,
     // and a missing id would otherwise reach the adapter as an undefined bind parameter and
     // update every row, which is not the setup this test intends. `node:assert` narrows the type
     // through its `asserts` signature, so the value is usable without a cast and without a bare
     // throw.
-    assert(typeof singleId === "string", "single_banner row has no id");
+    assert(typeof singleId === "string", "single_fpmbanner row has no id");
     await current.adapter.update(
-      "single_banner",
+      "single_fpmbanner",
       { first_published_at: new Date("2020-01-01T00:00:00.000Z") },
       { and: [{ column: "id", op: "=", value: singleId }] }
     );
-    const before = (await tableRows(current, "single_banner"))[0]
+    const before = (await tableRows(current, "single_fpmbanner"))[0]
       ?.first_published_at;
     expect(before).toBeTruthy();
 
     await singles.update(
-      "banner",
+      "fpmbanner",
       { status: "draft" },
       { overrideAccess: true }
     );
-    const unpublished = (await tableRows(current, "single_banner"))[0] ?? {};
+    const unpublished = (await tableRows(current, "single_fpmbanner"))[0] ?? {};
     expect(unpublished.status).toBe("draft");
     expect(unpublished.first_published_at).toBeTruthy();
 
     await singles.update(
-      "banner",
+      "fpmbanner",
       { status: "published" },
       { overrideAccess: true }
     );
     expect(
-      String((await tableRows(current, "single_banner"))[0]?.first_published_at)
+      String(
+        (await tableRows(current, "single_fpmbanner"))[0]?.first_published_at
+      )
     ).toBe(String(before));
   });
 });

--- a/packages/nextly/src/domains/collections/__tests__/first-published-marker.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/first-published-marker.integration.test.ts
@@ -435,6 +435,56 @@ describe("first_published_at", () => {
     expect(previousMarkers.every(m => m == null)).toBe(true);
   });
 
+  it("records a first publication made in a non-default locale", async () => {
+    // The marker is a property of the DOCUMENT: "has this ever been public in any language". A
+    // translation published on its own is reachable at the address the locales share, so it
+    // establishes the marker. Leaving it null until some later default-locale action would record
+    // a date after the document was already public, which is exactly the question the slug freeze
+    // and redirect capture ask it.
+    //
+    // The non-default-locale write carries its status on the companion, not the main row, so the
+    // main row's own status shows no transition at all — reading the wrong one records nothing.
+    current = await createTestNextly({
+      collections: [
+        defineCollection({
+          slug: "posts",
+          status: true,
+          localized: true,
+          fields: [text({ name: "title", localized: true })],
+        }),
+      ],
+      localization: { locales: ["en", "es"], defaultLocale: "en" },
+    });
+    const h = handler(current);
+
+    const created = await h.createEntry(
+      { collectionName: "posts", overrideAccess: true, locale: "en" },
+      { title: "wip", status: "draft" }
+    );
+    const id = (created.data as { id: string }).id;
+    expect((await storedRow(current, id)).first_published_at).toBeFalsy();
+
+    // Publish only the Spanish translation, as a trusted write. The access-controlled variant of
+    // this write reads the companion's prior status instead of the main row's; that selection is
+    // covered by `resolveFirstPublishedStamp`'s unit tests, because reaching it here would need a
+    // user holding a real `publish-posts` grant and the suite has no helper that seeds one.
+    await h.updateEntry(
+      {
+        collectionName: "posts",
+        entryId: id,
+        locale: "es",
+        overrideAccess: true,
+      },
+      { title: "hola", status: "published" }
+    );
+
+    const row = await storedRow(current, id);
+    // The main row is still a draft — only the translation went public — and that is the point:
+    // status and the marker answer different questions.
+    expect(row.status).toBe("draft");
+    expect(row.first_published_at).toBeTruthy();
+  });
+
   it("records a Single's first publication, and reads still work", async () => {
     // This test used to assert the OPPOSITE. A Single's physical table was built by a generator
     // that restated the system columns by hand, so this column reached the runtime schema and not

--- a/packages/nextly/src/domains/collections/__tests__/first-published-marker.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/first-published-marker.integration.test.ts
@@ -36,6 +36,12 @@ function handler(t: TestNextly) {
   return t.getService("collectionsHandler");
 }
 
+/** The transaction-scoped writer behind createMany and batch writes. Reached through the handler
+ *  because the service-level wrapper does not forward `overrideAccess`. */
+function txEntries(t: TestNextly) {
+  return t.getService("collectionsHandler").getEntryService();
+}
+
 /** Rows read straight from the physical table, so the assertion sees the column itself rather
  *  than whatever the read shape chooses to project. */
 async function tableRows(
@@ -287,6 +293,84 @@ describe("first_published_at", () => {
     const after = await storedRow(current, id);
     expect(after.status).toBe("published");
     expect(after.first_published_at).toBeTruthy();
+  });
+
+  it("records a first publication through the transaction create API", async () => {
+    // `createEntryInTransaction` is a public API and also backs createMany and batch writes. A
+    // document created as published through it must carry the same marker the pooled path gives
+    // it, or which API a caller happened to use would decide whether the history exists.
+    current = await createTestNextly({ collections: [posts()] });
+    const entries = txEntries(current);
+
+    const res = await current.adapter.transaction(tx =>
+      entries.createEntryInTransaction(
+        tx as never,
+        { collectionName: "posts", overrideAccess: true },
+        { title: "live", status: "published" }
+      )
+    );
+    const id = (res.data as { id: string }).id;
+
+    expect((await storedRow(current, id)).first_published_at).toBeTruthy();
+  });
+
+  it("records a first publication through the transaction update API", async () => {
+    current = await createTestNextly({ collections: [posts()] });
+    const entries = txEntries(current);
+
+    const created = await handler(current).createEntry(
+      { collectionName: "posts", overrideAccess: true },
+      { title: "wip", status: "draft" }
+    );
+    const id = (created.data as { id: string }).id;
+    expect((await storedRow(current, id)).first_published_at).toBeFalsy();
+
+    await current.adapter.transaction(tx =>
+      entries.updateEntryInTransaction(
+        tx as never,
+        { collectionName: "posts", entryId: id, overrideAccess: true },
+        { status: "published" }
+      )
+    );
+
+    expect((await storedRow(current, id)).first_published_at).toBeTruthy();
+  });
+
+  it("does not move the marker on a republish through the transaction API", async () => {
+    // The set-once rule has to hold on every write path, not only the pooled one.
+    current = await createTestNextly({ collections: [posts()] });
+    const entries = txEntries(current);
+
+    const created = await handler(current).createEntry(
+      { collectionName: "posts", overrideAccess: true },
+      { title: "live", status: "published" }
+    );
+    const id = (created.data as { id: string }).id;
+    await current.adapter.update(
+      "dc_posts",
+      { first_published_at: new Date("2020-01-01T00:00:00.000Z") },
+      { and: [{ column: "id", op: "=", value: id }] }
+    );
+    const before = String((await storedRow(current, id)).first_published_at);
+
+    await current.adapter.transaction(tx =>
+      entries.updateEntryInTransaction(
+        tx as never,
+        { collectionName: "posts", entryId: id, overrideAccess: true },
+        { status: "draft" }
+      )
+    );
+    await current.adapter.transaction(tx =>
+      entries.updateEntryInTransaction(
+        tx as never,
+        { collectionName: "posts", entryId: id, overrideAccess: true },
+        { status: "published" }
+      )
+    );
+
+    expect(String((await storedRow(current, id)).first_published_at)).toBe(
+      before
+    );
   });
 
   it("records a Single's first publication, and reads still work", async () => {

--- a/packages/nextly/src/domains/collections/__tests__/first-published-marker.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/first-published-marker.integration.test.ts
@@ -8,6 +8,8 @@
  * trip, so these run against a real database rather than asserting on statement text: what matters
  * is the value that is still there after the unpublish committed.
  */
+import assert from "node:assert/strict";
+
 import { afterEach, describe, expect, it } from "vitest";
 
 import { defineCollection, defineSingle, text } from "../../../config";
@@ -475,6 +477,61 @@ describe("first_published_at", () => {
     expect(read).toBeTruthy();
   });
 
+  it("ignores a marker supplied by the client on a Single", async () => {
+    // A Single's writer had no immutable-field stripping at all, so a supplied value reached the
+    // row: a draft update could invent a publication date, and an update to an already-published
+    // Single could reset a real one, since the stamp only replaces the value during a first
+    // publication. Both spellings, because the write snake-cases its keys before storing.
+    current = await createTestNextly({
+      singles: [
+        defineSingle({
+          slug: "banner",
+          status: true,
+          fields: [text({ name: "title" })],
+        }),
+      ],
+    });
+    const singles = current.getService("singleEntryService");
+
+    await singles.update(
+      "banner",
+      {
+        title: "hi",
+        status: "draft",
+        firstPublishedAt: new Date("1999-01-01T00:00:00.000Z"),
+        first_published_at: new Date("1999-01-01T00:00:00.000Z"),
+      },
+      { overrideAccess: true }
+    );
+    expect(
+      (await tableRows(current, "single_banner"))[0]?.first_published_at
+    ).toBeFalsy();
+
+    // And a real marker cannot be overwritten once the Single has been published.
+    await singles.update(
+      "banner",
+      { status: "published" },
+      { overrideAccess: true }
+    );
+    const stamped = String(
+      (await tableRows(current, "single_banner"))[0]?.first_published_at
+    );
+
+    await singles.update(
+      "banner",
+      {
+        title: "edited",
+        firstPublishedAt: new Date("1999-01-01T00:00:00.000Z"),
+        first_published_at: new Date("1999-01-01T00:00:00.000Z"),
+      },
+      { overrideAccess: true }
+    );
+
+    expect(
+      String((await tableRows(current, "single_banner"))[0]?.first_published_at)
+    ).toBe(stamped);
+  });
+
   it("keeps a Single's marker across an unpublish and a republish", async () => {
     // Same set-once guarantee collections get. Backdated first, because both publications
     // otherwise land inside the same second and these columns store no finer resolution — the
@@ -496,12 +553,12 @@ describe("first_published_at", () => {
       { overrideAccess: true }
     );
     const singleId = (await tableRows(current, "single_banner"))[0]?.id;
-    // Narrowed rather than asserted: the row is read back as `Record<string, unknown>`, and a
-    // missing id would otherwise reach the adapter as an undefined bind parameter and update
-    // every row, which is not the thing this test means to set up.
-    if (typeof singleId !== "string") {
-      throw new Error("single_banner row has no id");
-    }
+    // Narrowed rather than asserted loosely: the row is read back as `Record<string, unknown>`,
+    // and a missing id would otherwise reach the adapter as an undefined bind parameter and
+    // update every row, which is not the setup this test intends. `node:assert` narrows the type
+    // through its `asserts` signature, so the value is usable without a cast and without a bare
+    // throw.
+    assert(typeof singleId === "string", "single_banner row has no id");
     await current.adapter.update(
       "single_banner",
       { first_published_at: new Date("2020-01-01T00:00:00.000Z") },

--- a/packages/nextly/src/domains/collections/__tests__/first-published-marker.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/first-published-marker.integration.test.ts
@@ -184,12 +184,13 @@ describe("first_published_at", () => {
     expect(Object.keys(row)).not.toContain("first_published_at");
   });
 
-  it("is not added to a Single, whose physical table would not receive it", async () => {
-    // Not a claim that a Single's publication date is meaningless — it is exactly as meaningful.
-    // A Single's table does not get this column through the same path the runtime schema does, so
-    // injecting it made the schema select a column that is not there, failing EVERY read of a
-    // status-enabled Single rather than just leaving the marker unset. Pinned here so the day the
-    // Single DDL path is aligned, this test is what says so.
+  it("records a Single's first publication, and reads still work", async () => {
+    // This test used to assert the OPPOSITE. A Single's physical table was built by a generator
+    // that restated the system columns by hand, so this column reached the runtime schema and not
+    // the table, and the resulting SELECT named a column that is not there — failing EVERY read of
+    // a status-enabled Single rather than merely leaving the marker unset. That generator now
+    // renders from the descriptor, so the column arrives on its own. The read assertion is kept
+    // because it is what would catch that regression returning.
     current = await createTestNextly({
       singles: [
         defineSingle({
@@ -201,7 +202,15 @@ describe("first_published_at", () => {
     });
     const singles = current.getService("singleEntryService");
 
-    // Reads and writes both work, which is the thing the column would have broken.
+    await singles.update(
+      "banner",
+      { title: "hi", status: "draft" },
+      { overrideAccess: true }
+    );
+    expect(
+      (await tableRows(current, "single_banner"))[0]?.first_published_at
+    ).toBeFalsy();
+
     await singles.update(
       "banner",
       { title: "hi", status: "published" },
@@ -210,6 +219,65 @@ describe("first_published_at", () => {
 
     const row = (await tableRows(current, "single_banner"))[0] ?? {};
     expect(row.status).toBe("published");
-    expect(Object.keys(row)).not.toContain("first_published_at");
+    expect(row.first_published_at).toBeTruthy();
+    // The read path is the thing the missing column broke, so exercise it rather than only
+    // inspecting the table.
+    const read = await singles.get("banner", { overrideAccess: true });
+    expect(read).toBeTruthy();
+  });
+
+  it("keeps a Single's marker across an unpublish and a republish", async () => {
+    // Same set-once guarantee collections get. Backdated first, because both publications
+    // otherwise land inside the same second and these columns store no finer resolution — the
+    // assertion would then hold whether or not the guard exists.
+    current = await createTestNextly({
+      singles: [
+        defineSingle({
+          slug: "banner",
+          status: true,
+          fields: [text({ name: "title" })],
+        }),
+      ],
+    });
+    const singles = current.getService("singleEntryService");
+
+    await singles.update(
+      "banner",
+      { title: "hi", status: "published" },
+      { overrideAccess: true }
+    );
+    const singleId = (await tableRows(current, "single_banner"))[0]?.id;
+    // Narrowed rather than asserted: the row is read back as `Record<string, unknown>`, and a
+    // missing id would otherwise reach the adapter as an undefined bind parameter and update
+    // every row, which is not the thing this test means to set up.
+    if (typeof singleId !== "string") {
+      throw new Error("single_banner row has no id");
+    }
+    await current.adapter.update(
+      "single_banner",
+      { first_published_at: new Date("2020-01-01T00:00:00.000Z") },
+      { and: [{ column: "id", op: "=", value: singleId }] }
+    );
+    const before = (await tableRows(current, "single_banner"))[0]
+      ?.first_published_at;
+    expect(before).toBeTruthy();
+
+    await singles.update(
+      "banner",
+      { status: "draft" },
+      { overrideAccess: true }
+    );
+    const unpublished = (await tableRows(current, "single_banner"))[0] ?? {};
+    expect(unpublished.status).toBe("draft");
+    expect(unpublished.first_published_at).toBeTruthy();
+
+    await singles.update(
+      "banner",
+      { status: "published" },
+      { overrideAccess: true }
+    );
+    expect(
+      String((await tableRows(current, "single_banner"))[0]?.first_published_at)
+    ).toBe(String(before));
   });
 });

--- a/packages/nextly/src/domains/collections/__tests__/first-published-marker.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/first-published-marker.integration.test.ts
@@ -485,6 +485,44 @@ describe("first_published_at", () => {
     expect(row.first_published_at).toBeTruthy();
   });
 
+  it("returns the marker under one name whichever operation is called", async () => {
+    // The same entry gave different shapes depending on how it was fetched: a create response
+    // carried `firstPublishedAt` while list and detail reads returned the raw column name, so a
+    // client reading a field it had just written could not find it.
+    current = await createTestNextly({ collections: [posts()] });
+    const h = handler(current);
+
+    const created = await h.createEntry(
+      { collectionName: "posts", overrideAccess: true },
+      { title: "live", status: "published" }
+    );
+    const id = (created.data as { id: string }).id;
+
+    const detail = await h.getEntry({
+      collectionName: "posts",
+      entryId: id,
+      overrideAccess: true,
+    });
+    const list = await h.listEntries({
+      collectionName: "posts",
+      overrideAccess: true,
+    });
+
+    for (const [label, doc] of [
+      ["create", created.data],
+      ["detail", detail.data],
+      ["list", list.data?.docs?.[0]],
+    ] as const) {
+      assert(isRecord(doc), `${label} returned no document`);
+      expect({ [label]: "firstPublishedAt" in doc }).toEqual({ [label]: true });
+      // The raw column name must not also be present, or a consumer sees two spellings of the
+      // same value and has to guess which is canonical.
+      expect({ [label]: "first_published_at" in doc }).toEqual({
+        [label]: false,
+      });
+    }
+  });
+
   it("records a Single's first publication, and reads still work", async () => {
     // This test used to assert the OPPOSITE. A Single's physical table was built by a generator
     // that restated the system columns by hand, so this column reached the runtime schema and not

--- a/packages/nextly/src/domains/collections/__tests__/first-published-marker.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/first-published-marker.integration.test.ts
@@ -42,6 +42,12 @@ function txEntries(t: TestNextly) {
   return t.getService("collectionsHandler").getEntryService();
 }
 
+/** Narrow an unknown payload branch before indexing it, so a shape change surfaces as a failed
+ *  assertion rather than an `undefined` that quietly satisfies the test. */
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null;
+}
+
 /** Rows read straight from the physical table, so the assertion sees the column itself rather
  *  than whatever the read shape chooses to project. */
 async function tableRows(
@@ -371,6 +377,60 @@ describe("first_published_at", () => {
     expect(String((await storedRow(current, id)).first_published_at)).toBe(
       before
     );
+  });
+
+  it("reports the marker on the publish-all event that establishes it", async () => {
+    // The event payload, the version snapshot and the workflow reaction are all built from the
+    // PRE-update row with the new status overlaid, because publishing otherwise changes nothing
+    // else. The marker is the exception: it IS written by that update, so without carrying it
+    // across, the one event that announces a first publication reports no first publication.
+    current = await createTestNextly({ collections: [posts()] });
+    const h = handler(current);
+
+    const created = await h.createEntry(
+      { collectionName: "posts", overrideAccess: true },
+      { title: "wip", status: "draft" }
+    );
+    const id = (created.data as { id: string }).id;
+
+    await h.publishAllLocales({
+      collectionName: "posts",
+      entryId: id,
+      overrideAccess: true,
+    });
+    await current.events.settle();
+
+    const rows =
+      await current.adapter.select<Record<string, unknown>>("nextly_events");
+    const published = rows.filter(r => r.type === "entry.published");
+    expect(published.length).toBeGreaterThan(0);
+
+    // Asserting the VALUE, not the presence of the key. The pre-image row carries
+    // `first_published_at: null`, so the key is in the payload either way — a substring or
+    // `in` check passes with the overlay removed and proves nothing.
+    const markers = published.map(row => {
+      const raw = row.payload;
+      const payload =
+        typeof raw === "string"
+          ? (JSON.parse(raw) as Record<string, unknown>)
+          : ((raw ?? {}) as Record<string, unknown>);
+      const data = payload.data;
+      return isRecord(data) ? data.first_published_at : undefined;
+    });
+    expect(markers.some(m => m != null)).toBe(true);
+
+    // And the pre-image must still say it was absent: the event describes a transition, so a
+    // `previous` that already carried the marker would report no change.
+    const previousMarkers = published.map(row => {
+      const raw = row.payload;
+      const payload =
+        typeof raw === "string"
+          ? (JSON.parse(raw) as Record<string, unknown>)
+          : ((raw ?? {}) as Record<string, unknown>);
+      const previous = payload.previous;
+      return isRecord(previous) ? previous.first_published_at : undefined;
+    });
+    expect(previousMarkers.every(m => m == null)).toBe(true);
   });
 
   it("records a Single's first publication, and reads still work", async () => {

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -42,6 +42,7 @@ import { stripImmutableSystemFields } from "../../../lib/immutable-system-fields
 import {
   resolveFirstPublishedStamp,
   resolvePublishTransition,
+  selectPublicationTransition,
   stripUndefinedStatus,
 } from "../../../lib/status-transition";
 import {
@@ -5412,22 +5413,37 @@ export class CollectionMutationService extends BaseService {
           //
           // Written under the same row lock and in the same statement as the rest of the update,
           // so it cannot disagree with the status it accompanies. Only when the locked row has
-          // none: this dates the FIRST publication, and a later republish must not move it. A
-          // non-default-locale write is excluded for the same reason its status is stripped from
-          // the main payload — it does not change the main row's lifecycle.
-          const updateStamp = isNonDefaultLocaleStatusWrite
-            ? undefined
-            : resolveFirstPublishedStamp({
-                hasStatus: collectionHasStatus,
-                previousStatus:
-                  ((preUpdateRow as { status?: unknown } | undefined)
-                    ?.status as string | undefined) ?? null,
-                nextStatus: intendedStatus,
-                existingMarker: (
-                  preUpdateRow as { first_published_at?: unknown } | undefined
-                )?.first_published_at,
-                now: new Date(),
-              });
+          // none: this dates the FIRST publication, and a later republish must not move it.
+          //
+          // The marker is a property of the DOCUMENT, not of the main row's status column. It
+          // answers "has this ever been public in any language", which is what the slug freeze
+          // and redirect capture need for an address shared across locales. So a write that
+          // publishes only a non-default translation still establishes it: that language is
+          // reachable at the shared address, and leaving the marker null until some later
+          // default-locale action would record a date after the document was already public.
+          //
+          // Which transition to read therefore depends on where this write's status lands. A
+          // non-default-locale write has its status stripped from the main payload and carried on
+          // the companion instead, so the main row's status would show no move at all.
+          const publicationTransition = selectPublicationTransition({
+            writesStatusToCompanion: isNonDefaultLocaleStatusWrite,
+            mainPreviousStatus:
+              ((preUpdateRow as { status?: unknown } | undefined)?.status as
+                | string
+                | undefined) ?? null,
+            mainNextStatus: intendedStatus,
+            companionPreviousStatus: committedLocaleStatus,
+            companionNextStatus: localizedUpdate?.companionData?._status,
+          });
+          const updateStamp = resolveFirstPublishedStamp({
+            hasStatus: collectionHasStatus,
+            previousStatus: publicationTransition.previousStatus,
+            nextStatus: publicationTransition.nextStatus,
+            existingMarker: (
+              preUpdateRow as { first_published_at?: unknown } | undefined
+            )?.first_published_at,
+            now: new Date(),
+          });
           if (updateStamp) {
             updatePayload.firstPublishedAt = updateStamp;
           }

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -1557,6 +1557,34 @@ export class CollectionMutationService extends BaseService {
   }
 
   /**
+   * Whether any locale OTHER than `exceptLocale` currently has this document published.
+   *
+   * Answers a document-level question the per-locale status cannot: publishing one translation
+   * makes a document public only if no other part of it already was. Reads by table name through
+   * the transaction, mirroring `readCompanionStatus`, because the companion table is created
+   * dynamically and has no Drizzle object on this path.
+   */
+  private async hasOtherPublishedLocale(
+    tx: TransactionContext,
+    companionTableName: string,
+    entryId: string,
+    exceptLocale: string
+  ): Promise<boolean> {
+    const isMysqlDialect = this.dialect === "mysql";
+    const quote = (id: string) => (isMysqlDialect ? `\`${id}\`` : `"${id}"`);
+    const placeholder = (i: number) =>
+      this.dialect === "postgresql" ? `$${i}` : "?";
+    const rows = await tx.execute<{ _locale?: unknown }>(
+      `SELECT ${quote("_locale")} FROM ${quote(companionTableName)} ` +
+        `WHERE ${quote("_parent")} = ${placeholder(1)} ` +
+        `AND ${quote("_status")} = ${placeholder(2)} ` +
+        `AND ${quote("_locale")} <> ${placeholder(3)} LIMIT 1`,
+      [entryId, "published", exceptLocale]
+    );
+    return rows.length > 0;
+  }
+
+  /**
    * Assemble the document a draft promotion actually persists: the draft with the
    * caller's scalars overlaid, the caller's single-component patches merged onto
    * the draft's components (a patch wins per sub-field, recursing into nested
@@ -2757,7 +2785,7 @@ export class CollectionMutationService extends BaseService {
         // both snake and camel) so the generated id, stamped owner, and
         // timestamps below are authoritative — a stray `createdBy` alias can't
         // survive to overwrite the owner stamp.
-        ...stripImmutableSystemFields(finalData),
+        ...stripImmutableSystemFields(finalData, "collection"),
         created_at: now,
         updated_at: now,
         // Stamp the row owner with the creating user's id so owner-only access
@@ -5021,7 +5049,7 @@ export class CollectionMutationService extends BaseService {
           // rather than inferred: the literal's own shape would refuse the
           // first-publish stamp appended before the UPDATE is assembled.
           let updatePayload: Record<string, unknown> = {
-            ...stripImmutableSystemFields(finalData),
+            ...stripImmutableSystemFields(finalData, "collection"),
             updatedAt: new Date(),
           };
 
@@ -5386,7 +5414,7 @@ export class CollectionMutationService extends BaseService {
               componentFieldData = draftParts.componentFieldData;
               manyToManyData = draftParts.manyToManyData;
               updatePayload = {
-                ...stripImmutableSystemFields(finalData),
+                ...stripImmutableSystemFields(finalData, "collection"),
                 updatedAt: updatePayload.updatedAt,
               };
               promotedDraft = true;
@@ -5425,7 +5453,30 @@ export class CollectionMutationService extends BaseService {
           // Which transition to read therefore depends on where this write's status lands. A
           // non-default-locale write has its status stripped from the main payload and carried on
           // the companion instead, so the main row's status would show no move at all.
+          // Only asked when a per-locale write could otherwise record a first publication, which
+          // for any one document happens at most once ever — every later write is stopped by the
+          // marker already being set. So the common publish pays nothing for this read.
+          const couldRecordFirstPublication =
+            collectionHasStatus &&
+            isNonDefaultLocaleStatusWrite &&
+            (preUpdateRow as { first_published_at?: unknown } | undefined)
+              ?.first_published_at == null &&
+            localizedUpdate?.companionData?._status === "published";
+          const documentAlreadyPublic = couldRecordFirstPublication
+            ? ((preUpdateRow as { status?: unknown } | undefined)?.status as
+                | string
+                | undefined) === "published" ||
+              (localizedUpdate?.hasStatus === true &&
+                (await this.hasOtherPublishedLocale(
+                  tx,
+                  localizedUpdate.companionTableName,
+                  params.entryId,
+                  localizedUpdate.writeLocale
+                )))
+            : false;
+
           const publicationTransition = selectPublicationTransition({
+            documentAlreadyPublic,
             writesStatusToCompanion: isNonDefaultLocaleStatusWrite,
             mainPreviousStatus:
               ((preUpdateRow as { status?: unknown } | undefined)?.status as
@@ -7074,7 +7125,7 @@ export class CollectionMutationService extends BaseService {
         // both snake and camel) so the generated id, stamped owner, and
         // timestamps below are authoritative — a stray `createdBy` alias can't
         // survive to overwrite the owner stamp.
-        ...stripImmutableSystemFields(finalData),
+        ...stripImmutableSystemFields(finalData, "collection"),
         // Snake_case keys: the runtime Drizzle schema names these columns
         // created_at / updated_at / created_by, and the adapter maps by column
         // name. (The prior camelCase createdAt/updatedAt keys here were ignored
@@ -7707,7 +7758,7 @@ export class CollectionMutationService extends BaseService {
       const [updated] = await tx.update<unknown>(
         tableName,
         {
-          ...stripImmutableSystemFields(finalData),
+          ...stripImmutableSystemFields(finalData, "collection"),
           updatedAt: nowForTxUpdate,
           ...(txUpdateStamp ? { first_published_at: txUpdateStamp } : {}),
         },
@@ -8566,7 +8617,7 @@ export class CollectionMutationService extends BaseService {
         // both snake and camel) so the generated id, stamped owner, and
         // timestamps below are authoritative — a stray `createdBy` alias can't
         // survive to overwrite the owner stamp.
-        ...stripImmutableSystemFields(finalData),
+        ...stripImmutableSystemFields(finalData, "collection"),
         // Snake_case keys: the runtime Drizzle schema names these columns
         // created_at / updated_at / created_by, and the adapter maps by column
         // name. (The prior camelCase createdAt/updatedAt keys here were ignored
@@ -9221,7 +9272,7 @@ export class CollectionMutationService extends BaseService {
       const [updated] = await tx.update<unknown>(
         tableName,
         {
-          ...stripImmutableSystemFields(finalData),
+          ...stripImmutableSystemFields(finalData, "collection"),
           updatedAt: new Date(),
         },
         this.whereEq("id", entryId),

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -38,6 +38,7 @@ import type { ValidationPublicData } from "../../../errors/public-data";
 import { emitDocumentEvent } from "../../../events/domain-events";
 import { getEventBus } from "../../../events/event-bus";
 import { toSnakeCase } from "../../../lib/case-conversion";
+import { stripImmutableSystemFields } from "../../../lib/immutable-system-fields";
 import {
   resolveFirstPublishedStamp,
   resolvePublishTransition,
@@ -277,46 +278,6 @@ function errorToServiceResult<T = unknown>(
     message: mapped.publicMessage,
     data: null,
   };
-}
-
-/**
- * System columns a client must never write: the primary key, the timestamps,
- * the owner stamp, and the first-publication marker (both the snake_case column
- * name and the camelCase form a client might send). They are not declared
- * fields, so field validation passes
- * them through. Stripping them on BOTH create and update means the service
- * remains authoritative: on create the generated id / stamped `created_by` /
- * timestamps win (a stray `createdBy` alias can't survive the snake-case pass
- * and overwrite the stamp with an attacker-chosen owner), and on update an
- * authorized updater can't transfer a row to another user, forge `created_at`,
- * duplicate `updated_at`, or reassign `id`.
- *
- * `first_published_at` is here for a reason the others are not: it is meant to
- * be written once and never moved, and a value taken from the request would
- * make that guarantee decorative. A draft create could claim a publication that
- * never happened, and any later update could reset a real one. The service's own
- * stamps are applied AFTER this strip, so they still land.
- */
-const IMMUTABLE_SYSTEM_FIELDS = new Set([
-  "id",
-  "created_at",
-  "createdAt",
-  "updated_at",
-  "updatedAt",
-  "created_by",
-  "createdBy",
-  "first_published_at",
-  "firstPublishedAt",
-]);
-
-function stripImmutableSystemFields(
-  data: Record<string, unknown>
-): Record<string, unknown> {
-  const out: Record<string, unknown> = {};
-  for (const [key, value] of Object.entries(data)) {
-    if (!IMMUTABLE_SYSTEM_FIELDS.has(key)) out[key] = value;
-  }
-  return out;
 }
 
 /**

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -280,14 +280,21 @@ function errorToServiceResult<T = unknown>(
 
 /**
  * System columns a client must never write: the primary key, the timestamps,
- * and the owner stamp (both the snake_case column name and the camelCase form a
- * client might send). They are not declared fields, so field validation passes
+ * the owner stamp, and the first-publication marker (both the snake_case column
+ * name and the camelCase form a client might send). They are not declared
+ * fields, so field validation passes
  * them through. Stripping them on BOTH create and update means the service
  * remains authoritative: on create the generated id / stamped `created_by` /
  * timestamps win (a stray `createdBy` alias can't survive the snake-case pass
  * and overwrite the stamp with an attacker-chosen owner), and on update an
  * authorized updater can't transfer a row to another user, forge `created_at`,
  * duplicate `updated_at`, or reassign `id`.
+ *
+ * `first_published_at` is here for a reason the others are not: it is meant to
+ * be written once and never moved, and a value taken from the request would
+ * make that guarantee decorative. A draft create could claim a publication that
+ * never happened, and any later update could reset a real one. The service's own
+ * stamps are applied AFTER this strip, so they still land.
  */
 const IMMUTABLE_SYSTEM_FIELDS = new Set([
   "id",
@@ -297,6 +304,8 @@ const IMMUTABLE_SYSTEM_FIELDS = new Set([
   "updatedAt",
   "created_by",
   "createdBy",
+  "first_published_at",
+  "firstPublishedAt",
 ]);
 
 function stripImmutableSystemFields(
@@ -3626,12 +3635,25 @@ export class CollectionMutationService extends BaseService {
           }
 
           if (hasMainStatus) {
-            // `COALESCE` rather than a read-then-write: this dates the FIRST publication, so it
-            // must not move on a republish, and expressing "only if absent" in the statement
-            // makes that true of concurrent publishes too. `nowExpr` keeps it dialect-correct
-            // without round-tripping a Date through a raw parameter.
+            // Only when this call actually moves the row into published. A row that is already
+            // published is not having a first publication now, and stamping one would be worst
+            // for the rows it would hit: those published before this column existed, whose marker
+            // is null precisely because their history was never recorded. Dating them today
+            // reports a publication that did not happen, which is the one thing a null was
+            // supposed to avoid claiming.
+            //
+            // `COALESCE` still, for the transition case: it dates the FIRST publication, and
+            // expressing "only if absent" in the statement keeps that true of concurrent
+            // publishes. `nowExpr` keeps it dialect-correct without round-tripping a Date through
+            // a raw parameter.
+            const marksFirstPublication =
+              resolvePublishTransition(lockedPreviousStatus, "published") ===
+              "publish";
+            const markerAssignment = marksFirstPublication
+              ? `, ${q("first_published_at")} = COALESCE(${q("first_published_at")}, ${nowExpr})`
+              : "";
             await tx.execute(
-              `UPDATE ${q(tableName)} SET ${q("status")} = ${ph(1)}, ${q("updated_at")} = ${nowExpr}, ${q("first_published_at")} = COALESCE(${q("first_published_at")}, ${nowExpr}) WHERE ${q("id")} = ${ph(2)}`,
+              `UPDATE ${q(tableName)} SET ${q("status")} = ${ph(1)}, ${q("updated_at")} = ${nowExpr}${markerAssignment} WHERE ${q("id")} = ${ph(2)}`,
               ["published", params.entryId]
             );
           }

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -2797,6 +2797,19 @@ export class CollectionMutationService extends BaseService {
         entryData[toSnakeCase(key)] = value;
       }
 
+      // A create that lands directly on published IS a first publication — there is no prior
+      // status it could be repeating, which is the same reason the transition check below treats
+      // it as a publish. Read from the post-hook `finalData` for that reason too: a hook that
+      // derives `status: "published"`, or a status the caller could not write itself, must stamp
+      // the value actually stored. Taken before the locale split, which strips `status` from a
+      // non-default-locale main payload.
+      if (
+        (collection as { status?: boolean }).status === true &&
+        finalData.status === "published"
+      ) {
+        entryData.first_published_at = now;
+      }
+
       // Authorize the published state this create will persist, judged on the
       // post-hook `finalData` rather than the raw body: a beforeCreate/stored
       // hook that derives `status: "published"`, or a status field the caller
@@ -3613,8 +3626,12 @@ export class CollectionMutationService extends BaseService {
           }
 
           if (hasMainStatus) {
+            // `COALESCE` rather than a read-then-write: this dates the FIRST publication, so it
+            // must not move on a republish, and expressing "only if absent" in the statement
+            // makes that true of concurrent publishes too. `nowExpr` keeps it dialect-correct
+            // without round-tripping a Date through a raw parameter.
             await tx.execute(
-              `UPDATE ${q(tableName)} SET ${q("status")} = ${ph(1)}, ${q("updated_at")} = ${nowExpr} WHERE ${q("id")} = ${ph(2)}`,
+              `UPDATE ${q(tableName)} SET ${q("status")} = ${ph(1)}, ${q("updated_at")} = ${nowExpr}, ${q("first_published_at")} = COALESCE(${q("first_published_at")}, ${nowExpr}) WHERE ${q("id")} = ${ph(2)}`,
               ["published", params.entryId]
             );
           }
@@ -4995,8 +5012,10 @@ export class CollectionMutationService extends BaseService {
           componentFieldData = { ...baseComponentFieldData };
           workingDraftDocument = undefined;
           // `let` because promote-on-publish rebinds it from the merged
-          // draft+payload after the working draft is folded in below.
-          let updatePayload = {
+          // draft+payload after the working draft is folded in below. Annotated
+          // rather than inferred: the literal's own shape would refuse the
+          // first-publish stamp appended before the UPDATE is assembled.
+          let updatePayload: Record<string, unknown> = {
             ...stripImmutableSystemFields(finalData),
             updatedAt: new Date(),
           };
@@ -5378,6 +5397,34 @@ export class CollectionMutationService extends BaseService {
             this.dialect === "postgresql"
               ? `$${sqlParams.length}` // length already incremented by push below
               : "?";
+
+          // A row becoming public for the first time records when, once and for good.
+          //
+          // `status` says what a document IS; nothing said what it HAS BEEN, so an unpublish
+          // erased every trace it was ever live while the links, feeds and search results it
+          // accumulated stayed exactly where they were. Anything asking "was this address ever
+          // public" — slug stability, redirect capture — needs a fact that survives that round
+          // trip.
+          //
+          // Written under the same row lock and in the same statement as the rest of the update,
+          // so it cannot disagree with the status it accompanies. Only when the locked row has
+          // none: this dates the FIRST publication, and a later republish must not move it. A
+          // non-default-locale write is excluded for the same reason its status is stripped from
+          // the main payload — it does not change the main row's lifecycle.
+          if (
+            collectionHasStatus &&
+            !isNonDefaultLocaleStatusWrite &&
+            (preUpdateRow as { first_published_at?: unknown } | undefined)
+              ?.first_published_at == null &&
+            resolvePublishTransition(
+              ((preUpdateRow as { status?: unknown } | undefined)?.status as
+                | string
+                | undefined) ?? null,
+              intendedStatus
+            ) === "publish"
+          ) {
+            updatePayload.firstPublishedAt = new Date();
+          }
 
           const setClauses = Object.entries(updatePayload)
             .map(([key, val]) => {

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -3513,6 +3513,12 @@ export class CollectionMutationService extends BaseService {
       // post-commit transition event reads it. Defaults to the pre-read value so
       // a companion-only (no main status) publish still has a sane fallback.
       let lockedPreviousStatus = previousStatus;
+      // The first-publication marker this publish committed, or undefined when it recorded none.
+      // The event payload, version snapshot and workflow reaction are all built from the
+      // PRE-update row with the new status overlaid, so without carrying this across they would
+      // report the marker absent on the very publication that establishes it. Reset per attempt
+      // by the closure, so a retry after a concurrent winner does not reuse a stale value.
+      let publishFirstPublishedAt: Date | undefined;
       // The per-locale publish transitions recorded to the outbox inside the
       // transaction, replayed to the in-process workflow subscribers after it
       // commits — the durable event and the reaction event must not diverge on
@@ -3533,14 +3539,6 @@ export class CollectionMutationService extends BaseService {
       // for its event payload rather than falling back to the stale pre-read.
       const needsFreshParent = !!versionsConfig?.enabled || hasMainStatus;
 
-      // Bump `updated_at` alongside status so caches / revalidation see the change (a bare
-      // status flip left the timestamp stale). On SQLite the dynamic tables store `updated_at`
-      // as an integer Unix-seconds column (Drizzle `integer` timestamp mode), so `unixepoch()`
-      // keeps the value numeric; `CURRENT_TIMESTAMP` would write a text string and corrupt
-      // decoding/ordering. Postgres/MySQL use the native timestamp default.
-      const nowExpr =
-        this.dialect === "sqlite" ? "unixepoch()" : "CURRENT_TIMESTAMP";
-
       // Retry the whole publish+capture transaction on a version_no allocation
       // race, mirroring updateEntry.
       await withVersionConflictRetry(() =>
@@ -3553,6 +3551,7 @@ export class CollectionMutationService extends BaseService {
           // Reset per attempt because the conflict retry re-runs this closure.
           entryVanished = false;
           lockedPreviousStatus = previousStatus;
+          publishFirstPublishedAt = undefined;
           perLocaleTransitions = [];
           defaultCompanionTransitions = false;
           const lockedRow = await tx.selectOne<Record<string, unknown>>(
@@ -3638,26 +3637,35 @@ export class CollectionMutationService extends BaseService {
           }
 
           if (hasMainStatus) {
-            // Only when this call actually moves the row into published. A row that is already
-            // published is not having a first publication now, and stamping one would be worst
-            // for the rows it would hit: those published before this column existed, whose marker
-            // is null precisely because their history was never recorded. Dating them today
-            // reports a publication that did not happen, which is the one thing a null was
-            // supposed to avoid claiming.
-            //
-            // `COALESCE` still, for the transition case: it dates the FIRST publication, and
-            // expressing "only if absent" in the statement keeps that true of concurrent
-            // publishes. `nowExpr` keeps it dialect-correct without round-tripping a Date through
-            // a raw parameter.
-            const marksFirstPublication =
-              resolvePublishTransition(lockedPreviousStatus, "published") ===
-              "publish";
-            const markerAssignment = marksFirstPublication
-              ? `, ${q("first_published_at")} = COALESCE(${q("first_published_at")}, ${nowExpr})`
-              : "";
-            await tx.execute(
-              `UPDATE ${q(tableName)} SET ${q("status")} = ${ph(1)}, ${q("updated_at")} = ${nowExpr}${markerAssignment} WHERE ${q("id")} = ${ph(2)}`,
-              ["published", params.entryId]
+            // The marker this publish records, if any. Decided from the row read under the lock
+            // above, so an already-published row records nothing — which matters most for rows
+            // published before this column existed, whose marker is null precisely because their
+            // history was never captured. Dating those today would report a publication that
+            // never happened.
+            const publishNow = new Date();
+            publishFirstPublishedAt = resolveFirstPublishedStamp({
+              hasStatus: true,
+              previousStatus: lockedPreviousStatus,
+              nextStatus: "published",
+              existingMarker: (
+                lockedRow as { first_published_at?: unknown } | undefined
+              )?.first_published_at,
+              now: publishNow,
+            });
+            // Through the adapter's Drizzle layer rather than an interpolated statement. That
+            // also removes the reason the previous version needed a SQL `now()` expression: a
+            // `Date` bound as a raw parameter stores wrong against SQLite's integer timestamps,
+            // while Drizzle converts it per dialect.
+            await tx.update(
+              tableName,
+              {
+                status: "published",
+                updated_at: publishNow,
+                ...(publishFirstPublishedAt
+                  ? { first_published_at: publishFirstPublishedAt }
+                  : {}),
+              },
+              this.whereEq("id", params.entryId)
             );
           }
           if (companion && companionPublishable) {
@@ -3675,8 +3683,18 @@ export class CollectionMutationService extends BaseService {
             // this transaction holds one (which would deadlock a one-connection
             // pool). Undefined only if the row vanished, which the lock above
             // already rules out.
+            // The marker is overlaid alongside the status for the same reason: it was written by
+            // the UPDATE above and so is not on the pre-image this row is built from. Without it
+            // the publication event and the captured version would both report no first
+            // publication for the write that just established one.
             publishedParentRow = lockedSchemaRow
-              ? { ...lockedSchemaRow, status: "published" }
+              ? {
+                  ...lockedSchemaRow,
+                  status: "published",
+                  ...(publishFirstPublishedAt
+                    ? { first_published_at: publishFirstPublishedAt }
+                    : {}),
+                }
               : undefined;
 
             // Record a version snapshot for the publish: publishing changes the

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -39,6 +39,7 @@ import { emitDocumentEvent } from "../../../events/domain-events";
 import { getEventBus } from "../../../events/event-bus";
 import { toSnakeCase } from "../../../lib/case-conversion";
 import {
+  resolveFirstPublishedStamp,
   resolvePublishTransition,
   stripUndefinedStatus,
 } from "../../../lib/status-transition";
@@ -2806,17 +2807,19 @@ export class CollectionMutationService extends BaseService {
         entryData[toSnakeCase(key)] = value;
       }
 
-      // A create that lands directly on published IS a first publication — there is no prior
-      // status it could be repeating, which is the same reason the transition check below treats
-      // it as a publish. Read from the post-hook `finalData` for that reason too: a hook that
-      // derives `status: "published"`, or a status the caller could not write itself, must stamp
-      // the value actually stored. Taken before the locale split, which strips `status` from a
-      // non-default-locale main payload.
-      if (
-        (collection as { status?: boolean }).status === true &&
-        finalData.status === "published"
-      ) {
-        entryData.first_published_at = now;
+      // A create has no prior status, so landing on published IS a first publication. Read from
+      // the post-hook `finalData`: a hook that derives `status: "published"`, or a status the
+      // caller could not write itself, must stamp the value actually stored. Taken before the
+      // locale split, which strips `status` from a non-default-locale main payload.
+      const createStamp = resolveFirstPublishedStamp({
+        hasStatus: (collection as { status?: boolean }).status === true,
+        previousStatus: null,
+        nextStatus: finalData.status,
+        existingMarker: null,
+        now,
+      });
+      if (createStamp) {
+        entryData.first_published_at = createStamp;
       }
 
       // Authorize the published state this create will persist, judged on the
@@ -5433,19 +5436,21 @@ export class CollectionMutationService extends BaseService {
           // none: this dates the FIRST publication, and a later republish must not move it. A
           // non-default-locale write is excluded for the same reason its status is stripped from
           // the main payload — it does not change the main row's lifecycle.
-          if (
-            collectionHasStatus &&
-            !isNonDefaultLocaleStatusWrite &&
-            (preUpdateRow as { first_published_at?: unknown } | undefined)
-              ?.first_published_at == null &&
-            resolvePublishTransition(
-              ((preUpdateRow as { status?: unknown } | undefined)?.status as
-                | string
-                | undefined) ?? null,
-              intendedStatus
-            ) === "publish"
-          ) {
-            updatePayload.firstPublishedAt = new Date();
+          const updateStamp = isNonDefaultLocaleStatusWrite
+            ? undefined
+            : resolveFirstPublishedStamp({
+                hasStatus: collectionHasStatus,
+                previousStatus:
+                  ((preUpdateRow as { status?: unknown } | undefined)
+                    ?.status as string | undefined) ?? null,
+                nextStatus: intendedStatus,
+                existingMarker: (
+                  preUpdateRow as { first_published_at?: unknown } | undefined
+                )?.first_published_at,
+                now: new Date(),
+              });
+          if (updateStamp) {
+            updatePayload.firstPublishedAt = updateStamp;
           }
 
           const setClauses = Object.entries(updatePayload)
@@ -7088,6 +7093,22 @@ export class CollectionMutationService extends BaseService {
         created_by: params.user?.id ?? null,
       };
 
+      // A create landing directly on published is a first publication here exactly as it is on
+      // the pooled path. This is a public transaction API and also backs createMany and batch
+      // writes, so a document created as published through it would otherwise carry no marker at
+      // all — the same document created through `createEntry` would.
+      const txCreateStamp = resolveFirstPublishedStamp({
+        hasStatus: (collection as { status?: boolean }).status === true,
+        previousStatus: null,
+        nextStatus: finalData.status,
+        existingMarker: null,
+        now: nowForTxCreate,
+      });
+      if (txCreateStamp) {
+        (entryData as Record<string, unknown>).first_published_at =
+          txCreateStamp;
+      }
+
       // Authorize the published state this create will persist, on the post-hook
       // `finalData`: a hook that derives `status: "published"`, or a status field
       // the caller may not write, is judged on the value actually stored. A create
@@ -7658,11 +7679,42 @@ export class CollectionMutationService extends BaseService {
         return transitionDenied;
       }
 
+      // The first publication, decided under the lock the transition gate above already took, so
+      // the prior status and the stored marker are the committed ones rather than this
+      // transaction's earlier snapshot. Read only when the write could be a publish at all: a
+      // content-only edit transitions nothing and must not pay for an extra locked read.
+      //
+      // This is a public transaction API and backs batch writes, so a document published through
+      // it would otherwise carry no marker while the same document published through
+      // `updateEntry` would.
+      const nowForTxUpdate = new Date();
+      let txUpdateStamp: Date | undefined;
+      if (
+        (collection as { status?: boolean }).status === true &&
+        finalData.status === "published"
+      ) {
+        const lockedForMarker = await tx.selectOne<Record<string, unknown>>(
+          tableName,
+          { where: this.whereEq("id", params.entryId), forUpdate: true }
+        );
+        txUpdateStamp = resolveFirstPublishedStamp({
+          hasStatus: true,
+          previousStatus:
+            typeof lockedForMarker?.status === "string"
+              ? lockedForMarker.status
+              : null,
+          nextStatus: finalData.status,
+          existingMarker: lockedForMarker?.first_published_at,
+          now: nowForTxUpdate,
+        });
+      }
+
       const [updated] = await tx.update<unknown>(
         tableName,
         {
           ...stripImmutableSystemFields(finalData),
-          updatedAt: new Date(),
+          updatedAt: nowForTxUpdate,
+          ...(txUpdateStamp ? { first_published_at: txUpdateStamp } : {}),
         },
         this.whereEq("id", params.entryId),
         { returning: "*" }

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -8631,6 +8631,21 @@ export class CollectionMutationService extends BaseService {
         created_by: params.user?.id ?? null,
       };
 
+      // The bulk worker is a separate, streamlined path — the batch service calls it rather than
+      // `createEntryInTransaction` — so it needs the rule too. Leaving it out is how batch writes
+      // came to publish documents that carried no marker while single writes did.
+      const bulkCreateStamp = resolveFirstPublishedStamp({
+        hasStatus: (collection as { status?: boolean }).status === true,
+        previousStatus: null,
+        nextStatus: finalData.status,
+        existingMarker: null,
+        now: nowForTxCreate,
+      });
+      if (bulkCreateStamp) {
+        (entryData as Record<string, unknown>).first_published_at =
+          bulkCreateStamp;
+      }
+
       // The bulk create worker inserts status like any other field, so publishing
       // through it needs `publish-<slug>` the same as a single create — otherwise
       // batch create is a way around the gate. Judged on the post-hook `finalData`
@@ -9269,11 +9284,37 @@ export class CollectionMutationService extends BaseService {
         return transitionDenied;
       }
 
+      // Same rule as every other update seam. Read under the lock the transition gate above
+      // already holds, so the prior status and stored marker are the committed ones, and only
+      // when the write could publish at all — a content-only edit must not pay for the read.
+      const nowForBulkUpdate = new Date();
+      let bulkUpdateStamp: Date | undefined;
+      if (
+        (collection as { status?: boolean }).status === true &&
+        finalData.status === "published"
+      ) {
+        const lockedForMarker = await tx.selectOne<Record<string, unknown>>(
+          tableName,
+          { where: this.whereEq("id", entryId), forUpdate: true }
+        );
+        bulkUpdateStamp = resolveFirstPublishedStamp({
+          hasStatus: true,
+          previousStatus:
+            typeof lockedForMarker?.status === "string"
+              ? lockedForMarker.status
+              : null,
+          nextStatus: finalData.status,
+          existingMarker: lockedForMarker?.first_published_at,
+          now: nowForBulkUpdate,
+        });
+      }
+
       const [updated] = await tx.update<unknown>(
         tableName,
         {
           ...stripImmutableSystemFields(finalData, "collection"),
-          updatedAt: new Date(),
+          updatedAt: nowForBulkUpdate,
+          ...(bulkUpdateStamp ? { first_published_at: bulkUpdateStamp } : {}),
         },
         this.whereEq("id", entryId),
         { returning: "*" }

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -1557,31 +1557,47 @@ export class CollectionMutationService extends BaseService {
   }
 
   /**
-   * Whether any locale OTHER than `exceptLocale` currently has this document published.
+   * Whether this document is already reachable by the public, ignoring what the current write is
+   * about to do to one locale.
    *
-   * Answers a document-level question the per-locale status cannot: publishing one translation
-   * makes a document public only if no other part of it already was. Reads by table name through
-   * the transaction, mirroring `readCompanionStatus`, because the companion table is created
-   * dynamically and has no Drizzle object on this path.
+   * The marker records a document's FIRST publication, and a localized document can be public
+   * through its main row or through any one of its translations. A write that publishes a single
+   * locale therefore cannot tell, from its own transition alone, whether the document is becoming
+   * public or already was — and the rows where that matters are the upgraded ones, whose marker is
+   * null because the history was never recorded rather than because they were never public.
+   *
+   * Reads through the transaction's Drizzle handle via the same companion scan the publish path
+   * uses, so there is one way to ask a companion for its per-locale statuses.
+   *
+   * `exceptLocale` is the locale this write is changing: its committed status is the "before" of
+   * the transition being judged, so counting it here would make every publish look like a
+   * republish.
    */
-  private async hasOtherPublishedLocale(
+  private async isDocumentAlreadyPublic(
     tx: TransactionContext,
-    companionTableName: string,
+    collectionName: string,
     entryId: string,
-    exceptLocale: string
+    mainRowStatus: string | null | undefined,
+    exceptLocale: string | undefined
   ): Promise<boolean> {
-    const isMysqlDialect = this.dialect === "mysql";
-    const quote = (id: string) => (isMysqlDialect ? `\`${id}\`` : `"${id}"`);
-    const placeholder = (i: number) =>
-      this.dialect === "postgresql" ? `$${i}` : "?";
-    const rows = await tx.execute<{ _locale?: unknown }>(
-      `SELECT ${quote("_locale")} FROM ${quote(companionTableName)} ` +
-        `WHERE ${quote("_parent")} = ${placeholder(1)} ` +
-        `AND ${quote("_status")} = ${placeholder(2)} ` +
-        `AND ${quote("_locale")} <> ${placeholder(3)} LIMIT 1`,
-      [entryId, "published", exceptLocale]
+    if (mainRowStatus === "published") return true;
+
+    const companion = await this.fileManager.loadCompanionSchema(
+      collectionName,
+      tx.getDrizzle()
     );
-    return rows.length > 0;
+    if (!companion) return false;
+
+    const statusesByLocale = await readCompanionLocaleStatusAll(
+      tx.getDrizzle<Parameters<typeof readCompanionLocaleStatusAll>[0]>(),
+      companion.table,
+      entryId,
+      cachedCompanionReadiness(this.adapter, companion.companionTableName)
+    );
+    for (const [locale, status] of statusesByLocale) {
+      if (locale !== exceptLocale && status === "published") return true;
+    }
+    return false;
   }
 
   /**
@@ -3633,13 +3649,31 @@ export class CollectionMutationService extends BaseService {
             // history was never captured. Dating those today would report a publication that
             // never happened.
             const publishNow = new Date();
+            const lockedMarker = (
+              lockedRow as { first_published_at?: unknown } | undefined
+            )?.first_published_at;
+            // Publish-all can find a document in a mixed state: a draft main row alongside a
+            // translation that has been live since before this column existed. The main row's own
+            // transition then reads as a first publication when the document was already
+            // reachable, so the same document-level question is asked here. No locale is excluded
+            // — this write publishes all of them, so any already-published one predates it.
+            const alreadyPublicBeforePublishAll =
+              lockedMarker == null
+                ? await this.isDocumentAlreadyPublic(
+                    tx,
+                    params.collectionName,
+                    params.entryId,
+                    lockedPreviousStatus,
+                    undefined
+                  )
+                : false;
             publishFirstPublishedAt = resolveFirstPublishedStamp({
               hasStatus: true,
-              previousStatus: lockedPreviousStatus,
+              previousStatus: alreadyPublicBeforePublishAll
+                ? "published"
+                : lockedPreviousStatus,
               nextStatus: "published",
-              existingMarker: (
-                lockedRow as { first_published_at?: unknown } | undefined
-              )?.first_published_at,
+              existingMarker: lockedMarker,
               now: publishNow,
             });
             // Through the adapter's Drizzle layer rather than an interpolated statement. That
@@ -5453,26 +5487,39 @@ export class CollectionMutationService extends BaseService {
           // Which transition to read therefore depends on where this write's status lands. A
           // non-default-locale write has its status stripped from the main payload and carried on
           // the companion instead, so the main row's status would show no move at all.
-          // Only asked when a per-locale write could otherwise record a first publication, which
-          // for any one document happens at most once ever — every later write is stopped by the
-          // marker already being set. So the common publish pays nothing for this read.
+          // Asked for ANY write that could record a first publication, not only a per-locale one.
+          // A default-locale or non-localized publish can equally be the second way a document
+          // goes public: its main row may be a draft while a translation has been live since
+          // before this column existed. Restricting the question to the per-locale branch left
+          // exactly that case stamping today's date over an unknown history.
+          //
+          // The branch flag is not a proxy for "this write touches a locale", either — it is
+          // forced false for a trusted write, while the localized split still moves the status
+          // onto the companion. Keying the question on it would skip every server-side write.
+          //
+          // Still gated on a stamp being possible at all, which for any one document happens at
+          // most once ever, since every later write is stopped by the marker already being set.
+          // The ordinary publish pays nothing for the read.
+          const intendedPublish =
+            isNonDefaultLocaleStatusWrite ||
+            localizedUpdate?.companionData?._status !== undefined
+              ? localizedUpdate?.companionData?._status === "published"
+              : intendedStatus === "published";
           const couldRecordFirstPublication =
             collectionHasStatus &&
-            isNonDefaultLocaleStatusWrite &&
+            intendedPublish &&
             (preUpdateRow as { first_published_at?: unknown } | undefined)
-              ?.first_published_at == null &&
-            localizedUpdate?.companionData?._status === "published";
+              ?.first_published_at == null;
           const documentAlreadyPublic = couldRecordFirstPublication
-            ? ((preUpdateRow as { status?: unknown } | undefined)?.status as
-                | string
-                | undefined) === "published" ||
-              (localizedUpdate?.hasStatus === true &&
-                (await this.hasOtherPublishedLocale(
-                  tx,
-                  localizedUpdate.companionTableName,
-                  params.entryId,
-                  localizedUpdate.writeLocale
-                )))
+            ? await this.isDocumentAlreadyPublic(
+                tx,
+                params.collectionName,
+                params.entryId,
+                ((preUpdateRow as { status?: unknown } | undefined)?.status as
+                  | string
+                  | undefined) ?? null,
+                localizedUpdate?.writeLocale
+              )
             : false;
 
           const publicationTransition = selectPublicationTransition({

--- a/packages/nextly/src/domains/collections/services/collection-query-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-query-service.ts
@@ -62,7 +62,10 @@ import type {
 import type { FieldGroupDataService } from "../../../services/field-groups/field-group-data-service";
 import type { Logger } from "../../../services/shared";
 import { BaseService } from "../../../shared/base-service";
-import { convertTimestampsToCamelCase } from "../../../shared/lib/case-conversion";
+import {
+  convertTimestampsToCamelCase,
+  SYSTEM_TIMESTAMP_KEYS,
+} from "../../../shared/lib/case-conversion";
 import {
   applyFieldReadAccess,
   runFieldHooks,
@@ -2646,13 +2649,10 @@ export class CollectionQueryService extends BaseService {
               localeUnknown: false,
             }
           );
-          for (const key of [
-            "id",
-            "createdAt",
-            "created_at",
-            "updatedAt",
-            "updated_at",
-          ]) {
+          // Every system timestamp spelling, taken from the shared list rather than named here.
+          // Naming them is why the first-publication marker was pruned from this view while an
+          // ordinary read of the same document returned it.
+          for (const key of ["id", ...SYSTEM_TIMESTAMP_KEYS]) {
             if (key in rawSnapshot) shapedDraft[key] = rawSnapshot[key];
           }
           let draftEntry = shapedDraft;
@@ -3288,18 +3288,14 @@ export class CollectionQueryService extends BaseService {
       result.id = entry.id;
     }
 
-    // Always include timestamps for consistency across responses
-    if (entry.created_at !== undefined) {
-      result.created_at = entry.created_at;
-    }
-    if (entry.updated_at !== undefined) {
-      result.updated_at = entry.updated_at;
-    }
-    if (entry.createdAt !== undefined) {
-      result.createdAt = entry.createdAt;
-    }
-    if (entry.updatedAt !== undefined) {
-      result.updatedAt = entry.updatedAt;
+    // Always include the system timestamps, for consistency across responses. Taken from the
+    // shared list rather than named one by one: this ran BEFORE camelCase conversion and knew
+    // only the original two, so a selected read dropped the first-publication marker even when
+    // the caller asked for it by name.
+    for (const key of SYSTEM_TIMESTAMP_KEYS) {
+      if (entry[key] !== undefined) {
+        result[key] = entry[key];
+      }
     }
 
     for (const fieldPath of selectedFields) {

--- a/packages/nextly/src/domains/dynamic-collections/services/__tests__/builder-ddl-system-columns.test.ts
+++ b/packages/nextly/src/domains/dynamic-collections/services/__tests__/builder-ddl-system-columns.test.ts
@@ -129,3 +129,79 @@ describe.each(DIALECTS)("builder DDL system columns (%s)", dialect => {
     }
   });
 });
+
+describe.each(DIALECTS)("builder lifecycle toggle (%s)", dialect => {
+  const service = () => new DynamicCollectionSchemaService(undefined, dialect);
+
+  /** The columns the descriptor gains when the draft/publish lifecycle is enabled. */
+  const lifecycleColumns = (isSingle: boolean) => {
+    const off = new Set(
+      getSystemColumnDescriptors(dialect, {
+        hasTitleField: false,
+        hasSlugField: false,
+        hasStatus: false,
+        isSingle,
+      }).map(c => c.name)
+    );
+    return getSystemColumnDescriptors(dialect, {
+      hasTitleField: false,
+      hasSlugField: false,
+      hasStatus: true,
+      isSingle,
+    })
+      .map(c => c.name)
+      .filter(n => !off.has(n));
+  };
+
+  it.each([
+    { label: "collection", table: "dc_thing", isSingle: false },
+    { label: "single", table: "single_thing", isSingle: true },
+  ])(
+    "adds every lifecycle column when enabling: $label",
+    ({ table, isSingle }) => {
+      // Enabling the lifecycle must create every column the runtime schema starts selecting. Naming
+      // only `status` here left the marker expected by the schema and created by nothing, so the
+      // next read referenced a column the toggle had never added.
+      const sql = service().generateAlterTableMigration(table, [], [], {
+        wasStatus: false,
+        hasStatus: true,
+      });
+
+      for (const name of lifecycleColumns(isSingle)) {
+        expect(sql).toContain(`ADD COLUMN`);
+        expect(sql.includes(`"${name}"`) || sql.includes(`\`${name}\``)).toBe(
+          true
+        );
+      }
+    }
+  );
+
+  it.each([
+    { label: "collection", table: "dc_thing", isSingle: false },
+    { label: "single", table: "single_thing", isSingle: true },
+  ])(
+    "drops every lifecycle column when disabling: $label",
+    ({ table, isSingle }) => {
+      const sql = service().generateAlterTableMigration(table, [], [], {
+        wasStatus: true,
+        hasStatus: false,
+      });
+
+      for (const name of lifecycleColumns(isSingle)) {
+        expect(sql).toContain("DROP COLUMN");
+        expect(sql.includes(`"${name}"`) || sql.includes(`\`${name}\``)).toBe(
+          true
+        );
+      }
+    }
+  );
+
+  it("leaves the table alone when the lifecycle does not change", () => {
+    const sql = service().generateAlterTableMigration("dc_thing", [], [], {
+      wasStatus: true,
+      hasStatus: true,
+    });
+    expect(sql).not.toContain("DROP COLUMN");
+    expect(sql).not.toContain("first_published_at");
+  });
+});

--- a/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-schema-service.ts
+++ b/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-schema-service.ts
@@ -473,15 +473,35 @@ ${allColumnDefs.join(",\n")}
     // caller can't accidentally strip Draft/Published.
     const wasStatus = options?.wasStatus === true;
     const hasStatus = options?.hasStatus === true;
-    if (!wasStatus && hasStatus) {
-      const statusType = this.dialect === "sqlite" ? "text" : "varchar(20)";
-      statements.push(
-        `ALTER TABLE ${this.quoteIdentifier(tableName)} ADD COLUMN ${this.quoteIdentifier("status")} ${statusType} DEFAULT 'draft' NOT NULL;`
+    if (
+      wasStatus !== hasStatus &&
+      (hasStatus || options?.hasStatus === false)
+    ) {
+      // The columns the lifecycle owns, derived by asking the descriptor for the set with the
+      // lifecycle on and again with it off: whatever only the first has is what enabling adds and
+      // disabling removes. Naming `status` here instead is how the first-publication marker came
+      // to be expected by the runtime schema while this toggle never created it — the runtime
+      // schema reads the same descriptor, so a column added there arrives here for free.
+      const isSingleTable = tableName.startsWith("single_");
+      const forFlag = (flag: boolean) =>
+        getSystemColumnDescriptors(this.dialect, {
+          hasTitleField: false,
+          hasSlugField: false,
+          hasStatus: flag,
+          isSingle: isSingleTable,
+        });
+      const withoutLifecycle = new Set(forFlag(false).map(c => c.name));
+      const lifecycleColumns = forFlag(true).filter(
+        c => !withoutLifecycle.has(c.name)
       );
-    } else if (wasStatus && options?.hasStatus === false) {
-      statements.push(
-        `ALTER TABLE ${this.quoteIdentifier(tableName)} DROP COLUMN ${this.quoteIdentifier("status")};`
-      );
+
+      for (const column of lifecycleColumns) {
+        statements.push(
+          hasStatus
+            ? `ALTER TABLE ${this.quoteIdentifier(tableName)} ADD COLUMN ${renderSystemColumnSql(column, name => this.quoteIdentifier(name))};`
+            : `ALTER TABLE ${this.quoteIdentifier(tableName)} DROP COLUMN ${this.quoteIdentifier(column.name)};`
+        );
+      }
     }
 
     const oldFieldMap = new Map(oldFields.map(f => [f.name, f]));

--- a/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-validation-service.ts
+++ b/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-validation-service.ts
@@ -107,6 +107,12 @@ export const RESERVED_FIELD_NAMES = [
   // a `createdBy` field would otherwise collide with the system owner column.
   "created_by",
   "createdBy",
+  // First transition into published, auto-added when the draft/publish
+  // lifecycle is enabled. Reserved even for entities that have not enabled it,
+  // because enabling it later would otherwise collide at migration time rather
+  // than here, where the name is actually chosen.
+  "first_published_at",
+  "firstPublishedAt",
 ] as const;
 
 export const collectionNameSchema = z

--- a/packages/nextly/src/domains/schema/services/field-column-descriptor.ts
+++ b/packages/nextly/src/domains/schema/services/field-column-descriptor.ts
@@ -385,12 +385,11 @@ export interface SystemColumnSet {
  * Gated on `hasStatus`: a collection with no draft lifecycle has no transition to record, and its
  * rows are public from the moment they are saved.
  *
- * Gated on `!isSingle` as well, and that one is a deliberate limitation rather than a semantic
- * claim — a Single's publication date is just as meaningful. A Single's physical table does not
- * receive this column through the same path the runtime schema does, so injecting it produced a
- * runtime schema selecting a column that is not there, which fails EVERY read of a status-enabled
- * Single rather than merely leaving the marker unset. Aligning the Single DDL path is its own
- * piece of work; until then the column is collections-only.
+ * Singles get it too. They could not at first: a Single's physical table was created by a DDL
+ * generator that restated the system columns by hand, so a column added here reached the runtime
+ * schema and not the table, and the resulting SELECT named a column that does not exist — failing
+ * EVERY read of a status-enabled Single rather than merely leaving the marker unset. That
+ * generator now renders from this list, so a Single's table receives whatever is declared here.
  */
 const FIRST_PUBLISHED_AT = {
   postgresql: {
@@ -497,7 +496,7 @@ export function getSystemColumnDescriptors(
         primaryKey: false,
         default: "'draft'",
       });
-      if (!opts.isSingle) cols.push(FIRST_PUBLISHED_AT.postgresql);
+      cols.push(FIRST_PUBLISHED_AT.postgresql);
     }
   } else if (dialect === "mysql") {
     cols.push({
@@ -567,7 +566,7 @@ export function getSystemColumnDescriptors(
         primaryKey: false,
         default: "'draft'",
       });
-      if (!opts.isSingle) cols.push(FIRST_PUBLISHED_AT.mysql);
+      cols.push(FIRST_PUBLISHED_AT.mysql);
     }
   } else {
     // sqlite
@@ -630,7 +629,7 @@ export function getSystemColumnDescriptors(
         primaryKey: false,
         default: "'draft'",
       });
-      if (!opts.isSingle) cols.push(FIRST_PUBLISHED_AT.sqlite);
+      cols.push(FIRST_PUBLISHED_AT.sqlite);
     }
   }
   return cols;

--- a/packages/nextly/src/domains/schema/services/field-column-descriptor.ts
+++ b/packages/nextly/src/domains/schema/services/field-column-descriptor.ts
@@ -363,6 +363,56 @@ export interface SystemColumnSet {
   isSingle?: boolean;
 }
 
+/**
+ * When a document first became public, per dialect.
+ *
+ * `status` says what a document IS; nothing says what it HAS BEEN. Unpublishing returns a row to
+ * `draft` and erases every trace it was ever live, but the links, feeds and search results that
+ * accumulated while it was live do not go away. Anything deciding "was this address ever public" —
+ * slug stability, redirect capture — needs a fact that survives the round trip.
+ *
+ * NULLABLE with NO DEFAULT, and that is the whole design. `NULL` means "not known to have been
+ * published": true for a draft, and equally true for every row that predates this column, which
+ * cannot be distinguished from a draft after the fact. A default would assert a publication date
+ * that never happened.
+ *
+ * Set once on the first transition into `published` and never modified again, so it is not a
+ * "last published" timestamp. Those are different questions and Contentful, the most mature API
+ * surface here, carries both (`sys.firstPublishedAt` alongside `sys.publishedAt`); the second is
+ * left to a follow-up rather than guessed at, because whether it survives an unpublish is a
+ * product decision and this one has only one defensible answer.
+ *
+ * Gated on `hasStatus`: a collection with no draft lifecycle has no transition to record, and its
+ * rows are public from the moment they are saved.
+ *
+ * Gated on `!isSingle` as well, and that one is a deliberate limitation rather than a semantic
+ * claim — a Single's publication date is just as meaningful. A Single's physical table does not
+ * receive this column through the same path the runtime schema does, so injecting it produced a
+ * runtime schema selecting a column that is not there, which fails EVERY read of a status-enabled
+ * Single rather than merely leaving the marker unset. Aligning the Single DDL path is its own
+ * piece of work; until then the column is collections-only.
+ */
+const FIRST_PUBLISHED_AT = {
+  postgresql: {
+    name: "first_published_at",
+    dialectType: "timestamp",
+    nullable: true,
+    primaryKey: false,
+  },
+  mysql: {
+    name: "first_published_at",
+    dialectType: "timestamp",
+    nullable: true,
+    primaryKey: false,
+  },
+  sqlite: {
+    name: "first_published_at",
+    dialectType: "integer",
+    nullable: true,
+    primaryKey: false,
+  },
+} as const;
+
 export interface SystemColumnDescriptor {
   name: string;
   dialectType: string;
@@ -447,6 +497,7 @@ export function getSystemColumnDescriptors(
         primaryKey: false,
         default: "'draft'",
       });
+      if (!opts.isSingle) cols.push(FIRST_PUBLISHED_AT.postgresql);
     }
   } else if (dialect === "mysql") {
     cols.push({
@@ -516,6 +567,7 @@ export function getSystemColumnDescriptors(
         primaryKey: false,
         default: "'draft'",
       });
+      if (!opts.isSingle) cols.push(FIRST_PUBLISHED_AT.mysql);
     }
   } else {
     // sqlite
@@ -578,6 +630,7 @@ export function getSystemColumnDescriptors(
         primaryKey: false,
         default: "'draft'",
       });
+      if (!opts.isSingle) cols.push(FIRST_PUBLISHED_AT.sqlite);
     }
   }
   return cols;

--- a/packages/nextly/src/domains/schema/services/field-column-descriptor.ts
+++ b/packages/nextly/src/domains/schema/services/field-column-descriptor.ts
@@ -377,10 +377,10 @@ export interface SystemColumnSet {
  * that never happened.
  *
  * Set once on the first transition into `published` and never modified again, so it is not a
- * "last published" timestamp. Those are different questions and Contentful, the most mature API
- * surface here, carries both (`sys.firstPublishedAt` alongside `sys.publishedAt`); the second is
- * left to a follow-up rather than guessed at, because whether it survives an unpublish is a
- * product decision and this one has only one defensible answer.
+ * "last published" timestamp. Those are different questions: a last-published value moves on every
+ * republish and its behaviour across an unpublish is a product choice, while this one has a single
+ * defensible answer. Contentful, the most mature API surface here, carries both under distinct
+ * names (`sys.firstPublishedAt` alongside `sys.publishedAt`) for the same reason.
  *
  * Gated on `hasStatus`: a collection with no draft lifecycle has no transition to record, and its
  * rows are public from the moment they are saved.

--- a/packages/nextly/src/domains/schema/services/runtime-schema-generator.ts
+++ b/packages/nextly/src/domains/schema/services/runtime-schema-generator.ts
@@ -331,6 +331,12 @@ function buildSystemDrizzleColumn(
     // Row owner — nullable text (matches the id column type); no default so
     // system/seed creates and existing rows stay null.
     if (sys.name === "created_by") return pgText("created_by");
+    // No `defaultNow`, unlike the other two timestamps: a row that has never
+    // been published must read NULL, and a default would date a publication
+    // that did not happen.
+    if (sys.name === "first_published_at") {
+      return pgTimestamp("first_published_at");
+    }
     // title / slug — text NOT NULL.
     return pgText(sys.name).notNull();
   }
@@ -352,6 +358,10 @@ function buildSystemDrizzleColumn(
     if (sys.name === "created_by") {
       return mysqlVarchar("created_by", { length: 191 });
     }
+    // Nullable and undefaulted, unlike created_at/updated_at — see the pg branch.
+    if (sys.name === "first_published_at") {
+      return mysqlTimestamp("first_published_at");
+    }
     return mysqlVarchar(sys.name, { length: 255 }).notNull();
   }
   // sqlite
@@ -372,6 +382,10 @@ function buildSystemDrizzleColumn(
   }
   // Row owner — nullable text (matches the id column type).
   if (sys.name === "created_by") return sqliteText("created_by");
+  // Nullable and undefaulted, unlike created_at/updated_at — see the pg branch.
+  if (sys.name === "first_published_at") {
+    return sqliteInteger("first_published_at", { mode: "timestamp" });
+  }
   return sqliteText(sys.name).notNull();
 }
 

--- a/packages/nextly/src/domains/schema/services/schema-hash.ts
+++ b/packages/nextly/src/domains/schema/services/schema-hash.ts
@@ -31,8 +31,9 @@ import type { FieldConfig } from "@nextly/collections";
  * History:
  * - v1: Initial version (createdAt, updatedAt - camelCase)
  * - v2: Changed to snake_case (created_at, updated_at)
+ * - v3: Added first_published_at to status-enabled collections and singles
  */
-export const SYSTEM_SCHEMA_VERSION = 2;
+export const SYSTEM_SCHEMA_VERSION = 3;
 
 // ============================================================
 // Types

--- a/packages/nextly/src/domains/singles/services/single-mutation-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-mutation-service.ts
@@ -877,7 +877,8 @@ export class SingleMutationService extends BaseService {
       // and the marker is meant to be set once, so a caller able to supply it could date a
       // publication that never happened or overwrite a real one.
       const snakeCaseData = stripImmutableSystemFields(
-        keysToSnakeCase(serializedData) as Record<string, unknown>
+        keysToSnakeCase(serializedData) as Record<string, unknown>,
+        "single"
       );
       // Commit the scalar update, the component subtree writes, the companion
       // upsert, AND the version snapshot atomically so any failure rolls back the

--- a/packages/nextly/src/domains/singles/services/single-mutation-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-mutation-service.ts
@@ -30,6 +30,7 @@ import type { RBACAccessControlService } from "../../../domains/auth/services/rb
 import { NextlyError } from "../../../errors/nextly-error";
 import type { HookRegistry } from "../../../hooks/hook-registry";
 import { keysToSnakeCase } from "../../../lib/case-conversion";
+import { stripImmutableSystemFields } from "../../../lib/immutable-system-fields";
 import {
   resolvePublishTransition,
   stripUndefinedStatus,
@@ -867,15 +868,17 @@ export class SingleMutationService extends BaseService {
       // 7. Serialize JSON fields for storage
       const serializedData = serializeJsonFields(currentData, fieldConfigs);
 
-      // 8. Remove id and createdAt from update data (if present)
-      delete serializedData.id;
-      delete serializedData.createdAt;
-
-      // 9. Update document in database
-      const snakeCaseData = keysToSnakeCase(serializedData) as Record<
-        string,
-        unknown
-      >;
+      // 8. Update document in database.
+      //
+      // System columns are dropped AFTER snake-casing, so a caller cannot reach one by choosing
+      // its other spelling: `firstPublishedAt` and `first_published_at` both arrive here as the
+      // physical column name and both are refused. This previously removed `id` and `createdAt`
+      // only, which left `updatedAt` and the first-publication marker writable from the request —
+      // and the marker is meant to be set once, so a caller able to supply it could date a
+      // publication that never happened or overwrite a real one.
+      const snakeCaseData = stripImmutableSystemFields(
+        keysToSnakeCase(serializedData) as Record<string, unknown>
+      );
       // Commit the scalar update, the component subtree writes, the companion
       // upsert, AND the version snapshot atomically so any failure rolls back the
       // others (no partial single/localized/version state). The rows are RETURNED

--- a/packages/nextly/src/domains/singles/services/single-mutation-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-mutation-service.ts
@@ -1207,6 +1207,33 @@ export class SingleMutationService extends BaseService {
             const preRowMainStatus =
               typeof preRow?.status === "string" ? preRow.status : undefined;
 
+            // The first time this single becomes public, recorded on the row that is about to be
+            // written so it commits with the status it describes.
+            //
+            // Only when the marker is still absent, which is what makes it the FIRST publication
+            // rather than the latest: a republish after an unpublish must not move it.
+            //
+            // A non-default-locale write has already had `status` removed from `mainPayload`
+            // above, so it stamps nothing here — that language's publish state lives on the
+            // companion, and stamping the main row from it would date the entry's first
+            // publication from a translation.
+            //
+            // `singleHasStatus` further down this block answers a wider question (main row OR
+            // companion) and is declared after this point, so it cannot be read here; the main
+            // row's own flag is what governs a main-row column.
+            const mainStatusWritten = (mainPayload as Record<string, unknown>)
+              .status;
+            if (
+              (singleMeta as { status?: boolean }).status === true &&
+              mainStatusWritten === "published" &&
+              preRowMainStatus !== "published" &&
+              (preRow as { first_published_at?: unknown } | undefined)
+                ?.first_published_at == null
+            ) {
+              (mainPayload as Record<string, unknown>).first_published_at =
+                new Date();
+            }
+
             const rows = await tx.update<SingleDocument>(
               singleMeta.tableName,
               mainPayload,

--- a/packages/nextly/src/domains/versions/__tests__/restore-snapshot.test.ts
+++ b/packages/nextly/src/domains/versions/__tests__/restore-snapshot.test.ts
@@ -49,6 +49,26 @@ describe("buildRestorePayload", () => {
     expect(payload).toEqual({ title: "Hello", body: { root: {} } });
   });
 
+  it("does not report the first-publication marker as a dropped field", () => {
+    // A versioned status-enabled document's snapshot carries the marker. It is a system column,
+    // not a user field, so restoring must neither write it back nor count it as lost — a complete
+    // restore reported as partial sends the operator looking for data that was never missing.
+    const markerFields = [{ name: "title", type: "text" }] as FieldConfig[];
+
+    const { payload, droppedFields } = buildRestorePayload(
+      {
+        title: "Hello",
+        firstPublishedAt: "2026-01-01T00:00:00.000Z",
+        first_published_at: "2026-01-01T00:00:00.000Z",
+      },
+      markerFields
+    );
+
+    expect(droppedFields).toEqual([]);
+    expect("firstPublishedAt" in payload).toBe(false);
+    expect("first_published_at" in payload).toBe(false);
+  });
+
   it("drops a field the schema no longer has, and reports it", () => {
     // Validation walks the schema's fields rather than the payload's keys, so
     // it ignores this; the update then names the missing column in raw SQL.

--- a/packages/nextly/src/domains/versions/restore-snapshot.ts
+++ b/packages/nextly/src/domains/versions/restore-snapshot.ts
@@ -17,24 +17,25 @@
  */
 
 import type { FieldConfig } from "../../collections/fields/types";
+import { ALWAYS_IMMUTABLE_SYSTEM_FIELDS } from "../../lib/immutable-system-fields";
 import { STORAGE_FORMAT } from "../../schemas/storage-format";
 import { isFieldLocalized } from "../i18n/classify-fields";
 
 /**
- * Columns a write must never carry.
+ * Columns a restore must never carry back.
  *
- * The collection update path strips these too, but only inside its transaction
- * — long after `beforeUpdate` hooks have seen the payload. Stripping here means
- * a hook is never handed a forged `createdBy` or a stale `createdAt`. The
- * singles path strips only `id` and `createdAt`, so for that path this is the
- * only place ownership is protected at all.
+ * Both write paths strip these too, but only inside their transaction — long
+ * after `beforeUpdate` hooks have seen the payload. Stripping here means a hook
+ * is never handed a forged `createdBy` or a stale `createdAt`.
+ *
+ * The always-immutable names come from the shared list rather than being
+ * repeated: this copy had fallen behind it, so a restored snapshot reported the
+ * first-publication marker as an unknown field and every complete restore came
+ * back described as partial. The owner column is added on top because this path
+ * protects it for singles as well, where it is not a system column.
  */
 const IMMUTABLE_FIELDS = new Set([
-  "id",
-  "createdAt",
-  "created_at",
-  "updatedAt",
-  "updated_at",
+  ...ALWAYS_IMMUTABLE_SYSTEM_FIELDS,
   "createdBy",
   "created_by",
 ]);

--- a/packages/nextly/src/lib/immutable-system-fields.ts
+++ b/packages/nextly/src/lib/immutable-system-fields.ts
@@ -1,0 +1,55 @@
+/**
+ * System columns a client must never write.
+ *
+ * These are not declared fields, so field validation passes them straight through to the row.
+ * Stripping them on every write is what keeps the service authoritative: the generated id, the
+ * owner stamp, the timestamps and the first-publication marker are decided here, not by whatever
+ * a caller put in the body.
+ *
+ * Owned in one place because the entities that need it are written by different services. The
+ * collection writer had this list and the single writer did not, so a marker a caller supplied
+ * survived into a single's row — the same request that a collection rejected. A shared list makes
+ * that divergence impossible rather than merely fixed once.
+ *
+ * @module lib/immutable-system-fields
+ */
+
+/**
+ * Both spellings of every column: config validation accepts camelCase field names and
+ * snake-cases them to the same physical column, so reserving only one spelling reserves nothing.
+ *
+ * `first_published_at` is here for a reason the others are not. It is meant to be written once
+ * and never moved, and a value taken from the request would make that guarantee decorative: a
+ * draft create could claim a publication that never happened, and any later update could reset a
+ * real one.
+ *
+ * `created_by` is not a column on a single's table, but stripping it there is still correct — a
+ * caller cannot write an owner to an entity that has none.
+ */
+export const IMMUTABLE_SYSTEM_FIELDS: ReadonlySet<string> = new Set([
+  "id",
+  "created_at",
+  "createdAt",
+  "updated_at",
+  "updatedAt",
+  "created_by",
+  "createdBy",
+  "first_published_at",
+  "firstPublishedAt",
+]);
+
+/**
+ * A copy of `data` without any client-supplied system column.
+ *
+ * Returns a new object rather than mutating, so a caller can keep the original for hooks or
+ * event payloads that legitimately describe what was requested.
+ */
+export function stripImmutableSystemFields(
+  data: Record<string, unknown>
+): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(data)) {
+    if (!IMMUTABLE_SYSTEM_FIELDS.has(key)) out[key] = value;
+  }
+  return out;
+}

--- a/packages/nextly/src/lib/immutable-system-fields.ts
+++ b/packages/nextly/src/lib/immutable-system-fields.ts
@@ -29,7 +29,7 @@ export type WritableEntityKind = "collection" | "single";
  * a draft create could claim a publication that never happened, and any later update could reset
  * a real one.
  */
-const ALWAYS_IMMUTABLE: readonly string[] = [
+export const ALWAYS_IMMUTABLE_SYSTEM_FIELDS: readonly string[] = [
   "id",
   "created_at",
   "createdAt",
@@ -54,10 +54,10 @@ const COLLECTION_ONLY_IMMUTABLE: readonly string[] = [
 ];
 
 const COLLECTION_SET: ReadonlySet<string> = new Set([
-  ...ALWAYS_IMMUTABLE,
+  ...ALWAYS_IMMUTABLE_SYSTEM_FIELDS,
   ...COLLECTION_ONLY_IMMUTABLE,
 ]);
-const SINGLE_SET: ReadonlySet<string> = new Set(ALWAYS_IMMUTABLE);
+const SINGLE_SET: ReadonlySet<string> = new Set(ALWAYS_IMMUTABLE_SYSTEM_FIELDS);
 
 /** The names a client may not write for the given entity. */
 export function immutableSystemFieldsFor(

--- a/packages/nextly/src/lib/immutable-system-fields.ts
+++ b/packages/nextly/src/lib/immutable-system-fields.ts
@@ -8,48 +8,78 @@
  *
  * Owned in one place because the entities that need it are written by different services. The
  * collection writer had this list and the single writer did not, so a marker a caller supplied
- * survived into a single's row — the same request that a collection rejected. A shared list makes
- * that divergence impossible rather than merely fixed once.
+ * survived into a single's row — the same request that a collection rejected.
+ *
+ * The set is NOT "every system column". `title`, `slug` and `status` are system-injected and
+ * fully writable: they are content and lifecycle, not provenance. Only the columns the service
+ * alone decides belong here.
  *
  * @module lib/immutable-system-fields
  */
 
+/** Which entity is being written. The owner column exists on only one of them. */
+export type WritableEntityKind = "collection" | "single";
+
 /**
- * Both spellings of every column: config validation accepts camelCase field names and
- * snake-cases them to the same physical column, so reserving only one spelling reserves nothing.
+ * Reserved on every entity, in both spellings: config validation accepts camelCase field names
+ * and snake-cases them to the same physical column, so reserving one spelling reserves nothing.
  *
- * `first_published_at` is here for a reason the others are not. It is meant to be written once
- * and never moved, and a value taken from the request would make that guarantee decorative: a
- * draft create could claim a publication that never happened, and any later update could reset a
- * real one.
- *
- * `created_by` is not a column on a single's table, but stripping it there is still correct — a
- * caller cannot write an owner to an entity that has none.
+ * `first_published_at` is here for a reason the timestamps are not. It is meant to be written
+ * once and never moved, and a value taken from the request would make that guarantee decorative:
+ * a draft create could claim a publication that never happened, and any later update could reset
+ * a real one.
  */
-export const IMMUTABLE_SYSTEM_FIELDS: ReadonlySet<string> = new Set([
+const ALWAYS_IMMUTABLE: readonly string[] = [
   "id",
   "created_at",
   "createdAt",
   "updated_at",
   "updatedAt",
-  "created_by",
-  "createdBy",
   "first_published_at",
   "firstPublishedAt",
-]);
+];
 
 /**
- * A copy of `data` without any client-supplied system column.
+ * Reserved on collections only.
+ *
+ * A single is one global row, so owner-only access is meaningless and no `created_by` column is
+ * injected onto its table — which leaves `created_by` an ordinary, legal field name for a single
+ * to declare, and the single validator reserves only the publication marker for exactly that
+ * reason. Stripping it there would silently discard a user's own column on every update, so the
+ * reservation follows the column rather than the convenience of one shared list.
+ */
+const COLLECTION_ONLY_IMMUTABLE: readonly string[] = [
+  "created_by",
+  "createdBy",
+];
+
+const COLLECTION_SET: ReadonlySet<string> = new Set([
+  ...ALWAYS_IMMUTABLE,
+  ...COLLECTION_ONLY_IMMUTABLE,
+]);
+const SINGLE_SET: ReadonlySet<string> = new Set(ALWAYS_IMMUTABLE);
+
+/** The names a client may not write for the given entity. */
+export function immutableSystemFieldsFor(
+  entity: WritableEntityKind
+): ReadonlySet<string> {
+  return entity === "single" ? SINGLE_SET : COLLECTION_SET;
+}
+
+/**
+ * A copy of `data` without any client-supplied system column for that entity.
  *
  * Returns a new object rather than mutating, so a caller can keep the original for hooks or
  * event payloads that legitimately describe what was requested.
  */
 export function stripImmutableSystemFields(
-  data: Record<string, unknown>
+  data: Record<string, unknown>,
+  entity: WritableEntityKind
 ): Record<string, unknown> {
+  const reserved = immutableSystemFieldsFor(entity);
   const out: Record<string, unknown> = {};
   for (const [key, value] of Object.entries(data)) {
-    if (!IMMUTABLE_SYSTEM_FIELDS.has(key)) out[key] = value;
+    if (!reserved.has(key)) out[key] = value;
   }
   return out;
 }

--- a/packages/nextly/src/lib/status-transition.test.ts
+++ b/packages/nextly/src/lib/status-transition.test.ts
@@ -313,9 +313,11 @@ describe("selectPublicationTransition — already-public documents", () => {
     expect(stampFor(t)).toBe(now);
   });
 
-  it("ignores the flag for a main-row write", () => {
-    // A default-locale or non-localized write is judged on the main row's own transition; an
-    // already-published main row cannot publish again, which the shared rule already handles.
+  it("records nothing for a main-row publish of an already-public document", () => {
+    // A default-locale or non-localized publish is equally capable of being the SECOND way a
+    // document goes public: its main row can be a draft while a translation has been live since
+    // before the marker existed. Judging it on the main row's own transition alone would stamp
+    // today over a history that was simply never recorded.
     const t = selectPublicationTransition({
       writesStatusToCompanion: false,
       mainPreviousStatus: "draft",
@@ -323,6 +325,18 @@ describe("selectPublicationTransition — already-public documents", () => {
       companionPreviousStatus: "published",
       companionNextStatus: "published",
       documentAlreadyPublic: true,
+    });
+    expect(stampFor(t)).toBeUndefined();
+  });
+
+  it("still records a main-row publish when nothing else was public", () => {
+    const t = selectPublicationTransition({
+      writesStatusToCompanion: false,
+      mainPreviousStatus: "draft",
+      mainNextStatus: "published",
+      companionPreviousStatus: "draft",
+      companionNextStatus: undefined,
+      documentAlreadyPublic: false,
     });
     expect(stampFor(t)).toBe(now);
   });

--- a/packages/nextly/src/lib/status-transition.test.ts
+++ b/packages/nextly/src/lib/status-transition.test.ts
@@ -9,6 +9,7 @@ import { describe, it, expect } from "vitest";
 import {
   resolveFirstPublishedStamp,
   resolvePublishTransition,
+  selectPublicationTransition,
 } from "./status-transition";
 
 describe("resolvePublishTransition", () => {
@@ -158,5 +159,100 @@ describe("resolveFirstPublishedStamp", () => {
     expect(
       resolveFirstPublishedStamp({ ...base, nextStatus: 1 })
     ).toBeUndefined();
+  });
+});
+
+describe("selectPublicationTransition", () => {
+  const mainDraftToPublished = {
+    mainPreviousStatus: "draft" as string | null,
+    mainNextStatus: "published" as unknown,
+    companionPreviousStatus: "draft" as string | null,
+    companionNextStatus: "published" as unknown,
+  };
+
+  it("reads the main row when the write's status lands there", () => {
+    const t = selectPublicationTransition({
+      ...mainDraftToPublished,
+      writesStatusToCompanion: false,
+      companionPreviousStatus: null,
+      companionNextStatus: undefined,
+    });
+    expect(t).toEqual({ previousStatus: "draft", nextStatus: "published" });
+  });
+
+  it("reads the companion when the write's status lands there", () => {
+    // The case the marker was missing. A non-default-locale write leaves the main row's status
+    // untouched, so reading it sees no transition — and the document going public in that
+    // language would go unrecorded until some later, later-dated default-locale publish.
+    const t = selectPublicationTransition({
+      ...mainDraftToPublished,
+      writesStatusToCompanion: true,
+      mainPreviousStatus: "draft",
+      mainNextStatus: undefined,
+    });
+    expect(t).toEqual({ previousStatus: "draft", nextStatus: "published" });
+  });
+
+  it("does not report a publication when the main row alone moves and the write is per-locale", () => {
+    // Guards the inverse mistake: taking the main row's pair for a companion write would report a
+    // transition the write did not make.
+    const t = selectPublicationTransition({
+      writesStatusToCompanion: true,
+      mainPreviousStatus: "draft",
+      mainNextStatus: "published",
+      companionPreviousStatus: "published",
+      companionNextStatus: "published",
+    });
+    expect(
+      resolveFirstPublishedStamp({
+        hasStatus: true,
+        previousStatus: t.previousStatus,
+        nextStatus: t.nextStatus,
+        existingMarker: null,
+        now: new Date("2026-08-02T10:00:00.000Z"),
+      })
+    ).toBeUndefined();
+  });
+
+  it("feeds a companion draft-to-published straight into a stamp", () => {
+    const t = selectPublicationTransition({
+      writesStatusToCompanion: true,
+      mainPreviousStatus: "draft",
+      mainNextStatus: undefined,
+      companionPreviousStatus: "draft",
+      companionNextStatus: "published",
+    });
+    const now = new Date("2026-08-02T10:00:00.000Z");
+    expect(
+      resolveFirstPublishedStamp({
+        hasStatus: true,
+        previousStatus: t.previousStatus,
+        nextStatus: t.nextStatus,
+        existingMarker: null,
+        now,
+      })
+    ).toBe(now);
+  });
+
+  it("treats a first companion row (no prior status) as a publication", () => {
+    // A locale published before it ever had a companion row has no prior status at all; null is
+    // not "published", so the move still counts.
+    const t = selectPublicationTransition({
+      writesStatusToCompanion: true,
+      mainPreviousStatus: "draft",
+      mainNextStatus: undefined,
+      companionPreviousStatus: null,
+      companionNextStatus: "published",
+    });
+    const now = new Date("2026-08-02T10:00:00.000Z");
+    expect(
+      resolveFirstPublishedStamp({
+        hasStatus: true,
+        previousStatus: t.previousStatus,
+        nextStatus: t.nextStatus,
+        existingMarker: null,
+        now,
+      })
+    ).toBe(now);
   });
 });

--- a/packages/nextly/src/lib/status-transition.test.ts
+++ b/packages/nextly/src/lib/status-transition.test.ts
@@ -256,3 +256,74 @@ describe("selectPublicationTransition", () => {
     ).toBe(now);
   });
 });
+
+describe("selectPublicationTransition — already-public documents", () => {
+  const now = new Date("2026-08-02T10:00:00.000Z");
+  const stampFor = (t: {
+    previousStatus: string | null | undefined;
+    nextStatus: unknown;
+  }) =>
+    resolveFirstPublishedStamp({
+      hasStatus: true,
+      previousStatus: t.previousStatus,
+      nextStatus: t.nextStatus,
+      existingMarker: null,
+      now,
+    });
+
+  it("records nothing when the main row is already public", () => {
+    // The upgraded row: already published, marker null because the history was never recorded.
+    // Publishing a translation afterwards must not date its first publication from today.
+    const t = selectPublicationTransition({
+      writesStatusToCompanion: true,
+      mainPreviousStatus: "published",
+      mainNextStatus: undefined,
+      companionPreviousStatus: "draft",
+      companionNextStatus: "published",
+      documentAlreadyPublic: true,
+    });
+    expect(stampFor(t)).toBeUndefined();
+  });
+
+  it("records nothing when another locale is already public", () => {
+    // Same reasoning through a different route: some other translation is already live, so the
+    // document was reachable before this write.
+    const t = selectPublicationTransition({
+      writesStatusToCompanion: true,
+      mainPreviousStatus: "draft",
+      mainNextStatus: undefined,
+      companionPreviousStatus: "draft",
+      companionNextStatus: "published",
+      documentAlreadyPublic: true,
+    });
+    expect(stampFor(t)).toBeUndefined();
+  });
+
+  it("still records when nothing else was public", () => {
+    // The flag must not suppress the case it exists to disambiguate: a genuinely first
+    // publication made through a translation.
+    const t = selectPublicationTransition({
+      writesStatusToCompanion: true,
+      mainPreviousStatus: "draft",
+      mainNextStatus: undefined,
+      companionPreviousStatus: "draft",
+      companionNextStatus: "published",
+      documentAlreadyPublic: false,
+    });
+    expect(stampFor(t)).toBe(now);
+  });
+
+  it("ignores the flag for a main-row write", () => {
+    // A default-locale or non-localized write is judged on the main row's own transition; an
+    // already-published main row cannot publish again, which the shared rule already handles.
+    const t = selectPublicationTransition({
+      writesStatusToCompanion: false,
+      mainPreviousStatus: "draft",
+      mainNextStatus: "published",
+      companionPreviousStatus: "published",
+      companionNextStatus: "published",
+      documentAlreadyPublic: true,
+    });
+    expect(stampFor(t)).toBe(now);
+  });
+});

--- a/packages/nextly/src/lib/status-transition.test.ts
+++ b/packages/nextly/src/lib/status-transition.test.ts
@@ -6,7 +6,10 @@
  */
 import { describe, it, expect } from "vitest";
 
-import { resolvePublishTransition } from "./status-transition";
+import {
+  resolveFirstPublishedStamp,
+  resolvePublishTransition,
+} from "./status-transition";
 
 describe("resolvePublishTransition", () => {
   it("treats draft → published as a publish", () => {
@@ -68,5 +71,92 @@ describe("resolvePublishTransition", () => {
     // Some callers pass undefined rather than null for "no prior status".
     expect(resolvePublishTransition(undefined, "published")).toBe("publish");
     expect(resolvePublishTransition(undefined, "draft")).toBeNull();
+  });
+});
+
+describe("resolveFirstPublishedStamp", () => {
+  const now = new Date("2026-08-02T10:00:00.000Z");
+  const base = {
+    hasStatus: true,
+    previousStatus: "draft" as string | null | undefined,
+    nextStatus: "published" as unknown,
+    existingMarker: null as unknown,
+    now,
+  };
+
+  it("records the instant a draft becomes published", () => {
+    expect(resolveFirstPublishedStamp(base)).toBe(now);
+  });
+
+  it("records a create that lands directly on published", () => {
+    // A create has no prior status, so landing on published IS the first publication.
+    expect(resolveFirstPublishedStamp({ ...base, previousStatus: null })).toBe(
+      now
+    );
+  });
+
+  it("records nothing when the entity has no draft lifecycle", () => {
+    // Nothing transitions, so there is no publication moment to date.
+    expect(
+      resolveFirstPublishedStamp({ ...base, hasStatus: false })
+    ).toBeUndefined();
+  });
+
+  it("records nothing when a marker is already stored", () => {
+    // It dates the FIRST publication; a republish must not move it.
+    expect(
+      resolveFirstPublishedStamp({
+        ...base,
+        previousStatus: "draft",
+        existingMarker: new Date("2020-01-01T00:00:00.000Z"),
+      })
+    ).toBeUndefined();
+  });
+
+  it("records nothing for an already-published row", () => {
+    // The case that matters for rows published before the column existed: their marker is null
+    // because the history was never recorded, and dating them now would invent a publication.
+    expect(
+      resolveFirstPublishedStamp({ ...base, previousStatus: "published" })
+    ).toBeUndefined();
+  });
+
+  it("records nothing for an unpublish", () => {
+    expect(
+      resolveFirstPublishedStamp({
+        ...base,
+        previousStatus: "published",
+        nextStatus: "draft",
+      })
+    ).toBeUndefined();
+  });
+
+  it("records nothing when the write names no status", () => {
+    // A content-only edit moves nothing.
+    expect(
+      resolveFirstPublishedStamp({ ...base, nextStatus: undefined })
+    ).toBeUndefined();
+  });
+
+  it("treats a marker of 0 as already recorded", () => {
+    // SQLite stores these as integers, and the epoch is falsy — a truthiness check here would
+    // re-stamp a row that already carries a (very old) date.
+    expect(
+      resolveFirstPublishedStamp({ ...base, existingMarker: 0 })
+    ).toBeUndefined();
+  });
+
+  it("treats an absent column as nothing recorded", () => {
+    // A row read that did not project the column must not be mistaken for a stored value.
+    expect(
+      resolveFirstPublishedStamp({ ...base, existingMarker: undefined })
+    ).toBe(now);
+  });
+
+  it("does not record for a non-string status coerced into the column", () => {
+    // Only the exact string is published, matching resolvePublishTransition.
+    expect(
+      resolveFirstPublishedStamp({ ...base, nextStatus: 1 })
+    ).toBeUndefined();
   });
 });

--- a/packages/nextly/src/lib/status-transition.ts
+++ b/packages/nextly/src/lib/status-transition.ts
@@ -114,6 +114,47 @@ export function stripUndefinedStatus<T extends Record<string, unknown>>(
  * the later would win — the row lock the write already takes is what prevents
  * that interleaving, not this function.
  */
+/**
+ * The status pair that describes what a write does to a document's PUBLIC visibility.
+ *
+ * A localized collection can go public in two different places. A write for the default locale
+ * (or a non-localized one) moves the main row's `status`. A write for any other locale has its
+ * status stripped from the main payload and carried on that locale's companion row instead, so
+ * the main row's status shows no movement at all even though a translation just went live.
+ *
+ * The first-publication marker is a property of the DOCUMENT — "has this ever been public in any
+ * language" — because the address it protects is shared across locales. Reading the main row's
+ * status for a non-default-locale write therefore sees no transition and records nothing, and the
+ * marker would later be dated from whenever the default locale happened to publish: after the
+ * document was already reachable.
+ *
+ * Returned as a pair rather than decided inline at the write seam so it can be tested directly:
+ * the branch only executes for an access-controlled write to a non-default locale, which needs a
+ * caller holding a real publish grant.
+ */
+export function selectPublicationTransition(args: {
+  /** True when this write's status lands on a locale companion, not the main row. */
+  writesStatusToCompanion: boolean;
+  /** The main row's committed status. */
+  mainPreviousStatus: string | null | undefined;
+  /** The status this write assigns to the main row. */
+  mainNextStatus: unknown;
+  /** The write locale's committed companion status. */
+  companionPreviousStatus: string | null | undefined;
+  /** The status this write assigns to the companion. */
+  companionNextStatus: unknown;
+}): { previousStatus: string | null | undefined; nextStatus: unknown } {
+  return args.writesStatusToCompanion
+    ? {
+        previousStatus: args.companionPreviousStatus,
+        nextStatus: args.companionNextStatus,
+      }
+    : {
+        previousStatus: args.mainPreviousStatus,
+        nextStatus: args.mainNextStatus,
+      };
+}
+
 export function resolveFirstPublishedStamp(args: {
   /** Whether the collection or single has the draft/publish lifecycle enabled. */
   hasStatus: boolean;

--- a/packages/nextly/src/lib/status-transition.ts
+++ b/packages/nextly/src/lib/status-transition.ts
@@ -74,3 +74,64 @@ export function stripUndefinedStatus<T extends Record<string, unknown>>(
   }
   return data;
 }
+
+/**
+ * The value a write should record as a document's first publication, or
+ * `undefined` when it should record nothing.
+ *
+ * Three conditions have to hold, and the reason this is one function rather than
+ * a condition repeated at each write seam is that there are many seams: create,
+ * update, the transaction-scoped variants behind `createMany` and batch writes,
+ * publish-all-locales, and the single-entry writer. Every one of them can move a
+ * document into published, so every one of them has to agree. Restating the rule
+ * per seam is how three of them came to disagree — one stamping a document that
+ * was already public, others not stamping at all.
+ *
+ *   1. The entity has a draft/publish lifecycle. Without one there is no
+ *      transition to record, and its rows are public from the moment they save.
+ *   2. The write actually moves the document INTO published, judged by
+ *      `resolvePublishTransition` so "what counts as publishing" is decided in
+ *      exactly one place. A no-op publish of an already-published row records
+ *      nothing — which matters most for rows published before this column
+ *      existed, whose marker is null precisely because their history was never
+ *      recorded. Dating those today would report a publication that never
+ *      happened.
+ *   3. Nothing is recorded yet. This dates the FIRST publication, so a republish
+ *      after an unpublish must not move it.
+ *
+ * `existingMarker` is read as `unknown` because callers pass a column straight
+ * off a database row, where its type varies by dialect and driver — a `Date` on
+ * PostgreSQL, an integer on SQLite. Only its absence is examined, and `== null`
+ * covers both null and undefined; a row read that omitted the column entirely is
+ * therefore treated as "nothing recorded", which is the safe reading for a
+ * column that starts null.
+ *
+ * The caller supplies `now` so the marker can be the same instant as the
+ * `updated_at` written beside it, rather than a few microseconds later.
+ *
+ * Callers must read `existingMarker` under whatever lock guards the write. Two
+ * concurrent publishes that both observe an absent marker would both stamp, and
+ * the later would win — the row lock the write already takes is what prevents
+ * that interleaving, not this function.
+ */
+export function resolveFirstPublishedStamp(args: {
+  /** Whether the collection or single has the draft/publish lifecycle enabled. */
+  hasStatus: boolean;
+  /** The document's committed status before this write; `null` for a create. */
+  previousStatus: string | null | undefined;
+  /** The status this write assigns, exactly as the caller supplied it. */
+  nextStatus: unknown;
+  /** The marker already stored on the row, read under the write's lock. */
+  existingMarker: unknown;
+  /** The instant to record, shared with the write's other timestamps. */
+  now: Date;
+}): Date | undefined {
+  if (!args.hasStatus) return undefined;
+  if (args.existingMarker != null) return undefined;
+  if (
+    resolvePublishTransition(args.previousStatus, args.nextStatus) !== "publish"
+  ) {
+    return undefined;
+  }
+  return args.now;
+}

--- a/packages/nextly/src/lib/status-transition.ts
+++ b/packages/nextly/src/lib/status-transition.ts
@@ -143,16 +143,32 @@ export function selectPublicationTransition(args: {
   companionPreviousStatus: string | null | undefined;
   /** The status this write assigns to the companion. */
   companionNextStatus: unknown;
+  /**
+   * Whether the document is ALREADY reachable by some route this write does not touch — its main
+   * row, or another locale.
+   *
+   * Only consulted for a per-locale write, and it is what stops a translation going live from
+   * being read as the document becoming public. It matters most for rows published before the
+   * marker column existed: their marker is null because the history was never recorded, not
+   * because they were never public, and without this the next translation anyone publishes would
+   * date their first publication from today.
+   */
+  documentAlreadyPublic?: boolean;
 }): { previousStatus: string | null | undefined; nextStatus: unknown } {
-  return args.writesStatusToCompanion
-    ? {
-        previousStatus: args.companionPreviousStatus,
-        nextStatus: args.companionNextStatus,
-      }
-    : {
-        previousStatus: args.mainPreviousStatus,
-        nextStatus: args.mainNextStatus,
-      };
+  if (!args.writesStatusToCompanion) {
+    return {
+      previousStatus: args.mainPreviousStatus,
+      nextStatus: args.mainNextStatus,
+    };
+  }
+  return {
+    // Reported as already published rather than by a separate flag, so the one rule that decides
+    // what a publication is stays the only place that decides it.
+    previousStatus: args.documentAlreadyPublic
+      ? "published"
+      : args.companionPreviousStatus,
+    nextStatus: args.companionNextStatus,
+  };
 }
 
 export function resolveFirstPublishedStamp(args: {

--- a/packages/nextly/src/lib/status-transition.ts
+++ b/packages/nextly/src/lib/status-transition.ts
@@ -145,29 +145,30 @@ export function selectPublicationTransition(args: {
   companionNextStatus: unknown;
   /**
    * Whether the document is ALREADY reachable by some route this write does not touch — its main
-   * row, or another locale.
+   * row, or any other locale.
    *
-   * Only consulted for a per-locale write, and it is what stops a translation going live from
-   * being read as the document becoming public. It matters most for rows published before the
-   * marker column existed: their marker is null because the history was never recorded, not
-   * because they were never public, and without this the next translation anyone publishes would
-   * date their first publication from today.
+   * It stops one part of a document going live from being read as the whole document becoming
+   * public, and it applies to EVERY write, not only a per-locale one: a default-locale publish of
+   * a draft main row can equally be the second way a document goes public, if a translation has
+   * been live since before the marker column existed. Those rows carry a null marker because
+   * their history was never recorded rather than because they were never public, so stamping
+   * would replace an unknown past with today.
    */
   documentAlreadyPublic?: boolean;
 }): { previousStatus: string | null | undefined; nextStatus: unknown } {
-  if (!args.writesStatusToCompanion) {
-    return {
-      previousStatus: args.mainPreviousStatus,
-      nextStatus: args.mainNextStatus,
-    };
+  const nextStatus = args.writesStatusToCompanion
+    ? args.companionNextStatus
+    : args.mainNextStatus;
+  // Reported as an already-published previous state rather than as a separate veto, so the one
+  // rule that decides what a publication is stays the only place that decides it.
+  if (args.documentAlreadyPublic) {
+    return { previousStatus: "published", nextStatus };
   }
   return {
-    // Reported as already published rather than by a separate flag, so the one rule that decides
-    // what a publication is stays the only place that decides it.
-    previousStatus: args.documentAlreadyPublic
-      ? "published"
-      : args.companionPreviousStatus,
-    nextStatus: args.companionNextStatus,
+    previousStatus: args.writesStatusToCompanion
+      ? args.companionPreviousStatus
+      : args.mainPreviousStatus,
+    nextStatus,
   };
 }
 

--- a/packages/nextly/src/services/collections/collection-entry-service.ts
+++ b/packages/nextly/src/services/collections/collection-entry-service.ts
@@ -584,9 +584,15 @@ export class CollectionEntryService extends BaseService {
     return this.mutationService.discardWorkingDraft(params);
   }
 
+  // Params are taken from the method being delegated to rather than restated here. Restating them
+  // had already dropped `overrideAccess`, `routeAuthorized` and `transitionAuth`: the object is
+  // forwarded whole, so those kept working at runtime while the type denied they existed, and a
+  // caller doing a trusted server write through this facade could not say so without a cast.
   async createEntryInTransaction(
     tx: TransactionContext,
-    params: { collectionName: string; user?: UserContext },
+    params: Parameters<
+      CollectionMutationService["createEntryInTransaction"]
+    >[1],
     body: Record<string, unknown>
   ): Promise<CollectionServiceResult<unknown>> {
     return this.mutationService.createEntryInTransaction(tx, params, body);
@@ -594,7 +600,9 @@ export class CollectionEntryService extends BaseService {
 
   async updateEntryInTransaction(
     tx: TransactionContext,
-    params: { collectionName: string; entryId: string; user?: UserContext },
+    params: Parameters<
+      CollectionMutationService["updateEntryInTransaction"]
+    >[1],
     body: Record<string, unknown>
   ): Promise<CollectionServiceResult<unknown>> {
     return this.mutationService.updateEntryInTransaction(tx, params, body);

--- a/packages/nextly/src/shared/lib/case-conversion.ts
+++ b/packages/nextly/src/shared/lib/case-conversion.ts
@@ -130,9 +130,22 @@ export function keysToSnakeCase(obj: unknown): unknown {
 }
 
 /**
- * Convert the DB timestamp columns (`created_at`, `updated_at`) on a row
- * object into their camelCase API form (`createdAt`, `updatedAt`) and remove
- * the snake_case keys. Pre-existing camelCase values are preserved.
+ * The system timestamp columns, and the camelCase name each is published under.
+ *
+ * Listed once because a row can reach the API through several paths, and a column converted on
+ * some of them and not others gives the same entry different shapes depending on the operation
+ * that returned it. That is what happened to `first_published_at`: create responses carried
+ * `firstPublishedAt` while list and detail reads returned the raw column name.
+ */
+const TIMESTAMP_COLUMN_NAMES: ReadonlyArray<readonly [string, string]> = [
+  ["created_at", "createdAt"],
+  ["updated_at", "updatedAt"],
+  ["first_published_at", "firstPublishedAt"],
+];
+
+/**
+ * Convert the DB timestamp columns on a row object into their camelCase API form and remove the
+ * snake_case keys. Pre-existing camelCase values are preserved.
  *
  * @param entry - The row object to mutate in place.
  * @param options.normalize - Optional value transform applied to the
@@ -145,21 +158,14 @@ export function convertTimestampsToCamelCase<T extends Record<string, unknown>>(
 ): T {
   const record = entry as Record<string, unknown>;
   const normalize = options?.normalize;
-  if (record.created_at !== undefined) {
-    if (record.createdAt === undefined) {
-      record.createdAt = normalize
-        ? normalize(record.created_at)
-        : record.created_at;
+  for (const [column, apiName] of TIMESTAMP_COLUMN_NAMES) {
+    if (record[column] === undefined) continue;
+    if (record[apiName] === undefined) {
+      // A null marker is a meaningful value — "not known to have been published" — so it is
+      // converted like any other, rather than being dropped as if the column were absent.
+      record[apiName] = normalize ? normalize(record[column]) : record[column];
     }
-    delete record.created_at;
-  }
-  if (record.updated_at !== undefined) {
-    if (record.updatedAt === undefined) {
-      record.updatedAt = normalize
-        ? normalize(record.updated_at)
-        : record.updated_at;
-    }
-    delete record.updated_at;
+    delete record[column];
   }
   return entry;
 }

--- a/packages/nextly/src/shared/lib/case-conversion.ts
+++ b/packages/nextly/src/shared/lib/case-conversion.ts
@@ -137,11 +137,22 @@ export function keysToSnakeCase(obj: unknown): unknown {
  * that returned it. That is what happened to `first_published_at`: create responses carried
  * `firstPublishedAt` while list and detail reads returned the raw column name.
  */
-const TIMESTAMP_COLUMN_NAMES: ReadonlyArray<readonly [string, string]> = [
-  ["created_at", "createdAt"],
-  ["updated_at", "updatedAt"],
-  ["first_published_at", "firstPublishedAt"],
-];
+export const TIMESTAMP_COLUMN_NAMES: ReadonlyArray<readonly [string, string]> =
+  [
+    ["created_at", "createdAt"],
+    ["updated_at", "updatedAt"],
+    ["first_published_at", "firstPublishedAt"],
+  ];
+
+/**
+ * Every spelling of every system timestamp, both the physical column and the API name.
+ *
+ * Exported for the response shapers that decide which system keys to carry through a projection.
+ * They listed the two they knew about, which is why a third was pruned from selected reads and
+ * working-draft views while ordinary reads returned it.
+ */
+export const SYSTEM_TIMESTAMP_KEYS: readonly string[] =
+  TIMESTAMP_COLUMN_NAMES.flat();
 
 /**
  * Convert the DB timestamp columns on a row object into their camelCase API form and remove the

--- a/packages/nextly/src/singles/config/validate-single.marker-reserved.test.ts
+++ b/packages/nextly/src/singles/config/validate-single.marker-reserved.test.ts
@@ -1,0 +1,41 @@
+/**
+ * A Single gets the first-publication marker as a system column once the
+ * draft/publish lifecycle is enabled, so a user field of that name would
+ * collide with it in the table.
+ *
+ * A Single carries no owner column, so unlike a collection this is the only
+ * reserved system field name here — which is also why the check had to be added
+ * rather than extended: there was nothing for a Single's field to collide with
+ * until the marker reached its table.
+ */
+import { describe, expect, it } from "vitest";
+
+import { text } from "../../collections/fields/helpers";
+import { validateSingleConfig } from "./validate-single";
+
+function codesFor(fields: unknown[]): string[] {
+  return validateSingleConfig({
+    slug: "banner",
+    fields,
+  } as Parameters<typeof validateSingleConfig>[0]).errors.map(e => e.code);
+}
+
+describe("validateSingleConfig: first-publication marker reservation", () => {
+  it("rejects a top-level first_published_at field", () => {
+    expect(codesFor([text({ name: "first_published_at" })])).toContain(
+      "FIELD_NAME_RESERVED"
+    );
+  });
+
+  it("rejects the camelCase firstPublishedAt alias", () => {
+    expect(codesFor([text({ name: "firstPublishedAt" })])).toContain(
+      "FIELD_NAME_RESERVED"
+    );
+  });
+
+  it("leaves an ordinary single untouched", () => {
+    expect(codesFor([text({ name: "headline" })])).not.toContain(
+      "FIELD_NAME_RESERVED"
+    );
+  });
+});

--- a/packages/nextly/src/singles/config/validate-single.ts
+++ b/packages/nextly/src/singles/config/validate-single.ts
@@ -70,6 +70,8 @@ export type SingleValidationErrorCode =
   | "FIELD_NAME_INVALID_FORMAT"
   | "FIELD_NAME_SQL_KEYWORD"
   | "FIELD_NAME_DUPLICATE"
+  // A field named after a column the system injects onto the Single's table.
+  | "FIELD_NAME_RESERVED"
   | "FIELD_TYPE_REQUIRED"
   | "FIELD_TYPE_INVALID"
   // A declared default the field's own rules reject.
@@ -259,6 +261,16 @@ function validateField(
   }
 }
 
+// System columns injected onto a Single's table, under both the snake_case name
+// and the camelCase alias that snake-cases to the same column. A Single gets no
+// owner column, so unlike a collection only the first-publication marker is
+// reserved here — which is why this check had to be added rather than extended:
+// until the marker reached a Single's table there was nothing to collide with.
+const SINGLE_RESERVED_FIELD_NAMES: Set<string> = new Set([
+  "first_published_at",
+  "firstPublishedAt",
+]);
+
 /**
  * Validate an array of field configurations.
  */
@@ -301,6 +313,22 @@ function validateFields(
     });
     return;
   }
+
+  // Block the injected system columns at the top level, before per-field
+  // validation. Reserved even when the draft/publish lifecycle is off, so
+  // enabling it later fails here rather than at migration time. Nested
+  // repeater/group fields live inside JSON and are exempt, as for collections.
+  fields.forEach((field, index) => {
+    if (!field || typeof field !== "object") return;
+    const name = (field as Record<string, unknown>).name;
+    if (typeof name === "string" && SINGLE_RESERVED_FIELD_NAMES.has(name)) {
+      errors.push({
+        path: `${path}[${index}].name`,
+        message: `Field name '${name}' is reserved for a system column`,
+        code: "FIELD_NAME_RESERVED",
+      });
+    }
+  });
 
   // Why: empty fields list is now valid for both code-first defines and the
   // new modal-driven create flow (Builder redesign PR 2/3). System columns


### PR DESCRIPTION
Closes task 102.

## The gap

A row's `status` says what it IS. Nothing said what it HAS BEEN. Unpublishing returns it to `draft`
and erases every trace it was ever live — while the inbound links, feeds and search results it
accumulated while public stay exactly where they are.

Two things already need that answer and had nothing to read: the slug freeze in #456 (which
currently approximates it with a session-scoped latch that a page reload discards), and redirect
capture in task 032.

## The design, and why each choice

**Nullable, no default.** `NULL` means "not known to have been published" — true of a draft, and
equally true of every row that predates the column, which genuinely cannot be told apart from a
draft after the fact. A default would assert a publication date that never happened.

**Set once, never modified.** It dates the FIRST publication, not the most recent. Those are
different questions; Contentful, the most mature API surface here, carries both
(`sys.firstPublishedAt` alongside `sys.publishedAt`). The second is left alone rather than guessed
at, because whether it survives an unpublish is a product decision and this one has a single
defensible answer.

**Gated on `hasStatus`.** A collection with no draft lifecycle has no transition to record — its
rows are public from the moment they are saved.

## Where it is stamped

| path | how |
|---|---|
| `updateEntry` | into `updatePayload` from the row-locked pre-write row, only when it has none |
| `createEntry` | when the write lands directly on `published` — a create has no prior status it could be repeating |
| `publishAllLocales` | `first_published_at = COALESCE(first_published_at, ${nowExpr})` |

The `COALESCE` is deliberate over a read-then-write: expressing "only if absent" **in the
statement** keeps set-once true under concurrent publishes, and reusing the existing dialect-aware
`nowExpr` (`unixepoch()` / `CURRENT_TIMESTAMP`) avoids round-tripping a `Date` through a raw
parameter — which would store wrong on SQLite's integer timestamps.

**Bulk needed no change.** Verified rather than assumed: `bulkUpdateEntries` delegates per id to
`updateEntry`.

The create stamp reads post-hook `finalData`, matching how the create-publish authorization is
already decided a few lines below, so a hook-derived `status: "published"` stamps too.

## Singles are excluded, and the test says why

Not a claim that a Single's publication date is meaningless — it is exactly as meaningful. A
Single's physical table does not receive this column through the same path its runtime schema does,
so injecting it produced a runtime schema selecting a column that is not there: **every read of a
status-enabled Single failed**, rather than the marker merely going unset.

That is the lockstep hazard `field-column-descriptor.ts` warns about in its own comments, and the
integration test is what caught it. Singles are gated out the same way `created_by` already is, and
a test pins the exclusion so the day someone aligns the Single DDL path, that test is what tells
them. Filed as a follow-up.

## Verification

7 integration tests. Each stamp falsified individually — removing it fails exactly the cases that
name it.

One of them was initially **vacuous and I want to flag it rather than bury it**: the set-once test
passed with the guard removed, because both publications land inside the same second and these
columns store no finer resolution. It now backdates the marker first, and fails without the guard.
The falsification script also asserts its target pattern exists before editing, so a no-op edit
cannot produce a fake "it failed correctly" again.

| leg | result |
|---|---|
| postgres17 | 1074 passed, 56 skipped, **0 failed** |
| mysql | 1010 passed, 94 skipped, **0 failed** |
| sqlite | 939 passed, 140 skipped, **0 failed** |

Fresh databases, one leg at a time, build first.

## Not in this PR

The admin does not read the marker yet — that needs `entry-address.ts`, which only exists on #456.
Follow-up once it merges, and it will consult the marker only for a SHARED slug: this column lives
on the main table, so it answers "this entry has been published in some language", which is exactly
right for one slug serving every language and too coarse for a slug the author localized. Adding it
to companion tables would reopen the i18n transition machinery that task 077 is actively editing.

The marker can only ever ADD freezing, never remove it, which is what makes that partial coverage
safe rather than dangerous.
