### PR TITLE
fix(nextly): refuse colliding field names in a component too

### DIFF
--- a/.changeset/component-reserved-spellings.md
+++ b/.changeset/component-reserved-spellings.md
@@ -1,0 +1,29 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+Reject a field named `createdAt` or `updatedAt` in a Field Group (component) the way the Schema
+Builder already rejects one in a collection. A component keeps its values in a table of its own
+that carries `created_at` and `updated_at`, so such a field is emitted into the same
+`CREATE TABLE` as the injected column and the database refuses the statement. The name is now
+refused where it is chosen, with a message saying why.

--- a/.changeset/component-reserved-spellings.md
+++ b/.changeset/component-reserved-spellings.md
@@ -22,8 +22,11 @@
 "@nextlyhq/tsconfig": patch
 ---
 
-Reject a field named `createdAt` or `updatedAt` in a Field Group (component) the way the Schema
-Builder already rejects one in a collection. A component keeps its values in a table of its own
-that carries `created_at` and `updated_at`, so such a field is emitted into the same
-`CREATE TABLE` as the injected column and the database refuses the statement. The name is now
-refused where it is chosen, with a message saying why.
+Reject a field named `id`, `createdAt` or `updatedAt` in a Field Group (component), through both
+the visual builder and `defineFieldGroup`. A component keeps its values in a table of its own
+carrying those columns, so such a field is emitted into the same `CREATE TABLE` as the injected one
+and the database refuses the statement. The name is now refused where it is chosen, with a message
+saying which system column it collides with.
+
+Field groups that already declare such a field could never have had a working table, since creating
+it fails; they will now be reported at configuration time instead of during schema application.

--- a/packages/nextly/src/field-groups/config/validate-field-group.ts
+++ b/packages/nextly/src/field-groups/config/validate-field-group.ts
@@ -28,6 +28,7 @@
 import { RESERVED_SLUGS } from "../../collections/config/validate-config";
 import { isPluginFieldTypeOnSurface } from "../../domains/schema/field-types/field-type-registry";
 import { NextlyError } from "../../errors";
+import { reservedSystemFieldNames } from "../../lib/system-columns";
 import {
   type BaseValidationError,
   DEFAULT_SQL_KEYWORDS_SET,
@@ -89,6 +90,9 @@ export type FieldGroupValidationErrorCode =
   | "FIELD_NAME_INVALID_FORMAT"
   | "FIELD_NAME_SQL_KEYWORD"
   | "FIELD_NAME_DUPLICATE"
+  // A name that snake-cases onto a column this group's table already carries. The same code the
+  // collection and single validators report, because it is the same mistake with the same fix.
+  | "FIELD_NAME_RESERVED"
   | "FIELD_TYPE_REQUIRED"
   | "FIELD_TYPE_INVALID"
   // A declared default the field's own rules reject.
@@ -311,12 +315,37 @@ function validateFields(
     return;
   }
 
+  // Block the injected system columns at the top level, before per-field validation. A field group
+  // keeps its values in a table of its own carrying these three, and a name that snake-cases onto
+  // one is emitted alongside the injected column: the CREATE TABLE then declares it twice and the
+  // database refuses the statement, so the group could never have been created. Refusing the name
+  // reports that where it is chosen rather than as a migration failure. Nested fields live inside
+  // JSON and are exempt, as they are for collections.
+  fields.forEach((field, index) => {
+    if (!field || typeof field !== "object") return;
+    const name = (field as Record<string, unknown>).name;
+    if (
+      typeof name === "string" &&
+      FIELD_GROUP_RESERVED_FIELD_NAMES.has(name)
+    ) {
+      errors.push({
+        path: `${path}[${index}].name`,
+        message: `Field name '${name}' is reserved for a system column`,
+        code: "FIELD_NAME_RESERVED",
+      });
+    }
+  });
+
   // An empty fields list is valid for both code-first defines and the
   // modal-driven create flow. A field group's table still gets its id and the
   // system columns that bind a row to its parent entry, so a fieldless group is
   // a usable table and an author can scaffold first and add fields later.
   validateFieldsArray(fields, path, errors);
 }
+
+const FIELD_GROUP_RESERVED_FIELD_NAMES: ReadonlySet<string> = new Set(
+  reservedSystemFieldNames("fieldGroupConfig")
+);
 
 // ============================================================
 // Main Validation Function

--- a/packages/nextly/src/lib/__tests__/system-columns.test.ts
+++ b/packages/nextly/src/lib/__tests__/system-columns.test.ts
@@ -7,12 +7,19 @@
 import { getColumns } from "drizzle-orm";
 import { describe, expect, it } from "vitest";
 
+// The validators and generators below are imported so the projections can be checked against the
+// code that consumes them, not only against themselves: a declared set nobody reads would satisfy
+// every assertion about its own contents. `fieldNameSchema`, `uiSchemaFieldSchema` and
+// `validateFieldGroupConfig` are the three validators fed by a reservation projection, and the two
+// generators are what turn a declared shape into a physical table and a runtime column.
 import type { FieldConfig } from "../../collections/fields/types";
 import { fieldNameSchema } from "../../domains/dynamic-collections/services/dynamic-collection-validation-service";
 import { FieldGroupSchemaService } from "../../domains/field-groups/services/field-group-schema-service";
 import { getSystemColumnDescriptors } from "../../domains/schema/services/field-column-descriptor";
 import { generateRuntimeSchema } from "../../domains/schema/services/runtime-schema-generator";
 import { SYSTEM_SCHEMA_VERSION } from "../../domains/schema/services/schema-hash";
+import { validateFieldGroupConfig } from "../../field-groups/config/validate-field-group";
+import type { FieldGroupConfig } from "../../field-groups/config/types";
 import { uiSchemaFieldSchema } from "../../schemas/_zod/ui-schema";
 
 import {
@@ -141,6 +148,13 @@ describe("reservation projections", () => {
     );
   });
 
+  it("refuses both spellings of the universal columns in a code-first field group", () => {
+    // A field group's table carries exactly these three, so these are the names that collide.
+    expect(sorted(reservedSystemFieldNames("fieldGroupConfig"))).toEqual(
+      sorted(["id", "created_at", "createdAt", "updated_at", "updatedAt"])
+    );
+  });
+
   it("refuses both spellings of the universal columns in the UI field-payload schema", () => {
     // The narrowest surface, because it also validates component fields and a component's table
     // carries only these three. It carries them under the same physical names, though, so the
@@ -210,6 +224,29 @@ describe("component tables, which are declared elsewhere on purpose", () => {
     }
   });
 
+  it("does not collide with a structural column that only resembles a field name", () => {
+    // The parent-linkage columns carry a leading underscore, which a field name cannot: `parentId`
+    // becomes `parent_id` and sits beside `_parent_id`. Counted inside the CREATE TABLE body only,
+    // because those columns appear again in the parent index and would look like duplicates.
+    for (const name of [
+      "parentId",
+      "parentTable",
+      "parentField",
+      "order",
+      "type",
+    ]) {
+      const body = new FieldGroupSchemaService("postgresql")
+        .generateMigrationSQL("comp_probe", [
+          { name, type: "text" } as FieldConfig,
+        ])
+        .split("--> statement-breakpoint")[0];
+      const columns = [...body.matchAll(/^\s*"([a-z_]+)"/gm)].map(m => m[1]);
+      const duplicated = columns.filter((c, i) => columns.indexOf(c) !== i);
+
+      expect({ [name]: duplicated }).toEqual({ [name]: [] });
+    }
+  });
+
   it("would emit a duplicate column for a field named like a shared one", () => {
     // The reason the UI field-payload schema refuses both spellings. `createdAt` snake-cases onto
     // the injected `created_at` and both are emitted, which the database rejects — so the payload
@@ -256,6 +293,53 @@ describe("the validators actually refuse what the projection lists", () => {
     expect(
       uiSchemaFieldSchema.safeParse({ name: "headline", type: "text" }).success
     ).toBe(true);
+  });
+
+  it("refuses every projected name in a code-first field group", () => {
+    // The path a TypeScript author uses. The visual path and this one build the same table, so a
+    // name refused in one and accepted in the other leaves the supported path producing DDL the
+    // database rejects.
+    for (const name of reservedSystemFieldNames("fieldGroupConfig")) {
+      const result = validateFieldGroupConfig({
+        slug: "probe",
+        fields: [{ name, type: "text" }],
+      } as unknown as FieldGroupConfig);
+      expect({ [name]: result.valid }).toEqual({ [name]: false });
+    }
+  });
+
+  it("accepts an ordinary field name in a code-first field group", () => {
+    // The mirror, so the case above cannot be satisfied by a validator that refuses everything.
+    const result = validateFieldGroupConfig({
+      slug: "probe",
+      fields: [{ name: "headline", type: "text" }],
+    } as unknown as FieldGroupConfig);
+
+    expect(result.valid).toBe(true);
+  });
+
+  it("does not reserve a name that only resembles a structural column", () => {
+    // The parent-linkage columns carry a leading underscore, which a field name cannot: `parentId`
+    // becomes `parent_id` and sits beside `_parent_id`. Asserted on THIS rule rather than on
+    // validity overall, because `order` and `type` are refused anyway as SQL keywords — a
+    // pre-existing rule this change must neither rely on nor disturb.
+    for (const name of [
+      "parentId",
+      "parentTable",
+      "parentField",
+      "order",
+      "type",
+    ]) {
+      const result = validateFieldGroupConfig({
+        slug: "probe",
+        fields: [{ name, type: "text" }],
+      } as unknown as FieldGroupConfig);
+      const reserved = (result.errors ?? []).filter(
+        e => e.code === "FIELD_NAME_RESERVED"
+      );
+
+      expect({ [name]: reserved }).toEqual({ [name]: [] });
+    }
   });
 
   it("refuses the camelCase spelling of a timestamp column", () => {

--- a/packages/nextly/src/lib/__tests__/system-columns.test.ts
+++ b/packages/nextly/src/lib/__tests__/system-columns.test.ts
@@ -7,10 +7,13 @@
 import { getColumns } from "drizzle-orm";
 import { describe, expect, it } from "vitest";
 
+import type { FieldConfig } from "../../collections/fields/types";
 import { fieldNameSchema } from "../../domains/dynamic-collections/services/dynamic-collection-validation-service";
+import { FieldGroupSchemaService } from "../../domains/field-groups/services/field-group-schema-service";
 import { getSystemColumnDescriptors } from "../../domains/schema/services/field-column-descriptor";
 import { generateRuntimeSchema } from "../../domains/schema/services/runtime-schema-generator";
 import { SYSTEM_SCHEMA_VERSION } from "../../domains/schema/services/schema-hash";
+import { uiSchemaFieldSchema } from "../../schemas/_zod/ui-schema";
 
 import {
   immutableSystemFieldsFor,
@@ -138,12 +141,85 @@ describe("reservation projections", () => {
     );
   });
 
-  it("refuses only the physical spelling in the UI field-payload schema", () => {
-    // That surface also validates component fields, whose tables are not declared here, so it
-    // stays exactly as narrow as it was.
+  it("refuses both spellings of the universal columns in the UI field-payload schema", () => {
+    // The narrowest surface, because it also validates component fields and a component's table
+    // carries only these three. It carries them under the same physical names, though, so the
+    // camelCase spelling collides there exactly as it does on a collection.
     expect(sorted(reservedSystemFieldNames("uiSchema"))).toEqual(
-      sorted(["id", "created_at", "updated_at"])
+      sorted(["id", "created_at", "createdAt", "updated_at", "updatedAt"])
     );
+  });
+});
+
+describe("component tables, which are declared elsewhere on purpose", () => {
+  // A component keeps its values in a `comp_` table of its own, built by its own generator. Those
+  // tables are NOT projections of these declarations, and this records why so the question does
+  // not have to be answered again from the DDL:
+  //
+  //   - they carry three of the declared columns — id, created_at, updated_at — and none of the
+  //     rest: no title, slug, status, owner or publication marker;
+  //   - their timestamps are NOT NULL, where a collection's are nullable with the same default;
+  //   - their timestamps are emitted AFTER the author's fields, where a collection's come before;
+  //   - they carry five structural columns of their own (parent id, parent table, parent field,
+  //     order, type) that no other entity has.
+  //
+  // Two of those are shape differences and one is an ordering difference, so folding them into the
+  // declarations would mean per-entity overrides of both — a heavier model for one entity whose
+  // majority of columns still would not fit. What matters instead is that the columns they DO
+  // share cannot drift apart unnoticed, which is what these assert.
+
+  const componentDdl = (dialect: SystemColumnDialect): string =>
+    new FieldGroupSchemaService(dialect).generateMigrationSQL("comp_probe", [
+      { name: "headline", type: "text" } as FieldConfig,
+    ]);
+
+  /** MySQL quotes identifiers with backticks; the other two use double quotes. */
+  const quoted = (dialect: SystemColumnDialect, name: string): string =>
+    dialect === "mysql" ? `\`${name}\`` : `"${name}"`;
+
+  it("still carries every shared column under its declared name", () => {
+    // A rename in the declarations that the component generator does not follow would leave a
+    // component's rows describing themselves with a name nothing else uses.
+    const shared = ["id", "created_at", "updated_at"];
+    for (const dialect of [
+      "postgresql",
+      "mysql",
+      "sqlite",
+    ] as SystemColumnDialect[]) {
+      const ddl = componentDdl(dialect);
+      for (const name of shared) {
+        expect({
+          [`${dialect}.${name}`]: ddl.includes(quoted(dialect, name)),
+        }).toEqual({ [`${dialect}.${name}`]: true });
+      }
+    }
+    // And the names are the declared ones, not a copy that has drifted from them.
+    for (const name of shared) {
+      expect({ [name]: SYSTEM_COLUMNS.some(c => c.name === name) }).toEqual({
+        [name]: true,
+      });
+    }
+  });
+
+  it("carries none of the columns that belong to an entity with a lifecycle", () => {
+    // A component has no draft/published state and no owner, so a marker or owner column appearing
+    // in its table would mean a projection had started including it by accident.
+    const ddl = componentDdl("postgresql");
+    for (const name of ["status", "first_published_at", "created_by", "slug"]) {
+      expect({ [name]: ddl.includes(`"${name}"`) }).toEqual({ [name]: false });
+    }
+  });
+
+  it("would emit a duplicate column for a field named like a shared one", () => {
+    // The reason the UI field-payload schema refuses both spellings. `createdAt` snake-cases onto
+    // the injected `created_at` and both are emitted, which the database rejects — so the payload
+    // could never have produced a working table, and refusing the name loses nothing.
+    const ddl = new FieldGroupSchemaService("postgresql").generateMigrationSQL(
+      "comp_probe",
+      [{ name: "createdAt", type: "text" } as FieldConfig]
+    );
+
+    expect(ddl.match(/"created_at"/g)?.length).toBe(2);
   });
 });
 
@@ -163,6 +239,23 @@ describe("the validators actually refuse what the projection lists", () => {
   it("still accepts an ordinary field name", () => {
     // The mirror, so the case above cannot be satisfied by a validator that refuses everything.
     expect(fieldNameSchema.safeParse("headline").success).toBe(true);
+  });
+
+  it("refuses every projected name in the UI field-payload schema", () => {
+    // The surface that validates a component's fields as well as a collection's. Asserted through
+    // the schema rather than the projection, because a set nobody consults would satisfy the
+    // pinned test above and still let the payload through.
+    for (const name of reservedSystemFieldNames("uiSchema")) {
+      const parsed = uiSchemaFieldSchema.safeParse({ name, type: "text" });
+      expect({ [name]: parsed.success }).toEqual({ [name]: false });
+    }
+  });
+
+  it("accepts an ordinary field name in the UI field-payload schema", () => {
+    // The mirror, so the case above cannot pass because the payload shape is wrong.
+    expect(
+      uiSchemaFieldSchema.safeParse({ name: "headline", type: "text" }).success
+    ).toBe(true);
   });
 
   it("refuses the camelCase spelling of a timestamp column", () => {

--- a/packages/nextly/src/lib/system-columns.ts
+++ b/packages/nextly/src/lib/system-columns.ts
@@ -62,10 +62,10 @@ export type ReservationSurface =
  * A property of the surface rather than of the column: it depends on what that validator's payload
  * can express, not on what the column is.
  *
- * `uiSchema` validates field payloads for collections, singles AND components, and a component
- * keeps its values in tables of its own whose system columns are not described here. Refusing the
- * camelCase spelling there could reject a component field that is legal today, so it stays as
- * narrow as it is until those tables are declared too.
+ * Every surface refuses both, because every table these validate — a collection, a single, and a
+ * component in its own `comp_` table — carries the columns under their physical names, and a field
+ * whose camelCase name snake-cases onto one is emitted into the same `CREATE TABLE` as the injected
+ * column. The statement is then rejected, so the payload could never have produced a working table.
  */
 const RESERVATION_SPELLINGS: Readonly<
   Record<ReservationSurface, "both" | "columnOnly">
@@ -73,7 +73,7 @@ const RESERVATION_SPELLINGS: Readonly<
   builder: "both",
   collectionConfig: "both",
   singleConfig: "both",
-  uiSchema: "columnOnly",
+  uiSchema: "both",
 };
 
 /**

--- a/packages/nextly/src/lib/system-columns.ts
+++ b/packages/nextly/src/lib/system-columns.ts
@@ -54,6 +54,7 @@ export type ReservationSurface =
   | "builder"
   | "collectionConfig"
   | "singleConfig"
+  | "fieldGroupConfig"
   | "uiSchema";
 
 /**
@@ -73,6 +74,7 @@ const RESERVATION_SPELLINGS: Readonly<
   builder: "both",
   collectionConfig: "both",
   singleConfig: "both",
+  fieldGroupConfig: "both",
   uiSchema: "both",
 };
 
@@ -194,7 +196,7 @@ export const SYSTEM_COLUMNS: readonly SystemColumnDeclaration[] = [
     writableByClient: false,
     publishedUnderCamelName: false,
     strippedFromResponses: false,
-    reservedIn: ["builder", "uiSchema"],
+    reservedIn: ["builder", "fieldGroupConfig", "uiSchema"],
     shape: {
       postgresql: { kind: "text", nullable: false, primaryKey: true },
       mysql: {
@@ -249,7 +251,7 @@ export const SYSTEM_COLUMNS: readonly SystemColumnDeclaration[] = [
     writableByClient: false,
     publishedUnderCamelName: true,
     strippedFromResponses: false,
-    reservedIn: ["builder", "uiSchema"],
+    reservedIn: ["builder", "fieldGroupConfig", "uiSchema"],
     shape: {
       postgresql: {
         kind: "timestamp",
@@ -268,7 +270,7 @@ export const SYSTEM_COLUMNS: readonly SystemColumnDeclaration[] = [
     writableByClient: false,
     publishedUnderCamelName: true,
     strippedFromResponses: false,
-    reservedIn: ["builder", "uiSchema"],
+    reservedIn: ["builder", "fieldGroupConfig", "uiSchema"],
     shape: {
       postgresql: {
         kind: "timestamp",


### PR DESCRIPTION
Closes Part B of task `113-reservation-scopes-narrower-than-collisions.md`, which #494 filed as **blocked**. It turned out not to be blocked — the blocker was a question nobody had answered, and answering it took one generated `CREATE TABLE`.

## What was blocked, and why it wasn't

#494 left the UI field-payload schema as the one surface refusing only the *physical* spelling of `id` / `created_at` / `updated_at`. The reason: that surface also validates **component** fields, component values live in their own `comp_<slug>` table, and nothing described what columns those tables carry. Widening it might have rejected a component field that was legal.

Generated DDL for a component with a field named `createdAt`:

```sql
CREATE TABLE IF NOT EXISTS "comp_hero" (
  "id" text PRIMARY KEY NOT NULL,
  "_parent_id" text NOT NULL,
  "_parent_table" VARCHAR(255) NOT NULL,
  "_parent_field" VARCHAR(255) NOT NULL,
  "_order" INTEGER DEFAULT 0,
  "_component_type" VARCHAR(255),
  "created_at" TEXT,                              <- the author's field
  "created_at" TIMESTAMP NOT NULL DEFAULT NOW(),
  "updated_at" TIMESTAMP NOT NULL DEFAULT NOW()
);
```

The column is emitted twice and the database rejects the statement. So a component carrying such a field could never have been created, and refusing the name loses nothing — it moves the failure from a migration-time database error to a message where the name is chosen.

Every reservation surface now refuses both spellings, and the per-surface spelling escape hatch `RESERVATION_SPELLINGS` had introduced is no longer needed by any of them.

## Component tables stay outside the declarations, deliberately

The obvious follow-up to #494 was "declare component tables too". Having read them, that is the wrong call, and the reasons are recorded in the tests rather than left to be re-derived:

| | collection / single | component |
|---|---|---|
| declared columns carried | all eight | three (`id`, `created_at`, `updated_at`) |
| timestamp nullability | nullable, defaulted | **NOT NULL**, defaulted |
| timestamp position | before the author's fields | **after** them |
| own structural columns | none | five (`_parent_id`, `_parent_table`, `_parent_field`, `_order`, `_component_type`) |

Folding that in would mean per-entity overrides of both shape *and* column order, for one entity whose majority of columns still would not fit — a heavier model that makes the common case harder to read. What actually matters is that the columns they **do** share cannot drift apart unnoticed, so there are now tests asserting exactly that: every shared column still present under its declared name on all three dialects, and none of the lifecycle columns (`status`, `first_published_at`, `created_by`, `slug`) appearing in a component table.

The NOT NULL / nullable divergence is real and is **not** changed here — aligning it would rewrite existing tables. It is recorded so the decision is visible.

## Verification

Falsifications, each failing for its own reason:

| reverted | result |
|---|---|
| the UI schema back to `columnOnly` | pinned set fails |
| the UI schema validator reading the projection | wiring test fails |
| adding a column the component table *does* have to the negative guard | that guard fails, proving it can detect presence |

Wiring is asserted through `uiSchemaFieldSchema` itself, not just the projection — a set nobody consults would satisfy every pinned test and still let the payload through. Both directions covered: every projected name refused, and an ordinary name still accepted.

One bug the new tests caught in themselves: the first version asserted `"id"` appeared in the MySQL DDL, which fails because MySQL quotes with backticks. Fixed rather than loosened.

**Three dialect legs, one at a time, databases recreated before each:**

| leg | passed | failed |
|---|---|---|
| sqlite | 1010 | 0 |
| postgres17 | 1159 | 0 |
| mysql | 1090 | 0 |

Full `nextly` unit suite compared against the `origin/main` baseline measured in this same tree: **37 failing files both ways, no new failures.** `check-types` (source and tests) and `lint` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved protection for reserved system column names across UI schemas.
  * Prevented component tables from generating duplicate columns when names collide.
  * Ensured lifecycle columns are correctly excluded where required.
  * Added validation to reject reserved field names while accepting standard names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->