### PR TITLE
test(nextly): assert the core reconcile leaves a migrated registry alone

### DIFF
--- a/packages/nextly/src/domains/field-groups/migration/__tests__/storage-migration.integration.test.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/storage-migration.integration.test.ts
@@ -50,16 +50,21 @@ import { dynamicSinglesSqlite } from "../../../../schemas/dynamic-singles/sqlite
 import { nextlyMetaTables } from "../../../../schemas/nextly-meta";
 import { userTables } from "../../../../schemas/users";
 import { schemaEventsTables } from "../../../../schemas/schema-events";
+import { getCoreSchema, getCoreTableNames } from "../../../../schemas";
 import { STORAGE_FORMAT } from "../../../../schemas/storage-format";
 import { versionsTables } from "../../../../schemas/versions";
 import { webhookTables } from "../../../../schemas/webhooks";
+import { diffSnapshots } from "../../../schema/pipeline/diff/diff";
 import { introspectLiveSnapshot } from "../../../schema/pipeline/diff/introspect-live";
 import { splitStatements } from "../../../schema/pipeline/sql-statement-utils";
 import { DynamicCollectionSchemaService } from "../../../dynamic-collections/services/dynamic-collection-schema-service";
 import { FieldGroupSchemaService } from "../../services/field-group-schema-service";
 import { MIGRATION_TARGET } from "../manifest";
 import { runFieldGroupMigration } from "../run";
-import { resolveTypeColumns } from "../../storage/resolve-storage-names";
+import {
+  resolveRegistryNameFromCatalog,
+  resolveTypeColumns,
+} from "../../storage/resolve-storage-names";
 import { MIGRATION_LOCK_TABLE } from "../session";
 
 interface TestAdapter {
@@ -141,6 +146,30 @@ function systemTablesFor(dialect: SupportedDialect): Record<string, unknown> {
     ...versionsTables(dialect),
     ...webhookTables(dialect),
   };
+}
+
+/**
+ * The Drizzle handle behind a test adapter.
+ *
+ * `TestAdapter` is the narrow surface these cases drive; the handle is not part
+ * of it, so the narrowing is written once here rather than at each call.
+ */
+function drizzleOf(adapter: unknown): unknown {
+  return (adapter as { getDrizzle(): unknown }).getDrizzle();
+}
+
+/** The kinds of core operation that name a given table, for an exact assertion. */
+function namesRegistry(
+  ops: ReadonlyArray<{
+    type: string;
+    table?: { name: string };
+    tableName?: string;
+  }>,
+  table: string
+): string[] {
+  return ops
+    .filter(op => (op.table?.name ?? op.tableName) === table)
+    .map(op => op.type);
 }
 
 const logger = {
@@ -369,7 +398,7 @@ for (const entry of DIALECTS) {
      */
     async function columnsOf(table: string): Promise<string[]> {
       const snapshot = await introspectLiveSnapshot(
-        (adapter as unknown as { getDrizzle(): unknown }).getDrizzle(),
+        drizzleOf(adapter),
         entry.dialect,
         [table]
       );
@@ -586,6 +615,64 @@ for (const entry of DIALECTS) {
         expect(columns).toContain(MIGRATION_TARGET.columnType);
         expect(columns).not.toContain(STORAGE_FORMAT.columns.type);
       }
+    });
+
+    /**
+     * 🔴 The command an operator runs right after upgrading, on the exact
+     * database this migration just produced.
+     *
+     * The core schema is a DESIRED shape, so a registry name in it that the
+     * database does not have is an instruction to CREATE that table — and the
+     * reader rule is legacy-if-present, so an empty `dynamic_components` beside
+     * the populated `dynamic_field_groups` makes every field group unreachable
+     * with nothing raised anywhere.
+     *
+     * The whole core schema is not reconciled here because this fixture holds
+     * only the tables the migration touches; the invariant under test is
+     * narrower and exact: **no core operation may name either registry.** Not
+     * the legacy one, which must not be created, and not the migrated one,
+     * whose shape the rename left matching.
+     */
+    it("proposes no core-schema change for the registry after a run", async () => {
+      await migrate("up");
+
+      const options = {
+        fieldGroupRegistryTable: await resolveRegistryNameFromCatalog(
+          adapter as never
+        ),
+      };
+      expect(options.fieldGroupRegistryTable).toBe(
+        MIGRATION_TARGET.registryTable
+      );
+
+      const live = await introspectLiveSnapshot(
+        drizzleOf(adapter),
+        entry.dialect,
+        getCoreTableNames(options)
+      );
+      const ops = diffSnapshots(live, getCoreSchema(entry.dialect, options));
+
+      expect(namesRegistry(ops, STORAGE_FORMAT.registryTable)).toEqual([]);
+      expect(namesRegistry(ops, MIGRATION_TARGET.registryTable)).toEqual([]);
+    });
+
+    // The negative control for the case above, and the reason it is worth its
+    // own leg: run the same reconcile WITHOUT resolving, and it proposes
+    // creating the legacy registry on a database that has just been migrated.
+    // That is the defect, reproduced against a real database.
+    it("would create the legacy registry if the reconcile did not resolve", async () => {
+      await migrate("up");
+
+      const live = await introspectLiveSnapshot(
+        drizzleOf(adapter),
+        entry.dialect,
+        getCoreTableNames()
+      );
+      const ops = diffSnapshots(live, getCoreSchema(entry.dialect));
+
+      expect(namesRegistry(ops, STORAGE_FORMAT.registryTable)).toContain(
+        "add_table"
+      );
     });
 
     it("reports a second run as already migrated", async () => {


### PR DESCRIPTION
Adds the highest-value integration leg for the work #469 just landed: on a database the storage migration has **just produced**, the core reconcile must leave the field-group registry alone.

This is the command an operator runs right after upgrading. The core schema is a *desired* shape, so a registry name in it that the database does not have is an instruction to CREATE that table — and the reader rule is legacy-if-present, so an empty `dynamic_components` beside the populated `dynamic_field_groups` makes every field group unreachable with nothing raised anywhere.

## The two legs

**`proposes no core-schema change for the registry after a run`** — after `up`, resolve the registry from the catalog, then run exactly what `reconcileCore` runs (`getCoreTableNames(options)` → `introspectLiveSnapshot` → `diffSnapshots` against `getCoreSchema(dialect, options)`) and assert **no operation names either registry**. Not the legacy one, which must not be created; and not the migrated one, whose shape the rename left matching.

The whole core schema is deliberately not reconciled here — this fixture holds only the tables the migration touches, so `changed: false` would be the wrong assertion. The invariant under test is narrower and exact.

**`would create the legacy registry if the reconcile did not resolve`** — the negative control. The same reconcile without resolving proposes `add_table` for the legacy registry on a just-migrated database. That is the defect, reproduced against a real database, and it is what stops the first leg passing for an incidental reason.

## Verification

`pnpm build` clean · `pnpm check-types --force` 19/19 · `pnpm lint` exit 0 · unit **400 unique**, empty diff both ways.

Matrix on all three dialects: **14 passed** Postgres 17, **14 passed** MySQL, **7 passed** SQLite (the rest self-skip per dialect). Field-group integration overall: **38 passed** Postgres, **35 passed** MySQL.

Load-bearing: reverting `getCoreSchema` to ignore the resolved registry fails the first leg on both real-database dialects (2 failed / 12 passed, count unchanged) — and it fails on the assertion in its own title, not a borrowed one.

No changeset: this PR is tests only.
