### PR TITLE
fix(blocks-engine): account for malformed envelopes at every nesting level

### DIFF
--- a/.changeset/style-compiler-followups.md
+++ b/.changeset/style-compiler-followups.md
@@ -1,0 +1,32 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+The style compiler now accounts for every shape of persisted data it cannot use.
+A state map, a breakpoint map, a `visibility` envelope or its `devices` map that
+is not an object applies nothing, and each is reported rather than skipped, so a
+document with values and a page with no CSS are always connected by a warning.
+
+The node walk is bounded by what it READS rather than by what it could use, so
+an array of malformed entries can no longer pass the node cap without tripping
+it.

--- a/packages/blocks-engine/src/style/compile-page.test.ts
+++ b/packages/blocks-engine/src/style/compile-page.test.ts
@@ -1384,3 +1384,88 @@ describe("more of what the compiler skips is now accounted for", () => {
     ).toHaveLength(0);
   });
 });
+
+describe("malformed envelopes are accounted for at every level", () => {
+  it("reports a state whose value is not an object", () => {
+    const out = compilePageCss(
+      doc([node("n1", { base: [] as unknown as Record<string, unknown> })]),
+      CTX
+    );
+    expect(out.warnings.map(issue => issue.code)).toContain(
+      "invalid-style-values"
+    );
+  });
+
+  it("reports a breakpoint map whose value is not an object", () => {
+    const out = compilePageCss(
+      doc([node("n1", { base: { base: "red" } })]),
+      CTX
+    );
+    expect(out.css).toBe("");
+    expect(out.warnings.map(issue => issue.code)).toContain(
+      "invalid-style-values"
+    );
+  });
+
+  it("stays silent about a breakpoint a node simply says nothing about", () => {
+    // `undefined` is the normal case, not a malformed one. Reported, it would
+    // be one warning per unstyled breakpoint on every node in the document.
+    const out = compilePageCss(
+      doc([node("n1", { base: { base: { color: "#0f0" } } })]),
+      CTX
+    );
+    expect(out.warnings).toEqual([]);
+  });
+
+  it("reports a visibility envelope that is not an object", () => {
+    for (const visibility of [[], "hidden", null]) {
+      const out = compilePageCss(
+        doc([node("n1", undefined, { visibility })]),
+        CTX
+      );
+      expect(out.css).not.toContain("display: none");
+      expect(out.warnings.map(issue => issue.code)).toContain(
+        "invalid-visibility"
+      );
+    }
+  });
+
+  it("reports a devices map that is not an object", () => {
+    const out = compilePageCss(
+      doc([node("n1", undefined, { visibility: { devices: [] } })]),
+      CTX
+    );
+    expect(out.warnings.map(issue => issue.code)).toContain(
+      "invalid-visibility"
+    );
+  });
+});
+
+describe("the node walk is bounded by what it reads", () => {
+  it("stops at the cap even when every entry is malformed", () => {
+    // A malformed entry never reaches `placed`, so counting only successes let
+    // an array made entirely of them pass the cap without tripping it.
+    const nodes = Array.from(
+      { length: DEFAULT_LIMITS.maxNodes + 500 },
+      () => null
+    ) as unknown as BlockNode[];
+    const out = compilePageCss(doc(nodes), CTX);
+    expect(out.warnings.map(issue => issue.code)).toContain(
+      "node-count-exceeded"
+    );
+  });
+
+  it("styles nothing past the cap", () => {
+    // A guard on the outcome, not on the loop shape: breaking out of the array
+    // rather than running `forEach` to its end changes the work done and not
+    // the result, so this holds either way and is here to keep it holding.
+    const nodes = [
+      ...Array.from({ length: DEFAULT_LIMITS.maxNodes + 10 }, (_, index) =>
+        node(`n${index}`)
+      ),
+      node("beyond", { base: { base: { color: "#f00" } } }),
+    ];
+    const out = compilePageCss(doc(nodes), CTX);
+    expect(out.css).not.toContain("#f00");
+  });
+});

--- a/packages/blocks-engine/src/style/compile-page.ts
+++ b/packages/blocks-engine/src/style/compile-page.ts
@@ -430,11 +430,35 @@ function envelopeRules(
   //   what "this is what it looks like while hovered" has to mean.
   for (const state of STYLE_STATES) {
     const byBreakpoint = styles[state];
+    // The same account the envelope itself gets, one level down. A state whose
+    // value is `[]` or a string styles nothing, and skipping it quietly leaves
+    // an author with values in the document, no CSS on the page, and nothing
+    // connecting the two.
+    if (byBreakpoint !== undefined && !isPlainRecord(byBreakpoint)) {
+      pushBoundedWarning(warningAllowance, warnings, {
+        path: pointer(basePath, state),
+        code: "invalid-style-values",
+        severity: "warning",
+        message: `Styles for "${describeValue(state)}" are ${describeValue(byBreakpoint)} rather than an object, so none of them were written.`,
+      });
+      continue;
+    }
     if (!isPlainRecord(byBreakpoint)) continue;
     for (const context of contexts) {
       const values = byBreakpoint[context.id];
-      if (!isPlainRecord(values)) continue;
       const path = pointer(pointer(basePath, state), context.id);
+      // And one level down again. `undefined` stays silent: a breakpoint a node
+      // says nothing about is the normal case, not a malformed one.
+      if (values !== undefined && !isPlainRecord(values)) {
+        pushBoundedWarning(warningAllowance, warnings, {
+          path,
+          code: "invalid-style-values",
+          severity: "warning",
+          message: `Styles at "${describeValue(context.id)}" are ${describeValue(values)} rather than an object, so none of them were written.`,
+        });
+        continue;
+      }
+      if (!isPlainRecord(values)) continue;
       const compiled = compileStyleValues(
         values,
         path,
@@ -502,7 +526,32 @@ function visibilityRules(
   warnings: ValidationIssue[],
   warningAllowance: WarningAllowance
 ): CssRule[] {
-  const devices = node.visibility?.devices;
+  // The containing structures get the same account as the values inside them.
+  // A `visibility` or `devices` that is an array, a string or null applies none
+  // of what it holds, and returning quietly is indistinguishable from a node
+  // that simply said nothing about being hidden.
+  const visibility: unknown = node.visibility;
+  if (visibility !== undefined && !isPlainRecord(visibility)) {
+    pushBoundedWarning(warningAllowance, warnings, {
+      path: pointer(basePath, "visibility"),
+      code: "invalid-visibility",
+      severity: "warning",
+      message: `Visibility is ${describeValue(visibility)} rather than an object, so none of it was applied and the node stays visible.`,
+    });
+    return [];
+  }
+  const devices: unknown = isPlainRecord(visibility)
+    ? visibility.devices
+    : undefined;
+  if (devices !== undefined && !isPlainRecord(devices)) {
+    pushBoundedWarning(warningAllowance, warnings, {
+      path: pointer(pointer(basePath, "visibility"), "devices"),
+      code: "invalid-visibility",
+      severity: "warning",
+      message: `Visibility devices are ${describeValue(devices)} rather than an object, so none of them were applied and the node stays visible.`,
+    });
+    return [];
+  }
   if (!isPlainRecord(devices)) return [];
   const rules: CssRule[] = [];
   const known = new Set(contexts.map(context => context.id));
@@ -642,6 +691,8 @@ function documentNodes(
   // Stopping at the same limits validation enforces bounds the work rather than
   // only the shape of it.
   let stopped = false;
+  // Every array entry read, usable or not.
+  let seen = 0;
   const stop = (path: string, reason: string): void => {
     if (stopped) return;
     stopped = true;
@@ -662,19 +713,26 @@ function documentNodes(
       );
       break;
     }
-    level.nodes.forEach((node, index) => {
-      if (stopped) return;
-      if (placed.length >= limits.maxNodes) {
+    // An indexed loop rather than `forEach`, and counting every ENTRY rather
+    // than every entry that turned out usable. `forEach` cannot be broken out
+    // of, so reaching the cap still walked the rest of an oversized array; and
+    // a malformed entry never reached `placed`, so an array made entirely of
+    // them passed the cap without ever tripping it. The bound has to be on what
+    // is READ, since reading is the work being bounded.
+    for (let index = 0; index < level.nodes.length; index += 1) {
+      if (seen >= limits.maxNodes) {
         stop(
           level.base,
           `Only the first ${limits.maxNodes} nodes were styled, because the document holds more than a document may.`
         );
-        return;
+        break;
       }
-      if (!isPlainRecord(node) || typeof node.id !== "string") return;
+      seen += 1;
+      const node = level.nodes[index];
+      if (!isPlainRecord(node) || typeof node.id !== "string") continue;
       const path = pointer(level.base, index);
       placed.push({ node, path });
-      if (!isPlainRecord(node.slots)) return;
+      if (!isPlainRecord(node.slots)) continue;
       // Sorted, so two documents whose slots were written in a different order
       // still compile to the same bytes.
       for (const slot of Object.keys(node.slots).sort()) {
@@ -686,7 +744,7 @@ function documentNodes(
           depth: level.depth + 1,
         });
       }
-    });
+    }
   }
   return placed;
 }


### PR DESCRIPTION
Follow-up hardening for the style compiler (#492) and the site-context checks
(#488), both merged. Three findings arrived on #492 minutes before it merged and
are fixed here, together with the class of defect they belong to.

## What this fixes

**Malformed envelopes went unreported at every level but the outermost.** #492
began reporting a `styles` value that is not an object. The state map inside it,
the breakpoint map inside that, a `visibility` envelope and its `devices` map
all still returned quietly. Each applies nothing when malformed, so an author was
left with values in the document, no CSS on the page, and nothing connecting the
two — which is exactly the promise `CompiledPageCss.warnings` makes.

`undefined` stays silent at every level. A node saying nothing about a state or a
breakpoint is the normal case, and reporting it would be one warning per unstyled
breakpoint per node.

**The node walk was bounded by what it could USE, not by what it read.** A
malformed entry never reached `placed`, so an array made entirely of them passed
the node cap without ever tripping it. `forEach` also cannot be broken out of, so
reaching the cap still walked the rest of an oversized array. It counts every
entry read now, since reading is the work being bounded.

## Context

This is the continuation of a review loop that has run 17 rounds across #488,
#490 and #492. Those three merged with CI green and, for #488 and #490, a clean
Codex head; #492 merged with these three outstanding, deliberately, because
nothing consumes this package yet — no caller of `validateStyleValues`,
`compilePageCss` or `STYLE_CATALOG` exists outside `blocks-engine`, and the
page-builder plugin still runs its own PoC registry. The blast radius of a defect
here is zero until Phase 2 wires a renderer.

That is the reason merging was safe. It is **not** a claim that the loop had
converged: round 16 produced a P1 CSS injection, so severity has not been
declining monotonically. The loop continues here.

Two things are deliberately still open and belong to later PRs:

- Custom CSS is not emitted at all yet. PR-S5 is the sanitizer, and that is where
  a defect becomes a security hole rather than a wrong colour, so it does not
  merge on the same basis this did.
- A token name whose emitted custom property collides with another's is a PR-S6
  concern: the compiler sees references, never the table.

## Verification

- 683 tests pass in `blocks-engine`.
- Every new test is stub-verified — the fix is reverted and the test confirmed to
  fail. Five of the six do; the sixth (`styles nothing past the cap`) asserts an
  outcome that holds under both loop shapes, and its comment says so rather than
  implying a proof it does not provide.
