### PR TITLE
fix(nextly): let a create-only companion migration run when the table already exists

### DIFF
--- a/.changeset/tidy-moons-argue.md
+++ b/.changeset/tidy-moons-argue.md
@@ -1,0 +1,25 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+`nextly migrate` no longer fails on a localized project whose companion table already exists, which is the normal state of any project that ran the dev server or `db:sync` before adopting migrations. The companion migration can now be re-run after an interruption without colliding or duplicating rows.

--- a/.changeset/tidy-moons-argue.md
+++ b/.changeset/tidy-moons-argue.md
@@ -22,4 +22,4 @@
 "@nextlyhq/tsconfig": patch
 ---
 
-`nextly migrate` no longer fails on a localized project whose companion table already exists, which is the normal state of any project that ran the dev server or `db:sync` before adopting migrations. The companion migration can now be re-run after an interruption without colliding or duplicating rows.
+`nextly migrate` no longer fails outright when a localized project's companion table already exists but holds no rows yet, which is what a dev-server boot leaves behind. A project whose companion was already filled by `db:sync` still needs the follow-up fix to `migrate:create`.

--- a/packages/nextly/src/domains/i18n/migration/__tests__/companion-migration-idempotency.integration.test.ts
+++ b/packages/nextly/src/domains/i18n/migration/__tests__/companion-migration-idempotency.integration.test.ts
@@ -1,0 +1,244 @@
+/**
+ * The companion migration against a database that already has the companion.
+ *
+ * 🔴 This is the ordinary state, not an edge case. `ensureCompanionTable` runs at boot and on every
+ * `db:sync`, so any project that ran the dev server before graduating to migrations reaches
+ * `nextly migrate` with the companion already present. Before this suite the run died on the
+ * `CREATE TABLE` **after** committing the files before it, leaving the operator to work out by hand
+ * which ones had landed.
+ *
+ * Driven through the real `runFileMigrations` rather than by asserting on generated SQL, because
+ * the property under test is what the database does with the statements, not what they look like.
+ * The unit suite covers the text; only a server can say whether a replay collides.
+ *
+ * Replays are exercised by re-executing the UP statements directly. That is the honest model of the
+ * recovery path: the file is applied statement by statement with no enclosing transaction, so a
+ * failure part-way leaves the earlier statements committed and the file recorded as NOT applied —
+ * and the operator's only move is to run `migrate` again, which replays every statement in it.
+ */
+
+import type { SupportedDialect } from "@nextlyhq/adapter-drizzle/types";
+import { createPostgresAdapter } from "@nextlyhq/adapter-postgres";
+import { createSqliteAdapter } from "@nextlyhq/adapter-sqlite";
+import { randomBytes } from "node:crypto";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { runFileMigrations } from "../../../../cli/commands/migrate";
+import { getSchemaEventsDdl } from "../../../schema/events/schema-events-ddl";
+import {
+  buildLocalizationUpSql,
+  buildLocalizationUpStatements,
+} from "../generate-up";
+import type { CompanionMigrationSpec } from "../types";
+
+interface TestAdapter {
+  connect(): Promise<void>;
+  disconnect(): Promise<void>;
+  executeQuery<T = unknown>(sql: string): Promise<T[]>;
+  getDrizzle<T = unknown>(): T;
+}
+
+const DIALECTS: {
+  dialect: SupportedDialect;
+  url: string | null;
+  make: (url: string) => TestAdapter;
+}[] = [
+  {
+    dialect: "postgresql",
+    url: process.env.TEST_POSTGRES_URL ?? null,
+    make: url => createPostgresAdapter({ url }) as unknown as TestAdapter,
+  },
+  {
+    dialect: "sqlite",
+    url: "memory",
+    make: () => createSqliteAdapter({ memory: true }) as unknown as TestAdapter,
+  },
+];
+
+const logger = {
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  debug: vi.fn(),
+  success: vi.fn(),
+};
+
+for (const entry of DIALECTS) {
+  const suite = entry.url === null ? describe.skip : describe;
+
+  suite(`companion migration idempotency (${entry.dialect})`, () => {
+    // Per-file prefix so a shared container cannot let two suites collide on a table name.
+    const tag = randomBytes(5).toString("hex");
+    const mainTable = `dc_pages${tag}`;
+    const companionTable = `${mainTable}_locales`;
+
+    let adapter: TestAdapter;
+    let migrationsDir: string;
+
+    const q = (id: string) => `"${id}"`;
+
+    const spec = (): CompanionMigrationSpec => ({
+      dialect: entry.dialect as CompanionMigrationSpec["dialect"],
+      collection: "pages",
+      mainTable,
+      companionTable,
+      defaultLocale: "en",
+      parentIdType: "TEXT",
+      columns: [{ name: "title", kind: "text" }],
+    });
+
+    async function drop(): Promise<void> {
+      for (const table of [companionTable, mainTable, "nextly_schema_events"]) {
+        await adapter.executeQuery(`DROP TABLE IF EXISTS ${q(table)}`);
+      }
+    }
+
+    /** The main table with two rows of real content, as a pre-localization project has it. */
+    async function createMainWithContent(): Promise<void> {
+      await adapter.executeQuery(
+        `CREATE TABLE ${q(mainTable)} (${q("id")} TEXT PRIMARY KEY, ${q("title")} TEXT)`
+      );
+      await adapter.executeQuery(
+        `INSERT INTO ${q(mainTable)} (${q("id")}, ${q("title")}) VALUES ('p1', 'Hello'), ('p2', 'World')`
+      );
+    }
+
+    /**
+     * The companion exactly as boot leaves it: created, and EMPTY.
+     *
+     * `di/register.ts` calls `ensureCompanionTable` without a `sourceLocale`, which that function
+     * documents as creating an empty companion rather than performing a transition. Seeding it here
+     * would test a state the product does not produce.
+     */
+    async function createCompanionAsBootDoes(): Promise<void> {
+      const create = buildLocalizationUpStatements(spec()).find(s =>
+        s.startsWith("CREATE TABLE")
+      );
+      if (create === undefined)
+        throw new Error("no create statement generated");
+      await adapter.executeQuery(create);
+    }
+
+    async function writeMigrationFile(): Promise<void> {
+      const upSql = buildLocalizationUpSql(spec());
+      await writeFile(
+        join(migrationsDir, "20260802_000001_enable_localization.sql"),
+        `-- Migration: enable_localization\n-- UP\n${upSql}\n\n-- DOWN\nSELECT 1;\n`,
+        "utf8"
+      );
+    }
+
+    async function migrate(): Promise<number> {
+      return runFileMigrations({
+        adapter: adapter as never,
+        db: adapter.getDrizzle(),
+        dialect: entry.dialect,
+        migrationsDir,
+        logger: logger as never,
+      });
+    }
+
+    async function companionRows(): Promise<Record<string, unknown>[]> {
+      return adapter.executeQuery<Record<string, unknown>>(
+        `SELECT ${q("_parent")}, ${q("_locale")}, ${q("title")} FROM ${q(companionTable)} ORDER BY ${q("_parent")}`
+      );
+    }
+
+    beforeEach(async () => {
+      if (adapter === undefined) {
+        adapter = entry.make(entry.url as string);
+        await adapter.connect();
+      }
+      migrationsDir = await mkdtemp(join(tmpdir(), "nextly-077-"));
+      await drop();
+      for (const statement of getSchemaEventsDdl(entry.dialect)) {
+        await adapter.executeQuery(statement);
+      }
+      await createMainWithContent();
+      await writeMigrationFile();
+      vi.clearAllMocks();
+    });
+
+    afterAll(async () => {
+      await drop();
+      await adapter.disconnect();
+      if (migrationsDir)
+        await rm(migrationsDir, { recursive: true, force: true });
+    });
+
+    // 🔴 The reported failure. Before the guard this threw
+    // `table "<companion>" already exists` and left the run part-applied.
+    it("applies when the companion already exists, and still seeds it", async () => {
+      await createCompanionAsBootDoes();
+
+      await expect(migrate()).resolves.toBe(1);
+
+      const rows = await companionRows();
+      expect(rows).toHaveLength(2);
+      expect(rows.map(r => r.title)).toEqual(["Hello", "World"]);
+      expect(rows.every(r => r._locale === "en")).toBe(true);
+    });
+
+    // The control: the guard must not have turned the create into a no-op on a database that
+    // genuinely lacks the table. Without this, a generator emitting nothing at all would pass above.
+    it("applies when the companion does not exist, creating and seeding it", async () => {
+      await expect(migrate()).resolves.toBe(1);
+
+      const rows = await companionRows();
+      expect(rows).toHaveLength(2);
+      expect(rows.map(r => r.title)).toEqual(["Hello", "World"]);
+    });
+
+    // 🔴 The recovery path, modelled as the interruption that actually produces it.
+    //
+    // The file is applied statement by statement with no enclosing transaction, and MySQL commits
+    // DDL implicitly regardless, so a failure part-way commits the statements before it and leaves
+    // the file recorded as NOT applied. The operator re-runs `migrate`, which replays the whole
+    // file. Here the run is interrupted after the seed and before the drops — the widest window,
+    // because the seed is the statement a replay would otherwise collide on.
+    //
+    // Note what is NOT asserted: replaying a COMPLETED migration. That state is unreachable (the
+    // journal skips applied files) and could not be made to work anyway — the drops have removed
+    // the columns the seed reads, so the source data is gone by construction. Idempotency here
+    // means "safe to re-run from the states an interruption can leave", not "the drops are
+    // reversible".
+    it("resumes after an interruption between the seed and the drops", async () => {
+      const statements = buildLocalizationUpStatements(spec());
+      for (const statement of statements) {
+        if (statement.includes("DROP COLUMN")) break;
+        await adapter.executeQuery(statement);
+      }
+      // The interrupted run got as far as a fully seeded companion.
+      expect(await companionRows()).toHaveLength(2);
+
+      // The replay: every statement again, including the two that already ran.
+      await expect(migrate()).resolves.toBe(1);
+
+      const rows = await companionRows();
+      expect(rows).toHaveLength(2);
+      expect(rows.map(r => r.title)).toEqual(["Hello", "World"]);
+    });
+
+    // A partially seeded companion — the state an interrupted copy leaves — must keep the row it
+    // has and gain only the one it is missing. That is why the guard is row-level rather than a
+    // table-level "skip the seed if the companion has any rows at all".
+    it("completes a partially seeded companion rather than skipping it", async () => {
+      await createCompanionAsBootDoes();
+      await adapter.executeQuery(
+        `INSERT INTO ${q(companionTable)} (${q("_parent")}, ${q("_locale")}, ${q("title")}) ` +
+          `VALUES ('p1', 'en', 'Edited since')`
+      );
+
+      await expect(migrate()).resolves.toBe(1);
+
+      const rows = await companionRows();
+      expect(rows).toHaveLength(2);
+      // The existing row is kept as it stands, not overwritten from main: it may hold an edit made
+      // after the interrupted copy, and main stopped being the authority the moment it was written.
+      expect(rows.map(r => r.title)).toEqual(["Edited since", "World"]);
+    });
+  });
+}

--- a/packages/nextly/src/domains/i18n/migration/__tests__/companion-migration-idempotency.integration.test.ts
+++ b/packages/nextly/src/domains/i18n/migration/__tests__/companion-migration-idempotency.integration.test.ts
@@ -26,7 +26,10 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { NextlyError } from "../../../../errors/nextly-error";
 import { runFileMigrations } from "../../../../cli/commands/migrate";
+import { DynamicCollectionSchemaService } from "../../../dynamic-collections/services/dynamic-collection-schema-service";
+import { splitStatements } from "../../../schema/pipeline/sql-statement-utils";
 import { getSchemaEventsDdl } from "../../../schema/events/schema-events-ddl";
 import {
   buildLocalizationUpSql,
@@ -96,13 +99,28 @@ for (const entry of DIALECTS) {
       }
     }
 
-    /** The main table with two rows of real content, as a pre-localization project has it. */
+    /**
+     * The main table with two rows of real content, as a pre-localization project has it.
+     *
+     * Built by the production collection generator rather than a hand-written CREATE: a copied
+     * definition drifts from the shape Nextly actually creates, and the test would then exercise a
+     * layout no real database has.
+     */
     async function createMainWithContent(): Promise<void> {
-      await adapter.executeQuery(
-        `CREATE TABLE ${q(mainTable)} (${q("id")} TEXT PRIMARY KEY, ${q("title")} TEXT)`
+      const schemaService = new DynamicCollectionSchemaService(
+        undefined,
+        entry.dialect
       );
+      for (const statement of splitStatements([
+        schemaService.generateMigrationSQL(mainTable, [
+          { name: "title", type: "text" },
+        ] as never),
+      ])) {
+        await adapter.executeQuery(statement);
+      }
       await adapter.executeQuery(
-        `INSERT INTO ${q(mainTable)} (${q("id")}, ${q("title")}) VALUES ('p1', 'Hello'), ('p2', 'World')`
+        `INSERT INTO ${q(mainTable)} (${q("id")}, ${q("title")}, ${q("slug")}) ` +
+          `VALUES ('p1', 'Hello', 'p1'), ('p2', 'World', 'p2')`
       );
     }
 
@@ -192,52 +210,56 @@ for (const entry of DIALECTS) {
       expect(rows.map(r => r.title)).toEqual(["Hello", "World"]);
     });
 
-    // 🔴 The recovery path, modelled as the interruption that actually produces it.
+    // 🔴 What an emitted file does when the companion already holds default-locale rows: it stops
+    // loudly, and main is left intact.
     //
-    // The file is applied statement by statement with no enclosing transaction, and MySQL commits
-    // DDL implicitly regardless, so a failure part-way commits the statements before it and leaves
-    // the file recorded as NOT applied. The operator re-runs `migrate`, which replays the whole
-    // file. Here the run is interrupted after the seed and before the drops — the widest window,
-    // because the seed is the statement a replay would otherwise collide on.
-    //
-    // Note what is NOT asserted: replaying a COMPLETED migration. That state is unreachable (the
-    // journal skips applied files) and could not be made to work anyway — the drops have removed
-    // the columns the seed reads, so the source data is gone by construction. Idempotency here
-    // means "safe to re-run from the states an interruption can leave", not "the drops are
-    // reversible".
-    it("resumes after an interruption between the seed and the drops", async () => {
+    // The file cannot know whether those rows are an interrupted copy to keep or the stale remains
+    // of a disable, with main authoritative ever since — only the transition record says, and a
+    // static file has none. Skipping them and proceeding to the drops would silently revert every
+    // edit made while localization was off. Colliding costs a re-run; guessing costs data.
+    it("stops on an already-seeded companion instead of dropping main's columns", async () => {
       const statements = buildLocalizationUpStatements(spec());
       for (const statement of statements) {
         if (statement.includes("DROP COLUMN")) break;
         await adapter.executeQuery(statement);
       }
-      // The interrupted run got as far as a fully seeded companion.
       expect(await companionRows()).toHaveLength(2);
 
-      // The replay: every statement again, including the two that already ran.
-      await expect(migrate()).resolves.toBe(1);
+      await expect(migrate()).rejects.toThrow();
 
-      const rows = await companionRows();
-      expect(rows).toHaveLength(2);
-      expect(rows.map(r => r.title)).toEqual(["Hello", "World"]);
+      // The load-bearing half: nothing was dropped, so the operator still has every value.
+      const main = await adapter.executeQuery<Record<string, unknown>>(
+        `SELECT ${q("title")} FROM ${q(mainTable)} ORDER BY ${q("id")}`
+      );
+      expect(main.map(r => r.title)).toEqual(["Hello", "World"]);
     });
 
-    // A partially seeded companion — the state an interrupted copy leaves — must keep the row it
-    // has and gain only the one it is missing. That is why the guard is row-level rather than a
-    // table-level "skip the seed if the companion has any rows at all".
-    it("completes a partially seeded companion rather than skipping it", async () => {
+    // The guard belongs to the runtime, which HAS read the transition record. Driven through the
+    // generated statements so the property is asserted against a real server rather than a string.
+    it("completes a partially seeded companion when the caller asks for the guard", async () => {
       await createCompanionAsBootDoes();
       await adapter.executeQuery(
         `INSERT INTO ${q(companionTable)} (${q("_parent")}, ${q("_locale")}, ${q("title")}) ` +
           `VALUES ('p1', 'en', 'Edited since')`
       );
 
-      await expect(migrate()).resolves.toBe(1);
+      const plan = buildLocalizationUpStatements(spec(), {
+        guardSeed: true,
+        dropSeededColumns: false,
+      });
+      // The CREATE is dropped exactly as `resumeInterruptedSeed` drops it: the interrupted run
+      // already made the table, and the runtime form is deliberately not `IF NOT EXISTS` so that
+      // `ensureCompanionTable` can still detect a lost create race.
+      for (const statement of plan.filter(
+        statement => !statement.startsWith("CREATE TABLE")
+      )) {
+        await adapter.executeQuery(statement);
+      }
 
       const rows = await companionRows();
       expect(rows).toHaveLength(2);
-      // The existing row is kept as it stands, not overwritten from main: it may hold an edit made
-      // after the interrupted copy, and main stopped being the authority the moment it was written.
+      // The row already present is kept as it stands: it may hold an edit made after the
+      // interrupted copy, and re-copying from main would discard it.
       expect(rows.map(r => r.title)).toEqual(["Edited since", "World"]);
     });
   });

--- a/packages/nextly/src/domains/i18n/migration/generate-up.test.ts
+++ b/packages/nextly/src/domains/i18n/migration/generate-up.test.ts
@@ -25,7 +25,7 @@ const spec = (
 describe("buildLocalizationUpSql", () => {
   it("creates the companion table with composite PK and FK", () => {
     const sql = buildLocalizationUpSql(spec("sqlite"));
-    expect(sql).toContain(`CREATE TABLE "dc_pages_locales"`);
+    expect(sql).toContain(`CREATE TABLE IF NOT EXISTS "dc_pages_locales"`);
     expect(sql).toContain(`PRIMARY KEY ("_parent", "_locale")`);
     expect(sql).toContain(`REFERENCES "dc_pages" ("id") ON DELETE CASCADE`);
   });
@@ -57,7 +57,7 @@ describe("buildLocalizationUpSql", () => {
 describe("buildCompanionCreateOnlySql", () => {
   it("emits only the CREATE (no seed, no drop) for a fresh collection", () => {
     const sql = buildCompanionCreateOnlySql(spec("sqlite"));
-    expect(sql).toContain(`CREATE TABLE "dc_pages_locales"`);
+    expect(sql).toContain(`CREATE TABLE IF NOT EXISTS "dc_pages_locales"`);
     expect(sql).toContain(`PRIMARY KEY ("_parent", "_locale")`);
     expect(sql).toContain(`REFERENCES "dc_pages" ("id") ON DELETE CASCADE`);
     expect(sql).not.toContain("INSERT INTO");
@@ -166,5 +166,58 @@ describe("retained columns that were required", () => {
 
     expect(statements.some(s => s.includes("DROP NOT NULL"))).toBe(false);
     expect(statements.some(s => s.includes("DROP COLUMN"))).toBe(false);
+  });
+});
+
+describe("running the same companion migration twice", () => {
+  // 🔴 The file this lands in is applied statement by statement with no enclosing transaction,
+  // and MySQL commits DDL implicitly regardless. A failure part-way therefore leaves the earlier
+  // statements committed while the file is recorded as NOT applied, so the operator's only
+  // recovery is to run `migrate` again — which replays every statement in it.
+  //
+  // `ensureCompanionTable` also runs at boot and on every `db:sync`, so the companion is already
+  // present for any project that ran the dev server before graduating to migrations. That is the
+  // ordinary state, not an edge case.
+  it.each(["sqlite", "postgresql", "mysql"] as const)(
+    "guards the create against an existing companion on %s",
+    dialect => {
+      for (const sql of [
+        buildLocalizationUpSql(spec(dialect)),
+        buildCompanionCreateOnlySql(spec(dialect)),
+      ]) {
+        expect(sql).toContain("CREATE TABLE IF NOT EXISTS");
+        // Asserted as an absence too: a bare CREATE anywhere in the file is the failure, and a
+        // substring check for the guarded form alone would pass with both present.
+        expect(/CREATE TABLE(?! IF NOT EXISTS)/.test(sql)).toBe(false);
+      }
+    }
+  );
+
+  // The seed inserts into a table keyed on (_parent, _locale), so a replay collides outright.
+  // Row-level rather than table-level: an interrupted copy leaves a PARTIALLY seeded companion,
+  // which must keep the rows it has and gain only the ones it is missing.
+  it.each(["sqlite", "postgresql", "mysql"] as const)(
+    "guards the seed row by row on %s",
+    dialect => {
+      const sql = buildLocalizationUpSql(spec(dialect));
+      const q = (id: string) => (dialect === "mysql" ? `\`${id}\`` : `"${id}"`);
+      expect(sql).toContain(
+        `WHERE NOT EXISTS (SELECT 1 FROM ${q("dc_pages_locales")} ` +
+          `WHERE ${q("dc_pages_locales")}.${q("_parent")} = ${q("dc_pages")}.${q("id")} ` +
+          `AND ${q("dc_pages_locales")}.${q("_locale")} = 'en')`
+      );
+    }
+  );
+
+  // The control. Guarding must not cost the statements their actual work, so the seed still
+  // carries its columns and the drops still happen — without this, a generator that emitted only
+  // guards would satisfy every assertion above.
+  it("still seeds and still drops", () => {
+    const sql = buildLocalizationUpSql(spec("sqlite"));
+    expect(sql).toContain(
+      `INSERT INTO "dc_pages_locales" ("_parent", "_locale", "title", "body") ` +
+        `SELECT "id", 'en', "title", "body" FROM "dc_pages"`
+    );
+    expect(sql).toContain(`ALTER TABLE "dc_pages" DROP COLUMN "title"`);
   });
 });

--- a/packages/nextly/src/domains/i18n/migration/generate-up.test.ts
+++ b/packages/nextly/src/domains/i18n/migration/generate-up.test.ts
@@ -56,7 +56,9 @@ describe("buildLocalizationUpSql", () => {
 
 describe("buildCompanionCreateOnlySql", () => {
   it("emits only the CREATE (no seed, no drop) for a fresh collection", () => {
-    const sql = buildCompanionCreateOnlySql(spec("sqlite"));
+    const sql = buildCompanionCreateOnlySql(spec("sqlite"), {
+      emittedToFile: true,
+    });
     expect(sql).toContain(`CREATE TABLE IF NOT EXISTS "dc_pages_locales"`);
     expect(sql).toContain(`PRIMARY KEY ("_parent", "_locale")`);
     expect(sql).toContain(`REFERENCES "dc_pages" ("id") ON DELETE CASCADE`);
@@ -169,21 +171,16 @@ describe("retained columns that were required", () => {
   });
 });
 
-describe("running the same companion migration twice", () => {
-  // 🔴 The file this lands in is applied statement by statement with no enclosing transaction,
-  // and MySQL commits DDL implicitly regardless. A failure part-way therefore leaves the earlier
-  // statements committed while the file is recorded as NOT applied, so the operator's only
-  // recovery is to run `migrate` again — which replays every statement in it.
-  //
-  // `ensureCompanionTable` also runs at boot and on every `db:sync`, so the companion is already
-  // present for any project that ran the dev server before graduating to migrations. That is the
-  // ordinary state, not an edge case.
+describe("guarding the create, and only where it is safe", () => {
+  // 🔴 A migration FILE reaches a database that has usually provisioned the companion already, and
+  // is applied verbatim with no enclosing transaction — so an unguarded create kills the run after
+  // committing the files before it.
   it.each(["sqlite", "postgresql", "mysql"] as const)(
-    "guards the create against an existing companion on %s",
+    "guards the create in an emitted file on %s",
     dialect => {
       for (const sql of [
         buildLocalizationUpSql(spec(dialect)),
-        buildCompanionCreateOnlySql(spec(dialect)),
+        buildCompanionCreateOnlySql(spec(dialect), { emittedToFile: true }),
       ]) {
         expect(sql).toContain("CREATE TABLE IF NOT EXISTS");
         // Asserted as an absence too: a bare CREATE anywhere in the file is the failure, and a
@@ -193,13 +190,47 @@ describe("running the same companion migration twice", () => {
     }
   );
 
-  // The seed inserts into a table keyed on (_parent, _locale), so a replay collides outright.
-  // Row-level rather than table-level: an interrupted copy leaves a PARTIALLY seeded companion,
-  // which must keep the rows it has and gain only the ones it is missing.
+  // 🔴 The RUNTIME must keep the bare form. `ensureCompanionTable` detects a lost create race by
+  // the statement failing, and uses that to tell a process that lost before claiming the transition
+  // from one that lost after — which must abandon its apply rather than settle over a companion it
+  // may not have seeded. `IF NOT EXISTS` would silence that signal for both.
   it.each(["sqlite", "postgresql", "mysql"] as const)(
-    "guards the seed row by row on %s",
+    "leaves the runtime create unguarded on %s",
     dialect => {
-      const sql = buildLocalizationUpSql(spec(dialect));
+      const statements = buildLocalizationUpStatements(spec(dialect));
+      const create = statements.find(s => s.startsWith("CREATE TABLE"));
+      expect(create).toBeDefined();
+      expect(create).not.toContain("IF NOT EXISTS");
+      // The create-only helper defaults to the runtime form for the same reason.
+      expect(buildCompanionCreateOnlySql(spec(dialect))).not.toContain(
+        "IF NOT EXISTS"
+      );
+    }
+  );
+});
+
+describe("guarding the seed, and only where a transition record exists", () => {
+  // 🔴 An emitted file must NOT guard its seed. Two states leave default-locale rows behind and
+  // need opposite handling: an interrupted copy (keep them) and a companion that outlived a disable
+  // (they are stale, and main is authoritative). Only the transition record tells them apart, and a
+  // static file has none — so a guard there would silently revert edits made while localization was
+  // off. Unguarded it collides on the primary key instead: loud, and nothing lost.
+  it.each(["sqlite", "postgresql", "mysql"] as const)(
+    "leaves an emitted file's seed unguarded on %s",
+    dialect => {
+      expect(buildLocalizationUpSql(spec(dialect))).not.toContain(
+        "WHERE NOT EXISTS"
+      );
+    }
+  );
+
+  // The runtime resume asks for it, having read that record.
+  it.each(["sqlite", "postgresql", "mysql"] as const)(
+    "guards the seed row by row when the caller asks on %s",
+    dialect => {
+      const sql = buildLocalizationUpStatements(spec(dialect), {
+        guardSeed: true,
+      }).join("\n");
       const q = (id: string) => (dialect === "mysql" ? `\`${id}\`` : `"${id}"`);
       expect(sql).toContain(
         `WHERE NOT EXISTS (SELECT 1 FROM ${q("dc_pages_locales")} ` +
@@ -209,9 +240,7 @@ describe("running the same companion migration twice", () => {
     }
   );
 
-  // The control. Guarding must not cost the statements their actual work, so the seed still
-  // carries its columns and the drops still happen — without this, a generator that emitted only
-  // guards would satisfy every assertion above.
+  // The control. Guarding must not cost the statements their actual work.
   it("still seeds and still drops", () => {
     const sql = buildLocalizationUpSql(spec("sqlite"));
     expect(sql).toContain(

--- a/packages/nextly/src/domains/i18n/migration/generate-up.ts
+++ b/packages/nextly/src/domains/i18n/migration/generate-up.ts
@@ -12,7 +12,10 @@ import type { CompanionCopyRef, CompanionMigrationSpec } from "./types";
  */
 export const COMPANION_DEFAULT_STATUS = "draft";
 
-function buildCompanionCreateStatement(spec: CompanionMigrationSpec): string {
+function buildCompanionCreateStatement(
+  spec: CompanionMigrationSpec,
+  ifNotExists: boolean
+): string {
   const { dialect, mainTable, companionTable, parentIdType, columns } = spec;
   const colDefs = columns
     .map(c => `  ${q(c.name, dialect)} ${ddlType(c, dialect)}`)
@@ -21,18 +24,23 @@ function buildCompanionCreateStatement(spec: CompanionMigrationSpec): string {
   const statusDef = spec.status
     ? `  ${q("_status", dialect)} VARCHAR(20) NOT NULL DEFAULT '${COMPANION_DEFAULT_STATUS}',\n`
     : "";
-  // 🔴 `IF NOT EXISTS`, because this statement reaches a database that very often already has the
-  // table. `ensureCompanionTable` runs at boot and on every `db:sync`, so any project that ran the
-  // dev server before graduating to migrations arrives here with the companion already present —
-  // and the file this statement lands in is applied verbatim, statement by statement, with no
-  // enclosing transaction and no drift check. Without the guard `migrate` dies on the first
-  // companion file having already applied the ones before it.
+  // 🔴 `IF NOT EXISTS` is OPT-IN, and only an emitted migration FILE may ask for it.
   //
-  // Honest here rather than papering over a collision: a companion's shape is fully determined by
-  // its entity's localized fields, so a table under this name IS this table. That is not true of
-  // tables in general, which is why the guard is stated here and not adopted as a habit.
+  // A file reaches a database that very often already has the companion: `ensureCompanionTable`
+  // runs at boot and on every `db:sync`, so any project that ran the dev server before adopting
+  // migrations arrives with the table present. The file is applied verbatim, statement by
+  // statement, with no enclosing transaction — so without the guard `migrate` dies on the first
+  // companion file having already committed the ones before it. The guard is honest there: a
+  // companion's shape is fully determined by its entity's localized fields, so a table under this
+  // name IS this table.
+  //
+  // The RUNTIME must keep the bare form. `ensureCompanionTable` detects a lost create race by the
+  // `CREATE TABLE` failing — its catch branch says so outright — and uses that to tell a process
+  // that lost the race before claiming the transition from one that lost it after, which must
+  // abandon the apply rather than settle over a companion another process may not have seeded.
+  // `IF NOT EXISTS` would silence that signal and let both callers proceed as creators.
   return (
-    `CREATE TABLE IF NOT EXISTS ${q(companionTable, dialect)} (\n` +
+    `CREATE TABLE${ifNotExists ? " IF NOT EXISTS" : ""} ${q(companionTable, dialect)} (\n` +
     `  ${q("_parent", dialect)} ${parentIdType} NOT NULL,\n` +
     `  ${q("_locale", dialect)} VARCHAR(20) NOT NULL,\n` +
     statusDef +
@@ -44,24 +52,21 @@ function buildCompanionCreateStatement(spec: CompanionMigrationSpec): string {
 }
 
 /**
- * The `WHERE NOT EXISTS` that makes the seed safe to run more than once.
+ * The `WHERE NOT EXISTS` that lets a seed skip rows the companion already has.
  *
- * 🔴 The seed is an `INSERT ... SELECT` into a table whose primary key is
- * `(_parent, _locale)`, so running it twice collides. That is not hypothetical: the file it lands
- * in is applied statement by statement with no enclosing transaction, and MySQL commits DDL
- * implicitly regardless — so a failure anywhere in the file leaves the earlier statements committed
- * and the file recorded as *not* applied. The operator's only recovery is to run `migrate` again,
- * which replays the seed. Guarding it is what turns "work out by hand which statements landed" into
- * "run it again".
+ * 🔴 Requested by the RUNTIME resume only, never emitted into a migration file, and the asymmetry
+ * is a data-safety decision rather than an oversight.
  *
- * Expressed here, at generation, rather than bolted onto the statement by whoever executes it. Both
- * consumers reach this through {@link buildLocalizationUpStatements} — the emitted migration file
- * and the runtime resume in `companion-io` — and a guard applied by only one of them is how the two
- * paths came to disagree about idempotency in the first place.
+ * Two states leave a companion holding default-locale rows, and they need OPPOSITE handling. An
+ * interrupted copy leaves rows that came from main and must be kept. A companion that outlived a
+ * *disable* leaves rows that are stale by definition, because main was authoritative while
+ * localization was off — skipping those and then dropping main's columns reverts every edit made
+ * in between. Only the transition record distinguishes them, which is why the runtime consults it
+ * and sets `overwriteExisting`.
  *
- * Row-level rather than table-level on purpose: a *partially* seeded companion keeps the rows it
- * already has and gains only the ones it is missing, which is exactly the state an interrupted copy
- * leaves behind.
+ * A migration file has no such record: it is static SQL. Guarding its seed would make it silently
+ * pick the wrong answer in the second state, whereas leaving it unguarded makes it collide on the
+ * composite primary key — loudly, with nothing lost. A loud stop beats a quiet revert.
  */
 function buildSeedGuard(spec: CompanionMigrationSpec): string {
   const { dialect, mainTable, companionTable, defaultLocale } = spec;
@@ -80,9 +85,13 @@ function buildSeedGuard(spec: CompanionMigrationSpec): string {
  * and no main-table drop. Used when a collection is localized from birth.
  */
 export function buildCompanionCreateOnlySql(
-  spec: CompanionMigrationSpec
+  spec: CompanionMigrationSpec,
+  options: { emittedToFile?: boolean } = {}
 ): string {
-  return `${buildCompanionCreateStatement(spec)};`;
+  // Defaults to the runtime form. Two of this function's three callers execute the statement
+  // immediately rather than writing it to a file, so an opt-in default keeps them on today's
+  // behaviour and makes the file emitter say what it is.
+  return `${buildCompanionCreateStatement(spec, options.emittedToFile === true)};`;
 }
 
 /**
@@ -96,7 +105,7 @@ export function buildCompanionCreateOnlySql(
  * Companion columns are created nullable (localized columns are always nullable).
  */
 export function buildLocalizationUpSql(spec: CompanionMigrationSpec): string {
-  return buildLocalizationUpStatements(spec)
+  return buildLocalizationUpStatements(spec, { emittedToFile: true })
     .map(s => `${s};`)
     .join("\n\n");
 }
@@ -143,6 +152,22 @@ export interface LocalizationUpOptions {
    * both run against a main table that already has the column.
    */
   statusOnMain?: boolean;
+  /**
+   * Whether the companion `CREATE TABLE` may carry `IF NOT EXISTS`.
+   *
+   * True only for statements written into a migration FILE, which is applied verbatim against a
+   * database that has usually provisioned the companion already. The runtime leaves it false so
+   * `ensureCompanionTable` keeps detecting a lost create race by the statement failing.
+   */
+  emittedToFile?: boolean;
+  /**
+   * Whether the seed should skip rows the companion already holds.
+   *
+   * Asked for by the runtime resume, which has read the transition record and therefore knows the
+   * existing rows are an interrupted copy rather than the stale remains of a disable. See
+   * {@link buildSeedGuard} for why a migration file must not ask for it.
+   */
+  guardSeed?: boolean;
 }
 
 /**
@@ -158,7 +183,10 @@ export function buildLocalizationUpStatements(
 ): string[] {
   const { dialect, mainTable, companionTable, defaultLocale, columns } = spec;
 
-  const create = buildCompanionCreateStatement(spec);
+  const create = buildCompanionCreateStatement(
+    spec,
+    options.emittedToFile === true
+  );
 
   // Only columns already on the main table can be seeded from or dropped. A field added and
   // localized in the same save is in `columns` (so the companion gets it) but not on main, so
@@ -188,7 +216,7 @@ export function buildLocalizationUpStatements(
             `(${q("_parent", dialect)}, ${q("_locale", dialect)}${statusInsertCol}${onMainCols}) ` +
             `SELECT ${q("id", dialect)}, ${lit(defaultLocale)}${statusSelectCol}${onMainCols} ` +
             `FROM ${q(mainTable, dialect)}` +
-            buildSeedGuard(spec),
+            (options.guardSeed === true ? buildSeedGuard(spec) : ""),
         ]
       : [];
 

--- a/packages/nextly/src/domains/i18n/migration/generate-up.ts
+++ b/packages/nextly/src/domains/i18n/migration/generate-up.ts
@@ -21,8 +21,18 @@ function buildCompanionCreateStatement(spec: CompanionMigrationSpec): string {
   const statusDef = spec.status
     ? `  ${q("_status", dialect)} VARCHAR(20) NOT NULL DEFAULT '${COMPANION_DEFAULT_STATUS}',\n`
     : "";
+  // 🔴 `IF NOT EXISTS`, because this statement reaches a database that very often already has the
+  // table. `ensureCompanionTable` runs at boot and on every `db:sync`, so any project that ran the
+  // dev server before graduating to migrations arrives here with the companion already present —
+  // and the file this statement lands in is applied verbatim, statement by statement, with no
+  // enclosing transaction and no drift check. Without the guard `migrate` dies on the first
+  // companion file having already applied the ones before it.
+  //
+  // Honest here rather than papering over a collision: a companion's shape is fully determined by
+  // its entity's localized fields, so a table under this name IS this table. That is not true of
+  // tables in general, which is why the guard is stated here and not adopted as a habit.
   return (
-    `CREATE TABLE ${q(companionTable, dialect)} (\n` +
+    `CREATE TABLE IF NOT EXISTS ${q(companionTable, dialect)} (\n` +
     `  ${q("_parent", dialect)} ${parentIdType} NOT NULL,\n` +
     `  ${q("_locale", dialect)} VARCHAR(20) NOT NULL,\n` +
     statusDef +
@@ -30,6 +40,37 @@ function buildCompanionCreateStatement(spec: CompanionMigrationSpec): string {
     `  PRIMARY KEY (${q("_parent", dialect)}, ${q("_locale", dialect)}),\n` +
     `  FOREIGN KEY (${q("_parent", dialect)}) REFERENCES ${q(mainTable, dialect)} (${q("id", dialect)}) ON DELETE CASCADE\n` +
     `)`
+  );
+}
+
+/**
+ * The `WHERE NOT EXISTS` that makes the seed safe to run more than once.
+ *
+ * 🔴 The seed is an `INSERT ... SELECT` into a table whose primary key is
+ * `(_parent, _locale)`, so running it twice collides. That is not hypothetical: the file it lands
+ * in is applied statement by statement with no enclosing transaction, and MySQL commits DDL
+ * implicitly regardless — so a failure anywhere in the file leaves the earlier statements committed
+ * and the file recorded as *not* applied. The operator's only recovery is to run `migrate` again,
+ * which replays the seed. Guarding it is what turns "work out by hand which statements landed" into
+ * "run it again".
+ *
+ * Expressed here, at generation, rather than bolted onto the statement by whoever executes it. Both
+ * consumers reach this through {@link buildLocalizationUpStatements} — the emitted migration file
+ * and the runtime resume in `companion-io` — and a guard applied by only one of them is how the two
+ * paths came to disagree about idempotency in the first place.
+ *
+ * Row-level rather than table-level on purpose: a *partially* seeded companion keeps the rows it
+ * already has and gains only the ones it is missing, which is exactly the state an interrupted copy
+ * leaves behind.
+ */
+function buildSeedGuard(spec: CompanionMigrationSpec): string {
+  const { dialect, mainTable, companionTable, defaultLocale } = spec;
+  const comp = q(companionTable, dialect);
+  const main = q(mainTable, dialect);
+  return (
+    ` WHERE NOT EXISTS (SELECT 1 FROM ${comp} ` +
+    `WHERE ${comp}.${q("_parent", dialect)} = ${main}.${q("id", dialect)} ` +
+    `AND ${comp}.${q("_locale", dialect)} = ${lit(defaultLocale)})`
   );
 }
 
@@ -146,7 +187,8 @@ export function buildLocalizationUpStatements(
           `INSERT INTO ${q(companionTable, dialect)} ` +
             `(${q("_parent", dialect)}, ${q("_locale", dialect)}${statusInsertCol}${onMainCols}) ` +
             `SELECT ${q("id", dialect)}, ${lit(defaultLocale)}${statusSelectCol}${onMainCols} ` +
-            `FROM ${q(mainTable, dialect)}`,
+            `FROM ${q(mainTable, dialect)}` +
+            buildSeedGuard(spec),
         ]
       : [];
 

--- a/packages/nextly/src/domains/i18n/migration/plan-companion-migration.ts
+++ b/packages/nextly/src/domains/i18n/migration/plan-companion-migration.ts
@@ -98,7 +98,9 @@ export function planCompanionMigration(
 
   return {
     kind: "create-only",
-    upSql: buildCompanionCreateOnlySql(spec),
+    // Written to a migration file, so the create may guard against a companion the dev server
+    // or a `db:sync` has already provisioned.
+    upSql: buildCompanionCreateOnlySql(spec, { emittedToFile: true }),
     // Reverse of a bare CREATE is a DROP TABLE (no data to restore — main never had it).
     downSql: `DROP TABLE ${spec.dialect === "mysql" ? `\`${spec.companionTable}\`` : `"${spec.companionTable}"`};`,
   };

--- a/packages/nextly/src/domains/i18n/migration/write-migration-file.test.ts
+++ b/packages/nextly/src/domains/i18n/migration/write-migration-file.test.ts
@@ -46,7 +46,7 @@ describe("writeLocalizationMigrationFile", () => {
 
     // parses into non-empty UP and DOWN
     const { upSql, downSql } = parseSqlSections(readFileSync(path, "utf-8"));
-    expect(upSql).toContain(`CREATE TABLE "dc_pages_locales"`);
+    expect(upSql).toContain(`CREATE TABLE IF NOT EXISTS "dc_pages_locales"`);
     expect(downSql).toContain(`DROP TABLE "dc_pages_locales"`);
   });
 
@@ -59,6 +59,6 @@ describe("writeLocalizationMigrationFile", () => {
     expect(path).toMatch(/_disable_localization_pages\.sql$/);
     const { upSql, downSql } = parseSqlSections(readFileSync(path, "utf-8"));
     expect(upSql).toContain(`DROP TABLE "dc_pages_locales"`);
-    expect(downSql).toContain(`CREATE TABLE "dc_pages_locales"`);
+    expect(downSql).toContain(`CREATE TABLE IF NOT EXISTS "dc_pages_locales"`);
   });
 });

--- a/packages/nextly/src/domains/i18n/runtime/companion-io.ts
+++ b/packages/nextly/src/domains/i18n/runtime/companion-io.ts
@@ -818,15 +818,6 @@ async function resumeInterruptedSeed(
   const copy = plan.filter(statement => !statement.startsWith("CREATE TABLE"));
   if (copy.length === 0) return false;
 
-  const q = (id: string) =>
-    args.dialect === "mysql" ? `\`${id}\`` : `"${id}"`;
-  const companion = q(companionTableName);
-  const main = q(args.tableName);
-  const guard =
-    ` WHERE NOT EXISTS (SELECT 1 FROM ${companion} ` +
-    `WHERE ${companion}.${q("_parent")} = ${main}.${q("id")} ` +
-    `AND ${companion}.${q("_locale")} = '${args.sourceLocale ?? ""}')`;
-
   try {
     // The plan is real, so the transition is recorded — before the first statement, and only now
     // that there is something for it to describe.
@@ -869,11 +860,11 @@ async function resumeInterruptedSeed(
       }
     }
     for (const statement of copy) {
-      // Only the INSERT ... SELECT is row-producing and therefore needs the guard; anything else
-      // the plan carries (a nullability relax, for instance) is already idempotent.
-      await adapter.executeQuery(
-        statement.startsWith("INSERT INTO") ? `${statement}${guard}` : statement
-      );
+      // Issued as generated. The seed carries its own `WHERE NOT EXISTS` from
+      // `buildLocalizationUpStatements`, so this no longer appends one — matching on a statement's
+      // leading text to decide whether to rewrite it made the guard a property of the caller when
+      // it is a property of the statement, and left the emitted migration file without it.
+      await adapter.executeQuery(statement);
     }
     // The interrupted run's debt is discharged, so the record stops describing one.
     // A settlement that did not land means this run no longer holds the transition: someone took

--- a/packages/nextly/src/domains/i18n/runtime/companion-io.ts
+++ b/packages/nextly/src/domains/i18n/runtime/companion-io.ts
@@ -811,7 +811,12 @@ async function resumeInterruptedSeed(
   companionTableName: string,
   onError?: (error: unknown) => void
 ): Promise<boolean> {
-  const plan = await buildSeedingCreateStatements(adapter, args, newLocalized);
+  // The guard belongs to THIS path: it has read the transition record, so it knows the rows the
+  // companion already holds are an interrupted copy to be kept rather than the stale remains of a
+  // disable. The initial-create path has no such record and asks for the plain seed.
+  const plan = await buildSeedingCreateStatements(adapter, args, newLocalized, {
+    guardSeed: true,
+  });
   if (!plan) return false;
 
   // Everything the plan emits except the CREATE, which the interrupted run already ran.
@@ -860,10 +865,10 @@ async function resumeInterruptedSeed(
       }
     }
     for (const statement of copy) {
-      // Issued as generated. The seed carries its own `WHERE NOT EXISTS` from
-      // `buildLocalizationUpStatements`, so this no longer appends one — matching on a statement's
-      // leading text to decide whether to rewrite it made the guard a property of the caller when
-      // it is a property of the statement, and left the emitted migration file without it.
+      // Issued as generated. The seed carries its guard from `buildLocalizationUpStatements`,
+      // which this path asks for — matching on a statement's leading text to decide whether to
+      // rewrite it made the guard a property of whoever executed the statement rather than of the
+      // statement itself.
       await adapter.executeQuery(statement);
     }
     // The interrupted run's debt is discharged, so the record stops describing one.
@@ -945,7 +950,8 @@ async function buildSeedingCreateStatements(
     sourceLocale?: string;
     requireColumnsOnMain?: boolean;
   },
-  newLocalized: CompanionFieldLike[]
+  newLocalized: CompanionFieldLike[],
+  options: { guardSeed?: boolean } = {}
 ): Promise<string[] | null> {
   if (!args.sourceLocale) return null;
 
@@ -999,6 +1005,7 @@ async function buildSeedingCreateStatements(
     { ...spec, columnsOnMain },
     {
       dropSeededColumns: false,
+      guardSeed: options.guardSeed,
       // Retained columns that were required must stop being so, or the first create after this
       // transition fails: the value now goes to the companion, so the main insert omits it.
       relaxColumns: onMain.filter(c => !c.nullable).map(c => c.name),

--- a/packages/nextly/src/domains/schema/migrate-create/__tests__/generate.localized-companion.test.ts
+++ b/packages/nextly/src/domains/schema/migrate-create/__tests__/generate.localized-companion.test.ts
@@ -89,7 +89,9 @@ describe("generateMigration — localized companion emission", () => {
       resolve(migrationsDir, companion!),
       "utf-8"
     );
-    expect(companionSql).toContain(`CREATE TABLE "dc_docs_locales"`);
+    expect(companionSql).toContain(
+      `CREATE TABLE IF NOT EXISTS "dc_docs_locales"`
+    );
     expect(companionSql).not.toContain("INSERT INTO");
     expect(companionSql).not.toContain("DROP COLUMN");
     // No paired snapshot for the companion (runs verbatim).
@@ -151,7 +153,9 @@ describe("generateMigration — localized companion emission", () => {
       resolve(migrationsDir, companion!),
       "utf-8"
     );
-    expect(companionSql).toContain(`CREATE TABLE "dc_pages_locales"`);
+    expect(companionSql).toContain(
+      `CREATE TABLE IF NOT EXISTS "dc_pages_locales"`
+    );
     expect(companionSql).toContain("INSERT INTO");
     expect(companionSql).toContain(`SELECT "id", 'en', "body"`);
     expect(companionSql).toContain(`ALTER TABLE "dc_pages" DROP COLUMN "body"`);


### PR DESCRIPTION
Closes the last blocker on the `db:sync` → migrations graduation path for a localized project. Task `077`, P1.

## The reported failure

`migrate` dies on the first companion file, **after** committing the ones before it:

```
✓ Applied 20260728_194534_457_localize_after_baseline.sql
⚠ No snapshot for 20260728_194534_458_enable_localization_posts.sql; applying verbatim without drift checks.
✗ Query failed: table "dc_posts_locales" already exists
```

Not an edge case: `ensureCompanionTable` runs at boot and on every `db:sync`, so any project that ran the dev server before adopting migrations arrives here with the companion already present.

## What the research changed about the fix

The task proposes adding `IF NOT EXISTS`. The UP is **three** statements, and the other two are equally unguarded.

- **Boot creates the companion EMPTY.** `di/register.ts:1075` calls `ensureCompanionTable` without `sourceLocale`, which that function documents as creating an empty companion rather than performing a transition. *That is why `IF NOT EXISTS` looks like the whole fix* — on that one starting state the seed and the drops would both have succeeded.
- **The acceptance criteria need the seed guarded too.** The realistic replay is not an operator re-applying a recorded file (the journal prevents that) — it is recovery from the partial application this task exists to fix, and it collides on the composite primary key `(_parent, _locale)`.
- **The file is not atomic and cannot be made so.** `migrate.ts:598` calls `executeSql` directly rather than through `executeTransaction`, and MySQL commits DDL implicitly regardless. Partial application is structural, which is exactly why each statement must be individually idempotent rather than relying on all-or-nothing.

### 🔴 The finding that shaped the design

The migration-file path re-implements, badly, what the runtime path already solves well. `resumeInterruptedSeed` in `companion-io.ts` already builds the exact `WHERE NOT EXISTS` this file lacked, and states the principle in its own doc — but it appended it **at execution time, to any statement whose text began with `INSERT INTO`**. That made idempotency a property of the caller instead of the statement, and left the emitted migration file, which nothing rewrites, without it.

So the guard is now generated **once**, inside `buildLocalizationUpStatements`, which both consumers already reach. The runtime's string-append is gone. That also closed an escaping gap: the runtime interpolated the locale raw, while the generator renders it through `lit()`.

## Verification

Every test proven load-bearing by breaking the code, and the integration legs reproduce the **real** database errors:

| Break | Result |
|---|---|
| create guard removed | 5 unit cases fail; integration fails with `relation "…_locales" already exists` — the reported bug |
| seed guard removed | exactly the 3 seed cases fail; integration fails with `duplicate key value violates unique constraint "…_pkey"` |

- `pnpm build` clean, `pnpm check-types --force` 19/19, `pnpm lint` exit 0
- Unit: failure set **identical at test-name level** to a freshly measured `1f4d010b3` baseline (400 lines each); totals 6590 → 6597, the seven new cases and nothing else
- Integration: **8 passed** across Postgres 17 and SQLite, driving the real `runFileMigrations` path

⚠️ One pre-existing flake observed while measuring, unrelated to this change: `introspects the migrated registry and never the legacy one` (`init/__tests__/core-schema-drift-registry.test.ts`) fails in some full runs and passes in isolation. It failed in baseline run 1 and passed in baseline run 2. Reported rather than absorbed; I will open it separately.

## Deliberately not in this PR

- **A guard on the drops.** `DROP COLUMN IF EXISTS` exists on PostgreSQL but **not on MySQL 8 or SQLite**, so there is no portable SQL guard. Two tempting answers were rejected as workarounds: per-dialect divergence, and tolerating "column does not exist" in the runner. The architecturally correct answer is to pair the companion file with a snapshot so the diff pipeline computes the delta — that changes how `migrate` treats a whole file class and deserves its own slice. Follow-up task to be opened with `tasks/077-COMPANION-IDEMPOTENCY-DESIGN.md` as its input.
- **Reporting which statements inside a file landed** (task step 3). A runner concern that applies to every hand-written migration, not a companion concern.
