### PR TITLE
feat(nextly): re-check the registries before a migration settles

### DIFF
--- a/.changeset/wise-pugs-repeat.md
+++ b/.changeset/wise-pugs-repeat.md
@@ -1,0 +1,25 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+The field-group storage migration now re-checks the collection, single and field-group registries before it settles, so a definition saved while a run is in flight can no longer leave a database reporting success over storage that is only partly migrated.

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/data-steps.test.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/data-steps.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import { STORAGE_FORMAT } from "../../../../schemas/storage-format";
 import {
   buildDataMigrationSteps,
+  settleRegistryDefinitionsStep,
   FIELD_GROUP_STORAGE_VOCABULARY,
   LEGACY_STORAGE_VOCABULARY,
 } from "../data-steps";
@@ -247,6 +248,111 @@ describe("rewriting the vocabulary stored in registry rows", () => {
     await expect(
       stepNamed(renamed, "data:registry-definitions").run(renamed.session)
     ).rejects.toThrow(/not found in schema registry/);
+  });
+});
+
+describe("re-checking the registries once the renames have run", () => {
+  /** A world as it stands after an upward run has renamed the registry. */
+  function migrated() {
+    return createTableWorld({
+      dynamic_collections: registry([
+        { id: "c1", fields: storedFields(), configPath: "collections/post.ts" },
+      ]),
+      dynamic_singles: registry([
+        { id: "s1", fields: storedFields(), configPath: "singles/home.ts" },
+      ]),
+      [MIGRATION_TARGET.registryTable]: registry([
+        { id: "f1", fields: storedFields(), configPath: "components/hero.ts" },
+      ]),
+    });
+  }
+
+  function settleStep(registryTable: string): MigrationStep {
+    return settleRegistryDefinitionsStep({
+      from: LEGACY_STORAGE_VOCABULARY,
+      to: FIELD_GROUP_STORAGE_VOCABULARY,
+      resolveRegistryTable: async () => registryTable,
+    });
+  }
+
+  // 🔴 The whole point of the step. Going up it runs AFTER the registry rename,
+  // so the name the plan was assembled with is gone. The data step refuses in
+  // this exact world — the test directly above proves it — and this one must
+  // not, which is what makes the resolver load-bearing rather than decorative.
+  it("rewrites a registry that exists only under its migrated name", async () => {
+    const target = migrated();
+    const step = settleStep(MIGRATION_TARGET.registryTable);
+
+    await expect(step.verify(target.session)).resolves.toBe(false);
+    await step.run(target.session);
+    await expect(step.verify(target.session)).resolves.toBe(true);
+
+    expect(target.rows(MIGRATION_TARGET.registryTable)[0]?.fields).toEqual([
+      { name: "blocks", type: "fieldGroup", fieldGroups: ["hero", "cta"] },
+      { name: "seo", type: "fieldGroup", fieldGroup: "seo" },
+      { name: "title", type: "text" },
+    ]);
+  });
+
+  // 🔴 `config_path` is rewritten only for the field-group registry, and that
+  // gate is a comparison against a table name. Under the migrated spelling a
+  // comparison against the legacy name alone is false, so the path would stop
+  // being rewritten at precisely the moment this check exists to cover. Nothing
+  // else in this suite reads the path under the migrated name.
+  it("rewrites the config path under the migrated name too", async () => {
+    const target = migrated();
+    await settleStep(MIGRATION_TARGET.registryTable).run(target.session);
+    expect(target.rows(MIGRATION_TARGET.registryTable)[0]?.configPath).toBe(
+      "field-groups/hero.ts"
+    );
+  });
+
+  // The collection and single registries are never renamed and their services
+  // keep writing while a run is in flight, so a definition landing after the
+  // data step verified sits in a surface no later step revisits.
+  it("sees a legacy definition written into an un-renamed registry", async () => {
+    const target = migrated();
+    const step = settleStep(MIGRATION_TARGET.registryTable);
+    await step.run(target.session);
+    await expect(step.verify(target.session)).resolves.toBe(true);
+
+    target.insert("dynamic_collections", {
+      id: "c2",
+      fields: storedFields(),
+      configPath: "collections/late.ts",
+    });
+
+    await expect(step.verify(target.session)).resolves.toBe(false);
+  });
+
+  // Resolved per call rather than once, so a retry after storage moved again
+  // addresses what is there now instead of what was there when it was built.
+  it("asks which registry to address on every call", async () => {
+    const target = migrated();
+    let asked = 0;
+    const step = settleRegistryDefinitionsStep({
+      from: LEGACY_STORAGE_VOCABULARY,
+      to: FIELD_GROUP_STORAGE_VOCABULARY,
+      resolveRegistryTable: async () => {
+        asked += 1;
+        return MIGRATION_TARGET.registryTable;
+      },
+    });
+
+    await step.run(target.session);
+    await step.verify(target.session);
+    expect(asked).toBe(2);
+  });
+
+  // The control. A run whose registries are already right settles rather than
+  // refusing, without which every assertion above passes for a step that simply
+  // always reports work outstanding.
+  it("settles a run whose registries are already rewritten", async () => {
+    const target = migrated();
+    const step = settleStep(MIGRATION_TARGET.registryTable);
+    await step.run(target.session);
+    await step.run(target.session);
+    await expect(step.verify(target.session)).resolves.toBe(true);
   });
 });
 

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/plan.test.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/plan.test.ts
@@ -7,8 +7,6 @@ import {
   directedRenameEntries,
   renamePositionOffset,
   renameRunRecord,
-  resumePosition,
-  SETTLE_STEP_COUNT,
 } from "../plan";
 import type { ManifestEntry } from "../manifest";
 import type { MigrationSession } from "../session";
@@ -48,7 +46,7 @@ const meta = {} as unknown as MetaService;
  * build. The builder no longer inverts internally, because the caller has to
  * reconcile the directed entries against the catalog before executing them.
  */
-function plan(direction: "up" | "down"): string[] {
+function planSteps(direction: "up" | "down") {
   return buildMigrationPlan({
     direction,
     ownedDataTables: [],
@@ -58,7 +56,11 @@ function plan(direction: "up" | "down"): string[] {
     meta,
     migrationId: "run-1",
     resolveRegistryTable: async () => "dynamic_field_groups",
-  }).map(step => step.id);
+  });
+}
+
+function plan(direction: "up" | "down"): string[] {
+  return planSteps(direction).map(step => step.id);
 }
 
 describe("assembling the steps one run executes", () => {
@@ -115,10 +117,6 @@ describe("assembling the steps one run executes", () => {
     // they are the same checks asked at the end of whichever direction ran. The
     // reversal property describes the work, so it is asserted over the work.
     const SETTLE = ["data:settle-ledgers", "data:settle-registry-definitions"];
-    // The clamp that keeps a resume from stepping over these counts them, so a
-    // check added without updating that count fails here rather than letting a
-    // resume settle without asking.
-    expect(SETTLE).toHaveLength(SETTLE_STEP_COUNT);
     const work = (ids: string[]): string[] =>
       ids.filter(id => !SETTLE.includes(id));
     expect(work(down).map(kind)).toEqual([...work(up).map(kind)].reverse());
@@ -257,57 +255,39 @@ describe("assembling the steps one run executes", () => {
   });
 });
 
-describe("where a resume re-enters the plan", () => {
-  // A plan of ten steps ends with the two settlement checks at positions 9 and
-  // 10, so nine is the earliest position a resume may ever start from.
-  const TEN = { planLength: 10 };
+describe("which steps a marker remembers", () => {
+  const settleSteps = () =>
+    planSteps("up").filter(step => step.id.startsWith("data:settle-"));
+  const workSteps = () =>
+    planSteps("up").filter(step => !step.id.startsWith("data:settle-"));
 
-  it("resumes at the step after the one recorded", () => {
-    expect(resumePosition({ recorded: 3, ...TEN })).toBe(4);
+  // 🔴 The settlement checks are gates, not work. A recorded position is what
+  // lets a later run step over something, so recording these would let the very
+  // resume they exist to protect skip them and settle on whatever the database
+  // looked like before the interruption.
+  it("declines to record the settlement checks", () => {
+    const settle = settleSteps();
+    expect(settle).toHaveLength(2);
+    expect(settle.every(step => step.recordsProgress === false)).toBe(true);
   });
 
-  it("starts at the beginning when nothing was recorded", () => {
-    expect(resumePosition({ recorded: 0, ...TEN })).toBe(1);
+  // The control: everything else does record, so the assertion above cannot be
+  // satisfied by a plan whose every step declines.
+  it("records every step that is actual work", () => {
+    const work = workSteps();
+    expect(work).not.toHaveLength(0);
+    expect(work.every(step => step.recordsProgress !== false)).toBe(true);
   });
 
-  // 🔴 The case the clamp exists for. The runner records a step once it has
-  // verified, so a crash between the final record and the marker write would
-  // otherwise resume at position 11, execute nothing at all, and settle on
-  // structural evidence alone - leaving the entire crash-to-restart interval,
-  // during which writers are active and the migration is not, unexamined.
-  it("re-enters the settlement checks even when every step was recorded", () => {
-    expect(resumePosition({ recorded: 10, ...TEN })).toBe(9);
-  });
-
-  it("re-enters them when only the last check is outstanding", () => {
-    expect(resumePosition({ recorded: 9, ...TEN })).toBe(9);
-  });
-
-  // The control: a recorded position before the checks is honoured as it is, so
-  // the clamp cannot be satisfied by a function that always returns the same
-  // step. Without this every assertion above passes for `() => 9`.
-  it("does not drag a resume forward to the checks", () => {
-    expect(resumePosition({ recorded: 1, ...TEN })).toBe(2);
-    expect(resumePosition({ recorded: 7, ...TEN })).toBe(8);
-  });
-
-  // 🔴 A marker recording more steps than the plan holds cannot be trusted: it
-  // is what a restore or a hand repair leaves behind. Clamping it would turn it
-  // into one that looks ordinary, so the runner's past-the-end refusal would
-  // never see it and a run would enter the settlement checks having skipped
-  // every rename - rewriting vocabulary on storage whose tables never moved.
-  // `runner.test.ts` covers the refusal itself; this is what still reaches it.
-  it("passes an out-of-range position through for the runner to refuse", () => {
-    expect(resumePosition({ recorded: 100, ...TEN })).toBe(101);
-    expect(resumePosition({ recorded: 11, ...TEN })).toBe(12);
-  });
-
-  // A plan shorter than the checks it ends with cannot exist, but the floor is
-  // stated rather than assumed: `runMigrationSteps` refuses a position below one
-  // outright, so an arithmetic edge would surface as a refusal to run at all.
-  it("never returns a position below the first step", () => {
-    expect(
-      resumePosition({ recorded: 0, planLength: SETTLE_STEP_COUNT - 1 })
-    ).toBe(1);
+  // The gates have to be the LAST steps: a recorded position counts positions
+  // in the plan, so a gate in the middle leaves a gap the next recording step
+  // cannot advance across.
+  it("puts every gate at the end of the plan", () => {
+    for (const direction of ["up", "down"] as const) {
+      const flags = planSteps(direction).map(
+        step => step.recordsProgress !== false
+      );
+      expect(flags).toEqual([...flags].sort((a, b) => Number(b) - Number(a)));
+    }
   });
 });

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/plan.test.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/plan.test.ts
@@ -291,6 +291,17 @@ describe("where a resume re-enters the plan", () => {
     expect(resumePosition({ recorded: 7, ...TEN })).toBe(8);
   });
 
+  // 🔴 A marker recording more steps than the plan holds cannot be trusted: it
+  // is what a restore or a hand repair leaves behind. Clamping it would turn it
+  // into one that looks ordinary, so the runner's past-the-end refusal would
+  // never see it and a run would enter the settlement checks having skipped
+  // every rename - rewriting vocabulary on storage whose tables never moved.
+  // `runner.test.ts` covers the refusal itself; this is what still reaches it.
+  it("passes an out-of-range position through for the runner to refuse", () => {
+    expect(resumePosition({ recorded: 100, ...TEN })).toBe(101);
+    expect(resumePosition({ recorded: 11, ...TEN })).toBe(12);
+  });
+
   // A plan shorter than the checks it ends with cannot exist, but the floor is
   // stated rather than assumed: `runMigrationSteps` refuses a position below one
   // outright, so an arithmetic edge would surface as a refusal to run at all.

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/plan.test.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/plan.test.ts
@@ -55,6 +55,7 @@ function plan(direction: "up" | "down"): string[] {
     observer,
     meta,
     migrationId: "run-1",
+    resolveRegistryTable: async () => "dynamic_field_groups",
   }).map(step => step.id);
 }
 
@@ -93,6 +94,7 @@ describe("assembling the steps one run executes", () => {
       "registry:dynamic_components->dynamic_field_groups",
       // Last, so a write landing during the renames above is still caught.
       "data:settle-ledgers",
+      "data:settle-registry-definitions",
     ]);
   });
 
@@ -107,14 +109,16 @@ describe("assembling the steps one run executes", () => {
     // Same work, mirrored: each down id is its up counterpart with the rename
     // reversed, so comparing the ordering of KINDS is the honest check.
     const kind = (id: string): string => id.split(":")[0] ?? "";
-    // The settle step is appended to BOTH plans and is not mirrored work: it is
-    // the same check asked at the end of whichever direction ran. The reversal
-    // property describes the work, so it is asserted over the work.
+    // The settle steps are appended to BOTH plans and are not mirrored work:
+    // they are the same checks asked at the end of whichever direction ran. The
+    // reversal property describes the work, so it is asserted over the work.
+    const SETTLE = ["data:settle-ledgers", "data:settle-registry-definitions"];
     const work = (ids: string[]): string[] =>
-      ids.filter(id => id !== "data:settle-ledgers");
+      ids.filter(id => !SETTLE.includes(id));
     expect(work(down).map(kind)).toEqual([...work(up).map(kind)].reverse());
-    expect(up.at(-1)).toBe("data:settle-ledgers");
-    expect(down.at(-1)).toBe("data:settle-ledgers");
+    // In the same order at the end of both, rather than mirrored with the work.
+    expect(up.slice(-SETTLE.length)).toEqual(SETTLE);
+    expect(down.slice(-SETTLE.length)).toEqual(SETTLE);
   });
 
   it("reverses each rename rather than reissuing it", () => {
@@ -126,8 +130,9 @@ describe("assembling the steps one run executes", () => {
       "data:nextly_versions.snapshot",
       "data:schema-event-scope",
       "data:registry-definitions",
-      // Appended to both directions, so it closes the rollback too.
+      // Appended to both directions, so they close the rollback too.
       "data:settle-ledgers",
+      "data:settle-registry-definitions",
     ]);
   });
 

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/plan.test.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/plan.test.ts
@@ -7,6 +7,8 @@ import {
   directedRenameEntries,
   renamePositionOffset,
   renameRunRecord,
+  resumePosition,
+  SETTLE_STEP_COUNT,
 } from "../plan";
 import type { ManifestEntry } from "../manifest";
 import type { MigrationSession } from "../session";
@@ -113,6 +115,10 @@ describe("assembling the steps one run executes", () => {
     // they are the same checks asked at the end of whichever direction ran. The
     // reversal property describes the work, so it is asserted over the work.
     const SETTLE = ["data:settle-ledgers", "data:settle-registry-definitions"];
+    // The clamp that keeps a resume from stepping over these counts them, so a
+    // check added without updating that count fails here rather than letting a
+    // resume settle without asking.
+    expect(SETTLE).toHaveLength(SETTLE_STEP_COUNT);
     const work = (ids: string[]): string[] =>
       ids.filter(id => !SETTLE.includes(id));
     expect(work(down).map(kind)).toEqual([...work(up).map(kind)].reverse());
@@ -248,5 +254,49 @@ describe("assembling the steps one run executes", () => {
         offset: 4,
       })
     ).toEqual({ recorded: false });
+  });
+});
+
+describe("where a resume re-enters the plan", () => {
+  // A plan of ten steps ends with the two settlement checks at positions 9 and
+  // 10, so nine is the earliest position a resume may ever start from.
+  const TEN = { planLength: 10 };
+
+  it("resumes at the step after the one recorded", () => {
+    expect(resumePosition({ recorded: 3, ...TEN })).toBe(4);
+  });
+
+  it("starts at the beginning when nothing was recorded", () => {
+    expect(resumePosition({ recorded: 0, ...TEN })).toBe(1);
+  });
+
+  // 🔴 The case the clamp exists for. The runner records a step once it has
+  // verified, so a crash between the final record and the marker write would
+  // otherwise resume at position 11, execute nothing at all, and settle on
+  // structural evidence alone - leaving the entire crash-to-restart interval,
+  // during which writers are active and the migration is not, unexamined.
+  it("re-enters the settlement checks even when every step was recorded", () => {
+    expect(resumePosition({ recorded: 10, ...TEN })).toBe(9);
+  });
+
+  it("re-enters them when only the last check is outstanding", () => {
+    expect(resumePosition({ recorded: 9, ...TEN })).toBe(9);
+  });
+
+  // The control: a recorded position before the checks is honoured as it is, so
+  // the clamp cannot be satisfied by a function that always returns the same
+  // step. Without this every assertion above passes for `() => 9`.
+  it("does not drag a resume forward to the checks", () => {
+    expect(resumePosition({ recorded: 1, ...TEN })).toBe(2);
+    expect(resumePosition({ recorded: 7, ...TEN })).toBe(8);
+  });
+
+  // A plan shorter than the checks it ends with cannot exist, but the floor is
+  // stated rather than assumed: `runMigrationSteps` refuses a position below one
+  // outright, so an arithmetic edge would surface as a refusal to run at all.
+  it("never returns a position below the first step", () => {
+    expect(
+      resumePosition({ recorded: 0, planLength: SETTLE_STEP_COUNT - 1 })
+    ).toBe(1);
   });
 });

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/run.test.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/run.test.ts
@@ -24,7 +24,7 @@ vi.mock("../../../schema/pipeline/diff/introspect-live", () => ({
 }));
 
 import { introspectLiveSnapshot } from "../../../schema/pipeline/diff/introspect-live";
-import { FIELD_GROUP_MIGRATION_KEY } from "../state";
+import { FIELD_GROUP_MIGRATION_KEY, MIGRATION_MARKER_VERSION } from "../state";
 
 import { identifierCaseRules } from "../../../schema/utils/resolve-catalog-name";
 
@@ -277,10 +277,18 @@ const logger: Logger = {
   debug: vi.fn(),
 };
 
-/** A marker recording a completed upward run. */
-function settledAtV2() {
+/**
+ * A marker recording an upward run this build considers complete.
+ *
+ * Versioned from the constant rather than a literal, because these cases are
+ * about lock ordering and parent pointers rather than about what a version
+ * means. A literal here silently becomes a stale marker on the next bump, and
+ * the suite then reports a completeness refusal as though it were the behaviour
+ * under test. Cases that ARE about a version pin their own literal.
+ */
+function settledRun() {
   return {
-    version: 3,
+    version: MIGRATION_MARKER_VERSION,
     status: "settled",
     generation: "field-groups-v2",
   };
@@ -298,7 +306,7 @@ describe("runFieldGroupMigration", () => {
   // overwrite a settled marker with a fresh in-flight one.
   it("reads the marker only after taking the lock", async () => {
     const { adapter, trace } = createRunWorld({
-      marker: settledAtV2(),
+      marker: settledRun(),
       tables: [TARGET_REGISTRY, "fg_hero"],
       registryRows: [{ id: "1", slug: "hero", table_name: "fg_hero" }],
     });
@@ -318,7 +326,7 @@ describe("runFieldGroupMigration", () => {
   // later invocation into a report of success over storage nothing can serve.
   it("refuses a settled marker the catalog contradicts", async () => {
     const { adapter } = createRunWorld({
-      marker: settledAtV2(),
+      marker: settledRun(),
       // The marker says the migration finished, but the migrated registry is
       // not there and the legacy one is.
       tables: [LEGACY_REGISTRY, "comp_hero"],
@@ -340,7 +348,7 @@ describe("runFieldGroupMigration", () => {
   // serve blank content while the marker reported success.
   it("refuses a settled marker whose data table is missing", async () => {
     const { adapter } = createRunWorld({
-      marker: settledAtV2(),
+      marker: settledRun(),
       tables: [TARGET_REGISTRY],
       registryRows: [{ id: "1", slug: "hero", table_name: "fg_hero" }],
     });
@@ -358,7 +366,7 @@ describe("runFieldGroupMigration", () => {
   // legacy discriminator has not been migrated, whatever the marker says.
   it("refuses a settled marker whose discriminator was not renamed", async () => {
     const { adapter } = createRunWorld({
-      marker: settledAtV2(),
+      marker: settledRun(),
       tables: [TARGET_REGISTRY, "fg_hero"],
       columns: {
         fg_hero: ["id", "_parent_id", "_parent_table", "_component_type"],
@@ -379,7 +387,7 @@ describe("runFieldGroupMigration", () => {
   // property of the database says which `fg_*` names this migration created.
   it("refuses a rollback with no recorded plan", async () => {
     const { adapter } = createRunWorld({
-      marker: settledAtV2(),
+      marker: settledRun(),
       tables: [TARGET_REGISTRY, "fg_hero"],
       registryRows: [{ id: "1", slug: "hero", table_name: "fg_hero" }],
     });
@@ -492,6 +500,36 @@ describe("a settled marker older than this build's work", () => {
     }
   });
 
+  // 🔴 Version 3 settled without ever re-examining the registries, so a
+  // definition saved while that run was in flight could land behind the rewrite
+  // that had already passed and still be recorded as complete. Structure and
+  // parent pointers cannot see stored vocabulary, so accepting the marker would
+  // report success over legacy field definitions nothing would revisit. Pinned
+  // to the literal 3: an offset from the current constant moves with it.
+  it("refuses a settled marker from the build with no registry check", async () => {
+    const { adapter } = createRunWorld({
+      marker: { version: 3, status: "settled", generation: "field-groups-v2" },
+      tables: [TARGET_REGISTRY, "fg_hero"],
+      registryRows: [
+        { id: "1", slug: "hero", table_name: "fg_hero", localized: 0 },
+      ],
+    });
+
+    const error = await runFieldGroupMigration({
+      adapter,
+      logger,
+      direction: "up",
+    }).catch((caught: unknown) => caught);
+
+    expect(NextlyError.is(error)).toBe(true);
+    if (NextlyError.is(error)) {
+      expect(error.logContext?.reason).toBe(
+        "settled marker predates work this build performs"
+      );
+      expect(error.logContext?.recordedVersion).toBe(3);
+    }
+  });
+
   // A `legacy` marker claims no work was done, which is the same claim in every
   // build. Refusing there would strand a rollback that has nothing left to undo.
   it("accepts a legacy marker whatever version wrote it", async () => {
@@ -510,9 +548,15 @@ describe("a settled marker older than this build's work", () => {
 });
 
 describe("a settled marker over content that was restored", () => {
-  /** A completed run, with the plan it applied. */
+  /**
+   * A completed run, with the plan it applied.
+   *
+   * Versioned from the constant for the same reason {@link settledRun} is:
+   * these cases are about content that disagrees with a current marker, so a
+   * stale version would turn them into completeness-refusal cases instead.
+   */
   const settledWithPlan = {
-    version: 3,
+    version: MIGRATION_MARKER_VERSION,
     status: "settled",
     generation: "field-groups-v2",
     appliedManifest: [

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/runner.test.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/runner.test.ts
@@ -16,10 +16,17 @@ const SESSION = {
 function step(
   id: string,
   events: string[],
-  options: { verifies?: boolean; throws?: boolean } = {}
+  options: {
+    verifies?: boolean;
+    throws?: boolean;
+    recordsProgress?: boolean;
+  } = {}
 ): MigrationStep {
   return {
     id,
+    ...(options.recordsProgress === undefined
+      ? {}
+      : { recordsProgress: options.recordsProgress }),
     run: vi.fn(async () => {
       events.push(`run:${id}`);
       if (options.throws) {
@@ -234,5 +241,94 @@ describe("field-group migration runner", () => {
       })
     ).rejects.toThrowError(NextlyError);
     expect(meta.set).not.toHaveBeenCalled();
+  });
+});
+
+describe("steps that are gates rather than progress", () => {
+  // 🔴 A gate's position is never written. Recording it would let the next run
+  // step over the check, which is the opposite of what a check placed at the
+  // end of a plan is for.
+  it("runs and verifies a gate without recording it", async () => {
+    const events: string[] = [];
+    const meta = markerMeta(events, "run-1");
+    await runMigrationSteps({
+      session: SESSION,
+      meta,
+      migrationId: "run-1",
+      steps: [
+        step("a", events),
+        step("gate", events, { recordsProgress: false }),
+      ],
+      fromStep: 1,
+    });
+
+    expect(events).toEqual([
+      "run:a",
+      "verify:a",
+      "record:1",
+      "run:gate",
+      "verify:gate",
+    ]);
+  });
+
+  // 🔴 The case a recorded gate makes unrecoverable. With the gate's position in
+  // the marker, a resume would either step over the check or replay it and ask
+  // `advanceStep` to write a position it already holds, which it refuses - so
+  // every later attempt would fail identically. Left unrecorded, the marker
+  // still points at the last real work and the resume simply re-enters the gate.
+  it("re-enters the gate on a resume, having recorded nothing past the work", async () => {
+    const events: string[] = [];
+    const meta = markerMeta(events, "run-1");
+    const steps = [
+      step("a", events),
+      step("gate", events, { recordsProgress: false }),
+    ];
+    await runMigrationSteps({
+      session: SESSION,
+      meta,
+      migrationId: "run-1",
+      steps,
+      fromStep: 1,
+    });
+
+    events.length = 0;
+    // The marker records one step, so this is exactly where a resume lands.
+    await runMigrationSteps({
+      session: SESSION,
+      meta,
+      migrationId: "run-1",
+      steps,
+      fromStep: 2,
+    });
+
+    expect(events).toEqual(["run:gate", "verify:gate"]);
+  });
+
+  // A gate records nothing, so a recording step after one would have to advance
+  // the marker across the position it skipped, and `advanceStep` accepts only
+  // exactly one more than it holds. Refused when the plan is handed over rather
+  // than discovered as an unrecoverable marker after the first interruption.
+  it("refuses a plan that records progress after a gate", async () => {
+    const events: string[] = [];
+    const meta = markerMeta(events, "run-1");
+    await expect(
+      runMigrationSteps({
+        session: SESSION,
+        meta,
+        migrationId: "run-1",
+        steps: [
+          step("gate", events, { recordsProgress: false }),
+          step("later", events),
+        ],
+        fromStep: 1,
+      })
+    ).rejects.toMatchObject({
+      logContext: {
+        reason: "a migration plan records progress after a gate",
+        gate: "gate",
+        step: "later",
+      },
+    });
+    expect(events).toEqual([]);
   });
 });

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/state.test.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/state.test.ts
@@ -696,6 +696,48 @@ describe("field-group migration marker", () => {
     ).toBeUndefined();
   });
 
+  // 🔴 Version 3 recorded the settlement position as work; this build treats
+  // settlement as gates and appends a second one, so position N in a version 3
+  // marker addresses different steps here. A resume computed from it would begin
+  // AFTER the ledger check and never re-enter it, letting a legacy write
+  // committed during the interruption settle unseen. Pinned to the literal 3
+  // rather than to an offset, because the offset moves with the constant and
+  // would keep passing if the bump were reverted.
+  it("refuses an in-flight marker from the build that recorded settlement as work", async () => {
+    const { meta } = createMeta({
+      version: 3,
+      status: "migrating",
+      direction: "up",
+      migrationId: "r",
+      step: 9,
+      registryHash: "s",
+      manifestHash: "h",
+    });
+
+    const error = await readMigrationState(meta).catch((e: unknown) => e);
+    expect(NextlyError.is(error)).toBe(true);
+    if (NextlyError.is(error)) {
+      expect(error.logContext?.reason).toBe(
+        "migration marker version is not this build's"
+      );
+      expect(error.logContext?.recordedVersion).toBe(3);
+    }
+  });
+
+  // A settled version 3 marker is still accepted: version 4 adds a check over
+  // the storage a version 3 run produced rather than more rewriting, so refusing
+  // it would strand a complete installation with no way forward.
+  it("still accepts a settled marker from that build", async () => {
+    const { meta } = createMeta({
+      version: 3,
+      status: "settled",
+      generation: "field-groups-v2",
+    });
+
+    const state = await readMigrationState(meta);
+    expect(state.status).toBe("settled");
+  });
+
   it("refuses a marker written by a different version of Nextly", async () => {
     const { meta } = createMeta({
       version: MIGRATION_MARKER_VERSION - 1,

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/state.test.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/state.test.ts
@@ -724,10 +724,12 @@ describe("field-group migration marker", () => {
     }
   });
 
-  // A settled version 3 marker is still accepted: version 4 adds a check over
-  // the storage a version 3 run produced rather than more rewriting, so refusing
-  // it would strand a complete installation with no way forward.
-  it("still accepts a settled marker from that build", async () => {
+  // A settled marker is READ whatever wrote it, including one this build will go
+  // on to refuse as incomplete. The two questions are deliberately separate: the
+  // read layer reports what the marker says and hands over its version, and the
+  // run decides what that version is worth. Collapsing them would strip the
+  // recorded rollback plan from markers a later build could still reverse.
+  it("still reads a settled marker from that build, version and all", async () => {
     const { meta } = createMeta({
       version: 3,
       status: "settled",
@@ -736,6 +738,7 @@ describe("field-group migration marker", () => {
 
     const state = await readMigrationState(meta);
     expect(state.status).toBe("settled");
+    expect((state as { version?: number }).version).toBe(3);
   });
 
   it("refuses a marker written by a different version of Nextly", async () => {

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/storage-migration.integration.test.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/storage-migration.integration.test.ts
@@ -65,9 +65,11 @@ import {
   LEGACY_STORAGE_VOCABULARY,
   assertLedgersSettled,
   settleLedgersStep,
+  settleRegistryDefinitionsStep,
 } from "../data-steps";
 import { MIGRATION_TARGET } from "../manifest";
 import { runFieldGroupMigration } from "../run";
+import { getFieldGroupRegistryAliases } from "../../storage/registry-schemas";
 import {
   resolveRegistryNameFromCatalog,
   resolveTypeColumns,
@@ -187,6 +189,31 @@ function insertRow(
       insert(t: string, v: Record<string, unknown>): Promise<unknown>;
     }
   ).insert(table, values);
+}
+
+/**
+ * Update through the adapter's typed CRUD, narrowed for the same reason.
+ *
+ * A registry's `fields` column is `jsonb` on Postgres, `json` on MySQL and
+ * text-with-a-json-mode on SQLite. Going through the adapter is what makes one
+ * call correct on all three, where a hand-written statement would need three
+ * spellings and would encode the document differently from the code under test.
+ */
+function updateRow(
+  adapter: unknown,
+  table: string,
+  values: Record<string, unknown>,
+  where: unknown
+): Promise<unknown> {
+  return (
+    adapter as {
+      update(
+        t: string,
+        v: Record<string, unknown>,
+        w: unknown
+      ): Promise<unknown>;
+    }
+  ).update(table, values, where);
 }
 
 /** The kinds of core operation that name a given table, for an exact assertion. */
@@ -464,6 +491,34 @@ for (const entry of DIALECTS) {
       );
     }
 
+    /**
+     * The registry settlement step, built the way the plan builds it.
+     *
+     * The resolver is the production one rather than a fixed name, so these
+     * cases exercise the resolution itself: the step has to find the registry
+     * the run just renamed, from the catalog, with no help from the fixture.
+     */
+    function registrySettleStep() {
+      return settleRegistryDefinitionsStep({
+        from: LEGACY_STORAGE_VOCABULARY,
+        to: FIELD_GROUP_STORAGE_VOCABULARY,
+        resolveRegistryTable: () =>
+          resolveRegistryNameFromCatalog(adapter as never),
+      });
+    }
+
+    /** Whether the registries hold nothing left to rewrite. */
+    async function registrySettled(): Promise<boolean> {
+      return withMigrationSession(
+        {
+          adapter: adapter as never,
+          dialect: entry.dialect as MigrationDialect,
+          label: "registry-settlement-probe",
+        },
+        session => registrySettleStep().verify(session)
+      );
+    }
+
     async function migrate(direction: "up" | "down") {
       return runFieldGroupMigration({
         adapter: adapter as never,
@@ -517,7 +572,18 @@ for (const entry of DIALECTS) {
       // does not declare, so without them the registry service cannot read
       // `dynamic_components` at all — and the read path swallows that as "no
       // component data" rather than surfacing it.
-      registry.registerStaticSchemas(systemTablesFor(entry.dialect));
+      //
+      // 🔴 The aliases are added HERE and not to `systemTablesFor`, which is the
+      // same split production draws. That set also generates this fixture's DDL,
+      // and the migrated registry belongs in a schema REGISTRY but never in a
+      // schema PUSH: creating it up front would hand the migration a rename
+      // target that already exists. Every production site that builds a registry
+      // registers both spellings, so a fixture registering one would refuse a
+      // read production serves.
+      registry.registerStaticSchemas({
+        ...systemTablesFor(entry.dialect),
+        ...getFieldGroupRegistryAliases(entry.dialect),
+      });
       adapter.setTableResolver(registry);
 
       await dropEverything();
@@ -843,6 +909,65 @@ for (const entry of DIALECTS) {
       );
 
       await expect(settlementResidue()).resolves.toBeUndefined();
+    });
+
+    /**
+     * 🔴 The surface the ledger check cannot reach, and the reason this step
+     * resolves a name rather than being handed one.
+     *
+     * Going up, the registry has been RENAMED by the time settlement runs, so
+     * the name the plan was assembled with does not exist any more. A definition
+     * written back to the legacy vocabulary after its data step verified sits in
+     * a table only the resolved name can address — and against a real server,
+     * addressing it by the other one does not report residue, it fails outright.
+     * That is the failure the first attempt at this check shipped with, and only
+     * a real database on the real ordering exposes it.
+     */
+    it("sees a legacy definition left in the renamed registry", async () => {
+      await migrate("up");
+      // The control, and it is not optional: the assertion below passes against
+      // a check that reports every registry as unsettled.
+      await expect(registrySettled()).resolves.toBe(true);
+
+      // Exactly what a registry write landing during the renames leaves behind:
+      // one group's definitions back in the vocabulary the run moved away from.
+      await updateRow(
+        adapter,
+        MIGRATION_TARGET.registryTable,
+        { fields: outerFields },
+        { and: [{ column: "slug", op: "=", value: outerSlug }] }
+      );
+
+      await expect(registrySettled()).resolves.toBe(false);
+    });
+
+    /**
+     * The same convergence property the ledger step has, on this surface.
+     *
+     * The step re-runs the registry rewrite before it checks it, so a straggler
+     * is rewritten rather than refused forever. This is what an operator's
+     * re-run does, and what a post-hoc assertion could never offer.
+     */
+    it("rewrites a straggling definition rather than refusing forever", async () => {
+      await migrate("up");
+      await updateRow(
+        adapter,
+        MIGRATION_TARGET.registryTable,
+        { fields: outerFields },
+        { and: [{ column: "slug", op: "=", value: outerSlug }] }
+      );
+      await expect(registrySettled()).resolves.toBe(false);
+
+      await withMigrationSession(
+        {
+          adapter: adapter as never,
+          dialect: entry.dialect as MigrationDialect,
+          label: "registry-settle-retry",
+        },
+        session => registrySettleStep().run(session)
+      );
+
+      await expect(registrySettled()).resolves.toBe(true);
     });
 
     it("reports a second run as already migrated", async () => {

--- a/packages/nextly/src/domains/field-groups/migration/data-steps.ts
+++ b/packages/nextly/src/domains/field-groups/migration/data-steps.ts
@@ -34,6 +34,7 @@ import type {
 import { NextlyError } from "../../../errors/nextly-error";
 import { STORAGE_FORMAT } from "../../../schemas/storage-format";
 import type { MetaService } from "../../meta/services/meta-service";
+import { isFieldGroupRegistry } from "../storage/resolve-storage-names";
 
 import { MIGRATION_TARGET } from "./manifest";
 import { rewriteConfigPath } from "./rewrite-config-path";
@@ -102,19 +103,22 @@ export const FIELD_GROUP_STORAGE_VOCABULARY: FieldGroupStorageVocabulary = {
 };
 
 /**
- * Registry tables holding stored field definitions.
+ * Registry tables holding stored field definitions, for one registry spelling.
  *
  * Spelled here rather than taken from `STORAGE_FORMAT`, because only one of them
  * names the field-group concept. The other two are collection and single
  * storage, and they hold field-group *references* inside their own definitions —
  * which is exactly why they have to be rewritten too, and why they do not move
  * when the concept is renamed.
+ *
+ * The field-group registry arrives as an argument because this rewrite is asked
+ * twice per run, against two different physical tables: as a data step while the
+ * legacy name is live, and again at settlement, by which point going up the
+ * migrated name is the one that exists.
  */
-const DEFINITION_TABLES = [
-  "dynamic_collections",
-  "dynamic_singles",
-  STORAGE_FORMAT.registryTable,
-] as const;
+function definitionTables(registryTable: string): readonly string[] {
+  return ["dynamic_collections", "dynamic_singles", registryTable];
+}
 
 /** The columns one registry row needs written back. */
 type Patch = Record<string, unknown>;
@@ -254,7 +258,11 @@ export function buildDataMigrationSteps(args: {
   const { meta, migrationId, from, to } = args;
 
   return [
-    registryDefinitionsStep(from, to),
+    // The legacy name, unconditionally. These steps execute only while it is
+    // the live one: before the renames going up, and after they are undone
+    // going down. Resolving here would be asking a question whose answer is
+    // already fixed by where the step sits.
+    registryDefinitionsStep(from, to, STORAGE_FORMAT.registryTable),
     schemaEventScopeStep(from, to),
     ...CONTENT_TARGETS.map(target =>
       contentStep({ meta, migrationId, target, from, to })
@@ -278,8 +286,10 @@ export function buildDataMigrationSteps(args: {
  */
 function registryDefinitionsStep(
   from: FieldGroupStorageVocabulary,
-  to: FieldGroupStorageVocabulary
+  to: FieldGroupStorageVocabulary,
+  registryTable: string
 ): MigrationStep {
+  const tables = definitionTables(registryTable);
   return {
     id: "data:registry-definitions",
     async run(session) {
@@ -290,7 +300,7 @@ function registryDefinitionsStep(
         // that from committing the rows already rewritten and leaving exactly
         // the mixed-vocabulary registry set this step exists to prevent.
         const staged: { table: string; id: string; patch: Patch }[] = [];
-        for (const table of DEFINITION_TABLES) {
+        for (const table of tables) {
           for (const row of await readRegistryRows(ctx, table)) {
             const patch = registryPatch(row, table, from, to);
             if (!patch.ok) return patch;
@@ -309,7 +319,7 @@ function registryDefinitionsStep(
     },
     async verify(session) {
       const outcome = await session.inTransaction(async ctx => {
-        for (const table of DEFINITION_TABLES) {
+        for (const table of tables) {
           for (const row of await readRegistryRows(ctx, table)) {
             const patch = registryPatch(row, table, from, to);
             if (!patch.ok) return patch;
@@ -377,7 +387,13 @@ function registryPatch(
   // Only the field-group registry records a path under the renamed directory.
   // A collection's `config_path` names `collections/`, and rewriting it would be
   // renaming a directory this migration has nothing to do with.
-  if (table === STORAGE_FORMAT.registryTable) {
+  //
+  // Asked under BOTH spellings rather than compared against the legacy one. The
+  // settlement check addresses this registry by whichever name the catalog
+  // holds, so a comparison against a single name would quietly stop examining
+  // `config_path` the moment the rename had happened — the one moment the check
+  // exists for.
+  if (isFieldGroupRegistry(table)) {
     const configPath = readProperty(row, {
       table,
       property: CONFIG_PATH_PROPERTY,

--- a/packages/nextly/src/domains/field-groups/migration/data-steps.ts
+++ b/packages/nextly/src/domains/field-groups/migration/data-steps.ts
@@ -225,6 +225,10 @@ export function settleLedgersStep(args: {
   const ledgers = ledgerSteps(args);
   return {
     id: "data:settle-ledgers",
+    // A gate: re-entered by every invocation rather than recorded. A recorded
+    // position is what lets a later run step over something, and this must be
+    // true at the moment the marker settles.
+    recordsProgress: false,
     async run(session) {
       for (const step of ledgers) await step.run(session);
     },
@@ -274,6 +278,8 @@ export function settleRegistryDefinitionsStep(args: {
 
   return {
     id: "data:settle-registry-definitions",
+    // A gate, for the same reason as its ledger counterpart.
+    recordsProgress: false,
     async run(session) {
       await (await against()).run(session);
     },

--- a/packages/nextly/src/domains/field-groups/migration/data-steps.ts
+++ b/packages/nextly/src/domains/field-groups/migration/data-steps.ts
@@ -120,6 +120,17 @@ function definitionTables(registryTable: string): readonly string[] {
   return ["dynamic_collections", "dynamic_singles", registryTable];
 }
 
+/**
+ * How the settlement check learns which registry table to address.
+ *
+ * A function rather than a name because the plan is assembled before any rename
+ * executes and this check runs after them: a name captured at build time going
+ * up would be the one the run just moved away from. Supplied by the caller for
+ * the same reason `StorageObserver` is — the plan describes work, and the caller
+ * owns the database handle that answers questions about it.
+ */
+export type RegistryTableResolver = () => Promise<string>;
+
 /** The columns one registry row needs written back. */
 type Patch = Record<string, unknown>;
 
@@ -222,6 +233,52 @@ export function settleLedgersStep(args: {
         if (!(await step.verify(session))) return false;
       }
       return true;
+    },
+  };
+}
+
+/**
+ * The other last step of a plan: re-rewrite the registries, then re-check them.
+ *
+ * The companion to {@link settleLedgersStep}, kept separate rather than folded
+ * into it. The runner retries a step that does not verify, so one combined step
+ * would re-walk both ledgers every time a single registry row needed rewriting —
+ * redoing the expensive half to fix the cheap one. A refusal also names the step
+ * it came from, and two ids say which surface is unsettled where one would not.
+ *
+ * 🔴 The registry it addresses is resolved from the **catalog** rather than
+ * fixed when the plan was built. Going up this runs after the renames, so the
+ * name the plan started with is the one storage has just moved away from; going
+ * down it runs after the data steps have restored it. Reading the catalog is
+ * what makes one step correct in both directions, and it is the same rule the
+ * read path follows — resolve against what is observably there, never against
+ * what a marker claims.
+ *
+ * The read itself stays inside the ORM. Both spellings of the registry are
+ * registered as schema objects, so a resolved name is all typed CRUD needs, and
+ * the JSON column's three dialect encodings stay the ORM's problem rather than
+ * becoming this module's.
+ */
+export function settleRegistryDefinitionsStep(args: {
+  from: FieldGroupStorageVocabulary;
+  to: FieldGroupStorageVocabulary;
+  resolveRegistryTable: RegistryTableResolver;
+}): MigrationStep {
+  const { from, to, resolveRegistryTable } = args;
+  // Resolved on every call rather than once per step object. Caching across
+  // `run` and `verify` is correct only while no rename separates them, which is
+  // a property of today's plan and not of the contract; one catalog read on an
+  // operation that runs once per database is not worth pinning that to.
+  const against = async (): Promise<MigrationStep> =>
+    registryDefinitionsStep(from, to, await resolveRegistryTable());
+
+  return {
+    id: "data:settle-registry-definitions",
+    async run(session) {
+      await (await against()).run(session);
+    },
+    async verify(session) {
+      return (await against()).verify(session);
     },
   };
 }

--- a/packages/nextly/src/domains/field-groups/migration/plan.ts
+++ b/packages/nextly/src/domains/field-groups/migration/plan.ts
@@ -26,8 +26,10 @@ import type { IdentifierCaseRules } from "../../schema/utils/resolve-catalog-nam
 import {
   buildDataMigrationSteps,
   settleLedgersStep,
+  settleRegistryDefinitionsStep,
   FIELD_GROUP_STORAGE_VOCABULARY,
   LEGACY_STORAGE_VOCABULARY,
+  type RegistryTableResolver,
 } from "./data-steps";
 import { invertManifest, type ManifestEntry } from "./manifest";
 import type { MigrationStep } from "./runner";
@@ -135,6 +137,16 @@ export interface BuildPlanArgs {
    * the entries alone cannot name every table that holds instances.
    */
   ownedDataTables: readonly string[];
+  /**
+   * Which registry table the settlement check should address, asked when it
+   * runs rather than now.
+   *
+   * The plan is assembled before any rename executes, so a name decided here
+   * would be the one an upward run is about to move away from. Supplied
+   * alongside the observer because both are questions only the caller's
+   * database handle can answer.
+   */
+  resolveRegistryTable: RegistryTableResolver;
 }
 
 /**
@@ -153,6 +165,7 @@ export function buildMigrationPlan(args: BuildPlanArgs): MigrationStep[] {
     meta,
     migrationId,
     ownedDataTables,
+    resolveRegistryTable,
   } = args;
 
   const renameSteps = (plan: readonly ManifestEntry[]): MigrationStep[] =>
@@ -165,21 +178,27 @@ export function buildMigrationPlan(args: BuildPlanArgs): MigrationStep[] {
 
   // 🔴 Appended to BOTH directions, and last in each.
   //
-  // A write landing after a ledger step has verified is behind every check the
+  // A write landing after a data step has verified is behind every check the
   // plan has left, so the answer has to come after all the work — which is the
-  // end of the list whichever way the run is going. It is a STEP rather than an
-  // assertion after the runner's loop because the runner retries a step that
+  // end of the list whichever way the run is going. They are STEPS rather than
+  // an assertion after the runner's loop because the runner retries a step that
   // does not verify, while an assertion throws with every step already recorded
   // and refuses identically on every later attempt.
   //
   // Symmetric rather than up-only so the reversal property this module rests on
-  // still describes the work: the two plans mirror, each with the same check
+  // still describes the work: the two plans mirror, each with the same checks
   // appended. A rollback earns the same protection, and nothing has to reason
   // about a plan whose shape depends on its direction.
+  //
+  // Two steps rather than one because the runner retries per step: a registry
+  // row needing a second attempt would otherwise re-walk both ledgers with it.
   const settle = (
     from: typeof LEGACY_STORAGE_VOCABULARY,
     to: typeof LEGACY_STORAGE_VOCABULARY
-  ): MigrationStep => settleLedgersStep({ meta, migrationId, from, to });
+  ): MigrationStep[] => [
+    settleLedgersStep({ meta, migrationId, from, to }),
+    settleRegistryDefinitionsStep({ from, to, resolveRegistryTable }),
+  ];
 
   const dataSteps = (
     from: typeof LEGACY_STORAGE_VOCABULARY,
@@ -191,7 +210,7 @@ export function buildMigrationPlan(args: BuildPlanArgs): MigrationStep[] {
     return [
       ...dataSteps(LEGACY_STORAGE_VOCABULARY, FIELD_GROUP_STORAGE_VOCABULARY),
       ...renameSteps(entries),
-      settle(LEGACY_STORAGE_VOCABULARY, FIELD_GROUP_STORAGE_VOCABULARY),
+      ...settle(LEGACY_STORAGE_VOCABULARY, FIELD_GROUP_STORAGE_VOCABULARY),
     ];
   }
 
@@ -204,7 +223,7 @@ export function buildMigrationPlan(args: BuildPlanArgs): MigrationStep[] {
       FIELD_GROUP_STORAGE_VOCABULARY,
       LEGACY_STORAGE_VOCABULARY
     ).reverse(),
-    settle(FIELD_GROUP_STORAGE_VOCABULARY, LEGACY_STORAGE_VOCABULARY),
+    ...settle(FIELD_GROUP_STORAGE_VOCABULARY, LEGACY_STORAGE_VOCABULARY),
   ];
 }
 

--- a/packages/nextly/src/domains/field-groups/migration/plan.ts
+++ b/packages/nextly/src/domains/field-groups/migration/plan.ts
@@ -192,6 +192,16 @@ export function buildMigrationPlan(args: BuildPlanArgs): MigrationStep[] {
   //
   // Two steps rather than one because the runner retries per step: a registry
   // row needing a second attempt would otherwise re-walk both ledgers with it.
+  //
+  // 🔴 Ledgers first, registries last, and the order is not arbitrary. Whichever
+  // check is not last carries an exposure window as long as everything that
+  // follows it, so the question is which surface should wait behind which. The
+  // ledger walk grows with a site's history and is batched for that reason,
+  // while the registry set is bounded by how many collections, singles and field
+  // groups a project declares. Putting the bounded step last leaves the ledgers
+  // waiting behind something small; reversing it would leave the registries
+  // waiting behind a full walk of every version and event a site has ever
+  // recorded.
   const settle = (
     from: typeof LEGACY_STORAGE_VOCABULARY,
     to: typeof LEGACY_STORAGE_VOCABULARY
@@ -225,6 +235,39 @@ export function buildMigrationPlan(args: BuildPlanArgs): MigrationStep[] {
     ).reverse(),
     ...settle(FIELD_GROUP_STORAGE_VOCABULARY, LEGACY_STORAGE_VOCABULARY),
   ];
+}
+
+/**
+ * How many settlement checks every plan ends with.
+ *
+ * Stated once so the resume clamp and the plan agree about where they begin.
+ * A plan test asserts the last steps of both directions are exactly these, so a
+ * third check added without updating this fails rather than silently letting a
+ * resume step over one.
+ */
+export const SETTLE_STEP_COUNT = 2;
+
+/**
+ * Where a run resumes, never past the settlement checks.
+ *
+ * 🔴 The runner records a step only once it has verified, so a crash between the
+ * final record and the marker write would otherwise resume past every check and
+ * settle on structural evidence alone. That is the worst moment to stop looking:
+ * the interval between a crash and an operator's restart is unbounded, the
+ * migration is not running through it, and writers are. Re-entering the checks
+ * costs one pass over storage that is already clean, and heals it when it is
+ * not, because each one re-runs its rewrite before verifying.
+ *
+ * Only the resume position is clamped. The recorded position itself is left
+ * alone, because reconciliation reads it to decide which renames a previous run
+ * completed, and a clamped value would describe work that did not happen.
+ */
+export function resumePosition(args: {
+  recorded: number;
+  planLength: number;
+}): number {
+  const firstSettleStep = Math.max(args.planLength - SETTLE_STEP_COUNT + 1, 1);
+  return Math.min(args.recorded + 1, firstSettleStep);
 }
 
 /** How many data steps a plan carries, for translating a recorded position. */

--- a/packages/nextly/src/domains/field-groups/migration/plan.ts
+++ b/packages/nextly/src/domains/field-groups/migration/plan.ts
@@ -261,11 +261,21 @@ export const SETTLE_STEP_COUNT = 2;
  * Only the resume position is clamped. The recorded position itself is left
  * alone, because reconciliation reads it to decide which renames a previous run
  * completed, and a clamped value would describe work that did not happen.
+ *
+ * 🔴 A position past the end of the plan is passed through untouched rather than
+ * clamped. Such a marker cannot be trusted — it is what a restore or a hand
+ * repair leaves — and clamping would turn it into one that looks ordinary: the
+ * runner's own past-the-end refusal would never see it, and a run would enter
+ * the settlement checks having skipped every rename, rewriting vocabulary on
+ * storage whose tables were never moved. The refusal is left to the runner
+ * rather than raised here so there is one place that decides what an
+ * irreconcilable marker means.
  */
 export function resumePosition(args: {
   recorded: number;
   planLength: number;
 }): number {
+  if (args.recorded > args.planLength) return args.recorded + 1;
   const firstSettleStep = Math.max(args.planLength - SETTLE_STEP_COUNT + 1, 1);
   return Math.min(args.recorded + 1, firstSettleStep);
 }

--- a/packages/nextly/src/domains/field-groups/migration/plan.ts
+++ b/packages/nextly/src/domains/field-groups/migration/plan.ts
@@ -237,49 +237,6 @@ export function buildMigrationPlan(args: BuildPlanArgs): MigrationStep[] {
   ];
 }
 
-/**
- * How many settlement checks every plan ends with.
- *
- * Stated once so the resume clamp and the plan agree about where they begin.
- * A plan test asserts the last steps of both directions are exactly these, so a
- * third check added without updating this fails rather than silently letting a
- * resume step over one.
- */
-export const SETTLE_STEP_COUNT = 2;
-
-/**
- * Where a run resumes, never past the settlement checks.
- *
- * 🔴 The runner records a step only once it has verified, so a crash between the
- * final record and the marker write would otherwise resume past every check and
- * settle on structural evidence alone. That is the worst moment to stop looking:
- * the interval between a crash and an operator's restart is unbounded, the
- * migration is not running through it, and writers are. Re-entering the checks
- * costs one pass over storage that is already clean, and heals it when it is
- * not, because each one re-runs its rewrite before verifying.
- *
- * Only the resume position is clamped. The recorded position itself is left
- * alone, because reconciliation reads it to decide which renames a previous run
- * completed, and a clamped value would describe work that did not happen.
- *
- * 🔴 A position past the end of the plan is passed through untouched rather than
- * clamped. Such a marker cannot be trusted — it is what a restore or a hand
- * repair leaves — and clamping would turn it into one that looks ordinary: the
- * runner's own past-the-end refusal would never see it, and a run would enter
- * the settlement checks having skipped every rename, rewriting vocabulary on
- * storage whose tables were never moved. The refusal is left to the runner
- * rather than raised here so there is one place that decides what an
- * irreconcilable marker means.
- */
-export function resumePosition(args: {
-  recorded: number;
-  planLength: number;
-}): number {
-  if (args.recorded > args.planLength) return args.recorded + 1;
-  const firstSettleStep = Math.max(args.planLength - SETTLE_STEP_COUNT + 1, 1);
-  return Math.min(args.recorded + 1, firstSettleStep);
-}
-
 /** How many data steps a plan carries, for translating a recorded position. */
 export function dataStepCount(args: {
   meta: MetaService;

--- a/packages/nextly/src/domains/field-groups/migration/run.ts
+++ b/packages/nextly/src/domains/field-groups/migration/run.ts
@@ -56,6 +56,7 @@ import {
   directedRenameEntries,
   renamePositionOffset,
   renameRunRecord,
+  resumePosition,
 } from "./plan";
 import { probeStorage, reconcilePlan, type TableColumns } from "./reconcile";
 import { runMigrationSteps } from "./runner";
@@ -305,7 +306,10 @@ export async function runFieldGroupMigration(
         resolveRegistryTable: () => resolveRegistryNameFromCatalog(adapter),
       });
 
-      const fromStep = state.status === "migrating" ? state.step + 1 : 1;
+      const fromStep = resumePosition({
+        recorded: state.status === "migrating" ? state.step : 0,
+        planLength: steps.length,
+      });
       // 🔴 Invalidated whenever the steps may have RUN, not only when the run
       // reports success. A rename can commit and `assertStorageComplete` or
       // `settleMigration` can then throw — at which point the memoized registry

--- a/packages/nextly/src/domains/field-groups/migration/run.ts
+++ b/packages/nextly/src/domains/field-groups/migration/run.ts
@@ -56,7 +56,6 @@ import {
   directedRenameEntries,
   renamePositionOffset,
   renameRunRecord,
-  resumePosition,
 } from "./plan";
 import { probeStorage, reconcilePlan, type TableColumns } from "./reconcile";
 import { runMigrationSteps } from "./runner";
@@ -306,10 +305,9 @@ export async function runFieldGroupMigration(
         resolveRegistryTable: () => resolveRegistryNameFromCatalog(adapter),
       });
 
-      const fromStep = resumePosition({
-        recorded: state.status === "migrating" ? state.step : 0,
-        planLength: steps.length,
-      });
+      // The settlement checks are gates rather than recorded work, so a marker
+      // never points past them and a resume re-enters them on its own.
+      const fromStep = state.status === "migrating" ? state.step + 1 : 1;
       // 🔴 Invalidated whenever the steps may have RUN, not only when the run
       // reports success. A rename can commit and `assertStorageComplete` or
       // `settleMigration` can then throw — at which point the memoized registry

--- a/packages/nextly/src/domains/field-groups/migration/run.ts
+++ b/packages/nextly/src/domains/field-groups/migration/run.ts
@@ -31,7 +31,10 @@ import {
   resolveCatalogName,
   type IdentifierCaseRules,
 } from "../../schema/utils/resolve-catalog-name";
-import { forgetFieldGroupStorageNames } from "../storage/resolve-storage-names";
+import {
+  forgetFieldGroupStorageNames,
+  resolveRegistryNameFromCatalog,
+} from "../storage/resolve-storage-names";
 
 import { resolveStorageVerdict } from "./guard";
 import {
@@ -296,6 +299,10 @@ export async function runFieldGroupMigration(
         meta,
         migrationId,
         ownedDataTables: owned,
+        // Deliberately the un-memoized resolver. Its memoized sibling would
+        // answer with a name read before this run moved storage, which is the
+        // one answer a check running after the renames must not be given.
+        resolveRegistryTable: () => resolveRegistryNameFromCatalog(adapter),
       });
 
       const fromStep = state.status === "migrating" ? state.step + 1 : 1;
@@ -315,20 +322,11 @@ export async function runFieldGroupMigration(
           fromStep,
         });
 
-        // 🔴 The vocabulary half of the same question. A step's postcondition
-        // speaks for the moment it finished; a write committing afterwards puts
-        // the old spelling back into a surface no later step revisits, and the
-        // run would settle over storage that is not fully migrated — invisible
-        // until the contract release removes the arm that still reads it.
-        //
-        // Only the surfaces the renames leave alone are asked here. The registry
-        // definitions are addressed through typed CRUD under the legacy name and
-        // so are only expressible before the renames; asking them now would name
-        // a table that no longer exists.
-        // Asked of the database rather than inferred from the steps having run.
-        // A step reports its own postcondition; this asks whether the storage as
-        // a whole is now what the generation claims, which is the question a
-        // settled marker will be believed on afterwards.
+        // The structural half of the question the settle steps ask about
+        // vocabulary. Asked of the database rather than inferred from the steps
+        // having run: a step reports its own postcondition, while this asks
+        // whether the storage as a whole is now what the generation claims,
+        // which is the question a settled marker will be believed on afterwards.
         await assertStorageComplete({
           adapter,
           dialect,

--- a/packages/nextly/src/domains/field-groups/migration/runner.ts
+++ b/packages/nextly/src/domains/field-groups/migration/runner.ts
@@ -33,6 +33,22 @@ export interface MigrationStep {
   readonly id: string;
   run(session: MigrationSession): Promise<void>;
   verify(session: MigrationSession): Promise<boolean>;
+  /**
+   * Whether finishing this step is progress the marker should remember.
+   *
+   * 🔴 `false` makes a step a GATE rather than work: every invocation re-enters
+   * it, because a recorded position is what lets a later run step over
+   * something. A check that must be true at the moment the marker settles has
+   * to be one of these — recorded, it would be skipped by the very resume it
+   * exists to protect, and the run would settle on whatever the database looked
+   * like before the interruption.
+   *
+   * Only the TRAILING steps of a plan may decline. A recorded position counts
+   * positions in the plan, so a gate in the middle would leave a gap that the
+   * next recording step cannot advance across; {@link runMigrationSteps}
+   * refuses such a plan rather than discovering it one crash later.
+   */
+  readonly recordsProgress?: boolean;
 }
 
 /**
@@ -75,6 +91,27 @@ export async function runMigrationSteps(args: {
     });
   }
 
+  // A gate records nothing, so every step after one would have to advance the
+  // marker across the position it skipped — and `advanceStep` accepts only
+  // exactly one more than it holds. A plan shaped that way cannot record its own
+  // progress, and the failure would surface as an unrecoverable marker on the
+  // first interruption rather than here.
+  const firstGate = steps.findIndex(step => step.recordsProgress === false);
+  if (firstGate !== -1) {
+    const recordingAfterGate = steps
+      .slice(firstGate + 1)
+      .find(step => step.recordsProgress !== false);
+    if (recordingAfterGate !== undefined) {
+      throw NextlyError.internal({
+        logContext: {
+          reason: "a migration plan records progress after a gate",
+          gate: steps[firstGate]?.id ?? "",
+          step: recordingAfterGate.id,
+        },
+      });
+    }
+  }
+
   for (let position = fromStep; position <= steps.length; position += 1) {
     const step = steps[position - 1];
     if (!step) {
@@ -100,6 +137,10 @@ export async function runMigrationSteps(args: {
         },
       });
     }
+
+    // A gate is re-entered by every invocation, so its position is deliberately
+    // never written. Recording it would let the next run step over the check.
+    if (step.recordsProgress === false) continue;
 
     await advanceStep(meta, { migrationId, step: position });
   }

--- a/packages/nextly/src/domains/field-groups/migration/state.ts
+++ b/packages/nextly/src/domains/field-groups/migration/state.ts
@@ -99,13 +99,21 @@ export const MIN_READABLE_MANIFEST_VERSION = 2;
  * marker version moved. A build that only reorders or renumbers steps leaves
  * what a settled marker claims untouched.
  *
- * Deliberately left at 3 by version 4, which adds a settlement CHECK rather
- * than additional rewriting: the storage a version 3 run produces is the storage
- * a version 4 run produces, and the new check re-examines it rather than
- * changing it. Raising it would refuse every version 3 installation on upgrade
- * with no path forward, which is the wrong answer for storage that is complete.
+ * Version 4 qualifies. A version 3 run settled without ever re-examining the
+ * registries, so a definition saved while that run was in flight could land
+ * behind the rewrite that had already passed and be recorded as complete. The
+ * `already-migrated` path checks structure and parent pointers, neither of which
+ * can see stored vocabulary, so accepting such a marker would report success
+ * over legacy field definitions nothing would revisit. What a version 3 marker
+ * claims is therefore weaker than what this build means by settled, which is the
+ * one thing this constant exists to say.
+ *
+ * Refusing costs nothing an operator can feel: the migration has no caller, so
+ * no database holds a marker of any version, and the refusal names the remedy.
+ * A repair path for a state that cannot exist would be dead code carrying a
+ * maintenance cost for the life of the project.
  */
-export const MIN_COMPLETE_MARKER_VERSION = 3;
+export const MIN_COMPLETE_MARKER_VERSION = 4;
 
 /**
  * Whether a marker's recorded plan is in a format this build can execute.

--- a/packages/nextly/src/domains/field-groups/migration/state.ts
+++ b/packages/nextly/src/domains/field-groups/migration/state.ts
@@ -44,10 +44,19 @@ export const FIELD_GROUP_MIGRATION_KEY = "field_groups.storage_migration";
  * than persisted — so nothing in a version 2 marker's bytes reveals that
  * position N now addresses different work. This constant is what does.
  *
+ * Version 4 appends a second settlement check and stops recording either of
+ * them: they are gates, re-entered by every invocation, so a marker no longer
+ * points past the last rename. A version 3 marker CAN point past it, at a
+ * settlement position this build does not record — and a resume computed from
+ * that position would begin after the ledger check and never re-enter it,
+ * letting a legacy write committed during the interruption settle unseen.
+ * Nothing in the marker's bytes distinguishes the two meanings, which is
+ * exactly what this constant is for.
+ *
  * Bumping this does **not** invalidate a settled marker's recorded plan; see
  * `MIN_READABLE_MANIFEST_VERSION`, which tracks the entry format separately.
  */
-export const MIGRATION_MARKER_VERSION = 3;
+export const MIGRATION_MARKER_VERSION = 4;
 
 /**
  * Oldest marker version whose recorded plan this build can still execute.
@@ -89,6 +98,12 @@ export const MIN_READABLE_MANIFEST_VERSION = 2;
  * Raise this whenever a version adds work to a run — never merely because the
  * marker version moved. A build that only reorders or renumbers steps leaves
  * what a settled marker claims untouched.
+ *
+ * Deliberately left at 3 by version 4, which adds a settlement CHECK rather
+ * than additional rewriting: the storage a version 3 run produces is the storage
+ * a version 4 run produces, and the new check re-examines it rather than
+ * changing it. Raising it would refuse every version 3 installation on upgrade
+ * with no path forward, which is the wrong answer for storage that is complete.
  */
 export const MIN_COMPLETE_MARKER_VERSION = 3;
 


### PR DESCRIPTION
Second half of B1-9a. #472 landed `data:settle-ledgers`, which re-checks the three surfaces the renames never touch. It deliberately excluded the **registry definitions**, because the step that rewrites them addresses the field-group registry through typed CRUD under its legacy name, and going up that name is gone by the time a run settles.

That exclusion is the last window in which a write can leave a database reporting success over storage that is only partly migrated.

## What the research turned up

The blocker was never the read. It was the **name**.

- Only one of the three registries is renamed. `dynamic_collections` and `dynamic_singles` keep their names; only `dynamic_components` becomes `dynamic_field_groups`.
- `getFieldGroupRegistryAliases` already registers the migrated spelling as a schema object, `registerStaticSchemas` keys by physical name, and the adapter resolves by that key. **All five** schema-registry construction sites include the aliases, so the migrated table is already addressable through typed CRUD.
- So no raw SQL is needed. That matters: `fields` is `jsonb` on Postgres, `json` on MySQL and text-with-a-json-mode on SQLite, and two of the three hand back an object where the third hands back a string. Keeping the read inside the ORM keeps that the ORM's problem, which is the whole reason the plan is ordered the way it is.

## The change

`registryDefinitionsStep` takes the registry's name instead of hardcoding it. `buildDataMigrationSteps` passes the legacy name, which is correct because those steps only execute while it is live. A new `data:settle-registry-definitions` resolves the name **from the catalog at run time** and builds the same step against whatever is really there.

One rewrite, asked twice. `run` and `verify` cannot drift between the data step and the settlement check, because they are the same function.

- **A resolver, not a name** — the plan is assembled before any rename executes, so a name fixed then would be the one an upward run is about to move away from.
- **Resolved per call, not cached** — caching across `run` and `verify` is correct only while no rename separates them. That is a property of today's plan, not of the contract.
- **The catalog's preference order is the point** — `chooseRegistryTable` prefers the legacy name when both are somehow present, so the check examines the table readers will actually read.
- **Two settle steps, not one** — the runner retries per step, so combining them would re-walk both ledgers to fix a single registry row.

### The defect a naive parameterisation introduces

`registryPatch` gated the `config_path` rewrite on `table === STORAGE_FORMAT.registryTable`. Under the migrated name that is false, and `config_path` would quietly stop being checked at exactly the moment this step exists for. It now asks `isFieldGroupRegistry`, and that has its own test.

## Verification

Every test was proven load-bearing by breaking the code:

| Break | Result |
|---|---|
| `config_path` gate back to a single-name comparison | **1** failure, the case whose name claims it; 22 others pass |
| settle step ignores the resolver | migration cannot complete at all on a real database — the reverted first implementation's failure, reproduced |
| registry verifier always reports settled | exactly the **2** new integration legs fail, on both dialects; 20 others pass |
| fixture registers one registry spelling | every leg fails with `Table "dynamic_field_groups" not found in schema registry` |

- `pnpm build` clean, `pnpm check-types --force` 19/19, `pnpm lint` exit 0
- Unit: failure set **identical at test-name level** to a freshly measured baseline from `84f8a15b5` in its own installed and built worktree (400 lines each); totals 6515 → 6520, the five new cases and nothing else
- Integration: **24 passed** Postgres 17, **24 passed** MySQL (20 before; +2 legs × 2 dialects), SQLite in-memory covered in both runs

## Not in this PR

- **B1-9b**, the exclusion at `registerComponentInTransaction`, `CollectionRegistryService` and `SingleRegistryService` — narrows the windows this net catches.
- **B1-9c**, operator documentation for a refusal.
- An integration leg planting into `dynamic_collections`. Its unique integration risk is name resolution, which is identical before and after a run and is already exercised by the data steps; the unit suite covers the set membership. Called out rather than dropped silently.

The engine remains dark: nothing calls `runFieldGroupMigration`, so no database is in the migrated state yet.
