### PR TITLE
feat(nextly): record the outcome of every captured event

### DIFF
--- a/.changeset/event-outcome-field.md
+++ b/.changeset/event-outcome-field.md
@@ -1,0 +1,38 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+Record the outcome of every event the outbox captures. `success | failure |
+unknown` is the vocabulary the audit and observability schemas converge on, and
+the one field NIST SP 800-53 AU-3(e) requires that the envelope did not already
+carry.
+
+Absence means success, which is what every event recorded so far is: a row is
+written inside the transaction of a change that commits, so a recorded event is
+by construction a completed one — and that is also why the column's default is
+the correct value for existing rows. The field exists so that a refusal, such as
+a denied publish, can be recorded as the distinct thing it is rather than being
+indistinguishable from a change that happened.
+
+Additive and optional on the webhook envelope, so existing subscribers are
+unaffected.

--- a/packages/nextly/src/domains/webhooks/__tests__/outbox-capture.integration.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/outbox-capture.integration.test.ts
@@ -22,6 +22,7 @@ import {
 import { NextlyError } from "../../../errors";
 import type { CollectionService } from "../../collections/services/collection-service";
 import type { CollectionsHandler } from "../../../services/collections-handler";
+import { recordEvent } from "../record-event";
 import { recordMutationEvent } from "../record-mutation-event";
 import type { WebhookEvent } from "../types";
 
@@ -46,6 +47,7 @@ interface EventRow {
   payload: unknown;
   actorType: string | null;
   actorId: string | null;
+  outcome: string;
 }
 
 /**
@@ -81,6 +83,42 @@ async function events(handle: TestNextly): Promise<EventRow[]> {
 }
 
 describe("webhook outbox capture (integration)", () => {
+  it("stores a non-default outcome through the real schema", async () => {
+    // Asserting the DEFAULT here would prove nothing: the column defaults to
+    // "success", so a recorder that dropped the field entirely would still read
+    // back as one. Recording a REFUSAL is what separates the two — it can only
+    // arrive if the recorder carries the value and the column accepts it.
+    current = await createTestNextly({
+      collections: [
+        defineCollection({
+          slug: "posts",
+          access: { read: () => true, create: () => true, update: () => true },
+          fields: [text({ name: "title" })],
+        }),
+      ],
+    });
+
+    const envelope: WebhookEvent = {
+      id: "evt_outcome_1",
+      type: "entry.updated",
+      specversion: "1",
+      timestamp: new Date().toISOString(),
+      resource: { kind: "entry", collection: "posts", id: "p1" },
+      data: {},
+      previous: null,
+      changedFields: [],
+      outcome: "failure",
+    };
+    await current.adapter.transaction(async tx =>
+      recordEvent(tx, { envelope })
+    );
+
+    const rows = await events(current);
+    const recorded = rows.find(row => row.id === "evt_outcome_1");
+    expect(recorded).toBeDefined();
+    expect(recorded!.outcome).toBe("failure");
+  });
+
   it("records entry.created carrying the assembled document when versioning is OFF", async () => {
     // Versioning off is the case that regressed before: the document assembly
     // used to live inside the versioning branch, so nothing was available to

--- a/packages/nextly/src/domains/webhooks/__tests__/record-event-in-tx.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/record-event-in-tx.test.ts
@@ -81,3 +81,31 @@ describe("recordEventInTx", () => {
     }
   });
 });
+
+/**
+ * Every recorded event carries the outcome of the action it describes. Only
+ * successful writes are recorded today, so absence means success — but the
+ * column has to exist before anything records a refusal, or a denial and a
+ * completed change become indistinguishable after the fact.
+ */
+describe("recordEventInTx — outcome", () => {
+  it("records a successful outcome when the envelope states none", async () => {
+    const { tx, values } = fakeTx();
+
+    await recordEventInTx(tx, "sqlite", { envelope: makeEnvelope() });
+
+    const row = values.mock.calls[0][0] as Record<string, unknown>;
+    expect(row.outcome).toBe("success");
+  });
+
+  it("carries the outcome the envelope states", async () => {
+    const { tx, values } = fakeTx();
+
+    await recordEventInTx(tx, "sqlite", {
+      envelope: makeEnvelope({ outcome: "failure" }),
+    });
+
+    const row = values.mock.calls[0][0] as Record<string, unknown>;
+    expect(row.outcome).toBe("failure");
+  });
+});

--- a/packages/nextly/src/domains/webhooks/record-event.ts
+++ b/packages/nextly/src/domains/webhooks/record-event.ts
@@ -20,7 +20,7 @@ import type {
 
 import { webhookTables } from "../../schemas/webhooks";
 
-import type { WebhookEvent } from "./types";
+import { DEFAULT_EVENT_OUTCOME, type WebhookEvent } from "./types";
 
 /**
  * Row shape written to `nextly_events` (snake_case column names). `created_at`
@@ -54,6 +54,8 @@ function eventRow(envelope: WebhookEvent, now: Date): Record<string, unknown> {
     payload: JSON.stringify(envelope),
     actor_type: envelope.actor?.type ?? null,
     actor_id: envelope.actor?.id ?? null,
+    // Absent means the action completed; see WebhookEvent.outcome.
+    outcome: envelope.outcome ?? DEFAULT_EVENT_OUTCOME,
     created_at: now,
   };
 }
@@ -96,6 +98,8 @@ function eventRowForDrizzle(envelope: WebhookEvent): Record<string, unknown> {
     payload: envelope,
     actorType: envelope.actor?.type ?? null,
     actorId: envelope.actor?.id ?? null,
+    // Absent means the action completed; see WebhookEvent.outcome.
+    outcome: envelope.outcome ?? DEFAULT_EVENT_OUTCOME,
   };
 }
 

--- a/packages/nextly/src/domains/webhooks/types.ts
+++ b/packages/nextly/src/domains/webhooks/types.ts
@@ -155,7 +155,28 @@ export interface WebhookEvent {
    * published. Additive + optional: existing subscribers are unaffected.
    */
   statusChange?: { from: string | null; to: string };
+  /**
+   * Whether the action this event describes succeeded.
+   *
+   * Absent means `success`, which is what every event recorded today is: the
+   * outbox row is written inside the transaction of a change that commits, so
+   * a recorded event is by construction a completed one. The field exists so
+   * that a refusal — a denied publish, a rejected write — can be recorded as
+   * the distinct thing it is rather than being indistinguishable from a change
+   * that happened. Additive + optional: existing subscribers are unaffected.
+   *
+   * `success | failure | unknown` is the one outcome vocabulary the audit and
+   * observability schemas agree on, and the only field NIST SP 800-53 AU-3(e)
+   * requires that this envelope did not already carry.
+   */
+  outcome?: WebhookEventOutcome;
 }
+
+/** The outcome vocabulary shared by every audit record. */
+export type WebhookEventOutcome = "success" | "failure" | "unknown";
+
+/** What a recorded event means when it states no outcome. */
+export const DEFAULT_EVENT_OUTCOME: WebhookEventOutcome = "success";
 
 /** Lifecycle of one delivery row in the outbox ledger. */
 export type DeliveryStatus =

--- a/packages/nextly/src/schemas/webhooks/mysql.ts
+++ b/packages/nextly/src/schemas/webhooks/mysql.ts
@@ -42,6 +42,11 @@ export const nextlyEvents = mysqlTable(
     // NULL means the event still needs fan-out.
     fannedOutAt: datetime("fanned_out_at"),
     // Which retention window governs this row; see the PostgreSQL definition.
+    // Whether the action this row describes succeeded. Defaults to "success"
+    // because a row is only written inside the transaction of a change that
+    // commits, so every event recorded before this column existed was one —
+    // which is also why the default is the correct value for those rows.
+    outcome: varchar("outcome", { length: 16 }).notNull().default("success"),
     retentionClass: varchar("retention_class", { length: 20 })
       .notNull()
       .default("webhook"),

--- a/packages/nextly/src/schemas/webhooks/postgres.ts
+++ b/packages/nextly/src/schemas/webhooks/postgres.ts
@@ -62,6 +62,11 @@ export const nextlyEvents = pgTable(
     // Which retention window governs this row. A single event can serve both
     // roles at once, so this records the LONGEST retention it needs: rows the
     // audit log depends on outlive rows that only ever drove a webhook.
+    // Whether the action this row describes succeeded. Defaults to "success"
+    // because a row is only written inside the transaction of a change that
+    // commits, so every event recorded before this column existed was one —
+    // which is also why the default is the correct value for those rows.
+    outcome: varchar("outcome", { length: 16 }).notNull().default("success"),
     retentionClass: varchar("retention_class", { length: 20 })
       .notNull()
       .default("webhook"),

--- a/packages/nextly/src/schemas/webhooks/sqlite.ts
+++ b/packages/nextly/src/schemas/webhooks/sqlite.ts
@@ -40,6 +40,11 @@ export const nextlyEvents = sqliteTable(
     // NULL means the event still needs fan-out.
     fannedOutAt: integer("fanned_out_at", { mode: "timestamp" }),
     // Which retention window governs this row; see the PostgreSQL definition.
+    // Whether the action this row describes succeeded. Defaults to "success"
+    // because a row is only written inside the transaction of a change that
+    // commits, so every event recorded before this column existed was one —
+    // which is also why the default is the correct value for those rows.
+    outcome: text("outcome").notNull().default("success"),
     retentionClass: text("retention_class").notNull().default("webhook"),
   },
   t => [


### PR DESCRIPTION
First PR of task 052 (roadmap item 7, activity/audit), per the signed design doc.

## Why this one first

`success | failure | unknown` is the outcome vocabulary the audit and observability
schemas converge on, and the only field NIST SP 800-53 AU-3(e) requires that the
event envelope did not already carry. Without it every recorded row implicitly
means the action completed, so a refusal — a denied publish, a rejected write —
cannot be represented at all.

It leads the sequence because a later PR turns audit recording on by default. The
column has to exist before rows start accumulating without it.

## The honest part about the default

Absence means `success`, and that is not a guess: a row is written inside the
transaction of a change that commits, so a recorded event is by construction a
completed one. That is also why the column default is the correct value for the
rows that predate it, rather than a backfill with no right answer.

## What changed

- `WebhookEvent.outcome`, additive and optional, under the same rule the status
  delta was added: existing subscribers are unaffected.
- The column on all three dialects, `NOT NULL DEFAULT 'success'`.
- Both recorders carry it — the raw transactional INSERT and the Drizzle one.

## Testing, and a trap worth naming

Unit tests pin the row mapping on both recorders. The integration test is the
interesting one: my first version asserted the DEFAULT round-tripped, and it
**passed with the recorder's assignment deleted** — the column default supplied
the value, so the test proved nothing. It now records a `failure` through the real
schema, which only arrives if the recorder carries the value AND the column
accepts it. Verify-by-break confirms: `expected 'success' to be 'failure'`.

Green: 201 webhook integration tests, 246 webhook unit tests, `check-types` and
`lint` clean, 0 behind `origin/main`.

## Not in this PR

Marking audit-class rows, the two retention windows, `login-succeeded`, the
`audit_log` erasure, and turning recording on by default are PR-2 through PR-4 in
the design doc's sequence.