### PR TITLE
fix(blocks-engine): bound composite path text and read attr fallbacks as values

### DIFF
--- a/.changeset/style-catalog-followups.md
+++ b/.changeset/style-catalog-followups.md
@@ -1,0 +1,29 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+"create-nextly-app": patch
+"nextly": patch
+---
+
+Style values are read more carefully in three places. A composite no longer
+builds an unbounded amount of issue text before its allowance is checked, an
+`attr()` fallback is validated as the single value it substitutes rather than as
+an arithmetic expression, and an expression is still judged where it can be even
+when part of it cannot be read.

--- a/packages/blocks-engine/src/style/css-value.ts
+++ b/packages/blocks-engine/src/style/css-value.ts
@@ -270,16 +270,12 @@ function attrProducesDimension(
     // The fallback replaces the whole reference, so it is read as a standalone
     // value and not as an arithmetic expression: bare operators are illegal
     // here exactly as they are where the property is written out directly.
-    for (const term of fallback) {
-      if (
-        standaloneTermRejection(term, NO_KEYWORDS, {
-          ...limits,
-          allowNumber: false,
-        }) !== null
-      ) {
-        return false;
-      }
-    }
+    const rejection = standaloneValueRejection(fallback, NO_KEYWORDS, {
+      ...limits,
+      allowNumber: false,
+      maxParts: 1,
+    });
+    if (rejection !== null) return false;
   }
   const declared = first[1];
   if (declared === undefined) return false;
@@ -1182,17 +1178,40 @@ export function checkDimensionValue(
   if (ast === null || ast.type !== "Value") return "not-a-length";
   const allowed = new Set(keywords.map(keyword => asciiLower(keyword)));
   const allowedFunctions = new Set(functions.map(fnName => asciiLower(fnName)));
+  return standaloneValueRejection([...ast.children], allowed, {
+    allowNegative,
+    allowPercentage,
+    functions: allowedFunctions,
+    allowNumber,
+    maxParts,
+  });
+}
+
+/**
+ * Whether a run of terms is ONE standalone value.
+ *
+ * Per-term checks are not enough on their own: `1px 2px` is two well-formed
+ * lengths and no valid width, and `inherit 1px` is a CSS-wide keyword that
+ * voids whatever stands beside it. Both are properties of the run rather than
+ * of any term in it, so a caller that walks terms itself and stops there
+ * accepts values a browser discards.
+ *
+ * Shared with the `attr()` fallback, which is one standalone value in exactly
+ * this sense — a `px`-typed attribute substitutes a single length, so a
+ * fallback of two is as wrong there as it is written out.
+ */
+function standaloneValueRejection(
+  terms: readonly CssNode[],
+  keywords: ReadonlySet<string>,
+  rules: MeasurementLimits & { allowNumber: boolean; maxParts: number }
+): CssValueRejection | null {
+  const { maxParts, ...termRules } = rules;
   let parts = 0;
   let cssWideKeyword = false;
-  for (const child of ast.children) {
-    const childRejection = standaloneTermRejection(child, allowed, {
-      allowNegative,
-      allowPercentage,
-      functions: allowedFunctions,
-      allowNumber,
-    });
-    if (childRejection !== null) return childRejection;
-    if (child.type === "Identifier" && isCssWideKeyword(identifierOf(child))) {
+  for (const term of terms) {
+    const rejection = standaloneTermRejection(term, keywords, termRules);
+    if (rejection !== null) return rejection;
+    if (term.type === "Identifier" && isCssWideKeyword(identifierOf(term))) {
       cssWideKeyword = true;
     }
     parts += 1;

--- a/packages/blocks-engine/src/style/css-value.ts
+++ b/packages/blocks-engine/src/style/css-value.ts
@@ -267,8 +267,19 @@ function attrProducesDimension(
   // exactly as the same value would written out.
   const fallback = args[1];
   if (fallback !== undefined) {
-    const rejection = alternationRejection(fallback, NO_KEYWORDS, limits);
-    if (rejection !== null) return false;
+    // The fallback replaces the whole reference, so it is read as a standalone
+    // value and not as an arithmetic expression: bare operators are illegal
+    // here exactly as they are where the property is written out directly.
+    for (const term of fallback) {
+      if (
+        standaloneTermRejection(term, NO_KEYWORDS, {
+          ...limits,
+          allowNumber: false,
+        }) !== null
+      ) {
+        return false;
+      }
+    }
   }
   const declared = first[1];
   if (declared === undefined) return false;
@@ -1117,6 +1128,42 @@ export interface DimensionRules {
   allowNumber?: boolean;
 }
 
+/**
+ * Whether one term of a STANDALONE value is a measurement.
+ *
+ * A standalone value is what a property receives directly: `16px`, `auto`,
+ * `calc(1px + 2px)`. Arithmetic lives inside a math function and nowhere else,
+ * so a bare operator here means the browser discards the declaration.
+ *
+ * Shared with the `attr()` fallback, which is a standalone value too — it is
+ * substituted whole when the attribute is missing, so `attr(data-x px, 1px + 2)`
+ * hands the property `1px + 2` and it is refused for the same reason a
+ * written-out `1px + 2` is. Reading the fallback as an arithmetic expression
+ * instead accepted exactly what the browser throws away.
+ */
+function standaloneTermRejection(
+  node: CssNode,
+  keywords: ReadonlySet<string>,
+  rules: MeasurementLimits & { allowNumber: boolean }
+): CssValueRejection | null {
+  const { allowNumber, ...limits } = rules;
+  // No length property takes an operator at the top level. Corner radii are
+  // expressed per corner instead, which is also the only form that flips with
+  // writing direction.
+  if (node.type === "Operator") return "not-a-length";
+  const rejection = measurementRejection(node, false, keywords, limits);
+  if (rejection !== null) return rejection;
+  // The structural check above says the term is WELL FORMED. What it works out
+  // to is a separate question, asked once over the whole expression so that
+  // nesting and operator precedence are both visible.
+  if (node.type !== "Function") return null;
+  const type = numericType([node], "length");
+  if (type === "invalid") return "not-a-length";
+  return type !== "unknown" && !typeIsMeasurement(type, allowNumber)
+    ? "not-a-length"
+    : null;
+}
+
 export function checkDimensionValue(
   value: string,
   rules: DimensionRules = {}
@@ -1138,26 +1185,13 @@ export function checkDimensionValue(
   let parts = 0;
   let cssWideKeyword = false;
   for (const child of ast.children) {
-    // No length property takes an operator at the top level. Corner radii are
-    // expressed per corner instead, which is also the only form that flips with
-    // writing direction.
-    if (child.type === "Operator") return "not-a-length";
-    const childRejection = measurementRejection(child, false, allowed, {
+    const childRejection = standaloneTermRejection(child, allowed, {
       allowNegative,
       allowPercentage,
       functions: allowedFunctions,
+      allowNumber,
     });
     if (childRejection !== null) return childRejection;
-    // The structural checks above say the value is WELL FORMED. What it works
-    // out to is a separate question, asked once over the whole expression so
-    // that nesting and operator precedence are both visible.
-    if (child.type === "Function") {
-      const type = numericType([child], "length");
-      if (type === "invalid") return "not-a-length";
-      if (type !== "unknown" && !typeIsMeasurement(type, allowNumber)) {
-        return "not-a-length";
-      }
-    }
     if (child.type === "Identifier" && isCssWideKeyword(identifierOf(child))) {
       cssWideKeyword = true;
     }

--- a/packages/blocks-engine/src/style/validate-style-value.test.ts
+++ b/packages/blocks-engine/src/style/validate-style-value.test.ts
@@ -735,6 +735,29 @@ describe("the issue budget reaches composites too", () => {
     expect(issues.at(-1)?.code).toBe("style-issues-truncated");
   });
 
+  it("bounds path text inside a composite, not only between properties", () => {
+    // The run is charged when a walk RETURNS, so a composite that only asked
+    // the budget would build every field's issue first. `background` under a
+    // long breakpoint id is the shape that reaches hundreds of megabytes from
+    // a document inside the byte cap.
+    const longKey = "b".repeat(200_000);
+    const fields: Record<string, unknown> = {};
+    for (let index = 0; index < 199; index += 1) fields[`nope${index}`] = "x";
+    const budget = newStyleIssueBudget();
+    const issues = validateStyleValues(
+      { background: fields },
+      `/nodes/0/styles/base/${longKey}`,
+      "strict",
+      budget
+    );
+    const totalPathBytes = issues.reduce(
+      (sum, issue) => sum + issue.path.length,
+      0
+    );
+    expect(totalPathBytes).toBeLessThan(2_000_000);
+    expect(issues.at(-1)?.code).toBe("style-issues-truncated");
+  });
+
   it("bounds the total path text, not only the number of issues", () => {
     // A pointer repeats every key above it. One very long key is therefore
     // copied into every issue beneath it, so a document inside the byte cap
@@ -2482,6 +2505,21 @@ describe("a deferred value still needs its name", () => {
     expect(codes({ width: "var(--x)" })).toEqual([]);
     expect(codes({ width: "var(--x, 1px)" })).toEqual([]);
     expect(codes({ width: "env(safe-area-inset-top)" })).toEqual([]);
+  });
+
+  it("reads an attr fallback as the value it replaces", () => {
+    // The fallback is substituted whole when the attribute is missing, so
+    // `1px + 2` reaches the property as written. Arithmetic belongs inside a
+    // math function; bare operators here are discarded by the browser.
+    expect(codes({ width: "attr(data-x px, 1px + 2)" })).toEqual([
+      "invalid-style-value",
+    ]);
+    expect(codes({ width: "attr(data-x px, 1px * 2)" })).toEqual([
+      "invalid-style-value",
+    ]);
+    // Wrapped in a math function it is a value again.
+    expect(codes({ width: "attr(data-x px, calc(1px + 2px))" })).toEqual([]);
+    expect(codes({ width: "attr(data-x px, 1px)" })).toEqual([]);
   });
 
   it("reads the whole head, not only the name", () => {

--- a/packages/blocks-engine/src/style/validate-style-value.test.ts
+++ b/packages/blocks-engine/src/style/validate-style-value.test.ts
@@ -2520,6 +2520,15 @@ describe("a deferred value still needs its name", () => {
     // Wrapped in a math function it is a value again.
     expect(codes({ width: "attr(data-x px, calc(1px + 2px))" })).toEqual([]);
     expect(codes({ width: "attr(data-x px, 1px)" })).toEqual([]);
+    // The fallback is ONE value, not a run of them: a px-typed attribute
+    // substitutes a single length, so two adjacent ones are as wrong here as
+    // they are written out, and a CSS-wide keyword still voids its neighbours.
+    expect(codes({ width: "attr(data-x px, 1px 2px)" })).toEqual([
+      "invalid-style-value",
+    ]);
+    expect(codes({ width: "attr(data-x px, inherit 1px)" })).toEqual([
+      "invalid-style-value",
+    ]);
   });
 
   it("reads the whole head, not only the name", () => {

--- a/packages/blocks-engine/src/style/validate-style-value.ts
+++ b/packages/blocks-engine/src/style/validate-style-value.ts
@@ -359,7 +359,8 @@ function partIssues(
   path: string,
   partLabel: string,
   budget?: StyleIssueBudget,
-  spent = 0
+  spent = 0,
+  spentBytes = 0
 ): ValidationIssue[] {
   if (!isPlainRecord(value)) {
     return [
@@ -371,6 +372,12 @@ function partIssues(
     ];
   }
   const issues: ValidationIssue[] = [];
+  // Path text this level has produced. Tracked here and compared against the
+  // run's allowance for exactly the reason the count is: the run is charged
+  // when this walk RETURNS, so a loop that only asked the budget would build
+  // every issue it can first. One long key above a composite is enough for
+  // that to be hundreds of megabytes from a document inside the byte cap.
+  let bytes = 0;
   // Enumerated lazily rather than through `Object.entries`, which would build a
   // pair for every key before the budget below sees the first one — the budget
   // is meant to bound the work, not only the issues it reports.
@@ -384,7 +391,9 @@ function partIssues(
     // allowance again, so a value one level deeper reported past the cap.
     if (
       budget !== undefined &&
-      (budgetSpent(budget) || spent + issues.length >= budget.remaining)
+      (budgetSpent(budget) ||
+        spent + issues.length >= budget.remaining ||
+        spentBytes + bytes >= budget.pathBytes)
     ) {
       issues.push(...truncationNotice(budget, path));
       break;
@@ -396,24 +405,25 @@ function partIssues(
     const partValue = value[key];
     const partShape = Object.hasOwn(parts, key) ? parts[key] : undefined;
     if (partShape === undefined) {
-      issues.push(
-        invalid(
-          pointer(path, key),
-          `"${describeValue(key)}" is not a known ${partLabel}.`,
-          `Use one of: ${Object.keys(parts).join(", ")}.`
-        )
+      const unknownField = invalid(
+        pointer(path, key),
+        `"${describeValue(key)}" is not a known ${partLabel}.`,
+        `Use one of: ${Object.keys(parts).join(", ")}.`
       );
+      bytes += unknownField.path.length;
+      issues.push(unknownField);
       continue;
     }
-    issues.push(
-      ...shapeIssues(
-        partShape,
-        partValue,
-        pointer(path, key),
-        budget,
-        spent + issues.length
-      )
+    const nested = shapeIssues(
+      partShape,
+      partValue,
+      pointer(path, key),
+      budget,
+      spent + issues.length,
+      spentBytes + bytes
     );
+    for (const issue of nested) bytes += issue.path.length;
+    issues.push(...nested);
   }
   return issues;
 }
@@ -424,16 +434,41 @@ function shapeIssues(
   value: unknown,
   path: string,
   budget?: StyleIssueBudget,
-  spent = 0
+  spent = 0,
+  spentBytes = 0
 ): ValidationIssue[] {
   if (isStyleLeaf(shape)) return leafIssues(shape, value, path);
   switch (shape.kind) {
     case "logicalSides":
-      return partIssues(shape.sides, value, path, "side", budget, spent);
+      return partIssues(
+        shape.sides,
+        value,
+        path,
+        "side",
+        budget,
+        spent,
+        spentBytes
+      );
     case "logicalCorners":
-      return partIssues(shape.corners, value, path, "corner", budget, spent);
+      return partIssues(
+        shape.corners,
+        value,
+        path,
+        "corner",
+        budget,
+        spent,
+        spentBytes
+      );
     case "object":
-      return partIssues(shape.fields, value, path, "field", budget, spent);
+      return partIssues(
+        shape.fields,
+        value,
+        path,
+        "field",
+        budget,
+        spent,
+        spentBytes
+      );
     case "union": {
       // A union accepts the value if any variant does. Variants are tried in
       // order and the first clean one wins; when none accepts, the first
@@ -441,7 +476,14 @@ function shapeIssues(
       // lists first and therefore the one an author most likely intended.
       let best: ValidationIssue[] | undefined;
       for (const variant of shape.of) {
-        const issues = shapeIssues(variant, value, path, budget, spent);
+        const issues = shapeIssues(
+          variant,
+          value,
+          path,
+          budget,
+          spent,
+          spentBytes
+        );
         if (issues.length === 0) return [];
         // Prefer whichever variant the value structurally resembles: its issues
         // point at the offending leaf, while a mismatched variant only reports


### PR DESCRIPTION
Follow-up to #466 (the style-property catalog), which merged as `4dc8a464f`.
This PR carries the review loop forward: #466 ran **46 rounds and 180 review
threads**, and the loop had not converged when it merged, so it continues here
against a smaller diff that reviewers can actually read.

## What this PR fixes

**Path text is bounded where a composite produces it.** #466's last change gave
the issue budget a path-byte allowance beside its issue count, but the allowance
was only consulted BETWEEN properties. A run is charged when a walk returns, so
a composite holding hundreds of fields built every issue it could before
anything observed the overspend — under a long breakpoint id, hundreds of
megabytes of pointer text from a document inside the byte cap. The byte spend is
now threaded the way the issue count already was, so each level compares against
what the levels above it produced.

**An `attr()` fallback is read as the value it replaces.** It was validated as
an arithmetic expression, so `attr(data-x px, 1px + 2)` passed — but the
fallback is substituted whole, handing the property `1px + 2`, which is refused
for the same reason a written-out `1px + 2` is. The rule for what a standalone
term may be now lives in one place that both the top level and the fallback
call.

## Context a reviewer needs

**The catalog is experimental and is NOT frozen.** It freezes jointly with the
block API at Plan 01 PR-12, which blocks on Plan 02 PR-S10. Everything landing
here before that costs nothing extra.

**Nothing consumes the style validation yet.** No caller of
`validateStyleValues`, `STYLE_CATALOG` or `checkDimensionValue` exists outside
`blocks-engine`; the page-builder plugin still runs on its own PoC registry. So
defects here are dormant until PR-S3 (the compiler) or PR-11 (the DX-gate
blocks) wire them to something. **That is the real deadline for closing the URL
scheme class**, not this PR's merge.

**Standing principle (PB-D21).** Where a check cannot be made exact, prefer
accepting a value the browser drops over refusing one it honours. A false
rejection stops someone saving valid CSS; a false accept produces a declaration
the browser ignores, which the author sees immediately. Four separate rounds on
#466 found false rejections introduced by the previous round's tightening.

**Math expressions are typed with the algebra CSS Values and Units 4 defines** —
base types to exponents, multiplication adds them, division subtracts them,
addition requires agreement, and a percentage carries the property's percent
hint. This replaced five rounds of per-shape heuristics. Anything unreadable
makes the whole expression unreadable rather than partly readable.

**Five URL-scheme bypasses were found and closed on #466**, each one in the
repair for the last: escaped function names, `var()` fallbacks, unquoted escaped
arguments, CRLF escape terminators, and a fallback re-parsed out of its
enclosing URL context. Assume a sixth exists.

## Review posture

Every finding is verified against the code before it is fixed or declined, and
every new test is stub-verified — the covered code is disabled and THAT test
must fail. Three findings across #466 were declined with file/line evidence.
