### PR TITLE
feat(nextly): classify captured events by the retention they need

### DIFF
--- a/.changeset/event-retention-class.md
+++ b/.changeset/event-retention-class.md
@@ -48,6 +48,14 @@ longest retention it needs, so a shorter audit window would have pruned it
 earlier than the webhook setting allows — irreversibly, and in a supported
 configuration.
 
-No behaviour changes for an existing deployment: the audit seam is off unless
-`webhookAuditEnabled` is set, so rows continue to be recorded webhook-class and
-pruned on the same schedule as before.
+Upgrading, by deployment:
+
+- **`webhooks.audit` off** (the default, and most installs): nothing changes.
+  Events are still recorded webhook-class and pruned on `eventsMaxAgeMs` exactly
+  as before.
+- **`webhooks.audit` on**: events that used to be recorded webhook-class are now
+  audit-class, so they move from `eventsMaxAgeMs` to `auditEventsMaxAgeMs` — at
+  the defaults, from 30 days to 90. That is the intended behaviour, since those
+  rows are recorded for history rather than delivery, but it retains roughly
+  three times as many events and the storage that implies. Set
+  `webhooks.retention.auditEventsMaxAgeMs` if a shorter window is wanted.

--- a/.changeset/event-retention-class.md
+++ b/.changeset/event-retention-class.md
@@ -1,0 +1,46 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+Record which retention window governs each captured event, and shorten the audit
+window to 90 days.
+
+The event table has carried a `retention_class` column since the outbox shipped,
+but nothing ever wrote anything but `webhook`, so every row was measured against
+the short outbox-hygiene window. The class now follows from why the row was
+recorded: a row admitted by the audit seam is audit-class and outlives outbox
+hygiene, while one admitted only because an endpoint exists stays webhook-class.
+A row that is both takes the longer window, since evicting it on the delivery
+clock would lose history nothing can reconstruct.
+
+The audit window default moves from 365 days to 90. The previous value was
+justified as "SOC 2 practice is a one-year floor", which does not hold up:
+neither SOC 2 nor ISO 27001 A.8.15 mandates a period — both require only that
+retention be defined and risk-based — and the twelve-month figure is PCI DSS
+convention that has spread into the wider discourse. 90 days is where comparable
+products land for content activity. A deployment genuinely in PCI scope should
+raise `auditEventsMaxAgeMs`, which is a decision only the operator can make.
+
+No behaviour changes for an existing deployment: the audit seam is off unless
+`webhookAuditEnabled` is set, so rows continue to be recorded webhook-class and
+pruned on the same schedule as before.

--- a/.changeset/event-retention-class.md
+++ b/.changeset/event-retention-class.md
@@ -41,6 +41,13 @@ convention that has spread into the wider discourse. 90 days is where comparable
 products land for content activity. A deployment genuinely in PCI scope should
 raise `auditEventsMaxAgeMs`, which is a decision only the operator can make.
 
+`auditEventsMaxAgeMs` is now raised to `eventsMaxAgeMs` whenever the webhook
+window is the longer of the two, including when it is `false`. A row admitted by
+both the audit seam and an endpoint is labelled `audit` because that is the
+longest retention it needs, so a shorter audit window would have pruned it
+earlier than the webhook setting allows — irreversibly, and in a supported
+configuration.
+
 No behaviour changes for an existing deployment: the audit seam is off unless
 `webhookAuditEnabled` is set, so rows continue to be recorded webhook-class and
 pruned on the same schedule as before.

--- a/docs/guides/webhook-retention.mdx
+++ b/docs/guides/webhook-retention.mdx
@@ -15,7 +15,7 @@ When recording is active these tables fill continuously and are pruned automatic
 Retention runs **opportunistically on content writes** and as part of the delivery **drain** — you do not need to schedule anything for it to work. Each pass deletes:
 
 - **Terminal deliveries** (`delivered` / `failed`) older than `deliveriesMaxAgeMs`.
-- **Events** older than `eventsMaxAgeMs`, once they have been fanned out and no delivery still references them. (A separate, longer window governs audit-class events — see the note below the table.)
+- **Events** older than `eventsMaxAgeMs`, once they have been fanned out and no delivery still references them. (A separate window governs audit-class events, and is never shorter than this one — see the note below the table.)
 
 Passes are bounded so a single write never turns into an unbounded delete.
 
@@ -28,7 +28,7 @@ export default defineConfig({
   webhooks: {
     retention: {
       eventsMaxAgeMs: 30 * 24 * 60 * 60 * 1000, // webhook events — default 30 days
-      auditEventsMaxAgeMs: 365 * 24 * 60 * 60 * 1000, // audit events — default 365 days
+      auditEventsMaxAgeMs: 90 * 24 * 60 * 60 * 1000, // audit events — default 90 days
       deliveriesMaxAgeMs: 7 * 24 * 60 * 60 * 1000, // terminal deliveries — default 7 days
       intervalMs: 60 * 60 * 1000, // min gap between AUTOMATIC passes — default 1 hour
       batchSize: 500, // rows per delete batch — default 500
@@ -41,13 +41,17 @@ export default defineConfig({
 | Field | Default | Meaning |
 |---|---|---|
 | `eventsMaxAgeMs` | 30 days | Age after which a fanned-out `webhook`-class event is prunable. `false` keeps events forever. |
-| `auditEventsMaxAgeMs` | 365 days | Age for `audit`-class events. `false` keeps them forever. See the note below. |
+| `auditEventsMaxAgeMs` | 90 days | Age for `audit`-class events. `false` keeps them forever. Raised to `eventsMaxAgeMs` if that is longer — see the note below. |
 | `deliveriesMaxAgeMs` | 7 days | Age after which a `delivered`/`failed` delivery row is prunable. `false` keeps them forever. |
 | `intervalMs` | 1 hour | Minimum gap between **automatic** retention passes (the opportunistic and drain-driven ones). Does not affect `nextly webhooks:prune`, which always runs a pass when invoked. |
 | `batchSize` | 500 | Rows deleted per batch (capped at 900). |
 | `maxBatchesPerRun` | 20 | Batches per pass, so one write never triggers an unbounded delete. |
 
-**On the audit class:** every event today is recorded with the default `webhook` retention class, so `eventsMaxAgeMs` governs all pruning. The `audit` class and its longer `auditEventsMaxAgeMs` window are reserved for a future audit-log producer and are dormant until then — do not rely on the 365-day window to retain events longer.
+**On the audit class:** an event's class follows from why it was recorded. A write admitted only because a webhook endpoint exists is `webhook`-class and pruned on `eventsMaxAgeMs`. A write admitted by the audit seam — `webhooks.audit`, which records events whether or not anything is subscribed — is `audit`-class and pruned on `auditEventsMaxAgeMs`. A write that is both takes the audit window, because that is the longest retention the row needs and evicting it on the delivery schedule would lose history nothing can reconstruct.
+
+Because of that promise, `auditEventsMaxAgeMs` is **raised to `eventsMaxAgeMs` whenever the webhook window is longer** (including `false`, which means forever). Configuring a shorter audit window than webhook window would otherwise prune a dual-purpose row earlier than your webhook setting allows. The cost is that a row which is audit-only is kept as long as the webhook window in that configuration — retention errs toward keeping an audit trail rather than losing one.
+
+The audit seam is **off** unless you enable it, so an install that has not turned it on records only `webhook`-class rows and is pruned exactly as before.
 
 Set `webhooks.retention: false` to disable pruning entirely. Both the automatic passes **and** `nextly webhooks:prune` then do nothing, so the tables grow until you either re-enable retention or clean them up at the database level yourself.
 

--- a/docs/guides/webhook-retention.mdx
+++ b/docs/guides/webhook-retention.mdx
@@ -53,6 +53,8 @@ Because of that promise, `auditEventsMaxAgeMs` is **raised to `eventsMaxAgeMs` w
 
 The audit seam is **off** unless you enable it, so an install that has not turned it on records only `webhook`-class rows and is pruned exactly as before.
 
+**If you already run with `webhooks.audit` enabled,** note that those events previously fell under `eventsMaxAgeMs`, because nothing wrote the audit class. They now fall under `auditEventsMaxAgeMs` — at the defaults, 90 days instead of 30 — which retains roughly three times as many event rows. That is the point of the class, but it is a storage change worth planning for; lower `auditEventsMaxAgeMs` if you want the shorter window back.
+
 Set `webhooks.retention: false` to disable pruning entirely. Both the automatic passes **and** `nextly webhooks:prune` then do nothing, so the tables grow until you either re-enable retention or clean them up at the database level yourself.
 
 ## Pruning by hand: `nextly webhooks:prune`

--- a/packages/nextly/src/domains/webhooks/__tests__/outbox-capture.integration.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/outbox-capture.integration.test.ts
@@ -22,6 +22,10 @@ import {
 import { NextlyError } from "../../../errors";
 import type { CollectionService } from "../../collections/services/collection-service";
 import type { CollectionsHandler } from "../../../services/collections-handler";
+import {
+  resetWebhookActivation,
+  setWebhookAuditEnabled,
+} from "../recording-activation";
 import { recordEvent } from "../record-event";
 import { recordMutationEvent } from "../record-mutation-event";
 import type { WebhookEvent } from "../types";
@@ -31,6 +35,11 @@ let current: TestNextly | undefined;
 afterEach(async () => {
   await current?.destroy();
   current = undefined;
+  // The recording gates are process-global and this config runs every
+  // integration file in ONE fork, so a test that turns the audit seam on would
+  // otherwise leave it on for every file that runs after it — which changes
+  // both what gets recorded and which retention window prunes it.
+  resetWebhookActivation();
   // The post-commit-hook cases silence `console.error` to assert against it.
   // This config does not restore mocks between tests, so without this every
   // later test in the file would run with errors muted.
@@ -48,6 +57,7 @@ interface EventRow {
   actorType: string | null;
   actorId: string | null;
   outcome: string;
+  retentionClass: string;
 }
 
 /**
@@ -83,6 +93,32 @@ async function events(handle: TestNextly): Promise<EventRow[]> {
 }
 
 describe("webhook outbox capture (integration)", () => {
+  it("records an audit-relevant row under the audit retention window", async () => {
+    // The column defaults to "webhook", so asserting "audit" cannot pass by
+    // default — it arrives only if the recording path classified the row and
+    // carried the class through. Audit history outlives outbox hygiene, so a
+    // row admitted by the audit seam must not be pruned on the delivery clock.
+    current = await createTestNextly({
+      collections: [
+        defineCollection({
+          slug: "posts",
+          access: { read: () => true, create: () => true, update: () => true },
+          fields: [text({ name: "title" })],
+        }),
+      ],
+    });
+    setWebhookAuditEnabled(true);
+
+    await current.nextly.create({
+      collection: "posts",
+      data: { title: "hello" },
+    });
+
+    const rows = await events(current);
+    expect(rows.length).toBeGreaterThan(0);
+    expect(rows.every(row => row.retentionClass === "audit")).toBe(true);
+  });
+
   it("stores a non-default outcome through the real schema", async () => {
     // Asserting the DEFAULT here would prove nothing: the column defaults to
     // "success", so a recorder that dropped the field entirely would still read

--- a/packages/nextly/src/domains/webhooks/__tests__/recording-activation.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/recording-activation.test.ts
@@ -6,6 +6,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
   endpointsPresent,
+  resolveEventRetentionClass,
   isWebhookAuditEnabled,
   refreshEndpointPresence,
   resetWebhookActivation,
@@ -175,5 +176,32 @@ describe("endpoint presence flag", () => {
     await flush();
     expect(refresher).toHaveBeenCalledTimes(2);
     expect(endpointsPresent()).toBe(false);
+  });
+});
+
+/**
+ * Which retention window a recorded row falls under follows WHY it was
+ * recorded. The class records the longest retention the row needs, so a row
+ * that is both audit-relevant and deliverable is audit-class.
+ */
+describe("resolveEventRetentionClass", () => {
+  it("marks a row recorded for audit as audit-class", () => {
+    expect(
+      resolveEventRetentionClass({ auditEnabled: true, hasEndpoints: false })
+    ).toBe("audit");
+  });
+
+  it("marks a row recorded only for delivery as webhook-class", () => {
+    expect(
+      resolveEventRetentionClass({ auditEnabled: false, hasEndpoints: true })
+    ).toBe("webhook");
+  });
+
+  it("takes the longer window when the row is both", () => {
+    // Audit history outlives outbox hygiene, so a row needed for both must not
+    // be evicted on the delivery schedule.
+    expect(
+      resolveEventRetentionClass({ auditEnabled: true, hasEndpoints: true })
+    ).toBe("audit");
   });
 });

--- a/packages/nextly/src/domains/webhooks/__tests__/retention-config.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/retention-config.test.ts
@@ -33,11 +33,20 @@ describe("resolveWebhookRetentionConfig", () => {
     expect(resolveWebhookRetentionConfig(false)).toBeNull();
   });
 
-  it("keeps a class forever when its window is `false`", () => {
+  it("carries keep-forever from the webhook window into the audit window", () => {
+    // The two windows were independent while nothing recorded an audit-class
+    // row. They cannot be now: a row admitted by BOTH the audit seam and an
+    // endpoint is labelled `audit`, so an audit window shorter than the webhook
+    // one prunes it earlier than the webhook setting allows — irreversibly, and
+    // in a supported configuration. The label promises the longest retention the
+    // row needs, so resolution has to make that true rather than assume it.
+    //
+    // The cost is over-retention for a row that is audit-only, which is the safe
+    // direction to be wrong in for an audit trail. Telling the two apart would
+    // need the row to record that it was dual-purpose, which it does not.
     const policy = resolveWebhookRetentionConfig({ eventsMaxAgeMs: false });
     expect(policy?.eventsMaxAgeMs).toBe(false);
-    // The other class keeps its own window.
-    expect(policy?.auditEventsMaxAgeMs).toBe(DEFAULT_AUDIT_EVENTS_MAX_AGE_MS);
+    expect(policy?.auditEventsMaxAgeMs).toBe(false);
   });
 
   it("clamps the delivery window to the longest event window", () => {
@@ -99,5 +108,42 @@ describe("resolveWebhookRetentionConfig", () => {
     });
     expect(windowForClass(policy!, "webhook")).toBe(10);
     expect(windowForClass(policy!, "audit")).toBe(20);
+  });
+});
+
+/**
+ * The class a row carries is decided from why it was recorded, but the windows
+ * are configured independently — so an audit window shorter than the webhook
+ * one would prune a dual-purpose row earlier than the webhook setting allows.
+ * The class promises the LONGEST retention the row needs, so the resolved audit
+ * window can never be the shorter of the two.
+ */
+describe("audit window never undercuts the webhook window", () => {
+  it("keeps audit rows forever when webhook rows are kept forever", () => {
+    const policy = resolveWebhookRetentionConfig({
+      eventsMaxAgeMs: false,
+      auditEventsMaxAgeMs: 90 * 24 * 60 * 60 * 1000,
+    });
+
+    expect(policy?.auditEventsMaxAgeMs).toBe(false);
+  });
+
+  it("raises a shorter audit window to the webhook window", () => {
+    const twoHundredDays = 200 * 24 * 60 * 60 * 1000;
+    const policy = resolveWebhookRetentionConfig({
+      eventsMaxAgeMs: twoHundredDays,
+      auditEventsMaxAgeMs: 90 * 24 * 60 * 60 * 1000,
+    });
+
+    expect(policy?.auditEventsMaxAgeMs).toBe(twoHundredDays);
+  });
+
+  it("leaves a longer audit window alone", () => {
+    const policy = resolveWebhookRetentionConfig({
+      eventsMaxAgeMs: 30 * 24 * 60 * 60 * 1000,
+      auditEventsMaxAgeMs: 90 * 24 * 60 * 60 * 1000,
+    });
+
+    expect(policy?.auditEventsMaxAgeMs).toBe(90 * 24 * 60 * 60 * 1000);
   });
 });

--- a/packages/nextly/src/domains/webhooks/__tests__/retention.integration.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/retention.integration.test.ts
@@ -49,13 +49,19 @@ async function ageEvent(
   handle: TestNextly,
   id: string,
   createdAt: Date,
-  fannedOut: boolean
+  fannedOut: boolean,
+  // Stated per case rather than inherited. The test harness enables the audit
+  // seam, so a recorded row is audit-class and would be measured against the
+  // long window — a case about outbox hygiene has to say so, or it reads as
+  // testing one window while exercising another.
+  retentionClass: "webhook" | "audit" = "webhook"
 ): Promise<void> {
   await handle.adapter.update(
     "nextly_events",
     {
       created_at: createdAt,
       fanned_out_at: fannedOut ? createdAt : null,
+      retention_class: retentionClass,
     },
     { and: [{ column: "id", op: "=", value: id }] }
   );
@@ -64,9 +70,10 @@ async function ageEvent(
 const OLD = new Date("2020-01-01T00:00:00.000Z");
 
 describe("webhook retention (integration)", () => {
-  it("writes events with the webhook retention class by default", async () => {
-    // Audit-class rows only appear once the audit log exists; until then every
-    // row takes the short window.
+  it("records an audit-class row while the audit seam is on", async () => {
+    // The class follows from WHY the row was recorded, and the harness enables
+    // the audit seam. Nothing needs a row beyond delivery is webhook-class; this
+    // one is needed for history, so it takes the long window.
     const t = await boot();
     const handler = t.getService<CollectionsHandler>("collectionsHandler");
     await handler.createEntry(
@@ -76,7 +83,38 @@ describe("webhook retention (integration)", () => {
 
     const rows = await events(t);
     expect(rows).toHaveLength(1);
-    expect(rows[0].retentionClass).toBe("webhook");
+    expect(rows[0].retentionClass).toBe("audit");
+  });
+
+  it("keeps an audit-class row at an age that evicts a webhook-class one", async () => {
+    // The class is the ONLY difference: both rows are the same age, in the same
+    // pass, under the same config. One is past the webhook window and inside the
+    // audit window, so the short window evicts one and not the other. Aged to 60
+    // days for exactly that reason — past 30, inside 90.
+    const t = await boot();
+    const handler = t.getService<CollectionsHandler>("collectionsHandler");
+    await handler.createEntry(
+      { collectionName: "posts", overrideAccess: true },
+      { title: "kept" }
+    );
+    await handler.createEntry(
+      { collectionName: "posts", overrideAccess: true },
+      { title: "evicted" }
+    );
+    const [kept, evicted] = await events(t);
+    const sixtyDaysAgo = new Date(Date.now() - 60 * 24 * 60 * 60 * 1000);
+    await ageEvent(t, kept.id, sixtyDaysAgo, true, "audit");
+    await ageEvent(t, evicted.id, sixtyDaysAgo, true, "webhook");
+
+    const result = await pruneWebhookData(
+      { adapter: t.adapter },
+      resolveWebhookRetentionConfig({})!
+    );
+
+    expect(result.events.webhook).toBe(1);
+    const remaining = await events(t);
+    expect(remaining).toHaveLength(1);
+    expect(remaining[0].id).toBe(kept.id);
   });
 
   it("prunes an aged, fanned-out event", async () => {

--- a/packages/nextly/src/domains/webhooks/record-event.ts
+++ b/packages/nextly/src/domains/webhooks/record-event.ts
@@ -20,6 +20,10 @@ import type {
 
 import { webhookTables } from "../../schemas/webhooks";
 
+import {
+  DEFAULT_EVENT_RETENTION_CLASS,
+  type EventRetentionClass,
+} from "./retention-config";
 import { DEFAULT_EVENT_OUTCOME, type WebhookEvent } from "./types";
 
 /**
@@ -28,7 +32,11 @@ import { DEFAULT_EVENT_OUTCOME, type WebhookEvent } from "./types";
  * bypasses Drizzle's runtime `$defaultFn`, so a NOT NULL timestamp must be
  * provided rather than left to the column default.
  */
-function eventRow(envelope: WebhookEvent, now: Date): Record<string, unknown> {
+function eventRow(
+  envelope: WebhookEvent,
+  now: Date,
+  retentionClass: EventRetentionClass
+): Record<string, unknown> {
   return {
     id: envelope.id,
     type: envelope.type,
@@ -56,6 +64,10 @@ function eventRow(envelope: WebhookEvent, now: Date): Record<string, unknown> {
     actor_id: envelope.actor?.id ?? null,
     // Absent means the action completed; see WebhookEvent.outcome.
     outcome: envelope.outcome ?? DEFAULT_EVENT_OUTCOME,
+    // Storage policy, not envelope content: which window prunes this row. Kept
+    // off the envelope deliberately — a subscriber has no use for it, and the
+    // delivered payload should not carry the host's retention decisions.
+    retention_class: retentionClass,
     created_at: now,
   };
 }
@@ -67,14 +79,22 @@ function eventRow(envelope: WebhookEvent, now: Date): Record<string, unknown> {
  */
 export async function recordEvent(
   tx: TransactionContext,
-  params: { envelope: WebhookEvent }
+  params: { envelope: WebhookEvent; retentionClass?: EventRetentionClass }
 ): Promise<void> {
   // Project to `id` only: the result is ignored, and the default insert would
   // otherwise RETURN * (or select the row back), forcing the large JSON payload
   // we just wrote to be read and decoded again inside the content transaction.
-  await tx.insert("nextly_events", eventRow(params.envelope, new Date()), {
-    returning: ["id"],
-  });
+  await tx.insert(
+    "nextly_events",
+    eventRow(
+      params.envelope,
+      new Date(),
+      params.retentionClass ?? DEFAULT_EVENT_RETENTION_CLASS
+    ),
+    {
+      returning: ["id"],
+    }
+  );
 }
 
 /**
@@ -83,7 +103,10 @@ export async function recordEvent(
  * json/jsonb codec serializes it per dialect, and `createdAt`/`retentionClass`
  * are left to the column defaults the Drizzle insert applies.
  */
-function eventRowForDrizzle(envelope: WebhookEvent): Record<string, unknown> {
+function eventRowForDrizzle(
+  envelope: WebhookEvent,
+  retentionClass: EventRetentionClass
+): Record<string, unknown> {
   return {
     id: envelope.id,
     type: envelope.type,
@@ -100,6 +123,8 @@ function eventRowForDrizzle(envelope: WebhookEvent): Record<string, unknown> {
     actorId: envelope.actor?.id ?? null,
     // Absent means the action completed; see WebhookEvent.outcome.
     outcome: envelope.outcome ?? DEFAULT_EVENT_OUTCOME,
+    // See eventRow: storage policy, kept off the envelope.
+    retentionClass,
   };
 }
 
@@ -124,8 +149,15 @@ export interface DrizzleEventTx {
 export async function recordEventInTx(
   tx: DrizzleEventTx,
   dialect: SupportedDialect,
-  params: { envelope: WebhookEvent }
+  params: { envelope: WebhookEvent; retentionClass?: EventRetentionClass }
 ): Promise<void> {
   const { nextlyEvents } = webhookTables(dialect);
-  await tx.insert(nextlyEvents).values(eventRowForDrizzle(params.envelope));
+  await tx
+    .insert(nextlyEvents)
+    .values(
+      eventRowForDrizzle(
+        params.envelope,
+        params.retentionClass ?? DEFAULT_EVENT_RETENTION_CLASS
+      )
+    );
 }

--- a/packages/nextly/src/domains/webhooks/record-event.ts
+++ b/packages/nextly/src/domains/webhooks/record-event.ts
@@ -99,9 +99,14 @@ export async function recordEvent(
 
 /**
  * The Drizzle table row for one event (camelCase properties). Unlike
- * {@link eventRow}, the `payload` is passed as an OBJECT: the Drizzle
- * json/jsonb codec serializes it per dialect, and `createdAt`/`retentionClass`
- * are left to the column defaults the Drizzle insert applies.
+ * {@link eventRow}, the `payload` is passed as an OBJECT: the Drizzle json/jsonb
+ * codec serializes it per dialect, and `createdAt` is left to the column default
+ * the Drizzle insert applies.
+ *
+ * `retentionClass` is written explicitly, not defaulted. Which window prunes a
+ * row is decided by the caller from why the row was recorded, so leaving it to
+ * the column default would silently file an audit-relevant row under outbox
+ * hygiene.
  */
 function eventRowForDrizzle(
   envelope: WebhookEvent,

--- a/packages/nextly/src/domains/webhooks/record-mutation-event.ts
+++ b/packages/nextly/src/domains/webhooks/record-mutation-event.ts
@@ -28,9 +28,11 @@ import {
 import {
   endpointsPresent,
   isWebhookAuditEnabled,
+  resolveEventRetentionClass,
   shouldRecordEvent,
 } from "./recording-activation";
 import { isWebhookRecordingEnabled } from "./recording-policy";
+import type { EventRetentionClass } from "./retention-config";
 import {
   sensitiveFieldPaths,
   type SensitiveFieldSource,
@@ -94,23 +96,29 @@ export interface RecordMutationEventArgs {
  * the flag TTL across processes; a few events recorded just before the last
  * endpoint is removed are pruned by retention.
  */
-function prepareMutationEnvelope(
-  args: RecordMutationEventArgs
-): WebhookEvent | null {
+function prepareMutationEnvelope(args: RecordMutationEventArgs): {
+  envelope: WebhookEvent;
+  retentionClass: EventRetentionClass;
+} | null {
   if (!resourceRecordingEnabled(args.resource)) {
     return null;
   }
+  // Read once and reuse: the gate and the retention class are two decisions
+  // from the same facts, and reading the flags twice could straddle a refresh
+  // and record a row whose class disagrees with why it was admitted.
+  const auditEnabled = isWebhookAuditEnabled();
+  const hasEndpoints = endpointsPresent();
   if (
     !shouldRecordEvent({
       collectionAllows: true,
-      auditEnabled: isWebhookAuditEnabled(),
-      hasEndpoints: endpointsPresent(),
+      auditEnabled,
+      hasEndpoints,
     })
   ) {
     return null;
   }
 
-  return buildEnvelope({
+  const envelope = buildEnvelope({
     id: (args.newId ?? (() => crypto.randomUUID()))(),
     type: args.type,
     timestamp: args.timestamp ?? new Date(),
@@ -124,15 +132,19 @@ function prepareMutationEnvelope(
       ? { statusChange: args.statusChange }
       : {}),
   });
+  return {
+    envelope,
+    retentionClass: resolveEventRetentionClass({ auditEnabled, hasEndpoints }),
+  };
 }
 
 export async function recordMutationEvent(
   tx: TransactionContext,
   args: RecordMutationEventArgs
 ): Promise<boolean> {
-  const envelope = prepareMutationEnvelope(args);
-  if (!envelope) return false;
-  await recordEvent(tx, { envelope });
+  const prepared = prepareMutationEnvelope(args);
+  if (!prepared) return false;
+  await recordEvent(tx, prepared);
   return true;
 }
 
@@ -148,8 +160,8 @@ export async function recordMutationEventInTx(
   dialect: SupportedDialect,
   args: RecordMutationEventArgs
 ): Promise<boolean> {
-  const envelope = prepareMutationEnvelope(args);
-  if (!envelope) return false;
-  await recordEventInTx(tx, dialect, { envelope });
+  const prepared = prepareMutationEnvelope(args);
+  if (!prepared) return false;
+  await recordEventInTx(tx, dialect, prepared);
   return true;
 }

--- a/packages/nextly/src/domains/webhooks/recording-activation.ts
+++ b/packages/nextly/src/domains/webhooks/recording-activation.ts
@@ -34,6 +34,7 @@ import {
   isWebhookRecordingEnabled,
   type WebhookRecordingScope,
 } from "./recording-policy";
+import type { EventRetentionClass } from "./retention-config";
 
 /**
  * How long a primed presence value is trusted before a stale read schedules a
@@ -87,6 +88,24 @@ export function shouldRecordEvent(input: {
   hasEndpoints: boolean;
 }): boolean {
   return input.collectionAllows && (input.auditEnabled || input.hasEndpoints);
+}
+
+/**
+ * Which retention window a recorded row falls under.
+ *
+ * The class records the LONGEST retention the row needs, not what produced it,
+ * so a row that is both audit-relevant and deliverable is audit-class: audit
+ * history is measured in months while outbox hygiene is measured in days, and
+ * evicting a row on the delivery schedule would lose history nothing can
+ * reconstruct. Pure and total for its inputs, like {@link shouldRecordEvent},
+ * whose inputs it deliberately shares — the class follows from WHY the row was
+ * recorded, so the two decisions read from one set of facts.
+ */
+export function resolveEventRetentionClass(input: {
+  auditEnabled: boolean;
+  hasEndpoints: boolean;
+}): EventRetentionClass {
+  return input.auditEnabled ? "audit" : "webhook";
 }
 
 /** Publish whether the audit seam records events regardless of endpoints. */

--- a/packages/nextly/src/domains/webhooks/retention-config.ts
+++ b/packages/nextly/src/domains/webhooks/retention-config.ts
@@ -77,8 +77,24 @@ const DAY_MS = 24 * 60 * 60 * 1000;
  */
 export const DEFAULT_EVENTS_MAX_AGE_MS = 30 * DAY_MS;
 
-/** 365 days. Audit history is kept in years; SOC 2 practice is a one-year floor. */
-export const DEFAULT_AUDIT_EVENTS_MAX_AGE_MS = 365 * DAY_MS;
+/**
+ * 90 days. Audit history is measured in months where outbox hygiene is measured
+ * in days, and 90 is where comparable products land for CONTENT activity —
+ * Directus, Strapi, Sanity's mid tier, Vercel and Datadog all default there.
+ *
+ * An earlier note here put this at a year on the grounds that "SOC 2 practice is
+ * a one-year floor". That does not hold up: neither SOC 2 nor ISO 27001 A.8.15
+ * mandates a period — both require that retention be defined and risk-based —
+ * and the ubiquitous twelve-month figure is PCI DSS convention (10.5.1) that has
+ * been imported into the wider discourse. A deployment genuinely in PCI scope
+ * should raise `auditEventsMaxAgeMs` accordingly; that is a decision only the
+ * operator can make, so the default follows the norm rather than the strictest
+ * regime anyone might be under.
+ *
+ * Auth and security events are governed separately and kept longer; they live in
+ * their own table because they carry evidence content activity does not.
+ */
+export const DEFAULT_AUDIT_EVENTS_MAX_AGE_MS = 90 * DAY_MS;
 
 /**
  * 7 days. Deliveries are the faster-growing table (events x matching endpoints)

--- a/packages/nextly/src/domains/webhooks/retention-config.ts
+++ b/packages/nextly/src/domains/webhooks/retention-config.ts
@@ -174,9 +174,19 @@ export function resolveWebhookRetentionConfig(
     input.eventsMaxAgeMs,
     DEFAULT_EVENTS_MAX_AGE_MS
   );
-  const auditEventsMaxAgeMs = maxAge(
-    input.auditEventsMaxAgeMs,
-    DEFAULT_AUDIT_EVENTS_MAX_AGE_MS
+  // Raised to the webhook window when it is the shorter of the two. The class a
+  // row carries is decided from why it was recorded, and a row admitted by both
+  // the audit seam and an endpoint is labelled `audit` because that is the
+  // longest retention it needs — but the two windows are configured
+  // independently, so nothing stops an audit window shorter than the webhook
+  // one. Left alone, that combination prunes a dual-purpose row earlier than the
+  // webhook setting allows, which is the opposite of what its class promises and
+  // is not recoverable. Clamping here keeps the promise true for every
+  // configuration rather than only the ones where audit happens to be longer,
+  // and mirrors how `deliveriesMaxAgeMs` is bounded by the windows above it.
+  const auditEventsMaxAgeMs = longestEventWindow(
+    eventsMaxAgeMs,
+    maxAge(input.auditEventsMaxAgeMs, DEFAULT_AUDIT_EVENTS_MAX_AGE_MS)
   );
 
   // A delivery row is removed by cascade when its event goes, so a window

--- a/packages/nextly/src/domains/webhooks/retention-config.ts
+++ b/packages/nextly/src/domains/webhooks/retention-config.ts
@@ -16,10 +16,16 @@
 /**
  * Which retention window governs an event row.
  *
- * A single event can drive a webhook AND be audit-relevant, so the class
- * records the LONGEST retention the row needs rather than what produced it.
- * Everything written today is `webhook`; the audit-log feature will mark the
- * rows it depends on as `audit` so outbox hygiene cannot evict its history.
+ * A single event can drive a webhook AND be audit-relevant, so the class records
+ * the LONGEST retention the row needs rather than what produced it. The mutation
+ * seam decides it from why the row was admitted: a write the audit seam admitted
+ * is `audit` and outlives outbox hygiene, one admitted only because an endpoint
+ * exists is `webhook`, and one that is both takes `audit`.
+ *
+ * Because a row can be dual-purpose and only carries the one label, resolution
+ * raises the audit window to the webhook window whenever that is longer — see
+ * {@link resolveWebhookRetentionConfig}. Without that, the label would promise
+ * the longer retention while being pruned on the shorter one.
  */
 export type EventRetentionClass = "webhook" | "audit";
 
@@ -28,7 +34,14 @@ export const EVENT_RETENTION_CLASSES: readonly EventRetentionClass[] = [
   "audit",
 ];
 
-/** The class every event is written with until the audit log exists. */
+/**
+ * The class a row falls back to when a recorder is given none.
+ *
+ * Not the class most rows carry — the mutation seam always classifies what it
+ * records. This is the floor for a caller that appends an event without saying
+ * why, and it is the shorter window deliberately: a row nothing claimed as
+ * audit-relevant should not silently acquire audit retention.
+ */
 export const DEFAULT_EVENT_RETENTION_CLASS: EventRetentionClass = "webhook";
 
 /** User-facing retention options. `false` anywhere means "keep forever". */


### PR DESCRIPTION
PR-2 of task 052 (roadmap item 7), per the signed design doc. Follows #512.

## What was actually wrong

`nextly_events.retention_class` has existed since the outbox shipped, and its own
comment says the audit-log feature will mark rows `audit` so outbox hygiene cannot
evict their history. Nothing ever wrote anything but `webhook`, so every row —
including one kept for history — was measured against the short window.

## The rule

The class follows from **why** the row was recorded, which is the same pair of
facts the recording gate already reads:

| Admitted by | Class |
|---|---|
| the audit seam | `audit` |
| endpoint presence only | `webhook` |
| both | `audit` — the longer window wins |

Both decisions read **one** snapshot of those facts, so a refresh landing between
them cannot record a row whose class disagrees with why it was admitted.

Retention class is passed **beside** the envelope, not on it: it is storage
policy, and a subscriber has no use for the host's pruning decisions.

## The window change, and why I am changing a shipped default

`DEFAULT_AUDIT_EVENTS_MAX_AGE_MS` moves from **365 days to 90**, per the signed
design. Its previous justification in-code was "SOC 2 practice is a one-year
floor", and that does not hold up: neither SOC 2 nor ISO 27001 A.8.15 mandates a
period — both require only that retention be defined and risk-based — and the
twelve-month figure is PCI DSS 10.5.1 convention that has spread into the wider
discourse. 90 days is where comparable products land for content activity
(Directus, Strapi, Sanity's mid tier, Vercel, Datadog).

The constant was **dead** until this PR, since nothing wrote audit-class rows, so
nothing changes for anyone today. A deployment genuinely in PCI scope should raise
`auditEventsMaxAgeMs`; the comment says so.

**Upgrade impact, corrected after review.** With `webhooks.audit` **off** (the
default, and most installs) nothing changes — rows stay webhook-class and prune
exactly as before. With `webhooks.audit` **on**, events that were recorded
webhook-class are now audit-class, so they move from `eventsMaxAgeMs` to
`auditEventsMaxAgeMs` — at the defaults, 30 days to 90 — retaining roughly three
times as many rows. That is the intended result of the class, but it is a storage
change an operator has to plan for, so it is stated in the changeset and the
guide. Turning the seam on by DEFAULT is PR-4, deliberately after this.

## Tests

- Unit: the classifier, including that "both" takes the longer window.
- Integration: a recorded row carries `audit` — which the column's `webhook`
  default cannot mask. Verify-by-break confirms.
- Integration: **the class is the only variable.** Two rows, same age (60 days —
  past the 30-day webhook window, inside the 90-day audit one), same pass, same
  config; the webhook-class one is evicted and the audit-class one survives.

## Two test-quality problems this surfaced

1. **The suite leaked global state.** My first version called
   `setWebhookAuditEnabled(true)` and, because integration files share one fork,
   left the seam on for every file that ran afterwards. `resetWebhookActivation()`
   now runs in that file's `afterEach`.
2. **The retention suite was inheriting a harness default.** `test-nextly` sets
   `webhookAuditEnabled: true`, so once the class was written every row there
   became audit-class and the "webhook window" cases were silently measuring the
   other window. `ageEvent` now takes the class explicitly, so each case states
   which window it exercises rather than depending on a harness flag.

Green: 203 webhook integration, 249 webhook unit, 246 collections integration,
`check-types` and `lint` clean, 0 behind `origin/main`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added separate retention handling for audit-class webhook events.
  * Audit events now remain available for at least as long as general webhook events.
  * Existing audit-enabled installations receive increased retention where applicable.

* **Documentation**
  * Updated webhook retention guidance, including event classification, retention normalization, and audit behavior.

* **Bug Fixes**
  * Prevented audit events from being removed before the configured webhook retention period.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->