### PR TITLE
refactor(nextly): route builder-created schema through the shared pipeline

### DIFF
--- a/.changeset/builder-text-column-width.md
+++ b/.changeset/builder-text-column-width.md
@@ -1,0 +1,25 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+Schema Builder tables keep the text column width they had. Creating a field group or single routed its columns through the shared descriptor, which read a text field with no stated width as bounded where the previous generator read it as unbounded, so on MySQL a new text column held 255 characters instead of 65 535. A field that states its own width now gets exactly that width rather than the default.

--- a/packages/nextly/src/dispatcher/handlers/__tests__/component-dispatcher-shapes.test.ts
+++ b/packages/nextly/src/dispatcher/handlers/__tests__/component-dispatcher-shapes.test.ts
@@ -22,10 +22,7 @@ vi.mock("../../../di/container", () => ({
   },
 }));
 
-import {
-  getAdapterFromDI,
-  getComponentRegistryFromDI,
-} from "../../helpers/di";
+import { getAdapterFromDI, getComponentRegistryFromDI } from "../../helpers/di";
 import { dispatchComponents } from "../component-dispatcher";
 
 type Registry = {
@@ -34,6 +31,7 @@ type Registry = {
   getComponent: ReturnType<typeof vi.fn>;
   updateComponent: ReturnType<typeof vi.fn>;
   deleteComponent: ReturnType<typeof vi.fn>;
+  getComponentBySlug: ReturnType<typeof vi.fn>;
   isLocked: ReturnType<typeof vi.fn>;
 };
 
@@ -44,6 +42,9 @@ function makeRegistry(overrides: Partial<Registry> = {}): Registry {
     getComponent: vi.fn(),
     updateComponent: vi.fn(),
     deleteComponent: vi.fn(),
+    // Answers "no such slug" so a create reaches the path under test. The handler asks before it
+    // converges any schema, so a double that cannot answer fails the request instead.
+    getComponentBySlug: vi.fn().mockResolvedValue(null),
     isLocked: vi.fn().mockResolvedValue(false),
     ...overrides,
   };

--- a/packages/nextly/src/dispatcher/handlers/collection-dispatcher.ts
+++ b/packages/nextly/src/dispatcher/handlers/collection-dispatcher.ts
@@ -495,6 +495,8 @@ const COLLECTIONS_METHODS: Record<
         // must re-supply it or the preview would show translatable columns being
         // added to the main table.
         localized: (collection as { localized?: boolean }).localized === true,
+        // Authored in the Schema Builder: this handler is the Builder's own save path.
+        builderOwned: true,
       };
 
       const pipelinePreview = await previewDesiredSchema({
@@ -679,6 +681,8 @@ const COLLECTIONS_METHODS: Record<
         // toggle applies immediately; without this the apply re-adds translatable
         // columns to the main table.
         localized: isLocalized,
+        // Authored in the Schema Builder: this handler is the Builder's own save path.
+        builderOwned: true,
       };
 
       // Resolve adapter for the pipeline construction.

--- a/packages/nextly/src/dispatcher/handlers/component-dispatcher.ts
+++ b/packages/nextly/src/dispatcher/handlers/component-dispatcher.ts
@@ -65,6 +65,7 @@ import {
 import { STORAGE_FORMAT } from "../../schemas/storage-format";
 import type { FieldGroupRegistryService } from "../../services/field-groups/field-group-registry-service";
 import { FieldGroupSchemaService } from "../../services/field-groups/field-group-schema-service";
+import { applyBuilderSchema } from "../helpers/apply-builder-schema";
 import { buildFullDesiredSchema } from "../helpers/desired-schema";
 import {
   getAdapterFromDI,
@@ -110,31 +111,6 @@ function offsetPaginationToMeta(args: {
     hasNext: page < totalPages,
     hasPrev: page > 1,
   };
-}
-
-// ============================================================
-// Migration SQL execution helper
-// ============================================================
-
-async function executeMigrationStatements(
-  adapter: DrizzleAdapter,
-  migrationSQL: string
-): Promise<void> {
-  const statements = migrationSQL
-    .split("--> statement-breakpoint")
-    .map(s => s.trim())
-    .filter(s => s.length > 0);
-
-  for (const statement of statements) {
-    const cleanStatement = statement
-      .split("\n")
-      .filter(line => !line.trim().startsWith("--"))
-      .join("\n")
-      .trim();
-    if (cleanStatement) {
-      await adapter.executeQuery(cleanStatement);
-    }
-  }
 }
 
 // Refresh the cached Drizzle table so the next entry query joining this
@@ -384,20 +360,8 @@ const COMPONENTS_METHODS: Record<string, MethodHandler<ComponentsServices>> = {
       // migrate:create paths, so the created table and the registry row agree.
       const tableName = resolveComponentTableName(b.slug);
 
-      // Use FieldGroupSchemaService to generate tables with parent
-      // reference columns (_parent_id, _parent_table, _parent_field,
-      // _order, _component_type).
       const adapter = getAdapterFromDI();
       const dialect = adapter?.dialect || "postgresql";
-      const fieldGroupSchemaService = new FieldGroupSchemaService(dialect);
-
-      const migrationSQL = fieldGroupSchemaService.generateMigrationSQL(
-        tableName,
-        b.fields,
-        // i18n: omit translatable columns from the main comp_ table when localized — they live
-        // in the companion comp_<slug>_locales table (provisioned below).
-        { localized: isLocalized }
-      );
 
       let migrationStatus: "pending" | "applied" | "failed" = "pending";
 
@@ -405,7 +369,25 @@ const COMPONENTS_METHODS: Record<string, MethodHandler<ComponentsServices>> = {
         if (container.has("adapter")) {
           const diAdapter = container.get<DrizzleAdapter>("adapter");
 
-          await executeMigrationStatements(diAdapter, migrationSQL);
+          // The same route the EDIT handler below takes. Creating through the shared pipeline
+          // rather than executing generated SQL directly is what gives a created table the column
+          // types the ORM actually binds, an index set identical to a code-first definition, and a
+          // row in the schema journal — three things the create path silently did without.
+          await applyBuilderSchema({
+            adapter: diAdapter,
+            dialect,
+            slug: b.slug,
+            apply: desired => {
+              desired.components[b.slug!] = {
+                slug: b.slug!,
+                tableName,
+                fields: b.fields as DesiredFieldGroup["fields"],
+                // i18n: carry the flag so the diff omits translatable columns from the main
+                // comp_ table — they live in comp_<slug>_locales, reconciled out-of-band below.
+                localized: isLocalized,
+              };
+            },
+          });
 
           const tableExists = await diAdapter.tableExists(tableName);
           if (tableExists) {
@@ -476,8 +458,9 @@ const COMPONENTS_METHODS: Record<string, MethodHandler<ComponentsServices>> = {
           migrationError instanceof Error
             ? migrationError.message
             : String(migrationError);
+        // The statements are the pipeline's now, and it reports them through the journal row and
+        // the notifier rather than through this handler, so there is nothing local left to echo.
         console.error("[Components] Migration execution failed:", message);
-        console.error("[Components] Migration SQL was:", migrationSQL);
       }
 
       const created = await svc.registry.registerComponent({

--- a/packages/nextly/src/dispatcher/handlers/component-dispatcher.ts
+++ b/packages/nextly/src/dispatcher/handlers/component-dispatcher.ts
@@ -51,6 +51,7 @@ import { RegexRenameDetector } from "../../domains/schema/pipeline/rename-detect
 import type { Resolution } from "../../domains/schema/pipeline/resolution/types";
 import { isIdempotencyError } from "../../domains/schema/pipeline/sql-statement-utils";
 import type { DesiredFieldGroup } from "../../domains/schema/pipeline/types";
+import { withDeclaredTextWidth } from "../../domains/schema/services/builder-text-width";
 import { DrizzleStatementExecutor } from "../../domains/schema/services/drizzle-statement-executor";
 import type { FieldResolution } from "../../domains/schema/services/schema-change-types";
 import { calculateSchemaHash } from "../../domains/schema/services/schema-hash";
@@ -348,6 +349,14 @@ const COMPONENTS_METHODS: Record<string, MethodHandler<ComponentsServices>> = {
         throw new Error("Component slug and fields are required");
       }
 
+      // Settled once, in place, so the table that gets built, the hash that gets stored and the
+      // shape a later diff compares against all read the same answer. Converted the way every other
+      // read of this payload converts it: the handler annotates it as `FieldConfig`, but what the
+      // Builder sends is the Builder shape.
+      b.fields = withDeclaredTextWidth(
+        b.fields as unknown as FieldDefinition[]
+      ) as unknown as FieldConfig[];
+
       // These direct create/update handlers persist and run DDL without the
       // preview/apply handlers below. Their own rules cover names and shapes;
       // what none of them can judge is a plugin type's own options, so an
@@ -545,6 +554,13 @@ const COMPONENTS_METHODS: Record<string, MethodHandler<ComponentsServices>> = {
         b?.localized !== undefined ? b.localized === true : wasLocalized;
 
       if (b?.fields) {
+        // Settled before the fields are both stored and diffed. On this path it also states what an
+        // already-created table holds: a Builder text column with no declared width is unbounded,
+        // so saying so is what keeps a save from reading that column as a change.
+        b.fields = withDeclaredTextWidth(
+          b.fields as unknown as FieldDefinition[]
+        ) as unknown as FieldConfig[];
+
         assertValidPluginFieldOptions(b.fields);
         updateData.fields = b.fields;
         updateData.schemaHash = calculateSchemaHash(b.fields);

--- a/packages/nextly/src/dispatcher/handlers/component-dispatcher.ts
+++ b/packages/nextly/src/dispatcher/handlers/component-dispatcher.ts
@@ -348,6 +348,16 @@ const COMPONENTS_METHODS: Record<string, MethodHandler<ComponentsServices>> = {
         throw new Error("Component slug and fields are required");
       }
 
+      // Refused before any DDL runs, not after. `registerComponent` makes the authoritative check,
+      // but it runs once the schema has already converged — so a create aimed at an existing slug
+      // would alter that field group's live table and only then be rejected.
+      const slugTaken = await svc.registry.getComponentBySlug(b.slug);
+      if (slugTaken) {
+        throw NextlyError.duplicate({
+          logContext: { reason: "component-slug-conflict", slug: b.slug },
+        });
+      }
+
       // These direct create/update handlers persist and run DDL without the
       // preview/apply handlers below. Their own rules cover names and shapes;
       // what none of them can judge is a plugin type's own options, so an
@@ -386,6 +396,8 @@ const COMPONENTS_METHODS: Record<string, MethodHandler<ComponentsServices>> = {
                 // i18n: carry the flag so the diff omits translatable columns from the main
                 // comp_ table — they live in comp_<slug>_locales, reconciled out-of-band below.
                 localized: isLocalized,
+                // Authored in the Schema Builder: this handler is the Builder's own save path.
+                builderOwned: true,
               };
             },
           });
@@ -643,6 +655,8 @@ const COMPONENTS_METHODS: Record<string, MethodHandler<ComponentsServices>> = {
         // from the component's main table (they live in comp_<slug>_locales, reconciled
         // out-of-band below) — mirrors the collection/single apply path.
         localized: (component as { localized?: boolean }).localized === true,
+        // Authored in the Schema Builder: this handler is the Builder's own save path.
+        builderOwned: true,
       };
 
       const pipelinePreview = await previewDesiredSchema({
@@ -767,6 +781,8 @@ const COMPONENTS_METHODS: Record<string, MethodHandler<ComponentsServices>> = {
         // from the component's main table (they live in comp_<slug>_locales, reconciled
         // out-of-band below) — mirrors the collection/single apply path.
         localized: isLocalized,
+        // Authored in the Schema Builder: this handler is the Builder's own save path.
+        builderOwned: true,
       };
 
       const promptDispatcher = new BrowserPromptDispatcher(

--- a/packages/nextly/src/dispatcher/handlers/component-dispatcher.ts
+++ b/packages/nextly/src/dispatcher/handlers/component-dispatcher.ts
@@ -51,7 +51,6 @@ import { RegexRenameDetector } from "../../domains/schema/pipeline/rename-detect
 import type { Resolution } from "../../domains/schema/pipeline/resolution/types";
 import { isIdempotencyError } from "../../domains/schema/pipeline/sql-statement-utils";
 import type { DesiredFieldGroup } from "../../domains/schema/pipeline/types";
-import { withDeclaredTextWidth } from "../../domains/schema/services/builder-text-width";
 import { DrizzleStatementExecutor } from "../../domains/schema/services/drizzle-statement-executor";
 import type { FieldResolution } from "../../domains/schema/services/schema-change-types";
 import { calculateSchemaHash } from "../../domains/schema/services/schema-hash";
@@ -349,14 +348,6 @@ const COMPONENTS_METHODS: Record<string, MethodHandler<ComponentsServices>> = {
         throw new Error("Component slug and fields are required");
       }
 
-      // Settled once, in place, so the table that gets built, the hash that gets stored and the
-      // shape a later diff compares against all read the same answer. Converted the way every other
-      // read of this payload converts it: the handler annotates it as `FieldConfig`, but what the
-      // Builder sends is the Builder shape.
-      b.fields = withDeclaredTextWidth(
-        b.fields as unknown as FieldDefinition[]
-      ) as unknown as FieldConfig[];
-
       // These direct create/update handlers persist and run DDL without the
       // preview/apply handlers below. Their own rules cover names and shapes;
       // what none of them can judge is a plugin type's own options, so an
@@ -386,6 +377,7 @@ const COMPONENTS_METHODS: Record<string, MethodHandler<ComponentsServices>> = {
             adapter: diAdapter,
             dialect,
             slug: b.slug,
+            kind: "component",
             apply: desired => {
               desired.components[b.slug!] = {
                 slug: b.slug!,
@@ -554,13 +546,6 @@ const COMPONENTS_METHODS: Record<string, MethodHandler<ComponentsServices>> = {
         b?.localized !== undefined ? b.localized === true : wasLocalized;
 
       if (b?.fields) {
-        // Settled before the fields are both stored and diffed. On this path it also states what an
-        // already-created table holds: a Builder text column with no declared width is unbounded,
-        // so saying so is what keeps a save from reading that column as a change.
-        b.fields = withDeclaredTextWidth(
-          b.fields as unknown as FieldDefinition[]
-        ) as unknown as FieldConfig[];
-
         assertValidPluginFieldOptions(b.fields);
         updateData.fields = b.fields;
         updateData.schemaHash = calculateSchemaHash(b.fields);

--- a/packages/nextly/src/dispatcher/handlers/single-dispatcher.ts
+++ b/packages/nextly/src/dispatcher/handlers/single-dispatcher.ts
@@ -606,6 +606,17 @@ const SINGLES_METHODS: Record<string, MethodHandler<SinglesServices>> = {
       if (!b?.fields || !Array.isArray(b.fields))
         throw new Error("Single fields array is required");
 
+      // Refused before any DDL runs, not after. `registerSingle` makes the authoritative check
+      // inside its own transaction, but it runs after the schema has already converged — so a
+      // create aimed at a slug that exists would alter that single's live table and only then be
+      // rejected, leaving a table changed for a request that failed.
+      const slugTaken = await svc.registry.getSingleBySlug(b.slug);
+      if (slugTaken) {
+        throw NextlyError.duplicate({
+          logContext: { reason: "single-slug-conflict", slug: b.slug },
+        });
+      }
+
       // This create path persists and runs DDL without the schema
       // preview/apply handlers. It keeps its own field rules, but nothing here
       // can judge a plugin type's own options, so an unsatisfiable declaration
@@ -657,6 +668,8 @@ const SINGLES_METHODS: Record<string, MethodHandler<SinglesServices>> = {
                 // i18n: carry the flag so the diff omits translatable columns from the main
                 // table — they live in single_<slug>_locales, provisioned below.
                 localized: isLocalized,
+                // Authored in the Schema Builder: this handler is the Builder's own save path.
+                builderOwned: true,
               };
             },
           });
@@ -1212,6 +1225,8 @@ const SINGLES_METHODS: Record<string, MethodHandler<SinglesServices>> = {
                   fields: normalizedNewFields as DesiredSingle["fields"],
                   status: hasStatus,
                   localized: isLocalized,
+                  // Authored in the Schema Builder: this handler is the Builder's own save path.
+                  builderOwned: true,
                 };
               },
             });
@@ -1440,6 +1455,8 @@ const SINGLES_METHODS: Record<string, MethodHandler<SinglesServices>> = {
         // i18n: carry localized so the preview omits translatable columns from the
         // single's main table (mirrors the apply path).
         localized: (single as { localized?: boolean }).localized === true,
+        // Authored in the Schema Builder: this handler is the Builder's own save path.
+        builderOwned: true,
       };
 
       const pipelinePreview = await previewDesiredSchema({
@@ -1555,6 +1572,8 @@ const SINGLES_METHODS: Record<string, MethodHandler<SinglesServices>> = {
         // from the single's main table (they live in single_<slug>_locales, reconciled
         // out-of-band below) — mirrors the collection apply path.
         localized: isLocalized,
+        // Authored in the Schema Builder: this handler is the Builder's own save path.
+        builderOwned: true,
       };
 
       const promptDispatcher = new BrowserPromptDispatcher(

--- a/packages/nextly/src/dispatcher/handlers/single-dispatcher.ts
+++ b/packages/nextly/src/dispatcher/handlers/single-dispatcher.ts
@@ -63,6 +63,7 @@ import { RegexRenameDetector } from "../../domains/schema/pipeline/rename-detect
 import type { Resolution } from "../../domains/schema/pipeline/resolution/types";
 import { isIdempotencyError } from "../../domains/schema/pipeline/sql-statement-utils";
 import type { DesiredSingle } from "../../domains/schema/pipeline/types";
+import { withDeclaredTextWidth } from "../../domains/schema/services/builder-text-width";
 import { DrizzleStatementExecutor } from "../../domains/schema/services/drizzle-statement-executor";
 import { generateRuntimeSchema } from "../../domains/schema/services/runtime-schema-generator";
 import type { FieldResolution } from "../../domains/schema/services/schema-change-types";
@@ -606,6 +607,14 @@ const SINGLES_METHODS: Record<string, MethodHandler<SinglesServices>> = {
       if (!b?.fields || !Array.isArray(b.fields))
         throw new Error("Single fields array is required");
 
+      // Settled once, in place, so the table that gets built, the hash that gets stored and the
+      // shape a later diff compares against all read the same answer. Converted the way every other
+      // read of this payload converts it: the handler annotates it as `FieldConfig`, but what the
+      // Builder sends is the Builder shape.
+      b.fields = withDeclaredTextWidth(
+        b.fields as unknown as FieldDefinition[]
+      ) as unknown as typeof b.fields;
+
       // This create path persists and runs DDL without the schema
       // preview/apply handlers. It keeps its own field rules, but nothing here
       // can judge a plugin type's own options, so an unsatisfiable declaration
@@ -1142,6 +1151,13 @@ const SINGLES_METHODS: Record<string, MethodHandler<SinglesServices>> = {
       let migrationStatus = existing.migrationStatus;
 
       if (b.fields !== undefined) {
+        // Settled before the fields are both stored and diffed. On this path it also states what an
+        // already-created table holds: a Builder text column with no declared width is unbounded,
+        // so saying so is what keeps a save from reading that column as a change.
+        b.fields = withDeclaredTextWidth(
+          b.fields as unknown as FieldDefinition[]
+        ) as unknown as typeof b.fields;
+
         // Same rules as the ui-schema.json mirror (see api/fields-payload).
         assertValidFieldsPayload(b.fields);
         updateData.fields = b.fields;

--- a/packages/nextly/src/dispatcher/handlers/single-dispatcher.ts
+++ b/packages/nextly/src/dispatcher/handlers/single-dispatcher.ts
@@ -63,7 +63,6 @@ import { RegexRenameDetector } from "../../domains/schema/pipeline/rename-detect
 import type { Resolution } from "../../domains/schema/pipeline/resolution/types";
 import { isIdempotencyError } from "../../domains/schema/pipeline/sql-statement-utils";
 import type { DesiredSingle } from "../../domains/schema/pipeline/types";
-import { withDeclaredTextWidth } from "../../domains/schema/services/builder-text-width";
 import { DrizzleStatementExecutor } from "../../domains/schema/services/drizzle-statement-executor";
 import { generateRuntimeSchema } from "../../domains/schema/services/runtime-schema-generator";
 import type { FieldResolution } from "../../domains/schema/services/schema-change-types";
@@ -607,14 +606,6 @@ const SINGLES_METHODS: Record<string, MethodHandler<SinglesServices>> = {
       if (!b?.fields || !Array.isArray(b.fields))
         throw new Error("Single fields array is required");
 
-      // Settled once, in place, so the table that gets built, the hash that gets stored and the
-      // shape a later diff compares against all read the same answer. Converted the way every other
-      // read of this payload converts it: the handler annotates it as `FieldConfig`, but what the
-      // Builder sends is the Builder shape.
-      b.fields = withDeclaredTextWidth(
-        b.fields as unknown as FieldDefinition[]
-      ) as unknown as typeof b.fields;
-
       // This create path persists and runs DDL without the schema
       // preview/apply handlers. It keeps its own field rules, but nothing here
       // can judge a plugin type's own options, so an unsatisfiable declaration
@@ -656,6 +647,7 @@ const SINGLES_METHODS: Record<string, MethodHandler<SinglesServices>> = {
             adapter,
             dialect: adapter.getCapabilities().dialect,
             slug: b.slug,
+            kind: "single",
             apply: desired => {
               desired.singles[b.slug!] = {
                 slug: b.slug!,
@@ -1151,13 +1143,6 @@ const SINGLES_METHODS: Record<string, MethodHandler<SinglesServices>> = {
       let migrationStatus = existing.migrationStatus;
 
       if (b.fields !== undefined) {
-        // Settled before the fields are both stored and diffed. On this path it also states what an
-        // already-created table holds: a Builder text column with no declared width is unbounded,
-        // so saying so is what keeps a save from reading that column as a change.
-        b.fields = withDeclaredTextWidth(
-          b.fields as unknown as FieldDefinition[]
-        ) as unknown as typeof b.fields;
-
         // Same rules as the ui-schema.json mirror (see api/fields-payload).
         assertValidFieldsPayload(b.fields);
         updateData.fields = b.fields;
@@ -1169,16 +1154,14 @@ const SINGLES_METHODS: Record<string, MethodHandler<SinglesServices>> = {
         // optionally, matching how the execution below reads it.
         const tableName = existing.tableName;
 
-        // Normalize field lists for ALTER TABLE comparison. The physical
-        // table always has system columns (title, slug, updatedAt) added
-        // by generateMigrationSQL, but stored field definitions may not
-        // include them. We ensure both old and new lists include these
-        // so the diff doesn't try to ADD COLUMN for columns that already
-        // exist in the physical table.
-        const systemFields: FieldDefinition[] = [
-          { name: "title", type: "text", required: true },
-          { name: "slug", type: "text", required: true },
-        ];
+        // The system columns are NOT restated here. They were, back when the generator this path
+        // used did not inject them and the diff would otherwise have tried to add columns the table
+        // already had. The shared pipeline injects id, created_at and updated_at itself, and
+        // title/slug unless a user field claims those names, so restating them describes the same
+        // physical column twice: the appended user definition wins the name map and carries neither
+        // the system default nor the system nullability, and a rebuild hands Drizzle a duplicate
+        // column name. The create path above never restated them, so dropping them here also makes
+        // the two paths describe a single the same way.
 
         // i18n: when the single is localized (in either state), translatable columns live on the
         // companion, never the main table — drop them from the ALTER input so the main-table diff
@@ -1197,17 +1180,8 @@ const SINGLES_METHODS: Record<string, MethodHandler<SinglesServices>> = {
         // registry row can no longer produce an alter against a shape that was never there.
 
         const newFieldsRaw = b.fields as unknown as FieldDefinition[];
-        const newFieldsForAlter = omitLocalized(newFieldsRaw);
-        const newFieldNames = new Set(newFieldsForAlter.map(f => f.name));
-        const normalizedNewFields: FieldDefinition[] = [
-          ...systemFields.filter(sf => !newFieldNames.has(sf.name)),
-          ...newFieldsForAlter,
-          {
-            name: "updatedAt",
-            type: "date",
-            required: false,
-          },
-        ];
+        const normalizedNewFields: FieldDefinition[] =
+          omitLocalized(newFieldsRaw);
 
         // Forward status flags so the alter migration can ADD/DROP the
         // `status` column when the user toggles Draft/Published. `existing`
@@ -1230,6 +1204,7 @@ const SINGLES_METHODS: Record<string, MethodHandler<SinglesServices>> = {
               adapter,
               dialect: adapter.getCapabilities().dialect,
               slug,
+              kind: "single",
               apply: desired => {
                 desired.singles[slug] = {
                   slug,
@@ -1320,13 +1295,24 @@ const SINGLES_METHODS: Record<string, MethodHandler<SinglesServices>> = {
             );
           }
         } catch (migrationError) {
-          migrationStatus = "failed";
           const message =
             migrationError instanceof Error
               ? migrationError.message
               : String(migrationError);
           // Reported through the journal row and the notifier by the pipeline now.
           console.error("[Singles] Migration execution failed:", message);
+          // Refused rather than recorded. The field changes are already staged into `updateData`,
+          // so returning here would store definitions describing columns the table does not have —
+          // and the next save would then diff against a shape that was never applied. This endpoint
+          // carries no way to resolve a rename prompt, so a refusal is a real outcome rather than a
+          // remote one, and the caller has to learn the change did not happen.
+          throw NextlyError.internal({
+            logContext: {
+              reason: "single_schema_apply_failed",
+              slug,
+              detail: message,
+            },
+          });
         }
 
         updateData.migrationStatus = migrationStatus;

--- a/packages/nextly/src/dispatcher/handlers/single-dispatcher.ts
+++ b/packages/nextly/src/dispatcher/handlers/single-dispatcher.ts
@@ -36,7 +36,6 @@ import {
 } from "../../api/versions-access";
 import type { FieldConfig } from "../../collections/fields/types";
 import { container } from "../../di/container";
-import { DynamicCollectionSchemaService } from "../../domains/dynamic-collections/services/dynamic-collection-schema-service";
 import { teardownEntityComponentData } from "../../domains/field-groups/services/teardown-entity-field-group-data";
 import { resolveLocalizedFieldNames } from "../../domains/i18n/classify-fields";
 import { buildCompanionTransitionStatements } from "../../domains/i18n/migration/reconcile-companion";
@@ -87,6 +86,7 @@ import {
   isSuperAdmin,
   listEffectivePermissions,
 } from "../../services/lib/permissions";
+import { applyBuilderSchema } from "../helpers/apply-builder-schema";
 import {
   readAuthenticatedActor,
   readAuthenticatedScope,
@@ -193,28 +193,6 @@ function injectSingleDefaultFields<T extends SingleWithFields | null>(
 
 // ============================================================
 // Migration SQL execution helper
-// ============================================================
-
-async function executeMigrationStatements(
-  adapter: DrizzleAdapter,
-  migrationSQL: string
-): Promise<void> {
-  const statements = migrationSQL
-    .split("--> statement-breakpoint")
-    .map(s => s.trim())
-    .filter(s => s.length > 0);
-
-  for (const statement of statements) {
-    const cleanStatement = statement
-      .split("\n")
-      .filter(line => !line.trim().startsWith("--"))
-      .join("\n")
-      .trim();
-    if (cleanStatement) {
-      await adapter.executeQuery(cleanStatement);
-    }
-  }
-}
 
 // ============================================================
 // Singles services bundle
@@ -653,21 +631,7 @@ const SINGLES_METHODS: Record<string, MethodHandler<SinglesServices>> = {
       // adapter registered the statements are generated and never run, so the
       // service keeps its own default rather than this path demanding a
       // connection it is not going to use.
-      const createDialect = container.has("adapter")
-        ? container.get<DrizzleAdapter>("adapter").getCapabilities().dialect
-        : undefined;
-      const schemaService = new DynamicCollectionSchemaService(
-        undefined,
-        createDialect
-      );
       const isLocalized = b.localized === true;
-      const migrationSQL = schemaService.generateMigrationSQL(
-        tableName,
-        b.fields as unknown as FieldDefinition[],
-        // i18n: omit translatable columns from the main table when localized — they live in the
-        // companion single_<slug>_locales table (provisioned below), mirroring collections.
-        { isSingle: true, hasStatus: b.status === true, localized: isLocalized }
-      );
 
       // Run migration immediately (same semantics as Collections).
       let migrationStatus: "pending" | "applied" | "failed" = "pending";
@@ -676,7 +640,25 @@ const SINGLES_METHODS: Record<string, MethodHandler<SinglesServices>> = {
         if (container.has("adapter")) {
           const adapter = container.get<DrizzleAdapter>("adapter");
 
-          await executeMigrationStatements(adapter, migrationSQL);
+          // The same route the SAVE handler takes. Creating through the shared pipeline is what
+          // gives a created table the column types the ORM binds, the index set a code-first
+          // definition would produce, and a row in the schema journal.
+          await applyBuilderSchema({
+            adapter,
+            dialect: adapter.getCapabilities().dialect,
+            slug: b.slug,
+            apply: desired => {
+              desired.singles[b.slug!] = {
+                slug: b.slug!,
+                tableName,
+                fields: b.fields as DesiredSingle["fields"],
+                status: b.status === true,
+                // i18n: carry the flag so the diff omits translatable columns from the main
+                // table — they live in single_<slug>_locales, provisioned below.
+                localized: isLocalized,
+              };
+            },
+          });
 
           const tableExists = await adapter.tableExists(tableName);
           if (tableExists) {
@@ -761,8 +743,9 @@ const SINGLES_METHODS: Record<string, MethodHandler<SinglesServices>> = {
           migrationError instanceof Error
             ? migrationError.message
             : String(migrationError);
+        // The statements belong to the pipeline now, which reports them through the journal row
+        // and the notifier rather than through this handler.
         console.error("[Singles] Migration execution failed:", message);
-        console.error("[Singles] Migration SQL was:", migrationSQL);
       }
 
       const single = await svc.registry.registerSingle({
@@ -1168,13 +1151,6 @@ const SINGLES_METHODS: Record<string, MethodHandler<SinglesServices>> = {
         // the adapter that will run it, for the same reason as the create
         // path above: the service's own default is "postgresql". Read
         // optionally, matching how the execution below reads it.
-        const updateDialect = container.has("adapter")
-          ? container.get<DrizzleAdapter>("adapter").getCapabilities().dialect
-          : undefined;
-        const schemaService = new DynamicCollectionSchemaService(
-          undefined,
-          updateDialect
-        );
         const tableName = existing.tableName;
 
         // Normalize field lists for ALTER TABLE comparison. The physical
@@ -1188,8 +1164,6 @@ const SINGLES_METHODS: Record<string, MethodHandler<SinglesServices>> = {
           { name: "slug", type: "text", required: true },
         ];
 
-        const existingFields = (existing.fields ??
-          []) as unknown as FieldDefinition[];
         // i18n: when the single is localized (in either state), translatable columns live on the
         // companion, never the main table — drop them from the ALTER input so the main-table diff
         // never tries to ADD/DROP them. `reconcileSingleCompanion` owns the companion side.
@@ -1202,19 +1176,9 @@ const SINGLES_METHODS: Record<string, MethodHandler<SinglesServices>> = {
           );
           return fields.filter(f => !localizedNames.has(f.name));
         };
-        const existingFieldsForAlter = omitLocalized(existingFields);
-        const existingFieldNames = new Set(
-          existingFieldsForAlter.map(f => f.name)
-        );
-        const normalizedOldFields: FieldDefinition[] = [
-          ...systemFields.filter(sf => !existingFieldNames.has(sf.name)),
-          ...existingFieldsForAlter,
-          {
-            name: "updatedAt",
-            type: "date",
-            required: false,
-          },
-        ];
+        // The previous shape is no longer assembled here. The pipeline reads what the database
+        // actually has rather than being told what it used to hold, so a stale or hand-edited
+        // registry row can no longer produce an alter against a shape that was never there.
 
         const newFieldsRaw = b.fields as unknown as FieldDefinition[];
         const newFieldsForAlter = omitLocalized(newFieldsRaw);
@@ -1236,34 +1200,30 @@ const SINGLES_METHODS: Record<string, MethodHandler<SinglesServices>> = {
         const wasStatus = (existing as { status?: boolean }).status === true;
         const hasStatus =
           b.status !== undefined ? b.status === true : wasStatus;
-        const migrationSQL = schemaService.generateAlterTableMigration(
-          tableName,
-          normalizedOldFields,
-          normalizedNewFields,
-          { wasStatus, hasStatus }
-        );
-
         migrationStatus = "pending";
 
         try {
           if (container.has("adapter")) {
             const adapter = container.get<DrizzleAdapter>("adapter");
 
-            // If the table doesn't exist (e.g. earlier creation failed),
-            // create it fresh instead of altering nothing.
-            const tableExistsBefore = await adapter.tableExists(tableName);
-
-            if (!tableExistsBefore) {
-              const createSQL = schemaService.generateMigrationSQL(
-                tableName,
-                normalizedNewFields,
-                // i18n: fresh (re)create omits translatable columns when localized.
-                { isSingle: true, hasStatus, localized: isLocalized }
-              );
-              await executeMigrationStatements(adapter, createSQL);
-            } else {
-              await executeMigrationStatements(adapter, migrationSQL);
-            }
+            // One route whether or not the table is there. The pipeline diffs the declared shape
+            // against what the database actually has, so the missing-table case (an earlier create
+            // that failed) needs no branch of its own — it simply produces a create instead of an
+            // alter, from the same declaration.
+            await applyBuilderSchema({
+              adapter,
+              dialect: adapter.getCapabilities().dialect,
+              slug,
+              apply: desired => {
+                desired.singles[slug] = {
+                  slug,
+                  tableName,
+                  fields: normalizedNewFields as DesiredSingle["fields"],
+                  status: hasStatus,
+                  localized: isLocalized,
+                };
+              },
+            });
 
             const tableExistsAfter = await adapter.tableExists(tableName);
             if (tableExistsAfter) {
@@ -1349,8 +1309,8 @@ const SINGLES_METHODS: Record<string, MethodHandler<SinglesServices>> = {
             migrationError instanceof Error
               ? migrationError.message
               : String(migrationError);
+          // Reported through the journal row and the notifier by the pipeline now.
           console.error("[Singles] Migration execution failed:", message);
-          console.error("[Singles] Migration SQL was:", migrationSQL);
         }
 
         updateData.migrationStatus = migrationStatus;

--- a/packages/nextly/src/dispatcher/helpers/apply-builder-schema.ts
+++ b/packages/nextly/src/dispatcher/helpers/apply-builder-schema.ts
@@ -12,6 +12,7 @@ import {
 } from "../../domains/schema/pipeline/pushschema-pipeline-stubs";
 import { RegexRenameDetector } from "../../domains/schema/pipeline/rename-detector";
 import type { DesiredSchema } from "../../domains/schema/pipeline/types";
+import { resolveBuilderTextWidths } from "../../domains/schema/services/builder-text-width";
 import { DrizzleStatementExecutor } from "../../domains/schema/services/drizzle-statement-executor";
 import { NextlyError } from "../../errors";
 import { getProductionNotifier } from "../../runtime/notifications/index";
@@ -37,6 +38,8 @@ export interface ApplyBuilderSchemaArgs extends BuilderPromptResolutions {
   dialect: SupportedDialect;
   /** Scopes the journal row to the entity the operator acted on. */
   slug: string;
+  /** Which entity kind `slug` names, so the journal row is findable under the scope it belongs to. */
+  kind: "collection" | "single" | "component";
   /**
    * States this entity's desired shape on the schema the diff will run against.
    *
@@ -61,11 +64,18 @@ export interface ApplyBuilderSchemaArgs extends BuilderPromptResolutions {
 export async function applyBuilderSchema(
   args: ApplyBuilderSchemaArgs
 ): Promise<void> {
-  const { adapter, dialect, slug } = args;
+  const { adapter, dialect, slug, kind } = args;
   const db = adapter.getDrizzle();
 
   const desired = await buildFullDesiredSchema();
   args.apply(desired);
+
+  // After the caller states its entity, so the entity being saved is covered too, and over the whole
+  // schema rather than one entry: the pipeline diffs EVERY managed table, so an entity nobody is
+  // editing still has its columns compared. Resolving only the target's widths would let a save
+  // describe a sibling's unbounded text column as bounded and narrow a table the operator never
+  // touched.
+  resolveBuilderTextWidths(desired);
 
   const pipeline = new PushSchemaPipeline({
     executor: new DrizzleStatementExecutor(dialect, db),
@@ -97,6 +107,7 @@ export async function applyBuilderSchema(
         ? extractDatabaseNameFromUrl(process.env.DATABASE_URL)
         : undefined,
     uiTargetSlug: slug,
+    uiTargetKind: kind,
   });
 
   if (!result.success) {

--- a/packages/nextly/src/dispatcher/helpers/apply-builder-schema.ts
+++ b/packages/nextly/src/dispatcher/helpers/apply-builder-schema.ts
@@ -1,0 +1,111 @@
+import type { DrizzleAdapter } from "@nextlyhq/adapter-drizzle";
+import type { SupportedDialect } from "@nextlyhq/adapter-drizzle/types";
+
+import { RealClassifier } from "../../domains/schema/pipeline/classifier/classifier";
+import { extractDatabaseNameFromUrl } from "../../domains/schema/pipeline/database-url";
+import { RealPreCleanupExecutor } from "../../domains/schema/pipeline/pre-cleanup/executor";
+import { BrowserPromptDispatcher } from "../../domains/schema/pipeline/prompt-dispatcher/browser";
+import { PushSchemaPipeline } from "../../domains/schema/pipeline/pushschema-pipeline";
+import {
+  noopMigrationJournal,
+  noopPreRenameExecutor,
+} from "../../domains/schema/pipeline/pushschema-pipeline-stubs";
+import { RegexRenameDetector } from "../../domains/schema/pipeline/rename-detector";
+import type { DesiredSchema } from "../../domains/schema/pipeline/types";
+import { DrizzleStatementExecutor } from "../../domains/schema/services/drizzle-statement-executor";
+import { NextlyError } from "../../errors";
+import { getProductionNotifier } from "../../runtime/notifications/index";
+
+import { buildFullDesiredSchema } from "./desired-schema";
+import { getMigrationJournalFromDI } from "./di";
+
+/**
+ * Legacy resolutions a Schema Builder SAVE carries and a CREATE never does.
+ *
+ * A create has nothing to rename and no prior shape to reconcile, so every field here is absent on
+ * that path. They are named rather than spread so a caller cannot pass a save's payload to a create
+ * by accident.
+ */
+export interface BuilderPromptResolutions {
+  renameResolutions?: ConstructorParameters<typeof BrowserPromptDispatcher>[0];
+  eventResolutions?: ConstructorParameters<typeof BrowserPromptDispatcher>[1];
+  legacyBundle?: ConstructorParameters<typeof BrowserPromptDispatcher>[2];
+}
+
+export interface ApplyBuilderSchemaArgs extends BuilderPromptResolutions {
+  adapter: DrizzleAdapter;
+  dialect: SupportedDialect;
+  /** Scopes the journal row to the entity the operator acted on. */
+  slug: string;
+  /**
+   * States this entity's desired shape on the schema the diff will run against.
+   *
+   * A mutator rather than a value because the entity being created is not in the registry yet, so
+   * it cannot be read back out of the built schema — it has to be written in.
+   */
+  apply: (desired: DesiredSchema) => void;
+}
+
+/**
+ * Converge the database on the shape the Schema Builder just declared.
+ *
+ * 🔴 The single seam through which Builder-authored DDL reaches a database. Before it, creating an
+ * entity generated its own SQL and executed it directly while editing one went through the shared
+ * pipeline — so the same field type could produce two different columns depending on which action
+ * made it, a created table could disagree with an identical code-first definition on indexes, and
+ * a create left no row in the schema journal at all.
+ *
+ * It is also what makes the Builder's writes lockable. DDL arriving through one function can be
+ * excluded for the duration of a storage migration; DDL emitted from three handlers cannot.
+ */
+export async function applyBuilderSchema(
+  args: ApplyBuilderSchemaArgs
+): Promise<void> {
+  const { adapter, dialect, slug } = args;
+  const db = adapter.getDrizzle();
+
+  const desired = await buildFullDesiredSchema();
+  args.apply(desired);
+
+  const pipeline = new PushSchemaPipeline({
+    executor: new DrizzleStatementExecutor(dialect, db),
+    renameDetector: new RegexRenameDetector(),
+    classifier: new RealClassifier(),
+    promptDispatcher: new BrowserPromptDispatcher(
+      args.renameResolutions ?? [],
+      args.eventResolutions ?? [],
+      args.legacyBundle
+    ),
+    preRenameExecutor: noopPreRenameExecutor,
+    preCleanupExecutor: new RealPreCleanupExecutor(),
+    // Falls back to the noop only on a very early boot, before DI has registered one. A create that
+    // silently went unjournaled is the hole this function exists to close, so the fallback is the
+    // exception rather than the shape of the call.
+    migrationJournal: getMigrationJournalFromDI() ?? noopMigrationJournal,
+    notifier: getProductionNotifier(),
+  });
+
+  const result = await pipeline.apply({
+    desired,
+    db,
+    dialect,
+    source: "ui",
+    promptChannel: "browser",
+    // MySQL's pushSchema needs the database name; the other dialects ignore it.
+    databaseName:
+      dialect === "mysql"
+        ? extractDatabaseNameFromUrl(process.env.DATABASE_URL)
+        : undefined,
+    uiTargetSlug: slug,
+  });
+
+  if (!result.success) {
+    throw NextlyError.internal({
+      logContext: {
+        reason: "builder_schema_apply_failed",
+        slug,
+        detail: result.error?.message,
+      },
+    });
+  }
+}

--- a/packages/nextly/src/dispatcher/helpers/apply-builder-schema.ts
+++ b/packages/nextly/src/dispatcher/helpers/apply-builder-schema.ts
@@ -2,7 +2,7 @@ import type { DrizzleAdapter } from "@nextlyhq/adapter-drizzle";
 import type { SupportedDialect } from "@nextlyhq/adapter-drizzle/types";
 
 import { RealClassifier } from "../../domains/schema/pipeline/classifier/classifier";
-import { extractDatabaseNameFromUrl } from "../../domains/schema/pipeline/database-url";
+import { currentMysqlDatabaseName } from "../../domains/schema/pipeline/database-url";
 import { RealPreCleanupExecutor } from "../../domains/schema/pipeline/pre-cleanup/executor";
 import { BrowserPromptDispatcher } from "../../domains/schema/pipeline/prompt-dispatcher/browser";
 import { PushSchemaPipeline } from "../../domains/schema/pipeline/pushschema-pipeline";
@@ -12,7 +12,6 @@ import {
 } from "../../domains/schema/pipeline/pushschema-pipeline-stubs";
 import { RegexRenameDetector } from "../../domains/schema/pipeline/rename-detector";
 import type { DesiredSchema } from "../../domains/schema/pipeline/types";
-import { resolveBuilderTextWidths } from "../../domains/schema/services/builder-text-width";
 import { DrizzleStatementExecutor } from "../../domains/schema/services/drizzle-statement-executor";
 import { NextlyError } from "../../errors";
 import { getProductionNotifier } from "../../runtime/notifications/index";
@@ -70,13 +69,6 @@ export async function applyBuilderSchema(
   const desired = await buildFullDesiredSchema();
   args.apply(desired);
 
-  // After the caller states its entity, so the entity being saved is covered too, and over the whole
-  // schema rather than one entry: the pipeline diffs EVERY managed table, so an entity nobody is
-  // editing still has its columns compared. Resolving only the target's widths would let a save
-  // describe a sibling's unbounded text column as bounded and narrow a table the operator never
-  // touched.
-  resolveBuilderTextWidths(desired);
-
   const pipeline = new PushSchemaPipeline({
     executor: new DrizzleStatementExecutor(dialect, db),
     renameDetector: new RegexRenameDetector(),
@@ -101,11 +93,13 @@ export async function applyBuilderSchema(
     dialect,
     source: "ui",
     promptChannel: "browser",
-    // MySQL's pushSchema needs the database name; the other dialects ignore it.
+    // MySQL's pushSchema needs the database name; the other dialects ignore it. Asked of the
+    // connection rather than parsed out of the environment, because an adapter can be constructed
+    // programmatically with no DATABASE_URL set — or with one naming a different database. Reading
+    // the env there yields nothing usable, MySQL then refuses the apply for a missing database name,
+    // and the entity is registered with no table behind it.
     databaseName:
-      dialect === "mysql"
-        ? extractDatabaseNameFromUrl(process.env.DATABASE_URL)
-        : undefined,
+      dialect === "mysql" ? await currentMysqlDatabaseName(db) : undefined,
     uiTargetSlug: slug,
     uiTargetKind: kind,
   });

--- a/packages/nextly/src/dispatcher/helpers/desired-schema.ts
+++ b/packages/nextly/src/dispatcher/helpers/desired-schema.ts
@@ -49,6 +49,9 @@ export async function buildFullDesiredSchema(): Promise<DesiredSchema> {
           // Carry ownership so a UI save can be prevented from emitting DDL
           // against a code-first/plugin-owned table.
           locked: (c as { locked?: boolean }).locked === true,
+          // An unlocked registry row is one the Schema Builder authored. This is the only builder
+          // that reads the flag, so it is the one that states the origin the diff needs.
+          builderOwned: (c as { locked?: boolean }).locked !== true,
         };
       }
     } catch {
@@ -71,6 +74,7 @@ export async function buildFullDesiredSchema(): Promise<DesiredSchema> {
           // single's main table (they live in single_<slug>_locales).
           localized: (s as { localized?: boolean }).localized === true,
           locked: (s as { locked?: boolean }).locked === true,
+          builderOwned: (s as { locked?: boolean }).locked !== true,
         };
       }
     } catch {
@@ -92,6 +96,9 @@ export async function buildFullDesiredSchema(): Promise<DesiredSchema> {
           // component's main table (they live in comp_<slug>_locales).
           localized: (c as { localized?: boolean }).localized === true,
           locked: (c as { locked?: boolean }).locked === true,
+          // An unlocked registry row is one the Schema Builder authored. This is the only builder
+          // that reads the flag, so it is the one that states the origin the diff needs.
+          builderOwned: (c as { locked?: boolean }).locked !== true,
         };
       }
     } catch {

--- a/packages/nextly/src/domains/schema/pipeline/__tests__/builder-create-converges.integration.test.ts
+++ b/packages/nextly/src/domains/schema/pipeline/__tests__/builder-create-converges.integration.test.ts
@@ -1,0 +1,195 @@
+/**
+ * A table the Schema Builder just created must preview as unchanged.
+ *
+ * The create path and the preview path each build their own desired schema from the same registry
+ * row. When they disagree about a single column, an operator who has changed nothing opens the
+ * Builder and is shown a destructive type change against a table nobody touched — and confirming it
+ * narrows a live column.
+ *
+ * Not hypothetical: resolving the Builder's text-width rule inside the create handler alone produced
+ * exactly this, because preview builds its snapshot elsewhere and never applied the rule. A unit test
+ * over either path passes while the pair disagrees, which is why this asserts across the two. It is
+ * also invisible on PostgreSQL and SQLite, where both answers render `text`; only MySQL renders them
+ * differently, and there they are 65 535 and 255 characters.
+ */
+import { drizzle as drizzleMysql } from "drizzle-orm/mysql2";
+import { drizzle as drizzlePg } from "drizzle-orm/node-postgres";
+import { createPool, type Pool as MysqlPool } from "mysql2";
+import { Pool } from "pg";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { makeTestContext } from "../../../../database/__tests__/integration/helpers/test-db";
+import { DrizzleStatementExecutor } from "../../services/drizzle-statement-executor";
+import { introspectLiveSnapshot } from "../diff/introspect-live";
+import { previewDesiredSchema } from "../preview";
+import { PushSchemaPipeline } from "../pushschema-pipeline";
+import {
+  noopClassifier,
+  noopMigrationJournal,
+  noopNotifier,
+  noopPreCleanupExecutor,
+  noopPreRenameExecutor,
+  noopPromptDispatcher,
+  noopRenameDetector,
+} from "../pushschema-pipeline-stubs";
+import type { DesiredSchema } from "../types";
+
+// Per-file prefixes so this suite cannot collide with another that creates a table of its own.
+const PG = makeTestContext("postgresql");
+const MYSQL = makeTestContext("mysql");
+const PG_URL = PG.url ?? "";
+const MYSQL_URL = MYSQL.url ?? "";
+
+/** A Builder-authored single: unlocked, one plain text field stating no width anywhere. */
+function builderSingle(tableName: string): DesiredSchema {
+  return {
+    collections: {},
+    singles: {
+      page: {
+        slug: "page",
+        tableName,
+        fields: [{ name: "body", type: "text" }] as never,
+        locked: false,
+      },
+    },
+    components: {},
+  };
+}
+
+/**
+ * Everything the diff reports about columns.
+ *
+ * Index operations are excluded because a created table genuinely lacks its secondary indexes: the
+ * Drizzle schema handed to drizzle-kit declares none. Column shape is what this suite pins, and a
+ * disagreement between the two builders shows up there.
+ */
+function columnOperations(
+  operations: readonly { type: string }[]
+): readonly { type: string }[] {
+  return operations.filter(op => !op.type.endsWith("_index"));
+}
+
+function makePipeline(
+  dialect: "postgresql" | "mysql",
+  db: unknown
+): PushSchemaPipeline {
+  return new PushSchemaPipeline({
+    executor: new DrizzleStatementExecutor(dialect, db),
+    renameDetector: noopRenameDetector,
+    classifier: noopClassifier,
+    promptDispatcher: noopPromptDispatcher,
+    preRenameExecutor: noopPreRenameExecutor,
+    preCleanupExecutor: noopPreCleanupExecutor,
+    migrationJournal: noopMigrationJournal,
+    notifier: noopNotifier,
+  });
+}
+
+describe.skipIf(!PG_URL)("builder-created table converges (postgres)", () => {
+  const tableName = `${PG.prefix}_single_conv`;
+  let pool: Pool;
+  let db: ReturnType<typeof drizzlePg>;
+
+  beforeAll(async () => {
+    pool = new Pool({ connectionString: PG_URL });
+    db = drizzlePg({ client: pool });
+    await db.execute(`DROP TABLE IF EXISTS "${tableName}"`);
+  });
+
+  afterAll(async () => {
+    await db.execute(`DROP TABLE IF EXISTS "${tableName}"`);
+    await pool.end();
+  });
+
+  it("previews as unchanged immediately after being created", async () => {
+    const desired = builderSingle(tableName);
+
+    const applied = await makePipeline("postgresql", db).apply({
+      desired,
+      db,
+      dialect: "postgresql",
+      source: "ui",
+      promptChannel: "browser",
+      uiTargetSlug: "page",
+      uiTargetKind: "single",
+    });
+    expect(applied.success).toBe(true);
+
+    const preview = await previewDesiredSchema({
+      desired,
+      db,
+      dialect: "postgresql",
+    });
+
+    // Scoped past index operations deliberately. The Drizzle tables drizzle-kit builds its DDL from
+    // declare no secondary indexes, so a freshly created table has none and the next diff asks for
+    // them back. That is a real gap with its own fix pending, and a blanket zero here would fail on
+    // it forever — or, once someone relaxed the assertion, stop pinning the invariant this exists for.
+    expect(columnOperations(preview.operations)).toEqual([]);
+  });
+});
+
+describe.skipIf(!MYSQL_URL)("builder-created table converges (mysql)", () => {
+  const tableName = `${MYSQL.prefix}_single_conv`;
+  let pool: MysqlPool;
+  let db: ReturnType<typeof drizzleMysql<Record<string, never>, MysqlPool>>;
+
+  beforeAll(async () => {
+    pool = createPool({ uri: MYSQL_URL });
+    db = drizzleMysql({ client: pool });
+    await pool.promise().query(`DROP TABLE IF EXISTS \`${tableName}\``);
+  });
+
+  afterAll(async () => {
+    await pool.promise().query(`DROP TABLE IF EXISTS \`${tableName}\``);
+    await new Promise<void>(res => pool.end(() => res()));
+  });
+
+  it("previews as unchanged immediately after being created", async () => {
+    const desired = builderSingle(tableName);
+
+    const applied = await makePipeline("mysql", db).apply({
+      desired,
+      db,
+      dialect: "mysql",
+      source: "ui",
+      promptChannel: "browser",
+      databaseName: new URL(MYSQL_URL).pathname.slice(1),
+      uiTargetSlug: "page",
+      uiTargetKind: "single",
+    });
+    expect(applied.success).toBe(true);
+
+    const preview = await previewDesiredSchema({
+      desired,
+      db,
+      dialect: "mysql",
+    });
+
+    expect(columnOperations(preview.operations)).toEqual([]);
+  });
+
+  // The dialect where the two possible answers are physically different, and where getting this
+  // wrong truncates at 255 characters rather than merely reading as drift.
+  it("gives an unstated builder text field an unbounded column", async () => {
+    const desired = builderSingle(tableName);
+
+    await makePipeline("mysql", db).apply({
+      desired,
+      db,
+      dialect: "mysql",
+      source: "ui",
+      promptChannel: "browser",
+      databaseName: new URL(MYSQL_URL).pathname.slice(1),
+      uiTargetSlug: "page",
+      uiTargetKind: "single",
+    });
+
+    const live = await introspectLiveSnapshot(db, "mysql", [tableName]);
+    const body = live.tables
+      .find(t => t.name === tableName)
+      ?.columns.find(c => c.name === "body");
+
+    expect(body?.type).toBe("text");
+  });
+});

--- a/packages/nextly/src/domains/schema/pipeline/__tests__/builder-create-converges.integration.test.ts
+++ b/packages/nextly/src/domains/schema/pipeline/__tests__/builder-create-converges.integration.test.ts
@@ -49,7 +49,7 @@ function builderSingle(tableName: string): DesiredSchema {
         slug: "page",
         tableName,
         fields: [{ name: "body", type: "text" }] as never,
-        locked: false,
+        builderOwned: true,
       },
     },
     components: {},

--- a/packages/nextly/src/domains/schema/pipeline/__tests__/pushschema-pipeline.test.ts
+++ b/packages/nextly/src/domains/schema/pipeline/__tests__/pushschema-pipeline.test.ts
@@ -384,6 +384,64 @@ describe("PushSchemaPipeline (Option E flow) - introspection wired", () => {
     expect(opsArg.some(op => op.type === "drop_column")).toBe(true);
     expect(opsArg.some(op => op.type === "add_column")).toBe(true);
   });
+
+  // A UI save must not be refused over drift on a table it does not own. An unresolved rename
+  // candidate fails closed, so a locked table's operations reaching the detector is enough to
+  // refuse the whole save even though the apply would discard every one of them.
+  it("hides locked-table operations from rename detection on a UI save", async () => {
+    const lockedDesired: DesiredSchema = {
+      collections: {
+        posts: {
+          slug: "posts",
+          tableName: "dc_posts",
+          fields: [{ name: "summary", type: "text" }] as never,
+          locked: true,
+        },
+      },
+      singles: {},
+      components: {},
+    };
+
+    const introspectImpl = vi
+      .fn<
+        (
+          db: unknown,
+          dialect: SupportedDialect,
+          tableNames: string[]
+        ) => Promise<NextlySchemaSnapshot>
+      >()
+      .mockResolvedValue({
+        tables: [
+          {
+            name: "dc_posts",
+            columns: [
+              { name: "id", type: "text", nullable: false },
+              { name: "title", type: "text", nullable: false },
+              { name: "slug", type: "text", nullable: false },
+              { name: "created_at", type: "timestamp", nullable: true },
+              { name: "updated_at", type: "timestamp", nullable: true },
+              { name: "body", type: "text", nullable: true },
+            ],
+          },
+        ],
+      });
+
+    const { pipeline, mocks } = makePipeline({ introspectImpl });
+
+    await pipeline.apply({
+      desired: lockedDesired,
+      db: {},
+      dialect: "postgresql",
+      source: "ui",
+      promptChannel: "browser",
+    });
+
+    const [opsArg] = mocks.renameDetector.detect.mock.calls[0] as [
+      Operation[],
+      SupportedDialect,
+    ];
+    expect(opsArg).toEqual([]);
+  });
 });
 
 describe("PushSchemaPipeline (Option E flow) - prompt + resolution flow", () => {

--- a/packages/nextly/src/domains/schema/pipeline/diff/build-from-fields.ts
+++ b/packages/nextly/src/domains/schema/pipeline/diff/build-from-fields.ts
@@ -29,7 +29,6 @@ import type { SupportedDialect } from "@nextlyhq/adapter-drizzle/types";
 
 import { STORAGE_FORMAT } from "../../../../schemas/storage-format";
 import { resolveLocalizedFieldNames } from "../../../i18n/classify-fields";
-import { resolveBuilderTextWidths } from "../../services/builder-text-width";
 import {
   getColumnDescriptor,
   getSystemColumnDescriptors,
@@ -80,16 +79,6 @@ export interface BuildDesiredTableOptions {
    * dropped.
    */
   localized?: boolean;
-  /**
-   * When true, this entity was authored in the Schema Builder rather than in code, and a text field
-   * that states no width is read as unbounded.
-   *
-   * The two origins need different answers to the same silence: the Builder's previous generator
-   * created an unstated text field as `TEXT`, while the descriptor's default — which every
-   * code-first table was built with — is the bounded kind. Passed in rather than inferred because
-   * only the caller holds the registry's `locked` flag that records which one this is.
-   */
-  builderOwned?: boolean;
 }
 
 /**
@@ -196,17 +185,10 @@ export function collectionIndexSpecs<F extends MinimalFieldDef>(
 
 export function buildDesiredTableFromFields(
   tableName: string,
-  fieldsIn: MinimalFieldDef[],
+  fields: MinimalFieldDef[],
   dialect: SupportedDialect,
   options: BuildDesiredTableOptions = {}
 ): TableSpec {
-  // Resolved before anything reads a field, so every consumer below — the columns, the index rules
-  // and the system-column checks — sees one answer. Doing it here rather than at each call site is
-  // what makes it impossible for a path that builds its own desired schema to skip it.
-  const fields = options.builderOwned
-    ? (resolveBuilderTextWidths(fieldsIn) as MinimalFieldDef[])
-    : fieldsIn;
-
   const columns: ColumnSpec[] = [];
 
   // Localized fields live in the companion `_locales` table (migration-owned); omit them
@@ -300,12 +282,10 @@ export function buildDesiredTableFromFields(
  */
 export function buildDesiredTableFromComponentFields(
   tableName: string,
-  fieldsIn: MinimalFieldDef[],
+  fields: MinimalFieldDef[],
   dialect: SupportedDialect,
   options: {
     localized?: boolean;
-    /** Same meaning as on {@link BuildDesiredTableOptions} — a field group the Builder authored. */
-    builderOwned?: boolean;
     /**
      * The discriminator this table actually carries.
      *
@@ -322,12 +302,6 @@ export function buildDesiredTableFromComponentFields(
   } = {}
 ): TableSpec {
   const typeColumn = options.typeColumn ?? STORAGE_FORMAT.columns.type;
-  // Resolved before anything reads a field, for the same reason as the collection/single builder:
-  // this is the one place every field group's desired columns are derived, so a path that builds
-  // its own snapshot cannot skip it.
-  const fields = options.builderOwned
-    ? (resolveBuilderTextWidths(fieldsIn) as MinimalFieldDef[])
-    : fieldsIn;
   const columns: ColumnSpec[] = [];
 
   // i18n: when the component is localized, its translatable fields live in the

--- a/packages/nextly/src/domains/schema/pipeline/diff/build-from-fields.ts
+++ b/packages/nextly/src/domains/schema/pipeline/diff/build-from-fields.ts
@@ -29,6 +29,7 @@ import type { SupportedDialect } from "@nextlyhq/adapter-drizzle/types";
 
 import { STORAGE_FORMAT } from "../../../../schemas/storage-format";
 import { resolveLocalizedFieldNames } from "../../../i18n/classify-fields";
+import { resolveBuilderTextWidths } from "../../services/builder-text-width";
 import {
   getColumnDescriptor,
   getSystemColumnDescriptors,
@@ -79,6 +80,16 @@ export interface BuildDesiredTableOptions {
    * dropped.
    */
   localized?: boolean;
+  /**
+   * When true, this entity was authored in the Schema Builder rather than in code, and a text field
+   * that states no width is read as unbounded.
+   *
+   * The two origins need different answers to the same silence: the Builder's previous generator
+   * created an unstated text field as `TEXT`, while the descriptor's default — which every
+   * code-first table was built with — is the bounded kind. Passed in rather than inferred because
+   * only the caller holds the registry's `locked` flag that records which one this is.
+   */
+  builderOwned?: boolean;
 }
 
 /**
@@ -185,10 +196,17 @@ export function collectionIndexSpecs<F extends MinimalFieldDef>(
 
 export function buildDesiredTableFromFields(
   tableName: string,
-  fields: MinimalFieldDef[],
+  fieldsIn: MinimalFieldDef[],
   dialect: SupportedDialect,
   options: BuildDesiredTableOptions = {}
 ): TableSpec {
+  // Resolved before anything reads a field, so every consumer below — the columns, the index rules
+  // and the system-column checks — sees one answer. Doing it here rather than at each call site is
+  // what makes it impossible for a path that builds its own desired schema to skip it.
+  const fields = options.builderOwned
+    ? (resolveBuilderTextWidths(fieldsIn) as MinimalFieldDef[])
+    : fieldsIn;
+
   const columns: ColumnSpec[] = [];
 
   // Localized fields live in the companion `_locales` table (migration-owned); omit them
@@ -282,10 +300,12 @@ export function buildDesiredTableFromFields(
  */
 export function buildDesiredTableFromComponentFields(
   tableName: string,
-  fields: MinimalFieldDef[],
+  fieldsIn: MinimalFieldDef[],
   dialect: SupportedDialect,
   options: {
     localized?: boolean;
+    /** Same meaning as on {@link BuildDesiredTableOptions} — a field group the Builder authored. */
+    builderOwned?: boolean;
     /**
      * The discriminator this table actually carries.
      *
@@ -302,6 +322,12 @@ export function buildDesiredTableFromComponentFields(
   } = {}
 ): TableSpec {
   const typeColumn = options.typeColumn ?? STORAGE_FORMAT.columns.type;
+  // Resolved before anything reads a field, for the same reason as the collection/single builder:
+  // this is the one place every field group's desired columns are derived, so a path that builds
+  // its own snapshot cannot skip it.
+  const fields = options.builderOwned
+    ? (resolveBuilderTextWidths(fieldsIn) as MinimalFieldDef[])
+    : fieldsIn;
   const columns: ColumnSpec[] = [];
 
   // i18n: when the component is localized, its translatable fields live in the

--- a/packages/nextly/src/domains/schema/pipeline/preview.ts
+++ b/packages/nextly/src/domains/schema/pipeline/preview.ts
@@ -22,6 +22,8 @@
 
 import type { SupportedDialect } from "@nextlyhq/adapter-drizzle/types";
 
+import { withResolvedBuilderTextWidths } from "../services/builder-text-width";
+
 import { RealClassifier } from "./classifier/classifier";
 import {
   countNulls as countNullsHelper,
@@ -102,7 +104,11 @@ export async function previewDesiredSchema(
   args: PreviewDesiredSchemaArgs,
   deps: PreviewDesiredSchemaDeps = {}
 ): Promise<PipelinePreviewResult> {
-  const { desired, db, dialect } = args;
+  const { db, dialect } = args;
+  // Resolved once, here, so the snapshot this function builds and the DDL the apply path builds
+  // from the same declaration describe the same column. Two different builders read a desired
+  // schema, and normalising what they share is what keeps them from disagreeing forever.
+  const desired = withResolvedBuilderTextWidths(args.desired);
   const renameDetector = deps.renameDetector ?? new RegexRenameDetector();
   const classifier = deps.classifier ?? new RealClassifier();
   const introspect = deps.introspect ?? introspectLiveSnapshot;
@@ -136,7 +142,6 @@ export async function previewDesiredSchema(
       {
         hasStatus: c.status === true,
         localized: c.localized === true,
-        builderOwned: c.locked !== true,
       }
     )
   );
@@ -151,7 +156,6 @@ export async function previewDesiredSchema(
       {
         hasStatus: s.status === true,
         localized: s.localized === true,
-        builderOwned: s.locked !== true,
       }
     )
   );
@@ -166,7 +170,6 @@ export async function previewDesiredSchema(
       // preview's desired snapshot (they live in the companion), matching collections/singles.
       {
         localized: (c as { localized?: boolean }).localized === true,
-        builderOwned: c.locked !== true,
       }
     )
   );

--- a/packages/nextly/src/domains/schema/pipeline/preview.ts
+++ b/packages/nextly/src/domains/schema/pipeline/preview.ts
@@ -133,7 +133,11 @@ export async function previewDesiredSchema(
       // omitted from the preview's desired snapshot (they live in the companion
       // `_locales` table); otherwise the diff reports them as missing and the
       // SchemaChangeDialog tries to re-add them to the main table.
-      { hasStatus: c.status === true, localized: c.localized === true }
+      {
+        hasStatus: c.status === true,
+        localized: c.localized === true,
+        builderOwned: c.locked !== true,
+      }
     )
   );
   const singleTables = Object.values(desired.singles).map(s =>
@@ -144,7 +148,11 @@ export async function previewDesiredSchema(
       // Forward `localized` so a localized single's translatable columns are omitted from the
       // preview's desired snapshot (they live in the companion), matching the collection path —
       // otherwise the diff reports phantom main-table changes the apply never makes.
-      { hasStatus: s.status === true, localized: s.localized === true }
+      {
+        hasStatus: s.status === true,
+        localized: s.localized === true,
+        builderOwned: s.locked !== true,
+      }
     )
   );
   const componentTables = Object.values(desired.components).map(c =>
@@ -156,7 +164,10 @@ export async function previewDesiredSchema(
       dialect,
       // Forward `localized` so a localized component's translatable columns are omitted from the
       // preview's desired snapshot (they live in the companion), matching collections/singles.
-      { localized: (c as { localized?: boolean }).localized === true }
+      {
+        localized: (c as { localized?: boolean }).localized === true,
+        builderOwned: c.locked !== true,
+      }
     )
   );
   const desiredSnapshot: NextlySchemaSnapshot = {

--- a/packages/nextly/src/domains/schema/pipeline/pushschema-pipeline-interfaces.ts
+++ b/packages/nextly/src/domains/schema/pipeline/pushschema-pipeline-interfaces.ts
@@ -112,7 +112,9 @@ export interface PreCleanupExecutor {
 // NotificationCenter can render meaningful audit rows. Plan C1 maps this onto
 // `SchemaEventScopeKind` from `schemas/schema-events/types.ts`.
 export interface MigrationJournalScope {
-  kind: "collection" | "single" | "global" | "fresh-push";
+  // `component` is carried because a field group is one of the entity kinds a UI apply can target,
+  // and recording it as a collection made scope-filtered history unable to find it.
+  kind: "collection" | "single" | "component" | "global" | "fresh-push";
   slug?: string;
 }
 

--- a/packages/nextly/src/domains/schema/pipeline/pushschema-pipeline.ts
+++ b/packages/nextly/src/domains/schema/pipeline/pushschema-pipeline.ts
@@ -670,7 +670,11 @@ export class PushSchemaPipeline {
               // localized collection's translatable columns are omitted from the
               // main table's desired snapshot (they live in the companion
               // `_locales` table) rather than being re-added by the diff.
-              { hasStatus: c.status === true, localized: c.localized === true }
+              {
+                hasStatus: c.status === true,
+                localized: c.localized === true,
+                builderOwned: c.locked !== true,
+              }
             )
           ),
           ...Object.values(desired.singles).map(s =>
@@ -683,6 +687,7 @@ export class PushSchemaPipeline {
               {
                 hasStatus: s.status === true,
                 localized: (s as { localized?: boolean }).localized === true,
+                builderOwned: s.locked !== true,
               }
             )
           ),
@@ -696,13 +701,29 @@ export class PushSchemaPipeline {
               {
                 localized: (c as { localized?: boolean }).localized === true,
                 typeColumn: fieldGroupTypeColumns.get(c.tableName),
+                builderOwned: c.locked !== true,
               }
             )
           ),
         ],
       };
 
-      const operations = diffSnapshots(liveSnapshot, desiredSnapshot);
+      const allOperations = diffSnapshots(liveSnapshot, desiredSnapshot);
+
+      // A UI save owns only the entity being edited. An operation targeting a code-first or
+      // plugin-owned table is dropped here, BEFORE anything reads the operation set, because those
+      // tables belong to `nextly.config.ts` and reconciling their drift is db:sync's job.
+      //
+      // 🔴 Dropped before rename detection rather than after prompting, which is where this used to
+      // happen. An operation on a locked table still reached the rename detector and the prompt gate
+      // on the way, and an unresolved candidate fails closed — so unapplied drift on a table the
+      // save was never going to touch could refuse the entire save, over an operation the very next
+      // step discards. Code-first applies keep the full set: they ARE the authority for those tables.
+      const { kept: operations, skipped: skippedLockedOps } =
+        source === "ui"
+          ? excludeLockedTableOps(allOperations, desired)
+          : { kept: allOperations, skipped: [] as Operation[] };
+      logSkippedLockedOps(skippedLockedOps);
 
       // Phase B: rename detection + prompt + resolution application.
       const candidates = this.deps.renameDetector.detect(operations, dialect);
@@ -773,15 +794,9 @@ export class PushSchemaPipeline {
           toRenameResolutions(dispatchResult.confirmedRenames, candidates)
         );
 
-      // A UI save owns only the entity being edited. Drop any operation that
-      // targets a code-first/plugin-owned table so the Schema Builder can never
-      // alter schema the user did not edit. Code-first applies (db:sync) are
-      // the authority for those tables and keep the full operation set.
-      const { kept: resolvedOps, skipped: skippedLockedOps } =
-        source === "ui"
-          ? excludeLockedTableOps(allResolvedOps, desired)
-          : { kept: allResolvedOps, skipped: [] as Operation[] };
-      logSkippedLockedOps(skippedLockedOps);
+      // Already excluded above, before the operation set was read. Resolutions are keyed to the
+      // candidates and events that set produced, so none of them can reintroduce a locked table.
+      const resolvedOps = allResolvedOps;
 
       // Phase C+D: execute pre-resolution ops, then pushSchema for the rest.
       const drizzleSchema = this.testHooks._buildDrizzleSchemaOverride

--- a/packages/nextly/src/domains/schema/pipeline/pushschema-pipeline.ts
+++ b/packages/nextly/src/domains/schema/pipeline/pushschema-pipeline.ts
@@ -38,6 +38,7 @@ import {
   chooseTypeColumns,
   resolveRegistryNameFromCatalog,
 } from "../../field-groups/storage/resolve-storage-names";
+import { withResolvedBuilderTextWidths } from "../services/builder-text-width";
 import { generateRuntimeSchema } from "../services/runtime-schema-generator";
 import { identifierCaseRules } from "../utils/resolve-catalog-name";
 
@@ -519,7 +520,12 @@ export class PushSchemaPipeline {
     /** Which entity kind `uiTargetSlug` names, so the journal row records it accurately. */
     uiTargetKind?: "collection" | "single" | "component";
   }): Promise<PipelineResult> {
-    const { desired, db, dialect, source, promptChannel, databaseName } = args;
+    const { db, dialect, source, promptChannel, databaseName } = args;
+    // Resolved once, before anything reads it. A desired schema is consumed by TWO builders — the
+    // snapshot the diff compares and the Drizzle tables drizzle-kit turns into DDL — and resolving
+    // inside either leaves the other on the raw fields, so a table would converge and then report a
+    // type change against itself on every following diff.
+    const desired = withResolvedBuilderTextWidths(args.desired);
     const scope = computeJournalScope(
       source,
       args.uiTargetSlug,
@@ -673,7 +679,6 @@ export class PushSchemaPipeline {
               {
                 hasStatus: c.status === true,
                 localized: c.localized === true,
-                builderOwned: c.locked !== true,
               }
             )
           ),
@@ -687,7 +692,6 @@ export class PushSchemaPipeline {
               {
                 hasStatus: s.status === true,
                 localized: (s as { localized?: boolean }).localized === true,
-                builderOwned: s.locked !== true,
               }
             )
           ),
@@ -701,7 +705,6 @@ export class PushSchemaPipeline {
               {
                 localized: (c as { localized?: boolean }).localized === true,
                 typeColumn: fieldGroupTypeColumns.get(c.tableName),
-                builderOwned: c.locked !== true,
               }
             )
           ),

--- a/packages/nextly/src/domains/schema/pipeline/pushschema-pipeline.ts
+++ b/packages/nextly/src/domains/schema/pipeline/pushschema-pipeline.ts
@@ -372,10 +372,14 @@ export function computeJournalSummaryFromOperations(
 // Pure helper. Test seam: exported.
 export function computeJournalScope(
   source: "ui" | "code",
-  uiTargetSlug: string | undefined
+  uiTargetSlug: string | undefined,
+  // Defaulted to `collection` so the many existing UI callers that target one keep their scope
+  // without restating it. A single or field group must say so: recording either as a collection
+  // hid its migrations from every scope-filtered audit query.
+  uiTargetKind: "collection" | "single" | "component" = "collection"
 ): MigrationJournalScope {
   if (source === "ui" && uiTargetSlug) {
-    return { kind: "collection", slug: uiTargetSlug };
+    return { kind: uiTargetKind, slug: uiTargetSlug };
   }
   return { kind: "global" };
 }
@@ -484,7 +488,7 @@ function toNotificationScope(scope: MigrationJournalScope): MigrationScope {
       ? { kind: "global", slug: scope.slug }
       : { kind: "global" };
   }
-  // collection | single — both require a slug per
+  // collection | single | component — all three require a slug per
   // MigrationJournalScope's contract (asserted at the type-system
   // level because slug is optional only for fresh-push/global).
   return scope.slug
@@ -512,9 +516,15 @@ export class PushSchemaPipeline {
     // slug: <user's collection> }`. HMR/code-first applies omit it
     // and get tagged as global.
     uiTargetSlug?: string;
+    /** Which entity kind `uiTargetSlug` names, so the journal row records it accurately. */
+    uiTargetKind?: "collection" | "single" | "component";
   }): Promise<PipelineResult> {
     const { desired, db, dialect, source, promptChannel, databaseName } = args;
-    const scope = computeJournalScope(source, args.uiTargetSlug);
+    const scope = computeJournalScope(
+      source,
+      args.uiTargetSlug,
+      args.uiTargetKind
+    );
     // F10 PR 3: track wall-clock for the notification event. The
     // journal already computes its own duration; we duplicate here so
     // the notification event surfaces duration even when the journal

--- a/packages/nextly/src/domains/schema/pipeline/types.ts
+++ b/packages/nextly/src/domains/schema/pipeline/types.ts
@@ -44,6 +44,17 @@ export interface DesiredCollection {
    * so drift is reconciled by db:sync, not by the Schema Builder.
    */
   locked?: boolean;
+  /**
+   * Whether this entity was authored in the Schema Builder rather than in code.
+   *
+   * Stated explicitly rather than inferred from `locked`, because most snapshot builders omit
+   * `locked` entirely and an absent flag says nothing about origin: reading it as "not locked,
+   * therefore the Builder's" reclassified every code-first entity on the HMR and db:sync paths.
+   *
+   * Absent means code-first, which is the conservative answer — a producer that has not learned to
+   * state this leaves behaviour exactly as it was.
+   */
+  builderOwned?: boolean;
 }
 
 export interface DesiredSingle {
@@ -63,6 +74,17 @@ export interface DesiredSingle {
    * so drift is reconciled by db:sync, not by the Schema Builder.
    */
   locked?: boolean;
+  /**
+   * Whether this entity was authored in the Schema Builder rather than in code.
+   *
+   * Stated explicitly rather than inferred from `locked`, because most snapshot builders omit
+   * `locked` entirely and an absent flag says nothing about origin: reading it as "not locked,
+   * therefore the Builder's" reclassified every code-first entity on the HMR and db:sync paths.
+   *
+   * Absent means code-first, which is the conservative answer — a producer that has not learned to
+   * state this leaves behaviour exactly as it was.
+   */
+  builderOwned?: boolean;
 }
 
 export interface DesiredFieldGroup {
@@ -80,4 +102,15 @@ export interface DesiredFieldGroup {
    * so drift is reconciled by db:sync, not by the Schema Builder.
    */
   locked?: boolean;
+  /**
+   * Whether this entity was authored in the Schema Builder rather than in code.
+   *
+   * Stated explicitly rather than inferred from `locked`, because most snapshot builders omit
+   * `locked` entirely and an absent flag says nothing about origin: reading it as "not locked,
+   * therefore the Builder's" reclassified every code-first entity on the HMR and db:sync paths.
+   *
+   * Absent means code-first, which is the conservative answer — a producer that has not learned to
+   * state this leaves behaviour exactly as it was.
+   */
+  builderOwned?: boolean;
 }

--- a/packages/nextly/src/domains/schema/services/__tests__/builder-text-width.test.ts
+++ b/packages/nextly/src/domains/schema/services/__tests__/builder-text-width.test.ts
@@ -1,115 +1,99 @@
 import { describe, expect, it } from "vitest";
 
-import type { FieldConfig } from "../../../../collections/fields/types";
-import type { DesiredSchema } from "../../pipeline/types";
+import { buildDesiredTableFromFields } from "../../pipeline/diff/build-from-fields";
 import { resolveBuilderTextWidths } from "../builder-text-width";
-import { getColumnDescriptor } from "../field-column-descriptor";
 
-/**
- * The desired schema declares its fields as `FieldConfig` while the descriptor reads them as
- * `FieldDefinition`. `build-from-fields.ts` converts at exactly this boundary for the same reason,
- * so the assertions below go through the descriptor rather than reading the marker property:
- * the column a field produces is the contract, and how the width is recorded is not.
- */
-function mysqlType(field: FieldConfig): string | undefined {
-  return getColumnDescriptor(
-    field as unknown as Parameters<typeof getColumnDescriptor>[0],
-    "mysql"
-  )?.dialectType;
+/** Widened past the literal so a test can read back the modifiers the resolver writes. */
+function textField(extra: Record<string, unknown> = {}): {
+  name: string;
+  type: string;
+  options?: unknown;
+} {
+  return { name: "body", type: "text", ...extra };
 }
 
-function textField(extra: Record<string, unknown> = {}): FieldConfig {
-  return { name: "body", type: "text", ...extra } as unknown as FieldConfig;
+function bodyType(
+  fields: Parameters<typeof buildDesiredTableFromFields>[1],
+  builderOwned: boolean
+): string | undefined {
+  return buildDesiredTableFromFields("single_page", fields, "mysql", {
+    builderOwned,
+  }).columns.find(c => c.name === "body")?.type;
 }
 
-function schemaWith(
-  entity: Partial<DesiredSchema["singles"][string]>
-): DesiredSchema {
-  return {
-    collections: {},
-    singles: {
-      page: {
-        slug: "page",
-        tableName: "single_page",
-        fields: [],
-        ...entity,
-      },
-    },
-    components: {},
-  };
-}
+// The seam matters as much as the rule: preview and apply each build their own desired schema, and
+// resolving in only one of them reported a destructive type change against an untouched table.
+describe("buildDesiredTableFromFields — builder text width", () => {
+  it("gives a builder-owned text field an unbounded column on MySQL", () => {
+    expect(bodyType([textField()], true)).toBe("text");
+  });
+
+  it("leaves a code-first text field on the bounded default", () => {
+    expect(bodyType([textField()], false)).toBe("varchar(255)");
+  });
+
+  it("keeps a stated short variant bounded", () => {
+    expect(bodyType([textField({ options: { variant: "short" } })], true)).toBe(
+      "varchar(255)"
+    );
+  });
+
+  // A width the descriptor cannot render must not be read as a decision to stay bounded: doing so
+  // left a field declaring 500 characters in a varchar(255) column, rejecting values its own stored
+  // validation limit accepts.
+  it.each([
+    ["a validation maxLength", { validation: { maxLength: 500 } }],
+    ["a top-level length", { length: 500 }],
+  ])("does not treat %s as a reason to stay bounded", (_, extra) => {
+    expect(bodyType([textField(extra)], true)).toBe("text");
+  });
+
+  it("does not widen a type whose width is settled by what it holds", () => {
+    const table = buildDesiredTableFromFields(
+      "single_page",
+      [
+        { name: "email", type: "email" },
+        { name: "choice", type: "select" },
+      ],
+      "mysql",
+      { builderOwned: true }
+    );
+
+    for (const name of ["email", "choice"]) {
+      expect(table.columns.find(c => c.name === name)?.type).toBe(
+        "varchar(255)"
+      );
+    }
+  });
+});
 
 describe("resolveBuilderTextWidths", () => {
-  // MySQL renders the two kinds 255 characters apart, which is the whole reason this exists.
-  it("leaves a builder-owned text field unbounded on MySQL", () => {
-    const desired = schemaWith({ fields: [textField()] });
+  it("returns the original array when nothing needs resolving", () => {
+    const fields = [{ name: "n", type: "number" }];
 
-    resolveBuilderTextWidths(desired);
-
-    expect(mysqlType(desired.singles.page.fields[0])).toBe("text");
+    expect(resolveBuilderTextWidths(fields)).toBe(fields);
   });
 
-  // A locked entity's columns were built by the path whose default is the bounded kind, so
-  // rewriting them would make every code-first table read as drift.
-  it("leaves a locked entity on the bounded default", () => {
-    const desired = schemaWith({ fields: [textField()], locked: true });
+  // Running twice must not differ from running once: the resolved field states a variant, which the
+  // second pass reads as already answered.
+  it("is idempotent", () => {
+    const once = resolveBuilderTextWidths([textField()]);
 
-    resolveBuilderTextWidths(desired);
-
-    expect(mysqlType(desired.singles.page.fields[0])).toBe("varchar(255)");
-  });
-
-  it("resolves every entity, not only the one being saved", () => {
-    const desired: DesiredSchema = {
-      collections: {
-        posts: { slug: "posts", tableName: "dc_posts", fields: [textField()] },
-      },
-      singles: {},
-      components: {
-        hero: { slug: "hero", tableName: "comp_hero", fields: [textField()] },
-      },
-    };
-
-    resolveBuilderTextWidths(desired);
-
-    expect(mysqlType(desired.collections.posts.fields[0])).toBe("text");
-    expect(mysqlType(desired.components.hero.fields[0])).toBe("text");
-  });
-
-  it.each([
-    ["a stated variant", { options: { variant: "short" } }],
-    ["a top-level length", { length: 80 }],
-    ["a validation maxLength", { validation: { maxLength: 80 } }],
-  ])("treats %s as the author's answer and leaves it bounded", (_, extra) => {
-    const desired = schemaWith({ fields: [textField(extra)] });
-
-    resolveBuilderTextWidths(desired);
-
-    expect(mysqlType(desired.singles.page.fields[0])).toBe("varchar(255)");
+    expect(resolveBuilderTextWidths(once)).toBe(once);
   });
 
   // An array cannot carry a variant, and overwriting it with one would discard whatever it held.
   it("leaves a text field whose options is an array untouched", () => {
-    const field = textField({ options: [{ label: "A", value: "a" }] });
-    const desired = schemaWith({ fields: [field] });
+    const fields = [textField({ options: [{ label: "A", value: "a" }] })];
 
-    resolveBuilderTextWidths(desired);
-
-    expect(desired.singles.page.fields[0]).toBe(field);
+    expect(resolveBuilderTextWidths(fields)).toBe(fields);
   });
 
-  it("does not widen a type whose width is settled by what it holds", () => {
-    const desired = schemaWith({
-      fields: [
-        { name: "email", type: "email" } as unknown as FieldConfig,
-        { name: "password", type: "password" } as unknown as FieldConfig,
-      ],
-    });
+  it("preserves other modifiers on the field it resolves", () => {
+    const [field] = resolveBuilderTextWidths([
+      textField({ options: { target: "posts" } }),
+    ]);
 
-    resolveBuilderTextWidths(desired);
-
-    for (const field of desired.singles.page.fields) {
-      expect(mysqlType(field)).toBe("varchar(255)");
-    }
+    expect(field.options).toEqual({ target: "posts", variant: "long" });
   });
 });

--- a/packages/nextly/src/domains/schema/services/__tests__/builder-text-width.test.ts
+++ b/packages/nextly/src/domains/schema/services/__tests__/builder-text-width.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+
+import type { FieldDefinition } from "../../../../schemas/dynamic-collections";
+import { withDeclaredTextWidth } from "../builder-text-width";
+import { getColumnDescriptor } from "../field-column-descriptor";
+
+describe("withDeclaredTextWidth", () => {
+  it("states long for a text field that declares no width", () => {
+    const [field] = withDeclaredTextWidth([{ name: "body", type: "text" }]);
+
+    expect(field.options?.variant).toBe("long");
+  });
+
+  it("leaves a text field that already states a variant alone", () => {
+    const [field] = withDeclaredTextWidth([
+      { name: "slug", type: "text", options: { variant: "short" } },
+    ]);
+
+    expect(field.options?.variant).toBe("short");
+  });
+
+  it.each([
+    ["a top-level length", { length: 80 }],
+    ["a validation maxLength", { validation: { maxLength: 80 } }],
+  ])(
+    "treats %s as the author's answer and does not overrule it",
+    (_, extra) => {
+      const [field] = withDeclaredTextWidth([
+        { name: "title", type: "text", ...extra },
+      ]);
+
+      expect(field.options?.variant).toBeUndefined();
+    }
+  );
+
+  it("does not widen a type whose width is settled by what it holds", () => {
+    const fields: FieldDefinition[] = [
+      { name: "email", type: "email" },
+      { name: "password", type: "password" },
+      { name: "choice", type: "select" },
+    ];
+
+    for (const field of withDeclaredTextWidth(fields)) {
+      expect(field.options?.variant).toBeUndefined();
+    }
+  });
+
+  it("preserves other options on the field it stamps", () => {
+    const [field] = withDeclaredTextWidth([
+      { name: "body", type: "text", options: { target: "posts" } },
+    ]);
+
+    expect(field.options).toEqual({ target: "posts", variant: "long" });
+  });
+
+  // The reason this function exists: MySQL renders the two kinds 255 characters apart, so an
+  // unstated width decides how much text the column can hold.
+  it("keeps a Builder text column unbounded on MySQL", () => {
+    const raw = getColumnDescriptor({ name: "body", type: "text" }, "mysql");
+    expect(raw?.dialectType).toBe("varchar(255)");
+
+    const [stamped] = withDeclaredTextWidth([{ name: "body", type: "text" }]);
+    expect(getColumnDescriptor(stamped, "mysql")?.dialectType).toBe("text");
+  });
+});
+
+describe("getColumnDescriptor — declared width", () => {
+  it.each([
+    ["a top-level length", { length: 500 }],
+    ["a validation maxLength", { validation: { maxLength: 500 } }],
+  ])("renders %s rather than the fallback on MySQL", (_, extra) => {
+    const descriptor = getColumnDescriptor(
+      { name: "title", type: "text", ...extra },
+      "mysql"
+    );
+
+    expect(descriptor?.dialectType).toBe("varchar(500)");
+    expect(descriptor?.length).toBe(500);
+  });
+
+  it("falls back to 255 when the field declares no width", () => {
+    const descriptor = getColumnDescriptor(
+      { name: "title", type: "text" },
+      "mysql"
+    );
+
+    expect(descriptor?.dialectType).toBe("varchar(255)");
+  });
+
+  it("carries a declared width on PostgreSQL, whose text type takes no length", () => {
+    const descriptor = getColumnDescriptor(
+      { name: "title", type: "text", length: 500 },
+      "postgresql"
+    );
+
+    expect(descriptor?.dialectType).toBe("text");
+    expect(descriptor?.length).toBe(500);
+  });
+});

--- a/packages/nextly/src/domains/schema/services/__tests__/builder-text-width.test.ts
+++ b/packages/nextly/src/domains/schema/services/__tests__/builder-text-width.test.ts
@@ -18,6 +18,7 @@ function schemaWith(
         slug: "page",
         tableName: "single_page",
         fields: [],
+        builderOwned: true,
         ...entity,
       },
     },
@@ -47,11 +48,15 @@ describe("withResolvedBuilderTextWidths", () => {
     expect(bodyType(resolved)).toBe("text");
   });
 
-  // A locked entity's columns were built by the path whose default is bounded, so rewriting them
-  // would make every code-first table read as drift.
-  it("leaves a locked entity on the bounded default", () => {
+  // Code-first columns were built by the path whose default is bounded, so rewriting them would
+  // make every code-first table read as drift. Ownership is never inferred: most snapshot builders
+  // state nothing, and anything other than an explicit yes has to mean code-first.
+  it.each([
+    ["states code ownership", { builderOwned: false }],
+    ["states nothing at all", { builderOwned: undefined }],
+  ])("leaves an entity that %s on the bounded default", (_, ownership) => {
     const resolved = withResolvedBuilderTextWidths(
-      schemaWith({ fields: [textField()] as never, locked: true })
+      schemaWith({ fields: [textField()] as never, ...ownership })
     );
 
     expect(bodyType(resolved)).toBe("varchar(255)");
@@ -88,6 +93,7 @@ describe("withResolvedBuilderTextWidths", () => {
           slug: "posts",
           tableName: "dc_posts",
           fields: [textField()] as never,
+          builderOwned: true,
         },
       },
       singles: {},
@@ -96,6 +102,7 @@ describe("withResolvedBuilderTextWidths", () => {
           slug: "hero",
           tableName: "comp_hero",
           fields: [textField()] as never,
+          builderOwned: true,
         },
       },
     });

--- a/packages/nextly/src/domains/schema/services/__tests__/builder-text-width.test.ts
+++ b/packages/nextly/src/domains/schema/services/__tests__/builder-text-width.test.ts
@@ -1,156 +1,115 @@
 import { describe, expect, it } from "vitest";
 
+import type { FieldConfig } from "../../../../collections/fields/types";
 import type { DesiredSchema } from "../../pipeline/types";
 import { resolveBuilderTextWidths } from "../builder-text-width";
 import { getColumnDescriptor } from "../field-column-descriptor";
 
-function schemaWith(entity: Partial<DesiredSchema["singles"][string]>) {
-  const desired: DesiredSchema = {
-    collections: {},
-    singles: {},
-    components: {},
-  };
-  desired.singles.page = {
-    slug: "page",
-    tableName: "single_page",
-    fields: [],
-    ...entity,
-  } as DesiredSchema["singles"][string];
-  return desired;
+/**
+ * The desired schema declares its fields as `FieldConfig` while the descriptor reads them as
+ * `FieldDefinition`. `build-from-fields.ts` converts at exactly this boundary for the same reason,
+ * so the assertions below go through the descriptor rather than reading the marker property:
+ * the column a field produces is the contract, and how the width is recorded is not.
+ */
+function mysqlType(field: FieldConfig): string | undefined {
+  return getColumnDescriptor(
+    field as unknown as Parameters<typeof getColumnDescriptor>[0],
+    "mysql"
+  )?.dialectType;
 }
 
-function textField(extra: Record<string, unknown> = {}) {
-  return { name: "body", type: "text", ...extra };
+function textField(extra: Record<string, unknown> = {}): FieldConfig {
+  return { name: "body", type: "text", ...extra } as unknown as FieldConfig;
+}
+
+function schemaWith(
+  entity: Partial<DesiredSchema["singles"][string]>
+): DesiredSchema {
+  return {
+    collections: {},
+    singles: {
+      page: {
+        slug: "page",
+        tableName: "single_page",
+        fields: [],
+        ...entity,
+      },
+    },
+    components: {},
+  };
 }
 
 describe("resolveBuilderTextWidths", () => {
-  it("states long for a builder-owned text field that declares no width", () => {
+  // MySQL renders the two kinds 255 characters apart, which is the whole reason this exists.
+  it("leaves a builder-owned text field unbounded on MySQL", () => {
     const desired = schemaWith({ fields: [textField()] });
 
     resolveBuilderTextWidths(desired);
 
-    expect(desired.singles.page.fields[0]).toMatchObject({
-      options: { variant: "long" },
-    });
+    expect(mysqlType(desired.singles.page.fields[0])).toBe("text");
   });
 
-  // The reason this exists: a locked entity's columns were built by the path whose default is the
-  // bounded kind, so rewriting them would make every code-first table read as drift.
-  it("leaves a locked entity alone", () => {
+  // A locked entity's columns were built by the path whose default is the bounded kind, so
+  // rewriting them would make every code-first table read as drift.
+  it("leaves a locked entity on the bounded default", () => {
     const desired = schemaWith({ fields: [textField()], locked: true });
 
     resolveBuilderTextWidths(desired);
 
-    expect(desired.singles.page.fields[0]).not.toHaveProperty(
-      "options.variant"
-    );
+    expect(mysqlType(desired.singles.page.fields[0])).toBe("varchar(255)");
   });
 
   it("resolves every entity, not only the one being saved", () => {
     const desired: DesiredSchema = {
       collections: {
-        posts: {
-          slug: "posts",
-          tableName: "dc_posts",
-          fields: [textField()],
-        } as DesiredSchema["collections"][string],
+        posts: { slug: "posts", tableName: "dc_posts", fields: [textField()] },
       },
       singles: {},
       components: {
-        hero: {
-          slug: "hero",
-          tableName: "comp_hero",
-          fields: [textField()],
-        } as DesiredSchema["components"][string],
+        hero: { slug: "hero", tableName: "comp_hero", fields: [textField()] },
       },
     };
 
     resolveBuilderTextWidths(desired);
 
-    expect(desired.collections.posts.fields[0]).toMatchObject({
-      options: { variant: "long" },
-    });
-    expect(desired.components.hero.fields[0]).toMatchObject({
-      options: { variant: "long" },
-    });
+    expect(mysqlType(desired.collections.posts.fields[0])).toBe("text");
+    expect(mysqlType(desired.components.hero.fields[0])).toBe("text");
   });
 
   it.each([
     ["a stated variant", { options: { variant: "short" } }],
     ["a top-level length", { length: 80 }],
     ["a validation maxLength", { validation: { maxLength: 80 } }],
-  ])("treats %s as the author's answer and leaves it", (_, extra) => {
+  ])("treats %s as the author's answer and leaves it bounded", (_, extra) => {
     const desired = schemaWith({ fields: [textField(extra)] });
 
     resolveBuilderTextWidths(desired);
 
-    expect(desired.singles.page.fields[0]).not.toMatchObject({
-      options: { variant: "long" },
-    });
+    expect(mysqlType(desired.singles.page.fields[0])).toBe("varchar(255)");
   });
 
   // An array cannot carry a variant, and overwriting it with one would discard whatever it held.
   it("leaves a text field whose options is an array untouched", () => {
-    const choices = [{ label: "A", value: "a" }];
-    const desired = schemaWith({
-      fields: [
-        { name: "body", type: "text", options: choices },
-      ] as DesiredSchema["singles"][string]["fields"],
-    });
+    const field = textField({ options: [{ label: "A", value: "a" }] });
+    const desired = schemaWith({ fields: [field] });
 
     resolveBuilderTextWidths(desired);
 
-    expect(desired.singles.page.fields[0].options).toBe(choices);
-  });
-
-  // `options` is the choice array on a select, so a variant can only ever live on an object.
-  it("does not turn a select's options array into an object", () => {
-    const desired = schemaWith({
-      fields: [
-        {
-          name: "choice",
-          type: "select",
-          options: [{ label: "A", value: "a" }],
-        },
-      ] as DesiredSchema["singles"][string]["fields"],
-    });
-
-    resolveBuilderTextWidths(desired);
-
-    expect(Array.isArray(desired.singles.page.fields[0].options)).toBe(true);
+    expect(desired.singles.page.fields[0]).toBe(field);
   });
 
   it("does not widen a type whose width is settled by what it holds", () => {
     const desired = schemaWith({
       fields: [
-        { name: "email", type: "email" },
-        { name: "password", type: "password" },
-      ] as DesiredSchema["singles"][string]["fields"],
+        { name: "email", type: "email" } as unknown as FieldConfig,
+        { name: "password", type: "password" } as unknown as FieldConfig,
+      ],
     });
 
     resolveBuilderTextWidths(desired);
 
     for (const field of desired.singles.page.fields) {
-      expect(field).not.toMatchObject({ options: { variant: "long" } });
+      expect(mysqlType(field)).toBe("varchar(255)");
     }
-  });
-
-  // Why any of this matters: MySQL renders the two kinds 255 characters apart.
-  it("keeps a builder text column unbounded on MySQL", () => {
-    expect(
-      getColumnDescriptor({ name: "body", type: "text" }, "mysql")?.dialectType
-    ).toBe("varchar(255)");
-
-    const desired = schemaWith({ fields: [textField()] });
-    resolveBuilderTextWidths(desired);
-
-    expect(
-      getColumnDescriptor(
-        desired.singles.page.fields[0] as Parameters<
-          typeof getColumnDescriptor
-        >[0],
-        "mysql"
-      )?.dialectType
-    ).toBe("text");
   });
 });

--- a/packages/nextly/src/domains/schema/services/__tests__/builder-text-width.test.ts
+++ b/packages/nextly/src/domains/schema/services/__tests__/builder-text-width.test.ts
@@ -1,99 +1,156 @@
 import { describe, expect, it } from "vitest";
 
-import type { FieldDefinition } from "../../../../schemas/dynamic-collections";
-import { withDeclaredTextWidth } from "../builder-text-width";
+import type { DesiredSchema } from "../../pipeline/types";
+import { resolveBuilderTextWidths } from "../builder-text-width";
 import { getColumnDescriptor } from "../field-column-descriptor";
 
-describe("withDeclaredTextWidth", () => {
-  it("states long for a text field that declares no width", () => {
-    const [field] = withDeclaredTextWidth([{ name: "body", type: "text" }]);
+function schemaWith(entity: Partial<DesiredSchema["singles"][string]>) {
+  const desired: DesiredSchema = {
+    collections: {},
+    singles: {},
+    components: {},
+  };
+  desired.singles.page = {
+    slug: "page",
+    tableName: "single_page",
+    fields: [],
+    ...entity,
+  } as DesiredSchema["singles"][string];
+  return desired;
+}
 
-    expect(field.options?.variant).toBe("long");
+function textField(extra: Record<string, unknown> = {}) {
+  return { name: "body", type: "text", ...extra };
+}
+
+describe("resolveBuilderTextWidths", () => {
+  it("states long for a builder-owned text field that declares no width", () => {
+    const desired = schemaWith({ fields: [textField()] });
+
+    resolveBuilderTextWidths(desired);
+
+    expect(desired.singles.page.fields[0]).toMatchObject({
+      options: { variant: "long" },
+    });
   });
 
-  it("leaves a text field that already states a variant alone", () => {
-    const [field] = withDeclaredTextWidth([
-      { name: "slug", type: "text", options: { variant: "short" } },
-    ]);
+  // The reason this exists: a locked entity's columns were built by the path whose default is the
+  // bounded kind, so rewriting them would make every code-first table read as drift.
+  it("leaves a locked entity alone", () => {
+    const desired = schemaWith({ fields: [textField()], locked: true });
 
-    expect(field.options?.variant).toBe("short");
+    resolveBuilderTextWidths(desired);
+
+    expect(desired.singles.page.fields[0]).not.toHaveProperty(
+      "options.variant"
+    );
+  });
+
+  it("resolves every entity, not only the one being saved", () => {
+    const desired: DesiredSchema = {
+      collections: {
+        posts: {
+          slug: "posts",
+          tableName: "dc_posts",
+          fields: [textField()],
+        } as DesiredSchema["collections"][string],
+      },
+      singles: {},
+      components: {
+        hero: {
+          slug: "hero",
+          tableName: "comp_hero",
+          fields: [textField()],
+        } as DesiredSchema["components"][string],
+      },
+    };
+
+    resolveBuilderTextWidths(desired);
+
+    expect(desired.collections.posts.fields[0]).toMatchObject({
+      options: { variant: "long" },
+    });
+    expect(desired.components.hero.fields[0]).toMatchObject({
+      options: { variant: "long" },
+    });
   });
 
   it.each([
+    ["a stated variant", { options: { variant: "short" } }],
     ["a top-level length", { length: 80 }],
     ["a validation maxLength", { validation: { maxLength: 80 } }],
-  ])(
-    "treats %s as the author's answer and does not overrule it",
-    (_, extra) => {
-      const [field] = withDeclaredTextWidth([
-        { name: "title", type: "text", ...extra },
-      ]);
+  ])("treats %s as the author's answer and leaves it", (_, extra) => {
+    const desired = schemaWith({ fields: [textField(extra)] });
 
-      expect(field.options?.variant).toBeUndefined();
-    }
-  );
+    resolveBuilderTextWidths(desired);
+
+    expect(desired.singles.page.fields[0]).not.toMatchObject({
+      options: { variant: "long" },
+    });
+  });
+
+  // An array cannot carry a variant, and overwriting it with one would discard whatever it held.
+  it("leaves a text field whose options is an array untouched", () => {
+    const choices = [{ label: "A", value: "a" }];
+    const desired = schemaWith({
+      fields: [
+        { name: "body", type: "text", options: choices },
+      ] as DesiredSchema["singles"][string]["fields"],
+    });
+
+    resolveBuilderTextWidths(desired);
+
+    expect(desired.singles.page.fields[0].options).toBe(choices);
+  });
+
+  // `options` is the choice array on a select, so a variant can only ever live on an object.
+  it("does not turn a select's options array into an object", () => {
+    const desired = schemaWith({
+      fields: [
+        {
+          name: "choice",
+          type: "select",
+          options: [{ label: "A", value: "a" }],
+        },
+      ] as DesiredSchema["singles"][string]["fields"],
+    });
+
+    resolveBuilderTextWidths(desired);
+
+    expect(Array.isArray(desired.singles.page.fields[0].options)).toBe(true);
+  });
 
   it("does not widen a type whose width is settled by what it holds", () => {
-    const fields: FieldDefinition[] = [
-      { name: "email", type: "email" },
-      { name: "password", type: "password" },
-      { name: "choice", type: "select" },
-    ];
+    const desired = schemaWith({
+      fields: [
+        { name: "email", type: "email" },
+        { name: "password", type: "password" },
+      ] as DesiredSchema["singles"][string]["fields"],
+    });
 
-    for (const field of withDeclaredTextWidth(fields)) {
-      expect(field.options?.variant).toBeUndefined();
+    resolveBuilderTextWidths(desired);
+
+    for (const field of desired.singles.page.fields) {
+      expect(field).not.toMatchObject({ options: { variant: "long" } });
     }
   });
 
-  it("preserves other options on the field it stamps", () => {
-    const [field] = withDeclaredTextWidth([
-      { name: "body", type: "text", options: { target: "posts" } },
-    ]);
+  // Why any of this matters: MySQL renders the two kinds 255 characters apart.
+  it("keeps a builder text column unbounded on MySQL", () => {
+    expect(
+      getColumnDescriptor({ name: "body", type: "text" }, "mysql")?.dialectType
+    ).toBe("varchar(255)");
 
-    expect(field.options).toEqual({ target: "posts", variant: "long" });
-  });
+    const desired = schemaWith({ fields: [textField()] });
+    resolveBuilderTextWidths(desired);
 
-  // The reason this function exists: MySQL renders the two kinds 255 characters apart, so an
-  // unstated width decides how much text the column can hold.
-  it("keeps a Builder text column unbounded on MySQL", () => {
-    const raw = getColumnDescriptor({ name: "body", type: "text" }, "mysql");
-    expect(raw?.dialectType).toBe("varchar(255)");
-
-    const [stamped] = withDeclaredTextWidth([{ name: "body", type: "text" }]);
-    expect(getColumnDescriptor(stamped, "mysql")?.dialectType).toBe("text");
-  });
-});
-
-describe("getColumnDescriptor — declared width", () => {
-  it.each([
-    ["a top-level length", { length: 500 }],
-    ["a validation maxLength", { validation: { maxLength: 500 } }],
-  ])("renders %s rather than the fallback on MySQL", (_, extra) => {
-    const descriptor = getColumnDescriptor(
-      { name: "title", type: "text", ...extra },
-      "mysql"
-    );
-
-    expect(descriptor?.dialectType).toBe("varchar(500)");
-    expect(descriptor?.length).toBe(500);
-  });
-
-  it("falls back to 255 when the field declares no width", () => {
-    const descriptor = getColumnDescriptor(
-      { name: "title", type: "text" },
-      "mysql"
-    );
-
-    expect(descriptor?.dialectType).toBe("varchar(255)");
-  });
-
-  it("carries a declared width on PostgreSQL, whose text type takes no length", () => {
-    const descriptor = getColumnDescriptor(
-      { name: "title", type: "text", length: 500 },
-      "postgresql"
-    );
-
-    expect(descriptor?.dialectType).toBe("text");
-    expect(descriptor?.length).toBe(500);
+    expect(
+      getColumnDescriptor(
+        desired.singles.page.fields[0] as Parameters<
+          typeof getColumnDescriptor
+        >[0],
+        "mysql"
+      )?.dialectType
+    ).toBe("text");
   });
 });

--- a/packages/nextly/src/domains/schema/services/__tests__/builder-text-width.test.ts
+++ b/packages/nextly/src/domains/schema/services/__tests__/builder-text-width.test.ts
@@ -1,62 +1,163 @@
 import { describe, expect, it } from "vitest";
 
 import { buildDesiredTableFromFields } from "../../pipeline/diff/build-from-fields";
-import { resolveBuilderTextWidths } from "../builder-text-width";
+import type { DesiredSchema } from "../../pipeline/types";
+import { withResolvedBuilderTextWidths } from "../builder-text-width";
 
-/** Widened past the literal so a test can read back the modifiers the resolver writes. */
-function textField(extra: Record<string, unknown> = {}): {
-  name: string;
-  type: string;
-  options?: unknown;
-} {
+function textField(extra: Record<string, unknown> = {}) {
   return { name: "body", type: "text", ...extra };
 }
 
-function bodyType(
-  fields: Parameters<typeof buildDesiredTableFromFields>[1],
-  builderOwned: boolean
-): string | undefined {
-  return buildDesiredTableFromFields("single_page", fields, "mysql", {
-    builderOwned,
-  }).columns.find(c => c.name === "body")?.type;
+function schemaWith(
+  entity: Partial<DesiredSchema["singles"][string]>
+): DesiredSchema {
+  return {
+    collections: {},
+    singles: {
+      page: {
+        slug: "page",
+        tableName: "single_page",
+        fields: [],
+        ...entity,
+      },
+    },
+    components: {},
+  };
 }
 
-// The seam matters as much as the rule: preview and apply each build their own desired schema, and
-// resolving in only one of them reported a destructive type change against an untouched table.
-describe("buildDesiredTableFromFields — builder text width", () => {
-  it("gives a builder-owned text field an unbounded column on MySQL", () => {
-    expect(bodyType([textField()], true)).toBe("text");
+/** What the diff would compare, for the resolved schema's one single. */
+function bodyType(desired: DesiredSchema): string | undefined {
+  const single = desired.singles.page;
+  return buildDesiredTableFromFields(
+    single.tableName,
+    single.fields as unknown as Parameters<
+      typeof buildDesiredTableFromFields
+    >[1],
+    "mysql"
+  ).columns.find(c => c.name === "body")?.type;
+}
+
+describe("withResolvedBuilderTextWidths", () => {
+  // MySQL is the only dialect where the two readings differ, and there they are 65 535 and 255.
+  it("gives a builder-owned text field an unbounded column", () => {
+    const resolved = withResolvedBuilderTextWidths(
+      schemaWith({ fields: [textField()] as never })
+    );
+
+    expect(bodyType(resolved)).toBe("text");
   });
 
-  it("leaves a code-first text field on the bounded default", () => {
-    expect(bodyType([textField()], false)).toBe("varchar(255)");
+  // A locked entity's columns were built by the path whose default is bounded, so rewriting them
+  // would make every code-first table read as drift.
+  it("leaves a locked entity on the bounded default", () => {
+    const resolved = withResolvedBuilderTextWidths(
+      schemaWith({ fields: [textField()] as never, locked: true })
+    );
+
+    expect(bodyType(resolved)).toBe("varchar(255)");
   });
 
   it("keeps a stated short variant bounded", () => {
-    expect(bodyType([textField({ options: { variant: "short" } })], true)).toBe(
-      "varchar(255)"
+    const resolved = withResolvedBuilderTextWidths(
+      schemaWith({
+        fields: [textField({ options: { variant: "short" } })] as never,
+      })
     );
+
+    expect(bodyType(resolved)).toBe("varchar(255)");
   });
 
   // A width the descriptor cannot render must not be read as a decision to stay bounded: doing so
-  // left a field declaring 500 characters in a varchar(255) column, rejecting values its own stored
-  // validation limit accepts.
+  // left a field declaring 500 characters in a varchar(255) column that rejects values its own
+  // stored validation limit accepts.
   it.each([
     ["a validation maxLength", { validation: { maxLength: 500 } }],
     ["a top-level length", { length: 500 }],
   ])("does not treat %s as a reason to stay bounded", (_, extra) => {
-    expect(bodyType([textField(extra)], true)).toBe("text");
+    const resolved = withResolvedBuilderTextWidths(
+      schemaWith({ fields: [textField(extra)] as never })
+    );
+
+    expect(bodyType(resolved)).toBe("text");
+  });
+
+  it("resolves every entity kind, not only the one being saved", () => {
+    const resolved = withResolvedBuilderTextWidths({
+      collections: {
+        posts: {
+          slug: "posts",
+          tableName: "dc_posts",
+          fields: [textField()] as never,
+        },
+      },
+      singles: {},
+      components: {
+        hero: {
+          slug: "hero",
+          tableName: "comp_hero",
+          fields: [textField()] as never,
+        },
+      },
+    });
+
+    for (const entity of [
+      resolved.collections.posts,
+      resolved.components.hero,
+    ]) {
+      expect(entity.fields[0]).toMatchObject({ options: { variant: "long" } });
+    }
+  });
+
+  // The caller's schema is often the registry's own objects, and a preview must leave nothing
+  // changed behind it.
+  it("does not mutate the schema it is given", () => {
+    const original = schemaWith({ fields: [textField()] as never });
+
+    withResolvedBuilderTextWidths(original);
+
+    expect(original.singles.page.fields[0]).not.toHaveProperty(
+      "options.variant"
+    );
+  });
+
+  it("returns the same entity object when nothing needed resolving", () => {
+    const original = schemaWith({
+      fields: [{ name: "n", type: "number" }] as never,
+    });
+
+    const resolved = withResolvedBuilderTextWidths(original);
+
+    expect(resolved.singles.page).toBe(original.singles.page);
+  });
+
+  // An array cannot carry a variant, and overwriting it with one would discard whatever it held.
+  it("leaves a text field whose options is an array untouched", () => {
+    const choices = [{ label: "A", value: "a" }];
+    const original = schemaWith({
+      fields: [textField({ options: choices })] as never,
+    });
+
+    const resolved = withResolvedBuilderTextWidths(original);
+
+    expect(resolved.singles.page.fields[0]).toHaveProperty("options", choices);
   });
 
   it("does not widen a type whose width is settled by what it holds", () => {
+    const resolved = withResolvedBuilderTextWidths(
+      schemaWith({
+        fields: [
+          { name: "email", type: "email" },
+          { name: "choice", type: "select" },
+        ] as never,
+      })
+    );
+
     const table = buildDesiredTableFromFields(
       "single_page",
-      [
-        { name: "email", type: "email" },
-        { name: "choice", type: "select" },
-      ],
-      "mysql",
-      { builderOwned: true }
+      resolved.singles.page.fields as unknown as Parameters<
+        typeof buildDesiredTableFromFields
+      >[1],
+      "mysql"
     );
 
     for (const name of ["email", "choice"]) {
@@ -64,36 +165,5 @@ describe("buildDesiredTableFromFields — builder text width", () => {
         "varchar(255)"
       );
     }
-  });
-});
-
-describe("resolveBuilderTextWidths", () => {
-  it("returns the original array when nothing needs resolving", () => {
-    const fields = [{ name: "n", type: "number" }];
-
-    expect(resolveBuilderTextWidths(fields)).toBe(fields);
-  });
-
-  // Running twice must not differ from running once: the resolved field states a variant, which the
-  // second pass reads as already answered.
-  it("is idempotent", () => {
-    const once = resolveBuilderTextWidths([textField()]);
-
-    expect(resolveBuilderTextWidths(once)).toBe(once);
-  });
-
-  // An array cannot carry a variant, and overwriting it with one would discard whatever it held.
-  it("leaves a text field whose options is an array untouched", () => {
-    const fields = [textField({ options: [{ label: "A", value: "a" }] })];
-
-    expect(resolveBuilderTextWidths(fields)).toBe(fields);
-  });
-
-  it("preserves other modifiers on the field it resolves", () => {
-    const [field] = resolveBuilderTextWidths([
-      textField({ options: { target: "posts" } }),
-    ]);
-
-    expect(field.options).toEqual({ target: "posts", variant: "long" });
   });
 });

--- a/packages/nextly/src/domains/schema/services/builder-text-width.ts
+++ b/packages/nextly/src/domains/schema/services/builder-text-width.ts
@@ -1,3 +1,5 @@
+import type { DesiredSchema } from "../pipeline/types";
+
 /**
  * A text field with no stated width, on an entity the Schema Builder owns, describes an unbounded
  * column.
@@ -13,11 +15,17 @@
  * `nextly migrate` from applying anything. The two paths need different answers because they have
  * different histories, and `locked` already records which history a table has.
  *
- * 🔴 Applied where fields become columns rather than in a request handler. Preview and apply each
- * build their own desired schema, and several handlers build one directly, so any placement further
- * up is a placement one path can miss — which is not hypothetical: resolving this in the create
- * handler alone left preview describing the very column that handler had just created as
- * `varchar(255)`, reporting a destructive type change against a table nobody had touched.
+ * 🔴 Applied to the whole `DesiredSchema` at the entrance to apply and preview, and nowhere else.
+ *
+ * That placement is load-bearing, because a desired schema is read TWICE by two different builders:
+ * `buildDesiredTableFromFields` produces the snapshot the diff compares, and `generateRuntimeSchema`
+ * produces the Drizzle tables drizzle-kit turns into DDL. Resolving inside either one leaves the
+ * other reading the raw fields, and the two then disagree permanently: the diff expects `text` while
+ * the DDL creates `varchar(255)`, so a table converges and immediately reports a type change again.
+ * Normalising the input they share is the only placement that makes them agree by construction.
+ *
+ * Doing it in a request handler is worse still — the handlers are many, and each preview path that
+ * builds its own desired schema would have to remember.
  */
 
 /** The width signals a field can carry, named structurally because callers pass several field types. */
@@ -51,9 +59,7 @@ function modifierOptions(
  * Idempotent: a field this has resolved states a variant, so a second pass leaves it alone. Returns
  * the original array when nothing needed resolving.
  */
-export function resolveBuilderTextWidths<T>(
-  fields: readonly T[]
-): readonly T[] {
+function resolveFieldWidths<T>(fields: readonly T[]): readonly T[] {
   let changed = false;
 
   const out = fields.map(field => {
@@ -69,4 +75,41 @@ export function resolveBuilderTextWidths<T>(
   });
 
   return changed ? out : fields;
+}
+
+/**
+ * Return a desired schema whose Builder-owned entities state the width of every text field.
+ *
+ * A `locked` entity is owned by code-first config or a plugin, and its columns were built by the
+ * path whose default is the bounded kind. Rewriting those would make every code-first table read as
+ * drift and stop `nextly migrate` applying anything, so they are left exactly as they are.
+ *
+ * Copies rather than mutates: the caller's schema is often the registry's own objects, and a
+ * preview must not leave a field changed behind it.
+ */
+export function withResolvedBuilderTextWidths(
+  desired: DesiredSchema
+): DesiredSchema {
+  const resolveGroup = <
+    E extends { fields: readonly unknown[]; locked?: boolean },
+  >(
+    group: Record<string, E>
+  ): Record<string, E> => {
+    const out: Record<string, E> = {};
+    for (const [key, entity] of Object.entries(group)) {
+      if (entity.locked === true) {
+        out[key] = entity;
+        continue;
+      }
+      const fields = resolveFieldWidths(entity.fields);
+      out[key] = fields === entity.fields ? entity : { ...entity, fields };
+    }
+    return out;
+  };
+
+  return {
+    collections: resolveGroup(desired.collections),
+    singles: resolveGroup(desired.singles),
+    components: resolveGroup(desired.components),
+  };
 }

--- a/packages/nextly/src/domains/schema/services/builder-text-width.ts
+++ b/packages/nextly/src/domains/schema/services/builder-text-width.ts
@@ -1,42 +1,84 @@
-import type { FieldDefinition } from "../../../schemas/dynamic-collections";
+import type { DesiredSchema } from "../pipeline/types";
 
 /**
- * State the width of a Schema Builder text field that does not state one itself.
+ * A text field with no declared width, on an entity the Schema Builder owns, describes an unbounded
+ * column.
  *
- * `getColumnDescriptor` reads an unstated width as the bounded kind, which renders `varchar(255)`
- * on MySQL. The generator the Builder's create path used before it moved onto the shared pipeline
- * read the same silence as unbounded `TEXT`. Both answers are defensible, but they are 255 and
- * 65 535 characters apart, so leaving the silence to be interpreted means a field created before
- * the move and an identical field created after it hold different amounts of text.
+ * `getColumnDescriptor` reads an unstated width as the bounded kind, which renders `varchar(255)` on
+ * MySQL. The generator the Builder's create path used before it moved onto the shared pipeline read
+ * the same silence as unbounded `TEXT`. Both are defensible, but they are 255 and 65 535 characters
+ * apart, so leaving the silence to be interpreted means a field created before the move and an
+ * identical field created after it hold different amounts of text.
  *
- * Resolving it here rather than by changing the descriptor's default is deliberate: the default is
- * also what every code-first table was built with, and moving it would make those tables read as
- * drift and stop `nextly migrate` from applying anything. The two paths need different answers
- * because they have different histories, so the one that needs the non-default says so explicitly.
+ * Resolving it by changing the descriptor's default instead would be wrong: that default is also
+ * what every **code-first** table was built with, so moving it would make all of them read as drift
+ * and stop `nextly migrate` from applying anything. The two paths need different answers because
+ * they have different histories.
  *
- * A field that declares a width is returned untouched — that width is the author's answer, and the
- * descriptor renders it.
- *
- * Typed on `FieldDefinition` rather than on the create handlers' `FieldConfig`, because `options`
- * means different things in the two: here it holds the Builder's `variant`, while on a
- * `SelectFieldConfig` it holds the list of choices. The handlers annotate their payload as
- * `FieldConfig` but receive the Builder shape, which is why they already convert before reading it.
+ * Which history a table has is already recorded. `locked` marks an entity as owned by code-first
+ * config or a plugin, so an unlocked entity is one the Builder created, and its unstated widths are
+ * the Builder's. Reading that flag keeps the decision derivable from stored state rather than
+ * carried in a field payload — which matters twice over: the payload schema declares `options` as
+ * the select/radio choice **array**, so a marker written there fails validation, and only the
+ * entity being saved passes through a handler while the diff compares every entity at once.
  */
-export function withDeclaredTextWidth(
-  fields: readonly FieldDefinition[]
-): FieldDefinition[] {
+export function resolveBuilderTextWidths(desired: DesiredSchema): void {
+  for (const group of [
+    desired.collections,
+    desired.singles,
+    desired.components,
+  ]) {
+    for (const entity of Object.values(group)) {
+      // A locked entity is code-first or plugin-owned, and its columns were built by the path whose
+      // default is the bounded kind. Rewriting those would make every one of them read as drift.
+      if (entity.locked === true) continue;
+      entity.fields = widenUnstatedText(entity.fields);
+    }
+  }
+}
+
+/**
+ * The width signals a field can carry, named structurally because the desired schema's three entity
+ * kinds each declare their own field element type.
+ */
+interface WidthSignals {
+  type?: string;
+  length?: number;
+  options?: unknown;
+  validation?: { maxLength?: number } | null;
+}
+
+/** An `options` value a variant can be written onto without destroying what is already there. */
+function modifierOptions(
+  options: unknown
+): Record<string, unknown> | undefined {
+  if (options === undefined) return {};
+  // `options` is the choice array on a select or radio and an object of modifiers elsewhere. An
+  // array cannot carry a variant, and replacing it with one would discard the choices, so a field
+  // holding one is left exactly as it is.
+  if (options === null || typeof options !== "object") return undefined;
+  if (Array.isArray(options)) return undefined;
+  return { ...(options as Record<string, unknown>) };
+}
+
+function statesWidth(
+  field: WidthSignals,
+  options: Record<string, unknown>
+): boolean {
+  if (field.length !== undefined) return true;
+  if (typeof field.validation?.maxLength === "number") return true;
+  return options.variant !== undefined;
+}
+
+function widenUnstatedText<T>(fields: readonly T[]): T[] {
   return fields.map(field => {
-    if (field.type !== "text") return field;
+    const candidate = field as T & WidthSignals;
+    if (candidate.type !== "text") return field;
 
-    const statesWidth =
-      field.options?.variant !== undefined ||
-      field.length !== undefined ||
-      field.validation?.maxLength !== undefined;
-    if (statesWidth) return field;
+    const options = modifierOptions(candidate.options);
+    if (options === undefined) return field;
+    if (statesWidth(candidate, options)) return field;
 
-    return {
-      ...field,
-      options: { ...field.options, variant: "long" as const },
-    };
+    return { ...candidate, options: { ...options, variant: "long" } };
   });
 }

--- a/packages/nextly/src/domains/schema/services/builder-text-width.ts
+++ b/packages/nextly/src/domains/schema/services/builder-text-width.ts
@@ -1,7 +1,5 @@
-import type { DesiredSchema } from "../pipeline/types";
-
 /**
- * A text field with no declared width, on an entity the Schema Builder owns, describes an unbounded
+ * A text field with no stated width, on an entity the Schema Builder owns, describes an unbounded
  * column.
  *
  * `getColumnDescriptor` reads an unstated width as the bounded kind, which renders `varchar(255)` on
@@ -10,42 +8,22 @@ import type { DesiredSchema } from "../pipeline/types";
  * apart, so leaving the silence to be interpreted means a field created before the move and an
  * identical field created after it hold different amounts of text.
  *
- * Resolving it by changing the descriptor's default instead would be wrong: that default is also
- * what every **code-first** table was built with, so moving it would make all of them read as drift
- * and stop `nextly migrate` from applying anything. The two paths need different answers because
- * they have different histories.
+ * Changing the descriptor's default instead would be wrong: that default is also what every
+ * code-first table was built with, so moving it would make all of them read as drift and stop
+ * `nextly migrate` from applying anything. The two paths need different answers because they have
+ * different histories, and `locked` already records which history a table has.
  *
- * Which history a table has is already recorded. `locked` marks an entity as owned by code-first
- * config or a plugin, so an unlocked entity is one the Builder created, and its unstated widths are
- * the Builder's. Reading that flag keeps the decision derivable from stored state rather than
- * carried in a field payload — which matters twice over: the payload schema declares `options` as
- * the select/radio choice **array**, so a marker written there fails validation, and only the
- * entity being saved passes through a handler while the diff compares every entity at once.
+ * 🔴 Applied where fields become columns rather than in a request handler. Preview and apply each
+ * build their own desired schema, and several handlers build one directly, so any placement further
+ * up is a placement one path can miss — which is not hypothetical: resolving this in the create
+ * handler alone left preview describing the very column that handler had just created as
+ * `varchar(255)`, reporting a destructive type change against a table nobody had touched.
  */
-export function resolveBuilderTextWidths(desired: DesiredSchema): void {
-  for (const group of [
-    desired.collections,
-    desired.singles,
-    desired.components,
-  ]) {
-    for (const entity of Object.values(group)) {
-      // A locked entity is code-first or plugin-owned, and its columns were built by the path whose
-      // default is the bounded kind. Rewriting those would make every one of them read as drift.
-      if (entity.locked === true) continue;
-      entity.fields = widenUnstatedText(entity.fields);
-    }
-  }
-}
 
-/**
- * The width signals a field can carry, named structurally because the desired schema's three entity
- * kinds each declare their own field element type.
- */
+/** The width signals a field can carry, named structurally because callers pass several field types. */
 interface WidthSignals {
   type?: string;
-  length?: number;
   options?: unknown;
-  validation?: { maxLength?: number } | null;
 }
 
 /** An `options` value a variant can be written onto without destroying what is already there. */
@@ -61,24 +39,34 @@ function modifierOptions(
   return { ...(options as Record<string, unknown>) };
 }
 
-function statesWidth(
-  field: WidthSignals,
-  options: Record<string, unknown>
-): boolean {
-  if (field.length !== undefined) return true;
-  if (typeof field.validation?.maxLength === "number") return true;
-  return options.variant !== undefined;
-}
+/**
+ * Resolve the width of every unstated text field in a Builder-owned entity's field list.
+ *
+ * Only an explicit `variant` counts as stating the width. A `maxLength` or a `length` deliberately
+ * does NOT, because the descriptor renders neither: treating one as authoritative would leave a
+ * field declaring 500 characters in a `varchar(255)` column, rejecting values the stored validation
+ * limit accepts. Until a width can survive the diff, the honest reading of an unstated field is
+ * unbounded — wider than a bounded column, and never narrower than the data it is asked to hold.
+ *
+ * Idempotent: a field this has resolved states a variant, so a second pass leaves it alone. Returns
+ * the original array when nothing needed resolving.
+ */
+export function resolveBuilderTextWidths<T>(
+  fields: readonly T[]
+): readonly T[] {
+  let changed = false;
 
-function widenUnstatedText<T>(fields: readonly T[]): T[] {
-  return fields.map(field => {
+  const out = fields.map(field => {
     const candidate = field as T & WidthSignals;
     if (candidate.type !== "text") return field;
 
     const options = modifierOptions(candidate.options);
     if (options === undefined) return field;
-    if (statesWidth(candidate, options)) return field;
+    if (options.variant !== undefined) return field;
 
+    changed = true;
     return { ...candidate, options: { ...options, variant: "long" } };
   });
+
+  return changed ? out : fields;
 }

--- a/packages/nextly/src/domains/schema/services/builder-text-width.ts
+++ b/packages/nextly/src/domains/schema/services/builder-text-width.ts
@@ -80,9 +80,9 @@ function resolveFieldWidths<T>(fields: readonly T[]): readonly T[] {
 /**
  * Return a desired schema whose Builder-owned entities state the width of every text field.
  *
- * A `locked` entity is owned by code-first config or a plugin, and its columns were built by the
- * path whose default is the bounded kind. Rewriting those would make every code-first table read as
- * drift and stop `nextly migrate` applying anything, so they are left exactly as they are.
+ * An entity that does not state Builder ownership is left exactly as it is. Its columns were built
+ * by the path whose default is the bounded kind, and rewriting those would make every code-first
+ * table read as drift and stop `nextly migrate` applying anything.
  *
  * Copies rather than mutates: the caller's schema is often the registry's own objects, and a
  * preview must not leave a field changed behind it.
@@ -91,13 +91,16 @@ export function withResolvedBuilderTextWidths(
   desired: DesiredSchema
 ): DesiredSchema {
   const resolveGroup = <
-    E extends { fields: readonly unknown[]; locked?: boolean },
+    E extends { fields: readonly unknown[]; builderOwned?: boolean },
   >(
     group: Record<string, E>
   ): Record<string, E> => {
     const out: Record<string, E> = {};
     for (const [key, entity] of Object.entries(group)) {
-      if (entity.locked === true) {
+      // Explicit, never inferred. Most snapshot builders omit any ownership flag, so anything other
+      // than a stated yes has to mean code-first: the alternative reclassified every code-first
+      // entity on the HMR and db:sync paths and would have widened their columns.
+      if (entity.builderOwned !== true) {
         out[key] = entity;
         continue;
       }

--- a/packages/nextly/src/domains/schema/services/builder-text-width.ts
+++ b/packages/nextly/src/domains/schema/services/builder-text-width.ts
@@ -1,0 +1,42 @@
+import type { FieldDefinition } from "../../../schemas/dynamic-collections";
+
+/**
+ * State the width of a Schema Builder text field that does not state one itself.
+ *
+ * `getColumnDescriptor` reads an unstated width as the bounded kind, which renders `varchar(255)`
+ * on MySQL. The generator the Builder's create path used before it moved onto the shared pipeline
+ * read the same silence as unbounded `TEXT`. Both answers are defensible, but they are 255 and
+ * 65 535 characters apart, so leaving the silence to be interpreted means a field created before
+ * the move and an identical field created after it hold different amounts of text.
+ *
+ * Resolving it here rather than by changing the descriptor's default is deliberate: the default is
+ * also what every code-first table was built with, and moving it would make those tables read as
+ * drift and stop `nextly migrate` from applying anything. The two paths need different answers
+ * because they have different histories, so the one that needs the non-default says so explicitly.
+ *
+ * A field that declares a width is returned untouched — that width is the author's answer, and the
+ * descriptor renders it.
+ *
+ * Typed on `FieldDefinition` rather than on the create handlers' `FieldConfig`, because `options`
+ * means different things in the two: here it holds the Builder's `variant`, while on a
+ * `SelectFieldConfig` it holds the list of choices. The handlers annotate their payload as
+ * `FieldConfig` but receive the Builder shape, which is why they already convert before reading it.
+ */
+export function withDeclaredTextWidth(
+  fields: readonly FieldDefinition[]
+): FieldDefinition[] {
+  return fields.map(field => {
+    if (field.type !== "text") return field;
+
+    const statesWidth =
+      field.options?.variant !== undefined ||
+      field.length !== undefined ||
+      field.validation?.maxLength !== undefined;
+    if (statesWidth) return field;
+
+    return {
+      ...field,
+      options: { ...field.options, variant: "long" as const },
+    };
+  });
+}

--- a/packages/nextly/src/domains/schema/services/field-column-descriptor.test.ts
+++ b/packages/nextly/src/domains/schema/services/field-column-descriptor.test.ts
@@ -126,3 +126,52 @@ describe("getColumnDescriptor: number storage", () => {
     }
   });
 });
+
+// Free text is the one field type whose width is not settled by what it holds. On MySQL the two
+// renderings are 255 characters apart, so a field that knows it is unbounded has to be able to say
+// so rather than discover the ceiling when an editor's paste is rejected by the database.
+describe("a text field may state its own width", () => {
+  const textField = (variant?: "short" | "long") =>
+    ({
+      name: "body",
+      type: "text",
+      ...(variant ? { options: { variant } } : {}),
+    }) as never;
+
+  it("renders the wide type on every dialect when the field says it is long", () => {
+    expect(getColumnDescriptor(textField("long"), "mysql")?.kind).toBe(
+      "longText"
+    );
+    expect(getColumnDescriptor(textField("long"), "postgresql")?.kind).toBe(
+      "longText"
+    );
+    expect(getColumnDescriptor(textField("long"), "sqlite")?.kind).toBe(
+      "longText"
+    );
+  });
+
+  // 🔴 Absent, the answer must not move. Every table already created through this path has the
+  // narrow kind, and changing it would make each of them read as drift on the next diff.
+  it("keeps the existing kind when the field says nothing", () => {
+    for (const dialect of ["postgresql", "mysql", "sqlite"] as const) {
+      expect(getColumnDescriptor(textField(), dialect)?.kind).toBe("text");
+    }
+  });
+
+  it("keeps the existing kind when the field says it is short", () => {
+    expect(getColumnDescriptor(textField("short"), "mysql")?.kind).toBe("text");
+  });
+
+  // The signal belongs to free text alone. These are bounded by what they store, and widening them
+  // would cost MySQL the index it can build on a varchar.
+  it("ignores the signal on types whose width their content settles", () => {
+    for (const type of ["email", "password", "select", "radio"]) {
+      const field = {
+        name: "f",
+        type,
+        options: { variant: "long" },
+      } as never;
+      expect(getColumnDescriptor(field, "mysql")?.kind).toBe("text");
+    }
+  });
+});

--- a/packages/nextly/src/domains/schema/services/field-column-descriptor.ts
+++ b/packages/nextly/src/domains/schema/services/field-column-descriptor.ts
@@ -152,12 +152,16 @@ export function getColumnDescriptor(
         }
       : undefined;
 
+  // Resolved before the type is rendered, because on MySQL the width IS part of the type: a
+  // bounded column declaring 500 renders `varchar(500)`, and computing the length afterwards
+  // left every one of them rendering the default 255 instead.
+  const length = lengthForKind(kind, field);
+
   const dialectType = renderDialectType(kind, dialect, {
-    length: undefined,
+    length,
     precision: decimal?.precision,
     scale: decimal?.scale,
   });
-  const length = lengthForKind(kind);
 
   return {
     name,
@@ -342,9 +346,21 @@ function renderDialectType(
  * Returns the length for kinds that carry one. Used by both the
  * dialect-token rendering and the runtime Drizzle builder.
  */
-function lengthForKind(kind: ColumnKind): number | undefined {
-  if (kind === "text") return 255;
-  if (kind === "varchar") return 255;
+function lengthForKind(
+  kind: ColumnKind,
+  field: FieldDefinition
+): number | undefined {
+  if (kind === "text" || kind === "varchar") {
+    // A width the field declares is the author's answer and outranks the fallback. Both generators
+    // this descriptor replaces rendered it, so ignoring it here would silently cut a column sized
+    // at 500 down to 255 on MySQL.
+    //
+    // Widths are invisible to the convergence diff — `normalize-type.ts` strips the modifier before
+    // comparing, because the live introspector reads a type name that never carries one. So
+    // honouring a declared width changes what a NEW column is created as without making any
+    // existing column read as drift.
+    return field.length ?? field.validation?.maxLength ?? 255;
+  }
   if (kind === "fkSingle") return 36;
   return undefined;
 }

--- a/packages/nextly/src/domains/schema/services/field-column-descriptor.ts
+++ b/packages/nextly/src/domains/schema/services/field-column-descriptor.ts
@@ -179,6 +179,15 @@ export function getColumnDescriptor(
 function classifyFieldKind(field: FieldDefinition): ColumnKind {
   switch (field.type) {
     case "text":
+      // A text field may state its own width, and only this type may: an email, a password and a
+      // select value are bounded by what they hold, while free text is bounded by nothing.
+      //
+      // Absent, the answer stays what it has always been for this path. The signal exists so a
+      // caller that KNOWS the field is unbounded can say so instead of discovering the ceiling
+      // when a paste is rejected — on MySQL the two render 255 characters apart.
+      if (field.options?.variant === "long") return "longText";
+      return "text";
+
     case "email":
     case "password":
     case "select":

--- a/packages/nextly/src/domains/schema/services/field-column-descriptor.ts
+++ b/packages/nextly/src/domains/schema/services/field-column-descriptor.ts
@@ -152,10 +152,7 @@ export function getColumnDescriptor(
         }
       : undefined;
 
-  // Resolved before the type is rendered, because on MySQL the width IS part of the type: a
-  // bounded column declaring 500 renders `varchar(500)`, and computing the length afterwards
-  // left every one of them rendering the default 255 instead.
-  const length = lengthForKind(kind, field);
+  const length = lengthForKind(kind);
 
   const dialectType = renderDialectType(kind, dialect, {
     length,
@@ -346,21 +343,14 @@ function renderDialectType(
  * Returns the length for kinds that carry one. Used by both the
  * dialect-token rendering and the runtime Drizzle builder.
  */
-function lengthForKind(
-  kind: ColumnKind,
-  field: FieldDefinition
-): number | undefined {
-  if (kind === "text" || kind === "varchar") {
-    // A width the field declares is the author's answer and outranks the fallback. Both generators
-    // this descriptor replaces rendered it, so ignoring it here would silently cut a column sized
-    // at 500 down to 255 on MySQL.
-    //
-    // Widths are invisible to the convergence diff — `normalize-type.ts` strips the modifier before
-    // comparing, because the live introspector reads a type name that never carries one. So
-    // honouring a declared width changes what a NEW column is created as without making any
-    // existing column read as drift.
-    return field.length ?? field.validation?.maxLength ?? 255;
-  }
+function lengthForKind(kind: ColumnKind): number | undefined {
+  // A width the field declares is deliberately NOT read here. `normalize-type.ts` strips the
+  // modifier before the diff compares, so a bounded column's width is invisible to convergence:
+  // rendering a declared width would size a column correctly on creation and then silently ignore
+  // every later edit to it, leaving writes to fail against a column the stored limit says is wide
+  // enough. Resizing needs the diff to compare widths first.
+  if (kind === "text") return 255;
+  if (kind === "varchar") return 255;
   if (kind === "fkSingle") return 36;
   return undefined;
 }

--- a/packages/nextly/src/init/reload-config.ts
+++ b/packages/nextly/src/init/reload-config.ts
@@ -1979,6 +1979,10 @@ async function applyReload(opts?: {
           tableName: s.tableName,
           fields: (s.fields ?? []) as DesiredSingle["fields"],
           status: s.status === true,
+          // Read out of the registry, so this is a single the Schema Builder created — the code
+          // config above already claimed every code-first slug. Stating it keeps its columns
+          // described the same way here as on the path that created them.
+          builderOwned: true,
         };
       }
     }
@@ -2005,6 +2009,9 @@ async function applyReload(opts?: {
           slug: c.slug,
           tableName: c.tableName,
           fields: (c.fields ?? []) as DesiredFieldGroup["fields"],
+          // Registry-sourced, so Builder-authored: the code config above already claimed every
+          // code-first slug.
+          builderOwned: true,
         };
       }
     }

--- a/packages/nextly/src/runtime/notifications/types.ts
+++ b/packages/nextly/src/runtime/notifications/types.ts
@@ -8,6 +8,7 @@
 export type MigrationScope =
   | { kind: "collection"; slug: string }
   | { kind: "single"; slug: string }
+  | { kind: "component"; slug: string }
   | { kind: "global"; slug?: string }
   | { kind: "fresh-push" };
 


### PR DESCRIPTION
Unifies the DDL the Schema Builder issues when it **creates** an entity with the DDL it already issued when it **saves** one.

Before this, editing an entity converged through the shared pipeline while creating one generated its own SQL and executed it directly. Three consequences: the same field type could produce two different columns depending on which action made it, a created table could differ from an identical code-first definition on indexes, and a create left no row in the schema journal at all.

## Commits, in review order

**1. `let a text field state whether it is short or long`**
Free text is the one field type whose width is not settled by what it holds. The signal (`options.variant`) already existed and only the legacy builder mapper read it. Purely additive: absent, the kind is unchanged.

**2. `route builder-created schema through the shared pipeline`**
Field groups and singles create through `applyBuilderSchema`, a single seam. The direct update handler loses its create-or-alter branch (the pipeline diffs the declared shape against what the database actually has, so a missing table produces a create from the same declaration). Both copies of the raw statement executor and the alter generator they fed are gone.

**3. `keep a builder text column as wide as it was`**
Commit 2 alone shipped a regression, caught before it left the branch. The generator it replaced read a text field with no declared width as unbounded `TEXT`; the descriptor reads the same silence as bounded, which on MySQL renders `varchar(255)`. That is 65 535 versus 255 characters for the same field.

**4. `resolve builder text widths on the schema, not the payload`** — Codex round 1, all 7 findings confirmed and fixed by root cause.

**5-6. `resolve builder text widths where fields become columns`** — Codex round 2. The width rule moved again, this time to the seam where a field becomes a column.

## Why this is the shape it is

The obvious fix — default an unstated width to "long" globally — was considered and rejected. That default is also what every **code-first** MySQL table was built with, so moving it would make all of them read as drift and stop `nextly migrate` from applying anything. The two paths need different answers because they have different histories.

My first attempt stated the width on the **payload**. Review showed two reasons that layer is wrong, and commit 4 moves it:

- the payload schema declares `options` as the select/radio choice **array**, so a marker written there fails `assertValidFieldsPayload` and broke every settings-only save carrying a text field
- a payload is one entity, but the pipeline diffs **every** managed table, so a save could describe an unrelated Builder-owned table's unbounded column as bounded and narrow a table nobody edited

Round 2 showed that fix was still one layer too high: **seven** other `buildFullDesiredSchema` call sites — every preview/apply handler — never called it, so preview described a column the create path had just made `TEXT` as `varchar(255)` and reported a destructive type change against an untouched table.

The rule now lives in `buildDesiredTableFromFields` and `buildDesiredTableFromComponentFields`, behind a `builderOwned` option the four Builder diff sites derive from `locked`. That is the one place every field becomes a column, so a path that builds its own desired schema cannot skip it.

**Only an explicit `variant` states a width.** A `maxLength` deliberately does not: the descriptor renders no width, so treating one as authoritative left a field declaring 500 characters in a `varchar(255)` column that rejects values its own stored limit accepts. A signal the column cannot express must not decide the column.

**Honouring a declared `maxLength` is reverted.** The property I cited as making it safe — widths are stripped before the diff compares — is the same one that makes edits invisible: a column created at 80 is never resized when the limit becomes 500, and writes in between fail with nothing reporting why. Create-works/edit-silently-doesn't is worse than not shipping it. Resizing needs the diff to compare widths first (084/107).

## Scope: collections are deliberately not included

They are not the same shape. `collection-metadata-service.ts` has three `runMigration` sites, all gated on `isDevelopment()`, and the caller both writes a `.sql` file and executes it. Routing only the execution through the pipeline would leave the persisted artifact and the applied schema produced by two mappers that disagree — worse than today, where both come from the same SQL. Whether that artifact should exist is task 040's question, and `mapFieldTypeToSQL` cannot be deleted before it is answered.

Critically, collections do **not** block the migration lock this work exists to enable: `collection-dispatcher` delegates to one service method that does the DDL *and* the registry write, so a lock there already holds rather than samples. That was the specific objection for field groups and singles, and this PR resolves it for them.

## Also fixed from review

- The update path no longer restates `title`/`slug`/`updatedAt` as **user** fields. Those existed for a generator that did not inject system columns; `build-from-fields.ts:224` does. Restating them described one physical column twice and the user definition won the name map without the system default. The create path never restated them, so the two paths now describe a single identically.
- A journal row records **which kind** of entity a UI save targeted. `computeJournalScope` returned `{ kind: "collection" }` for every UI target, so single and field-group migrations were unfindable under their own scope. `applyBuilderSchema` now requires `kind`, making the type checker the completeness proof.
- 🔴 **Behaviour change:** a single whose schema apply fails now **throws** instead of returning success with `migrationStatus: "failed"`. The field definitions were being persisted regardless, so the registry described columns the table did not have and the next save diffed against a shape never applied.
- **Locked-table operations are excluded before rename detection**, not after prompting. They reached the prompt gate on the way, and an unresolved rename candidate fails closed, so unapplied drift on a code-first table could refuse an entire Builder save over operations the next step discards.
- **The MySQL database name comes from the connection**, not `process.env.DATABASE_URL`, so a programmatically-constructed adapter no longer fails the apply and leaves an entity registered with no table.

## Reviewer note

`applyBuilderSchema` converges the full desired schema where the create path it replaced executed statements for one table. The Builder's save path already behaved this way, so the widening is in reach rather than in kind.

Whether an unambiguous rename should auto-resolve on the direct update endpoint is deliberately **not** decided here. That endpoint carries no resolution channel; the Builder's `applySchema` handler does, and that is where the question belongs.

**Two review findings are answered rather than fixed, both stated on their threads:**
- *No `withMigrationExcluded` around Builder applies.* Correct, and it is what this PR exists to enable: the guard needs one seam to hold, and there were three. The engine that would race it is dark (`runFieldGroupMigration` has no non-test caller), so nothing can be in flight. The lock is the next slice.
- *The journal reports success before companion provisioning.* Real. The fix needs an `afterApply` step inside `PushSchemaPipeline.apply`, because that is where the journal lifecycle lives — a shared-contract change that deserves its own PR. Impact is an inaccurate audit row on a rare path, not data loss.

## Verification

- `pnpm build` 17/17, `pnpm check-types --force` 19/19, `pnpm lint` exit 0
- Full `packages/nextly` unit run diffed at test-name level against a baseline freshly measured from `origin/main` @ `387061eb8` in its own installed and built worktree: **397 failures on both sides, zero branch-only, zero disappeared** (re-run after the round-1 fixes, same result)
- New tests proven load-bearing by breaking each half of the change and confirming the intended tests fail with the count unchanged
- Local MySQL integration showed 2 failures in RBAC suites that pass in isolation and pass in CI against a fresh database, so they are shared-database residue rather than a branch regression.

## Still open in this task

Index restore for the singles/field-group `db:sync` corner, and the cross-dialect golden tests, are not in this PR yet.
