### PR TITLE
refactor(nextly): declare the system columns in one place

### DIFF
--- a/.changeset/system-column-declarations.md
+++ b/.changeset/system-column-declarations.md
@@ -1,0 +1,31 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+Reject a Schema Builder field named `createdAt` or `updatedAt` when the name is chosen, rather
+than letting it fail later as a database error. Both snake-case onto a system column and land in
+the same `CREATE TABLE` twice, so a collection carrying one could never be created.
+
+Internally, what a system column is now lives in one declaration per column instead of ten
+hand-written lists across the codebase, so a column added in future reaches the schema, the
+write paths, the response shapes and every validator at once.

--- a/packages/nextly/src/collections/config/validate-config.ts
+++ b/packages/nextly/src/collections/config/validate-config.ts
@@ -25,6 +25,7 @@
  */
 
 import { isPluginFieldTypeOnSurface } from "../../domains/schema/field-types/field-type-registry";
+import { reservedSystemFieldNames } from "../../lib/system-columns";
 import { SYSTEM_RESOURCES } from "../../schemas/_zod/rbac";
 import {
   type BaseValidationError,
@@ -180,12 +181,9 @@ const RESERVED_SLUGS_SET: Set<string> = new Set<string>([
 // Components embed in JSON and carry neither column, so they may use both names
 // freely. Nested repeater/group fields are stored inside JSON, not as table
 // columns, so the reservation applies to the top level only.
-const COLLECTION_RESERVED_FIELD_NAMES: Set<string> = new Set([
-  "created_by",
-  "createdBy",
-  "first_published_at",
-  "firstPublishedAt",
-]);
+const COLLECTION_RESERVED_FIELD_NAMES: ReadonlySet<string> = new Set(
+  reservedSystemFieldNames("collectionConfig")
+);
 
 // ============================================================
 // Index Validation (collection-specific)

--- a/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-validation-service.ts
+++ b/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-validation-service.ts
@@ -10,6 +10,9 @@ import type { FieldDefinition } from "@nextly/schemas/dynamic-collections";
  * vector for hiding catastrophic-backtracking constructs that defeat
  * static analyzers.
  */
+
+import { reservedSystemFieldNames } from "../../../lib/system-columns";
+
 const MAX_REGEX_PATTERN_LENGTH = 200;
 
 /**
@@ -95,25 +98,16 @@ export const RESERVED_COLLECTION_NAMES = [
 ] as const;
 
 /** Reserved field names (added automatically). */
-export const RESERVED_FIELD_NAMES = [
-  "id",
-  "title",
-  "slug",
-  "created_at",
-  "updated_at",
-  // System owner column, auto-added and stamped on create. Both the physical
-  // snake_case name and the camelCase alias are reserved: config validation
-  // accepts camelCase field names and snake-cases them to the same column, so
-  // a `createdBy` field would otherwise collide with the system owner column.
-  "created_by",
-  "createdBy",
-  // First transition into published, auto-added when the draft/publish
-  // lifecycle is enabled. Reserved even for entities that have not enabled it,
-  // because enabling it later would otherwise collide at migration time rather
-  // than here, where the name is actually chosen.
-  "first_published_at",
-  "firstPublishedAt",
-] as const;
+/**
+ * Field names the Schema Builder refuses, in both spellings.
+ *
+ * A projection of the columns declared reserved on this surface. Config validation accepts a
+ * camelCase field name and snake-cases it, so the two spellings reach the same column and
+ * reserving one alone reserves nothing — a field named `createdAt` lands in the same CREATE TABLE
+ * as the injected `created_at`, which the database refuses.
+ */
+export const RESERVED_FIELD_NAMES: readonly string[] =
+  reservedSystemFieldNames("builder");
 
 export const collectionNameSchema = z
   .string()
@@ -151,7 +145,7 @@ export const fieldNameSchema = z
     /^[a-z][a-z0-9_]*$/,
     "Field name must start with lowercase letter and contain only lowercase letters, numbers, and underscores"
   )
-  .refine((name: string) => !RESERVED_FIELD_NAMES.includes(name as never), {
+  .refine((name: string) => !RESERVED_FIELD_NAMES.includes(name), {
     message: "Field name is reserved",
   })
   .refine(

--- a/packages/nextly/src/domains/schema/services/field-column-descriptor.ts
+++ b/packages/nextly/src/domains/schema/services/field-column-descriptor.ts
@@ -26,6 +26,11 @@
  * lockstep automatically.
  */
 
+import {
+  SYSTEM_COLUMNS,
+  type SystemColumnEntity,
+  type SystemColumnPresence,
+} from "../../../lib/system-columns";
 import type { FieldDefinition } from "../../../schemas/dynamic-collections";
 import { getFieldType } from "../field-types/field-type-registry";
 
@@ -363,55 +368,6 @@ export interface SystemColumnSet {
   isSingle?: boolean;
 }
 
-/**
- * When a document first became public, per dialect.
- *
- * `status` says what a document IS; nothing says what it HAS BEEN. Unpublishing returns a row to
- * `draft` and erases every trace it was ever live, but the links, feeds and search results that
- * accumulated while it was live do not go away. Anything deciding "was this address ever public" —
- * slug stability, redirect capture — needs a fact that survives the round trip.
- *
- * NULLABLE with NO DEFAULT, and that is the whole design. `NULL` means "not known to have been
- * published": true for a draft, and equally true for every row that predates this column, which
- * cannot be distinguished from a draft after the fact. A default would assert a publication date
- * that never happened.
- *
- * Set once on the first transition into `published` and never modified again, so it is not a
- * "last published" timestamp. Those are different questions: a last-published value moves on every
- * republish and its behaviour across an unpublish is a product choice, while this one has a single
- * defensible answer. Contentful, the most mature API surface here, carries both under distinct
- * names (`sys.firstPublishedAt` alongside `sys.publishedAt`) for the same reason.
- *
- * Gated on `hasStatus`: a collection with no draft lifecycle has no transition to record, and its
- * rows are public from the moment they are saved.
- *
- * Singles get it too. They could not at first: a Single's physical table was created by a DDL
- * generator that restated the system columns by hand, so a column added here reached the runtime
- * schema and not the table, and the resulting SELECT named a column that does not exist — failing
- * EVERY read of a status-enabled Single rather than merely leaving the marker unset. That
- * generator now renders from this list, so a Single's table receives whatever is declared here.
- */
-const FIRST_PUBLISHED_AT = {
-  postgresql: {
-    name: "first_published_at",
-    dialectType: "timestamp",
-    nullable: true,
-    primaryKey: false,
-  },
-  mysql: {
-    name: "first_published_at",
-    dialectType: "timestamp",
-    nullable: true,
-    primaryKey: false,
-  },
-  sqlite: {
-    name: "first_published_at",
-    dialectType: "integer",
-    nullable: true,
-    primaryKey: false,
-  },
-} as const;
-
 export interface SystemColumnDescriptor {
   name: string;
   dialectType: string;
@@ -424,215 +380,56 @@ export interface SystemColumnDescriptor {
   default?: string;
 }
 
+/**
+ * Whether a declared column is part of a table built with `opts`.
+ *
+ * `title` and `slug` step aside for an author's own fields of those names, and the lifecycle pair
+ * exists only where Draft/Published is enabled.
+ */
+function isPresent(
+  presence: SystemColumnPresence,
+  opts: SystemColumnSet
+): boolean {
+  switch (presence) {
+    case "always":
+      return true;
+    case "unlessAuthorDeclaredTitle":
+      return !opts.hasTitleField;
+    case "unlessAuthorDeclaredSlug":
+      return !opts.hasSlugField;
+    case "withStatusLifecycle":
+      return opts.hasStatus === true;
+  }
+}
+
+/**
+ * The system columns of one table, in declaration order.
+ *
+ * A projection of `SYSTEM_COLUMNS` rather than a per-dialect listing of its own: the three dialect
+ * branches this replaced restated the same eight columns three times, so a column added to one
+ * could be missed in another, and the set was invisible to every consumer that is not a DDL
+ * generator.
+ */
 export function getSystemColumnDescriptors(
   dialect: SupportedDialect,
   opts: SystemColumnSet
 ): SystemColumnDescriptor[] {
-  const cols: SystemColumnDescriptor[] = [];
-  if (dialect === "postgresql") {
-    cols.push({
-      name: "id",
-      dialectType: "text",
-      nullable: false,
-      primaryKey: true,
-    });
-    if (!opts.hasTitleField) {
-      cols.push({
-        name: "title",
-        dialectType: "text",
-        nullable: false,
-        primaryKey: false,
-      });
-    }
-    if (!opts.hasSlugField) {
-      cols.push({
-        name: "slug",
-        dialectType: "text",
-        nullable: false,
-        primaryKey: false,
-      });
-    }
-    // Timestamp defaults must mirror runtime-schema-generator's
-    // pgTimestamp(...).defaultNow() — otherwise the diff sees a phantom
-    // change_column_default (now() → undefined) on every apply and routes
-    // around the fast-path DDL emitter.
-    cols.push({
-      name: "created_at",
-      dialectType: "timestamp",
-      nullable: true,
-      primaryKey: false,
-      default: "now()",
-    });
-    cols.push({
-      name: "updated_at",
-      dialectType: "timestamp",
-      nullable: true,
-      primaryKey: false,
-      default: "now()",
-    });
-    // Owner of the row, stamped with the creating user's id. Collections only
-    // (never singles). Nullable: existing rows and system/seed creates have no
-    // user. Mirrors runtime-schema-generator's pgText("created_by") (text,
-    // matching the id column type).
-    if (!opts.isSingle) {
-      cols.push({
-        name: "created_by",
-        dialectType: "text",
-        nullable: true,
-        primaryKey: false,
-      });
-    }
-    if (opts.hasStatus) {
-      // Must mirror runtime-schema-generator's
-      // pgVarchar("status", { length: 20 }).notNull().default("draft").
-      // information_schema reports udt_name=varchar for that DDL, so
-      // emitting "text" here would cause a phantom change_column_type
-      // on every apply.
-      cols.push({
-        name: "status",
-        dialectType: "varchar",
-        length: 20,
-        nullable: false,
-        primaryKey: false,
-        default: "'draft'",
-      });
-      cols.push(FIRST_PUBLISHED_AT.postgresql);
-    }
-  } else if (dialect === "mysql") {
-    cols.push({
-      name: "id",
-      dialectType: "varchar(36)",
-      length: 36,
-      nullable: false,
-      primaryKey: true,
-    });
-    if (!opts.hasTitleField) {
-      cols.push({
-        name: "title",
-        dialectType: "varchar(255)",
-        length: 255,
-        nullable: false,
-        primaryKey: false,
-      });
-    }
-    if (!opts.hasSlugField) {
-      cols.push({
-        name: "slug",
-        dialectType: "varchar(255)",
-        length: 255,
-        nullable: false,
-        primaryKey: false,
-      });
-    }
-    // The runtime generator builds these as mysqlTimestamp(...).defaultNow(), so the physical
-    // column carries DEFAULT CURRENT_TIMESTAMP. Reporting no default here described the diff's
-    // desired state as something neither creation path produces — the drift this module exists to
-    // prevent, in the very pair its header promises to keep in lockstep. The PostgreSQL branch
-    // already carries its `now()`; this is the same fact, spelled the way MySQL spells it.
-    cols.push({
-      name: "created_at",
-      dialectType: "timestamp",
-      nullable: true,
-      primaryKey: false,
-      default: "CURRENT_TIMESTAMP",
-    });
-    cols.push({
-      name: "updated_at",
-      dialectType: "timestamp",
-      nullable: true,
-      primaryKey: false,
-      default: "CURRENT_TIMESTAMP",
-    });
-    // Owner of the row (creating user's id, NOT the row id). Collections only
-    // (never singles). Sized to match the MySQL users.id column (varchar(191),
-    // Auth.js-compatible), not the varchar(36) row id — a longer user id would
-    // otherwise be truncated. Nullable; mirrors runtime-schema-generator's
-    // created_by column.
-    if (!opts.isSingle) {
-      cols.push({
-        name: "created_by",
-        dialectType: "varchar(191)",
-        length: 191,
-        nullable: true,
-        primaryKey: false,
-      });
-    }
-    if (opts.hasStatus) {
-      cols.push({
-        name: "status",
-        dialectType: "varchar(20)",
-        length: 20,
-        nullable: false,
-        primaryKey: false,
-        default: "'draft'",
-      });
-      cols.push(FIRST_PUBLISHED_AT.mysql);
-    }
-  } else {
-    // sqlite
-    cols.push({
-      name: "id",
-      dialectType: "text",
-      nullable: false,
-      primaryKey: true,
-    });
-    if (!opts.hasTitleField) {
-      cols.push({
-        name: "title",
-        dialectType: "text",
-        nullable: false,
-        primaryKey: false,
-      });
-    }
-    if (!opts.hasSlugField) {
-      cols.push({
-        name: "slug",
-        dialectType: "text",
-        nullable: false,
-        primaryKey: false,
-      });
-    }
-    // SQLite was the one dialect whose timestamps had no default, so an insert that omitted
-    // them stored NULL where PostgreSQL and MySQL stored a time. The Schema Builder has always
-    // emitted this exact expression for SQLite; the runtime side was the half that lacked it,
-    // which is also why the two disagreed about the same table.
-    cols.push({
-      name: "created_at",
-      dialectType: "integer",
-      nullable: true,
-      primaryKey: false,
-      default: "(strftime('%s', 'now'))",
-    });
-    cols.push({
-      name: "updated_at",
-      dialectType: "integer",
-      nullable: true,
-      primaryKey: false,
-      default: "(strftime('%s', 'now'))",
-    });
-    // Owner of the row (creating user's id). Collections only (never singles).
-    // Nullable; mirrors runtime-schema-generator's sqliteText("created_by")
-    // (matching the id column type).
-    if (!opts.isSingle) {
-      cols.push({
-        name: "created_by",
-        dialectType: "text",
-        nullable: true,
-        primaryKey: false,
-      });
-    }
-    if (opts.hasStatus) {
-      cols.push({
-        name: "status",
-        dialectType: "text",
-        nullable: false,
-        primaryKey: false,
-        default: "'draft'",
-      });
-      cols.push(FIRST_PUBLISHED_AT.sqlite);
-    }
-  }
-  return cols;
+  const entity: SystemColumnEntity = opts.isSingle ? "single" : "collection";
+
+  return SYSTEM_COLUMNS.filter(
+    column =>
+      column.appliesTo.includes(entity) && isPresent(column.presence, opts)
+  ).map(column => {
+    const shape = column.shape[dialect];
+    return {
+      name: column.name,
+      dialectType: shape.dialectType,
+      ...(shape.length !== undefined ? { length: shape.length } : {}),
+      nullable: shape.nullable,
+      primaryKey: shape.primaryKey === true,
+      ...(shape.default !== undefined ? { default: shape.default } : {}),
+    };
+  });
 }
 
 /**

--- a/packages/nextly/src/domains/schema/services/field-column-descriptor.ts
+++ b/packages/nextly/src/domains/schema/services/field-column-descriptor.ts
@@ -28,7 +28,11 @@
 
 import {
   SYSTEM_COLUMNS,
+  systemColumnDefaultSql,
+  systemColumnDialectType,
+  type SystemColumnDefault,
   type SystemColumnEntity,
+  type SystemColumnKind,
   type SystemColumnPresence,
 } from "../../../lib/system-columns";
 import type { FieldDefinition } from "../../../schemas/dynamic-collections";
@@ -370,6 +374,14 @@ export interface SystemColumnSet {
 
 export interface SystemColumnDescriptor {
   name: string;
+  /**
+   * The column family, for consumers that build a column rather than describe one.
+   *
+   * The runtime Drizzle generator dispatches on this. It used to dispatch on the NAME, with a
+   * fall-through that made every unrecognised column non-null text, so a newly declared timestamp
+   * would be created as a timestamp and read through a text column.
+   */
+  kind: SystemColumnKind;
   dialectType: string;
   length?: number;
   nullable: boolean;
@@ -378,6 +390,8 @@ export interface SystemColumnDescriptor {
   // Must match what runtime-schema-generator.ts emits so the diff doesn't
   // classify ADD COLUMN as an interactive "required field with no default."
   default?: string;
+  /** The same default, before it was rendered as DDL, for callers that need the value itself. */
+  defaultValue?: SystemColumnDefault;
 }
 
 /**
@@ -421,13 +435,16 @@ export function getSystemColumnDescriptors(
       column.appliesTo.includes(entity) && isPresent(column.presence, opts)
   ).map(column => {
     const shape = column.shape[dialect];
+    const defaultSql = systemColumnDefaultSql(shape, dialect);
     return {
       name: column.name,
-      dialectType: shape.dialectType,
+      kind: shape.kind,
+      dialectType: systemColumnDialectType(shape, dialect),
       ...(shape.length !== undefined ? { length: shape.length } : {}),
       nullable: shape.nullable,
       primaryKey: shape.primaryKey === true,
-      ...(shape.default !== undefined ? { default: shape.default } : {}),
+      ...(defaultSql !== undefined ? { default: defaultSql } : {}),
+      ...(shape.default !== undefined ? { defaultValue: shape.default } : {}),
     };
   });
 }

--- a/packages/nextly/src/domains/schema/services/runtime-schema-generator.ts
+++ b/packages/nextly/src/domains/schema/services/runtime-schema-generator.ts
@@ -302,91 +302,92 @@ function buildDrizzleColumnRecord(
 }
 
 /**
- * Translates a system-column descriptor (id / title / slug /
- * created_at / updated_at) into the appropriate Drizzle column
- * builder for the given dialect. Mirrors the legacy hardcoded
- * builders byte-for-byte: id is primaryKey, title/slug are
- * notNull, timestamps carry a database-side default on every dialect.
+ * Applies the modifiers every column family shares.
+ *
+ * Structurally typed rather than tied to one Drizzle builder, because the three families return
+ * three unrelated builder types that all carry these two methods. A primary key is already NOT NULL
+ * on every dialect, so it is not also marked.
+ */
+function finishColumn<T extends { notNull(): unknown; primaryKey(): unknown }>(
+  column: T,
+  spec: { nullable: boolean; primaryKey: boolean }
+): unknown {
+  if (spec.primaryKey) return column.primaryKey();
+  return spec.nullable ? column : column.notNull();
+}
+
+/**
+ * Translates a system-column descriptor into the Drizzle column builder for the given dialect.
+ *
+ * Dispatches on the declared column FAMILY, never on the column name. Name dispatch carried a
+ * fall-through that made anything unrecognised a non-null text column, so a newly declared
+ * timestamp was created in the database as a timestamp and read back through a text column —
+ * precisely the drift between the physical table and the runtime schema that the declarations
+ * exist to prevent.
  *
  * The timestamps stay nullable, but a row reaching the database without them does not: the
  * default supplies a value for any insert that omits the column, which is what an insert
  * bypassing the write path does. Nullable and defaulted are independent choices, and only
- * the default can be added to a table a user already has without rewriting its rows.
+ * the default can be added to a table a user already has without rewriting its rows. A column
+ * declared with no default keeps none — a first-publication marker must read NULL until it is
+ * earned, and a default would date a publication that never happened.
  */
 function buildSystemDrizzleColumn(
   sys: ReturnType<typeof getSystemColumnDescriptors>[number],
   dialect: SupportedDialect
 ): unknown {
+  const literal =
+    sys.defaultValue?.kind === "literal" ? sys.defaultValue.value : undefined;
+  const clockDefault = sys.defaultValue?.kind === "now";
+
   if (dialect === "postgresql") {
-    if (sys.name === "id") return pgText("id").primaryKey();
-    if (sys.name === "created_at")
-      return pgTimestamp("created_at").defaultNow();
-    if (sys.name === "updated_at")
-      return pgTimestamp("updated_at").defaultNow();
-    if (sys.name === "status") {
-      // Why: 'draft' default ensures backfill on enable doesn't accidentally
-      // publish anything. Length 20 leaves headroom over "published" (9 chars).
-      return pgVarchar("status", { length: 20 }).notNull().default("draft");
+    if (sys.kind === "timestamp") {
+      const col = pgTimestamp(sys.name);
+      return finishColumn(clockDefault ? col.defaultNow() : col, sys);
     }
-    // Row owner — nullable text (matches the id column type); no default so
-    // system/seed creates and existing rows stay null.
-    if (sys.name === "created_by") return pgText("created_by");
-    // No `defaultNow`, unlike the other two timestamps: a row that has never
-    // been published must read NULL, and a default would date a publication
-    // that did not happen.
-    if (sys.name === "first_published_at") {
-      return pgTimestamp("first_published_at");
+    if (sys.kind === "varchar") {
+      const col = pgVarchar(sys.name, { length: sys.length ?? 255 });
+      return finishColumn(
+        literal === undefined ? col : col.default(literal),
+        sys
+      );
     }
-    // title / slug — text NOT NULL.
-    return pgText(sys.name).notNull();
+    const col = pgText(sys.name);
+    return finishColumn(
+      literal === undefined ? col : col.default(literal),
+      sys
+    );
   }
+
   if (dialect === "mysql") {
-    if (sys.name === "id") {
-      return mysqlVarchar("id", { length: 36 }).primaryKey();
+    if (sys.kind === "timestamp") {
+      const col = mysqlTimestamp(sys.name);
+      return finishColumn(clockDefault ? col.defaultNow() : col, sys);
     }
-    if (sys.name === "created_at") {
-      return mysqlTimestamp("created_at").defaultNow();
+    if (sys.kind === "varchar") {
+      const col = mysqlVarchar(sys.name, { length: sys.length ?? 255 });
+      return finishColumn(
+        literal === undefined ? col : col.default(literal),
+        sys
+      );
     }
-    if (sys.name === "updated_at") {
-      return mysqlTimestamp("updated_at").defaultNow();
-    }
-    if (sys.name === "status") {
-      return mysqlVarchar("status", { length: 20 }).notNull().default("draft");
-    }
-    // Row owner — nullable varchar(191) sized to the MySQL users.id column
-    // (holds a user id, not the row id).
-    if (sys.name === "created_by") {
-      return mysqlVarchar("created_by", { length: 191 });
-    }
-    // Nullable and undefaulted, unlike created_at/updated_at — see the pg branch.
-    if (sys.name === "first_published_at") {
-      return mysqlTimestamp("first_published_at");
-    }
-    return mysqlVarchar(sys.name, { length: 255 }).notNull();
-  }
-  // sqlite
-  if (sys.name === "id") return sqliteText("id").primaryKey();
-  if (sys.name === "created_at") {
-    return sqliteInteger("created_at", { mode: "timestamp" }).default(
-      sql`(strftime('%s', 'now'))`
+    const col = mysqlText(sys.name);
+    return finishColumn(
+      literal === undefined ? col : col.default(literal),
+      sys
     );
   }
-  if (sys.name === "updated_at") {
-    return sqliteInteger("updated_at", { mode: "timestamp" }).default(
-      sql`(strftime('%s', 'now'))`
+
+  // SQLite stores a timestamp as an epoch integer and has no distinct varchar.
+  if (sys.kind === "timestamp") {
+    const col = sqliteInteger(sys.name, { mode: "timestamp" });
+    return finishColumn(
+      clockDefault ? col.default(sql`(strftime('%s', 'now'))`) : col,
+      sys
     );
   }
-  if (sys.name === "status") {
-    // SQLite has no varchar — text with default 'draft' is the equivalent.
-    return sqliteText("status").notNull().default("draft");
-  }
-  // Row owner — nullable text (matches the id column type).
-  if (sys.name === "created_by") return sqliteText("created_by");
-  // Nullable and undefaulted, unlike created_at/updated_at — see the pg branch.
-  if (sys.name === "first_published_at") {
-    return sqliteInteger("first_published_at", { mode: "timestamp" });
-  }
-  return sqliteText(sys.name).notNull();
+  const col = sqliteText(sys.name);
+  return finishColumn(literal === undefined ? col : col.default(literal), sys);
 }
 
 /**

--- a/packages/nextly/src/domains/versions/restore-snapshot.ts
+++ b/packages/nextly/src/domains/versions/restore-snapshot.ts
@@ -17,7 +17,7 @@
  */
 
 import type { FieldConfig } from "../../collections/fields/types";
-import { ALWAYS_IMMUTABLE_SYSTEM_FIELDS } from "../../lib/immutable-system-fields";
+import { IMMUTABLE_SYSTEM_FIELDS_ANY_ENTITY } from "../../lib/immutable-system-fields";
 import { STORAGE_FORMAT } from "../../schemas/storage-format";
 import { isFieldLocalized } from "../i18n/classify-fields";
 
@@ -28,17 +28,13 @@ import { isFieldLocalized } from "../i18n/classify-fields";
  * after `beforeUpdate` hooks have seen the payload. Stripping here means a hook
  * is never handed a forged `createdBy` or a stale `createdAt`.
  *
- * The always-immutable names come from the shared list rather than being
- * repeated: this copy had fallen behind it, so a restored snapshot reported the
- * first-publication marker as an unknown field and every complete restore came
- * back described as partial. The owner column is added on top because this path
- * protects it for singles as well, where it is not a system column.
+ * The set spans every entity rather than the one being restored, because this
+ * path protects the owner column for singles as well, where it is not a system
+ * column at all. Assembled by hand, this copy fell behind the writers' one and
+ * a restored snapshot then reported the first-publication marker as an unknown
+ * field, describing every complete restore as partial.
  */
-const IMMUTABLE_FIELDS = new Set([
-  ...ALWAYS_IMMUTABLE_SYSTEM_FIELDS,
-  "createdBy",
-  "created_by",
-]);
+const IMMUTABLE_FIELDS = IMMUTABLE_SYSTEM_FIELDS_ANY_ENTITY;
 
 /**
  * A component's own schema, as the payload filter needs to see it.

--- a/packages/nextly/src/lib/__tests__/system-columns.test.ts
+++ b/packages/nextly/src/lib/__tests__/system-columns.test.ts
@@ -1,12 +1,15 @@
 // The system columns are declared once and every consumer reads a projection of that declaration.
-// Two kinds of test guard it. The pinned sets below name today's columns on purpose: they are the
-// contract each consumer had before the declarations existed, so a projection that silently widens
-// or narrows one is caught rather than discovered by a reviewer. The property tests that follow
-// name no column at all — they are what makes the NEXT column safe.
+// Two kinds of test guard it. The pinned sets below name today's columns on purpose: they record
+// the exact contract each consumer holds, so a projection that silently widens or narrows one
+// fails here. The property tests that follow name no column at all — they are what makes the NEXT
+// column safe.
 
+import { getColumns } from "drizzle-orm";
 import { describe, expect, it } from "vitest";
 
 import { fieldNameSchema } from "../../domains/dynamic-collections/services/dynamic-collection-validation-service";
+import { getSystemColumnDescriptors } from "../../domains/schema/services/field-column-descriptor";
+import { generateRuntimeSchema } from "../../domains/schema/services/runtime-schema-generator";
 import { SYSTEM_SCHEMA_VERSION } from "../../domains/schema/services/schema-hash";
 
 import {
@@ -16,8 +19,12 @@ import {
 import {
   reservedSystemFieldNames,
   SYSTEM_COLUMNS,
+  systemColumnDefaultSql,
+  systemColumnDialectType,
   systemColumnNames,
   type ReservationSurface,
+  type SystemColumnDialect,
+  type SystemColumnKind,
 } from "../system-columns";
 
 const sorted = (names: Iterable<string>): string[] => [...names].sort();
@@ -196,8 +203,10 @@ describe("the declaration set itself", () => {
     for (const column of SYSTEM_COLUMNS) {
       for (const dialect of ["postgresql", "mysql", "sqlite"] as const) {
         expect({
-          [`${column.name}.${dialect}`]:
-            typeof column.shape[dialect]?.dialectType,
+          [`${column.name}.${dialect}`]: typeof systemColumnDialectType(
+            column.shape[dialect],
+            dialect
+          ),
         }).toEqual({ [`${column.name}.${dialect}`]: "string" });
       }
     }
@@ -208,6 +217,84 @@ describe("the declaration set itself", () => {
       expect({ [column.name]: column.appliesTo.length > 0 }).toEqual({
         [column.name]: true,
       });
+    }
+  });
+
+  it("builds the runtime schema to match every declared shape", () => {
+    // The physical table and the runtime schema are made by different code from the same
+    // declaration, and a disagreement between them is silent: the table is created one way and
+    // every query reads it another. The runtime builder used to dispatch on the column NAME, with
+    // a fall-through that made anything it did not recognise non-null text, so a newly declared
+    // timestamp would have been created as a timestamp and read through text.
+    //
+    // This asserts the two agree for every declared column rather than for the ones that exist
+    // today, so a column added to the declarations cannot be silently mishandled by the builder.
+    const EXPECTED_COLUMN_TYPE: Record<
+      SystemColumnDialect,
+      Record<SystemColumnKind, string>
+    > = {
+      postgresql: {
+        text: "PgText",
+        varchar: "PgVarchar",
+        timestamp: "PgTimestamp",
+      },
+      mysql: {
+        text: "MySqlText",
+        varchar: "MySqlVarChar",
+        timestamp: "MySqlTimestamp",
+      },
+      sqlite: {
+        text: "SQLiteText",
+        varchar: "SQLiteText",
+        timestamp: "SQLiteTimestamp",
+      },
+    };
+
+    for (const dialect of [
+      "postgresql",
+      "mysql",
+      "sqlite",
+    ] as SystemColumnDialect[]) {
+      for (const isSingle of [false, true]) {
+        const { table } = generateRuntimeSchema(
+          isSingle ? "single_probe" : "dc_probe",
+          [{ name: "body", type: "textarea" }],
+          dialect,
+          { status: true, isSingle }
+        );
+        const built = getColumns(table as never) as Record<string, unknown>;
+        const byName = new Map(
+          Object.values(built).map(column => {
+            const c = column as Record<string, unknown>;
+            return [c.name as string, c];
+          })
+        );
+
+        for (const descriptor of getSystemColumnDescriptors(dialect, {
+          hasTitleField: false,
+          hasSlugField: false,
+          hasStatus: true,
+          isSingle,
+        })) {
+          const where = `${dialect}${isSingle ? "/single" : ""}.${descriptor.name}`;
+          const built = byName.get(descriptor.name);
+          expect({ [where]: built !== undefined }).toEqual({ [where]: true });
+          if (!built) continue;
+
+          expect({
+            [`${where}.type`]: built.columnType,
+            [`${where}.notNull`]: built.notNull,
+            [`${where}.hasDefault`]: built.hasDefault,
+            [`${where}.primary`]: built.primary,
+          }).toEqual({
+            [`${where}.type`]: EXPECTED_COLUMN_TYPE[dialect][descriptor.kind],
+            // A primary key is NOT NULL whether or not it says so.
+            [`${where}.notNull`]: descriptor.primaryKey || !descriptor.nullable,
+            [`${where}.hasDefault`]: descriptor.default !== undefined,
+            [`${where}.primary`]: descriptor.primaryKey,
+          });
+        }
+      }
     }
   });
 
@@ -250,11 +337,11 @@ describe("the physical shape is pinned to the schema version", () => {
           const s = column.shape[dialect];
           return [
             dialect.slice(0, 2),
-            s.dialectType,
+            systemColumnDialectType(s, dialect),
             s.length ?? "-",
             s.nullable ? "null" : "notnull",
             s.primaryKey ? "pk" : "-",
-            s.default ?? "-",
+            systemColumnDefaultSql(s, dialect) ?? "-",
           ].join(":");
         })
         .join(" ");

--- a/packages/nextly/src/lib/__tests__/system-columns.test.ts
+++ b/packages/nextly/src/lib/__tests__/system-columns.test.ts
@@ -7,6 +7,7 @@
 import { describe, expect, it } from "vitest";
 
 import { fieldNameSchema } from "../../domains/dynamic-collections/services/dynamic-collection-validation-service";
+import { SYSTEM_SCHEMA_VERSION } from "../../domains/schema/services/schema-hash";
 
 import {
   immutableSystemFieldsFor,
@@ -232,5 +233,62 @@ describe("the declaration set itself", () => {
         [column.name]: false,
       });
     }
+  });
+});
+
+describe("the physical shape is pinned to the schema version", () => {
+  /**
+   * One line per column, carrying only what decides a physical table: the name, when the column is
+   * present, which entities carry it, and its shape per dialect. Policies that never reach a
+   * `CREATE TABLE` — who may write it, who publishes it, who reserves the name — are deliberately
+   * absent, so changing one of those does not demand a schema-version bump.
+   */
+  const physicalShape = (): string[] =>
+    SYSTEM_COLUMNS.map(column => {
+      const shapes = (["postgresql", "mysql", "sqlite"] as const)
+        .map(dialect => {
+          const s = column.shape[dialect];
+          return [
+            dialect.slice(0, 2),
+            s.dialectType,
+            s.length ?? "-",
+            s.nullable ? "null" : "notnull",
+            s.primaryKey ? "pk" : "-",
+            s.default ?? "-",
+          ].join(":");
+        })
+        .join(" ");
+      return `${column.name} | ${column.presence} | ${[...column.appliesTo].sort().join(",")} | ${shapes}`;
+    });
+
+  it("has not changed without SYSTEM_SCHEMA_VERSION being bumped", () => {
+    // `SYSTEM_SCHEMA_VERSION` is mixed into every collection's stored schema hash, and a table is
+    // only rebuilt when that hash changes. Add or reshape a column without bumping it and existing
+    // installs are never told: the runtime schema selects a column their table does not have, and
+    // the failure is silent until a read runs. That is the worst of the ways this can go wrong,
+    // because it hits upgrades rather than new installs.
+    //
+    // It is pinned rather than derived on purpose. Deriving would change the value now, for every
+    // install at once, and every stored hash would read as "schema changed" — a migration for
+    // everyone, to record a refactor. So the fingerprint is checked and the bump stays a decision.
+    //
+    // If this fails: confirm the diff is the column change you meant, bump SYSTEM_SCHEMA_VERSION,
+    // add its line to the history in schema-hash.ts, and update both values here.
+    expect({
+      version: SYSTEM_SCHEMA_VERSION,
+      shape: physicalShape(),
+    }).toEqual({
+      version: 3,
+      shape: [
+        "id | always | collection,single | po:text:-:notnull:pk:- my:varchar(36):36:notnull:pk:- sq:text:-:notnull:pk:-",
+        "title | unlessAuthorDeclaredTitle | collection,single | po:text:-:notnull:-:- my:varchar(255):255:notnull:-:- sq:text:-:notnull:-:-",
+        "slug | unlessAuthorDeclaredSlug | collection,single | po:text:-:notnull:-:- my:varchar(255):255:notnull:-:- sq:text:-:notnull:-:-",
+        "created_at | always | collection,single | po:timestamp:-:null:-:now() my:timestamp:-:null:-:CURRENT_TIMESTAMP sq:integer:-:null:-:(strftime('%s', 'now'))",
+        "updated_at | always | collection,single | po:timestamp:-:null:-:now() my:timestamp:-:null:-:CURRENT_TIMESTAMP sq:integer:-:null:-:(strftime('%s', 'now'))",
+        "created_by | always | collection | po:text:-:null:-:- my:varchar(191):191:null:-:- sq:text:-:null:-:-",
+        "status | withStatusLifecycle | collection,single | po:varchar:20:notnull:-:'draft' my:varchar(20):20:notnull:-:'draft' sq:text:-:notnull:-:'draft'",
+        "first_published_at | withStatusLifecycle | collection,single | po:timestamp:-:null:-:- my:timestamp:-:null:-:- sq:integer:-:null:-:-",
+      ],
+    });
   });
 });

--- a/packages/nextly/src/lib/__tests__/system-columns.test.ts
+++ b/packages/nextly/src/lib/__tests__/system-columns.test.ts
@@ -6,6 +6,8 @@
 
 import { describe, expect, it } from "vitest";
 
+import { fieldNameSchema } from "../../domains/dynamic-collections/services/dynamic-collection-validation-service";
+
 import {
   immutableSystemFieldsFor,
   IMMUTABLE_SYSTEM_FIELDS_ANY_ENTITY,
@@ -134,6 +136,33 @@ describe("reservation projections", () => {
     expect(sorted(reservedSystemFieldNames("uiSchema"))).toEqual(
       sorted(["id", "created_at", "updated_at"])
     );
+  });
+});
+
+describe("the validators actually refuse what the projection lists", () => {
+  // The projections above prove the SET. These prove the wiring: a validator reading the
+  // projection rather than a literal of its own is the whole point, and a set nobody consults
+  // would satisfy every test above.
+
+  it("refuses every projected name in the Schema Builder", () => {
+    for (const name of reservedSystemFieldNames("builder")) {
+      expect({ [name]: fieldNameSchema.safeParse(name).success }).toEqual({
+        [name]: false,
+      });
+    }
+  });
+
+  it("still accepts an ordinary field name", () => {
+    // The mirror, so the case above cannot be satisfied by a validator that refuses everything.
+    expect(fieldNameSchema.safeParse("headline").success).toBe(true);
+  });
+
+  it("refuses the camelCase spelling of a timestamp column", () => {
+    // The name this widened to. It snake-cases onto the injected column and lands in the same
+    // CREATE TABLE twice, so the collection could never have been created; refusing it here
+    // reports the collision where the name is chosen instead of as a database error.
+    expect(fieldNameSchema.safeParse("createdAt").success).toBe(false);
+    expect(fieldNameSchema.safeParse("updatedAt").success).toBe(false);
   });
 });
 

--- a/packages/nextly/src/lib/__tests__/system-columns.test.ts
+++ b/packages/nextly/src/lib/__tests__/system-columns.test.ts
@@ -1,0 +1,207 @@
+// The system columns are declared once and every consumer reads a projection of that declaration.
+// Two kinds of test guard it. The pinned sets below name today's columns on purpose: they are the
+// contract each consumer had before the declarations existed, so a projection that silently widens
+// or narrows one is caught rather than discovered by a reviewer. The property tests that follow
+// name no column at all — they are what makes the NEXT column safe.
+
+import { describe, expect, it } from "vitest";
+
+import {
+  immutableSystemFieldsFor,
+  IMMUTABLE_SYSTEM_FIELDS_ANY_ENTITY,
+} from "../immutable-system-fields";
+import {
+  reservedSystemFieldNames,
+  SYSTEM_COLUMNS,
+  systemColumnNames,
+  type ReservationSurface,
+} from "../system-columns";
+
+const sorted = (names: Iterable<string>): string[] => [...names].sort();
+
+describe("immutability projections", () => {
+  it("closes exactly the provenance columns on a collection", () => {
+    expect(sorted(immutableSystemFieldsFor("collection"))).toEqual(
+      sorted([
+        "id",
+        "created_at",
+        "createdAt",
+        "updated_at",
+        "updatedAt",
+        "created_by",
+        "createdBy",
+        "first_published_at",
+        "firstPublishedAt",
+      ])
+    );
+  });
+
+  it("leaves a single's own created_by alone", () => {
+    // No owner column is injected onto a single's table, so the name is an ordinary one there.
+    // Sharing one list wholesale is how a single's own column got stripped on every write.
+    const single = immutableSystemFieldsFor("single");
+
+    expect(single.has("created_by")).toBe(false);
+    expect(single.has("createdBy")).toBe(false);
+    expect(sorted(single)).toEqual(
+      sorted([
+        "id",
+        "created_at",
+        "createdAt",
+        "updated_at",
+        "updatedAt",
+        "first_published_at",
+        "firstPublishedAt",
+      ])
+    );
+  });
+
+  it("protects the owner column on every entity when the entity is not known", () => {
+    // A restore runs before the write paths strip anything and protects both kinds at once.
+    expect(sorted(IMMUTABLE_SYSTEM_FIELDS_ANY_ENTITY)).toEqual(
+      sorted([
+        "id",
+        "created_at",
+        "createdAt",
+        "updated_at",
+        "updatedAt",
+        "created_by",
+        "createdBy",
+        "first_published_at",
+        "firstPublishedAt",
+      ])
+    );
+  });
+
+  it("leaves content and lifecycle writable", () => {
+    // `title`, `slug` and `status` are system-injected but authored. Closing them would make the
+    // editor unable to set a title.
+    for (const entity of ["collection", "single"] as const) {
+      const closed = immutableSystemFieldsFor(entity);
+      for (const name of ["title", "slug", "status"]) {
+        expect({ [`${entity}.${name}`]: closed.has(name) }).toEqual({
+          [`${entity}.${name}`]: false,
+        });
+      }
+    }
+  });
+});
+
+describe("reservation projections", () => {
+  it("refuses both spellings of every column the Schema Builder reserves", () => {
+    // Widened from the previous literal, which held `created_by`/`createdBy` but only
+    // `created_at`. A field named `createdAt` snake-cases onto the injected column and lands in
+    // the same CREATE TABLE twice, which the database rejects — so no collection carrying one can
+    // exist, and refusing the name moves the failure to where it is chosen.
+    expect(sorted(reservedSystemFieldNames("builder"))).toEqual(
+      sorted([
+        "id",
+        "title",
+        "slug",
+        "created_at",
+        "createdAt",
+        "updated_at",
+        "updatedAt",
+        "created_by",
+        "createdBy",
+        "first_published_at",
+        "firstPublishedAt",
+      ])
+    );
+  });
+
+  it("refuses the owner column and the marker in a code-first collection", () => {
+    expect(sorted(reservedSystemFieldNames("collectionConfig"))).toEqual(
+      sorted([
+        "created_by",
+        "createdBy",
+        "first_published_at",
+        "firstPublishedAt",
+      ])
+    );
+  });
+
+  it("refuses only the marker in a code-first single", () => {
+    // A single gets no owner column, so `created_by` stays a legal field name there.
+    expect(sorted(reservedSystemFieldNames("singleConfig"))).toEqual(
+      sorted(["first_published_at", "firstPublishedAt"])
+    );
+  });
+
+  it("refuses only the physical spelling in the UI field-payload schema", () => {
+    // That surface also validates component fields, whose tables are not declared here, so it
+    // stays exactly as narrow as it was.
+    expect(sorted(reservedSystemFieldNames("uiSchema"))).toEqual(
+      sorted(["id", "created_at", "updated_at"])
+    );
+  });
+});
+
+describe("the declaration set itself", () => {
+  const SURFACES: ReservationSurface[] = [
+    "builder",
+    "collectionConfig",
+    "singleConfig",
+    "uiSchema",
+  ];
+
+  it("gives every column a camelCase spelling that snake-cases back to it", () => {
+    // The two spellings reach the same column, which is why reserving one alone reserves nothing.
+    const toSnake = (name: string) =>
+      name
+        .replace(/([A-Z])/g, "_$1")
+        .toLowerCase()
+        .replace(/^_/, "");
+
+    for (const column of SYSTEM_COLUMNS) {
+      expect({ [column.name]: toSnake(column.camelName) }).toEqual({
+        [column.name]: column.name,
+      });
+    }
+  });
+
+  it("declares a shape for every dialect", () => {
+    // A column missing a dialect would reach the runtime schema and not the table, and every read
+    // of that entity would then select a column that does not exist.
+    for (const column of SYSTEM_COLUMNS) {
+      for (const dialect of ["postgresql", "mysql", "sqlite"] as const) {
+        expect({
+          [`${column.name}.${dialect}`]:
+            typeof column.shape[dialect]?.dialectType,
+        }).toEqual({ [`${column.name}.${dialect}`]: "string" });
+      }
+    }
+  });
+
+  it("applies every column to at least one entity", () => {
+    for (const column of SYSTEM_COLUMNS) {
+      expect({ [column.name]: column.appliesTo.length > 0 }).toEqual({
+        [column.name]: true,
+      });
+    }
+  });
+
+  it("never reserves a name on a surface without declaring the column", () => {
+    // The projections are the only source, so this holds by construction — it is asserted so that
+    // a future surface added to the union cannot be forgotten in `reservedSystemFieldNames`.
+    const declared = new Set(systemColumnNames(() => true));
+    for (const surface of SURFACES) {
+      for (const name of reservedSystemFieldNames(surface)) {
+        expect({ [`${surface}:${name}`]: declared.has(name) }).toEqual({
+          [`${surface}:${name}`]: true,
+        });
+      }
+    }
+  });
+
+  it("closes every column that is stripped from responses", () => {
+    // A value the server refuses to return is not one a client may set. The owner column is the
+    // case: owner-only access filters on it in SQL, so it never leaves the server.
+    for (const column of SYSTEM_COLUMNS) {
+      if (!column.strippedFromResponses) continue;
+      expect({ [column.name]: column.writableByClient }).toEqual({
+        [column.name]: false,
+      });
+    }
+  });
+});

--- a/packages/nextly/src/lib/immutable-system-fields.ts
+++ b/packages/nextly/src/lib/immutable-system-fields.ts
@@ -6,64 +6,56 @@
  * owner stamp, the timestamps and the first-publication marker are decided here, not by whatever
  * a caller put in the body.
  *
- * Owned in one place because the entities that need it are written by different services. The
- * collection writer had this list and the single writer did not, so a marker a caller supplied
- * survived into a single's row — the same request that a collection rejected.
+ * The set is a projection of the system-column declarations rather than a list of its own. The
+ * collection writer had a list and the single writer did not, so a marker a caller supplied
+ * survived into a single's row on the same request a collection rejected.
  *
- * The set is NOT "every system column". `title`, `slug` and `status` are system-injected and
- * fully writable: they are content and lifecycle, not provenance. Only the columns the service
- * alone decides belong here.
+ * It is NOT "every system column". `title`, `slug` and `status` are system-injected and fully
+ * writable: they are content and lifecycle, not provenance. Only the columns the service alone
+ * decides are closed, which is exactly what `writableByClient` records.
  *
  * @module lib/immutable-system-fields
  */
 
+import {
+  immutableSystemColumnNames,
+  immutableSystemColumnNamesAnyEntity,
+  type SystemColumnEntity,
+} from "./system-columns";
+
 /** Which entity is being written. The owner column exists on only one of them. */
-export type WritableEntityKind = "collection" | "single";
+export type WritableEntityKind = SystemColumnEntity;
 
 /**
- * Reserved on every entity, in both spellings: config validation accepts camelCase field names
- * and snake-cases them to the same physical column, so reserving one spelling reserves nothing.
- *
- * `first_published_at` is here for a reason the timestamps are not. It is meant to be written
- * once and never moved, and a value taken from the request would make that guarantee decorative:
- * a draft create could claim a publication that never happened, and any later update could reset
- * a real one.
- */
-export const ALWAYS_IMMUTABLE_SYSTEM_FIELDS: readonly string[] = [
-  "id",
-  "created_at",
-  "createdAt",
-  "updated_at",
-  "updatedAt",
-  "first_published_at",
-  "firstPublishedAt",
-];
-
-/**
- * Reserved on collections only.
+ * Built once per entity, because the answer cannot change at runtime and every write asks it.
  *
  * A single is one global row, so owner-only access is meaningless and no `created_by` column is
  * injected onto its table — which leaves `created_by` an ordinary, legal field name for a single
- * to declare, and the single validator reserves only the publication marker for exactly that
- * reason. Stripping it there would silently discard a user's own column on every update, so the
- * reservation follows the column rather than the convenience of one shared list.
+ * to declare. Stripping it there would silently discard the author's own column on every update,
+ * so the reservation follows the column, which is what `appliesTo` on the declaration expresses.
  */
-const COLLECTION_ONLY_IMMUTABLE: readonly string[] = [
-  "created_by",
-  "createdBy",
-];
+const IMMUTABLE_BY_ENTITY: Readonly<
+  Record<WritableEntityKind, ReadonlySet<string>>
+> = {
+  collection: new Set(immutableSystemColumnNames("collection")),
+  single: new Set(immutableSystemColumnNames("single")),
+};
 
-const COLLECTION_SET: ReadonlySet<string> = new Set([
-  ...ALWAYS_IMMUTABLE_SYSTEM_FIELDS,
-  ...COLLECTION_ONLY_IMMUTABLE,
-]);
-const SINGLE_SET: ReadonlySet<string> = new Set(ALWAYS_IMMUTABLE_SYSTEM_FIELDS);
+/**
+ * The columns closed to clients on any entity at all.
+ *
+ * For callers that protect both kinds at once rather than one at a time: a restore refuses to
+ * carry the owner column back even for a single, where it is not a system column.
+ */
+export const IMMUTABLE_SYSTEM_FIELDS_ANY_ENTITY: ReadonlySet<string> = new Set(
+  immutableSystemColumnNamesAnyEntity()
+);
 
 /** The names a client may not write for the given entity. */
 export function immutableSystemFieldsFor(
   entity: WritableEntityKind
 ): ReadonlySet<string> {
-  return entity === "single" ? SINGLE_SET : COLLECTION_SET;
+  return IMMUTABLE_BY_ENTITY[entity];
 }
 
 /**

--- a/packages/nextly/src/lib/system-columns.ts
+++ b/packages/nextly/src/lib/system-columns.ts
@@ -3,15 +3,13 @@
  *
  * A system column is not one fact but several: which tables carry it, what shape it has per
  * dialect, whether a client may write it, what name it is published under, whether a user may take
- * that name for a field of their own. Those answers were spread across nine modules, each holding a
- * hand-written list of the columns it happened to know about when it was written. Nothing connected
- * them, so adding a column had no definition of done — it was finished when a reviewer stopped
- * finding lists that had not been edited, and roughly a third of the review findings on the two
- * pull requests that added `first_published_at` were exactly that.
+ * that name for a field of their own. Each of those questions used to be answered by a separate
+ * hand-written list, and a list only ever knows the columns that existed when it was written, so a
+ * column could reach the physical table while some other surface went on as if it did not exist.
  *
- * Every one of those lists is now a projection of this one. A column added here reaches all of them
- * at once, and the disagreements between them became visible instead of accidental: see
- * `reservedIn`, where the four validators genuinely do not agree and now say so.
+ * Every one of those lists is a projection of this one, so a column declared here reaches all of
+ * them at once. Where they genuinely differ, the difference is declared rather than implied: see
+ * `reservedIn`, where the four validators do not agree and now say so.
  *
  * This module deliberately has no imports. Its consumers span the config layer, the shared response
  * helpers and the schema pipeline, and a leaf cannot create a cycle with any of them.
@@ -78,15 +76,76 @@ const RESERVATION_SPELLINGS: Readonly<
   uiSchema: "columnOnly",
 };
 
+/**
+ * The column family a shape belongs to.
+ *
+ * Semantic rather than spelled per dialect, because three consumers need three different renderings
+ * of the same fact: the introspection token the diff compares, the `CREATE TABLE` text, and the
+ * Drizzle builder the runtime schema is made of. Spelling any of them out separately is how they
+ * drift — a runtime schema built as text against a table created as a timestamp is exactly the
+ * disagreement this module exists to prevent.
+ */
+export type SystemColumnKind = "text" | "varchar" | "timestamp";
+
+/**
+ * What a column defaults to, if anything.
+ *
+ * `now` is a database-side clock, spelled differently by every dialect. `literal` is a value, which
+ * the DDL quotes and the Drizzle builder does not.
+ */
+export type SystemColumnDefault =
+  | { kind: "now" }
+  | { kind: "literal"; value: string };
+
 /** The physical column, for one dialect. */
 export interface SystemColumnShape {
-  dialectType: string;
-  /** Declared size, where the dialect carries one separately from `dialectType`. */
+  kind: SystemColumnKind;
+  /** Declared size, for the dialects whose type carries one. */
   length?: number;
   nullable: boolean;
   primaryKey?: boolean;
-  /** Raw DDL default expression, exactly as it must appear (`now()`, `'draft'`). */
-  default?: string;
+  default?: SystemColumnDefault;
+}
+
+/**
+ * The type token introspection reports for a shape: PostgreSQL `udt_name`, MySQL `COLUMN_TYPE`,
+ * SQLite's declared PRAGMA type. The diff compares desired against live using this exact string.
+ *
+ * PostgreSQL reports `varchar` without its length while MySQL reports the full declared type, which
+ * is why the two differ for the same column.
+ */
+export function systemColumnDialectType(
+  shape: SystemColumnShape,
+  dialect: SystemColumnDialect
+): string {
+  if (dialect === "postgresql") {
+    return shape.kind === "timestamp" ? "timestamp" : shape.kind;
+  }
+  if (dialect === "mysql") {
+    if (shape.kind === "timestamp") return "timestamp";
+    if (shape.kind === "varchar") return `varchar(${shape.length ?? 255})`;
+    return "text";
+  }
+  // SQLite stores a timestamp as an epoch integer and has no distinct varchar.
+  return shape.kind === "timestamp" ? "integer" : "text";
+}
+
+/**
+ * The default as it must appear in `CREATE TABLE`, or undefined when there is none.
+ *
+ * Must match what the runtime Drizzle builder emits for the same shape, or the diff reads a
+ * phantom default change on every apply.
+ */
+export function systemColumnDefaultSql(
+  shape: SystemColumnShape,
+  dialect: SystemColumnDialect
+): string | undefined {
+  const value = shape.default;
+  if (!value) return undefined;
+  if (value.kind === "literal") return `'${value.value}'`;
+  if (dialect === "postgresql") return "now()";
+  if (dialect === "mysql") return "CURRENT_TIMESTAMP";
+  return "(strftime('%s', 'now'))";
 }
 
 export interface SystemColumnDeclaration {
@@ -137,14 +196,14 @@ export const SYSTEM_COLUMNS: readonly SystemColumnDeclaration[] = [
     strippedFromResponses: false,
     reservedIn: ["builder", "uiSchema"],
     shape: {
-      postgresql: { dialectType: "text", nullable: false, primaryKey: true },
+      postgresql: { kind: "text", nullable: false, primaryKey: true },
       mysql: {
-        dialectType: "varchar(36)",
+        kind: "varchar",
         length: 36,
         nullable: false,
         primaryKey: true,
       },
-      sqlite: { dialectType: "text", nullable: false, primaryKey: true },
+      sqlite: { kind: "text", nullable: false, primaryKey: true },
     },
   },
   {
@@ -157,9 +216,9 @@ export const SYSTEM_COLUMNS: readonly SystemColumnDeclaration[] = [
     strippedFromResponses: false,
     reservedIn: ["builder"],
     shape: {
-      postgresql: { dialectType: "text", nullable: false },
-      mysql: { dialectType: "varchar(255)", length: 255, nullable: false },
-      sqlite: { dialectType: "text", nullable: false },
+      postgresql: { kind: "text", nullable: false },
+      mysql: { kind: "varchar", length: 255, nullable: false },
+      sqlite: { kind: "text", nullable: false },
     },
   },
   {
@@ -172,9 +231,9 @@ export const SYSTEM_COLUMNS: readonly SystemColumnDeclaration[] = [
     strippedFromResponses: false,
     reservedIn: ["builder"],
     shape: {
-      postgresql: { dialectType: "text", nullable: false },
-      mysql: { dialectType: "varchar(255)", length: 255, nullable: false },
-      sqlite: { dialectType: "text", nullable: false },
+      postgresql: { kind: "text", nullable: false },
+      mysql: { kind: "varchar", length: 255, nullable: false },
+      sqlite: { kind: "text", nullable: false },
     },
   },
   {
@@ -193,20 +252,12 @@ export const SYSTEM_COLUMNS: readonly SystemColumnDeclaration[] = [
     reservedIn: ["builder", "uiSchema"],
     shape: {
       postgresql: {
-        dialectType: "timestamp",
+        kind: "timestamp",
         nullable: true,
-        default: "now()",
+        default: { kind: "now" },
       },
-      mysql: {
-        dialectType: "timestamp",
-        nullable: true,
-        default: "CURRENT_TIMESTAMP",
-      },
-      sqlite: {
-        dialectType: "integer",
-        nullable: true,
-        default: "(strftime('%s', 'now'))",
-      },
+      mysql: { kind: "timestamp", nullable: true, default: { kind: "now" } },
+      sqlite: { kind: "timestamp", nullable: true, default: { kind: "now" } },
     },
   },
   {
@@ -220,20 +271,12 @@ export const SYSTEM_COLUMNS: readonly SystemColumnDeclaration[] = [
     reservedIn: ["builder", "uiSchema"],
     shape: {
       postgresql: {
-        dialectType: "timestamp",
+        kind: "timestamp",
         nullable: true,
-        default: "now()",
+        default: { kind: "now" },
       },
-      mysql: {
-        dialectType: "timestamp",
-        nullable: true,
-        default: "CURRENT_TIMESTAMP",
-      },
-      sqlite: {
-        dialectType: "integer",
-        nullable: true,
-        default: "(strftime('%s', 'now'))",
-      },
+      mysql: { kind: "timestamp", nullable: true, default: { kind: "now" } },
+      sqlite: { kind: "timestamp", nullable: true, default: { kind: "now" } },
     },
   },
   {
@@ -257,9 +300,9 @@ export const SYSTEM_COLUMNS: readonly SystemColumnDeclaration[] = [
     strippedFromResponses: true,
     reservedIn: ["builder", "collectionConfig"],
     shape: {
-      postgresql: { dialectType: "text", nullable: true },
-      mysql: { dialectType: "varchar(191)", length: 191, nullable: true },
-      sqlite: { dialectType: "text", nullable: true },
+      postgresql: { kind: "text", nullable: true },
+      mysql: { kind: "varchar", length: 191, nullable: true },
+      sqlite: { kind: "text", nullable: true },
     },
   },
   {
@@ -278,18 +321,22 @@ export const SYSTEM_COLUMNS: readonly SystemColumnDeclaration[] = [
     reservedIn: [],
     shape: {
       postgresql: {
-        dialectType: "varchar",
+        kind: "varchar",
         length: 20,
         nullable: false,
-        default: "'draft'",
+        default: { kind: "literal", value: "draft" },
       },
       mysql: {
-        dialectType: "varchar(20)",
+        kind: "varchar",
         length: 20,
         nullable: false,
-        default: "'draft'",
+        default: { kind: "literal", value: "draft" },
       },
-      sqlite: { dialectType: "text", nullable: false, default: "'draft'" },
+      sqlite: {
+        kind: "text",
+        nullable: false,
+        default: { kind: "literal", value: "draft" },
+      },
     },
   },
   {
@@ -324,9 +371,9 @@ export const SYSTEM_COLUMNS: readonly SystemColumnDeclaration[] = [
     // would otherwise collide at migration time rather than here, where the name is chosen.
     reservedIn: ["builder", "collectionConfig", "singleConfig"],
     shape: {
-      postgresql: { dialectType: "timestamp", nullable: true },
-      mysql: { dialectType: "timestamp", nullable: true },
-      sqlite: { dialectType: "integer", nullable: true },
+      postgresql: { kind: "timestamp", nullable: true },
+      mysql: { kind: "timestamp", nullable: true },
+      sqlite: { kind: "timestamp", nullable: true },
     },
   },
 ];

--- a/packages/nextly/src/lib/system-columns.ts
+++ b/packages/nextly/src/lib/system-columns.ts
@@ -1,0 +1,393 @@
+/**
+ * What a system column is, declared once.
+ *
+ * A system column is not one fact but several: which tables carry it, what shape it has per
+ * dialect, whether a client may write it, what name it is published under, whether a user may take
+ * that name for a field of their own. Those answers were spread across nine modules, each holding a
+ * hand-written list of the columns it happened to know about when it was written. Nothing connected
+ * them, so adding a column had no definition of done — it was finished when a reviewer stopped
+ * finding lists that had not been edited, and roughly a third of the review findings on the two
+ * pull requests that added `first_published_at` were exactly that.
+ *
+ * Every one of those lists is now a projection of this one. A column added here reaches all of them
+ * at once, and the disagreements between them became visible instead of accidental: see
+ * `reservedIn`, where the four validators genuinely do not agree and now say so.
+ *
+ * This module deliberately has no imports. Its consumers span the config layer, the shared response
+ * helpers and the schema pipeline, and a leaf cannot create a cycle with any of them.
+ *
+ * @module lib/system-columns
+ */
+
+/** The dialects a physical shape is declared for. */
+export type SystemColumnDialect = "postgresql" | "mysql" | "sqlite";
+
+/** Which kind of table is being described. */
+export type SystemColumnEntity = "collection" | "single";
+
+/**
+ * When a column is part of a table.
+ *
+ * `title` and `slug` are injected only when the author has not declared fields of their own by
+ * those names, and the lifecycle pair exists only when Draft/Published is enabled. Spelled as a
+ * token rather than a predicate so the set stays inspectable: a test can ask which columns the
+ * lifecycle owns without evaluating anything.
+ */
+export type SystemColumnPresence =
+  | "always"
+  | "unlessAuthorDeclaredTitle"
+  | "unlessAuthorDeclaredSlug"
+  | "withStatusLifecycle";
+
+/**
+ * A validator that refuses a name for an author's own field.
+ *
+ * Four surfaces ask this question and they do NOT agree on the answer: the Schema Builder refuses
+ * the widest set, the UI field-payload schema three universal columns, a code-first collection two,
+ * a code-first single one. The narrower ones are missing names that collide — a code-first
+ * collection may declare `createdAt` today, and it lands in the same `CREATE TABLE` as the injected
+ * `created_at`, which the database rejects outright.
+ *
+ * Declared per surface rather than derived from one rule precisely because of that. One rule would
+ * widen every validator at once, and a payload that is legal today would begin failing without
+ * anyone deciding it should. Recording the disagreement is what makes correcting it a choice.
+ */
+export type ReservationSurface =
+  | "builder"
+  | "collectionConfig"
+  | "singleConfig"
+  | "uiSchema";
+
+/**
+ * Whether a surface refuses both spellings of a column or only the physical one.
+ *
+ * A property of the surface rather than of the column: it depends on what that validator's payload
+ * can express, not on what the column is.
+ *
+ * `uiSchema` validates field payloads for collections, singles AND components, and a component
+ * keeps its values in tables of its own whose system columns are not described here. Refusing the
+ * camelCase spelling there could reject a component field that is legal today, so it stays as
+ * narrow as it is until those tables are declared too.
+ */
+const RESERVATION_SPELLINGS: Readonly<
+  Record<ReservationSurface, "both" | "columnOnly">
+> = {
+  builder: "both",
+  collectionConfig: "both",
+  singleConfig: "both",
+  uiSchema: "columnOnly",
+};
+
+/** The physical column, for one dialect. */
+export interface SystemColumnShape {
+  dialectType: string;
+  /** Declared size, where the dialect carries one separately from `dialectType`. */
+  length?: number;
+  nullable: boolean;
+  primaryKey?: boolean;
+  /** Raw DDL default expression, exactly as it must appear (`now()`, `'draft'`). */
+  default?: string;
+}
+
+export interface SystemColumnDeclaration {
+  /** The physical, snake_case column name. */
+  name: string;
+  /**
+   * The camelCase spelling that snake-cases back to `name`, equal to `name` for a single word.
+   *
+   * Config validation accepts camelCase field names and converts them, so the two spellings reach
+   * the same column and reserving one alone reserves nothing.
+   */
+  camelName: string;
+  /** The tables that carry it. */
+  appliesTo: readonly SystemColumnEntity[];
+  presence: SystemColumnPresence;
+  /**
+   * Whether a value in a request body is honoured.
+   *
+   * False means the service alone decides it and a supplied value is stripped. `title`, `slug` and
+   * `status` are system-injected and fully writable: they are content and lifecycle. Only the
+   * columns describing provenance are closed.
+   */
+  writableByClient: boolean;
+  /** Whether responses publish it under `camelName` and drop the snake_case key. */
+  publishedUnderCamelName: boolean;
+  /** Whether it is removed from responses entirely. */
+  strippedFromResponses: boolean;
+  reservedIn: readonly ReservationSurface[];
+  shape: Readonly<Record<SystemColumnDialect, SystemColumnShape>>;
+}
+
+const BOTH_ENTITIES: readonly SystemColumnEntity[] = ["collection", "single"];
+
+/**
+ * Every system column, in the order a table declares them.
+ *
+ * Order is load-bearing: it is the column order of the emitted `CREATE TABLE`, so reordering this
+ * array reorders physical tables.
+ */
+export const SYSTEM_COLUMNS: readonly SystemColumnDeclaration[] = [
+  {
+    name: "id",
+    camelName: "id",
+    appliesTo: BOTH_ENTITIES,
+    presence: "always",
+    writableByClient: false,
+    publishedUnderCamelName: false,
+    strippedFromResponses: false,
+    reservedIn: ["builder", "uiSchema"],
+    shape: {
+      postgresql: { dialectType: "text", nullable: false, primaryKey: true },
+      mysql: {
+        dialectType: "varchar(36)",
+        length: 36,
+        nullable: false,
+        primaryKey: true,
+      },
+      sqlite: { dialectType: "text", nullable: false, primaryKey: true },
+    },
+  },
+  {
+    name: "title",
+    camelName: "title",
+    appliesTo: BOTH_ENTITIES,
+    presence: "unlessAuthorDeclaredTitle",
+    writableByClient: true,
+    publishedUnderCamelName: false,
+    strippedFromResponses: false,
+    reservedIn: ["builder"],
+    shape: {
+      postgresql: { dialectType: "text", nullable: false },
+      mysql: { dialectType: "varchar(255)", length: 255, nullable: false },
+      sqlite: { dialectType: "text", nullable: false },
+    },
+  },
+  {
+    name: "slug",
+    camelName: "slug",
+    appliesTo: BOTH_ENTITIES,
+    presence: "unlessAuthorDeclaredSlug",
+    writableByClient: true,
+    publishedUnderCamelName: false,
+    strippedFromResponses: false,
+    reservedIn: ["builder"],
+    shape: {
+      postgresql: { dialectType: "text", nullable: false },
+      mysql: { dialectType: "varchar(255)", length: 255, nullable: false },
+      sqlite: { dialectType: "text", nullable: false },
+    },
+  },
+  {
+    // The defaults mirror what the runtime Drizzle generator builds, per dialect. A shape that
+    // reports no default where the generator emits one describes the diff's desired state as
+    // something neither creation path produces, and the diff then sees a phantom default change on
+    // every apply. SQLite was the dialect that had none while the Schema Builder emitted this exact
+    // expression, so an insert omitting the column stored NULL where the other two stored a time.
+    name: "created_at",
+    camelName: "createdAt",
+    appliesTo: BOTH_ENTITIES,
+    presence: "always",
+    writableByClient: false,
+    publishedUnderCamelName: true,
+    strippedFromResponses: false,
+    reservedIn: ["builder", "uiSchema"],
+    shape: {
+      postgresql: {
+        dialectType: "timestamp",
+        nullable: true,
+        default: "now()",
+      },
+      mysql: {
+        dialectType: "timestamp",
+        nullable: true,
+        default: "CURRENT_TIMESTAMP",
+      },
+      sqlite: {
+        dialectType: "integer",
+        nullable: true,
+        default: "(strftime('%s', 'now'))",
+      },
+    },
+  },
+  {
+    name: "updated_at",
+    camelName: "updatedAt",
+    appliesTo: BOTH_ENTITIES,
+    presence: "always",
+    writableByClient: false,
+    publishedUnderCamelName: true,
+    strippedFromResponses: false,
+    reservedIn: ["builder", "uiSchema"],
+    shape: {
+      postgresql: {
+        dialectType: "timestamp",
+        nullable: true,
+        default: "now()",
+      },
+      mysql: {
+        dialectType: "timestamp",
+        nullable: true,
+        default: "CURRENT_TIMESTAMP",
+      },
+      sqlite: {
+        dialectType: "integer",
+        nullable: true,
+        default: "(strftime('%s', 'now'))",
+      },
+    },
+  },
+  {
+    // The creating user's id, not the row id, which is why MySQL sizes it to the users table's
+    // varchar(191) rather than the varchar(36) row id: a longer user id would be truncated.
+    // Nullable because existing rows and system or seed writes have no user.
+    //
+    // Collections only. A single is one global row, so owner-only access is meaningless and no
+    // owner column is injected — which leaves `created_by` an ordinary, legal field name for a
+    // single to declare. That is the case `appliesTo` exists for: sharing one list wholesale made
+    // a single's own column get stripped on every write.
+    name: "created_by",
+    camelName: "createdBy",
+    appliesTo: ["collection"],
+    presence: "always",
+    writableByClient: false,
+    publishedUnderCamelName: false,
+    // Owner-only access filters on this in SQL, so the value never needs to leave the server.
+    // Returning it would hand a stable user id to anyone who can read a collection whose rows
+    // were created by other people.
+    strippedFromResponses: true,
+    reservedIn: ["builder", "collectionConfig"],
+    shape: {
+      postgresql: { dialectType: "text", nullable: true },
+      mysql: { dialectType: "varchar(191)", length: 191, nullable: true },
+      sqlite: { dialectType: "text", nullable: true },
+    },
+  },
+  {
+    // PostgreSQL declares this one as `varchar` with the size held only in `length`, because
+    // information_schema reports udt_name=varchar for the runtime generator's
+    // pgVarchar("status", { length: 20 }); emitting "varchar(20)" as the type would read as a
+    // phantom type change on every apply. Existing rows backfill to 'draft' so unpublished
+    // content cannot leak during the migration that adds the column.
+    name: "status",
+    camelName: "status",
+    appliesTo: BOTH_ENTITIES,
+    presence: "withStatusLifecycle",
+    writableByClient: true,
+    publishedUnderCamelName: false,
+    strippedFromResponses: false,
+    reservedIn: [],
+    shape: {
+      postgresql: {
+        dialectType: "varchar",
+        length: 20,
+        nullable: false,
+        default: "'draft'",
+      },
+      mysql: {
+        dialectType: "varchar(20)",
+        length: 20,
+        nullable: false,
+        default: "'draft'",
+      },
+      sqlite: { dialectType: "text", nullable: false, default: "'draft'" },
+    },
+  },
+  {
+    // When a document first became public.
+    //
+    // `status` says what a document IS; nothing said what it HAS BEEN. Unpublishing returns a row
+    // to `draft` and erases every trace it was ever live, while the links, feeds and search results
+    // it accumulated stay where they are. Anything deciding "was this address ever public" — slug
+    // stability, redirect capture — needs a fact that survives that round trip.
+    //
+    // NULLABLE with NO DEFAULT, and that is the whole design. NULL means "not known to have been
+    // published": true of a draft, and equally true of every row predating the column, which cannot
+    // be told apart from a draft after the fact. A default would assert a publication that never
+    // happened.
+    //
+    // Set once on the first transition into published and never moved, so it is not a
+    // "last published" value. Those are different questions: a last-published timestamp moves on
+    // every republish and its behaviour across an unpublish is a product choice, while this one has
+    // a single defensible answer. Contentful carries both under distinct names for the same reason.
+    //
+    // Closed to clients for a reason the timestamps are not: it is meant to be written once, and a
+    // value taken from a request would make that guarantee decorative — a draft create could claim
+    // a publication that never happened, and any later update could reset a real one.
+    name: "first_published_at",
+    camelName: "firstPublishedAt",
+    appliesTo: BOTH_ENTITIES,
+    presence: "withStatusLifecycle",
+    writableByClient: false,
+    publishedUnderCamelName: true,
+    strippedFromResponses: false,
+    // Reserved even on an entity that has not enabled the lifecycle, because enabling it later
+    // would otherwise collide at migration time rather than here, where the name is chosen.
+    reservedIn: ["builder", "collectionConfig", "singleConfig"],
+    shape: {
+      postgresql: { dialectType: "timestamp", nullable: true },
+      mysql: { dialectType: "timestamp", nullable: true },
+      sqlite: { dialectType: "integer", nullable: true },
+    },
+  },
+];
+
+// ============================================================
+// Projections
+// ============================================================
+
+/**
+ * Both spellings of a column, deduplicated.
+ *
+ * Single-word columns spell the same in either case, and a list that repeated them would make
+ * every consumer's set look larger than the set of columns it describes.
+ */
+function bothSpellings(column: SystemColumnDeclaration): string[] {
+  return column.name === column.camelName
+    ? [column.name]
+    : [column.name, column.camelName];
+}
+
+/** Every spelling of every column matching `predicate`, in declaration order. */
+export function systemColumnNames(
+  predicate: (column: SystemColumnDeclaration) => boolean
+): string[] {
+  return SYSTEM_COLUMNS.filter(predicate).flatMap(bothSpellings);
+}
+
+/** The names a validator on `surface` refuses for an author's own field. */
+export function reservedSystemFieldNames(
+  surface: ReservationSurface
+): string[] {
+  const columns = SYSTEM_COLUMNS.filter(column =>
+    column.reservedIn.includes(surface)
+  );
+  return RESERVATION_SPELLINGS[surface] === "columnOnly"
+    ? columns.map(column => column.name)
+    : columns.flatMap(bothSpellings);
+}
+
+/**
+ * The columns a client may never write, for a given entity.
+ *
+ * `appliesTo` is what keeps a single's own `created_by` field: the column does not exist on a
+ * single's table, so the name is an ordinary one there and stripping it would silently discard the
+ * author's own value on every write.
+ */
+export function immutableSystemColumnNames(
+  entity: SystemColumnEntity
+): string[] {
+  return systemColumnNames(
+    column => !column.writableByClient && column.appliesTo.includes(entity)
+  );
+}
+
+/**
+ * The columns a client may never write, on any entity.
+ *
+ * The union rather than one entity's view, for callers that run before the entity is known or that
+ * protect both — a restore refuses to carry the owner column back even for a single, where it is
+ * not a system column at all.
+ */
+export function immutableSystemColumnNamesAnyEntity(): string[] {
+  return systemColumnNames(column => !column.writableByClient);
+}

--- a/packages/nextly/src/schemas/_zod/ui-schema.ts
+++ b/packages/nextly/src/schemas/_zod/ui-schema.ts
@@ -12,8 +12,10 @@
  * @module schemas/_zod/ui-schema
  * @since v0.0.3-alpha (Plan D1)
  */
+
 import { z } from "zod";
 
+import { reservedSystemFieldNames } from "../../lib/system-columns";
 import {
   isPluginOptionContainer,
   RESERVED_PLUGIN_OPTION_KEYS,
@@ -55,7 +57,9 @@ const BUILT_IN_UI_FIELD_TYPES = new Set<string>(UI_FIELD_TYPES);
 // component). The collection-only owner column (`created_by`/`createdBy`) is
 // NOT reserved here — it would wrongly reject valid single/component fields;
 // it is enforced per-entity by assertValidFieldsPayload({ kind: "collection" }).
-const RESERVED_FIELD_NAMES = new Set(["id", "created_at", "updated_at"]);
+const RESERVED_FIELD_NAMES: ReadonlySet<string> = new Set(
+  reservedSystemFieldNames("uiSchema")
+);
 
 const SLUG_RE = /^[a-z][a-z0-9_-]*$/;
 

--- a/packages/nextly/src/shared/lib/case-conversion.ts
+++ b/packages/nextly/src/shared/lib/case-conversion.ts
@@ -7,6 +7,8 @@
  * @module lib/case-conversion
  */
 
+import { SYSTEM_COLUMNS } from "../../lib/system-columns";
+
 /**
  * Convert a snake_case string to camelCase.
  * Example: "created_at" -> "createdAt"
@@ -132,17 +134,16 @@ export function keysToSnakeCase(obj: unknown): unknown {
 /**
  * The system timestamp columns, and the camelCase name each is published under.
  *
- * Listed once because a row can reach the API through several paths, and a column converted on
- * some of them and not others gives the same entry different shapes depending on the operation
- * that returned it. That is what happened to `first_published_at`: create responses carried
- * `firstPublishedAt` while list and detail reads returned the raw column name.
+ * A projection of the columns declared `publishedUnderCamelName`, because a row reaches the API
+ * through several paths and a column converted on some of them and not others gives the same
+ * entry different shapes depending on the operation that returned it. That is what happened to
+ * `first_published_at`: create responses carried `firstPublishedAt` while list and detail reads
+ * returned the raw column name.
  */
 export const TIMESTAMP_COLUMN_NAMES: ReadonlyArray<readonly [string, string]> =
-  [
-    ["created_at", "createdAt"],
-    ["updated_at", "updatedAt"],
-    ["first_published_at", "firstPublishedAt"],
-  ];
+  SYSTEM_COLUMNS.filter(column => column.publishedUnderCamelName).map(
+    column => [column.name, column.camelName] as const
+  );
 
 /**
  * Every spelling of every system timestamp, both the physical column and the API name.

--- a/packages/nextly/src/shared/lib/password-fields.ts
+++ b/packages/nextly/src/shared/lib/password-fields.ts
@@ -15,6 +15,7 @@
  */
 
 import { hashPassword } from "../../auth/password";
+import { systemColumnNames } from "../../lib/system-columns";
 
 /** The minimal field shape both FieldConfig and FieldDefinition satisfy. */
 interface NamedField {
@@ -163,8 +164,15 @@ export function hasPasswordField(fields: NamedField[]): boolean {
   );
 }
 
-/** System owner column, in the snake_case column form and the camelCase form. */
-const OWNER_COLUMN_KEYS = ["created_by", "createdBy"] as const;
+/**
+ * The system columns that never leave the server, in every spelling.
+ *
+ * A projection of `strippedFromResponses` rather than a list of its own, so a column added with
+ * that policy is removed here without an edit.
+ */
+const RESPONSE_STRIPPED_KEYS: readonly string[] = systemColumnNames(
+  column => column.strippedFromResponses
+);
 
 /**
  * Remove the system owner column (`created_by`) from a response row, in place.
@@ -176,7 +184,7 @@ const OWNER_COLUMN_KEYS = ["created_by", "createdBy"] as const;
  * response boundary, the same place password values are cleared.
  */
 export function stripSystemOwnerField(entry: Record<string, unknown>): void {
-  for (const key of OWNER_COLUMN_KEYS) {
+  for (const key of RESPONSE_STRIPPED_KEYS) {
     if (key in entry) delete entry[key];
   }
 }

--- a/packages/nextly/src/singles/config/validate-single.ts
+++ b/packages/nextly/src/singles/config/validate-single.ts
@@ -23,6 +23,7 @@
 
 import { RESERVED_SLUGS } from "../../collections/config/validate-config";
 import { isPluginFieldTypeOnSurface } from "../../domains/schema/field-types/field-type-registry";
+import { reservedSystemFieldNames } from "../../lib/system-columns";
 import { SYSTEM_RESOURCES } from "../../schemas/_zod/rbac";
 import {
   type BaseValidationError,
@@ -266,10 +267,9 @@ function validateField(
 // owner column, so unlike a collection only the first-publication marker is
 // reserved here — which is why this check had to be added rather than extended:
 // until the marker reached a Single's table there was nothing to collide with.
-const SINGLE_RESERVED_FIELD_NAMES: Set<string> = new Set([
-  "first_published_at",
-  "firstPublishedAt",
-]);
+const SINGLE_RESERVED_FIELD_NAMES: ReadonlySet<string> = new Set(
+  reservedSystemFieldNames("singleConfig")
+);
 
 /**
  * Validate an array of field configurations.


### PR DESCRIPTION
Task `111-system-columns-need-declared-policies.md`. Seven commits, each moving one list, so a regression is bisectable.

## The problem this ends

"What is a system column" was answered separately in **ten** modules, each holding a hand-written list of the columns it knew about when it was written. Nothing connected them, so *add a system column* had no definition of done — you were finished when a reviewer stopped finding lists you had not edited.

The evidence: #465 and #493 added **one** column between them and took five review rounds. Roughly a third of the findings were a missing entry in one of these lists, each found separately and fixed separately.

| where | the question it answered |
|---|---|
| `getSystemColumnDescriptors` | what exists, and its shape per dialect |
| `immutable-system-fields.ts` (2 lists) | which a client may never write |
| `restore-snapshot.ts` | which a restore may not carry back |
| `case-conversion.ts` | which are published under a camelCase name |
| `password-fields.ts` | which never leave the server |
| `dynamic-collection-validation-service.ts` | which names the Schema Builder refuses |
| `validate-config.ts` / `validate-single.ts` | same, code-first, two different scopes |
| `_zod/ui-schema.ts` | same, UI field payloads, a fourth scope |
| `SYSTEM_SCHEMA_VERSION` | hand-incremented, or stored hashes never notice |

The task filed seven. Tracing it found **ten** — `password-fields.ts` and `_zod/ui-schema.ts` were not on the list.

## What this does

One declaration per column carrying the policies every consumer needs; every list above becomes a projection.

`created_by` is the case that proves `appliesTo` is required: immutable and reserved on a collection, an ordinary field name on a single, whose table has no owner column. #465 shipped a bug in exactly that shape by sharing one list wholesale.

## Two findings that changed the design

**1. `SYSTEM_SCHEMA_VERSION` is pinned, not derived.** The task proposed deriving it. It is mixed into every collection's stored schema hash, and six registry services compare that hash to decide whether a table needs rebuilding — so deriving it changes the value *now*, for every install at once, and every stored hash reads as "schema changed". A migration for everybody, to record a refactor.

Instead a test pins the physical shape alongside the version. It carries only what decides a table, so changing who may write a column does not demand a bump. Same protection, no migration risk.

**2. Reservation is per surface, not one boolean.** The four validators genuinely disagree, and one derived rule would widen all of them at once. `reservedIn` records the disagreement instead — the first time it has been visible.

## The one behaviour change

The Schema Builder now refuses `createdAt` and `updatedAt`. It reserved `created_by` *and* `createdBy` but only `created_at`: an artifact of when each entry was added, not a policy.

This cannot break an existing collection, and here is the proof rather than the argument — generated DDL for a Builder collection with a field named `createdAt`:

```sql
CREATE TABLE IF NOT EXISTS "scratchy" (
  "id" text PRIMARY KEY NOT NULL,
  ...
  "created_at" timestamp DEFAULT now(),
  "created_by" text,
"created_at" text            <- the user field
);
```

The column is declared twice and PostgreSQL rejects the statement, so no collection carrying such a field can exist. Refusing the name moves the failure from a raw database error at migration time to a clear message where the name is chosen.

Two narrower scopes are left alone deliberately. The UI field-payload schema also validates *component* fields, whose tables are not declared here, so widening it could reject a component field that is legal today. The code-first validators are missing `id` and the timestamps — the same collision, but they run at boot, so widening them could fail an app on startup. Both filed as follow-ups rather than smuggled in here.

## Verification

**The descriptor translation is proven, not argued.** All 48 combinations of dialect x table options were dumped from this implementation and from `origin/main`'s, and compared: **byte-identical, 39,346 bytes each**.

Falsifications, each failing for its own reason:

| reverted | result |
|---|---|
| camel spellings in Builder reservations | pinned Builder set fails |
| the Builder validator reading the projection | wiring test fails |
| a dialect shape (`varchar(191)` -> `varchar(255)`) | schema-version pin fails |
| adding a column without bumping the version | 4 tests fail, including the pin |

That last one initially "passed" — because the edit had not applied, its anchor not matching a comment above the declaration. Redone with an assertion that the column count changed before running.

Tests come in two kinds and the file says which is which: **pinned** sets naming today's columns, recording the contract each consumer had before the declarations existed, and **property** tests naming no column at all, which are what make the next column safe. Plus wiring tests, because a declaration nobody consults would satisfy every projection test.

**Three dialect legs, one at a time, databases recreated before each:**

| leg | passed | failed |
|---|---|---|
| sqlite | 1010 | 0 |
| postgres17 | 1159 | 0 |
| mysql | 1090 | 0 |

Full `nextly` unit suite measured against a baseline captured by reverting all eleven files to `origin/main` content in this same tree: **37 failing files / 397 failing tests both ways — no new failures**, plus 17 more passing from the new suite. `check-types` (source and tests) and `lint` clean.
