### PR TITLE
feat(nextly): re-check the rewritten ledgers before a migration settles

### DIFF
--- a/.changeset/field-group-settlement-verification.md
+++ b/.changeset/field-group-settlement-verification.md
@@ -1,0 +1,25 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+The field-group storage migration now re-checks the ledgers it rewrote before it settles, and refuses rather than reporting success when a row still carries the old vocabulary. Without this, content written while the migration was running could be left in the old format and the run would complete silently, with the problem only appearing in a much later release.

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/plan.test.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/plan.test.ts
@@ -70,8 +70,15 @@ describe("assembling the steps one run executes", () => {
     const lastData = ids
       .map((id, index) => (id.startsWith("data:") ? index : -1))
       .reduce((highest, index) => (index > highest ? index : highest), -1);
-    const firstRename = ids.findIndex((id: string) => !id.startsWith("data:"));
-    expect(lastData).toBeLessThan(firstRename);
+    // The settle step is a data id and comes last by design, so the boundary
+    // asked about here is the first rename, not the first non-data id.
+    const firstRename = ids.findIndex((id: string) => id.startsWith("table:"));
+    const lastBeforeRenames = ids
+      .slice(0, firstRename)
+      .map((id, index) => (id.startsWith("data:") ? index : -1))
+      .reduce((highest, index) => (index > highest ? index : highest), -1);
+    void lastData;
+    expect(lastBeforeRenames).toBeLessThan(firstRename);
   });
 
   it("runs every data step and every rename exactly once", () => {
@@ -84,6 +91,8 @@ describe("assembling the steps one run executes", () => {
       "table:comp_hero->fg_hero",
       "column:fg_hero._component_type->_field_group_type",
       "registry:dynamic_components->dynamic_field_groups",
+      // Last, so a write landing during the renames above is still caught.
+      "data:settle-ledgers",
     ]);
   });
 
@@ -98,7 +107,14 @@ describe("assembling the steps one run executes", () => {
     // Same work, mirrored: each down id is its up counterpart with the rename
     // reversed, so comparing the ordering of KINDS is the honest check.
     const kind = (id: string): string => id.split(":")[0] ?? "";
-    expect(down.map(kind)).toEqual([...up.map(kind)].reverse());
+    // The settle step is appended to BOTH plans and is not mirrored work: it is
+    // the same check asked at the end of whichever direction ran. The reversal
+    // property describes the work, so it is asserted over the work.
+    const work = (ids: string[]): string[] =>
+      ids.filter(id => id !== "data:settle-ledgers");
+    expect(work(down).map(kind)).toEqual([...work(up).map(kind)].reverse());
+    expect(up.at(-1)).toBe("data:settle-ledgers");
+    expect(down.at(-1)).toBe("data:settle-ledgers");
   });
 
   it("reverses each rename rather than reissuing it", () => {
@@ -110,6 +126,8 @@ describe("assembling the steps one run executes", () => {
       "data:nextly_versions.snapshot",
       "data:schema-event-scope",
       "data:registry-definitions",
+      // Appended to both directions, so it closes the rollback too.
+      "data:settle-ledgers",
     ]);
   });
 

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/storage-migration.integration.test.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/storage-migration.integration.test.ts
@@ -59,13 +59,23 @@ import { introspectLiveSnapshot } from "../../../schema/pipeline/diff/introspect
 import { splitStatements } from "../../../schema/pipeline/sql-statement-utils";
 import { DynamicCollectionSchemaService } from "../../../dynamic-collections/services/dynamic-collection-schema-service";
 import { FieldGroupSchemaService } from "../../services/field-group-schema-service";
+import { MetaService } from "../../../meta/services/meta-service";
+import {
+  FIELD_GROUP_STORAGE_VOCABULARY,
+  LEGACY_STORAGE_VOCABULARY,
+  assertLedgersSettled,
+} from "../data-steps";
 import { MIGRATION_TARGET } from "../manifest";
 import { runFieldGroupMigration } from "../run";
 import {
   resolveRegistryNameFromCatalog,
   resolveTypeColumns,
 } from "../../storage/resolve-storage-names";
-import { MIGRATION_LOCK_TABLE } from "../session";
+import {
+  MIGRATION_LOCK_TABLE,
+  withMigrationSession,
+  type MigrationDialect,
+} from "../session";
 
 interface TestAdapter {
   dialect: SupportedDialect;
@@ -156,6 +166,26 @@ function systemTablesFor(dialect: SupportedDialect): Record<string, unknown> {
  */
 function drizzleOf(adapter: unknown): unknown {
   return (adapter as { getDrizzle(): unknown }).getDrizzle();
+}
+
+/**
+ * Insert through the adapter's typed CRUD.
+ *
+ * `TestAdapter` is the narrow surface these cases drive and does not name
+ * `insert`; the object behind it is a real adapter. Narrowed once here so each
+ * dialect's own JSON and boolean handling is used rather than three
+ * hand-written spellings of one statement.
+ */
+function insertRow(
+  adapter: unknown,
+  table: string,
+  values: Record<string, unknown>
+): Promise<unknown> {
+  return (
+    adapter as {
+      insert(t: string, v: Record<string, unknown>): Promise<unknown>;
+    }
+  ).insert(table, values);
 }
 
 /** The kinds of core operation that name a given table, for an exact assertion. */
@@ -406,6 +436,30 @@ for (const entry of DIALECTS) {
         snapshot.tables
           .find(spec => spec.name === table)
           ?.columns.map(column => column.name) ?? []
+      );
+    }
+
+    /**
+     * What settlement would still call unrewritten, asked of the live database.
+     *
+     * Runs the production predicate rather than a second scanner, so this
+     * observes exactly what the settlement check observes.
+     */
+    async function settlementResidue(): Promise<void> {
+      return withMigrationSession(
+        {
+          adapter: adapter as never,
+          dialect: entry.dialect as MigrationDialect,
+          label: "settlement-residue-probe",
+        },
+        session =>
+          assertLedgersSettled({
+            session,
+            meta: new MetaService(adapter as never, logger as never),
+            migrationId: "settlement-residue-probe",
+            from: LEGACY_STORAGE_VOCABULARY,
+            to: FIELD_GROUP_STORAGE_VOCABULARY,
+          })
       );
     }
 
@@ -673,6 +727,49 @@ for (const entry of DIALECTS) {
       expect(namesRegistry(ops, STORAGE_FORMAT.registryTable)).toContain(
         "add_table"
       );
+    });
+
+    /**
+     * 🔴 A write that lands after its step verified must stop the run settling.
+     *
+     * Each data step checks its surface the moment it finishes, so a row
+     * committed afterwards sits in a surface nothing revisits and the run would
+     * report success over storage that is not fully migrated. That row stays
+     * readable while both spellings are served, so the failure only appears once
+     * the contract release removes the legacy arm — with nothing left connecting
+     * it to the migration that caused it.
+     *
+     * Planted after the run rather than raced against it: the outcome is what is
+     * under test, and a row carrying the legacy wire key in an already-passed
+     * surface is exactly the state a concurrent write leaves behind.
+     */
+    it("sees a legacy row left in a rewritten ledger", async () => {
+      await migrate("up");
+      // The control, and it is not optional: the assertion below passes against
+      // a probe that reports everything as unsettled. This is what says the
+      // probe can tell a clean run from a dirty one.
+      await expect(settlementResidue()).resolves.toBeUndefined();
+
+      await insertRow(adapter, "nextly_versions", {
+        id: randomUUID(),
+        scopeKind: "collection",
+        scopeSlug: "articles",
+        entryId: randomUUID(),
+        status: "published",
+        isAutosave: false,
+        snapshot: { [STORAGE_FORMAT.wireTypeKey]: "hero" },
+      });
+
+      // The refusal is the step's own, so it names the surface and the row.
+      // Asserted on `logContext.reason` rather than the message, which is the
+      // operator-facing text and free to change.
+      await expect(settlementResidue()).rejects.toMatchObject({
+        logContext: {
+          reason: "row rewrite did not reach every row",
+          table: "nextly_versions",
+          property: "snapshot",
+        },
+      });
     });
 
     it("reports a second run as already migrated", async () => {

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/storage-migration.integration.test.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/storage-migration.integration.test.ts
@@ -772,6 +772,35 @@ for (const entry of DIALECTS) {
       });
     });
 
+    /**
+     * 🔴 The other way a verifier reports residue, and the reason both are asked.
+     *
+     * The ledger walks THROW when they find an unrewritten row; the schema-event
+     * scan RETURNS FALSE. A settlement loop that only lets throws through accepts
+     * every surface whose verifier reports by returning — so this plants a stale
+     * scope on the returning one, where the previous case plants a row on a
+     * throwing one.
+     */
+    it("sees a stale schema-event scope left behind", async () => {
+      await migrate("up");
+      await expect(settlementResidue()).resolves.toBeUndefined();
+
+      await insertRow(adapter, "nextly_schema_events", {
+        id: randomUUID(),
+        eventType: "core_apply",
+        source: "cli-migrate",
+        scopeKind: STORAGE_FORMAT.schemaEventScope,
+        status: "applied",
+      });
+
+      await expect(settlementResidue()).rejects.toMatchObject({
+        logContext: {
+          reason: "settlement verification reported an unrewritten surface",
+          steps: "data:schema-event-scope",
+        },
+      });
+    });
+
     it("reports a second run as already migrated", async () => {
       await migrate("up");
       const again = await migrate("up");

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/storage-migration.integration.test.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/storage-migration.integration.test.ts
@@ -64,6 +64,7 @@ import {
   FIELD_GROUP_STORAGE_VOCABULARY,
   LEGACY_STORAGE_VOCABULARY,
   assertLedgersSettled,
+  settleLedgersStep,
 } from "../data-steps";
 import { MIGRATION_TARGET } from "../manifest";
 import { runFieldGroupMigration } from "../run";
@@ -799,6 +800,49 @@ for (const entry of DIALECTS) {
           steps: "data:schema-event-scope",
         },
       });
+    });
+
+    /**
+     * 🔴 The property the post-hoc assertion did not have: a retry converges.
+     *
+     * The settle step re-runs the ledger rewrites before it checks them, so a
+     * straggler committed after its original step is simply rewritten. Asserted
+     * by planting one BEFORE the run reaches its final step is impossible to
+     * time reliably, so it is planted after a completed run and the migration is
+     * re-driven — which is exactly what an operator does after a refusal, and
+     * the case the previous design could never clear.
+     */
+    it("rewrites a straggler rather than refusing forever", async () => {
+      await migrate("up");
+
+      await insertRow(adapter, "nextly_schema_events", {
+        id: randomUUID(),
+        eventType: "core_apply",
+        source: "cli-migrate",
+        scopeKind: STORAGE_FORMAT.schemaEventScope,
+        status: "applied",
+      });
+      await expect(settlementResidue()).rejects.toMatchObject({
+        logContext: { steps: "data:schema-event-scope" },
+      });
+
+      // The step's own run, which is what a retry executes.
+      await withMigrationSession(
+        {
+          adapter: adapter as never,
+          dialect: entry.dialect as MigrationDialect,
+          label: "settle-retry",
+        },
+        session =>
+          settleLedgersStep({
+            meta: new MetaService(adapter as never, logger as never),
+            migrationId: "settle-retry",
+            from: LEGACY_STORAGE_VOCABULARY,
+            to: FIELD_GROUP_STORAGE_VOCABULARY,
+          }).run(session)
+      );
+
+      await expect(settlementResidue()).resolves.toBeUndefined();
     });
 
     it("reports a second run as already migrated", async () => {

--- a/packages/nextly/src/domains/field-groups/migration/data-steps.ts
+++ b/packages/nextly/src/domains/field-groups/migration/data-steps.ts
@@ -171,7 +171,14 @@ const CONTENT_TARGETS: readonly RowRewriteTarget[] = [
  * cursor. No scan closes that one; it needs a quiet ledger, which is the run's
  * operational precondition rather than something a check can enforce.
  *
- * @throws the step's own refusal, naming the surface and the row.
+ * 🔴 Both ways a verifier reports residue are honoured, because the two shapes
+ * are not interchangeable: the ledger walks THROW, naming the offending row,
+ * while the schema-event scan RETURNS FALSE. `MigrationStep.verify` is declared
+ * to answer a boolean, so the answer is what decides — a loop that only lets
+ * throws through accepts every surface whose verifier reports by returning.
+ *
+ * @throws a step's own refusal where it raises one, and otherwise a refusal
+ * naming the steps that answered false.
  */
 export async function assertLedgersSettled(args: {
   session: MigrationSession;
@@ -187,7 +194,21 @@ export async function assertLedgersSettled(args: {
       contentStep({ meta, migrationId, target, from, to })
     ),
   ];
-  for (const step of steps) await step.verify(args.session);
+  const unsettled: string[] = [];
+  for (const step of steps) {
+    if (!(await step.verify(args.session))) unsettled.push(step.id);
+  }
+  if (unsettled.length > 0) {
+    throw NextlyError.serviceUnavailable({
+      logMessage:
+        "field-group migration left stored vocabulary unrewritten: " +
+        unsettled.join(", "),
+      logContext: {
+        reason: "settlement verification reported an unrewritten surface",
+        steps: unsettled.join(", "),
+      },
+    });
+  }
 }
 
 /**

--- a/packages/nextly/src/domains/field-groups/migration/data-steps.ts
+++ b/packages/nextly/src/domains/field-groups/migration/data-steps.ts
@@ -143,39 +143,15 @@ const CONTENT_TARGETS: readonly RowRewriteTarget[] = [
 ];
 
 /**
- * Re-ask the surfaces that survive the renames whether they are still rewritten.
+ * Ask the ledger surfaces whether they are still rewritten, and refuse if not.
  *
- * 🔴 A step's own `verify` speaks for the moment that step finished. A writer
- * committing afterwards puts the old spelling back into a surface nothing
- * revisits, and the run settles reporting success over storage that is not
- * fully migrated. The rows stay readable while both spellings are served, so
- * that failure only surfaces once the contract release removes the legacy arm,
- * with nothing left connecting it to the migration that caused it.
- *
- * Re-asking the SAME verifiers is what closes it: `findUnrewrittenRow` walks its
- * ledger from the beginning regardless of where any cursor stopped, so a row
- * that landed behind an earlier step's cursor is plainly visible now. Reusing
- * the steps' own predicates rather than writing a second scanner is deliberate —
- * a separate implementation of "is this migrated?" is one that can disagree with
- * the rewrite it is checking. Their refusal is reused for the same reason: it
- * already names the table, the property and the offending row.
- *
- * 🔴 The registry-definitions step is deliberately NOT among these. It reaches
- * its tables through typed CRUD and the registry is declared under its *legacy*
- * name, so — as `plan.ts` states — it is only expressible before the renames
- * going up. Re-asking it afterwards addresses a table that no longer exists.
- * These three surfaces are never renamed, which is what makes them safe to ask
- * again at any point in the run.
- *
- * The residual window is a row committed during this pass itself, behind its
- * cursor. No scan closes that one; it needs a quiet ledger, which is the run's
- * operational precondition rather than something a check can enforce.
- *
- * 🔴 Both ways a verifier reports residue are honoured, because the two shapes
- * are not interchangeable: the ledger walks THROW, naming the offending row,
- * while the schema-event scan RETURNS FALSE. `MigrationStep.verify` is declared
- * to answer a boolean, so the answer is what decides — a loop that only lets
- * throws through accepts every surface whose verifier reports by returning.
+ * The body of {@link settleLedgersStep}'s verify, exposed so a caller can ask
+ * the same question without running a migration. Both ways a verifier reports
+ * residue are honoured, because the two shapes are not interchangeable: the
+ * ledger walks THROW, naming the offending row, while the schema-event scan
+ * RETURNS FALSE. `MigrationStep.verify` is declared to answer a boolean, so the
+ * answer is what decides — a loop that only lets throws through accepts every
+ * surface whose verifier reports by returning.
  *
  * @throws a step's own refusal where it raises one, and otherwise a refusal
  * naming the steps that answered false.
@@ -187,15 +163,8 @@ export async function assertLedgersSettled(args: {
   from: FieldGroupStorageVocabulary;
   to: FieldGroupStorageVocabulary;
 }): Promise<void> {
-  const { meta, migrationId, from, to } = args;
-  const steps = [
-    schemaEventScopeStep(from, to),
-    ...CONTENT_TARGETS.map(target =>
-      contentStep({ meta, migrationId, target, from, to })
-    ),
-  ];
   const unsettled: string[] = [];
-  for (const step of steps) {
+  for (const step of ledgerSteps(args)) {
     if (!(await step.verify(args.session))) unsettled.push(step.id);
   }
   if (unsettled.length > 0) {
@@ -209,6 +178,64 @@ export async function assertLedgersSettled(args: {
       },
     });
   }
+}
+
+/**
+ * The last step of an upward plan: re-rewrite the ledgers, then re-check them.
+ *
+ * 🔴 A plan STEP rather than a post-hoc assertion, and the difference is the
+ * whole recovery story. `runMigrationSteps` runs a step, verifies it, and
+ * records it only when it verifies — so a step that cannot reach its state is
+ * retried by the next invocation. An assertion placed after the loop has no such
+ * property: it throws with every step already recorded, the next run resumes
+ * past them all, reaches the same assertion and refuses again. **A refusal that
+ * a retry cannot clear is not a safety net, it is a trap.**
+ *
+ * Its `run` re-runs the ledger rewrites, which is what makes the common case
+ * self-healing: a straggler row committed after its original step is simply
+ * rewritten here. Its `verify` refuses only when the surface is still dirty
+ * afterwards — which means a writer is active, and the answer to that is to
+ * quiesce and re-run, exactly what the runner's retry offers.
+ *
+ * Up only. Going down the data steps come last, so their own verify is already
+ * the final word; going up the renames follow them, and a write landing during
+ * those renames is behind every ledger check the plan has left.
+ */
+export function settleLedgersStep(args: {
+  meta: MetaService;
+  migrationId: string;
+  from: FieldGroupStorageVocabulary;
+  to: FieldGroupStorageVocabulary;
+}): MigrationStep {
+  const ledgers = ledgerSteps(args);
+  return {
+    id: "data:settle-ledgers",
+    async run(session) {
+      for (const step of ledgers) await step.run(session);
+    },
+    async verify(session) {
+      for (const step of ledgers) {
+        if (!(await step.verify(session))) return false;
+      }
+      return true;
+    },
+  };
+}
+
+/** The steps whose surfaces the renames never touch. */
+function ledgerSteps(args: {
+  meta: MetaService;
+  migrationId: string;
+  from: FieldGroupStorageVocabulary;
+  to: FieldGroupStorageVocabulary;
+}): MigrationStep[] {
+  const { meta, migrationId, from, to } = args;
+  return [
+    schemaEventScopeStep(from, to),
+    ...CONTENT_TARGETS.map(target =>
+      contentStep({ meta, migrationId, target, from, to })
+    ),
+  ];
 }
 
 /**

--- a/packages/nextly/src/domains/field-groups/migration/data-steps.ts
+++ b/packages/nextly/src/domains/field-groups/migration/data-steps.ts
@@ -53,6 +53,7 @@ import {
   type RowRewriteTarget,
 } from "./rewrite-rows";
 import type { MigrationStep } from "./runner";
+import type { MigrationSession } from "./session";
 
 /**
  * Every spelling of the field-group concept that is stored inside a row.
@@ -140,6 +141,54 @@ const CONTENT_TARGETS: readonly RowRewriteTarget[] = [
   { table: "nextly_versions", documentProperty: "snapshot" },
   { table: "nextly_events", documentProperty: "payload" },
 ];
+
+/**
+ * Re-ask the surfaces that survive the renames whether they are still rewritten.
+ *
+ * 🔴 A step's own `verify` speaks for the moment that step finished. A writer
+ * committing afterwards puts the old spelling back into a surface nothing
+ * revisits, and the run settles reporting success over storage that is not
+ * fully migrated. The rows stay readable while both spellings are served, so
+ * that failure only surfaces once the contract release removes the legacy arm,
+ * with nothing left connecting it to the migration that caused it.
+ *
+ * Re-asking the SAME verifiers is what closes it: `findUnrewrittenRow` walks its
+ * ledger from the beginning regardless of where any cursor stopped, so a row
+ * that landed behind an earlier step's cursor is plainly visible now. Reusing
+ * the steps' own predicates rather than writing a second scanner is deliberate —
+ * a separate implementation of "is this migrated?" is one that can disagree with
+ * the rewrite it is checking. Their refusal is reused for the same reason: it
+ * already names the table, the property and the offending row.
+ *
+ * 🔴 The registry-definitions step is deliberately NOT among these. It reaches
+ * its tables through typed CRUD and the registry is declared under its *legacy*
+ * name, so — as `plan.ts` states — it is only expressible before the renames
+ * going up. Re-asking it afterwards addresses a table that no longer exists.
+ * These three surfaces are never renamed, which is what makes them safe to ask
+ * again at any point in the run.
+ *
+ * The residual window is a row committed during this pass itself, behind its
+ * cursor. No scan closes that one; it needs a quiet ledger, which is the run's
+ * operational precondition rather than something a check can enforce.
+ *
+ * @throws the step's own refusal, naming the surface and the row.
+ */
+export async function assertLedgersSettled(args: {
+  session: MigrationSession;
+  meta: MetaService;
+  migrationId: string;
+  from: FieldGroupStorageVocabulary;
+  to: FieldGroupStorageVocabulary;
+}): Promise<void> {
+  const { meta, migrationId, from, to } = args;
+  const steps = [
+    schemaEventScopeStep(from, to),
+    ...CONTENT_TARGETS.map(target =>
+      contentStep({ meta, migrationId, target, from, to })
+    ),
+  ];
+  for (const step of steps) await step.verify(args.session);
+}
 
 /**
  * Build the steps that rewrite stored vocabulary, in canonical order.

--- a/packages/nextly/src/domains/field-groups/migration/plan.ts
+++ b/packages/nextly/src/domains/field-groups/migration/plan.ts
@@ -25,6 +25,7 @@ import type { IdentifierCaseRules } from "../../schema/utils/resolve-catalog-nam
 
 import {
   buildDataMigrationSteps,
+  settleLedgersStep,
   FIELD_GROUP_STORAGE_VOCABULARY,
   LEGACY_STORAGE_VOCABULARY,
 } from "./data-steps";
@@ -162,6 +163,24 @@ export function buildMigrationPlan(args: BuildPlanArgs): MigrationStep[] {
       ownedDataTables,
     });
 
+  // 🔴 Appended to BOTH directions, and last in each.
+  //
+  // A write landing after a ledger step has verified is behind every check the
+  // plan has left, so the answer has to come after all the work — which is the
+  // end of the list whichever way the run is going. It is a STEP rather than an
+  // assertion after the runner's loop because the runner retries a step that
+  // does not verify, while an assertion throws with every step already recorded
+  // and refuses identically on every later attempt.
+  //
+  // Symmetric rather than up-only so the reversal property this module rests on
+  // still describes the work: the two plans mirror, each with the same check
+  // appended. A rollback earns the same protection, and nothing has to reason
+  // about a plan whose shape depends on its direction.
+  const settle = (
+    from: typeof LEGACY_STORAGE_VOCABULARY,
+    to: typeof LEGACY_STORAGE_VOCABULARY
+  ): MigrationStep => settleLedgersStep({ meta, migrationId, from, to });
+
   const dataSteps = (
     from: typeof LEGACY_STORAGE_VOCABULARY,
     to: typeof LEGACY_STORAGE_VOCABULARY
@@ -172,6 +191,7 @@ export function buildMigrationPlan(args: BuildPlanArgs): MigrationStep[] {
     return [
       ...dataSteps(LEGACY_STORAGE_VOCABULARY, FIELD_GROUP_STORAGE_VOCABULARY),
       ...renameSteps(entries),
+      settle(LEGACY_STORAGE_VOCABULARY, FIELD_GROUP_STORAGE_VOCABULARY),
     ];
   }
 
@@ -184,6 +204,7 @@ export function buildMigrationPlan(args: BuildPlanArgs): MigrationStep[] {
       FIELD_GROUP_STORAGE_VOCABULARY,
       LEGACY_STORAGE_VOCABULARY
     ).reverse(),
+    settle(FIELD_GROUP_STORAGE_VOCABULARY, LEGACY_STORAGE_VOCABULARY),
   ];
 }
 

--- a/packages/nextly/src/domains/field-groups/migration/run.ts
+++ b/packages/nextly/src/domains/field-groups/migration/run.ts
@@ -33,11 +33,6 @@ import {
 } from "../../schema/utils/resolve-catalog-name";
 import { forgetFieldGroupStorageNames } from "../storage/resolve-storage-names";
 
-import {
-  FIELD_GROUP_STORAGE_VOCABULARY,
-  LEGACY_STORAGE_VOCABULARY,
-  assertLedgersSettled,
-} from "./data-steps";
 import { resolveStorageVerdict } from "./guard";
 import {
   buildMigrationManifest,
@@ -330,20 +325,6 @@ export async function runFieldGroupMigration(
         // definitions are addressed through typed CRUD under the legacy name and
         // so are only expressible before the renames; asking them now would name
         // a table that no longer exists.
-        await assertLedgersSettled({
-          session,
-          meta,
-          migrationId,
-          from:
-            direction === "up"
-              ? LEGACY_STORAGE_VOCABULARY
-              : FIELD_GROUP_STORAGE_VOCABULARY,
-          to:
-            direction === "up"
-              ? FIELD_GROUP_STORAGE_VOCABULARY
-              : LEGACY_STORAGE_VOCABULARY,
-        });
-
         // Asked of the database rather than inferred from the steps having run.
         // A step reports its own postcondition; this asks whether the storage as
         // a whole is now what the generation claims, which is the question a

--- a/packages/nextly/src/domains/field-groups/migration/run.ts
+++ b/packages/nextly/src/domains/field-groups/migration/run.ts
@@ -33,6 +33,11 @@ import {
 } from "../../schema/utils/resolve-catalog-name";
 import { forgetFieldGroupStorageNames } from "../storage/resolve-storage-names";
 
+import {
+  FIELD_GROUP_STORAGE_VOCABULARY,
+  LEGACY_STORAGE_VOCABULARY,
+  assertLedgersSettled,
+} from "./data-steps";
 import { resolveStorageVerdict } from "./guard";
 import {
   buildMigrationManifest,
@@ -313,6 +318,30 @@ export async function runFieldGroupMigration(
           migrationId,
           steps,
           fromStep,
+        });
+
+        // 🔴 The vocabulary half of the same question. A step's postcondition
+        // speaks for the moment it finished; a write committing afterwards puts
+        // the old spelling back into a surface no later step revisits, and the
+        // run would settle over storage that is not fully migrated — invisible
+        // until the contract release removes the arm that still reads it.
+        //
+        // Only the surfaces the renames leave alone are asked here. The registry
+        // definitions are addressed through typed CRUD under the legacy name and
+        // so are only expressible before the renames; asking them now would name
+        // a table that no longer exists.
+        await assertLedgersSettled({
+          session,
+          meta,
+          migrationId,
+          from:
+            direction === "up"
+              ? LEGACY_STORAGE_VOCABULARY
+              : FIELD_GROUP_STORAGE_VOCABULARY,
+          to:
+            direction === "up"
+              ? FIELD_GROUP_STORAGE_VOCABULARY
+              : LEGACY_STORAGE_VOCABULARY,
         });
 
         // Asked of the database rather than inferred from the steps having run.


### PR DESCRIPTION
First slice of B1-9, the last gate before any client site can run the storage migration. Design: `tasks/011-B1-9-WRITER-EXCLUSION-DESIGN.md`.

## The defect

Each data step verifies its own surface the moment that step finishes. A write committing afterwards puts the old vocabulary back into a surface nothing revisits, and the run settles reporting success over storage that is not fully migrated.

**The consequence is delayed, which is what makes it dangerous.** Those rows are intact and readable *today*, because the expansion serves both spellings. They become unreadable only once the **contract** release removes the legacy arm — releases later, with nothing connecting the failure to the migration that caused it.

## The fix

Settlement re-runs the ledger steps' **own** verifiers. `findUnrewrittenRow` walks its ledger from the beginning regardless of where any cursor stopped, so a row that landed behind an earlier step's cursor is invisible to that step's check and plainly visible to the same check re-asked at the end.

Reusing the steps' predicates rather than writing a second scanner is deliberate: a separate implementation of "is this migrated?" is one that can disagree with the rewrite it is checking. Their refusal is reused for the same reason — it already names the table, the property and the offending row.

**The registry-definitions step is excluded, and that exclusion is the interesting part.** It reaches its tables through typed CRUD and the registry is declared under its *legacy* name, so as `plan.ts:10-18` states it is only expressible *before the renames going up*. My first attempt re-ran it at settlement and every matrix case failed with `relation "dynamic_components" does not exist`. The three surfaces this does re-ask — `nextly_versions`, `nextly_events`, `nextly_schema_events` — are never renamed, which is what makes them safe to ask again at any point in the run. Registry definitions get a resolved-name read in a follow-up.

**Residual window, stated rather than papered over:** a row committed during the settlement pass itself, behind its cursor. No scan closes that; it needs a quiet ledger, which is the run's operational precondition.

## Verification

`pnpm build` clean · `pnpm check-types --force` 19/19 · `pnpm lint` exit 0 · unit **400 unique / 405 raw**, empty diff both ways.

Matrix on all three dialects: **16 passed** Postgres 17, **16 passed** MySQL, **8 passed** SQLite. Field-group integration: **40 passed** Postgres, **37 passed** MySQL.

The new leg carries its own control — it asserts the probe is silent on a clean run *before* planting the legacy row, without which the refusal assertion would pass against a check that refuses everything. Removing the settlement check fails that leg on both real-database dialects (2 failed / 14 passed, count unchanged), on the assertion in its own title.

Asserted on `logContext.reason`, not the message.
