### PR TITLE
fix(nextly): compare reserved names as the column they become

### DIFF
--- a/.changeset/normalized-column-reservations.md
+++ b/.changeset/normalized-column-reservations.md
@@ -24,8 +24,11 @@
 
 Catch every spelling of a Field Group field name that collides with one of its table's system
 columns, not only the two that were listed. `CreatedAt` reaches the same `created_at` column as
-`createdAt` does, and was accepted. Names are now compared as the column they become.
+`createdAt` does, and was accepted. Names are now compared as the column they become, so a field
+declared with a plugin-contributed type is checked too — its type registers after the config is
+read, and it was previously skipped.
 
-A Field Group field that references another Field Group may take any name again. Those keep their
-data in the referenced table and produce no column of their own, so the previous check refused
-configurations that work — and, because it runs at startup, could stop an application booting.
+A Field Group field that references another Field Group may take any name except `id`. Those keep
+their data in the referenced table and produce no column of their own, so the previous check
+refused configurations that work. `id` stays reserved because an instance uses it for its own
+identity.

--- a/.changeset/normalized-column-reservations.md
+++ b/.changeset/normalized-column-reservations.md
@@ -28,7 +28,7 @@ columns, not only the two that were listed. `CreatedAt` reaches the same `create
 declared with a plugin-contributed type is checked too — its type registers after the config is
 read, and it was previously skipped.
 
-A Field Group field that references another Field Group may take any name except `id`. Those keep
-their data in the referenced table and produce no column of their own, so the previous check
-refused configurations that work. `id` stays reserved because an instance uses it for its own
-identity.
+A Field Group field that references another Field Group may take any name that a Field Group
+instance does not already use for itself: not `id`, which is the instance's own identity, and not a
+name that converts to `created_at` or `updated_at`, which a read would fill with the row's
+timestamp instead of the referenced data.

--- a/.changeset/normalized-column-reservations.md
+++ b/.changeset/normalized-column-reservations.md
@@ -1,0 +1,31 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+Catch every spelling of a Field Group field name that collides with one of its table's system
+columns, not only the two that were listed. `CreatedAt` reaches the same `created_at` column as
+`createdAt` does, and was accepted. Names are now compared as the column they become.
+
+A Field Group field that references another Field Group may take any name again. Those keep their
+data in the referenced table and produce no column of their own, so the previous check refused
+configurations that work — and, because it runs at startup, could stop an application booting.

--- a/packages/nextly/src/field-groups/config/validate-field-group.ts
+++ b/packages/nextly/src/field-groups/config/validate-field-group.ts
@@ -26,9 +26,18 @@
  */
 
 import { RESERVED_SLUGS } from "../../collections/config/validate-config";
+import {
+  isDataField,
+  isFieldGroupField,
+} from "../../collections/fields/guards";
+import type { FieldConfig } from "../../collections/fields/types";
 import { isPluginFieldTypeOnSurface } from "../../domains/schema/field-types/field-type-registry";
+import { isPluginDataField } from "../../domains/schema/services/plugin-codegen";
 import { NextlyError } from "../../errors";
-import { reservedSystemFieldNames } from "../../lib/system-columns";
+import {
+  isReservedSystemColumn,
+  toPhysicalColumnName,
+} from "../../lib/system-columns";
 import {
   type BaseValidationError,
   DEFAULT_SQL_KEYWORDS_SET,
@@ -315,22 +324,31 @@ function validateFields(
     return;
   }
 
-  // Block the injected system columns at the top level, before per-field validation. A field group
-  // keeps its values in a table of its own carrying these three, and a name that snake-cases onto
-  // one is emitted alongside the injected column: the CREATE TABLE then declares it twice and the
-  // database refuses the statement, so the group could never have been created. Refusing the name
-  // reports that where it is chosen rather than as a migration failure. Nested fields live inside
-  // JSON and are exempt, as they are for collections.
+  // Block names that collide with a column this group's table already carries. Such a field is
+  // emitted alongside the injected column, so the CREATE TABLE declares it twice and the database
+  // refuses the statement — the group could never have been created, and refusing the name reports
+  // that where it is chosen rather than as a migration failure.
+  //
+  // Compared as the PHYSICAL column rather than as a spelling, because a field name reaches the
+  // column through the generator's own conversion: `createdAt` and `CreatedAt` both arrive at
+  // `created_at`, and a set of literal spellings can only ever hold the ones somebody listed.
+  //
+  // Only fields that actually emit a column are checked. A field group referencing another group
+  // keeps its data in the referenced table and the generator emits nothing for it, so its name
+  // never reaches a column and refusing it would reject a configuration that works.
   fields.forEach((field, index) => {
     if (!field || typeof field !== "object") return;
+    const candidate = field as FieldConfig;
+    if (!isDataField(candidate) && !isPluginDataField(candidate)) return;
+    if (isFieldGroupField(candidate)) return;
+
     const name = (field as Record<string, unknown>).name;
-    if (
-      typeof name === "string" &&
-      FIELD_GROUP_RESERVED_FIELD_NAMES.has(name)
-    ) {
+    if (typeof name !== "string") return;
+    const column = toPhysicalColumnName(name);
+    if (isReservedSystemColumn(column, "fieldGroupConfig")) {
       errors.push({
         path: `${path}[${index}].name`,
-        message: `Field name '${name}' is reserved for a system column`,
+        message: `Field name '${name}' is reserved: it becomes the system column '${column}'`,
         code: "FIELD_NAME_RESERVED",
       });
     }
@@ -342,10 +360,6 @@ function validateFields(
   // a usable table and an author can scaffold first and add fields later.
   validateFieldsArray(fields, path, errors);
 }
-
-const FIELD_GROUP_RESERVED_FIELD_NAMES: ReadonlySet<string> = new Set(
-  reservedSystemFieldNames("fieldGroupConfig")
-);
 
 // ============================================================
 // Main Validation Function

--- a/packages/nextly/src/field-groups/config/validate-field-group.ts
+++ b/packages/nextly/src/field-groups/config/validate-field-group.ts
@@ -26,13 +26,9 @@
  */
 
 import { RESERVED_SLUGS } from "../../collections/config/validate-config";
-import {
-  isDataField,
-  isFieldGroupField,
-} from "../../collections/fields/guards";
+import { isFieldGroupField } from "../../collections/fields/guards";
 import type { FieldConfig } from "../../collections/fields/types";
 import { isPluginFieldTypeOnSurface } from "../../domains/schema/field-types/field-type-registry";
-import { isPluginDataField } from "../../domains/schema/services/plugin-codegen";
 import { NextlyError } from "../../errors";
 import {
   isReservedSystemColumn,
@@ -333,18 +329,34 @@ function validateFields(
   // column through the generator's own conversion: `createdAt` and `CreatedAt` both arrive at
   // `created_at`, and a set of literal spellings can only ever hold the ones somebody listed.
   //
-  // Only fields that actually emit a column are checked. A field group referencing another group
-  // keeps its data in the referenced table and the generator emits nothing for it, so its name
-  // never reaches a column and refusing it would reject a configuration that works.
+  // A reference to another field group is the ONE field known to emit no column: its data lives in
+  // the table it points at. Every other field is checked, including a contributed type whose
+  // registration has not happened yet — `defineFieldGroup` runs before the plugin registry is
+  // populated, so asking whether such a field emits a column answers "no" for one that will. The
+  // check is therefore written to fail closed: refusing a name that turns out to emit nothing costs
+  // an author a name they had no reason to want, while skipping one that does emit a column costs
+  // a table that cannot be created at all.
   fields.forEach((field, index) => {
     if (!field || typeof field !== "object") return;
-    const candidate = field as FieldConfig;
-    if (!isDataField(candidate) && !isPluginDataField(candidate)) return;
-    if (isFieldGroupField(candidate)) return;
-
     const name = (field as Record<string, unknown>).name;
     if (typeof name !== "string") return;
     const column = toPhysicalColumnName(name);
+
+    if (isFieldGroupField(field as FieldConfig)) {
+      // No column, but the value still travels on the instance payload, and that payload uses
+      // `id` for the instance's own identity: a read seeds it from the row and a repeatable write
+      // decides insert-or-update by it. A reference stored under the same key would displace the
+      // identity, so existing instances would be read as new ones and the originals deleted.
+      if (column === "id") {
+        errors.push({
+          path: `${path}[${index}].name`,
+          message: `Field name '${name}' is reserved: a field group instance uses 'id' for its own identity`,
+          code: "FIELD_NAME_RESERVED",
+        });
+      }
+      return;
+    }
+
     if (isReservedSystemColumn(column, "fieldGroupConfig")) {
       errors.push({
         path: `${path}[${index}].name`,

--- a/packages/nextly/src/field-groups/config/validate-field-group.ts
+++ b/packages/nextly/src/field-groups/config/validate-field-group.ts
@@ -29,11 +29,9 @@ import { RESERVED_SLUGS } from "../../collections/config/validate-config";
 import { isFieldGroupField } from "../../collections/fields/guards";
 import type { FieldConfig } from "../../collections/fields/types";
 import { isPluginFieldTypeOnSurface } from "../../domains/schema/field-types/field-type-registry";
+import { toSnakeCase } from "../../domains/schema/services/field-column-descriptor";
 import { NextlyError } from "../../errors";
-import {
-  isReservedSystemColumn,
-  toPhysicalColumnName,
-} from "../../lib/system-columns";
+import { isReservedSystemColumn } from "../../lib/system-columns";
 import {
   type BaseValidationError,
   DEFAULT_SQL_KEYWORDS_SET,
@@ -340,17 +338,34 @@ function validateFields(
     if (!field || typeof field !== "object") return;
     const name = (field as Record<string, unknown>).name;
     if (typeof name !== "string") return;
-    const column = toPhysicalColumnName(name);
+    const column = toSnakeCase(name);
 
     if (isFieldGroupField(field as FieldConfig)) {
-      // No column, but the value still travels on the instance payload, and that payload uses
-      // `id` for the instance's own identity: a read seeds it from the row and a repeatable write
-      // decides insert-or-update by it. A reference stored under the same key would displace the
-      // identity, so existing instances would be read as new ones and the originals deleted.
-      if (column === "id") {
+      // A reference emits no column, but its value still rides on the instance payload, where two
+      // keys are already spoken for — and they are spoken for in different ways.
+      //
+      // The identity is assigned straight onto the payload and read back under the exact key `id`,
+      // so only that literal displaces it. `Id` is a separate property and stays usable.
+      if (name === "id") {
         errors.push({
           path: `${path}[${index}].name`,
           message: `Field name '${name}' is reserved: a field group instance uses 'id' for its own identity`,
+          code: "FIELD_NAME_RESERVED",
+        });
+        return;
+      }
+
+      // The timestamps are the opposite: the read indexes the row's columns by each field's
+      // CONVERTED name, so any spelling that converts to one of them is handed the row's timestamp
+      // in place of the referenced data — which then round-trips back as the reference's value.
+      // `id` is excluded because it is the case above, where conversion does not apply.
+      if (
+        column !== "id" &&
+        isReservedSystemColumn(column, "fieldGroupConfig")
+      ) {
+        errors.push({
+          path: `${path}[${index}].name`,
+          message: `Field name '${name}' is reserved: a field group instance carries '${column}' of its own`,
           code: "FIELD_NAME_RESERVED",
         });
       }

--- a/packages/nextly/src/lib/__tests__/system-columns.test.ts
+++ b/packages/nextly/src/lib/__tests__/system-columns.test.ts
@@ -27,11 +27,13 @@ import {
   IMMUTABLE_SYSTEM_FIELDS_ANY_ENTITY,
 } from "../immutable-system-fields";
 import {
+  isReservedSystemColumn,
   reservedSystemFieldNames,
   SYSTEM_COLUMNS,
   systemColumnDefaultSql,
   systemColumnDialectType,
   systemColumnNames,
+  toPhysicalColumnName,
   type ReservationSurface,
   type SystemColumnDialect,
   type SystemColumnKind,
@@ -148,11 +150,42 @@ describe("reservation projections", () => {
     );
   });
 
-  it("refuses both spellings of the universal columns in a code-first field group", () => {
-    // A field group's table carries exactly these three, so these are the names that collide.
-    expect(sorted(reservedSystemFieldNames("fieldGroupConfig"))).toEqual(
-      sorted(["id", "created_at", "createdAt", "updated_at", "updatedAt"])
-    );
+  it("reserves exactly the columns a field group's table carries", () => {
+    // Matched as physical columns, because a field name reaches one through the generator's own
+    // conversion and any number of spellings arrive at the same column.
+    for (const column of ["id", "created_at", "updated_at"]) {
+      expect({
+        [column]: isReservedSystemColumn(column, "fieldGroupConfig"),
+      }).toEqual({ [column]: true });
+    }
+    for (const column of [
+      "status",
+      "first_published_at",
+      "created_by",
+      "slug",
+    ]) {
+      expect({
+        [column]: isReservedSystemColumn(column, "fieldGroupConfig"),
+      }).toEqual({ [column]: false });
+    }
+  });
+
+  it("normalizes a field name to the column the generator would emit", () => {
+    // The conversion the check depends on. `CreatedAt` is the case a literal set of spellings
+    // missed: the substitution introduces a leading underscore that the generator then drops.
+    expect({
+      createdAt: toPhysicalColumnName("createdAt"),
+      CreatedAt: toPhysicalColumnName("CreatedAt"),
+      created_at: toPhysicalColumnName("created_at"),
+      Id: toPhysicalColumnName("Id"),
+      headline: toPhysicalColumnName("headline"),
+    }).toEqual({
+      createdAt: "created_at",
+      CreatedAt: "created_at",
+      created_at: "created_at",
+      Id: "id",
+      headline: "headline",
+    });
   });
 
   it("refuses both spellings of the universal columns in the UI field-payload schema", () => {
@@ -295,16 +328,75 @@ describe("the validators actually refuse what the projection lists", () => {
     ).toBe(true);
   });
 
-  it("refuses every projected name in a code-first field group", () => {
-    // The path a TypeScript author uses. The visual path and this one build the same table, so a
-    // name refused in one and accepted in the other leaves the supported path producing DDL the
-    // database rejects.
-    for (const name of reservedSystemFieldNames("fieldGroupConfig")) {
+  it("agrees with the generator about which names collide", () => {
+    // The property that matters, asserted against the generator rather than against a list: for
+    // each candidate, the validator refuses it exactly when the emitted CREATE TABLE would declare
+    // a column twice. A spelling nobody thought of cannot pass one and fail the other.
+    const candidates = [
+      "createdAt",
+      "CreatedAt",
+      "created_at",
+      "updatedAt",
+      "UpdatedAt",
+      "Id",
+      "id",
+      "headline",
+      "parentId",
+      "bodyText",
+    ];
+
+    for (const name of candidates) {
+      const body = new FieldGroupSchemaService("postgresql")
+        .generateMigrationSQL("comp_probe", [
+          { name, type: "text" } as FieldConfig,
+        ])
+        .split("--> statement-breakpoint")[0];
+      const columns = [...body.matchAll(/^\s*"([a-z_]+)"/gm)].map(m => m[1]);
+      const generatorCollides = columns.some(
+        (c, i) => columns.indexOf(c) !== i
+      );
+
+      const refused = (
+        validateFieldGroupConfig({
+          slug: "probe",
+          fields: [{ name, type: "text" }],
+        } as unknown as FieldGroupConfig).errors ?? []
+      ).some(e => e.code === "FIELD_NAME_RESERVED");
+
+      expect({ [name]: refused }).toEqual({ [name]: generatorCollides });
+    }
+  });
+
+  it("allows a field group reference to take any name", () => {
+    // A reference keeps its data in the table it points at and the generator emits no column for
+    // it, so its name never reaches one. Refusing it would reject a configuration that works and,
+    // because this runs at boot, could stop an application starting after an upgrade.
+    //
+    // The type token is `component`, which IS a data field — so the guard that skips non-column
+    // fields does not cover it and the reference check is doing real work here. Written with the
+    // wrong token this assertion passes for the wrong reason, because no branch is reached at all.
+    for (const name of ["id", "createdAt", "CreatedAt", "updatedAt"]) {
+      const field = { name, type: "component", component: "child" };
       const result = validateFieldGroupConfig({
         slug: "probe",
-        fields: [{ name, type: "text" }],
+        fields: [field],
       } as unknown as FieldGroupConfig);
-      expect({ [name]: result.valid }).toEqual({ [name]: false });
+      const reserved = (result.errors ?? []).filter(
+        e => e.code === "FIELD_NAME_RESERVED"
+      );
+
+      // And the generator agrees: no column is emitted for it, so nothing can collide.
+      const body = new FieldGroupSchemaService("postgresql")
+        .generateMigrationSQL("comp_probe", [field as unknown as FieldConfig])
+        .split("--> statement-breakpoint")[0];
+      const columns = [...body.matchAll(/^\s*"([a-z_]+)"/gm)].map(m => m[1]);
+
+      expect({
+        [`${name}.refused`]: reserved.length,
+        [`${name}.duplicated`]: columns.filter(
+          (c, i) => columns.indexOf(c) !== i
+        ),
+      }).toEqual({ [`${name}.refused`]: 0, [`${name}.duplicated`]: [] });
     }
   });
 

--- a/packages/nextly/src/lib/__tests__/system-columns.test.ts
+++ b/packages/nextly/src/lib/__tests__/system-columns.test.ts
@@ -15,7 +15,10 @@ import { describe, expect, it } from "vitest";
 import type { FieldConfig } from "../../collections/fields/types";
 import { fieldNameSchema } from "../../domains/dynamic-collections/services/dynamic-collection-validation-service";
 import { FieldGroupSchemaService } from "../../domains/field-groups/services/field-group-schema-service";
-import { getSystemColumnDescriptors } from "../../domains/schema/services/field-column-descriptor";
+import {
+  getSystemColumnDescriptors,
+  toSnakeCase,
+} from "../../domains/schema/services/field-column-descriptor";
 import { generateRuntimeSchema } from "../../domains/schema/services/runtime-schema-generator";
 import { SYSTEM_SCHEMA_VERSION } from "../../domains/schema/services/schema-hash";
 import { validateFieldGroupConfig } from "../../field-groups/config/validate-field-group";
@@ -33,7 +36,6 @@ import {
   systemColumnDefaultSql,
   systemColumnDialectType,
   systemColumnNames,
-  toPhysicalColumnName,
   type ReservationSurface,
   type SystemColumnDialect,
   type SystemColumnKind,
@@ -171,14 +173,15 @@ describe("reservation projections", () => {
   });
 
   it("normalizes a field name to the column the generator would emit", () => {
-    // The conversion the check depends on. `CreatedAt` is the case a literal set of spellings
-    // missed: the substitution introduces a leading underscore that the generator then drops.
+    // The canonical conversion, shared with the generators rather than restated — the reservation
+    // is only correct while it agrees with them. `CreatedAt` is the case a literal set of
+    // spellings missed: the substitution introduces a leading underscore that is then dropped.
     expect({
-      createdAt: toPhysicalColumnName("createdAt"),
-      CreatedAt: toPhysicalColumnName("CreatedAt"),
-      created_at: toPhysicalColumnName("created_at"),
-      Id: toPhysicalColumnName("Id"),
-      headline: toPhysicalColumnName("headline"),
+      createdAt: toSnakeCase("createdAt"),
+      CreatedAt: toSnakeCase("CreatedAt"),
+      created_at: toSnakeCase("created_at"),
+      Id: toSnakeCase("Id"),
+      headline: toSnakeCase("headline"),
     }).toEqual({
       createdAt: "created_at",
       CreatedAt: "created_at",
@@ -390,7 +393,36 @@ describe("the validators actually refuse what the projection lists", () => {
     // uses `id` for the instance's own identity: the read seeds it from the row, and a repeatable
     // write decides insert-or-update by it. A reference stored under the same key would displace
     // the identity, so existing instances would read as new and the originals be removed.
-    for (const name of ["id", "Id"]) {
+    // Only the literal `id`. The identity is assigned straight onto the payload and read back
+    // under that exact key, so `Id` is a separate property and stays usable — normalizing here
+    // would refuse a configuration that works.
+    for (const [name, expected] of [
+      ["id", 1],
+      ["Id", 0],
+    ] as const) {
+      const result = validateFieldGroupConfig({
+        slug: "probe",
+        fields: [{ name, type: "component", component: "child" }],
+      } as unknown as FieldGroupConfig);
+      const reserved = (result.errors ?? []).filter(
+        e => e.code === "FIELD_NAME_RESERVED"
+      );
+
+      expect({ [name]: reserved.length }).toEqual({ [name]: expected });
+    }
+  });
+
+  it("keeps the timestamp payload keys reserved on a reference", () => {
+    // The opposite of `id`: the read indexes the row's columns by each field's CONVERTED name, so
+    // every spelling that converts to a timestamp column would be handed the row's timestamp in
+    // place of the referenced data.
+    for (const name of [
+      "createdAt",
+      "created_at",
+      "CreatedAt",
+      "updatedAt",
+      "updated_at",
+    ]) {
       const result = validateFieldGroupConfig({
         slug: "probe",
         fields: [{ name, type: "component", component: "child" }],
@@ -411,7 +443,7 @@ describe("the validators actually refuse what the projection lists", () => {
     // The type token is `component`, which IS a data field — so the guard that skips non-column
     // fields does not cover it and the reference check is doing real work here. Written with the
     // wrong token this assertion passes for the wrong reason, because no branch is reached at all.
-    for (const name of ["createdAt", "CreatedAt", "updatedAt", "headline"]) {
+    for (const name of ["headline", "Id", "seoBlock"]) {
       const field = { name, type: "component", component: "child" };
       const result = validateFieldGroupConfig({
         slug: "probe",

--- a/packages/nextly/src/lib/__tests__/system-columns.test.ts
+++ b/packages/nextly/src/lib/__tests__/system-columns.test.ts
@@ -367,6 +367,42 @@ describe("the validators actually refuse what the projection lists", () => {
     }
   });
 
+  it("refuses a colliding name on a type it cannot classify yet", () => {
+    // `defineFieldGroup` runs before plugin field types are registered, so a contributed type
+    // looks like nothing the guards recognise. Gating the check on "does this emit a column" would
+    // answer no for a field that will, and the collision would surface as DDL the database
+    // refuses. The check fails closed instead.
+    for (const name of ["createdAt", "CreatedAt", "id"]) {
+      const result = validateFieldGroupConfig({
+        slug: "probe",
+        fields: [{ name, type: "somePluginType" }],
+      } as unknown as FieldGroupConfig);
+      const reserved = (result.errors ?? []).filter(
+        e => e.code === "FIELD_NAME_RESERVED"
+      );
+
+      expect({ [name]: reserved.length }).toEqual({ [name]: 1 });
+    }
+  });
+
+  it("keeps id reserved on a reference, whose payload needs it for identity", () => {
+    // A reference emits no column, but its value rides on the instance payload, and that payload
+    // uses `id` for the instance's own identity: the read seeds it from the row, and a repeatable
+    // write decides insert-or-update by it. A reference stored under the same key would displace
+    // the identity, so existing instances would read as new and the originals be removed.
+    for (const name of ["id", "Id"]) {
+      const result = validateFieldGroupConfig({
+        slug: "probe",
+        fields: [{ name, type: "component", component: "child" }],
+      } as unknown as FieldGroupConfig);
+      const reserved = (result.errors ?? []).filter(
+        e => e.code === "FIELD_NAME_RESERVED"
+      );
+
+      expect({ [name]: reserved.length }).toEqual({ [name]: 1 });
+    }
+  });
+
   it("allows a field group reference to take any name", () => {
     // A reference keeps its data in the table it points at and the generator emits no column for
     // it, so its name never reaches one. Refusing it would reject a configuration that works and,
@@ -375,7 +411,7 @@ describe("the validators actually refuse what the projection lists", () => {
     // The type token is `component`, which IS a data field — so the guard that skips non-column
     // fields does not cover it and the reference check is doing real work here. Written with the
     // wrong token this assertion passes for the wrong reason, because no branch is reached at all.
-    for (const name of ["id", "createdAt", "CreatedAt", "updatedAt"]) {
+    for (const name of ["createdAt", "CreatedAt", "updatedAt", "headline"]) {
       const field = { name, type: "component", component: "child" };
       const result = validateFieldGroupConfig({
         slug: "probe",

--- a/packages/nextly/src/lib/system-columns.ts
+++ b/packages/nextly/src/lib/system-columns.ts
@@ -403,6 +403,38 @@ export function systemColumnNames(
   return SYSTEM_COLUMNS.filter(predicate).flatMap(bothSpellings);
 }
 
+/**
+ * The physical column a field name becomes.
+ *
+ * Must match how the generator for that entity spells it, or a reservation checked against the
+ * result protects the wrong name. The component generator applies exactly this rule, including
+ * dropping the underscore its own substitution introduces before a leading capital — which is why
+ * `CreatedAt` and `createdAt` reach the same column and both have to be refused.
+ */
+export function toPhysicalColumnName(fieldName: string): string {
+  return fieldName
+    .replace(/([A-Z])/g, "_$1")
+    .toLowerCase()
+    .replace(/^_/, "");
+}
+
+/**
+ * Whether a physical column name is one this surface reserves.
+ *
+ * Takes the column rather than the field name, so a caller normalizes with the rule its own
+ * generator uses and no spelling can slip past by being cased differently. Matching literal
+ * spellings can only ever cover the ones somebody thought of.
+ */
+export function isReservedSystemColumn(
+  physicalName: string,
+  surface: ReservationSurface
+): boolean {
+  return SYSTEM_COLUMNS.some(
+    column =>
+      column.name === physicalName && column.reservedIn.includes(surface)
+  );
+}
+
 /** The names a validator on `surface` refuses for an author's own field. */
 export function reservedSystemFieldNames(
   surface: ReservationSurface

--- a/packages/nextly/src/lib/system-columns.ts
+++ b/packages/nextly/src/lib/system-columns.ts
@@ -404,21 +404,6 @@ export function systemColumnNames(
 }
 
 /**
- * The physical column a field name becomes.
- *
- * Must match how the generator for that entity spells it, or a reservation checked against the
- * result protects the wrong name. The component generator applies exactly this rule, including
- * dropping the underscore its own substitution introduces before a leading capital — which is why
- * `CreatedAt` and `createdAt` reach the same column and both have to be refused.
- */
-export function toPhysicalColumnName(fieldName: string): string {
-  return fieldName
-    .replace(/([A-Z])/g, "_$1")
-    .toLowerCase()
-    .replace(/^_/, "");
-}
-
-/**
  * Whether a physical column name is one this surface reserves.
  *
  * Takes the column rather than the field name, so a caller normalizes with the rule its own


### PR DESCRIPTION
Fixes the two findings codex raised on #496 after it merged. Both are mine, and the first says the *approach* was wrong rather than incomplete.

## 1. Matching spellings can never be complete — match the column

A field name reaches a column through the generator's own conversion, and that conversion drops the underscore its own substitution introduces before a leading capital:

```
createdAt  -> created_at
CreatedAt  -> created_at     <- accepted before this PR
created_at -> created_at
Id         -> id             <- accepted before this PR
```

#496 reserved a *set of spellings*, so it caught the two that were written down and missed the PascalCase forms, which `FIELD_NAME_PATTERN` (`/^[a-zA-Z][a-zA-Z0-9_]*$/`) explicitly permits. Those still produced a `CREATE TABLE` declaring the column twice.

Names are now normalized to the physical column and compared against the declared columns, so correctness no longer depends on anyone having listed the spelling. The error names the column too:

```
Field name 'CreatedAt' is reserved: it becomes the system column 'created_at'
```

## 2. A field that emits no column must not be refused

A field group referencing another field group keeps its data in the referenced table; the generator skips it entirely. The unconditional check in #496 refused such a field if it happened to be named `id` — a configuration that works, rejected. Because this validator runs at startup, that could stop an application booting after an upgrade. Only fields that actually emit a column are checked now.

## A correction to what #494 and #496 claimed

While verifying, I found that part of what those PRs said was overstated, so it should be on the record here.

Both widened the **Schema Builder** and the **UI field-payload schema** to reserve `createdAt`/`updatedAt`, described as closing a real hole. Measured, those two surfaces reject a camelCase name by their own pattern (`/^[a-z][a-z0-9_]*$/`) **before** any reservation is consulted:

```
builder  "createdAt":  ["must start with lowercase letter…", "Field name is reserved"]
builder  "CreatedAt":  ["must start with lowercase letter…"]
uiSchema "createdAt":  ["must match ^[a-z][a-z0-9_]*$", "'createdAt' is reserved"]
```

So those widenings are defence-in-depth, not fixes. The collision is real, but it is only *reachable* through the code-first paths, whose shared name pattern allows an uppercase first letter. That makes the code-first validators the ones that matter — this PR fixes field groups, and `tasks/left-tasks/113` Part A still covers collections and singles.

## Verification

Falsifications, each failing for its own reason:

| reverted | result |
|---|---|
| normalization (compare the raw name again) | generator-agreement test fails |
| the reference-field exemption | reference test fails |

**The exemption falsification initially passed**, and that was my test being wrong, not the fix: I built the probe field as `type: "fieldGroup"`, but the real token is `"component"`. With the wrong token the field is not a data field at all, so no branch was reached and the assertion passed for the wrong reason. Corrected, and the test now says so in a comment. `isDataField` is `true` for `"component"`, so the exemption is genuinely load-bearing.

The central test no longer asserts against a list. For each candidate name it generates the DDL and asserts **the validator refuses it exactly when the emitted `CREATE TABLE` would declare a column twice** — so a spelling nobody thought of cannot pass one and fail the other.

**Three dialect legs, one at a time, databases recreated before each:**

| leg | passed | failed |
|---|---|---|
| sqlite | 1034 | 0 |
| postgres17 | 1183 | 0 |
| mysql | 1114 | 0 |

Full `nextly` unit suite against the `origin/main` baseline measured in this tree: **37 failing files both ways, no new failures.** `check-types` (source and tests) and `lint` clean.
