### PR TITLE
feat(nextly): return the mutation envelope from updateSingle

### DIFF
--- a/.changeset/single-mutation-envelope.md
+++ b/.changeset/single-mutation-envelope.md
@@ -1,0 +1,37 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+"create-nextly-app": patch
+"nextly": patch
+---
+
+**Breaking (Direct API):** `nextly.updateSingle()` now returns the same `{ message, item }` mutation envelope the collection mutations return, instead of the bare updated document. Read the document from `.item`:
+
+```ts
+// before
+const settings = await nextly.updateSingle({ slug: "site-settings", data });
+settings.siteName;
+
+// after
+const { item } = await nextly.updateSingle({ slug: "site-settings", data });
+item.siteName;
+```
+
+This makes every mutation report its outcome the same way, and gives a single's post-commit hook failures somewhere to be reported: the result carries the same optional `warnings` array a collection mutation does. Singles run the same after-write phases as collections, so previously a hook that threw after a single was saved was logged and never reached the caller.

--- a/docs/api-reference/direct-api.mdx
+++ b/docs/api-reference/direct-api.mdx
@@ -328,19 +328,34 @@ console.log(settings.siteName);
 
 ### updateSingle
 
-Update a single's content by slug. Returns the bare updated document.
+Update a single's content by slug. Returns the same `{ message, item }` envelope
+the collection mutations return, so every mutation reports its outcome the same
+way.
 
 ```typescript
-const updated = await nextly.updateSingle({
+const { item, warnings } = await nextly.updateSingle({
   slug: "site-settings",
   data: {
     siteName: "My Awesome Site",
     maintenanceMode: false,
   },
 });
+
+item.siteName; // "My Awesome Site"
+
+if (warnings) {
+  // The document was saved. A hook that runs after the write committed threw,
+  // so a side effect did not happen — each warning names the phase, the single
+  // and the error code.
+}
 ```
 
-**Returns:** `T` (the updated single document).
+**Returns:** `MutationResult<T>` — `{ message, item, warnings? }`.
+
+`warnings` is present only when a post-commit hook failed. The write itself
+succeeded: an `afterChange` hook cannot un-save the document, so the operation
+reports success and the failed side effect is reported beside it rather than
+being turned into an error that would invite a retry.
 
 ### findSingles
 

--- a/packages/nextly/src/direct-api/__tests__/singles.test.ts
+++ b/packages/nextly/src/direct-api/__tests__/singles.test.ts
@@ -159,7 +159,11 @@ describe("Direct API - Singles Operations", () => {
         data: { siteName: "Updated Site" },
       });
 
-      expect(result).toEqual(mockData);
+      // The mutation envelope, matching the collection mutations. `warnings`
+      // is absent because no hook failed, so an ordinary result carries what
+      // it always did plus the message.
+      expect(result.item).toEqual(mockData);
+      expect(result.warnings).toBeUndefined();
       expect(mocks.singleEntryService.update).toHaveBeenCalledWith(
         "site-settings",
         { siteName: "Updated Site" },

--- a/packages/nextly/src/direct-api/namespaces/collections.ts
+++ b/packages/nextly/src/direct-api/namespaces/collections.ts
@@ -10,11 +10,7 @@
  */
 
 import { NextlyError } from "../../errors/nextly-error";
-import type { HookWarning } from "../../hooks/side-effect-warnings";
-import {
-  toHookWarning,
-  withSideEffectWarnings,
-} from "../../hooks/side-effect-warnings";
+import { collectingWarnings } from "../../hooks/side-effect-warnings";
 import type { PaginatedResponse } from "../../types/pagination";
 import type {
   BulkDeleteArgs,
@@ -158,23 +154,6 @@ export async function findByID<TSlug extends CollectionSlug>(
  * collection slug capitalized (e.g. `"Posts created."`) so callers can
  * surface a generic toast without hand-writing copy per collection.
  */
-/**
- * Run a write and hand back the post-commit hook failures it collected.
- *
- * The scope opens here because a Direct API call is its own operation boundary
- * -- there is no request around it to open one. A scope already open (the call
- * came from inside a request, or from another collection's hook) still receives
- * the same failures, so an in-process call cannot hide one from the client
- * waiting on the request that triggered it.
- */
-async function collectingWarnings<T>(
-  operation: () => Promise<T>
-): Promise<{ result: T; warnings?: HookWarning[] }> {
-  const { result, failures } = await withSideEffectWarnings(operation);
-  return failures.length > 0
-    ? { result, warnings: failures.map(toHookWarning) }
-    : { result };
-}
 
 export async function create<TSlug extends CollectionSlug>(
   ctx: NextlyContext,

--- a/packages/nextly/src/direct-api/namespaces/singles.ts
+++ b/packages/nextly/src/direct-api/namespaces/singles.ts
@@ -7,8 +7,10 @@
  * @packageDocumentation
  */
 
+import { collectingWarnings } from "../../hooks/side-effect-warnings";
 import { transformRichTextFields } from "../../lib/field-transform";
 import type {
+  MutationResult,
   DataFromSingleSlug,
   FindSingleArgs,
   FindSinglesArgs,
@@ -18,7 +20,11 @@ import type {
 } from "../types/index";
 
 import type { NextlyContext } from "./context";
-import { createErrorFromSingleResult, mergeConfig } from "./helpers";
+import {
+  buildMutationMessage,
+  createErrorFromSingleResult,
+  mergeConfig,
+} from "./helpers";
 
 /**
  * Retrieve the content of a single by slug.
@@ -75,22 +81,28 @@ export async function findSingle<TSlug extends SingleSlug>(
 export async function updateSingle<TSlug extends SingleSlug>(
   ctx: NextlyContext,
   args: UpdateSingleArgs<TSlug>
-): Promise<DataFromSingleSlug<TSlug>> {
+): Promise<MutationResult<DataFromSingleSlug<TSlug>>> {
   const config = mergeConfig(ctx.defaultConfig, args);
 
-  const result = await ctx.singleEntryService.update(args.slug, args.data, {
-    locale: config.locale,
-    user: config.user,
-    overrideAccess: config.overrideAccess,
-    context: config.context,
-    disableRevalidate: config.disableRevalidate,
-  });
+  const { result, warnings } = await collectingWarnings(() =>
+    ctx.singleEntryService.update(args.slug, args.data, {
+      locale: config.locale,
+      user: config.user,
+      overrideAccess: config.overrideAccess,
+      context: config.context,
+      disableRevalidate: config.disableRevalidate,
+    })
+  );
 
   if (!result.success) {
     throw createErrorFromSingleResult(result);
   }
 
-  return result.data as DataFromSingleSlug<TSlug>;
+  return {
+    message: buildMutationMessage(args.slug, "updated"),
+    item: result.data as DataFromSingleSlug<TSlug>,
+    ...(warnings ? { warnings } : {}),
+  };
 }
 
 /**

--- a/packages/nextly/src/direct-api/nextly.ts
+++ b/packages/nextly/src/direct-api/nextly.ts
@@ -543,10 +543,16 @@ export class Nextly implements NextlyContext {
     return singlesNs.findSingle(this, args);
   }
 
-  /** Update a Single (global) document by slug. */
+  /**
+   * Update a Single (global) document by slug.
+   *
+   * Returns the same `{ message, item }` envelope the collection mutations do,
+   * so every mutation reports its outcome the same way and a post-commit hook
+   * failure has somewhere to be reported.
+   */
   updateSingle<TSlug extends SingleSlug>(
     args: UpdateSingleArgs<TSlug>
-  ): Promise<DataFromSingleSlug<TSlug>> {
+  ): Promise<MutationResult<DataFromSingleSlug<TSlug>>> {
     return singlesNs.updateSingle(this, args);
   }
 

--- a/packages/nextly/src/domains/field-groups/__tests__/field-group-validation-request.integration.test.ts
+++ b/packages/nextly/src/domains/field-groups/__tests__/field-group-validation-request.integration.test.ts
@@ -160,7 +160,7 @@ describe("a field group's validators and the parent write's request", () => {
       overrideAccess: true,
     });
 
-    expect((updated as { headline?: string }).headline).toBe("Hello");
+    expect(updated.item.headline).toBe("Hello");
   });
 
   it("refuses the same single update when nobody is signed in", async () => {

--- a/packages/nextly/src/hooks/__tests__/side-effect-warnings.integration.test.ts
+++ b/packages/nextly/src/hooks/__tests__/side-effect-warnings.integration.test.ts
@@ -17,6 +17,7 @@
 import { afterEach, describe, expect, it } from "vitest";
 
 import { defineCollection } from "../../collections/config/define-collection";
+import { defineSingle } from "../../singles/config/define-single";
 import { text } from "../../collections/fields";
 import { NextlyError } from "../../errors/nextly-error";
 import { createTestNextly, type TestNextly } from "../../plugins/test-nextly";
@@ -92,5 +93,48 @@ describe("a post-commit hook failure is reported as a warning", () => {
     const serialized = JSON.stringify(created.warnings);
     expect(serialized).not.toContain("secret-detail");
     expect(serialized).not.toContain("logContext");
+  });
+});
+
+describe("a single reports its post-commit failures the same way", () => {
+  it("returns the envelope AND the warning when a single's hook throws", async () => {
+    // Singles run the same post-commit phases as collections. Before the
+    // mutation envelope they returned a bare document, so a hook failure had
+    // nowhere to go and a caller updating a single was told nothing while a
+    // caller updating a collection was told everything.
+    current = await createTestNextly({
+      singles: [
+        defineSingle({
+          slug: "site-settings",
+          fields: [text({ name: "siteName" })],
+          hooks: {
+            afterChange: [
+              () => {
+                throw NextlyError.internal({
+                  logContext: { detail: "single-secret" },
+                });
+              },
+            ],
+          },
+        }),
+      ],
+    });
+
+    const updated = await current.nextly.updateSingle({
+      slug: "site-settings",
+      data: { siteName: "Saved anyway" },
+    });
+
+    expect(updated.item).toBeDefined();
+    expect(updated.warnings).toHaveLength(1);
+    // `collection` carries the registry key, which for a single is namespaced.
+    // Asserted rather than loosened: a collection and a single may share a
+    // slug, so the bare slug would not tell a consumer which one failed.
+    expect(updated.warnings?.[0]).toMatchObject({
+      phase: "afterUpdate",
+      collection: "single:site-settings",
+      code: "INTERNAL_ERROR",
+    });
+    expect(JSON.stringify(updated.warnings)).not.toContain("single-secret");
   });
 });

--- a/packages/nextly/src/hooks/side-effect-warnings.ts
+++ b/packages/nextly/src/hooks/side-effect-warnings.ts
@@ -43,7 +43,13 @@ const collectorStack = new AsyncLocalStorage<SideEffectHookFailure[][]>();
 export interface HookWarning {
   /** The lifecycle phase whose handler failed. */
   phase: string;
-  /** The collection or single the handler was registered against. */
+  /**
+   * The registry key the handler was registered against.
+   *
+   * A collection's slug, or `single:<slug>` for a single. Namespaced rather
+   * than bare because a collection and a single may share a slug, and a
+   * consumer reacting to the warning has to know which one it came from.
+   */
   collection: string;
   /** The canonical `NextlyError` code, for a caller branching on the failure. */
   code: string;
@@ -101,4 +107,22 @@ export function currentSideEffectWarnings(): HookWarning[] {
   const stack = collectorStack.getStore();
   const innermost = stack?.[stack.length - 1];
   return (innermost ?? []).map(toHookWarning);
+}
+
+/**
+ * Run a write and hand back the post-commit hook failures it collected.
+ *
+ * The scope opens here because a Direct API call is its own operation boundary
+ * -- there is no request around it to open one. A scope already open (the call
+ * came from inside a request, or from another collection's hook) still receives
+ * the same failures, so an in-process call cannot hide one from the client
+ * waiting on the request that triggered it.
+ */
+export async function collectingWarnings<T>(
+  operation: () => Promise<T>
+): Promise<{ result: T; warnings?: HookWarning[] }> {
+  const { result, failures } = await withSideEffectWarnings(operation);
+  return failures.length > 0
+    ? { result, warnings: failures.map(toHookWarning) }
+    : { result };
 }

--- a/packages/nextly/src/init/nextly-instance.ts
+++ b/packages/nextly/src/init/nextly-instance.ts
@@ -269,17 +269,26 @@ export interface Nextly {
   /**
    * Update a Single document.
    *
+   * Returns the same `{ message, item }` envelope the collection mutations do.
+   * `warnings` is present only when a hook failed after the write committed:
+   * the document is saved either way, so this reports a side effect that did
+   * not run rather than a failed write.
+   *
    * @example
    * ```typescript
-   * const updated = await nextly.updateSingle({
+   * const { item, warnings } = await nextly.updateSingle({
    *   slug: 'site-settings',
    *   data: { siteName: 'My Site' },
    * });
+   * item.siteName;
+   * if (warnings) {
+   *   // saved, but a post-commit hook threw
+   * }
    * ```
    */
   updateSingle: <TSlug extends SingleSlug>(
     args: UpdateSingleArgs<TSlug>
-  ) => Promise<DataFromSingleSlug<TSlug>>;
+  ) => Promise<MutationResult<DataFromSingleSlug<TSlug>>>;
 
   /**
    * List all registered Single type definitions.


### PR DESCRIPTION
> **Stacked on #483.** Base is `fix/hook-side-effect-warnings` — it uses the warnings collector that PR introduces. Merge #483 first and this retargets to `main` cleanly.

Found by self-reviewing #483 rather than by a reviewer, and it is the gap that PR left.

## The defect

`single-mutation-service.ts` runs `hookRegistry.execute` **4 times** — singles run the same post-commit phases as collections. But `nextly.updateSingle()` returned the **bare updated document**, so a hook that threw after the write committed had nowhere to be reported.

Result after #483: a caller updating a collection is told a side effect failed; a caller updating a single is told nothing. That is the two surfaces disagreeing at a finer grain — the thing "both surfaces in one go" was chosen to prevent.

## Why the envelope, and not a warnings accessor

The alternative — leave every return shape alone and expose `nextly.lastWarnings()` — was rejected on two grounds:

1. **It has to be stateful to work**, which makes it racy: two concurrent in-process writes and you cannot say which warnings belong to which.
2. **Poor DX.** A warning discoverable only if you already know to look is close to no warning at all.

The envelope also fixes something that predates warnings entirely: **`updateSingle` was the only mutation not reporting its outcome the way the others do.** Warnings were the symptom; the inconsistent return shape was the cause.

## Breaking, deliberately

```ts
// before
const settings = await nextly.updateSingle({ slug: "site-settings", data });
settings.siteName;

// after
const { item, warnings } = await nextly.updateSingle({ slug: "site-settings", data });
item.siteName;
if (warnings) { /* saved, but a post-commit hook threw */ }
```

Alpha is the cheap moment. Everything that describes the old shape moves in this PR:

- `NextlyInstance.updateSingle` declaration **and its worked example**
- `docs/api-reference/direct-api.mdx` — the section said "Returns the bare updated document"
- the unit and integration tests

**The admin's API Playground needed no change**: it already emits `const result = await nextly.update(...)` for collection mutations, so its singles snippet now *matches* rather than diverging. The `templates/blog` seed calls ignore the return value, so they are unaffected. `packages/admin`'s `useSingles.updateSingle` is a React Query mutation, not this method.

## A cast was hiding the change

`field-group-validation-request.integration.test.ts` asserted through `(updated as { headline?: string }).headline`. That cast meant `check-types` stayed green while the test was reading a field that no longer exists at the top level — it failed only in the integration run. It now reads `.item.headline` with no cast.

Worth recording as evidence for the repo's no-casts rule: the cast did not just hide a type error, it delayed a real breakage from typecheck to test-run.

## Tests

New: `a single reports its post-commit failures the same way` — a single whose `afterChange` hook throws returns the envelope, the item, and one warning, with the private `logContext` detail absent from it.

It asserts `collection: "single:site-settings"` rather than the bare slug, deliberately: that is the registry key, and a collection and a single may share a slug, so the bare slug would not tell a consumer which failed. The `HookWarning.collection` doc now says so.

**Revert-checked** by dropping the `warnings` forwarding, proven by `diff`: `AssertionError: Target cannot be null or undefined.`

## Verification

- Full SQLite integration suite: **173 files, 975 tests, 0 failures**.
- Unit failing-test **name set**: **13, identical to `main`, zero new**. The one new failure this change caused (`singles.test.ts > should return updated document on success`) is fixed here, not suppressed.
- `pnpm run check-types` green, both tsconfigs, all 19 packages.
- Changeset marks the break with a before/after snippet.

## Still open, unchanged from #483

`delete` by `where` returns `DeleteResult` (`{ deleted, ids }`) and still has nowhere to put warnings. It should be decided together with whether the bulk envelopes carry them at all — a separate question from this one, since bulk operations report per-item outcomes already.