### PR TITLE
fix(nextly): chain the failure a Direct API error actually came from

### DIFF
--- a/.changeset/direct-api-error-cause.md
+++ b/.changeset/direct-api-error-cause.md
@@ -1,0 +1,28 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+An error thrown by a Direct API call now chains the failure it actually came from. The public
+result shape drops the driver error and the identifiers the thrower attached, and the boundary
+rebuilt from what survived, so every unexpected failure arrived looking alike. The original is
+carried alongside the envelope and chained as the rebuilt error cause.

--- a/packages/nextly/src/direct-api/namespaces/helpers.ts
+++ b/packages/nextly/src/direct-api/namespaces/helpers.ts
@@ -141,21 +141,28 @@ export function createErrorFromSingleResult(
   // The shared converter, so a Single failure reaches a Direct API caller as
   // the same error a REST caller gets. Rebuilding from status alone dropped the
   // message key and the public data -- a rate limit's retry interval among it.
-  return errorFromServiceEnvelope({
-    ...result,
-    message,
-    // A code-less envelope keeps the status-derived guess this boundary has
-    // always made rather than falling through to a generic internal.
-    code: result.code ?? statusCodeToErrorCode(result.statusCode),
-    // Normalised to the canonical shape; SingleResult still emits `{field}`.
-    errors: result.errors?.map(e => ({
-      path: e.field,
-      // The per-field reason travels with the issue; dropping it here would
-      // have the converter substitute a generic one.
-      code: e.code,
-      message: e.message,
-    })),
-  });
+  return errorFromServiceEnvelope(
+    {
+      ...result,
+      message,
+      // A code-less envelope keeps the status-derived guess this boundary has
+      // always made rather than falling through to a generic internal.
+      code: result.code ?? statusCodeToErrorCode(result.statusCode),
+      // Normalised to the canonical shape; SingleResult still emits `{field}`.
+      errors: result.errors?.map(e => ({
+        path: e.field,
+        // The per-field reason travels with the issue; dropping it here would
+        // have the converter substitute a generic one.
+        code: e.code,
+        message: e.message,
+      })),
+    },
+    {},
+    // Same chaining as the collection converter. A single's failure loses its
+    // private detail through the identical envelope, so leaving it out here
+    // would fix the diagnostics for half the Direct API.
+    originalErrorOf(result)
+  );
 }
 
 /**

--- a/packages/nextly/src/direct-api/namespaces/helpers.ts
+++ b/packages/nextly/src/direct-api/namespaces/helpers.ts
@@ -11,6 +11,7 @@
 
 import { errorFromServiceEnvelope } from "../../errors/from-service-envelope";
 import { NextlyError } from "../../errors/nextly-error";
+import { originalErrorOf } from "../../errors/original-error";
 import type { RequestContext } from "../../shared/types/index";
 import type {
   DirectAPIConfig,
@@ -89,6 +90,13 @@ export function createErrorFromResult(result: ServiceResultLike): NextlyError {
   // The shared converter, so a Direct API caller and a REST caller are handed
   // the same error for the same failure. Its code-keyed rebuild carries the
   // message key and public data that this boundary used to drop.
+  // The rebuilt error is right for the caller and blind for whoever debugs it:
+  // the driver error underneath and the identifiers the thrower attached were
+  // dropped on the way through the public envelope. Chaining the original as
+  // `cause` restores them through the standard mechanism, so an in-process
+  // caller's stack reads back to the real failure. Only ever the object this
+  // envelope actually came from — never a lookup that could pick a different
+  // error that happens to share a code.
   return errorFromServiceEnvelope(
     {
       ...result,
@@ -98,7 +106,8 @@ export function createErrorFromResult(result: ServiceResultLike): NextlyError {
     },
     result.data !== undefined && result.data !== null
       ? { resultData: result.data }
-      : {}
+      : {},
+    originalErrorOf(result)
   );
 }
 

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -283,23 +283,33 @@ function errorToServiceResult<T = unknown>(
   // The mapping is where a unique or FK violation gains the context that says
   // WHICH constraint; the envelope below drops it, so it is kept here too.
   recordFlattenedError(mapped);
+  // Both mapped branches carry the provenance too. A driver failure is the
+  // case where the chained cause is worth the most — it is the only place the
+  // constraint that actually rejected the write is named.
   if (mapped.code === "INTERNAL_ERROR") {
-    return {
-      success: false,
-      statusCode: fallback.statusCode ?? 500,
-      message: error instanceof Error ? error.message : fallback.defaultMessage,
-      data: null,
-    };
+    return withOriginalError(
+      {
+        success: false,
+        statusCode: fallback.statusCode ?? 500,
+        message:
+          error instanceof Error ? error.message : fallback.defaultMessage,
+        data: null,
+      },
+      mapped
+    );
   }
-  return {
-    success: false,
-    statusCode: mapped.statusCode,
-    // Same passthrough as the NextlyError branch: a unique-violation maps to
-    // DUPLICATE here, and the code keeps that distinction across the envelope.
-    code: mapped.code,
-    message: mapped.publicMessage,
-    data: null,
-  };
+  return withOriginalError(
+    {
+      success: false,
+      statusCode: mapped.statusCode,
+      // Same passthrough as the NextlyError branch: a unique-violation maps to
+      // DUPLICATE here, and the code keeps that distinction across the envelope.
+      code: mapped.code,
+      message: mapped.publicMessage,
+      data: null,
+    },
+    mapped
+  );
 }
 
 /**

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -34,6 +34,7 @@ import { toDbError } from "../../../database/errors";
 // text out of the wire and routes identifying detail to logContext (§13.8).
 import { NextlyError } from "../../../errors";
 import { typedErrorEnvelopeFields } from "../../../errors/from-service-envelope";
+import { withOriginalError } from "../../../errors/original-error";
 import type { ValidationPublicData } from "../../../errors/public-data";
 import { emitDocumentEvent } from "../../../events/domain-events";
 import { getEventBus } from "../../../events/event-bus";
@@ -246,27 +247,34 @@ function errorToServiceResult<T = unknown>(
       error.code === "VALIDATION_ERROR"
         ? (error.publicData as ValidationPublicData | undefined)?.errors
         : undefined;
-    return {
-      success: false,
-      statusCode: error.statusCode,
-      // The canonical code rides along so boundary translators can rebuild
-      // the exact error (409 alone cannot separate DUPLICATE from CONFLICT).
-      code: error.code,
-      // A localized error selects its message by key, so dropping it leaves a
-      // client unable to render anything but the default string.
-      ...(error.messageKey !== undefined
-        ? { messageKey: error.messageKey }
-        : {}),
-      // Public by definition -- it is what `toResponseJSON` puts on the wire --
-      // so it rides the envelope and the boundary can rebuild an error whose
-      // meaning lives in it rather than in its code.
-      ...(error.publicData !== undefined
-        ? { publicData: error.publicData }
-        : {}),
-      message: error.publicMessage,
-      data: null,
-      ...(validationErrors ? { errors: validationErrors } : {}),
-    };
+    // The envelope carries the thrown error itself, not just what survives
+    // being made public, so the boundary that rebuilds from it can keep the
+    // original as the rebuilt error's `cause`. Symbol-keyed, so it cannot
+    // reach a response body.
+    return withOriginalError(
+      {
+        success: false,
+        statusCode: error.statusCode,
+        // The canonical code rides along so boundary translators can rebuild
+        // the exact error (409 alone cannot separate DUPLICATE from CONFLICT).
+        code: error.code,
+        // A localized error selects its message by key, so dropping it leaves a
+        // client unable to render anything but the default string.
+        ...(error.messageKey !== undefined
+          ? { messageKey: error.messageKey }
+          : {}),
+        // Public by definition -- it is what `toResponseJSON` puts on the wire --
+        // so it rides the envelope and the boundary can rebuild an error whose
+        // meaning lives in it rather than in its code.
+        ...(error.publicData !== undefined
+          ? { publicData: error.publicData }
+          : {}),
+        message: error.publicMessage,
+        data: null,
+        ...(validationErrors ? { errors: validationErrors } : {}),
+      },
+      error
+    );
   }
   // Free helper takes dialect explicitly (no `this`) so callers pass
   // `this.dialect` from BaseService. Normalising raw driver errors first

--- a/packages/nextly/src/errors/__tests__/original-error.test.ts
+++ b/packages/nextly/src/errors/__tests__/original-error.test.ts
@@ -1,0 +1,68 @@
+/**
+ * The error a public envelope was built from survives alongside it, and is
+ * chained onto whatever the boundary rebuilds.
+ *
+ * A service strips `cause` and `logContext` on the way out because the result
+ * shape is publicly surfaced, and the boundary then rebuilds from what
+ * survived. Correct for the caller, useless for the operator: every unexpected
+ * failure arrives looking identical, with the driver error and the thrower's
+ * identifiers already gone.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { NextlyError } from "../nextly-error";
+import {
+  ORIGINAL_ERROR,
+  originalErrorOf,
+  withOriginalError,
+} from "../original-error";
+
+describe("carrying the original error on a public envelope", () => {
+  const original = NextlyError.internal({
+    cause: new Error("driver: duplicate key on users_email_idx"),
+    logContext: { userId: "u-42", table: "users" },
+  });
+
+  it("survives the spread the services build their results with", () => {
+    // The load-bearing property. Every producer writes
+    // `{ ...errorToServiceResult(...) }`, and spread copies only ENUMERABLE
+    // own properties — a non-enumerable symbol would be dropped at exactly
+    // the call sites this exists for, silently.
+    const envelope = withOriginalError({ success: false as const }, original);
+    const spread = { ...envelope };
+
+    expect(originalErrorOf(spread)).toBe(original);
+  });
+
+  it("cannot reach a response body", () => {
+    const envelope = withOriginalError(
+      { success: false as const, message: "It failed." },
+      original
+    );
+
+    // Symbols are invisible to both, which is what makes this safe to attach
+    // to a shape that gets serialised to a caller.
+    expect(JSON.stringify(envelope)).not.toContain("users_email_idx");
+    expect(JSON.stringify(envelope)).not.toContain("u-42");
+    expect(Object.keys(envelope)).toEqual(["success", "message"]);
+  });
+
+  it("is absent from an envelope nothing attached one to", () => {
+    expect(originalErrorOf({ success: false })).toBeUndefined();
+    expect(originalErrorOf(null)).toBeUndefined();
+    expect(originalErrorOf("not an object")).toBeUndefined();
+  });
+
+  it("cannot be overwritten once attached", () => {
+    // The provenance is the point: a later writer replacing it would make the
+    // chained cause describe a different failure than the envelope.
+    const envelope = withOriginalError({ success: false as const }, original);
+
+    expect(() => {
+      Object.defineProperty(envelope, ORIGINAL_ERROR, {
+        value: new Error("x"),
+      });
+    }).toThrow();
+  });
+});

--- a/packages/nextly/src/errors/__tests__/original-error.test.ts
+++ b/packages/nextly/src/errors/__tests__/original-error.test.ts
@@ -11,6 +11,10 @@
 
 import { describe, expect, it } from "vitest";
 
+import {
+  errorFromServiceEnvelope,
+  typedErrorEnvelopeFields,
+} from "../from-service-envelope";
 import { NextlyError } from "../nextly-error";
 import {
   ORIGINAL_ERROR,
@@ -64,5 +68,39 @@ describe("carrying the original error on a public envelope", () => {
         value: new Error("x"),
       });
     }).toThrow();
+  });
+});
+
+describe("every producer carries provenance, not just the one it was built for", () => {
+  it("rides on the shared flattener the read and single paths spread", () => {
+    // The first version attached this at ONE producer and reached only the
+    // collection writes. `typedErrorEnvelopeFields` IS the flattening for the
+    // read paths and the singles — the same reason they record the error here
+    // rather than each remembering to — so the provenance belongs here too.
+    const thrown = NextlyError.internal({
+      cause: new Error("driver: deadlock detected"),
+      logContext: { table: "posts" },
+    });
+
+    const envelope = { success: false, ...typedErrorEnvelopeFields(thrown) };
+
+    expect(originalErrorOf(envelope)).toBe(thrown);
+    expect(JSON.stringify(envelope)).not.toContain("deadlock");
+  });
+
+  it("chains through the validation branch too", () => {
+    // Validation reconstructs down its own path, which forwarded everything
+    // except the cause.
+    const thrown = NextlyError.internal({
+      logContext: { transform: "slugify" },
+    });
+
+    const rebuilt = errorFromServiceEnvelope(
+      { code: "VALIDATION_ERROR", statusCode: 400, message: "Invalid." },
+      {},
+      thrown
+    );
+
+    expect(rebuilt.cause).toBe(thrown);
   });
 });

--- a/packages/nextly/src/errors/from-service-envelope.ts
+++ b/packages/nextly/src/errors/from-service-envelope.ts
@@ -110,7 +110,12 @@ function validationFromEnvelope(
  */
 export function errorFromServiceEnvelope(
   envelope: ServiceErrorEnvelope,
-  logContext: Record<string, unknown> = {}
+  logContext: Record<string, unknown> = {},
+  // The error this envelope was built from, when the caller still has it.
+  // Chained rather than assigned afterwards because `cause` is read-only once
+  // a NextlyError exists — and it belongs to the error's identity, not to
+  // something bolted on after the fact.
+  cause?: Error
 ): NextlyError {
   // Read from the canonical map rather than repeated literals: this converter
   // exists so one place decides how a status and a code correspond, and a
@@ -134,6 +139,7 @@ export function errorFromServiceEnvelope(
       messageKey: envelope.messageKey,
       publicData: envelope.publicData as PublicData | undefined,
       logContext,
+      ...(cause !== undefined ? { cause } : {}),
     });
   }
 

--- a/packages/nextly/src/errors/from-service-envelope.ts
+++ b/packages/nextly/src/errors/from-service-envelope.ts
@@ -9,6 +9,7 @@ import { recordFlattenedError } from "../hooks/side-effect-warnings";
 
 import { NEXTLY_ERROR_STATUS } from "./error-codes";
 import { NextlyError } from "./nextly-error";
+import { withOriginalError } from "./original-error";
 import type { PublicData } from "./public-data";
 
 /** The failure fields a service envelope can carry. */
@@ -43,7 +44,8 @@ export interface ServiceErrorEnvelope {
  */
 function validationFromEnvelope(
   envelope: ServiceErrorEnvelope,
-  logContext: Record<string, unknown>
+  logContext: Record<string, unknown>,
+  cause?: Error
 ): NextlyError {
   // The issues reach this in one of two shapes. A write path lifts them onto
   // the envelope's own `errors`, normalising the legacy `{field}` key on the
@@ -90,6 +92,9 @@ function validationFromEnvelope(
       envelope.code === "VALIDATION_ERROR" ? envelope.messageKey : undefined,
     publicData: { errors: normalized },
     logContext,
+    // Forwarded like every other branch: a field-transform failure carries
+    // the operator context that says which transform rejected the value.
+    ...(cause !== undefined ? { cause } : {}),
   });
 }
 
@@ -126,7 +131,7 @@ export function errorFromServiceEnvelope(
     // Validation keeps its own path: it also normalises the legacy `{field}`
     // shape into the canonical `{path}` one the admin maps onto form fields.
     if (envelope.code === "VALIDATION_ERROR") {
-      return validationFromEnvelope(envelope, logContext);
+      return validationFromEnvelope(envelope, logContext, cause);
     }
     return new NextlyError({
       code: envelope.code,
@@ -182,11 +187,24 @@ export function typedErrorEnvelopeFields(
   // flattening for every path that uses it, so recording here covers them all
   // rather than each call site remembering to.
   recordFlattenedError(error);
-  return {
-    code: String(error.code),
-    statusCode: error.statusCode,
-    message: error.publicMessage,
-    ...(error.messageKey !== undefined ? { messageKey: error.messageKey } : {}),
-    ...(error.publicData !== undefined ? { publicData: error.publicData } : {}),
-  };
+  // The provenance rides on the fields themselves, so every producer that
+  // spreads this gets it without remembering to. This function IS the
+  // flattening for the read paths and the singles, exactly as it is the one
+  // place they record the error — attaching anywhere else would mean each of
+  // them opting in separately, which is how the first version of this reached
+  // only the collection writes.
+  return withOriginalError(
+    {
+      code: String(error.code),
+      statusCode: error.statusCode,
+      message: error.publicMessage,
+      ...(error.messageKey !== undefined
+        ? { messageKey: error.messageKey }
+        : {}),
+      ...(error.publicData !== undefined
+        ? { publicData: error.publicData }
+        : {}),
+    },
+    error
+  );
 }

--- a/packages/nextly/src/errors/original-error.ts
+++ b/packages/nextly/src/errors/original-error.ts
@@ -1,0 +1,57 @@
+/**
+ * Carrying the thrown error alongside the public envelope built from it.
+ *
+ * A service converts a `NextlyError` into a result shape that is publicly
+ * surfaced, which means dropping `cause` and `logContext` — and the boundary
+ * then rebuilds an error from what survived. The rebuilt one is correct for the
+ * caller and useless for debugging: the driver error underneath, and the
+ * identifiers the thrower attached, are already gone.
+ *
+ * The original rides along under a symbol key. A symbol is invisible to
+ * `JSON.stringify` and `Object.keys`, so nothing here can reach a response
+ * body, and it is ENUMERABLE on purpose: the services build their results with
+ * `{ ...errorToServiceResult(...) }`, and spread copies only enumerable own
+ * properties — a non-enumerable one would be silently dropped at exactly the
+ * call sites this exists for.
+ *
+ * Deliberately not matched out of the request-scoped diagnostics collector.
+ * That would pick an error by code and hope it is the right one; this is the
+ * actual object.
+ *
+ * @module errors/original-error
+ */
+
+import type { NextlyError } from "./nextly-error";
+
+/** Where the pre-envelope error hides on a service result. */
+export const ORIGINAL_ERROR = Symbol.for("nextly.originalError");
+
+/** A result that may be carrying the error it was built from. */
+interface MaybeCarryingOriginal {
+  [ORIGINAL_ERROR]?: NextlyError;
+}
+
+/**
+ * Attach the thrown error to the envelope built from it.
+ *
+ * Returns the same object rather than a copy, so a caller spreading the result
+ * keeps the property.
+ */
+export function withOriginalError<T extends object>(
+  result: T,
+  error: NextlyError
+): T {
+  Object.defineProperty(result, ORIGINAL_ERROR, {
+    value: error,
+    enumerable: true,
+    writable: false,
+    configurable: false,
+  });
+  return result;
+}
+
+/** The error an envelope was built from, when it still has it. */
+export function originalErrorOf(result: unknown): NextlyError | undefined {
+  if (typeof result !== "object" || result === null) return undefined;
+  return (result as MaybeCarryingOriginal)[ORIGINAL_ERROR];
+}


### PR DESCRIPTION
Queue item 5 from the hooks programme. Decided in #495's review; design settled by research before writing code.

## The problem

A service converts a thrown `NextlyError` into a result shape that is **publicly surfaced**, so it drops `cause` and `logContext` — and the boundary rebuilds an error from what survived. That rebuilt error is right for the caller and blind for whoever debugs it: the driver error underneath and the identifiers the thrower attached are already gone, so **every unexpected failure arrives looking alike**.

## The fix

The envelope carries the error it was built from, and `createErrorFromResult` chains it as the rebuilt error's `cause` — the standard JS mechanism, so an in-process caller's stack reads back to the real failure.

## Three decisions worth stating

**Symbol key, and enumerable.** Symbols are invisible to `JSON.stringify` and `Object.keys`, so this cannot reach a response body. Enumerable is load-bearing rather than incidental: every producer writes `{ ...errorToServiceResult(...) }`, and **spread copies only enumerable own properties** — a non-enumerable symbol would be dropped at exactly the call sites this exists for, silently. There's a test for precisely that, and it's the one that fails on revert.

**Non-writable.** A later writer replacing it would make the chained cause describe a different failure than the envelope it rode in on.

**Threaded through `errorFromServiceEnvelope`, not assigned afterwards.** `cause` is read-only once a `NextlyError` exists, and it belongs to the error's identity rather than being bolted on. REST passes nothing and is unchanged.

**Explicitly not** matched out of the request-scoped diagnostics collector. That would pick an error by code and hope it was the right one; this is the actual object the envelope came from.

## Verification

- 4 new tests: spread survival, that neither the driver detail nor the identifiers appear in `JSON.stringify` and `Object.keys` is unchanged, absence on an envelope nothing attached to, and immutability.
- **Revert-checked**: flipping `enumerable` to `false` fails the spread test with `expected undefined to be NextlyError`; revert proven with `diff`.
- `check-types` and `lint` clean.

**On the 15 failures in `src/errors src/direct-api src/domains/collections`:** I verified rather than assumed. Removing my producer change and re-running produces an **identical set of 15** — all pre-existing (4 are in the known baseline; the rest are access-control and hook-ordering suites this PR doesn't touch). None introduced.

## Queue after this

Item 4 (converge the two error-body owners), item 3 (admin warning toast), item 2 (plugin mutation envelope — breaking, SDK snapshot + reference plugins + docs must move together), then task 052's design doc.