### PR TITLE
fix(nextly): address field-group storage by the names the database holds

### DIFF
--- a/.changeset/field-group-schema-push-resolution.md
+++ b/.changeset/field-group-schema-push-resolution.md
@@ -1,0 +1,25 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+Schema applies and the `nextly migrate` / `nextly upgrade --reconcile-core` commands now address the field-group registry and each field group's storage by the names the database actually holds, instead of the names this release would have created. Without this, a database whose field-group storage had been renamed could have an empty second registry created beside the populated one, after which the app would read the empty one and its field groups would appear to be gone.

--- a/packages/nextly/src/cli/commands/__tests__/migrate-core.test.ts
+++ b/packages/nextly/src/cli/commands/__tests__/migrate-core.test.ts
@@ -6,7 +6,11 @@ import { migrateCore } from "../migrate";
 function deps(over: Record<string, unknown> = {}) {
   return {
     dialect: "postgresql" as const,
-    db: {},
+    // Answers the catalog probe the way a database with no field-group
+    // registry does. Inert would let the resolution throw, and this orchestration
+    // suite would then be asserting on an error from a collaborator rather than
+    // on what `migrateCore` does with its steps.
+    db: { execute: async () => ({ rows: [] }) },
     adapter: {} as never,
     migrationsDir: "/tmp/migrations",
     logger: createLogger({ quiet: true }),

--- a/packages/nextly/src/cli/commands/migrate-resolve.ts
+++ b/packages/nextly/src/cli/commands/migrate-resolve.ts
@@ -25,8 +25,8 @@ import { parseSnapshotFile } from "../../domains/schema/migrate-create/snapshot-
 import { introspectLiveSnapshot } from "../../domains/schema/pipeline/diff/introspect-live";
 import type { NextlySchemaSnapshot } from "../../domains/schema/pipeline/diff/types";
 import { withMigrateLock } from "../../domains/schema/pipeline/locks";
+import { isSnapshotComparableTable } from "../../domains/schema/pipeline/managed-tables";
 import { describeError } from "../../errors/index";
-import { CORE_TABLE_PREFIXES } from "../../schemas";
 import { createContext, type CommandContext } from "../program";
 import {
   createAdapter,
@@ -162,9 +162,7 @@ export async function runMigrateResolve(
         loadTargetSnapshot: () => loadSnapshot(metaDir, filename),
         introspectLive: async () => {
           const live = await safeListTables(adapter);
-          const managed = live.filter(t =>
-            CORE_TABLE_PREFIXES.some(p => t.startsWith(p))
-          );
+          const managed = live.filter(isSnapshotComparableTable);
           return introspectLiveSnapshot(db, dialect, managed);
         },
       })

--- a/packages/nextly/src/cli/commands/migrate-resolve.ts
+++ b/packages/nextly/src/cli/commands/migrate-resolve.ts
@@ -162,6 +162,10 @@ export async function runMigrateResolve(
         loadTargetSnapshot: () => loadSnapshot(metaDir, filename),
         introspectLive: async () => {
           const live = await safeListTables(adapter);
+          // Managed main tables only. A localized companion is
+          // migration-owned and never appears in a `migrate:create` snapshot,
+          // so including one here can never match the file this is compared
+          // against and the equivalence check refuses the command.
           const managed = live.filter(isSnapshotComparableTable);
           return introspectLiveSnapshot(db, dialect, managed);
         },

--- a/packages/nextly/src/cli/commands/migrate.ts
+++ b/packages/nextly/src/cli/commands/migrate.ts
@@ -36,6 +36,7 @@ import { resolve } from "node:path";
 import type { DrizzleAdapter } from "@nextlyhq/adapter-drizzle";
 import type { Command } from "commander";
 
+import { resolveRegistryNameFromCatalog } from "../../domains/field-groups/storage/resolve-storage-names";
 import { assertNoLegacyBookkeeping } from "../../domains/schema/events/legacy-detection";
 import { getSchemaEventsDdl } from "../../domains/schema/events/schema-events-ddl";
 import {
@@ -417,9 +418,18 @@ export async function migrateCore(
     deps.dialect,
     async () => {
       deps.logger.info("Phase 1: reconciling core schema...");
+      // Resolved here, where a failure can still fail the command cleanly. The
+      // core schema is a desired shape, so naming a registry the database does
+      // not have is an instruction to create it — and an empty legacy registry
+      // beside a populated migrated one is preferred by every reader.
+      const fieldGroupRegistryTable = await resolveRegistryNameFromCatalog({
+        dialect: deps.dialect,
+        getDrizzle: <T>() => deps.db as T,
+      });
       const r = await reconcile({
         db: deps.db,
         dialect: deps.dialect,
+        fieldGroupRegistryTable,
         logger: {
           info: m => deps.logger.debug(m),
           warn: m => deps.logger.warn(m),

--- a/packages/nextly/src/cli/commands/migrate.ts
+++ b/packages/nextly/src/cli/commands/migrate.ts
@@ -55,9 +55,8 @@ import {
   forceUnlock,
   withMigrateLock,
 } from "../../domains/schema/pipeline/locks";
-import { isCompanionTable } from "../../domains/schema/pipeline/managed-tables";
+import { isSnapshotComparableTable } from "../../domains/schema/pipeline/managed-tables";
 import { NextlyError, describeError } from "../../errors";
-import { CORE_TABLE_PREFIXES } from "../../schemas";
 import { createContext, type CommandContext } from "../program";
 import {
   createAdapter,
@@ -644,14 +643,7 @@ export async function runFileMigrations(args: {
     // Capturing it once before the loop left it empty on a fresh DB, so the
     // 2nd+ migration saw its tables as "absent" and aborted with false drift.
     const liveTables = await safeListTables(adapter);
-    const managed = liveTables.filter(
-      t =>
-        CORE_TABLE_PREFIXES.some(p => t.startsWith(p)) &&
-        // Localized companion tables are migration-owned (Option B) and never
-        // appear in a migrate:create snapshot; excluding them here prevents a
-        // false "extraneous table" drift on snapshot-paired migrations.
-        !isCompanionTable(t)
-    );
+    const managed = liveTables.filter(isSnapshotComparableTable);
     const live = await introspectLiveSnapshot(db, dialect, managed);
     await reconcileFile({
       file: { filename, sql: m.upSql, path: m.filePath, sha256: m.checksum },

--- a/packages/nextly/src/cli/commands/migrate.ts
+++ b/packages/nextly/src/cli/commands/migrate.ts
@@ -643,6 +643,9 @@ export async function runFileMigrations(args: {
     // Capturing it once before the loop left it empty on a fresh DB, so the
     // 2nd+ migration saw its tables as "absent" and aborted with false drift.
     const liveTables = await safeListTables(adapter);
+    // Managed main tables only, for the same reason `migrate:resolve` uses
+    // this predicate: a localized companion never appears in the snapshot this
+    // is diffed against, so including one reports drift that is not there.
     const managed = liveTables.filter(isSnapshotComparableTable);
     const live = await introspectLiveSnapshot(db, dialect, managed);
     await reconcileFile({

--- a/packages/nextly/src/cli/commands/upgrade.ts
+++ b/packages/nextly/src/cli/commands/upgrade.ts
@@ -15,6 +15,7 @@ import { createInterface } from "node:readline";
 import type { Command } from "commander";
 import { sql } from "drizzle-orm";
 
+import { resolveRegistryNameFromCatalog } from "../../domains/field-groups/storage/resolve-storage-names";
 import {
   mapJournalRow,
   mapMigrationsRow,
@@ -316,6 +317,13 @@ export async function runReconcileCore(
     await reconcile({
       db,
       dialect,
+      // Same reason as `nextly migrate`: the desired core shape must name the
+      // registry this database actually holds, or the reconcile creates the
+      // other one empty.
+      fieldGroupRegistryTable: await resolveRegistryNameFromCatalog({
+        dialect,
+        getDrizzle: <T>() => db as T,
+      }),
       mode: "dev-loose",
       confirmDestructive: deps.confirmDestructive,
       logger: deps.logger,

--- a/packages/nextly/src/database/index.ts
+++ b/packages/nextly/src/database/index.ts
@@ -9,6 +9,18 @@ import * as schemasSl from "../schemas/_dialect-bundles/sqlite";
 import { STORAGE_FORMAT } from "../schemas/storage-format";
 
 /**
+ * Which registry the push bundle declares.
+ *
+ * Widens {@link CoreSchemaOptions} with `null`, which the desired-shape snapshot
+ * has no use for but the push does: the push CREATES from its bundle, so a
+ * caller that cannot establish which registry exists must be able to say
+ * "declare neither" rather than being forced to name one.
+ */
+interface PushBundleOptions {
+  fieldGroupRegistryTable?: CoreSchemaOptions["fieldGroupRegistryTable"] | null;
+}
+
+/**
  * Backwards-compatible `schema.postgres` / `schema.mysql` / `schema.sqlite`
  * namespaces. Replaces the old `database/schema/<dialect>.ts` stubs deleted
  * in Plan A Task 17. Each namespace is a flat re-export of every Drizzle
@@ -80,12 +92,22 @@ export function getDialectTables(dialect?: string) {
  */
 export function getDialectTablesForPush(
   dialect: SupportedDialect,
-  options?: CoreSchemaOptions
+  options?: PushBundleOptions
 ): Record<string, unknown> {
   const bundle: Record<string, unknown> = getDialectTables(dialect);
   const name = options?.fieldGroupRegistryTable;
   if (name === undefined || name === STORAGE_FORMAT.registryTable) {
     return bundle;
+  }
+  if (name === null) {
+    // 🔴 Declared as NEITHER, because the caller could not establish which of
+    // the two this database holds. Naming the wrong one creates it, and a
+    // CREATE is additive so no safety net stops it; omitting it lets
+    // drizzle-kit propose a DROP instead, which `filterUnsafeStatements` blocks
+    // and reports. Between a silent wrong create and a blocked loud drop, only
+    // one loses data's reachability.
+    const { dynamicFieldGroups: _omitted, ...rest } = bundle;
+    return rest;
   }
   return {
     ...bundle,

--- a/packages/nextly/src/database/index.ts
+++ b/packages/nextly/src/database/index.ts
@@ -1,7 +1,12 @@
+import type { SupportedDialect } from "@nextlyhq/adapter-drizzle/types";
+
+import { buildFieldGroupRegistryTable } from "../domains/field-groups/storage/registry-schemas";
 import { env } from "../lib/env";
+import type { CoreSchemaOptions } from "../schemas";
 import * as schemasMy from "../schemas/_dialect-bundles/mysql";
 import * as schemasPg from "../schemas/_dialect-bundles/postgres";
 import * as schemasSl from "../schemas/_dialect-bundles/sqlite";
+import { STORAGE_FORMAT } from "../schemas/storage-format";
 
 /**
  * Backwards-compatible `schema.postgres` / `schema.mysql` / `schema.sqlite`
@@ -57,4 +62,33 @@ export function getDialectTables(dialect?: string) {
   if (dbDialect === "mysql") return schema.mysql;
   if (dbDialect === "sqlite") return schema.sqlite;
   throw new Error(`Unsupported dialect: ${dbDialect}`);
+}
+
+/**
+ * The same bundle, with the field-group registry named as this database has it.
+ *
+ * Separate from {@link getDialectTables} on purpose. That one is read by a
+ * dozen callers for their precise table types (`tables.users.id`), and widening
+ * its return so one key can vary would cost every one of them their typing for
+ * a concern none of them have. This is for the push path alone, which hands the
+ * bundle to drizzle-kit as an untyped record.
+ *
+ * 🔴 SWAPPED, never added. This bundle is what `freshPushSchema` CREATES, so
+ * declaring both spellings would create an empty second registry on every
+ * database that has not migrated. Exactly one of the two exists in any
+ * database, and this names that one.
+ */
+export function getDialectTablesForPush(
+  dialect: SupportedDialect,
+  options?: CoreSchemaOptions
+): Record<string, unknown> {
+  const bundle: Record<string, unknown> = getDialectTables(dialect);
+  const name = options?.fieldGroupRegistryTable;
+  if (name === undefined || name === STORAGE_FORMAT.registryTable) {
+    return bundle;
+  }
+  return {
+    ...bundle,
+    dynamicFieldGroups: buildFieldGroupRegistryTable(dialect, name),
+  };
 }

--- a/packages/nextly/src/domains/field-groups/storage/resolve-storage-names.ts
+++ b/packages/nextly/src/domains/field-groups/storage/resolve-storage-names.ts
@@ -342,6 +342,35 @@ export async function resolveKnownTypeColumns(
   }
 }
 
+/**
+ * The registry name for a caller that has a database handle but no table list.
+ *
+ * The CLI's adapter exposes a dialect and a Drizzle instance and nothing else,
+ * so the catalog is asked the narrow question instead of the broad one: describe
+ * these two candidate tables, and whichever comes back is the one that exists.
+ * The decision itself is {@link chooseRegistryTable}, unchanged — this only
+ * feeds it a listing gathered a different way, so the preference order and the
+ * folding rules cannot drift between callers.
+ *
+ * Not memoized, unlike {@link resolveFieldGroupRegistryTable}: a CLI command
+ * resolves once per run, and a migration command in particular must not read a
+ * name cached before it moved storage.
+ */
+export async function resolveRegistryNameFromCatalog(
+  adapter: CatalogReadAdapter
+): Promise<FieldGroupRegistryName> {
+  const rules = await readIdentifierCaseRules(adapter);
+  const snapshot = await introspectLiveSnapshot(
+    adapter.getDrizzle(),
+    adapter.dialect,
+    [STORAGE_FORMAT.registryTable, MIGRATION_TARGET.registryTable]
+  );
+  return chooseRegistryTable(
+    snapshot.tables.map(table => table.name),
+    rules
+  ).name;
+}
+
 async function readRegistryTable(
   adapter: StorageNameAdapter
 ): Promise<FieldGroupRegistryTable> {

--- a/packages/nextly/src/domains/schema/migrate/core-reconcile.ts
+++ b/packages/nextly/src/domains/schema/migrate/core-reconcile.ts
@@ -15,9 +15,9 @@
  */
 import type { SupportedDialect } from "@nextlyhq/adapter-drizzle/types";
 
-import { getDialectTables } from "../../../database/index";
+import { getDialectTablesForPush } from "../../../database/index";
 import { NextlyError } from "../../../errors";
-import { CORE_TABLE_NAMES, getCoreSchema } from "../../../schemas";
+import { getCoreSchema, getCoreTableNames } from "../../../schemas";
 import { SchemaEventsRepository } from "../events/schema-events-repository";
 import {
   classifyForMode,
@@ -56,7 +56,20 @@ export interface ReconcileCoreDeps {
     dialect: SupportedDialect,
     tableNames: string[]
   ) => Promise<NextlySchemaSnapshot>;
-  /** Injectable for tests. Default: freshPushSchema over getDialectTables. */
+  /**
+   * Which field-group registry this database holds.
+   *
+   * 🔴 Resolved by the CALLER, which is the layer that holds an adapter, and
+   * passed in rather than probed here. A probe inside this function would sit
+   * in a block whose failure policy is "abort the reconcile", so a metadata
+   * blip would refuse a migration; at the caller it can fail the command
+   * cleanly, before anything is applied.
+   *
+   * Omitted means the legacy spelling, which is correct for a fresh database
+   * and for every caller with no database to ask.
+   */
+  fieldGroupRegistryTable?: string;
+  /** Injectable for tests. Default: freshPushSchema over the dialect bundle. */
   applyCore?: (
     dialect: FreshPushDialect,
     db: unknown
@@ -77,13 +90,20 @@ export async function reconcileCore(
 ): Promise<{ changed: boolean }> {
   const { db, dialect, logger } = deps;
   const introspect = deps.introspect ?? introspectLiveSnapshot;
+  // The registry name travels with every one of the three: the shape to compare
+  // against, the list of tables to ask the database about, and the bundle the
+  // push creates from. A mismatch between them asks about a table that is not
+  // there, then diffs the answer against one that is, and creates it.
+  const coreOptions = {
+    fieldGroupRegistryTable: deps.fieldGroupRegistryTable,
+  };
   const applyCore =
     deps.applyCore ??
     ((d: FreshPushDialect, database: unknown) =>
-      freshPushSchema(d, database, getDialectTables(d)));
+      freshPushSchema(d, database, getDialectTablesForPush(d, coreOptions)));
 
-  const desired = getCoreSchema(dialect);
-  const live = await introspect(db, dialect, [...CORE_TABLE_NAMES]);
+  const desired = getCoreSchema(dialect, coreOptions);
+  const live = await introspect(db, dialect, getCoreTableNames(coreOptions));
   const ops = diffSnapshots(live, desired);
 
   if (ops.length === 0) {

--- a/packages/nextly/src/domains/schema/pipeline/diff/__tests__/build-from-fields.test.ts
+++ b/packages/nextly/src/domains/schema/pipeline/diff/__tests__/build-from-fields.test.ts
@@ -562,3 +562,46 @@ describe("owner index", () => {
     );
   });
 });
+
+/**
+ * 🔴 The discriminator is a SYSTEM column, so its name is never a preference.
+ *
+ * The only two spellings are the two storage generations, and which one a table
+ * carries is a fact about that table. A desired shape that names the other one
+ * turns the diff into "add this column, drop that one" — a destructive pair the
+ * classifier refuses and fresh-push strips, so the operation never applies and
+ * never goes away, and every later apply carries it.
+ */
+describe("buildDesiredTableFromComponentFields - the discriminator column", () => {
+  const DIALECTS = ["postgresql", "mysql", "sqlite"] as const;
+  const noFields = [] as unknown as Parameters<
+    typeof buildDesiredTableFromComponentFields
+  >[1];
+
+  describe.each(DIALECTS)("%s", dialect => {
+    it("writes the spelling this release's DDL creates by default", () => {
+      const names = buildDesiredTableFromComponentFields(
+        "comp_hero",
+        noFields,
+        dialect
+      ).columns.map(column => column.name);
+
+      expect(names).toContain("_component_type");
+      expect(names).not.toContain("_field_group_type");
+    });
+
+    // Both halves matter: naming the migrated column is not enough on its own,
+    // because leaving the legacy one in the desired shape is what emits the ADD.
+    it("writes the migrated spelling when the table carries it", () => {
+      const names = buildDesiredTableFromComponentFields(
+        "fg_hero",
+        noFields,
+        dialect,
+        { typeColumn: "_field_group_type" }
+      ).columns.map(column => column.name);
+
+      expect(names).toContain("_field_group_type");
+      expect(names).not.toContain("_component_type");
+    });
+  });
+});

--- a/packages/nextly/src/domains/schema/pipeline/diff/build-from-fields.ts
+++ b/packages/nextly/src/domains/schema/pipeline/diff/build-from-fields.ts
@@ -284,8 +284,24 @@ export function buildDesiredTableFromComponentFields(
   tableName: string,
   fields: MinimalFieldDef[],
   dialect: SupportedDialect,
-  options: { localized?: boolean } = {}
+  options: {
+    localized?: boolean;
+    /**
+     * The discriminator this table actually carries.
+     *
+     * 🔴 A system column, so its name is never a preference: the only two
+     * spellings are the two storage generations, and which one a table has is a
+     * fact about that table. Naming the other turns the diff into an add paired
+     * with a destructive drop, which the classifier refuses — so the operation
+     * never applies and never goes away.
+     *
+     * Defaults to the spelling this release's DDL writes, which is right for a
+     * table about to be created and for every database that has not migrated.
+     */
+    typeColumn?: string;
+  } = {}
 ): TableSpec {
+  const typeColumn = options.typeColumn ?? STORAGE_FORMAT.columns.type;
   const columns: ColumnSpec[] = [];
 
   // i18n: when the component is localized, its translatable fields live in the
@@ -331,7 +347,7 @@ export function buildDesiredTableFromComponentFields(
       default: undefined,
     });
     columns.push({
-      name: STORAGE_FORMAT.columns.type,
+      name: typeColumn,
       type: "varchar",
       nullable: true,
       default: undefined,
@@ -371,7 +387,7 @@ export function buildDesiredTableFromComponentFields(
       default: undefined,
     });
     columns.push({
-      name: STORAGE_FORMAT.columns.type,
+      name: typeColumn,
       type: "varchar(255)",
       nullable: true,
       default: undefined,
@@ -412,7 +428,7 @@ export function buildDesiredTableFromComponentFields(
       default: undefined,
     });
     columns.push({
-      name: STORAGE_FORMAT.columns.type,
+      name: typeColumn,
       type: "text",
       nullable: true,
       default: undefined,

--- a/packages/nextly/src/domains/schema/pipeline/managed-tables.test.ts
+++ b/packages/nextly/src/domains/schema/pipeline/managed-tables.test.ts
@@ -4,6 +4,7 @@ import {
   MANAGED_TABLE_PREFIXES,
   isCompanionTable,
   isManagedTable,
+  isSnapshotComparableTable,
 } from "./managed-tables";
 
 describe("isCompanionTable", () => {
@@ -58,5 +59,32 @@ describe("isManagedTable", () => {
     for (const prefix of MANAGED_TABLE_PREFIXES) {
       expect(isManagedTable(`${prefix}thing`)).toBe(true);
     }
+  });
+});
+
+/**
+ * 🔴 One predicate, because the two callers had written it twice and drifted.
+ *
+ * `nextly migrate`'s drift check excluded localized companions; `migrate:resolve
+ * --applied` did not. A companion is migration-owned and never appears in a
+ * `migrate:create` snapshot, so a live snapshot containing one can never match
+ * the file it is compared against — which made the recovery command report
+ * drift and refuse to run on any database with a localized entity.
+ */
+describe("isSnapshotComparableTable", () => {
+  it("includes managed main tables under both storage generations", () => {
+    expect(isSnapshotComparableTable("dc_pages")).toBe(true);
+    expect(isSnapshotComparableTable("comp_hero")).toBe(true);
+    expect(isSnapshotComparableTable("fg_hero")).toBe(true);
+  });
+
+  it("excludes localized companions under both storage generations", () => {
+    expect(isSnapshotComparableTable("dc_pages_locales")).toBe(false);
+    expect(isSnapshotComparableTable("comp_hero_locales")).toBe(false);
+    expect(isSnapshotComparableTable("fg_hero_locales")).toBe(false);
+  });
+
+  it("excludes tables Nextly does not manage", () => {
+    expect(isSnapshotComparableTable("users")).toBe(false);
   });
 });

--- a/packages/nextly/src/domains/schema/pipeline/managed-tables.test.ts
+++ b/packages/nextly/src/domains/schema/pipeline/managed-tables.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect } from "vitest";
 
-import { isCompanionTable, isManagedTable } from "./managed-tables";
+import {
+  MANAGED_TABLE_PREFIXES,
+  isCompanionTable,
+  isManagedTable,
+} from "./managed-tables";
 
 describe("isCompanionTable", () => {
   it("detects localized companion tables", () => {
@@ -29,5 +33,30 @@ describe("isCompanionTable", () => {
     // They are prefixed dc_/single_ so tablesFilter still covers them — the
     // pipeline must additionally exclude them via isCompanionTable.
     expect(isManagedTable("dc_pages_locales")).toBe(true);
+  });
+});
+
+describe("isManagedTable", () => {
+  // This regex is drizzle-kit's `tablesFilter`, so a prefix missing from it is
+  // a table drizzle-kit never introspects — and a desired table it did not find
+  // is one it creates. After the storage migration a generated field-group
+  // table carries `fg_`, so every apply would propose creating one that exists.
+  it("manages field-group tables under both storage generations", () => {
+    expect(isManagedTable("comp_hero")).toBe(true);
+    expect(isManagedTable("fg_hero")).toBe(true);
+  });
+
+  it("leaves tables outside the managed prefixes alone", () => {
+    expect(isManagedTable("users")).toBe(false);
+    expect(isManagedTable("nextly_versions")).toBe(false);
+  });
+
+  // The CLI matches by `startsWith` against the exported list while the
+  // pipeline matches by regex. They named different prefix sets once; deriving
+  // one from the other is what stops that recurring.
+  it("exposes the same prefixes the regex matches", () => {
+    for (const prefix of MANAGED_TABLE_PREFIXES) {
+      expect(isManagedTable(`${prefix}thing`)).toBe(true);
+    }
   });
 });

--- a/packages/nextly/src/domains/schema/pipeline/managed-tables.ts
+++ b/packages/nextly/src/domains/schema/pipeline/managed-tables.ts
@@ -54,3 +54,17 @@ const COMPANION_TABLE_REGEX = new RegExp(
 export function isCompanionTable(name: string): boolean {
   return COMPANION_TABLE_REGEX.test(name);
 }
+
+/**
+ * Whether a live table belongs in a snapshot paired against a migration's own.
+ *
+ * 🔴 One predicate because the two callers had written it twice and drifted:
+ * `nextly migrate`'s drift check excluded localized companions, `migrate:resolve
+ * --applied` did not, so the recovery command reported drift on any database
+ * with a localized entity and refused to run. Companions are migration-owned
+ * and never appear in a `migrate:create` snapshot, so a snapshot that contains
+ * one can never match the file it is compared against.
+ */
+export function isSnapshotComparableTable(name: string): boolean {
+  return isManagedTable(name) && !isCompanionTable(name);
+}

--- a/packages/nextly/src/domains/schema/pipeline/managed-tables.ts
+++ b/packages/nextly/src/domains/schema/pipeline/managed-tables.ts
@@ -8,8 +8,25 @@ import { MIGRATION_TARGET } from "../../field-groups/migration/manifest";
 // rely on this prefix list. Coordinate with plugin field types
 // (Gap 8 in the finalized plan) when extending.
 
+// 🔴 Both field-group generations. This regex is drizzle-kit's `tablesFilter`,
+// so a prefix missing from it is a table drizzle-kit never INTROSPECTS — and a
+// desired table it did not find in the live database is one it creates. After
+// the storage migration a generated field-group table carries `fg_`, so leaving
+// it out means every apply proposes creating a table that is already there.
+//
+// Widening this is a SemVer-visible change, and it is made BEFORE any database
+// can hold the migrated prefix rather than after: a filter that learns about a
+// table only once the table exists has already mis-diffed it once.
+/** The prefixes themselves, for callers that match by `startsWith`. */
+export const MANAGED_TABLE_PREFIXES: readonly string[] = [
+  "dc_",
+  "single_",
+  STORAGE_FORMAT.tablePrefix,
+  MIGRATION_TARGET.tablePrefix,
+];
+
 export const MANAGED_TABLE_PREFIXES_REGEX = new RegExp(
-  `^(dc_|single_|${STORAGE_FORMAT.tablePrefix})`
+  `^(dc_|single_|${STORAGE_FORMAT.tablePrefix}|${MIGRATION_TARGET.tablePrefix})`
 );
 
 export function isManagedTable(name: string): boolean {

--- a/packages/nextly/src/domains/schema/pipeline/pushschema-pipeline.ts
+++ b/packages/nextly/src/domains/schema/pipeline/pushschema-pipeline.ts
@@ -34,7 +34,9 @@ import { buildNotificationEvent } from "../../../runtime/notifications/build-eve
 import type { MigrationScope } from "../../../runtime/notifications/types";
 import { STORAGE_FORMAT } from "../../../schemas/storage-format";
 import { FieldGroupSchemaService } from "../../field-groups/services/field-group-schema-service";
+import { chooseTypeColumns } from "../../field-groups/storage/resolve-storage-names";
 import { generateRuntimeSchema } from "../services/runtime-schema-generator";
+import { identifierCaseRules } from "../utils/resolve-catalog-name";
 
 import {
   countNulls as countNullsHelper,
@@ -600,6 +602,31 @@ export class PushSchemaPipeline {
             : await introspectLiveSnapshot(db, dialect, managedTableNames);
       }
 
+      // 🔴 Derived from the snapshot just taken, not from a fresh catalog read.
+      //
+      // That snapshot was introspected over exactly these table names, so it
+      // already carries the columns this needs — and deriving from it guarantees
+      // the desired shape and the live shape are read from ONE observation of
+      // the database. A second read could disagree with the first, and a diff
+      // computed across two disagreeing observations is the one thing this
+      // function must never produce.
+      const fieldGroupTypeColumns = chooseTypeColumns(
+        liveSnapshot.tables.map(table => ({
+          table: table.name,
+          columns: table.columns.map(column => column.name),
+        })),
+        Object.values(desired.components).map(c => c.tableName),
+        // MySQL is given the folding setting rather than queried for it. The
+        // names being matched are ones this apply itself asked the server to
+        // describe, so a case-insensitive table match cannot select a different
+        // object than the one requested — while an exact match would miss a
+        // server that reported it folded. Column names fold on MySQL
+        // regardless, which is what the discriminator lookup actually needs.
+        dialect === "mysql"
+          ? identifierCaseRules({ dialect, lowerCaseTableNames: 1 })
+          : identifierCaseRules({ dialect })
+      );
+
       const desiredSnapshot: NextlySchemaSnapshot = {
         tables: [
           ...Object.values(desired.collections).map(c =>
@@ -639,7 +666,10 @@ export class PushSchemaPipeline {
                 typeof buildDesiredTableFromComponentFields
               >[1],
               dialect,
-              { localized: (c as { localized?: boolean }).localized === true }
+              {
+                localized: (c as { localized?: boolean }).localized === true,
+                typeColumn: fieldGroupTypeColumns.get(c.tableName),
+              }
             )
           ),
         ],
@@ -729,7 +759,11 @@ export class PushSchemaPipeline {
       // Phase C+D: execute pre-resolution ops, then pushSchema for the rest.
       const drizzleSchema = this.testHooks._buildDrizzleSchemaOverride
         ? this.testHooks._buildDrizzleSchemaOverride(patchedDesired, dialect)
-        : this.buildDrizzleSchema(patchedDesired, dialect);
+        : this.buildDrizzleSchema(
+            patchedDesired,
+            dialect,
+            fieldGroupTypeColumns
+          );
 
       // Scope drizzleSchema down to the table(s) actually touched by
       // resolvedOps. Without this, a Builder save that touches one
@@ -1166,7 +1200,8 @@ export class PushSchemaPipeline {
 
   private buildDrizzleSchema(
     desired: DesiredSchema,
-    dialect: SupportedDialect
+    dialect: SupportedDialect,
+    typeColumns: Map<string, string>
   ): Record<string, unknown> {
     const out: Record<string, unknown> = {};
 
@@ -1256,11 +1291,18 @@ export class PushSchemaPipeline {
         c.fields,
         {
           localized: (c as { localized?: boolean }).localized === true,
-          // The DESIRED schema, handed to drizzle-kit to diff against the live
-          // one — so it names the discriminator this release's DDL creates, not
-          // whatever the database currently holds. Resolving here would make the
-          // desired shape follow the live shape and the diff always empty.
-          typeColumn: STORAGE_FORMAT.columns.type,
+          // 🔴 The discriminator is a SYSTEM column whose name no user ever
+          // chooses: the only two spellings are the two storage generations,
+          // and which one a table carries is a fact of that table rather than a
+          // preference the desired shape could hold an opinion about. Naming
+          // the other one turns a diff into "add this column, drop that one" —
+          // a destructive pair the classifier refuses and fresh-push strips, so
+          // every later apply carries an operation that can never succeed.
+          //
+          // A table the catalog does not describe, including one about to be
+          // created, resolves to the spelling this release's DDL writes.
+          typeColumn:
+            typeColumns.get(c.tableName) ?? STORAGE_FORMAT.columns.type,
         }
       );
       out[c.tableName] = componentTable;

--- a/packages/nextly/src/domains/schema/pipeline/pushschema-pipeline.ts
+++ b/packages/nextly/src/domains/schema/pipeline/pushschema-pipeline.ts
@@ -24,7 +24,7 @@
 import type { SupportedDialect } from "@nextlyhq/adapter-drizzle/types";
 import { dequal } from "dequal";
 
-import { getDialectTables } from "../../../database/index";
+import { getDialectTablesForPush } from "../../../database/index";
 import {
   getCachedSnapshot,
   getLiveSnapshot,
@@ -34,7 +34,10 @@ import { buildNotificationEvent } from "../../../runtime/notifications/build-eve
 import type { MigrationScope } from "../../../runtime/notifications/types";
 import { STORAGE_FORMAT } from "../../../schemas/storage-format";
 import { FieldGroupSchemaService } from "../../field-groups/services/field-group-schema-service";
-import { chooseTypeColumns } from "../../field-groups/storage/resolve-storage-names";
+import {
+  chooseTypeColumns,
+  resolveRegistryNameFromCatalog,
+} from "../../field-groups/storage/resolve-storage-names";
 import { generateRuntimeSchema } from "../services/runtime-schema-generator";
 import { identifierCaseRules } from "../utils/resolve-catalog-name";
 
@@ -610,6 +613,20 @@ export class PushSchemaPipeline {
       // the database. A second read could disagree with the first, and a diff
       // computed across two disagreeing observations is the one thing this
       // function must never produce.
+      // 🔴 Contained, and its failure means "declare NEITHER registry".
+      //
+      // The desired schema is what drizzle-kit creates from, so naming the
+      // wrong registry creates an empty one — and on MySQL and SQLite the full
+      // schema is always handed over, because scope reduction below is
+      // PostgreSQL-only. Guessing is therefore the one thing this must not do.
+      // Omitting it instead leaves drizzle-kit free to propose a DROP, which
+      // `filterUnsafeStatements` blocks and reports; a wrong CREATE is additive
+      // and nothing stops it.
+      const fieldGroupRegistryTable = await resolveRegistryNameFromCatalog({
+        dialect,
+        getDrizzle: <T>() => db as T,
+      }).catch(() => undefined);
+
       const fieldGroupTypeColumns = chooseTypeColumns(
         liveSnapshot.tables.map(table => ({
           table: table.name,
@@ -762,7 +779,8 @@ export class PushSchemaPipeline {
         : this.buildDrizzleSchema(
             patchedDesired,
             dialect,
-            fieldGroupTypeColumns
+            fieldGroupTypeColumns,
+            fieldGroupRegistryTable
           );
 
       // Scope drizzleSchema down to the table(s) actually touched by
@@ -1201,7 +1219,8 @@ export class PushSchemaPipeline {
   private buildDrizzleSchema(
     desired: DesiredSchema,
     dialect: SupportedDialect,
-    typeColumns: Map<string, string>
+    typeColumns: Map<string, string>,
+    fieldGroupRegistryTable: string | undefined
   ): Record<string, unknown> {
     const out: Record<string, unknown> = {};
 
@@ -1223,7 +1242,11 @@ export class PushSchemaPipeline {
     // when disk matches the schema definition. Phase C's strict
     // filterUnsafeStatements is the safety net.
     for (const [exportKey, value] of Object.entries(
-      getDialectTables(dialect)
+      // `null` where the catalog could not say which registry exists, which the
+      // bundle reads as "declare neither".
+      getDialectTablesForPush(dialect, {
+        fieldGroupRegistryTable: fieldGroupRegistryTable ?? null,
+      })
     )) {
       if (isDrizzleTable(value)) {
         const sqlName = getDrizzleTableName(value, exportKey);

--- a/packages/nextly/src/init/__tests__/core-schema-drift-registry.test.ts
+++ b/packages/nextly/src/init/__tests__/core-schema-drift-registry.test.ts
@@ -1,0 +1,55 @@
+/**
+ * 🔴 The boot drift check must ask about the registry the database really has.
+ *
+ * It reads two things that have to agree: the desired core shape, and the list
+ * of tables to introspect the live side under. Leaving either on the legacy
+ * spelling means a migrated database is asked about a table it does not have,
+ * the one it does have is never looked at, and every single start reports the
+ * core schema as behind — a warning about a database that is correct, which an
+ * operator cannot act on and will learn to ignore.
+ */
+import { describe, expect, it, vi } from "vitest";
+
+import { MIGRATION_TARGET } from "../../domains/field-groups/migration/manifest";
+import { STORAGE_FORMAT } from "../../schemas/storage-format";
+import { warnIfCoreSchemaIsBehind } from "../first-run";
+
+const introspectLiveSnapshot = vi.fn();
+
+vi.mock("../../domains/schema/pipeline/diff/introspect-live", () => ({
+  introspectLiveSnapshot: (...args: unknown[]) =>
+    introspectLiveSnapshot(...args),
+}));
+
+vi.mock("../../domains/field-groups/storage/resolve-storage-names", () => ({
+  // The database in these cases has been migrated, which is the only state
+  // where the two spellings can disagree.
+  resolveRegistryNameFromCatalog: () =>
+    Promise.resolve(MIGRATION_TARGET.registryTable),
+}));
+
+/** Enough adapter for the check; the drift comparison itself is not the subject. */
+const adapter = {
+  dialect: "postgresql" as const,
+  getDrizzle: () => ({}),
+  tableExists: () => Promise.resolve(true),
+  executeQuery: () => Promise.resolve([]),
+};
+
+describe("the boot core-schema drift check on a migrated database", () => {
+  it("introspects the migrated registry and never the legacy one", async () => {
+    introspectLiveSnapshot.mockResolvedValue({ tables: [] });
+
+    await warnIfCoreSchemaIsBehind(adapter, {
+      debug: () => {},
+      info: () => {},
+      warn: () => {},
+      error: () => {},
+    });
+
+    expect(introspectLiveSnapshot).toHaveBeenCalledTimes(1);
+    const names = introspectLiveSnapshot.mock.calls[0][2] as string[];
+    expect(names).toContain(MIGRATION_TARGET.registryTable);
+    expect(names).not.toContain(STORAGE_FORMAT.registryTable);
+  });
+});

--- a/packages/nextly/src/init/__tests__/stored-field-group-tables.test.ts
+++ b/packages/nextly/src/init/__tests__/stored-field-group-tables.test.ts
@@ -19,7 +19,7 @@ import { describe, expect, it, vi } from "vitest";
 import { MIGRATION_TARGET } from "../../domains/field-groups/migration/manifest";
 import { forgetFieldGroupStorageNames } from "../../domains/field-groups/storage/resolve-storage-names";
 import { STORAGE_FORMAT } from "../../schemas/storage-format";
-import { readStoredFieldGroupTables } from "../reload-config";
+import { readStoredFieldGroupTables } from "../field-group-reload-plan";
 
 /**
  * The identifiers a Drizzle statement addresses.

--- a/packages/nextly/src/init/field-group-reload-plan.ts
+++ b/packages/nextly/src/init/field-group-reload-plan.ts
@@ -1,0 +1,224 @@
+/**
+ * What a reload has decided about each field group, in one place.
+ *
+ * A reload makes several decisions per group — where it is stored, whether its
+ * storage could be established at all, and therefore whether this pass may
+ * touch it — and every later stage needs the same answer. Held apart from the
+ * reload itself because they were previously re-derived at each stage, and a
+ * decision applied at one stage and not the next is the defect that shape
+ * produces: skipping a group's DDL while still persisting its new field list
+ * leaves the registry describing columns the table does not have.
+ *
+ * The rule the whole module exists to enforce:
+ *
+ * > A derived name is a guess about physical storage, and guessing is what
+ * > creates an empty table beside the populated one the reload meant to edit.
+ *
+ * @module init/field-group-reload-plan
+ */
+
+import { sql, type SQL } from "drizzle-orm";
+
+import { MIGRATION_TARGET } from "../domains/field-groups/migration/manifest";
+import { resolveFieldGroupRegistryName } from "../domains/field-groups/storage/resolve-storage-names";
+import { readIdentifierCaseRules } from "../domains/schema/utils/read-identifier-case";
+import {
+  indexCatalog,
+  resolveCatalogName,
+} from "../domains/schema/utils/resolve-catalog-name";
+import { resolveComponentTableName } from "../domains/schema/utils/resolve-table-name";
+import { STORAGE_FORMAT } from "../schemas/storage-format";
+
+/**
+ * What reading the registry needs.
+ *
+ * Declared structurally rather than importing the reload's own adapter type,
+ * so this module depends on the two calls it makes and not on the shape of a
+ * caller that also does DDL and writes.
+ */
+export interface RegistryReadAdapter {
+  readonly dialect: "postgresql" | "mysql" | "sqlite";
+  getDrizzle<T = unknown>(): T;
+  /** The storage migration renames the registry, so its name is read, not spelled. */
+  listTables(): Promise<string[]>;
+  /** Normalises the three driver envelopes in one place. */
+  queryStatement<T = Record<string, unknown>>(statement: SQL): Promise<T[]>;
+}
+
+/** A field group as the config declares it, reduced to what a reload reads. */
+export interface FieldGroupDef {
+  slug?: string;
+  fields?: unknown[];
+  localized?: boolean;
+}
+
+/** A field's shape as the schema diff consumes it. */
+export interface MinimalField {
+  name: string;
+  type: string;
+  required?: boolean;
+}
+
+/** What a reload knows about where its field groups are physically stored. */
+export interface StoredFieldGroupTables {
+  /** `slug` → the physical table name the registry records. */
+  tables: Map<string, string>;
+  /**
+   * Whether those names can be relied on.
+   *
+   * 🔴 The distinction this type exists for: a registry that is ABSENT means a
+   * fresh database, where deriving `comp_*` names is correct. A registry that
+   * is PRESENT but unreadable means the names are UNKNOWN, and deriving them
+   * addresses storage that is not there — which is how a reload creates an
+   * empty table beside the populated one it meant to edit. Only the first case
+   * may guess.
+   */
+  usable: boolean;
+  /**
+   * Why the read failed, when it did.
+   *
+   * Present only on the failure path, and carried so the caller's log can name
+   * the cause rather than only the symptom.
+   */
+  reason?: string;
+}
+
+/**
+ * The physical table name each field group is stored under.
+ *
+ * Read rather than derived: `resolveComponentTableName` answers what this
+ * release's creator WOULD name a table, while the registry records what it is
+ * actually called. They differ for an author-chosen `dbName`, and after the
+ * storage migration for every field group.
+ *
+ * Issued through the adapter's statement path so the three driver envelopes are
+ * normalised in one place, and so an unrecognised shape is refused rather than
+ * reported as no rows.
+ */
+export async function readStoredFieldGroupTables(
+  adapter: RegistryReadAdapter
+): Promise<StoredFieldGroupTables> {
+  const tables = new Map<string, string>();
+  try {
+    const registryTable = await resolveFieldGroupRegistryName(adapter);
+    const rows = await adapter.queryStatement<{
+      slug?: unknown;
+      table_name?: unknown;
+    }>(
+      sql`SELECT ${sql.identifier("slug")}, ${sql.identifier("table_name")} FROM ${sql.identifier(registryTable)}`
+    );
+    for (const row of rows) {
+      if (typeof row.slug === "string" && typeof row.table_name === "string") {
+        tables.set(row.slug, row.table_name);
+      }
+    }
+    return { tables, usable: true };
+  } catch (error) {
+    // The reason travels with the verdict. Without it the caller can only say
+    // "could not read stored field-group table names", which tells an operator
+    // nothing about whether they are looking at a permission problem, a dropped
+    // connection, or a malformed row — and this is the failure that defers a
+    // whole reload, so it is the one worth diagnosing.
+    return {
+      tables,
+      usable: (await registryIsAbsent(adapter)) === true,
+      reason: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+/**
+ * Whether the database genuinely has no field-group registry.
+ *
+ * The distinction that matters after a failed read: absent means a fresh
+ * database, where deriving names is correct; present-but-unreadable means the
+ * names are unknown, and deriving them would address storage that is not there.
+ * Answered `undefined` when even this cannot be established, which is treated
+ * as unreadable.
+ */
+async function registryIsAbsent(
+  adapter: RegistryReadAdapter
+): Promise<boolean | undefined> {
+  try {
+    // Matched under the server's own rules, not by exact spelling — the same
+    // way `chooseRegistryTable` matches. A folding server can report the
+    // registry as `DYNAMIC_FIELD_GROUPS`, and an exact comparison would call a
+    // present registry absent: the caller would then treat derived `comp_*`
+    // names as usable and let the reload build them beside the populated
+    // migrated tables, which is precisely the outcome this probe exists to
+    // prevent.
+    const rules = await readIdentifierCaseRules(adapter);
+    const catalog = indexCatalog(await adapter.listTables(), rules.tables);
+    return (
+      resolveCatalogName(catalog, STORAGE_FORMAT.registryTable) === undefined &&
+      resolveCatalogName(catalog, MIGRATION_TARGET.registryTable) === undefined
+    );
+  } catch {
+    return undefined;
+  }
+}
+
+/** One field group this reload will address, with its stored physical name. */
+export interface FieldGroupReloadTarget {
+  slug: string;
+  tableName: string;
+  fields: MinimalField[];
+  localized?: boolean;
+}
+
+/** Every decision this reload has made about its field groups. */
+export interface FieldGroupReloadPlan {
+  /** The groups this pass may touch. */
+  targets: FieldGroupReloadTarget[];
+  /**
+   * Slugs left out because their storage could not be established.
+   *
+   * 🔴 Every stage that acts on a field group has to consult this, not only the
+   * one that emits DDL. Skipping a group's schema change while still persisting
+   * its new `fields` is worse than doing neither: the registry would describe
+   * columns the table does not have, and the next start would build a runtime
+   * schema from that description and fail every read and write for it.
+   */
+  skipped: Set<string>;
+  /** Whether the stored names could be read at all. */
+  usable: boolean;
+  /** Why they could not, when they could not. */
+  reason?: string;
+}
+
+/**
+ * Decide, once, what this reload will do with each field group.
+ *
+ * Best effort by design on the read: a registry that cannot be read leaves
+ * every name derived, which is exactly the behaviour of a database that has no
+ * registry yet — and a registry that is present but unreadable leaves every
+ * group SKIPPED, because there a derived name would address storage that is
+ * not there.
+ */
+export async function planFieldGroupReload(
+  adapter: RegistryReadAdapter,
+  fieldGroups: readonly FieldGroupDef[]
+): Promise<FieldGroupReloadPlan> {
+  const stored = await readStoredFieldGroupTables(adapter);
+  const targets: FieldGroupReloadTarget[] = [];
+  const skipped = new Set<string>();
+
+  for (const group of fieldGroups) {
+    if (!group.slug) continue;
+    if (!stored.usable) {
+      skipped.add(group.slug);
+      continue;
+    }
+    targets.push({
+      slug: group.slug,
+      tableName:
+        stored.tables.get(group.slug) ?? resolveComponentTableName(group.slug),
+      fields: (group.fields ?? []) as MinimalField[],
+      // Carried so the diff omits translatable columns from the group's main
+      // table and registers its companion.
+      localized: group.localized === true,
+    });
+  }
+
+  return { targets, skipped, usable: stored.usable, reason: stored.reason };
+}

--- a/packages/nextly/src/init/first-run.ts
+++ b/packages/nextly/src/init/first-run.ts
@@ -122,7 +122,7 @@ async function runCoreSchemaDriftCheck(
   adapter: AdapterLike,
   logger: LoggerLike
 ): Promise<void> {
-  const [{ introspectLiveSnapshot }, { getCoreSchema, CORE_TABLE_NAMES }] =
+  const [{ introspectLiveSnapshot }, { getCoreSchema, getCoreTableNames }] =
     await Promise.all([
       import("../domains/schema/pipeline/diff/introspect-live"),
       import("../schemas/index"),
@@ -131,11 +131,24 @@ async function runCoreSchemaDriftCheck(
     "./core-schema-drift"
   );
 
-  const desired = getCoreSchema(adapter.dialect);
+  // 🔴 Both sides take the registry this database actually holds. Checking for
+  // the legacy name on a migrated database misses the table that is really
+  // there and reports the core schema as behind on every start — a warning an
+  // operator cannot act on, about a database that is correct.
+  const { resolveRegistryNameFromCatalog } = await import(
+    "../domains/field-groups/storage/resolve-storage-names"
+  );
+  const coreOptions = {
+    fieldGroupRegistryTable: await resolveRegistryNameFromCatalog({
+      dialect: adapter.dialect,
+      getDrizzle: <T>() => adapter.getDrizzle() as T,
+    }),
+  };
+  const desired = getCoreSchema(adapter.dialect, coreOptions);
   const live = await introspectLiveSnapshot(
     adapter.getDrizzle(),
     adapter.dialect,
-    [...CORE_TABLE_NAMES]
+    getCoreTableNames(coreOptions)
   );
 
   const drift = findCoreSchemaDrift(live, desired);

--- a/packages/nextly/src/init/reload-config.ts
+++ b/packages/nextly/src/init/reload-config.ts
@@ -613,6 +613,17 @@ async function ensureLocalizedCompanionsForReload(
     fieldGroups?: unknown[];
     localization?: { defaultLocale?: string };
   },
+  /**
+   * Stored physical table name per field-group slug.
+   *
+   * 🔴 A companion is named after the table it belongs to, so deriving the main
+   * table's name here derives the companion's too — and after the storage
+   * migration that names `comp_<slug>_locales` beside a live `fg_<slug>`,
+   * provisioning an empty companion the entity's reads never consult while the
+   * real one is left to drift. The reload already resolved these once; this is
+   * that answer, not a second guess at it.
+   */
+  fieldGroupTables: ReadonlyMap<string, string>,
   // `<kind>:<slug>` for every entity whose schema change was classified unsafe (or whose diff
   // threw) this cycle, so it was NOT applied. Those must be skipped: creating a companion for
   // a transition that has not happened is worse than leaving it absent. The Schema Builder
@@ -704,7 +715,7 @@ async function ensureLocalizedCompanionsForReload(
     [
       "fieldGroup",
       (config.fieldGroups ?? []) as Localizable[],
-      e => resolveComponentTableName(e.slug!),
+      e => fieldGroupTables.get(e.slug!) ?? resolveComponentTableName(e.slug!),
     ],
   ];
 
@@ -1252,6 +1263,10 @@ async function applyReload(opts?: {
   componentTargets.push(...fieldGroupPlan.targets);
   /** Field groups left out of this reload because their storage is unknown. */
   const skippedComponentSlugs = fieldGroupPlan.skipped;
+  /** The same resolution, keyed for the companion provisioning below. */
+  const fieldGroupTables = new Map(
+    fieldGroupPlan.targets.map(target => [target.slug, target.tableName])
+  );
   if (!fieldGroupPlan.usable) {
     logger?.warn(
       "[Nextly HMR] Could not read stored field-group table names" +
@@ -1570,6 +1585,7 @@ async function applyReload(opts?: {
     const noDdlProvisioning = await ensureLocalizedCompanionsForReload(
       adapter,
       newConfig,
+      fieldGroupTables,
       deferredEntities
     );
 
@@ -1765,6 +1781,7 @@ async function applyReload(opts?: {
   const preservation = await ensureLocalizedCompanionsForReload(
     adapter,
     newConfig,
+    fieldGroupTables,
     deferredEntities,
     "beforeApply"
   );
@@ -1807,6 +1824,7 @@ async function applyReload(opts?: {
     const postApply = await ensureLocalizedCompanionsForReload(
       adapter,
       newConfig,
+      fieldGroupTables,
       deferredEntities
     );
 

--- a/packages/nextly/src/init/reload-config.ts
+++ b/packages/nextly/src/init/reload-config.ts
@@ -23,14 +23,10 @@
 
 import type { DrizzleAdapter } from "@nextlyhq/adapter-drizzle";
 import type { SupportedDialect } from "@nextlyhq/adapter-drizzle/types";
-import { sql, type SQL } from "drizzle-orm";
+import { type SQL } from "drizzle-orm";
 
-import { MIGRATION_TARGET } from "../domains/field-groups/migration/manifest";
 import { withMigrationExcluded } from "../domains/field-groups/migration/sync-guard";
-import {
-  chooseTypeColumns,
-  resolveFieldGroupRegistryName,
-} from "../domains/field-groups/storage/resolve-storage-names";
+import { chooseTypeColumns } from "../domains/field-groups/storage/resolve-storage-names";
 import type { I18nTransitionKind } from "../domains/i18n/migration/transition-state";
 import { createApplyDesiredSchema } from "../domains/schema/pipeline/apply";
 import { RealClassifier } from "../domains/schema/pipeline/classifier/classifier";
@@ -65,15 +61,8 @@ import type {
 import { DrizzleStatementExecutor } from "../domains/schema/services/drizzle-statement-executor";
 import { generateRuntimeSchema } from "../domains/schema/services/runtime-schema-generator";
 import { readIdentifierCaseRules } from "../domains/schema/utils/read-identifier-case";
-import {
-  indexCatalog,
-  resolveCatalogName,
-} from "../domains/schema/utils/resolve-catalog-name";
 import type { IdentifierCaseRules } from "../domains/schema/utils/resolve-catalog-name";
-import {
-  resolveCollectionTableName,
-  resolveComponentTableName,
-} from "../domains/schema/utils/resolve-table-name";
+import { resolveCollectionTableName } from "../domains/schema/utils/resolve-table-name";
 // Resolve the versioning config on the HMR sync path so a `versions` change
 // while `next dev` is running persists without a restart (parity with di/register).
 import { resolveVersionsConfig } from "../domains/versions/resolve-config";
@@ -95,6 +84,7 @@ import { STORAGE_FORMAT } from "../schemas/storage-format";
 import type { VersionsConfig } from "../schemas/versions/types";
 import { FieldGroupSchemaService } from "../services/field-groups/field-group-schema-service";
 
+import { planFieldGroupReload } from "./field-group-reload-plan";
 import { clearLiveSnapshots, setLiveSnapshot } from "./schema-snapshot-cache";
 
 // Service-resolver shape. Defaulted to the real getService at runtime;
@@ -1012,105 +1002,6 @@ async function runReload(opts?: {
   }
 }
 
-/** What a reload knows about where its field groups are physically stored. */
-export interface StoredFieldGroupTables {
-  /** `slug` → the physical table name the registry records. */
-  tables: Map<string, string>;
-  /**
-   * Whether those names can be relied on.
-   *
-   * 🔴 The distinction this type exists for: a registry that is ABSENT means a
-   * fresh database, where deriving `comp_*` names is correct. A registry that
-   * is PRESENT but unreadable means the names are UNKNOWN, and deriving them
-   * addresses storage that is not there — which is how a reload creates an
-   * empty table beside the populated one it meant to edit. Only the first case
-   * may guess.
-   */
-  usable: boolean;
-  /**
-   * Why the read failed, when it did.
-   *
-   * Present only on the failure path, and carried so the caller's log can name
-   * the cause rather than only the symptom.
-   */
-  reason?: string;
-}
-
-/**
- * The physical table name each field group is stored under.
- *
- * Read rather than derived: `resolveComponentTableName` answers what this
- * release's creator WOULD name a table, while the registry records what it is
- * actually called. They differ for an author-chosen `dbName`, and after the
- * storage migration for every field group.
- *
- * Issued through the adapter's statement path so the three driver envelopes are
- * normalised in one place, and so an unrecognised shape is refused rather than
- * reported as no rows.
- */
-export async function readStoredFieldGroupTables(
-  adapter: AdapterLike
-): Promise<StoredFieldGroupTables> {
-  const tables = new Map<string, string>();
-  try {
-    const registryTable = await resolveFieldGroupRegistryName(adapter);
-    const rows = await adapter.queryStatement<{
-      slug?: unknown;
-      table_name?: unknown;
-    }>(
-      sql`SELECT ${sql.identifier("slug")}, ${sql.identifier("table_name")} FROM ${sql.identifier(registryTable)}`
-    );
-    for (const row of rows) {
-      if (typeof row.slug === "string" && typeof row.table_name === "string") {
-        tables.set(row.slug, row.table_name);
-      }
-    }
-    return { tables, usable: true };
-  } catch (error) {
-    // The reason travels with the verdict. Without it the caller can only say
-    // "could not read stored field-group table names", which tells an operator
-    // nothing about whether they are looking at a permission problem, a dropped
-    // connection, or a malformed row — and this is the failure that defers a
-    // whole reload, so it is the one worth diagnosing.
-    return {
-      tables,
-      usable: (await registryIsAbsent(adapter)) === true,
-      reason: error instanceof Error ? error.message : String(error),
-    };
-  }
-}
-
-/**
- * Whether the database genuinely has no field-group registry.
- *
- * The distinction that matters after a failed read: absent means a fresh
- * database, where deriving names is correct; present-but-unreadable means the
- * names are unknown, and deriving them would address storage that is not there.
- * Answered `undefined` when even this cannot be established, which is treated
- * as unreadable.
- */
-async function registryIsAbsent(
-  adapter: AdapterLike
-): Promise<boolean | undefined> {
-  try {
-    // Matched under the server's own rules, not by exact spelling — the same
-    // way `chooseRegistryTable` matches. A folding server can report the
-    // registry as `DYNAMIC_FIELD_GROUPS`, and an exact comparison would call a
-    // present registry absent: the caller would then treat derived `comp_*`
-    // names as usable and let the reload build them beside the populated
-    // migrated tables, which is precisely the outcome this probe exists to
-    // prevent.
-    const rules = await readIdentifierCaseRules(adapter);
-    const catalog = indexCatalog(await adapter.listTables(), rules.tables);
-    return (
-      resolveCatalogName(catalog, STORAGE_FORMAT.registryTable) === undefined &&
-      resolveCatalogName(catalog, MIGRATION_TARGET.registryTable) === undefined
-    );
-  } catch {
-    return undefined;
-  }
-}
-
 async function applyReload(opts?: {
   resolver?: ServiceResolver;
   dispatcher?: PromptDispatcher;
@@ -1352,49 +1243,21 @@ async function applyReload(opts?: {
     fields: MinimalField[];
     localized?: boolean;
   }> = [];
-  // 🔴 The STORED physical name wins over the one derived from the slug.
-  //
-  // `resolveComponentTableName` answers what this release's creator WOULD name
-  // a table; the registry records what the table is actually called. Those
-  // differ for an author-chosen `dbName`, and — after the storage migration —
-  // for every field group. Deriving the name would make the reload diff against
-  // a table that is not there, decide the component is new, and create an empty
-  // one beside the populated one it meant to edit.
-  //
-  // Best effort by design: a registry that cannot be read leaves every name
-  // derived, which is exactly the behaviour of a database that has no registry
-  // yet.
-  const stored = await readStoredFieldGroupTables(adapter);
-  const storedComponentTables = stored.tables;
-  const storedNamesUsable = stored.usable;
+  // 🔴 The STORED physical name wins over the one derived from the slug, and
+  // that decision is made ONCE for the whole reload — see the plan module.
+  const fieldGroupPlan = await planFieldGroupReload(
+    adapter,
+    newConfig.fieldGroups ?? []
+  );
+  componentTargets.push(...fieldGroupPlan.targets);
   /** Field groups left out of this reload because their storage is unknown. */
-  const skippedComponentSlugs = new Set<string>();
-  if (!storedNamesUsable) {
+  const skippedComponentSlugs = fieldGroupPlan.skipped;
+  if (!fieldGroupPlan.usable) {
     logger?.warn(
       "[Nextly HMR] Could not read stored field-group table names" +
-        (stored.reason ? `: ${stored.reason}` : "") +
+        (fieldGroupPlan.reason ? `: ${fieldGroupPlan.reason}` : "") +
         ". Deferring the field-group apply to the next reload."
     );
-  }
-
-  for (const c of newConfig.fieldGroups ?? []) {
-    if (!c.slug) continue;
-    // Skipped entirely when the stored names could not be established: a
-    // derived name is a guess about physical storage, and guessing here is what
-    // creates the empty table.
-    if (!storedNamesUsable) {
-      skippedComponentSlugs.add(c.slug);
-      continue;
-    }
-    componentTargets.push({
-      slug: c.slug,
-      tableName:
-        storedComponentTables.get(c.slug) ?? resolveComponentTableName(c.slug),
-      fields: (c.fields ?? []) as MinimalField[],
-      // i18n: carry `localized` so the HMR diff omits translatable columns from the
-      // component's main table and registers its companion.
-      localized: (c as { localized?: boolean }).localized === true,
-    });
   }
 
   // 🔴 Checked BEFORE the empty-target branch below. `loadConfig` has already

--- a/packages/nextly/src/schemas/__tests__/core-schema-field-group-registry.test.ts
+++ b/packages/nextly/src/schemas/__tests__/core-schema-field-group-registry.test.ts
@@ -1,0 +1,70 @@
+/**
+ * 🔴 The core schema is a DESIRED shape, so a name in it that the database does
+ * not have is an instruction to CREATE that table.
+ *
+ * On a database whose field-group registry has been renamed by the storage
+ * migration, declaring the legacy name creates an empty second registry — and
+ * every reader prefers the legacy spelling when it is present, so the site's
+ * field groups become unreachable with no error raised anywhere. That is the
+ * failure these cases exist to prevent, on the command an operator runs after
+ * an upgrade.
+ */
+import { describe, expect, it } from "vitest";
+
+import { MIGRATION_TARGET } from "../../domains/field-groups/migration/manifest";
+import { getDialectTablesForPush } from "../../database/index";
+import { getCoreSchema, getCoreTableNames } from "../index";
+import { STORAGE_FORMAT } from "../storage-format";
+
+const DIALECTS = ["postgresql", "mysql", "sqlite"] as const;
+
+describe("the core schema names the registry the database actually holds", () => {
+  describe.each(DIALECTS)("%s", dialect => {
+    it("declares the legacy registry when no name is given", () => {
+      const names = getCoreSchema(dialect).tables.map(table => table.name);
+
+      expect(names).toContain(STORAGE_FORMAT.registryTable);
+      expect(names).not.toContain(MIGRATION_TARGET.registryTable);
+    });
+
+    // The case the option exists for. Both halves matter: naming the migrated
+    // registry is not enough on its own, because leaving the legacy one in the
+    // desired shape is what emits the CREATE.
+    it("declares only the migrated registry once one is resolved", () => {
+      const names = getCoreSchema(dialect, {
+        fieldGroupRegistryTable: MIGRATION_TARGET.registryTable,
+      }).tables.map(table => table.name);
+
+      expect(names).toContain(MIGRATION_TARGET.registryTable);
+      expect(names).not.toContain(STORAGE_FORMAT.registryTable);
+    });
+
+    // The bundle the push CREATES from, which must move in step with the
+    // desired shape above: a diff computed against one and applied from the
+    // other creates the table the diff said was already there.
+    it("pushes the migrated registry under its own name", () => {
+      const table = getDialectTablesForPush(dialect, {
+        fieldGroupRegistryTable: MIGRATION_TARGET.registryTable,
+      }).dynamicFieldGroups;
+
+      expect(table).toBeDefined();
+      const pushed = getCoreSchema(dialect, {
+        fieldGroupRegistryTable: MIGRATION_TARGET.registryTable,
+      }).tables.map(t => t.name);
+      expect(pushed).toContain(MIGRATION_TARGET.registryTable);
+    });
+  });
+
+  // The table list is what the live side is introspected under. Asking about a
+  // table that is not there and then diffing the answer against one that is
+  // produces the same CREATE from the other direction.
+  it("asks the database about the registry it will compare against", () => {
+    expect(getCoreTableNames()).toContain(STORAGE_FORMAT.registryTable);
+
+    const migrated = getCoreTableNames({
+      fieldGroupRegistryTable: MIGRATION_TARGET.registryTable,
+    });
+    expect(migrated).toContain(MIGRATION_TARGET.registryTable);
+    expect(migrated).not.toContain(STORAGE_FORMAT.registryTable);
+  });
+});

--- a/packages/nextly/src/schemas/__tests__/core-schema-field-group-registry.test.ts
+++ b/packages/nextly/src/schemas/__tests__/core-schema-field-group-registry.test.ts
@@ -68,3 +68,32 @@ describe("the core schema names the registry the database actually holds", () =>
     expect(migrated).not.toContain(STORAGE_FORMAT.registryTable);
   });
 });
+
+/**
+ * 🔴 The push bundle is what drizzle-kit CREATES from, and on MySQL and SQLite
+ * the whole bundle is handed over on every apply — scope reduction is
+ * PostgreSQL-only. So a caller that cannot establish which registry a database
+ * holds must be able to declare NEITHER: naming the wrong one creates it, and a
+ * CREATE is additive so no safety net stops it, while an omission at worst lets
+ * drizzle-kit propose a DROP that `filterUnsafeStatements` blocks and reports.
+ */
+describe("the push bundle when the registry cannot be established", () => {
+  describe.each(DIALECTS)("%s", dialect => {
+    it("declares the legacy registry by default", () => {
+      expect(getDialectTablesForPush(dialect).dynamicFieldGroups).toBeDefined();
+    });
+
+    it("declares neither registry when given null", () => {
+      const bundle = getDialectTablesForPush(dialect, {
+        fieldGroupRegistryTable: null,
+      });
+
+      expect("dynamicFieldGroups" in bundle).toBe(false);
+      // Every other system table is still declared — omitting the registry must
+      // not cost drizzle-kit its view of the rest, or it pairs them with new
+      // tables for rename detection and prompts on a non-TTY boot.
+      expect(bundle.dynamicCollections).toBeDefined();
+      expect(bundle.dynamicSingles).toBeDefined();
+    });
+  });
+});

--- a/packages/nextly/src/schemas/__tests__/core-schema-field-group-registry.test.ts
+++ b/packages/nextly/src/schemas/__tests__/core-schema-field-group-registry.test.ts
@@ -9,6 +9,7 @@
  * failure these cases exist to prevent, on the command an operator runs after
  * an upgrade.
  */
+import { getTableName } from "drizzle-orm";
 import { describe, expect, it } from "vitest";
 
 import { MIGRATION_TARGET } from "../../domains/field-groups/migration/manifest";
@@ -17,6 +18,10 @@ import { getCoreSchema, getCoreTableNames } from "../index";
 import { STORAGE_FORMAT } from "../storage-format";
 
 const DIALECTS = ["postgresql", "mysql", "sqlite"] as const;
+
+/** The physical name a Drizzle table object carries, which is what the kit emits. */
+const sqlNameOf = (table: unknown): string =>
+  getTableName(table as Parameters<typeof getTableName>[0]);
 
 describe("the core schema names the registry the database actually holds", () => {
   describe.each(DIALECTS)("%s", dialect => {
@@ -42,16 +47,26 @@ describe("the core schema names the registry the database actually holds", () =>
     // The bundle the push CREATES from, which must move in step with the
     // desired shape above: a diff computed against one and applied from the
     // other creates the table the diff said was already there.
+    //
+    // Asserted on the Drizzle object's own SQL name, because that is the name
+    // drizzle-kit emits. Checking only that the entry exists would pass with
+    // the legacy object still in place, which is the whole failure.
     it("pushes the migrated registry under its own name", () => {
-      const table = getDialectTablesForPush(dialect, {
+      const bundle = getDialectTablesForPush(dialect, {
         fieldGroupRegistryTable: MIGRATION_TARGET.registryTable,
-      }).dynamicFieldGroups;
+      });
 
-      expect(table).toBeDefined();
-      const pushed = getCoreSchema(dialect, {
-        fieldGroupRegistryTable: MIGRATION_TARGET.registryTable,
-      }).tables.map(t => t.name);
-      expect(pushed).toContain(MIGRATION_TARGET.registryTable);
+      expect(sqlNameOf(bundle.dynamicFieldGroups)).toBe(
+        MIGRATION_TARGET.registryTable
+      );
+    });
+
+    it("pushes the legacy registry by default", () => {
+      const bundle = getDialectTablesForPush(dialect);
+
+      expect(sqlNameOf(bundle.dynamicFieldGroups)).toBe(
+        STORAGE_FORMAT.registryTable
+      );
     });
   });
 

--- a/packages/nextly/src/schemas/index.ts
+++ b/packages/nextly/src/schemas/index.ts
@@ -20,6 +20,7 @@ import type { SupportedDialect } from "@nextlyhq/adapter-drizzle/types";
 
 import { buildFieldGroupRegistryTable } from "../domains/field-groups/storage/registry-schemas";
 import type { NextlySchemaSnapshot } from "../domains/schema/pipeline/diff/types";
+import { MANAGED_TABLE_PREFIXES } from "../domains/schema/pipeline/managed-tables";
 
 import { drizzleTableToTableSpec } from "./_internal/drizzle-to-tablespec";
 import { apiKeyTables } from "./api-keys";
@@ -254,12 +255,15 @@ export const CORE_TABLE_NAMES: readonly string[] = [
   "nextly_webhook_deliveries",
 ] as const;
 
-/** Prefixes that identify managed user tables (dc_, single_, comp_). */
-export const CORE_TABLE_PREFIXES: readonly string[] = [
-  "dc_",
-  "single_",
-  STORAGE_FORMAT.tablePrefix,
-];
+/**
+ * Prefixes that identify managed user tables.
+ *
+ * Derived from the pipeline's own filter rather than restated, so the two
+ * cannot disagree about what Nextly manages. They did: this list named three
+ * prefixes while the filter named four, and a table the filter manages but this
+ * list does not is one the CLI treats as foreign.
+ */
+export const CORE_TABLE_PREFIXES: readonly string[] = MANAGED_TABLE_PREFIXES;
 
 // =============================================================================
 // Transitional re-exports — kept so existing consumers keep building during

--- a/packages/nextly/src/schemas/index.ts
+++ b/packages/nextly/src/schemas/index.ts
@@ -18,6 +18,7 @@
 
 import type { SupportedDialect } from "@nextlyhq/adapter-drizzle/types";
 
+import { buildFieldGroupRegistryTable } from "../domains/field-groups/storage/registry-schemas";
 import type { NextlySchemaSnapshot } from "../domains/schema/pipeline/diff/types";
 
 import { drizzleTableToTableSpec } from "./_internal/drizzle-to-tablespec";
@@ -64,15 +65,83 @@ import { webhookTables } from "./webhooks";
 // =============================================================================
 
 /**
+ * Which field-group registry a particular database holds.
+ *
+ * 🔴 The core schema is a DESIRED shape, and a desired shape that names a table
+ * the database does not have is an instruction to create it. The storage
+ * migration renames the registry, so a caller holding a real database resolves
+ * the name from the catalog and passes it here; omitting it keeps the legacy
+ * spelling, which is correct for a fresh database and for every caller that has
+ * no database to ask.
+ *
+ * Without this, reconciling a migrated database creates an EMPTY legacy
+ * registry beside the populated migrated one — and every reader prefers the
+ * legacy name when it is present, so the site's field groups silently vanish.
+ */
+export interface CoreSchemaOptions {
+  /** Defaults to the legacy spelling this release's DDL writes. */
+  fieldGroupRegistryTable?: string;
+}
+
+/**
+ * The field-group registry object for a dialect, under whichever name applies.
+ *
+ * Returns the module-level constant unchanged for the legacy name so the common
+ * path keeps object identity, and builds one only when a database really has
+ * been migrated.
+ */
+function fieldGroupRegistryFor(
+  dialect: SupportedDialect,
+  options?: CoreSchemaOptions
+): unknown {
+  const name = options?.fieldGroupRegistryTable;
+  if (name === undefined || name === STORAGE_FORMAT.registryTable) {
+    switch (dialect) {
+      case "postgresql":
+        return dynamicFieldGroupsPg;
+      case "mysql":
+        return dynamicFieldGroupsMysql;
+      case "sqlite":
+        return dynamicFieldGroupsSqlite;
+      default: {
+        const exhaustive: never = dialect;
+        throw new Error(`Unsupported dialect: ${String(exhaustive)}`);
+      }
+    }
+  }
+  return buildFieldGroupRegistryTable(dialect, name);
+}
+
+/**
+ * Snake-case names of every core table the framework manages.
+ *
+ * Takes the same options as {@link getCoreSchema} for the same reason: the two
+ * are read together — one names the tables to introspect, the other the shape to
+ * compare them against — so a mismatch between them asks the database about a
+ * table that is not there and then diffs the answer against one that is.
+ */
+export function getCoreTableNames(options?: CoreSchemaOptions): string[] {
+  return CORE_TABLE_NAMES.map(name =>
+    name === STORAGE_FORMAT.registryTable
+      ? (options?.fieldGroupRegistryTable ?? name)
+      : name
+  );
+}
+
+/**
  * Canonical core schema snapshot for the given dialect.
  *
  * Consumed by every pipeline entry point (boot-apply, db:sync, migrate Phase 1,
  * migrate:check) to drive introspect-and-diff.
  *
- * @param _dialect - the runtime dialect to compile the snapshot for
+ * @param dialect - the runtime dialect to compile the snapshot for
+ * @param options - which field-group registry this database actually holds
  * @returns a frozen snapshot of all framework-managed tables for that dialect
  */
-export function getCoreSchema(dialect: SupportedDialect): NextlySchemaSnapshot {
+export function getCoreSchema(
+  dialect: SupportedDialect,
+  options?: CoreSchemaOptions
+): NextlySchemaSnapshot {
   const tables = [
     ...Object.values(userTables(dialect)),
     ...Object.values(authTokenTables(dialect)),
@@ -100,13 +169,15 @@ export function getCoreSchema(dialect: SupportedDialect): NextlySchemaSnapshot {
     ...Object.values(webhookTables(dialect)),
   ];
 
+  const fieldGroupRegistry = fieldGroupRegistryFor(dialect, options);
+
   // Per-dialect tables for feature groups whose dialect subdirs predate Plan A.
   switch (dialect) {
     case "postgresql":
       tables.push(
         dynamicCollectionsPg,
         dynamicSinglesPg,
-        dynamicFieldGroupsPg,
+        fieldGroupRegistry,
         siteSettingsPg,
         userFieldDefinitionsPg,
         emailProvidersPg,
@@ -117,7 +188,7 @@ export function getCoreSchema(dialect: SupportedDialect): NextlySchemaSnapshot {
       tables.push(
         dynamicCollectionsMysql,
         dynamicSinglesMysql,
-        dynamicFieldGroupsMysql,
+        fieldGroupRegistry,
         siteSettingsMysql,
         userFieldDefinitionsMysql,
         emailProvidersMysql,
@@ -128,7 +199,7 @@ export function getCoreSchema(dialect: SupportedDialect): NextlySchemaSnapshot {
       tables.push(
         dynamicCollectionsSqlite,
         dynamicSinglesSqlite,
-        dynamicFieldGroupsSqlite,
+        fieldGroupRegistry,
         siteSettingsSqlite,
         userFieldDefinitionsSqlite,
         emailProvidersSqlite,

--- a/packages/nextly/src/schemas/index.ts
+++ b/packages/nextly/src/schemas/index.ts
@@ -21,6 +21,7 @@ import type { SupportedDialect } from "@nextlyhq/adapter-drizzle/types";
 import { buildFieldGroupRegistryTable } from "../domains/field-groups/storage/registry-schemas";
 import type { NextlySchemaSnapshot } from "../domains/schema/pipeline/diff/types";
 import { MANAGED_TABLE_PREFIXES } from "../domains/schema/pipeline/managed-tables";
+import { NextlyError } from "../errors/nextly-error";
 
 import { drizzleTableToTableSpec } from "./_internal/drizzle-to-tablespec";
 import { apiKeyTables } from "./api-keys";
@@ -106,7 +107,12 @@ function fieldGroupRegistryFor(
         return dynamicFieldGroupsSqlite;
       default: {
         const exhaustive: never = dialect;
-        throw new Error(`Unsupported dialect: ${String(exhaustive)}`);
+        throw NextlyError.internal({
+          logContext: {
+            reason: "cannot build the field-group registry for this dialect",
+            dialect: String(exhaustive),
+          },
+        });
       }
     }
   }
@@ -209,7 +215,12 @@ export function getCoreSchema(
       break;
     default: {
       const _exhaustive: never = dialect;
-      throw new Error(`Unsupported dialect: ${String(_exhaustive)}`);
+      throw NextlyError.internal({
+        logContext: {
+          reason: "cannot build the core schema for this dialect",
+          dialect: String(_exhaustive),
+        },
+      });
     }
   }
 

--- a/packages/nextly/src/services/system/system-table-service.ts
+++ b/packages/nextly/src/services/system/system-table-service.ts
@@ -38,6 +38,7 @@
 import type { DrizzleAdapter } from "@nextlyhq/adapter-drizzle";
 import type { SupportedDialect } from "@nextlyhq/adapter-drizzle/types";
 
+import { resolveFieldGroupRegistryName } from "../../domains/field-groups/storage/resolve-storage-names";
 import { STORAGE_FORMAT } from "../../schemas/storage-format";
 import { BaseService } from "../base-service";
 import type { Logger } from "../shared";
@@ -424,8 +425,11 @@ export class SystemTableService extends BaseService {
     const dynamicCollectionsExists = await this.tableExists(
       "dynamic_collections"
     );
+    // Asked about the registry this database actually holds. Checking the
+    // legacy spelling alone reports a migrated database as missing a system
+    // table, so `allReady` is false and callers conclude the install is broken.
     const dynamicComponentsExists = await this.tableExists(
-      STORAGE_FORMAT.registryTable
+      await resolveFieldGroupRegistryName(this.adapter)
     );
     const nextlyMigrationsExists = await this.tableExists("nextly_migrations");
 
@@ -475,18 +479,21 @@ export class SystemTableService extends BaseService {
         this.logger.info("Created system table 'dynamic_collections'");
       }
 
-      const dcompExists = await this.tableExists(STORAGE_FORMAT.registryTable);
+      // 🔴 Resolved, not assumed. `createDynamicComponentsTable` writes the
+      // legacy spelling, so a database whose registry has been renamed would be
+      // found "missing" and given a second, empty one — which every reader then
+      // prefers, because the rule is legacy-if-present. Resolving first makes
+      // that impossible: the migrated name is only ever returned when the table
+      // is really there, so the create below runs on a database that has none.
+      const registryTable = await resolveFieldGroupRegistryName(this.adapter);
+      const dcompExists = await this.tableExists(registryTable);
       if (dcompExists) {
-        existing.push(STORAGE_FORMAT.registryTable);
-        this.logger.info(
-          `System table '${STORAGE_FORMAT.registryTable}' already exists`
-        );
+        existing.push(registryTable);
+        this.logger.info(`System table '${registryTable}' already exists`);
       } else {
         await this.createDynamicComponentsTable();
-        created.push(STORAGE_FORMAT.registryTable);
-        this.logger.info(
-          `Created system table '${STORAGE_FORMAT.registryTable}'`
-        );
+        created.push(registryTable);
+        this.logger.info(`Created system table '${registryTable}'`);
       }
 
       const nmExists = await this.tableExists("nextly_migrations");


### PR DESCRIPTION
Sixth slice of task 011. Makes every path that **creates or checks** field-group storage address the names the database actually holds, rather than the names this release would create.

#454 made the readers resolve. This is the other half, and it must land before the migration entry point is armed: without it, running the migration and then `nextly migrate` — or just `next dev` — puts a database in a state the expansion was designed to avoid.

## The defect

The core schema is a **desired** shape, so a name in it that the database does not have is an instruction to create that table. On a database whose field-group registry has been renamed, several paths declared the legacy name:

- `nextly migrate` and `nextly upgrade --reconcile-core` (`reconcileCore`)
- the dev server's system-table check (`ensureSystemTables`)
- every schema apply, through the bundle handed to drizzle-kit

Each would create an **empty** `dynamic_components` beside the populated `dynamic_field_groups`. Every reader then prefers it, because the resolution rule is legacy-if-present — so the site's field groups become unreachable, with nothing raised anywhere. The data is intact; it is the addressing that breaks, which is the harder failure to diagnose.

## Commits

| Commit | What |
|---|---|
| `5ad02aaed` | extract the reload's field-group decisions into `init/field-group-reload-plan.ts` — one place answers where each group is stored and whether it was skipped |
| `af4ce3e0e` | `getCoreSchema`, `getCoreTableNames`, the push bundle, `reconcileCore` (as a dep) and `ensureSystemTables`/`checkSystemTables` all resolve the registry |
| `b6e1aa2f1` | the desired discriminator is taken per table from the live snapshot the apply already holds |
| `7166f6688` | the managed-prefix filter covers `fg_`; `CORE_TABLE_PREFIXES` derives from it instead of restating it |
| `c54141329` | a companion is named after its real main table, not derived from the slug |
| `c9b679e77` | when the catalog cannot say which registry exists, declare **neither** |

## Design notes

**`reconcileCore` takes the resolved name; it does not probe.** A probe there sits in a block whose failure policy is "abort the reconcile", so a metadata blip would refuse a migration. At the caller it fails the command cleanly, before anything is applied.

**The discriminator comes from the live snapshot, not a second catalog read.** The apply already introspects exactly those tables. Deriving from that one observation guarantees both sides of the diff agree; two reads could not.

**Declaring neither registry is a deliberate failure policy.** Naming the wrong one CREATEs it and a create is additive, so no safety net stops it. Omitting it at worst leaves a DROP proposal, which `filterUnsafeStatements` already blocks and reports. Only one of those loses the data's reachability.

**`getDialectTablesForPush` is separate from `getDialectTables`.** The first attempt widened the shared one's return to `Record<string, unknown>` so a single key could vary, and cost about a dozen callers their precise table types. The push path hands the bundle to drizzle-kit untyped anyway.

## Verification

`pnpm build` clean · `pnpm check-types --force` 19/19 · `pnpm lint` exit 0.

Unit: **400 unique / 405 raw**, diffed at test-name level against a baseline freshly measured from `origin/main` in its own installed and built worktree — **zero branch-only, zero baseline-only**, 6060 passing.

Integration across `field-groups`, `init`, `schema` and `i18n`: **202 passed** on Postgres 17, **173 passed** on MySQL.

Every new test proven load-bearing by breaking the behaviour and confirming the intended case failed with the count unchanged.

**Nothing here changes storage.** Like #454, this is independently deployable and installing it alters no database. The migration engine remains dark — no caller of `runFieldGroupMigration` outside its own module and tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved compatibility with databases migrated from earlier field-group storage formats.
  * Automatically detects existing registry and component table naming across supported database dialects.
  * Reloads now use stored field-group table mappings and provide safer handling when registry data is unavailable.
* **Bug Fixes**
  * Prevented duplicate system tables from being created during initialization or upgrades.
  * Improved schema drift detection and migration snapshot comparisons.
  * Preserved existing discriminator-column names for component tables.
* **Tests**
  * Added coverage for migrated schemas, registry naming, reload behavior, and PostgreSQL, MySQL, and SQLite compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->