### PR TITLE
feat(nextly): refuse colliding field names in code-first configs

### DIFF
--- a/.changeset/code-first-column-reservations.md
+++ b/.changeset/code-first-column-reservations.md
@@ -1,0 +1,35 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+**Behaviour change.** A code-first collection or single that declares a field named `id`,
+`createdAt`, `created_at`, `updatedAt` or `updated_at` is now refused when the config is read,
+instead of failing later during schema application. Any casing that resolves to one of those
+columns is refused too, so `CreatedAt` is caught alongside `createdAt`.
+
+Such a collection could never have worked: the field is emitted alongside the injected column and
+the database rejects a table that declares the same column twice. The error now names the column
+it collides with, and arrives where the name is chosen.
+
+`title`, `slug` and `status` are unaffected and remain declarable — the first two step aside for
+an author's own field, and a `status` field is taken up by the draft/publish lifecycle.

--- a/packages/nextly/src/collections/config/validate-config.ts
+++ b/packages/nextly/src/collections/config/validate-config.ts
@@ -25,7 +25,8 @@
  */
 
 import { isPluginFieldTypeOnSurface } from "../../domains/schema/field-types/field-type-registry";
-import { reservedSystemFieldNames } from "../../lib/system-columns";
+import { toSnakeCase } from "../../domains/schema/services/field-column-descriptor";
+import { isReservedSystemColumn } from "../../lib/system-columns";
 import { SYSTEM_RESOURCES } from "../../schemas/_zod/rbac";
 import {
   type BaseValidationError,
@@ -181,9 +182,6 @@ const RESERVED_SLUGS_SET: Set<string> = new Set<string>([
 // Components embed in JSON and carry neither column, so they may use both names
 // freely. Nested repeater/group fields are stored inside JSON, not as table
 // columns, so the reservation applies to the top level only.
-const COLLECTION_RESERVED_FIELD_NAMES: ReadonlySet<string> = new Set(
-  reservedSystemFieldNames("collectionConfig")
-);
 
 // ============================================================
 // Index Validation (collection-specific)
@@ -519,16 +517,29 @@ function validateFields(
     return;
   }
 
-  // Block the injected owner column at the top level before per-field
-  // validation. Nested fields are validated recursively inside
-  // validateFieldsArray and are intentionally exempt (JSON-stored, no column).
+  // Block names that become a column the table already carries. Such a field is emitted alongside
+  // the injected one, so the table declares the column twice and the database refuses the
+  // statement — a collection carrying one could never have been created.
+  //
+  // Compared as the PHYSICAL column, through the same conversion schema generation uses, because a
+  // field name reaches its column that way: `createdAt`, `created_at` and `CreatedAt` all arrive at
+  // `created_at`, and a set of literal spellings can only hold the ones somebody listed.
+  //
+  // `title`, `slug` and `status` are deliberately absent. The first two step aside for an author's
+  // own field by design, and a `status` field is accepted by the lifecycle rather than duplicated;
+  // reserving any of them would refuse a configuration that works today.
+  //
+  // Nested fields are validated recursively inside validateFieldsArray and are intentionally
+  // exempt: they are stored inside JSON and never become columns of their own.
   fields.forEach((field, index) => {
     if (!field || typeof field !== "object") return;
     const name = (field as Record<string, unknown>).name;
-    if (typeof name === "string" && COLLECTION_RESERVED_FIELD_NAMES.has(name)) {
+    if (typeof name !== "string") return;
+    const column = toSnakeCase(name);
+    if (isReservedSystemColumn(column, "collectionConfig")) {
       errors.push({
         path: `${path}[${index}].name`,
-        message: `Field name '${name}' is reserved for a system column`,
+        message: `Field name '${name}' is reserved: it becomes the system column '${column}'`,
         code: "FIELD_NAME_RESERVED",
       });
     }

--- a/packages/nextly/src/lib/__tests__/system-columns.test.ts
+++ b/packages/nextly/src/lib/__tests__/system-columns.test.ts
@@ -21,7 +21,9 @@ import {
 } from "../../domains/schema/services/field-column-descriptor";
 import { generateRuntimeSchema } from "../../domains/schema/services/runtime-schema-generator";
 import { SYSTEM_SCHEMA_VERSION } from "../../domains/schema/services/schema-hash";
+import { validateCollectionConfig } from "../../collections/config/validate-config";
 import { validateFieldGroupConfig } from "../../field-groups/config/validate-field-group";
+import { validateSingleConfig } from "../../singles/config/validate-single";
 import type { FieldGroupConfig } from "../../field-groups/config/types";
 import { uiSchemaFieldSchema } from "../../schemas/_zod/ui-schema";
 
@@ -134,9 +136,16 @@ describe("reservation projections", () => {
     );
   });
 
-  it("refuses the owner column and the marker in a code-first collection", () => {
+  it("refuses every unconditionally injected column in a code-first collection", () => {
+    // Not `title`, `slug` or `status`: those step aside for an author's own field, or are taken up
+    // by the lifecycle, so declaring one is supported rather than a collision.
     expect(sorted(reservedSystemFieldNames("collectionConfig"))).toEqual(
       sorted([
+        "id",
+        "created_at",
+        "createdAt",
+        "updated_at",
+        "updatedAt",
         "created_by",
         "createdBy",
         "first_published_at",
@@ -145,10 +154,18 @@ describe("reservation projections", () => {
     );
   });
 
-  it("refuses only the marker in a code-first single", () => {
-    // A single gets no owner column, so `created_by` stays a legal field name there.
+  it("refuses the same set in a code-first single, minus the owner column", () => {
+    // A single's table gets no owner column, so `created_by` stays a legal field name there.
     expect(sorted(reservedSystemFieldNames("singleConfig"))).toEqual(
-      sorted(["first_published_at", "firstPublishedAt"])
+      sorted([
+        "id",
+        "created_at",
+        "createdAt",
+        "updated_at",
+        "updatedAt",
+        "first_published_at",
+        "firstPublishedAt",
+      ])
     );
   });
 
@@ -508,6 +525,76 @@ describe("the validators actually refuse what the projection lists", () => {
     // reports the collision where the name is chosen instead of as a database error.
     expect(fieldNameSchema.safeParse("createdAt").success).toBe(false);
     expect(fieldNameSchema.safeParse("updatedAt").success).toBe(false);
+  });
+});
+
+describe("code-first collections and singles", () => {
+  // These validators run when the config is read, which is at startup. What they refuse was
+  // measured against the schema pipeline rather than chosen: a name is reserved exactly when the
+  // desired table or the runtime schema would end up with the column twice.
+
+  const collection = (name: string) =>
+    (
+      validateCollectionConfig({
+        slug: "probe",
+        fields: [{ name, type: "text" }],
+      } as never).errors ?? []
+    ).filter(e => e.code === "FIELD_NAME_RESERVED");
+
+  const single = (name: string) =>
+    (
+      validateSingleConfig({
+        slug: "probe",
+        fields: [{ name, type: "text" }],
+      } as never).errors ?? []
+    ).filter(e => e.code === "FIELD_NAME_RESERVED");
+
+  it("refuses every spelling that becomes an injected column", () => {
+    // Through the conversion, so a casing nobody listed is caught too.
+    for (const name of [
+      "id",
+      "Id",
+      "createdAt",
+      "created_at",
+      "CreatedAt",
+      "updatedAt",
+      "updated_at",
+      "firstPublishedAt",
+    ]) {
+      expect({ [`collection.${name}`]: collection(name).length }).toEqual({
+        [`collection.${name}`]: 1,
+      });
+      expect({ [`single.${name}`]: single(name).length }).toEqual({
+        [`single.${name}`]: 1,
+      });
+    }
+  });
+
+  it("refuses the owner column on a collection and allows it on a single", () => {
+    // The case `appliesTo` exists for: a single's table has no owner column, so the name is an
+    // ordinary one there. Measured — a single declaring it produces no duplicate.
+    for (const name of ["createdBy", "created_by"]) {
+      expect({ [`collection.${name}`]: collection(name).length }).toEqual({
+        [`collection.${name}`]: 1,
+      });
+      expect({ [`single.${name}`]: single(name).length }).toEqual({
+        [`single.${name}`]: 0,
+      });
+    }
+  });
+
+  it("still accepts the columns an author is meant to be able to declare", () => {
+    // `title` and `slug` step aside for an author's own field by design, and a `status` field is
+    // taken up by the lifecycle rather than duplicated. Reserving any of them would refuse a
+    // configuration that works, which is the failure mode this whole change has to avoid.
+    for (const name of ["title", "slug", "status", "headline", "publishedAt"]) {
+      expect({ [`collection.${name}`]: collection(name).length }).toEqual({
+        [`collection.${name}`]: 0,
+      });
+      expect({ [`single.${name}`]: single(name).length }).toEqual({
+        [`single.${name}`]: 0,
+      });
+    }
   });
 });
 

--- a/packages/nextly/src/lib/system-columns.ts
+++ b/packages/nextly/src/lib/system-columns.ts
@@ -196,7 +196,13 @@ export const SYSTEM_COLUMNS: readonly SystemColumnDeclaration[] = [
     writableByClient: false,
     publishedUnderCamelName: false,
     strippedFromResponses: false,
-    reservedIn: ["builder", "fieldGroupConfig", "uiSchema"],
+    reservedIn: [
+      "builder",
+      "collectionConfig",
+      "singleConfig",
+      "fieldGroupConfig",
+      "uiSchema",
+    ],
     shape: {
       postgresql: { kind: "text", nullable: false, primaryKey: true },
       mysql: {
@@ -251,7 +257,13 @@ export const SYSTEM_COLUMNS: readonly SystemColumnDeclaration[] = [
     writableByClient: false,
     publishedUnderCamelName: true,
     strippedFromResponses: false,
-    reservedIn: ["builder", "fieldGroupConfig", "uiSchema"],
+    reservedIn: [
+      "builder",
+      "collectionConfig",
+      "singleConfig",
+      "fieldGroupConfig",
+      "uiSchema",
+    ],
     shape: {
       postgresql: {
         kind: "timestamp",
@@ -270,7 +282,13 @@ export const SYSTEM_COLUMNS: readonly SystemColumnDeclaration[] = [
     writableByClient: false,
     publishedUnderCamelName: true,
     strippedFromResponses: false,
-    reservedIn: ["builder", "fieldGroupConfig", "uiSchema"],
+    reservedIn: [
+      "builder",
+      "collectionConfig",
+      "singleConfig",
+      "fieldGroupConfig",
+      "uiSchema",
+    ],
     shape: {
       postgresql: {
         kind: "timestamp",

--- a/packages/nextly/src/singles/config/validate-single.ts
+++ b/packages/nextly/src/singles/config/validate-single.ts
@@ -23,7 +23,8 @@
 
 import { RESERVED_SLUGS } from "../../collections/config/validate-config";
 import { isPluginFieldTypeOnSurface } from "../../domains/schema/field-types/field-type-registry";
-import { reservedSystemFieldNames } from "../../lib/system-columns";
+import { toSnakeCase } from "../../domains/schema/services/field-column-descriptor";
+import { isReservedSystemColumn } from "../../lib/system-columns";
 import { SYSTEM_RESOURCES } from "../../schemas/_zod/rbac";
 import {
   type BaseValidationError,
@@ -267,9 +268,6 @@ function validateField(
 // owner column, so unlike a collection only the first-publication marker is
 // reserved here — which is why this check had to be added rather than extended:
 // until the marker reached a Single's table there was nothing to collide with.
-const SINGLE_RESERVED_FIELD_NAMES: ReadonlySet<string> = new Set(
-  reservedSystemFieldNames("singleConfig")
-);
 
 /**
  * Validate an array of field configurations.
@@ -321,10 +319,12 @@ function validateFields(
   fields.forEach((field, index) => {
     if (!field || typeof field !== "object") return;
     const name = (field as Record<string, unknown>).name;
-    if (typeof name === "string" && SINGLE_RESERVED_FIELD_NAMES.has(name)) {
+    if (typeof name !== "string") return;
+    const column = toSnakeCase(name);
+    if (isReservedSystemColumn(column, "singleConfig")) {
       errors.push({
         path: `${path}[${index}].name`,
-        message: `Field name '${name}' is reserved for a system column`,
+        message: `Field name '${name}' is reserved: it becomes the system column '${column}'`,
         code: "FIELD_NAME_RESERVED",
       });
     }


### PR DESCRIPTION
Closes Part A of task `113-reservation-scopes-narrower-than-collisions.md`, the last item in this program. **This one changes behaviour for existing apps** — the decision is spelled out below so it can be declined on its merits.

## What was wrong

The Schema Builder and both field-group validators already refuse a field name that becomes a column the table injects. A **code-first** collection or single did not. It accepted `id`, `createdAt`, `created_at`, `updatedAt`, `updated_at`, and the collision surfaced later as a table declaring the same column twice — which the database rejects.

So the supported TypeScript path was the one left unguarded, which is the same shape codex flagged twice on #496 and #499.

## Which names to reserve was measured, not chosen

Every candidate was run through **both** the desired-table builder (what the diff wants) and the runtime schema generator (what queries are built from), on collections and singles, and reserved only where one of them ended up with the column twice:

| name | collection | single |
|---|---|---|
| `id` / `Id` | duplicate | duplicate |
| `createdAt` / `created_at` / `CreatedAt` | duplicate | duplicate |
| `updatedAt` / `updated_at` | duplicate | duplicate |
| `createdBy` / `created_by` | duplicate | **clean** |
| `firstPublishedAt` | duplicate | duplicate |
| `title`, `slug`, `status`, `headline` | **clean** | **clean** |

Two results are the reason this was measured rather than reasoned:

- **`created_by` is clean on a single.** A single's table has no owner column, so the name is an ordinary one there — `appliesTo` already expressed that, and the projection gets it right without a special case.
- **`title`, `slug` and `status` are clean everywhere.** The first two step aside for an author's own field by design, and a `status` field is taken up by the lifecycle rather than duplicated. Reserving any of them would have refused a configuration that works, which is precisely the failure this change has to avoid.

Names are compared as the **physical column**, through the conversion schema generation uses, so `CreatedAt` is caught alongside `createdAt` without anyone having listed it.

## The behaviour change, stated plainly

These validators run when the config is read, which is **at startup**. An app whose collection declares one of these names will now fail to start, where before it failed during schema application.

That app could not have had a working table either way — creating it fails in the database. So this moves a raw SQL error at migration time to a startup error naming the column it collides with. My recommendation is that this is the right trade, but it is a real change in when the failure lands, and it is reasonable to prefer warn-then-refuse instead. If you would rather have that, say so and I will convert it — the reservation set and the tests stay as they are; only the reporting changes.

## Verification

Falsifications, each failing for its own reason:

| reverted | result |
|---|---|
| the code-first surfaces on the declarations | 3 tests fail |
| comparing the raw name instead of the column | 2 tests fail (`CreatedAt`, `createdBy`) |

Three test groups: the widened pinned sets, the accept/refuse matrix through the **real validators**, and an explicit test that `title`/`slug`/`status` are still accepted — the case that would otherwise break silently.

**Three dialect legs, one at a time, databases recreated before each:**

| leg | passed | failed |
|---|---|---|
| sqlite | 1043 | 0 |
| postgres17 | 1195 | 0 |
| mysql | 1125 | 0 |

Full `nextly` unit suite against the `origin/main` baseline measured in this tree: **37 failing files both ways, no new failures.** `check-types` (source and tests) and `lint` clean.

## Left for a follow-up, deliberately

`Status` (capitalised) produces a duplicate in the **runtime schema only**, not in the desired table — the generators dedupe by field name in one place and by column name in the other. Reserving `status` would break the legitimate lowercase case, so the fix belongs in the generator, not here. Worth filing separately.
