### PR TITLE
fix(nextly): resolve field names to one column, once

### DIFF
--- a/.changeset/collection-column-name-normalization.md
+++ b/.changeset/collection-column-name-normalization.md
@@ -22,11 +22,15 @@
 "@nextlyhq/tsconfig": patch
 ---
 
-Create a Schema Builder collection's columns under the same names the rest of the framework uses.
-A field whose name began with a capital was created with an extra leading underscore, while the
-runtime schema and the schema diff both addressed it without one — so the table and every read of
-it disagreed, and the diff reported the column missing on every apply.
+Resolve a field name to its database column the same way everywhere. A Schema Builder collection
+created a field whose name began with a capital under an extra leading underscore, while the
+runtime schema and the schema diff addressed it without one — so the table and every read of it
+disagreed, and the diff reported the column missing on every apply.
 
-No collection is affected: the Schema Builder already refuses a field name beginning with a
-capital, which is why the divergence had gone unnoticed. Emitted SQL is unchanged for every name
-it accepts.
+Two decisions that depended on the field's declared name now use its column instead, so correcting
+the conversion does not break configurations that work: a field named `Title` replaces the injected
+`title` column rather than colliding with it, and two fields whose names reach one column (such as
+`foo_bar` and `FooBar`) are reported as duplicates where the names are chosen instead of failing
+during schema application.
+
+Emitted SQL is unchanged for every field name the Schema Builder accepts.

--- a/.changeset/collection-column-name-normalization.md
+++ b/.changeset/collection-column-name-normalization.md
@@ -1,0 +1,32 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+Create a Schema Builder collection's columns under the same names the rest of the framework uses.
+A field whose name began with a capital was created with an extra leading underscore, while the
+runtime schema and the schema diff both addressed it without one — so the table and every read of
+it disagreed, and the diff reported the column missing on every apply.
+
+No collection is affected: the Schema Builder already refuses a field name beginning with a
+capital, which is why the divergence had gone unnoticed. Emitted SQL is unchanged for every name
+it accepts.

--- a/.changeset/collection-column-name-normalization.md
+++ b/.changeset/collection-column-name-normalization.md
@@ -27,12 +27,24 @@ created a field whose name began with a capital under an extra leading underscor
 runtime schema and the schema diff addressed it without one — so the table and every read of it
 disagreed, and the diff reported the column missing on every apply.
 
-Two decisions that depended on the field's declared name now use its column instead, so correcting
-the conversion does not break configurations that work: a field named `Title` replaces the injected
-`title` column rather than colliding with it, and two fields whose names reach one column (such as
-`foo_bar` and `FooBar`) are reported as duplicates where the names are chosen instead of failing
-during schema application. Field types that store their values in their own tables, such as a
-component or a many-to-many relationship, are exempt from that duplicate rule: they are keyed by the
-field's declared name, so two of them whose names converge stay distinct.
+Every decision about which column a field occupies now asks the same question of the same
+conversion: which system column an author's field replaces, whether two names collide, which system
+fields a config factory injects, and which columns an ALTER may touch. Two fields whose names reach
+one column (such as `foo_bar` and `FooBar`) are now reported where the names are chosen rather than
+failing during schema application, and editing a many-to-many field's index or flags no longer emits
+statements against a column it never had.
+
+Field types that store their values in their own tables, such as a component or a many-to-many
+relationship, are consistently treated as occupying no column: they neither collide with each other
+nor suppress a system column that still has to be injected beside them.
+
+**Two configurations that were previously accepted are now refused at startup, with an error naming
+the fix.** A field may replace the system `title` or `slug` column only under that column's own
+name: `title` still works and is unchanged, while `Title` is refused, because it reaches the same
+column while remaining a separate identity in every payload — a create carrying `Title` gained a
+second generated `title` and the generated value overwrote the author's. And a field whose name
+reaches a column the Draft/Published lifecycle owns is refused while that lifecycle is enabled; such
+a collection could never have been created, since the column was declared twice. With the lifecycle
+off, `status` remains an ordinary field name.
 
 Emitted SQL is unchanged for every field name the Schema Builder accepts.

--- a/.changeset/collection-column-name-normalization.md
+++ b/.changeset/collection-column-name-normalization.md
@@ -31,6 +31,8 @@ Two decisions that depended on the field's declared name now use its column inst
 the conversion does not break configurations that work: a field named `Title` replaces the injected
 `title` column rather than colliding with it, and two fields whose names reach one column (such as
 `foo_bar` and `FooBar`) are reported as duplicates where the names are chosen instead of failing
-during schema application.
+during schema application. Field types that store their values in their own tables, such as a
+component or a many-to-many relationship, are exempt from that duplicate rule: they are keyed by the
+field's declared name, so two of them whose names converge stay distinct.
 
 Emitted SQL is unchanged for every field name the Schema Builder accepts.

--- a/packages/nextly/src/cli/commands/dev-server.ts
+++ b/packages/nextly/src/cli/commands/dev-server.ts
@@ -43,6 +43,7 @@ import type {
   DesiredSingle,
 } from "../../domains/schema/pipeline/types";
 import { DrizzleStatementExecutor } from "../../domains/schema/services/drizzle-statement-executor";
+import { columnsDeclaredBy } from "../../domains/schema/services/field-column-descriptor";
 import { generateRuntimeSchema } from "../../domains/schema/services/runtime-schema-generator";
 // F8 PR 1: SchemaPushService dropped from this module. The env check
 // (was getEnvironment().isProduction) is now an inline NODE_ENV read.
@@ -633,17 +634,17 @@ export async function performSinglesAutoSync(
         // Ensure system columns (title, slug) exist — they may be missing
         // on tables created before the fix that added them to the schema.
         // Singles always need title/slug for createDefaultDocument().
+        // Matched on the COLUMN each field becomes, as `defineSingle` and the generators do. An
+        // author writing `Title` already owns the `title` column, so adding the system field
+        // beside it asks for that column twice.
         const systemFields = [];
-        const hasTitleField = (
-          singleConfig.fields as Array<{ name?: string }>
-        ).some(f => f.name === "title");
-        if (!hasTitleField) {
+        const declaredColumns = columnsDeclaredBy(
+          (singleConfig.fields as Array<{ name?: string }>).map(f => f.name)
+        );
+        if (!declaredColumns.has("title")) {
           systemFields.push({ name: "title", type: "text" });
         }
-        const hasSlugField = (
-          singleConfig.fields as Array<{ name?: string }>
-        ).some(f => f.name === "slug");
-        if (!hasSlugField) {
+        if (!declaredColumns.has("slug")) {
           systemFields.push({ name: "slug", type: "text" });
         }
 

--- a/packages/nextly/src/cli/commands/dev-server.ts
+++ b/packages/nextly/src/cli/commands/dev-server.ts
@@ -639,7 +639,7 @@ export async function performSinglesAutoSync(
         // beside it asks for that column twice.
         const systemFields = [];
         const declaredColumns = columnsDeclaredBy(
-          (singleConfig.fields as Array<{ name?: string }>).map(f => f.name)
+          singleConfig.fields as Array<{ name?: string; type?: string }>
         );
         if (!declaredColumns.has("title")) {
           systemFields.push({ name: "title", type: "text" });

--- a/packages/nextly/src/collections/config/define-collection.ts
+++ b/packages/nextly/src/collections/config/define-collection.ts
@@ -34,7 +34,7 @@
 import type { BeforeOperationHandler, HookHandler } from "@nextly/hooks/types";
 
 import type { CollectionAccessControl } from "../../domains/auth/services/access-control-types";
-import { toSnakeCase } from "../../domains/schema/services/field-column-descriptor";
+import { columnsDeclaredBy } from "../../domains/schema/services/field-column-descriptor";
 import type { WebhookEventType } from "../../domains/webhooks/types";
 import type { RevalidateConfig } from "../../revalidation/types";
 import type { VersionsConfig } from "../../schemas/versions/types";
@@ -1122,13 +1122,8 @@ export function defineCollection(
   // Keyed by the COLUMN each field becomes, not by its declared name. A field named `Title` owns
   // the `title` column, so injecting the system one beside it declares that column twice and the
   // table cannot be created — the injection has to ask the same question the generators do.
-  const userFieldColumns = new Set(
-    config.fields
-      .filter(
-        (f): f is FieldConfig & { name: string } =>
-          "name" in f && typeof f.name === "string"
-      )
-      .map(f => toSnakeCase(f.name))
+  const userFieldColumns = columnsDeclaredBy(
+    config.fields.map(f => ("name" in f ? f.name : undefined))
   );
 
   const systemFields: FieldConfig[] = [];

--- a/packages/nextly/src/collections/config/define-collection.ts
+++ b/packages/nextly/src/collections/config/define-collection.ts
@@ -34,6 +34,7 @@
 import type { BeforeOperationHandler, HookHandler } from "@nextly/hooks/types";
 
 import type { CollectionAccessControl } from "../../domains/auth/services/access-control-types";
+import { toSnakeCase } from "../../domains/schema/services/field-column-descriptor";
 import type { WebhookEventType } from "../../domains/webhooks/types";
 import type { RevalidateConfig } from "../../revalidation/types";
 import type { VersionsConfig } from "../../schemas/versions/types";
@@ -1118,18 +1119,21 @@ export function defineCollection(
   // matching the Schema Builder behavior. If the user already defined
   // fields with these names, their definitions take priority.
 
-  const userFieldNames = new Set(
+  // Keyed by the COLUMN each field becomes, not by its declared name. A field named `Title` owns
+  // the `title` column, so injecting the system one beside it declares that column twice and the
+  // table cannot be created — the injection has to ask the same question the generators do.
+  const userFieldColumns = new Set(
     config.fields
       .filter(
         (f): f is FieldConfig & { name: string } =>
           "name" in f && typeof f.name === "string"
       )
-      .map(f => f.name)
+      .map(f => toSnakeCase(f.name))
   );
 
   const systemFields: FieldConfig[] = [];
 
-  if (!userFieldNames.has("title")) {
+  if (!userFieldColumns.has("title")) {
     systemFields.push({
       type: "text",
       name: "title",
@@ -1142,7 +1146,7 @@ export function defineCollection(
     });
   }
 
-  if (!userFieldNames.has("slug")) {
+  if (!userFieldColumns.has("slug")) {
     systemFields.push({
       type: "text",
       name: "slug",

--- a/packages/nextly/src/collections/config/define-collection.ts
+++ b/packages/nextly/src/collections/config/define-collection.ts
@@ -1122,9 +1122,7 @@ export function defineCollection(
   // Keyed by the COLUMN each field becomes, not by its declared name. A field named `Title` owns
   // the `title` column, so injecting the system one beside it declares that column twice and the
   // table cannot be created — the injection has to ask the same question the generators do.
-  const userFieldColumns = columnsDeclaredBy(
-    config.fields.map(f => ("name" in f ? f.name : undefined))
-  );
+  const userFieldColumns = columnsDeclaredBy(config.fields);
 
   const systemFields: FieldConfig[] = [];
 

--- a/packages/nextly/src/collections/config/validate-config.ts
+++ b/packages/nextly/src/collections/config/validate-config.ts
@@ -25,7 +25,10 @@
  */
 
 import { isPluginFieldTypeOnSurface } from "../../domains/schema/field-types/field-type-registry";
-import { toSnakeCase } from "../../domains/schema/services/field-column-descriptor";
+import {
+  fieldProducesColumn,
+  toSnakeCase,
+} from "../../domains/schema/services/field-column-descriptor";
 import { isReservedSystemColumn } from "../../lib/system-columns";
 import { SYSTEM_RESOURCES } from "../../schemas/_zod/rbac";
 import {
@@ -534,7 +537,8 @@ function validateFields(
   const columnOwners = new Map<string, string>();
   fields.forEach((field, index) => {
     if (!field || typeof field !== "object") return;
-    const name = (field as Record<string, unknown>).name;
+    const candidate = field as Record<string, unknown>;
+    const name = candidate.name;
     if (typeof name !== "string") return;
     const column = toSnakeCase(name);
     if (isReservedSystemColumn(column, "collectionConfig")) {
@@ -549,6 +553,11 @@ function validateFields(
     // created. Checked here rather than in the shared field-name rule because only this level has
     // columns at all: a repeater or group keeps its children inside a single JSON column, where
     // two names that convert alike are simply two keys.
+    //
+    // Column-less field types are exempt for the same reason. A component and a many-to-many
+    // relationship store their values in their own tables, keyed by the field's declared name, so
+    // two of them whose names converge stay distinct and nothing is emitted twice.
+    if (!fieldProducesColumn(candidate)) return;
     const owner = columnOwners.get(column);
     if (owner !== undefined) {
       errors.push({

--- a/packages/nextly/src/collections/config/validate-config.ts
+++ b/packages/nextly/src/collections/config/validate-config.ts
@@ -24,6 +24,7 @@
  * ```
  */
 
+import { isFieldLocalized } from "../../domains/i18n/classify-fields";
 import { isPluginFieldTypeOnSurface } from "../../domains/schema/field-types/field-type-registry";
 import {
   fieldProducesColumn,
@@ -489,7 +490,8 @@ function validateFieldsArray(
 function validateFields(
   fields: unknown,
   errors: ValidationError[],
-  allCollectionSlugs?: string[]
+  allCollectionSlugs?: string[],
+  collectionLocalized = false
 ): void {
   const path = "fields";
 
@@ -534,7 +536,15 @@ function validateFields(
   //
   // Nested fields are validated recursively inside validateFieldsArray and are intentionally
   // exempt: they are stored inside JSON and never become columns of their own.
-  const columnOwners = new Map<string, string>();
+  //
+  // Ownership is tracked per TABLE, not per collection. When the collection is localized its
+  // translatable fields are emitted into the `_locales` companion instead of the main table, so a
+  // shared `foo_bar` and a localized `FooBar` reach one column name in two different tables and
+  // never collide. One global map would refuse a schema the generators represent correctly.
+  const columnOwners = new Map<string, Map<string, string>>([
+    ["main", new Map()],
+    ["companion", new Map()],
+  ]);
   fields.forEach((field, index) => {
     if (!field || typeof field !== "object") return;
     const candidate = field as Record<string, unknown>;
@@ -558,7 +568,15 @@ function validateFields(
     // relationship store their values in their own tables, keyed by the field's declared name, so
     // two of them whose names converge stay distinct and nothing is emitted twice.
     if (!fieldProducesColumn(candidate)) return;
-    const owner = columnOwners.get(column);
+    const table = isFieldLocalized(
+      candidate as unknown as Parameters<typeof isFieldLocalized>[0],
+      collectionLocalized
+    )
+      ? "companion"
+      : "main";
+    const owners = columnOwners.get(table);
+    if (!owners) return;
+    const owner = owners.get(column);
     if (owner !== undefined) {
       errors.push({
         path: `${path}[${index}].name`,
@@ -567,7 +585,7 @@ function validateFields(
       });
       return;
     }
-    columnOwners.set(column, name);
+    owners.set(column, name);
   });
 
   validateFieldsArray(fields, path, errors, allCollectionSlugs);
@@ -649,7 +667,12 @@ export function validateCollectionConfig(
     sqlKeywordsSet: DEFAULT_SQL_KEYWORDS_SET,
   });
 
-  validateFields(config.fields, errors, allCollectionSlugs);
+  validateFields(
+    config.fields,
+    errors,
+    allCollectionSlugs,
+    (config as { localized?: boolean }).localized === true
+  );
 
   validateIndexes(config.indexes, config.fields, errors);
 

--- a/packages/nextly/src/collections/config/validate-config.ts
+++ b/packages/nextly/src/collections/config/validate-config.ts
@@ -24,7 +24,6 @@
  * ```
  */
 
-import { isFieldLocalized } from "../../domains/i18n/classify-fields";
 import { isPluginFieldTypeOnSurface } from "../../domains/schema/field-types/field-type-registry";
 import {
   fieldProducesColumn,
@@ -500,7 +499,6 @@ function validateFields(
   fields: unknown,
   errors: ValidationError[],
   allCollectionSlugs?: string[],
-  collectionLocalized = false,
   lifecycleEnabled = false
 ): void {
   const path = "fields";
@@ -547,14 +545,17 @@ function validateFields(
   // Nested fields are validated recursively inside validateFieldsArray and are intentionally
   // exempt: they are stored inside JSON and never become columns of their own.
   //
-  // Ownership is tracked per TABLE, not per collection. When the collection is localized its
-  // translatable fields are emitted into the `_locales` companion instead of the main table, so a
-  // shared `foo_bar` and a localized `FooBar` reach one column name in two different tables and
-  // never collide. One global map would refuse a schema the generators represent correctly.
-  const columnOwners = new Map<string, Map<string, string>>([
-    ["main", new Map()],
-    ["companion", new Map()],
-  ]);
+  // Ownership is GLOBAL, not per table. Two names that reach one column are refused even when the
+  // generators would put them in different tables — a shared `foo_bar` beside a localized
+  // `FooBar`. Physical separation does not keep the two values apart, because the write path
+  // normalizes payload keys through the same conversion BEFORE it splits localized fields off:
+  //
+  //   for (const [key, value] of Object.entries(rawEntryData))
+  //     entryData[toSnakeCase(key)] = value;
+  //
+  // Both keys land on `foo_bar` and the second silently overwrites the first, so one of the two
+  // authored values is already gone by the time anything decides which table it belongs to.
+  const columnOwners = new Map<string, string>();
   fields.forEach((field, index) => {
     if (!field || typeof field !== "object") return;
     const candidate = field as Record<string, unknown>;
@@ -608,15 +609,7 @@ function validateFields(
     // Column-less field types are exempt for the same reason. A component and a many-to-many
     // relationship store their values in their own tables, keyed by the field's declared name, so
     // two of them whose names converge stay distinct and nothing is emitted twice.
-    const table = isFieldLocalized(
-      candidate as unknown as Parameters<typeof isFieldLocalized>[0],
-      collectionLocalized
-    )
-      ? "companion"
-      : "main";
-    const owners = columnOwners.get(table);
-    if (!owners) return;
-    const owner = owners.get(column);
+    const owner = columnOwners.get(column);
     if (owner !== undefined) {
       errors.push({
         path: `${path}[${index}].name`,
@@ -625,7 +618,7 @@ function validateFields(
       });
       return;
     }
-    owners.set(column, name);
+    columnOwners.set(column, name);
   });
 
   validateFieldsArray(fields, path, errors, allCollectionSlugs);
@@ -711,7 +704,6 @@ export function validateCollectionConfig(
     config.fields,
     errors,
     allCollectionSlugs,
-    (config as { localized?: boolean }).localized === true,
     (config as { status?: boolean }).status === true
   );
 

--- a/packages/nextly/src/collections/config/validate-config.ts
+++ b/packages/nextly/src/collections/config/validate-config.ts
@@ -531,6 +531,7 @@ function validateFields(
   //
   // Nested fields are validated recursively inside validateFieldsArray and are intentionally
   // exempt: they are stored inside JSON and never become columns of their own.
+  const columnOwners = new Map<string, string>();
   fields.forEach((field, index) => {
     if (!field || typeof field !== "object") return;
     const name = (field as Record<string, unknown>).name;
@@ -542,7 +543,22 @@ function validateFields(
         message: `Field name '${name}' is reserved: it becomes the system column '${column}'`,
         code: "FIELD_NAME_RESERVED",
       });
+      return;
     }
+    // Two names that reach one column cannot both be emitted, so the table could never be
+    // created. Checked here rather than in the shared field-name rule because only this level has
+    // columns at all: a repeater or group keeps its children inside a single JSON column, where
+    // two names that convert alike are simply two keys.
+    const owner = columnOwners.get(column);
+    if (owner !== undefined) {
+      errors.push({
+        path: `${path}[${index}].name`,
+        message: `Field name '${name}' collides with '${owner}': both become the column '${column}'`,
+        code: "FIELD_NAME_DUPLICATE",
+      });
+      return;
+    }
+    columnOwners.set(column, name);
   });
 
   validateFieldsArray(fields, path, errors, allCollectionSlugs);

--- a/packages/nextly/src/collections/config/validate-config.ts
+++ b/packages/nextly/src/collections/config/validate-config.ts
@@ -30,7 +30,11 @@ import {
   fieldProducesColumn,
   toSnakeCase,
 } from "../../domains/schema/services/field-column-descriptor";
-import { isReservedSystemColumn } from "../../lib/system-columns";
+import {
+  isLifecycleSystemColumn,
+  isOwnableSystemColumn,
+  isReservedSystemColumn,
+} from "../../lib/system-columns";
 import { SYSTEM_RESOURCES } from "../../schemas/_zod/rbac";
 import {
   type BaseValidationError,
@@ -86,6 +90,11 @@ export type ValidationErrorCode =
   | "FIELD_NAME_SQL_KEYWORD"
   | "FIELD_NAME_DUPLICATE"
   | "FIELD_NAME_RESERVED"
+  // A name that reaches a system column under a different spelling. Allowed only as the
+  // column's own name, because the declared name stays the identity in every payload.
+  | "FIELD_NAME_SYSTEM_ALIAS"
+  // A name that reaches a column the Draft/Published lifecycle owns, while it is enabled.
+  | "FIELD_NAME_LIFECYCLE_RESERVED"
   | "FIELD_TYPE_REQUIRED"
   | "FIELD_TYPE_INVALID"
   // A declared default the field's own rules reject.
@@ -491,7 +500,8 @@ function validateFields(
   fields: unknown,
   errors: ValidationError[],
   allCollectionSlugs?: string[],
-  collectionLocalized = false
+  collectionLocalized = false,
+  lifecycleEnabled = false
 ): void {
   const path = "fields";
 
@@ -559,6 +569,37 @@ function validateFields(
       });
       return;
     }
+    // Everything below is about columns, so a field that occupies none is exempt. A component or
+    // a many-to-many named `Title` takes over nothing: its values live in its own table and its
+    // payload key stays `Title`, distinct from the system field's `title`.
+    if (!fieldProducesColumn(candidate)) return;
+    // A field may take over `title` or `slug` — that is the documented "user wins" behaviour —
+    // but only under the column's own name. `Title` reaches the same column while staying a
+    // different identity everywhere the declared name is the key: the runtime table's property,
+    // the payload keys a mutation generates, the response document, the generated types. The two
+    // would then write one column under two names, and the generated value would overwrite the
+    // author's. Refused here, with the spelling that works, rather than normalized at every layer.
+    if (column !== name && isOwnableSystemColumn(column, "collection")) {
+      errors.push({
+        path: `${path}[${index}].name`,
+        message: `Field name '${name}' becomes the system column '${column}'. Name the field '${column}' to replace that column, or choose a different name`,
+        code: "FIELD_NAME_SYSTEM_ALIAS",
+      });
+      return;
+    }
+    // The Draft/Published lifecycle owns its columns outright: their length, their NOT NULL, the
+    // 'draft' default and the values publish/unpublish write. An author's field cannot stand in
+    // for one, so any name reaching them is a collision rather than a takeover, and the table
+    // would declare the column twice. Only when the lifecycle is on — with it off these are
+    // ordinary names and a `status` field is measured clean in all three generators.
+    if (lifecycleEnabled && isLifecycleSystemColumn(column, "collection")) {
+      errors.push({
+        path: `${path}[${index}].name`,
+        message: `Field name '${name}' becomes the column '${column}', which the Draft/Published lifecycle owns. Rename the field, or turn the lifecycle off`,
+        code: "FIELD_NAME_LIFECYCLE_RESERVED",
+      });
+      return;
+    }
     // Two names that reach one column cannot both be emitted, so the table could never be
     // created. Checked here rather than in the shared field-name rule because only this level has
     // columns at all: a repeater or group keeps its children inside a single JSON column, where
@@ -567,7 +608,6 @@ function validateFields(
     // Column-less field types are exempt for the same reason. A component and a many-to-many
     // relationship store their values in their own tables, keyed by the field's declared name, so
     // two of them whose names converge stay distinct and nothing is emitted twice.
-    if (!fieldProducesColumn(candidate)) return;
     const table = isFieldLocalized(
       candidate as unknown as Parameters<typeof isFieldLocalized>[0],
       collectionLocalized
@@ -671,7 +711,8 @@ export function validateCollectionConfig(
     config.fields,
     errors,
     allCollectionSlugs,
-    (config as { localized?: boolean }).localized === true
+    (config as { localized?: boolean }).localized === true,
+    (config as { status?: boolean }).status === true
   );
 
   validateIndexes(config.indexes, config.fields, errors);

--- a/packages/nextly/src/dispatcher/handlers/single-dispatcher.ts
+++ b/packages/nextly/src/dispatcher/handlers/single-dispatcher.ts
@@ -1207,7 +1207,7 @@ const SINGLES_METHODS: Record<string, MethodHandler<SinglesServices>> = {
         // field named `Title` already owns the `title` column, so prepending the system one beside
         // it hands the alter two fields for a single column.
         const declaredColumns = (fields: FieldDefinition[]): Set<string> =>
-          columnsDeclaredBy(fields.map(f => f.name));
+          columnsDeclaredBy(fields);
         const existingFieldsForAlter = omitLocalized(existingFields);
         const existingFieldColumns = declaredColumns(existingFieldsForAlter);
         const normalizedOldFields: FieldDefinition[] = [

--- a/packages/nextly/src/dispatcher/handlers/single-dispatcher.ts
+++ b/packages/nextly/src/dispatcher/handlers/single-dispatcher.ts
@@ -65,6 +65,7 @@ import type { Resolution } from "../../domains/schema/pipeline/resolution/types"
 import { isIdempotencyError } from "../../domains/schema/pipeline/sql-statement-utils";
 import type { DesiredSingle } from "../../domains/schema/pipeline/types";
 import { DrizzleStatementExecutor } from "../../domains/schema/services/drizzle-statement-executor";
+import { columnsDeclaredBy } from "../../domains/schema/services/field-column-descriptor";
 import { generateRuntimeSchema } from "../../domains/schema/services/runtime-schema-generator";
 import type { FieldResolution } from "../../domains/schema/services/schema-change-types";
 import { calculateSchemaHash } from "../../domains/schema/services/schema-hash";
@@ -1202,12 +1203,15 @@ const SINGLES_METHODS: Record<string, MethodHandler<SinglesServices>> = {
           );
           return fields.filter(f => !localizedNames.has(f.name));
         };
+        // Keyed by the COLUMN each field becomes, matching `defineSingle` and the generators. A
+        // field named `Title` already owns the `title` column, so prepending the system one beside
+        // it hands the alter two fields for a single column.
+        const declaredColumns = (fields: FieldDefinition[]): Set<string> =>
+          columnsDeclaredBy(fields.map(f => f.name));
         const existingFieldsForAlter = omitLocalized(existingFields);
-        const existingFieldNames = new Set(
-          existingFieldsForAlter.map(f => f.name)
-        );
+        const existingFieldColumns = declaredColumns(existingFieldsForAlter);
         const normalizedOldFields: FieldDefinition[] = [
-          ...systemFields.filter(sf => !existingFieldNames.has(sf.name)),
+          ...systemFields.filter(sf => !existingFieldColumns.has(sf.name)),
           ...existingFieldsForAlter,
           {
             name: "updatedAt",
@@ -1218,9 +1222,9 @@ const SINGLES_METHODS: Record<string, MethodHandler<SinglesServices>> = {
 
         const newFieldsRaw = b.fields as unknown as FieldDefinition[];
         const newFieldsForAlter = omitLocalized(newFieldsRaw);
-        const newFieldNames = new Set(newFieldsForAlter.map(f => f.name));
+        const newFieldColumns = declaredColumns(newFieldsForAlter);
         const normalizedNewFields: FieldDefinition[] = [
-          ...systemFields.filter(sf => !newFieldNames.has(sf.name)),
+          ...systemFields.filter(sf => !newFieldColumns.has(sf.name)),
           ...newFieldsForAlter,
           {
             name: "updatedAt",

--- a/packages/nextly/src/domains/dynamic-collections/__tests__/column-name-agreement.test.ts
+++ b/packages/nextly/src/domains/dynamic-collections/__tests__/column-name-agreement.test.ts
@@ -16,6 +16,7 @@ import type { FieldDefinition } from "../../../schemas/dynamic-collections";
 import { buildDesiredTableFromFields } from "../../schema/pipeline/diff/build-from-fields";
 import { generateRuntimeSchema } from "../../schema/services/runtime-schema-generator";
 import {
+  columnsDeclaredBy,
   fieldProducesColumn,
   getColumnDescriptor,
   toSnakeCase,
@@ -304,6 +305,25 @@ describe("all three descriptions of the main table agree", () => {
         }
       }
     }
+  });
+});
+
+describe("columnsDeclaredBy", () => {
+  it("answers on the column, and tolerates entries that are not names", () => {
+    // The shared definition behind four "has the author already declared this?" decisions.
+    // Anything that is not a string is skipped rather than coerced, because two of those callers
+    // run before the config has been parsed.
+    expect([
+      ...columnsDeclaredBy([
+        "Title",
+        "publishedAt",
+        "x_y",
+        undefined,
+        null,
+        42,
+        { name: "nope" },
+      ]),
+    ]).toEqual(["title", "published_at", "x_y"]);
   });
 });
 

--- a/packages/nextly/src/domains/dynamic-collections/__tests__/column-name-agreement.test.ts
+++ b/packages/nextly/src/domains/dynamic-collections/__tests__/column-name-agreement.test.ts
@@ -160,6 +160,33 @@ describe("two field names that reach one column", () => {
     }
   });
 
+  it("leaves nested fields alone, because they share one JSON column", () => {
+    // A repeater or group keeps its children inside a single column, so two child names that
+    // convert alike are two keys in one JSON value — nothing collides. Applying a column rule at
+    // a level that has no columns would refuse a configuration that works.
+    for (const type of ["group", "repeater"]) {
+      const result = validateCollectionConfig({
+        slug: "probe",
+        fields: [
+          {
+            name: "wrapper",
+            type,
+            fields: [
+              { name: "foo_bar", type: "text" },
+              { name: "FooBar", type: "text" },
+            ],
+          },
+        ],
+      } as never);
+
+      expect({
+        [type]: (result.errors ?? []).filter(
+          e => e.code === "FIELD_NAME_DUPLICATE"
+        ),
+      }).toEqual({ [type]: [] });
+    }
+  });
+
   it("still accepts two names that reach different columns", () => {
     // The mirror, so the case above cannot be satisfied by refusing every pair.
     const result = validateCollectionConfig({

--- a/packages/nextly/src/domains/dynamic-collections/__tests__/column-name-agreement.test.ts
+++ b/packages/nextly/src/domains/dynamic-collections/__tests__/column-name-agreement.test.ts
@@ -14,10 +14,12 @@ import { describe, expect, it } from "vitest";
 
 import type { FieldDefinition } from "../../../schemas/dynamic-collections";
 import {
+  fieldProducesColumn,
   getColumnDescriptor,
   type SupportedDialect,
 } from "../../schema/services/field-column-descriptor";
 import { validateCollectionConfig } from "../../../collections/config/validate-config";
+import { validateSingleConfig } from "../../../singles/config/validate-single";
 import { DynamicCollectionSchemaService } from "../services/dynamic-collection-schema-service";
 
 /** Names that reach a column, including the shapes the Builder refuses but code paths allow. */
@@ -200,5 +202,117 @@ describe("two field names that reach one column", () => {
     expect(
       (result.errors ?? []).filter(e => e.code === "FIELD_NAME_DUPLICATE")
     ).toEqual([]);
+  });
+});
+
+describe("the duplicate-column rule and the generator agree on which fields have a column", () => {
+  it("exempts field types that store their values in their own tables", () => {
+    // A component and a many-to-many relationship are declared on the table but keep their values
+    // elsewhere, keyed by the field's declared name. Two of them whose names converge stay
+    // distinct, so refusing the pair would reject a configuration that works — the same mistake as
+    // applying the rule to nested fields, one level up.
+    const component = (name: string) => ({
+      name,
+      type: "component",
+      component: "hero",
+    });
+    const manyToMany = (name: string) => ({
+      name,
+      type: "relationship",
+      relationTo: "tags",
+      options: { relationTo: "tags", relationType: "manyToMany" },
+    });
+
+    const cases: Array<[string, unknown[]]> = [
+      ["two components", [component("foo_bar"), component("FooBar")]],
+      [
+        "component beside a text field",
+        [component("foo_bar"), { name: "FooBar", type: "text" }],
+      ],
+      ["two many-to-many", [manyToMany("foo_bar"), manyToMany("FooBar")]],
+    ];
+
+    for (const [label, fields] of cases) {
+      const collection = validateCollectionConfig({
+        slug: "probe",
+        fields,
+      } as never);
+      const single = validateSingleConfig({
+        slug: "probe",
+        fields,
+      } as never);
+
+      expect({
+        [`${label} (collection)`]: (collection.errors ?? []).filter(
+          e => e.code === "FIELD_NAME_DUPLICATE"
+        ),
+        [`${label} (single)`]: (single.errors ?? []).filter(
+          e => e.code === "FIELD_NAME_DUPLICATE"
+        ),
+      }).toEqual({
+        [`${label} (collection)`]: [],
+        [`${label} (single)`]: [],
+      });
+    }
+  });
+
+  it("does not exempt a field type it cannot recognise", () => {
+    // An unregistered type falls back to a text column, so the rule has to keep applying to it.
+    // Exempting the unknown case instead would let a plugin whose registration has not run yet
+    // slip a table past validation that the database then refuses.
+    const fields = [
+      { name: "foo_bar", type: "somePluginTypeNotRegisteredYet" },
+      { name: "FooBar", type: "somePluginTypeNotRegisteredYet" },
+    ];
+
+    const result = validateCollectionConfig({ slug: "probe", fields } as never);
+
+    expect(
+      (result.errors ?? []).filter(e => e.code === "FIELD_NAME_DUPLICATE")
+    ).toHaveLength(1);
+  });
+
+  it("says a field has a column exactly when the generator emits one", () => {
+    // The property the exemption depends on. If a new `return null` path appears in the descriptor
+    // without the predicate learning about it, the rule starts refusing a field that has no column
+    // again — which is the defect this describe block exists for.
+    const VARIANTS: Array<Record<string, unknown>> = [
+      {},
+      { required: true },
+      { hasMany: true },
+      { relationTo: "tags" },
+      { relationTo: ["tags", "cats"] },
+      { options: { relationType: "manyToMany" } },
+      { options: { relationType: "oneToMany" } },
+    ];
+    const TYPES = [
+      "text",
+      "number",
+      "checkbox",
+      "date",
+      "relationship",
+      "upload",
+      "repeater",
+      "group",
+      "json",
+      "component",
+      "aTypeNobodyRegistered",
+    ];
+
+    const disagreements: string[] = [];
+    for (const type of TYPES) {
+      for (const [index, variant] of VARIANTS.entries()) {
+        const field = { type, name: "probe", ...variant };
+        for (const dialect of DIALECTS) {
+          const emitsColumn =
+            getColumnDescriptor(field as FieldDefinition, dialect) !== null;
+          if (fieldProducesColumn(field) !== emitsColumn) {
+            disagreements.push(`${type}|v${index}|${dialect}`);
+          }
+        }
+      }
+    }
+
+    expect(disagreements).toEqual([]);
   });
 });

--- a/packages/nextly/src/domains/dynamic-collections/__tests__/column-name-agreement.test.ts
+++ b/packages/nextly/src/domains/dynamic-collections/__tests__/column-name-agreement.test.ts
@@ -13,6 +13,8 @@
 import { describe, expect, it } from "vitest";
 
 import type { FieldDefinition } from "../../../schemas/dynamic-collections";
+import { buildDesiredTableFromFields } from "../../schema/pipeline/diff/build-from-fields";
+import { generateRuntimeSchema } from "../../schema/services/runtime-schema-generator";
 import {
   fieldProducesColumn,
   getColumnDescriptor,
@@ -34,6 +36,25 @@ const FIELD_NAMES = [
 ];
 
 const DIALECTS: SupportedDialect[] = ["postgresql", "mysql", "sqlite"];
+
+/**
+ * The column names a generated Drizzle table carries.
+ *
+ * Read off `Symbol("drizzle:Columns")` rather than through drizzle-orm's column-listing helper,
+ * which is deprecated on v1 yet still compiles — `scripts/check-drizzle-v1-legacy.cjs` refuses it
+ * for exactly that reason. `filter-unsafe-statements.ts` reads `Symbol("drizzle:Name")` the same
+ * way. If the symbol ever moves, the set comes back empty and the assertions below fail loudly.
+ */
+function runtimeColumnNames(table: unknown): string[] {
+  const symbol = Object.getOwnPropertySymbols(table as object).find(
+    candidate => String(candidate) === "Symbol(drizzle:Columns)"
+  );
+  if (!symbol) return [];
+  const columns = (table as Record<symbol, unknown>)[symbol];
+  return Object.values(columns as Record<string, { name: string }>).map(
+    column => column.name
+  );
+}
 
 /** The identifiers declared in the CREATE TABLE body, before any index statement. */
 function declaredColumns(sql: string): string[] {
@@ -132,6 +153,103 @@ describe("collection column names agree across the generators", () => {
           expect({ [`${dialect}.${table}.${name}`]: duplicated }).toEqual({
             [`${dialect}.${table}.${name}`]: [],
           });
+        }
+      }
+    }
+  });
+});
+
+describe("all three descriptions of the main table agree", () => {
+  // The created table, the runtime schema every query is built from, and the diff's desired state
+  // are produced by three modules from one field list. Comparing each against the descriptor, as
+  // the tests above do, cannot catch them disagreeing with EACH OTHER — which is what a name
+  // matched before localization is resolved does.
+  function columnSets(
+    fields: unknown[],
+    dialect: SupportedDialect,
+    options: { hasStatus?: boolean; localized?: boolean }
+  ) {
+    const service = new DynamicCollectionSchemaService(undefined, dialect);
+    const generate = service as unknown as {
+      generateMigrationSQL: (
+        name: string,
+        fields: unknown[],
+        options?: unknown
+      ) => string;
+    };
+
+    const created = declaredColumns(
+      generate.generateMigrationSQL("dc_agree", fields, options)
+    );
+    const desired = buildDesiredTableFromFields(
+      "dc_agree",
+      fields as Parameters<typeof buildDesiredTableFromFields>[1],
+      dialect,
+      options
+    ).columns.map(column => column.name);
+    // The runtime generator spells the publish-lifecycle toggle `status` where the other two
+    // spell it `hasStatus`; passing the wrong one silently omits the system column instead of
+    // failing, so it is translated here rather than assumed.
+    const runtime = runtimeColumnNames(
+      generateRuntimeSchema("dc_agree", fields as FieldDefinition[], dialect, {
+        status: options.hasStatus,
+        localized: options.localized,
+      }).table
+    );
+
+    return {
+      created: [...created].sort(),
+      desired: [...desired].sort(),
+      runtime: [...runtime].sort(),
+    };
+  }
+
+  it("agrees when a localized field is named Title or Slug", () => {
+    // A localized field lives in the companion table, so the main table has neither the user's
+    // column nor the injected system one. Deciding that on the declared name made the created
+    // table drop it while the other two injected it, and the diff then reconciled a column the
+    // table does not have.
+    for (const dialect of DIALECTS) {
+      for (const name of ["Title", "Slug", "title", "slug"]) {
+        const sets = columnSets(
+          [
+            { name, type: "text", localized: true },
+            { name: "body", type: "text" },
+          ],
+          dialect,
+          { hasStatus: false, localized: true }
+        );
+
+        expect({
+          [`${dialect}.${name}.desired`]: sets.desired,
+          [`${dialect}.${name}.runtime`]: sets.runtime,
+        }).toEqual({
+          [`${dialect}.${name}.desired`]: sets.created,
+          [`${dialect}.${name}.runtime`]: sets.created,
+        });
+      }
+    }
+  });
+
+  it("agrees for every name shape, localized or not", () => {
+    for (const dialect of DIALECTS) {
+      for (const name of FIELD_NAMES) {
+        for (const localized of [false, true]) {
+          for (const hasStatus of [false, true]) {
+            const sets = columnSets([{ name, type: "text" }], dialect, {
+              hasStatus,
+              localized,
+            });
+            const label = `${dialect}.${name}.loc=${localized}.status=${hasStatus}`;
+
+            expect({
+              [`${label}.desired`]: sets.desired,
+              [`${label}.runtime`]: sets.runtime,
+            }).toEqual({
+              [`${label}.desired`]: sets.created,
+              [`${label}.runtime`]: sets.created,
+            });
+          }
         }
       }
     }

--- a/packages/nextly/src/domains/dynamic-collections/__tests__/column-name-agreement.test.ts
+++ b/packages/nextly/src/domains/dynamic-collections/__tests__/column-name-agreement.test.ts
@@ -304,6 +304,92 @@ describe("all three descriptions of the main table agree", () => {
   });
 });
 
+describe("altering a field that has no column", () => {
+  // The CREATE path knows a many-to-many stores its links in a junction table. The ALTER paths
+  // asked the same question by naming the component type alone, so a many-to-many reached them as
+  // though it owned a column: toggling its index emitted CREATE INDEX and ALTER COLUMN against a
+  // name the table does not have, which fails the whole save rather than that one field.
+  function alterSql(
+    dialect: SupportedDialect,
+    oldFields: unknown[],
+    newFields: unknown[]
+  ): string {
+    const service = new DynamicCollectionSchemaService(undefined, dialect);
+    const alter = service as unknown as {
+      generateAlterTableMigration: (
+        table: string,
+        oldFields: unknown[],
+        newFields: unknown[]
+      ) => string;
+    };
+    return alter.generateAlterTableMigration("dc_p", oldFields, newFields);
+  }
+
+  const columnLess = {
+    manyToMany: (extra: Record<string, unknown>) => ({
+      name: "tags",
+      type: "relationship",
+      relationTo: "tags",
+      options: { relationTo: "tags", relationType: "manyToMany" },
+      ...extra,
+    }),
+    component: (extra: Record<string, unknown>) => ({
+      name: "tags",
+      type: "component",
+      component: "hero",
+      ...extra,
+    }),
+  };
+
+  it("emits no column statement when its index or flags change", () => {
+    for (const dialect of DIALECTS) {
+      for (const [label, make] of Object.entries(columnLess)) {
+        for (const change of [
+          { index: true },
+          { required: true },
+          { unique: true },
+        ]) {
+          const sql = alterSql(dialect, [make({})], [make(change)]);
+          const offending = [
+            "CREATE INDEX",
+            "DROP INDEX",
+            "ALTER COLUMN",
+            "ADD COLUMN",
+          ].filter(statement => sql.includes(statement));
+          const at = `${dialect}.${label}.${Object.keys(change)[0]}`;
+
+          expect({ [at]: offending }).toEqual({ [at]: [] });
+        }
+      }
+    }
+  });
+
+  it("emits no DROP COLUMN when one is removed", () => {
+    // The junction table is torn down elsewhere; the parent never had the column. On SQLite this
+    // mattered most, because its DROP COLUMN carries no IF EXISTS to absorb the mistake.
+    for (const dialect of DIALECTS) {
+      for (const [label, make] of Object.entries(columnLess)) {
+        const sql = alterSql(dialect, [make({})], []);
+
+        expect({
+          [`${dialect}.${label}`]: sql.includes("DROP COLUMN"),
+        }).toEqual({ [`${dialect}.${label}`]: false });
+      }
+    }
+  });
+
+  it("still alters an ordinary field", () => {
+    // The mirror, so the tests above cannot be satisfied by emitting nothing at all.
+    const sql = alterSql(
+      "postgresql",
+      [{ name: "headline", type: "text" }],
+      [{ name: "headline", type: "text", index: true }]
+    );
+
+    expect(sql).toContain("CREATE INDEX");
+  });
+});
+
 describe("two field names that reach one column", () => {
   it("are refused as duplicates before any DDL is generated", () => {
     // `foo_bar` and `FooBar` are different names that become the same column, so a table carrying

--- a/packages/nextly/src/domains/dynamic-collections/__tests__/column-name-agreement.test.ts
+++ b/packages/nextly/src/domains/dynamic-collections/__tests__/column-name-agreement.test.ts
@@ -569,7 +569,7 @@ describe("a rename between two spellings of one column", () => {
   });
 });
 
-describe("duplicate columns are judged per table", () => {
+describe("duplicate columns are judged globally, not per table", () => {
   const pair = [
     { type: "text", name: "foo_bar", localized: false },
     { type: "text", name: "FooBar", localized: true },
@@ -579,10 +579,24 @@ describe("duplicate columns are judged per table", () => {
     return (result.errors ?? []).filter(e => e.code === "FIELD_NAME_DUPLICATE");
   }
 
-  it("accepts one shared and one localized field reaching the same column name", () => {
-    // The localized field is emitted into the `_locales` companion and the shared one into the
-    // main table, so the column name occurs once in each. Refusing the pair would reject a schema
-    // the generators represent correctly.
+  it("collapses two converging keys before anything splits them by table", () => {
+    // The reason the rule cannot be relaxed for localized entities. The write path normalizes
+    // payload keys through the same conversion BEFORE extracting localized fields, so the two
+    // authored values land on one key and the second overwrites the first. Whatever table the
+    // survivor is then routed to, one of the author's values is already gone.
+    const authored = { foo_bar: "shared value", FooBar: "localized value" };
+    const normalized: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(authored)) {
+      normalized[toSnakeCase(key)] = value;
+    }
+
+    expect(Object.keys(normalized)).toEqual(["foo_bar"]);
+    expect(Object.keys(authored)).toHaveLength(2);
+  });
+
+  it("refuses one shared and one localized field reaching the same column name", () => {
+    // They are emitted into different tables, so physically nothing is declared twice — but the
+    // payload has already merged them by then, so accepting the pair would silently drop a value.
     expect({
       collection: duplicates(
         validateCollectionConfig({
@@ -591,7 +605,7 @@ describe("duplicate columns are judged per table", () => {
           localized: true,
           fields: pair,
         } as never)
-      ),
+      ).length,
       single: duplicates(
         validateSingleConfig({
           slug: "home",
@@ -599,29 +613,25 @@ describe("duplicate columns are judged per table", () => {
           localized: true,
           fields: pair,
         } as never)
-      ),
-    }).toEqual({ collection: [], single: [] });
+      ).length,
+    }).toEqual({ collection: 1, single: 1 });
   });
 
-  it("still refuses two fields that land in the same table", () => {
-    // Both localized, so both go to the companion — and an unlocalized collection puts everything
-    // in main, which is the case the rule was written for.
-    const bothLocalized = validateCollectionConfig({
-      slug: "posts",
-      labels: { singular: "Post", plural: "Posts" },
-      localized: true,
-      fields: pair.map(field => ({ ...field, localized: true })),
-    } as never);
-    const notLocalized = validateCollectionConfig({
-      slug: "posts",
-      labels: { singular: "Post", plural: "Posts" },
-      fields: pair,
-    } as never);
-
-    expect({
-      bothLocalized: duplicates(bothLocalized).length,
-      notLocalized: duplicates(notLocalized).length,
-    }).toEqual({ bothLocalized: 1, notLocalized: 1 });
+  it("still accepts two names that reach different columns when localized", () => {
+    // The mirror, so the rule above cannot be satisfied by refusing every localized pair.
+    expect(
+      duplicates(
+        validateCollectionConfig({
+          slug: "posts",
+          labels: { singular: "Post", plural: "Posts" },
+          localized: true,
+          fields: [
+            { type: "text", name: "alpha", localized: false },
+            { type: "text", name: "beta", localized: true },
+          ],
+        } as never)
+      )
+    ).toEqual([]);
   });
 });
 

--- a/packages/nextly/src/domains/dynamic-collections/__tests__/column-name-agreement.test.ts
+++ b/packages/nextly/src/domains/dynamic-collections/__tests__/column-name-agreement.test.ts
@@ -18,9 +18,12 @@ import { generateRuntimeSchema } from "../../schema/services/runtime-schema-gene
 import {
   fieldProducesColumn,
   getColumnDescriptor,
+  toSnakeCase,
   type SupportedDialect,
 } from "../../schema/services/field-column-descriptor";
+import { defineCollection } from "../../../collections/config/define-collection";
 import { validateCollectionConfig } from "../../../collections/config/validate-config";
+import { defineSingle } from "../../../singles/config/define-single";
 import { validateSingleConfig } from "../../../singles/config/validate-single";
 import { DynamicCollectionSchemaService } from "../services/dynamic-collection-schema-service";
 
@@ -301,6 +304,156 @@ describe("all three descriptions of the main table agree", () => {
         }
       }
     }
+  });
+});
+
+describe("the config factories inject on the column too", () => {
+  it("does not add a system field beside an author's capitalised one", () => {
+    // `defineCollection` prepends `title`/`slug` when the author has not declared them, and it
+    // decided that by exact name. An author writing `Title` owns the same column, so the injected
+    // field arrived beside it and the table declared `title` twice — it could not be created at
+    // all. Validation runs before the injection, so nothing downstream caught it.
+    for (const declared of ["Title", "Slug"]) {
+      const collection = defineCollection({
+        slug: "posts",
+        labels: { singular: "Post", plural: "Posts" },
+        fields: [{ type: "text", name: declared }],
+      } as never) as { fields: Array<{ name?: string }> };
+      const single = defineSingle({
+        slug: "home",
+        label: "Home",
+        fields: [{ type: "text", name: declared }],
+      } as never) as { fields: Array<{ name?: string }> };
+
+      for (const [label, config] of [
+        ["collection", collection],
+        ["single", single],
+      ] as const) {
+        const columns = config.fields
+          .map(field => (typeof field.name === "string" ? field.name : ""))
+          .filter(Boolean)
+          .map(toSnakeCase);
+        const duplicated = columns.filter(
+          (column, index) => columns.indexOf(column) !== index
+        );
+
+        expect({ [`${label}.${declared}`]: duplicated }).toEqual({
+          [`${label}.${declared}`]: [],
+        });
+      }
+    }
+  });
+
+  it("still injects the system field when the author declares neither", () => {
+    // The mirror: the case above must not be satisfied by never injecting anything.
+    const collection = defineCollection({
+      slug: "posts",
+      labels: { singular: "Post", plural: "Posts" },
+      fields: [{ type: "text", name: "headline" }],
+    } as never) as { fields: Array<{ name?: string }> };
+
+    expect(collection.fields.map(field => field.name)).toEqual([
+      "title",
+      "slug",
+      "headline",
+    ]);
+  });
+});
+
+describe("a rename between two spellings of one column", () => {
+  it("emits no statement, because the database has nothing to do", () => {
+    // `foo_bar` to `FooBar` is a rename in the config and a no-op in the table. Emitted anyway it
+    // asks the dialect to rename a column to its own name, which PostgreSQL rejects because the
+    // target already exists — failing an update that had nothing to change.
+    for (const dialect of DIALECTS) {
+      const service = new DynamicCollectionSchemaService(undefined, dialect);
+      const alter = service as unknown as {
+        generateAlterTableMigration: (
+          table: string,
+          oldFields: unknown[],
+          newFields: unknown[]
+        ) => string;
+      };
+
+      const sameColumn = alter.generateAlterTableMigration(
+        "dc_p",
+        [{ name: "foo_bar", type: "text" }],
+        [{ name: "FooBar", type: "text" }]
+      );
+      const realRename = alter.generateAlterTableMigration(
+        "dc_p",
+        [{ name: "foo_bar", type: "text" }],
+        [{ name: "baz_qux", type: "text" }]
+      );
+
+      expect({
+        [`${dialect}.sameColumn`]: sameColumn.includes("RENAME COLUMN"),
+        [`${dialect}.realRename`]: realRename.includes("RENAME COLUMN"),
+        [`${dialect}.sameColumn.dropped`]: sameColumn.includes("DROP COLUMN"),
+        [`${dialect}.sameColumn.added`]: sameColumn.includes("ADD COLUMN"),
+      }).toEqual({
+        [`${dialect}.sameColumn`]: false,
+        [`${dialect}.realRename`]: true,
+        [`${dialect}.sameColumn.dropped`]: false,
+        [`${dialect}.sameColumn.added`]: false,
+      });
+    }
+  });
+});
+
+describe("duplicate columns are judged per table", () => {
+  const pair = [
+    { type: "text", name: "foo_bar", localized: false },
+    { type: "text", name: "FooBar", localized: true },
+  ];
+
+  function duplicates(result: { errors?: Array<{ code: string }> }) {
+    return (result.errors ?? []).filter(e => e.code === "FIELD_NAME_DUPLICATE");
+  }
+
+  it("accepts one shared and one localized field reaching the same column name", () => {
+    // The localized field is emitted into the `_locales` companion and the shared one into the
+    // main table, so the column name occurs once in each. Refusing the pair would reject a schema
+    // the generators represent correctly.
+    expect({
+      collection: duplicates(
+        validateCollectionConfig({
+          slug: "posts",
+          labels: { singular: "Post", plural: "Posts" },
+          localized: true,
+          fields: pair,
+        } as never)
+      ),
+      single: duplicates(
+        validateSingleConfig({
+          slug: "home",
+          label: "Home",
+          localized: true,
+          fields: pair,
+        } as never)
+      ),
+    }).toEqual({ collection: [], single: [] });
+  });
+
+  it("still refuses two fields that land in the same table", () => {
+    // Both localized, so both go to the companion — and an unlocalized collection puts everything
+    // in main, which is the case the rule was written for.
+    const bothLocalized = validateCollectionConfig({
+      slug: "posts",
+      labels: { singular: "Post", plural: "Posts" },
+      localized: true,
+      fields: pair.map(field => ({ ...field, localized: true })),
+    } as never);
+    const notLocalized = validateCollectionConfig({
+      slug: "posts",
+      labels: { singular: "Post", plural: "Posts" },
+      fields: pair,
+    } as never);
+
+    expect({
+      bothLocalized: duplicates(bothLocalized).length,
+      notLocalized: duplicates(notLocalized).length,
+    }).toEqual({ bothLocalized: 1, notLocalized: 1 });
   });
 });
 

--- a/packages/nextly/src/domains/dynamic-collections/__tests__/column-name-agreement.test.ts
+++ b/packages/nextly/src/domains/dynamic-collections/__tests__/column-name-agreement.test.ts
@@ -345,41 +345,171 @@ describe("columnsDeclaredBy", () => {
   });
 });
 
-describe("the config factories inject on the column too", () => {
-  it("does not add a system field beside an author's capitalised one", () => {
-    // `defineCollection` prepends `title`/`slug` when the author has not declared them, and it
-    // decided that by exact name. An author writing `Title` owns the same column, so the injected
-    // field arrived beside it and the table declared `title` twice — it could not be created at
-    // all. Validation runs before the injection, so nothing downstream caught it.
-    for (const declared of ["Title", "Slug"]) {
-      const collection = defineCollection({
+describe("a system column may be taken over only under its own name", () => {
+  function codes(result: { errors?: Array<{ code: string }> }, code: string) {
+    return (result.errors ?? []).filter(e => e.code === code).length;
+  }
+
+  const collection = (fields: unknown[], extra: object = {}) =>
+    validateCollectionConfig({
+      slug: "posts",
+      labels: { singular: "Post", plural: "Posts" },
+      fields,
+      ...extra,
+    } as never);
+  const single = (fields: unknown[], extra: object = {}) =>
+    validateSingleConfig({
+      slug: "home",
+      label: "Home",
+      fields,
+      ...extra,
+    } as never);
+
+  it("accepts the exact name, so the documented takeover still works", () => {
+    // `title`/`slug` stepping aside for an author's own field is a feature, not an accident, and
+    // the blog template relies on it. Only the ALIAS is refused.
+    for (const name of ["title", "slug"]) {
+      expect({
+        [`collection.${name}`]: codes(
+          collection([{ type: "text", name }]),
+          "FIELD_NAME_SYSTEM_ALIAS"
+        ),
+        [`single.${name}`]: codes(
+          single([{ type: "text", name }]),
+          "FIELD_NAME_SYSTEM_ALIAS"
+        ),
+      }).toEqual({ [`collection.${name}`]: 0, [`single.${name}`]: 0 });
+    }
+  });
+
+  it("refuses a spelling that only reaches the column after conversion", () => {
+    // `Title` is the same column but a different identity in every payload — the runtime table's
+    // property key, the keys a mutation generates, the response, the generated types. Two names
+    // for one column means the generated value overwrites the author's, silently.
+    for (const name of ["Title", "Slug"]) {
+      expect({
+        [`collection.${name}`]: codes(
+          collection([{ type: "text", name }]),
+          "FIELD_NAME_SYSTEM_ALIAS"
+        ),
+        [`single.${name}`]: codes(
+          single([{ type: "text", name }]),
+          "FIELD_NAME_SYSTEM_ALIAS"
+        ),
+      }).toEqual({ [`collection.${name}`]: 1, [`single.${name}`]: 1 });
+    }
+  });
+
+  it("names the spelling that would work", () => {
+    // The error has to be actionable: an author who wrote `Title` needs to be told `title`.
+    const message = (collection([{ type: "text", name: "Title" }]).errors ?? [])
+      .filter(e => e.code === "FIELD_NAME_SYSTEM_ALIAS")
+      .map(e => e.message)
+      .join("");
+
+    expect(message).toContain("'Title'");
+    expect(message).toContain("'title'");
+  });
+
+  it("leaves an ordinary name alone", () => {
+    // The mirror, so the rule cannot be satisfied by refusing everything capitalised.
+    expect(
+      codes(
+        collection([{ type: "text", name: "Headline" }]),
+        "FIELD_NAME_SYSTEM_ALIAS"
+      )
+    ).toBe(0);
+  });
+});
+
+describe("the publish lifecycle owns its columns while it is on", () => {
+  function lifecycleErrors(fields: unknown[], status: boolean) {
+    return (
+      validateCollectionConfig({
         slug: "posts",
         labels: { singular: "Post", plural: "Posts" },
-        fields: [{ type: "text", name: declared }],
-      } as never) as { fields: Array<{ name?: string }> };
-      const single = defineSingle({
-        slug: "home",
-        label: "Home",
-        fields: [{ type: "text", name: declared }],
-      } as never) as { fields: Array<{ name?: string }> };
+        status,
+        fields,
+      } as never).errors ?? []
+    ).filter(e => e.code === "FIELD_NAME_LIFECYCLE_RESERVED").length;
+  }
 
-      for (const [label, config] of [
-        ["collection", collection],
-        ["single", single],
-      ] as const) {
-        const columns = config.fields
-          .map(field => (typeof field.name === "string" ? field.name : ""))
-          .filter(Boolean)
-          .map(toSnakeCase);
-        const duplicated = columns.filter(
-          (column, index) => columns.indexOf(column) !== index
-        );
+  it("refuses a status field only when the lifecycle is enabled", () => {
+    // Measured across all three generators: with the lifecycle ON a `status` field duplicates the
+    // column in the created table AND the diff's desired state, so the table cannot be created.
+    // With it OFF every generator is clean and `status` is an ordinary, common field name.
+    expect({
+      "status.on": lifecycleErrors([{ type: "text", name: "status" }], true),
+      "status.off": lifecycleErrors([{ type: "text", name: "status" }], false),
+      "Status.on": lifecycleErrors([{ type: "text", name: "Status" }], true),
+      "Status.off": lifecycleErrors([{ type: "text", name: "Status" }], false),
+    }).toEqual({
+      "status.on": 1,
+      "status.off": 0,
+      "Status.on": 1,
+      "Status.off": 0,
+    });
+  });
 
-        expect({ [`${label}.${declared}`]: duplicated }).toEqual({
-          [`${label}.${declared}`]: [],
-        });
-      }
+  it("leaves other fields alone with the lifecycle on", () => {
+    // The mirror: enabling the lifecycle must not refuse an ordinary schema.
+    expect(
+      lifecycleErrors(
+        [
+          { type: "text", name: "headline" },
+          { type: "text", name: "body" },
+        ],
+        true
+      )
+    ).toBe(0);
+  });
+});
+
+describe("the config factories inject on the column too", () => {
+  it("refuses the capitalised alias before the injection can duplicate it", () => {
+    // The factories prepend `title`/`slug` when the author has not declared them. An author
+    // writing `Title` owns the same column, so the injected field arrived beside it and the table
+    // declared `title` twice. That is now refused at validation, which runs first, so the
+    // duplicate can no longer be constructed at all.
+    for (const declared of ["Title", "Slug"]) {
+      expect(() =>
+        defineCollection({
+          slug: "posts",
+          labels: { singular: "Post", plural: "Posts" },
+          fields: [{ type: "text", name: declared }],
+        } as never)
+      ).toThrow();
+      expect(() =>
+        defineSingle({
+          slug: "home",
+          label: "Home",
+          fields: [{ type: "text", name: declared }],
+        } as never)
+      ).toThrow();
     }
+  });
+
+  it("keys the injection on the column for names it does accept", () => {
+    // The factories still have to ask on the column rather than the spelling, because a
+    // column-less field named `Title` is legal and must NOT suppress the system one: its values
+    // live in its own table, so the table still needs `title`.
+    const collection = defineCollection({
+      slug: "posts",
+      labels: { singular: "Post", plural: "Posts" },
+      fields: [
+        { type: "component", name: "Title", component: "hero" },
+        { type: "text", name: "body" },
+      ],
+    } as never) as { fields: Array<{ name?: string }> };
+    const names = collection.fields.map(f => f.name);
+    const columns = names
+      .filter((n): n is string => typeof n === "string")
+      .map(toSnakeCase);
+
+    expect({
+      injectedTitle: names.includes("title"),
+      duplicates: columns.filter((c, i) => columns.indexOf(c) !== i),
+    }).toEqual({ injectedTitle: true, duplicates: ["title"] });
   });
 
   it("still injects the system field when the author declares neither", () => {

--- a/packages/nextly/src/domains/dynamic-collections/__tests__/column-name-agreement.test.ts
+++ b/packages/nextly/src/domains/dynamic-collections/__tests__/column-name-agreement.test.ts
@@ -231,6 +231,54 @@ describe("all three descriptions of the main table agree", () => {
     }
   });
 
+  it("agrees when a column-less field is named after a system column", () => {
+    // The gap the name-only cases above leave: a field can carry a system column's name AND
+    // produce no column. A many-to-many relationship or a component named `Title` must not
+    // suppress the injected `title` anywhere, because it puts nothing in its place — and each
+    // generator has to reach that conclusion the same way, through the canonical predicate rather
+    // than a hand-rolled list of the types it happens to remember.
+    const columnLess = [
+      {
+        label: "manyToMany",
+        make: (name: string) => ({
+          name,
+          type: "relationship",
+          relationTo: "tags",
+          options: { relationTo: "tags", relationType: "manyToMany" },
+        }),
+      },
+      {
+        label: "component",
+        make: (name: string) => ({
+          name,
+          type: "component",
+          component: "hero",
+        }),
+      },
+    ];
+
+    for (const dialect of DIALECTS) {
+      for (const { label, make } of columnLess) {
+        for (const name of ["Title", "title", "Slug", "slug"]) {
+          const sets = columnSets(
+            [make(name), { name: "body", type: "text" }],
+            dialect,
+            { hasStatus: false, localized: false }
+          );
+          const at = `${dialect}.${label}.${name}`;
+
+          expect({
+            [`${at}.desired`]: sets.desired,
+            [`${at}.runtime`]: sets.runtime,
+          }).toEqual({
+            [`${at}.desired`]: sets.created,
+            [`${at}.runtime`]: sets.created,
+          });
+        }
+      }
+    }
+  });
+
   it("agrees for every name shape, localized or not", () => {
     for (const dialect of DIALECTS) {
       for (const name of FIELD_NAMES) {

--- a/packages/nextly/src/domains/dynamic-collections/__tests__/column-name-agreement.test.ts
+++ b/packages/nextly/src/domains/dynamic-collections/__tests__/column-name-agreement.test.ts
@@ -309,21 +309,39 @@ describe("all three descriptions of the main table agree", () => {
 });
 
 describe("columnsDeclaredBy", () => {
-  it("answers on the column, and tolerates entries that are not names", () => {
+  it("answers on the column, and tolerates entries that are not fields", () => {
     // The shared definition behind four "has the author already declared this?" decisions.
-    // Anything that is not a string is skipped rather than coerced, because two of those callers
+    // Anything without a string name is skipped rather than coerced, because two of those callers
     // run before the config has been parsed.
     expect([
       ...columnsDeclaredBy([
-        "Title",
-        "publishedAt",
-        "x_y",
-        undefined,
+        { name: "Title", type: "text" },
+        { name: "publishedAt", type: "text" },
+        { name: "x_y", type: "text" },
+        { type: "text" },
+        { name: 42, type: "text" },
         null,
-        42,
-        { name: "nope" },
+        undefined,
       ]),
     ]).toEqual(["title", "published_at", "x_y"]);
+  });
+
+  it("claims no column for a field that occupies none", () => {
+    // A component or many-to-many named `Title` keeps its values in its own table, so it does not
+    // own the `title` column and the system field still has to be injected beside it. Counting it
+    // dropped `title` from the config while the generators went on emitting the column.
+    const declared: Array<Record<string, unknown>> = [
+      { name: "Title", type: "component", component: "hero" },
+      {
+        name: "Slug",
+        type: "relationship",
+        relationTo: "tags",
+        options: { relationTo: "tags", relationType: "manyToMany" },
+      },
+      { name: "body", type: "text" },
+    ];
+
+    expect([...columnsDeclaredBy(declared)]).toEqual(["body"]);
   });
 });
 

--- a/packages/nextly/src/domains/dynamic-collections/__tests__/column-name-agreement.test.ts
+++ b/packages/nextly/src/domains/dynamic-collections/__tests__/column-name-agreement.test.ts
@@ -17,6 +17,7 @@ import {
   getColumnDescriptor,
   type SupportedDialect,
 } from "../../schema/services/field-column-descriptor";
+import { validateCollectionConfig } from "../../../collections/config/validate-config";
 import { DynamicCollectionSchemaService } from "../services/dynamic-collection-schema-service";
 
 /** Names that reach a column, including the shapes the Builder refuses but code paths allow. */
@@ -98,5 +99,79 @@ describe("collection column names agree across the generators", () => {
         });
       }
     }
+  });
+
+  it("lets an author's own capitalised title or slug replace the injected one", () => {
+    // Converting the name is only half the job: the injected `title` steps aside for an author's
+    // own field, and that decision has to be made on the COLUMN too. Comparing declared names
+    // would inject `title` beside a field named `Title` — two columns of one name, which no
+    // dialect creates.
+    for (const dialect of DIALECTS) {
+      const service = new DynamicCollectionSchemaService(undefined, dialect);
+      const generate = service as unknown as {
+        generateMigrationSQL: (
+          name: string,
+          fields: unknown[],
+          options?: unknown
+        ) => string;
+      };
+
+      for (const name of ["Title", "Slug"]) {
+        for (const table of ["dc_agree", "single_agree"]) {
+          const columns = declaredColumns(
+            generate.generateMigrationSQL(table, [{ name, type: "text" }], {
+              hasStatus: false,
+            })
+          );
+          const duplicated = columns.filter(
+            (column, index) => columns.indexOf(column) !== index
+          );
+
+          expect({ [`${dialect}.${table}.${name}`]: duplicated }).toEqual({
+            [`${dialect}.${table}.${name}`]: [],
+          });
+        }
+      }
+    }
+  });
+});
+
+describe("two field names that reach one column", () => {
+  it("are refused as duplicates before any DDL is generated", () => {
+    // `foo_bar` and `FooBar` are different names that become the same column, so a table carrying
+    // both cannot be created. Caught where the names are chosen rather than by the database.
+    // `foo_bar`/`fooBar` was already broken this way and went unreported.
+    for (const pair of [
+      ["foo_bar", "FooBar"],
+      ["foo_bar", "fooBar"],
+      ["fooBar", "foobar"],
+    ]) {
+      const result = validateCollectionConfig({
+        slug: "probe",
+        fields: pair.map(name => ({ name, type: "text" })),
+      } as never);
+      const duplicates = (result.errors ?? []).filter(
+        e => e.code === "FIELD_NAME_DUPLICATE"
+      );
+
+      expect({ [pair.join("+")]: duplicates.length }).toEqual({
+        [pair.join("+")]: 1,
+      });
+    }
+  });
+
+  it("still accepts two names that reach different columns", () => {
+    // The mirror, so the case above cannot be satisfied by refusing every pair.
+    const result = validateCollectionConfig({
+      slug: "probe",
+      fields: [
+        { name: "alpha", type: "text" },
+        { name: "beta", type: "text" },
+      ],
+    } as never);
+
+    expect(
+      (result.errors ?? []).filter(e => e.code === "FIELD_NAME_DUPLICATE")
+    ).toEqual([]);
   });
 });

--- a/packages/nextly/src/domains/dynamic-collections/__tests__/column-name-agreement.test.ts
+++ b/packages/nextly/src/domains/dynamic-collections/__tests__/column-name-agreement.test.ts
@@ -1,0 +1,102 @@
+// A collection's table is created by one generator and addressed by two others: the runtime Drizzle
+// schema every query is built from, and the diff engine's description of the desired table. All
+// three derive the column name from the field name, and they did it with separate copies of the
+// same conversion — one of which had lost the step that drops the underscore the substitution
+// introduces before a leading capital. A field named `PublishedAt` was therefore created as
+// `_published_at` and addressed as `published_at`: the table and every read of it disagreed, and
+// the diff reported a column missing on every apply.
+//
+// The Schema Builder's own name pattern refuses a leading capital, which is why this never
+// surfaced. That makes it a latent divergence rather than a live bug, and exactly the kind that
+// stops being latent the moment another caller reaches the same generator.
+
+import { describe, expect, it } from "vitest";
+
+import type { FieldDefinition } from "../../../schemas/dynamic-collections";
+import {
+  getColumnDescriptor,
+  type SupportedDialect,
+} from "../../schema/services/field-column-descriptor";
+import { DynamicCollectionSchemaService } from "../services/dynamic-collection-schema-service";
+
+/** Names that reach a column, including the shapes the Builder refuses but code paths allow. */
+const FIELD_NAMES = [
+  "headline",
+  "publishedAt",
+  "bodyText",
+  "PublishedAt",
+  "BodyText",
+  "a1",
+  "x_y",
+];
+
+const DIALECTS: SupportedDialect[] = ["postgresql", "mysql", "sqlite"];
+
+/** The identifiers declared in the CREATE TABLE body, before any index statement. */
+function declaredColumns(sql: string): string[] {
+  const body = sql.split("--> statement-breakpoint")[0];
+  return [...body.matchAll(/^\s*[`"]([A-Za-z_][A-Za-z0-9_]*)[`"]/gm)].map(
+    match => match[1]
+  );
+}
+
+describe("collection column names agree across the generators", () => {
+  it("creates every field under the name the runtime schema and diff address", () => {
+    for (const dialect of DIALECTS) {
+      const service = new DynamicCollectionSchemaService(undefined, dialect);
+      const generate = service as unknown as {
+        generateMigrationSQL: (
+          name: string,
+          fields: unknown[],
+          options?: unknown
+        ) => string;
+      };
+
+      for (const name of FIELD_NAMES) {
+        const field = { name, type: "text" } as FieldDefinition;
+        const expected = getColumnDescriptor(field, dialect)?.name;
+        const columns = declaredColumns(
+          generate.generateMigrationSQL("dc_agree", [field], {
+            hasStatus: false,
+          })
+        );
+
+        // The descriptor is what the runtime schema and the diff both build from, so the created
+        // table has to contain exactly that name.
+        expect({
+          [`${dialect}.${name}`]: columns.includes(expected ?? ""),
+        }).toEqual({ [`${dialect}.${name}`]: true });
+      }
+    }
+  });
+
+  it("declares no column twice", () => {
+    // The other half: agreeing on a name is worthless if it agrees by colliding with a system
+    // column. A duplicate makes the statement invalid, so the table is never created at all.
+    for (const dialect of DIALECTS) {
+      const service = new DynamicCollectionSchemaService(undefined, dialect);
+      const generate = service as unknown as {
+        generateMigrationSQL: (
+          name: string,
+          fields: unknown[],
+          options?: unknown
+        ) => string;
+      };
+
+      for (const name of FIELD_NAMES) {
+        const columns = declaredColumns(
+          generate.generateMigrationSQL("dc_agree", [{ name, type: "text" }], {
+            hasStatus: true,
+          })
+        );
+        const duplicated = columns.filter(
+          (column, index) => columns.indexOf(column) !== index
+        );
+
+        expect({ [`${dialect}.${name}`]: duplicated }).toEqual({
+          [`${dialect}.${name}`]: [],
+        });
+      }
+    }
+  });
+});

--- a/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-schema-service.ts
+++ b/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-schema-service.ts
@@ -63,9 +63,24 @@ export class DynamicCollectionSchemaService {
     return `"${name}"`;
   }
 
-  /** Convert camelCase to snake_case (e.g., publishedAt → published_at) */
+  /**
+   * Convert a field name to its column name (e.g., publishedAt -> published_at).
+   *
+   * The trailing strip is what every other copy of this conversion does, including the one the
+   * runtime schema and the diff are built from. Without it a name beginning with a capital keeps
+   * the underscore the substitution introduces, so this generator created `_published_at` while
+   * both of those addressed `published_at`: the table and every read of it would disagree, and the
+   * diff would report a column missing forever.
+   *
+   * A name beginning with a lowercase letter never grows a leading underscore, so this changes
+   * nothing for any name the Schema Builder accepts — its own pattern already refuses a leading
+   * capital, which is why the divergence had not surfaced.
+   */
   private toSnakeCase(str: string): string {
-    return str.replace(/([A-Z])/g, "_$1").toLowerCase();
+    return str
+      .replace(/([A-Z])/g, "_$1")
+      .toLowerCase()
+      .replace(/^_/, "");
   }
 
   /**

--- a/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-schema-service.ts
+++ b/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-schema-service.ts
@@ -33,6 +33,7 @@ import {
   getColumnDescriptor,
   getSystemColumnDescriptors,
   renderSystemColumnSql,
+  toSnakeCase,
 } from "../../schema/services/field-column-descriptor";
 import { quoteJsonSqlDefault } from "../../schema/utils/sql-literal";
 
@@ -64,26 +65,6 @@ export class DynamicCollectionSchemaService {
   }
 
   /**
-   * Convert a field name to its column name (e.g., publishedAt -> published_at).
-   *
-   * The trailing strip is what every other copy of this conversion does, including the one the
-   * runtime schema and the diff are built from. Without it a name beginning with a capital keeps
-   * the underscore the substitution introduces, so this generator created `_published_at` while
-   * both of those addressed `published_at`: the table and every read of it would disagree, and the
-   * diff would report a column missing forever.
-   *
-   * A name beginning with a lowercase letter never grows a leading underscore, so this changes
-   * nothing for any name the Schema Builder accepts — its own pattern already refuses a leading
-   * capital, which is why the divergence had not surfaced.
-   */
-  private toSnakeCase(str: string): string {
-    return str
-      .replace(/([A-Z])/g, "_$1")
-      .toLowerCase()
-      .replace(/^_/, "");
-  }
-
-  /**
    * The column type for a declared `slug`, taken from the canonical
    * descriptor rather than this class's own type map.
    *
@@ -100,7 +81,7 @@ export class DynamicCollectionSchemaService {
    * `mapFieldTypeToSQL`.
    */
   private canonicalSlugType(field: FieldDefinition): string | null {
-    if (this.toSnakeCase(field.name) !== "slug") return null;
+    if (toSnakeCase(field.name) !== "slug") return null;
     return getColumnDescriptor(field, this.dialect)?.dialectType ?? null;
   }
 
@@ -221,11 +202,11 @@ export class DynamicCollectionSchemaService {
 
             if (this.dialect === "mysql") {
               checks.push(
-                `${this.quoteIdentifier(this.toSnakeCase(f.name))} REGEXP '${escapedRegex}'`
+                `${this.quoteIdentifier(toSnakeCase(f.name))} REGEXP '${escapedRegex}'`
               );
             } else {
               checks.push(
-                `${this.quoteIdentifier(this.toSnakeCase(f.name))} ~ '${escapedRegex}'`
+                `${this.quoteIdentifier(toSnakeCase(f.name))} ~ '${escapedRegex}'`
               );
             }
           }
@@ -249,7 +230,7 @@ export class DynamicCollectionSchemaService {
               f.options.onUpdate || "no action"
             );
 
-            const fkColName = this.toSnakeCase(f.name);
+            const fkColName = toSnakeCase(f.name);
             constraints.push(
               `  CONSTRAINT ${this.quoteIdentifier(`fk_${tableName}_${fkColName}`)} FOREIGN KEY (${this.quoteIdentifier(fkColName)}) REFERENCES ${this.quoteIdentifier(targetTable)}(${this.quoteIdentifier("id")}) ON DELETE ${onDelete} ON UPDATE ${onUpdate}`
             );
@@ -258,7 +239,7 @@ export class DynamicCollectionSchemaService {
 
         // Convert camelCase field names to snake_case for column names
         // (matches the convention used by CollectionEntryService)
-        const colName = this.toSnakeCase(f.name);
+        const colName = toSnakeCase(f.name);
         return `  ${this.quoteIdentifier(colName)} ${type} ${nullable} ${unique} ${defaultVal}`.trim();
       })
       .filter(Boolean)
@@ -279,12 +260,19 @@ export class DynamicCollectionSchemaService {
     //
     // A component named "title" produces no column, so it must not suppress the system title
     // column; the same holds for "slug".
-    const hasTitleField = fields.some(
-      f => f.name === "title" && f.type !== STORAGE_FORMAT.fieldType
-    );
-    const hasSlugField = fields.some(
-      f => f.name === "slug" && f.type !== STORAGE_FORMAT.fieldType
-    );
+    //
+    // Matched on the COLUMN the field becomes rather than on its declared name. An author writing
+    // `Title` means the same column, and comparing the raw name would inject the system one beside
+    // it — two columns of the same name, which no dialect will create.
+    const declaresColumn = (column: string) =>
+      fields.some(
+        f =>
+          typeof f.name === "string" &&
+          toSnakeCase(f.name) === column &&
+          f.type !== STORAGE_FORMAT.fieldType
+      );
+    const hasTitleField = declaresColumn("title");
+    const hasSlugField = declaresColumn("slug");
     // A single is one global row, so owner-only ownership is meaningless and it gets no
     // `created_by`. Prefer the explicit flag, but fall back to the `single_` table prefix so this
     // stays in lockstep with the runtime schema and the diff, which derive it from the name, even
@@ -351,7 +339,7 @@ ${allColumnDefs.join(",\n")}
         // Use the snake_case column name for both the index name and the
         // indexed column so this matches the actual physical column (created
         // snake_cased) and the migrate:create desired-state index naming.
-        const col = this.toSnakeCase(f.name);
+        const col = toSnakeCase(f.name);
         const indexName = `idx_${tableName}_${col}`;
         if (this.dialect === "mysql") {
           indexStatements.push(
@@ -375,7 +363,7 @@ ${allColumnDefs.join(",\n")}
         f.type !== "relationship" &&
         f.type !== STORAGE_FORMAT.fieldType
       ) {
-        const col = this.toSnakeCase(f.name);
+        const col = toSnakeCase(f.name);
         const indexName = `idx_${tableName}_${col}`;
         if (this.dialect === "mysql") {
           indexStatements.push(
@@ -542,8 +530,8 @@ ${allColumnDefs.join(",\n")}
     const renamedFromName = rename?.from.name ?? null;
     const renamedToName = rename?.to.name ?? null;
     if (rename) {
-      const fromCol = this.toSnakeCase(rename.from.name);
-      const toCol = this.toSnakeCase(rename.to.name);
+      const fromCol = toSnakeCase(rename.from.name);
+      const toCol = toSnakeCase(rename.to.name);
       // RENAME COLUMN syntax is consistent across PG, MySQL 8.0+,
       // and SQLite 3.25+ — all dialects we support.
       statements.push(
@@ -588,7 +576,7 @@ ${allColumnDefs.join(",\n")}
           defaultVal = `DEFAULT ${this.getDefaultValueForType(field.type, field)}`;
         }
 
-        const addColName = this.toSnakeCase(field.name);
+        const addColName = toSnakeCase(field.name);
         statements.push(
           `ALTER TABLE ${this.quoteIdentifier(tableName)} ADD COLUMN ${this.quoteIdentifier(addColName)} ${type} ${nullable} ${defaultVal};`.trim()
         );
@@ -630,7 +618,7 @@ ${allColumnDefs.join(",\n")}
       if (field.type === STORAGE_FORMAT.fieldType) continue;
       const oldField = oldFieldMap.get(field.name);
       if (oldField && oldField.index !== field.index) {
-        const idxCol = this.toSnakeCase(field.name);
+        const idxCol = toSnakeCase(field.name);
         const indexName = `idx_${tableName}_${idxCol}`;
         if (field.index) {
           // Add index
@@ -667,7 +655,7 @@ ${allColumnDefs.join(",\n")}
       // (and SQLite's DROP COLUMN has no IF EXISTS to tolerate the absence).
       if (field.type === STORAGE_FORMAT.fieldType) continue;
       if (!newFieldMap.has(field.name)) {
-        const dropCol = this.toSnakeCase(field.name);
+        const dropCol = toSnakeCase(field.name);
         // SQLite doesn't support IF EXISTS on DROP COLUMN
         if (this.dialect === "sqlite") {
           statements.push(
@@ -690,7 +678,7 @@ ${allColumnDefs.join(",\n")}
         if (field.type === STORAGE_FORMAT.fieldType) continue;
         const oldField = oldFieldMap.get(field.name);
         if (oldField && this.isFieldModified(oldField, field)) {
-          const alterCol = this.toSnakeCase(field.name);
+          const alterCol = toSnakeCase(field.name);
           const type = this.mapFieldTypeToSQL(field.type, field.length);
           statements.push(
             `ALTER TABLE ${this.quoteIdentifier(tableName)} ALTER COLUMN ${this.quoteIdentifier(alterCol)} TYPE ${type};`

--- a/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-schema-service.ts
+++ b/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-schema-service.ts
@@ -536,11 +536,18 @@ ${allColumnDefs.join(",\n")}
     if (rename) {
       const fromCol = toSnakeCase(rename.from.name);
       const toCol = toSnakeCase(rename.to.name);
-      // RENAME COLUMN syntax is consistent across PG, MySQL 8.0+,
-      // and SQLite 3.25+ — all dialects we support.
-      statements.push(
-        `ALTER TABLE ${this.quoteIdentifier(tableName)} RENAME COLUMN ${this.quoteIdentifier(fromCol)} TO ${this.quoteIdentifier(toCol)};`
-      );
+      // Two spellings of one column — `foo_bar` to `FooBar` — are a rename in the config and no
+      // change at all in the database. Emitting it anyway asks the dialect to rename a column to
+      // its own name, which PostgreSQL rejects because the target already exists, failing an
+      // update that has nothing to do. The pair still skips the add/drop loops below, so the
+      // column is neither dropped nor re-added.
+      if (fromCol !== toCol) {
+        // RENAME COLUMN syntax is consistent across PG, MySQL 8.0+,
+        // and SQLite 3.25+ — all dialects we support.
+        statements.push(
+          `ALTER TABLE ${this.quoteIdentifier(tableName)} RENAME COLUMN ${this.quoteIdentifier(fromCol)} TO ${this.quoteIdentifier(toCol)};`
+        );
+      }
     }
 
     // Find added fields

--- a/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-schema-service.ts
+++ b/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-schema-service.ts
@@ -30,6 +30,7 @@ import {
 } from "../../../shared/lib/plugin-storage";
 import { resolveLocalizedFieldNames } from "../../i18n/classify-fields";
 import {
+  fieldProducesColumn,
   getColumnDescriptor,
   getSystemColumnDescriptors,
   renderSystemColumnSql,
@@ -258,8 +259,11 @@ export class DynamicCollectionSchemaService {
     // of the entity fails. Iterating the list — rather than sourcing each column in place — is
     // what makes that impossible, since a new entry needs no edit here to be created.
     //
-    // A component named "title" produces no column, so it must not suppress the system title
-    // column; the same holds for "slug".
+    // A field that produces no column must not suppress the system title or slug column, or the
+    // table would have neither: a component and a many-to-many relationship both keep their values
+    // in their own tables. Asked through the shared predicate rather than a list of the types this
+    // file remembers, because the runtime schema and the diff ask it that way and all three have to
+    // reach the same answer.
     //
     // Matched on the COLUMN the field becomes rather than on its declared name. An author writing
     // `Title` means the same column, and comparing the raw name would inject the system one beside
@@ -269,7 +273,7 @@ export class DynamicCollectionSchemaService {
         f =>
           typeof f.name === "string" &&
           toSnakeCase(f.name) === column &&
-          f.type !== STORAGE_FORMAT.fieldType
+          fieldProducesColumn(f)
       );
     const hasTitleField = declaresColumn("title");
     const hasSlugField = declaresColumn("slug");

--- a/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-schema-service.ts
+++ b/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-schema-service.ts
@@ -618,8 +618,10 @@ ${allColumnDefs.join(",\n")}
 
     // Find fields that were modified to add/remove an index
     for (const field of newFields) {
-      // Component fields have no parent column, so there is no index to add/drop.
-      if (field.type === STORAGE_FORMAT.fieldType) continue;
+      // A field with no parent column has no index to add or drop. Asked through the shared
+      // predicate: a many-to-many relationship has no column either, and indexing one emitted
+      // CREATE INDEX against a name the table does not have, which fails the whole save.
+      if (!fieldProducesColumn(field)) continue;
       const oldField = oldFieldMap.get(field.name);
       if (oldField && oldField.index !== field.index) {
         const idxCol = toSnakeCase(field.name);
@@ -655,9 +657,10 @@ ${allColumnDefs.join(",\n")}
       // Phase D: skip the renamed source — it's already been handled
       // above as ALTER TABLE RENAME COLUMN.
       if (field.name === renamedFromName) continue;
-      // Component fields never had a parent column, so there is nothing to drop
-      // (and SQLite's DROP COLUMN has no IF EXISTS to tolerate the absence).
-      if (field.type === STORAGE_FORMAT.fieldType) continue;
+      // A field with no parent column has nothing to drop, and SQLite's DROP COLUMN has no
+      // IF EXISTS to tolerate the absence. A many-to-many relationship is in that set too: its
+      // links live in a junction table, so dropping one must not touch the parent.
+      if (!fieldProducesColumn(field)) continue;
       if (!newFieldMap.has(field.name)) {
         const dropCol = toSnakeCase(field.name);
         // SQLite doesn't support IF EXISTS on DROP COLUMN
@@ -678,8 +681,9 @@ ${allColumnDefs.join(",\n")}
     // For simplicity, we skip column modifications for SQLite
     if (this.dialect !== "sqlite") {
       for (const field of newFields) {
-        // Component fields have no parent column to alter.
-        if (field.type === STORAGE_FORMAT.fieldType) continue;
+        // A field with no parent column has nothing to alter. Toggling `required` on a
+        // many-to-many emitted ALTER COLUMN against a name the table does not have.
+        if (!fieldProducesColumn(field)) continue;
         const oldField = oldFieldMap.get(field.name);
         if (oldField && this.isFieldModified(oldField, field)) {
           const alterCol = toSnakeCase(field.name);

--- a/packages/nextly/src/domains/schema/pipeline/diff/build-from-fields.ts
+++ b/packages/nextly/src/domains/schema/pipeline/diff/build-from-fields.ts
@@ -32,6 +32,7 @@ import { resolveLocalizedFieldNames } from "../../../i18n/classify-fields";
 import {
   getColumnDescriptor,
   getSystemColumnDescriptors,
+  toSnakeCase,
 } from "../../services/field-column-descriptor";
 
 import { indexKey } from "./index-util";
@@ -211,10 +212,13 @@ export function buildDesiredTableFromFields(
   // Inject reserved system columns first - mirrors runtime-schema-generator's
   // behavior. title/slug only when a column-producing user field replaces them
   // (user wins). status only when Draft/Published is enabled.
-  const hasTitleField = fields.some(
-    f => f.name === "title" && producesColumn(f)
-  );
-  const hasSlugField = fields.some(f => f.name === "slug" && producesColumn(f));
+  // Matched on the COLUMN the field becomes, so this agrees with the runtime schema and the DDL
+  // generator. Comparing declared names makes `Title` suppress the column in one place and not
+  // the others, and the diff then reconciles a column the table does not have.
+  const declaresColumn = (column: string): boolean =>
+    fields.some(f => toSnakeCase(f.name) === column && producesColumn(f));
+  const hasTitleField = declaresColumn("title");
+  const hasSlugField = declaresColumn("slug");
   for (const reserved of getSystemColumnDescriptors(dialect, {
     hasTitleField,
     hasSlugField,

--- a/packages/nextly/src/domains/schema/services/field-column-descriptor.ts
+++ b/packages/nextly/src/domains/schema/services/field-column-descriptor.ts
@@ -118,7 +118,7 @@ export function toSnakeCase(name: string): string {
 }
 
 /**
- * The physical columns a list of declared field names occupies.
+ * The physical columns a list of fields occupies.
  *
  * Anything deciding "has the author already declared this system field?" has to ask it of the
  * COLUMN rather than the spelling. `Title` and `title` are one column, so injecting the system
@@ -126,12 +126,22 @@ export function toSnakeCase(name: string): string {
  * Four places make that decision — both config factories, the dev-server single sync and the
  * single dispatcher's alter input — and this is the one definition they share.
  *
- * Accepts unknown entries because two of those callers run before the config has been parsed.
+ * A field that occupies no column claims none: a component or a many-to-many named `Title` keeps
+ * its values in its own table, so the system column still has to be injected beside it. Counting
+ * it would drop the system field from the config while the generators still emit the column.
+ *
+ * Takes loosely-typed fields because two of those callers run before the config has been parsed.
  */
-export function columnsDeclaredBy(names: Iterable<unknown>): Set<string> {
+export function columnsDeclaredBy(
+  fields: Iterable<
+    { name?: unknown; type?: unknown; options?: unknown } | null | undefined
+  >
+): Set<string> {
   const columns = new Set<string>();
-  for (const name of names) {
-    if (typeof name === "string") columns.add(toSnakeCase(name));
+  for (const field of fields) {
+    if (!field || typeof field.name !== "string") continue;
+    if (!fieldProducesColumn(field)) continue;
+    columns.add(toSnakeCase(field.name));
   }
   return columns;
 }

--- a/packages/nextly/src/domains/schema/services/field-column-descriptor.ts
+++ b/packages/nextly/src/domains/schema/services/field-column-descriptor.ts
@@ -118,6 +118,25 @@ export function toSnakeCase(name: string): string {
 }
 
 /**
+ * The physical columns a list of declared field names occupies.
+ *
+ * Anything deciding "has the author already declared this system field?" has to ask it of the
+ * COLUMN rather than the spelling. `Title` and `title` are one column, so injecting the system
+ * field beside an author's `Title` declares that column twice and the table cannot be created.
+ * Four places make that decision — both config factories, the dev-server single sync and the
+ * single dispatcher's alter input — and this is the one definition they share.
+ *
+ * Accepts unknown entries because two of those callers run before the config has been parsed.
+ */
+export function columnsDeclaredBy(names: Iterable<unknown>): Set<string> {
+  const columns = new Set<string>();
+  for (const name of names) {
+    if (typeof name === "string") columns.add(toSnakeCase(name));
+  }
+  return columns;
+}
+
+/**
  * Whether a field becomes a column of the table it is declared on.
  *
  * The single answer to that question: `classifyFieldKind` and `getColumnDescriptor` both defer to

--- a/packages/nextly/src/domains/schema/services/field-column-descriptor.ts
+++ b/packages/nextly/src/domains/schema/services/field-column-descriptor.ts
@@ -118,9 +118,44 @@ export function toSnakeCase(name: string): string {
 }
 
 /**
+ * Whether a field becomes a column of the table it is declared on.
+ *
+ * The single answer to that question: `classifyFieldKind` and `getColumnDescriptor` both defer to
+ * it, so a rule that only applies to columns cannot disagree with the generator about which fields
+ * have one.
+ *
+ * Dialect-free by construction — a component and a many-to-many relationship keep their values in
+ * their own tables on every dialect. Structural rather than typed because config validation asks
+ * this before the field has been parsed. Anything unrecognised counts as a column, matching the
+ * text fallback below, so a field type whose plugin has not registered yet is still held to the
+ * rules that columns carry rather than quietly escaping them.
+ */
+export function fieldProducesColumn(field: {
+  type?: unknown;
+  options?: unknown;
+}): boolean {
+  if (typeof field.type !== "string") return true;
+  if (LAYOUT_FIELD_TYPES.has(field.type)) return false;
+  // Component values live in their own comp_{slug} tables and are stripped from the parent row on
+  // write, so the parent needs no column.
+  if (field.type === "component") return false;
+  // A many-to-many relationship stores its links in a dedicated junction table, not on the parent
+  // row. Every other relationship shape does get a column.
+  if (field.type === "relationship" || field.type === "upload") {
+    const options: unknown = field.options;
+    const relationType =
+      typeof options === "object" && options !== null
+        ? (options as { relationType?: unknown }).relationType
+        : undefined;
+    return relationType !== "manyToMany";
+  }
+  return true;
+}
+
+/**
  * Given a Nextly field config, returns the database column shape
- * for the requested dialect. Returns `null` for layout-only field
- * types that don't get a column.
+ * for the requested dialect. Returns `null` for every field type
+ * that gets no column of its own — see `fieldProducesColumn`.
  *
  * The output is consumed by:
  *   - `runtime-schema-generator.ts` — translates `kind` +
@@ -132,9 +167,8 @@ export function getColumnDescriptor(
   field: FieldDefinition,
   dialect: SupportedDialect
 ): ColumnDescriptor | null {
-  if (LAYOUT_FIELD_TYPES.has(field.type)) return null;
-
   const name = toSnakeCase(field.name);
+  // "skip" covers every column-less field type, layout ones included, via fieldProducesColumn.
   const kind = classifyFieldKind(field);
   // FK columns are always created without NOT NULL in the DDL (both generateMigrationSQL
   // and the Drizzle runtime builder). `required` is enforced at the application layer.
@@ -177,6 +211,8 @@ export function getColumnDescriptor(
  * `build-from-fields.ts` ignored it and shipped wrong types.
  */
 function classifyFieldKind(field: FieldDefinition): ColumnKind {
+  if (!fieldProducesColumn(field)) return "skip";
+
   switch (field.type) {
     case "text":
     case "email":
@@ -212,16 +248,9 @@ function classifyFieldKind(field: FieldDefinition): ColumnKind {
 
     case "relationship":
     case "upload": {
-      // A many-to-many relationship stores its links in a dedicated junction
-      // table, not on the parent row, so the parent needs no column (mirrors
-      // component fields, which return "skip"). Emitting an fkSingle column
-      // here produced a phantom parent column the junction-only physical
-      // schema never has, so the runtime table object disagreed with the DB.
-      const relationType = (field as { options?: { relationType?: string } })
-        .options?.relationType;
-      if (relationType === "manyToMany") return "skip";
-      // hasMany or array-target relationships are stored as JSON
-      // arrays of FK ids. Single-target -> plain FK column.
+      // Many-to-many is already excluded by fieldProducesColumn, which owns the junction-table
+      // rule. hasMany or array-target relationships are stored as JSON arrays of FK ids.
+      // Single-target -> plain FK column.
       const hasMany = (field as { hasMany?: boolean }).hasMany;
       const relationTo = (field as { relationTo?: unknown }).relationTo;
       if (hasMany || Array.isArray(relationTo)) return "json";
@@ -233,12 +262,6 @@ function classifyFieldKind(field: FieldDefinition): ColumnKind {
     case "json":
     case "chips":
       return "json";
-
-    case "component":
-      // Component values live in their own comp_{slug} tables and are stripped
-      // from the parent row on write, so the parent needs no column. Emitting
-      // one (NOT NULL when required) produced an orphan that broke every insert.
-      return "skip";
 
     default: {
       // Plugin-contributed custom field type maps to its declared storage

--- a/packages/nextly/src/domains/schema/services/runtime-schema-generator.ts
+++ b/packages/nextly/src/domains/schema/services/runtime-schema-generator.ts
@@ -56,6 +56,7 @@ import {
   DEFAULT_DECIMAL_SCALE,
   getColumnDescriptor,
   getSystemColumnDescriptors,
+  toSnakeCase,
 } from "./field-column-descriptor";
 
 export type SupportedDialect = DescriptorDialect;
@@ -263,10 +264,13 @@ function buildDrizzleColumnRecord(
   // suppress the system title/slug column, or the table would have neither.
   const producesColumn = (f: FieldDefinition): boolean =>
     getColumnDescriptor(f, dialect) !== null;
-  const hasTitleField = fields.some(
-    f => f.name === "title" && producesColumn(f)
-  );
-  const hasSlugField = fields.some(f => f.name === "slug" && producesColumn(f));
+  // Matched on the COLUMN the field becomes, not its declared name: an author writing `Title`
+  // means the same column, and the three places that make this decision have to agree or one
+  // injects a system column the others do not have.
+  const declaresColumn = (column: string): boolean =>
+    fields.some(f => toSnakeCase(f.name) === column && producesColumn(f));
+  const hasTitleField = declaresColumn("title");
+  const hasSlugField = declaresColumn("slug");
 
   // Localized fields live in the companion `_locales` table; omit them from the main table.
   const localizedNames = options.localized

--- a/packages/nextly/src/lib/system-columns.ts
+++ b/packages/nextly/src/lib/system-columns.ts
@@ -438,6 +438,48 @@ export function isReservedSystemColumn(
   );
 }
 
+/**
+ * Whether an author's own field may take over this column by declaring it.
+ *
+ * True only for the columns whose presence is conditional on the author declaring them — today
+ * `title` and `slug`. Taking one over is allowed **under that column's own name only**: a field
+ * named `Title` reaches the same column but stays a different identity everywhere the declared
+ * name is the key — the runtime table's property, the payload keys a mutation generates, the
+ * response document, the generated types — so the two would write one column under two names and
+ * the generated value would overwrite the author's.
+ */
+export function isOwnableSystemColumn(
+  physicalName: string,
+  entity: SystemColumnEntity
+): boolean {
+  return SYSTEM_COLUMNS.some(
+    column =>
+      column.name === physicalName &&
+      column.appliesTo.includes(entity) &&
+      (column.presence === "unlessAuthorDeclaredTitle" ||
+        column.presence === "unlessAuthorDeclaredSlug")
+  );
+}
+
+/**
+ * Whether this column exists only because the publish lifecycle is enabled.
+ *
+ * The lifecycle owns the column's exact shape — its length, its NOT NULL, its `'draft'` default
+ * and the values publish/unpublish write — so an author's field cannot stand in for it. When the
+ * lifecycle is on, a field reaching one of these columns is a collision rather than a takeover.
+ */
+export function isLifecycleSystemColumn(
+  physicalName: string,
+  entity: SystemColumnEntity
+): boolean {
+  return SYSTEM_COLUMNS.some(
+    column =>
+      column.name === physicalName &&
+      column.appliesTo.includes(entity) &&
+      column.presence === "withStatusLifecycle"
+  );
+}
+
 /** The names a validator on `surface` refuses for an author's own field. */
 export function reservedSystemFieldNames(
   surface: ReservationSurface

--- a/packages/nextly/src/shared/base-validator.ts
+++ b/packages/nextly/src/shared/base-validator.ts
@@ -20,6 +20,8 @@
  * @since 1.0.0
  */
 
+import { toSnakeCase } from "../domains/schema/services/field-column-descriptor";
+
 import { pluginFieldOptionIssues } from "./lib/plugin-field-options";
 import { RESERVED_SLUGS, SQL_RESERVED_KEYWORDS } from "./sql-reserved";
 
@@ -290,8 +292,13 @@ export function validateFieldNameShared(
     });
   }
 
+  // Two keys per field, because two different things can collide. The lower-cased name catches a
+  // repeat an author would read as the same field, and the column the name becomes catches one the
+  // DATABASE would read as the same field: `foo_bar` and `FooBar` are distinct names that reach one
+  // column, and emitting both produces a CREATE TABLE no dialect will accept.
   const nameLower = name.toLowerCase();
-  if (seenNames.has(nameLower)) {
+  const columnName = toSnakeCase(name);
+  if (seenNames.has(nameLower) || seenNames.has(`column:${columnName}`)) {
     errors.push({
       path: `${path}.name`,
       message: `Duplicate field name '${name}' at this level`,
@@ -299,6 +306,7 @@ export function validateFieldNameShared(
     });
   } else {
     seenNames.add(nameLower);
+    seenNames.add(`column:${columnName}`);
   }
 }
 

--- a/packages/nextly/src/shared/base-validator.ts
+++ b/packages/nextly/src/shared/base-validator.ts
@@ -20,8 +20,6 @@
  * @since 1.0.0
  */
 
-import { toSnakeCase } from "../domains/schema/services/field-column-descriptor";
-
 import { pluginFieldOptionIssues } from "./lib/plugin-field-options";
 import { RESERVED_SLUGS, SQL_RESERVED_KEYWORDS } from "./sql-reserved";
 
@@ -292,13 +290,8 @@ export function validateFieldNameShared(
     });
   }
 
-  // Two keys per field, because two different things can collide. The lower-cased name catches a
-  // repeat an author would read as the same field, and the column the name becomes catches one the
-  // DATABASE would read as the same field: `foo_bar` and `FooBar` are distinct names that reach one
-  // column, and emitting both produces a CREATE TABLE no dialect will accept.
   const nameLower = name.toLowerCase();
-  const columnName = toSnakeCase(name);
-  if (seenNames.has(nameLower) || seenNames.has(`column:${columnName}`)) {
+  if (seenNames.has(nameLower)) {
     errors.push({
       path: `${path}.name`,
       message: `Duplicate field name '${name}' at this level`,
@@ -306,7 +299,6 @@ export function validateFieldNameShared(
     });
   } else {
     seenNames.add(nameLower);
-    seenNames.add(`column:${columnName}`);
   }
 }
 

--- a/packages/nextly/src/singles/config/define-single.ts
+++ b/packages/nextly/src/singles/config/define-single.ts
@@ -44,7 +44,7 @@ import type {
   FieldConfig,
 } from "../../collections/fields/types";
 import type { SingleAccessControl } from "../../domains/auth/services/access-control-types";
-import { toSnakeCase } from "../../domains/schema/services/field-column-descriptor";
+import { columnsDeclaredBy } from "../../domains/schema/services/field-column-descriptor";
 
 import type {
   SingleConfig,
@@ -236,13 +236,8 @@ export function defineSingle(config: SingleConfigInput): SingleConfig {
   // Keyed by the COLUMN each field becomes, not by its declared name. A field named `Title` owns
   // the `title` column, so injecting the system one beside it declares that column twice and the
   // table cannot be created — the injection has to ask the same question the generators do.
-  const userFieldColumns = new Set(
-    config.fields
-      .filter(
-        (f): f is FieldConfig & { name: string } =>
-          "name" in f && typeof f.name === "string"
-      )
-      .map(f => toSnakeCase(f.name))
+  const userFieldColumns = columnsDeclaredBy(
+    config.fields.map(f => ("name" in f ? f.name : undefined))
   );
 
   const systemFields: FieldConfig[] = [];

--- a/packages/nextly/src/singles/config/define-single.ts
+++ b/packages/nextly/src/singles/config/define-single.ts
@@ -236,9 +236,7 @@ export function defineSingle(config: SingleConfigInput): SingleConfig {
   // Keyed by the COLUMN each field becomes, not by its declared name. A field named `Title` owns
   // the `title` column, so injecting the system one beside it declares that column twice and the
   // table cannot be created — the injection has to ask the same question the generators do.
-  const userFieldColumns = columnsDeclaredBy(
-    config.fields.map(f => ("name" in f ? f.name : undefined))
-  );
+  const userFieldColumns = columnsDeclaredBy(config.fields);
 
   const systemFields: FieldConfig[] = [];
 

--- a/packages/nextly/src/singles/config/define-single.ts
+++ b/packages/nextly/src/singles/config/define-single.ts
@@ -44,6 +44,7 @@ import type {
   FieldConfig,
 } from "../../collections/fields/types";
 import type { SingleAccessControl } from "../../domains/auth/services/access-control-types";
+import { toSnakeCase } from "../../domains/schema/services/field-column-descriptor";
 
 import type {
   SingleConfig,
@@ -232,18 +233,21 @@ export function defineSingle(config: SingleConfigInput): SingleConfig {
   // (createDefaultDocument always writes them). If the user already defined
   // fields with these names, their definitions take priority.
 
-  const userFieldNames = new Set(
+  // Keyed by the COLUMN each field becomes, not by its declared name. A field named `Title` owns
+  // the `title` column, so injecting the system one beside it declares that column twice and the
+  // table cannot be created — the injection has to ask the same question the generators do.
+  const userFieldColumns = new Set(
     config.fields
       .filter(
         (f): f is FieldConfig & { name: string } =>
           "name" in f && typeof f.name === "string"
       )
-      .map(f => f.name)
+      .map(f => toSnakeCase(f.name))
   );
 
   const systemFields: FieldConfig[] = [];
 
-  if (!userFieldNames.has("title")) {
+  if (!userFieldColumns.has("title")) {
     systemFields.push({
       type: "text",
       name: "title",
@@ -258,7 +262,7 @@ export function defineSingle(config: SingleConfigInput): SingleConfig {
     });
   }
 
-  if (!userFieldNames.has("slug")) {
+  if (!userFieldColumns.has("slug")) {
     systemFields.push({
       type: "text",
       name: "slug",

--- a/packages/nextly/src/singles/config/validate-single.ts
+++ b/packages/nextly/src/singles/config/validate-single.ts
@@ -23,7 +23,10 @@
 
 import { RESERVED_SLUGS } from "../../collections/config/validate-config";
 import { isPluginFieldTypeOnSurface } from "../../domains/schema/field-types/field-type-registry";
-import { toSnakeCase } from "../../domains/schema/services/field-column-descriptor";
+import {
+  fieldProducesColumn,
+  toSnakeCase,
+} from "../../domains/schema/services/field-column-descriptor";
 import { isReservedSystemColumn } from "../../lib/system-columns";
 import { SYSTEM_RESOURCES } from "../../schemas/_zod/rbac";
 import {
@@ -319,7 +322,8 @@ function validateFields(
   const columnOwners = new Map<string, string>();
   fields.forEach((field, index) => {
     if (!field || typeof field !== "object") return;
-    const name = (field as Record<string, unknown>).name;
+    const candidate = field as Record<string, unknown>;
+    const name = candidate.name;
     if (typeof name !== "string") return;
     const column = toSnakeCase(name);
     if (isReservedSystemColumn(column, "singleConfig")) {
@@ -334,6 +338,11 @@ function validateFields(
     // created. Checked here rather than in the shared field-name rule because only this level has
     // columns at all: a repeater or group keeps its children inside a single JSON column, where
     // two names that convert alike are simply two keys.
+    //
+    // Column-less field types are exempt for the same reason. A component and a many-to-many
+    // relationship store their values in their own tables, keyed by the field's declared name, so
+    // two of them whose names converge stay distinct and nothing is emitted twice.
+    if (!fieldProducesColumn(candidate)) return;
     const owner = columnOwners.get(column);
     if (owner !== undefined) {
       errors.push({

--- a/packages/nextly/src/singles/config/validate-single.ts
+++ b/packages/nextly/src/singles/config/validate-single.ts
@@ -22,7 +22,6 @@
  */
 
 import { RESERVED_SLUGS } from "../../collections/config/validate-config";
-import { isFieldLocalized } from "../../domains/i18n/classify-fields";
 import { isPluginFieldTypeOnSurface } from "../../domains/schema/field-types/field-type-registry";
 import {
   fieldProducesColumn,
@@ -304,7 +303,6 @@ function validateFieldsArray(
 function validateFields(
   fields: unknown,
   errors: SingleValidationError[],
-  singleLocalized = false,
   lifecycleEnabled = false
 ): void {
   const path = "fields";
@@ -332,14 +330,13 @@ function validateFields(
   // enabling it later fails here rather than at migration time. Nested
   // repeater/group fields live inside JSON and are exempt, as for collections.
   //
-  // Ownership is tracked per TABLE, not per single. When the single is localized its translatable
-  // fields are emitted into the `_locales` companion instead of the main table, so a shared
-  // `foo_bar` and a localized `FooBar` reach one column name in two different tables and never
-  // collide. One global map would refuse a schema the generators represent correctly.
-  const columnOwners = new Map<string, Map<string, string>>([
-    ["main", new Map()],
-    ["companion", new Map()],
-  ]);
+  // Ownership is GLOBAL, not per table. Two names that reach one column are refused even when the
+  // generators would put them in different tables — a shared `foo_bar` beside a localized
+  // `FooBar`. Physical separation does not keep the two values apart, because the write path
+  // normalizes payload keys through the same conversion BEFORE it splits localized fields off, so
+  // both keys land on `foo_bar` and the second silently overwrites the first. One of the two
+  // authored values is already gone by the time anything decides which table it belongs to.
+  const columnOwners = new Map<string, string>();
   fields.forEach((field, index) => {
     if (!field || typeof field !== "object") return;
     const candidate = field as Record<string, unknown>;
@@ -389,15 +386,7 @@ function validateFields(
     // Column-less field types are exempt for the same reason. A component and a many-to-many
     // relationship store their values in their own tables, keyed by the field's declared name, so
     // two of them whose names converge stay distinct and nothing is emitted twice.
-    const table = isFieldLocalized(
-      candidate as unknown as Parameters<typeof isFieldLocalized>[0],
-      singleLocalized
-    )
-      ? "companion"
-      : "main";
-    const owners = columnOwners.get(table);
-    if (!owners) return;
-    const owner = owners.get(column);
+    const owner = columnOwners.get(column);
     if (owner !== undefined) {
       errors.push({
         path: `${path}[${index}].name`,
@@ -406,7 +395,7 @@ function validateFields(
       });
       return;
     }
-    owners.set(column, name);
+    columnOwners.set(column, name);
   });
 
   // Why: empty fields list is now valid for both code-first defines and the
@@ -493,7 +482,6 @@ export function validateSingleConfig(
   validateFields(
     config.fields,
     errors,
-    (config as { localized?: boolean }).localized === true,
     (config as { status?: boolean }).status === true
   );
 

--- a/packages/nextly/src/singles/config/validate-single.ts
+++ b/packages/nextly/src/singles/config/validate-single.ts
@@ -316,6 +316,7 @@ function validateFields(
   // validation. Reserved even when the draft/publish lifecycle is off, so
   // enabling it later fails here rather than at migration time. Nested
   // repeater/group fields live inside JSON and are exempt, as for collections.
+  const columnOwners = new Map<string, string>();
   fields.forEach((field, index) => {
     if (!field || typeof field !== "object") return;
     const name = (field as Record<string, unknown>).name;
@@ -327,7 +328,22 @@ function validateFields(
         message: `Field name '${name}' is reserved: it becomes the system column '${column}'`,
         code: "FIELD_NAME_RESERVED",
       });
+      return;
     }
+    // Two names that reach one column cannot both be emitted, so the table could never be
+    // created. Checked here rather than in the shared field-name rule because only this level has
+    // columns at all: a repeater or group keeps its children inside a single JSON column, where
+    // two names that convert alike are simply two keys.
+    const owner = columnOwners.get(column);
+    if (owner !== undefined) {
+      errors.push({
+        path: `${path}[${index}].name`,
+        message: `Field name '${name}' collides with '${owner}': both become the column '${column}'`,
+        code: "FIELD_NAME_DUPLICATE",
+      });
+      return;
+    }
+    columnOwners.set(column, name);
   });
 
   // Why: empty fields list is now valid for both code-first defines and the

--- a/packages/nextly/src/singles/config/validate-single.ts
+++ b/packages/nextly/src/singles/config/validate-single.ts
@@ -28,7 +28,11 @@ import {
   fieldProducesColumn,
   toSnakeCase,
 } from "../../domains/schema/services/field-column-descriptor";
-import { isReservedSystemColumn } from "../../lib/system-columns";
+import {
+  isLifecycleSystemColumn,
+  isOwnableSystemColumn,
+  isReservedSystemColumn,
+} from "../../lib/system-columns";
 import { SYSTEM_RESOURCES } from "../../schemas/_zod/rbac";
 import {
   type BaseValidationError,
@@ -78,6 +82,11 @@ export type SingleValidationErrorCode =
   | "FIELD_NAME_DUPLICATE"
   // A field named after a column the system injects onto the Single's table.
   | "FIELD_NAME_RESERVED"
+  // A name that reaches a system column under a different spelling. Allowed only as the
+  // column's own name, because the declared name stays the identity in every payload.
+  | "FIELD_NAME_SYSTEM_ALIAS"
+  // A name that reaches a column the Draft/Published lifecycle owns, while it is enabled.
+  | "FIELD_NAME_LIFECYCLE_RESERVED"
   | "FIELD_TYPE_REQUIRED"
   | "FIELD_TYPE_INVALID"
   // A declared default the field's own rules reject.
@@ -295,7 +304,8 @@ function validateFieldsArray(
 function validateFields(
   fields: unknown,
   errors: SingleValidationError[],
-  singleLocalized = false
+  singleLocalized = false,
+  lifecycleEnabled = false
 ): void {
   const path = "fields";
 
@@ -344,6 +354,33 @@ function validateFields(
       });
       return;
     }
+    // Everything below is about columns, so a field that occupies none is exempt. A component or
+    // a many-to-many named `Title` takes over nothing: its values live in its own table and its
+    // payload key stays `Title`, distinct from the system field's `title`.
+    if (!fieldProducesColumn(candidate)) return;
+    // A field may take over `title` or `slug` — the documented "user wins" behaviour — but only
+    // under the column's own name. `Title` reaches the same column while staying a different
+    // identity everywhere the declared name is the key, so the two would write one column under
+    // two names and the generated value would overwrite the author's.
+    if (column !== name && isOwnableSystemColumn(column, "single")) {
+      errors.push({
+        path: `${path}[${index}].name`,
+        message: `Field name '${name}' becomes the system column '${column}'. Name the field '${column}' to replace that column, or choose a different name`,
+        code: "FIELD_NAME_SYSTEM_ALIAS",
+      });
+      return;
+    }
+    // The Draft/Published lifecycle owns its columns outright, so any name reaching them is a
+    // collision rather than a takeover. Only when the lifecycle is on — with it off these are
+    // ordinary names.
+    if (lifecycleEnabled && isLifecycleSystemColumn(column, "single")) {
+      errors.push({
+        path: `${path}[${index}].name`,
+        message: `Field name '${name}' becomes the column '${column}', which the Draft/Published lifecycle owns. Rename the field, or turn the lifecycle off`,
+        code: "FIELD_NAME_LIFECYCLE_RESERVED",
+      });
+      return;
+    }
     // Two names that reach one column cannot both be emitted, so the table could never be
     // created. Checked here rather than in the shared field-name rule because only this level has
     // columns at all: a repeater or group keeps its children inside a single JSON column, where
@@ -352,7 +389,6 @@ function validateFields(
     // Column-less field types are exempt for the same reason. A component and a many-to-many
     // relationship store their values in their own tables, keyed by the field's declared name, so
     // two of them whose names converge stay distinct and nothing is emitted twice.
-    if (!fieldProducesColumn(candidate)) return;
     const table = isFieldLocalized(
       candidate as unknown as Parameters<typeof isFieldLocalized>[0],
       singleLocalized
@@ -457,7 +493,8 @@ export function validateSingleConfig(
   validateFields(
     config.fields,
     errors,
-    (config as { localized?: boolean }).localized === true
+    (config as { localized?: boolean }).localized === true,
+    (config as { status?: boolean }).status === true
   );
 
   validateAccess(config.access, errors);

--- a/packages/nextly/src/singles/config/validate-single.ts
+++ b/packages/nextly/src/singles/config/validate-single.ts
@@ -22,6 +22,7 @@
  */
 
 import { RESERVED_SLUGS } from "../../collections/config/validate-config";
+import { isFieldLocalized } from "../../domains/i18n/classify-fields";
 import { isPluginFieldTypeOnSurface } from "../../domains/schema/field-types/field-type-registry";
 import {
   fieldProducesColumn,
@@ -293,7 +294,8 @@ function validateFieldsArray(
  */
 function validateFields(
   fields: unknown,
-  errors: SingleValidationError[]
+  errors: SingleValidationError[],
+  singleLocalized = false
 ): void {
   const path = "fields";
 
@@ -319,7 +321,15 @@ function validateFields(
   // validation. Reserved even when the draft/publish lifecycle is off, so
   // enabling it later fails here rather than at migration time. Nested
   // repeater/group fields live inside JSON and are exempt, as for collections.
-  const columnOwners = new Map<string, string>();
+  //
+  // Ownership is tracked per TABLE, not per single. When the single is localized its translatable
+  // fields are emitted into the `_locales` companion instead of the main table, so a shared
+  // `foo_bar` and a localized `FooBar` reach one column name in two different tables and never
+  // collide. One global map would refuse a schema the generators represent correctly.
+  const columnOwners = new Map<string, Map<string, string>>([
+    ["main", new Map()],
+    ["companion", new Map()],
+  ]);
   fields.forEach((field, index) => {
     if (!field || typeof field !== "object") return;
     const candidate = field as Record<string, unknown>;
@@ -343,7 +353,15 @@ function validateFields(
     // relationship store their values in their own tables, keyed by the field's declared name, so
     // two of them whose names converge stay distinct and nothing is emitted twice.
     if (!fieldProducesColumn(candidate)) return;
-    const owner = columnOwners.get(column);
+    const table = isFieldLocalized(
+      candidate as unknown as Parameters<typeof isFieldLocalized>[0],
+      singleLocalized
+    )
+      ? "companion"
+      : "main";
+    const owners = columnOwners.get(table);
+    if (!owners) return;
+    const owner = owners.get(column);
     if (owner !== undefined) {
       errors.push({
         path: `${path}[${index}].name`,
@@ -352,7 +370,7 @@ function validateFields(
       });
       return;
     }
-    columnOwners.set(column, name);
+    owners.set(column, name);
   });
 
   // Why: empty fields list is now valid for both code-first defines and the
@@ -436,7 +454,11 @@ export function validateSingleConfig(
     sqlKeywordsSet: DEFAULT_SQL_KEYWORDS_SET,
   });
 
-  validateFields(config.fields, errors);
+  validateFields(
+    config.fields,
+    errors,
+    (config as { localized?: boolean }).localized === true
+  );
 
   validateAccess(config.access, errors);
 


### PR DESCRIPTION
**This touches DDL.** The scope grew across three review rounds, and each round found that the previous one had created the next defect. All are fixed; the history is worth reading before merging.

## The defect this started from

`dynamic-collection-schema-service.ts` carried a private copy of the field-name-to-column conversion that had lost its final step:

```ts
// before — a private copy, missing the leading-underscore strip
return str.replace(/([A-Z])/g, "_$1").toLowerCase();
```

Measured on `main`, for a field named `PublishedAt`:

| | column |
|---|---|
| created by the generator | `_published_at` |
| addressed by the runtime Drizzle schema | `published_at` |
| desired by the diff engine | `published_at` |

The table and every read of it disagree, and the diff reports the column missing on every apply. It is **latent**: the Schema Builder's own name pattern is `^[a-z][a-z0-9_]*$`, so it cannot produce a leading capital. Nothing is broken for any user today.

## What review found, in order

**Round 1 — correcting the conversion alone breaks working configs.** I claimed the change was "provably inert" on a test covering 27 combinations. Every one was a *single lowercase-start field* — the shape I designed the test around, not the shapes that break:

| config | before | round 1 |
|---|---|---|
| `Title` on a collection or single | works | **duplicate `title` — table cannot be created** |
| `Slug` | works | **duplicate `slug`** |
| `foo_bar` + `FooBar` | works | **duplicate `foo_bar`** |

**Round 2 — one generator canonical is worse than three wrong together.** Making only the DDL generator canonical meant it suppressed the injected `title` for a field named `Title` while the runtime schema and the diff still injected it, so both addressed a column the table does not have.

**Round 3 — a column rule was applied where there are no columns.** First inside the shared field-name rule, which recurses into nested fields that share one JSON column. Then, after moving it to the top level, it still applied to field types that never become a column at all. Measured:

| config | emits | before |
|---|---|---|
| `foo_bar` + `FooBar`, both `text` | one column, twice | duplicate — correct |
| `foo_bar` + `FooBar`, both `component` | **no columns** | **duplicate — wrong** |
| component `foo_bar` beside text `FooBar` | one column | **duplicate — wrong** |
| two `manyToMany` relationships | **no columns** | **duplicate — wrong** |

A component and a many-to-many keep their values in their own tables, keyed by `_parent_field`, which stores the field's **declared** name. Two whose names converge stay distinct.

**Round 4 — the same question, asked four more ways in one file.** The DDL generator decided whether an author's field replaces the injected `title`/`slug` by excluding components *by type token* — a hand-written subset — where the runtime schema and the diff ask `getColumnDescriptor`. So a many-to-many named `Title` suppressed the system column here and not there:

| description of the table | has `title` |
|---|---|
| created — this generator | **no** |
| runtime Drizzle schema | yes |
| diff's desired state | yes |

Looking for siblings rather than fixing the one instance found three more, in the ALTER paths, and those emit invalid SQL rather than merely disagreeing. Toggling `index` on a many-to-many, PostgreSQL:

```sql
CREATE INDEX IF NOT EXISTS "idx_dc_p_tags" ON "dc_p"("tags");
ALTER TABLE "dc_p" ALTER COLUMN "tags" TYPE text;
```

`tags` is a junction table, not a column. Both statements fail, and they fail the **entire schema save**, not just that field — `IF NOT EXISTS` guards the index, not the column. `required` and `unique` do the same, since `isFieldModified` compares them with no relationship exclusion, and removing such a field emitted `DROP COLUMN`, which SQLite cannot soften with `IF EXISTS`. **Pre-existing on `main`**, not introduced here, but it is the same defect and the predicate that fixes it is the one this PR adds.

**Round 5 — three decisions still comparing declared names, upstream and downstream of the generators.** The worst turns a badly-named table into one that cannot be created:

```
defineCollection({ slug: "posts", fields: [text({ name: "Title" })] })

fields after the factory   ["title", "slug", "Title"]
created columns            [..., "title", "slug", "title"]     <-- declared twice
```

`assertValidCollectionConfig` runs *before* the factory injects `title`/`slug`, and the injection tested `userFieldNames.has("title")` by declared spelling. The validator sees one legitimate owner of `title`; the injection then adds a second. **Before this PR the same config produced `title` + `_title`** — the drifted mapper accidentally kept them apart — so correcting the mapper is what makes the collision real, and it had to be fixed here rather than filed. `defineSingle` had the identical shape.

Renaming a field between two spellings of one column emitted `ALTER TABLE ... RENAME COLUMN "foo_bar" TO "foo_bar"`, which PostgreSQL rejects because the target already exists — failing an update that had nothing to do.

And duplicate detection kept one owner map per entity, so on a localized collection a shared `foo_bar` and a localized `FooBar` were refused even though they are emitted into the main table and the `_locales` companion respectively. That is the third over-refusal this one rule has produced, each at a different layer — nested fields, then column-less types, now the companion table. Its real question is not "do two names converge" but **"do two names converge in the same table"**.

**Round 6 — the identity question, and a recorded decision that was wrong.** Correcting the physical column left `Title` as *the same column and a different identity*: the runtime table's Drizzle property is `Title`, while `collection-mutation-service` generates a payload key `title` and snake-cases everything. A create carrying `Title` therefore gains a second generated `title`, both write one column, and **the generated value overwrites the author's** — silent data loss.

That forks: normalize identity at eight layers (Drizzle keys, generated payload keys, response, generated types, Zod, admin, both APIs) and still owe an answer to "does the API return `Title` or `title`?" — or refuse the alias in one rule. **This PR refuses it.** The documented takeover is untouched: a field spelled exactly `title`/`slug` still replaces the injected system column, which is what the blog template relies on. Only the alias fails, and the error names the spelling that works.

Separately, `status`: our own `tasks/left-tasks/117` recorded that a plain `status` field is "measured clean in both generators" and that reserving it "would refuse a configuration that works today". That measurement never asked the DDL generator. All three, PostgreSQL:

| field | lifecycle | created | runtime | desired |
|---|---|---|---|---|
| `status` | **on** | **duplicate** | clean | **duplicate** |
| `status` | off | clean | clean | clean |
| `Status` | **on** | **duplicate** | **duplicate** | **duplicate** |
| `Status` | off | clean | clean | clean |

So no working configuration has a `status` field with the lifecycle on — the table cannot be created. It is refused **only while the lifecycle is enabled**; with it off, `status` stays an ordinary and very common name. The task file has been corrected rather than left wrong. (Corroboration in-repo: the blog template's Posts config carries the comment *"Replaces the previous user-defined `select({ name: "status" })` field"*.)

## What it does now

**1. One conversion.** The private copy is deleted; the generator calls the `toSnakeCase` the runtime schema and the diff are built from. Correcting a copy leaves it free to drift again — that is the defect, not the symptom.

**2. All three generators decide on the COLUMN.** The injected `title`/`slug` yields to an author's own field, matched by the column it becomes rather than its spelling, in the DDL generator, the runtime schema and the diff alike. A capitalised alias replaces the injected column everywhere or nowhere.

**3. Duplicate detection keys on the column too.** It lower-cased names, which cannot see that `foo_bar` and `FooBar` reach one column. Both keys are checked, so today's strictness is preserved and the canonical case is added. **This also fixes a pre-existing bug:** `foo_bar` + `fooBar` already produced an uncreatable table on `main` and nothing reported it.

**4. That rule applies only where columns exist.** Not to nested fields, and not to column-less field types. `fieldProducesColumn` is now the single answer to "does this field become a column"; `classifyFieldKind` and `getColumnDescriptor` both defer to it, so a rule about columns cannot disagree with the generator about which fields have one. An unrecognised type still counts as a column, matching the existing text fallback, so a field type whose plugin has not registered yet stays subject to the rule rather than escaping it.

**5. One predicate answers "does this field have a column".** `fieldProducesColumn` owns it; `classifyFieldKind`, `getColumnDescriptor`, the CREATE-side title/slug gate and the three ALTER paths all defer to it. A field type added to that set later reaches every generator at once instead of the ones somebody remembered.

**6. Every system-field injection asks on the column.** A swept search for "has the author already declared this?" found **four** sites, not the two review named: both config factories, the dev-server singles auto-sync, and the single dispatcher's alter input. The dev-server one undid the factory fix — once `defineSingle` correctly stopped injecting `title` beside an author's `Title`, the auto-sync added it back by exact name. All four now share one tested definition, `columnsDeclaredBy`.

The sweep's other result: the remaining `f.name === "title"` comparisons are **payload-level** — `buildRestorePayload`'s `hasTitle`/`hasSlug`, the metadata service, `restore-version.ts` — deciding what keys a shaped document carries, where the declared name is the right thing to match. Deliberately untouched.

**7. A rename that changes no column emits no statement** — while still keeping the pair out of the add/drop loops, so the column is not dropped and re-added.

**8. Duplicate detection is judged globally, including across localization tables.** This was briefly relaxed per-table — a localized field goes to the `_locales` companion, so nothing is declared twice — and that was wrong. The write path normalizes payload keys through the same conversion *before* extracting localized fields:

```ts
for (const [key, value] of Object.entries(rawEntryData)) {
  entryData[toSnakeCase(key)] = value;
}
```

Both authored keys land on `foo_bar` and the second overwrites the first, so one value is gone before anything decides which table it belongs to. Physical separation separates columns, not values. A test pins the collapse itself, not only the refusal, so the rule can be relaxed deliberately if the write path ever preserves declared identities through the split.

**9. A system column may be taken over only under its own name.** `title`/`slug` still step aside for a field spelled exactly that way; `Title` is refused with an error naming the spelling that works. Derived from the declarations' `presence` token rather than a hardcoded pair, and gated on `fieldProducesColumn` so a component named `Title` — which takes over nothing and keeps its own payload key — stays legal.

**10. The publish lifecycle owns its columns while it is on.** A field reaching `status` or `first_published_at` is refused only when the lifecycle is enabled. Letting an author's field win instead was considered and rejected: the lifecycle owns that column's length, NOT NULL, `'draft'` default and the values publish/unpublish write, so a `select` standing in for it would break publishing in a way validation cannot see.

**11. The three descriptions are now required to agree.** See below — this is the part that would have caught rounds 2, 3 and 4 on its own.

## The assertion that was missing

The main table is described three times from one field list: the DDL that creates it, the runtime Drizzle schema every query is built from, and the diff's desired state. Each was only ever compared against the column descriptor — which cannot catch the three disagreeing with *each other*.

A new test builds all three and requires an **identical column multiset**, across every name shape × localized × publish-lifecycle × three dialects. A localized field named `Title` therefore has to be absent from all three or present in all three: the companion `_locales` table owns it, so the main table gets neither the author's column nor the injected system one.

Writing it surfaced an asymmetry worth recording: the runtime generator spells the lifecycle toggle `status` where the other two spell it `hasStatus`, so passing the wrong one silently omits the system column instead of failing. Not changed here — renaming a public option belongs in its own change — but it is the kind of thing that lets these three drift.

## Verification

Falsifications, each failing for its own reason and hitting one test:

| reverted | fails |
|---|---|
| the conversion | `expected { 'postgresql.PublishedAt': false } to deeply equal { … true }` |
| the title/slug gates matching on the column | capitalised-title test |
| the canonical key in duplicate detection | duplicate-pair test |
| the column-less exemption | *exempts field types that store their values in their own tables* |
| making unknown types exempt | *does not exempt a field type it cannot recognise* |
| the runtime generator matching on the column | *agrees when a localized field is named Title or Slug* |
| the desired-state builder matching on the column | *agrees when a localized field is named Title or Slug* |
| the CREATE-side gate to a component-only test | *agrees when a column-less field is named after a system column* |
| the index-toggle guard | *emits no column statement when its index or flags change* |
| the drop guard | *emits no DROP COLUMN when one is removed* |
| the modify guard | *emits no column statement when its index or flags change* |
| the factories' set to exact names | *does not add a system field beside an author's capitalised one* |
| the no-op rename guard | *emits no statement, because the database has nothing to do* |
| global duplicate detection | *refuses one shared and one localized field reaching the same column name* |
| the alias rule | *refuses a spelling that only reaches the column after conversion* |
| the lifecycle rule | *refuses a status field only when the lifecycle is enabled* |
| the column-less gate on both new rules | *keys the injection on the column for names it does accept* |
| the column-less guard in `columnsDeclaredBy` | *claims no column for a field that occupies none* |

The `fieldProducesColumn` refactor is inert where it must be: **2736** field-type × variant × name × dialect combinations produce byte-identical descriptor output before and after. Emitted SQL is unchanged for every name the Schema Builder accepts.

**Three dialect legs, one at a time, databases recreated before each:**

| leg | passed | failed |
|---|---|---|
| sqlite | 1054 | 0 |
| postgres17 | 1206 | 0 |
| mysql | 1136 | 0 |

Full `nextly` unit suite against an `origin/main` baseline measured in the same tree: **identical failure sets, no new failures.** `check-types` (source and tests) and `lint` clean.

## What this PR deliberately does NOT do

A table created by an earlier release from a capitalised code-first field carries `_published_at`
where everything now addresses `published_at`. Such an entity **has never been readable** — Drizzle
emits an explicit column list, so every read of it already fails — but this change does alter the
failure mode of a schema *edit* on it.

The repair cannot live in this generator: `generateAlterTableMigration` receives field definitions
only, with no live schema, so it cannot tell a legacy table from a fresh one, and an unconditional
rename would break every table created after this change. No dialect offers
`RENAME COLUMN ... IF EXISTS` across all three engines. It needs introspection, which the reconcile
layer already has — `pipeline/pre-resolution/executor.ts` already models `rename_column`.

Filed as `tasks/left-tasks/119-legacy-underscore-columns-need-a-repair-step.md` with the
reachability evidence and the bound that keeps it safe.

## Sequencing note

#506 pins this generator's DDL "before it is relocated" and #504 makes the diff agree with the Builder. #506's snapshot exercises only lowercase names, so it does not conflict. If the relocation lands first, this wants rebasing onto it rather than the reverse.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate `title` and `slug` columns when field names differ in capitalization or formatting.
  * Improved schema generation, migrations, and runtime behavior to consistently recognize normalized column names.
  * Prevented unnecessary rename migrations when source and target names resolve to the same column.
  * Added validation for duplicate fields, reserved lifecycle columns, and aliases of system columns.
  * Improved handling of column-less and relationship fields across dynamic collections and single configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->