### PR TITLE
fix(nextly): report the MySQL timestamp defaults the tables actually get

### DIFF
--- a/.changeset/mysql-timestamp-default-lockstep.md
+++ b/.changeset/mysql-timestamp-default-lockstep.md
@@ -1,0 +1,25 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+On MySQL, the internal description of a collection table's `created_at` and `updated_at` columns said they had no database default, while the tables actually created for them do have one (`CURRENT_TIMESTAMP`). The schema comparison that decides what a migration should contain was reading the description rather than reality, so it could see a difference that was not there. The description now matches what is created.

--- a/packages/nextly/src/domains/schema/services/field-column-descriptor.ts
+++ b/packages/nextly/src/domains/schema/services/field-column-descriptor.ts
@@ -474,17 +474,24 @@ export function getSystemColumnDescriptors(
         primaryKey: false,
       });
     }
+    // The runtime generator builds these as mysqlTimestamp(...).defaultNow(), so the physical
+    // column carries DEFAULT CURRENT_TIMESTAMP. Reporting no default here described the diff's
+    // desired state as something neither creation path produces — the drift this module exists to
+    // prevent, in the very pair its header promises to keep in lockstep. The PostgreSQL branch
+    // already carries its `now()`; this is the same fact, spelled the way MySQL spells it.
     cols.push({
       name: "created_at",
       dialectType: "timestamp",
       nullable: true,
       primaryKey: false,
+      default: "CURRENT_TIMESTAMP",
     });
     cols.push({
       name: "updated_at",
       dialectType: "timestamp",
       nullable: true,
       primaryKey: false,
+      default: "CURRENT_TIMESTAMP",
     });
     // Owner of the row (creating user's id, NOT the row id). Collections only
     // (never singles). Sized to match the MySQL users.id column (varchar(191),


### PR DESCRIPTION
First slice of task 103. Self-contained: no migration for anyone, no behaviour change to what gets
created. It corrects what the diff engine is *told* about columns that already exist.

## The bug

`field-column-descriptor.ts` exists, by its own header, because this mapping was once duplicated,
drifted, and made the diff engine report "56 false positives" on a stable schema. It names the two
consumers it keeps in lockstep: the runtime Drizzle schema, and the diff's `desired` input.

On MySQL those two disagree about `created_at` / `updated_at`:

| | says |
|---|---|
| `buildSystemDrizzleColumn` | `mysqlTimestamp("created_at").defaultNow()` → the column is created **with** `DEFAULT CURRENT_TIMESTAMP` |
| `getSystemColumnDescriptors` | **no default** |

So the diff's desired state described a column neither creation path produces. That is the exact
drift this module was written to prevent, in the exact pair its header promises to protect.

PostgreSQL already carries its `now()`. This is the same fact in MySQL's spelling.

## Why only MySQL

Measured all three rather than assuming they matched:

| dialect | descriptor | Drizzle builder | Builder DDL | odd one out |
|---|---|---|---|---|
| pg | `now()` | `.defaultNow()` | `DEFAULT now()` | — all three agree |
| mysql | **NONE** | `.defaultNow()` | `DEFAULT CURRENT_TIMESTAMP` | **the descriptor** ← this PR |
| sqlite | NONE | no default | `DEFAULT (strftime('%s','now'))` | the Builder DDL |

SQLite is a **separate and different** problem: there the descriptor and the runtime agree, and only
the Schema-Builder DDL adds a default — so a Builder-created SQLite table has one that a code-first
table does not. That is a design question (should all dialects behave alike?) rather than a bug, so
it is deliberately **not** in this PR. Task 103 carries it.

## Verification

Not "the suite is green" — specifically that this changed nothing it should not:

- Captured the `src/domains/schema` failure set with the edit reverted, re-applied it, and diffed:
  **identical**. The 6 red tests there are pre-existing.
- Three dialect legs, fresh databases, build first:

| leg | result |
|---|---|
| postgres17 | 1087 passed, 57 skipped, **0 failed** |
| mysql | 1023 passed, 95 skipped, **0 failed** |
| sqlite | 951 passed, 142 skipped, **0 failed** |

One honest note on how that MySQL number was reached. The first run showed
`upgrade-sim-045` failing with `Unknown database 'nextly_upgrade_v1'`. That is the existing-user
upgrade simulation — the single most relevant test to a descriptor change — so I did not wave it
through. It passed in isolation, but "passes in isolation" has misled me before, so I re-ran the
**full** leg with the stray database dropped first: green, exit 0. The cause was my own leg script
leaving `nextly_upgrade_v1` behind, not this change.

## What is still ahead in task 103

This PR is step 1 of four. The remaining ones remove the underlying cause — that
`generateMigrationSQL` restates the system-column set by hand instead of rendering it from the
descriptor, which is why a newly added system column silently misses Schema-Builder tables (and
Singles). Two of those steps change what gets created and need a deliberate call on timestamp
nullability, so they are not bundled here.
