### PR TITLE
fix(nextly): keep a raw driver failure as the cause a caller receives

### DIFF
--- a/.changeset/raw-error-provenance.md
+++ b/.changeset/raw-error-provenance.md
@@ -32,3 +32,15 @@ produces — dropped it too.
 
 `NextlyError.notFound`, `.forbidden` and `.conflict` accept a `cause` alongside `logContext`,
 matching `.internal`.
+
+One place now builds the error response body, so plugin routes answer with what every other
+route answers with. Three consequences for a plugin route:
+
+- Failures now carry `_devDiagnostics` in development, which this surface never had.
+- A handler that throws a non-`NextlyError` still answers 500, but the thrown error is now
+  chained onto it instead of discarded.
+- A 401 or 403 now returns the canonical `{ error: { code, message, requestId } }` body with
+  `application/problem+json`, matching the rest of the API. It previously returned the legacy
+  `{ data: { ... } }` body with `application/json`, so a single plugin route answered rejected
+  requests and failing handlers in two different shapes. A client reading a plugin route's
+  auth-failure body needs updating; one reading the status or a handler failure does not.

--- a/.changeset/raw-error-provenance.md
+++ b/.changeset/raw-error-provenance.md
@@ -22,6 +22,13 @@
 "@nextlyhq/tsconfig": patch
 ---
 
-A read that fails with a raw database error now chains that error onto what the caller
-receives. Only typed failures carried their origin before, so a connection drop or a constraint
-rejection on find, findByID or count arrived with nothing naming what actually went wrong.
+A failure now chains the error it actually came from onto what the caller receives, through
+every boundary that rebuilds one: REST routes, the Direct API, the singles route, the
+plugin-facing collection facade, the bulk-by-query paths and the version writes. Previously
+only typed failures carried their origin, and only on the Direct API, so a connection drop or
+a constraint rejection arrived with nothing naming what actually went wrong. The status-derived
+rebuilds — a code-less 404, 403, 409 or 500, which is exactly what a raw driver rejection
+produces — dropped it too.
+
+`NextlyError.notFound`, `.forbidden` and `.conflict` accept a `cause` alongside `logContext`,
+matching `.internal`.

--- a/.changeset/raw-error-provenance.md
+++ b/.changeset/raw-error-provenance.md
@@ -1,0 +1,27 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+A read that fails with a raw database error now chains that error onto what the caller
+receives. Only typed failures carried their origin before, so a connection drop or a constraint
+rejection on find, findByID or count arrived with nothing naming what actually went wrong.

--- a/packages/nextly/src/api/__tests__/dev-error-diagnostics.test.ts
+++ b/packages/nextly/src/api/__tests__/dev-error-diagnostics.test.ts
@@ -13,7 +13,7 @@
 
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { typedErrorEnvelopeFields } from "../../errors/from-service-envelope";
+import { errorEnvelopeFields } from "../../errors/from-service-envelope";
 import { NextlyError } from "../../errors/nextly-error";
 import {
   currentFlattenedErrors,
@@ -106,11 +106,11 @@ describe("development-only error diagnostics", () => {
 });
 
 describe("diagnostics survive every flattening path", () => {
-  it("records from typedErrorEnvelopeFields", async () => {
+  it("records from errorEnvelopeFields", async () => {
     // That function IS the flattening for the paths that use it, so it records
     // rather than each of its call sites remembering to.
     const { result } = await withSideEffectWarnings(async () => {
-      typedErrorEnvelopeFields(
+      errorEnvelopeFields(
         NextlyError.conflict({ logContext: { constraint: "posts_slug_key" } })
       );
       return currentFlattenedErrors();
@@ -123,10 +123,11 @@ describe("diagnostics survive every flattening path", () => {
   });
 
   it("records nothing for a value that is not a typed error", async () => {
-    // The control: it returns null for those, and recording one would put a
-    // fabricated entry in the operator log.
+    // The control: an untyped error still leaves with its provenance, but it
+    // is not RECORDED — the operator log is for typed failures, and an entry
+    // fabricated from a bare Error would carry no code to act on.
     const { result } = await withSideEffectWarnings(async () => {
-      typedErrorEnvelopeFields(new Error("plain"));
+      errorEnvelopeFields(new Error("plain"));
       return currentFlattenedErrors();
     });
 

--- a/packages/nextly/src/api/__tests__/error-response-owner.test.ts
+++ b/packages/nextly/src/api/__tests__/error-response-owner.test.ts
@@ -1,0 +1,176 @@
+/**
+ * One owner builds the error body, so every boundary answers with the same one.
+ *
+ * Two places used to build it. They agreed on the status and the content type
+ * and diverged on everything either had gained since, which is why a plugin
+ * route was the only surface with no development diagnostics and why a rejected
+ * request and a failing handler on that same route came back in two different
+ * envelopes.
+ *
+ * These compare the boundaries against each other rather than against a fixed
+ * expected body: a shared owner that both call is the property under test, and
+ * a literal would keep passing if one of them stopped calling it and happened
+ * to reproduce today's shape.
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { NextlyError } from "../../errors/nextly-error";
+import { runPluginRoute } from "../../plugins/routes/dispatch";
+import type { PluginContext } from "../../plugins/plugin-context";
+import type { RouteMatch } from "../../plugins/routes/route-registry";
+import type { PluginRoute } from "../../plugins/routes/route-types";
+import { withErrorHandler } from "../with-error-handler";
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+const baseCtx = {
+  self: { name: "@a/x", collections: {}, singles: {} },
+  logger: { info() {}, warn() {}, error() {} },
+} as unknown as PluginContext;
+
+/** The same failure, thrown from a plugin route. */
+function pluginRouteThrowing(thrown: unknown): RouteMatch {
+  const route: PluginRoute = {
+    method: "GET",
+    path: "/r",
+    public: true,
+    handler: () => {
+      throw thrown;
+    },
+  } as PluginRoute;
+  return { pluginName: "@a/x", route, baseCtx, params: {} };
+}
+
+function request(): Request {
+  return new Request("http://x/api/plugins/@a/x/r");
+}
+
+/** The same failure, thrown from an ordinary route handler. */
+function ordinaryRouteThrowing(thrown: unknown): Promise<Response> {
+  return withErrorHandler(async (_req: Request) => {
+    throw thrown;
+  })(request());
+}
+
+function failure(): NextlyError {
+  return NextlyError.internal({
+    cause: new Error("driver: connection terminated"),
+    logContext: { table: "submissions" },
+  });
+}
+
+describe("both boundaries answer with the same error body", () => {
+  it("agrees on the envelope and the content type", async () => {
+    const [plugin, ordinary] = await Promise.all([
+      runPluginRoute(request(), pluginRouteThrowing(failure())),
+      ordinaryRouteThrowing(failure()),
+    ]);
+
+    expect(plugin.status).toBe(ordinary.status);
+    expect(plugin.headers.get("content-type")).toBe(
+      ordinary.headers.get("content-type")
+    );
+
+    const [pluginBody, ordinaryBody] = (await Promise.all([
+      plugin.json(),
+      ordinary.json(),
+    ])) as Array<{ error: Record<string, unknown> }>;
+
+    // The request id differs per request by design, so the comparison is over
+    // the keys and the values that must not.
+    expect(Object.keys(pluginBody.error).sort()).toEqual(
+      Object.keys(ordinaryBody.error).sort()
+    );
+    expect(pluginBody.error.code).toBe(ordinaryBody.error.code);
+    expect(pluginBody.error.message).toBe(ordinaryBody.error.message);
+  });
+
+  it("agrees on the development diagnostics, which one of them never had", async () => {
+    vi.stubEnv("NODE_ENV", "development");
+    vi.stubEnv("NEXTLY_DEV_DIAGNOSTICS", "1");
+
+    const [plugin, ordinary] = await Promise.all([
+      runPluginRoute(request(), pluginRouteThrowing(failure())),
+      ordinaryRouteThrowing(failure()),
+    ]);
+    const [pluginBody, ordinaryBody] = (await Promise.all([
+      plugin.json(),
+      ordinary.json(),
+    ])) as Array<{ error: Record<string, unknown> }>;
+
+    expect(pluginBody.error._devDiagnostics).toEqual(
+      ordinaryBody.error._devDiagnostics
+    );
+    expect(pluginBody.error._devDiagnostics).toMatchObject({
+      logContext: { table: "submissions" },
+      cause: "driver: connection terminated",
+    });
+  });
+
+  it("withholds them from both under production", async () => {
+    // The gate belongs to the owner now, so a boundary cannot opt out of it by
+    // building its own body — and cannot opt INTO it either.
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("NEXTLY_DEV_DIAGNOSTICS", "1");
+
+    const [plugin, ordinary] = await Promise.all([
+      runPluginRoute(request(), pluginRouteThrowing(failure())),
+      ordinaryRouteThrowing(failure()),
+    ]);
+
+    for (const response of [plugin, ordinary]) {
+      const serialized = JSON.stringify(await response.json());
+      expect(serialized).not.toContain("connection terminated");
+      expect(serialized).not.toContain("submissions");
+    }
+  });
+
+  it("sets the request id header on both", async () => {
+    // The plugin boundary has no later wrapper to add it, so the owner does.
+    const [plugin, ordinary] = await Promise.all([
+      runPluginRoute(request(), pluginRouteThrowing(failure())),
+      ordinaryRouteThrowing(failure()),
+    ]);
+
+    expect(plugin.headers.get("x-request-id")).toBeTruthy();
+    expect(ordinary.headers.get("x-request-id")).toBeTruthy();
+  });
+});
+
+describe("a plugin route keeps the failure it could not type", () => {
+  it("chains a thrown non-NextlyError rather than discarding it", async () => {
+    // The generic 500 exists so a handler failure cannot take the server down.
+    // Discarding the thrown value along with it left the one failure carrying
+    // no typed detail as the one failure carrying no detail at all.
+    vi.stubEnv("NODE_ENV", "development");
+    vi.stubEnv("NEXTLY_DEV_DIAGNOSTICS", "1");
+
+    const response = await runPluginRoute(
+      request(),
+      pluginRouteThrowing(new Error("plugin exploded"))
+    );
+    const body = (await response.json()) as {
+      error: { _devDiagnostics?: { cause?: string } };
+    };
+
+    expect(response.status).toBe(500);
+    expect(body.error._devDiagnostics?.cause).toBe("plugin exploded");
+  });
+
+  it("still answers when a non-Error is thrown", async () => {
+    // A handler can throw a string or an object. The chain has nothing to take
+    // from those, and the response must not depend on it having something.
+    const response = await runPluginRoute(
+      request(),
+      pluginRouteThrowing("just a string")
+    );
+
+    expect(response.status).toBe(500);
+    expect((await response.json()) as unknown).toMatchObject({
+      error: { code: "INTERNAL_ERROR" },
+    });
+  });
+});

--- a/packages/nextly/src/api/error-response.ts
+++ b/packages/nextly/src/api/error-response.ts
@@ -1,0 +1,180 @@
+/**
+ * Building the finished error `Response` a caller receives.
+ *
+ * One owner, because the body is not only `toResponseJSON()`. It also carries
+ * the development-only detail, the `Retry-After` a rate limit needs, the
+ * problem+json content type and the request id an operator joins on — and a
+ * second boundary rebuilding that by hand agrees on the parts it remembered
+ * and differs on the rest. That is what happened: plugin routes hand-built the
+ * body and so answered without the diagnostics every other route carries.
+ *
+ * A boundary composes this rather than being handed a finished response to
+ * amend. Rewriting a body that is already final means parsing what was just
+ * serialized and re-serializing it, which is how a diagnostic aid ends up able
+ * to fail the request it describes.
+ *
+ * @module api/error-response
+ */
+
+import type { NextlyError } from "../errors/nextly-error";
+
+/**
+ * A value that is safe to put on a response body, or undefined.
+ *
+ * `logContext` is whatever a thrower attached, so it can hold a cycle, a
+ * BigInt, or anything else `JSON.stringify` refuses. Serializing the response
+ * happens after this, inside the error path, so a value that throws there
+ * would reject the request instead of returning the error the handler built --
+ * turning a diagnostic aid into a failure worse than the one it describes.
+ *
+ * Round-tripped rather than inspected: that is the same operation the response
+ * will perform, so it answers the exact question rather than an approximation
+ * of it.
+ */
+function jsonSafe(value: unknown): unknown {
+  if (value === undefined) return undefined;
+  try {
+    return JSON.parse(JSON.stringify(value)) as unknown;
+  } catch {
+    return "[unserializable]";
+  }
+}
+
+/**
+ * Whether an error response may carry the detail the public shape withholds.
+ *
+ * Two signals, both required. `NODE_ENV` is not sufficient on its own because
+ * this package is published pre-built and app builds keep it external, so the
+ * check runs at runtime and a misconfigured production deployment would
+ * satisfy it. `NEXTLY_DEV_DIAGNOSTICS` is named for exactly one purpose, so
+ * nothing sets it incidentally.
+ *
+ * Read per call rather than cached, so a test can exercise both sides and so a
+ * process cannot latch the permissive answer from however it happened to start.
+ */
+export function devDiagnosticsEnabled(): boolean {
+  return (
+    process.env.NODE_ENV === "development" &&
+    process.env.NEXTLY_DEV_DIAGNOSTICS === "1"
+  );
+}
+
+/**
+ * The detail an author cannot see from a public error response.
+ *
+ * Built only for a development response. `logContext` and `cause` are what the
+ * public shape deliberately withholds, so this exists to shorten the loop
+ * between a failure and its cause while writing code -- not to be a second
+ * error surface. A cause is reduced to its message: a serialized stack is
+ * large, and the log already has the whole thing against the same request id.
+ *
+ * Returns undefined when there is nothing to add, so an ordinary development
+ * error response is the same shape a production one is.
+ */
+function buildDevDiagnostics(
+  thrown: NextlyError,
+  flattened: readonly NextlyError[]
+): Record<string, unknown> | undefined {
+  const causeMessage = (error: NextlyError): string | undefined =>
+    error.cause instanceof Error ? error.cause.message : undefined;
+
+  const detail: Record<string, unknown> = {};
+  const context = jsonSafe(thrown.logContext);
+  if (context !== undefined) detail.logContext = context;
+  const thrownCause = causeMessage(thrown);
+  if (thrownCause !== undefined) detail.cause = thrownCause;
+
+  // Errors the envelope flattened before this frame. Without them the response
+  // names only the boundary's reconstruction, which is the defect that makes
+  // every unexpected failure look alike.
+  const earlier = flattened.map(error => ({
+    code: error.code,
+    ...(jsonSafe(error.logContext) !== undefined
+      ? { logContext: jsonSafe(error.logContext) }
+      : {}),
+    ...(causeMessage(error) !== undefined
+      ? { cause: causeMessage(error) }
+      : {}),
+  }));
+  if (earlier.length > 0) detail.flattened = earlier;
+
+  return Object.keys(detail).length > 0 ? detail : undefined;
+}
+
+/** What a boundary supplies beyond the error itself. */
+export interface ErrorResponseOptions {
+  /** The id the caller sees and an operator joins the log on. */
+  requestId: string;
+  /**
+   * Public message for an `INTERNAL_ERROR`, when the boundary was configured
+   * with one. Applied at the wire-format step so the error's own identity is
+   * unchanged and only what leaves differs.
+   */
+  internalMessage?: string;
+  /**
+   * Errors flattened earlier in this request. Passed in rather than read from
+   * the request scope here: the scope closes when the handler returns, so the
+   * boundary is the only frame that can still see it.
+   */
+  flattened?: readonly NextlyError[];
+}
+
+/**
+ * Serialize an error into the response a caller receives.
+ *
+ * Sets the request id here rather than leaving it to a later wrapper, so a
+ * boundary that has no such wrapper is not the one that answers without it.
+ */
+export function buildErrorResponse(
+  error: NextlyError,
+  options: ErrorResponseOptions
+): Response {
+  const responseJson = error.toResponseJSON(options.requestId);
+  if (
+    error.code === "INTERNAL_ERROR" &&
+    options.internalMessage !== undefined
+  ) {
+    responseJson.message = options.internalMessage;
+  }
+
+  // Development-only diagnostics, gated on TWO independent signals.
+  //
+  // `nextly` ships as a pre-built package and app builds keep it external, so
+  // nothing rewrites this file: `NODE_ENV` is read at runtime, and a production
+  // deployment started with the wrong value would otherwise disclose the detail
+  // the public shape exists to withhold. So the gate also requires an
+  // explicitly named opt-in that nothing sets by accident, and neither signal
+  // alone is enough.
+  //
+  // Same shape as the dev auto-login, which is the more dangerous feature of
+  // the two and is already guarded this way: an explicit opt-in plus a
+  // production block, rather than an environment name on its own.
+  if (devDiagnosticsEnabled()) {
+    const devDetail = buildDevDiagnostics(error, options.flattened ?? []);
+    if (devDetail) {
+      (responseJson as Record<string, unknown>)._devDiagnostics = devDetail;
+    }
+  }
+
+  const responseHeaders: Record<string, string> = {
+    "content-type": "application/problem+json",
+    "x-request-id": options.requestId,
+  };
+  // Type-narrow on shape rather than cast -- defends against future
+  // PublicData variants.
+  if (error.code === "RATE_LIMITED") {
+    const data = error.publicData;
+    if (
+      data &&
+      "retryAfterSeconds" in data &&
+      typeof data.retryAfterSeconds === "number"
+    ) {
+      responseHeaders["retry-after"] = String(data.retryAfterSeconds);
+    }
+  }
+
+  return new Response(JSON.stringify({ error: responseJson }), {
+    status: error.statusCode,
+    headers: responseHeaders,
+  });
+}

--- a/packages/nextly/src/api/with-error-handler.ts
+++ b/packages/nextly/src/api/with-error-handler.ts
@@ -28,6 +28,7 @@ import {
 import { getNextlyLogger } from "../observability/logger";
 import { getGlobalOnError, type OnErrorHook } from "../observability/on-error";
 
+import { buildErrorResponse } from "./error-response";
 import { readOrGenerateRequestId, withRequestIdHeader } from "./request-id";
 
 type UnstableRethrow = (err: unknown) => void;
@@ -71,91 +72,6 @@ const DEFAULT_INTERNAL_MESSAGE = "An unexpected error occurred.";
  * Generic over `TArgs` so it transparently supports both static handlers
  * (`(req)`) and dynamic-segment handlers (`(req, { params })`).
  */
-
-/**
- * The detail an author cannot see from a public error response.
- *
- * Built only for a development response. `logContext` and `cause` are what the
- * public shape deliberately withholds, so this exists to shorten the loop
- * between a failure and its cause while writing code -- not to be a second
- * error surface. A cause is reduced to its message: a serialized stack is
- * large, and the log already has the whole thing against the same request id.
- *
- * Returns undefined when there is nothing to add, so an ordinary development
- * error response is the same shape a production one is.
- */
-
-/**
- * Whether an error response may carry the detail the public shape withholds.
- *
- * Two signals, both required. `NODE_ENV` is not sufficient on its own because
- * this package is published pre-built and app builds keep it external, so the
- * check runs at runtime and a misconfigured production deployment would
- * satisfy it. `NEXTLY_DEV_DIAGNOSTICS` is named for exactly one purpose, so
- * nothing sets it incidentally.
- *
- * Read per call rather than cached, so a test can exercise both sides and so a
- * process cannot latch the permissive answer from however it happened to start.
- */
-
-/**
- * A value that is safe to put on a response body, or undefined.
- *
- * `logContext` is whatever a thrower attached, so it can hold a cycle, a
- * BigInt, or anything else `JSON.stringify` refuses. Serializing the response
- * happens after this, inside the error path, so a value that throws there
- * would reject the request instead of returning the error the handler built --
- * turning a diagnostic aid into a failure worse than the one it describes.
- *
- * Round-tripped rather than inspected: that is the same operation the response
- * will perform, so it answers the exact question rather than an approximation
- * of it.
- */
-function jsonSafe(value: unknown): unknown {
-  if (value === undefined) return undefined;
-  try {
-    return JSON.parse(JSON.stringify(value)) as unknown;
-  } catch {
-    return "[unserializable]";
-  }
-}
-
-function devDiagnosticsEnabled(): boolean {
-  return (
-    process.env.NODE_ENV === "development" &&
-    process.env.NEXTLY_DEV_DIAGNOSTICS === "1"
-  );
-}
-
-function buildDevDiagnostics(
-  thrown: NextlyError,
-  flattened: readonly NextlyError[]
-): Record<string, unknown> | undefined {
-  const causeMessage = (error: NextlyError): string | undefined =>
-    error.cause instanceof Error ? error.cause.message : undefined;
-
-  const detail: Record<string, unknown> = {};
-  const context = jsonSafe(thrown.logContext);
-  if (context !== undefined) detail.logContext = context;
-  const thrownCause = causeMessage(thrown);
-  if (thrownCause !== undefined) detail.cause = thrownCause;
-
-  // Errors the envelope flattened before this frame. Without them the response
-  // names only the boundary's reconstruction, which is the defect that makes
-  // every unexpected failure look alike.
-  const earlier = flattened.map(error => ({
-    code: error.code,
-    ...(jsonSafe(error.logContext) !== undefined
-      ? { logContext: jsonSafe(error.logContext) }
-      : {}),
-    ...(causeMessage(error) !== undefined
-      ? { cause: causeMessage(error) }
-      : {}),
-  }));
-  if (earlier.length > 0) detail.flattened = earlier;
-
-  return Object.keys(detail).length > 0 ? detail : undefined;
-}
 
 export function withErrorHandler<TArgs extends unknown[]>(
   handler: (...args: TArgs) => Promise<Response>,
@@ -281,55 +197,20 @@ export function withErrorHandler<TArgs extends unknown[]>(
         }
       }
 
-      // (5) Serialize. For INTERNAL_ERROR with a custom internalMessage option,
-      // override the public message at the wire-format step.
-      const responseJson = nextlyErr.toResponseJSON(requestId);
-      if (
-        nextlyErr.code === "INTERNAL_ERROR" &&
-        options?.internalErrorMessage !== undefined
-      ) {
-        responseJson.message = internalMessage;
-      }
-      // Development-only diagnostics, gated on TWO independent signals.
+      // (5) Serialize. The body, its development-only detail, `Retry-After`
+      // and the content type belong to the shared builder, so a route reached
+      // through this wrapper and one reached through the plugin dispatcher
+      // answer with the same thing.
       //
-      // `nextly` ships as a pre-built package and app builds keep it external,
-      // so nothing rewrites this file: `NODE_ENV` is read at runtime, and a
-      // production deployment started with the wrong value would otherwise
-      // disclose the detail the public shape exists to withhold. So the gate
-      // also requires an explicitly named opt-in that nothing sets by
-      // accident, and neither signal alone is enough.
-      //
-      // Same shape as the dev auto-login, which is the more dangerous feature
-      // of the two and is already guarded this way: an explicit opt-in plus a
-      // production block, rather than an environment name on its own.
-      //
-      // Carries the thrown error's own context and anything the envelope
-      // flattened on the way here, which is what an author cannot otherwise
-      // see without reading the server log.
-      if (devDiagnosticsEnabled()) {
-        const devDetail = buildDevDiagnostics(nextlyErr, flattenedInRequest);
-        if (devDetail) {
-          (responseJson as Record<string, unknown>)._devDiagnostics = devDetail;
-        }
-      }
-      const responseHeaders: Record<string, string> = {
-        "content-type": "application/problem+json",
-      };
-      // Set Retry-After for rate-limited responses. Type-narrow on shape
-      // rather than cast — defends against future PublicData variants.
-      if (nextlyErr.code === "RATE_LIMITED") {
-        const data = nextlyErr.publicData;
-        if (
-          data &&
-          "retryAfterSeconds" in data &&
-          typeof data.retryAfterSeconds === "number"
-        ) {
-          responseHeaders["retry-after"] = String(data.retryAfterSeconds);
-        }
-      }
-      response = new Response(JSON.stringify({ error: responseJson }), {
-        status: nextlyErr.statusCode,
-        headers: responseHeaders,
+      // `flattenedInRequest` is passed rather than read there: the scope it
+      // comes from closed when the handler returned, so this frame is the last
+      // one that can still see it.
+      response = buildErrorResponse(nextlyErr, {
+        requestId,
+        ...(options?.internalErrorMessage !== undefined
+          ? { internalMessage }
+          : {}),
+        flattened: flattenedInRequest,
       });
     }
 

--- a/packages/nextly/src/direct-api/namespaces/helpers.ts
+++ b/packages/nextly/src/direct-api/namespaces/helpers.ts
@@ -11,7 +11,6 @@
 
 import { errorFromServiceEnvelope } from "../../errors/from-service-envelope";
 import { NextlyError } from "../../errors/nextly-error";
-import { originalErrorOf } from "../../errors/original-error";
 import type { RequestContext } from "../../shared/types/index";
 import type {
   DirectAPIConfig,
@@ -90,13 +89,13 @@ export function createErrorFromResult(result: ServiceResultLike): NextlyError {
   // The shared converter, so a Direct API caller and a REST caller are handed
   // the same error for the same failure. Its code-keyed rebuild carries the
   // message key and public data that this boundary used to drop.
+  //
   // The rebuilt error is right for the caller and blind for whoever debugs it:
   // the driver error underneath and the identifiers the thrower attached were
-  // dropped on the way through the public envelope. Chaining the original as
-  // `cause` restores them through the standard mechanism, so an in-process
-  // caller's stack reads back to the real failure. Only ever the object this
-  // envelope actually came from — never a lookup that could pick a different
-  // error that happens to share a code.
+  // dropped on the way through the public envelope. The converter chains the
+  // original back on as `cause` by reading it off the envelope, and the spread
+  // below is what carries it there — it is an enumerable own property, so it
+  // survives into the object handed over.
   return errorFromServiceEnvelope(
     {
       ...result,
@@ -106,8 +105,7 @@ export function createErrorFromResult(result: ServiceResultLike): NextlyError {
     },
     result.data !== undefined && result.data !== null
       ? { resultData: result.data }
-      : {},
-    originalErrorOf(result)
+      : {}
   );
 }
 
@@ -157,11 +155,7 @@ export function createErrorFromSingleResult(
         message: e.message,
       })),
     },
-    {},
-    // Same chaining as the collection converter. A single's failure loses its
-    // private detail through the identical envelope, so leaving it out here
-    // would fix the diagnostics for half the Direct API.
-    originalErrorOf(result)
+    {}
   );
 }
 

--- a/packages/nextly/src/domains/collections/services/collection-metadata-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-metadata-service.ts
@@ -10,7 +10,7 @@ import { toDbError } from "../../../database/errors";
 // still consume the result tuple; only the internal error mapping changed.
 import type { PermissionSeedService } from "../../../domains/auth/services/permission-seed-service";
 import { NextlyError, isProgrammerError } from "../../../errors";
-import { typedErrorEnvelopeFields } from "../../../errors/from-service-envelope";
+import { errorEnvelopeFields } from "../../../errors/from-service-envelope";
 import type { CollectionFileManager } from "../../../services/collection-file-manager";
 import type { Logger } from "../../../services/shared";
 import { BaseService } from "../../../shared/base-service";
@@ -61,7 +61,7 @@ function errorToMetadataResult(
       // The code above all: a boundary rebuilding from status alone cannot tell
       // a DUPLICATE from a CONFLICT, and an occupied slug would be reported as
       // a stale-resource conflict.
-      ...typedErrorEnvelopeFields(error),
+      ...errorEnvelopeFields(error),
     };
   }
   // Best-effort DbError detection — fromDatabaseError handles both DbError
@@ -101,7 +101,7 @@ function errorToMetadataResult(
     // The mapped error is typed too. Without its code a raw unique violation
     // becomes a code-less 409, which a boundary reads as staleness rather than
     // the duplicate it is, and a mapped timeout loses DATABASE_ERROR.
-    ...typedErrorEnvelopeFields(mapped),
+    ...errorEnvelopeFields(mapped),
   };
 }
 

--- a/packages/nextly/src/domains/collections/services/collection-metadata-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-metadata-service.ts
@@ -79,6 +79,11 @@ function errorToMetadataResult(
       statusCode: 500,
       message: fallback.defaultMessage,
       data: null,
+      // The thrown error itself, which is all this branch has to contribute:
+      // a defect in our own code must not lend the result a typed code, but it
+      // is the only thing that names where the defect was, and a boundary
+      // rebuilding a bare 500 has nothing else to chain.
+      ...errorEnvelopeFields(error),
     };
   }
   const mapped = NextlyError.fromDatabaseError(toDbError(dialect, error));
@@ -91,6 +96,11 @@ function errorToMetadataResult(
       statusCode: fallback.statusCode,
       message: error instanceof Error ? error.message : fallback.defaultMessage,
       data: null,
+      // The ORIGINAL throwable, not `mapped`. This branch exists to refuse
+      // `mapped`'s typing so the caller's fallback status survives, and taking
+      // its fields here would put back the code the branch just declined; the
+      // thrown error is also the one that actually names the failure.
+      ...errorEnvelopeFields(error),
     };
   }
   return {

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -33,7 +33,7 @@ import { toDbError } from "../../../database/errors";
 // only the internal error mapping changed. fromDatabaseError keeps driver
 // text out of the wire and routes identifying detail to logContext (§13.8).
 import { NextlyError } from "../../../errors";
-import { typedErrorEnvelopeFields } from "../../../errors/from-service-envelope";
+import { errorEnvelopeFields } from "../../../errors/from-service-envelope";
 import { withOriginalError } from "../../../errors/original-error";
 import type { ValidationPublicData } from "../../../errors/public-data";
 import { emitDocumentEvent } from "../../../events/domain-events";
@@ -4128,7 +4128,7 @@ export class CollectionMutationService extends BaseService {
         // A typed error keeps its own status and code. Hardcoding 500 reported
         // a hook's refusal or rate limit as a server fault, and left a boundary
         // nothing to rebuild it from.
-        ...(typedErrorEnvelopeFields(error) ?? {}),
+        ...errorEnvelopeFields(error),
       };
     }
   }
@@ -6873,7 +6873,7 @@ export class CollectionMutationService extends BaseService {
         // A typed error keeps its own status and code. Hardcoding 500 reported
         // a hook's refusal or rate limit as a server fault, and left a boundary
         // nothing to rebuild it from.
-        ...(typedErrorEnvelopeFields(error) ?? {}),
+        ...errorEnvelopeFields(error),
         eventRecorded,
         revalidationIntent,
         committed: committedWrite,
@@ -8382,7 +8382,7 @@ export class CollectionMutationService extends BaseService {
         // A typed error keeps its own status and code. Hardcoding 500 reported
         // a hook's refusal or rate limit as a server fault, and left a boundary
         // nothing to rebuild it from.
-        ...(typedErrorEnvelopeFields(error) ?? {}),
+        ...errorEnvelopeFields(error),
         revalidationIntent,
       };
     }
@@ -10000,7 +10000,7 @@ export class CollectionMutationService extends BaseService {
         // A typed error keeps its own status and code. Hardcoding 500 reported
         // a hook's refusal or rate limit as a server fault, and left a boundary
         // nothing to rebuild it from.
-        ...(typedErrorEnvelopeFields(error) ?? {}),
+        ...errorEnvelopeFields(error),
         eventRecorded,
         revalidationIntent,
       };

--- a/packages/nextly/src/domains/collections/services/collection-query-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-query-service.ts
@@ -23,7 +23,7 @@ import type { FieldDefinition } from "@nextly/schemas/dynamic-collections";
 import type { AuthenticatedScope } from "../../../auth/authenticated-scope";
 import { isFieldGroupField } from "../../../collections/fields/guards";
 import type { FieldConfig } from "../../../collections/fields/types";
-import { typedErrorEnvelopeFields } from "../../../errors/from-service-envelope";
+import { errorEnvelopeFields } from "../../../errors/from-service-envelope";
 import { NextlyError } from "../../../errors/nextly-error";
 import { getFilterRegistry, FilterSeams } from "../../../filters";
 import { toSnakeCase } from "../../../lib/case-conversion";
@@ -1775,7 +1775,7 @@ export class CollectionQueryService extends BaseService {
         // status alone left a read hook's `rateLimited()` or `authRequired()`
         // arriving at the caller as a generic 500, because the code-keyed
         // rebuild had no code to key on.
-        ...(typedErrorEnvelopeFields(error) ?? {}),
+        ...errorEnvelopeFields(error),
       };
     }
   }
@@ -2228,7 +2228,7 @@ export class CollectionQueryService extends BaseService {
         data: null,
         // Same reason as listEntries: without the code the boundary rebuilds a
         // typed refusal as a generic internal error.
-        ...(typedErrorEnvelopeFields(error) ?? {}),
+        ...errorEnvelopeFields(error),
       };
     }
   }
@@ -3017,7 +3017,7 @@ export class CollectionQueryService extends BaseService {
         // A typed error keeps its own status and code. Hardcoding 500 reported
         // a read hook's refusal as a server fault, and told a caller nothing it
         // could act on.
-        ...(typedErrorEnvelopeFields(error) ?? {}),
+        ...errorEnvelopeFields(error),
       };
     }
   }

--- a/packages/nextly/src/domains/collections/services/collection-service-error-converter.test.ts
+++ b/packages/nextly/src/domains/collections/services/collection-service-error-converter.test.ts
@@ -1,0 +1,165 @@
+/**
+ * The plugin-facing facade routes every failure through the shared converter.
+ *
+ * Five methods carried an identical copy of the same short-circuit: a code-less
+ * 404 and a code-less 403 threw a generic factory before the converter was
+ * reached. The converter answers those two statuses with the same generic
+ * error, so the copies changed nothing a caller sees and cost those two
+ * outcomes the failure they came from.
+ *
+ * The equivalence is the load-bearing claim, so it is asserted rather than
+ * argued: the public code, status and message must be what the short-circuit
+ * produced, and the identifiers must still be absent from the public message.
+ */
+import { describe, expect, it, vi } from "vitest";
+
+import { NextlyError } from "../../../errors/nextly-error";
+import { errorEnvelopeFields } from "../../../errors/from-service-envelope";
+
+import { CollectionService } from "./collection-service";
+
+const noopLogger = {
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+};
+
+function make(entry: Record<string, unknown>): CollectionService {
+  return new CollectionService(
+    {} as never,
+    noopLogger as never,
+    {} as never,
+    entry as never
+  );
+}
+
+/** A failed envelope as the entry service builds one. */
+function failure(
+  statusCode: number,
+  extra: Record<string, unknown> = {}
+): Record<string, unknown> {
+  return {
+    success: false,
+    statusCode,
+    message: "owner rule denied: user 42 is not the author",
+    data: null,
+    ...extra,
+  };
+}
+
+const ctx = { overrideAccess: true } as never;
+
+/** Every method that carried a copy of the short-circuit. */
+const METHODS: Array<{
+  name: string;
+  entryMethod: string;
+  call: (s: CollectionService) => Promise<unknown>;
+}> = [
+  {
+    name: "findEntryById",
+    entryMethod: "getEntry",
+    call: s => s.findEntryById("posts", "e1", ctx),
+  },
+  {
+    name: "updateEntry",
+    entryMethod: "updateEntry",
+    call: s => s.updateEntry("posts", "e1", { title: "x" }, ctx),
+  },
+  {
+    name: "deleteEntry",
+    entryMethod: "deleteEntry",
+    call: s => s.deleteEntry("posts", "e1", ctx),
+  },
+];
+
+describe("a code-less failure keeps the error the short-circuit produced", () => {
+  it.each(METHODS)(
+    "$name answers 404 as a generic NOT_FOUND",
+    async ({ entryMethod, call }) => {
+      const entry = {
+        [entryMethod]: vi.fn().mockResolvedValue(failure(404)),
+      };
+
+      const thrown = await call(make(entry)).catch((e: unknown) => e);
+
+      expect(NextlyError.is(thrown)).toBe(true);
+      const error = thrown as NextlyError;
+      expect(error.code).toBe("NOT_FOUND");
+      expect(error.statusCode).toBe(404);
+      expect(error.publicMessage).toBe("Not found.");
+    }
+  );
+
+  it.each(METHODS)(
+    "$name answers 403 as a generic FORBIDDEN with the inner reason withheld",
+    async ({ entryMethod, call }) => {
+      const entry = {
+        [entryMethod]: vi.fn().mockResolvedValue(failure(403)),
+      };
+
+      const thrown = (await call(make(entry)).catch(
+        (e: unknown) => e
+      )) as NextlyError;
+
+      expect(thrown.code).toBe("FORBIDDEN");
+      expect(thrown.statusCode).toBe(403);
+      // The envelope's message names the rule and the user id. §13.8 keeps
+      // that off the wire, which the deleted short-circuit did by dropping it
+      // and the converter does by not reading it for a code-less status.
+      expect(thrown.publicMessage).not.toContain("user 42");
+      expect(thrown.logContext).toMatchObject({
+        entity: "entry",
+        collectionName: "posts",
+        entryId: "e1",
+      });
+    }
+  );
+
+  it.each(METHODS)(
+    "$name now carries the failure the envelope came from",
+    async ({ entryMethod, call }) => {
+      // What the short-circuit cost. It returned before the converter, so the
+      // two most common outcomes of a failed facade call named nothing.
+      const original = new Error("connection terminated unexpectedly");
+      const entry = {
+        [entryMethod]: vi
+          .fn()
+          .mockResolvedValue(failure(404, errorEnvelopeFields(original))),
+      };
+
+      const thrown = (await call(make(entry)).catch(
+        (e: unknown) => e
+      )) as NextlyError;
+
+      expect(thrown.cause).toBe(original);
+    }
+  );
+});
+
+describe("a typed failure still answers as itself", () => {
+  it.each(METHODS)(
+    "$name keeps a plugin's own code through a 404",
+    async ({ entryMethod, call }) => {
+      // The short-circuit was guarded on `!result.code` for this reason, so the
+      // guard has to survive its deletion: a typed 404 must not collapse into
+      // the generic one.
+      const entry = {
+        [entryMethod]: vi.fn().mockResolvedValue(
+          failure(404, {
+            code: "ARCHIVE_EXPIRED",
+            message: "That archive is no longer available.",
+          })
+        ),
+      };
+
+      const thrown = (await call(make(entry)).catch(
+        (e: unknown) => e
+      )) as NextlyError;
+
+      expect(thrown.code).toBe("ARCHIVE_EXPIRED");
+      expect(thrown.statusCode).toBe(404);
+      expect(thrown.publicMessage).toBe("That archive is no longer available.");
+    }
+  );
+});

--- a/packages/nextly/src/domains/collections/services/collection-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-service.ts
@@ -723,28 +723,16 @@ export class CollectionService extends BaseService {
     });
 
     if (!result.success) {
-      // Only a code-less legacy result takes the generic factory. A typed
-      // one -- a plugin's own error, or BUILDER_DISABLED -- keeps its code,
-      // message key and public data through the shared converter below.
-      if (!result.code && result.statusCode === 404) {
-        // Generic "Not found." from the factory; identifiers go to logContext.
-        throw NextlyError.notFound({
-          logContext: { entity: "entry", collectionName, entryId },
-        });
-      }
-      if (!result.code && result.statusCode === 403) {
-        // Generic forbidden message; the inner result.message often echoes
-        // policy reasons that §13.8 keeps off the wire — drop them here and
-        // preserve them in logContext only.
-        throw NextlyError.forbidden({
-          logContext: {
-            collectionName,
-            entryId,
-            innerMessage: result.message,
-          },
-        });
-      }
-      throw this.mapLegacyErrorToNextlyError(result);
+      // Every failure goes through the converter, including the code-less 404
+      // and 403 that used to short-circuit to a factory here. The converter
+      // answers those with the same generic error -- the identifiers stay in
+      // the log context and never reach the wire -- and short-circuiting only
+      // meant those two outcomes arrived without the failure they came from.
+      throw this.mapLegacyErrorToNextlyError(result, {
+        entity: "entry",
+        collectionName,
+        entryId,
+      });
     }
 
     return result.data as CollectionEntry;
@@ -779,33 +767,21 @@ export class CollectionService extends BaseService {
     );
 
     if (!result.success) {
-      // Only a code-less legacy result takes the generic factory. A typed
-      // one -- a plugin's own error, or BUILDER_DISABLED -- keeps its code,
-      // message key and public data through the shared converter below.
-      if (!result.code && result.statusCode === 404) {
-        // Generic "Not found." from the factory; identifiers go to logContext.
-        throw NextlyError.notFound({
-          logContext: { entity: "entry", collectionName, entryId },
-        });
-      }
-      if (!result.code && result.statusCode === 403) {
-        // Generic forbidden message; the inner result.message often echoes
-        // policy reasons that §13.8 keeps off the wire — drop them here and
-        // preserve them in logContext only.
-        throw NextlyError.forbidden({
-          logContext: {
-            collectionName,
-            entryId,
-            innerMessage: result.message,
-          },
-        });
-      }
+      // Every failure goes through the converter, including the code-less 404
+      // and 403 that used to short-circuit to a factory here. The converter
+      // answers those with the same generic error -- the identifiers stay in
+      // the log context and never reach the wire -- and short-circuiting only
+      // meant those two outcomes arrived without the failure they came from.
       this.logger.warn("Entry update failed", {
         collectionName,
         entryId,
         message: result.message,
       });
-      throw this.mapLegacyErrorToNextlyError(result);
+      throw this.mapLegacyErrorToNextlyError(result, {
+        entity: "entry",
+        collectionName,
+        entryId,
+      });
     }
 
     this.logger.info("Entry updated", { collectionName, entryId });
@@ -836,28 +812,16 @@ export class CollectionService extends BaseService {
     });
 
     if (!result.success) {
-      // Only a code-less legacy result takes the generic factory. A typed
-      // one -- a plugin's own error, or BUILDER_DISABLED -- keeps its code,
-      // message key and public data through the shared converter below.
-      if (!result.code && result.statusCode === 404) {
-        // Generic "Not found." from the factory; identifiers go to logContext.
-        throw NextlyError.notFound({
-          logContext: { entity: "entry", collectionName, entryId },
-        });
-      }
-      if (!result.code && result.statusCode === 403) {
-        // Generic forbidden message; the inner result.message often echoes
-        // policy reasons that §13.8 keeps off the wire — drop them here and
-        // preserve them in logContext only.
-        throw NextlyError.forbidden({
-          logContext: {
-            collectionName,
-            entryId,
-            innerMessage: result.message,
-          },
-        });
-      }
-      throw this.mapLegacyErrorToNextlyError(result);
+      // Every failure goes through the converter, including the code-less 404
+      // and 403 that used to short-circuit to a factory here. The converter
+      // answers those with the same generic error -- the identifiers stay in
+      // the log context and never reach the wire -- and short-circuiting only
+      // meant those two outcomes arrived without the failure they came from.
+      throw this.mapLegacyErrorToNextlyError(result, {
+        entity: "entry",
+        collectionName,
+        entryId,
+      });
     }
 
     this.logger.info("Entry deleted", { collectionName, entryId });
@@ -995,33 +959,21 @@ export class CollectionService extends BaseService {
     this.collectTxCommittedWrite(tx, result.success);
 
     if (!result.success) {
-      // Only a code-less legacy result takes the generic factory. A typed
-      // one -- a plugin's own error, or BUILDER_DISABLED -- keeps its code,
-      // message key and public data through the shared converter below.
-      if (!result.code && result.statusCode === 404) {
-        // Generic "Not found." from the factory; identifiers go to logContext.
-        throw NextlyError.notFound({
-          logContext: { entity: "entry", collectionName, entryId },
-        });
-      }
-      if (!result.code && result.statusCode === 403) {
-        // Generic forbidden message; the inner result.message often echoes
-        // policy reasons that §13.8 keeps off the wire — drop them here and
-        // preserve them in logContext only.
-        throw NextlyError.forbidden({
-          logContext: {
-            collectionName,
-            entryId,
-            innerMessage: result.message,
-          },
-        });
-      }
+      // Every failure goes through the converter, including the code-less 404
+      // and 403 that used to short-circuit to a factory here. The converter
+      // answers those with the same generic error -- the identifiers stay in
+      // the log context and never reach the wire -- and short-circuiting only
+      // meant those two outcomes arrived without the failure they came from.
       this.logger.warn("Entry update in transaction failed", {
         collectionName,
         entryId,
         message: result.message,
       });
-      throw this.mapLegacyErrorToNextlyError(result);
+      throw this.mapLegacyErrorToNextlyError(result, {
+        entity: "entry",
+        collectionName,
+        entryId,
+      });
     }
 
     this.logger.info("Entry updated in transaction", {
@@ -1072,28 +1024,16 @@ export class CollectionService extends BaseService {
     this.collectTxCommittedWrite(tx, result.success);
 
     if (!result.success) {
-      // Only a code-less legacy result takes the generic factory. A typed
-      // one -- a plugin's own error, or BUILDER_DISABLED -- keeps its code,
-      // message key and public data through the shared converter below.
-      if (!result.code && result.statusCode === 404) {
-        // Generic "Not found." from the factory; identifiers go to logContext.
-        throw NextlyError.notFound({
-          logContext: { entity: "entry", collectionName, entryId },
-        });
-      }
-      if (!result.code && result.statusCode === 403) {
-        // Generic forbidden message; the inner result.message often echoes
-        // policy reasons that §13.8 keeps off the wire — drop them here and
-        // preserve them in logContext only.
-        throw NextlyError.forbidden({
-          logContext: {
-            collectionName,
-            entryId,
-            innerMessage: result.message,
-          },
-        });
-      }
-      throw this.mapLegacyErrorToNextlyError(result);
+      // Every failure goes through the converter, including the code-less 404
+      // and 403 that used to short-circuit to a factory here. The converter
+      // answers those with the same generic error -- the identifiers stay in
+      // the log context and never reach the wire -- and short-circuiting only
+      // meant those two outcomes arrived without the failure they came from.
+      throw this.mapLegacyErrorToNextlyError(result, {
+        entity: "entry",
+        collectionName,
+        entryId,
+      });
     }
 
     this.logger.info("Entry deleted in transaction", {
@@ -1123,21 +1063,29 @@ export class CollectionService extends BaseService {
    * `code`, `errors` and `publicData` entirely, so a validation failure also
    * arrived without its per-field issues.
    */
-  private mapLegacyErrorToNextlyError(result: {
-    success: boolean;
-    statusCode: number;
-    code?: string;
-    message: string;
-    messageKey?: string;
-    publicData?: unknown;
-    data: unknown;
-    errors?: Array<{
-      path?: string;
-      field?: string;
+  private mapLegacyErrorToNextlyError(
+    result: {
+      success: boolean;
+      statusCode: number;
       code?: string;
       message: string;
-    }>;
-  }): NextlyError {
-    return errorFromServiceEnvelope(result, { innerMessage: result.message });
+      messageKey?: string;
+      publicData?: unknown;
+      data: unknown;
+      errors?: Array<{
+        path?: string;
+        field?: string;
+        code?: string;
+        message: string;
+      }>;
+    },
+    // What the caller knows and the envelope does not: which entity and which
+    // ids. Operator-only, so it goes to the log context and never the wire.
+    logContext: Record<string, unknown> = {}
+  ): NextlyError {
+    return errorFromServiceEnvelope(result, {
+      innerMessage: result.message,
+      ...logContext,
+    });
   }
 }

--- a/packages/nextly/src/domains/singles/services/single-utils.ts
+++ b/packages/nextly/src/domains/singles/services/single-utils.ts
@@ -692,17 +692,26 @@ export function buildSingleErrorResult(
     };
   }
 
+  // Every branch routes through the helper, including the ones with no typed
+  // fields to lift. A raw database rejection has nothing to contribute to the
+  // envelope except itself, and that is precisely what the boundary needs to
+  // chain — a branch that returns early is a branch that silently opts out.
   if (error instanceof Error) {
     return {
       success: false,
       statusCode: 500,
       message: error.message || defaultMessage,
+      ...errorEnvelopeFields(error),
     };
   }
 
+  // A thrown non-Error carries no provenance, and the helper says so by
+  // returning nothing — spread here anyway so the shape of this function is
+  // the same on every path.
   return {
     success: false,
     statusCode: 500,
     message: defaultMessage,
+    ...errorEnvelopeFields(error),
   };
 }

--- a/packages/nextly/src/domains/singles/services/single-utils.ts
+++ b/packages/nextly/src/domains/singles/services/single-utils.ts
@@ -17,7 +17,7 @@
 
 import type { FieldConfig } from "../../../collections/fields/types";
 import { NextlyError } from "../../../errors";
-import { typedErrorEnvelopeFields } from "../../../errors/from-service-envelope";
+import { errorEnvelopeFields } from "../../../errors/from-service-envelope";
 import { convertTimestampsToCamelCase } from "../../../shared/lib/case-conversion";
 import type { ValidatableField } from "../../../shared/lib/entry-validation";
 import { validateEntryData } from "../../../shared/lib/entry-validation";
@@ -688,7 +688,7 @@ export function buildSingleErrorResult(
       // Without the code, a Single hook's `authRequired()` or `rateLimited()`
       // took the boundary's status fallback and reached the caller as a
       // generic 500, losing the rate-limit backoff with it.
-      ...typedErrorEnvelopeFields(error),
+      ...errorEnvelopeFields(error),
     };
   }
 

--- a/packages/nextly/src/domains/versions/__tests__/discard-working-draft.test.ts
+++ b/packages/nextly/src/domains/versions/__tests__/discard-working-draft.test.ts
@@ -34,8 +34,19 @@ vi.mock("../../../di", () => ({
   }),
 }));
 
+import { errorEnvelopeFields } from "../../../errors/from-service-envelope";
 import type { UserContext } from "../../singles/types";
 import { discardWorkingDraft } from "../discard-working-draft";
+
+/**
+ * A failure envelope as the read path actually produces one, rather than a
+ * literal with the carrier attached by hand: the assertion is that what the
+ * producer attaches is what the rebuild reads, so a fixture attaching it itself
+ * would pass even if those two halves disagreed.
+ */
+function buildEntryErrorEnvelope(error: Error) {
+  return { success: false, statusCode: 500, ...errorEnvelopeFields(error) };
+}
 
 const user = { id: "u1", roles: ["editor"] } as unknown as UserContext;
 
@@ -105,5 +116,22 @@ describe("discardWorkingDraft", () => {
     await expect(discardWorkingDraft(args)).rejects.toMatchObject({
       code: "NOT_FOUND",
     });
+  });
+
+  it("propagates the failure the read was built from, not only its envelope", async () => {
+    // The read attaches the thrown error to the result it returns, and the
+    // rebuild reads it back off that object. Copying the envelope field by
+    // field left it behind, so a driver failure under a discard reached the
+    // caller as a bare internal error with nothing naming the real fault.
+    const driverFailure = new Error("connection terminated unexpectedly");
+    getEntrySpy.mockResolvedValue({
+      ...buildEntryErrorEnvelope(driverFailure),
+      data: null,
+    });
+
+    await expect(discardWorkingDraft(args)).rejects.toMatchObject({
+      cause: driverFailure,
+    });
+    expect(discardSpy).not.toHaveBeenCalled();
   });
 });

--- a/packages/nextly/src/domains/versions/__tests__/restore-version.test.ts
+++ b/packages/nextly/src/domains/versions/__tests__/restore-version.test.ts
@@ -55,6 +55,7 @@ import {
   applyFieldReadAccess,
   applyFieldWriteAccess,
 } from "../../../shared/lib/field-level-registry";
+import { errorEnvelopeFields } from "../../../errors/from-service-envelope";
 import { resolveComponentSchemas, restoreVersion } from "../restore-version";
 
 const user = { id: "u1" };
@@ -255,6 +256,34 @@ describe("restoreVersion", () => {
       code: "NOT_FOUND",
     });
   });
+
+  // A failed restore has five ways to answer and only one of them ran through
+  // the shared converter, so the other four reached the caller naming nothing.
+  // Each outcome is checked for the failure underneath as well as its code.
+  it.each([
+    ["a denied write", 403, undefined, "NOT_FOUND"],
+    ["a missing document", 404, undefined, "NOT_FOUND"],
+    ["a collision", 409, undefined, "CONFLICT"],
+    ["a snapshot today's rules reject", 422, undefined, "VALIDATION_ERROR"],
+    ["a server fault", 500, undefined, "INTERNAL_ERROR"],
+    ["a typed failure", 429, "RATE_LIMITED", "RATE_LIMITED"],
+  ])(
+    "carries the update failure through %s",
+    async (_label, statusCode, code, expectedCode) => {
+      const original = new Error("connection terminated unexpectedly");
+      updateEntrySpy.mockResolvedValue({
+        success: false,
+        statusCode,
+        ...(code ? { code } : {}),
+        ...errorEnvelopeFields(original),
+      });
+
+      await expect(restoreVersion(base)).rejects.toMatchObject({
+        code: expectedCode,
+        cause: original,
+      });
+    }
+  );
 
   it("restores a Single through its own update path", async () => {
     await restoreVersion({ ...base, scopeKind: "single", slug: "settings" });

--- a/packages/nextly/src/domains/versions/discard-working-draft.ts
+++ b/packages/nextly/src/domains/versions/discard-working-draft.ts
@@ -65,14 +65,11 @@ export async function discardWorkingDraft(
   // discard of an empty document — and because nothing has been deleted yet, the
   // draft is left intact for a retry.
   if (!result.success) {
-    throw errorFromServiceEnvelope({
-      statusCode: result.statusCode,
-      code: result.code,
-      message: result.message,
-      messageKey: result.messageKey,
-      publicData: result.publicData,
-      errors: result.errors,
-    });
+    // The result object itself rather than a field-by-field copy of it. The
+    // read attached the thrown error to this object, and copying only the
+    // fields named here left that behind — so a driver failure underneath a
+    // discard reached the caller with nothing naming it.
+    throw errorFromServiceEnvelope(result);
   }
 
   // Now remove the sidecar through the collections handler, which deletes it

--- a/packages/nextly/src/domains/versions/restore-version.ts
+++ b/packages/nextly/src/domains/versions/restore-version.ts
@@ -21,6 +21,7 @@ import { getService } from "../../di";
 import { NextlyError } from "../../errors";
 import type { ServiceErrorEnvelope } from "../../errors/from-service-envelope";
 import { errorFromServiceEnvelope } from "../../errors/from-service-envelope";
+import { originalErrorOf } from "../../errors/original-error";
 import type { VersionScopeKind } from "../../schemas/versions/types";
 import {
   applyFieldReadAccess,
@@ -554,8 +555,15 @@ function assertWriteSucceeded(
 
   const status = result.statusCode ?? 500;
 
+  // The failure the update was built from, chained onto whichever branch below
+  // answers. Only the code-keyed branch went through the converter, so every
+  // other outcome of a failed restore -- a denial, a conflict, a rejected
+  // snapshot, a server fault -- reached the caller naming nothing.
+  const original = originalErrorOf(result);
+
   if (status === 403 || status === 404) {
     throw NextlyError.notFound({
+      cause: original,
       logContext: {
         reason: "restore-write-denied",
         statusCode: status,
@@ -585,6 +593,7 @@ function assertWriteSucceeded(
   // collision reports through an ordinary update.
   if (status === 409) {
     throw NextlyError.conflict({
+      cause: original,
       logContext: {
         reason: "restore-write-conflict",
         message: result.message,
@@ -612,6 +621,7 @@ function assertWriteSucceeded(
                 "This version could not be applied to the document as it is now.",
             },
           ],
+      cause: original,
       logContext: {
         reason: "restore-write-rejected",
         statusCode: status,
@@ -623,6 +633,7 @@ function assertWriteSucceeded(
   }
 
   throw NextlyError.internal({
+    cause: original,
     logContext: {
       reason: "restore-write-failed",
       statusCode: status,

--- a/packages/nextly/src/errors/__tests__/from-service-envelope.test.ts
+++ b/packages/nextly/src/errors/__tests__/from-service-envelope.test.ts
@@ -6,9 +6,11 @@
 
 import { describe, expect, it } from "vitest";
 
+import { originalErrorOf } from "../original-error";
+
 import {
   errorFromServiceEnvelope,
-  typedErrorEnvelopeFields,
+  errorEnvelopeFields,
 } from "../from-service-envelope";
 import { NextlyError } from "../nextly-error";
 
@@ -60,12 +62,12 @@ describe("errorFromServiceEnvelope", () => {
   });
 });
 
-describe("typedErrorEnvelopeFields", () => {
+describe("errorEnvelopeFields", () => {
   it("round-trips a typed error through the envelope and back", () => {
     // The two halves are only useful together: a converter can rebuild nothing
     // the catch did not record.
     const original = NextlyError.rateLimited({ retryAfterSeconds: 15 });
-    const fields = typedErrorEnvelopeFields(original);
+    const fields = errorEnvelopeFields(original);
     expect(fields).not.toBeNull();
 
     const rebuilt = errorFromServiceEnvelope(fields!);
@@ -75,8 +77,17 @@ describe("typedErrorEnvelopeFields", () => {
     expect(rebuilt.publicData).toEqual(original.publicData);
   });
 
-  it("reports nothing for an untyped error, so callers keep their fallback", () => {
-    expect(typedErrorEnvelopeFields(new Error("boom"))).toBeNull();
+  it("lifts no fields from an untyped error, but still carries it", () => {
+    // The contract is now "always spreadable". An untyped error has no code,
+    // status or message worth lifting — inventing one would have the boundary
+    // rebuild a fabricated error — so nothing is lifted. It leaves with the
+    // provenance alone, which is what a raw driver rejection has to offer and
+    // what the typed-only guard used to discard.
+    const raw = new Error("boom");
+    const fields = errorEnvelopeFields(raw);
+
+    expect(Object.keys(fields)).toEqual([]);
+    expect(originalErrorOf(fields)).toBe(raw);
   });
 });
 

--- a/packages/nextly/src/errors/__tests__/original-error.test.ts
+++ b/packages/nextly/src/errors/__tests__/original-error.test.ts
@@ -11,6 +11,8 @@
 
 import { describe, expect, it } from "vitest";
 
+import { buildSingleErrorResult } from "../../domains/singles/services/single-utils";
+
 import {
   errorFromServiceEnvelope,
   errorEnvelopeFields,
@@ -139,5 +141,38 @@ describe("a raw driver failure keeps its provenance too", () => {
     // something spreadable rather than a null it has to guard.
     expect(Object.keys(errorEnvelopeFields("nope"))).toEqual([]);
     expect(originalErrorOf(errorEnvelopeFields("nope"))).toBeUndefined();
+  });
+});
+
+describe("a single's failure result carries provenance on every branch", () => {
+  it("keeps a raw database rejection", () => {
+    // The branch that returned early. A single's raw failure had nothing to
+    // lift into the envelope and so skipped the helper entirely, which is the
+    // one case where the error itself is all the boundary has to chain.
+    const raw = new Error("driver: could not serialize access");
+
+    const result = buildSingleErrorResult(raw, "Failed.");
+
+    expect(originalErrorOf(result)).toBe(raw);
+    expect(result.statusCode).toBe(500);
+    // The provenance itself stays off the wire. This path separately puts the
+    // driver's own message into `message`, which predates this and is not what
+    // is being asserted here.
+    expect(Object.keys(result)).toEqual(["success", "statusCode", "message"]);
+  });
+
+  it("keeps a typed failure too, so neither branch is the special one", () => {
+    const typed = NextlyError.internal({ logContext: { single: "site" } });
+
+    expect(originalErrorOf(buildSingleErrorResult(typed, "Failed."))).toBe(
+      typed
+    );
+  });
+
+  it("carries nothing for a thrown non-Error, without throwing itself", () => {
+    const result = buildSingleErrorResult("not an error", "Failed.");
+
+    expect(originalErrorOf(result)).toBeUndefined();
+    expect(result.success).toBe(false);
   });
 });

--- a/packages/nextly/src/errors/__tests__/original-error.test.ts
+++ b/packages/nextly/src/errors/__tests__/original-error.test.ts
@@ -13,7 +13,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   errorFromServiceEnvelope,
-  typedErrorEnvelopeFields,
+  errorEnvelopeFields,
 } from "../from-service-envelope";
 import { NextlyError } from "../nextly-error";
 import {
@@ -74,7 +74,7 @@ describe("carrying the original error on a public envelope", () => {
 describe("every producer carries provenance, not just the one it was built for", () => {
   it("rides on the shared flattener the read and single paths spread", () => {
     // The first version attached this at ONE producer and reached only the
-    // collection writes. `typedErrorEnvelopeFields` IS the flattening for the
+    // collection writes. `errorEnvelopeFields` IS the flattening for the
     // read paths and the singles — the same reason they record the error here
     // rather than each remembering to — so the provenance belongs here too.
     const thrown = NextlyError.internal({
@@ -82,7 +82,7 @@ describe("every producer carries provenance, not just the one it was built for",
       logContext: { table: "posts" },
     });
 
-    const envelope = { success: false, ...typedErrorEnvelopeFields(thrown) };
+    const envelope = { success: false, ...errorEnvelopeFields(thrown) };
 
     expect(originalErrorOf(envelope)).toBe(thrown);
     expect(JSON.stringify(envelope)).not.toContain("deadlock");
@@ -102,5 +102,42 @@ describe("every producer carries provenance, not just the one it was built for",
     );
 
     expect(rebuilt.cause).toBe(thrown);
+  });
+});
+
+describe("a raw driver failure keeps its provenance too", () => {
+  it("carries the original even with no typed fields to lift", () => {
+    // The case the typed guard used to drop on the floor. A read that rejects
+    // with a driver error has nothing to lift into the envelope, and that is
+    // exactly when the chained cause matters most: it is the only thing that
+    // names the constraint or the connection that actually failed.
+    const raw = new Error("driver: connection terminated unexpectedly");
+
+    const envelope = { success: false, ...errorEnvelopeFields(raw) };
+
+    expect(originalErrorOf(envelope)).toBe(raw);
+    // Nothing was invented for it: an untyped error has no code to guess at.
+    expect(Object.keys(envelope)).toEqual(["success"]);
+    expect(JSON.stringify(envelope)).not.toContain("connection terminated");
+  });
+
+  it("chains that raw error onto what the boundary rebuilds", () => {
+    const raw = new Error("driver: deadlock detected");
+    const envelope = { statusCode: 500, ...errorEnvelopeFields(raw) };
+
+    const rebuilt = errorFromServiceEnvelope(
+      { code: "INTERNAL_ERROR", statusCode: 500, message: "It failed." },
+      {},
+      originalErrorOf(envelope)
+    );
+
+    expect(rebuilt.cause).toBe(raw);
+  });
+
+  it("returns a plain object for a value that is not an Error at all", () => {
+    // A thrown string has no provenance to carry, and the caller still needs
+    // something spreadable rather than a null it has to guard.
+    expect(Object.keys(errorEnvelopeFields("nope"))).toEqual([]);
+    expect(originalErrorOf(errorEnvelopeFields("nope"))).toBeUndefined();
   });
 });

--- a/packages/nextly/src/errors/__tests__/provenance-across-boundaries.test.ts
+++ b/packages/nextly/src/errors/__tests__/provenance-across-boundaries.test.ts
@@ -1,0 +1,195 @@
+/**
+ * The thrown error reaches every boundary that rebuilds one, not just some.
+ *
+ * A service converts a failure into a public envelope and a boundary rebuilds
+ * an error from it. The rebuilt error is correct for the caller and blind for
+ * whoever debugs it, so the original rides along on the envelope. What decides
+ * whether that survives is WHERE it is read: an argument each boundary passes
+ * is an opt-in, and the boundaries that forgot were the REST dispatcher, the
+ * singles route, the plugin-facing facade, both bulk-by-query paths and the
+ * version writes.
+ *
+ * These assert the read happens in the converter, so a boundary is covered by
+ * handing over the envelope it already hands over.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { unwrapServiceResult } from "../../dispatcher/helpers/service-envelope";
+import {
+  createErrorFromResult,
+  createErrorFromSingleResult,
+} from "../../direct-api/namespaces/helpers";
+import { buildSingleErrorResult } from "../../domains/singles/services/single-utils";
+import { NEXTLY_ERROR_STATUS } from "../error-codes";
+import {
+  errorEnvelopeFields,
+  errorFromServiceEnvelope,
+} from "../from-service-envelope";
+import { NextlyError } from "../nextly-error";
+import { originalErrorOf } from "../original-error";
+
+/** The failure a rebuild has nothing to say about and most needs to name. */
+function driverFailure(): Error {
+  return new Error("connection terminated unexpectedly");
+}
+
+/**
+ * A failed envelope exactly as a service builds one, rather than a literal
+ * carrying a hand-attached symbol. The point under test is that what the
+ * PRODUCERS attach is what the CONSUMERS read, so a fixture that attaches it
+ * itself would pass even if the two halves disagreed.
+ */
+function envelopeFrom(error: Error, statusCode: number) {
+  return { success: false as const, statusCode, ...errorEnvelopeFields(error) };
+}
+
+describe("the converter reads provenance off the envelope", () => {
+  it("chains it on the code-keyed branch", () => {
+    const original = new NextlyError({
+      code: "RATE_LIMITED",
+      publicMessage: "Too many requests.",
+      statusCode: 429,
+      cause: driverFailure(),
+    });
+
+    const rebuilt = errorFromServiceEnvelope(envelopeFrom(original, 429));
+
+    expect(rebuilt.cause).toBe(original);
+  });
+
+  it("chains it on the validation branch", () => {
+    const original = NextlyError.validation({
+      errors: [{ path: "title", code: "REQUIRED", message: "Required." }],
+    });
+
+    const rebuilt = errorFromServiceEnvelope(
+      envelopeFrom(original, NEXTLY_ERROR_STATUS.VALIDATION_ERROR)
+    );
+
+    expect(rebuilt.code).toBe("VALIDATION_ERROR");
+    expect(rebuilt.cause).toBe(original);
+  });
+
+  // The branches that carry the least information about the failure are the
+  // ones whose cause is worth the most: a code-less envelope is what a raw
+  // driver rejection produces, and each of these built its error from a
+  // factory call that named only the log context.
+  it.each([
+    ["not found", NEXTLY_ERROR_STATUS.NOT_FOUND],
+    ["forbidden", NEXTLY_ERROR_STATUS.FORBIDDEN],
+    ["conflict", NEXTLY_ERROR_STATUS.CONFLICT],
+    ["validation", NEXTLY_ERROR_STATUS.VALIDATION_ERROR],
+    ["internal", NEXTLY_ERROR_STATUS.INTERNAL_ERROR],
+  ])("chains it on the code-less %s branch", (_label, statusCode) => {
+    const original = driverFailure();
+
+    const rebuilt = errorFromServiceEnvelope(
+      envelopeFrom(original, statusCode)
+    );
+
+    expect(rebuilt.code).not.toBe("RATE_LIMITED");
+    expect(rebuilt.cause).toBe(original);
+  });
+
+  it("prefers an explicit cause over the envelope's own", () => {
+    // The argument stays for the caller that holds the error but has no
+    // envelope carrying it; where both exist the caller is the more specific
+    // of the two and must not be silently overridden.
+    const carried = driverFailure();
+    const explicit = new Error("the one the caller actually holds");
+
+    const rebuilt = errorFromServiceEnvelope(
+      envelopeFrom(carried, NEXTLY_ERROR_STATUS.INTERNAL_ERROR),
+      {},
+      explicit
+    );
+
+    expect(rebuilt.cause).toBe(explicit);
+  });
+
+  it("leaves cause undefined when the envelope carries nothing", () => {
+    // The control. Without it every assertion above would still pass if the
+    // converter attached some fallback error of its own.
+    const rebuilt = errorFromServiceEnvelope({
+      success: false,
+      statusCode: 500,
+    } as never);
+
+    expect(rebuilt.cause).toBeUndefined();
+  });
+});
+
+describe("provenance survives the boundaries that rebuild", () => {
+  it("survives the REST dispatcher", () => {
+    const original = driverFailure();
+    const result = envelopeFrom(original, 500);
+
+    let thrown: unknown;
+    try {
+      unwrapServiceResult(result, { op: "update" });
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(NextlyError.is(thrown)).toBe(true);
+    expect((thrown as NextlyError).cause).toBe(original);
+  });
+
+  it("survives the Direct API collection helper", () => {
+    const original = driverFailure();
+    // `message` and `data` after the spread rather than inside the fixture:
+    // this boundary's own result shape requires both, and a raw rejection
+    // contributes no envelope fields for either.
+    const result = {
+      ...envelopeFrom(original, 500),
+      message: "Operation failed.",
+      data: null,
+    };
+
+    expect(createErrorFromResult(result).cause).toBe(original);
+  });
+
+  it("survives the Direct API single helper", () => {
+    const original = driverFailure();
+
+    expect(createErrorFromSingleResult(envelopeFrom(original, 500)).cause).toBe(
+      original
+    );
+  });
+
+  it("survives a single service result built from a raw rejection", () => {
+    // The full round trip through the producer the singles route reads: a raw
+    // rejection has no typed field to lift, so the envelope it produces
+    // carries nothing BUT the provenance — which is the case that was lost.
+    const original = driverFailure();
+    const result = buildSingleErrorResult(original, "Operation failed");
+
+    expect(errorFromServiceEnvelope(result).cause).toBe(original);
+  });
+});
+
+describe("the mechanism the spreading boundaries depend on", () => {
+  it("keeps the carrier across a spread", () => {
+    // The singles route and both Direct API helpers hand over
+    // `{ ...result, ... }` rather than the result itself, so they are covered
+    // only while the carrier is an ENUMERABLE own property — spread copies no
+    // other kind. Asserted here so making it non-enumerable fails once, with a
+    // reason, instead of quietly emptying `cause` at three boundaries.
+    const original = driverFailure();
+    const result = envelopeFrom(original, 500);
+
+    expect(originalErrorOf({ ...result })).toBe(original);
+  });
+
+  it("keeps the carrier off the wire", () => {
+    // Enumerable is the requirement above; serializable is what it must not
+    // become. A symbol key is skipped by both `JSON.stringify` and
+    // `Object.keys`, which is what lets the envelope carry a driver message
+    // that §13.8 keeps out of a response body.
+    const result = envelopeFrom(driverFailure(), 500);
+
+    expect(JSON.stringify(result)).not.toContain("connection terminated");
+    expect(Object.keys(result)).not.toContain("cause");
+  });
+});

--- a/packages/nextly/src/errors/__tests__/provenance-envelope-branches.test.ts
+++ b/packages/nextly/src/errors/__tests__/provenance-envelope-branches.test.ts
@@ -1,0 +1,83 @@
+/**
+ * A branch that returns early is a branch that silently opts out.
+ *
+ * These cover the places that build a failure from a service envelope WITHOUT
+ * going through the converter, or that return before reaching the helper that
+ * attaches the thrown error. Each one answered correctly and named nothing, so
+ * the failure they describe was the failure nobody could find.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { errorEnvelopeFields } from "../from-service-envelope";
+import { NextlyError } from "../nextly-error";
+import { originalErrorOf } from "../original-error";
+
+function driverFailure(): Error {
+  return new Error("connection terminated unexpectedly");
+}
+
+describe("the factories that a status-derived rebuild reaches", () => {
+  // The converter names `cause:` explicitly rather than spreading it in,
+  // because an option a factory does not declare is a type error when written
+  // out and accepted in silence when spread. These pin the declarations that
+  // spelling depends on: without them the converter would still compile and
+  // still drop the cause.
+  it.each([
+    ["notFound", () => NextlyError.notFound],
+    ["forbidden", () => NextlyError.forbidden],
+    ["conflict", () => NextlyError.conflict],
+    ["internal", () => NextlyError.internal],
+  ])("%s carries a cause", (_name, factory) => {
+    const original = driverFailure();
+
+    expect(factory()({ cause: original }).cause).toBe(original);
+  });
+
+  it("validation carries a cause alongside its errors", () => {
+    // Separate because its options are not optional: it is the only one of the
+    // five whose `errors` must be supplied, and a restore rejected by today's
+    // rules reaches it holding the update failure underneath.
+    const original = driverFailure();
+
+    const error = NextlyError.validation({
+      errors: [{ path: "versionNo", code: "RESTORE_REJECTED", message: "no" }],
+      cause: original,
+    });
+
+    expect(error.cause).toBe(original);
+    expect(error.code).toBe("VALIDATION_ERROR");
+  });
+});
+
+describe("errorEnvelopeFields on the branches that used to return first", () => {
+  it("carries a programmer error without lending it a code", () => {
+    // A defect in our own code must not inherit a caller's 4xx fallback, so
+    // this branch contributes no typed fields on purpose. That is the reason it
+    // returned early, and the reason it left with nothing: the thrown error is
+    // the only thing that names where the defect was.
+    const thrown = new TypeError("cannot read properties of undefined");
+    const fields = errorEnvelopeFields(thrown);
+
+    expect(fields.code).toBeUndefined();
+    expect(fields.statusCode).toBeUndefined();
+    expect(originalErrorOf(fields)).toBe(thrown);
+  });
+
+  it("survives being spread into the result the branch returns", () => {
+    // The branches build a literal and spread the helper into it, so this is
+    // the shape the boundary actually receives.
+    const thrown = driverFailure();
+    const result = {
+      success: false,
+      statusCode: 500,
+      message: "Failed to create collection",
+      data: null,
+      ...errorEnvelopeFields(thrown),
+    };
+
+    expect(originalErrorOf(result)).toBe(thrown);
+    // Still not on the wire: the carrier is symbol-keyed.
+    expect(JSON.stringify(result)).not.toContain("connection terminated");
+  });
+});

--- a/packages/nextly/src/errors/from-service-envelope.ts
+++ b/packages/nextly/src/errors/from-service-envelope.ts
@@ -176,13 +176,23 @@ export function errorFromServiceEnvelope(
  * Returns null for an untyped error, so a caller keeps whatever fallback it
  * already applies to those.
  */
-export function typedErrorEnvelopeFields(
+export function errorEnvelopeFields(
   error: unknown
-): Pick<
-  ServiceErrorEnvelope,
-  "code" | "statusCode" | "message" | "messageKey" | "publicData"
-> | null {
-  if (!NextlyError.is(error)) return null;
+): Partial<
+  Pick<
+    ServiceErrorEnvelope,
+    "code" | "statusCode" | "message" | "messageKey" | "publicData"
+  >
+> {
+  // A raw driver rejection has no typed fields to lift, but it is still the
+  // failure the operator needs to see — so it leaves with the provenance and
+  // nothing else, rather than with nothing at all. Returning an object in both
+  // cases is what stops this being an opt-in: a caller spreads the result and
+  // is covered, instead of each failure branch remembering to attach the
+  // original itself.
+  if (!NextlyError.is(error)) {
+    return error instanceof Error ? withOriginalError({}, error) : {};
+  }
   // Kept for the operator before the detail is dropped. This function IS the
   // flattening for every path that uses it, so recording here covers them all
   // rather than each call site remembering to.

--- a/packages/nextly/src/errors/from-service-envelope.ts
+++ b/packages/nextly/src/errors/from-service-envelope.ts
@@ -9,7 +9,7 @@ import { recordFlattenedError } from "../hooks/side-effect-warnings";
 
 import { NEXTLY_ERROR_STATUS } from "./error-codes";
 import { NextlyError } from "./nextly-error";
-import { withOriginalError } from "./original-error";
+import { originalErrorOf, withOriginalError } from "./original-error";
 import type { PublicData } from "./public-data";
 
 /** The failure fields a service envelope can carry. */
@@ -116,12 +116,23 @@ function validationFromEnvelope(
 export function errorFromServiceEnvelope(
   envelope: ServiceErrorEnvelope,
   logContext: Record<string, unknown> = {},
-  // The error this envelope was built from, when the caller still has it.
+  // Only for a caller that holds the thrown error WITHOUT an envelope carrying
+  // it. An envelope built by a service already carries its own, read below, so
+  // passing this is not how a boundary normally forwards provenance.
   // Chained rather than assigned afterwards because `cause` is read-only once
   // a NextlyError exists — and it belongs to the error's identity, not to
   // something bolted on after the fact.
   cause?: Error
 ): NextlyError {
+  // Taken off the envelope rather than from each boundary's argument list. The
+  // envelope IS what the services attached the thrown error to, and it is the
+  // one value every boundary already hands this function, so reading it here
+  // covers all of them — the REST dispatcher, the singles route, the plugin
+  // facade, the bulk-by-query paths and the version writes — instead of each
+  // remembering to forward it. An explicit argument wins when given, for the
+  // caller that has the error but no envelope to carry it.
+  const original = cause ?? originalErrorOf(envelope);
+
   // Read from the canonical map rather than repeated literals: this converter
   // exists so one place decides how a status and a code correspond, and a
   // literal here would drift the moment that map changed.
@@ -131,7 +142,7 @@ export function errorFromServiceEnvelope(
     // Validation keeps its own path: it also normalises the legacy `{field}`
     // shape into the canonical `{path}` one the admin maps onto form fields.
     if (envelope.code === "VALIDATION_ERROR") {
-      return validationFromEnvelope(envelope, logContext, cause);
+      return validationFromEnvelope(envelope, logContext, original);
     }
     return new NextlyError({
       code: envelope.code,
@@ -144,25 +155,33 @@ export function errorFromServiceEnvelope(
       messageKey: envelope.messageKey,
       publicData: envelope.publicData as PublicData | undefined,
       logContext,
-      ...(cause !== undefined ? { cause } : {}),
+      ...(original !== undefined ? { cause: original } : {}),
     });
   }
 
+  // The status-derived branches chain the original too. A code-less envelope is
+  // exactly the one a raw driver rejection produces, so the branch with the
+  // least to say about the failure is the branch whose cause is worth the most.
+  //
+  // Named explicitly rather than spread in from a conditional object: an option
+  // a factory does not declare is a type error when written out and is accepted
+  // in silence when spread, so the spelling that catches the omission is the
+  // one that reads as if it does.
   if (status === NEXTLY_ERROR_STATUS.NOT_FOUND) {
-    return NextlyError.notFound({ logContext });
+    return NextlyError.notFound({ logContext, cause: original });
   }
   if (status === NEXTLY_ERROR_STATUS.FORBIDDEN) {
-    return NextlyError.forbidden({ logContext });
+    return NextlyError.forbidden({ logContext, cause: original });
   }
   if (status === NEXTLY_ERROR_STATUS.CONFLICT) {
     // Without a code, staleness is the safer default: it tells the user to
     // refresh rather than implying the write itself was invalid.
-    return NextlyError.conflict({ logContext });
+    return NextlyError.conflict({ logContext, cause: original });
   }
   if (status === NEXTLY_ERROR_STATUS.VALIDATION_ERROR) {
-    return validationFromEnvelope(envelope, logContext);
+    return validationFromEnvelope(envelope, logContext, original);
   }
-  return NextlyError.internal({ logContext });
+  return NextlyError.internal({ logContext, cause: original });
 }
 
 /**
@@ -173,8 +192,13 @@ export function errorFromServiceEnvelope(
  * the status alone leaves the code-keyed rebuild nothing to key on and the
  * error reaches the caller as a generic 500 however good the converter is.
  *
- * Returns null for an untyped error, so a caller keeps whatever fallback it
- * already applies to those.
+ * Always returns an object, so no caller needs a null guard. A `NextlyError`
+ * yields the full set of envelope fields; any other `Error` yields no fields at
+ * all but still carries the thrown error itself, which
+ * {@link errorFromServiceEnvelope} reads back off the envelope; a non-`Error`
+ * value yields an empty object. Spreading the result is therefore correct in
+ * every case, and a caller that keeps its own fallback for an untyped failure
+ * keeps it by seeing no fields rather than by testing for null.
  */
 export function errorEnvelopeFields(
   error: unknown

--- a/packages/nextly/src/errors/nextly-error.ts
+++ b/packages/nextly/src/errors/nextly-error.ts
@@ -251,21 +251,28 @@ export class NextlyError extends Error {
   }
 
   static notFound(opts?: {
+    // Declared so a rebuild from a status-only envelope can chain the failure
+    // it came from. Without it the option is accepted and dropped whenever it
+    // arrives through a spread, which reads as forwarded and is not.
+    cause?: Error;
     logContext?: Record<string, unknown>;
   }): NextlyError {
     return new NextlyError({
       code: "NOT_FOUND",
       publicMessage: "Not found.",
+      cause: opts?.cause,
       logContext: opts?.logContext,
     });
   }
 
   static forbidden(opts?: {
+    cause?: Error;
     logContext?: Record<string, unknown>;
   }): NextlyError {
     return new NextlyError({
       code: "FORBIDDEN",
       publicMessage: "You don't have permission to perform this action.",
+      cause: opts?.cause,
       logContext: opts?.logContext,
     });
   }
@@ -310,6 +317,7 @@ export class NextlyError extends Error {
     // for state conflicts where "refresh and try again" would misdirect the
     // caller (a disabled endpoint, an in-flight delivery, and so on).
     message?: string;
+    cause?: Error;
     logContext?: Record<string, unknown>;
   }): NextlyError {
     return new NextlyError({
@@ -317,6 +325,7 @@ export class NextlyError extends Error {
       publicMessage:
         opts?.message ??
         "The resource has changed since you last loaded it. Please refresh and try again.",
+      cause: opts?.cause,
       logContext: { reason: opts?.reason, ...opts?.logContext },
     });
   }

--- a/packages/nextly/src/errors/nextly-error.ts
+++ b/packages/nextly/src/errors/nextly-error.ts
@@ -301,12 +301,14 @@ export class NextlyError extends Error {
 
   static validation(opts: {
     errors: ValidationPublicData["errors"];
+    cause?: Error;
     logContext?: Record<string, unknown>;
   }): NextlyError {
     return new NextlyError({
       code: "VALIDATION_ERROR",
       publicMessage: "Validation failed.",
       publicData: { errors: opts.errors },
+      cause: opts.cause,
       logContext: opts.logContext,
     });
   }

--- a/packages/nextly/src/errors/original-error.ts
+++ b/packages/nextly/src/errors/original-error.ts
@@ -21,14 +21,19 @@
  * @module errors/original-error
  */
 
-import type { NextlyError } from "./nextly-error";
-
 /** Where the pre-envelope error hides on a service result. */
 export const ORIGINAL_ERROR = Symbol.for("nextly.originalError");
 
+/**
+ * Any `Error`, not only a `NextlyError`.
+ *
+ * A raw driver rejection is the case where the chained cause is worth the most
+ * — it is the only thing that names the constraint or the connection failure —
+ * and it is exactly the shape that never reaches the typed branch.
+ */
 /** A result that may be carrying the error it was built from. */
 interface MaybeCarryingOriginal {
-  [ORIGINAL_ERROR]?: NextlyError;
+  [ORIGINAL_ERROR]?: Error;
 }
 
 /**
@@ -39,7 +44,7 @@ interface MaybeCarryingOriginal {
  */
 export function withOriginalError<T extends object>(
   result: T,
-  error: NextlyError
+  error: Error
 ): T {
   Object.defineProperty(result, ORIGINAL_ERROR, {
     value: error,
@@ -51,7 +56,7 @@ export function withOriginalError<T extends object>(
 }
 
 /** The error an envelope was built from, when it still has it. */
-export function originalErrorOf(result: unknown): NextlyError | undefined {
+export function originalErrorOf(result: unknown): Error | undefined {
   if (typeof result !== "object" || result === null) return undefined;
   return (result as MaybeCarryingOriginal)[ORIGINAL_ERROR];
 }

--- a/packages/nextly/src/plugins/routes/dispatch-auth.test.ts
+++ b/packages/nextly/src/plugins/routes/dispatch-auth.test.ts
@@ -1,14 +1,17 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 // Mock the auth middleware so we drive the secure-by-default branches without a
-// real session. isErrorResponse/createJsonErrorResponse keep their real shape.
+// real session. `isErrorResponse` keeps its real shape.
+//
+// The conversion from a legacy auth result to the canonical error is NOT
+// mocked: it lives in its own module, and the point of the body assertions
+// below is what a caller actually receives, which a stubbed converter would
+// decide instead of the code.
 vi.mock("../../auth/middleware", () => ({
   requireAuthentication: vi.fn(),
   requirePermission: vi.fn(),
   isErrorResponse: (x: unknown) =>
     !!x && typeof x === "object" && "statusCode" in x,
-  createJsonErrorResponse: (e: { statusCode: number; error?: string }) =>
-    new Response(JSON.stringify({ error: e }), { status: e.statusCode }),
 }));
 
 import {
@@ -67,6 +70,17 @@ describe("secure-by-default plugin route dispatch", () => {
     const res = await runPluginRoute(req(), match(route({})));
     expect(res.status).toBe(401);
     expect(handlerCalls).toBe(0);
+    // The canonical envelope, not the legacy auth one. A rejected request and
+    // a failing handler on the SAME route answered in two different shapes,
+    // because each was built by a different owner; a status-only assertion is
+    // what let that stand.
+    expect(res.headers.get("content-type")).toBe("application/problem+json");
+    expect(await res.json()).toEqual({
+      error: expect.objectContaining({
+        code: "AUTH_REQUIRED",
+        requestId: expect.any(String),
+      }),
+    });
   });
 
   it("protected route runs with a mapped ctx.user when authenticated", async () => {
@@ -86,6 +100,10 @@ describe("secure-by-default plugin route dispatch", () => {
       match(route({ requiredPermission: "export-submissions" }))
     );
     expect(res.status).toBe(403);
+    expect(res.headers.get("content-type")).toBe("application/problem+json");
+    expect(await res.json()).toEqual({
+      error: expect.objectContaining({ code: "FORBIDDEN" }),
+    });
     expect(reqPerm).toHaveBeenCalledWith(
       expect.anything(),
       "export",

--- a/packages/nextly/src/plugins/routes/dispatch.ts
+++ b/packages/nextly/src/plugins/routes/dispatch.ts
@@ -1,11 +1,13 @@
+import { buildErrorResponse } from "../../api/error-response";
 import { readOrGenerateRequestId } from "../../api/request-id";
 import {
-  createJsonErrorResponse,
   isErrorResponse,
   requireAuthentication,
   requirePermission,
 } from "../../auth/middleware";
+import { toNextlyAuthError } from "../../auth/middleware/to-nextly-error";
 import { NextlyError } from "../../errors/nextly-error";
+import { currentFlattenedErrors } from "../../hooks/side-effect-warnings";
 import type { AuthUser } from "../../types/auth";
 
 import { composeMiddleware } from "./middleware";
@@ -14,36 +16,49 @@ import type { RouteMatch } from "./route-registry";
 import type { PluginRoute, PluginRouteContext } from "./route-types";
 
 /**
- * Map an error thrown by a plugin route handler to a JSON error Response,
- * reusing the dispatcher's `{ error: ... }` / problem+json convention. A
- * non-NextlyError becomes a generic 500 — a handler failure must never crash
- * the server (D28-adjacent robustness).
+ * Map a failure on a plugin route to the error Response a caller receives.
+ *
+ * Through the shared builder, so a plugin route answers with what every other
+ * route answers with. Hand-building the body here agreed on the status and the
+ * content type and differed on everything the builder had gained since, so a
+ * plugin route was the one surface with no development diagnostics.
+ *
+ * A non-NextlyError becomes a generic 500 with the thrown error chained, never
+ * a crash: a handler failure must not take the server down (D28-adjacent
+ * robustness), and discarding it left the one failure with no typed detail as
+ * the one failure with no detail at all.
  */
 function toErrorResponse(req: Request, err: unknown): Response {
-  const requestId = readOrGenerateRequestId(req);
-  const nextlyErr = NextlyError.is(err) ? err : NextlyError.internal();
-  return new Response(
-    JSON.stringify({ error: nextlyErr.toResponseJSON(requestId) }),
-    {
-      status: nextlyErr.statusCode,
-      headers: {
-        "content-type": "application/problem+json",
-        "x-request-id": requestId,
-      },
-    }
-  );
+  const nextlyErr = NextlyError.is(err)
+    ? err
+    : NextlyError.internal({
+        ...(err instanceof Error ? { cause: err } : {}),
+        logContext: { kind: "plugin-route-handler-error" },
+      });
+  return buildErrorResponse(nextlyErr, {
+    requestId: readOrGenerateRequestId(req),
+    // Read here because this frame is inside the request's warning scope --
+    // the dynamic router opens it around the dispatch that reaches this.
+    flattened: currentFlattenedErrors(),
+  });
 }
 
 /**
  * Resolve secure-by-default auth for a route. `public: true` skips auth
  * (`user` is `null`). Otherwise the request must be authenticated; if the route
  * declares `requiredPermission`, that permission is enforced too. Returns either
- * the resolved `user` or a ready-to-return error Response (401/403).
+ * the resolved `user` or the failure (401/403) for the caller to serialize.
+ *
+ * The failure rather than a finished Response, so the one boundary that builds
+ * a plugin route's error body builds all of them. Returning a ready response
+ * here is how a rejected request came back in the legacy `{ data }` shape while
+ * a failing handler on the same route came back in the canonical `{ error }`
+ * one.
  */
 async function resolvePluginRouteAuth(
   req: Request,
   route: PluginRoute
-): Promise<{ user: AuthUser | null } | { errorResponse: Response }> {
+): Promise<{ user: AuthUser | null } | { error: NextlyError }> {
   if (route.public === true) return { user: null };
 
   // requirePermission already enforces authentication, so the permission-gated
@@ -53,7 +68,7 @@ async function resolvePluginRouteAuth(
     : await requireAuthentication(req);
 
   if (isErrorResponse(authResult)) {
-    return { errorResponse: createJsonErrorResponse(authResult) };
+    return { error: toNextlyAuthError(authResult) };
   }
 
   const user: AuthUser = {
@@ -80,7 +95,12 @@ export async function runPluginRoute(
   matched: RouteMatch
 ): Promise<Response> {
   const auth = await resolvePluginRouteAuth(req, matched.route);
-  if ("errorResponse" in auth) return auth.errorResponse;
+  if ("error" in auth) {
+    return buildErrorResponse(auth.error, {
+      requestId: readOrGenerateRequestId(req),
+      flattened: currentFlattenedErrors(),
+    });
+  }
 
   const ctx: PluginRouteContext = {
     ...matched.baseCtx,


### PR DESCRIPTION
Closes the gap I left open on #508 and stated on its thread rather than resolving.

## The gap

`typedErrorEnvelopeFields` returned `null` at its `NextlyError.is` guard **before** reaching the provenance attachment, and the read branches spread `...(fields ?? {})`. So a raw driver rejection on `find` / `findByID` / `count`, and the equivalent branch in `single-utils.ts`, still reconstructed with `originalErrorOf(result) === undefined`.

**That is the case where the chained cause is worth the most** — a connection drop or a constraint rejection is the only thing naming what actually failed, and it was the one shape guaranteed never to reach the typed branch.

## The fix, and why it is one function rather than two

The obvious move was a sibling helper carrying provenance for any `Error`. I rejected it: a second function means every failure branch chooses which to call, which is **exactly the defect #508's own review caught** — provenance wired only where someone remembered.

Instead the existing function's contract changed: **it always returns something spreadable.** An untyped error has no code, status or message worth lifting — inventing one would have the boundary rebuild a fabricated error — so nothing is lifted and it leaves with the provenance alone. A caller spreads the result and is covered.

This was safe to change because `null` was never used meaningfully: every call site either wrote `?? {}` or spread it directly (spreading `null` is a no-op). The function is not in the package's public surface. The `?? {}` noise goes away with it.

**Renamed** `typedErrorEnvelopeFields` → `errorEnvelopeFields`, because a function named for the typed case that also handles the untyped one misdescribes itself.

`withOriginalError` / `originalErrorOf` widened from `NextlyError` to `Error`, which is what makes a raw driver error a valid `cause`.

## Verification

- **Three new tests**: a raw error carries its original with no fields invented; that original chains onto what the boundary rebuilds; and a thrown non-`Error` still yields a spreadable object with no provenance.
- **Revert-checked**: restoring the empty return fails all three; revert proven with `diff`.
- The contract test that asserted `null` is updated deliberately — it now pins the new behaviour rather than being deleted.
- Failing-test set across `errors`, `direct-api`, `collections`, `singles` and `api` is **identical to before the change** (15, all pre-existing).
- `check-types` and `lint` clean.

## Queue after this

Item 4 (converge the two error-body owners) is the remaining error-diagnostics work; then item 3 (admin warning toast), item 2 (plugin mutation envelope — breaking, SDK snapshot + reference plugins + docs together), then task 052's design doc, which needs founder sign-off rather than code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error reporting across collection and single-item operations.
  - Preserved original error details and provenance, including database and driver failures.
  - Ensured structured error metadata remains available across all success and failure paths.
  - Prevented internal error provenance from appearing in serialized response data.
  - Improved handling of untyped and unexpected error values.

- **Tests**
  - Expanded coverage for error conversion, chaining, flattening, recording, and serialization behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->