### PR TITLE
feat(admin): freeze a slug the row records as once public

### DIFF
--- a/.changeset/admin-first-published-freeze.md
+++ b/.changeset/admin-first-published-freeze.md
@@ -1,0 +1,32 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+Keep the durable first-publication marker on every shape the entry editor uses, and let the
+editor trust it. A published entry that was unpublished and then reloaded no longer offers its
+slug back to the title generator, so republishing lands at the address the links already point
+at. The marker is consulted only for a slug shared by every language, because it records that a
+document was public somewhere rather than in one particular language.
+
+The marker also survives editing: a document with a pending working draft now reports it on the
+save response and on the draft read, as a date rather than a string, matching an ordinary read.

--- a/packages/admin/src/components/features/entries/EntryForm/__tests__/entry-address.test.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/__tests__/entry-address.test.tsx
@@ -170,9 +170,14 @@ describe("everPublishedOnRecord", () => {
   });
 
   it("does not treat an unparseable value as a publication", () => {
-    // An empty string and an invalid date are not timestamps. Accepting either would freeze a slug
-    // on the strength of a malformed field.
+    // Freezing is permanent for the session, so a value that does not describe a moment in time
+    // must not buy it. A serialized marker goes through the same parse as a decoded one: taking a
+    // string on trust for being non-empty would let a malformed value a custom `afterRead` hook
+    // substituted freeze the slug of an entry that may never have been published.
     expect(everPublishedOnRecord(entry({ firstPublishedAt: "" }))).toBe(false);
+    expect(
+      everPublishedOnRecord(entry({ firstPublishedAt: "not a date" }))
+    ).toBe(false);
     expect(
       everPublishedOnRecord(entry({ firstPublishedAt: new Date("nonsense") }))
     ).toBe(false);

--- a/packages/admin/src/components/features/entries/EntryForm/__tests__/entry-address.test.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/__tests__/entry-address.test.tsx
@@ -8,6 +8,7 @@ import { describe, expect, it } from "vitest";
 import {
   anyLocalePublished,
   effectiveEntryStatus,
+  everPublishedOnRecord,
   useHasPublicAddress,
   type PublicAddressArgs,
 } from "../entry-address";
@@ -142,6 +143,39 @@ describe("anyLocalePublished", () => {
     // so trusting it would call an entry unpublished while another language is live and hand its
     // shared slug back to the generator. Losing auto-slug convenience is the cheaper mistake.
     expect(anyLocalePublished(entry({ status: "draft" }), true)).toBe(true);
+  });
+});
+
+describe("everPublishedOnRecord", () => {
+  it("reads the serialized timestamp an API response carries", () => {
+    expect(
+      everPublishedOnRecord(entry({ firstPublishedAt: "2026-02-01T10:00:00Z" }))
+    ).toBe(true);
+  });
+
+  it("reads the Date a hook-shaped document carries", () => {
+    expect(
+      everPublishedOnRecord(entry({ firstPublishedAt: new Date("2026-02-01") }))
+    ).toBe(true);
+  });
+
+  it("is false for a row that predates the column", () => {
+    // The column is nullable and null for every entry written before it existed, so an absent
+    // marker means "not known to have been published" and must not assert anything.
+    expect(everPublishedOnRecord(entry({ firstPublishedAt: null }))).toBe(
+      false
+    );
+    expect(everPublishedOnRecord(entry())).toBe(false);
+    expect(everPublishedOnRecord(null)).toBe(false);
+  });
+
+  it("does not treat an unparseable value as a publication", () => {
+    // An empty string and an invalid date are not timestamps. Accepting either would freeze a slug
+    // on the strength of a malformed field.
+    expect(everPublishedOnRecord(entry({ firstPublishedAt: "" }))).toBe(false);
+    expect(
+      everPublishedOnRecord(entry({ firstPublishedAt: new Date("nonsense") }))
+    ).toBe(false);
   });
 });
 
@@ -345,5 +379,67 @@ describe("useHasPublicAddress", () => {
     rerender(perLocale({ entry: entry(EN_LIVE_DE_DRAFT), locale: "de" }));
 
     expect(result.current).toBe(false);
+  });
+
+  it("freezes a shared slug on a fresh mount when the row records a publication", () => {
+    // The sequence the session latch cannot see: publish, unpublish, RELOAD, retitle. The reload
+    // discards the latch, so before the row recorded anything this remounted editor believed it was
+    // looking at an entry that had never been public and handed its URL back to the generator.
+    const { result } = render(
+      shared({
+        entry: entry({
+          status: "draft",
+          firstPublishedAt: "2026-02-01T10:00:00Z",
+        }),
+      })
+    );
+
+    expect(result.current).toBe(true);
+  });
+
+  it("leaves a localized slug free even when the entry has been public elsewhere", () => {
+    // The marker lives on the main row, so it answers "public in SOME language". A slug the author
+    // opted into localizing is genuinely per-language: German's own address has never been served,
+    // and freezing it because English once was would take away auto-slug for no reason.
+    const { result } = render(
+      perLocale({
+        entry: entry({
+          ...EN_LIVE_DE_DRAFT,
+          firstPublishedAt: "2026-02-01T10:00:00Z",
+        }),
+        locale: "de",
+      })
+    );
+
+    expect(result.current).toBe(false);
+  });
+
+  it("is unchanged for a draft whose row records no publication", () => {
+    // The marker may only ever ADD freezing. An entry that has genuinely never been published, and
+    // every row written before the column existed, must behave exactly as they did before.
+    const { result } = render(
+      shared({ entry: entry({ status: "draft", firstPublishedAt: null }) })
+    );
+
+    expect(result.current).toBe(false);
+  });
+
+  it("keeps the freeze when a later response omits the marker", () => {
+    // Not every response shape carries every system column, and one that drops the key must not be
+    // read as a row that was never published — that would unfreeze a live URL mid-edit. The marker
+    // is a committed server value rather than an optimistic one, so it is latched on sight.
+    const { result, rerender } = render(
+      shared({
+        entry: entry({
+          status: "draft",
+          firstPublishedAt: "2026-02-01T10:00:00Z",
+        }),
+      })
+    );
+    expect(result.current).toBe(true);
+
+    rerender(shared({ entry: entry({ status: "draft" }) }));
+
+    expect(result.current).toBe(true);
   });
 });

--- a/packages/admin/src/components/features/entries/EntryForm/entry-address.ts
+++ b/packages/admin/src/components/features/entries/EntryForm/entry-address.ts
@@ -133,15 +133,20 @@ export function anyLocalePublished(
  *
  * The column is nullable and null for every row that predates it, so a missing marker means "not
  * known to have been published" rather than "never published" — which is why it may only ever add
- * to the answer. Both the serialized string an API response carries and the `Date` a hook-shaped
- * document carries are accepted; an empty string is not a timestamp.
+ * to the answer.
+ *
+ * A response carries the timestamp serialized while a hook-shaped document carries it decoded, so
+ * both are accepted, and both are put through the same parse rather than a string being taken on
+ * trust for being non-empty. Freezing is permanent for the session, so a value that does not
+ * describe a moment in time — an empty string, a malformed one a custom `afterRead` hook
+ * substituted, an `Invalid Date` — must not buy it.
  */
 export function everPublishedOnRecord(
   entry: EntryData | null | undefined
 ): boolean {
   const marker = entry?.firstPublishedAt;
-  if (marker instanceof Date) return !Number.isNaN(marker.getTime());
-  return typeof marker === "string" && marker.length > 0;
+  if (typeof marker !== "string" && !(marker instanceof Date)) return false;
+  return !Number.isNaN(new Date(marker).getTime());
 }
 
 export interface PublicAddressArgs {

--- a/packages/admin/src/components/features/entries/EntryForm/entry-address.ts
+++ b/packages/admin/src/components/features/entries/EntryForm/entry-address.ts
@@ -123,6 +123,27 @@ export function anyLocalePublished(
   return entry?.status === "published";
 }
 
+/**
+ * Whether the row records that this entry has been public at some point.
+ *
+ * `firstPublishedAt` is stamped once, on the first transition into published, and never cleared —
+ * so unlike `status` it survives an unpublish, and unlike the latch below it survives a reload.
+ * It lives on the main row, which makes it an ENTRY-level fact: "public in some language", not
+ * "public in this one".
+ *
+ * The column is nullable and null for every row that predates it, so a missing marker means "not
+ * known to have been published" rather than "never published" — which is why it may only ever add
+ * to the answer. Both the serialized string an API response carries and the `Date` a hook-shaped
+ * document carries are accepted; an empty string is not a timestamp.
+ */
+export function everPublishedOnRecord(
+  entry: EntryData | null | undefined
+): boolean {
+  const marker = entry?.firstPublishedAt;
+  if (marker instanceof Date) return !Number.isNaN(marker.getTime());
+  return typeof marker === "string" && marker.length > 0;
+}
+
 export interface PublicAddressArgs {
   /** Create forms have no address yet; only a persisted entry can have one. */
   mode: "create" | "edit";
@@ -168,7 +189,7 @@ export interface PublicAddressArgs {
 /**
  * Whether this entry's slug is already a public address.
  *
- * Three things make it one, and each covers a case the others miss:
+ * Four things make it one, and each covers a case the others miss:
  *
  * - **No Draft/Published lifecycle.** A collection without status has no unpublished state: saving
  *   an entry makes it readable. Asking whether such an entry is "published" can only ever answer
@@ -176,6 +197,8 @@ export interface PublicAddressArgs {
  * - **Published where this slug is served.** For a slug the author localized, that is the language
  *   in view. For the default shared slug it is ANY language, because they all resolve through the
  *   one field.
+ * - **Recorded as having been published before.** The row's own `firstPublishedAt` outlives the
+ *   session, so an entry unpublished, reloaded and then retitled is still recognised.
  * - **Published at any point while this editor has been open.** Unpublishing returns the row to
  *   draft, but the links, feeds and search results that accumulated while it was live do not go
  *   away, so republishing under a title-derived slug would silently move it.
@@ -185,10 +208,16 @@ export interface PublicAddressArgs {
  * language, or navigating away and back, does not discard what was already observed. A single slot
  * loses the first address the moment a second one is looked at.
  *
- * The latch is still bounded by the editing session, because nothing durable records that an entry
- * was once published: there is no first-published timestamp on the row. An entry unpublished,
- * reloaded, and then retitled still tracks. Closing that needs a persisted marker in core rather
- * than a longer-lived ref here.
+ * The recorded marker is consulted only for a SHARED slug. It answers "this entry has been public
+ * in some language", which is exactly right when one field serves every language's URL and too
+ * coarse when it does not: for a slug the author opted into localizing it would freeze a
+ * translation whose own address has never been public. Per-language durability would need the
+ * marker on the companion rows; until then the opt-in case keeps the session latch it has now.
+ *
+ * The four terms are combined by OR alone, so each can only ever ADD freezing. That is what makes
+ * partial coverage safe in both directions: a row written before the marker existed, or by a write
+ * path that does not stamp it yet, falls back to exactly today's behaviour instead of unfreezing a
+ * URL that is live.
  */
 export function useHasPublicAddress({
   mode,
@@ -214,8 +243,14 @@ export function useHasPublicAddress({
   const liveNow = slugLocalized
     ? effectiveEntryStatus(entry, locale) === "published"
     : anyLocalePublished(entry, collectionLocalized);
+  // An entry-level fact answers for an entry-level address only. See the note above on why a slug
+  // the author localized is left to the latch.
+  const publishedOnRecord = !slugLocalized && everPublishedOnRecord(entry);
   // Freeze on the pending state, but only REMEMBER it once the write has settled — the cache may
-  // still be holding an optimistic publish that is about to be rolled back.
+  // still be holding an optimistic publish that is about to be rolled back. The recorded marker
+  // needs no such wait: it is a value the server has already committed, so it is latched at once
+  // and a later response that omits the key cannot unfreeze the address.
   if (liveNow && !mutationPending) seenRef.current.add(addressKey);
-  return liveNow || seenRef.current.has(addressKey);
+  if (publishedOnRecord) seenRef.current.add(addressKey);
+  return liveNow || publishedOnRecord || seenRef.current.has(addressKey);
 }

--- a/packages/nextly/src/domains/collections/__tests__/first-published-marker.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/first-published-marker.integration.test.ts
@@ -524,6 +524,73 @@ describe("first_published_at", () => {
     }
   });
 
+  it("keeps the marker on the working-draft shapes of a published document", async () => {
+    // A document with a pending working draft is written and read through documents rebuilt from a
+    // stored snapshot rather than from the row, and each rebuild restored the system columns from a
+    // list written out by hand. The marker was missing from those while an ordinary read of the
+    // same document returned it, so a published entry looked like one that had never been public
+    // for exactly as long as someone was editing it.
+    current = await createTestNextly({
+      collections: [
+        defineCollection({
+          slug: "fpmdrafts",
+          status: true,
+          versions: { drafts: true },
+          fields: [text({ name: "title" })],
+        }),
+      ],
+    });
+    const h = handler(current);
+    const trusted = { collectionName: "fpmdrafts", overrideAccess: true };
+
+    const created = await h.createEntry(trusted, {
+      title: "live",
+      status: "published",
+    });
+    const id = (created.data as { id: string }).id;
+
+    // An update carrying no status accumulates a working draft instead of touching the live row.
+    const updated = await h.updateEntry(
+      { ...trusted, entryId: id },
+      { title: "edited" }
+    );
+    assert(isRecord(updated.data), "the update returned no document");
+    // The live row is untouched, which is what proves the response above came from the draft
+    // shaper rather than from an ordinary row update that would carry the column anyway.
+    const rows = await tableRows(current, "dc_fpmdrafts");
+    expect(rows.find(r => r.id === id)?.title).toBe("live");
+    expect(updated.data.title).toBe("edited");
+    expect(updated.data.firstPublishedAt).toBeInstanceOf(Date);
+
+    // A second save is the one that exercises the snapshot round trip: the first accumulated its
+    // document from the live row, where the timestamp is still database-decoded, while this one
+    // rebuilds from the stored draft, where JSON has left it a string.
+    const resaved = await h.updateEntry(
+      { ...trusted, entryId: id },
+      { title: "edited again" }
+    );
+    assert(isRecord(resaved.data), "the second update returned no document");
+    expect(resaved.data.title).toBe("edited again");
+    expect(resaved.data.firstPublishedAt).toBeInstanceOf(Date);
+
+    // The read that overlays that draft has to agree with an ordinary read on both counts: that
+    // the marker is present, and that it is a Date. A hook calling a date method would otherwise
+    // fail only for an entry that happens to be drafted.
+    const overlaid = await h.getEntry({
+      ...trusted,
+      entryId: id,
+      includeWorkingDraft: true,
+    });
+    assert(isRecord(overlaid.data), "the draft read returned no document");
+    expect(overlaid.data._isWorkingDraft).toBe(true);
+    expect(overlaid.data.title).toBe("edited again");
+    expect(overlaid.data.firstPublishedAt).toBeInstanceOf(Date);
+
+    const live = await h.getEntry({ ...trusted, entryId: id });
+    assert(isRecord(live.data), "the live read returned no document");
+    expect(live.data.firstPublishedAt).toBeInstanceOf(Date);
+  });
+
   it("leaves a legacy already-public document unmarked when a translation publishes", async () => {
     // The row this protects: published before this column existed, so its marker is null because
     // the history was never recorded, not because it was never public. Publishing a translation

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -61,7 +61,11 @@ import type {
 import type { FieldGroupDataService } from "../../../services/field-groups/field-group-data-service";
 import type { Logger } from "../../../services/shared";
 import { BaseService } from "../../../shared/base-service";
-import { convertTimestampsToCamelCase } from "../../../shared/lib/case-conversion";
+import {
+  convertTimestampsToCamelCase,
+  rehydrateSystemTimestamps,
+  SYSTEM_TIMESTAMP_KEYS,
+} from "../../../shared/lib/case-conversion";
 import { validateEntryData } from "../../../shared/lib/entry-validation";
 import { applyFieldDefaults } from "../../../shared/lib/field-defaults";
 import {
@@ -1689,22 +1693,14 @@ export class CollectionMutationService extends BaseService {
       documentLocalized: false,
       localeUnknown: false,
     });
-    for (const key of [
-      "id",
-      "createdAt",
-      "created_at",
-      "updatedAt",
-      "updated_at",
-    ]) {
+    // Every system timestamp spelling, taken from the shared list rather than named here: a list
+    // written out by hand carries only the columns that existed when it was written, so the
+    // first-publication marker was absent from a working-draft save's response document while an
+    // ordinary read of the same entry returned it.
+    for (const key of ["id", ...SYSTEM_TIMESTAMP_KEYS]) {
       if (key in rawDraft) payload[key] = rawDraft[key];
     }
-    for (const key of ["createdAt", "updatedAt"]) {
-      const value = payload[key];
-      if (typeof value === "string") {
-        const parsed = new Date(value);
-        if (!Number.isNaN(parsed.getTime())) payload[key] = parsed;
-      }
-    }
+    rehydrateSystemTimestamps(payload);
     rehydrateSnapshotDates(payload, fields, componentSchemas);
     return payload;
   }

--- a/packages/nextly/src/domains/collections/services/collection-query-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-query-service.ts
@@ -64,6 +64,7 @@ import type { Logger } from "../../../services/shared";
 import { BaseService } from "../../../shared/base-service";
 import {
   convertTimestampsToCamelCase,
+  rehydrateSystemTimestamps,
   SYSTEM_TIMESTAMP_KEYS,
 } from "../../../shared/lib/case-conversion";
 import {
@@ -2711,13 +2712,7 @@ export class CollectionQueryService extends BaseService {
           // drafted entry. Rehydrate the system timestamps and every declared
           // date field — including those nested inside components — to Date
           // before the read pipeline runs below.
-          for (const key of ["createdAt", "updatedAt"]) {
-            const value = draftEntry[key];
-            if (typeof value === "string") {
-              const parsed = new Date(value);
-              if (!Number.isNaN(parsed.getTime())) draftEntry[key] = parsed;
-            }
-          }
+          rehydrateSystemTimestamps(draftEntry);
           rehydrateSnapshotDates(
             draftEntry,
             declaredFields,

--- a/packages/nextly/src/shared/lib/__tests__/case-conversion.test.ts
+++ b/packages/nextly/src/shared/lib/__tests__/case-conversion.test.ts
@@ -1,0 +1,103 @@
+// The system timestamps are described in one place because a row reaches the API through several
+// paths, and a column handled on some of them and not others gives the same document different
+// shapes depending on the operation that returned it. These exercise that list's two consumers
+// directly, so a column added to it is carried by both without either being edited.
+
+import { describe, expect, it } from "vitest";
+
+import {
+  convertTimestampsToCamelCase,
+  rehydrateSystemTimestamps,
+  SYSTEM_TIMESTAMP_KEYS,
+  TIMESTAMP_COLUMN_NAMES,
+} from "../case-conversion";
+
+describe("SYSTEM_TIMESTAMP_KEYS", () => {
+  it("carries both spellings of every declared timestamp", () => {
+    // The shapers that decide which system keys survive a projection match on whichever spelling
+    // reaches them, because they can run either side of the camelCase conversion.
+    for (const [column, apiName] of TIMESTAMP_COLUMN_NAMES) {
+      expect({ [column]: SYSTEM_TIMESTAMP_KEYS.includes(column) }).toEqual({
+        [column]: true,
+      });
+      expect({ [apiName]: SYSTEM_TIMESTAMP_KEYS.includes(apiName) }).toEqual({
+        [apiName]: true,
+      });
+    }
+  });
+});
+
+describe("convertTimestampsToCamelCase", () => {
+  it("publishes every declared column under its API name and removes the raw one", () => {
+    const row: Record<string, unknown> = {};
+    for (const [column] of TIMESTAMP_COLUMN_NAMES) {
+      row[column] = new Date("2026-02-01T10:00:00Z");
+    }
+
+    const converted = convertTimestampsToCamelCase(row);
+
+    for (const [column, apiName] of TIMESTAMP_COLUMN_NAMES) {
+      expect({ [apiName]: converted[apiName] }).toEqual({
+        [apiName]: new Date("2026-02-01T10:00:00Z"),
+      });
+      expect({ [column]: column in converted }).toEqual({ [column]: false });
+    }
+  });
+
+  it("converts a null rather than dropping it", () => {
+    // A null first-publication marker means "not known to have been published", which a consumer
+    // can only distinguish from "this shape does not report it" if the key is present.
+    const converted = convertTimestampsToCamelCase({
+      first_published_at: null,
+    });
+
+    expect(converted).toEqual({ firstPublishedAt: null });
+  });
+
+  it("leaves an absent column absent", () => {
+    expect(convertTimestampsToCamelCase({ id: "e1" })).toEqual({ id: "e1" });
+  });
+});
+
+describe("rehydrateSystemTimestamps", () => {
+  it("restores every declared timestamp, under either spelling", () => {
+    const document: Record<string, unknown> = {};
+    for (const [column, apiName] of TIMESTAMP_COLUMN_NAMES) {
+      document[column] = "2026-02-01T10:00:00Z";
+      document[apiName] = "2026-03-01T10:00:00Z";
+    }
+
+    rehydrateSystemTimestamps(document);
+
+    for (const [column, apiName] of TIMESTAMP_COLUMN_NAMES) {
+      expect({ [column]: document[column] }).toEqual({
+        [column]: new Date("2026-02-01T10:00:00Z"),
+      });
+      expect({ [apiName]: document[apiName] }).toEqual({
+        [apiName]: new Date("2026-03-01T10:00:00Z"),
+      });
+    }
+  });
+
+  it("leaves a value that is already decoded alone", () => {
+    const decoded = new Date("2026-02-01T10:00:00Z");
+
+    const document = rehydrateSystemTimestamps({ createdAt: decoded });
+
+    expect(document.createdAt).toBe(decoded);
+  });
+
+  it("leaves a null marker null rather than dating it", () => {
+    // `new Date(null)` is the epoch, so a marker that says "never known to be public" would come
+    // back claiming a publication in 1970.
+    expect(rehydrateSystemTimestamps({ firstPublishedAt: null })).toEqual({
+      firstPublishedAt: null,
+    });
+  });
+
+  it("keeps an unparseable string instead of replacing it with an invalid date", () => {
+    expect(rehydrateSystemTimestamps({ updatedAt: "not a date" })).toEqual({
+      updatedAt: "not a date",
+    });
+  });
+});

--- a/packages/nextly/src/shared/lib/case-conversion.ts
+++ b/packages/nextly/src/shared/lib/case-conversion.ts
@@ -180,3 +180,27 @@ export function convertTimestampsToCamelCase<T extends Record<string, unknown>>(
   }
   return entry;
 }
+
+/**
+ * Turn any system timestamp still held as an ISO string back into a `Date`, in place.
+ *
+ * A row loaded from the database arrives Drizzle-decoded, but a row reassembled from a stored
+ * snapshot arrives as JSON, where a timestamp is a string. A caller that overlays a snapshot onto a
+ * read has to restore the decoded shape or the same hook that works for every other entry fails on
+ * a drafted one the moment it calls a date method.
+ *
+ * Both spellings are covered, because an overlay can run either side of the camelCase conversion.
+ * A value that does not parse is left as it is rather than replaced with an `Invalid Date`.
+ */
+export function rehydrateSystemTimestamps<T extends Record<string, unknown>>(
+  entry: T
+): T {
+  const record = entry as Record<string, unknown>;
+  for (const key of SYSTEM_TIMESTAMP_KEYS) {
+    const value = record[key];
+    if (typeof value !== "string") continue;
+    const parsed = new Date(value);
+    if (!Number.isNaN(parsed.getTime())) record[key] = parsed;
+  }
+  return entry;
+}


### PR DESCRIPTION
Closes the loop opened by #465: the entry editor now trusts the durable first-publication marker, and the marker survives every shape the editor puts a document through.

Task `104-admin-reads-first-published-marker.md`.

## The bug

`useHasPublicAddress` decided whether an entry's slug was already a public address from its current status plus a latch that lived only as long as the editor stayed mounted. So this still moved a live URL:

```
publish → unpublish → RELOAD → retitle → republish
```

The reload discards the latch, and a draft that has been public looks exactly like one that never was. #465 added the durable answer; nothing read it.

## What this does

**`packages/admin` — the editor consults the row.**

```
hasPublicAddress =
     !hasStatus                                     // no lifecycle: saving is publishing
  || liveNow                                        // published where this slug is served
  || (!slugLocalized && firstPublishedAt is set)    // NEW: durable, entry-scoped
  || sessionLatch                                   // seen published while mounted
```

The `!slugLocalized` guard is the whole subtlety. The column lives on the main row, so it answers *"this entry has been public in SOME language"*. For the default shared slug — one field serving every language's URL — that is exactly right. For a slug the author opted into localizing it is too coarse: it would freeze a translation whose own address has never been served. Per-language durability needs the marker on the companion rows; until then the opt-in case keeps the latch it has today.

The four terms are combined by **OR alone**, so each can only ever ADD freezing. A row written before the column existed, or by a write path that does not stamp it yet, falls back to exactly the previous behaviour rather than unfreezing a URL that is live.

The marker is latched on sight, without the `mutationPending` guard `liveNow` needs: it is a value the server has already committed rather than an optimistic one, so a later response that omits the key cannot unfreeze the address mid-edit.

**`packages/nextly` — the marker survives being edited.**

Verifying the payload turned up two shapes that dropped it, both the same defect #465 fixed twice already: a document with a pending working draft is written and read through documents rebuilt from a stored snapshot, and each rebuild restored the system columns from a list written out by hand. Those lists carried the two timestamps that existed when they were written.

- `shapeDraftForResponse` omitted the marker from a working-draft save's response document, and from the prior-draft document the `afterUpdate` hooks diff against.
- the draft-overlay read left it an ISO string while an ordinary read of the same document hands hooks a decoded `Date`.

Both now take `SYSTEM_TIMESTAMP_KEYS`, and the two copies of the string→`Date` loop collapse into one `rehydrateSystemTimestamps` beside the list they depend on. A column added to that list is carried by all of these shapes without an edit at any of them.

This is the fifth and sixth occurrence of one shape. `tasks/left-tasks/111-system-columns-need-declared-policies.md` is the standing proposal to end it.

## Verification

Every change has a falsification that fails without it, each for its own reason:

| reverted | fails with |
|---|---|
| the durable term in the predicate | 2 admin tests |
| the `!slugLocalized` guard | localized slug wrongly frozen |
| the empty-string / invalid-date guard | a malformed marker freezes a slug |
| the widened draft copy-back | `expected undefined to be an instance of Date` |
| the rehydrate in the draft response shaper | `expected '2026-…Z' to be an instance of Date` |
| the rehydrate in the draft overlay read | `expected '2026-…Z' to be an instance of Date` |

The integration case asserts the live row still reads `"live"` while the response reads `"edited"`, so it cannot pass through an ordinary row update that would carry the column anyway, and it saves **twice** — the first save assembles from the row, where the timestamp is still database-decoded; only the second round-trips through stored JSON.

**Three dialect legs, run one at a time, databases recreated before each:**

| leg | passed | failed |
|---|---|---|
| sqlite | 1010 | 0 |
| postgres17 | 1159 | 0 |
| mysql | 1090 | 0 |

`check-types` (source and tests) and `lint` clean in both packages. Unit suites measured against a baseline captured from this same tree with the change reverted: admin 37 failures both with and without it, nextly 37 failing files both ways — **no new failures**.
