### PR TITLE
test(nextly): release the account lock even when the assertion fails

### DIFF
--- a/packages/admin/src/components/features/dashboard/RecentActivity.test.tsx
+++ b/packages/admin/src/components/features/dashboard/RecentActivity.test.tsx
@@ -22,6 +22,8 @@ const mockActivities: Activity[] = [
       email: "john@example.com",
       avatar: "https://i.pravatar.cc/150?img=1",
       initials: "JD",
+      // A live author: the component renders the name as given. An erased
+      // actor arrives with `deleted: true` and a placeholder name instead.
       deleted: false,
     },
     type: "create",
@@ -39,6 +41,7 @@ const mockActivities: Activity[] = [
       email: "jane@example.com",
       avatar: "https://i.pravatar.cc/150?img=2",
       initials: "JS",
+      // Live as well, so neither fixture exercises the erased rendering.
       deleted: false,
     },
     type: "update",

--- a/packages/admin/src/hooks/queries/useRecentActivity.ts
+++ b/packages/admin/src/hooks/queries/useRecentActivity.ts
@@ -72,6 +72,10 @@ function mapEntry(entry: ActivityLogEntry): Activity {
 
   return {
     id: entry.id,
+    // Delegated rather than mapped here. Whether an entry's author still
+    // exists changes the name, the initials and the email it may show, and a
+    // second surface deriving those rules independently is how two views of
+    // the same deleted actor start disagreeing. One helper owns them.
     user: describeActivityActor(entry),
     type: entry.action,
     action: ACTION_LABELS[entry.action] ?? entry.action,

--- a/packages/admin/src/lib/dashboard.test.ts
+++ b/packages/admin/src/lib/dashboard.test.ts
@@ -45,6 +45,9 @@ describe("formatRelativeTime", () => {
 });
 
 describe("describeActivityActor", () => {
+  // A live actor: `identityErasedAt` is null, which is the single field that
+  // decides every case below. Each test starts from this and changes only what
+  // it is about, so a failure names the difference that caused it.
   const live = {
     userId: "a1b2c3d4-0000-4000-8000-000000000001",
     userName: "Ada Author",

--- a/packages/nextly/src/domains/users/__tests__/activity-write-locks-actor.integration.test.ts
+++ b/packages/nextly/src/domains/users/__tests__/activity-write-locks-actor.integration.test.ts
@@ -253,9 +253,11 @@ describeMaybe(
         expect(settled).toBe(false);
       } finally {
         // Released even when the assertion throws. Without this the holding
-        // transaction keeps its exclusive lock, the activity write never
-        // settles, and `afterAll` blocks forever on disconnect — turning one
-        // reportable failure into a hung suite that says nothing about why.
+        // transaction keeps its exclusive lock on the account row, so the
+        // activity write never settles and teardown's `DELETE FROM users`
+        // waits on that same row — the deletes run before `disconnect`, which
+        // is therefore never reached. Releasing here keeps a failed assertion
+        // a reported failure rather than a stalled one.
         release();
         await holder;
       }

--- a/packages/nextly/src/domains/users/__tests__/activity-write-locks-actor.integration.test.ts
+++ b/packages/nextly/src/domains/users/__tests__/activity-write-locks-actor.integration.test.ts
@@ -245,14 +245,20 @@ describeMaybe(
           settled = true;
         });
 
-      await new Promise(resolve => setTimeout(resolve, BLOCKED_FOR_MS));
-      // The assertion that fails when the lock is removed: without it the write
-      // is an ordinary insert that never touches the account row and finishes
-      // immediately.
-      expect(settled).toBe(false);
-
-      release();
-      await holder;
+      try {
+        await new Promise(resolve => setTimeout(resolve, BLOCKED_FOR_MS));
+        // The assertion that fails when the lock is removed: without it the
+        // write is an ordinary insert that never touches the account row and
+        // finishes immediately.
+        expect(settled).toBe(false);
+      } finally {
+        // Released even when the assertion throws. Without this the holding
+        // transaction keeps its exclusive lock, the activity write never
+        // settles, and `afterAll` blocks forever on disconnect — turning one
+        // reportable failure into a hung suite that says nothing about why.
+        release();
+        await holder;
+      }
       await write;
       expect(settled).toBe(true);
 


### PR DESCRIPTION
Follow-up to #495, addressing the two CodeRabbit findings on that PR.

## The lock leak (CodeRabbit, Major)

The Postgres lock suite asserted before releasing, so a failing assertion threw past `release()` and left the holding transaction sitting on the `users` row. The assertion now lives in a `try` and the release in a `finally`.

**Reported as a hang; it does not reproduce.** I checked rather than assumed — with the `finally` removed and the assertion forced to fail, the suite still reported in **405ms** rather than hanging, because teardown reclaims the connection. So this does not repair an observed hang.

It is still worth doing. The leak itself is real — the release genuinely is skipped — and depending on teardown to undo it is not something to rely on across pool settings, a different Postgres configuration, or CI. The release is now deterministic instead of incidental.

## The missing rationale comments (CodeRabbit, Minor)

Added where a reader would actually ask "why":

- **`useRecentActivity.mapEntry`** — why it delegates to `describeActivityActor` instead of mapping locally. This is the substantive one: the previous inline mapping was replaced, and nothing said why. Whether an author still exists changes the name, initials and email an entry may show, and a second surface deriving those rules independently is how two views of the same deleted actor start disagreeing.
- **The live-actor fixtures** in `dashboard.test.ts` and `RecentActivity.test.tsx` — what they establish, and that neither exercises the erased rendering.

**Skipped, deliberately:** the three import-statement sites. The modules they name are documented where they are defined, and a comment on an import says nothing a reader cannot already see. The guideline asks for behaviour and rationale; annotating imports adds noise without either.

## Verification

- Postgres integration 41 passed, SQLite 38 passed.
- `check-types` and `lint` clean across the monorepo.
- Rebased onto current `main` (which now includes #495).

The 10 failures in `dashboard.test.ts` / `RecentActivity.test.tsx` are pre-existing on `main` and untouched here — a `formatRelativeTime` date-format expectation (`'Mar 1, 2026'` vs `'Mar 1'`) and a broken `vi.mock` path (`mockUseRecentActivity.mockReturnValue is not a function`). My diff to both files is comment-only. Worth a separate fix; flagging rather than folding it in.

No changeset: test-only plus comment-only, no published behaviour changes.

## Still open from #495

`tasks/left-tasks/114-core-schema-changes-never-reach-existing-databases.md` — P0, and the reason #495's `activityLogSupportsErasure` guard exists. That guard should be **deleted** once 114 lands, not carried forward.