### PR TITLE
fix(admin): say field group where the UI still said component

### DIFF
--- a/.changeset/field-group-display-vocabulary.md
+++ b/.changeset/field-group-display-vocabulary.md
@@ -1,0 +1,27 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+The admin now calls field groups "field groups" everywhere it used to say "components".
+
+The field picker, the Schema Builder's field-group editor, the entry form, the entries table badge and the Field Groups list all carried the old wording, so a page titled "Field Groups" could tell you that you had selected components. Only the words changed: the stored field type, table names and API payloads are untouched, so no data or integration is affected.

--- a/.changeset/field-group-display-vocabulary.md
+++ b/.changeset/field-group-display-vocabulary.md
@@ -22,6 +22,6 @@
 "@nextlyhq/tsconfig": patch
 ---
 
-The admin now calls field groups "field groups" everywhere it used to say "components".
+The admin now calls field groups "field groups" in the places that used to say "components".
 
-The field picker, the Schema Builder's field-group editor, the entry form, the entries table badge and the Field Groups list all carried the old wording, so a page titled "Field Groups" could tell you that you had selected components. Only the words changed: the stored field type, table names and API payloads are untouched, so no data or integration is affected.
+The field picker, the Schema Builder's field-group editor, the entry form, the entries table badge, the Field Groups list and its empty states, and the dashboard's getting-started panel all carried the old wording, so a page titled "Field Groups" could tell you that you had selected components. Only the words changed: the stored field type, table names and API payloads are untouched, so no data or integration is affected.

--- a/packages/admin/src/components/features/dashboard/DynamicFieldGroupNav.tsx
+++ b/packages/admin/src/components/features/dashboard/DynamicFieldGroupNav.tsx
@@ -87,7 +87,7 @@ function ComponentSkeleton() {
     <SidebarMenuItem>
       <SidebarMenuButton disabled className="opacity-50">
         <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
-        <span className="text-muted-foreground">Loading components...</span>
+        <span className="text-muted-foreground">Loading field groups...</span>
       </SidebarMenuButton>
     </SidebarMenuItem>
   );

--- a/packages/admin/src/components/features/dashboard/GetStartedEmptyState.tsx
+++ b/packages/admin/src/components/features/dashboard/GetStartedEmptyState.tsx
@@ -72,8 +72,8 @@ export function GetStartedEmptyState() {
           Get started
         </h2>
         <p className="text-sm text-muted-foreground">
-          Pick a starting point. Collections, singles, components, and users can
-          coexist in any Nextly project.
+          Pick a starting point. Collections, singles, field groups, and users
+          can coexist in any Nextly project.
         </p>
       </header>
 

--- a/packages/admin/src/components/features/entries/EntryList/EntryTableCell.tsx
+++ b/packages/admin/src/components/features/entries/EntryList/EntryTableCell.tsx
@@ -564,9 +564,10 @@ export function EntryTableCell({
       );
     }
 
-    // Component field — indicate a nested component
+    // Field-group field — indicate a nested field group. The case value is the STORED
+    // field type and stays as it is; only the badge text is display copy.
     case "component": {
-      return <Badge variant="default">Component</Badge>;
+      return <Badge variant="default">Field Group</Badge>;
     }
 
     // Rich content

--- a/packages/admin/src/components/features/entries/fields/structured/ComponentInput.tsx
+++ b/packages/admin/src/components/features/entries/fields/structured/ComponentInput.tsx
@@ -395,7 +395,7 @@ function SingleComponentNonRepeatable({
           })}
           {componentFields.length === 0 && (
             <p className="text-sm text-muted-foreground text-center py-4">
-              No fields configured for this component.
+              No fields configured for this field group.
             </p>
           )}
         </div>

--- a/packages/admin/src/components/features/entries/fields/structured/ComponentInput.tsx
+++ b/packages/admin/src/components/features/entries/fields/structured/ComponentInput.tsx
@@ -283,7 +283,7 @@ function SingleComponentNonRepeatable({
     field.label ||
     (field.componentSchemas?.[field.component!]?.label ??
       field.component ??
-      "Component");
+      "Field Group");
 
   const isSidebar = field.admin?.position === "sidebar";
   const [isOpen, setIsOpen] = useState(true);
@@ -453,7 +453,7 @@ function MultiComponentNonRepeatable({
     setValue(name, null, { shouldDirty: true });
   }, [name, setValue]);
 
-  const label = field.label || "Component";
+  const label = field.label || "Field Group";
 
   return (
     <Card className={cn("", field.admin?.className)}>
@@ -644,8 +644,8 @@ function RepeatableComponent<TFieldValues extends FieldValues = FieldValues>({
   const isSortable = field.admin?.isSortable !== false;
 
   // Labels
-  const singularLabel = field.label || "Component";
-  const pluralLabel = field.label ? `${field.label}s` : "Components";
+  const singularLabel = field.label || "Field Group";
+  const pluralLabel = field.label ? `${field.label}s` : "Field Groups";
 
   return (
     <div className={cn("space-y-3", field.admin?.className)}>

--- a/packages/admin/src/components/features/entries/fields/structured/ComponentInput.tsx
+++ b/packages/admin/src/components/features/entries/fields/structured/ComponentInput.tsx
@@ -929,11 +929,11 @@ export function ComponentInput<TFieldValues extends FieldValues = FieldValues>({
       )}
     >
       <p className="text-sm text-warning-700 dark:text-warning-300">
-        <strong>Component field:</strong> {field.name}
+        <strong>Field group field:</strong> {field.name}
       </p>
       <p className="text-xs text-warning-600 dark:text-warning-400 mt-1">
         Schema data not available. Ensure the collection schema API returns
-        enriched component fields.
+        enriched field-group fields.
       </p>
     </div>
   );

--- a/packages/admin/src/components/features/entries/fields/structured/ComponentInput.tsx
+++ b/packages/admin/src/components/features/entries/fields/structured/ComponentInput.tsx
@@ -453,6 +453,8 @@ function MultiComponentNonRepeatable({
     setValue(name, null, { shouldDirty: true });
   }, [name, setValue]);
 
+  // Shown when the field carries no label of its own. The field TYPE stays `component`; only
+  // what the editor is called changed.
   const label = field.label || "Field Group";
 
   return (
@@ -484,14 +486,14 @@ function MultiComponentNonRepeatable({
       <CardContent className="space-y-4">
         {/* Type Selector */}
         <div className="space-y-2">
-          <label className="text-sm font-medium">Component Type</label>
+          <label className="text-sm font-medium">Field Group</label>
           <Select
             value={currentType || ""}
             onValueChange={handleTypeChange}
             disabled={disabled || readOnly}
           >
             <SelectTrigger>
-              <SelectValue placeholder="Select a component type..." />
+              <SelectValue placeholder="Select a field group..." />
             </SelectTrigger>
             <SelectContent>
               {availableSlugs.map(slug => {
@@ -526,7 +528,7 @@ function MultiComponentNonRepeatable({
 
         {!currentType && (
           <p className="text-sm text-muted-foreground text-center py-4  border border-border border-dashed rounded-md bg-primary/5">
-            Select a component type to add fields.
+            Select a field group to add fields.
           </p>
         )}
       </CardContent>
@@ -741,7 +743,7 @@ function RepeatableComponent<TFieldValues extends FieldValues = FieldValues>({
                 availableSlugs={availableSlugs}
                 onSelect={handleAdd}
                 title={`Add ${singularLabel}`}
-                description={`Choose a component type to add to ${pluralLabel.toLowerCase()}.`}
+                description={`Choose a field group to add to ${pluralLabel.toLowerCase()}.`}
               />
             </>
           ) : (

--- a/packages/admin/src/components/features/entries/fields/structured/ComponentRow.tsx
+++ b/packages/admin/src/components/features/entries/fields/structured/ComponentRow.tsx
@@ -342,7 +342,7 @@ export function ComponentRow<TFieldValues extends FieldValues = FieldValues>({
               })()
             ) : (
               <div className="text-sm text-muted-foreground text-center py-4">
-                No fields configured for this component.
+                No fields configured for this field group.
               </div>
             )}
           </CardContent>

--- a/packages/admin/src/components/features/entries/fields/structured/ComponentSelector.tsx
+++ b/packages/admin/src/components/features/entries/fields/structured/ComponentSelector.tsx
@@ -63,13 +63,13 @@ export interface ComponentSelectorProps {
 
   /**
    * Optional title for the dialog.
-   * @default "Add Component"
+   * @default "Add Field Group"
    */
   title?: string;
 
   /**
    * Optional description for the dialog.
-   * @default "Choose a component type to add."
+   * @default "Choose a field group to add."
    */
   description?: string;
 }
@@ -254,8 +254,10 @@ export function ComponentSelector({
   componentSchemas,
   availableSlugs,
   onSelect,
-  title = "Add Component",
-  description = "Choose a component type to add.",
+  // Defaults are display copy. Slugs and schema keys threaded through this component keep the
+  // stored `component` spelling.
+  title = "Add Field Group",
+  description = "Choose a field group to add.",
 }: ComponentSelectorProps) {
   // Search state
   const [searchQuery, setSearchQuery] = useState("");
@@ -316,7 +318,7 @@ export function ComponentSelector({
           <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground pointer-events-none" />
           <Input
             type="search"
-            placeholder="Search components..."
+            placeholder="Search field groups..."
             value={searchQuery}
             onChange={e => setSearchQuery(e.target.value)}
             className="pl-10 pr-10"
@@ -380,8 +382,8 @@ export function ComponentSelector({
                 <Puzzle className="h-12 w-12 mx-auto text-muted-foreground mb-3" />
                 <p className="text-muted-foreground">
                   {searchQuery
-                    ? "No components match your search."
-                    : "No components available."}
+                    ? "No field groups match your search."
+                    : "No field groups available."}
                 </p>
                 {searchQuery && (
                   <Button

--- a/packages/admin/src/components/features/entries/fields/structured/ComponentSelector.tsx
+++ b/packages/admin/src/components/features/entries/fields/structured/ComponentSelector.tsx
@@ -340,7 +340,7 @@ export function ComponentSelector({
         {searchQuery && filteredCount !== totalCount && (
           <div className="flex items-center gap-2">
             <Badge variant="default" className="text-xs">
-              {filteredCount} of {totalCount} components
+              {filteredCount} of {totalCount} field groups
             </Badge>
           </div>
         )}

--- a/packages/admin/src/components/features/schema-builder/ComponentFieldEditor.tsx
+++ b/packages/admin/src/components/features/schema-builder/ComponentFieldEditor.tsx
@@ -468,8 +468,8 @@ export function ComponentFieldEditor({
       {/* PR H feedback 2.2: subtle EditorAlert replaces the
           bg-primary/5 Tip box. */}
       <EditorAlert>
-        Components are reusable field groups. Each instance stores its own data
-        in a separate table.
+        Field groups are reusable sets of fields. Each instance stores its own
+        data in a separate table.
       </EditorAlert>
     </div>
   );

--- a/packages/admin/src/components/features/schema-builder/ComponentFieldEditor.tsx
+++ b/packages/admin/src/components/features/schema-builder/ComponentFieldEditor.tsx
@@ -41,6 +41,9 @@ import type { ComponentFieldEditorProps, ComponentFieldMode } from "./types";
 // ComponentFieldEditor Component
 // ============================================================
 
+// Field groups are called field groups in the UI. The `component` spelling that remains here is
+// the STORED one and stays: it is the field type written into `fields` JSON and the registry key
+// the API is addressed by, so renaming it would make existing content unreadable.
 export function ComponentFieldEditor({
   component,
   onComponentChange,
@@ -305,7 +308,7 @@ export function ComponentFieldEditor({
             <SelectContent>
               <SelectItem value="__none__">
                 <span className="text-muted-foreground">
-                  No component selected
+                  No field group selected
                 </span>
               </SelectItem>
               {availableComponents.map(comp => (

--- a/packages/admin/src/components/features/schema-builder/ComponentFieldEditor.tsx
+++ b/packages/admin/src/components/features/schema-builder/ComponentFieldEditor.tsx
@@ -172,12 +172,14 @@ export function ComponentFieldEditor({
       <div className="space-y-4">
         <div className="flex items-center gap-2">
           <Icons.Puzzle className="h-4 w-4 text-muted-foreground" />
-          <Label className="text-xs font-medium">Component Configuration</Label>
+          <Label className="text-xs font-medium">
+            Field Group Configuration
+          </Label>
         </div>
         <div className="flex items-center justify-center p-6">
           <Icons.Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
           <span className="ml-2 text-sm text-muted-foreground">
-            Loading components...
+            Loading field groups...
           </span>
         </div>
       </div>
@@ -190,14 +192,16 @@ export function ComponentFieldEditor({
       <div className="space-y-4">
         <div className="flex items-center gap-2">
           <Icons.Puzzle className="h-4 w-4 text-muted-foreground" />
-          <Label className="text-xs font-medium">Component Configuration</Label>
+          <Label className="text-xs font-medium">
+            Field Group Configuration
+          </Label>
         </div>
         {/* PR H feedback 2.2: subtle EditorAlert replaces the loud
             amber empty state. */}
         <EditorAlert>
           <div className="space-y-2">
             <p>
-              No components available. Create a component first to use this
+              No field groups available. Create a field group first to use this
               field type.
             </p>
             <Link
@@ -205,7 +209,7 @@ export function ComponentFieldEditor({
               className="inline-flex items-center gap-1 text-foreground hover:underline"
             >
               <Icons.Plus className="h-3 w-3" />
-              Create component
+              Create field group
             </Link>
           </div>
         </EditorAlert>
@@ -218,7 +222,7 @@ export function ComponentFieldEditor({
       {/* Section Header */}
       <div className="flex items-center gap-2">
         <Icons.Puzzle className="h-4 w-4 text-muted-foreground" />
-        <Label className="text-xs font-medium">Component Configuration</Label>
+        <Label className="text-xs font-medium">Field Group Configuration</Label>
       </div>
 
       {/* Mode Toggle */}
@@ -278,15 +282,15 @@ export function ComponentFieldEditor({
         </div>
         <p className="text-xs text-muted-foreground mt-2">
           {currentMode === "single"
-            ? "Embed one specific component type"
-            : "Allow editors to choose from multiple component types"}
+            ? "Embed one specific field group"
+            : "Allow editors to choose from multiple field groups"}
         </p>
       </div>
 
       {/* Component Selection */}
       <div className="space-y-2 pt-2  border-t border-border">
         <Label className="text-xs font-medium">
-          {currentMode === "single" ? "Component" : "Available Components"}
+          {currentMode === "single" ? "Field Group" : "Available Field Groups"}
         </Label>
 
         {currentMode === "single" ? (
@@ -296,7 +300,7 @@ export function ComponentFieldEditor({
             onValueChange={handleSingleComponentChange}
           >
             <SelectTrigger className="h-8 text-sm">
-              <SelectValue placeholder="Select a component" />
+              <SelectValue placeholder="Select a field group" />
             </SelectTrigger>
             <SelectContent>
               <SelectItem value="__none__">

--- a/packages/admin/src/components/features/schema-builder/ComponentFieldEditor.tsx
+++ b/packages/admin/src/components/features/schema-builder/ComponentFieldEditor.tsx
@@ -367,7 +367,7 @@ export function ComponentFieldEditor({
             </Badge>
             {(!components || components.length === 0) && (
               <span className="text-xs text-muted-foreground">
-                Select at least one component
+                Select at least one field group
               </span>
             )}
           </div>

--- a/packages/admin/src/components/features/schema-builder/field-editor-sheet/AdvancedTab.tsx
+++ b/packages/admin/src/components/features/schema-builder/field-editor-sheet/AdvancedTab.tsx
@@ -24,7 +24,7 @@ type Props = {
 };
 
 const NESTED_UNIQUE_TOOLTIP =
-  "Unique can't be enforced inside a repeater or repeatable component. The constraint would apply across the whole table, not per row. For per-row uniqueness, use code-first config.";
+  "Unique can't be enforced inside a repeater or repeatable field group. The constraint would apply across the whole table, not per row. For per-row uniqueness, use code-first config.";
 
 export function AdvancedTab({
   field,

--- a/packages/admin/src/components/features/schema-builder/field-editor-sheet/__tests__/AdvancedTab.test.tsx
+++ b/packages/admin/src/components/features/schema-builder/field-editor-sheet/__tests__/AdvancedTab.test.tsx
@@ -109,7 +109,7 @@ describe("AdvancedTab -- unique disabled when nested (PR E3)", () => {
     expect(screen.getByRole("switch", { name: /^unique$/i })).toBeDisabled();
     expect(
       screen.getByText(
-        /unique can't be enforced inside a repeater or repeatable component/i
+        /unique can't be enforced inside a repeater or repeatable field group/i
       )
     ).toBeInTheDocument();
   });

--- a/packages/admin/src/components/icons/index.ts
+++ b/packages/admin/src/components/icons/index.ts
@@ -147,7 +147,7 @@ export {
   Phone, // Collection Settings: icon picker
   Play, // APIPlayground: execute request button
   Plus,
-  Puzzle, // Component Builder: default component icon
+  Puzzle, // Field Group builder: default field-group icon
   Quote, // Rich text editor
   Redo, // Rich text editor
   RefreshCw,

--- a/packages/admin/src/hooks/queries/useFieldGroups.ts
+++ b/packages/admin/src/hooks/queries/useFieldGroups.ts
@@ -199,7 +199,7 @@ export function useFieldGroup(
       : fieldGroupKeys.details(),
     queryFn: async () => {
       if (!fieldGroupSlug) {
-        throw new Error("Component slug is required");
+        throw new Error("Field group slug is required");
       }
       return await fieldGroupApi.get(fieldGroupSlug);
     },

--- a/packages/admin/src/lib/builder/__tests__/field-validators.test.ts
+++ b/packages/admin/src/lib/builder/__tests__/field-validators.test.ts
@@ -43,7 +43,7 @@ describe("validateBuilderFields", () => {
     });
   });
 
-  it("returns the missing-component-reference error for a component field with no component", () => {
+  it("returns the missing-reference error for a field-group field with no field group", () => {
     const fields: BuilderField[] = [
       baseField({
         id: "f1",
@@ -55,7 +55,9 @@ describe("validateBuilderFields", () => {
     ];
     const result = validateBuilderFields(fields);
     expect(result.valid).toBe(false);
-    expect(result.errorMessage).toMatch(/Component field "hero" must have/);
+    expect(result.errorMessage).toMatch(
+      /Field "hero" must have a field group selected/
+    );
   });
 
   it("returns the missing-options error for a select field with no options", () => {

--- a/packages/admin/src/lib/builder/field-validators.ts
+++ b/packages/admin/src/lib/builder/field-validators.ts
@@ -29,7 +29,7 @@ export function validateBuilderFields(
   if (missingRef) {
     return {
       valid: false,
-      errorMessage: `Component field "${missingRef}" must have a component selected`,
+      errorMessage: `Field "${missingRef}" must have a field group selected`,
     };
   }
 

--- a/packages/admin/src/pages/dashboard/field-group/builder/[slug].tsx
+++ b/packages/admin/src/pages/dashboard/field-group/builder/[slug].tsx
@@ -447,7 +447,7 @@ export default function FieldGroupBuilderEditPage({
             Field Group Not Found
           </h2>
           <p className="text-muted-foreground">
-            No component slug was provided.
+            No field group slug was provided.
           </p>
         </div>
       </div>
@@ -719,7 +719,7 @@ export default function FieldGroupBuilderEditPage({
 
       {(isSaving || isApplyingSchema) && (
         <div aria-live="polite" className="sr-only">
-          Saving component changes…
+          Saving field group changes…
         </div>
       )}
     </div>

--- a/packages/admin/src/pages/dashboard/field-group/components/FieldGroupTable.tsx
+++ b/packages/admin/src/pages/dashboard/field-group/components/FieldGroupTable.tsx
@@ -226,7 +226,7 @@ export default function FieldGroupTable() {
 
   const handleBulkDelete = useCallback(() => {
     if (selectedCount === 0) {
-      toast.error("No components selected");
+      toast.error("No field groups selected");
       return;
     }
     setBulkDeleteDialogOpen(true);
@@ -240,22 +240,22 @@ export default function FieldGroupTable() {
       onSuccess: result => {
         if (result.failed === 0) {
           toast.success("Field groups deleted", {
-            description: `${result.succeeded} components deleted successfully.`,
+            description: `${result.succeeded} field groups deleted successfully.`,
           });
         } else {
           toast.warning("Partially completed", {
             description: `${result.succeeded} deleted, ${result.failed} failed.`,
           });
-          console.error("Failed to delete components:", result.failedIds);
+          console.error("Failed to delete field groups:", result.failedIds);
         }
         setBulkDeleteDialogOpen(false);
         clearSelection();
       },
       onError: result => {
         toast.error("Deletion failed", {
-          description: `Failed to delete ${result.failed} components.`,
+          description: `Failed to delete ${result.failed} field groups.`,
         });
-        console.error("Failed components:", result.failedIds);
+        console.error("Failed field groups:", result.failedIds);
       },
     });
   }, [filteredData, selectedIds, bulkDeleteFieldGroups, clearSelection]);
@@ -269,7 +269,7 @@ export default function FieldGroupTable() {
     () => [
       {
         name: "label",
-        header: "COMPONENT",
+        header: "FIELD GROUP",
         cell: ({ row }) => {
           const iconName = row.admin?.icon || "Puzzle";
           const IconComponent =
@@ -453,7 +453,7 @@ export default function FieldGroupTable() {
         <SearchBar
           value={search}
           onChange={setSearch}
-          placeholder="Search components..."
+          placeholder="Search field groups..."
           isLoading={isFetching}
           className="w-full border-border bg-background text-foreground md:max-w-sm"
         />
@@ -585,7 +585,7 @@ export default function FieldGroupTable() {
         <Alert variant="destructive">
           {error instanceof Error
             ? error.message
-            : "Failed to load components. Please try again."}
+            : "Failed to load field groups. Please try again."}
         </Alert>
       ) : showLoadingSkeleton ? (
         <FieldGroupTableSkeleton />
@@ -600,9 +600,10 @@ export default function FieldGroupTable() {
             primaryColumn="label"
             selection={selection}
             rowActions={rowActions}
+            // Storage identifier, not copy: this addresses the registry the API serves.
             registryKey="components"
             ariaLabel="Field Groups table"
-            emptyMessage="No components found. Try adjusting your search or filters."
+            emptyMessage="No field groups found. Try adjusting your search or filters."
           />
           {data && (
             <Pagination

--- a/packages/admin/src/pages/dashboard/field-group/components/FieldGroupTable.tsx
+++ b/packages/admin/src/pages/dashboard/field-group/components/FieldGroupTable.tsx
@@ -445,7 +445,7 @@ export default function FieldGroupTable() {
           collection={undefined}
           onDelete={handleBulkDelete}
           onClear={clearSelection}
-          itemLabel="component"
+          itemLabel="field group"
         />
       )}
 

--- a/packages/admin/src/pages/dashboard/field-group/components/FieldGroupsEmptyState.tsx
+++ b/packages/admin/src/pages/dashboard/field-group/components/FieldGroupsEmptyState.tsx
@@ -57,14 +57,14 @@ export const FieldGroupsEmptyState: React.FC<FieldGroupsEmptyStateProps> = ({
 
       {/* Headline */}
       <h3 className="text-lg font-semibold text-foreground mb-2">
-        {isSearching ? "No components found" : "No components yet"}
+        {isSearching ? "No field groups found" : "No field groups yet"}
       </h3>
 
       {/* Description */}
       <p className="text-sm text-muted-foreground mb-6 max-w-sm mx-auto">
         {isSearching
-          ? "No components match your search. Try adjusting your search terms or filters."
-          : "Get started by creating your first reusable component to share across your collections."}
+          ? "No field groups match your search. Try adjusting your search terms or filters."
+          : "Get started by creating your first reusable field group to share across your collections."}
       </p>
 
       {/* CTA (only show when not searching/filtering) */}

--- a/packages/nextly/src/collections/fields/catalog.test.ts
+++ b/packages/nextly/src/collections/fields/catalog.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vitest";
 
+import { STORAGE_FORMAT } from "../../schemas/storage-format";
+
 import {
   BINDABLE_KINDS,
   BLOCK_FIELD_TYPES,
@@ -351,5 +353,33 @@ describe("binding kinds", () => {
     expect(canBindFieldToProp({ type: "toString" }, { type: "text" })).toBe(
       false
     );
+  });
+});
+
+// The field group's field type has two spellings that must not be confused: what the picker SHOWS
+// and what gets written to disk. The label was renamed with the rest of the vocabulary; the stored
+// value deliberately was not, because changing it rewrites `fields` JSON in three registry tables.
+//
+// This pins them apart. A sweep that renames the label and takes the value with it would pass every
+// other test in the suite while silently making existing content unreadable.
+describe("field group entry: display name vs stored value", () => {
+  const entry = FIELD_TYPE_CATALOG.find(f => f.label === "Field Group");
+
+  it("presents itself as a field group", () => {
+    expect(entry).toBeDefined();
+    expect(entry?.hint).toBe("Embed a reusable field group");
+  });
+
+  it("still stores the value the on-disk format defines, not the label", () => {
+    expect(entry?.type).toBe(STORAGE_FORMAT.fieldType);
+    expect(STORAGE_FORMAT.fieldType).toBe("component");
+  });
+
+  // No catalog entry may present itself with the pre-rename vocabulary.
+  it("leaves no catalog entry labelled or hinted 'component'", () => {
+    const stale = FIELD_TYPE_CATALOG.filter(
+      f => /component/i.test(f.label) || /component/i.test(f.hint ?? "")
+    );
+    expect(stale.map(f => f.label)).toEqual([]);
   });
 });

--- a/packages/nextly/src/collections/fields/catalog.ts
+++ b/packages/nextly/src/collections/fields/catalog.ts
@@ -173,6 +173,9 @@ export const FIELD_TYPE_CATALOG: readonly FieldTypeCatalogEntry[] = [
     icon: "FolderOpen",
   },
   {
+    // `type` is the STORED value and deliberately still reads `component`; the label is what the
+    // picker shows. Renaming the type would make every existing `fields` JSON row unreadable, so
+    // the two are pinned apart by a test rather than left to be kept in step by hand.
     type: STORAGE_FORMAT.fieldType,
     label: "Field Group",
     category: "Structured",

--- a/packages/nextly/src/collections/fields/catalog.ts
+++ b/packages/nextly/src/collections/fields/catalog.ts
@@ -174,9 +174,9 @@ export const FIELD_TYPE_CATALOG: readonly FieldTypeCatalogEntry[] = [
   },
   {
     type: STORAGE_FORMAT.fieldType,
-    label: "Component",
+    label: "Field Group",
     category: "Structured",
-    hint: "Embed a reusable component",
+    hint: "Embed a reusable field group",
     icon: "Puzzle",
   },
 ];

--- a/packages/nextly/src/init/__tests__/core-schema-drift-registry.test.ts
+++ b/packages/nextly/src/init/__tests__/core-schema-drift-registry.test.ts
@@ -40,12 +40,21 @@ describe("the boot core-schema drift check on a migrated database", () => {
   it("introspects the migrated registry and never the legacy one", async () => {
     introspectLiveSnapshot.mockResolvedValue({ tables: [] });
 
-    await warnIfCoreSchemaIsBehind(adapter, {
-      debug: () => {},
-      info: () => {},
-      warn: () => {},
-      error: () => {},
-    });
+    // The production timeout is deliberately overridden. `warnIfCoreSchemaIsBehind` races the
+    // check against a 2s deadline so a slow database cannot delay boot, and the check begins with
+    // two dynamic imports — under a loaded full-suite run those lose the race, the check never
+    // reaches `introspectLiveSnapshot`, and this fails with "called 0 times" while passing alone.
+    // What is under test is WHICH tables get introspected, not whether the check beats a clock.
+    await warnIfCoreSchemaIsBehind(
+      adapter,
+      {
+        debug: () => {},
+        info: () => {},
+        warn: () => {},
+        error: () => {},
+      },
+      60_000
+    );
 
     expect(introspectLiveSnapshot).toHaveBeenCalledTimes(1);
     const names = introspectLiveSnapshot.mock.calls[0][2] as string[];


### PR DESCRIPTION
Found while answering a question about a fresh `create-nextly-app` project on alpha.50 still showing "components".

Phase A of the field-groups rename flipped the API, the routes, the generated types and the docs. It missed display copy, so the product contradicts itself: a page titled **Field Groups** tells you that you selected **components**, and the field picker offers a type called **Component**.

## What changes

Words only, across five surfaces:

| Surface | Before | After |
|---|---|---|
| Field picker | "Component" / "Embed a reusable component" | "Field Group" / "Embed a reusable field group" |
| Schema Builder editor | "Component Configuration", "Available Components", "Select a component", "Loading components...", "No components available. Create a component first", "Embed one specific component type" | the field-group wording throughout |
| Entry form | fallback labels "Component" / "Components" | "Field Group" / "Field Groups" |
| Entries table | badge "Component" | badge "Field Group" |
| Field Groups list | "N components selected" | "N field groups selected" |
| Builder validation | `Component field "x" must have a component selected` | `Field "x" must have a field group selected` |

## What deliberately does NOT change

The **stored** vocabulary, all of it: the field type value `component`, the `comp_` table prefix, `dynamic_components`, the `_componentType` wire key. Those are phase B2 and moving them means rewriting live databases. Nothing here touches data, table names or API payloads.

That distinction is now enforced rather than trusted. A catalog test pins the label and the stored value apart:

```ts
expect(entry?.type).toBe(STORAGE_FORMAT.fieldType);
expect(STORAGE_FORMAT.fieldType).toBe("component");
```

Proven load-bearing by making exactly the mistake it guards: renaming `STORAGE_FORMAT.fieldType` to `fieldGroup` alongside the label fails it (and a pre-existing catalog test as well). A sweep that renamed both would otherwise pass the whole suite while making existing content unreadable.

A third case asserts no catalog entry is left labelled or hinted "component", so the next field type added with the old wording is caught rather than shipped.

## Verification

`pnpm build` 17/17 · `check-types --force` 19/19 · `lint` exit 0.

Both affected packages diffed at test-name level against `origin/main` measured in its own installed and built worktree:
- `nextly`: **zero branch-only failures** (396 unique both sides), total 6633 → 6636
- `@nextlyhq/admin`: **zero branch-only failures** (37 unique both sides), total 1431

One admin test did fail on the first run, correctly: it pinned the old validator copy. Updated to the new wording, keeping the behaviour it checks.