### PR TITLE
fix(nextly): resolve the test harness Direct API on access

### DIFF
--- a/.changeset/test-harness-lazy-direct-api.md
+++ b/.changeset/test-harness-lazy-direct-api.md
@@ -1,0 +1,25 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+"create-nextly-app": patch
+"nextly": patch
+---
+
+`createTestNextly` no longer resolves the Direct API while building its return value. `t.nextly` is now resolved when it is read. Resolving it registers the `nextlyDirectAPI` container binding as a side effect, and that binding is where a hook's `req.nextly` comes from, so the old eager call meant the binding always existed under the harness whatever the code under test did. Property access is unchanged for callers; a test that wants to assert something about `req.nextly` should do so before reading `t.nextly`.

--- a/packages/nextly/src/direct-api/nextly.ts
+++ b/packages/nextly/src/direct-api/nextly.ts
@@ -684,6 +684,21 @@ export function resetNextlyInstance(): void {
 }
 
 /**
+ * Whether the Direct API singleton has been built in this process.
+ *
+ * Answers the question without building it, which `getNextly()` cannot: asking
+ * it constructs the instance and registers the container binding. That makes
+ * "was the Direct API resolved?" unobservable through the ordinary surface, so
+ * a test cannot tell a caller that resolved it lazily from one that never
+ * touched it at all.
+ *
+ * @internal
+ */
+export function isNextlyInstantiated(): boolean {
+  return Boolean(globalForDirectApi.__nextly_directApiInstance);
+}
+
+/**
  * Module-level convenience object for Direct API operations.
  *
  * Each method lazily resolves the Nextly singleton on first call,

--- a/packages/nextly/src/domains/collections/__tests__/hook-req-nextly.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/hook-req-nextly.integration.test.ts
@@ -20,7 +20,10 @@ import { afterEach, describe, expect, it } from "vitest";
 import { createAdapter } from "../../../database/factory";
 import { container } from "../../../di/container";
 import { registerServices, shutdownServices } from "../../../di/register";
-import { resetNextlyInstance } from "../../../direct-api/nextly";
+import {
+  isNextlyInstantiated,
+  resetNextlyInstance,
+} from "../../../direct-api/nextly";
 import { resetEventBus } from "../../../events/event-bus";
 import { resetFilterRegistry } from "../../../filters";
 import { resetHookRegistry } from "../../../hooks/hook-registry";
@@ -103,21 +106,43 @@ describe("the ordinary test harness leaves the binding to service registration",
     resetAll();
   });
 
-  it("has nextlyDirectAPI bound after createTestNextly, without reading t.nextly", async () => {
+  it("boots without resolving the Direct API, and binds it anyway", async () => {
     await shutdownServices();
     resetAll();
 
-    // The control: nothing in this process has resolved the Direct API, so a
-    // binding found below was made by the boot rather than left behind.
+    // The controls: nothing in this process has resolved the Direct API or
+    // bound it, so neither observation below can be left over from earlier.
+    expect(isNextlyInstantiated()).toBe(false);
     expect(container.has("nextlyDirectAPI")).toBe(false);
 
     current = await createTestNextly({ dialect: "sqlite" });
 
-    // Deliberately does NOT touch `current.nextly`. That property resolves the
-    // Direct API on access, and resolving it registers the binding as a side
-    // effect -- so reading it here would satisfy the assertion by itself and
-    // certify nothing. What is under test is that service registration bound
-    // it, which is what gives a hook its `req.nextly`.
+    // The binding exists, and the harness is not what created it. Checking the
+    // binding alone would not say that: service registration binds it before
+    // the harness assembles its return value, so `container.has(...)` is true
+    // whether the harness resolves the Direct API or not, and a guard reading
+    // only that stays green if the harness goes back to resolving it eagerly.
+    // Whether the singleton was BUILT is the independent observation, because
+    // that is what an eager `getNextly()` does and a lazy property does not.
+    expect(isNextlyInstantiated()).toBe(false);
     expect(container.has("nextlyDirectAPI")).toBe(true);
+
+    // The mirror: reading the property does resolve it, so the assertion above
+    // reflects the boot rather than the Direct API being unreachable.
+    expect(current.nextly).toBeDefined();
+    expect(isNextlyInstantiated()).toBe(true);
+  });
+
+  it("keeps `nextly` assignable, as the declared type allows", async () => {
+    // `TestNextly.nextly` is not readonly, so `handle.nextly = stub` compiles
+    // and did work while the property was a plain data property. A getter with
+    // no setter would make that same code throw under the strict mode ES
+    // modules run in, which is a silent break for any suite that stubs it.
+    current = await createTestNextly({ dialect: "sqlite" });
+
+    const stub = { marker: "stubbed" } as unknown as typeof current.nextly;
+    current.nextly = stub;
+
+    expect(current.nextly).toBe(stub);
   });
 });

--- a/packages/nextly/src/domains/collections/__tests__/hook-req-nextly.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/hook-req-nextly.integration.test.ts
@@ -7,10 +7,12 @@
  * so the handle the collections guide's own example reads was absent on exactly
  * the paths hooks run on most.
  *
- * Asserted against a production-shaped boot rather than the `createTestNextly`
- * harness. That harness calls `getNextly()` while building its return value, so
- * the binding always exists under it and a test written there cannot fail no
- * matter what the code does.
+ * Asserted against a production-shaped boot, and — since the harness stopped
+ * resolving the Direct API while building its return value — through the
+ * ordinary `createTestNextly` harness as well. The harness case is the one that
+ * matters for everything written afterwards: while it called `getNextly()`
+ * eagerly, the binding existed under it whatever the code did, so a test
+ * written there could not fail.
  */
 
 import { afterEach, describe, expect, it } from "vitest";
@@ -27,6 +29,10 @@ import {
   clearLiveSnapshots,
 } from "../../../init/schema-snapshot-cache";
 import { resetPluginRouteRegistry } from "../../../plugins/routes/route-registry";
+import {
+  createTestNextly,
+  type TestNextly,
+} from "../../../plugins/test-nextly";
 import { getImageProcessor } from "../../../storage/image-processor";
 
 function resetAll(): void {
@@ -85,5 +91,33 @@ describe("the Direct API is bound for hook contexts at boot", () => {
 
     expect(resolved).toBeDefined();
     expect(typeof resolved?.create).toBe("function");
+  });
+});
+
+describe("the ordinary test harness leaves the binding to service registration", () => {
+  let current: TestNextly | undefined;
+
+  afterEach(async () => {
+    await current?.destroy();
+    current = undefined;
+    resetAll();
+  });
+
+  it("has nextlyDirectAPI bound after createTestNextly, without reading t.nextly", async () => {
+    await shutdownServices();
+    resetAll();
+
+    // The control: nothing in this process has resolved the Direct API, so a
+    // binding found below was made by the boot rather than left behind.
+    expect(container.has("nextlyDirectAPI")).toBe(false);
+
+    current = await createTestNextly({ dialect: "sqlite" });
+
+    // Deliberately does NOT touch `current.nextly`. That property resolves the
+    // Direct API on access, and resolving it registers the binding as a side
+    // effect -- so reading it here would satisfy the assertion by itself and
+    // certify nothing. What is under test is that service registration bound
+    // it, which is what gives a hook its `req.nextly`.
+    expect(container.has("nextlyDirectAPI")).toBe(true);
   });
 });

--- a/packages/nextly/src/plugins/test-nextly.ts
+++ b/packages/nextly/src/plugins/test-nextly.ts
@@ -763,6 +763,13 @@ async function bootServices(
     }
   }
 
+  // A handle a caller assigned over `nextly`. The property was a plain data
+  // property before it became lazy, and `TestNextly.nextly` is not declared
+  // readonly, so `handle.nextly = stub` compiles and has to keep working --
+  // a getter without a setter would turn that into a TypeError under the
+  // strict mode ES modules always run in.
+  let nextlyOverride: Nextly | undefined;
+
   return {
     // Resolved on access, not while assembling this object. `getNextly()`
     // registers the `nextlyDirectAPI` container binding as a side effect of
@@ -773,7 +780,10 @@ async function bootServices(
     // the harness was answering the question the test was asking. Deferring
     // leaves the container the shape service registration alone gives it.
     get nextly(): Nextly {
-      return getNextly();
+      return nextlyOverride ?? getNextly();
+    },
+    set nextly(replacement: Nextly) {
+      nextlyOverride = replacement;
     },
     getService,
     hooks: getHookRegistry(),

--- a/packages/nextly/src/plugins/test-nextly.ts
+++ b/packages/nextly/src/plugins/test-nextly.ts
@@ -303,7 +303,15 @@ export interface CreateTestNextlyOptions {
 }
 
 export interface TestNextly {
-  /** The booted direct-API facade for CRUD assertions. */
+  /**
+   * The booted direct-API facade for CRUD assertions.
+   *
+   * Resolved on access. Resolving it registers the `nextlyDirectAPI` container
+   * binding as a side effect, and that binding is what a hook's `req.nextly`
+   * comes from — so a test that reads this property before asserting anything
+   * about `req.nextly` has supplied the answer itself. Assert the binding
+   * first, then read this.
+   */
   nextly: Nextly;
   /** Container accessor for inspecting any registered service. */
   getService: typeof getService;
@@ -756,7 +764,17 @@ async function bootServices(
   }
 
   return {
-    nextly: getNextly(),
+    // Resolved on access, not while assembling this object. `getNextly()`
+    // registers the `nextlyDirectAPI` container binding as a side effect of
+    // building its instance, so calling it here made that binding exist under
+    // this harness whatever the code under test did. `req.nextly` resolves
+    // through exactly that binding, so a test asserting a hook receives the
+    // handle passed whether or not service registration had provided it --
+    // the harness was answering the question the test was asking. Deferring
+    // leaves the container the shape service registration alone gives it.
+    get nextly(): Nextly {
+      return getNextly();
+    },
     getService,
     hooks: getHookRegistry(),
     events: getEventBus(),


### PR DESCRIPTION
Closes task `106-test-harness-masks-req-nextly-defects`.

## The defect

`createTestNextly` called `getNextly()` while assembling its return value (`test-nextly.ts:759`). That call registers the `nextlyDirectAPI` container binding as a side effect of building the instance (`direct-api/nextly.ts:664-669`), and a hook's `req.nextly` resolves through exactly that binding (`collection-hook-service.ts:81`).

So under this harness the binding existed **no matter what the code under test did**. A test asserting a hook receives `req.nextly` passed whether or not service registration provided it — the harness was answering the question the test was asking.

This is how the `req.nextly` defect #467 fixed shipped and survived: `req.nextly` was `undefined` for every REST and admin write, the paths hooks run on most, and the suite could not see it.

## Proven, not argued

#467 also made `registerServices()` register the binding (`di/register.ts:986`), so production is wired today. That moves the hole rather than closing it: the harness boots `registerServices` first, so `getNextly()` skips its own registration — but if the `registerServices` binding regressed, the harness would supply it and everything would still pass.

Deleted that binding and ran `src/domains/collections src/plugins src/di src/hooks`:

```
baseline:      24 failures
binding gone:  24 failures
name-set diff: IDENTICAL
```

**Nothing in the suite caught it.**

## The change

`TestNextly.nextly` is a getter. The harness no longer resolves the Direct API while building its return value, so the container keeps the shape service registration alone gives it. Property access is unchanged for the 149 integration files that use it.

The interface doc now states the hazard at the property: reading `t.nextly` before asserting anything about `req.nextly` supplies the answer itself.

## The guard

`hook-req-nextly.integration.test.ts` gains `has nextlyDirectAPI bound after createTestNextly, without reading t.nextly` — a boot through the **ordinary** harness, with a control asserting the binding is absent beforehand so a leftover from an earlier call cannot satisfy it.

Revert-checked: with the `registerServices` binding removed it fails `expected false to be true`. That is acceptance criterion 1 — a `req.nextly` regression is now catchable by a test written through the ordinary harness.

Deliberately **not** a source-scanning test ("no `container.register` outside `di/register.ts`"). That shape passed vacuously once already in this programme and was deleted rather than made cleverer; text proximity cannot express control flow.

## The audit (task scope item 2) — answer: nothing else

Two passes, both recorded in the task file:

1. Every `container.register(` outside `di/register.ts` in non-test source: **exactly one**, `direct-api/nextly.ts:665` — the one addressed here. (A second hit is a docstring example in `di/container.ts:14`.)
2. Every `get*`/`ensure*`/`init*`/`reset*` the harness calls that `registerServices` never does: `ensureCollectionTables`, `getCollection`, `getConfiguredTestDialects`, `resetEventBus`, `resetFilterRegistry`, `resetHookRegistry`, `resetPluginRouteRegistry`. The first three are test provisioning; the `reset*` family **clears** state, making the harness stricter than production rather than looser.

`getHookRegistry()` and `getEventBus()` are resolved eagerly by the harness too, but `registerServices` calls both, so the harness is not their only source.

## Verification

- **Full SQLite integration suite: 172 files passed, 30 skipped, 0 failures** (962 tests). This is the check that matters, since 149 integration files read `t.nextly`.
- Unit failing-test **name set** over `src/hooks src/di src/plugins src/init`: **13, identical to `main`, zero new**.
- `pnpm run check-types` green, both tsconfigs.
- Changeset generated from `.changeset/config.json` (21 packages, `patch`) — `nextly/testing` is a published entry point, so this is a shipped behaviour change rather than a test-only one.