### PR TITLE
fix(nextly): apply nested relationship field access before parent hooks

### DIFF
--- a/.changeset/nested-child-access-order.md
+++ b/.changeset/nested-child-access-order.md
@@ -1,0 +1,27 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+Field-level read access on an expanded relationship now applies to each related row before its parent's `afterRead` field hooks run, matching a direct read. Previously a parent hook was handed a nested child with the caller's denied fields still present, so a hook that copied such a field onto an allowed key exposed it under that key even though the child's own field was redacted afterward.
+
+Behavior change: a field `afterRead` hook can no longer observe a related row's caller-denied field, so it can neither leak nor mask on one. A value that must stay hidden should be protected with an `access.read` rule keyed on the caller rather than a hook that reads another field the caller cannot see. Trusted reads (`overrideAccess`) are unaffected, since field access is skipped for them.

--- a/packages/nextly/src/domains/collections/__tests__/collection-test-helpers.ts
+++ b/packages/nextly/src/domains/collections/__tests__/collection-test-helpers.ts
@@ -253,7 +253,7 @@ export function createMockRelationshipService(): MockRecord {
       fields: new Map(),
       labelFields: new Map(),
       redactions: new WeakMap(),
-      redactionsById: new Map(),
+      originalRowById: new Map(),
       pending: [],
       applyFieldHooks: true,
     })),

--- a/packages/nextly/src/domains/collections/__tests__/collection-test-helpers.ts
+++ b/packages/nextly/src/domains/collections/__tests__/collection-test-helpers.ts
@@ -253,6 +253,7 @@ export function createMockRelationshipService(): MockRecord {
       fields: new Map(),
       labelFields: new Map(),
       redactions: new WeakMap(),
+      redactionsById: new Map(),
       pending: [],
       applyFieldHooks: true,
     })),

--- a/packages/nextly/src/domains/collections/__tests__/collection-test-helpers.ts
+++ b/packages/nextly/src/domains/collections/__tests__/collection-test-helpers.ts
@@ -254,6 +254,7 @@ export function createMockRelationshipService(): MockRecord {
       labelFields: new Map(),
       redactions: new WeakMap(),
       originalRowById: new Map(),
+      failClosed: new WeakSet(),
       pending: [],
       applyFieldHooks: true,
     })),

--- a/packages/nextly/src/domains/collections/__tests__/collection-test-helpers.ts
+++ b/packages/nextly/src/domains/collections/__tests__/collection-test-helpers.ts
@@ -254,6 +254,7 @@ export function createMockRelationshipService(): MockRecord {
       labelFields: new Map(),
       redactions: new WeakMap(),
       originalRowById: new Map(),
+      originalNestedRows: new WeakSet(),
       failClosed: new WeakSet(),
       pending: [],
       applyFieldHooks: true,

--- a/packages/nextly/src/domains/collections/__tests__/collection-test-helpers.ts
+++ b/packages/nextly/src/domains/collections/__tests__/collection-test-helpers.ts
@@ -244,11 +244,17 @@ export function createMockRelationshipService(): MockRecord {
     // whole listing has been walked, so a double carrying only the first half
     // certifies a path that throws for real.
     finalizeRelatedRows: vi.fn().mockResolvedValue(undefined),
+    // The authoritative re-sanitization the read paths run over the assembled
+    // response after every source hook. Both list and detail paths now call it on
+    // every successful read, so a double without it certifies a path that throws.
+    resanitizeAssembledRows: vi.fn().mockResolvedValue(undefined),
     createNestedHookState: vi.fn().mockImplementation(() => ({
       visited: new Set(),
       fields: new Map(),
       labelFields: new Map(),
+      redactions: new WeakMap(),
       pending: [],
+      applyFieldHooks: true,
     })),
     insertManyToManyRelations: vi.fn().mockResolvedValue(undefined),
     deleteManyToManyRelations: vi.fn().mockResolvedValue(undefined),

--- a/packages/nextly/src/domains/collections/__tests__/nested-field-hooks.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/nested-field-hooks.integration.test.ts
@@ -106,6 +106,26 @@ async function boot(): Promise<TestNextly> {
               }),
             ],
           }),
+          // A group holding a denied field, beside a top-level sibling whose
+          // visibility depends on that nested value. The nested read judges each
+          // row twice — before and after the parent's hooks — and the second pass
+          // snapshots the org row before descending to restore the group's
+          // evidence, so re-judging `emblem` against the already-stripped group
+          // would wrongly drop it. A direct read judges `emblem` once with the
+          // group intact and keeps it; restoring the whole subtree's evidence
+          // before the ancestor snapshot is what keeps the two reads in step.
+          group({
+            name: "charter",
+            fields: [text({ name: "sealed", access: { read: () => false } })],
+          }),
+          text({
+            name: "emblem",
+            access: {
+              read: ({ data }) =>
+                (data as { charter?: { sealed?: unknown } } | undefined)
+                  ?.charter?.sealed === "yes",
+            },
+          }),
         ],
       }),
       defineCollection({
@@ -681,6 +701,46 @@ describe("a target's field hooks apply to rows reached through a relationship", 
     expect(org!.region).toBe("emea");
     // The denied sibling is still withheld.
     expect(org!.classification).toBeUndefined();
+  });
+
+  it("keeps an outer field whose access reads a denied value nested in a group", async () => {
+    // `emblem` is allowed only while the group's denied `sealed` is present as
+    // evidence; `sealed` denies read. A direct read judges `emblem` once, with
+    // the group intact, and keeps it. The nested read judges twice — before and
+    // after the parent's hooks — and the second pass snapshots the org row before
+    // descending to restore the group, so unless the whole subtree's evidence is
+    // restored FIRST it sees the stripped group and wrongly drops `emblem`.
+    const t = await boot();
+    await t.nextly.create({
+      collection: ORGS,
+      data: { name: "acme", charter: { sealed: "yes" }, emblem: "crest" },
+    });
+    const orgId = await onlyId(t, ORGS);
+    await t.nextly.create({
+      collection: AUTHORS,
+      data: { name: "ada", organization: orgId },
+    });
+    const authorId = await onlyId(t, AUTHORS);
+    await t.nextly.create({
+      collection: POSTS,
+      data: { title: "p", author: authorId },
+    });
+    const postId = await onlyId(t, POSTS);
+
+    const expanded = await handlerOf(t).getEntry({
+      collectionName: POSTS,
+      entryId: postId,
+      depth: 2,
+    });
+
+    const author = expanded.data!.author as Record<string, unknown>;
+    const org = author.organization as Record<string, unknown> | undefined;
+    expect(org).toBeTruthy();
+    // Kept: judged with the group's evidence intact, as a direct read would.
+    expect(org!.emblem).toBe("crest");
+    // The denied nested field is still withheld from the response.
+    const charter = org!.charter as Record<string, unknown> | undefined;
+    if (charter) expect(charter.sealed).toBeUndefined();
   });
 
   it("judges a repeater row a parent hook appends after the first pass", async () => {

--- a/packages/nextly/src/domains/collections/__tests__/nested-field-hooks.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/nested-field-hooks.integration.test.ts
@@ -73,6 +73,19 @@ async function boot(): Promise<TestNextly> {
             name: "classification",
             access: { read: () => false },
           }),
+          // Allowed ONLY while `classification` is present as evidence. Its rule
+          // reads the row as `data`, so evaluating it a second time against the
+          // already-stripped row (where classification is gone) would wrongly
+          // deny it — which is why the finalize step replays decisions instead of
+          // re-evaluating.
+          text({
+            name: "region",
+            access: {
+              read: ({ data }) =>
+                (data as { classification?: unknown } | undefined)
+                  ?.classification === "private",
+            },
+          }),
         ],
       }),
       defineCollection({
@@ -533,6 +546,44 @@ describe("a target's field hooks apply to rows reached through a relationship", 
     const org = author.organization as Record<string, unknown> | undefined;
     // The second pass removed the value the hook wrote back — not "reintroduced".
     if (org) expect(org.classification).toBeUndefined();
+  });
+
+  it("keeps a field whose access depended on a denied sibling, judged once", async () => {
+    // `region` is allowed only while `classification` is present; `classification`
+    // is denied. The first pass judges `region` against the complete row (keeps
+    // it) and removes `classification`. The finalize step must REPLAY that
+    // decision, not re-judge `region` against the now-stripped row — re-judging
+    // would wrongly deny it, unlike a direct read which evaluates it once.
+    const t = await boot();
+    await t.nextly.create({
+      collection: ORGS,
+      data: { name: "acme", classification: "private", region: "emea" },
+    });
+    const orgId = await onlyId(t, ORGS);
+    await t.nextly.create({
+      collection: AUTHORS,
+      data: { name: "ada", organization: orgId },
+    });
+    const authorId = await onlyId(t, AUTHORS);
+    await t.nextly.create({
+      collection: POSTS,
+      data: { title: "p", author: authorId },
+    });
+    const postId = await onlyId(t, POSTS);
+
+    const expanded = await handlerOf(t).getEntry({
+      collectionName: POSTS,
+      entryId: postId,
+      depth: 2,
+    });
+
+    const author = expanded.data!.author as Record<string, unknown>;
+    const org = author.organization as Record<string, unknown> | undefined;
+    expect(org).toBeTruthy();
+    // Kept: judged once, while its evidence was still present.
+    expect(org!.region).toBe("emea");
+    // The denied sibling is still withheld.
+    expect(org!.classification).toBeUndefined();
   });
 
   it("masks a dropped relationship before a source hook can copy out of it", async () => {

--- a/packages/nextly/src/domains/collections/__tests__/nested-field-hooks.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/nested-field-hooks.integration.test.ts
@@ -26,6 +26,7 @@ import {
 const ORGS = "nestedhook_orgs";
 const AUTHORS = "nestedhook_authors";
 const POSTS = "nestedhook_posts";
+const VAULTS = "nestedhook_vaults";
 
 // How many times the target's token hook ran, for the selection test.
 let tokenHookRuns = 0;
@@ -62,6 +63,14 @@ async function onlyId(t: TestNextly, collection: string): Promise<string> {
 async function boot(): Promise<TestNextly> {
   current = await createTestNextly({
     collections: [
+      // Its only text field is denied, so the auto-selected display label is
+      // built from a value the caller may not see — the setup for the label-copy
+      // exfiltration test.
+      defineCollection({
+        slug: VAULTS,
+        access: { read: () => true, create: () => true, update: () => true },
+        fields: [text({ name: "codename", access: { read: () => false } })],
+      }),
       defineCollection({
         slug: ORGS,
         access: { read: () => true, create: () => true, update: () => true },
@@ -330,6 +339,26 @@ async function boot(): Promise<TestNextly> {
               ],
             },
           }),
+          // A relationship whose target's only text field — and so its derived
+          // display label — is DENIED. Expansion builds the label from the raw
+          // value, then the access pass strips the field but the label lingers, so
+          // a parent hook reading `data.vault.label` can copy the denied value
+          // unless the label is rebuilt right after that access pass.
+          relationship({ name: "vault", relationTo: VAULTS }),
+          // Copies the nested vault's `label` onto an allowed field of its own,
+          // the exfiltration the label rebuild must close.
+          text({
+            name: "vaultLabelCopy",
+            hooks: {
+              afterRead: [
+                ({ value, data }) => {
+                  if (value !== "on") return value;
+                  const vault = (data as { vault?: { label?: unknown } }).vault;
+                  return typeof vault?.label === "string" ? vault.label : value;
+                },
+              ],
+            },
+          }),
         ],
       }),
       defineCollection({
@@ -338,6 +367,24 @@ async function boot(): Promise<TestNextly> {
         fields: [
           text({ name: "title" }),
           relationship({ name: "author", relationTo: AUTHORS }),
+          // A source field-level afterRead hook that writes a denied field back
+          // onto a related row. It runs after the related-row sanitization the
+          // earlier rounds added, so only a pass after the field hooks strips it.
+          text({
+            name: "annotate",
+            hooks: {
+              afterRead: [
+                ({ value, data }) => {
+                  if (value !== "on") return value;
+                  const author = (data as { author?: unknown }).author;
+                  if (author && typeof author === "object") {
+                    (author as Record<string, unknown>).dossier = "LEAKED";
+                  }
+                  return value;
+                },
+              ],
+            },
+          }),
           // The blog template's shape: a relationship to the built-in users
           // entity, which has no dynamic-collection record.
           relationship({ name: "owner", relationTo: "users" }),
@@ -1080,5 +1127,101 @@ describe("a target's field hooks apply to rows reached through a relationship", 
     // The source hook's write-back onto the related author was stripped by the
     // pass after the hooks.
     expect(author.dossier).toBeUndefined();
+  });
+
+  it("re-sanitizes related rows a source hook returns in a reshaped document", async () => {
+    // A source afterRead hook may RETURN a new document (the hook registry
+    // supports reshaping the response), so the response can hold related rows that
+    // are new objects the walk never queued. Sanitizing only the queued rows would
+    // miss them; the authoritative pass re-walks the ACTUAL response.
+    const t = await boot();
+    const postId = await seed(t);
+
+    t.hooks.register("afterRead", POSTS, ctx => {
+      const entry = ctx.data as Record<string, unknown>;
+      const author = entry.author as Record<string, unknown> | undefined;
+      // A RESHAPED clone whose author is a NEW object carrying a denied field.
+      return { ...entry, author: { ...(author ?? {}), dossier: "LEAKED" } };
+    });
+
+    const expanded = await handlerOf(t).getEntry({
+      collectionName: POSTS,
+      entryId: postId,
+      depth: 2,
+    });
+
+    const author = expanded.data!.author as Record<string, unknown>;
+    expect(author).toBeTruthy();
+    // The denied field on the hook's replacement object was stripped too.
+    expect(author.dossier).toBeUndefined();
+  });
+
+  it("re-sanitizes a related row a source field hook writes to", async () => {
+    // A source collection FIELD-level afterRead hook runs after the related-row
+    // sanitization the earlier rounds added; it too can write a denied target
+    // field onto a related row, so the authoritative pass must run after the field
+    // hooks, not only after the code and stored hooks.
+    const t = await boot();
+    await t.nextly.create({ collection: ORGS, data: { name: "acme" } });
+    const orgId = await onlyId(t, ORGS);
+    await t.nextly.create({
+      collection: AUTHORS,
+      data: { name: "ada", organization: orgId },
+    });
+    const authorId = await onlyId(t, AUTHORS);
+    await t.nextly.create({
+      collection: POSTS,
+      // `annotate` present, so its field hook fires and writes the denied field.
+      data: { title: "p", author: authorId, annotate: "on" },
+    });
+    const postId = await onlyId(t, POSTS);
+
+    const expanded = await handlerOf(t).getEntry({
+      collectionName: POSTS,
+      entryId: postId,
+      depth: 2,
+    });
+
+    const author = expanded.data!.author as Record<string, unknown>;
+    expect(author).toBeTruthy();
+    expect(author.dossier).toBeUndefined();
+  });
+
+  it("rebuilds a related row's label before a parent hook can copy it", async () => {
+    // `vault`'s only text field — and so its derived label — is DENIED. Expansion
+    // builds the label from the raw value; the access pass strips the field but
+    // the derived label lingers. A parent hook copying `data.vault.label` would
+    // exfiltrate the denied value unless the label is rebuilt right after that
+    // access pass, before the parent's hooks run.
+    const t = await boot();
+    await t.nextly.create({
+      collection: VAULTS,
+      data: { codename: "TOPSECRET" },
+    });
+    const vaultId = await onlyId(t, VAULTS);
+    await t.nextly.create({
+      collection: AUTHORS,
+      data: { name: "ada", vault: vaultId, vaultLabelCopy: "on" },
+    });
+    const authorId = await onlyId(t, AUTHORS);
+    await t.nextly.create({
+      collection: POSTS,
+      data: { title: "p", author: authorId },
+    });
+    const postId = await onlyId(t, POSTS);
+
+    const expanded = await handlerOf(t).getEntry({
+      collectionName: POSTS,
+      entryId: postId,
+      depth: 2,
+    });
+
+    const author = expanded.data!.author as Record<string, unknown>;
+    expect(author).toBeTruthy();
+    // The copied label is not the denied `codename` value.
+    expect(author.vaultLabelCopy).not.toBe("TOPSECRET");
+    // And the nested vault's own label was rebuilt off a value the caller may see.
+    const vault = author.vault as Record<string, unknown> | undefined;
+    if (vault) expect(vault.label).not.toBe("TOPSECRET");
   });
 });

--- a/packages/nextly/src/domains/collections/__tests__/nested-field-hooks.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/nested-field-hooks.integration.test.ts
@@ -449,6 +449,24 @@ async function boot(): Promise<TestNextly> {
               ],
             },
           }),
+          // A field-level (last-phase) hook that copies the related author's
+          // denied `dossier` onto an allowed source key. A code or stored hook
+          // that reintroduces `dossier` on the author must be re-sanitized before
+          // this phase runs, or the copy escapes the field-access system.
+          text({
+            name: "harvest",
+            hooks: {
+              afterRead: [
+                ({ value, data }) => {
+                  if (value !== "on") return value;
+                  const author = (data as { author?: { dossier?: unknown } })
+                    .author;
+                  (data as Record<string, unknown>).leaked = author?.dossier;
+                  return value;
+                },
+              ],
+            },
+          }),
           // The blog template's shape: a relationship to the built-in users
           // entity, which has no dynamic-collection record.
           relationship({ name: "owner", relationTo: "users" }),
@@ -1664,5 +1682,128 @@ describe("a target's field hooks apply to rows reached through a relationship", 
     // Fail-closed: an id-less clone cannot be matched, so the reintroduced
     // `openInfo` was denied along with the org's other access-controlled fields.
     expect(org!.openInfo).toBeUndefined();
+  });
+
+  it("decodes a relationship a hook returns as JSON with leading whitespace", async () => {
+    // A populated relationship serialized to JSON can arrive with leading
+    // whitespace (a pretty-printed hook return). The container guard detects it by
+    // the first non-whitespace character; otherwise the walk leaves it a string
+    // and the denied `dossier` inside reaches the response unsanitized.
+    const t = await boot();
+    await t.nextly.create({ collection: AUTHORS, data: { name: "c" } });
+    const contributorId = await onlyId(t, AUTHORS);
+    await t.nextly.create({ collection: POSTS, data: { title: "p" } });
+    const postId = await onlyId(t, POSTS);
+
+    t.hooks.register("afterRead", POSTS, ctx => {
+      const entry = ctx.data as Record<string, unknown>;
+      entry.contributors =
+        "\n  " +
+        JSON.stringify([{ id: contributorId, name: "c", dossier: "LEAKED" }]);
+      return entry;
+    });
+
+    const expanded = await handlerOf(t).getEntry({
+      collectionName: POSTS,
+      entryId: postId,
+      depth: 2,
+    });
+
+    const contributors = expanded.data!.contributors as
+      | Record<string, unknown>[]
+      | undefined;
+    expect(Array.isArray(contributors)).toBe(true);
+    expect(contributors![0].dossier).toBeUndefined();
+  });
+
+  it("fails closed on a nested row a hook replaces in place under an unchanged root", async () => {
+    // A source hook keeps the related root object identical but REPLACES a row
+    // inside its repeater, reintroducing an inverse-conditional field on the new
+    // row. The root's identity does not prove the nested row's provenance: the
+    // replacement carries no evidence, so it fails closed rather than judging the
+    // inverse field against a row that dropped its denied sibling.
+    const t = await boot();
+    await t.nextly.create({
+      collection: ORGS,
+      data: {
+        name: "acme",
+        divisions: [{ label: "d", grade: "restricted", openTag: "topsecret" }],
+      },
+    });
+    const orgId = await onlyId(t, ORGS);
+    await t.nextly.create({
+      collection: AUTHORS,
+      data: { name: "ada", organization: orgId },
+    });
+    const authorId = await onlyId(t, AUTHORS);
+    await t.nextly.create({
+      collection: POSTS,
+      data: { title: "p", author: authorId },
+    });
+    const postId = await onlyId(t, POSTS);
+
+    t.hooks.register("afterRead", POSTS, ctx => {
+      const entry = ctx.data as Record<string, unknown>;
+      const author = entry.author as Record<string, unknown> | undefined;
+      const org = author?.organization as Record<string, unknown> | undefined;
+      const divisions = org?.divisions as Record<string, unknown>[] | undefined;
+      if (Array.isArray(divisions) && divisions.length > 0) {
+        // Same org object, same divisions array — only the row is swapped.
+        divisions[0] = { label: "d", openTag: "LEAKED" };
+      }
+      return entry;
+    });
+
+    const expanded = await handlerOf(t).getEntry({
+      collectionName: POSTS,
+      entryId: postId,
+      depth: 2,
+    });
+
+    const author = expanded.data!.author as Record<string, unknown>;
+    const org = author.organization as Record<string, unknown> | undefined;
+    const divisions = (org?.divisions ?? []) as Record<string, unknown>[];
+    expect(divisions[0]?.label).toBe("d");
+    // Fail-closed: the replaced nested row carries no evidence, so its inverse
+    // field is denied.
+    expect(divisions[0]?.openTag).toBeUndefined();
+  });
+
+  it("re-sanitizes a related row a code hook reshapes before a later field hook reads it", async () => {
+    // A code (entity-level) afterRead hook reintroduces a denied field on a
+    // related row; a LATER field-level hook copies it onto an allowed source key.
+    // The authoritative pass runs after EACH source phase, so the denied field is
+    // stripped after the code hook and before the field hook can read it.
+    const t = await boot();
+    await t.nextly.create({ collection: ORGS, data: { name: "acme" } });
+    const orgId = await onlyId(t, ORGS);
+    await t.nextly.create({
+      collection: AUTHORS,
+      data: { name: "ada", organization: orgId, dossier: "SECRET" },
+    });
+    const authorId = await onlyId(t, AUTHORS);
+    await t.nextly.create({
+      collection: POSTS,
+      data: { title: "p", author: authorId, harvest: "on" },
+    });
+    const postId = await onlyId(t, POSTS);
+
+    t.hooks.register("afterRead", POSTS, ctx => {
+      const entry = ctx.data as Record<string, unknown>;
+      const author = entry.author as Record<string, unknown> | undefined;
+      if (author) author.dossier = "SECRET";
+      return entry;
+    });
+
+    const expanded = await handlerOf(t).getEntry({
+      collectionName: POSTS,
+      entryId: postId,
+      depth: 2,
+    });
+
+    // The field hook was handed a sanitized author, so it copied nothing.
+    expect(expanded.data!.leaked).toBeUndefined();
+    const author = expanded.data!.author as Record<string, unknown>;
+    expect(author.dossier).toBeUndefined();
   });
 });

--- a/packages/nextly/src/domains/collections/__tests__/nested-field-hooks.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/nested-field-hooks.integration.test.ts
@@ -192,6 +192,7 @@ async function boot(): Promise<TestNextly> {
             hooks: {
               afterRead: [
                 ({ value, data }) => {
+                  if (value !== "on") return value;
                   const org = (data as { organization?: unknown }).organization;
                   if (org && typeof org === "object") {
                     (org as Record<string, unknown>).classification =
@@ -210,6 +211,7 @@ async function boot(): Promise<TestNextly> {
             hooks: {
               afterRead: [
                 ({ value, data }) => {
+                  if (value !== "on") return value;
                   const org = (data as { organization?: unknown }).organization;
                   const divisions =
                     org && typeof org === "object"
@@ -231,6 +233,7 @@ async function boot(): Promise<TestNextly> {
             hooks: {
               afterRead: [
                 ({ value, data }) => {
+                  if (value !== "on") return value;
                   const org = (data as { organization?: unknown }).organization;
                   const divisions =
                     org && typeof org === "object"
@@ -242,6 +245,34 @@ async function boot(): Promise<TestNextly> {
                       tier: "private",
                       code: "SNEAKED",
                     };
+                  }
+                  return value;
+                },
+              ],
+            },
+          }),
+          // MUTATES the org's first division IN PLACE (same object): flips it to
+          // private and writes a fresh `code`. Object identity is unchanged, so a
+          // cached verdict would let the new `code` through — only re-judging the
+          // current content strips it.
+          text({
+            name: "mutator",
+            hooks: {
+              afterRead: [
+                ({ value, data }) => {
+                  if (value !== "on") return value;
+                  const org = (data as { organization?: unknown }).organization;
+                  const divisions =
+                    org && typeof org === "object"
+                      ? (org as { divisions?: unknown }).divisions
+                      : undefined;
+                  const first =
+                    Array.isArray(divisions) && divisions[0]
+                      ? (divisions[0] as Record<string, unknown>)
+                      : undefined;
+                  if (first) {
+                    first.tier = "private";
+                    first.code = "MUTATED";
                   }
                   return value;
                 },
@@ -734,6 +765,46 @@ describe("a target's field hooks apply to rows reached through a relationship", 
     expect(divisions[0]?.label).toBe("swapped");
     // ...and its `code`, denied for a private division, did not ride in on the
     // public original's verdict.
+    expect(divisions[0]?.code).toBeUndefined();
+  });
+
+  it("re-judges a row a parent hook mutates in place", async () => {
+    // The division is public, so its `code` is allowed on the first pass. A hook
+    // then flips the SAME object to private and rewrites `code`. Object identity
+    // is unchanged, so reusing the earlier "allowed" verdict would leak the new
+    // code; only re-judging the current content denies it.
+    const t = await boot();
+    await t.nextly.create({
+      collection: ORGS,
+      data: {
+        name: "acme",
+        divisions: [{ label: "d", tier: "public", code: "OK" }],
+      },
+    });
+    const orgId = await onlyId(t, ORGS);
+    await t.nextly.create({
+      collection: AUTHORS,
+      data: { name: "ada", organization: orgId, mutator: "on" },
+    });
+    const authorId = await onlyId(t, AUTHORS);
+    await t.nextly.create({
+      collection: POSTS,
+      data: { title: "p", author: authorId },
+    });
+    const postId = await onlyId(t, POSTS);
+
+    const expanded = await handlerOf(t).getEntry({
+      collectionName: POSTS,
+      entryId: postId,
+      depth: 2,
+    });
+
+    const author = expanded.data!.author as Record<string, unknown>;
+    const org = author.organization as Record<string, unknown> | undefined;
+    const divisions = (org?.divisions ?? []) as Record<string, unknown>[];
+    // The mutation landed (now private)...
+    expect(divisions[0]?.tier).toBe("private");
+    // ...and the `code` the hook wrote is denied for a private division.
     expect(divisions[0]?.code).toBeUndefined();
   });
 

--- a/packages/nextly/src/domains/collections/__tests__/nested-field-hooks.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/nested-field-hooks.integration.test.ts
@@ -113,6 +113,21 @@ async function boot(): Promise<TestNextly> {
                     (data as { tier?: unknown } | undefined)?.tier === "public",
                 },
               }),
+              // A denied field on the repeater ROW, and an INVERSE sibling visible
+              // only while `grade` is NOT "restricted". A restricted division
+              // strips both. A hook that deep-clones the org and REORDERS this
+              // repeater must not let the restricted row inherit a public row's
+              // evidence by array position and fall open: repeater rows are matched
+              // by id, not index, and an unmatchable clone row fails closed.
+              text({ name: "grade", access: { read: () => false } }),
+              text({
+                name: "openTag",
+                access: {
+                  read: ({ data }) =>
+                    (data as { grade?: unknown } | undefined)?.grade !==
+                    "restricted",
+                },
+              }),
             ],
           }),
           // A group holding a denied field, beside a top-level sibling whose
@@ -1539,5 +1554,115 @@ describe("a target's field hooks apply to rows reached through a relationship", 
     expect(Array.isArray(contributors)).toBe(true);
     expect(contributors![0]).toBeTruthy();
     expect(contributors![0].dossier).toBeUndefined();
+  });
+
+  it("matches cloned repeater rows by id, not index, when a hook reorders them", async () => {
+    // `openTag` on a division is visible only while the denied `grade` is NOT
+    // "restricted". A restricted division strips both. A source hook DEEP-clones
+    // the org and REVERSES its divisions, reintroducing `openTag` on the restricted
+    // row now sitting at the index a public row held. Transferring the cloned
+    // rows' evidence by array position would hand the restricted row the public
+    // row's (empty) evidence and let `openTag` fall open; matching by id keeps it
+    // closed, and a clone row that cannot be matched fails closed.
+    const t = await boot();
+    await t.nextly.create({
+      collection: ORGS,
+      data: {
+        name: "acme",
+        divisions: [
+          { label: "pub", grade: "open" },
+          { label: "sec", grade: "restricted", openTag: "topsecret" },
+        ],
+      },
+    });
+    const orgId = await onlyId(t, ORGS);
+    await t.nextly.create({
+      collection: AUTHORS,
+      data: { name: "ada", organization: orgId },
+    });
+    const authorId = await onlyId(t, AUTHORS);
+    await t.nextly.create({
+      collection: POSTS,
+      data: { title: "p", author: authorId },
+    });
+    const postId = await onlyId(t, POSTS);
+
+    t.hooks.register("afterRead", POSTS, ctx => {
+      const entry = ctx.data as Record<string, unknown>;
+      const author = entry.author as Record<string, unknown> | undefined;
+      const org = author?.organization as Record<string, unknown> | undefined;
+      const divisions = org?.divisions as Record<string, unknown>[] | undefined;
+      if (author && org && Array.isArray(divisions)) {
+        const reordered = [...divisions].reverse().map(d => ({ ...d }));
+        const restricted = reordered.find(d => d.label === "sec");
+        if (restricted) restricted.openTag = "LEAKED";
+        author.organization = { ...org, divisions: reordered };
+      }
+      return entry;
+    });
+
+    const expanded = await handlerOf(t).getEntry({
+      collectionName: POSTS,
+      entryId: postId,
+      depth: 2,
+    });
+
+    const author = expanded.data!.author as Record<string, unknown>;
+    const org = author.organization as Record<string, unknown> | undefined;
+    const divisions = (org?.divisions ?? []) as Record<string, unknown>[];
+    const restricted = divisions.find(d => d.label === "sec");
+    expect(restricted).toBeTruthy();
+    // Closed: the restricted row was judged with its OWN evidence (or failed
+    // closed), never the public row's, so the reintroduced `openTag` was stripped.
+    expect(restricted!.openTag).toBeUndefined();
+  });
+
+  it("fails closed on a related-row clone that omits its id", async () => {
+    // `openInfo` is visible only while the denied `classification` is NOT
+    // "private". A private org strips both. A source hook returns a CLONE of the
+    // sanitized org that carries `openInfo` but DROPS its id, so it cannot be
+    // matched to the original whose evidence would keep the inverse rule closed.
+    // Its provenance is unrecoverable, so its access-controlled fields are denied.
+    const t = await boot();
+    await t.nextly.create({
+      collection: ORGS,
+      data: { name: "acme", classification: "private" },
+    });
+    const orgId = await onlyId(t, ORGS);
+    await t.nextly.create({
+      collection: AUTHORS,
+      data: { name: "ada", organization: orgId },
+    });
+    const authorId = await onlyId(t, AUTHORS);
+    await t.nextly.create({
+      collection: POSTS,
+      data: { title: "p", author: authorId },
+    });
+    const postId = await onlyId(t, POSTS);
+
+    t.hooks.register("afterRead", POSTS, ctx => {
+      const entry = ctx.data as Record<string, unknown>;
+      const author = entry.author as Record<string, unknown> | undefined;
+      const org = author?.organization as Record<string, unknown> | undefined;
+      if (author && org) {
+        const clone: Record<string, unknown> = { ...org, openInfo: "LEAKED" };
+        delete clone.id;
+        author.organization = clone;
+      }
+      return entry;
+    });
+
+    const expanded = await handlerOf(t).getEntry({
+      collectionName: POSTS,
+      entryId: postId,
+      depth: 2,
+    });
+
+    const author = expanded.data!.author as Record<string, unknown>;
+    const org = author.organization as Record<string, unknown> | undefined;
+    expect(org).toBeTruthy();
+    // Fail-closed: an id-less clone cannot be matched, so the reintroduced
+    // `openInfo` was denied along with the org's other access-controlled fields.
+    expect(org!.openInfo).toBeUndefined();
   });
 });

--- a/packages/nextly/src/domains/collections/__tests__/nested-field-hooks.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/nested-field-hooks.integration.test.ts
@@ -299,6 +299,32 @@ async function boot(): Promise<TestNextly> {
               ],
             },
           }),
+          // Flips the org's first division to public WITHOUT setting `code`. The
+          // first pass removed `code` for the private division; the second pass
+          // restores it only as evidence to re-judge the row, so the restored
+          // value must not ride out in the response just because the flipped
+          // condition now allows the field — the hook never supplied `code`.
+          text({
+            name: "tierflip",
+            hooks: {
+              afterRead: [
+                ({ value, data }) => {
+                  if (value !== "on") return value;
+                  const org = (data as { organization?: unknown }).organization;
+                  const divisions =
+                    org && typeof org === "object"
+                      ? (org as { divisions?: unknown }).divisions
+                      : undefined;
+                  const first =
+                    Array.isArray(divisions) && divisions[0]
+                      ? (divisions[0] as Record<string, unknown>)
+                      : undefined;
+                  if (first) first.tier = "public";
+                  return value;
+                },
+              ],
+            },
+          }),
         ],
       }),
       defineCollection({
@@ -865,6 +891,49 @@ describe("a target's field hooks apply to rows reached through a relationship", 
     // The mutation landed (now private)...
     expect(divisions[0]?.tier).toBe("private");
     // ...and the `code` the hook wrote is denied for a private division.
+    expect(divisions[0]?.code).toBeUndefined();
+  });
+
+  it("withholds a denied field a hook only unlocks by flipping its condition", async () => {
+    // The first pass removes the private division's denied `code`. A parent hook
+    // then flips only `tier` to public, never supplying `code`. The second pass
+    // restores `code` so it can re-judge the row against the same evidence a
+    // direct read would, but that restored value is the one the caller was denied
+    // and the hook never reintroduced — it must be withheld again rather than
+    // returned just because the flipped condition now allows the field.
+    const t = await boot();
+    await t.nextly.create({
+      collection: ORGS,
+      data: {
+        name: "acme",
+        divisions: [{ label: "d", tier: "private", code: "SECRET" }],
+      },
+    });
+    const orgId = await onlyId(t, ORGS);
+    await t.nextly.create({
+      collection: AUTHORS,
+      data: { name: "ada", organization: orgId, tierflip: "on" },
+    });
+    const authorId = await onlyId(t, AUTHORS);
+    await t.nextly.create({
+      collection: POSTS,
+      data: { title: "p", author: authorId },
+    });
+    const postId = await onlyId(t, POSTS);
+
+    const expanded = await handlerOf(t).getEntry({
+      collectionName: POSTS,
+      entryId: postId,
+      depth: 2,
+    });
+
+    const author = expanded.data!.author as Record<string, unknown>;
+    const org = author.organization as Record<string, unknown> | undefined;
+    const divisions = (org?.divisions ?? []) as Record<string, unknown>[];
+    // The hook's flip landed...
+    expect(divisions[0]?.tier).toBe("public");
+    // ...but the denied `code`, restored only as evidence and never supplied by
+    // the hook, does not ride out in the response.
     expect(divisions[0]?.code).toBeUndefined();
   });
 

--- a/packages/nextly/src/domains/collections/__tests__/nested-field-hooks.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/nested-field-hooks.integration.test.ts
@@ -135,6 +135,18 @@ async function boot(): Promise<TestNextly> {
                   ?.charter?.sealed === "yes",
             },
           }),
+          // INVERSE conditional: visible only while the denied `classification` is
+          // NOT "private". A private row strips both; a hook cloning it drops
+          // `classification`, so a pass that judged the clone without restoring the
+          // original evidence would read `undefined !== "private"` and fall OPEN.
+          text({
+            name: "openInfo",
+            access: {
+              read: ({ data }) =>
+                (data as { classification?: unknown } | undefined)
+                  ?.classification !== "private",
+            },
+          }),
         ],
       }),
       defineCollection({
@@ -1225,5 +1237,137 @@ describe("a target's field hooks apply to rows reached through a relationship", 
     // And the nested vault's own label was rebuilt off a value the caller may see.
     const vault = author.vault as Record<string, unknown> | undefined;
     if (vault) expect(vault.label).not.toBe("TOPSECRET");
+  });
+
+  it("restores evidence for a related row a hook clones, keeping an inverse rule closed", async () => {
+    // `openInfo` is visible only while the denied `classification` is NOT
+    // "private". A private org strips both. A source hook returns a CLONE of the
+    // sanitized org (a new object) carrying `openInfo` but no `classification`;
+    // without restoring the original evidence the authoritative pass reads
+    // `undefined !== "private"` and returns it — a fail-OPEN, not over-redaction.
+    const t = await boot();
+    await t.nextly.create({
+      collection: ORGS,
+      data: { name: "acme", classification: "private" },
+    });
+    const orgId = await onlyId(t, ORGS);
+    await t.nextly.create({
+      collection: AUTHORS,
+      data: { name: "ada", organization: orgId },
+    });
+    const authorId = await onlyId(t, AUTHORS);
+    await t.nextly.create({
+      collection: POSTS,
+      data: { title: "p", author: authorId },
+    });
+    const postId = await onlyId(t, POSTS);
+
+    t.hooks.register("afterRead", POSTS, ctx => {
+      const entry = ctx.data as Record<string, unknown>;
+      const author = entry.author as Record<string, unknown> | undefined;
+      const org = author?.organization as Record<string, unknown> | undefined;
+      if (author && org) {
+        author.organization = { ...org, openInfo: "LEAKED" };
+      }
+      return entry;
+    });
+
+    const expanded = await handlerOf(t).getEntry({
+      collectionName: POSTS,
+      entryId: postId,
+      depth: 2,
+    });
+
+    const author = expanded.data!.author as Record<string, unknown>;
+    const org = author.organization as Record<string, unknown> | undefined;
+    expect(org).toBeTruthy();
+    // The original evidence was restored for the clone, so the inverse rule denied
+    // openInfo. Fail-closed.
+    expect(org!.openInfo).toBeUndefined();
+  });
+
+  it("decodes a container a hook returns as a JSON string and sanitizes inside it", async () => {
+    // A source hook returns `credits` as the JSON string SQLite stores it as, with
+    // a populated editor carrying a denied field. Left a string the walk derives no
+    // rows from it; decoded, the editor's denied `dossier` is stripped.
+    const t = await boot();
+    await t.nextly.create({ collection: AUTHORS, data: { name: "ed" } });
+    const editorId = await onlyId(t, AUTHORS);
+    await t.nextly.create({ collection: POSTS, data: { title: "p" } });
+    const postId = await onlyId(t, POSTS);
+
+    t.hooks.register("afterRead", POSTS, ctx => {
+      const entry = ctx.data as Record<string, unknown>;
+      entry.credits = JSON.stringify({
+        editor: { id: editorId, name: "ed", dossier: "LEAKED" },
+      });
+      return entry;
+    });
+
+    const expanded = await handlerOf(t).getEntry({
+      collectionName: POSTS,
+      entryId: postId,
+      depth: 2,
+    });
+
+    const credits = expanded.data!.credits as
+      | Record<string, unknown>
+      | undefined;
+    expect(credits).toBeTruthy();
+    const editor = credits!.editor as Record<string, unknown> | undefined;
+    expect(editor).toBeTruthy();
+    expect(editor!.dossier).toBeUndefined();
+  });
+
+  it("re-strips a password a source hook reintroduces under overrideAccess", async () => {
+    // Password removal is unconditional, trusted reads included. A source hook
+    // writes a password back onto a related row after the walk; under override the
+    // authoritative pass was skipped, leaving it in the response.
+    const t = await boot();
+    const postId = await seed(t);
+
+    t.hooks.register("afterRead", POSTS, ctx => {
+      const entry = ctx.data as Record<string, unknown>;
+      const author = entry.author as Record<string, unknown> | undefined;
+      if (author) author.passwordHash = "$2yLEAKED";
+      return entry;
+    });
+
+    const expanded = await handlerOf(t).getEntry({
+      collectionName: POSTS,
+      entryId: postId,
+      overrideAccess: true,
+      depth: 2,
+    });
+
+    const author = expanded.data!.author as Record<string, unknown>;
+    expect(author).toBeTruthy();
+    expect(author.passwordHash).toBeUndefined();
+  });
+
+  it("re-strips a system-entity secret column a hook reintroduces", async () => {
+    // A `users` target has no field registry, so the registry-based password strip
+    // never sees its secret columns; they are stripped by name. A source hook can
+    // reintroduce `passwordHash`, so the walk must re-strip it by column name.
+    const t = await boot();
+    const service = t.getService("relationshipService") as unknown as {
+      applyNestedFieldHooks: (
+        entry: Record<string, unknown>,
+        collection: string,
+        access: Record<string, unknown>
+      ) => Promise<void>;
+    };
+
+    const doc = {
+      title: "owned",
+      owner: { id: "u1", email: "owner@example.test", passwordHash: "$2yHASH" },
+    };
+
+    await service.applyNestedFieldHooks(doc, POSTS, {
+      enforceFieldAccess: true,
+    });
+
+    const owner = doc.owner as Record<string, unknown>;
+    expect(owner.passwordHash).toBeUndefined();
   });
 });

--- a/packages/nextly/src/domains/collections/__tests__/nested-field-hooks.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/nested-field-hooks.integration.test.ts
@@ -12,6 +12,7 @@ import {
   group,
   relationship,
   password,
+  repeater,
   text,
   upload,
 } from "../../../config";
@@ -85,6 +86,16 @@ async function boot(): Promise<TestNextly> {
                 (data as { classification?: unknown } | undefined)
                   ?.classification === "private",
             },
+          }),
+          // A repeater whose `code` is denied. A parent hook can append a row
+          // here after the child's first access pass; the row it introduces has
+          // no recorded verdict, so the pass after the hooks must judge it fresh.
+          repeater({
+            name: "divisions",
+            fields: [
+              text({ name: "label" }),
+              text({ name: "code", access: { read: () => false } }),
+            ],
           }),
         ],
       }),
@@ -176,6 +187,27 @@ async function boot(): Promise<TestNextly> {
                   if (org && typeof org === "object") {
                     (org as Record<string, unknown>).classification =
                       "reintroduced";
+                  }
+                  return value;
+                },
+              ],
+            },
+          }),
+          // Appends a NEW row to the nested org's `divisions` repeater after that
+          // child's first access pass, so the appended row's denied `code` has no
+          // recorded verdict and must be judged fresh by the pass after the hooks.
+          text({
+            name: "appender",
+            hooks: {
+              afterRead: [
+                ({ value, data }) => {
+                  const org = (data as { organization?: unknown }).organization;
+                  const divisions =
+                    org && typeof org === "object"
+                      ? (org as { divisions?: unknown }).divisions
+                      : undefined;
+                  if (Array.isArray(divisions)) {
+                    divisions.push({ label: "added", code: "SNEAKED" });
                   }
                   return value;
                 },
@@ -584,6 +616,49 @@ describe("a target's field hooks apply to rows reached through a relationship", 
     expect(org!.region).toBe("emea");
     // The denied sibling is still withheld.
     expect(org!.classification).toBeUndefined();
+  });
+
+  it("judges a repeater row a parent hook appends after the first pass", async () => {
+    // The first pass strips the denied `code` from the existing division. A
+    // parent hook then appends a NEW division carrying its own `code`. That row
+    // has no recorded verdict, so the pass after the hooks must judge it fresh
+    // and strip its `code` — an index-keyed replay would skip the appended row.
+    const t = await boot();
+    await t.nextly.create({
+      collection: ORGS,
+      data: {
+        name: "acme",
+        divisions: [{ label: "core", code: "ORIGINAL" }],
+      },
+    });
+    const orgId = await onlyId(t, ORGS);
+    await t.nextly.create({
+      collection: AUTHORS,
+      // `appender` present, so its hook fires and pushes a division onto the org.
+      data: { name: "ada", organization: orgId, appender: "on" },
+    });
+    const authorId = await onlyId(t, AUTHORS);
+    await t.nextly.create({
+      collection: POSTS,
+      data: { title: "p", author: authorId },
+    });
+    const postId = await onlyId(t, POSTS);
+
+    const expanded = await handlerOf(t).getEntry({
+      collectionName: POSTS,
+      entryId: postId,
+      depth: 2,
+    });
+
+    const author = expanded.data!.author as Record<string, unknown>;
+    const org = author.organization as Record<string, unknown> | undefined;
+    const divisions = (org?.divisions ?? []) as Record<string, unknown>[];
+    // The hook's row landed...
+    expect(divisions.some(d => d.label === "added")).toBe(true);
+    // ...and NO division exposes `code`, including the appended one.
+    for (const division of divisions) {
+      expect(division.code).toBeUndefined();
+    }
   });
 
   it("masks a dropped relationship before a source hook can copy out of it", async () => {

--- a/packages/nextly/src/domains/collections/__tests__/nested-field-hooks.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/nested-field-hooks.integration.test.ts
@@ -141,6 +141,11 @@ async function boot(): Promise<TestNextly> {
           // batch expansion does not recurse into a related row's OWN
           // relationships, so a hook needing that evidence cannot mask there.
           password({ name: "passwordHash" }),
+          // Denied to everyone. Unlike the org's `classification`, this sits on
+          // the author itself, which a list read walks (a related row's own
+          // relations are not expanded on a list), so it is the field a
+          // source-hook re-contamination test uses on the list path.
+          text({ name: "dossier", access: { read: () => false } }),
           // Writes a secret back after the fetch stripped it. Only a second
           // strip AFTER the hooks keeps it out of the response.
           text({
@@ -1011,5 +1016,69 @@ describe("a target's field hooks apply to rows reached through a relationship", 
     // The masked value, not the stored "RAW_TOKEN": the hook was handed a row
     // the target's own protections had already run on.
     expect(expanded.data!.leaked).toBe("HIDDEN");
+  });
+
+  it("re-sanitizes a related row a source collection hook re-contaminates", async () => {
+    // The related-row field-access pass runs BEFORE the source collection's own
+    // code/stored afterRead hooks. One of those hooks can write a denied field
+    // straight back onto an already-sanitized related row
+    // (`entry.author.organization.classification`), and the root field-access
+    // pass knows only the SOURCE collection's schema, so it never descends into
+    // the related row to strip it. A field-access pass AFTER the source hooks
+    // re-sanitizes the related rows and keeps the denied value out.
+    const t = await boot();
+    const postId = await seed(t);
+
+    t.hooks.register("afterRead", POSTS, ctx => {
+      const entry = ctx.data as Record<string, unknown>;
+      const author = entry.author as Record<string, unknown> | undefined;
+      const org = author?.organization as Record<string, unknown> | undefined;
+      if (org) org.classification = "LEAKED";
+      return entry;
+    });
+
+    const expanded = await handlerOf(t).getEntry({
+      collectionName: POSTS,
+      entryId: postId,
+      depth: 2,
+    });
+
+    const author = expanded.data!.author as Record<string, unknown>;
+    const org = author.organization as Record<string, unknown> | undefined;
+    expect(org).toBeTruthy();
+    // The source hook's write-back was stripped by the pass after the hooks.
+    expect(org!.classification).toBeUndefined();
+  });
+
+  it("re-sanitizes a related row a source hook re-contaminates on a list read", async () => {
+    // The same re-contamination on the list path, whose source hooks run after
+    // its own finalize pass at a different call site than the detail path's. A
+    // list read walks the immediate `author` but not the author's OWN relations,
+    // so the denied field lives on the author itself here.
+    const t = await boot();
+    await seed(t);
+
+    t.hooks.register("afterRead", POSTS, ctx => {
+      const rows = (Array.isArray(ctx.data) ? ctx.data : [ctx.data]) as Record<
+        string,
+        unknown
+      >[];
+      for (const entry of rows) {
+        const author = entry.author as Record<string, unknown> | undefined;
+        if (author) author.dossier = "LEAKED";
+      }
+      return ctx.data;
+    });
+
+    const listed = await handlerOf(t).listEntries({
+      collectionName: POSTS,
+      depth: 2,
+    });
+
+    const author = listed.data!.docs[0].author as Record<string, unknown>;
+    expect(author).toBeTruthy();
+    // The source hook's write-back onto the related author was stripped by the
+    // pass after the hooks.
+    expect(author.dossier).toBeUndefined();
   });
 });

--- a/packages/nextly/src/domains/collections/__tests__/nested-field-hooks.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/nested-field-hooks.integration.test.ts
@@ -84,10 +84,10 @@ async function boot(): Promise<TestNextly> {
             access: { read: () => false },
           }),
           // Allowed ONLY while `classification` is present as evidence. Its rule
-          // reads the row as `data`, so evaluating it a second time against the
-          // already-stripped row (where classification is gone) would wrongly
-          // deny it — which is why the finalize step replays decisions instead of
-          // re-evaluating.
+          // reads the row as `data`, so a later pass judging it against the
+          // already-stripped row (where classification is gone) would wrongly deny
+          // it — which is why each pass first RESTORES the values a prior pass
+          // removed as evidence, then re-runs the rule against that restored row.
           text({
             name: "region",
             access: {
@@ -743,12 +743,13 @@ describe("a target's field hooks apply to rows reached through a relationship", 
     if (org) expect(org.classification).toBeUndefined();
   });
 
-  it("keeps a field whose access depended on a denied sibling, judged once", async () => {
+  it("keeps a field whose access depended on a denied sibling, evidence restored", async () => {
     // `region` is allowed only while `classification` is present; `classification`
     // is denied. The first pass judges `region` against the complete row (keeps
-    // it) and removes `classification`. The finalize step must REPLAY that
-    // decision, not re-judge `region` against the now-stripped row — re-judging
-    // would wrongly deny it, unlike a direct read which evaluates it once.
+    // it) and removes `classification`. Every later pass must RESTORE the removed
+    // `classification` as evidence and re-run the rule against the restored row,
+    // not re-judge `region` against the stripped row — that would wrongly deny it,
+    // unlike a direct read where the sibling is still present.
     const t = await boot();
     await t.nextly.create({
       collection: ORGS,
@@ -775,7 +776,7 @@ describe("a target's field hooks apply to rows reached through a relationship", 
     const author = expanded.data!.author as Record<string, unknown>;
     const org = author.organization as Record<string, unknown> | undefined;
     expect(org).toBeTruthy();
-    // Kept: judged once, while its evidence was still present.
+    // Kept: every pass re-ran the rule with its evidence restored.
     expect(org!.region).toBe("emea");
     // The denied sibling is still withheld.
     expect(org!.classification).toBeUndefined();
@@ -824,8 +825,9 @@ describe("a target's field hooks apply to rows reached through a relationship", 
   it("judges a repeater row a parent hook appends after the first pass", async () => {
     // The first pass strips the denied `code` from the existing division. A
     // parent hook then appends a NEW division carrying its own `code`. That row
-    // has no recorded verdict, so the pass after the hooks must judge it fresh
-    // and strip its `code` — an index-keyed replay would skip the appended row.
+    // has no removed-evidence recorded against it, so the pass after the hooks
+    // judges it against its own content and strips its `code` — nothing about the
+    // existing rows lets the appended one inherit an "allowed" outcome.
     const t = await boot();
     await t.nextly.create({
       collection: ORGS,

--- a/packages/nextly/src/domains/collections/__tests__/nested-field-hooks.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/nested-field-hooks.integration.test.ts
@@ -150,6 +150,25 @@ async function boot(): Promise<TestNextly> {
               ],
             },
           }),
+          // Writes a denied field back ONTO the child after the child's access
+          // pass has already removed it. Fires only when the field is present, so
+          // a test opts in per row; a second access pass after all hooks must
+          // strip what it reintroduced.
+          text({
+            name: "reintroducer",
+            hooks: {
+              afterRead: [
+                ({ value, data }) => {
+                  const org = (data as { organization?: unknown }).organization;
+                  if (org && typeof org === "object") {
+                    (org as Record<string, unknown>).classification =
+                      "reintroduced";
+                  }
+                  return value;
+                },
+              ],
+            },
+          }),
         ],
       }),
       defineCollection({
@@ -478,6 +497,42 @@ describe("a target's field hooks apply to rows reached through a relationship", 
     // either, so it did not mask — the value it tried to guard on that basis is
     // returned unchanged. Masking must not depend on data the caller cannot see.
     expect(author.secret).toBe("TOP_SECRET");
+  });
+
+  it("re-strips a denied child field a parent hook reintroduces after the first pass", async () => {
+    // The first access pass (during the walk) removes the child's denied field
+    // before the parent's hooks run. A parent hook can still write it back onto
+    // the child afterward — to mask or derive a value — so a second access pass
+    // after every hook is what keeps that reintroduced field out of the response.
+    const t = await boot();
+    await t.nextly.create({
+      collection: ORGS,
+      data: { name: "acme", classification: "private" },
+    });
+    const orgId = await onlyId(t, ORGS);
+    await t.nextly.create({
+      collection: AUTHORS,
+      // `reintroducer` present, so its hook fires and reassigns the org's denied
+      // `classification` after the first pass stripped it.
+      data: { name: "ada", organization: orgId, reintroducer: "on" },
+    });
+    const authorId = await onlyId(t, AUTHORS);
+    await t.nextly.create({
+      collection: POSTS,
+      data: { title: "p", author: authorId },
+    });
+    const postId = await onlyId(t, POSTS);
+
+    const expanded = await handlerOf(t).getEntry({
+      collectionName: POSTS,
+      entryId: postId,
+      depth: 2,
+    });
+
+    const author = expanded.data!.author as Record<string, unknown>;
+    const org = author.organization as Record<string, unknown> | undefined;
+    // The second pass removed the value the hook wrote back — not "reintroduced".
+    if (org) expect(org.classification).toBeUndefined();
   });
 
   it("masks a dropped relationship before a source hook can copy out of it", async () => {

--- a/packages/nextly/src/domains/collections/__tests__/nested-field-hooks.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/nested-field-hooks.integration.test.ts
@@ -125,7 +125,23 @@ async function boot(): Promise<TestNextly> {
           // before the ancestor snapshot is what keeps the two reads in step.
           group({
             name: "charter",
-            fields: [text({ name: "sealed", access: { read: () => false } })],
+            fields: [
+              text({ name: "sealed", access: { read: () => false } }),
+              // A NESTED inverse conditional: visible only while the denied nested
+              // `sealed` is NOT "locked". A locked charter strips both; a deep-clone
+              // drops the nested `sealed`, so a pass judging the clone without
+              // transferring the SUBTREE evidence reads `undefined !== "locked"` and
+              // falls open on the nested field — the root-only id bridge is not
+              // enough.
+              text({
+                name: "openSeal",
+                access: {
+                  read: ({ data }) =>
+                    (data as { sealed?: unknown } | undefined)?.sealed !==
+                    "locked",
+                },
+              }),
+            ],
           }),
           text({
             name: "emblem",
@@ -371,6 +387,27 @@ async function boot(): Promise<TestNextly> {
               ],
             },
           }),
+          // A target-collection FIELD hook that REPLACES this author's own
+          // `organization` relationship with a freshly populated org carrying a
+          // denied field, AFTER the walk already descended the original. The new
+          // child missed that descent, so unless the walk descends again the source
+          // collection's hooks could read its denied field and copy it out.
+          text({
+            name: "swapOrg",
+            hooks: {
+              afterRead: [
+                ({ value, data }) => {
+                  if (value !== "on") return value;
+                  (data as Record<string, unknown>).organization = {
+                    id: "swapped-org",
+                    name: "swapped",
+                    classification: "SECRET",
+                  };
+                  return value;
+                },
+              ],
+            },
+          }),
         ],
       }),
       defineCollection({
@@ -408,6 +445,14 @@ async function boot(): Promise<TestNextly> {
           group({
             name: "credits",
             fields: [relationship({ name: "editor", relationTo: AUTHORS })],
+          }),
+          // A hasMany relationship: populated + serialized it is a JSON ARRAY
+          // string, which a hook can hand back. The walk must decode that string
+          // before it can reach the denied fields on the rows inside.
+          relationship({
+            name: "contributors",
+            relationTo: AUTHORS,
+            hasMany: true,
           }),
         ],
       }),
@@ -1369,5 +1414,130 @@ describe("a target's field hooks apply to rows reached through a relationship", 
 
     const owner = doc.owner as Record<string, unknown>;
     expect(owner.passwordHash).toBeUndefined();
+  });
+
+  it("transfers subtree evidence to a deep-cloned relation, keeping a nested inverse rule closed", async () => {
+    // `charter.openSeal` is visible only while the denied nested `charter.sealed`
+    // is NOT "locked". A locked charter strips both. A source hook DEEP-clones the
+    // org (charter included) and reintroduces openSeal; without transferring the
+    // NESTED evidence the pass reads `undefined !== "locked"` and returns it — the
+    // root-only id bridge would miss it.
+    const t = await boot();
+    await t.nextly.create({
+      collection: ORGS,
+      data: {
+        name: "acme",
+        charter: { sealed: "locked", openSeal: "visible" },
+      },
+    });
+    const orgId = await onlyId(t, ORGS);
+    await t.nextly.create({
+      collection: AUTHORS,
+      data: { name: "ada", organization: orgId },
+    });
+    const authorId = await onlyId(t, AUTHORS);
+    await t.nextly.create({
+      collection: POSTS,
+      data: { title: "p", author: authorId },
+    });
+    const postId = await onlyId(t, POSTS);
+
+    t.hooks.register("afterRead", POSTS, ctx => {
+      const entry = ctx.data as Record<string, unknown>;
+      const author = entry.author as Record<string, unknown> | undefined;
+      const org = author?.organization as Record<string, unknown> | undefined;
+      if (author && org) {
+        const charter = (org.charter ?? {}) as Record<string, unknown>;
+        author.organization = {
+          ...org,
+          charter: { ...charter, openSeal: "LEAKED" },
+        };
+      }
+      return entry;
+    });
+
+    const expanded = await handlerOf(t).getEntry({
+      collectionName: POSTS,
+      entryId: postId,
+      depth: 2,
+    });
+
+    const author = expanded.data!.author as Record<string, unknown>;
+    const org = author.organization as Record<string, unknown> | undefined;
+    const charter = org?.charter as Record<string, unknown> | undefined;
+    expect(charter).toBeTruthy();
+    // Closed: the nested `sealed` evidence was transferred to the clone's charter.
+    expect(charter!.openSeal).toBeUndefined();
+  });
+
+  it("walks a relationship a target field hook swaps in before source hooks read it", async () => {
+    // The author's `swapOrg` field hook REPLACES its organization with a fresh org
+    // carrying denied `classification`, after the walk already descended the
+    // original. A source POSTS hook then copies `author.organization.classification`
+    // onto an allowed key. Only re-descending after the target field hooks strips
+    // the swapped org before the source hook can read it.
+    const t = await boot();
+    await t.nextly.create({ collection: ORGS, data: { name: "acme" } });
+    const orgId = await onlyId(t, ORGS);
+    await t.nextly.create({
+      collection: AUTHORS,
+      data: { name: "ada", organization: orgId, swapOrg: "on" },
+    });
+    const authorId = await onlyId(t, AUTHORS);
+    await t.nextly.create({
+      collection: POSTS,
+      data: { title: "p", author: authorId },
+    });
+    const postId = await onlyId(t, POSTS);
+
+    t.hooks.register("afterRead", POSTS, ctx => {
+      const entry = ctx.data as Record<string, unknown>;
+      const author = entry.author as Record<string, unknown> | undefined;
+      const org = author?.organization as Record<string, unknown> | undefined;
+      entry.leaked = org?.classification;
+      return entry;
+    });
+
+    const expanded = await handlerOf(t).getEntry({
+      collectionName: POSTS,
+      entryId: postId,
+      depth: 2,
+    });
+
+    // The swapped org's denied classification was stripped before the source hook
+    // ran, so it copied nothing.
+    expect(expanded.data!.leaked).toBeUndefined();
+  });
+
+  it("decodes a hasMany relationship a hook returns as a JSON string and sanitizes its rows", async () => {
+    // A populated hasMany relationship serializes to a JSON array string, which a
+    // hook can hand back. Left a string the walk derives no rows; decoded, the
+    // denied `dossier` on each contributor row is stripped.
+    const t = await boot();
+    await t.nextly.create({ collection: AUTHORS, data: { name: "c" } });
+    const contributorId = await onlyId(t, AUTHORS);
+    await t.nextly.create({ collection: POSTS, data: { title: "p" } });
+    const postId = await onlyId(t, POSTS);
+
+    t.hooks.register("afterRead", POSTS, ctx => {
+      const entry = ctx.data as Record<string, unknown>;
+      entry.contributors = JSON.stringify([
+        { id: contributorId, name: "c", dossier: "LEAKED" },
+      ]);
+      return entry;
+    });
+
+    const expanded = await handlerOf(t).getEntry({
+      collectionName: POSTS,
+      entryId: postId,
+      depth: 2,
+    });
+
+    const contributors = expanded.data!.contributors as
+      | Record<string, unknown>[]
+      | undefined;
+    expect(Array.isArray(contributors)).toBe(true);
+    expect(contributors![0]).toBeTruthy();
+    expect(contributors![0].dossier).toBeUndefined();
   });
 });

--- a/packages/nextly/src/domains/collections/__tests__/nested-field-hooks.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/nested-field-hooks.integration.test.ts
@@ -129,6 +129,27 @@ async function boot(): Promise<TestNextly> {
               ],
             },
           }),
+          // Copies the org's denied `classification` value onto an allowed field
+          // of its own. Only reachable when the parent's hook is handed the child
+          // with that field still present, so it is the exfiltration a nested
+          // read must not allow.
+          text({
+            name: "stolen",
+            hooks: {
+              afterRead: [
+                ({ value, data }) => {
+                  const org = (data as { organization?: unknown }).organization;
+                  const classification =
+                    typeof org === "object" && org !== null
+                      ? (org as { classification?: unknown }).classification
+                      : undefined;
+                  return typeof classification === "string"
+                    ? classification
+                    : value;
+                },
+              ],
+            },
+          }),
         ],
       }),
       defineCollection({
@@ -421,14 +442,21 @@ describe("a target's field hooks apply to rows reached through a relationship", 
     expect(tokenHookRuns).toBeGreaterThan(0);
   });
 
-  it("judges a masking rule before the denied sibling it reads is removed", async () => {
-    // `classification` denies read, and the author's `secret` rule masks on it.
-    // Removing denied fields as a row is fetched hands that rule a row its
-    // evidence has already been cut out of: it reads `undefined`, declines to
-    // mask, and the value it guards goes out. Masking has to run first.
+  it("hands a parent's hooks a nested child with its denied fields already removed", async () => {
+    // `classification` denies read. A parent hook that reads it — to copy it out
+    // (`stolen`) or to mask a sibling on it (`secret`) — must be handed the child
+    // with that field already gone, or the copy leaks it under an allowed key and
+    // outlives the child's own redaction. Applying each child's field access
+    // before its parent's hooks is what a direct read does; the nested walk now
+    // matches it.
     //
-    // Read WITHOUT overrideAccess: field rules are skipped for a trusted read,
-    // so an overriding caller cannot show this either way.
+    // The deliberate trade-off: a hook can no longer mask on a caller-denied
+    // field, because it can no longer see one. A value that must stay hidden
+    // needs an access rule keyed on the caller, not a hook reading data the
+    // caller cannot see.
+    //
+    // Read WITHOUT overrideAccess: field rules are skipped for a trusted read, so
+    // an overriding caller is handed the complete row either way.
     const t = await boot();
     const postId = await seed(t);
 
@@ -440,13 +468,16 @@ describe("a target's field hooks apply to rows reached through a relationship", 
 
     const author = expanded.data!.author as Record<string, unknown>;
     expect(author).toBeTruthy();
-    // Masked, because the rule saw the classification.
-    expect(author.secret).toBe("REDACTED");
-
-    // And the evidence is still withheld from the response: deferring WHEN the
-    // rules run must not change WHETHER they run.
+    // The exfiltration is closed: the copy hook was handed a child whose denied
+    // field had already been removed, so it copied nothing.
+    expect(author.stolen).not.toBe("private");
+    // The denied field is absent from the response itself.
     const org = author.organization as Record<string, unknown> | undefined;
     if (org) expect(org.classification).toBeUndefined();
+    // Same cause, visible from the other hook: it could not read the classification
+    // either, so it did not mask — the value it tried to guard on that basis is
+    // returned unchanged. Masking must not depend on data the caller cannot see.
+    expect(author.secret).toBe("TOP_SECRET");
   });
 
   it("masks a dropped relationship before a source hook can copy out of it", async () => {

--- a/packages/nextly/src/domains/collections/__tests__/nested-field-hooks.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/nested-field-hooks.integration.test.ts
@@ -87,14 +87,23 @@ async function boot(): Promise<TestNextly> {
                   ?.classification === "private",
             },
           }),
-          // A repeater whose `code` is denied. A parent hook can append a row
-          // here after the child's first access pass; the row it introduces has
-          // no recorded verdict, so the pass after the hooks must judge it fresh.
+          // A repeater whose `code` is visible only for a public division. A
+          // parent hook can append, or replace, a row here after the child's
+          // first access pass; the row it introduces has no recorded verdict (it
+          // is a new object), so the pass after the hooks must judge it fresh
+          // rather than inherit the previous occupant's.
           repeater({
             name: "divisions",
             fields: [
               text({ name: "label" }),
-              text({ name: "code", access: { read: () => false } }),
+              text({ name: "tier" }),
+              text({
+                name: "code",
+                access: {
+                  read: ({ data }) =>
+                    (data as { tier?: unknown } | undefined)?.tier === "public",
+                },
+              }),
             ],
           }),
         ],
@@ -208,6 +217,31 @@ async function boot(): Promise<TestNextly> {
                       : undefined;
                   if (Array.isArray(divisions)) {
                     divisions.push({ label: "added", code: "SNEAKED" });
+                  }
+                  return value;
+                },
+              ],
+            },
+          }),
+          // REPLACES the org's first division with a private one carrying `code`
+          // after the child's first pass. The replacement is a new object, so it
+          // must not inherit the public original's "allowed" verdict by index.
+          text({
+            name: "replacer",
+            hooks: {
+              afterRead: [
+                ({ value, data }) => {
+                  const org = (data as { organization?: unknown }).organization;
+                  const divisions =
+                    org && typeof org === "object"
+                      ? (org as { divisions?: unknown }).divisions
+                      : undefined;
+                  if (Array.isArray(divisions) && divisions.length > 0) {
+                    divisions[0] = {
+                      label: "swapped",
+                      tier: "private",
+                      code: "SNEAKED",
+                    };
                   }
                   return value;
                 },
@@ -659,6 +693,48 @@ describe("a target's field hooks apply to rows reached through a relationship", 
     for (const division of divisions) {
       expect(division.code).toBeUndefined();
     }
+  });
+
+  it("re-judges a repeater row a parent hook replaces with a stricter one", async () => {
+    // The original division is public, so its `code` is allowed on the first
+    // pass. A parent hook then REPLACES it with a private division carrying
+    // `code`. Keying the verdict by array index would hand the replacement the
+    // original's "allowed" result and leak it; keyed by object identity, the
+    // replacement (a new object) is judged fresh and its `code` is stripped.
+    const t = await boot();
+    await t.nextly.create({
+      collection: ORGS,
+      data: {
+        name: "acme",
+        divisions: [{ label: "public-div", tier: "public", code: "OK" }],
+      },
+    });
+    const orgId = await onlyId(t, ORGS);
+    await t.nextly.create({
+      collection: AUTHORS,
+      data: { name: "ada", organization: orgId, replacer: "on" },
+    });
+    const authorId = await onlyId(t, AUTHORS);
+    await t.nextly.create({
+      collection: POSTS,
+      data: { title: "p", author: authorId },
+    });
+    const postId = await onlyId(t, POSTS);
+
+    const expanded = await handlerOf(t).getEntry({
+      collectionName: POSTS,
+      entryId: postId,
+      depth: 2,
+    });
+
+    const author = expanded.data!.author as Record<string, unknown>;
+    const org = author.organization as Record<string, unknown> | undefined;
+    const divisions = (org?.divisions ?? []) as Record<string, unknown>[];
+    // The replacement landed...
+    expect(divisions[0]?.label).toBe("swapped");
+    // ...and its `code`, denied for a private division, did not ride in on the
+    // public original's verdict.
+    expect(divisions[0]?.code).toBeUndefined();
   });
 
   it("masks a dropped relationship before a source hook can copy out of it", async () => {

--- a/packages/nextly/src/domains/collections/services/collection-query-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-query-service.ts
@@ -1616,6 +1616,18 @@ export class CollectionQueryService extends BaseService {
       let finalData = (storedAfterResult.data ??
         dataAfterCodeHooks) as unknown[];
 
+      // Re-apply each related row's field access after the SOURCE collection's
+      // own afterRead hooks. Those hooks are handed the whole assembled document
+      // and can write a denied target field straight back onto an already
+      // sanitized related row (`entry.author.secret`); the root read-access pass
+      // below evaluates only this collection's schema and never descends into a
+      // related row, so without this the reintroduced value is returned. Runs
+      // before selection, while the response still holds the walked row objects.
+      await this.relationshipService.finalizeRelatedRows(
+        nestedHookState,
+        nestedAccess
+      );
+
       // Apply field selection if select parameter is provided
       // This filters the response to only include requested fields
       if (params.select && Object.keys(params.select).length > 0) {
@@ -2767,15 +2779,29 @@ export class CollectionQueryService extends BaseService {
       // a root property, and before selection rebuilds the row without the
       // siblings a masking rule judges on. Every populated related row is
       // walked, including one the projection drops.
+      //
+      // The state is held here rather than left to the inline finalize so the
+      // related rows can be sanitized twice: once now (so the source collection's
+      // hooks below are handed already sanitized rows), and again after those
+      // hooks (so a denied field one of them writes back onto a related row is
+      // stripped before the response).
+      const detailNestedState =
+        this.relationshipService.createNestedHookState();
+      const detailNestedAccess = {
+        enforceFieldAccess: true,
+        user: params.user,
+        overrideAccess: params.overrideAccess,
+        authenticatedScope: params.authenticatedScope,
+      };
       await this.relationshipService.applyNestedFieldHooks(
         expandedEntry,
         params.collectionName,
-        {
-          enforceFieldAccess: true,
-          user: params.user,
-          overrideAccess: params.overrideAccess,
-          authenticatedScope: params.authenticatedScope,
-        }
+        detailNestedAccess,
+        detailNestedState
+      );
+      await this.relationshipService.finalizeRelatedRows(
+        detailNestedState,
+        detailNestedAccess
       );
 
       // Execute afterRead hooks (code-registered)
@@ -2813,6 +2839,16 @@ export class CollectionQueryService extends BaseService {
         string,
         unknown
       >;
+
+      // Re-apply each related row's field access after this collection's own
+      // afterRead hooks, for the reason given at the same point on the list path:
+      // a source hook can write a denied target field back onto an already
+      // sanitized related row, and the root read-access pass below sees only this
+      // collection's schema. Runs before selection rebuilds the related rows.
+      await this.relationshipService.finalizeRelatedRows(
+        detailNestedState,
+        detailNestedAccess
+      );
 
       // Apply field selection if select parameter is provided
       // This filters the response to only include requested fields

--- a/packages/nextly/src/domains/collections/services/collection-query-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-query-service.ts
@@ -1616,27 +1616,6 @@ export class CollectionQueryService extends BaseService {
       let finalData = (storedAfterResult.data ??
         dataAfterCodeHooks) as unknown[];
 
-      // Re-apply each related row's field access after the SOURCE collection's
-      // own afterRead hooks. Those hooks are handed the whole assembled document
-      // and can write a denied target field straight back onto an already
-      // sanitized related row (`entry.author.secret`); the root read-access pass
-      // below evaluates only this collection's schema and never descends into a
-      // related row, so without this the reintroduced value is returned. Runs
-      // before selection, while the response still holds the walked row objects.
-      await this.relationshipService.finalizeRelatedRows(
-        nestedHookState,
-        nestedAccess
-      );
-
-      // Apply field selection if select parameter is provided
-      // This filters the response to only include requested fields
-      if (params.select && Object.keys(params.select).length > 0) {
-        finalData = this.applyFieldSelectionToArray(
-          finalData as Record<string, unknown>[],
-          params.select
-        );
-      }
-
       // Convert snake_case timestamp columns to their camelCase API form.
       finalData = (finalData as Record<string, unknown>[]).map(entry =>
         convertTimestampsToCamelCase(entry)
@@ -1652,7 +1631,9 @@ export class CollectionQueryService extends BaseService {
 
       // Field-level afterRead hooks + read access (code-first functions
       // resolved via the field-level registry): hooks may transform values;
-      // fields whose access.read denies are stripped from the response.
+      // fields whose access.read denies are stripped from the response. Runs on
+      // the whole rows, before selection, so a masking rule reads the sibling
+      // evidence a projected slice would be missing.
       for (const entry of finalData as Record<string, unknown>[]) {
         await runFieldHooks({
           kind: "collection",
@@ -1669,6 +1650,31 @@ export class CollectionQueryService extends BaseService {
           user: params.user,
           overrideAccess: params.overrideAccess,
         });
+      }
+
+      // Authoritative related-row sanitization: re-apply each related row's OWN
+      // collection field access over the ASSEMBLED response, after EVERY source
+      // afterRead hook phase above (code, stored, and field-level). Those hooks
+      // can write a denied target field back onto a related row, or return a
+      // reshaped document whose related rows are new objects the earlier walk
+      // never held; the root access pass above knows only this collection's
+      // schema and never descends into a related row. Before selection, so it
+      // judges whole rows with their sibling evidence intact.
+      await this.relationshipService.resanitizeAssembledRows(
+        finalData as Record<string, unknown>[],
+        params.collectionName,
+        nestedAccess,
+        nestedHookState
+      );
+
+      // Apply field selection if select parameter is provided. Last of the
+      // sanitizing steps, so every hook and access pass above judged the whole
+      // row rather than the projected slice.
+      if (params.select && Object.keys(params.select).length > 0) {
+        finalData = this.applyFieldSelectionToArray(
+          finalData as Record<string, unknown>[],
+          params.select
+        );
       }
 
       // Transform rich text fields to requested format (html, both)
@@ -2840,22 +2846,6 @@ export class CollectionQueryService extends BaseService {
         unknown
       >;
 
-      // Re-apply each related row's field access after this collection's own
-      // afterRead hooks, for the reason given at the same point on the list path:
-      // a source hook can write a denied target field back onto an already
-      // sanitized related row, and the root read-access pass below sees only this
-      // collection's schema. Runs before selection rebuilds the related rows.
-      await this.relationshipService.finalizeRelatedRows(
-        detailNestedState,
-        detailNestedAccess
-      );
-
-      // Apply field selection if select parameter is provided
-      // This filters the response to only include requested fields
-      if (params.select && Object.keys(params.select).length > 0) {
-        finalData = this.applyFieldSelection(finalData, params.select);
-      }
-
       // Convert snake_case timestamp columns to their camelCase API form.
       finalData = convertTimestampsToCamelCase(finalData);
 
@@ -2868,7 +2858,8 @@ export class CollectionQueryService extends BaseService {
       stripSystemOwnerField(finalData);
 
       // Field-level afterRead hooks + read access — same semantics as the
-      // list path above.
+      // list path above. On the whole row, before selection, so a masking rule
+      // reads the sibling evidence a projected slice would be missing.
       await runFieldHooks({
         kind: "collection",
         slug: params.collectionName,
@@ -2884,6 +2875,27 @@ export class CollectionQueryService extends BaseService {
         user: params.user,
         overrideAccess: params.overrideAccess,
       });
+
+      // Authoritative related-row sanitization over the assembled response,
+      // after EVERY source afterRead hook phase above (code, stored, and
+      // field-level), for the reason given at the same point on the list path:
+      // those hooks can write a denied target field back onto a related row or
+      // return a reshaped document whose related rows are new objects, and the
+      // root access pass sees only this collection's schema. Before selection, so
+      // it judges whole rows with their sibling evidence intact.
+      await this.relationshipService.resanitizeAssembledRows(
+        [finalData],
+        params.collectionName,
+        detailNestedAccess,
+        detailNestedState
+      );
+
+      // Apply field selection if select parameter is provided. Last of the
+      // sanitizing steps, so every hook and access pass above judged the whole
+      // row rather than the projected slice.
+      if (params.select && Object.keys(params.select).length > 0) {
+        finalData = this.applyFieldSelection(finalData, params.select);
+      }
 
       // Transform rich text fields to requested format (html, both)
       // Default is "json" which returns the Lexical JSON structure as-is

--- a/packages/nextly/src/domains/collections/services/collection-query-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-query-service.ts
@@ -1571,8 +1571,10 @@ export class CollectionQueryService extends BaseService {
           nestedHookState
         );
       }
-      // Once, after the whole listing: hiding a row as it is finished would take
-      // the evidence away from a rule on a row walked later.
+      // Once, after the whole listing: the walk already applied field access to
+      // each related row before its parent's hooks; this runs the SECOND pass
+      // (stripping a denied field a parent hook reintroduced) and rebuilds labels
+      // from the survivors.
       await this.relationshipService.finalizeRelatedRows(
         nestedHookState,
         nestedAccess

--- a/packages/nextly/src/domains/collections/services/collection-query-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-query-service.ts
@@ -1598,6 +1598,18 @@ export class CollectionQueryService extends BaseService {
       const dataAfterCodeHooks = (transformedData ??
         expandedEntries) as unknown[];
 
+      // A code hook may have RETURNED a reshaped related row carrying a denied
+      // field; sanitize now, before the stored and field-level hooks run, so one
+      // of them cannot read that field and copy it onto an allowed source key the
+      // final pass no longer looks at. The authoritative pass is idempotent over
+      // the shared walk state, so running it after each source phase is safe.
+      await this.relationshipService.resanitizeAssembledRows(
+        dataAfterCodeHooks as Record<string, unknown>[],
+        params.collectionName,
+        nestedAccess,
+        nestedHookState
+      );
+
       // Execute stored afterRead hooks (UI-configured)
       const storedAfterResult =
         await this.hookService.storedHookExecutor.execute(
@@ -1628,6 +1640,15 @@ export class CollectionQueryService extends BaseService {
           stripPasswordFieldValues(entry, fields);
         }
       }
+
+      // A stored hook may likewise have reintroduced a denied related field;
+      // sanitize before the field-level hooks read the assembled document.
+      await this.relationshipService.resanitizeAssembledRows(
+        finalData as Record<string, unknown>[],
+        params.collectionName,
+        nestedAccess,
+        nestedHookState
+      );
 
       // Field-level afterRead hooks + read access (code-first functions
       // resolved via the field-level registry): hooks may transform values;
@@ -2826,6 +2847,17 @@ export class CollectionQueryService extends BaseService {
       );
       const dataAfterCodeHooks = transformedData ?? expandedEntry;
 
+      // A code hook may have RETURNED a reshaped related row carrying a denied
+      // field; sanitize now, before the stored and field-level hooks run, so one
+      // of them cannot read that field and copy it onto an allowed source key the
+      // final pass no longer looks at. Idempotent over the shared walk state.
+      await this.relationshipService.resanitizeAssembledRows(
+        [dataAfterCodeHooks],
+        params.collectionName,
+        detailNestedAccess,
+        detailNestedState
+      );
+
       // Execute stored afterRead hooks (UI-configured)
       const storedAfterResult =
         await this.hookService.storedHookExecutor.execute(
@@ -2856,6 +2888,15 @@ export class CollectionQueryService extends BaseService {
       }
       // Same defense in depth for the owner column.
       stripSystemOwnerField(finalData);
+
+      // A stored hook may likewise have reintroduced a denied related field;
+      // sanitize before the field-level hooks read the assembled document.
+      await this.relationshipService.resanitizeAssembledRows(
+        [finalData],
+        params.collectionName,
+        detailNestedAccess,
+        detailNestedState
+      );
 
       // Field-level afterRead hooks + read access — same semantics as the
       // list path above. On the whole row, before selection, so a masking rule

--- a/packages/nextly/src/domains/collections/services/collection-query-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-query-service.ts
@@ -1571,10 +1571,11 @@ export class CollectionQueryService extends BaseService {
           nestedHookState
         );
       }
-      // Once, after the whole listing: the walk already applied field access to
-      // each related row before its parent's hooks; this runs the SECOND pass
-      // (stripping a denied field a parent hook reintroduced) and rebuilds labels
-      // from the survivors.
+      // Once, after the whole listing: the walk already evaluated and applied
+      // field access to each related row before its parent's hooks; this replays
+      // each row's captured redaction (stripping a denied field a parent hook
+      // reintroduced, without re-running the policy) and rebuilds labels from the
+      // survivors.
       await this.relationshipService.finalizeRelatedRows(
         nestedHookState,
         nestedAccess

--- a/packages/nextly/src/domains/collections/services/collection-query-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-query-service.ts
@@ -1571,10 +1571,11 @@ export class CollectionQueryService extends BaseService {
           nestedHookState
         );
       }
-      // Once, after the whole listing: the walk already evaluated and applied
-      // field access to each related row before its parent's hooks; this replays
-      // each row's captured redaction (stripping a denied field a parent hook
-      // reintroduced, without re-running the policy) and rebuilds labels from the
+      // Once, after the whole listing: the walk already applied field access to
+      // each related row before its parent's hooks; this re-applies it (reusing
+      // each row's verdict memo, so unchanged content is not re-judged or
+      // re-queried while content a hook introduced is judged fresh) to strip
+      // anything a parent hook reintroduced, then rebuilds labels from the
       // survivors.
       await this.relationshipService.finalizeRelatedRows(
         nestedHookState,

--- a/packages/nextly/src/domains/collections/services/collection-query-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-query-service.ts
@@ -1572,11 +1572,10 @@ export class CollectionQueryService extends BaseService {
         );
       }
       // Once, after the whole listing: the walk already applied field access to
-      // each related row before its parent's hooks; this re-applies it (reusing
-      // each row's verdict memo, so unchanged content is not re-judged or
-      // re-queried while content a hook introduced is judged fresh) to strip
-      // anything a parent hook reintroduced, then rebuilds labels from the
-      // survivors.
+      // each related row before its parent's hooks; this re-applies it (restoring
+      // the removed evidence and re-judging the current content) to strip a denied
+      // field a parent hook reintroduced, mutated, or added, then rebuilds labels
+      // from the survivors.
       await this.relationshipService.finalizeRelatedRows(
         nestedHookState,
         nestedAccess

--- a/packages/nextly/src/domains/collections/services/collection-relationship-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-relationship-service.ts
@@ -102,15 +102,16 @@ interface NestedHookStateBase {
    */
   redactions: ReadAccessRedactions;
   /**
-   * The same removed values as `redactions`, but keyed by `relationKey(collection,
-   * id)` instead of the row object. A source hook can return a CLONE of a related
-   * row (a new object the WeakMap cannot key); the authoritative re-walk seeds the
-   * clone's evidence from here so an inverse conditional rule — a field visible
-   * only while a DENIED sibling is absent — cannot fall open on the clone. Keyed by
-   * id and re-judged (never a cached verdict): a replacement's denied fields are
-   * still stripped, and a same-id clone is judged against the original's evidence.
+   * The ORIGINAL related row object for each `relationKey(collection, id)` seen in
+   * the first walk. A source hook can return a CLONE of a related row (a new object
+   * graph the WeakMap cannot key); the authoritative re-walk finds the original
+   * here by id and transfers its removed-field evidence — at the root AND through
+   * every group/repeater below it — onto the clone, so an inverse conditional rule
+   * (a field visible only while a DENIED sibling is absent) cannot fall open on the
+   * clone at any depth. The clone is then re-judged (never a cached verdict): a
+   * replacement's own denied fields are still stripped.
    */
-  redactionsById: Map<string, Record<string, unknown>>;
+  originalRowById: Map<string, Record<string, unknown>>;
   /**
    * Every related row the pass reached, in visit order, with what is needed to
    * finish it. These entries drive the finalize step after every hook has run: it
@@ -141,7 +142,7 @@ function createNestedHookState(): NestedHookState {
     fields: new Map(),
     labelFields: new Map(),
     redactions: new WeakMap(),
-    redactionsById: new Map(),
+    originalRowById: new Map(),
     pending: [],
     applyFieldHooks: true,
   };
@@ -369,6 +370,25 @@ function parseJsonIfString(data: unknown): unknown {
     }
   }
   return data;
+}
+
+/**
+ * The row objects inside a container value (a `group` object, or a `repeater`
+ * array), parsing a JSON string first. Non-object entries are dropped. Used to
+ * walk an original and its clone in parallel when transferring redaction evidence.
+ */
+function containerRowsOf(value: unknown): Record<string, unknown>[] {
+  const parsed = parseJsonIfString(value);
+  if (Array.isArray(parsed)) {
+    return parsed.filter(
+      (row): row is Record<string, unknown> =>
+        row !== null && typeof row === "object"
+    );
+  }
+  if (parsed !== null && typeof parsed === "object") {
+    return [parsed as Record<string, unknown>];
+  }
+  return [];
 }
 
 /**
@@ -3109,7 +3129,7 @@ export class CollectionRelationshipService extends BaseService {
       fields: walkState.fields,
       labelFields: walkState.labelFields,
       redactions: walkState.redactions,
-      redactionsById: walkState.redactionsById,
+      originalRowById: walkState.originalRowById,
       applyFieldHooks: false,
     };
     for (const entry of entries) {
@@ -3173,25 +3193,89 @@ export class CollectionRelationshipService extends BaseService {
   }
 
   /**
-   * Decode a `group`/`repeater` field held as a JSON string into its objects, in
-   * place, so the walk can descend into the relationships inside it.
+   * Decode a JSON-backed field held as a string into its objects, in place, so the
+   * walk can descend into the relationships inside or behind it.
    *
-   * A source `afterRead` hook can return a container as the storage string SQLite
-   * keeps it as (the normal read decodes containers to objects before this walk;
-   * a hook that reshapes the document can hand one back as a string). Left as a
-   * string, {@link walkFieldValue} derives no rows from it and a denied target
-   * field on a relationship inside it would reach the response. Writing the decoded
-   * value back matches the object shape a normal read returns.
+   * A source `afterRead` hook can return a value as the storage string SQLite keeps
+   * it as (the normal read decodes these before this walk; a hook that reshapes the
+   * document can hand one back as a string). Two field kinds are JSON-backed:
+   * `group`/`repeater` containers, and a POPULATED `hasMany` or polymorphic
+   * relationship, which serializes to a JSON array (`[...]`) or object
+   * (`{"relationTo":...}`). Left a string, {@link walkFieldValue} derives no rows
+   * from it and a denied target field inside would reach the response.
+   *
+   * A relationship is decoded only when the string opens with `[` or `{`: a bare id
+   * is left alone (parsing `"12"` would coerce it to a number), and a Postgres
+   * array literal (`{id,...}`) is not JSON so {@link parseJsonIfString} returns it
+   * unchanged. Writing the decoded value back matches the shape a normal read
+   * returns.
    */
-  private decodeContainerFieldInPlace(
+  private decodeJsonBackedFieldInPlace(
     holder: Record<string, unknown>,
     field: FieldDefinition
   ): void {
-    if (
-      isRepeaterOrGroupField(field) &&
-      typeof holder[field.name] === "string"
+    const value = holder[field.name];
+    if (typeof value !== "string") return;
+    if (isRepeaterOrGroupField(field)) {
+      holder[field.name] = parseJsonIfString(value);
+    } else if (
+      isRelationshipField(field) &&
+      (value.startsWith("[") || value.startsWith("{"))
     ) {
-      holder[field.name] = parseJsonIfString(holder[field.name]);
+      holder[field.name] = parseJsonIfString(value);
+    }
+  }
+
+  /**
+   * Copy the removed-field evidence of an ORIGINAL related row, and of every row
+   * inside its groups/repeaters, onto a CLONE a source hook returned in its place.
+   *
+   * The redaction WeakMap keys evidence by object, so a deep clone loses it at
+   * every level; the id bridge finds the original, and this transfers its subtree
+   * evidence onto the clone so the authoritative re-walk can restore an inverse
+   * conditional's denied sibling throughout the tree, not only at the root, then
+   * re-judge. Matched by container index — a genuine replacement whose shape
+   * diverges inherits less and is judged on its own content.
+   */
+  private async transferSubtreeEvidence(
+    original: Record<string, unknown>,
+    clone: Record<string, unknown>,
+    collection: string,
+    state: NestedHookState
+  ): Promise<void> {
+    const rootEvidence = state.redactions.get(original);
+    if (rootEvidence && !state.redactions.has(clone)) {
+      state.redactions.set(clone, rootEvidence);
+    }
+    const fields = await this.fieldsForNestedWalk(collection, state);
+    this.transferContainerEvidence(original, clone, fields, state);
+  }
+
+  /** The recursive, container-level worker for {@link transferSubtreeEvidence}. */
+  private transferContainerEvidence(
+    original: Record<string, unknown>,
+    clone: Record<string, unknown>,
+    fields: FieldDefinition[],
+    state: NestedHookState
+  ): void {
+    for (const field of fields) {
+      if (!isRepeaterOrGroupField(field) || !field.name) continue;
+      const originalRows = containerRowsOf(original[field.name]);
+      const cloneRows = containerRowsOf(clone[field.name]);
+      const inner = getNestedFields(field);
+      const shared = Math.min(originalRows.length, cloneRows.length);
+      for (let i = 0; i < shared; i++) {
+        const evidence = state.redactions.get(originalRows[i]);
+        if (evidence && !state.redactions.has(cloneRows[i])) {
+          state.redactions.set(cloneRows[i], evidence);
+        }
+        this.transferContainerEvidence(
+          originalRows[i],
+          cloneRows[i],
+          inner,
+          state
+        );
+      }
     }
   }
 
@@ -3213,7 +3297,7 @@ export class CollectionRelationshipService extends BaseService {
 
     const fields = await this.fieldsForNestedWalk(collectionName, state);
     for (const field of fields) {
-      this.decodeContainerFieldInPlace(entry, field);
+      this.decodeJsonBackedFieldInPlace(entry, field);
       await this.walkFieldValue(entry[field.name], field, access, state, depth);
     }
   }
@@ -3247,7 +3331,7 @@ export class CollectionRelationshipService extends BaseService {
       // hooks of their own -- only the relationships inside them do.
       for (const row of rows) {
         for (const inner of nested) {
-          this.decodeContainerFieldInPlace(row, inner);
+          this.decodeJsonBackedFieldInPlace(row, inner);
           await this.walkFieldValue(
             row[inner.name],
             inner,
@@ -3307,6 +3391,21 @@ export class CollectionRelationshipService extends BaseService {
           operation: "read",
           user: access.user,
         });
+        // A field hook may have ADDED or REPLACED one of this row's own populated
+        // relationships. That child missed the descent above, so descend again:
+        // a genuinely new child is walked — its denied fields stripped and it
+        // queued — before this row returns to its parent, whose hooks (and the
+        // source collection's) run next and could otherwise read a denied value
+        // off the still-unsanitized child and copy it onto an allowed key the
+        // later pass no longer looks at. Rows already claimed in `visited` are
+        // skipped, so only new children are re-walked.
+        await this.walkNestedRows(
+          resolved.row,
+          resolved.collection,
+          access,
+          state,
+          depth + 1
+        );
       }
 
       // Apply THIS row's field access now, before returning to its parent —
@@ -3321,20 +3420,27 @@ export class CollectionRelationshipService extends BaseService {
       // recorded in the shared `redactions` so `finalizeRelatedRows` can restore
       // it as evidence and re-judge the row after every hook has run.
       //
-      // Seed this row's removed-evidence from the id-keyed store when the WeakMap
-      // has none for it: a source hook can return a CLONE (a new object the
-      // WeakMap cannot key), and without the original's evidence an inverse
+      // Transfer evidence from the ORIGINAL row (by id) when the WeakMap has none
+      // for this one: a source hook can return a CLONE (a new object graph the
+      // WeakMap cannot key), and without the original's removed siblings an inverse
       // conditional rule — a field visible only while a DENIED sibling is absent —
-      // would fall open on the clone. It is re-judged below, so a replacement's own
-      // denied fields are still stripped; only the removed siblings are restored.
+      // would fall open on the clone. Transferred through the whole subtree, then
+      // re-judged below (a replacement's own denied fields are still stripped).
       if (
         !state.redactions.has(resolved.row) &&
         typeof resolved.row.id === "string"
       ) {
-        const byId = state.redactionsById.get(
+        const original = state.originalRowById.get(
           relationKey(resolved.collection, resolved.row.id)
         );
-        if (byId) state.redactions.set(resolved.row, byId);
+        if (original && original !== resolved.row) {
+          await this.transferSubtreeEvidence(
+            original,
+            resolved.row,
+            resolved.collection,
+            state
+          );
+        }
       }
       await this.applyRelatedRowReadAccess(
         resolved.collection,
@@ -3342,13 +3448,12 @@ export class CollectionRelationshipService extends BaseService {
         access,
         state.redactions
       );
-      // Mirror what this row had removed into the id-keyed store, so a later clone
-      // of it can restore the same evidence.
-      const removedForRow = state.redactions.get(resolved.row);
-      if (removedForRow && typeof resolved.row.id === "string") {
-        state.redactionsById.set(
+      // Remember the ORIGINAL row object by id (first walk only), so a later clone
+      // of it can inherit its subtree evidence.
+      if (state.applyFieldHooks && typeof resolved.row.id === "string") {
+        state.originalRowById.set(
           relationKey(resolved.collection, resolved.row.id),
-          removedForRow
+          resolved.row
         );
       }
 

--- a/packages/nextly/src/domains/collections/services/collection-relationship-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-relationship-service.ts
@@ -2998,20 +2998,29 @@ export class CollectionRelationshipService extends BaseService {
   }
 
   /**
-   * Re-apply each related row's field access after every hook has run, then
-   * rebuild the labels.
+   * Re-apply each related row's field access, then rebuild the labels.
    *
    * The walk already applied access to each row (before its parent's hooks, so a
-   * parent hook cannot read a denied child field to copy it). This runs it once
-   * more because a parent hook can REINTRODUCE a denied field onto an
-   * already-redacted child (assigning `data.child.secret` to mask or derive a
-   * value), mutate a row in place, or add/replace/reorder rows -- and without a
-   * pass after the hooks that would be returned. It re-judges the current content
-   * (a cached verdict cannot be trusted once a hook may have changed what a rule
-   * reads), restoring from the shared `redactions` what the first pass removed
-   * from each row so a rule reading a now-denied sibling as evidence still sees
-   * it -- keeping an unchanged verdict stable, as a direct read's single pass
-   * would, while judging everything a hook touched afresh.
+   * parent hook cannot read a denied child field to copy it). This runs it again
+   * because a hook can REINTRODUCE a denied field onto an already-redacted row
+   * (assigning `data.child.secret` to mask or derive a value), mutate a row in
+   * place, or add/replace/reorder rows -- and without a pass after the hooks that
+   * would be returned. It re-judges the current content (a cached verdict cannot
+   * be trusted once a hook may have changed what a rule reads), restoring from the
+   * shared `redactions` what a prior pass removed from each row so a rule reading
+   * a now-denied sibling as evidence still sees it -- keeping an unchanged verdict
+   * stable, as a direct read's single pass would, while judging everything a hook
+   * touched afresh.
+   *
+   * Called more than once per read, and safe to repeat: once after the related
+   * rows' OWN field hooks (so the source collection's hooks are handed already
+   * sanitized rows), and again after the SOURCE collection's code and stored
+   * afterRead hooks. Those hooks receive the whole assembled document and can
+   * write a denied field straight back onto a related row (`entry.author.secret`);
+   * the root-level read-access pass evaluates only the source collection's schema
+   * and never descends into a related row, so without a pass here after them the
+   * reintroduced value is returned. It leaves `pending` in place for exactly that
+   * repeat; the state is scoped to one read and discarded when it finishes.
    *
    * Labels come last of all, from the values that survived: a label copies a
    * field under another key, so one rebuilt earlier would outlive the removal of
@@ -3033,7 +3042,6 @@ export class CollectionRelationshipService extends BaseService {
     for (const { row, collection, field } of state.pending) {
       await this.refreshRelatedRowLabel(row, field, { collection }, state);
     }
-    state.pending.length = 0;
   }
 
   /**

--- a/packages/nextly/src/domains/collections/services/collection-relationship-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-relationship-service.ts
@@ -41,7 +41,9 @@ import type { Logger } from "../../../services/shared";
 import { BaseService } from "../../../shared/base-service";
 import {
   applyFieldReadAccess,
+  replayFieldRedaction,
   runFieldHooks,
+  type FieldRedactionPlan,
 } from "../../../shared/lib/field-level-registry";
 import {
   hasPasswordField,
@@ -95,17 +97,21 @@ interface NestedHookStateBase {
    * Every related row the pass reached, in visit order, with what is needed to
    * finish it.
    *
-   * Field access is applied to each row during the walk (before its parent's
-   * hooks, so a parent hook cannot read a denied child field to copy it). These
-   * entries drive a SECOND access pass and the label rebuild in
-   * `finalizeRelatedRows`, after every hook has run: the second pass strips a
-   * denied field a parent hook reintroduced onto an already-redacted child, and
-   * labels are rebuilt last from the values that survived.
+   * Field access is EVALUATED and applied to each row during the walk (before its
+   * parent's hooks, so a parent hook cannot read a denied child field to copy
+   * it), and the redaction it performed is captured as `redaction`. These entries
+   * drive the finalize step after every hook has run: it REPLAYS each row's
+   * captured redaction -- stripping a denied field a parent hook reintroduced
+   * onto an already-redacted child, without re-running the policy -- then rebuilds
+   * labels last from the values that survived.
    */
   pending: Array<{
     row: Record<string, unknown>;
     collection: string;
     field: FieldDefinition;
+    /** The redaction applied to `row` during the walk, replayed in finalize.
+     *  Undefined for a trusted/override read. */
+    redaction?: FieldRedactionPlan;
   }>;
 }
 
@@ -2992,29 +2998,31 @@ export class CollectionRelationshipService extends BaseService {
   }
 
   /**
-   * The SECOND field-access pass over every related row the walk reached, then
-   * the label rebuild.
+   * Re-apply each related row's redaction after every hook has run, then rebuild
+   * the labels.
    *
-   * Access is applied to each row once during the walk already -- right after
-   * its own hooks and before its parent's, so a parent hook cannot read a denied
-   * child field to copy it elsewhere. This pass runs it again, after every hook
-   * in the document has run, because a parent hook can also REINTRODUCE a denied
-   * field onto an already-redacted child (assigning `data.child.secret` to mask
-   * or derive a value); without a pass after the hooks that reintroduced field
-   * would be returned. It is idempotent on a row nothing reintroduced into -- the
-   * denied field is simply already gone.
+   * The walk already EVALUATED and applied field access to each row (before its
+   * parent's hooks, so a parent hook cannot read a denied child field to copy
+   * it). This REPLAYS that redaction -- deleting the same fields again -- because
+   * a parent hook can REINTRODUCE a denied field onto an already-redacted child
+   * (assigning `data.child.secret` to mask or derive a value); without a pass
+   * after the hooks it would be returned. Replaying the captured decisions rather
+   * than re-running the policy is deliberate: a rule reads the row as `data`, so
+   * re-evaluating against the already-stripped row could flip a decision (a field
+   * kept only while a now-denied sibling was present) or re-issue an async rule's
+   * queries. It is a no-op on a row nothing reintroduced into.
    *
-   * Labels come last of all, from the values that survived both passes: a label
-   * copies a field under another key, so one rebuilt earlier would outlive the
-   * removal of its own source field.
+   * Labels come last of all, from the values that survived: a label copies a
+   * field under another key, so one rebuilt earlier would outlive the removal of
+   * its own source field.
    */
   async finalizeRelatedRows(
     state: NestedHookState,
     access: RelatedRowAccess
   ): Promise<void> {
     if (!access.enforceFieldAccess) return;
-    for (const { row, collection } of state.pending) {
-      await this.applyRelatedRowReadAccess(collection, [row], access);
+    for (const { row, redaction } of state.pending) {
+      if (redaction) replayFieldRedaction(row, redaction);
     }
     for (const { row, collection, field } of state.pending) {
       await this.refreshRelatedRowLabel(row, field, { collection }, state);
@@ -3193,23 +3201,26 @@ export class CollectionRelationshipService extends BaseService {
       // values, and a direct read redacts a nested row before the parent
       // collection's field hooks for the same reason, so applying it here keeps
       // the nested path consistent with the direct one. Under `overrideAccess`
-      // this is a no-op, leaving trusted assembly untouched. This is the FIRST of
-      // two passes: `finalizeRelatedRows` runs it once more after every hook, to
-      // strip a denied field a later parent hook reintroduces onto this row.
-      await this.applyRelatedRowReadAccess(
+      // this is a no-op, leaving trusted assembly untouched. This is the only
+      // place the policy is EVALUATED; `finalizeRelatedRows` replays the
+      // decisions it captured to catch anything a later parent hook reintroduces.
+      const [redaction] = await this.applyRelatedRowReadAccess(
         resolved.collection,
         [resolved.row],
         access
       );
 
-      // Queued for the second access pass and the label refresh, both in
-      // `finalizeRelatedRows` once every hook has run. Labels come last of all,
-      // from the values that survived: a label copies a field under another key,
-      // so one rebuilt earlier would outlive the removal of its own source field.
+      // Queued with the redaction the pass performed. `finalizeRelatedRows`
+      // replays it after every hook has run — stripping a denied field a parent
+      // hook wrote back onto this row — WITHOUT re-evaluating the policy, which
+      // run against the already-stripped row could flip a decision (a field
+      // allowed only while a now-denied sibling is present) or re-issue an async
+      // rule's queries. Labels come last, from the values that survived.
       state.pending.push({
         row: resolved.row,
         collection: resolved.collection,
         field,
+        redaction,
       });
 
       // Secrets are stripped from a related row when it is fetched, but a hook
@@ -3290,18 +3301,25 @@ export class CollectionRelationshipService extends BaseService {
     targetCollection: string,
     rows: Record<string, unknown>[],
     access: RelatedRowAccess
-  ): Promise<void> {
-    if (!access.enforceFieldAccess) return;
-    if (access.overrideAccess) return;
-    for (const row of rows) {
-      await applyFieldReadAccess({
-        kind: "collection",
-        slug: targetCollection,
-        entry: row,
-        user: access.user,
-        overrideAccess: false,
-      });
+  ): Promise<Array<FieldRedactionPlan | undefined>> {
+    if (!access.enforceFieldAccess || access.overrideAccess) {
+      return rows.map(() => undefined);
     }
+    // The redaction each row got, in row order, so the caller can replay it after
+    // later hooks run instead of re-evaluating the policy against a mutated row.
+    const plans: Array<FieldRedactionPlan | undefined> = [];
+    for (const row of rows) {
+      plans.push(
+        await applyFieldReadAccess({
+          kind: "collection",
+          slug: targetCollection,
+          entry: row,
+          user: access.user,
+          overrideAccess: false,
+        })
+      );
+    }
+    return plans;
   }
 
   /**

--- a/packages/nextly/src/domains/collections/services/collection-relationship-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-relationship-service.ts
@@ -114,6 +114,17 @@ interface NestedHookStateBase {
    */
   originalRowById: Map<string, Record<string, unknown>>;
   /**
+   * Every group/repeater ROW object present inside a related row during the first
+   * walk. A source hook can keep a related root in place (same object, so it is
+   * judged normally) yet REPLACE or APPEND a row inside one of its containers; the
+   * new row carries no evidence, and judging it fresh would let an inverse rule
+   * fall open. Membership here distinguishes an original nested row (mutated in
+   * place, judged with its evidence) from a hook's replacement, which is failed
+   * closed. Keyed by object identity, so a replacement is a new object that is
+   * simply absent.
+   */
+  originalNestedRows: WeakSet<Record<string, unknown>>;
+  /**
    * Every related row the pass reached, in visit order, with what is needed to
    * finish it. These entries drive the finalize step after every hook has run: it
    * re-applies access to each row (see `redactions`), then rebuilds labels last
@@ -153,6 +164,7 @@ function createNestedHookState(): NestedHookState {
     labelFields: new Map(),
     redactions: new WeakMap(),
     originalRowById: new Map(),
+    originalNestedRows: new WeakSet(),
     failClosed: new WeakSet(),
     pending: [],
     applyFieldHooks: true,
@@ -3142,6 +3154,7 @@ export class CollectionRelationshipService extends BaseService {
       labelFields: walkState.labelFields,
       redactions: walkState.redactions,
       originalRowById: walkState.originalRowById,
+      originalNestedRows: walkState.originalNestedRows,
       failClosed: walkState.failClosed,
       applyFieldHooks: false,
     };
@@ -3231,11 +3244,19 @@ export class CollectionRelationshipService extends BaseService {
     if (typeof value !== "string") return;
     if (isRepeaterOrGroupField(field)) {
       holder[field.name] = parseJsonIfString(value);
-    } else if (
-      isRelationshipField(field) &&
-      (value.startsWith("[") || value.startsWith("{"))
-    ) {
-      holder[field.name] = parseJsonIfString(value);
+    } else if (isRelationshipField(field)) {
+      // A populated `hasMany`/polymorphic relationship serializes to a JSON array
+      // (`[...]`) or object (`{"relationTo":...}`). Detect it by the first
+      // NON-WHITESPACE character, so a hook that hands back pretty-printed JSON
+      // (a leading newline or spaces) is still decoded rather than left a string
+      // the walk cannot descend — otherwise a denied field inside would reach the
+      // response. A bare id or a Postgres array literal is left alone:
+      // parseJsonIfString only replaces the value when JSON.parse succeeds, and
+      // neither is valid JSON.
+      const start = value.trimStart();
+      if (start.startsWith("[") || start.startsWith("{")) {
+        holder[field.name] = parseJsonIfString(value);
+      }
     }
   }
 
@@ -3247,8 +3268,10 @@ export class CollectionRelationshipService extends BaseService {
    * every level; the id bridge finds the original, and this transfers its subtree
    * evidence onto the clone so the authoritative re-walk can restore an inverse
    * conditional's denied sibling throughout the tree, not only at the root, then
-   * re-judge. Matched by container index — a genuine replacement whose shape
-   * diverges inherits less and is judged on its own content.
+   * re-judge. Containers are reconciled by kind: a GROUP is one object at a fixed
+   * field name, matched by position; a REPEATER is matched by row `id`, and a
+   * clone row whose id is absent from the originals (reordered, id-less, or
+   * fabricated) is failed closed rather than matched by an unstable array index.
    */
   private async transferSubtreeEvidence(
     original: Record<string, unknown>,
@@ -3372,6 +3395,67 @@ export class CollectionRelationshipService extends BaseService {
       for (const child of containerRowsOf(row[field.name])) {
         state.failClosed.add(child);
         this.flagContainerRowsFailClosed(child, inner, state);
+      }
+    }
+  }
+
+  /**
+   * Record every group/repeater row currently inside a related root (first walk
+   * only), so the re-walk can tell an original nested row — mutated in place, and
+   * judged with its own evidence — from one a source hook replaced or appended.
+   */
+  private recordOriginalNestedRows(
+    row: Record<string, unknown>,
+    fields: FieldDefinition[],
+    state: NestedHookState
+  ): void {
+    for (const field of fields) {
+      if (!isRepeaterOrGroupField(field) || !field.name) continue;
+      const inner = getNestedFields(field);
+      for (const child of containerRowsOf(row[field.name])) {
+        state.originalNestedRows.add(child);
+        this.recordOriginalNestedRows(child, inner, state);
+      }
+    }
+  }
+
+  /**
+   * Fail closed on any group/repeater row inside an IN-PLACE related root that was
+   * not present in the first walk — a source hook replaced or appended it.
+   *
+   * A hook can keep the related root object identical (so it is judged normally)
+   * yet swap or add a row inside one of its containers. The new row carries no
+   * redaction evidence, and judging it fresh would let an inverse rule — a field
+   * visible only while a DENIED sibling is absent — fall open, because the clone
+   * dropped the sibling. A row still present from the first walk (mutated in place)
+   * keeps its evidence and is judged normally; only the unrecorded ones fail closed.
+   */
+  private async failCloseReplacedNestedRows(
+    root: Record<string, unknown>,
+    collection: string,
+    state: NestedHookState
+  ): Promise<void> {
+    const fields = await this.fieldsForNestedWalk(collection, state);
+    this.failCloseUnrecordedNestedRows(root, fields, state);
+  }
+
+  /** Recursive worker for {@link failCloseReplacedNestedRows}: descends into rows
+   *  the first walk recorded, and fails closed (whole subtree) on rows it did not. */
+  private failCloseUnrecordedNestedRows(
+    row: Record<string, unknown>,
+    fields: FieldDefinition[],
+    state: NestedHookState
+  ): void {
+    for (const field of fields) {
+      if (!isRepeaterOrGroupField(field) || !field.name) continue;
+      const inner = getNestedFields(field);
+      for (const child of containerRowsOf(row[field.name])) {
+        if (state.originalNestedRows.has(child)) {
+          this.failCloseUnrecordedNestedRows(child, inner, state);
+        } else {
+          state.failClosed.add(child);
+          this.flagContainerRowsFailClosed(child, inner, state);
+        }
       }
     }
   }
@@ -3531,28 +3615,38 @@ export class CollectionRelationshipService extends BaseService {
       //    seen in the first walk (an unidentifiable or fabricated clone) — has
       //    its whole subtree failed closed, so every access-controlled field on
       //    it is denied rather than judged on evidence that cannot be trusted.
-      if (!state.applyFieldHooks && !state.redactions.has(resolved.row)) {
+      if (!state.applyFieldHooks) {
         const id =
           typeof resolved.row.id === "string" ? resolved.row.id : undefined;
         const original = id
           ? state.originalRowById.get(relationKey(resolved.collection, id))
           : undefined;
         if (original === resolved.row) {
-          // The row IS the first-walk original; nothing was redacted from it, so
-          // there is no evidence to transfer and no provenance gap — judged below.
-        } else if (original) {
-          await this.transferSubtreeEvidence(
-            original,
+          // An in-place ORIGINAL root (same object): judged with its own evidence,
+          // but a source hook may have REPLACED or APPENDED a row inside one of its
+          // groups/repeaters. Such a nested row is a new object with no recorded
+          // evidence, so an inverse rule would fall open on it — fail it closed,
+          // leaving the originals (mutated in place) judged normally.
+          await this.failCloseReplacedNestedRows(
             resolved.row,
             resolved.collection,
             state
           );
-        } else {
-          await this.flagSubtreeFailClosed(
-            resolved.row,
-            resolved.collection,
-            state
-          );
+        } else if (!state.redactions.has(resolved.row)) {
+          if (original) {
+            await this.transferSubtreeEvidence(
+              original,
+              resolved.row,
+              resolved.collection,
+              state
+            );
+          } else {
+            await this.flagSubtreeFailClosed(
+              resolved.row,
+              resolved.collection,
+              state
+            );
+          }
         }
       }
       await this.applyRelatedRowReadAccess(
@@ -3562,12 +3656,18 @@ export class CollectionRelationshipService extends BaseService {
         state.redactions,
         state.failClosed
       );
-      // Remember the ORIGINAL row object by id (first walk only), so a later clone
-      // of it can inherit its subtree evidence.
+      // Remember the ORIGINAL row object by id, and its current nested container
+      // rows (first walk only), so a later clone can inherit its subtree evidence
+      // and a replaced/appended nested row can be told from one mutated in place.
       if (state.applyFieldHooks && typeof resolved.row.id === "string") {
         state.originalRowById.set(
           relationKey(resolved.collection, resolved.row.id),
           resolved.row
+        );
+        this.recordOriginalNestedRows(
+          resolved.row,
+          await this.fieldsForNestedWalk(resolved.collection, state),
+          state
         );
       }
 

--- a/packages/nextly/src/domains/collections/services/collection-relationship-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-relationship-service.ts
@@ -2991,28 +2991,19 @@ export class CollectionRelationshipService extends BaseService {
   }
 
   /**
-   * Hide denied fields on every related row the walk reached, then rebuild the
-   * labels.
+   * Rebuild the labels of every related row the walk reached.
    *
-   * Separated from the walk because the two orders are not the same order. A
-   * field hook masks; a field rule hides; and the hooks of a row's PARENT run
-   * after the row itself is finished, so hiding as each row completes takes the
-   * evidence away from a rule that has not run yet. Masking the whole document
-   * first, then hiding it, is the order a direct read has always used -- one
-   * document, not one row at a time.
-   *
-   * Labels come last of all, from the values that survived: a label copies a
-   * field under another key, so one built earlier outlives the removal of its
-   * own source field.
+   * Field access is applied during the walk now (each row right after its own
+   * hooks, before its parent's), so this no longer hides anything -- it only
+   * refreshes labels. Labels come last of all, from the values that survived
+   * redaction: a label copies a field under another key, so one rebuilt earlier
+   * would outlive the removal of its own source field.
    */
   async finalizeRelatedRows(
     state: NestedHookState,
     access: RelatedRowAccess
   ): Promise<void> {
     if (!access.enforceFieldAccess) return;
-    for (const { row, collection } of state.pending) {
-      await this.applyRelatedRowReadAccess(collection, [row], access);
-    }
     for (const { row, collection, field } of state.pending) {
       await this.refreshRelatedRowLabel(row, field, { collection }, state);
     }
@@ -3182,9 +3173,25 @@ export class CollectionRelationshipService extends BaseService {
         user: access.user,
       });
 
-      // Queued, not applied. Hiding this row's denied fields now would remove
-      // the evidence its PARENT's masking rule reads a moment later, because
-      // this walk finishes a child before its parent's hooks run.
+      // Apply THIS row's field access now, before returning to its parent —
+      // whose afterRead hooks run next up the stack. Deferring it (as this once
+      // did) let a parent hook read a child field the caller may not see, and
+      // copy it under an allowed parent key where it outlived the child's own
+      // redaction. The row's own hooks above already ran against its complete
+      // values, and a direct read redacts a nested row before the parent
+      // collection's field hooks for the same reason, so applying it here keeps
+      // the nested path consistent with the direct one. Under `overrideAccess`
+      // this is a no-op, leaving trusted assembly untouched.
+      await this.applyRelatedRowReadAccess(
+        resolved.collection,
+        [resolved.row],
+        access
+      );
+
+      // Still queued for the label refresh, which runs last of all (in
+      // `finalizeRelatedRows`) from the values that survived redaction: a label
+      // copies a field under another key, so one rebuilt earlier would outlive
+      // the removal of its own source field.
       state.pending.push({
         row: resolved.row,
         collection: resolved.collection,

--- a/packages/nextly/src/domains/collections/services/collection-relationship-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-relationship-service.ts
@@ -102,6 +102,16 @@ interface NestedHookStateBase {
    */
   redactions: ReadAccessRedactions;
   /**
+   * The same removed values as `redactions`, but keyed by `relationKey(collection,
+   * id)` instead of the row object. A source hook can return a CLONE of a related
+   * row (a new object the WeakMap cannot key); the authoritative re-walk seeds the
+   * clone's evidence from here so an inverse conditional rule — a field visible
+   * only while a DENIED sibling is absent — cannot fall open on the clone. Keyed by
+   * id and re-judged (never a cached verdict): a replacement's denied fields are
+   * still stripped, and a same-id clone is judged against the original's evidence.
+   */
+  redactionsById: Map<string, Record<string, unknown>>;
+  /**
    * Every related row the pass reached, in visit order, with what is needed to
    * finish it. These entries drive the finalize step after every hook has run: it
    * re-applies access to each row (see `redactions`), then rebuilds labels last
@@ -131,6 +141,7 @@ function createNestedHookState(): NestedHookState {
     fields: new Map(),
     labelFields: new Map(),
     redactions: new WeakMap(),
+    redactionsById: new Map(),
     pending: [],
     applyFieldHooks: true,
   };
@@ -3081,17 +3092,24 @@ export class CollectionRelationshipService extends BaseService {
     access: RelatedRowAccess,
     walkState: NestedHookState
   ): Promise<void> {
-    if (!access.enforceFieldAccess || access.overrideAccess) return;
+    // NOT gated on `overrideAccess`. A trusted read skips the field RULES (each
+    // row's access pass is a no-op under override), but password and system-secret
+    // stripping is unconditional even for trusted reads, and a source hook can
+    // reintroduce a secret onto a related row after the first walk — so this pass
+    // still has to run to re-strip it.
+    if (!access.enforceFieldAccess) return;
     // Fresh `visited`/`pending` so every related row in the assembled response is
     // reached again (the first walk already claimed them), but the SAME
-    // `redactions` and metadata caches, so evidence carries over and the schema
-    // reads are not repeated.
+    // `redactions` (and its id-keyed twin) and metadata caches, so evidence carries
+    // over — including to a row a hook cloned — and the schema reads are not
+    // repeated.
     const repass: NestedHookState = {
       visited: new Set(),
       pending: [],
       fields: walkState.fields,
       labelFields: walkState.labelFields,
       redactions: walkState.redactions,
+      redactionsById: walkState.redactionsById,
       applyFieldHooks: false,
     };
     for (const entry of entries) {
@@ -3155,6 +3173,29 @@ export class CollectionRelationshipService extends BaseService {
   }
 
   /**
+   * Decode a `group`/`repeater` field held as a JSON string into its objects, in
+   * place, so the walk can descend into the relationships inside it.
+   *
+   * A source `afterRead` hook can return a container as the storage string SQLite
+   * keeps it as (the normal read decodes containers to objects before this walk;
+   * a hook that reshapes the document can hand one back as a string). Left as a
+   * string, {@link walkFieldValue} derives no rows from it and a denied target
+   * field on a relationship inside it would reach the response. Writing the decoded
+   * value back matches the object shape a normal read returns.
+   */
+  private decodeContainerFieldInPlace(
+    holder: Record<string, unknown>,
+    field: FieldDefinition
+  ): void {
+    if (
+      isRepeaterOrGroupField(field) &&
+      typeof holder[field.name] === "string"
+    ) {
+      holder[field.name] = parseJsonIfString(holder[field.name]);
+    }
+  }
+
+  /**
    * One level of {@link applyNestedFieldHooks}.
    *
    * Rows are claimed in {@link walkFieldValue} rather than here, so the claim
@@ -3172,6 +3213,7 @@ export class CollectionRelationshipService extends BaseService {
 
     const fields = await this.fieldsForNestedWalk(collectionName, state);
     for (const field of fields) {
+      this.decodeContainerFieldInPlace(entry, field);
       await this.walkFieldValue(entry[field.name], field, access, state, depth);
     }
   }
@@ -3205,6 +3247,7 @@ export class CollectionRelationshipService extends BaseService {
       // hooks of their own -- only the relationships inside them do.
       for (const row of rows) {
         for (const inner of nested) {
+          this.decodeContainerFieldInPlace(row, inner);
           await this.walkFieldValue(
             row[inner.name],
             inner,
@@ -3277,12 +3320,37 @@ export class CollectionRelationshipService extends BaseService {
       // this is a no-op, leaving trusted assembly untouched. What it removes is
       // recorded in the shared `redactions` so `finalizeRelatedRows` can restore
       // it as evidence and re-judge the row after every hook has run.
+      //
+      // Seed this row's removed-evidence from the id-keyed store when the WeakMap
+      // has none for it: a source hook can return a CLONE (a new object the
+      // WeakMap cannot key), and without the original's evidence an inverse
+      // conditional rule — a field visible only while a DENIED sibling is absent —
+      // would fall open on the clone. It is re-judged below, so a replacement's own
+      // denied fields are still stripped; only the removed siblings are restored.
+      if (
+        !state.redactions.has(resolved.row) &&
+        typeof resolved.row.id === "string"
+      ) {
+        const byId = state.redactionsById.get(
+          relationKey(resolved.collection, resolved.row.id)
+        );
+        if (byId) state.redactions.set(resolved.row, byId);
+      }
       await this.applyRelatedRowReadAccess(
         resolved.collection,
         [resolved.row],
         access,
         state.redactions
       );
+      // Mirror what this row had removed into the id-keyed store, so a later clone
+      // of it can restore the same evidence.
+      const removedForRow = state.redactions.get(resolved.row);
+      if (removedForRow && typeof resolved.row.id === "string") {
+        state.redactionsById.set(
+          relationKey(resolved.collection, resolved.row.id),
+          removedForRow
+        );
+      }
 
       // Rebuild the label from what survived the access pass, NOW, before the
       // parent's hooks run next up the stack. The fetch derives a row's `label`
@@ -3320,6 +3388,15 @@ export class CollectionRelationshipService extends BaseService {
       );
       if (hasPasswordField(targetFields)) {
         stripPasswordFieldValues(resolved.row, targetFields);
+      }
+      // A system entity (users) has no field registry, so the password strip above
+      // — which reads the registry — never sees its secret columns. They are
+      // stripped by name at fetch, but a source hook can reintroduce one onto the
+      // populated row afterward, so re-strip them on every walk, override included.
+      if (isSystemEntity(resolved.collection)) {
+        for (const col of SYSTEM_ENTITY_SECRET_COLUMNS) {
+          delete resolved.row[col];
+        }
       }
       stripSystemOwnerField(resolved.row);
     }

--- a/packages/nextly/src/domains/collections/services/collection-relationship-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-relationship-service.ts
@@ -41,6 +41,7 @@ import type { Logger } from "../../../services/shared";
 import { BaseService } from "../../../shared/base-service";
 import {
   applyFieldReadAccess,
+  type FailClosedRows,
   runFieldHooks,
   type ReadAccessRedactions,
 } from "../../../shared/lib/field-level-registry";
@@ -124,6 +125,15 @@ interface NestedHookStateBase {
     field: FieldDefinition;
   }>;
   /**
+   * Related-row clones whose redaction provenance the re-walk could not recover
+   * (a reshaped or id-less clone a source hook returned in place of the original,
+   * or a repeater row it reordered without a matchable id). Shared across the
+   * read like `redactions`; each flagged row has every access-controlled field
+   * denied when access is re-applied, the fail-secure default for a clone that
+   * cannot be matched to the row whose evidence would judge it correctly.
+   */
+  failClosed: FailClosedRows;
+  /**
    * Whether the walk runs each related row's `afterRead` field hooks. True for
    * the first walk; false for the authoritative re-walk of the ASSEMBLED response
    * (see {@link CollectionRelationshipService.resanitizeAssembledRows}), which
@@ -143,6 +153,7 @@ function createNestedHookState(): NestedHookState {
     labelFields: new Map(),
     redactions: new WeakMap(),
     originalRowById: new Map(),
+    failClosed: new WeakSet(),
     pending: [],
     applyFieldHooks: true,
   };
@@ -3076,7 +3087,8 @@ export class CollectionRelationshipService extends BaseService {
         collection,
         [row],
         access,
-        state.redactions
+        state.redactions,
+        state.failClosed
       );
     }
     for (const { row, collection, field } of state.pending) {
@@ -3130,6 +3142,7 @@ export class CollectionRelationshipService extends BaseService {
       labelFields: walkState.labelFields,
       redactions: walkState.redactions,
       originalRowById: walkState.originalRowById,
+      failClosed: walkState.failClosed,
       applyFieldHooks: false,
     };
     for (const entry of entries) {
@@ -3243,12 +3256,22 @@ export class CollectionRelationshipService extends BaseService {
     collection: string,
     state: NestedHookState
   ): Promise<void> {
-    const rootEvidence = state.redactions.get(original);
-    if (rootEvidence && !state.redactions.has(clone)) {
-      state.redactions.set(clone, rootEvidence);
-    }
+    this.copyRowEvidence(original, clone, state);
     const fields = await this.fieldsForNestedWalk(collection, state);
     this.transferContainerEvidence(original, clone, fields, state);
+  }
+
+  /** Copy one row's removed-field evidence onto its clone, unless the clone
+   *  already carries evidence of its own. */
+  private copyRowEvidence(
+    original: Record<string, unknown>,
+    clone: Record<string, unknown>,
+    state: NestedHookState
+  ): void {
+    const evidence = state.redactions.get(original);
+    if (evidence && !state.redactions.has(clone)) {
+      state.redactions.set(clone, evidence);
+    }
   }
 
   /** The recursive, container-level worker for {@link transferSubtreeEvidence}. */
@@ -3263,18 +3286,92 @@ export class CollectionRelationshipService extends BaseService {
       const originalRows = containerRowsOf(original[field.name]);
       const cloneRows = containerRowsOf(clone[field.name]);
       const inner = getNestedFields(field);
-      const shared = Math.min(originalRows.length, cloneRows.length);
-      for (let i = 0; i < shared; i++) {
-        const evidence = state.redactions.get(originalRows[i]);
-        if (evidence && !state.redactions.has(cloneRows[i])) {
-          state.redactions.set(cloneRows[i], evidence);
+      // A group is a single object at a fixed field name, so its original and
+      // clone correspond one-to-one with no positional guess.
+      if (isGroupField(field)) {
+        const shared = Math.min(originalRows.length, cloneRows.length);
+        for (let i = 0; i < shared; i++) {
+          this.copyRowEvidence(originalRows[i], cloneRows[i], state);
+          this.transferContainerEvidence(
+            originalRows[i],
+            cloneRows[i],
+            inner,
+            state
+          );
         }
-        this.transferContainerEvidence(
-          originalRows[i],
-          cloneRows[i],
-          inner,
-          state
-        );
+        continue;
+      }
+      // A repeater is matched by ROW id, never by array position: a hook can
+      // filter, prepend, or reorder its rows, so index i can name a different
+      // logical row on the clone than on the original — transferring evidence by
+      // index would hand a private row a public row's "allowed" evidence and let
+      // an inverse rule fall open. A clone row whose id is absent from the
+      // originals (a reordered row with no id, or a fabricated one) cannot be
+      // matched, so its whole subtree is failed closed instead of guessed.
+      const byId = new Map<string, Record<string, unknown>>();
+      for (const originalRow of originalRows) {
+        if (typeof originalRow.id === "string") {
+          byId.set(originalRow.id, originalRow);
+        }
+      }
+      for (const cloneRow of cloneRows) {
+        const match =
+          typeof cloneRow.id === "string" ? byId.get(cloneRow.id) : undefined;
+        if (match) {
+          this.copyRowEvidence(match, cloneRow, state);
+          this.transferContainerEvidence(match, cloneRow, inner, state);
+        } else {
+          state.failClosed.add(cloneRow);
+          this.flagContainerRowsFailClosed(cloneRow, inner, state);
+        }
+      }
+    }
+  }
+
+  /**
+   * Flag a related-row clone whose redaction provenance cannot be recovered, and
+   * every row inside its groups/repeaters, so the field-access pass denies each
+   * access-controlled field on it (fail-closed).
+   *
+   * A source hook that returns a deep-cloned or reshaped related row (a new object
+   * graph, or one whose id was dropped) breaks the object-keyed evidence the
+   * re-walk needs to keep an inverse conditional rule — a field visible only while
+   * a DENIED sibling is absent — from falling open. When the clone cannot be
+   * matched to its original, denying its access-controlled fields is the only safe
+   * verdict; a hook that instead transforms related rows in place, preserving
+   * their id and array order, is matched and judged normally.
+   */
+  private async flagSubtreeFailClosed(
+    row: Record<string, unknown>,
+    collection: string,
+    state: NestedHookState
+  ): Promise<void> {
+    state.failClosed.add(row);
+    const fields = await this.fieldsForNestedWalk(collection, state);
+    this.flagContainerRowsFailClosed(row, fields, state);
+    // A well-behaved hook mutates related rows in place; a reshaped or id-less
+    // clone that lands here is an anti-pattern, and silently over-removing its
+    // fields is hard to diagnose. Surface it in development so the author can
+    // switch to in-place mutation, without adding noise to production reads.
+    if (process.env.NODE_ENV !== "production") {
+      this.logger.warn(
+        `A related "${collection}" row returned by an afterRead hook could not be matched to its source row (a reshaped or id-less clone); its access-controlled fields were denied. Transform related rows in place and preserve their id to keep field access exact.`
+      );
+    }
+  }
+
+  /** Recursively flag every group/repeater row beneath `row` fail-closed. */
+  private flagContainerRowsFailClosed(
+    row: Record<string, unknown>,
+    fields: FieldDefinition[],
+    state: NestedHookState
+  ): void {
+    for (const field of fields) {
+      if (!isRepeaterOrGroupField(field) || !field.name) continue;
+      const inner = getNestedFields(field);
+      for (const child of containerRowsOf(row[field.name])) {
+        state.failClosed.add(child);
+        this.flagContainerRowsFailClosed(child, inner, state);
       }
     }
   }
@@ -3420,22 +3517,38 @@ export class CollectionRelationshipService extends BaseService {
       // recorded in the shared `redactions` so `finalizeRelatedRows` can restore
       // it as evidence and re-judge the row after every hook has run.
       //
-      // Transfer evidence from the ORIGINAL row (by id) when the WeakMap has none
-      // for this one: a source hook can return a CLONE (a new object graph the
-      // WeakMap cannot key), and without the original's removed siblings an inverse
-      // conditional rule — a field visible only while a DENIED sibling is absent —
-      // would fall open on the clone. Transferred through the whole subtree, then
-      // re-judged below (a replacement's own denied fields are still stripped).
-      if (
-        !state.redactions.has(resolved.row) &&
-        typeof resolved.row.id === "string"
-      ) {
-        const original = state.originalRowById.get(
-          relationKey(resolved.collection, resolved.row.id)
-        );
-        if (original && original !== resolved.row) {
+      // Re-establish the provenance of a row the authoritative re-walk reaches
+      // that carries no evidence of its own. A source hook can return a CLONE of
+      // a related row (a new object graph the WeakMap cannot key), and without
+      // the original's removed siblings an inverse conditional rule — a field
+      // visible only while a DENIED sibling is absent — would fall open on the
+      // clone. Only the re-walk runs this (the first walk's rows ARE the
+      // originals, recorded below and judged normally):
+      //  - a clone of a KNOWN original (same id) inherits the original's subtree
+      //    evidence and is re-judged, so a replacement's own denied fields are
+      //    still stripped;
+      //  - a row whose provenance cannot be recovered — no id, or an id never
+      //    seen in the first walk (an unidentifiable or fabricated clone) — has
+      //    its whole subtree failed closed, so every access-controlled field on
+      //    it is denied rather than judged on evidence that cannot be trusted.
+      if (!state.applyFieldHooks && !state.redactions.has(resolved.row)) {
+        const id =
+          typeof resolved.row.id === "string" ? resolved.row.id : undefined;
+        const original = id
+          ? state.originalRowById.get(relationKey(resolved.collection, id))
+          : undefined;
+        if (original === resolved.row) {
+          // The row IS the first-walk original; nothing was redacted from it, so
+          // there is no evidence to transfer and no provenance gap — judged below.
+        } else if (original) {
           await this.transferSubtreeEvidence(
             original,
+            resolved.row,
+            resolved.collection,
+            state
+          );
+        } else {
+          await this.flagSubtreeFailClosed(
             resolved.row,
             resolved.collection,
             state
@@ -3446,7 +3559,8 @@ export class CollectionRelationshipService extends BaseService {
         resolved.collection,
         [resolved.row],
         access,
-        state.redactions
+        state.redactions,
+        state.failClosed
       );
       // Remember the ORIGINAL row object by id (first walk only), so a later clone
       // of it can inherit its subtree evidence.
@@ -3568,13 +3682,16 @@ export class CollectionRelationshipService extends BaseService {
     targetCollection: string,
     rows: Record<string, unknown>[],
     access: RelatedRowAccess,
-    redactions?: ReadAccessRedactions
+    redactions?: ReadAccessRedactions,
+    failClosed?: FailClosedRows
   ): Promise<void> {
     if (!access.enforceFieldAccess || access.overrideAccess) return;
     // Share `redactions` across the two passes: the second (after hooks) restores
     // what the first removed from each row as evidence and re-judges the current
     // content, so a denied field a hook reintroduced or a row it changed is
-    // caught while an unchanged verdict stays put.
+    // caught while an unchanged verdict stays put. `failClosed` carries the rows
+    // whose provenance the re-walk could not recover, so their access-controlled
+    // fields are denied outright.
     for (const row of rows) {
       await applyFieldReadAccess(
         {
@@ -3584,7 +3701,8 @@ export class CollectionRelationshipService extends BaseService {
           user: access.user,
           overrideAccess: false,
         },
-        redactions
+        redactions,
+        failClosed
       );
     }
   }

--- a/packages/nextly/src/domains/collections/services/collection-relationship-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-relationship-service.ts
@@ -42,7 +42,7 @@ import { BaseService } from "../../../shared/base-service";
 import {
   applyFieldReadAccess,
   runFieldHooks,
-  type ReadAccessMemo,
+  type ReadAccessRedactions,
 } from "../../../shared/lib/field-level-registry";
 import {
   hasPasswordField,
@@ -93,24 +93,24 @@ interface NestedHookStateBase {
    */
   labelFields: Map<string, Promise<string>>;
   /**
+   * The values field access removed from each related row, keyed by the row
+   * object, shared across the whole read. The walk applies access to each row
+   * before its parent's hooks (so a hook cannot read a denied child field to copy
+   * it), recording what it removed here; finalize re-applies access after every
+   * hook, restoring those values as evidence and re-judging the current content,
+   * so anything a hook reintroduced, mutated, or added is caught.
+   */
+  redactions: ReadAccessRedactions;
+  /**
    * Every related row the pass reached, in visit order, with what is needed to
-   * finish it.
-   *
-   * Field access is applied to each row during the walk (before its parent's
-   * hooks, so a parent hook cannot read a denied child field to copy it), and the
-   * verdicts it made are captured as `memo`. These entries drive the finalize
-   * step after every hook has run: it re-applies access reusing `memo` -- so an
-   * unchanged field keeps its verdict while a field or row a hook introduced is
-   * judged fresh -- stripping anything a parent hook reintroduced, then rebuilds
-   * labels last from the values that survived.
+   * finish it. These entries drive the finalize step after every hook has run: it
+   * re-applies access to each row (see `redactions`), then rebuilds labels last
+   * from the values that survived.
    */
   pending: Array<{
     row: Record<string, unknown>;
     collection: string;
     field: FieldDefinition;
-    /** The read-access verdicts made for `row` during the walk, reused when
-     *  finalize re-applies access. Undefined for a trusted/override read. */
-    memo?: ReadAccessMemo;
   }>;
 }
 
@@ -122,6 +122,7 @@ function createNestedHookState(): NestedHookState {
     visited: new Set(),
     fields: new Map(),
     labelFields: new Map(),
+    redactions: new WeakMap(),
     pending: [],
   };
 }
@@ -3004,13 +3005,13 @@ export class CollectionRelationshipService extends BaseService {
    * parent hook cannot read a denied child field to copy it). This runs it once
    * more because a parent hook can REINTRODUCE a denied field onto an
    * already-redacted child (assigning `data.child.secret` to mask or derive a
-   * value), or add/reorder rows in the child, and without a pass after the hooks
-   * that would be returned. It reuses the walk's verdict memo, so an unchanged
-   * field keeps its first verdict -- a rule reads the row as `data`, and re-judging
-   * against the already-stripped row could flip a decision (a field kept only
-   * while a now-denied sibling was present) or re-issue an async rule's queries --
-   * while a field or row a hook introduced between the passes misses the memo and
-   * is judged fresh. A no-op on a row nothing changed.
+   * value), mutate a row in place, or add/replace/reorder rows -- and without a
+   * pass after the hooks that would be returned. It re-judges the current content
+   * (a cached verdict cannot be trusted once a hook may have changed what a rule
+   * reads), restoring from the shared `redactions` what the first pass removed
+   * from each row so a rule reading a now-denied sibling as evidence still sees
+   * it -- keeping an unchanged verdict stable, as a direct read's single pass
+   * would, while judging everything a hook touched afresh.
    *
    * Labels come last of all, from the values that survived: a label copies a
    * field under another key, so one rebuilt earlier would outlive the removal of
@@ -3021,8 +3022,13 @@ export class CollectionRelationshipService extends BaseService {
     access: RelatedRowAccess
   ): Promise<void> {
     if (!access.enforceFieldAccess) return;
-    for (const { row, collection, memo } of state.pending) {
-      await this.applyRelatedRowReadAccess(collection, [row], access, [memo]);
+    for (const { row, collection } of state.pending) {
+      await this.applyRelatedRowReadAccess(
+        collection,
+        [row],
+        access,
+        state.redactions
+      );
     }
     for (const { row, collection, field } of state.pending) {
       await this.refreshRelatedRowLabel(row, field, { collection }, state);
@@ -3201,26 +3207,24 @@ export class CollectionRelationshipService extends BaseService {
       // values, and a direct read redacts a nested row before the parent
       // collection's field hooks for the same reason, so applying it here keeps
       // the nested path consistent with the direct one. Under `overrideAccess`
-      // this is a no-op, leaving trusted assembly untouched. The verdicts it
-      // makes are memoized so `finalizeRelatedRows` can run access once more
-      // after every hook — stripping anything a parent hook reintroduced —
-      // without re-judging (or re-querying) content that has not changed.
-      const [memo] = await this.applyRelatedRowReadAccess(
+      // this is a no-op, leaving trusted assembly untouched. What it removes is
+      // recorded in the shared `redactions` so `finalizeRelatedRows` can restore
+      // it as evidence and re-judge the row after every hook has run.
+      await this.applyRelatedRowReadAccess(
         resolved.collection,
         [resolved.row],
-        access
+        access,
+        state.redactions
       );
 
-      // Queued with that verdict memo. `finalizeRelatedRows` re-applies access
-      // after every hook, reusing the memo so an unchanged field keeps its
-      // verdict (no flip when a rule reads a now-denied sibling, no second query)
-      // while a field or row a hook introduced since is judged fresh. Labels come
+      // Queued for the finalize step, which re-applies access after every hook
+      // (restoring the removed evidence and re-judging the current content so a
+      // reintroduced or hook-mutated denied field is caught) and rebuilds labels
       // last, from the values that survived.
       state.pending.push({
         row: resolved.row,
         collection: resolved.collection,
         field,
-        memo,
       });
 
       // Secrets are stripped from a related row when it is fetched, but a hook
@@ -3301,31 +3305,25 @@ export class CollectionRelationshipService extends BaseService {
     targetCollection: string,
     rows: Record<string, unknown>[],
     access: RelatedRowAccess,
-    priorMemos?: Array<ReadAccessMemo | undefined>
-  ): Promise<Array<ReadAccessMemo | undefined>> {
-    if (!access.enforceFieldAccess || access.overrideAccess) {
-      return rows.map(() => undefined);
-    }
-    // The verdict memo for each row, in row order, so a second pass after later
-    // hooks reuses those verdicts (unchanged content is neither re-judged nor
-    // re-queried) while judging anew only what a hook introduced. Passing a
-    // row's prior memo back is what makes that second pass reuse them.
-    const memos: Array<ReadAccessMemo | undefined> = [];
-    for (let i = 0; i < rows.length; i++) {
-      memos.push(
-        await applyFieldReadAccess(
-          {
-            kind: "collection",
-            slug: targetCollection,
-            entry: rows[i],
-            user: access.user,
-            overrideAccess: false,
-          },
-          priorMemos?.[i]
-        )
+    redactions?: ReadAccessRedactions
+  ): Promise<void> {
+    if (!access.enforceFieldAccess || access.overrideAccess) return;
+    // Share `redactions` across the two passes: the second (after hooks) restores
+    // what the first removed from each row as evidence and re-judges the current
+    // content, so a denied field a hook reintroduced or a row it changed is
+    // caught while an unchanged verdict stays put.
+    for (const row of rows) {
+      await applyFieldReadAccess(
+        {
+          kind: "collection",
+          slug: targetCollection,
+          entry: row,
+          user: access.user,
+          overrideAccess: false,
+        },
+        redactions
       );
     }
-    return memos;
   }
 
   /**

--- a/packages/nextly/src/domains/collections/services/collection-relationship-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-relationship-service.ts
@@ -112,6 +112,14 @@ interface NestedHookStateBase {
     collection: string;
     field: FieldDefinition;
   }>;
+  /**
+   * Whether the walk runs each related row's `afterRead` field hooks. True for
+   * the first walk; false for the authoritative re-walk of the ASSEMBLED response
+   * (see {@link CollectionRelationshipService.resanitizeAssembledRows}), which
+   * only re-applies field access — the hooks already ran once, and running them
+   * again would transform values twice.
+   */
+  applyFieldHooks: boolean;
 }
 
 /** The state the walk carries; named separately so the interface reads first. */
@@ -124,6 +132,7 @@ function createNestedHookState(): NestedHookState {
     labelFields: new Map(),
     redactions: new WeakMap(),
     pending: [],
+    applyFieldHooks: true,
   };
 }
 
@@ -3045,6 +3054,52 @@ export class CollectionRelationshipService extends BaseService {
   }
 
   /**
+   * Re-apply related-row field access over the ASSEMBLED response, after every
+   * source-collection `afterRead` hook — code, stored, AND field-level — has run.
+   *
+   * {@link finalizeRelatedRows} sanitizes the row objects the first walk queued;
+   * this is the authoritative pass, and it covers what those objects cannot:
+   * - a source hook may RETURN a reshaped document (the registry supports it), so
+   *   the response can hold related rows that are new objects the pending list
+   *   never referenced;
+   * - a source field-level hook runs after the finalize pass and can write a
+   *   denied target field straight back onto a related row.
+   * The root read-access pass sees only the source collection's schema and never
+   * descends into a related row, so neither is caught without re-walking the
+   * actual response here.
+   *
+   * Runs on the whole rows, before selection projects them to slices: a sliced
+   * row is a fresh object missing the sibling evidence a conditional rule reads,
+   * so judging it would wrongly drop a field a full read keeps. It re-walks the
+   * given entries applying access ONLY (field hooks already ran), reusing the
+   * walk's `redactions` so an unchanged row keeps its verdict while a row a hook
+   * reshaped or reintroduced is judged against its current content.
+   */
+  async resanitizeAssembledRows(
+    entries: Record<string, unknown>[],
+    collectionName: string,
+    access: RelatedRowAccess,
+    walkState: NestedHookState
+  ): Promise<void> {
+    if (!access.enforceFieldAccess || access.overrideAccess) return;
+    // Fresh `visited`/`pending` so every related row in the assembled response is
+    // reached again (the first walk already claimed them), but the SAME
+    // `redactions` and metadata caches, so evidence carries over and the schema
+    // reads are not repeated.
+    const repass: NestedHookState = {
+      visited: new Set(),
+      pending: [],
+      fields: walkState.fields,
+      labelFields: walkState.labelFields,
+      redactions: walkState.redactions,
+      applyFieldHooks: false,
+    };
+    for (const entry of entries) {
+      await this.walkNestedRows(entry, collectionName, access, repass, 0);
+    }
+  }
+
+  /**
    * The collection's fields, read once per collection per read.
    *
    * A target whose schema will not load runs no hooks, and the read continues.
@@ -3197,15 +3252,19 @@ export class CollectionRelationshipService extends BaseService {
         await this.fieldsForNestedWalk(resolved.collection, state)
       );
       // Deepest first, so a hook reading into its own relations sees them
-      // already transformed rather than half-processed.
-      await runFieldHooks({
-        kind: "collection",
-        slug: resolved.collection,
-        phase: "afterRead",
-        data: resolved.row,
-        operation: "read",
-        user: access.user,
-      });
+      // already transformed rather than half-processed. Skipped on the
+      // access-only re-walk of the assembled response — the hooks already ran on
+      // the first walk, and running them again would transform values twice.
+      if (state.applyFieldHooks) {
+        await runFieldHooks({
+          kind: "collection",
+          slug: resolved.collection,
+          phase: "afterRead",
+          data: resolved.row,
+          operation: "read",
+          user: access.user,
+        });
+      }
 
       // Apply THIS row's field access now, before returning to its parent —
       // whose afterRead hooks run next up the stack. Deferring it (as this once
@@ -3223,6 +3282,20 @@ export class CollectionRelationshipService extends BaseService {
         [resolved.row],
         access,
         state.redactions
+      );
+
+      // Rebuild the label from what survived the access pass, NOW, before the
+      // parent's hooks run next up the stack. The fetch derives a row's `label`
+      // from a target field, so a label built from a caller-denied field still
+      // carries that value after the field itself is stripped; a parent hook
+      // reading `data.child.label` would copy the denied value under an allowed
+      // key. The finalize pass rebuilds labels again for hook mutations, but that
+      // runs after the parent hooks and cannot remove a copy they already made.
+      await this.refreshRelatedRowLabel(
+        resolved.row,
+        field,
+        { collection: resolved.collection },
+        state
       );
 
       // Queued for the finalize step, which re-applies access after every hook

--- a/packages/nextly/src/domains/collections/services/collection-relationship-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-relationship-service.ts
@@ -95,11 +95,12 @@ interface NestedHookStateBase {
    * Every related row the pass reached, in visit order, with what is needed to
    * finish it.
    *
-   * Masking and hiding cannot be interleaved per row. The walk descends deepest
-   * first, so hiding a child's fields as it is finished removes exactly the
-   * evidence its PARENT's masking rule is about to read -- reproducing, one
-   * level down, the defect the reordering exists to fix. So the rows are
-   * collected here and hidden only once every hook in the document has run.
+   * Field access is applied to each row during the walk (before its parent's
+   * hooks, so a parent hook cannot read a denied child field to copy it). These
+   * entries drive a SECOND access pass and the label rebuild in
+   * `finalizeRelatedRows`, after every hook has run: the second pass strips a
+   * denied field a parent hook reintroduced onto an already-redacted child, and
+   * labels are rebuilt last from the values that survived.
    */
   pending: Array<{
     row: Record<string, unknown>;
@@ -2991,19 +2992,30 @@ export class CollectionRelationshipService extends BaseService {
   }
 
   /**
-   * Rebuild the labels of every related row the walk reached.
+   * The SECOND field-access pass over every related row the walk reached, then
+   * the label rebuild.
    *
-   * Field access is applied during the walk now (each row right after its own
-   * hooks, before its parent's), so this no longer hides anything -- it only
-   * refreshes labels. Labels come last of all, from the values that survived
-   * redaction: a label copies a field under another key, so one rebuilt earlier
-   * would outlive the removal of its own source field.
+   * Access is applied to each row once during the walk already -- right after
+   * its own hooks and before its parent's, so a parent hook cannot read a denied
+   * child field to copy it elsewhere. This pass runs it again, after every hook
+   * in the document has run, because a parent hook can also REINTRODUCE a denied
+   * field onto an already-redacted child (assigning `data.child.secret` to mask
+   * or derive a value); without a pass after the hooks that reintroduced field
+   * would be returned. It is idempotent on a row nothing reintroduced into -- the
+   * denied field is simply already gone.
+   *
+   * Labels come last of all, from the values that survived both passes: a label
+   * copies a field under another key, so one rebuilt earlier would outlive the
+   * removal of its own source field.
    */
   async finalizeRelatedRows(
     state: NestedHookState,
     access: RelatedRowAccess
   ): Promise<void> {
     if (!access.enforceFieldAccess) return;
+    for (const { row, collection } of state.pending) {
+      await this.applyRelatedRowReadAccess(collection, [row], access);
+    }
     for (const { row, collection, field } of state.pending) {
       await this.refreshRelatedRowLabel(row, field, { collection }, state);
     }
@@ -3181,17 +3193,19 @@ export class CollectionRelationshipService extends BaseService {
       // values, and a direct read redacts a nested row before the parent
       // collection's field hooks for the same reason, so applying it here keeps
       // the nested path consistent with the direct one. Under `overrideAccess`
-      // this is a no-op, leaving trusted assembly untouched.
+      // this is a no-op, leaving trusted assembly untouched. This is the FIRST of
+      // two passes: `finalizeRelatedRows` runs it once more after every hook, to
+      // strip a denied field a later parent hook reintroduces onto this row.
       await this.applyRelatedRowReadAccess(
         resolved.collection,
         [resolved.row],
         access
       );
 
-      // Still queued for the label refresh, which runs last of all (in
-      // `finalizeRelatedRows`) from the values that survived redaction: a label
-      // copies a field under another key, so one rebuilt earlier would outlive
-      // the removal of its own source field.
+      // Queued for the second access pass and the label refresh, both in
+      // `finalizeRelatedRows` once every hook has run. Labels come last of all,
+      // from the values that survived: a label copies a field under another key,
+      // so one rebuilt earlier would outlive the removal of its own source field.
       state.pending.push({
         row: resolved.row,
         collection: resolved.collection,

--- a/packages/nextly/src/domains/collections/services/collection-relationship-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-relationship-service.ts
@@ -41,9 +41,8 @@ import type { Logger } from "../../../services/shared";
 import { BaseService } from "../../../shared/base-service";
 import {
   applyFieldReadAccess,
-  replayFieldRedaction,
   runFieldHooks,
-  type FieldRedactionPlan,
+  type ReadAccessMemo,
 } from "../../../shared/lib/field-level-registry";
 import {
   hasPasswordField,
@@ -97,21 +96,21 @@ interface NestedHookStateBase {
    * Every related row the pass reached, in visit order, with what is needed to
    * finish it.
    *
-   * Field access is EVALUATED and applied to each row during the walk (before its
-   * parent's hooks, so a parent hook cannot read a denied child field to copy
-   * it), and the redaction it performed is captured as `redaction`. These entries
-   * drive the finalize step after every hook has run: it REPLAYS each row's
-   * captured redaction -- stripping a denied field a parent hook reintroduced
-   * onto an already-redacted child, without re-running the policy -- then rebuilds
+   * Field access is applied to each row during the walk (before its parent's
+   * hooks, so a parent hook cannot read a denied child field to copy it), and the
+   * verdicts it made are captured as `memo`. These entries drive the finalize
+   * step after every hook has run: it re-applies access reusing `memo` -- so an
+   * unchanged field keeps its verdict while a field or row a hook introduced is
+   * judged fresh -- stripping anything a parent hook reintroduced, then rebuilds
    * labels last from the values that survived.
    */
   pending: Array<{
     row: Record<string, unknown>;
     collection: string;
     field: FieldDefinition;
-    /** The redaction applied to `row` during the walk, replayed in finalize.
-     *  Undefined for a trusted/override read. */
-    redaction?: FieldRedactionPlan;
+    /** The read-access verdicts made for `row` during the walk, reused when
+     *  finalize re-applies access. Undefined for a trusted/override read. */
+    memo?: ReadAccessMemo;
   }>;
 }
 
@@ -2998,19 +2997,20 @@ export class CollectionRelationshipService extends BaseService {
   }
 
   /**
-   * Re-apply each related row's redaction after every hook has run, then rebuild
-   * the labels.
+   * Re-apply each related row's field access after every hook has run, then
+   * rebuild the labels.
    *
-   * The walk already EVALUATED and applied field access to each row (before its
-   * parent's hooks, so a parent hook cannot read a denied child field to copy
-   * it). This REPLAYS that redaction -- deleting the same fields again -- because
-   * a parent hook can REINTRODUCE a denied field onto an already-redacted child
-   * (assigning `data.child.secret` to mask or derive a value); without a pass
-   * after the hooks it would be returned. Replaying the captured decisions rather
-   * than re-running the policy is deliberate: a rule reads the row as `data`, so
-   * re-evaluating against the already-stripped row could flip a decision (a field
-   * kept only while a now-denied sibling was present) or re-issue an async rule's
-   * queries. It is a no-op on a row nothing reintroduced into.
+   * The walk already applied access to each row (before its parent's hooks, so a
+   * parent hook cannot read a denied child field to copy it). This runs it once
+   * more because a parent hook can REINTRODUCE a denied field onto an
+   * already-redacted child (assigning `data.child.secret` to mask or derive a
+   * value), or add/reorder rows in the child, and without a pass after the hooks
+   * that would be returned. It reuses the walk's verdict memo, so an unchanged
+   * field keeps its first verdict -- a rule reads the row as `data`, and re-judging
+   * against the already-stripped row could flip a decision (a field kept only
+   * while a now-denied sibling was present) or re-issue an async rule's queries --
+   * while a field or row a hook introduced between the passes misses the memo and
+   * is judged fresh. A no-op on a row nothing changed.
    *
    * Labels come last of all, from the values that survived: a label copies a
    * field under another key, so one rebuilt earlier would outlive the removal of
@@ -3021,8 +3021,8 @@ export class CollectionRelationshipService extends BaseService {
     access: RelatedRowAccess
   ): Promise<void> {
     if (!access.enforceFieldAccess) return;
-    for (const { row, redaction } of state.pending) {
-      if (redaction) replayFieldRedaction(row, redaction);
+    for (const { row, collection, memo } of state.pending) {
+      await this.applyRelatedRowReadAccess(collection, [row], access, [memo]);
     }
     for (const { row, collection, field } of state.pending) {
       await this.refreshRelatedRowLabel(row, field, { collection }, state);
@@ -3201,26 +3201,26 @@ export class CollectionRelationshipService extends BaseService {
       // values, and a direct read redacts a nested row before the parent
       // collection's field hooks for the same reason, so applying it here keeps
       // the nested path consistent with the direct one. Under `overrideAccess`
-      // this is a no-op, leaving trusted assembly untouched. This is the only
-      // place the policy is EVALUATED; `finalizeRelatedRows` replays the
-      // decisions it captured to catch anything a later parent hook reintroduces.
-      const [redaction] = await this.applyRelatedRowReadAccess(
+      // this is a no-op, leaving trusted assembly untouched. The verdicts it
+      // makes are memoized so `finalizeRelatedRows` can run access once more
+      // after every hook — stripping anything a parent hook reintroduced —
+      // without re-judging (or re-querying) content that has not changed.
+      const [memo] = await this.applyRelatedRowReadAccess(
         resolved.collection,
         [resolved.row],
         access
       );
 
-      // Queued with the redaction the pass performed. `finalizeRelatedRows`
-      // replays it after every hook has run — stripping a denied field a parent
-      // hook wrote back onto this row — WITHOUT re-evaluating the policy, which
-      // run against the already-stripped row could flip a decision (a field
-      // allowed only while a now-denied sibling is present) or re-issue an async
-      // rule's queries. Labels come last, from the values that survived.
+      // Queued with that verdict memo. `finalizeRelatedRows` re-applies access
+      // after every hook, reusing the memo so an unchanged field keeps its
+      // verdict (no flip when a rule reads a now-denied sibling, no second query)
+      // while a field or row a hook introduced since is judged fresh. Labels come
+      // last, from the values that survived.
       state.pending.push({
         row: resolved.row,
         collection: resolved.collection,
         field,
-        redaction,
+        memo,
       });
 
       // Secrets are stripped from a related row when it is fetched, but a hook
@@ -3300,26 +3300,32 @@ export class CollectionRelationshipService extends BaseService {
   private async applyRelatedRowReadAccess(
     targetCollection: string,
     rows: Record<string, unknown>[],
-    access: RelatedRowAccess
-  ): Promise<Array<FieldRedactionPlan | undefined>> {
+    access: RelatedRowAccess,
+    priorMemos?: Array<ReadAccessMemo | undefined>
+  ): Promise<Array<ReadAccessMemo | undefined>> {
     if (!access.enforceFieldAccess || access.overrideAccess) {
       return rows.map(() => undefined);
     }
-    // The redaction each row got, in row order, so the caller can replay it after
-    // later hooks run instead of re-evaluating the policy against a mutated row.
-    const plans: Array<FieldRedactionPlan | undefined> = [];
-    for (const row of rows) {
-      plans.push(
-        await applyFieldReadAccess({
-          kind: "collection",
-          slug: targetCollection,
-          entry: row,
-          user: access.user,
-          overrideAccess: false,
-        })
+    // The verdict memo for each row, in row order, so a second pass after later
+    // hooks reuses those verdicts (unchanged content is neither re-judged nor
+    // re-queried) while judging anew only what a hook introduced. Passing a
+    // row's prior memo back is what makes that second pass reuse them.
+    const memos: Array<ReadAccessMemo | undefined> = [];
+    for (let i = 0; i < rows.length; i++) {
+      memos.push(
+        await applyFieldReadAccess(
+          {
+            kind: "collection",
+            slug: targetCollection,
+            entry: rows[i],
+            user: access.user,
+            overrideAccess: false,
+          },
+          priorMemos?.[i]
+        )
       );
     }
-    return plans;
+    return memos;
   }
 
   /**

--- a/packages/nextly/src/domains/versions/__tests__/restore-version.test.ts
+++ b/packages/nextly/src/domains/versions/__tests__/restore-version.test.ts
@@ -542,6 +542,7 @@ describe("restoreVersion", () => {
     vi.mocked(applyFieldReadAccess).mockImplementation(
       async ({ entry }: { entry: Record<string, unknown> }) => {
         delete entry.secret;
+        return undefined;
       }
     );
 
@@ -577,6 +578,7 @@ describe("restoreVersion", () => {
       async ({ entry }: { entry: Record<string, unknown> }) => {
         const meta = entry.meta as Record<string, unknown> | undefined;
         if (meta) delete meta.secret;
+        return undefined;
       }
     );
 
@@ -594,6 +596,7 @@ describe("restoreVersion", () => {
     vi.mocked(applyFieldReadAccess).mockImplementation(
       async ({ entry }: { entry: Record<string, unknown> }) => {
         seenId = entry.id;
+        return undefined;
       }
     );
 

--- a/packages/nextly/src/shared/lib/__tests__/field-level-registry.test.ts
+++ b/packages/nextly/src/shared/lib/__tests__/field-level-registry.test.ts
@@ -13,6 +13,7 @@ import {
   attachFieldValidators,
   clearFieldFunctions,
   getFieldFunctions,
+  type ReadAccessRedactions,
   registerFieldFunctions,
   runFieldHooks,
 } from "../field-level-registry";
@@ -702,5 +703,62 @@ describe("field-level registry", () => {
     });
     expect(data.meta).toEqual({ slug: "HI" });
     expect(data.rows).toEqual([{ slug: "ONE" }, { slug: "TWO" }]);
+  });
+
+  it("clears a field's stale redaction once a later pass supplies and allows it", async () => {
+    // A field denied in one pass, then supplied by a hook and ALLOWED in a later
+    // pass, must clear its recorded removed value. Otherwise a still-later pass
+    // restores that stale value as evidence and a NEW protected field whose rule
+    // reads it is wrongly allowed. Three passes over one row with a shared
+    // redaction store reproduce the sequence the nested-read pipeline runs.
+    registerFieldFunctions("collection", "posts", [
+      { name: "flag", type: "text" },
+      {
+        name: "secret",
+        type: "text",
+        access: {
+          read: ({ data }: { data: Record<string, unknown> }) =>
+            data.flag === "on",
+        },
+      },
+      {
+        name: "derived",
+        type: "text",
+        access: {
+          read: ({ data }: { data: Record<string, unknown> }) =>
+            data.secret === "stale",
+        },
+      },
+    ]);
+    const redactions: ReadAccessRedactions = new WeakMap();
+
+    // Pass 1: flag off, so `secret` is denied and its value recorded as evidence.
+    const entry: Record<string, unknown> = { flag: "off", secret: "stale" };
+    await applyFieldReadAccess(
+      { kind: "collection", slug: "posts", entry },
+      redactions
+    );
+    expect(entry.secret).toBeUndefined();
+
+    // Pass 2 (a hook set flag on and supplied a fresh `secret`): it is allowed
+    // now, so its stale evidence must be discarded rather than kept.
+    entry.flag = "on";
+    entry.secret = "fresh";
+    await applyFieldReadAccess(
+      { kind: "collection", slug: "posts", entry },
+      redactions
+    );
+    expect(entry.secret).toBe("fresh");
+
+    // Pass 3 (a later hook deleted `secret` and added `derived`, whose rule reads
+    // the OLD secret value): with the stale evidence cleared, nothing restores
+    // `secret`, so `derived`'s rule sees none and it is withheld.
+    delete entry.secret;
+    entry.derived = "leak";
+    await applyFieldReadAccess(
+      { kind: "collection", slug: "posts", entry },
+      redactions
+    );
+    expect(entry.derived).toBeUndefined();
   });
 });

--- a/packages/nextly/src/shared/lib/field-level-registry.ts
+++ b/packages/nextly/src/shared/lib/field-level-registry.ts
@@ -364,6 +364,12 @@ export async function applyFieldWriteAccess(opts: {
  * read — judged against, while the current values of everything a hook touched
  * are seen and re-judged.
  *
+ * A restored value is EVIDENCE only, never response data: it is one the caller
+ * was denied and the post-hook row did not itself supply, so it is removed again
+ * once every snapshot that needed it has been taken. Otherwise a hook that flips
+ * a field's CONDITION from deny to allow (say, a sibling `tier`) without
+ * reintroducing the value would resurrect the value the first pass removed.
+ *
  * The restore runs over the WHOLE subtree before any level's snapshot is taken,
  * because the evidence a rule reads is not always a sibling: an outer field's
  * rule can depend on a value inside a nested group or repeater the first pass
@@ -381,11 +387,22 @@ export type ReadAccessRedactions = WeakMap<
   Record<string, unknown>
 >;
 
+/** One value a pass put back purely as evidence: the row it was written onto and
+ *  the key, so it can be removed again once the snapshots that needed it are
+ *  taken. */
+interface RestoredEvidence {
+  row: Record<string, unknown>;
+  name: string;
+}
+
 /**
  * Restore, throughout the subtree rooted at `entry`, the values a prior pass
  * removed from each row — unless a hook has since set the key, so a hook's own
  * value stands. Runs once before any snapshot is taken, so a rule at any level is
- * judged against the evidence a single direct read would see.
+ * judged against the evidence a single direct read would see. Every value it puts
+ * back is recorded in `restored`, because it is EVIDENCE, not response data: the
+ * caller was denied it and the post-hook row did not supply it, so it must be
+ * removed again once the snapshots are taken (see {@link applyFieldReadAccess}).
  *
  * The restore has to span the whole subtree, not just the current row: an outer
  * field's rule can read a value that lives in a nested group or repeater a prior
@@ -396,12 +413,16 @@ export type ReadAccessRedactions = WeakMap<
 function restoreReadAccessEvidence(
   entry: Record<string, unknown>,
   fns: Record<string, FieldFunctions>,
-  redactions: ReadAccessRedactions
+  redactions: ReadAccessRedactions,
+  restored: RestoredEvidence[]
 ): void {
   const priorlyRemoved = redactions.get(entry);
   if (priorlyRemoved) {
     for (const [name, value] of Object.entries(priorlyRemoved)) {
-      if (!(name in entry)) entry[name] = value;
+      if (!(name in entry)) {
+        entry[name] = value;
+        restored.push({ row: entry, name });
+      }
     }
   }
   for (const [name, fieldFns] of Object.entries(fns)) {
@@ -409,7 +430,7 @@ function restoreReadAccessEvidence(
     const container = openNestedContainer(entry[name]);
     if (!container) continue;
     for (const row of container.rows) {
-      restoreReadAccessEvidence(row, fieldFns.fields, redactions);
+      restoreReadAccessEvidence(row, fieldFns.fields, redactions, restored);
     }
     entry[name] = container.serialize();
   }
@@ -505,7 +526,8 @@ export async function applyFieldReadAccess(
   // so an outer rule reading a value nested in a group or repeater is judged
   // against the same content a single direct read would (a no-op on the first
   // pass, whose store is empty). The judge below re-removes what stays denied.
-  restoreReadAccessEvidence(opts.entry, fns, store);
+  const restored: RestoredEvidence[] = [];
+  restoreReadAccessEvidence(opts.entry, fns, store, restored);
   await applyReadAccessRec(
     opts.entry,
     fns,
@@ -515,6 +537,13 @@ export async function applyFieldReadAccess(
     },
     store
   );
+  // A restored value existed only to feed the snapshots above. The caller was
+  // denied it and the post-hook row did not supply it, so it must not appear in
+  // the response even when the current pass judged it allowed — a hook that
+  // flipped the field's CONDITION from deny to allow (say, a sibling `tier`)
+  // without reintroducing the value must not resurrect the value the first pass
+  // removed. Removed after every snapshot is taken, so re-judging still saw it.
+  for (const { row, name } of restored) delete row[name];
 }
 
 /** Recursive worker for hooks. Transforms values in registration order. */

--- a/packages/nextly/src/shared/lib/field-level-registry.ts
+++ b/packages/nextly/src/shared/lib/field-level-registry.ts
@@ -346,12 +346,29 @@ export async function applyFieldWriteAccess(opts: {
   });
 }
 
-/** Recursive worker for read access — same snapshot + recurse contract. */
+/**
+ * What a read-access pass removed from one row, at every depth, so a later
+ * cleanup can remove the SAME fields a hook reintroduced without re-running the
+ * policy. Re-running it is unsafe: a rule reads the row as `data`, so evaluating
+ * it a second time against the already-stripped row can flip a decision (a field
+ * allowed only while a now-denied sibling is present would be wrongly removed),
+ * and an async rule would issue its queries twice.
+ */
+export interface FieldRedactionPlan {
+  /** Field names denied at this level. */
+  denied: string[];
+  /** Per container field, the plan for each of its rows, by index. */
+  nested: Array<{ name: string; rows: FieldRedactionPlan[] }>;
+}
+
+/** Recursive worker for read access — same snapshot + recurse contract.
+ *  Returns the redaction it performed so it can be replayed (see
+ *  {@link replayFieldRedaction}). */
 async function applyReadAccessRec(
   entry: Record<string, unknown>,
   fns: Record<string, FieldFunctions>,
   ctx: { user?: Record<string, unknown>; id?: string }
-): Promise<void> {
+): Promise<FieldRedactionPlan> {
   // Taken BEFORE the recursion below replaces nested containers with their
   // redacted serialization: a parent-level rule reading a protected nested
   // value would otherwise find it already removed, and the outcome would turn
@@ -360,15 +377,18 @@ async function applyReadAccessRec(
     ? detachData(entry)
     : undefined;
   const denied: string[] = [];
+  const nested: FieldRedactionPlan["nested"] = [];
   for (const [name, fieldFns] of Object.entries(fns)) {
     if (!(name in entry)) continue;
     if (fieldFns.fields) {
       const container = openNestedContainer(entry[name]);
       if (container) {
+        const rows: FieldRedactionPlan[] = [];
         for (const row of container.rows) {
-          await applyReadAccessRec(row, fieldFns.fields, ctx);
+          rows.push(await applyReadAccessRec(row, fieldFns.fields, ctx));
         }
         entry[name] = container.serialize();
+        nested.push({ name, rows });
       }
     }
     const fn = fieldFns.access?.read;
@@ -386,11 +406,40 @@ async function applyReadAccessRec(
     if (!allowed) denied.push(name);
   }
   for (const name of denied) delete entry[name];
+  return { denied, nested };
+}
+
+/**
+ * Re-remove the fields a prior {@link applyFieldReadAccess} pass denied on a
+ * row, WITHOUT re-running the policy, so a denied value a later hook wrote back
+ * onto the row is stripped again. The policy already ran once (that produced the
+ * plan); replaying its decisions avoids both re-deciding against mutated data
+ * and re-issuing async rule queries.
+ */
+export function replayFieldRedaction(
+  entry: Record<string, unknown>,
+  plan: FieldRedactionPlan
+): void {
+  for (const { name, rows } of plan.nested) {
+    if (!(name in entry)) continue;
+    const container = openNestedContainer(entry[name]);
+    if (container) {
+      container.rows.forEach((row, index) => {
+        const rowPlan = rows[index];
+        if (rowPlan) replayFieldRedaction(row, rowPlan);
+      });
+      entry[name] = container.serialize();
+    }
+  }
+  for (const name of plan.denied) delete entry[name];
 }
 
 /**
  * Enforce field-level read access on a serialized entry: fields whose
- * `access.read` denies are removed from the response, at every depth.
+ * `access.read` denies are removed from the response, at every depth. Returns
+ * the redaction it performed (undefined for a trusted/override read or an
+ * unregistered entity), which {@link replayFieldRedaction} can re-apply after
+ * later hooks run.
  */
 export async function applyFieldReadAccess(opts: {
   kind: EntityKind;
@@ -398,11 +447,11 @@ export async function applyFieldReadAccess(opts: {
   entry: Record<string, unknown>;
   user?: Record<string, unknown>;
   overrideAccess?: boolean;
-}): Promise<void> {
-  if (opts.overrideAccess) return;
+}): Promise<FieldRedactionPlan | undefined> {
+  if (opts.overrideAccess) return undefined;
   const fns = getFieldFunctions(opts.kind, opts.slug);
-  if (!fns) return;
-  await applyReadAccessRec(opts.entry, fns, {
+  if (!fns) return undefined;
+  return applyReadAccessRec(opts.entry, fns, {
     user: opts.user,
     id: typeof opts.entry.id === "string" ? opts.entry.id : undefined,
   });

--- a/packages/nextly/src/shared/lib/field-level-registry.ts
+++ b/packages/nextly/src/shared/lib/field-level-registry.ts
@@ -357,12 +357,19 @@ export async function applyFieldWriteAccess(opts: {
  * place, or added, replaced, or reordered rows). The second pass MUST re-run the
  * rules against the post-hook content — a cached verdict cannot be trusted once a
  * hook may have changed what the rule reads. Re-running alone would flip a
- * verdict, though: the first pass already removed the denied siblings a rule
- * reads as evidence, so a field kept only while such a sibling was present would
- * be wrongly dropped. Restoring each row's removed values first (unless a hook
- * has since set them) gives the rules the same evidence the first pass — and a
- * direct read — judged against, while the current values of everything a hook
- * touched are seen and re-judged.
+ * verdict, though: the first pass already removed the denied values a rule reads
+ * as evidence, so a field kept only while such a value was present would be
+ * wrongly dropped. Restoring each row's removed values first (unless a hook has
+ * since set them) gives the rules the same evidence the first pass — and a direct
+ * read — judged against, while the current values of everything a hook touched
+ * are seen and re-judged.
+ *
+ * The restore runs over the WHOLE subtree before any level's snapshot is taken,
+ * because the evidence a rule reads is not always a sibling: an outer field's
+ * rule can depend on a value inside a nested group or repeater the first pass
+ * already redacted. Snapshotting a level before descending to restore its nested
+ * rows would judge that outer rule against a stripped subtree and drop it, unlike
+ * a direct read which judges once with the subtree intact.
  *
  * Keyed by the row object, never by an `id`: two rows may carry the same `id`,
  * and a replacement row is a genuinely new object that must be judged on its own
@@ -374,25 +381,51 @@ export type ReadAccessRedactions = WeakMap<
   Record<string, unknown>
 >;
 
-/** Recursive worker for read access — same snapshot + recurse contract. When
- *  `redactions` carries values a prior pass removed from this row, they are
- *  restored as evidence (unless a hook has since set them) before the rules run,
- *  then re-removed; the rules always run against the current content. */
-async function applyReadAccessRec(
+/**
+ * Restore, throughout the subtree rooted at `entry`, the values a prior pass
+ * removed from each row — unless a hook has since set the key, so a hook's own
+ * value stands. Runs once before any snapshot is taken, so a rule at any level is
+ * judged against the evidence a single direct read would see.
+ *
+ * The restore has to span the whole subtree, not just the current row: an outer
+ * field's rule can read a value that lives in a nested group or repeater a prior
+ * pass already redacted. Restoring per row on the way down would take the outer
+ * level's snapshot before descending to restore that nested value, and the rule
+ * would judge against the stripped subtree and wrongly drop the outer field.
+ */
+function restoreReadAccessEvidence(
   entry: Record<string, unknown>,
   fns: Record<string, FieldFunctions>,
-  ctx: { user?: Record<string, unknown>; id?: string },
   redactions: ReadAccessRedactions
-): Promise<void> {
-  // Restore what a prior pass removed from THIS row, so a rule reading a denied
-  // sibling as evidence sees it again — matching a direct read's single pass.
-  // Only where a hook has not since set the key, so a hook's own value stands.
+): void {
   const priorlyRemoved = redactions.get(entry);
   if (priorlyRemoved) {
     for (const [name, value] of Object.entries(priorlyRemoved)) {
       if (!(name in entry)) entry[name] = value;
     }
   }
+  for (const [name, fieldFns] of Object.entries(fns)) {
+    if (!fieldFns.fields || !(name in entry)) continue;
+    const container = openNestedContainer(entry[name]);
+    if (!container) continue;
+    for (const row of container.rows) {
+      restoreReadAccessEvidence(row, fieldFns.fields, redactions);
+    }
+    entry[name] = container.serialize();
+  }
+}
+
+/** Recursive worker for read access — same snapshot + recurse contract. Prior
+ *  passes' removed values are restored across the whole subtree by
+ *  {@link restoreReadAccessEvidence} before this runs, so the snapshot reflects
+ *  the content a single direct read would judge; the rules always run against the
+ *  current content, and what this pass removes is recorded for the next. */
+async function applyReadAccessRec(
+  entry: Record<string, unknown>,
+  fns: Record<string, FieldFunctions>,
+  ctx: { user?: Record<string, unknown>; id?: string },
+  redactions: ReadAccessRedactions
+): Promise<void> {
   // Taken BEFORE the recursion below replaces nested containers with their
   // redacted serialization: a parent-level rule reading a protected nested
   // value would otherwise find it already removed, and the outcome would turn
@@ -428,8 +461,10 @@ async function applyReadAccessRec(
     if (!allowed) denied.push(name);
   }
   if (denied.length > 0) {
-    // Record the removed values (merged with any this row already carried) so a
-    // later pass can restore them as evidence and re-judge.
+    // Record the removed values (merged with any this row already carried, so a
+    // value a hook restored then this pass re-denied is still remembered) for the
+    // next pass to restore as evidence and re-judge.
+    const priorlyRemoved = redactions.get(entry);
     const removed: Record<string, unknown> = priorlyRemoved
       ? { ...priorlyRemoved }
       : {};
@@ -465,6 +500,12 @@ export async function applyFieldReadAccess(
   if (opts.overrideAccess) return;
   const fns = getFieldFunctions(opts.kind, opts.slug);
   if (!fns) return;
+  const store = redactions ?? new WeakMap();
+  // Restore the whole subtree's prior-pass evidence before any level's snapshot,
+  // so an outer rule reading a value nested in a group or repeater is judged
+  // against the same content a single direct read would (a no-op on the first
+  // pass, whose store is empty). The judge below re-removes what stays denied.
+  restoreReadAccessEvidence(opts.entry, fns, store);
   await applyReadAccessRec(
     opts.entry,
     fns,
@@ -472,7 +513,7 @@ export async function applyFieldReadAccess(
       user: opts.user,
       id: typeof opts.entry.id === "string" ? opts.entry.id : undefined,
     },
-    redactions ?? new WeakMap()
+    store
   );
 }
 

--- a/packages/nextly/src/shared/lib/field-level-registry.ts
+++ b/packages/nextly/src/shared/lib/field-level-registry.ts
@@ -364,15 +364,47 @@ export async function applyFieldWriteAccess(opts: {
  * Keys are field paths built from stable row identity (`id` when a row has one,
  * else its index), so a memo survives a hook reordering rows a row still owns.
  */
-export type ReadAccessMemo = Map<string, boolean>;
+export interface ReadAccessMemo {
+  /** The `access.read` verdict recorded for each field path. */
+  verdicts: Map<string, boolean>;
+  /**
+   * A stable synthetic id for each container row OBJECT that has no `id` of its
+   * own, so a verdict follows the row across a reorder while a REPLACEMENT row (a
+   * different object) misses the memo and is judged fresh. Keying such a row by
+   * its array index instead would hand a replacement the previous occupant's
+   * verdict. Row objects survive between the two passes because the nested walk
+   * decodes container values to arrays before hooks run, so the same objects are
+   * re-visited (a replacement is a genuinely new object).
+   */
+  rowIds: WeakMap<Record<string, unknown>, string>;
+  nextRowId: { value: number };
+}
 
-/** The stable key segment for a container row: its `id` when it has one (so it
- *  survives a reorder), otherwise its position. */
-function rowKeySegment(row: Record<string, unknown>, index: number): string {
+/** A fresh, empty read-access memo. */
+export function createReadAccessMemo(): ReadAccessMemo {
+  return {
+    verdicts: new Map(),
+    rowIds: new WeakMap(),
+    nextRowId: { value: 0 },
+  };
+}
+
+/** The stable key segment for a container row: its own `id` when it has one (so
+ *  it survives serialization), otherwise a synthetic id assigned by object
+ *  identity — so a reorder keeps the verdict and a replacement row misses it. */
+function rowKeySegment(
+  row: Record<string, unknown>,
+  memo: ReadAccessMemo
+): string {
   const id = row.id;
-  return typeof id === "string" || typeof id === "number"
-    ? `#${id}`
-    : `@${index}`;
+  if (typeof id === "string" || typeof id === "number") return `#${id}`;
+  let synthetic = memo.rowIds.get(row);
+  if (synthetic === undefined) {
+    synthetic = `~${memo.nextRowId.value}`;
+    memo.nextRowId.value += 1;
+    memo.rowIds.set(row, synthetic);
+  }
+  return synthetic;
 }
 
 /** Recursive worker for read access — same snapshot + recurse contract. Each
@@ -398,14 +430,13 @@ async function applyReadAccessRec(
     if (fieldFns.fields) {
       const container = openNestedContainer(entry[name]);
       if (container) {
-        for (let index = 0; index < container.rows.length; index++) {
-          const row = container.rows[index];
+        for (const row of container.rows) {
           await applyReadAccessRec(
             row,
             fieldFns.fields,
             ctx,
             memo,
-            `${path}.${name}[${rowKeySegment(row, index)}]`
+            `${path}.${name}[${rowKeySegment(row, memo)}]`
           );
         }
         entry[name] = container.serialize();
@@ -416,7 +447,7 @@ async function applyReadAccessRec(
     // Reuse a verdict already recorded for this exact field path; only judge it
     // (running the rule, possibly querying) when it is new to this row.
     const key = `${path}.${name}`;
-    let allowed = memo.get(key);
+    let allowed = memo.verdicts.get(key);
     if (allowed === undefined) {
       try {
         allowed = await fn({
@@ -428,7 +459,7 @@ async function applyReadAccessRec(
         // Fail-secure: an access rule that throws denies the field.
         allowed = false;
       }
-      memo.set(key, allowed);
+      memo.verdicts.set(key, allowed);
     }
     if (!allowed) denied.push(name);
   }
@@ -459,7 +490,7 @@ export async function applyFieldReadAccess(
   if (opts.overrideAccess) return undefined;
   const fns = getFieldFunctions(opts.kind, opts.slug);
   if (!fns) return undefined;
-  const verdicts: ReadAccessMemo = memo ?? new Map();
+  const used = memo ?? createReadAccessMemo();
   await applyReadAccessRec(
     opts.entry,
     fns,
@@ -467,10 +498,10 @@ export async function applyFieldReadAccess(
       user: opts.user,
       id: typeof opts.entry.id === "string" ? opts.entry.id : undefined,
     },
-    verdicts,
+    used,
     ""
   );
-  return verdicts;
+  return used;
 }
 
 /** Recursive worker for hooks. Transforms values in registration order. */

--- a/packages/nextly/src/shared/lib/field-level-registry.ts
+++ b/packages/nextly/src/shared/lib/field-level-registry.ts
@@ -347,76 +347,52 @@ export async function applyFieldWriteAccess(opts: {
 }
 
 /**
- * A record of each `access.read` verdict from one pass, keyed by field path, so
- * a second pass over the same row reuses them instead of re-running the rules.
+ * The values each read-access pass removed from a row, keyed by the row OBJECT,
+ * so a later pass over the same row can restore them as EVIDENCE before it
+ * re-judges the row.
  *
  * The nested-read pipeline applies access to a related row BEFORE its parent's
- * hooks (so a hook cannot read a denied child field to copy it), then again
- * AFTER all hooks (to strip a denied field a hook wrote back). Re-running the
- * rules on that second pass would be wrong: a rule reads the row as `data`, so
- * judging it again against the already-stripped row could flip a verdict (a
- * field kept only while a now-denied sibling was present), and an async rule
- * would issue its queries twice. Reusing the memo keeps EXISTING content's
- * verdicts stable and query-free, while content a hook INTRODUCED between the
- * passes (a new field, or a new/reordered container row) misses the memo and is
- * judged fresh — which is exactly what must happen for it.
+ * hooks (so a hook cannot read a denied child field to copy it), then AGAIN
+ * after all hooks (a hook may have written a denied field back, mutated a row in
+ * place, or added, replaced, or reordered rows). The second pass MUST re-run the
+ * rules against the post-hook content — a cached verdict cannot be trusted once a
+ * hook may have changed what the rule reads. Re-running alone would flip a
+ * verdict, though: the first pass already removed the denied siblings a rule
+ * reads as evidence, so a field kept only while such a sibling was present would
+ * be wrongly dropped. Restoring each row's removed values first (unless a hook
+ * has since set them) gives the rules the same evidence the first pass — and a
+ * direct read — judged against, while the current values of everything a hook
+ * touched are seen and re-judged.
  *
- * Keys are field paths built from stable row identity (`id` when a row has one,
- * else its index), so a memo survives a hook reordering rows a row still owns.
+ * Keyed by the row object, never by an `id`: two rows may carry the same `id`,
+ * and a replacement row is a genuinely new object that must be judged on its own
+ * content. Row objects survive between the passes because the nested walk decodes
+ * container values to arrays before hooks run.
  */
-export interface ReadAccessMemo {
-  /** The `access.read` verdict recorded for each field path. */
-  verdicts: Map<string, boolean>;
-  /**
-   * A stable synthetic id for each container row OBJECT that has no `id` of its
-   * own, so a verdict follows the row across a reorder while a REPLACEMENT row (a
-   * different object) misses the memo and is judged fresh. Keying such a row by
-   * its array index instead would hand a replacement the previous occupant's
-   * verdict. Row objects survive between the two passes because the nested walk
-   * decodes container values to arrays before hooks run, so the same objects are
-   * re-visited (a replacement is a genuinely new object).
-   */
-  rowIds: WeakMap<Record<string, unknown>, string>;
-  nextRowId: { value: number };
-}
+export type ReadAccessRedactions = WeakMap<
+  Record<string, unknown>,
+  Record<string, unknown>
+>;
 
-/** A fresh, empty read-access memo. */
-export function createReadAccessMemo(): ReadAccessMemo {
-  return {
-    verdicts: new Map(),
-    rowIds: new WeakMap(),
-    nextRowId: { value: 0 },
-  };
-}
-
-/** The stable key segment for a container row: its own `id` when it has one (so
- *  it survives serialization), otherwise a synthetic id assigned by object
- *  identity — so a reorder keeps the verdict and a replacement row misses it. */
-function rowKeySegment(
-  row: Record<string, unknown>,
-  memo: ReadAccessMemo
-): string {
-  const id = row.id;
-  if (typeof id === "string" || typeof id === "number") return `#${id}`;
-  let synthetic = memo.rowIds.get(row);
-  if (synthetic === undefined) {
-    synthetic = `~${memo.nextRowId.value}`;
-    memo.nextRowId.value += 1;
-    memo.rowIds.set(row, synthetic);
-  }
-  return synthetic;
-}
-
-/** Recursive worker for read access — same snapshot + recurse contract. Each
- *  `access.read` verdict is memoized under its field path, so a later pass over
- *  the same row (after hooks) reuses it and only judges content introduced since. */
+/** Recursive worker for read access — same snapshot + recurse contract. When
+ *  `redactions` carries values a prior pass removed from this row, they are
+ *  restored as evidence (unless a hook has since set them) before the rules run,
+ *  then re-removed; the rules always run against the current content. */
 async function applyReadAccessRec(
   entry: Record<string, unknown>,
   fns: Record<string, FieldFunctions>,
   ctx: { user?: Record<string, unknown>; id?: string },
-  memo: ReadAccessMemo,
-  path: string
+  redactions: ReadAccessRedactions
 ): Promise<void> {
+  // Restore what a prior pass removed from THIS row, so a rule reading a denied
+  // sibling as evidence sees it again — matching a direct read's single pass.
+  // Only where a hook has not since set the key, so a hook's own value stands.
+  const priorlyRemoved = redactions.get(entry);
+  if (priorlyRemoved) {
+    for (const [name, value] of Object.entries(priorlyRemoved)) {
+      if (!(name in entry)) entry[name] = value;
+    }
+  }
   // Taken BEFORE the recursion below replaces nested containers with their
   // redacted serialization: a parent-level rule reading a protected nested
   // value would otherwise find it already removed, and the outcome would turn
@@ -431,51 +407,50 @@ async function applyReadAccessRec(
       const container = openNestedContainer(entry[name]);
       if (container) {
         for (const row of container.rows) {
-          await applyReadAccessRec(
-            row,
-            fieldFns.fields,
-            ctx,
-            memo,
-            `${path}.${name}[${rowKeySegment(row, memo)}]`
-          );
+          await applyReadAccessRec(row, fieldFns.fields, ctx, redactions);
         }
         entry[name] = container.serialize();
       }
     }
     const fn = fieldFns.access?.read;
     if (!fn) continue;
-    // Reuse a verdict already recorded for this exact field path; only judge it
-    // (running the rule, possibly querying) when it is new to this row.
-    const key = `${path}.${name}`;
-    let allowed = memo.verdicts.get(key);
-    if (allowed === undefined) {
-      try {
-        allowed = await fn({
-          req: { user: ctx.user },
-          id: ctx.id,
-          data: snapshot,
-        });
-      } catch {
-        // Fail-secure: an access rule that throws denies the field.
-        allowed = false;
-      }
-      memo.verdicts.set(key, allowed);
+    let allowed = false;
+    try {
+      allowed = await fn({
+        req: { user: ctx.user },
+        id: ctx.id,
+        data: snapshot,
+      });
+    } catch {
+      // Fail-secure: an access rule that throws denies the field.
+      allowed = false;
     }
     if (!allowed) denied.push(name);
   }
-  for (const name of denied) delete entry[name];
+  if (denied.length > 0) {
+    // Record the removed values (merged with any this row already carried) so a
+    // later pass can restore them as evidence and re-judge.
+    const removed: Record<string, unknown> = priorlyRemoved
+      ? { ...priorlyRemoved }
+      : {};
+    for (const name of denied) {
+      removed[name] = entry[name];
+      delete entry[name];
+    }
+    redactions.set(entry, removed);
+  }
 }
 
 /**
  * Enforce field-level read access on a serialized entry: fields whose
  * `access.read` denies are removed from the response, at every depth.
  *
- * Returns the {@link ReadAccessMemo} of the verdicts it made (undefined for a
- * trusted/override read or an unregistered entity). Passing that memo back on a
- * later call over the same row — after hooks may have mutated it — re-strips a
- * denied field a hook reintroduced while reusing the recorded verdicts, so
- * unchanged content is neither re-judged (no flipped verdict) nor re-queried,
- * and only content introduced since is judged anew.
+ * Pass a shared {@link ReadAccessRedactions} to run access more than once over
+ * rows a hook may have mutated in between (the nested-read pipeline's
+ * before-hooks and after-hooks passes): each pass restores the values a prior
+ * pass removed from a row as evidence, then re-judges the row against its current
+ * content — so a denied field a hook reintroduced or a row it changed is caught,
+ * while a field kept only because of a now-removed sibling keeps its verdict.
  */
 export async function applyFieldReadAccess(
   opts: {
@@ -485,12 +460,11 @@ export async function applyFieldReadAccess(
     user?: Record<string, unknown>;
     overrideAccess?: boolean;
   },
-  memo?: ReadAccessMemo
-): Promise<ReadAccessMemo | undefined> {
-  if (opts.overrideAccess) return undefined;
+  redactions?: ReadAccessRedactions
+): Promise<void> {
+  if (opts.overrideAccess) return;
   const fns = getFieldFunctions(opts.kind, opts.slug);
-  if (!fns) return undefined;
-  const used = memo ?? createReadAccessMemo();
+  if (!fns) return;
   await applyReadAccessRec(
     opts.entry,
     fns,
@@ -498,10 +472,8 @@ export async function applyFieldReadAccess(
       user: opts.user,
       id: typeof opts.entry.id === "string" ? opts.entry.id : undefined,
     },
-    used,
-    ""
+    redactions ?? new WeakMap()
   );
-  return used;
 }
 
 /** Recursive worker for hooks. Transforms values in registration order. */

--- a/packages/nextly/src/shared/lib/field-level-registry.ts
+++ b/packages/nextly/src/shared/lib/field-level-registry.ts
@@ -347,28 +347,44 @@ export async function applyFieldWriteAccess(opts: {
 }
 
 /**
- * What a read-access pass removed from one row, at every depth, so a later
- * cleanup can remove the SAME fields a hook reintroduced without re-running the
- * policy. Re-running it is unsafe: a rule reads the row as `data`, so evaluating
- * it a second time against the already-stripped row can flip a decision (a field
- * allowed only while a now-denied sibling is present would be wrongly removed),
- * and an async rule would issue its queries twice.
+ * A record of each `access.read` verdict from one pass, keyed by field path, so
+ * a second pass over the same row reuses them instead of re-running the rules.
+ *
+ * The nested-read pipeline applies access to a related row BEFORE its parent's
+ * hooks (so a hook cannot read a denied child field to copy it), then again
+ * AFTER all hooks (to strip a denied field a hook wrote back). Re-running the
+ * rules on that second pass would be wrong: a rule reads the row as `data`, so
+ * judging it again against the already-stripped row could flip a verdict (a
+ * field kept only while a now-denied sibling was present), and an async rule
+ * would issue its queries twice. Reusing the memo keeps EXISTING content's
+ * verdicts stable and query-free, while content a hook INTRODUCED between the
+ * passes (a new field, or a new/reordered container row) misses the memo and is
+ * judged fresh — which is exactly what must happen for it.
+ *
+ * Keys are field paths built from stable row identity (`id` when a row has one,
+ * else its index), so a memo survives a hook reordering rows a row still owns.
  */
-export interface FieldRedactionPlan {
-  /** Field names denied at this level. */
-  denied: string[];
-  /** Per container field, the plan for each of its rows, by index. */
-  nested: Array<{ name: string; rows: FieldRedactionPlan[] }>;
+export type ReadAccessMemo = Map<string, boolean>;
+
+/** The stable key segment for a container row: its `id` when it has one (so it
+ *  survives a reorder), otherwise its position. */
+function rowKeySegment(row: Record<string, unknown>, index: number): string {
+  const id = row.id;
+  return typeof id === "string" || typeof id === "number"
+    ? `#${id}`
+    : `@${index}`;
 }
 
-/** Recursive worker for read access — same snapshot + recurse contract.
- *  Returns the redaction it performed so it can be replayed (see
- *  {@link replayFieldRedaction}). */
+/** Recursive worker for read access — same snapshot + recurse contract. Each
+ *  `access.read` verdict is memoized under its field path, so a later pass over
+ *  the same row (after hooks) reuses it and only judges content introduced since. */
 async function applyReadAccessRec(
   entry: Record<string, unknown>,
   fns: Record<string, FieldFunctions>,
-  ctx: { user?: Record<string, unknown>; id?: string }
-): Promise<FieldRedactionPlan> {
+  ctx: { user?: Record<string, unknown>; id?: string },
+  memo: ReadAccessMemo,
+  path: string
+): Promise<void> {
   // Taken BEFORE the recursion below replaces nested containers with their
   // redacted serialization: a parent-level rule reading a protected nested
   // value would otherwise find it already removed, and the outcome would turn
@@ -377,84 +393,84 @@ async function applyReadAccessRec(
     ? detachData(entry)
     : undefined;
   const denied: string[] = [];
-  const nested: FieldRedactionPlan["nested"] = [];
   for (const [name, fieldFns] of Object.entries(fns)) {
     if (!(name in entry)) continue;
     if (fieldFns.fields) {
       const container = openNestedContainer(entry[name]);
       if (container) {
-        const rows: FieldRedactionPlan[] = [];
-        for (const row of container.rows) {
-          rows.push(await applyReadAccessRec(row, fieldFns.fields, ctx));
+        for (let index = 0; index < container.rows.length; index++) {
+          const row = container.rows[index];
+          await applyReadAccessRec(
+            row,
+            fieldFns.fields,
+            ctx,
+            memo,
+            `${path}.${name}[${rowKeySegment(row, index)}]`
+          );
         }
         entry[name] = container.serialize();
-        nested.push({ name, rows });
       }
     }
     const fn = fieldFns.access?.read;
     if (!fn) continue;
-    let allowed = false;
-    try {
-      allowed = await fn({
-        req: { user: ctx.user },
-        id: ctx.id,
-        data: snapshot,
-      });
-    } catch {
-      allowed = false;
+    // Reuse a verdict already recorded for this exact field path; only judge it
+    // (running the rule, possibly querying) when it is new to this row.
+    const key = `${path}.${name}`;
+    let allowed = memo.get(key);
+    if (allowed === undefined) {
+      try {
+        allowed = await fn({
+          req: { user: ctx.user },
+          id: ctx.id,
+          data: snapshot,
+        });
+      } catch {
+        // Fail-secure: an access rule that throws denies the field.
+        allowed = false;
+      }
+      memo.set(key, allowed);
     }
     if (!allowed) denied.push(name);
   }
   for (const name of denied) delete entry[name];
-  return { denied, nested };
-}
-
-/**
- * Re-remove the fields a prior {@link applyFieldReadAccess} pass denied on a
- * row, WITHOUT re-running the policy, so a denied value a later hook wrote back
- * onto the row is stripped again. The policy already ran once (that produced the
- * plan); replaying its decisions avoids both re-deciding against mutated data
- * and re-issuing async rule queries.
- */
-export function replayFieldRedaction(
-  entry: Record<string, unknown>,
-  plan: FieldRedactionPlan
-): void {
-  for (const { name, rows } of plan.nested) {
-    if (!(name in entry)) continue;
-    const container = openNestedContainer(entry[name]);
-    if (container) {
-      container.rows.forEach((row, index) => {
-        const rowPlan = rows[index];
-        if (rowPlan) replayFieldRedaction(row, rowPlan);
-      });
-      entry[name] = container.serialize();
-    }
-  }
-  for (const name of plan.denied) delete entry[name];
 }
 
 /**
  * Enforce field-level read access on a serialized entry: fields whose
- * `access.read` denies are removed from the response, at every depth. Returns
- * the redaction it performed (undefined for a trusted/override read or an
- * unregistered entity), which {@link replayFieldRedaction} can re-apply after
- * later hooks run.
+ * `access.read` denies are removed from the response, at every depth.
+ *
+ * Returns the {@link ReadAccessMemo} of the verdicts it made (undefined for a
+ * trusted/override read or an unregistered entity). Passing that memo back on a
+ * later call over the same row — after hooks may have mutated it — re-strips a
+ * denied field a hook reintroduced while reusing the recorded verdicts, so
+ * unchanged content is neither re-judged (no flipped verdict) nor re-queried,
+ * and only content introduced since is judged anew.
  */
-export async function applyFieldReadAccess(opts: {
-  kind: EntityKind;
-  slug: string;
-  entry: Record<string, unknown>;
-  user?: Record<string, unknown>;
-  overrideAccess?: boolean;
-}): Promise<FieldRedactionPlan | undefined> {
+export async function applyFieldReadAccess(
+  opts: {
+    kind: EntityKind;
+    slug: string;
+    entry: Record<string, unknown>;
+    user?: Record<string, unknown>;
+    overrideAccess?: boolean;
+  },
+  memo?: ReadAccessMemo
+): Promise<ReadAccessMemo | undefined> {
   if (opts.overrideAccess) return undefined;
   const fns = getFieldFunctions(opts.kind, opts.slug);
   if (!fns) return undefined;
-  return applyReadAccessRec(opts.entry, fns, {
-    user: opts.user,
-    id: typeof opts.entry.id === "string" ? opts.entry.id : undefined,
-  });
+  const verdicts: ReadAccessMemo = memo ?? new Map();
+  await applyReadAccessRec(
+    opts.entry,
+    fns,
+    {
+      user: opts.user,
+      id: typeof opts.entry.id === "string" ? opts.entry.id : undefined,
+    },
+    verdicts,
+    ""
+  );
+  return verdicts;
 }
 
 /** Recursive worker for hooks. Transforms values in registration order. */

--- a/packages/nextly/src/shared/lib/field-level-registry.ts
+++ b/packages/nextly/src/shared/lib/field-level-registry.ts
@@ -387,6 +387,18 @@ export type ReadAccessRedactions = WeakMap<
   Record<string, unknown>
 >;
 
+/**
+ * Rows whose redaction provenance could not be established, keyed by the row
+ * OBJECT like {@link ReadAccessRedactions}. The nested-read pipeline flags a
+ * related-row clone here when it cannot be matched to its source row (a reshaped
+ * or id-less clone a hook returned); every field on such a row that carries an
+ * `access.read` rule is then denied WITHOUT running the rule, because the rule's
+ * evidence — sibling values on an untrusted clone — cannot be relied on. This is
+ * the fail-secure default: deny when the inputs to an access decision are not
+ * trustworthy, rather than judge on them.
+ */
+export type FailClosedRows = WeakSet<Record<string, unknown>>;
+
 /** One value a pass put back purely as evidence: the row it was written onto and
  *  the key, so it can be removed again once the snapshots that needed it are
  *  taken. */
@@ -394,6 +406,14 @@ interface RestoredEvidence {
   row: Record<string, unknown>;
   name: string;
 }
+
+/**
+ * The field names a pass RESTORED onto each row purely as evidence, keyed by the
+ * row object. The recorder consults it to tell a value the post-hook row
+ * genuinely supplies — which clears its stale redaction — from one present only
+ * because this pass restored it, which must be remembered as still-removed.
+ */
+type RestoredByRow = WeakMap<Record<string, unknown>, Set<string>>;
 
 /**
  * Restore, throughout the subtree rooted at `entry`, the values a prior pass
@@ -414,7 +434,8 @@ function restoreReadAccessEvidence(
   entry: Record<string, unknown>,
   fns: Record<string, FieldFunctions>,
   redactions: ReadAccessRedactions,
-  restored: RestoredEvidence[]
+  restored: RestoredEvidence[],
+  restoredByRow: RestoredByRow
 ): void {
   const priorlyRemoved = redactions.get(entry);
   if (priorlyRemoved) {
@@ -422,6 +443,14 @@ function restoreReadAccessEvidence(
       if (!(name in entry)) {
         entry[name] = value;
         restored.push({ row: entry, name });
+        // Recorded so the judge can distinguish this evidence-only value, which
+        // stays removed, from one the post-hook row genuinely supplied.
+        let names = restoredByRow.get(entry);
+        if (!names) {
+          names = new Set();
+          restoredByRow.set(entry, names);
+        }
+        names.add(name);
       }
     }
   }
@@ -430,7 +459,13 @@ function restoreReadAccessEvidence(
     const container = openNestedContainer(entry[name]);
     if (!container) continue;
     for (const row of container.rows) {
-      restoreReadAccessEvidence(row, fieldFns.fields, redactions, restored);
+      restoreReadAccessEvidence(
+        row,
+        fieldFns.fields,
+        redactions,
+        restored,
+        restoredByRow
+      );
     }
     entry[name] = container.serialize();
   }
@@ -445,8 +480,16 @@ async function applyReadAccessRec(
   entry: Record<string, unknown>,
   fns: Record<string, FieldFunctions>,
   ctx: { user?: Record<string, unknown>; id?: string },
-  redactions: ReadAccessRedactions
+  redactions: ReadAccessRedactions,
+  restoredByRow: RestoredByRow,
+  failClosed?: FailClosedRows
 ): Promise<void> {
+  // A row whose redaction provenance could not be established (a reshaped or
+  // id-less related-row clone). Every access-controlled field on it is denied
+  // without consulting its rule, because the rule's evidence — sibling values on
+  // an untrusted clone — cannot be relied on. Recursion into containers still
+  // runs, so each nested row is judged against this same set individually.
+  const failed = failClosed?.has(entry) ?? false;
   // Taken BEFORE the recursion below replaces nested containers with their
   // redacted serialization: a parent-level rule reading a protected nested
   // value would otherwise find it already removed, and the outcome would turn
@@ -461,13 +504,26 @@ async function applyReadAccessRec(
       const container = openNestedContainer(entry[name]);
       if (container) {
         for (const row of container.rows) {
-          await applyReadAccessRec(row, fieldFns.fields, ctx, redactions);
+          await applyReadAccessRec(
+            row,
+            fieldFns.fields,
+            ctx,
+            redactions,
+            restoredByRow,
+            failClosed
+          );
         }
         entry[name] = container.serialize();
       }
     }
     const fn = fieldFns.access?.read;
     if (!fn) continue;
+    if (failed) {
+      // Fail-closed: deny every access-controlled field on an untrusted row
+      // without running its rule.
+      denied.push(name);
+      continue;
+    }
     let allowed = false;
     try {
       allowed = await fn({
@@ -481,19 +537,32 @@ async function applyReadAccessRec(
     }
     if (!allowed) denied.push(name);
   }
-  if (denied.length > 0) {
-    // Record the removed values (merged with any this row already carried, so a
-    // value a hook restored then this pass re-denied is still remembered) for the
-    // next pass to restore as evidence and re-judge.
-    const priorlyRemoved = redactions.get(entry);
-    const removed: Record<string, unknown> = priorlyRemoved
-      ? { ...priorlyRemoved }
-      : {};
-    for (const name of denied) {
-      removed[name] = entry[name];
-      delete entry[name];
+  // Record what stays removed for the next pass to restore as evidence. A prior
+  // pass's removed value is carried forward only while the row still lacks the
+  // key, or holds it solely because THIS pass restored it as evidence (about to
+  // be stripped again). A field the post-hook row genuinely supplies and that was
+  // allowed clears its stale evidence, so a later rule keyed on the old value is
+  // not judged against a value the row no longer carries.
+  const priorlyRemoved = redactions.get(entry);
+  const restoredHere = restoredByRow.get(entry);
+  const removed: Record<string, unknown> = {};
+  if (priorlyRemoved) {
+    for (const [name, value] of Object.entries(priorlyRemoved)) {
+      if (!(name in entry) || restoredHere?.has(name)) {
+        removed[name] = value;
+      }
     }
+  }
+  for (const name of denied) {
+    removed[name] = entry[name];
+    delete entry[name];
+  }
+  if (Object.keys(removed).length > 0) {
     redactions.set(entry, removed);
+  } else {
+    // Nothing stays removed: drop any stale entry so a later pass does not
+    // restore a value this row now legitimately carries or no longer hides.
+    redactions.delete(entry);
   }
 }
 
@@ -507,6 +576,10 @@ async function applyReadAccessRec(
  * pass removed from a row as evidence, then re-judges the row against its current
  * content — so a denied field a hook reintroduced or a row it changed is caught,
  * while a field kept only because of a now-removed sibling keeps its verdict.
+ *
+ * Pass a {@link FailClosedRows} set to deny every access-controlled field on a
+ * row whose provenance could not be established (a reshaped or id-less clone),
+ * without running its rules.
  */
 export async function applyFieldReadAccess(
   opts: {
@@ -516,7 +589,8 @@ export async function applyFieldReadAccess(
     user?: Record<string, unknown>;
     overrideAccess?: boolean;
   },
-  redactions?: ReadAccessRedactions
+  redactions?: ReadAccessRedactions,
+  failClosed?: FailClosedRows
 ): Promise<void> {
   if (opts.overrideAccess) return;
   const fns = getFieldFunctions(opts.kind, opts.slug);
@@ -526,8 +600,11 @@ export async function applyFieldReadAccess(
   // so an outer rule reading a value nested in a group or repeater is judged
   // against the same content a single direct read would (a no-op on the first
   // pass, whose store is empty). The judge below re-removes what stays denied.
+  // The restored keys are tracked so the judge can tell them from values the row
+  // genuinely supplies when it decides what stays recorded as removed.
   const restored: RestoredEvidence[] = [];
-  restoreReadAccessEvidence(opts.entry, fns, store, restored);
+  const restoredByRow: RestoredByRow = new WeakMap();
+  restoreReadAccessEvidence(opts.entry, fns, store, restored, restoredByRow);
   await applyReadAccessRec(
     opts.entry,
     fns,
@@ -535,7 +612,9 @@ export async function applyFieldReadAccess(
       user: opts.user,
       id: typeof opts.entry.id === "string" ? opts.entry.id : undefined,
     },
-    store
+    store,
+    restoredByRow,
+    failClosed
   );
   // A restored value existed only to feed the snapshots above. The caller was
   // denied it and the post-hook row did not supply it, so it must not appear in


### PR DESCRIPTION
## Problem

A codex review on #449 flagged an unresolved P1 in `collection-relationship-service.ts` that merged into `main`: when an expanded relationship is assembled, field-level read access was **deferred** until after every nested `afterRead` hook had run (`finalizeRelatedRows`). So a parent row's field hook was handed a nested child with the caller's **denied** fields still present. A hook that copies such a value onto an allowed key exposed it there, and it outlived the child's own redaction which ran afterward.

Confirmed empirically: reading `POSTS → author (AUTHORS) → organization (ORGS)` without `overrideAccess`, a hook on `AUTHORS` that copied `data.organization.classification` (denied via `access.read: () => false`) returned `stolen: "private"` — the denied value leaked under an allowed key, while `organization.classification` itself was correctly removed.

## Fix

Apply each related row's field access **right after its own hooks, before returning to its parent** whose hooks run next up the stack. `finalizeRelatedRows` now only rebuilds labels (still last, from surviving values).

This matches how a **direct read already behaves**: `finalizeRelatedRows` runs before the root collection's own field hooks (`collection-query-service.ts`), so a root hook already sees nested rows with denied fields removed. The nested walk was the inconsistent outlier; this makes it uniform.

## Deliberate trade-off (least-privilege)

A field `afterRead` hook can no longer observe a related row's caller-denied field, so it can neither **leak** it (the bug) nor **mask on** it. A value that must stay hidden should be protected with an `access.read` rule keyed on the **caller**, not a hook that reads another field the caller cannot see — masking on data the caller can't see is itself the anti-pattern that made the copy-leak possible.

`overrideAccess` (trusted/system) reads are unaffected: field access is skipped for them, so this is a no-op there.

## Tests

- `nested-field-hooks.integration.test.ts`: added a `stolen` copy-hook and reworked the masking test to pin the new guarantee — the copy hook is handed a child whose denied field is already removed (`stolen !== "private"`), the denied field is absent from the response, and (the documented consequence) a mask-on-denied-evidence hook no longer masks.
- Verified no regression across `related-row-collection-access`, `related-row-status`, `write-response-related-access` (collections + singles), `component-field-filter`, `custom-read-constraint`, and the full `draft-published-split` suite (the draft-overlay expansion path that shares this deferral). Type-check + lint clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved access-control handling for nested related data.
  * Prevented restricted fields from being reintroduced during processing or used in masking.
  * Updated displayed labels to exclude values from removed fields.
  * Ensured access rules are consistently applied before and after relationship processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->