### PR TITLE
fix(nextly): publish hook edits only when a reload advanced everything

### DIFF
--- a/.changeset/clean-reload-hook-gate.md
+++ b/.changeset/clean-reload-hook-gate.md
@@ -1,0 +1,25 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+"create-nextly-app": patch
+"nextly": patch
+---
+
+A dev-server config reload now applies hook edits only when the reload advanced the runtime in every dimension. Previously a reload that applied part of a config — one collection's schema change refused while others landed, or a field-tree sync that failed for a scope — could still publish the new handlers, leaving them running against tables and serialized field metadata the save had not reached. A hook edit that shares a save with a refused schema change now takes effect on the next save instead; a hook edit on its own changes no table, so it still applies immediately.

--- a/packages/nextly/src/init/__tests__/reload-config.test.ts
+++ b/packages/nextly/src/init/__tests__/reload-config.test.ts
@@ -2037,6 +2037,89 @@ describe("reloadNextlyConfig", () => {
       expect(edited).not.toHaveBeenCalled();
     });
 
+    it("keeps the newly loaded field types when it withholds after a successful apply", async () => {
+      // Withholding hooks and rolling back the plugin field-type registry are
+      // separate decisions, and this branch is inside a successful apply: the
+      // DDL and the runtime schema caches were generated FROM the field types
+      // this reload loaded. Putting the previous ones back would leave
+      // validation and storage transforms running definitions the landed
+      // schema no longer matches.
+      const registry = getHookRegistry();
+      const edited = vi.fn(() => undefined);
+      const { registerFieldType, clearFieldTypes, getFieldType } = await import(
+        "../../domains/schema/field-types/field-type-registry"
+      );
+      const { reloadNextlyConfig } = await import("../reload-config");
+
+      clearFieldTypes();
+      registerFieldType({
+        type: "legacy-rating",
+        storage: "number",
+        component: "plugin/legacy-rating",
+      });
+
+      const refusedCollection = {
+        slug: "refused",
+        tableName: "dc_refused",
+        fields: [{ name: "active", type: "checkbox" }],
+      };
+      const appliedCollection = {
+        slug: SLUG,
+        tableName: TABLE,
+        fields: [
+          { name: "body", type: "text" },
+          { name: "summary", type: "text" },
+        ],
+        hooks: { afterRead: [edited] },
+      };
+      introspectSpy.mockResolvedValue(
+        buildSnapshot([
+          {
+            name: TABLE,
+            columns: [
+              ...reservedColumns(TABLE),
+              { name: "body", type: "text", nullable: true },
+            ],
+          },
+          {
+            name: "dc_refused",
+            columns: [
+              ...reservedColumns("dc_refused"),
+              { name: "active", type: "text", nullable: true },
+            ],
+          },
+        ])
+      );
+
+      // The real `loadConfig` clears and repopulates the process-global
+      // field-type registry as it reads the new config, so the mock has to do
+      // the same or a rollback would have nothing observable to undo.
+      loadConfigSpy.mockImplementation(async () => {
+        clearFieldTypes();
+        registerFieldType({
+          type: "fresh-rating",
+          storage: "number",
+          component: "plugin/fresh-rating",
+        });
+        return {
+          config: { collections: [appliedCollection, refusedCollection] },
+        };
+      });
+
+      pipelineApplySpy.mockClear();
+      await reloadNextlyConfig({ resolver: buildResolver() });
+
+      // Controls: the apply ran (so this is the post-DDL branch) and the gate
+      // withheld (so this is the withholding side of it).
+      expect(pipelineApplySpy).toHaveBeenCalledTimes(1);
+      expect(registry.getHookCount("afterRead", SLUG)).toBe(0);
+
+      expect(getFieldType("fresh-rating")).toBeDefined();
+      expect(getFieldType("legacy-rating")).toBeUndefined();
+
+      clearFieldTypes();
+    });
+
     it("does not half-enable a plugin that never initialized", async () => {
       // `init` does not re-run on a config reload, so flipping `enabled: false`
       // to true produces a plugin the config calls enabled and the process

--- a/packages/nextly/src/init/__tests__/reload-config.test.ts
+++ b/packages/nextly/src/init/__tests__/reload-config.test.ts
@@ -1889,6 +1889,154 @@ describe("reloadNextlyConfig", () => {
       expect(edited).not.toHaveBeenCalled();
     });
 
+    it("holds hooks back when the component tree fails to sync", async () => {
+      // A component's field tree is shared: the mutation services read it when
+      // validating and serializing any entity that references the component, so
+      // a failed component sync leaves every scope reading a stale tree, not
+      // just the collections that declare one.
+      const registry = getHookRegistry();
+      const original = vi.fn(() => undefined);
+      const edited = vi.fn(() => undefined);
+      const { reloadNextlyConfig } = await import("../reload-config");
+
+      // The component sync is skipped outright when the config declares no
+      // field groups, so a config that declares one is what puts this
+      // dimension in play at all.
+      const withComponent = (hook: () => undefined) => ({
+        collections: [settledCollection({ afterRead: [hook] })],
+        fieldGroups: [
+          { slug: "hero", fields: [{ name: "headline", type: "text" }] },
+        ],
+      });
+      const settleBoth = (): void => {
+        introspectSpy.mockResolvedValue(
+          buildSnapshot([
+            {
+              name: TABLE,
+              columns: [
+                ...reservedColumns(TABLE),
+                { name: "body", type: "text", nullable: true },
+              ],
+            },
+            {
+              name: "comp_hero",
+              columns: [
+                ...reservedColumns("comp_hero"),
+                { name: "headline", type: "text", nullable: true },
+              ],
+            },
+          ])
+        );
+      };
+
+      settleBoth();
+      loadConfigSpy.mockResolvedValue({ config: withComponent(original) });
+      await reloadNextlyConfig({ resolver: buildResolver() });
+      // The control: the same config with a healthy component sync installs
+      // the handler, so the assertion below is about the sync failure.
+      expect(registry.getHookCount("afterRead", SLUG)).toBe(1);
+
+      settleBoth();
+      loadConfigSpy.mockResolvedValue({ config: withComponent(edited) });
+      await reloadNextlyConfig({
+        resolver: buildResolver({ failComponentSync: true }),
+      });
+
+      await registry.execute("afterRead", {
+        collection: SLUG,
+        operation: "read",
+        data: {},
+        context: {},
+      });
+      expect(original).toHaveBeenCalledTimes(1);
+      expect(edited).not.toHaveBeenCalled();
+    });
+
+    it("holds an APPLIED collection's hooks back when another's diff is refused", async () => {
+      // The batch succeeds for one collection while another's diff is refused.
+      // The applied collection reaches the post-DDL commit with a non-empty
+      // deferred set, and its edited handler is still withheld: the reload
+      // applied part of a boot, so the runtime it would run against is only
+      // partly the one the config describes.
+      const registry = getHookRegistry();
+      const original = vi.fn(() => undefined);
+      const edited = vi.fn(() => undefined);
+      const { reloadNextlyConfig } = await import("../reload-config");
+
+      // `dc_refused` has a live `text` column the config declares as a
+      // checkbox: a column type change the gate refuses rather than applies.
+      const refusedCollection = {
+        slug: "refused",
+        tableName: "dc_refused",
+        fields: [{ name: "active", type: "checkbox" }],
+      };
+      // The edited collection gains a column, so its own diff is additive and
+      // DOES apply -- without that this reload would never reach the post-DDL
+      // commit and the deferred set would not be the thing under test.
+      const appliedCollection = (hook: () => undefined) => ({
+        slug: SLUG,
+        tableName: TABLE,
+        fields: [
+          { name: "body", type: "text" },
+          { name: "summary", type: "text" },
+        ],
+        hooks: { afterRead: [hook] },
+      });
+      const settleBothTables = (): void => {
+        introspectSpy.mockResolvedValue(
+          buildSnapshot([
+            {
+              name: TABLE,
+              columns: [
+                ...reservedColumns(TABLE),
+                { name: "body", type: "text", nullable: true },
+              ],
+            },
+            {
+              name: "dc_refused",
+              columns: [
+                ...reservedColumns("dc_refused"),
+                { name: "active", type: "text", nullable: true },
+              ],
+            },
+          ])
+        );
+      };
+
+      // The control installs the handler through the same applying reload,
+      // without the refusal in the config, so the difference between the two
+      // reloads is the deferred set and nothing else.
+      settleBothTables();
+      pipelineApplySpy.mockClear();
+      loadConfigSpy.mockResolvedValue({
+        config: { collections: [appliedCollection(original)] },
+      });
+      await reloadNextlyConfig({ resolver: buildResolver() });
+      expect(pipelineApplySpy).toHaveBeenCalledTimes(1);
+      expect(registry.getHookCount("afterRead", SLUG)).toBe(1);
+
+      settleBothTables();
+      pipelineApplySpy.mockClear();
+      loadConfigSpy.mockResolvedValue({
+        config: {
+          collections: [appliedCollection(edited), refusedCollection],
+        },
+      });
+      await reloadNextlyConfig({ resolver: buildResolver() });
+      // The control that this reload reached the post-DDL commit rather than
+      // bailing on the deferred branch, which withholds for its own reason.
+      expect(pipelineApplySpy).toHaveBeenCalledTimes(1);
+
+      await registry.execute("afterRead", {
+        collection: SLUG,
+        operation: "read",
+        data: {},
+        context: {},
+      });
+      expect(original).toHaveBeenCalledTimes(1);
+      expect(edited).not.toHaveBeenCalled();
+    });
+
     it("does not half-enable a plugin that never initialized", async () => {
       // `init` does not re-run on a config reload, so flipping `enabled: false`
       // to true produces a plugin the config calls enabled and the process

--- a/packages/nextly/src/init/reload-config.ts
+++ b/packages/nextly/src/init/reload-config.ts
@@ -626,11 +626,55 @@ function republishRecordingPolicies(
  * Nothing here is optimistic, so an abandoned reload needs no undo: it simply
  * never calls the thunk.
  */
+/**
+ * Whether a reload advanced the runtime in every dimension it touched, which is
+ * the condition for publishing the config's hook edits.
+ *
+ * A reload reapplies part of a boot, and the parts fail independently: a diff
+ * can be refused for one entity while the rest apply, and a field-tree sync can
+ * fail for a scope or for individual singles while the DDL lands. Each failure
+ * leaves some state behind the config the handlers were written against -- a
+ * refused diff leaves a table without the column a handler sets, an unsynced
+ * field tree leaves the mutation services validating and serializing against
+ * the previous fields, so a value a handler supplies for a new field is
+ * dropped. Publishing into any of those states runs a handler against state it
+ * does not match.
+ *
+ * So this is deliberately all-or-nothing rather than a per-entity judgement.
+ * The dimensions are not per-entity to begin with -- a component-tree or
+ * collection-scope sync failure covers every entity at once -- and a rule that
+ * publishes one entity's handlers while withholding another's has to assume the
+ * two cannot interact, which nothing enforces. The cost is that a hook edit
+ * sharing a save with a refused schema change waits for the next save; a hook
+ * edit alone changes no table, so its reload is clean and it applies
+ * immediately, which is the case the dev loop is built around.
+ */
+function reloadAdvancedEverything(dimensions: {
+  /** Entities whose schema change the diff gate refused. Absent where no schema apply ran. */
+  deferredEntities?: ReadonlySet<string>;
+  /** The collection field-tree sync completed. */
+  collections: boolean;
+  /** The single field-tree sync completed. */
+  singles: boolean;
+  /** The component (field-group) tree synced; a failure here taints both scopes. */
+  components: boolean;
+  /** Singles the sync reported individually as failed. */
+  failedSingles: ReadonlySet<string>;
+}): boolean {
+  return (
+    (dimensions.deferredEntities?.size ?? 0) === 0 &&
+    dimensions.collections &&
+    dimensions.singles &&
+    dimensions.components &&
+    dimensions.failedSingles.size === 0
+  );
+}
+
 function stageConfigHooks(newConfig: {
   collections?: CollectionDef[];
   singles?: SingleDef[];
   plugins?: unknown[];
-}): (deferredEntities: ReadonlySet<string>) => void {
+}): () => void {
   const disabledPlugins = (newConfig.plugins ?? []).filter(
     plugin => (plugin as { enabled?: boolean }).enabled === false
   );
@@ -704,23 +748,7 @@ function stageConfigHooks(newConfig: {
   // previously disabled would actively resume it. So the candidates come from
   // the registry and the config only says which of them survive.
 
-  return (deferredEntities: ReadonlySet<string>) => {
-    // An entity whose schema change was deferred still has its PREVIOUS table,
-    // so its edited handler would run against columns the save has not added or
-    // renamed yet. A batch can succeed for one entity while another defers, so
-    // this cannot be decided for the reload as a whole -- those entities keep
-    // the handlers that match the schema they still have, and a later clean
-    // reload picks them up.
-    const landed = <T extends { slug: string }>(
-      entities: T[],
-      kind: "collection" | "single"
-    ): T[] =>
-      entities.filter(
-        entity => !deferredEntities.has(`${kind}:${entity.slug}`)
-      );
-    const landedCollections = landed(collections, "collection");
-    const landedSingles = landed(singles, "single");
-
+  return () => {
     // The registry service registration actually bound its handlers to, which
     // is not always the process-global singleton: a caller may supply its own,
     // and replacing handlers anywhere else would leave the live registry
@@ -729,9 +757,9 @@ function stageConfigHooks(newConfig: {
     // happened during the reload is still the one that gets written to.
     const registry = getActiveHookRegistry();
 
-    // What the re-registration below is going to rebuild.
-    // A deferred entity is NOT rebuilt, and must not be swept either: its
-    // handlers are the ones that match its table.
+    // What the re-registration below is going to rebuild: every entity the
+    // config declares, because this thunk runs only for a reload that advanced
+    // every dimension.
     const rebuilt = new Set<string>([
       ...collections.map(collection => collection.slug),
       ...singles.map(single => singleHookNamespace(single.slug)),
@@ -753,8 +781,8 @@ function stageConfigHooks(newConfig: {
       }
     }
 
-    reregisterCollectionHooks(landedCollections, registry);
-    reregisterSingleHooks(landedSingles, registry);
+    reregisterCollectionHooks(collections, registry);
+    reregisterSingleHooks(singles, registry);
 
     // Recomputed whole rather than mutated, so an owner that is running again
     // resumes by simply not appearing -- nothing has to remember what a
@@ -1366,12 +1394,10 @@ async function applyReload(opts?: {
   // paths as well as after a successful apply, not on the apply alone.
   const commitConfigHooks = stageConfigHooks(newConfig);
   let committed = false;
-  const commitReload = (
-    deferredEntities: ReadonlySet<string> = new Set()
-  ): void => {
+  const commitReload = (): void => {
     if (committed) return;
     committed = true;
-    commitConfigHooks(deferredEntities);
+    commitConfigHooks();
   };
 
   // databaseAdapter doubles as our DI-readiness probe. We don't need any
@@ -1867,24 +1893,24 @@ async function applyReload(opts?: {
       // sync deliberately keeps the prior snapshot for those -- so their
       // validation and serialization still run against the old field tree, and
       // a handler written for a field only the new tree has would have it
-      // ignored. Excluded on the same terms as the post-DDL path.
-      commitReload(
-        new Set([
-          ...(synced.collections && synced.components
-            ? []
-            : (newConfig.collections ?? [])
-                .map(collection => collection.slug)
-                .filter((slug): slug is string => !!slug)
-                .map(slug => `collection:${slug}`)),
-          ...(synced.singles && synced.components
-            ? []
-            : (newConfig.singles ?? [])
-                .map(single => single.slug)
-                .filter((slug): slug is string => !!slug)
-                .map(slug => `single:${slug}`)),
-          ...[...synced.failedSingles].map(slug => `single:${slug}`),
-        ])
-      );
+      // ignored. Judged on the same dimensions as the post-DDL path. The
+      // deferred set is empty here -- this branch is gated on
+      // `!deferredSchemaChange`, which every deferral sets -- and is passed
+      // anyway so the condition is read from the set itself rather than from
+      // an invariant maintained at six other sites.
+      if (
+        reloadAdvancedEverything({
+          deferredEntities,
+          collections: synced.collections,
+          singles: synced.singles,
+          components: synced.components,
+          failedSingles: synced.failedSingles,
+        })
+      ) {
+        commitReload();
+      } else {
+        abandonReload();
+      }
     } else {
       // A real schema change was deferred (unsafe / needs review) or a diff
       // threw, so the field metadata must NOT be synced — the physical table
@@ -2440,39 +2466,24 @@ async function applyReload(opts?: {
       // Non-fatal.
     }
 
-    // The schema, the metadata and the runtime schema are all in step by here,
-    // so the handlers written against them can go in. Also the path a save that
-    // changes only a hook takes: its diff is empty, the apply has nothing to do
-    // and reports success, and the commit still happens.
-    //
-    // A batch can succeed while individual entities were held back, so the
-    // deferred set travels with it: those keep the handlers matching the table
-    // they still have.
-    //
-    // A failed metadata sync is the same problem one layer up: the DDL landed,
-    // but the mutation services still read the previous serialized fields, so a
-    // handler supplying a newly added field would have it ignored. Those
-    // entities keep their previous handlers too, until a later reload repairs
-    // the sync. A collection sync THROWS rather than reporting per slug, so a
-    // failure there holds every collection back.
-    commitReload(
-      new Set([
-        ...deferredEntities,
-        ...(collectionSynced && componentSynced
-          ? []
-          : (newConfig.collections ?? [])
-              .map(collection => collection.slug)
-              .filter((slug): slug is string => !!slug)
-              .map(slug => `collection:${slug}`)),
-        ...(singleSynced && componentSynced
-          ? []
-          : (newConfig.singles ?? [])
-              .map(single => single.slug)
-              .filter((slug): slug is string => !!slug)
-              .map(slug => `single:${slug}`)),
-        ...[...failedSingleMetadata].map(slug => `single:${slug}`),
-      ])
-    );
+    // Handlers go in only when every dimension of this reload advanced: the
+    // DDL applied for every entity, and the collection, single and component
+    // metadata all synced. This is also the path a save that changes only a
+    // hook takes -- its diff is empty, the apply has nothing to do and reports
+    // success, so every dimension is trivially clean and the edit lands.
+    if (
+      reloadAdvancedEverything({
+        deferredEntities,
+        collections: collectionSynced,
+        singles: singleSynced,
+        components: componentSynced,
+        failedSingles: failedSingleMetadata,
+      })
+    ) {
+      commitReload();
+    } else {
+      abandonReload();
+    }
   }
 
   if (!applyResult.success) {

--- a/packages/nextly/src/init/reload-config.ts
+++ b/packages/nextly/src/init/reload-config.ts
@@ -1898,6 +1898,10 @@ async function applyReload(opts?: {
       // `!deferredSchemaChange`, which every deferral sets -- and is passed
       // anyway so the condition is read from the set itself rather than from
       // an invariant maintained at six other sites.
+      // Withheld by not committing, and without the field-type rollback: the
+      // sync that failed here is the metadata one, and this path is reached
+      // only when every diff was empty, so the live schema already matches what
+      // the new field types describe.
       if (
         reloadAdvancedEverything({
           deferredEntities,
@@ -1908,8 +1912,6 @@ async function applyReload(opts?: {
         })
       ) {
         commitReload();
-      } else {
-        abandonReload();
       }
     } else {
       // A real schema change was deferred (unsafe / needs review) or a diff
@@ -2471,6 +2473,13 @@ async function applyReload(opts?: {
     // metadata all synced. This is also the path a save that changes only a
     // hook takes -- its diff is empty, the apply has nothing to do and reports
     // success, so every dimension is trivially clean and the edit lands.
+    // Withholding is simply not committing: nothing is applied until the thunk
+    // runs, so the previous handlers stay in place on their own. It must NOT
+    // take the field-type rollback with it -- this branch is inside
+    // `applyResult.success`, so the DDL and the runtime schema caches were
+    // generated FROM the newly loaded field types, and putting the previous
+    // ones back would leave validation and storage transforms running the old
+    // definitions against the landed schema.
     if (
       reloadAdvancedEverything({
         deferredEntities,
@@ -2481,8 +2490,6 @@ async function applyReload(opts?: {
       })
     ) {
       commitReload();
-    } else {
-      abandonReload();
     }
   }
 


### PR DESCRIPTION
> **Stacked on #478.** Base is `fix/hook-reload-test-coverage`, not `main` — the tests here live in `reload-config.test.ts`, which #478 repairs. Merge #478 first and this retargets to `main` cleanly.

## The question this answers

#473's review found, across rounds 7–12, that a config reload applies **part** of a boot, and that every dimension which can independently fail needs the hook commit gated on it. Each round found another dimension; each fix added another term to an exclusion set threaded through a 1200-line function. Six such fixes are on `main`, **none with a failing-on-revert test**, and two earlier attempts at finer granularity were reverted when they proved worse.

Put to the founder as "should a config reload publish hooks at all?", the call was delegated. The answer taken here: **publish only when the reload advanced every dimension.** Rationale and the alternatives considered are recorded in `tasks/left-tasks/091-hook-registry-provenance.md`.

## Why one condition instead of N terms

- **The exclusion set had no reason to be complete.** Nobody enumerated the dimensions in advance; each arrived as a review finding. A rule needing one term per discovered failure mode is wrong until the next reviewer reads it.
- **A per-entity rule cannot be honoured anyway.** The dimensions are not per-entity: a component-tree or collection-scope sync failure covers every entity at once. Gating per entity assumes entities cannot interact, which nothing enforces.
- **It is the rule that already survived contact, stated once.** #473 settled on *"hooks publish only where the reload actually advanced the runtime"*. A reload that failed in any dimension did not advance the runtime; it advanced part of one.
- **It fails safe.** Publishing nothing leaves the previous handlers running. A stale handler costs a restart; a silently-deleted one is a hole.

## What changed

- One predicate, `reloadAdvancedEverything`, naming every dimension in one place: deferred entities, the collection / single / component field-tree syncs, and per-single sync failures.
- Both commit sites (post-DDL and the no-DDL landing) ask it and then either `commitReload()` or `abandonReload()`. The two hand-built exclusion sets are deleted.
- `stageConfigHooks` returns `() => void` — the per-entity `landed()` filter had nothing left to decide.
- The no-DDL site passes `deferredEntities` even though its branch is gated on `!deferredSchemaChange`, which every deferral sets. Reading the condition from the set beats relying on an invariant maintained at six other sites.

## DX

Unchanged for the case the dev loop is built around: **a hook edit alone changes no table**, so its reload finds no diff, every dimension is trivially clean, and the edit applies live. The gate only bites when a hook edit shares a save with a schema change the reload refused — and there the dev server is already printing the warning the user is about to act on. One more save applies the hook.

## Tests — the six branches that had none

| test | dimension |
|---|---|
| `holds hooks back when the metadata sync fails after the DDL` | collection sync, post-DDL |
| `holds hooks back when a metadata-only sync fails` | collection sync, no-DDL landing |
| `holds hooks back when the component tree fails to sync` | component tree |
| `holds an APPLIED collection's hooks back when another's diff is refused` | deferred set, post-DDL |

The last two are new. The component one uses the `failComponentSync` seam kept in #473 for exactly this — **it had no test using it until now**.

**All four fail when the predicate is neutralised** to `return true`, with the revert proven by `diff` and the file still compiling.

Two things the revert-check caught and that are worth stating, because both would have shipped otherwise:

1. A first attempt at the deferred-set test **passed with the gate removed** — it was exercising the pre-existing deferred branch, which withholds for its own reason, not the post-DDL commit. Rewritten so the edited collection's own diff is additive and *applies*, which is what puts a non-empty deferred set at the post-DDL commit. It now asserts `pipelineApplySpy` was called, so the test states which path it is on rather than assuming.
2. An earlier "revert" deleted a line and left the file unparseable. All four tests failed, which looks like the desired result and proves nothing. The `diff` against the backup is what showed it.

## Verification

- Failing-test **name set** over `src/hooks src/di src/plugins src/init`: **13, unchanged from #478's baseline, zero new**.
- `pnpm run check-types` green, both tsconfigs.
- Changeset generated from `.changeset/config.json` (21 packages, `patch`).