### PR TITLE
fix(nextly): make the schema diff agree with what the builder created

### DIFF
--- a/.changeset/builder-text-column-width.md
+++ b/.changeset/builder-text-column-width.md
@@ -22,4 +22,6 @@
 "@nextlyhq/tsconfig": patch
 ---
 
-Schema Builder tables keep the text column width they had. Creating a field group or single routed its columns through the shared descriptor, which read a text field with no stated width as bounded where the previous generator read it as unbounded, so on MySQL a new text column held 255 characters instead of 65 535. A field that states its own width now gets exactly that width rather than the default.
+Schema Builder tables keep the text column width they had. Creating a field group or single routed its columns through the shared descriptor, which read a text field with no stated width as bounded where the previous generator read it as unbounded, so on MySQL a new text column held 255 characters instead of 65 535.
+
+A text field that states its own width now gets a column at exactly that width, on every path that can build one: a field limited to 400 characters no longer lands in a column that rejects what its own validation accepts. Localized companion migrations, Single identity seeding, and columns added to an existing table all recognise the bounded text column, so a freshly generated migration applies, a new Single keeps its seeded title and slug, and a column added at boot is not reported as changed on the next preview.

--- a/.changeset/builder-text-column-width.md
+++ b/.changeset/builder-text-column-width.md
@@ -27,3 +27,5 @@ Schema Builder tables keep the text column width they had. Creating a field grou
 A text field that states its own width now gets a column at exactly that width, on every path that can build one: a field limited to 400 characters no longer lands in a column that rejects what its own validation accepts. Localized companion migrations, Single identity seeding, and columns added to an existing table all recognise the bounded text column, so a freshly generated migration applies, a new Single keeps its seeded title and slug, and a column added at boot is not reported as changed on the next preview.
 
 A field whose type belongs to a plugin that is not loaded also keeps the unbounded column it was built with, instead of being reported as a narrowing on a table nothing has touched.
+
+A field group's text field that declares a maximum length keeps the bounded column it was created with. Its width is declared under a different key from a collection's, which the schema comparison did not read, so on PostgreSQL such a field was reported as a type change on a column that had not changed.

--- a/.changeset/builder-text-column-width.md
+++ b/.changeset/builder-text-column-width.md
@@ -25,3 +25,5 @@
 Schema Builder tables keep the text column width they had. Creating a field group or single routed its columns through the shared descriptor, which read a text field with no stated width as bounded where the previous generator read it as unbounded, so on MySQL a new text column held 255 characters instead of 65 535.
 
 A text field that states its own width now gets a column at exactly that width, on every path that can build one: a field limited to 400 characters no longer lands in a column that rejects what its own validation accepts. Localized companion migrations, Single identity seeding, and columns added to an existing table all recognise the bounded text column, so a freshly generated migration applies, a new Single keeps its seeded title and slug, and a column added at boot is not reported as changed on the next preview.
+
+A field whose type belongs to a plugin that is not loaded also keeps the unbounded column it was built with, instead of being reported as a narrowing on a table nothing has touched.

--- a/.changeset/builder-text-column-width.md
+++ b/.changeset/builder-text-column-width.md
@@ -24,7 +24,7 @@
 
 Schema Builder tables keep the text column width they had. Creating a field group or single routed its columns through the shared descriptor, which read a text field with no stated width as bounded where the previous generator read it as unbounded, so on MySQL a new text column held 255 characters instead of 65 535.
 
-A text field that states its own width now gets a column at exactly that width, on every path that can build one: a field limited to 400 characters no longer lands in a column that rejects what its own validation accepts. Localized companion migrations, Single identity seeding, and columns added to an existing table all recognise the bounded text column, so a freshly generated migration applies, a new Single keeps its seeded title and slug, and a column added at boot is not reported as changed on the next preview.
+A text field that limits its length now gets a column at exactly that limit, on every path that can build one: a field limited to 400 characters no longer lands in a column that rejects what its own validation accepts. The limit is the field's validation maximum, which is the one the Schema Builder has always sized a bounded column from. Localized companion migrations, Single identity seeding, and columns added to an existing table all recognise the bounded text column, so a freshly generated migration applies, a new Single keeps its seeded title and slug, and a column added at boot is not reported as changed on the next preview.
 
 A field whose type belongs to a plugin that is not loaded also keeps the unbounded column it was built with, instead of being reported as a narrowing on a table nothing has touched.
 

--- a/.changeset/builder-text-column-width.md
+++ b/.changeset/builder-text-column-width.md
@@ -1,0 +1,25 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+Schema Builder tables keep the text column width they had. Creating a field group or single routed its columns through the shared descriptor, which read a text field with no stated width as bounded where the previous generator read it as unbounded, so on MySQL a new text column held 255 characters instead of 65 535. A field that states its own width now gets exactly that width rather than the default.

--- a/packages/admin/src/services/journalApi.ts
+++ b/packages/admin/src/services/journalApi.ts
@@ -7,6 +7,7 @@ import { protectedApi } from "@admin/lib/api/protectedApi";
 export type JournalScope =
   | { kind: "collection"; slug: string }
   | { kind: "single"; slug: string }
+  | { kind: "component"; slug: string }
   | { kind: "global"; slug?: string }
   | { kind: "fresh-push" };
 

--- a/packages/nextly/src/dispatcher/handlers/__tests__/component-dispatcher-shapes.test.ts
+++ b/packages/nextly/src/dispatcher/handlers/__tests__/component-dispatcher-shapes.test.ts
@@ -22,10 +22,7 @@ vi.mock("../../../di/container", () => ({
   },
 }));
 
-import {
-  getAdapterFromDI,
-  getComponentRegistryFromDI,
-} from "../../helpers/di";
+import { getAdapterFromDI, getComponentRegistryFromDI } from "../../helpers/di";
 import { dispatchComponents } from "../component-dispatcher";
 
 type Registry = {
@@ -34,6 +31,7 @@ type Registry = {
   getComponent: ReturnType<typeof vi.fn>;
   updateComponent: ReturnType<typeof vi.fn>;
   deleteComponent: ReturnType<typeof vi.fn>;
+  getComponentBySlug: ReturnType<typeof vi.fn>;
   isLocked: ReturnType<typeof vi.fn>;
 };
 
@@ -44,6 +42,9 @@ function makeRegistry(overrides: Partial<Registry> = {}): Registry {
     getComponent: vi.fn(),
     updateComponent: vi.fn(),
     deleteComponent: vi.fn(),
+    // Answers "no such slug" so a create reaches the path under test. The handler asks before it
+    // converges any schema, so a double that cannot answer fails the request instead.
+    getComponentBySlug: vi.fn().mockResolvedValue(null),
     isLocked: vi.fn().mockResolvedValue(false),
     ...overrides,
   };

--- a/packages/nextly/src/dispatcher/handlers/__tests__/component-dispatcher-shapes.test.ts
+++ b/packages/nextly/src/dispatcher/handlers/__tests__/component-dispatcher-shapes.test.ts
@@ -32,6 +32,7 @@ type Registry = {
   updateComponent: ReturnType<typeof vi.fn>;
   deleteComponent: ReturnType<typeof vi.fn>;
   getComponentBySlug: ReturnType<typeof vi.fn>;
+  getAllComponents: ReturnType<typeof vi.fn>;
   isLocked: ReturnType<typeof vi.fn>;
 };
 
@@ -45,6 +46,9 @@ function makeRegistry(overrides: Partial<Registry> = {}): Registry {
     // Answers "no such slug" so a create reaches the path under test. The handler asks before it
     // converges any schema, so a double that cannot answer fails the request instead.
     getComponentBySlug: vi.fn().mockResolvedValue(null),
+    // Answers "no field group owns that table" so a create reaches the path under test. The
+    // handler asks before it emits any DDL, so a double that cannot answer fails the request.
+    getAllComponents: vi.fn().mockResolvedValue([]),
     isLocked: vi.fn().mockResolvedValue(false),
     ...overrides,
   };

--- a/packages/nextly/src/dispatcher/handlers/__tests__/single-dispatcher-shapes.test.ts
+++ b/packages/nextly/src/dispatcher/handlers/__tests__/single-dispatcher-shapes.test.ts
@@ -63,6 +63,7 @@ type Registry = {
   listSingles: ReturnType<typeof vi.fn>;
   registerSingle: ReturnType<typeof vi.fn>;
   getSingleBySlug: ReturnType<typeof vi.fn>;
+  getAllSingles: ReturnType<typeof vi.fn>;
   updateSingle: ReturnType<typeof vi.fn>;
   deleteSingle: ReturnType<typeof vi.fn>;
 };
@@ -76,6 +77,9 @@ function makeRegistry(overrides: Partial<Registry> = {}): Registry {
     listSingles: vi.fn(),
     registerSingle: vi.fn(),
     getSingleBySlug: vi.fn(),
+    // Answers "no single owns that table" so a create reaches the path under test. The handler
+    // asks before it emits any DDL, so a double that cannot answer fails the request instead.
+    getAllSingles: vi.fn().mockResolvedValue([]),
     updateSingle: vi.fn(),
     deleteSingle: vi.fn(),
     ...overrides,

--- a/packages/nextly/src/dispatcher/handlers/collection-dispatcher.ts
+++ b/packages/nextly/src/dispatcher/handlers/collection-dispatcher.ts
@@ -747,6 +747,8 @@ const COLLECTIONS_METHODS: Record<
             // editing so the admin NotificationCenter can render "Posts
             // schema updated" instead of generic "global".
             uiTargetSlug: p.collectionName,
+            // Stated rather than relying on the default, so the default stops being load-bearing.
+            uiTargetKind: "collection" as const,
           });
         },
         // The optimistic-lock check now runs up front via

--- a/packages/nextly/src/dispatcher/handlers/collection-dispatcher.ts
+++ b/packages/nextly/src/dispatcher/handlers/collection-dispatcher.ts
@@ -495,6 +495,8 @@ const COLLECTIONS_METHODS: Record<
         // must re-supply it or the preview would show translatable columns being
         // added to the main table.
         localized: (collection as { localized?: boolean }).localized === true,
+        // Authored in the Schema Builder: this is the Builder's own save path.
+        builderOwned: true,
       };
 
       const pipelinePreview = await previewDesiredSchema({
@@ -679,6 +681,8 @@ const COLLECTIONS_METHODS: Record<
         // toggle applies immediately; without this the apply re-adds translatable
         // columns to the main table.
         localized: isLocalized,
+        // Authored in the Schema Builder: this is the Builder's own save path.
+        builderOwned: true,
       };
 
       // Resolve adapter for the pipeline construction.

--- a/packages/nextly/src/dispatcher/handlers/component-dispatcher.ts
+++ b/packages/nextly/src/dispatcher/handlers/component-dispatcher.ts
@@ -825,6 +825,9 @@ const COMPONENTS_METHODS: Record<string, MethodHandler<ComponentsServices>> = {
         promptChannel: "browser",
         databaseName,
         uiTargetSlug: slug,
+        // Named, not defaulted: the scope defaults to a collection, and a field group recorded under
+        // that kind is invisible to every history query filtered by its own.
+        uiTargetKind: "component" as const,
       });
 
       if (!result.success) {

--- a/packages/nextly/src/dispatcher/handlers/component-dispatcher.ts
+++ b/packages/nextly/src/dispatcher/handlers/component-dispatcher.ts
@@ -376,15 +376,6 @@ const COMPONENTS_METHODS: Record<string, MethodHandler<ComponentsServices>> = {
       // preview/apply handlers below. Their own rules cover names and shapes;
       // what none of them can judge is a plugin type's own options, so an
       // unsatisfiable declaration would be stored and fail on every write.
-      // Refused before any DDL runs, for the same reason as the single create path: the
-      // authoritative duplicate check in `registerComponent` happens after the table has been
-      // created, so a create aimed at an existing slug altered that field group's live table first.
-      const slugTaken = await svc.registry.getComponentBySlug(b.slug);
-      if (slugTaken) {
-        throw NextlyError.duplicate({
-          logContext: { reason: "component-slug-conflict", slug: b.slug },
-        });
-      }
       assertValidPluginFieldOptions(b.fields);
 
       const isLocalized = b.localized === true;
@@ -392,6 +383,27 @@ const COMPONENTS_METHODS: Record<string, MethodHandler<ComponentsServices>> = {
       // Canonical name derivation, shared with the registry sync and
       // migrate:create paths, so the created table and the registry row agree.
       const tableName = resolveComponentTableName(b.slug);
+
+      // Refused before any DDL runs, and keyed on the TABLE NAME rather than the slug. The two are
+      // not the same key: a slug is normalised on its way to a table name, so `foo-bar` and
+      // `foo_bar` name one physical table while looking like two free slugs. Left to the registry's
+      // own check, which runs after the DDL, `CREATE TABLE IF NOT EXISTS` reports success against
+      // the table that already exists and the runtime registration then rebinds it to this
+      // request's fields — so a rejected create leaves the existing field group reading through a
+      // schema that does not describe it.
+      const owner = (await svc.registry.getAllComponents()).find(
+        c => c.tableName === tableName
+      );
+      if (owner) {
+        throw NextlyError.duplicate({
+          logContext: {
+            reason: "component-table-conflict",
+            slug: b.slug,
+            tableName,
+            ownedBy: owner.slug,
+          },
+        });
+      }
 
       // Use FieldGroupSchemaService to generate tables with parent
       // reference columns (_parent_id, _parent_table, _parent_field,

--- a/packages/nextly/src/dispatcher/handlers/component-dispatcher.ts
+++ b/packages/nextly/src/dispatcher/handlers/component-dispatcher.ts
@@ -376,6 +376,15 @@ const COMPONENTS_METHODS: Record<string, MethodHandler<ComponentsServices>> = {
       // preview/apply handlers below. Their own rules cover names and shapes;
       // what none of them can judge is a plugin type's own options, so an
       // unsatisfiable declaration would be stored and fail on every write.
+      // Refused before any DDL runs, for the same reason as the single create path: the
+      // authoritative duplicate check in `registerComponent` happens after the table has been
+      // created, so a create aimed at an existing slug altered that field group's live table first.
+      const slugTaken = await svc.registry.getComponentBySlug(b.slug);
+      if (slugTaken) {
+        throw NextlyError.duplicate({
+          logContext: { reason: "component-slug-conflict", slug: b.slug },
+        });
+      }
       assertValidPluginFieldOptions(b.fields);
 
       const isLocalized = b.localized === true;
@@ -659,6 +668,8 @@ const COMPONENTS_METHODS: Record<string, MethodHandler<ComponentsServices>> = {
         // from the component's main table (they live in comp_<slug>_locales, reconciled
         // out-of-band below) — mirrors the collection/single apply path.
         localized: (component as { localized?: boolean }).localized === true,
+        // Authored in the Schema Builder: this is the Builder's own save path.
+        builderOwned: true,
       };
 
       const pipelinePreview = await previewDesiredSchema({
@@ -783,6 +794,8 @@ const COMPONENTS_METHODS: Record<string, MethodHandler<ComponentsServices>> = {
         // from the component's main table (they live in comp_<slug>_locales, reconciled
         // out-of-band below) — mirrors the collection/single apply path.
         localized: isLocalized,
+        // Authored in the Schema Builder: this is the Builder's own save path.
+        builderOwned: true,
       };
 
       const promptDispatcher = new BrowserPromptDispatcher(

--- a/packages/nextly/src/dispatcher/handlers/single-dispatcher.ts
+++ b/packages/nextly/src/dispatcher/handlers/single-dispatcher.ts
@@ -1640,6 +1640,9 @@ const SINGLES_METHODS: Record<string, MethodHandler<SinglesServices>> = {
         promptChannel: "browser",
         databaseName,
         uiTargetSlug: slug,
+        // Named, not defaulted: the scope defaults to a collection, and a single recorded under that
+        // kind is invisible to every history query filtered by its own.
+        uiTargetKind: "single" as const,
       });
 
       if (!result.success) {

--- a/packages/nextly/src/dispatcher/handlers/single-dispatcher.ts
+++ b/packages/nextly/src/dispatcher/handlers/single-dispatcher.ts
@@ -633,6 +633,16 @@ const SINGLES_METHODS: Record<string, MethodHandler<SinglesServices>> = {
       // preview/apply handlers. It keeps its own field rules, but nothing here
       // can judge a plugin type's own options, so an unsatisfiable declaration
       // would be stored and then fail on every write to the single.
+      // Refused before any DDL runs, not after. `registerSingle` makes the authoritative check
+      // inside its own transaction, but that happens once the table has already been created or
+      // altered — so a create aimed at a slug that exists changed that single's live table and was
+      // only then rejected, leaving a table altered for a request that failed.
+      const slugTaken = await svc.registry.getSingleBySlug(b.slug);
+      if (slugTaken) {
+        throw NextlyError.duplicate({
+          logContext: { reason: "single-slug-conflict", slug: b.slug },
+        });
+      }
       assertValidPluginFieldOptions(b.fields);
 
       const schemaHash = calculateSchemaHash(b.fields);
@@ -1482,6 +1492,8 @@ const SINGLES_METHODS: Record<string, MethodHandler<SinglesServices>> = {
         // i18n: carry localized so the preview omits translatable columns from the
         // single's main table (mirrors the apply path).
         localized: (single as { localized?: boolean }).localized === true,
+        // Authored in the Schema Builder: this is the Builder's own save path.
+        builderOwned: true,
       };
 
       const pipelinePreview = await previewDesiredSchema({
@@ -1597,6 +1609,8 @@ const SINGLES_METHODS: Record<string, MethodHandler<SinglesServices>> = {
         // from the single's main table (they live in single_<slug>_locales, reconciled
         // out-of-band below) — mirrors the collection apply path.
         localized: isLocalized,
+        // Authored in the Schema Builder: this is the Builder's own save path.
+        builderOwned: true,
       };
 
       const promptDispatcher = new BrowserPromptDispatcher(

--- a/packages/nextly/src/dispatcher/handlers/single-dispatcher.ts
+++ b/packages/nextly/src/dispatcher/handlers/single-dispatcher.ts
@@ -633,22 +633,31 @@ const SINGLES_METHODS: Record<string, MethodHandler<SinglesServices>> = {
       // preview/apply handlers. It keeps its own field rules, but nothing here
       // can judge a plugin type's own options, so an unsatisfiable declaration
       // would be stored and then fail on every write to the single.
-      // Refused before any DDL runs, not after. `registerSingle` makes the authoritative check
-      // inside its own transaction, but that happens once the table has already been created or
-      // altered — so a create aimed at a slug that exists changed that single's live table and was
-      // only then rejected, leaving a table altered for a request that failed.
-      const slugTaken = await svc.registry.getSingleBySlug(b.slug);
-      if (slugTaken) {
-        throw NextlyError.duplicate({
-          logContext: { reason: "single-slug-conflict", slug: b.slug },
-        });
-      }
       assertValidPluginFieldOptions(b.fields);
 
       const schemaHash = calculateSchemaHash(b.fields);
       // Canonical resolver keeps the UI-create path in sync with registry
       // and DDL so every call site writes and reads the same physical table.
       const tableName = resolveSingleTableName({ slug: b.slug });
+
+      // Refused before any DDL runs, and keyed on the TABLE NAME rather than the slug. A slug is
+      // normalised on its way to a table name, so `foo-bar` and `foo_bar` name one physical table
+      // while looking like two free slugs. The registry's own check runs after the DDL, by which
+      // point `CREATE TABLE IF NOT EXISTS` has reported success against the table that already
+      // exists and the runtime registration has rebound it to this request's fields.
+      const owner = (await svc.registry.getAllSingles()).find(
+        s => s.tableName === tableName
+      );
+      if (owner) {
+        throw NextlyError.duplicate({
+          logContext: {
+            reason: "single-table-conflict",
+            slug: b.slug,
+            tableName,
+            ownedBy: owner.slug,
+          },
+        });
+      }
 
       // Generate migration SQL for the Single's data table. Passing
       // isSingle: true skips the slug column and auto-adds updated_at.

--- a/packages/nextly/src/dispatcher/helpers/__tests__/desired-schema-ownership.test.ts
+++ b/packages/nextly/src/dispatcher/helpers/__tests__/desired-schema-ownership.test.ts
@@ -1,0 +1,99 @@
+/**
+ * A registry row's provenance decides both ownership answers, not just one of them.
+ *
+ * Two consumers ask the same question in opposite directions: the exclusion that stops a UI save
+ * emitting DDL against a code-owned table reads `locked`, and the text-width rule reads
+ * `builderOwned`. Deriving one from the stored flag and the other from provenance left a row that
+ * names a code or plugin source without a populated `locked` flag protected from a width change and
+ * unprotected from a column rewrite.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../di", () => ({
+  getCollectionRegistryFromDI: vi.fn(),
+  getSingleRegistryFromDI: vi.fn(),
+  getComponentRegistryFromDI: vi.fn(),
+}));
+
+import {
+  getCollectionRegistryFromDI,
+  getComponentRegistryFromDI,
+  getSingleRegistryFromDI,
+} from "../di";
+import { buildFullDesiredSchema } from "../desired-schema";
+
+/** A stored row that names its source but predates the `locked` flag being populated. */
+const legacyCodeRow = {
+  slug: "posts",
+  tableName: "dc_posts",
+  fields: [],
+  source: "code",
+};
+
+const builderRow = {
+  slug: "notes",
+  tableName: "dc_notes",
+  fields: [],
+  source: "ui",
+};
+
+function wire(rows: readonly unknown[]) {
+  vi.mocked(getCollectionRegistryFromDI).mockReturnValue({
+    getAllCollections: vi.fn().mockResolvedValue(rows),
+  } as unknown as ReturnType<typeof getCollectionRegistryFromDI>);
+  vi.mocked(getSingleRegistryFromDI).mockReturnValue({
+    getAllSingles: vi.fn().mockResolvedValue(rows),
+  } as unknown as ReturnType<typeof getSingleRegistryFromDI>);
+  vi.mocked(getComponentRegistryFromDI).mockReturnValue({
+    getAllComponents: vi.fn().mockResolvedValue(rows),
+  } as unknown as ReturnType<typeof getComponentRegistryFromDI>);
+}
+
+beforeEach(() => {
+  vi.mocked(getCollectionRegistryFromDI).mockReset();
+  vi.mocked(getSingleRegistryFromDI).mockReset();
+  vi.mocked(getComponentRegistryFromDI).mockReset();
+});
+
+describe("buildFullDesiredSchema — ownership from provenance", () => {
+  it("locks a row that names a code source but leaves the flag unset", async () => {
+    wire([legacyCodeRow]);
+
+    const desired = await buildFullDesiredSchema();
+
+    // Both answers, because the two consumers read different keys for the same fact.
+    expect(desired.collections.posts.locked).toBe(true);
+    expect(desired.collections.posts.builderOwned).toBe(false);
+  });
+
+  it("locks a plugin-owned row the same way", async () => {
+    wire([{ ...legacyCodeRow, source: "plugin:acme" }]);
+
+    const desired = await buildFullDesiredSchema();
+
+    expect(desired.collections.posts.locked).toBe(true);
+    expect(desired.collections.posts.builderOwned).toBe(false);
+  });
+
+  it("leaves a builder-created row unlocked and builder-owned", async () => {
+    wire([builderRow]);
+
+    const desired = await buildFullDesiredSchema();
+
+    expect(desired.collections.notes.locked).toBe(false);
+    expect(desired.collections.notes.builderOwned).toBe(true);
+  });
+
+  // Every entity kind, because the same pair of assignments is repeated per kind and a fix applied
+  // to one of them is the shape this codebase has had to correct more than once.
+  it("answers the same way for singles and field groups", async () => {
+    wire([legacyCodeRow]);
+
+    const desired = await buildFullDesiredSchema();
+
+    for (const entity of [desired.singles.posts, desired.components.posts]) {
+      expect(entity.locked).toBe(true);
+      expect(entity.builderOwned).toBe(false);
+    }
+  });
+});

--- a/packages/nextly/src/dispatcher/helpers/desired-schema.ts
+++ b/packages/nextly/src/dispatcher/helpers/desired-schema.ts
@@ -49,6 +49,9 @@ export async function buildFullDesiredSchema(): Promise<DesiredSchema> {
           // Carry ownership so a UI save can be prevented from emitting DDL
           // against a code-first/plugin-owned table.
           locked: (c as { locked?: boolean }).locked === true,
+          // An unlocked registry row is one the Schema Builder authored. This is the only builder
+          // that reads the flag, so it is the one that states the origin the diff needs.
+          builderOwned: (c as { locked?: boolean }).locked !== true,
         };
       }
     } catch {
@@ -71,6 +74,7 @@ export async function buildFullDesiredSchema(): Promise<DesiredSchema> {
           // single's main table (they live in single_<slug>_locales).
           localized: (s as { localized?: boolean }).localized === true,
           locked: (s as { locked?: boolean }).locked === true,
+          builderOwned: (s as { locked?: boolean }).locked !== true,
         };
       }
     } catch {
@@ -92,6 +96,9 @@ export async function buildFullDesiredSchema(): Promise<DesiredSchema> {
           // component's main table (they live in comp_<slug>_locales).
           localized: (c as { localized?: boolean }).localized === true,
           locked: (c as { locked?: boolean }).locked === true,
+          // An unlocked registry row is one the Schema Builder authored. This is the only builder
+          // that reads the flag, so it is the one that states the origin the diff needs.
+          builderOwned: (c as { locked?: boolean }).locked !== true,
         };
       }
     } catch {

--- a/packages/nextly/src/dispatcher/helpers/desired-schema.ts
+++ b/packages/nextly/src/dispatcher/helpers/desired-schema.ts
@@ -16,6 +16,7 @@
  * pre-populates the rest so the schema handed to drizzle-kit is complete.
  */
 
+import { isCodeOwned } from "../../domains/schema/pipeline/registered-collections";
 import type { DesiredSchema } from "../../domains/schema/pipeline/types";
 
 import {
@@ -49,9 +50,10 @@ export async function buildFullDesiredSchema(): Promise<DesiredSchema> {
           // Carry ownership so a UI save can be prevented from emitting DDL
           // against a code-first/plugin-owned table.
           locked: (c as { locked?: boolean }).locked === true,
-          // An unlocked registry row is one the Schema Builder authored. This is the only builder
-          // that reads the flag, so it is the one that states the origin the diff needs.
-          builderOwned: (c as { locked?: boolean }).locked !== true,
+          // Provenance, not just the lock flag: a row written before `locked` was populated can be
+          // code- or plugin-owned while leaving it unset, and reading it as the Builder's would let
+          // an unrelated save rewrite that table's columns.
+          builderOwned: !isCodeOwned(c),
         };
       }
     } catch {
@@ -74,7 +76,7 @@ export async function buildFullDesiredSchema(): Promise<DesiredSchema> {
           // single's main table (they live in single_<slug>_locales).
           localized: (s as { localized?: boolean }).localized === true,
           locked: (s as { locked?: boolean }).locked === true,
-          builderOwned: (s as { locked?: boolean }).locked !== true,
+          builderOwned: !isCodeOwned(s),
         };
       }
     } catch {
@@ -96,9 +98,10 @@ export async function buildFullDesiredSchema(): Promise<DesiredSchema> {
           // component's main table (they live in comp_<slug>_locales).
           localized: (c as { localized?: boolean }).localized === true,
           locked: (c as { locked?: boolean }).locked === true,
-          // An unlocked registry row is one the Schema Builder authored. This is the only builder
-          // that reads the flag, so it is the one that states the origin the diff needs.
-          builderOwned: (c as { locked?: boolean }).locked !== true,
+          // Provenance, not just the lock flag: a row written before `locked` was populated can be
+          // code- or plugin-owned while leaving it unset, and reading it as the Builder's would let
+          // an unrelated save rewrite that table's columns.
+          builderOwned: !isCodeOwned(c),
         };
       }
     } catch {

--- a/packages/nextly/src/dispatcher/helpers/desired-schema.ts
+++ b/packages/nextly/src/dispatcher/helpers/desired-schema.ts
@@ -47,12 +47,13 @@ export async function buildFullDesiredSchema(): Promise<DesiredSchema> {
           // translatable columns from the main table (they live in the
           // companion `_locales` table) instead of re-adding them.
           localized: (c as { localized?: boolean }).localized === true,
-          // Carry ownership so a UI save can be prevented from emitting DDL
-          // against a code-first/plugin-owned table.
-          locked: (c as { locked?: boolean }).locked === true,
-          // Provenance, not just the lock flag: a row written before `locked` was populated can be
-          // code- or plugin-owned while leaving it unset, and reading it as the Builder's would let
-          // an unrelated save rewrite that table's columns.
+          // Both answers come from provenance, not from the stored flag alone. A row written
+          // before `locked` was populated can be code- or plugin-owned while leaving it unset, and
+          // the two consumers ask the same question in opposite directions: the exclusion that
+          // stops a UI save emitting DDL against such a table reads `locked`, while the width rule
+          // reads `builderOwned`. Deriving one from the flag and the other from provenance left
+          // that table protected from a width change and unprotected from a column rewrite.
+          locked: isCodeOwned(c),
           builderOwned: !isCodeOwned(c),
         };
       }
@@ -75,7 +76,7 @@ export async function buildFullDesiredSchema(): Promise<DesiredSchema> {
           // i18n: carry localized so the diff omits translatable columns from the
           // single's main table (they live in single_<slug>_locales).
           localized: (s as { localized?: boolean }).localized === true,
-          locked: (s as { locked?: boolean }).locked === true,
+          locked: isCodeOwned(s),
           builderOwned: !isCodeOwned(s),
         };
       }
@@ -97,7 +98,7 @@ export async function buildFullDesiredSchema(): Promise<DesiredSchema> {
           // i18n: carry localized so the diff omits translatable columns from the
           // component's main table (they live in comp_<slug>_locales).
           localized: (c as { localized?: boolean }).localized === true,
-          locked: (c as { locked?: boolean }).locked === true,
+          locked: isCodeOwned(c),
           // Provenance, not just the lock flag: a row written before `locked` was populated can be
           // code- or plugin-owned while leaving it unset, and reading it as the Builder's would let
           // an unrelated save rewrite that table's columns.

--- a/packages/nextly/src/domains/i18n/migration/ddl-types.ts
+++ b/packages/nextly/src/domains/i18n/migration/ddl-types.ts
@@ -24,6 +24,9 @@ export function ddlType(
       return dialect === "mysql" ? `VARCHAR(${len})` : "TEXT";
     case "longText":
       return dialect === "mysql" ? "LONGTEXT" : "TEXT";
+    case "shortText":
+      // Bounded on both dialects that have a bounded string; SQLite has only one.
+      return dialect === "sqlite" ? "TEXT" : `VARCHAR(${len})`;
     case "boolean":
       return dialect === "postgresql"
         ? "BOOLEAN"

--- a/packages/nextly/src/domains/i18n/migration/migration-intent.test.ts
+++ b/packages/nextly/src/domains/i18n/migration/migration-intent.test.ts
@@ -12,7 +12,7 @@ import {
   LOCALIZATION_INTENT_VERSION,
   parseLocalizationIntent,
 } from "./migration-intent";
-import type { CompanionMigrationSpec } from "./types";
+import { LOCALIZED_COLUMN_KINDS, type CompanionMigrationSpec } from "./types";
 
 const spec = (
   overrides: Partial<CompanionMigrationSpec> = {}
@@ -51,6 +51,22 @@ describe("localization migration intent", () => {
     expect(parsed?.spec.columnsOnMain).toEqual(["body"]);
     expect(parsed?.spec.status).toBe(true);
     expect(parsed?.spec.columns).toEqual([{ name: "body", kind: "text" }]);
+  });
+
+  // Every kind the spec type permits, rather than a chosen one. The generator may write any member
+  // of this set into a header, so a parser that accepts a subset aborts a run on a file the same
+  // build just produced. Enumerating the set is what makes the next kind added fail here instead of
+  // at a user's migrate.
+  it.each(LOCALIZED_COLUMN_KINDS)("round-trips the %s column kind", kind => {
+    const line = formatLocalizationIntent({
+      kind: "enable",
+      entity: "collection",
+      spec: spec({ columns: [{ name: "body", kind }] }),
+    });
+
+    const parsed = parseLocalizationIntent(fileWith(line), "m.sql");
+
+    expect(parsed?.spec.columns).toEqual([{ name: "body", kind }]);
   });
 
   // The file's checksum covers this line, so an unstable rendering would make two runs that

--- a/packages/nextly/src/domains/i18n/migration/migration-intent.ts
+++ b/packages/nextly/src/domains/i18n/migration/migration-intent.ts
@@ -1,7 +1,7 @@
 import { NextlyError } from "../../../errors/nextly-error";
 
 import type { I18nTransitionKind } from "./transition-state";
-import type { CompanionMigrationSpec } from "./types";
+import { LOCALIZED_COLUMN_KINDS, type CompanionMigrationSpec } from "./types";
 
 /**
  * Header field carrying a companion migration's declared intent.
@@ -160,18 +160,17 @@ export function isLocalizationIntentRefusal(error: unknown): boolean {
 /** Dialects a spec may name. Drives DDL, so an unknown one cannot be carried forward. */
 const DIALECTS = new Set(["postgresql", "mysql", "sqlite"]);
 
-/** Storage kinds a localized column may declare, mirroring `LocalizedColumnSpec["kind"]`. */
-const COLUMN_KINDS = new Set([
-  "text",
-  "longText",
-  "boolean",
-  "integer",
-  "double",
-  "decimal",
-  "timestamp",
-  "json",
-  "fkSingle",
-]);
+/**
+ * Storage kinds a localized column may declare.
+ *
+ * Built from the declaration the spec's own type is derived from, so the set this parser accepts
+ * and the set the generator can write are the same set. A hand-kept copy drifted the moment a kind
+ * was added: the generator wrote it, this refused it, and the run aborted on a file it had just
+ * produced itself.
+ */
+const COLUMN_KINDS: ReadonlySet<string> = new Set<string>(
+  LOCALIZED_COLUMN_KINDS
+);
 
 /**
  * A column dimension: absent, or a whole number in range.

--- a/packages/nextly/src/domains/i18n/migration/types.ts
+++ b/packages/nextly/src/domains/i18n/migration/types.ts
@@ -12,6 +12,7 @@ export interface LocalizedColumnSpec {
   kind:
     | "text"
     | "longText"
+    | "shortText"
     | "boolean"
     | "integer"
     | "double"

--- a/packages/nextly/src/domains/i18n/migration/types.ts
+++ b/packages/nextly/src/domains/i18n/migration/types.ts
@@ -1,6 +1,31 @@
 import type { SupportedDialect } from "@nextlyhq/adapter-drizzle/types";
 
 /**
+ * Every storage kind a localized column may declare.
+ *
+ * Stated once, as a value, because both a type and a runtime check need it: the generator writes
+ * one of these into a migration file's header and the parser that reads that file back has to
+ * accept exactly the same set. Kept as two independent lists, the parser rejected a kind the
+ * generator had just written and aborted the run — so the list is the value, and the type is
+ * derived from it.
+ */
+export const LOCALIZED_COLUMN_KINDS = [
+  "text",
+  "longText",
+  "shortText",
+  "boolean",
+  "integer",
+  "double",
+  "decimal",
+  "timestamp",
+  "json",
+  "fkSingle",
+] as const;
+
+/** Logical storage kind — drives the per-dialect DDL type. */
+export type LocalizedColumnKind = (typeof LOCALIZED_COLUMN_KINDS)[number];
+
+/**
  * A single localized column, described independently of the field system.
  * M3 will derive these from field descriptors; M1 accepts them directly so the
  * migration generator is self-contained and testable.
@@ -8,18 +33,7 @@ import type { SupportedDialect } from "@nextlyhq/adapter-drizzle/types";
 export interface LocalizedColumnSpec {
   /** snake_case column name; identical on the main and companion tables. */
   name: string;
-  /** logical storage kind — drives the per-dialect DDL type. */
-  kind:
-    | "text"
-    | "longText"
-    | "shortText"
-    | "boolean"
-    | "integer"
-    | "double"
-    | "decimal"
-    | "timestamp"
-    | "json"
-    | "fkSingle";
+  kind: LocalizedColumnKind;
   /** optional length for text/varchar-like columns. */
   length?: number;
   /** precision/scale for the `decimal` kind (DECIMAL/NUMERIC); ignored otherwise. */

--- a/packages/nextly/src/domains/schema/journal/migration-journal.ts
+++ b/packages/nextly/src/domains/schema/journal/migration-journal.ts
@@ -110,7 +110,11 @@ export class DrizzleMigrationJournal implements MigrationJournal {
         eventType,
         source,
         scopeKind: args.scope ? mapScopeKind(args.scope.kind) : undefined,
-        scopeSlug: args.scope?.slug,
+        // A fresh push replaces the whole schema, so it names no entity to record.
+        scopeSlug:
+          args.scope && args.scope.kind !== "fresh-push"
+            ? args.scope.slug
+            : undefined,
       });
       this.startTimes.set(id, Date.now());
       return id;

--- a/packages/nextly/src/domains/schema/journal/read-journal.ts
+++ b/packages/nextly/src/domains/schema/journal/read-journal.ts
@@ -24,6 +24,7 @@ export type Dialect = "postgresql" | "mysql" | "sqlite";
 export type JournalScopeApi =
   | { kind: "collection"; slug: string }
   | { kind: "single"; slug: string }
+  | { kind: "component"; slug: string }
   | { kind: "global"; slug?: string }
   | { kind: "fresh-push" };
 
@@ -120,21 +121,24 @@ function mapRow(r: Record<string, unknown>): JournalRowApi {
   const scopeKind = r.scopeKind as string | null | undefined;
   const scopeSlug = r.scopeSlug as string | null | undefined;
   let scope: JournalScopeApi | null = null;
-  if (
-    scopeKind === "global" ||
-    scopeKind === "core" ||
-    scopeKind === STORAGE_FORMAT.schemaEventScope
-  ) {
-    // Events-only kinds (core/component) have no admin-facing equivalent;
-    // fold them into the generic "global" bucket.
+  if (scopeKind === "global" || scopeKind === "core") {
+    // `core` describes Nextly's own tables and names no user entity, so it has no scope of its own
+    // to report and folds into the generic bucket.
     scope = scopeSlug
       ? { kind: "global", slug: scopeSlug }
       : { kind: "global" };
   } else if (
-    (scopeKind === "collection" || scopeKind === "single") &&
+    (scopeKind === "collection" ||
+      scopeKind === "single" ||
+      // A field-group save records its own kind, so reporting it as global would discard the one
+      // thing a caller filtering this feed by entity is asking for.
+      scopeKind === STORAGE_FORMAT.schemaEventScope) &&
     typeof scopeSlug === "string"
   ) {
-    scope = { kind: scopeKind, slug: scopeSlug };
+    scope =
+      scopeKind === STORAGE_FORMAT.schemaEventScope
+        ? { kind: "component", slug: scopeSlug }
+        : { kind: scopeKind, slug: scopeSlug };
   }
 
   return {

--- a/packages/nextly/src/domains/schema/pipeline/__tests__/builder-create-converges.integration.test.ts
+++ b/packages/nextly/src/domains/schema/pipeline/__tests__/builder-create-converges.integration.test.ts
@@ -1,0 +1,195 @@
+/**
+ * A table the Schema Builder just created must preview as unchanged.
+ *
+ * The create path and the preview path each build their own desired schema from the same registry
+ * row. When they disagree about a single column, an operator who has changed nothing opens the
+ * Builder and is shown a destructive type change against a table nobody touched — and confirming it
+ * narrows a live column.
+ *
+ * Not hypothetical: resolving the Builder's text-width rule inside the create handler alone produced
+ * exactly this, because preview builds its snapshot elsewhere and never applied the rule. A unit test
+ * over either path passes while the pair disagrees, which is why this asserts across the two. It is
+ * also invisible on PostgreSQL and SQLite, where both answers render `text`; only MySQL renders them
+ * differently, and there they are 65 535 and 255 characters.
+ */
+import { drizzle as drizzleMysql } from "drizzle-orm/mysql2";
+import { drizzle as drizzlePg } from "drizzle-orm/node-postgres";
+import { createPool, type Pool as MysqlPool } from "mysql2";
+import { Pool } from "pg";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { makeTestContext } from "../../../../database/__tests__/integration/helpers/test-db";
+import { DrizzleStatementExecutor } from "../../services/drizzle-statement-executor";
+import { introspectLiveSnapshot } from "../diff/introspect-live";
+import { previewDesiredSchema } from "../preview";
+import { PushSchemaPipeline } from "../pushschema-pipeline";
+import {
+  noopClassifier,
+  noopMigrationJournal,
+  noopNotifier,
+  noopPreCleanupExecutor,
+  noopPreRenameExecutor,
+  noopPromptDispatcher,
+  noopRenameDetector,
+} from "../pushschema-pipeline-stubs";
+import type { DesiredSchema } from "../types";
+
+// Per-file prefixes so this suite cannot collide with another that creates a table of its own.
+const PG = makeTestContext("postgresql");
+const MYSQL = makeTestContext("mysql");
+const PG_URL = PG.url ?? "";
+const MYSQL_URL = MYSQL.url ?? "";
+
+/** A Builder-authored single: unlocked, one plain text field stating no width anywhere. */
+function builderSingle(tableName: string): DesiredSchema {
+  return {
+    collections: {},
+    singles: {
+      page: {
+        slug: "page",
+        tableName,
+        fields: [{ name: "body", type: "text" }] as never,
+        builderOwned: true,
+      },
+    },
+    components: {},
+  };
+}
+
+/**
+ * Everything the diff reports about columns.
+ *
+ * Index operations are excluded because a created table genuinely lacks its secondary indexes: the
+ * Drizzle schema handed to drizzle-kit declares none. Column shape is what this suite pins, and a
+ * disagreement between the two builders shows up there.
+ */
+function columnOperations(
+  operations: readonly { type: string }[]
+): readonly { type: string }[] {
+  return operations.filter(op => !op.type.endsWith("_index"));
+}
+
+function makePipeline(
+  dialect: "postgresql" | "mysql",
+  db: unknown
+): PushSchemaPipeline {
+  return new PushSchemaPipeline({
+    executor: new DrizzleStatementExecutor(dialect, db),
+    renameDetector: noopRenameDetector,
+    classifier: noopClassifier,
+    promptDispatcher: noopPromptDispatcher,
+    preRenameExecutor: noopPreRenameExecutor,
+    preCleanupExecutor: noopPreCleanupExecutor,
+    migrationJournal: noopMigrationJournal,
+    notifier: noopNotifier,
+  });
+}
+
+describe.skipIf(!PG_URL)("builder-created table converges (postgres)", () => {
+  const tableName = `${PG.prefix}_single_conv`;
+  let pool: Pool;
+  let db: ReturnType<typeof drizzlePg>;
+
+  beforeAll(async () => {
+    pool = new Pool({ connectionString: PG_URL });
+    db = drizzlePg({ client: pool });
+    await db.execute(`DROP TABLE IF EXISTS "${tableName}"`);
+  });
+
+  afterAll(async () => {
+    await db.execute(`DROP TABLE IF EXISTS "${tableName}"`);
+    await pool.end();
+  });
+
+  it("previews as unchanged immediately after being created", async () => {
+    const desired = builderSingle(tableName);
+
+    const applied = await makePipeline("postgresql", db).apply({
+      desired,
+      db,
+      dialect: "postgresql",
+      source: "ui",
+      promptChannel: "browser",
+      uiTargetSlug: "page",
+      uiTargetKind: "single",
+    });
+    expect(applied.success).toBe(true);
+
+    const preview = await previewDesiredSchema({
+      desired,
+      db,
+      dialect: "postgresql",
+    });
+
+    // Scoped past index operations deliberately. The Drizzle tables drizzle-kit builds its DDL from
+    // declare no secondary indexes, so a freshly created table has none and the next diff asks for
+    // them back. That is a real gap with its own fix pending, and a blanket zero here would fail on
+    // it forever — or, once someone relaxed the assertion, stop pinning the invariant this exists for.
+    expect(columnOperations(preview.operations)).toEqual([]);
+  });
+});
+
+describe.skipIf(!MYSQL_URL)("builder-created table converges (mysql)", () => {
+  const tableName = `${MYSQL.prefix}_single_conv`;
+  let pool: MysqlPool;
+  let db: ReturnType<typeof drizzleMysql<Record<string, never>, MysqlPool>>;
+
+  beforeAll(async () => {
+    pool = createPool({ uri: MYSQL_URL });
+    db = drizzleMysql({ client: pool });
+    await pool.promise().query(`DROP TABLE IF EXISTS \`${tableName}\``);
+  });
+
+  afterAll(async () => {
+    await pool.promise().query(`DROP TABLE IF EXISTS \`${tableName}\``);
+    await new Promise<void>(res => pool.end(() => res()));
+  });
+
+  it("previews as unchanged immediately after being created", async () => {
+    const desired = builderSingle(tableName);
+
+    const applied = await makePipeline("mysql", db).apply({
+      desired,
+      db,
+      dialect: "mysql",
+      source: "ui",
+      promptChannel: "browser",
+      databaseName: new URL(MYSQL_URL).pathname.slice(1),
+      uiTargetSlug: "page",
+      uiTargetKind: "single",
+    });
+    expect(applied.success).toBe(true);
+
+    const preview = await previewDesiredSchema({
+      desired,
+      db,
+      dialect: "mysql",
+    });
+
+    expect(columnOperations(preview.operations)).toEqual([]);
+  });
+
+  // The dialect where the two possible answers are physically different, and where getting this
+  // wrong truncates at 255 characters rather than merely reading as drift.
+  it("gives an unstated builder text field an unbounded column", async () => {
+    const desired = builderSingle(tableName);
+
+    await makePipeline("mysql", db).apply({
+      desired,
+      db,
+      dialect: "mysql",
+      source: "ui",
+      promptChannel: "browser",
+      databaseName: new URL(MYSQL_URL).pathname.slice(1),
+      uiTargetSlug: "page",
+      uiTargetKind: "single",
+    });
+
+    const live = await introspectLiveSnapshot(db, "mysql", [tableName]);
+    const body = live.tables
+      .find(t => t.name === tableName)
+      ?.columns.find(c => c.name === "body");
+
+    expect(body?.type).toBe("text");
+  });
+});

--- a/packages/nextly/src/domains/schema/pipeline/__tests__/journal-summary-and-scope.test.ts
+++ b/packages/nextly/src/domains/schema/pipeline/__tests__/journal-summary-and-scope.test.ts
@@ -76,7 +76,11 @@ describe("computeJournalSummaryFromOperations", () => {
 
   it("counts add_column and add_table as added", () => {
     expect(
-      computeJournalSummaryFromOperations([addColumn(), addColumn(), addTable()])
+      computeJournalSummaryFromOperations([
+        addColumn(),
+        addColumn(),
+        addTable(),
+      ])
     ).toEqual({ added: 3, removed: 0, renamed: 0, changed: 0 });
   });
 
@@ -122,6 +126,20 @@ describe("computeJournalScope", () => {
       slug: "posts",
     });
   });
+
+  // Every entity kind, not just the defaulted one. A scope naming a kind carries the entity it
+  // names — the type now requires it — because a kind arriving without one had to be retargeted to
+  // the whole schema by the notification conversion, losing the target a scope-filtered history is
+  // searched by.
+  it.each(["collection", "single", "component"] as const)(
+    "ui + slug -> %s scope carrying its slug",
+    kind => {
+      expect(computeJournalScope("ui", "hero", kind)).toEqual({
+        kind,
+        slug: "hero",
+      });
+    }
+  );
 
   it("code source -> global scope", () => {
     expect(computeJournalScope("code", undefined)).toEqual({ kind: "global" });

--- a/packages/nextly/src/domains/schema/pipeline/__tests__/pushschema-pipeline.test.ts
+++ b/packages/nextly/src/domains/schema/pipeline/__tests__/pushschema-pipeline.test.ts
@@ -384,6 +384,64 @@ describe("PushSchemaPipeline (Option E flow) - introspection wired", () => {
     expect(opsArg.some(op => op.type === "drop_column")).toBe(true);
     expect(opsArg.some(op => op.type === "add_column")).toBe(true);
   });
+
+  // A UI save must not be refused over drift on a table it does not own. An unresolved rename
+  // candidate fails closed, so a locked table's operations reaching the detector is enough to
+  // refuse the whole save even though the apply would discard every one of them.
+  it("hides locked-table operations from rename detection on a UI save", async () => {
+    const lockedDesired: DesiredSchema = {
+      collections: {
+        posts: {
+          slug: "posts",
+          tableName: "dc_posts",
+          fields: [{ name: "summary", type: "text" }] as never,
+          locked: true,
+        },
+      },
+      singles: {},
+      components: {},
+    };
+
+    const introspectImpl = vi
+      .fn<
+        (
+          db: unknown,
+          dialect: SupportedDialect,
+          tableNames: string[]
+        ) => Promise<NextlySchemaSnapshot>
+      >()
+      .mockResolvedValue({
+        tables: [
+          {
+            name: "dc_posts",
+            columns: [
+              { name: "id", type: "text", nullable: false },
+              { name: "title", type: "text", nullable: false },
+              { name: "slug", type: "text", nullable: false },
+              { name: "created_at", type: "timestamp", nullable: true },
+              { name: "updated_at", type: "timestamp", nullable: true },
+              { name: "body", type: "text", nullable: true },
+            ],
+          },
+        ],
+      });
+
+    const { pipeline, mocks } = makePipeline({ introspectImpl });
+
+    await pipeline.apply({
+      desired: lockedDesired,
+      db: {},
+      dialect: "postgresql",
+      source: "ui",
+      promptChannel: "browser",
+    });
+
+    const [opsArg] = mocks.renameDetector.detect.mock.calls[0] as [
+      Operation[],
+      SupportedDialect,
+    ];
+    expect(opsArg).toEqual([]);
+  });
 });
 
 describe("PushSchemaPipeline (Option E flow) - prompt + resolution flow", () => {

--- a/packages/nextly/src/domains/schema/pipeline/__tests__/registered-collections.test.ts
+++ b/packages/nextly/src/domains/schema/pipeline/__tests__/registered-collections.test.ts
@@ -81,6 +81,23 @@ describe("mergeRegisteredCollections", () => {
     expect(merged.hero.builderOwned).toBe(true);
   });
 
+  // A code-first or plugin entity dropped from the config keeps its registry row on purpose, so
+  // reaching this merge does not make it the Builder's. Calling it so would rewrite its columns on
+  // the next sync against a table that orphan retention exists to leave alone.
+  it.each([
+    ["a locked row", { locked: true }],
+    ["a code-sourced row", { source: "code" }],
+    ["a plugin-sourced row", { source: "plugin:seo" }],
+  ])("does not claim %s for the Builder", (_, ownership) => {
+    const merged = mergeRegisteredEntities(
+      {},
+      [{ slug: "orphan", tableName: "dc_orphan", fields: [], ...ownership }],
+      (_row, base) => base
+    );
+
+    expect(merged.orphan.builderOwned).toBe(false);
+  });
+
   it("defaults localized to false rather than undefined", () => {
     const merged = mergeRegisteredEntities(
       {},

--- a/packages/nextly/src/domains/schema/pipeline/__tests__/registered-collections.test.ts
+++ b/packages/nextly/src/domains/schema/pipeline/__tests__/registered-collections.test.ts
@@ -67,6 +67,20 @@ describe("mergeRegisteredCollections", () => {
     expect(merged.hero.localized).toBe(true);
   });
 
+  it("states Builder ownership for every registry-sourced entity", () => {
+    // A row only reaches this merge when the registry holds it and no config entry claimed the
+    // slug, which is exactly what it means for the Schema Builder to own it. Left unstated, such an
+    // entity is described the way a code-first table is, and a db:sync or HMR pass reports its
+    // columns as drift — on MySQL, an existing unbounded text column as a narrowing to 255.
+    const merged = mergeRegisteredEntities(
+      {},
+      [{ slug: "hero", tableName: "single_hero", fields: [] }],
+      (_row, base) => base
+    );
+
+    expect(merged.hero.builderOwned).toBe(true);
+  });
+
   it("defaults localized to false rather than undefined", () => {
     const merged = mergeRegisteredEntities(
       {},

--- a/packages/nextly/src/domains/schema/pipeline/preview.ts
+++ b/packages/nextly/src/domains/schema/pipeline/preview.ts
@@ -36,6 +36,10 @@ import {
 import { diffSnapshots } from "./diff/diff";
 import { introspectLiveSnapshot } from "./diff/introspect-live";
 import type { NextlySchemaSnapshot, Operation } from "./diff/types";
+import {
+  excludeLockedTableOps,
+  logSkippedLockedOps,
+} from "./pushschema-pipeline";
 import type {
   Classifier,
   ClassificationLevel,
@@ -177,7 +181,17 @@ export async function previewDesiredSchema(
     tables: [...collectionTables, ...singleTables, ...componentTables],
   };
 
-  const operations = diffSnapshots(liveSnapshot, desiredSnapshot);
+  const allOperations = diffSnapshots(liveSnapshot, desiredSnapshot);
+
+  // Preview is what the browser asks the operator to confirm, so it must show the operation set the
+  // apply can actually run. The apply drops operations on code-first and plugin-owned tables before
+  // it reads them; leaving them in here surfaced destructive warnings and rename prompts for drift
+  // on a table the save does not own and would never have touched.
+  const { kept: operations, skipped } = excludeLockedTableOps(
+    allOperations,
+    desired
+  );
+  logSkippedLockedOps(skipped);
 
   // Phase B: rename detection + classification.
   // The rename detector reads typed Operation[] (post Option E) and

--- a/packages/nextly/src/domains/schema/pipeline/preview.ts
+++ b/packages/nextly/src/domains/schema/pipeline/preview.ts
@@ -22,6 +22,8 @@
 
 import type { SupportedDialect } from "@nextlyhq/adapter-drizzle/types";
 
+import { withResolvedBuilderTextWidths } from "../services/builder-text-width";
+
 import { RealClassifier } from "./classifier/classifier";
 import {
   countNulls as countNullsHelper,
@@ -102,7 +104,11 @@ export async function previewDesiredSchema(
   args: PreviewDesiredSchemaArgs,
   deps: PreviewDesiredSchemaDeps = {}
 ): Promise<PipelinePreviewResult> {
-  const { desired, db, dialect } = args;
+  const { db, dialect } = args;
+  // Resolved once, here, so the snapshot this function builds and the DDL the apply path builds
+  // from the same declaration describe the same column. Two different builders read a desired
+  // schema, and normalising what they share is what keeps them from disagreeing forever.
+  const desired = withResolvedBuilderTextWidths(args.desired);
   const renameDetector = deps.renameDetector ?? new RegexRenameDetector();
   const classifier = deps.classifier ?? new RealClassifier();
   const introspect = deps.introspect ?? introspectLiveSnapshot;
@@ -133,7 +139,10 @@ export async function previewDesiredSchema(
       // omitted from the preview's desired snapshot (they live in the companion
       // `_locales` table); otherwise the diff reports them as missing and the
       // SchemaChangeDialog tries to re-add them to the main table.
-      { hasStatus: c.status === true, localized: c.localized === true }
+      {
+        hasStatus: c.status === true,
+        localized: c.localized === true,
+      }
     )
   );
   const singleTables = Object.values(desired.singles).map(s =>
@@ -144,7 +153,10 @@ export async function previewDesiredSchema(
       // Forward `localized` so a localized single's translatable columns are omitted from the
       // preview's desired snapshot (they live in the companion), matching the collection path —
       // otherwise the diff reports phantom main-table changes the apply never makes.
-      { hasStatus: s.status === true, localized: s.localized === true }
+      {
+        hasStatus: s.status === true,
+        localized: s.localized === true,
+      }
     )
   );
   const componentTables = Object.values(desired.components).map(c =>
@@ -156,7 +168,9 @@ export async function previewDesiredSchema(
       dialect,
       // Forward `localized` so a localized component's translatable columns are omitted from the
       // preview's desired snapshot (they live in the companion), matching collections/singles.
-      { localized: (c as { localized?: boolean }).localized === true }
+      {
+        localized: (c as { localized?: boolean }).localized === true,
+      }
     )
   );
   const desiredSnapshot: NextlySchemaSnapshot = {

--- a/packages/nextly/src/domains/schema/pipeline/pushschema-pipeline-interfaces.ts
+++ b/packages/nextly/src/domains/schema/pipeline/pushschema-pipeline-interfaces.ts
@@ -112,7 +112,9 @@ export interface PreCleanupExecutor {
 // NotificationCenter can render meaningful audit rows. Plan C1 maps this onto
 // `SchemaEventScopeKind` from `schemas/schema-events/types.ts`.
 export interface MigrationJournalScope {
-  kind: "collection" | "single" | "global" | "fresh-push";
+  // `component` is carried because a field group is one of the entity kinds a UI apply can target,
+  // and recording it as a collection made scope-filtered history unable to find it.
+  kind: "collection" | "single" | "component" | "global" | "fresh-push";
   slug?: string;
 }
 

--- a/packages/nextly/src/domains/schema/pipeline/pushschema-pipeline-interfaces.ts
+++ b/packages/nextly/src/domains/schema/pipeline/pushschema-pipeline-interfaces.ts
@@ -111,12 +111,18 @@ export interface PreCleanupExecutor {
 // F10 PR 2: scope of the apply, persisted into the journal so the admin
 // NotificationCenter can render meaningful audit rows. Plan C1 maps this onto
 // `SchemaEventScopeKind` from `schemas/schema-events/types.ts`.
-export interface MigrationJournalScope {
-  // `component` is carried because a field group is one of the entity kinds a UI apply can target,
-  // and recording it as a collection made scope-filtered history unable to find it.
-  kind: "collection" | "single" | "component" | "global" | "fresh-push";
-  slug?: string;
-}
+// A scope that names an entity kind carries the entity it names. Written as a union rather than one
+// shape with an optional slug because the difference is not decoration: a slugless entity scope has
+// nothing to filter history by, and the conversion to a notification scope had to invent a fallback
+// for a state it could not otherwise rule out. Stating it in the type retires the fallback.
+//
+// `component` is carried because a field group is one of the entity kinds a UI apply can target, and
+// recording it as a collection made scope-filtered history unable to find it.
+export type MigrationJournalScope =
+  | { kind: "collection" | "single" | "component"; slug: string }
+  // A whole-schema apply may still name the entity that prompted it.
+  | { kind: "global"; slug?: string }
+  | { kind: "fresh-push" };
 
 // F10 PR 2: per-change-kind counts derived from the pipeline's diff
 // result. Persisted into the journal so audit rows can show

--- a/packages/nextly/src/domains/schema/pipeline/pushschema-pipeline.ts
+++ b/packages/nextly/src/domains/schema/pipeline/pushschema-pipeline.ts
@@ -456,7 +456,7 @@ export function excludeLockedTableOps(
   return { kept, skipped };
 }
 
-function logSkippedLockedOps(skipped: Operation[]): void {
+export function logSkippedLockedOps(skipped: Operation[]): void {
   if (skipped.length === 0 || process.env.DEBUG_SCHEMA !== "1") return;
   const tables = [
     ...new Set(skipped.map(op => operationTargetTable(op) ?? "<unknown>")),

--- a/packages/nextly/src/domains/schema/pipeline/pushschema-pipeline.ts
+++ b/packages/nextly/src/domains/schema/pipeline/pushschema-pipeline.ts
@@ -38,6 +38,7 @@ import {
   chooseTypeColumns,
   resolveRegistryNameFromCatalog,
 } from "../../field-groups/storage/resolve-storage-names";
+import { withResolvedBuilderTextWidths } from "../services/builder-text-width";
 import { generateRuntimeSchema } from "../services/runtime-schema-generator";
 import { identifierCaseRules } from "../utils/resolve-catalog-name";
 
@@ -372,10 +373,14 @@ export function computeJournalSummaryFromOperations(
 // Pure helper. Test seam: exported.
 export function computeJournalScope(
   source: "ui" | "code",
-  uiTargetSlug: string | undefined
+  uiTargetSlug: string | undefined,
+  // Defaulted to `collection` so the many existing UI callers that target one keep their scope
+  // without restating it. A single or field group must say so: recording either as a collection
+  // hid its migrations from every scope-filtered audit query.
+  uiTargetKind: "collection" | "single" | "component" = "collection"
 ): MigrationJournalScope {
   if (source === "ui" && uiTargetSlug) {
-    return { kind: "collection", slug: uiTargetSlug };
+    return { kind: uiTargetKind, slug: uiTargetSlug };
   }
   return { kind: "global" };
 }
@@ -484,7 +489,7 @@ function toNotificationScope(scope: MigrationJournalScope): MigrationScope {
       ? { kind: "global", slug: scope.slug }
       : { kind: "global" };
   }
-  // collection | single — both require a slug per
+  // collection | single | component — all three require a slug per
   // MigrationJournalScope's contract (asserted at the type-system
   // level because slug is optional only for fresh-push/global).
   return scope.slug
@@ -512,9 +517,20 @@ export class PushSchemaPipeline {
     // slug: <user's collection> }`. HMR/code-first applies omit it
     // and get tagged as global.
     uiTargetSlug?: string;
+    /** Which entity kind `uiTargetSlug` names, so the journal row records it accurately. */
+    uiTargetKind?: "collection" | "single" | "component";
   }): Promise<PipelineResult> {
-    const { desired, db, dialect, source, promptChannel, databaseName } = args;
-    const scope = computeJournalScope(source, args.uiTargetSlug);
+    const { db, dialect, source, promptChannel, databaseName } = args;
+    // Resolved once, before anything reads it. A desired schema is consumed by TWO builders — the
+    // snapshot the diff compares and the Drizzle tables drizzle-kit turns into DDL — and resolving
+    // inside either leaves the other on the raw fields, so a table would converge and then report a
+    // type change against itself on every following diff.
+    const desired = withResolvedBuilderTextWidths(args.desired);
+    const scope = computeJournalScope(
+      source,
+      args.uiTargetSlug,
+      args.uiTargetKind
+    );
     // F10 PR 3: track wall-clock for the notification event. The
     // journal already computes its own duration; we duplicate here so
     // the notification event surfaces duration even when the journal
@@ -660,7 +676,10 @@ export class PushSchemaPipeline {
               // localized collection's translatable columns are omitted from the
               // main table's desired snapshot (they live in the companion
               // `_locales` table) rather than being re-added by the diff.
-              { hasStatus: c.status === true, localized: c.localized === true }
+              {
+                hasStatus: c.status === true,
+                localized: c.localized === true,
+              }
             )
           ),
           ...Object.values(desired.singles).map(s =>
@@ -692,7 +711,22 @@ export class PushSchemaPipeline {
         ],
       };
 
-      const operations = diffSnapshots(liveSnapshot, desiredSnapshot);
+      const allOperations = diffSnapshots(liveSnapshot, desiredSnapshot);
+
+      // A UI save owns only the entity being edited. An operation targeting a code-first or
+      // plugin-owned table is dropped here, BEFORE anything reads the operation set, because those
+      // tables belong to `nextly.config.ts` and reconciling their drift is db:sync's job.
+      //
+      // 🔴 Dropped before rename detection rather than after prompting, which is where this used to
+      // happen. An operation on a locked table still reached the rename detector and the prompt gate
+      // on the way, and an unresolved candidate fails closed — so unapplied drift on a table the
+      // save was never going to touch could refuse the entire save, over an operation the very next
+      // step discards. Code-first applies keep the full set: they ARE the authority for those tables.
+      const { kept: operations, skipped: skippedLockedOps } =
+        source === "ui"
+          ? excludeLockedTableOps(allOperations, desired)
+          : { kept: allOperations, skipped: [] as Operation[] };
+      logSkippedLockedOps(skippedLockedOps);
 
       // Phase B: rename detection + prompt + resolution application.
       const candidates = this.deps.renameDetector.detect(operations, dialect);
@@ -763,15 +797,9 @@ export class PushSchemaPipeline {
           toRenameResolutions(dispatchResult.confirmedRenames, candidates)
         );
 
-      // A UI save owns only the entity being edited. Drop any operation that
-      // targets a code-first/plugin-owned table so the Schema Builder can never
-      // alter schema the user did not edit. Code-first applies (db:sync) are
-      // the authority for those tables and keep the full operation set.
-      const { kept: resolvedOps, skipped: skippedLockedOps } =
-        source === "ui"
-          ? excludeLockedTableOps(allResolvedOps, desired)
-          : { kept: allResolvedOps, skipped: [] as Operation[] };
-      logSkippedLockedOps(skippedLockedOps);
+      // Already excluded above, before the operation set was read. Resolutions are keyed to the
+      // candidates and events that set produced, so none of them can reintroduce a locked table.
+      const resolvedOps = allResolvedOps;
 
       // Phase C+D: execute pre-resolution ops, then pushSchema for the rest.
       const drizzleSchema = this.testHooks._buildDrizzleSchemaOverride

--- a/packages/nextly/src/domains/schema/pipeline/pushschema-pipeline.ts
+++ b/packages/nextly/src/domains/schema/pipeline/pushschema-pipeline.ts
@@ -489,12 +489,10 @@ function toNotificationScope(scope: MigrationJournalScope): MigrationScope {
       ? { kind: "global", slug: scope.slug }
       : { kind: "global" };
   }
-  // collection | single | component — all three require a slug per
-  // MigrationJournalScope's contract (asserted at the type-system
-  // level because slug is optional only for fresh-push/global).
-  return scope.slug
-    ? { kind: scope.kind, slug: scope.slug }
-    : { kind: "global" };
+  // collection | single | component — the scope type requires a slug on each of them, so there is
+  // no slugless case left to fall back for. The fallback this replaces silently retargeted such a
+  // scope to the whole schema, which is the one outcome an entity-scoped apply must not produce.
+  return { kind: scope.kind, slug: scope.slug };
 }
 
 export class PushSchemaPipeline {

--- a/packages/nextly/src/domains/schema/pipeline/registered-collections.ts
+++ b/packages/nextly/src/domains/schema/pipeline/registered-collections.ts
@@ -43,6 +43,23 @@ export interface RegisteredCollectionRow {
   fields?: unknown[];
   status?: boolean;
   localized?: boolean;
+  /** Set for a row owned by code-first config or a plugin. */
+  locked?: boolean;
+  /** `code`, `plugin:<name>`, or the UI source. Read only to corroborate `locked`. */
+  source?: string;
+}
+
+/**
+ * Whether a registry row belongs to code-first config or a plugin rather than the Schema Builder.
+ *
+ * `locked` is the persisted answer; `source` corroborates it for a row written before the flag was
+ * populated. Either one being set is enough, because misreading code as Builder-authored is the
+ * direction that rewrites a table nobody asked to change.
+ */
+function isCodeOwned(row: RegisteredCollectionRow): boolean {
+  if (row.locked === true) return true;
+  const source = row.source;
+  return source === "code" || (!!source && source.startsWith("plugin:"));
 }
 
 /** Logger slice used to report a registry that could not be read. */
@@ -80,11 +97,12 @@ export function mergeRegisteredEntities<T>(
       // a companion `_locales` table, and an entity whose flag is dropped has
       // those columns re-added to its main table by the very next diff.
       localized: row.localized === true,
-      // Every row reaching this point came from the registry and lost to no config entry, which
-      // is what it means for the Schema Builder to own it. Stated here rather than by each caller
-      // for the same reason as `localized`: an entity that arrives without it is described the way
-      // a code-first table is described, and the next diff reports its columns as drift.
-      builderOwned: true,
+      // Registry-only is NOT the same as Builder-authored. A code-first or plugin collection
+      // dropped from the current config keeps its row on purpose — `findOrphanedCollections`
+      // retains exactly those — so it reaches this merge while still being owned by code. Calling
+      // it the Builder's would rewrite its columns on the next sync against a table that orphan
+      // retention exists to leave alone. The row says which it is, so the row is asked.
+      builderOwned: !isCodeOwned(row),
     });
   }
 

--- a/packages/nextly/src/domains/schema/pipeline/registered-collections.ts
+++ b/packages/nextly/src/domains/schema/pipeline/registered-collections.ts
@@ -56,7 +56,7 @@ export interface RegisteredCollectionRow {
  * populated. Either one being set is enough, because misreading code as Builder-authored is the
  * direction that rewrites a table nobody asked to change.
  */
-function isCodeOwned(row: RegisteredCollectionRow): boolean {
+export function isCodeOwned(row: RegisteredCollectionRow): boolean {
   if (row.locked === true) return true;
   const source = row.source;
   return source === "code" || (!!source && source.startsWith("plugin:"));

--- a/packages/nextly/src/domains/schema/pipeline/registered-collections.ts
+++ b/packages/nextly/src/domains/schema/pipeline/registered-collections.ts
@@ -29,6 +29,7 @@ export interface RegisteredEntityBase {
   tableName: string;
   fields: DesiredCollection["fields"];
   localized: boolean;
+  builderOwned: boolean;
 }
 
 /**
@@ -79,6 +80,11 @@ export function mergeRegisteredEntities<T>(
       // a companion `_locales` table, and an entity whose flag is dropped has
       // those columns re-added to its main table by the very next diff.
       localized: row.localized === true,
+      // Every row reaching this point came from the registry and lost to no config entry, which
+      // is what it means for the Schema Builder to own it. Stated here rather than by each caller
+      // for the same reason as `localized`: an entity that arrives without it is described the way
+      // a code-first table is described, and the next diff reports its columns as drift.
+      builderOwned: true,
     });
   }
 

--- a/packages/nextly/src/domains/schema/pipeline/types.ts
+++ b/packages/nextly/src/domains/schema/pipeline/types.ts
@@ -44,6 +44,17 @@ export interface DesiredCollection {
    * so drift is reconciled by db:sync, not by the Schema Builder.
    */
   locked?: boolean;
+  /**
+   * Whether this entity was authored in the Schema Builder rather than in code.
+   *
+   * Stated explicitly rather than inferred from `locked`, because most snapshot builders omit
+   * `locked` entirely and an absent flag says nothing about origin: reading it as "not locked,
+   * therefore the Builder's" reclassified every code-first entity on the HMR and db:sync paths.
+   *
+   * Absent means code-first, which is the conservative answer — a producer that has not learned to
+   * state this leaves behaviour exactly as it was.
+   */
+  builderOwned?: boolean;
 }
 
 export interface DesiredSingle {
@@ -63,6 +74,17 @@ export interface DesiredSingle {
    * so drift is reconciled by db:sync, not by the Schema Builder.
    */
   locked?: boolean;
+  /**
+   * Whether this entity was authored in the Schema Builder rather than in code.
+   *
+   * Stated explicitly rather than inferred from `locked`, because most snapshot builders omit
+   * `locked` entirely and an absent flag says nothing about origin: reading it as "not locked,
+   * therefore the Builder's" reclassified every code-first entity on the HMR and db:sync paths.
+   *
+   * Absent means code-first, which is the conservative answer — a producer that has not learned to
+   * state this leaves behaviour exactly as it was.
+   */
+  builderOwned?: boolean;
 }
 
 export interface DesiredFieldGroup {
@@ -80,4 +102,15 @@ export interface DesiredFieldGroup {
    * so drift is reconciled by db:sync, not by the Schema Builder.
    */
   locked?: boolean;
+  /**
+   * Whether this entity was authored in the Schema Builder rather than in code.
+   *
+   * Stated explicitly rather than inferred from `locked`, because most snapshot builders omit
+   * `locked` entirely and an absent flag says nothing about origin: reading it as "not locked,
+   * therefore the Builder's" reclassified every code-first entity on the HMR and db:sync paths.
+   *
+   * Absent means code-first, which is the conservative answer — a producer that has not learned to
+   * state this leaves behaviour exactly as it was.
+   */
+  builderOwned?: boolean;
 }

--- a/packages/nextly/src/domains/schema/services/__tests__/builder-text-width.test.ts
+++ b/packages/nextly/src/domains/schema/services/__tests__/builder-text-width.test.ts
@@ -227,9 +227,23 @@ describe("withResolvedBuilderTextWidths", () => {
       },
     });
 
-    expect(resolved.components.hero.fields[0]).not.toMatchObject({
-      options: { variant: "long" },
-    });
+    // Asserted as the column the diff would compare, not merely as "not widened": the generator
+    // bounds this at 120 on both dialects that bound a string, and the descriptor reads a width from
+    // neither the top-level key nor an absent variant, so an unwidened field still came back as the
+    // unbounded default and previewed as a type change on PostgreSQL.
+    const columnType = (dialect: "postgresql" | "mysql" | "sqlite") =>
+      buildDesiredTableFromFields(
+        "comp_hero",
+        resolved.components.hero.fields as unknown as Parameters<
+          typeof buildDesiredTableFromFields
+        >[1],
+        dialect
+      ).columns.find(c => c.name === "body")?.type;
+
+    expect(columnType("postgresql")).toBe("varchar(120)");
+    expect(columnType("mysql")).toBe("varchar(120)");
+    // SQLite has one string type, which is what that generator emits for it too.
+    expect(columnType("sqlite")).toBe("text");
   });
 
   // The field-group generator never reads a variant, so a stated one settles nothing there: the

--- a/packages/nextly/src/domains/schema/services/__tests__/builder-text-width.test.ts
+++ b/packages/nextly/src/domains/schema/services/__tests__/builder-text-width.test.ts
@@ -1,4 +1,9 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  clearFieldTypes,
+  registerFieldType,
+} from "../../field-types/field-type-registry";
 
 import { buildDesiredTableFromFields } from "../../pipeline/diff/build-from-fields";
 import type { DesiredSchema } from "../../pipeline/types";
@@ -37,6 +42,10 @@ function bodyType(desired: DesiredSchema): string | undefined {
     "mysql"
   ).columns.find(c => c.name === "body")?.type;
 }
+
+afterEach(() => {
+  clearFieldTypes();
+});
 
 describe("withResolvedBuilderTextWidths", () => {
   // MySQL is the only dialect where the two readings differ, and there they are 65 535 and 255.
@@ -147,6 +156,33 @@ describe("withResolvedBuilderTextWidths", () => {
     const resolved = withResolvedBuilderTextWidths(original);
 
     expect(resolved.singles.page.fields[0]).toHaveProperty("options", choices);
+  });
+
+  // A contributed type declaring `storage: "text"` reaches the database through the same column as
+  // a plain text field — both generators resolve it that way before rendering — so matching the
+  // declared token alone left it bounded while the table held an unbounded column.
+  it("resolves a contributed type to what it stores", () => {
+    registerFieldType({
+      type: "color-swatch",
+      storage: "text",
+      component: "@acme/swatch/admin#ColorSwatch",
+    });
+
+    const resolved = withResolvedBuilderTextWidths(
+      schemaWith({
+        fields: [{ name: "swatch", type: "color-swatch" }] as never,
+      })
+    );
+
+    expect(
+      buildDesiredTableFromFields(
+        "single_page",
+        resolved.singles.page.fields as unknown as Parameters<
+          typeof buildDesiredTableFromFields
+        >[1],
+        "mysql"
+      ).columns.find(c => c.name === "swatch")?.type
+    ).toBe("text");
   });
 
   it("does not widen a type whose width is settled by what it holds", () => {

--- a/packages/nextly/src/domains/schema/services/__tests__/builder-text-width.test.ts
+++ b/packages/nextly/src/domains/schema/services/__tests__/builder-text-width.test.ts
@@ -162,6 +162,30 @@ describe("withResolvedBuilderTextWidths", () => {
   // A contributed type declaring `storage: "text"` reaches the database through the same column as
   // a plain text field — both generators resolve it that way before rendering — so matching the
   // declared token alone left it bounded while the table held an unbounded column.
+  // The field schema accepts any slug-shaped token, so a stored field can name a type whose plugin
+  // is not loaded. Both sides then reach for text — the creators fall through their type map to an
+  // unbounded column, the descriptor falls through its switch to the bounded default — so reading
+  // the unresolved token as non-text left an untouched column reading as a narrowing.
+  it("gives a field with an unregistered type an unbounded column", () => {
+    const resolved = withResolvedBuilderTextWidths(
+      schemaWith({
+        fields: [{ name: "body", type: "acme-not-loaded" }] as never,
+      })
+    );
+
+    expect(bodyType(resolved)).toBe("text");
+  });
+
+  // A built-in whose column the creators bound too. Widening it would invent a disagreement rather
+  // than remove one.
+  it("leaves a built-in bounded type alone", () => {
+    const resolved = withResolvedBuilderTextWidths(
+      schemaWith({ fields: [{ name: "body", type: "email" }] as never })
+    );
+
+    expect(bodyType(resolved)).toBe("varchar(255)");
+  });
+
   it("resolves a contributed type to what it stores", () => {
     registerFieldType({
       type: "color-swatch",

--- a/packages/nextly/src/domains/schema/services/__tests__/builder-text-width.test.ts
+++ b/packages/nextly/src/domains/schema/services/__tests__/builder-text-width.test.ts
@@ -185,6 +185,38 @@ describe("withResolvedBuilderTextWidths", () => {
     ).toBe("text");
   });
 
+  // The two generators read a declared width from different places, so this must too. A field
+  // group's generator bounds a column on a top-level maxLength; a collection's does not, and would
+  // leave the same field unbounded.
+  it("leaves a field group's declared maxLength bounded", () => {
+    const resolved = withResolvedBuilderTextWidths({
+      collections: {},
+      singles: {},
+      components: {
+        hero: {
+          slug: "hero",
+          tableName: "comp_hero",
+          fields: [{ name: "body", type: "text", maxLength: 120 }] as never,
+          builderOwned: true,
+        },
+      },
+    });
+
+    expect(resolved.components.hero.fields[0]).not.toMatchObject({
+      options: { variant: "long" },
+    });
+  });
+
+  it("still widens a collection field carrying only a maxLength", () => {
+    const resolved = withResolvedBuilderTextWidths(
+      schemaWith({
+        fields: [{ name: "body", type: "text", maxLength: 120 }] as never,
+      })
+    );
+
+    expect(bodyType(resolved)).toBe("text");
+  });
+
   it("does not widen a type whose width is settled by what it holds", () => {
     const resolved = withResolvedBuilderTextWidths(
       schemaWith({

--- a/packages/nextly/src/domains/schema/services/__tests__/builder-text-width.test.ts
+++ b/packages/nextly/src/domains/schema/services/__tests__/builder-text-width.test.ts
@@ -207,6 +207,30 @@ describe("withResolvedBuilderTextWidths", () => {
     });
   });
 
+  // The field-group generator never reads a variant, so a stated one settles nothing there: the
+  // column comes out unbounded whatever it says, and treating it as settled left the diff expecting
+  // varchar(255) against a TEXT column.
+  it("ignores a variant on a field group, which its generator never reads", () => {
+    const resolved = withResolvedBuilderTextWidths({
+      collections: {},
+      singles: {},
+      components: {
+        hero: {
+          slug: "hero",
+          tableName: "comp_hero",
+          fields: [
+            { name: "body", type: "text", options: { variant: "short" } },
+          ] as never,
+          builderOwned: true,
+        },
+      },
+    });
+
+    expect(resolved.components.hero.fields[0]).toMatchObject({
+      options: { variant: "long" },
+    });
+  });
+
   it("still widens a collection field carrying only a maxLength", () => {
     const resolved = withResolvedBuilderTextWidths(
       schemaWith({

--- a/packages/nextly/src/domains/schema/services/__tests__/builder-text-width.test.ts
+++ b/packages/nextly/src/domains/schema/services/__tests__/builder-text-width.test.ts
@@ -270,6 +270,64 @@ describe("withResolvedBuilderTextWidths", () => {
     });
   });
 
+  // The field-group generator reads the width and nothing else, so a variant the field already
+  // carries settles nothing there: `{ maxLength: 120, variant: "long" }` is created varchar(120),
+  // and honouring the variant described as unbounded a column that was built bounded.
+  it("lets a field group's maxLength win over a variant it already carries", () => {
+    const resolved = withResolvedBuilderTextWidths({
+      collections: {},
+      singles: {},
+      components: {
+        hero: {
+          slug: "hero",
+          tableName: "comp_hero",
+          fields: [
+            {
+              name: "body",
+              type: "text",
+              maxLength: 120,
+              options: { variant: "long" },
+            },
+          ] as never,
+          builderOwned: true,
+        },
+      },
+    });
+
+    const columnType = (dialect: "postgresql" | "mysql") =>
+      buildDesiredTableFromFields(
+        "comp_hero",
+        resolved.components.hero.fields as unknown as Parameters<
+          typeof buildDesiredTableFromFields
+        >[1],
+        dialect
+      ).columns.find(c => c.name === "body")?.type;
+
+    expect(columnType("postgresql")).toBe("varchar(120)");
+    expect(columnType("mysql")).toBe("varchar(120)");
+  });
+
+  // Running twice must settle on the same answer, which is what lets preview and apply agree.
+  it("is idempotent over a field group's declared width", () => {
+    const schema = {
+      collections: {},
+      singles: {},
+      components: {
+        hero: {
+          slug: "hero",
+          tableName: "comp_hero",
+          fields: [{ name: "body", type: "text", maxLength: 120 }] as never,
+          builderOwned: true,
+        },
+      },
+    };
+
+    const once = withResolvedBuilderTextWidths(schema);
+    const twice = withResolvedBuilderTextWidths(once);
+
+    expect(twice.components.hero.fields).toBe(once.components.hero.fields);
+  });
+
   it("still widens a collection field carrying only a maxLength", () => {
     const resolved = withResolvedBuilderTextWidths(
       schemaWith({

--- a/packages/nextly/src/domains/schema/services/__tests__/builder-text-width.test.ts
+++ b/packages/nextly/src/domains/schema/services/__tests__/builder-text-width.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it } from "vitest";
+
+import { buildDesiredTableFromFields } from "../../pipeline/diff/build-from-fields";
+import type { DesiredSchema } from "../../pipeline/types";
+import { withResolvedBuilderTextWidths } from "../builder-text-width";
+
+function textField(extra: Record<string, unknown> = {}) {
+  return { name: "body", type: "text", ...extra };
+}
+
+function schemaWith(
+  entity: Partial<DesiredSchema["singles"][string]>
+): DesiredSchema {
+  return {
+    collections: {},
+    singles: {
+      page: {
+        slug: "page",
+        tableName: "single_page",
+        fields: [],
+        builderOwned: true,
+        ...entity,
+      },
+    },
+    components: {},
+  };
+}
+
+/** What the diff would compare, for the resolved schema's one single. */
+function bodyType(desired: DesiredSchema): string | undefined {
+  const single = desired.singles.page;
+  return buildDesiredTableFromFields(
+    single.tableName,
+    single.fields as unknown as Parameters<
+      typeof buildDesiredTableFromFields
+    >[1],
+    "mysql"
+  ).columns.find(c => c.name === "body")?.type;
+}
+
+describe("withResolvedBuilderTextWidths", () => {
+  // MySQL is the only dialect where the two readings differ, and there they are 65 535 and 255.
+  it("gives a builder-owned text field an unbounded column", () => {
+    const resolved = withResolvedBuilderTextWidths(
+      schemaWith({ fields: [textField()] as never })
+    );
+
+    expect(bodyType(resolved)).toBe("text");
+  });
+
+  // Code-first columns were built by the path whose default is bounded, so rewriting them would
+  // make every code-first table read as drift. Ownership is never inferred: most snapshot builders
+  // state nothing, and anything other than an explicit yes has to mean code-first.
+  it.each([
+    ["states code ownership", { builderOwned: false }],
+    ["states nothing at all", { builderOwned: undefined }],
+  ])("leaves an entity that %s on the bounded default", (_, ownership) => {
+    const resolved = withResolvedBuilderTextWidths(
+      schemaWith({ fields: [textField()] as never, ...ownership })
+    );
+
+    expect(bodyType(resolved)).toBe("varchar(255)");
+  });
+
+  it("keeps a stated short variant bounded", () => {
+    const resolved = withResolvedBuilderTextWidths(
+      schemaWith({
+        fields: [textField({ options: { variant: "short" } })] as never,
+      })
+    );
+
+    expect(bodyType(resolved)).toBe("varchar(255)");
+  });
+
+  // A width the descriptor cannot render must not be read as a decision to stay bounded: doing so
+  // left a field declaring 500 characters in a varchar(255) column that rejects values its own
+  // stored validation limit accepts.
+  it.each([
+    ["a validation maxLength", { validation: { maxLength: 500 } }],
+    ["a top-level length", { length: 500 }],
+  ])("does not treat %s as a reason to stay bounded", (_, extra) => {
+    const resolved = withResolvedBuilderTextWidths(
+      schemaWith({ fields: [textField(extra)] as never })
+    );
+
+    expect(bodyType(resolved)).toBe("text");
+  });
+
+  it("resolves every entity kind, not only the one being saved", () => {
+    const resolved = withResolvedBuilderTextWidths({
+      collections: {
+        posts: {
+          slug: "posts",
+          tableName: "dc_posts",
+          fields: [textField()] as never,
+          builderOwned: true,
+        },
+      },
+      singles: {},
+      components: {
+        hero: {
+          slug: "hero",
+          tableName: "comp_hero",
+          fields: [textField()] as never,
+          builderOwned: true,
+        },
+      },
+    });
+
+    for (const entity of [
+      resolved.collections.posts,
+      resolved.components.hero,
+    ]) {
+      expect(entity.fields[0]).toMatchObject({ options: { variant: "long" } });
+    }
+  });
+
+  // The caller's schema is often the registry's own objects, and a preview must leave nothing
+  // changed behind it.
+  it("does not mutate the schema it is given", () => {
+    const original = schemaWith({ fields: [textField()] as never });
+
+    withResolvedBuilderTextWidths(original);
+
+    expect(original.singles.page.fields[0]).not.toHaveProperty(
+      "options.variant"
+    );
+  });
+
+  it("returns the same entity object when nothing needed resolving", () => {
+    const original = schemaWith({
+      fields: [{ name: "n", type: "number" }] as never,
+    });
+
+    const resolved = withResolvedBuilderTextWidths(original);
+
+    expect(resolved.singles.page).toBe(original.singles.page);
+  });
+
+  // An array cannot carry a variant, and overwriting it with one would discard whatever it held.
+  it("leaves a text field whose options is an array untouched", () => {
+    const choices = [{ label: "A", value: "a" }];
+    const original = schemaWith({
+      fields: [textField({ options: choices })] as never,
+    });
+
+    const resolved = withResolvedBuilderTextWidths(original);
+
+    expect(resolved.singles.page.fields[0]).toHaveProperty("options", choices);
+  });
+
+  it("does not widen a type whose width is settled by what it holds", () => {
+    const resolved = withResolvedBuilderTextWidths(
+      schemaWith({
+        fields: [
+          { name: "email", type: "email" },
+          { name: "choice", type: "select" },
+        ] as never,
+      })
+    );
+
+    const table = buildDesiredTableFromFields(
+      "single_page",
+      resolved.singles.page.fields as unknown as Parameters<
+        typeof buildDesiredTableFromFields
+      >[1],
+      "mysql"
+    );
+
+    for (const name of ["email", "choice"]) {
+      expect(table.columns.find(c => c.name === name)?.type).toBe(
+        "varchar(255)"
+      );
+    }
+  });
+});

--- a/packages/nextly/src/domains/schema/services/__tests__/builder-text-width.test.ts
+++ b/packages/nextly/src/domains/schema/services/__tests__/builder-text-width.test.ts
@@ -8,6 +8,7 @@ import {
 import { buildDesiredTableFromFields } from "../../pipeline/diff/build-from-fields";
 import type { DesiredSchema } from "../../pipeline/types";
 import { withResolvedBuilderTextWidths } from "../builder-text-width";
+import { getColumnDescriptor } from "../field-column-descriptor";
 
 function textField(extra: Record<string, unknown> = {}) {
   return { name: "body", type: "text", ...extra };
@@ -239,6 +240,61 @@ describe("withResolvedBuilderTextWidths", () => {
     );
 
     expect(bodyType(resolved)).toBe("text");
+  });
+
+  // The payload schema permits an options ARRAY on any field. A text field carrying one states no
+  // width, and every generator reads that as unbounded, so the descriptor has to agree or an
+  // untouched column is reported as a narrowing on every diff.
+  it("treats a text field whose options is an array as unbounded", () => {
+    const desired = schemaWith({
+      fields: [
+        { name: "body", type: "text", options: [{ label: "A", value: "a" }] },
+      ] as never,
+    });
+
+    expect(bodyType(desired)).toBe("text");
+  });
+
+  // Explicitly short means bounded on every dialect that HAS a bounded string, PostgreSQL included
+  // — its legacy creator emits varchar there, and rendering plain text would drop the width bound.
+  it.each([
+    ["mysql", "varchar(255)"],
+    ["postgresql", "varchar(255)"],
+    ["sqlite", "text"],
+  ])("renders an explicitly short field bounded on %s", (dialect, expected) => {
+    const descriptor = getColumnDescriptor(
+      { name: "code", type: "text", options: { variant: "short" } },
+      dialect as Parameters<typeof getColumnDescriptor>[1]
+    );
+
+    expect(descriptor?.dialectType).toBe(expected);
+  });
+
+  // `asMappableField` strips maxLength from a contributed field before the component creator maps
+  // it, so on one of those the key says nothing about the column.
+  it("ignores a contributed type's maxLength on a field group", () => {
+    registerFieldType({
+      type: "swatch-2",
+      storage: "text",
+      component: "@acme/swatch/admin#ColorSwatch",
+    });
+
+    const resolved = withResolvedBuilderTextWidths({
+      collections: {},
+      singles: {},
+      components: {
+        hero: {
+          slug: "hero",
+          tableName: "comp_hero",
+          fields: [{ name: "sw", type: "swatch-2", maxLength: 40 }] as never,
+          builderOwned: true,
+        },
+      },
+    });
+
+    expect(resolved.components.hero.fields[0]).toMatchObject({
+      options: { variant: "long" },
+    });
   });
 
   it("does not widen a type whose width is settled by what it holds", () => {

--- a/packages/nextly/src/domains/schema/services/__tests__/field-column-descriptor.test.ts
+++ b/packages/nextly/src/domains/schema/services/__tests__/field-column-descriptor.test.ts
@@ -78,6 +78,18 @@ describe("getColumnDescriptor — a declared text width", () => {
     expect(desc?.dialectType).toBe("text");
   });
 
+  // The creators size a bounded string from validation.maxLength and read no other key, so a
+  // top-level `length` must not become the physical width: honouring it gave the same declaration
+  // one capacity when created directly and another through the pipeline.
+  it("ignores a top-level length the creators do not read", () => {
+    const desc = getColumnDescriptor(
+      field({ options: { variant: "short" }, length: 500 }),
+      "mysql"
+    );
+
+    expect(desc?.dialectType).toBe("varchar(255)");
+  });
+
   it("falls back to the default width when none is declared", () => {
     const desc = getColumnDescriptor(
       field({ options: { variant: "short" } }),

--- a/packages/nextly/src/domains/schema/services/__tests__/field-column-descriptor.test.ts
+++ b/packages/nextly/src/domains/schema/services/__tests__/field-column-descriptor.test.ts
@@ -1,6 +1,28 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 
-import { getColumnDescriptor } from "../field-column-descriptor";
+import type { FieldDefinition } from "../../../../schemas/dynamic-collections";
+import type { PluginFieldType } from "../../../../plugins/contributions";
+import {
+  clearFieldTypes,
+  registerFieldType,
+} from "../../field-types/field-type-registry";
+import {
+  getColumnDescriptor,
+  isTextStorageKind,
+  type ColumnKind,
+} from "../field-column-descriptor";
+
+const field = (overrides: Partial<FieldDefinition>): FieldDefinition =>
+  ({ name: "value", type: "text", ...overrides }) as FieldDefinition;
+
+/**
+ * A field whose type a plugin contributed, which is by definition not a member of the built-in
+ * union — so it is stated structurally rather than through the built-in field type.
+ */
+const contributedField = (
+  overrides: Record<string, unknown>
+): FieldDefinition =>
+  ({ name: "value", ...overrides }) as unknown as FieldDefinition;
 
 describe("getColumnDescriptor — toggle", () => {
   it("maps a toggle field to a boolean column (Postgres)", () => {
@@ -9,5 +31,161 @@ describe("getColumnDescriptor — toggle", () => {
       "postgresql"
     );
     expect(desc?.dialectType).toBe("bool");
+  });
+});
+
+/**
+ * A field that declares itself short gets a column at the width it declared.
+ *
+ * The Builder's own creators emit `varchar(120)` for such a field on both dialects that bound a
+ * string. A fixed 255 here would size the same field differently depending on which path created
+ * the table, and a field declaring more than 255 characters would sit in a column that rejects
+ * what its own stored validation accepts.
+ */
+describe("getColumnDescriptor — a declared text width", () => {
+  it.each([
+    ["postgresql", "varchar(120)"],
+    ["mysql", "varchar(120)"],
+  ] as const)("renders the declared width on %s", (dialect, expected) => {
+    const desc = getColumnDescriptor(
+      field({ options: { variant: "short" }, validation: { maxLength: 120 } }),
+      dialect
+    );
+
+    expect(desc?.dialectType).toBe(expected);
+    expect(desc?.length).toBe(120);
+  });
+
+  // Above the fixed default too, which is the case that loses data rather than merely differing:
+  // a value of 400 characters is accepted by validation and refused by a varchar(255).
+  it("renders a width wider than the default", () => {
+    const desc = getColumnDescriptor(
+      field({ options: { variant: "short" }, validation: { maxLength: 400 } }),
+      "mysql"
+    );
+
+    expect(desc?.dialectType).toBe("varchar(400)");
+  });
+
+  // SQLite has one string type, so the bound lives in validation there. Rendering a width would
+  // describe a column the dialect cannot declare.
+  it("stays text on sqlite", () => {
+    const desc = getColumnDescriptor(
+      field({ options: { variant: "short" }, validation: { maxLength: 120 } }),
+      "sqlite"
+    );
+
+    expect(desc?.dialectType).toBe("text");
+  });
+
+  it("falls back to the default width when none is declared", () => {
+    const desc = getColumnDescriptor(
+      field({ options: { variant: "short" } }),
+      "postgresql"
+    );
+
+    expect(desc?.dialectType).toBe("varchar(255)");
+  });
+
+  // These reach DDL as `VARCHAR(n)`, so a value that is not a whole positive count would be
+  // rendered into the statement as written and fail the create.
+  it.each([[0], [-5], [12.5]])(
+    "ignores a width of %s and uses the default",
+    maxLength => {
+      const desc = getColumnDescriptor(
+        field({ options: { variant: "short" }, validation: { maxLength } }),
+        "postgresql"
+      );
+
+      expect(desc?.dialectType).toBe("varchar(255)");
+    }
+  );
+});
+
+/**
+ * A plugin type that stores text answers the width question exactly as a built-in text field does.
+ *
+ * Its column is rendered by the same branch, so a narrower rule here bounded a field the Builder's
+ * creators left unbounded, and an untouched column then read as a narrowing on every diff.
+ */
+describe("getColumnDescriptor — a contributed text type", () => {
+  const SLUG_TYPE: PluginFieldType = {
+    type: "acme-slug",
+    storage: "text",
+    component: "@acme/slug/admin#SlugField",
+  };
+
+  afterEach(() => {
+    clearFieldTypes();
+  });
+
+  // `options` is the choice list on a select and the payload schema permits that shape on any
+  // field, so a field carrying one states no width at all.
+  it("reads an array options list as unbounded", () => {
+    registerFieldType(SLUG_TYPE);
+
+    const desc = getColumnDescriptor(
+      contributedField({
+        type: "acme-slug",
+        options: [{ label: "A", value: "a" }],
+      }),
+      "mysql"
+    );
+
+    expect(desc?.dialectType).toBe("text");
+  });
+
+  it("reads a declared short variant as bounded", () => {
+    registerFieldType(SLUG_TYPE);
+
+    const desc = getColumnDescriptor(
+      contributedField({
+        type: "acme-slug",
+        options: { variant: "short" },
+        validation: { maxLength: 64 },
+      }),
+      "postgresql"
+    );
+
+    expect(desc?.dialectType).toBe("varchar(64)");
+  });
+
+  it("reads a declared long variant as unbounded", () => {
+    registerFieldType(SLUG_TYPE);
+
+    const desc = getColumnDescriptor(
+      contributedField({ type: "acme-slug", options: { variant: "long" } }),
+      "mysql"
+    );
+
+    expect(desc?.dialectType).toBe("text");
+  });
+});
+
+/**
+ * Every kind that reaches a string column, enumerated here rather than restated by each caller.
+ *
+ * A caller holding a string asks this before seeding it. Answered from a local list instead, a
+ * caller silently said "not text" for a kind added after it was written.
+ */
+describe("isTextStorageKind", () => {
+  it.each<ColumnKind>(["text", "longText", "shortText", "varchar"])(
+    "accepts %s",
+    kind => {
+      expect(isTextStorageKind(kind)).toBe(true);
+    }
+  );
+
+  it.each<ColumnKind>([
+    "boolean",
+    "integer",
+    "double",
+    "decimal",
+    "timestamp",
+    "json",
+    "fkSingle",
+    "skip",
+  ])("rejects %s", kind => {
+    expect(isTextStorageKind(kind)).toBe(false);
   });
 });

--- a/packages/nextly/src/domains/schema/services/builder-text-width.ts
+++ b/packages/nextly/src/domains/schema/services/builder-text-width.ts
@@ -78,7 +78,7 @@ function modifierOptions(
  */
 function resolveFieldWidths<T>(
   fields: readonly T[],
-  honoursMaxLength: boolean
+  signal: "variant" | "maxLength"
 ): readonly T[] {
   let changed = false;
 
@@ -88,7 +88,7 @@ function resolveFieldWidths<T>(
 
     const options = modifierOptions(candidate.options);
     if (options === undefined) return field;
-    if (statesWidth(candidate, options, honoursMaxLength)) return field;
+    if (statesWidth(candidate, options, signal)) return field;
 
     changed = true;
     return { ...candidate, options: { ...options, variant: "long" } };
@@ -110,20 +110,25 @@ function resolveFieldWidths<T>(
 /**
  * Whether a field already states a width its own generator will render.
  *
- * The two generators do not read the same signal, so neither does this. A field group's generator
- * bounds a column on a top-level `maxLength` (`field-group-schema-service.ts`:
- * `field.maxLength ? varchar(maxLength) : text`), while a collection's bounds it only on
- * `options.variant === "short"` — a `maxLength` alone leaves that column unbounded. Applying either
- * rule to both kinds is wrong in one direction or the other: it would either widen a field group
- * column the author sized, or leave a collection column bounded that its generator never bounded.
+ * Each kind is given ONLY the signal its own generator acts on, because reading both would be wrong
+ * for each in a different direction:
+ *
+ * - a field group's generator branches on a top-level `maxLength` and nothing else
+ *   (`field-group-schema-service.ts`: `field.maxLength ? varchar(maxLength) : text`). It never reads
+ *   a variant, so honouring one would leave that column unbounded while the diff expected it bounded.
+ * - a collection's generator branches only on `options.variant === "short"`. A `maxLength` alone
+ *   leaves that column unbounded, so honouring one would bound a column its generator never bounded.
+ *
+ * The caller states which generator a list belongs to rather than this guessing from the field.
  */
 function statesWidth(
   field: WidthSignals,
   options: Record<string, unknown>,
-  honoursMaxLength: boolean
+  signal: "variant" | "maxLength"
 ): boolean {
-  if (options.variant !== undefined) return true;
-  return honoursMaxLength && field.maxLength !== undefined;
+  return signal === "maxLength"
+    ? field.maxLength !== undefined
+    : options.variant !== undefined;
 }
 
 export function withResolvedBuilderTextWidths(
@@ -133,7 +138,7 @@ export function withResolvedBuilderTextWidths(
     E extends { fields: readonly unknown[]; builderOwned?: boolean },
   >(
     group: Record<string, E>,
-    honoursMaxLength: boolean
+    signal: "variant" | "maxLength"
   ): Record<string, E> => {
     const out: Record<string, E> = {};
     for (const [key, entity] of Object.entries(group)) {
@@ -144,16 +149,16 @@ export function withResolvedBuilderTextWidths(
         out[key] = entity;
         continue;
       }
-      const fields = resolveFieldWidths(entity.fields, honoursMaxLength);
+      const fields = resolveFieldWidths(entity.fields, signal);
       out[key] = fields === entity.fields ? entity : { ...entity, fields };
     }
     return out;
   };
 
   return {
-    collections: resolveGroup(desired.collections, false),
-    singles: resolveGroup(desired.singles, false),
-    // Field groups alone: their generator is the one that renders a declared `maxLength`.
-    components: resolveGroup(desired.components, true),
+    collections: resolveGroup(desired.collections, "variant"),
+    singles: resolveGroup(desired.singles, "variant"),
+    // A field group's generator reads a declared `maxLength`, and never a variant.
+    components: resolveGroup(desired.components, "maxLength"),
   };
 }

--- a/packages/nextly/src/domains/schema/services/builder-text-width.ts
+++ b/packages/nextly/src/domains/schema/services/builder-text-width.ts
@@ -126,9 +126,11 @@ function statesWidth(
   options: Record<string, unknown>,
   signal: "variant" | "maxLength"
 ): boolean {
-  return signal === "maxLength"
-    ? field.maxLength !== undefined
-    : options.variant !== undefined;
+  if (signal === "variant") return options.variant !== undefined;
+  // Only for the built-in type. `asMappableField` strips `maxLength` from a contributed field
+  // before the component creator maps it, so on one of those the key states nothing about the
+  // column and honouring it would leave the field bounded against an unbounded table.
+  return field.type === "text" && field.maxLength !== undefined;
 }
 
 export function withResolvedBuilderTextWidths(

--- a/packages/nextly/src/domains/schema/services/builder-text-width.ts
+++ b/packages/nextly/src/domains/schema/services/builder-text-width.ts
@@ -35,6 +35,8 @@ interface WidthSignals {
   type?: string;
   options?: unknown;
   maxLength?: number;
+  /** The one key a bounded string's width is read from, on either generator's fields. */
+  validation?: { maxLength?: number };
 }
 
 /**
@@ -171,9 +173,11 @@ function canonicalBoundedWidth<T extends WidthSignals>(
   return {
     ...field,
     options: { ...options, variant: "short" },
-    // The width itself, under the key the descriptor reads it from. Stating the variant alone would
-    // bound the column at the default 255 while the generator had bounded it at what was declared.
-    length: declared,
+    // The width itself, under the one key a bounded string is sized from. Stating the variant alone
+    // would bound the column at the default 255 while the generator had bounded it at what was
+    // declared. Written here rather than to a top-level `length` so there is a single width key: a
+    // second one would be honoured for collections too, whose creator ignores it.
+    validation: { ...(field.validation ?? {}), maxLength: declared },
   };
 }
 

--- a/packages/nextly/src/domains/schema/services/builder-text-width.ts
+++ b/packages/nextly/src/domains/schema/services/builder-text-width.ts
@@ -1,3 +1,4 @@
+import { storageTypeToken } from "../../../shared/lib/plugin-storage";
 import type { DesiredSchema } from "../pipeline/types";
 
 /**
@@ -34,6 +35,21 @@ interface WidthSignals {
   options?: unknown;
 }
 
+/**
+ * Whether a field ends up in a string column, resolving a contributed type to what it actually
+ * stores.
+ *
+ * A plugin type declaring `storage: "text"` reaches the database through the same column as a plain
+ * text field — both generators resolve it that way before rendering — so it needs the same answer
+ * here. Matching the declared token alone left those fields on the bounded default while the table
+ * held an unbounded column, which is the disagreement this module exists to remove.
+ */
+function storesText(field: WidthSignals): boolean {
+  if (field.type === undefined) return false;
+  if (field.type === "text") return true;
+  return storageTypeToken({ type: field.type }) === "text";
+}
+
 /** An `options` value a variant can be written onto without destroying what is already there. */
 function modifierOptions(
   options: unknown
@@ -64,7 +80,7 @@ function resolveFieldWidths<T>(fields: readonly T[]): readonly T[] {
 
   const out = fields.map(field => {
     const candidate = field as T & WidthSignals;
-    if (candidate.type !== "text") return field;
+    if (!storesText(candidate)) return field;
 
     const options = modifierOptions(candidate.options);
     if (options === undefined) return field;

--- a/packages/nextly/src/domains/schema/services/builder-text-width.ts
+++ b/packages/nextly/src/domains/schema/services/builder-text-width.ts
@@ -33,6 +33,7 @@ import type { DesiredSchema } from "../pipeline/types";
 interface WidthSignals {
   type?: string;
   options?: unknown;
+  maxLength?: number;
 }
 
 /**
@@ -75,7 +76,10 @@ function modifierOptions(
  * Idempotent: a field this has resolved states a variant, so a second pass leaves it alone. Returns
  * the original array when nothing needed resolving.
  */
-function resolveFieldWidths<T>(fields: readonly T[]): readonly T[] {
+function resolveFieldWidths<T>(
+  fields: readonly T[],
+  honoursMaxLength: boolean
+): readonly T[] {
   let changed = false;
 
   const out = fields.map(field => {
@@ -84,7 +88,7 @@ function resolveFieldWidths<T>(fields: readonly T[]): readonly T[] {
 
     const options = modifierOptions(candidate.options);
     if (options === undefined) return field;
-    if (options.variant !== undefined) return field;
+    if (statesWidth(candidate, options, honoursMaxLength)) return field;
 
     changed = true;
     return { ...candidate, options: { ...options, variant: "long" } };
@@ -103,13 +107,33 @@ function resolveFieldWidths<T>(fields: readonly T[]): readonly T[] {
  * Copies rather than mutates: the caller's schema is often the registry's own objects, and a
  * preview must not leave a field changed behind it.
  */
+/**
+ * Whether a field already states a width its own generator will render.
+ *
+ * The two generators do not read the same signal, so neither does this. A field group's generator
+ * bounds a column on a top-level `maxLength` (`field-group-schema-service.ts`:
+ * `field.maxLength ? varchar(maxLength) : text`), while a collection's bounds it only on
+ * `options.variant === "short"` — a `maxLength` alone leaves that column unbounded. Applying either
+ * rule to both kinds is wrong in one direction or the other: it would either widen a field group
+ * column the author sized, or leave a collection column bounded that its generator never bounded.
+ */
+function statesWidth(
+  field: WidthSignals,
+  options: Record<string, unknown>,
+  honoursMaxLength: boolean
+): boolean {
+  if (options.variant !== undefined) return true;
+  return honoursMaxLength && field.maxLength !== undefined;
+}
+
 export function withResolvedBuilderTextWidths(
   desired: DesiredSchema
 ): DesiredSchema {
   const resolveGroup = <
     E extends { fields: readonly unknown[]; builderOwned?: boolean },
   >(
-    group: Record<string, E>
+    group: Record<string, E>,
+    honoursMaxLength: boolean
   ): Record<string, E> => {
     const out: Record<string, E> = {};
     for (const [key, entity] of Object.entries(group)) {
@@ -120,15 +144,16 @@ export function withResolvedBuilderTextWidths(
         out[key] = entity;
         continue;
       }
-      const fields = resolveFieldWidths(entity.fields);
+      const fields = resolveFieldWidths(entity.fields, honoursMaxLength);
       out[key] = fields === entity.fields ? entity : { ...entity, fields };
     }
     return out;
   };
 
   return {
-    collections: resolveGroup(desired.collections),
-    singles: resolveGroup(desired.singles),
-    components: resolveGroup(desired.components),
+    collections: resolveGroup(desired.collections, false),
+    singles: resolveGroup(desired.singles, false),
+    // Field groups alone: their generator is the one that renders a declared `maxLength`.
+    components: resolveGroup(desired.components, true),
   };
 }

--- a/packages/nextly/src/domains/schema/services/builder-text-width.ts
+++ b/packages/nextly/src/domains/schema/services/builder-text-width.ts
@@ -101,7 +101,13 @@ function resolveFieldWidths<T>(
 
     const options = modifierOptions(candidate.options);
     if (options === undefined) return field;
-    if (statesWidth(candidate, options, signal)) return field;
+
+    if (statesWidth(candidate, options, signal)) {
+      const bounded = canonicalBoundedWidth(candidate, options, signal);
+      if (bounded === undefined) return field;
+      changed = true;
+      return bounded;
+    }
 
     changed = true;
     return { ...candidate, options: { ...options, variant: "long" } };
@@ -134,6 +140,43 @@ function resolveFieldWidths<T>(
  *
  * The caller states which generator a list belongs to rather than this guessing from the field.
  */
+/**
+ * Rewrite a stated width into the one signal the descriptor reads, or nothing when it already is.
+ *
+ * A field group's generator takes its width from a top-level `maxLength`, a key the descriptor does
+ * not look at. Left as it was, such a field reached the descriptor stating nothing, came back as the
+ * unbounded default, and previewed as a type change against the `varchar(120)` its own generator had
+ * just created — on PostgreSQL, where the two answers are different types rather than two widths of
+ * one type.
+ *
+ * Translating here rather than teaching the descriptor that key is what keeps the per-generator rules
+ * from leaking into it: the descriptor answers one question about one canonical shape, and this
+ * module owns the fact that two generators ask it in two different words. Teaching the descriptor to
+ * read `maxLength` would also bound every COLLECTION field carrying one, which that generator leaves
+ * unbounded.
+ */
+function canonicalBoundedWidth<T extends WidthSignals>(
+  field: T,
+  options: Record<string, unknown>,
+  signal: "variant" | "maxLength"
+): T | undefined {
+  // A collection or single already states its width the way the descriptor reads it.
+  if (signal !== "maxLength") return undefined;
+  // Already canonical, so rewriting would be the second pass changing what the first settled.
+  if (options.variant !== undefined) return undefined;
+  const declared = field.maxLength;
+  if (typeof declared !== "number") return undefined;
+  if (!Number.isInteger(declared) || declared <= 0) return undefined;
+
+  return {
+    ...field,
+    options: { ...options, variant: "short" },
+    // The width itself, under the key the descriptor reads it from. Stating the variant alone would
+    // bound the column at the default 255 while the generator had bounded it at what was declared.
+    length: declared,
+  };
+}
+
 function statesWidth(
   field: WidthSignals,
   options: Record<string, unknown>,

--- a/packages/nextly/src/domains/schema/services/builder-text-width.ts
+++ b/packages/nextly/src/domains/schema/services/builder-text-width.ts
@@ -1,0 +1,118 @@
+import type { DesiredSchema } from "../pipeline/types";
+
+/**
+ * A text field with no stated width, on an entity the Schema Builder owns, describes an unbounded
+ * column.
+ *
+ * `getColumnDescriptor` reads an unstated width as the bounded kind, which renders `varchar(255)` on
+ * MySQL. The generator the Builder's create path used before it moved onto the shared pipeline read
+ * the same silence as unbounded `TEXT`. Both are defensible, but they are 255 and 65 535 characters
+ * apart, so leaving the silence to be interpreted means a field created before the move and an
+ * identical field created after it hold different amounts of text.
+ *
+ * Changing the descriptor's default instead would be wrong: that default is also what every
+ * code-first table was built with, so moving it would make all of them read as drift and stop
+ * `nextly migrate` from applying anything. The two paths need different answers because they have
+ * different histories, and `locked` already records which history a table has.
+ *
+ * 🔴 Applied to the whole `DesiredSchema` at the entrance to apply and preview, and nowhere else.
+ *
+ * That placement is load-bearing, because a desired schema is read TWICE by two different builders:
+ * `buildDesiredTableFromFields` produces the snapshot the diff compares, and `generateRuntimeSchema`
+ * produces the Drizzle tables drizzle-kit turns into DDL. Resolving inside either one leaves the
+ * other reading the raw fields, and the two then disagree permanently: the diff expects `text` while
+ * the DDL creates `varchar(255)`, so a table converges and immediately reports a type change again.
+ * Normalising the input they share is the only placement that makes them agree by construction.
+ *
+ * Doing it in a request handler is worse still — the handlers are many, and each preview path that
+ * builds its own desired schema would have to remember.
+ */
+
+/** The width signals a field can carry, named structurally because callers pass several field types. */
+interface WidthSignals {
+  type?: string;
+  options?: unknown;
+}
+
+/** An `options` value a variant can be written onto without destroying what is already there. */
+function modifierOptions(
+  options: unknown
+): Record<string, unknown> | undefined {
+  if (options === undefined) return {};
+  // `options` is the choice array on a select or radio and an object of modifiers elsewhere. An
+  // array cannot carry a variant, and replacing it with one would discard the choices, so a field
+  // holding one is left exactly as it is.
+  if (options === null || typeof options !== "object") return undefined;
+  if (Array.isArray(options)) return undefined;
+  return { ...(options as Record<string, unknown>) };
+}
+
+/**
+ * Resolve the width of every unstated text field in a Builder-owned entity's field list.
+ *
+ * Only an explicit `variant` counts as stating the width. A `maxLength` or a `length` deliberately
+ * does NOT, because the descriptor renders neither: treating one as authoritative would leave a
+ * field declaring 500 characters in a `varchar(255)` column, rejecting values the stored validation
+ * limit accepts. Until a width can survive the diff, the honest reading of an unstated field is
+ * unbounded — wider than a bounded column, and never narrower than the data it is asked to hold.
+ *
+ * Idempotent: a field this has resolved states a variant, so a second pass leaves it alone. Returns
+ * the original array when nothing needed resolving.
+ */
+function resolveFieldWidths<T>(fields: readonly T[]): readonly T[] {
+  let changed = false;
+
+  const out = fields.map(field => {
+    const candidate = field as T & WidthSignals;
+    if (candidate.type !== "text") return field;
+
+    const options = modifierOptions(candidate.options);
+    if (options === undefined) return field;
+    if (options.variant !== undefined) return field;
+
+    changed = true;
+    return { ...candidate, options: { ...options, variant: "long" } };
+  });
+
+  return changed ? out : fields;
+}
+
+/**
+ * Return a desired schema whose Builder-owned entities state the width of every text field.
+ *
+ * An entity that does not state Builder ownership is left exactly as it is. Its columns were built
+ * by the path whose default is the bounded kind, and rewriting those would make every code-first
+ * table read as drift and stop `nextly migrate` applying anything.
+ *
+ * Copies rather than mutates: the caller's schema is often the registry's own objects, and a
+ * preview must not leave a field changed behind it.
+ */
+export function withResolvedBuilderTextWidths(
+  desired: DesiredSchema
+): DesiredSchema {
+  const resolveGroup = <
+    E extends { fields: readonly unknown[]; builderOwned?: boolean },
+  >(
+    group: Record<string, E>
+  ): Record<string, E> => {
+    const out: Record<string, E> = {};
+    for (const [key, entity] of Object.entries(group)) {
+      // Explicit, never inferred. Most snapshot builders omit any ownership flag, so anything other
+      // than a stated yes has to mean code-first: the alternative reclassified every code-first
+      // entity on the HMR and db:sync paths and would have widened their columns.
+      if (entity.builderOwned !== true) {
+        out[key] = entity;
+        continue;
+      }
+      const fields = resolveFieldWidths(entity.fields);
+      out[key] = fields === entity.fields ? entity : { ...entity, fields };
+    }
+    return out;
+  };
+
+  return {
+    collections: resolveGroup(desired.collections),
+    singles: resolveGroup(desired.singles),
+    components: resolveGroup(desired.components),
+  };
+}

--- a/packages/nextly/src/domains/schema/services/builder-text-width.ts
+++ b/packages/nextly/src/domains/schema/services/builder-text-width.ts
@@ -156,6 +156,11 @@ function resolveFieldWidths<T>(
  * module owns the fact that two generators ask it in two different words. Teaching the descriptor to
  * read `maxLength` would also bound every COLLECTION field carrying one, which that generator leaves
  * unbounded.
+ *
+ * A stated `maxLength` wins over any variant the field already carries, because the generator this
+ * translates for reads the width and nothing else: a field saying `{ maxLength: 120, variant: "long" }`
+ * is created `varchar(120)`, so honouring the variant would describe as unbounded a column that was
+ * built bounded. Idempotence comes from recognising this function's own output instead.
  */
 function canonicalBoundedWidth<T extends WidthSignals>(
   field: T,
@@ -164,11 +169,13 @@ function canonicalBoundedWidth<T extends WidthSignals>(
 ): T | undefined {
   // A collection or single already states its width the way the descriptor reads it.
   if (signal !== "maxLength") return undefined;
-  // Already canonical, so rewriting would be the second pass changing what the first settled.
-  if (options.variant !== undefined) return undefined;
   const declared = field.maxLength;
   if (typeof declared !== "number") return undefined;
   if (!Number.isInteger(declared) || declared <= 0) return undefined;
+  // Already canonical — the second pass would rewrite what the first settled, to the same value.
+  if (options.variant === "short" && field.validation?.maxLength === declared) {
+    return undefined;
+  }
 
   return {
     ...field,

--- a/packages/nextly/src/domains/schema/services/builder-text-width.ts
+++ b/packages/nextly/src/domains/schema/services/builder-text-width.ts
@@ -67,11 +67,15 @@ function modifierOptions(
 /**
  * Resolve the width of every unstated text field in a Builder-owned entity's field list.
  *
- * Only an explicit `variant` counts as stating the width. A `maxLength` or a `length` deliberately
- * does NOT, because the descriptor renders neither: treating one as authoritative would leave a
- * field declaring 500 characters in a `varchar(255)` column, rejecting values the stored validation
- * limit accepts. Until a width can survive the diff, the honest reading of an unstated field is
- * unbounded — wider than a bounded column, and never narrower than the data it is asked to hold.
+ * What counts as stating the width is whatever the entity's own generator acts on, which is not the
+ * same key for both — see `statesWidth`. A field that states nothing its generator reads is filled
+ * in as unbounded, which is the honest reading: wider than a bounded column, and never narrower
+ * than the data the field is asked to hold.
+ *
+ * A field that DOES state a width keeps it, and the descriptor renders that width rather than a
+ * fixed 255, so a field declaring 500 characters gets a column that accepts what its own stored
+ * validation accepts. What a declared width still cannot do is survive a later EDIT: the diff
+ * strips length modifiers before comparing, so widening an existing column emits no resize.
  *
  * Idempotent: a field this has resolved states a variant, so a second pass leaves it alone. Returns
  * the original array when nothing needed resolving.

--- a/packages/nextly/src/domains/schema/services/builder-text-width.ts
+++ b/packages/nextly/src/domains/schema/services/builder-text-width.ts
@@ -1,3 +1,4 @@
+import { isBuiltInFieldType } from "../../../schemas/_zod/ui-schema";
 import { storageTypeToken } from "../../../shared/lib/plugin-storage";
 import type { DesiredSchema } from "../pipeline/types";
 
@@ -46,9 +47,17 @@ interface WidthSignals {
  * held an unbounded column, which is the disagreement this module exists to remove.
  */
 function storesText(field: WidthSignals): boolean {
-  if (field.type === undefined) return false;
+  if (typeof field.type !== "string") return false;
   if (field.type === "text") return true;
-  return storageTypeToken({ type: field.type }) === "text";
+  const token = storageTypeToken({ type: field.type });
+  if (token === "text") return true;
+  // A token nothing has registered. The field schema accepts any slug-shaped type, so a stored
+  // field can name a type whose plugin is not loaded — and both sides then reach for text: the
+  // creators fall through their type map to an unbounded column, the descriptor falls through its
+  // switch to the bounded default. `storageTypeToken` hands back the unresolved token rather than
+  // that fallback, so matching only the resolved one read those fields as non-text and left exactly
+  // the disagreement this module exists to remove.
+  return token === field.type && !isBuiltInFieldType(field.type);
 }
 
 /** An `options` value a variant can be written onto without destroying what is already there. */

--- a/packages/nextly/src/domains/schema/services/field-column-descriptor.ts
+++ b/packages/nextly/src/domains/schema/services/field-column-descriptor.ts
@@ -97,6 +97,7 @@ export const DEFAULT_DECIMAL_SCALE = 2;
 export type ColumnKind =
   | "text" // PG: text, MySQL: varchar(255), SQLite: text
   | "longText" // PG: text, MySQL: text, SQLite: text — for textarea/richtext
+  | "shortText" // PG/MySQL: varchar(N), SQLite: text — a text field explicitly declared short
   | "varchar" // varchar(N) explicitly (uses `length`)
   | "boolean" // PG: bool, MySQL: tinyint(1), SQLite: integer(boolean mode)
   | "integer" // PG: int4, MySQL: int, SQLite: integer
@@ -244,15 +245,27 @@ function classifyFieldKind(field: FieldDefinition): ColumnKind {
   if (!fieldProducesColumn(field)) return "skip";
 
   switch (field.type) {
-    case "text":
+    case "text": {
       // A text field may state its own width, and only this type may: an email, a password and a
       // select value are bounded by what they hold, while free text is bounded by nothing.
       //
       // Absent, the answer stays what it has always been for this path. The signal exists so a
       // caller that KNOWS the field is unbounded can say so instead of discovering the ceiling
       // when a paste is rejected — on MySQL the two render 255 characters apart.
-      if (field.options?.variant === "long") return "longText";
+      const options = field.options;
+      if (options?.variant === "long") return "longText";
+      // Declared short, so bounded on every dialect that has a bounded string. Its own kind rather
+      // than the existing `varchar` one, which renders PostgreSQL `text` and is what the system
+      // `status` column uses — widening that to a real varchar would make every existing status
+      // column read as a type change.
+      if (options?.variant === "short") return "shortText";
+      // `options` is the choice list on a select, and the payload schema permits that shape on any
+      // field. A text field carrying one states no width, and every generator reads it the same
+      // way — as unbounded — so reading it as bounded here would report an untouched column as a
+      // narrowing on every diff.
+      if (Array.isArray(options)) return "longText";
       return "text";
+    }
 
     case "email":
     case "password":
@@ -360,6 +373,12 @@ function renderDialectType(
     if (dialect === "mysql") return "text";
     return "text"; // sqlite
   }
+  if (kind === "shortText") {
+    // SQLite has one string type, so a short field is `text` there and the bound lives in
+    // validation alone — which is what the generators emit for it too.
+    if (dialect === "sqlite") return "text";
+    return `varchar(${length ?? 255})`;
+  }
   if (kind === "varchar") {
     if (dialect === "postgresql") return "text";
     if (dialect === "mysql") return `varchar(${length ?? 255})`;
@@ -410,6 +429,7 @@ function lengthForKind(kind: ColumnKind): number | undefined {
   // every later edit to it, leaving writes to fail against a column the stored limit says is wide
   // enough. Resizing needs the diff to compare widths first.
   if (kind === "text") return 255;
+  if (kind === "shortText") return 255;
   if (kind === "varchar") return 255;
   if (kind === "fkSingle") return 36;
   return undefined;

--- a/packages/nextly/src/domains/schema/services/field-column-descriptor.ts
+++ b/packages/nextly/src/domains/schema/services/field-column-descriptor.ts
@@ -472,14 +472,20 @@ function lengthForField(
 }
 
 /**
- * The width a field declares, from the two keys that carry one, or nothing when it declares none.
+ * The width a field declares, or nothing when it declares none.
+ *
+ * Read from `validation.maxLength` and from nowhere else, because that is the only key the creators
+ * size a bounded string from. A top-level `length` is deliberately NOT consulted: a field declaring
+ * `{ variant: "short", length: 500 }` gets `varchar(255)` from the creator, so honouring the 500
+ * here gave the same declaration one capacity when created directly and another through the
+ * pipeline, with the width normalisation then hiding the difference from any later diff.
  *
  * Rejects anything that is not a whole positive count. These reach DDL as `VARCHAR(n)`, so a
  * fraction, a zero or a negative would be rendered into the statement as written and the create
  * would fail on a value the field system had already accepted.
  */
 function declaredMaxLength(field: FieldDefinition): number | undefined {
-  const declared = field.validation?.maxLength ?? field.length;
+  const declared = field.validation?.maxLength;
   if (typeof declared !== "number") return undefined;
   if (!Number.isInteger(declared) || declared <= 0) return undefined;
   return declared;

--- a/packages/nextly/src/domains/schema/services/field-column-descriptor.ts
+++ b/packages/nextly/src/domains/schema/services/field-column-descriptor.ts
@@ -215,12 +215,13 @@ export function getColumnDescriptor(
         }
       : undefined;
 
+  const length = lengthForKind(kind);
+
   const dialectType = renderDialectType(kind, dialect, {
-    length: undefined,
+    length,
     precision: decimal?.precision,
     scale: decimal?.scale,
   });
-  const length = lengthForKind(kind);
 
   return {
     name,
@@ -244,6 +245,15 @@ function classifyFieldKind(field: FieldDefinition): ColumnKind {
 
   switch (field.type) {
     case "text":
+      // A text field may state its own width, and only this type may: an email, a password and a
+      // select value are bounded by what they hold, while free text is bounded by nothing.
+      //
+      // Absent, the answer stays what it has always been for this path. The signal exists so a
+      // caller that KNOWS the field is unbounded can say so instead of discovering the ceiling
+      // when a paste is rejected — on MySQL the two render 255 characters apart.
+      if (field.options?.variant === "long") return "longText";
+      return "text";
+
     case "email":
     case "password":
     case "select":
@@ -386,6 +396,11 @@ function renderDialectType(
  * dialect-token rendering and the runtime Drizzle builder.
  */
 function lengthForKind(kind: ColumnKind): number | undefined {
+  // A width the field declares is deliberately NOT read here. `normalize-type.ts` strips the
+  // modifier before the diff compares, so a bounded column's width is invisible to convergence:
+  // rendering a declared width would size a column correctly on creation and then silently ignore
+  // every later edit to it, leaving writes to fail against a column the stored limit says is wide
+  // enough. Resizing needs the diff to compare widths first.
   if (kind === "text") return 255;
   if (kind === "varchar") return 255;
   if (kind === "fkSingle") return 36;

--- a/packages/nextly/src/domains/schema/services/field-column-descriptor.ts
+++ b/packages/nextly/src/domains/schema/services/field-column-descriptor.ts
@@ -216,7 +216,7 @@ export function getColumnDescriptor(
         }
       : undefined;
 
-  const length = lengthForKind(kind);
+  const length = lengthForField(kind, field);
 
   const dialectType = renderDialectType(kind, dialect, {
     length,
@@ -235,6 +235,52 @@ export function getColumnDescriptor(
 }
 
 /**
+ * Which string kind a text-storing field asks for, from what it says about its own width.
+ *
+ * Only a field that reaches a string column may state a width: an email, a password and a select
+ * value are bounded by what they hold, while free text is bounded by nothing. Silence keeps the
+ * answer this path has always given, so the signal only ever adds information — a caller that KNOWS
+ * a field is unbounded can say so instead of discovering the ceiling when a paste is rejected, and
+ * on MySQL the two render 255 characters apart.
+ *
+ * One function rather than a branch per caller: a plugin-contributed type declaring `storage: "text"`
+ * lands in the same column as a built-in text field and is rendered by the same branch, so it has to
+ * answer this question the same way. Asking it in only one of the two places left a contributed
+ * field the caller had declared unbounded sitting in a bounded column.
+ */
+function textKindForDeclaredWidth(field: FieldDefinition): ColumnKind {
+  const options = field.options;
+  if (options?.variant === "long") return "longText";
+  // Declared short, so bounded on every dialect that has a bounded string. Its own kind rather
+  // than the existing `varchar` one, which renders PostgreSQL `text` and is what the system
+  // `status` column uses — widening that to a real varchar would make every existing status
+  // column read as a type change.
+  if (options?.variant === "short") return "shortText";
+  // `options` is the choice list on a select, and the payload schema permits that shape on any
+  // field. A text field carrying one states no width, and every generator reads it the same
+  // way — as unbounded — so reading it as bounded here would report an untouched column as a
+  // narrowing on every diff.
+  if (Array.isArray(options)) return "longText";
+  return "text";
+}
+
+/**
+ * Whether a kind stores a string, so a caller holding a string has somewhere valid to put it.
+ *
+ * Asked here rather than restated as a list of kind names by each caller: the kinds that store text
+ * are a property of the kind set, so a set that grows has one place to say whether the new member
+ * belongs. A caller carrying its own copy silently answered "no" for a kind added after it.
+ */
+export function isTextStorageKind(kind: ColumnKind): boolean {
+  return (
+    kind === "text" ||
+    kind === "longText" ||
+    kind === "shortText" ||
+    kind === "varchar"
+  );
+}
+
+/**
  * Maps a field config to a logical column kind. Centralises the
  * field-type to column-kind matrix that used to live in two
  * dialect-specific switches per file. The hasMany / relationTo[]
@@ -245,27 +291,8 @@ function classifyFieldKind(field: FieldDefinition): ColumnKind {
   if (!fieldProducesColumn(field)) return "skip";
 
   switch (field.type) {
-    case "text": {
-      // A text field may state its own width, and only this type may: an email, a password and a
-      // select value are bounded by what they hold, while free text is bounded by nothing.
-      //
-      // Absent, the answer stays what it has always been for this path. The signal exists so a
-      // caller that KNOWS the field is unbounded can say so instead of discovering the ceiling
-      // when a paste is rejected — on MySQL the two render 255 characters apart.
-      const options = field.options;
-      if (options?.variant === "long") return "longText";
-      // Declared short, so bounded on every dialect that has a bounded string. Its own kind rather
-      // than the existing `varchar` one, which renders PostgreSQL `text` and is what the system
-      // `status` column uses — widening that to a real varchar would make every existing status
-      // column read as a type change.
-      if (options?.variant === "short") return "shortText";
-      // `options` is the choice list on a select, and the payload schema permits that shape on any
-      // field. A text field carrying one states no width, and every generator reads it the same
-      // way — as unbounded — so reading it as bounded here would report an untouched column as a
-      // narrowing on every diff.
-      if (Array.isArray(options)) return "longText";
-      return "text";
-    }
+    case "text":
+      return textKindForDeclaredWidth(field);
 
     case "email":
     case "password":
@@ -322,11 +349,10 @@ function classifyFieldKind(field: FieldDefinition): ColumnKind {
       if (custom) {
         const kind = STORAGE_TO_COLUMN_KIND[custom.storage] ?? "text";
         // A contributed type that stores text answers the same width question a built-in text
-        // field does, and its column is rendered by the same branch. Ignoring the signal here left
-        // a field the caller had declared unbounded in a bounded column.
-        return kind === "text" && field.options?.variant === "long"
-          ? "longText"
-          : kind;
+        // field does, and its column is rendered by the same branch, so it is asked in the same
+        // way. Answering it here with a narrower rule left a contributed field bounded while the
+        // creators made it unbounded, which reports an untouched column as a narrowing.
+        return kind === "text" ? textKindForDeclaredWidth(field) : kind;
       }
       return "text";
     }
@@ -422,17 +448,37 @@ function renderDialectType(
  * Returns the length for kinds that carry one. Used by both the
  * dialect-token rendering and the runtime Drizzle builder.
  */
-function lengthForKind(kind: ColumnKind): number | undefined {
-  // A width the field declares is deliberately NOT read here. `normalize-type.ts` strips the
-  // modifier before the diff compares, so a bounded column's width is invisible to convergence:
-  // rendering a declared width would size a column correctly on creation and then silently ignore
-  // every later edit to it, leaving writes to fail against a column the stored limit says is wide
-  // enough. Resizing needs the diff to compare widths first.
+function lengthForField(
+  kind: ColumnKind,
+  field: FieldDefinition
+): number | undefined {
+  // The one kind a field asks for by declaring a width, so it is the one kind built at the width
+  // asked for. The others are sized by what they hold, not by the field.
+  //
+  // What this width does NOT do is survive a later edit: `normalize-type.ts` strips the modifier
+  // before the diff compares, so widening an existing column from 120 to 500 is invisible to
+  // convergence and no resize is emitted. Creating at the declared width is still strictly better
+  // than creating at 255 — a field declaring 500 characters otherwise gets a column that rejects
+  // what its own stored validation accepts — but resizing needs the diff to compare widths first.
+  if (kind === "shortText") return declaredMaxLength(field) ?? 255;
   if (kind === "text") return 255;
-  if (kind === "shortText") return 255;
   if (kind === "varchar") return 255;
   if (kind === "fkSingle") return 36;
   return undefined;
+}
+
+/**
+ * The width a field declares, from the two keys that carry one, or nothing when it declares none.
+ *
+ * Rejects anything that is not a whole positive count. These reach DDL as `VARCHAR(n)`, so a
+ * fraction, a zero or a negative would be rendered into the statement as written and the create
+ * would fail on a value the field system had already accepted.
+ */
+function declaredMaxLength(field: FieldDefinition): number | undefined {
+  const declared = field.validation?.maxLength ?? field.length;
+  if (typeof declared !== "number") return undefined;
+  if (!Number.isInteger(declared) || declared <= 0) return undefined;
+  return declared;
 }
 
 // ============================================================================

--- a/packages/nextly/src/domains/schema/services/field-column-descriptor.ts
+++ b/packages/nextly/src/domains/schema/services/field-column-descriptor.ts
@@ -306,7 +306,15 @@ function classifyFieldKind(field: FieldDefinition): ColumnKind {
       // Plugin-contributed custom field type maps to its declared storage
       // primitive; otherwise fall back to text (legacy default — no change).
       const custom = getFieldType(field.type);
-      if (custom) return STORAGE_TO_COLUMN_KIND[custom.storage] ?? "text";
+      if (custom) {
+        const kind = STORAGE_TO_COLUMN_KIND[custom.storage] ?? "text";
+        // A contributed type that stores text answers the same width question a built-in text
+        // field does, and its column is rendered by the same branch. Ignoring the signal here left
+        // a field the caller had declared unbounded in a bounded column.
+        return kind === "text" && field.options?.variant === "long"
+          ? "longText"
+          : kind;
+      }
       return "text";
     }
   }

--- a/packages/nextly/src/domains/schema/services/field-column-descriptor.ts
+++ b/packages/nextly/src/domains/schema/services/field-column-descriptor.ts
@@ -354,7 +354,11 @@ function classifyFieldKind(field: FieldDefinition): ColumnKind {
         // creators made it unbounded, which reports an untouched column as a narrowing.
         return kind === "text" ? textKindForDeclaredWidth(field) : kind;
       }
-      return "text";
+      // An unregistered type: the field schema accepts any slug-shaped token, so a stored field can
+      // name a type whose plugin is not loaded. It lands in a text column like the rest of this
+      // branch, so it answers the width question the same way rather than being forced to the
+      // bounded default.
+      return textKindForDeclaredWidth(field);
     }
   }
 }

--- a/packages/nextly/src/domains/schema/services/runtime-schema-generator.ts
+++ b/packages/nextly/src/domains/schema/services/runtime-schema-generator.ts
@@ -445,6 +445,12 @@ function buildPgColumnFromKind(
     case "longText":
     case "varchar":
       return nullable ? pgText(name) : pgText(name).notNull();
+    case "shortText": {
+      // The one string kind PostgreSQL bounds. The others render `text` there, so binding this as
+      // text too would leave the ORM describing a column the DDL declared with a width.
+      const col = pgVarchar(name, { length: desc.length ?? 255 });
+      return nullable ? col : col.notNull();
+    }
     case "boolean":
       return nullable ? pgBoolean(name) : pgBoolean(name).notNull();
     case "integer":
@@ -477,6 +483,7 @@ function buildMysqlColumnFromKind(
 ): unknown {
   switch (kind) {
     case "text":
+    case "shortText":
     case "varchar": {
       const col = mysqlVarchar(name, { length: length ?? 255 });
       return nullable ? col : col.notNull();
@@ -512,6 +519,7 @@ function buildSqliteColumnFromKind(
   switch (kind) {
     case "text":
     case "longText":
+    case "shortText":
     case "varchar":
       return nullable ? sqliteText(name) : sqliteText(name).notNull();
     case "boolean":

--- a/packages/nextly/src/domains/schema/utils/__tests__/plugin-missing-columns.test.ts
+++ b/packages/nextly/src/domains/schema/utils/__tests__/plugin-missing-columns.test.ts
@@ -94,3 +94,39 @@ describe("built-in columns agree with the descriptor the ORM binds", () => {
     expect(fieldToColumnDef(date, "mysql")).toMatch(/DATETIME/i);
   });
 });
+
+/**
+ * A text field that declared its own width gets the bounded column the descriptor binds.
+ *
+ * This helper stated TEXT for every string field, so a short field added to an existing table got a
+ * column the ORM then described as a varchar — and the next preview reported a type change on a
+ * column this path had just created.
+ */
+describe("adding a declared-short text field to an existing table", () => {
+  const shortField = {
+    name: "short_code",
+    type: "text",
+    options: { variant: "short" },
+    validation: { maxLength: 120 },
+  } as unknown as FieldConfig;
+
+  it.each([
+    ["postgresql", /VARCHAR\(120\)/i],
+    ["mysql", /VARCHAR\(120\)/i],
+  ] as const)("bounds the column on %s", (dialect, expected) => {
+    expect(fieldToColumnDef(shortField, dialect)).toMatch(expected);
+  });
+
+  // SQLite has one string type, so TEXT is what the descriptor says for it there too.
+  it("stays TEXT on sqlite", () => {
+    expect(fieldToColumnDef(shortField, "sqlite")).toMatch(/TEXT/i);
+  });
+
+  // A field that declares no width keeps the type this path has always emitted; only the declared
+  // case changes, so existing columns are not re-described.
+  it("leaves an undeclared text field as TEXT", () => {
+    const plain = { name: "body", type: "text" } as unknown as FieldConfig;
+    expect(fieldToColumnDef(plain, "postgresql")).toMatch(/TEXT/i);
+    expect(fieldToColumnDef(plain, "mysql")).toMatch(/TEXT/i);
+  });
+});

--- a/packages/nextly/src/domains/schema/utils/__tests__/plugin-missing-columns.test.ts
+++ b/packages/nextly/src/domains/schema/utils/__tests__/plugin-missing-columns.test.ts
@@ -130,3 +130,32 @@ describe("adding a declared-short text field to an existing table", () => {
     expect(fieldToColumnDef(plain, "mysql")).toMatch(/TEXT/i);
   });
 });
+
+/**
+ * A contributed type keeps the unbounded column its creator builds.
+ *
+ * The field-group creator deletes `options` from a contributed type before mapping it — a plugin's
+ * options are its own, and one that happens to be named `variant` must not reshape the column — so
+ * it builds such a field as TEXT. Reading the option here bounded a column the creator had just made
+ * unbounded, reporting a type change on it.
+ */
+describe("adding a contributed text field that carries a width option", () => {
+  it("keeps TEXT rather than reading the plugin's own option", () => {
+    registerFieldType({
+      type: "acme-swatch",
+      storage: "text",
+      component: "@acme/swatch/admin#Swatch",
+      surfaces: ["entries", "singles", "components"],
+    });
+
+    const field = {
+      name: "swatch",
+      type: "acme-swatch",
+      options: { variant: "short" },
+      validation: { maxLength: 64 },
+    } as unknown as FieldConfig;
+
+    expect(fieldToColumnDef(field, "postgresql")).toMatch(/TEXT/i);
+    expect(fieldToColumnDef(field, "mysql")).toMatch(/TEXT/i);
+  });
+});

--- a/packages/nextly/src/domains/schema/utils/missing-columns.ts
+++ b/packages/nextly/src/domains/schema/utils/missing-columns.ts
@@ -25,6 +25,7 @@
 import type { DrizzleAdapter } from "@nextlyhq/adapter-drizzle";
 
 import type { FieldConfig } from "../../../collections/fields/types/index";
+import { isBuiltInFieldType } from "../../../schemas/_zod/ui-schema";
 import type { FieldDefinition } from "../../../schemas/dynamic-collections/legacy-types";
 import { STORAGE_FORMAT } from "../../../schemas/storage-format";
 import type { Logger } from "../../../shared/types/index";
@@ -87,6 +88,16 @@ function ddlTypeForKind(
       // The one string kind that is not TEXT everywhere. Stated here because a column this path
       // adds to an existing table is read back by the same descriptor the ORM binds: emitting TEXT
       // for it left the next preview reporting a type change on a column boot had just created.
+      //
+      // Only for a type this schema names. A field group's creator deletes `options` from a
+      // contributed type before mapping it — a plugin's options are its own, and one that happens
+      // to be called `variant` must not reshape the column — so it builds such a field as TEXT.
+      // Bounding it here would report a type change on the column that creator had just made, which
+      // is the same defect in the opposite direction. Deciding it correctly needs to know which
+      // entity is being built, which this helper is not told.
+      if (!("type" in field) || !isBuiltInFieldType(String(field.type))) {
+        return undefined;
+      }
       // SQLite has one string type, so the bound lives in validation there and TEXT is correct.
       if (dialect === "sqlite") return "TEXT";
       return `VARCHAR(${descriptor.length ?? 255})`;

--- a/packages/nextly/src/domains/schema/utils/missing-columns.ts
+++ b/packages/nextly/src/domains/schema/utils/missing-columns.ts
@@ -83,6 +83,14 @@ function ddlTypeForKind(
         ? `DECIMAL${dimensions}`
         : `NUMERIC${dimensions}`;
     }
+    case "shortText": {
+      // The one string kind that is not TEXT everywhere. Stated here because a column this path
+      // adds to an existing table is read back by the same descriptor the ORM binds: emitting TEXT
+      // for it left the next preview reporting a type change on a column boot had just created.
+      // SQLite has one string type, so the bound lives in validation there and TEXT is correct.
+      if (dialect === "sqlite") return "TEXT";
+      return `VARCHAR(${descriptor.length ?? 255})`;
+    }
     case "timestamp":
       // Only SQLite routes here; it stores a timestamp as an integer.
       return dialect === "sqlite" ? "INTEGER" : undefined;
@@ -136,7 +144,10 @@ export function fieldToColumnDef(
     case "email":
     case "code":
     case "textarea":
-      columnType = "TEXT";
+      // A field that declared its own width gets the bounded column the descriptor binds and a
+      // freshly created table gets; every other string field keeps TEXT, which is what the
+      // descriptor says for them on all three dialects.
+      columnType = ddlTypeForKind(field, dialect) ?? "TEXT";
       break;
 
     case "number":

--- a/packages/nextly/src/domains/singles/services/single-query-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-query-service.ts
@@ -85,7 +85,10 @@ import {
   isCompanionReady,
   resolveCompanionSchemaReadiness,
 } from "../../i18n/runtime/companion-readiness";
-import { getColumnDescriptor } from "../../schema/services/field-column-descriptor";
+import {
+  getColumnDescriptor,
+  isTextStorageKind,
+} from "../../schema/services/field-column-descriptor";
 import { captureInTx } from "../../versions/capture-in-tx";
 import { VersionCaptureService } from "../../versions/version-capture-service";
 import { withVersionConflictRetry } from "../../versions/version-conflict";
@@ -115,15 +118,6 @@ import {
  * the system column or receives a wrong-typed default.
  */
 const SINGLE_IDENTITY_FIELDS = new Set(["title", "slug"]);
-
-/**
- * Column-descriptor kinds that store text, so the label/slug string seed for a
- * reserved identity field is valid for them. Covers plain text (text/email/
- * password/select/radio) and long text (textarea/richText/code), plus explicit
- * varchar. Non-text kinds (number, json, fkSingle, ...) fall through to the
- * field's own default instead, so a label string never lands in them.
- */
-const IDENTITY_TEXT_COLUMN_KINDS = new Set(["text", "varchar", "longText"]);
 
 /**
  * A Single's default document, built but not yet written. The read path judges
@@ -2055,8 +2049,12 @@ export class SingleQueryService extends BaseService {
           field as unknown as FieldDefinition,
           this.adapter.dialect
         );
-        if (!desc || IDENTITY_TEXT_COLUMN_KINDS.has(desc.kind)) {
-          continue; // keep the seeded label/slug for a text-storage column
+        // Keep the seeded label/slug whenever the column stores text. The descriptor answers that
+        // rather than a list of kind names kept here: a list restated locally judged a kind added
+        // later as non-text, replacing a Single's seeded identity with an empty default on the
+        // first read that created it.
+        if (!desc || isTextStorageKind(desc.kind)) {
+          continue;
         }
         if ("required" in field && field.required) {
           defaults[field.name] = getDefaultValue(field);

--- a/packages/nextly/src/init/reload-config.ts
+++ b/packages/nextly/src/init/reload-config.ts
@@ -51,7 +51,10 @@ import {
   noopMigrationJournal,
   noopPreRenameExecutor,
 } from "../domains/schema/pipeline/pushschema-pipeline-stubs";
-import { mergeRegisteredCollectionsSafely } from "../domains/schema/pipeline/registered-collections";
+import {
+  isCodeOwned,
+  mergeRegisteredCollectionsSafely,
+} from "../domains/schema/pipeline/registered-collections";
 import { RegexRenameDetector } from "../domains/schema/pipeline/rename-detector";
 import type {
   DesiredCollection,
@@ -1979,10 +1982,11 @@ async function applyReload(opts?: {
           tableName: s.tableName,
           fields: (s.fields ?? []) as DesiredSingle["fields"],
           status: s.status === true,
-          // Read out of the registry, so this is a single the Schema Builder created — the code
-          // config above already claimed every code-first slug. Stating it keeps its columns
-          // described the same way here as on the path that created them.
-          builderOwned: true,
+          // Read from the row, not inferred from the row's presence. A code-first single dropped
+          // from the config keeps its registry row for optional orphan cleanup, so it reaches this
+          // loop while still owned by code; calling it the Builder's would widen its columns on the
+          // apply that follows, for a removal nobody requested.
+          builderOwned: !isCodeOwned(s),
         };
       }
     }
@@ -2009,9 +2013,8 @@ async function applyReload(opts?: {
           slug: c.slug,
           tableName: c.tableName,
           fields: (c.fields ?? []) as DesiredFieldGroup["fields"],
-          // Registry-sourced, so Builder-authored: the code config above already claimed every
-          // code-first slug.
-          builderOwned: true,
+          // Read from the row, for the same reason as the singles loop above.
+          builderOwned: !isCodeOwned(c),
         };
       }
     }

--- a/packages/nextly/src/init/reload-config.ts
+++ b/packages/nextly/src/init/reload-config.ts
@@ -1979,6 +1979,10 @@ async function applyReload(opts?: {
           tableName: s.tableName,
           fields: (s.fields ?? []) as DesiredSingle["fields"],
           status: s.status === true,
+          // Read out of the registry, so this is a single the Schema Builder created — the code
+          // config above already claimed every code-first slug. Stating it keeps its columns
+          // described the same way here as on the path that created them.
+          builderOwned: true,
         };
       }
     }
@@ -2005,6 +2009,9 @@ async function applyReload(opts?: {
           slug: c.slug,
           tableName: c.tableName,
           fields: (c.fields ?? []) as DesiredFieldGroup["fields"],
+          // Registry-sourced, so Builder-authored: the code config above already claimed every
+          // code-first slug.
+          builderOwned: true,
         };
       }
     }

--- a/packages/nextly/src/runtime/notifications/types.ts
+++ b/packages/nextly/src/runtime/notifications/types.ts
@@ -8,6 +8,7 @@
 export type MigrationScope =
   | { kind: "collection"; slug: string }
   | { kind: "single"; slug: string }
+  | { kind: "component"; slug: string }
   | { kind: "global"; slug?: string }
   | { kind: "fresh-push" };
 

--- a/packages/nextly/src/schemas/_zod/ui-schema.ts
+++ b/packages/nextly/src/schemas/_zod/ui-schema.ts
@@ -52,6 +52,19 @@ export const UI_FIELD_TYPES = [
 
 const BUILT_IN_UI_FIELD_TYPES = new Set<string>(UI_FIELD_TYPES);
 
+/**
+ * Whether a field type is one this schema names, rather than a token a plugin contributed or a
+ * token nothing has registered at all.
+ *
+ * The field schema accepts any slug-shaped token, so "not one of ours" is a state a stored field can
+ * genuinely be in, and the layers that decide storage have to tell it apart from a built-in. Asked
+ * here because this is where the list of built-ins is declared; a caller keeping its own copy would
+ * answer wrongly the first time the list grew.
+ */
+export function isBuiltInFieldType(type: string): boolean {
+  return BUILT_IN_UI_FIELD_TYPES.has(type);
+}
+
 /** Field names the framework reserves (system columns). */
 // Universal system columns present on every entity table (collection, single,
 // component). The collection-only owner column (`created_by`/`createdBy`) is


### PR DESCRIPTION
Makes the schema diff describe Builder-created tables the way the Builder actually created them, and closes three ways a save could do the wrong thing.

**This is the safe half of PR #498.** That PR also routed Builder *creates* through the shared pipeline; review established the pipeline cannot yet do that faithfully, so the create-routing is now its own task and this branch was cut fresh from `main`. Detail at the bottom.

## The main fix

The Schema Builder creates a text field with no stated width as an **unbounded** column. The shared descriptor reads the same silence as **bounded**. On MySQL those are 65 535 and 255 characters, so every diff against a Builder-created table proposed narrowing a column that was already holding more than the proposal allowed.

A desired schema now states, per entity, whether the Builder authored it, and the width is resolved once on the schema **both** consumers read.

🔴 **Why that placement.** A desired schema is read twice: `buildDesiredTableFromFields` produces the snapshot the diff compares, and `generateRuntimeSchema` produces the Drizzle tables drizzle-kit turns into DDL. Resolving inside either leaves the other on the raw fields, and they then disagree permanently — a table converges and immediately reports a type change against itself. Normalising the input they share is the only placement that makes them agree by construction. `pushschema-pipeline.ts` already warns about this exact hazard for the `status` flag.

**Ownership is stated, never inferred.** Reading an absent `locked` flag as "the Builder's" would have been wrong in both directions:

| Producer | Builds | States `locked`? |
|---|---|---|
| `dispatcher/helpers/desired-schema.ts` | registry entities | yes |
| `cli/commands/dev-server.ts`, `di/register.ts`, `init/reload-config.ts` (code paths) | **code-first** | **no** |
| `init/reload-config.ts:1977,2004` | **UI-created**, preserved during HMR | **no** |

`!== true` widens every code-first entity; `=== false` stops resolving the UI entities HMR preserves. So entities carry an explicit `builderOwned`, and absent means code-first — a producer that has not learned to state it changes nothing.

**A declared width is rendered, and read from exactly one key.** Review rounds reversed the original decision here, correctly: the width is invisible to the *diff* (which strips length modifiers), but it was never invisible to *creation* — `length` goes straight from the descriptor into the Drizzle builder. The merged snapshots settle it, since both creators emit `varchar(120)` for a field declaring 120.

The one key is `validation.maxLength`, which is what the creators size a bounded column from. A top-level `length` is deliberately **not** read: honouring it gave `{ variant: "short", length: 500 }` one capacity when built by the creator and another through the pipeline, with the diff's width-stripping then hiding the difference forever. A field group declares its width under a different key, so the width resolver translates that into the canonical one rather than teaching the descriptor a second place to look — teaching it would bound every collection field carrying a `maxLength`, which that creator leaves unbounded.

## Also fixed

- **A journal row records which kind of entity a save targeted.** `computeJournalScope` returned `{ kind: "collection" }` for every UI target, so a single's migrations were unfindable under their own scope.
- **Locked-table operations are excluded before rename detection**, not after prompting. They reached the prompt gate on the way, and an unresolved rename candidate fails closed, so drift on a code-first table could refuse an entire Builder save over operations the next step discards.
- **A create naming an existing slug is refused before the schema converges.** The registry's authoritative check runs after the pipeline, so such a request altered the existing entity's live table and was only then rejected.

## Verification

- `pnpm build` 17/17 · `pnpm check-types --force` 19/19 · `pnpm lint` exit 0
- Full `packages/nextly` unit run diffed at test-name level against a baseline freshly measured from `origin/main` @ `c9ef62a6d` in its own installed and built worktree: **396 failures on both sides (396 / 6949 vs 396 / 6887), zero branch-only, zero disappeared**
- New cross-dialect convergence tests run against **real Postgres and MySQL**: a table created from a declaration previews as unchanged against that same declaration, and an unstated text field is unbounded on MySQL
- Every guard proven load-bearing by breaking it and confirming the intended test fails with the count unchanged

## What was removed, and why

Routing Builder **create** through `PushSchemaPipeline` came out. Review showed the pipeline is not yet a faithful replacement for the generators that path uses:

- **`add_table` emits no secondary indexes**, so a field declaring `unique: true` would get no unique constraint — data integrity, not performance
- **`DesiredSchema` does not model `manyToMany` junction tables** at all, so neither the junction nor the parent column would exist
- **field-group DDL comes from a separate type table**, mapping relationships to scalar FKs and MySQL timestamps differently from the snapshot

Those are the scope of the follow-up task, along with scoping UI operations to the target entity. The storage-migration engine that waits on it remains dark, so nothing is at risk while it waits.


## What the review rounds added

Seven findings, each verified against the code before being acted on. Six were real; one was unreachable but exposed a false guarantee.

| Finding | Outcome |
|---|---|
| The new bounded kind was refused by the localization intent parser | 🔴 a freshly generated migration read as malformed and **aborted the run**. The kind set is now declared once and the parser's allowlist derived from it |
| Its width was fixed at 255 | a field limited to 400 characters got a column rejecting what its validation accepts |
| A contributed text type carrying a choice list | read as a narrowing on an untouched column; both branches now ask one function |
| Single identity seeding judged it non-text | a new Single lost its seeded title and slug; the descriptor now answers that question |
| The incremental column path emitted `TEXT` for it | the next preview reported a type change on a column boot had just created |
| A field group's declared width was unread | previewed as a type change on PostgreSQL; the resolver now translates it |
| `MigrationJournalScope` allowed an entity scope with no entity | unreachable, but the comment claimed a type guarantee that did not exist. Now a union — adopting it immediately caught a real reader where `fresh-push` genuinely has no slug |

**Recorded, not fixed** — with reasons, in `tasks/left-tasks/`:

- `select` and `radio` fall through the creator's type map to unbounded `text` while the descriptor bounds them.
- A field group whose text field carries **both** a choice list and a `maxLength`. Neither is fixable from the width resolver: normalising means writing a variant into `options`, and there `options` *is* the choice list. Both need the entity kind, which the descriptor does not have.
- A column added to an existing table gets `TEXT` on MySQL where a fresh table gets `varchar(255)` — pre-existing, filed as task 121, and left alone deliberately because the smallest fix is the only one that can silently narrow a `text` column.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added component-scoped journal and migration history support.
  * Improved schema previews and applications with ownership and target tracking.
  * Added duplicate table-name safeguards for singles and components.
  * Added bounded text-field support with database-specific sizing.
  * Improved handling of Builder-owned fields and entities.

* **Bug Fixes**
  * Locked tables are excluded from unintended schema operations.
  * Schema previews and applications consistently resolve text widths.

* **Tests**
  * Expanded coverage for ownership, migrations, text fields, database dialects, and schema convergence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
