### PR TITLE
fix(nextly): re-push after a degraded reconcile so alterations are not lost

### DIFF
--- a/.changeset/core-reconcile-two-pass.md
+++ b/.changeset/core-reconcile-two-pass.md
@@ -1,0 +1,29 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+A core schema change now reaches a database that already holds content. Adding a column to
+one of Nextly own tables, or changing a constraint on one, was silently skipped on SQLite and
+MySQL whenever any content table existed, while nextly migrate still reported success. The
+reconcile now runs a second pass after a degraded one: with nothing left to create, the schema
+differ has no ambiguity to resolve and emits the alterations it previously abandoned.

--- a/packages/nextly/src/domains/schema/migrate/__tests__/core-reconcile-activity-actor.integration.test.ts
+++ b/packages/nextly/src/domains/schema/migrate/__tests__/core-reconcile-activity-actor.integration.test.ts
@@ -10,12 +10,14 @@
  * add missing TABLES but never alters an existing one, and whose redundant
  * `CREATE` statements are swallowed as "already exists".
  *
- * If this change's alterations landed in that degraded pass, an upgrade would
- * report success while leaving `activity_log` on its old shape — and the
- * erasure would then fail on a column that does not exist, taking every user
- * deletion down with it. The upgrade simulation cannot answer this: it puts
- * its dynamic table in the DESIRED schema, so drizzle-kit never sees an
- * orphan and never takes the fallback.
+ * A degraded pass alone would report success while leaving `activity_log` on
+ * its old shape, and the erasure would then fail on a column that does not
+ * exist. What makes the alterations land is the SECOND push: once the first
+ * has created whatever was missing, nothing is added, the resolver has no pair
+ * to resolve, and drizzle-kit emits the alterations itself.
+ *
+ * The upgrade simulation cannot cover this: it puts its dynamic table in the
+ * DESIRED schema, so drizzle-kit never sees an orphan and never degrades.
  *
  * The fixture is the pre-change shape written out by hand on purpose. It is a
  * historical artifact, not a copy of the current schema — deriving it from
@@ -106,12 +108,7 @@ describe("core reconcile on a pre-change SQLite database with content", () => {
     rmSync(TEST_DIR, { recursive: true, force: true });
   });
 
-  // `it.fails` because the reconcile does NOT do this today, and the assertions
-  // below say what it must do. Written as an expectation rather than a
-  // description of the bug so it inverts the moment someone repairs the
-  // degraded pass — at which point delete this wrapper, and the guard in
-  // `UserMutationService.activityLogSupportsErasure` that exists to survive it.
-  it.fails("applies the actor-column changes and keeps the rows", async () => {
+  it("applies the actor-column changes and keeps the rows", async () => {
     // The premise: the old shape really is in place, and there really is an
     // orphan content table for the resolver to trip over. Without both, this
     // suite would exercise the ordinary path and prove nothing.

--- a/packages/nextly/src/domains/schema/pipeline/fresh-push.ts
+++ b/packages/nextly/src/domains/schema/pipeline/fresh-push.ts
@@ -95,8 +95,53 @@ export async function freshPushSchema(
     });
   }
 
-  const result = await pushForDialect(dialect, db, schema);
+  // TWO PASSES, when and only when the first one degraded.
+  //
+  // The rename resolver crashes while pairing a live table outside the desired
+  // schema against one being ADDED, and the recovery baseline is diffed from an
+  // empty snapshot — so it creates missing tables and silently drops every
+  // alteration to a table that already exists. That is why a column added to a
+  // core table never reached an installation holding ordinary content.
+  //
+  // Once the first pass has created what was missing, nothing is added any
+  // more. The resolver has no pair to resolve, does not crash, and drizzle-kit
+  // emits the alterations itself — including the table rebuilds SQLite needs
+  // for a nullability change, which it already knows how to express and this
+  // code would otherwise have to reimplement.
+  //
+  // The second pass runs only after a degraded one. An ordinary push already
+  // applied everything, and re-running it would be a wasted introspection on
+  // every boot.
+  const first = await pushForDialect(dialect, db, schema);
+  const firstPass = await applyPushResult(dialect, db, schema, first);
+  if (!first.hints.some(h => h.hint.startsWith(DEGRADED_PASS_HINT))) {
+    return firstPass;
+  }
 
+  const second = await pushForDialect(dialect, db, schema);
+  const secondPass = await applyPushResult(dialect, db, schema, second);
+  return {
+    hints: [...firstPass.hints, ...secondPass.hints],
+    statementsExecuted: [
+      ...firstPass.statementsExecuted,
+      ...secondPass.statementsExecuted,
+    ],
+  };
+}
+
+/**
+ * Filter one push result for safety and execute what survives.
+ *
+ * Extracted so a degraded first pass and the retry after it go through exactly
+ * the same guards — a second path here is a second place for a destructive
+ * statement to slip past.
+ */
+async function applyPushResult(
+  dialect: FreshPushDialect,
+  db: unknown,
+  schema: Record<string, unknown>,
+  result: { sqlStatements: string[]; hints: KitHint[] }
+): Promise<FreshPushResult> {
   const desiredTableNames = drizzleTableNames(schema);
   const pieces = splitStatements(result.sqlStatements);
   const safe = filterUnsafeStatements(pieces, desiredTableNames);
@@ -138,6 +183,15 @@ export async function freshPushSchema(
 
   return { hints, statementsExecuted: executed };
 }
+
+/**
+ * Marks a pass that degraded to the additive-TABLES-only baseline.
+ *
+ * That baseline is diffed from an EMPTY snapshot, so it can create a missing
+ * table but never alter an existing one. Recognising it is what lets the push
+ * run again once the tables exist.
+ */
+const DEGRADED_PASS_HINT = "[nextly] pushSchema hit v1's rename-resolver crash";
 
 // Per-dialect pushSchema invocation. MySQL's v1 entrypoint requires the
 // database name positionally; resolve it from the live connection so
@@ -234,10 +288,10 @@ async function withResolverCrashFallback(
           // are not told a fully-handled fallback is an "uninterpreted
           // drizzle-kit hint".
           hint:
-            "[nextly] pushSchema hit v1's rename-resolver crash (live " +
-            "tables outside the desired schema); fell back to the " +
-            "additive-TABLES-only baseline — no drops, and no column adds " +
-            "to pre-existing tables, were applied this pass",
+            DEGRADED_PASS_HINT +
+            " (live tables outside the desired schema); applied the " +
+            "additive-TABLES-only baseline, then re-pushed so the " +
+            "alterations it cannot express are not lost",
         },
       ],
     };


### PR DESCRIPTION
Fixes `tasks/left-tasks/114-...` (P0). **A column added to any core table, or a constraint changed on one, never reached an installation that already held content — and `nextly migrate` reported success.**

## Why it happened

`reconcileCore` pushes core tables only, but drizzle-kit's SQLite and MySQL entrypoints take **no tables filter** (verified against the shipped rc.4 signature), so they introspect the whole database and read every `dc_*` table as an orphan. The rename resolver crashes pairing one against a table being **added**, and the recovery baseline is diffed from an empty snapshot: it creates what is missing and silently abandons every alteration to a table that already exists.

**Postgres was never affected** — it passes `{schemas, tables}` and never sees the orphans. That asymmetry is the entire bug.

## The fix

The crash needs a table on **both** sides. After a degraded pass nothing is added any more, so a second push has no pair to resolve, does not crash, and emits the alterations itself.

Crucially it emits **the SQLite table rebuild for a nullability change, and the foreign-key drop** — both of which drizzle-kit already knows how to express.

The retry runs **only** after a degraded pass, so an ordinary push costs nothing extra. Both passes go through the same unsafe-statement filter, so there is no second route for a destructive statement.

## The approach I rejected, and why it mattered

The task originally specified rendering Nextly's own scoped diff through `sql-templates/*`. **That would have been actively harmful.** `sql-templates/sqlite.ts` *throws* for `change_column_nullable` / `change_column_type` / `change_column_default` — SQLite cannot alter those in place. For `activity_log` it would have landed `identity_erased_at` while leaving `user_name`/`user_email` NOT NULL, so `activityLogSupportsErasure` would judge the table ready, run the erasure, and **every user deletion would fail on the NOT NULL columns** — worse than the safe degradation it replaced. It would also have meant reimplementing table rebuilds drizzle-kit already does.

## The guard stays — correcting the earlier plan

#495's `activityLogSupportsErasure` was slated for deletion "when 114 lands". That was wrong: this makes `nextly migrate` work, it does not retroactively migrate anyone. The guard is what keeps user deletion working between upgrading the package and running migrate, and a database can still lack `activity_log` entirely. Removing it now would reintroduce the exact breakage.

## Verification

- **Acceptance test flipped**: `core-reconcile-activity-actor.integration.test.ts` was written with `it.fails` to pin the defect; it is now a plain `it` and passes. It asserts the column arrives, both identity columns become nullable, the cascade is gone, **and the existing row survives** — a rebuild that reached the right shape by discarding data would be the defect in another form.
- **Revert-checked**: removing the second pass fails it with `expected [...] to include 'identity_erased_at'`; revert proven with `diff`.
- Schema + users + DI integration on all three dialects: **SQLite 58, Postgres 102, MySQL 75 passed, 0 failures**.
- Failing-test **name set** identical to `main`. `check-types` and `lint` clean.

## Still open (not this PR)

`ensureCoreTables` and `ensureFirstRunSetup` still return early, so a missing core **table** is still repaired only by an explicit `nextly migrate`. Recorded in 114.