### PR TITLE
fix(nextly): build schema-builder tables from the column descriptor

### DIFF
--- a/.changeset/builder-ddl-system-columns.md
+++ b/.changeset/builder-ddl-system-columns.md
@@ -1,0 +1,31 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+Collections and singles created through the Schema Builder now get their system columns from the same definition the runtime schema and the migration diff already use, instead of a separate hand-written copy.
+
+The copy had drifted. A Builder-created table declared `createdAt` and `updatedAt` as required while the rest of Nextly described them as optional, so `nextly db:sync` proposed a change to those columns on every Builder collection, and applying it rebuilt the table. On SQLite that rebuild also dropped the timestamp defaults. Both now agree, and the sync proposes nothing.
+
+Newly created Builder tables declare the two timestamp columns as optional. Existing tables are brought in line by one schema sync, which preserves their rows.
+
+The practical effect is that a system column added to Nextly in future reaches Builder-created tables as well as code-first ones. Previously it reached only code-first tables, and reading a Builder collection or single failed with a missing-column error.

--- a/packages/nextly/src/domains/dynamic-collections/services/__tests__/builder-ddl-system-columns.test.ts
+++ b/packages/nextly/src/domains/dynamic-collections/services/__tests__/builder-ddl-system-columns.test.ts
@@ -1,0 +1,131 @@
+/**
+ * The Schema Builder's DDL creates exactly the system columns the descriptor defines.
+ *
+ * The descriptor exists so the runtime Drizzle schema and the diff's `desired` snapshot cannot
+ * drift apart. This generator is the third consumer, and it used to restate the set as per-dialect
+ * SQL strings, so a system column added to the descriptor reached the runtime schema and never
+ * reached the physical table. The generated SELECT then named a column that did not exist and
+ * every read of the entity failed.
+ *
+ * Asserted as set equality against `getSystemColumnDescriptors` rather than against a list of
+ * today's column names: a test naming the columns would keep passing while the next one added
+ * goes missing, which is the failure being prevented.
+ */
+import { describe, expect, it } from "vitest";
+
+import { getSystemColumnDescriptors } from "../../../schema/services/field-column-descriptor";
+import { DynamicCollectionSchemaService } from "../dynamic-collection-schema-service";
+
+import type { FieldDefinition } from "../../../../schemas/dynamic-collections";
+import type { SupportedDialect } from "../../../schema/services/field-column-descriptor";
+
+const DIALECTS: SupportedDialect[] = ["postgresql", "mysql", "sqlite"];
+
+/** Column names in the CREATE TABLE body, read back from the generated statement. */
+function columnNamesIn(sql: string): string[] {
+  const createTable = sql.slice(sql.indexOf("("), sql.lastIndexOf(")"));
+  const names: string[] = [];
+  for (const line of createTable.split("\n")) {
+    // Quoted leading identifier only, so CONSTRAINT / FOREIGN KEY lines contribute nothing.
+    const match = /^\s*[`"]([a-z0-9_]+)[`"]\s+\S/i.exec(line);
+    if (match) names.push(match[1]);
+  }
+  return names;
+}
+
+const userField = (name: string): FieldDefinition =>
+  ({ name, type: "text" }) as FieldDefinition;
+
+describe.each(DIALECTS)("builder DDL system columns (%s)", dialect => {
+  const service = () => new DynamicCollectionSchemaService(undefined, dialect);
+
+  it.each([
+    { label: "collection with status", hasStatus: true, isSingle: false },
+    { label: "collection without status", hasStatus: false, isSingle: false },
+    { label: "single with status", hasStatus: true, isSingle: true },
+  ])(
+    "creates exactly the descriptor set: $label",
+    ({ hasStatus, isSingle }) => {
+      const tableName = isSingle ? "single_thing" : "dc_thing";
+      const sql = service().generateMigrationSQL(
+        tableName,
+        [userField("body")],
+        {
+          hasStatus,
+          isSingle,
+        }
+      );
+
+      const expected = getSystemColumnDescriptors(dialect, {
+        hasTitleField: false,
+        hasSlugField: false,
+        hasStatus,
+        isSingle,
+      }).map(c => c.name);
+
+      const present = columnNamesIn(sql);
+      // Set equality both ways: a missing column is the bug this prevents, and an extra one means
+      // the generator is still inventing system columns of its own.
+      expect(present.filter(n => n !== "body").sort()).toEqual(
+        [...expected].sort()
+      );
+    }
+  );
+
+  it("omits title and slug when the user defines them", () => {
+    // The descriptor drops both when the user owns them, and the generator has its own reason to
+    // do so; if the two disagree the table gets a duplicate column and CREATE TABLE fails.
+    const sql = service().generateMigrationSQL(
+      "dc_thing",
+      [userField("title"), userField("slug")],
+      { hasStatus: false }
+    );
+
+    const expected = getSystemColumnDescriptors(dialect, {
+      hasTitleField: true,
+      hasSlugField: true,
+      hasStatus: false,
+      isSingle: false,
+    }).map(c => c.name);
+
+    expect(columnNamesIn(sql).sort()).toEqual(
+      [...expected, "title", "slug"].sort()
+    );
+  });
+
+  it("treats a `single_` table as a single even when the flag is omitted", () => {
+    // The runtime schema and the diff derive this from the table name, so a caller that passes
+    // no flag must not get an owner column the other two paths do not expect.
+    const sql = service().generateMigrationSQL("single_thing", [], {
+      hasStatus: false,
+    });
+    expect(columnNamesIn(sql)).not.toContain("created_by");
+  });
+
+  it("renders each system column's type, default and constraints", () => {
+    // Set equality alone would pass if every column were emitted as bare `text`. This pins the
+    // rendering itself against the descriptor's own values.
+    const sql = service().generateMigrationSQL("dc_thing", [], {
+      hasStatus: true,
+    });
+
+    for (const column of getSystemColumnDescriptors(dialect, {
+      hasTitleField: false,
+      hasSlugField: false,
+      hasStatus: true,
+      isSingle: false,
+    })) {
+      const line = sql
+        .split("\n")
+        .find(l => new RegExp(`^\\s*[\`"]${column.name}[\`"]\\s`).test(l));
+      expect(line).toBeDefined();
+      if (column.default !== undefined) {
+        expect(line).toContain(`DEFAULT ${column.default}`);
+      }
+      if (column.primaryKey) expect(line).toContain("PRIMARY KEY");
+      // Nullable columns must not be constrained; a NOT NULL the descriptor does not declare is
+      // exactly the divergence that made the diff propose a change on every reconcile.
+      expect(line?.includes("NOT NULL")).toBe(!column.nullable);
+    }
+  });
+});

--- a/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-schema-service.ts
+++ b/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-schema-service.ts
@@ -29,7 +29,11 @@ import {
   storageTypeToken,
 } from "../../../shared/lib/plugin-storage";
 import { resolveLocalizedFieldNames } from "../../i18n/classify-fields";
-import { getColumnDescriptor } from "../../schema/services/field-column-descriptor";
+import {
+  getColumnDescriptor,
+  getSystemColumnDescriptors,
+  renderSystemColumnSql,
+} from "../../schema/services/field-column-descriptor";
 import { quoteJsonSqlDefault } from "../../schema/utils/sql-literal";
 
 import { DynamicCollectionValidationService } from "./dynamic-collection-validation-service";
@@ -252,70 +256,41 @@ export class DynamicCollectionSchemaService {
     // comma before the timestamp section, producing invalid SQL.
     const allColumnDefs: string[] = [];
 
-    // id
-    if (this.dialect === "mysql") {
-      allColumnDefs.push(
-        `  ${this.quoteIdentifier("id")} varchar(36) PRIMARY KEY NOT NULL`
-      );
-    } else {
-      allColumnDefs.push(
-        `  ${this.quoteIdentifier("id")} text PRIMARY KEY NOT NULL`
-      );
-    }
-
-    // title (only if not user-defined). A component named "title" produces no
-    // column, so it must not suppress the system title column.
+    // System columns, rendered from the one list that defines them rather than restated here.
+    // Restating them is how a newly added system column reached the runtime schema and missed the
+    // physical table: the generated SELECT then names a column that does not exist and every read
+    // of the entity fails. Iterating the list — rather than sourcing each column in place — is
+    // what makes that impossible, since a new entry needs no edit here to be created.
+    //
+    // A component named "title" produces no column, so it must not suppress the system title
+    // column; the same holds for "slug".
     const hasTitleField = fields.some(
       f => f.name === "title" && f.type !== STORAGE_FORMAT.fieldType
     );
-    if (!hasTitleField) {
-      if (this.dialect === "mysql") {
-        allColumnDefs.push(
-          `  ${this.quoteIdentifier("title")} varchar(255) NOT NULL`
-        );
-      } else {
-        allColumnDefs.push(`  ${this.quoteIdentifier("title")} text NOT NULL`);
-      }
-    }
-
-    // slug (only if not user-defined). Same column-less exclusion as title.
     const hasSlugField = fields.some(
       f => f.name === "slug" && f.type !== STORAGE_FORMAT.fieldType
     );
-    if (!hasSlugField) {
-      if (this.dialect === "mysql") {
-        allColumnDefs.push(
-          `  ${this.quoteIdentifier("slug")} varchar(255) NOT NULL`
-        );
-      } else {
-        allColumnDefs.push(`  ${this.quoteIdentifier("slug")} text NOT NULL`);
-      }
+    // A single is one global row, so owner-only ownership is meaningless and it gets no
+    // `created_by`. Prefer the explicit flag, but fall back to the `single_` table prefix so this
+    // stays in lockstep with the runtime schema and the diff, which derive it from the name, even
+    // when a caller omits the option.
+    const isSingleTable =
+      _options?.isSingle === true || tableName.startsWith("single_");
+
+    for (const systemColumn of getSystemColumnDescriptors(this.dialect, {
+      hasTitleField,
+      hasSlugField,
+      hasStatus: _options?.hasStatus === true,
+      isSingle: isSingleTable,
+    })) {
+      allColumnDefs.push(
+        `  ${renderSystemColumnSql(systemColumn, name => this.quoteIdentifier(name))}`
+      );
     }
 
     // user-defined columns (may be multi-line, already comma-separated internally)
     if (columns.length > 0) {
       allColumnDefs.push(columns);
-    }
-
-    // Status system column: only emitted when the collection / single opts
-    // into the Draft/Published lifecycle. Default 'draft' is critical —
-    // every existing row gets it on enable so writes don't violate NOT NULL.
-    if (_options?.hasStatus) {
-      if (this.dialect === "sqlite") {
-        // SQLite has no varchar; text + default is the equivalent.
-        allColumnDefs.push(
-          `  ${this.quoteIdentifier("status")} text DEFAULT 'draft' NOT NULL`
-        );
-      } else if (this.dialect === "mysql") {
-        // varchar(20) leaves headroom over "published" (9 chars).
-        allColumnDefs.push(
-          `  ${this.quoteIdentifier("status")} varchar(20) DEFAULT 'draft' NOT NULL`
-        );
-      } else {
-        allColumnDefs.push(
-          `  ${this.quoteIdentifier("status")} varchar(20) DEFAULT 'draft' NOT NULL`
-        );
-      }
     }
 
     // CHECK constraints
@@ -328,47 +303,6 @@ export class DynamicCollectionSchemaService {
     // FK constraints (each already indented)
     for (const c of constraints) {
       allColumnDefs.push(c);
-    }
-
-    // timestamp columns
-    if (this.dialect === "sqlite") {
-      allColumnDefs.push(
-        `  ${this.quoteIdentifier("created_at")} integer DEFAULT (strftime('%s', 'now')) NOT NULL`
-      );
-      allColumnDefs.push(
-        `  ${this.quoteIdentifier("updated_at")} integer DEFAULT (strftime('%s', 'now')) NOT NULL`
-      );
-    } else if (this.dialect === "mysql") {
-      allColumnDefs.push(
-        `  ${this.quoteIdentifier("created_at")} timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL`
-      );
-      allColumnDefs.push(
-        `  ${this.quoteIdentifier("updated_at")} timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL`
-      );
-    } else {
-      allColumnDefs.push(
-        `  ${this.quoteIdentifier("created_at")} timestamp DEFAULT now() NOT NULL`
-      );
-      allColumnDefs.push(
-        `  ${this.quoteIdentifier("updated_at")} timestamp DEFAULT now() NOT NULL`
-      );
-    }
-
-    // Owner column — COLLECTIONS ONLY. A single is one global row, so
-    // owner-only ownership is meaningless; singles never stamp or query it.
-    // Nullable with no default (matches getSystemColumnDescriptors) so existing
-    // rows and system creates stay null; sized to the users.id column on MySQL
-    // since it holds a user id, not the row id.
-    // Prefer the explicit flag, but also fall back to the `single_` table
-    // prefix so this stays in lockstep with the runtime schema / diff (which
-    // derive it from the name) even if a caller omits the option.
-    const isSingleTable =
-      _options?.isSingle === true || tableName.startsWith("single_");
-    if (!isSingleTable) {
-      const ownerType = this.dialect === "mysql" ? "varchar(191)" : "text";
-      allColumnDefs.push(
-        `  ${this.quoteIdentifier("created_by")} ${ownerType}`
-      );
     }
 
     let sql = `-- Create dynamic collection: ${tableName}

--- a/packages/nextly/src/domains/schema/services/field-column-descriptor.ts
+++ b/packages/nextly/src/domains/schema/services/field-column-descriptor.ts
@@ -582,3 +582,42 @@ export function getSystemColumnDescriptors(
   }
   return cols;
 }
+
+/**
+ * Spell one system-column descriptor as the column definition of a `CREATE TABLE`.
+ *
+ * The module that owns what the columns ARE owns how they are written, so a DDL generator can
+ * iterate `getSystemColumnDescriptors` instead of restating the set. Restating it is what let a
+ * newly added system column reach the runtime schema and miss the physical table, which makes
+ * every read of that entity select a column that is not there.
+ *
+ * `quoteIdentifier` is the caller's, because quoting is a property of the generator's dialect
+ * handling rather than of the column.
+ *
+ * Clause order is `type [DEFAULT x] [PRIMARY KEY] [NOT NULL]`, which is what the generators
+ * already emitted by hand. A default is a literal DDL expression (`now()`, `'draft'`), not a
+ * value to be escaped: the descriptor stores it exactly as it must appear.
+ */
+export function renderSystemColumnSql(
+  column: SystemColumnDescriptor,
+  quoteIdentifier: (name: string) => string
+): string {
+  // `length` is redundant on some dialects and load-bearing on others: MySQL's descriptors carry
+  // the size inside `dialectType` ("varchar(36)") as well as in `length`, while PostgreSQL's
+  // status column is "varchar" with the 20 held only in `length`. Appending unconditionally would
+  // emit "varchar(36)(36)", so the size is added only when the type does not already state one.
+  const statesItsOwnSize = column.dialectType.includes("(");
+  const type =
+    column.length === undefined || statesItsOwnSize
+      ? column.dialectType
+      : `${column.dialectType}(${column.length})`;
+
+  const clauses = [quoteIdentifier(column.name), type];
+  if (column.default !== undefined) clauses.push(`DEFAULT ${column.default}`);
+  if (column.primaryKey) clauses.push("PRIMARY KEY");
+  // A primary key is already NOT NULL on every dialect, and the generators spelled it out. Kept
+  // so the emitted text does not change for the columns that were not the point of this.
+  if (!column.nullable) clauses.push("NOT NULL");
+
+  return clauses.join(" ");
+}


### PR DESCRIPTION
## What

`DynamicCollectionSchemaService.generateMigrationSQL` — the DDL behind every Schema-Builder collection and single — no longer restates the system-column set as per-dialect SQL strings. It iterates `getSystemColumnDescriptors` and renders each entry through a new `renderSystemColumnSql`, which lives beside the descriptor that owns what the columns are.

Net effect on the generator: **-95 lines** of hand-maintained mirror.

## Why

`field-column-descriptor.ts` opens by explaining that it exists *because* this mapping was once duplicated, drifted, and made the diff engine report 56 false positives on a stable schema. It names the two consumers it keeps in lockstep.

There was a third that did not use it. One of its own comments read *"Nullable with no default (matches getSystemColumnDescriptors)"* — a hand-maintained mirror of the module whose entire purpose is to make hand-maintained mirrors unnecessary.

The consequence is not cosmetic: a system column added to the descriptor reached code-first tables and silently missed Builder ones. The runtime schema then `SELECT`ed a column that does not exist, so **every read of that entity failed**. That is exactly what happened to `first_published_at` in #465, and it is why that PR had to exclude Singles.

**It iterates rather than sourcing each column in place.** Keeping each column where it sits and only sourcing its text would still require placing a newly added descriptor entry by hand, which is the precise failure being removed.

## The divergence this resolves

The Builder emitted the timestamps `NOT NULL`; the descriptor calls them nullable. Measured on `main` with a probe that seeds a Builder collection the way the admin does, then runs the real pipeline (preview, apply, preview) and reads the table back:

| | phantom ops on a Builder SQLite collection |
|---|---|
| before #474 | 4 |
| after #474 | 2 |
| **with this PR** | **0** |

The two that remained were `change_column_nullable` on `created_at` / `updated_at`. New Builder tables now match the descriptor. Existing ones converge in one reconcile that relaxes the columns to nullable, which loses no data.

Boot is unaffected either way: boot-time auto-sync filters to tables that do not exist yet, so it never diffs an existing Builder table. These ops surface on `nextly db:sync` and the HMR reload path.

## Column order changes

System columns are now one contiguous block, so `CREATE TABLE` emits them in descriptor order rather than interleaved with user columns and constraints. Checked before accepting it: every DDL assertion in the suite is `toContain(...)` on individual columns, the only whole-statement `CREATE TABLE` assertions belong to the companion generator (a different path), and no snapshots pin the order. Column order in a fresh table is not semantically meaningful and the diff compares by name.

It is also an improvement: the runtime schema already iterates this same list, so the Drizzle table and the physical table are now built in the same order from the same source.

## One thing worth a reviewer's eye

`length` is not uniform across dialects. MySQL's descriptors carry the size **inside** `dialectType` (`"varchar(36)"`) *and* in `length`; PostgreSQL's `status` is `"varchar"` with the 20 held only in `length`. Composing unconditionally emitted `varchar(36)(36)` — invalid DDL on every MySQL Builder table. The renderer appends the size only when the type does not already state one, and the rendered output was printed per dialect and compared line by line against what the generator emitted before this change.

## Verification

18 property tests, per dialect, asserting the system columns in the generated DDL **equal** the set `getSystemColumnDescriptors` returns for the same options. Deliberately set equality rather than a list of today's column names: a test naming the columns would pass forever while the next one added goes missing, which is the failure this PR exists to prevent. Separate cases cover the rendering itself (type, default, `PRIMARY KEY`, and that a nullable column carries no `NOT NULL`), the user-defined `title`/`slug` suppression, and the `single_` prefix fallback.

Both falsifications bite:

- generator skips one descriptor entry (`created_by`) → **12 tests fail**
- renderer restores the old `NOT NULL` on the timestamps → **3 tests fail**

Unit failure sets for `src/domains/dynamic-collections` and `src/domains/schema` are **identical to a baseline captured from this same tree with the change reverted**: 8 pre-existing, 0 new.

Integration legs, freshly recreated databases:

| leg | result |
|---|---|
| sqlite | 959 passed, 0 failed |
| postgres17 | 1101 passed, 0 failed |
| mysql | 1037 passed, 0 failed |

## Follow-up filed, not done here

There are four `generateMigrationSQL` implementations. `user-ext-schema-service` and `field-group-schema-service` each carry a character-for-character copy of the same per-dialect timestamp-default map, and `system-table-service` hardcodes its columns inline. They create different tables with different column sets, so folding them in would have widened a bounded change into a four-service sweep. Filed as task 107 with the reasoning, including the possibility that `system-table-service` is genuinely exempt.
