### PR TITLE
fix(nextly): give sqlite's system timestamps a database default

### DIFF
--- a/.changeset/sqlite-system-timestamp-defaults.md
+++ b/.changeset/sqlite-system-timestamp-defaults.md
@@ -1,0 +1,29 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+On SQLite, the `createdAt` and `updatedAt` columns of collection and single tables now carry a database default, matching PostgreSQL and MySQL and matching what the Schema Builder has always created.
+
+Nextly sets both on every write, so content created through the admin panel or the API is unaffected. The difference shows up for rows written another way, such as a direct insert or a data import: on SQLite those stored no timestamp at all, and the value read back as null.
+
+Existing SQLite tables pick the default up on the next schema sync, which rebuilds the affected tables in place and preserves their rows. Rows that already hold a null timestamp keep it, because a default applies only to inserts that omit the column.

--- a/packages/nextly/src/domains/schema/pipeline/__tests__/preview.test.ts
+++ b/packages/nextly/src/domains/schema/pipeline/__tests__/preview.test.ts
@@ -44,8 +44,22 @@ describe("previewDesiredSchema", () => {
     { name: "id", type: "text", nullable: false },
     { name: "title", type: "text", nullable: false },
     { name: "slug", type: "text", nullable: false },
-    { name: "created_at", type: "integer", nullable: true },
-    { name: "updated_at", type: "integer", nullable: true },
+    // Nullable, with a default. The default is what makes an omitted INSERT work; NOT NULL is
+    // deliberately NOT applied, because tightening a column on a table a user already has is not
+    // an additive upgrade — see `upgrade-sim-045`, which fails any non-additive statement against
+    // a pre-existing table.
+    {
+      name: "created_at",
+      type: "integer",
+      nullable: true,
+      default: "(strftime('%s', 'now'))",
+    },
+    {
+      name: "updated_at",
+      type: "integer",
+      nullable: true,
+      default: "(strftime('%s', 'now'))",
+    },
     { name: "created_by", type: "text", nullable: true },
   ];
 

--- a/packages/nextly/src/domains/schema/services/__tests__/system-timestamp-defaults.integration.test.ts
+++ b/packages/nextly/src/domains/schema/services/__tests__/system-timestamp-defaults.integration.test.ts
@@ -1,0 +1,60 @@
+/**
+ * `created_at` and `updated_at` get their value from the database, on every dialect.
+ *
+ * Nextly's own write path sets both, so nothing reaching the database through the API depends on
+ * this. What does depend on it is everything that does NOT go through that path: a direct insert, a
+ * data import, a migration backfilling rows. On PostgreSQL and MySQL those got a time; on SQLite
+ * the column had no default and they got NULL, and a NULL timestamp is indistinguishable from the
+ * "never set" the reader treats as missing.
+ *
+ * Asserted through a real insert rather than by reading the descriptor back: the descriptor is one
+ * of three descriptions of this column set, and agreeing with itself is what it already did while
+ * the physical table disagreed.
+ */
+import { afterEach, describe, expect, it } from "vitest";
+
+import { defineCollection, text } from "../../../../config";
+import {
+  createTestNextly,
+  getConfiguredTestDialects,
+  type TestNextly,
+} from "../../../../plugins/test-nextly";
+
+let current: TestNextly | undefined;
+
+afterEach(async () => {
+  await current?.destroy();
+  current = undefined;
+});
+
+describe.each(getConfiguredTestDialects())(
+  "system timestamp defaults (%s)",
+  dialect => {
+    it("fills both timestamps for an insert that omits them", async () => {
+      current = await createTestNextly({
+        dialect,
+        collections: [
+          defineCollection({
+            slug: "posts",
+            fields: [text({ name: "title" })],
+          }),
+        ],
+      });
+
+      // Straight at the table, carrying only the columns a caller must supply. Going through
+      // `createEntry` would stamp both itself and prove nothing about the column.
+      await current.adapter.insert("dc_posts", {
+        id: "row-1",
+        title: "t",
+        slug: "t",
+      });
+
+      const rows =
+        await current.adapter.select<Record<string, unknown>>("dc_posts");
+      const row = rows.find(r => r.id === "row-1") ?? {};
+
+      expect(row.created_at).toBeTruthy();
+      expect(row.updated_at).toBeTruthy();
+    });
+  }
+);

--- a/packages/nextly/src/domains/schema/services/field-column-descriptor.ts
+++ b/packages/nextly/src/domains/schema/services/field-column-descriptor.ts
@@ -541,17 +541,23 @@ export function getSystemColumnDescriptors(
         primaryKey: false,
       });
     }
+    // SQLite was the one dialect whose timestamps had no default, so an insert that omitted
+    // them stored NULL where PostgreSQL and MySQL stored a time. The Schema Builder has always
+    // emitted this exact expression for SQLite; the runtime side was the half that lacked it,
+    // which is also why the two disagreed about the same table.
     cols.push({
       name: "created_at",
       dialectType: "integer",
       nullable: true,
       primaryKey: false,
+      default: "(strftime('%s', 'now'))",
     });
     cols.push({
       name: "updated_at",
       dialectType: "integer",
       nullable: true,
       primaryKey: false,
+      default: "(strftime('%s', 'now'))",
     });
     // Owner of the row (creating user's id). Collections only (never singles).
     // Nullable; mirrors runtime-schema-generator's sqliteText("created_by")

--- a/packages/nextly/src/domains/schema/services/runtime-schema-generator.ts
+++ b/packages/nextly/src/domains/schema/services/runtime-schema-generator.ts
@@ -13,6 +13,7 @@
  * @module services/schema/runtime-schema-generator
  */
 
+import { sql } from "drizzle-orm";
 import {
   mysqlTable,
   text as mysqlText,
@@ -305,7 +306,12 @@ function buildDrizzleColumnRecord(
  * created_at / updated_at) into the appropriate Drizzle column
  * builder for the given dialect. Mirrors the legacy hardcoded
  * builders byte-for-byte: id is primaryKey, title/slug are
- * notNull, timestamps default to defaultNow on PG/MySQL.
+ * notNull, timestamps carry a database-side default on every dialect.
+ *
+ * The timestamps stay nullable, but a row reaching the database without them does not: the
+ * default supplies a value for any insert that omits the column, which is what an insert
+ * bypassing the write path does. Nullable and defaulted are independent choices, and only
+ * the default can be added to a table a user already has without rewriting its rows.
  */
 function buildSystemDrizzleColumn(
   sys: ReturnType<typeof getSystemColumnDescriptors>[number],
@@ -351,10 +357,14 @@ function buildSystemDrizzleColumn(
   // sqlite
   if (sys.name === "id") return sqliteText("id").primaryKey();
   if (sys.name === "created_at") {
-    return sqliteInteger("created_at", { mode: "timestamp" });
+    return sqliteInteger("created_at", { mode: "timestamp" }).default(
+      sql`(strftime('%s', 'now'))`
+    );
   }
   if (sys.name === "updated_at") {
-    return sqliteInteger("updated_at", { mode: "timestamp" });
+    return sqliteInteger("updated_at", { mode: "timestamp" }).default(
+      sql`(strftime('%s', 'now'))`
+    );
   }
   if (sys.name === "status") {
     // SQLite has no varchar — text with default 'draft' is the equivalent.


### PR DESCRIPTION
## What

On SQLite, `created_at` and `updated_at` now carry a database default, matching PostgreSQL and MySQL and matching what the Schema Builder has always created.

## Why

The system-column set is described in three places, and they disagree. This is the SQLite half of that divergence (task 103 step 2):

| dialect | descriptor | Drizzle builder | Schema Builder DDL |
|---|---|---|---|
| pg | `now()` | `.defaultNow()` | `DEFAULT now()` |
| mysql | `CURRENT_TIMESTAMP` (fixed in #468) | `.defaultNow()` | `DEFAULT CURRENT_TIMESTAMP` |
| sqlite | **none** | **none** | `DEFAULT (strftime('%s','now'))` |

So a Builder-created SQLite table had a default that a code-first one did not. Nextly's own write path sets both columns, so nothing reaching the database through the API depended on this. What did depend on it is everything that does not go through that path: a direct insert, a data import, a migration backfilling rows. On SQLite those stored NULL, and a NULL timestamp is indistinguishable from the "never set" the reader treats as missing.

## The columns stay nullable

An earlier version of this branch also made them `NOT NULL`. That is reverted, and deliberately so.

`upgrade-sim-045` enforces that an existing user's upgrade emits only additive statements against tables they already have. `SET NOT NULL` is not additive, and it fails outright against any row holding a NULL, which is a hard stop on someone's production database mid-upgrade. The first attempt also failed 37/32/31 tests across the three legs, every one a SQLite `NOT NULL constraint failed: created_at` — because NOT NULL without a default breaks exactly the inserts that omit the column.

Adding a default is additive-safe; requiring a value is not. This PR does the first only.

## Verification

`system-timestamp-defaults.integration.test.ts` inserts straight at the table with only the columns a caller must supply, on every configured dialect, and asserts both timestamps come back set. Going through `createEntry` would stamp them itself and prove nothing about the column.

Falsified: with the default removed from the SQLite branch of `buildSystemDrizzleColumn`, the test fails with `created_at: null`. The falsification asserts its target pattern exists before editing, so a no-op edit cannot fake it.

Existing SQLite tables converge: `upgrade-sim-045` does one data-preserving rebuild and then diffs to silence, which is what proves the default round-trips rather than being re-proposed forever.

Integration legs, freshly recreated databases:

| leg | result |
|---|---|
| sqlite | 956 passed, 0 failed |
| postgres17 | 1095 passed, 0 failed |
| mysql | 1031 passed, 0 failed |
