### PR TITLE
feat(admin): report a save whose follow-up actions failed

### DIFF
--- a/.changeset/admin-post-commit-warning-toast.md
+++ b/.changeset/admin-post-commit-warning-toast.md
@@ -1,0 +1,40 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+The admin now reports a save whose follow-up actions failed, instead of showing it as a clean save.
+
+A post-commit hook (`afterCreate` / `afterUpdate` / `afterDelete`) runs once the row is already
+durable, so a handler failing there cannot un-save it. The server has always answered success and
+carried the failure alongside as `warnings`, but the admin's entry clients returned only `item` and
+discarded that array, so a search index that was not reindexed, a webhook that was not delivered or
+a cache that was not purged looked identical to a clean write.
+
+Creating, updating or deleting an entry now shows "Entry updated successfully, but 2 follow-up
+actions failed" with the failures behind a disclosure. It stays a success toast, never an error:
+the row IS saved, and reporting a failure would invite the editor to repeat a write that already
+took effect.
+
+`entryApi.create`, `entryApi.update` and `entryApi.delete` now resolve to `{ item, warnings? }`
+rather than the entry alone. The `onSuccess` callbacks on `useCreateEntry`, `useUpdateEntry` and
+`useDeleteEntry` still receive the entry, so callers of those hooks are unaffected.

--- a/packages/admin/src/components/features/entries/EntryForm/useEntryForm.ts
+++ b/packages/admin/src/components/features/entries/EntryForm/useEntryForm.ts
@@ -707,7 +707,10 @@ export function useEntryForm({
             );
             // Reset form to mark as clean after successful create
             form.reset(data);
-            onSuccess?.(result);
+            // The entry, not the envelope: the mutation now resolves to the
+            // whole response so the hook can report post-commit failures, and
+            // this callback's contract is the saved row.
+            onSuccess?.(result.item);
           } else {
             if (!entry?.id) {
               throw new Error("Entry ID is required for update");
@@ -718,7 +721,7 @@ export function useEntryForm({
             );
             // Reset form to mark as clean after successful update
             form.reset(data);
-            onSuccess?.(result);
+            onSuccess?.(result.item);
           }
         } catch (error) {
           // Server errors are automatically mapped to form fields via setError

--- a/packages/admin/src/hooks/queries/__tests__/entry-mutation-warnings.test.tsx
+++ b/packages/admin/src/hooks/queries/__tests__/entry-mutation-warnings.test.tsx
@@ -1,0 +1,168 @@
+/**
+ * The warnings the server sends reach the toast, on all three write hooks.
+ *
+ * `warnings` rides on every mutation envelope, and each API client returned
+ * `result.item` — so the array was dropped one layer below the code that could
+ * have shown it. A side effect that silently did not run looked exactly like a
+ * clean save.
+ *
+ * Asserted per hook rather than once, because the drop was per client: covering
+ * update alone would leave create and delete free to differ again.
+ */
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { createSpy, updateSpy, deleteSpy, successSpy, warningSpy } = vi.hoisted(
+  () => ({
+    createSpy: vi.fn(),
+    updateSpy: vi.fn(),
+    deleteSpy: vi.fn(),
+    successSpy: vi.fn(),
+    warningSpy: vi.fn(),
+  })
+);
+
+vi.mock("@admin/services/entryApi", async importOriginal => {
+  const actual =
+    await importOriginal<typeof import("@admin/services/entryApi")>();
+  return {
+    ...actual,
+    entryApi: {
+      ...actual.entryApi,
+      create: createSpy,
+      update: updateSpy,
+      delete: deleteSpy,
+    },
+  };
+});
+
+vi.mock("@admin/hooks/useLocalization", () => ({
+  useLocalization: () => ({ enabled: false }),
+}));
+
+vi.mock("@admin/components/ui", () => ({
+  toast: { success: successSpy, warning: warningSpy, error: vi.fn() },
+}));
+
+import { useCreateEntry } from "../useCreateEntry";
+import { useDeleteEntry } from "../useDeleteEntry";
+import { useUpdateEntry } from "../useUpdateEntry";
+
+function makeWrapper(client: QueryClient) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={client}>{children}</QueryClientProvider>
+    );
+  };
+}
+
+const entry = { id: "e1", title: "Hello" };
+
+const warnings = [
+  {
+    phase: "afterUpdate",
+    collection: "posts",
+    code: "INTERNAL_ERROR",
+    message: "The search index could not be updated.",
+  },
+];
+
+/** Only the part of the mutation result these cases drive. */
+interface MutationLike {
+  mutateAsync: (variables: unknown) => Promise<unknown>;
+}
+
+/** Each hook, with the client it drops through and how it is invoked. */
+const HOOKS = [
+  {
+    name: "useCreateEntry",
+    spy: createSpy,
+    use: (onSuccess?: (entry: unknown) => void) =>
+      useCreateEntry({ collectionSlug: "posts", onSuccess }) as MutationLike,
+    invoke: (m: MutationLike) => m.mutateAsync({ title: "Hello" }),
+    successMessage: "Entry created successfully",
+  },
+  {
+    name: "useUpdateEntry",
+    spy: updateSpy,
+    use: (onSuccess?: (entry: unknown) => void) =>
+      useUpdateEntry({
+        collectionSlug: "posts",
+        entryId: "e1",
+        onSuccess,
+      }) as MutationLike,
+    invoke: (m: MutationLike) => m.mutateAsync({ title: "Hello" }),
+    successMessage: "Entry updated successfully",
+  },
+  {
+    name: "useDeleteEntry",
+    spy: deleteSpy,
+    use: (onSuccess?: (entry: unknown) => void) =>
+      useDeleteEntry({ collectionSlug: "posts", onSuccess }) as MutationLike,
+    invoke: (m: MutationLike) => m.mutateAsync("e1"),
+    successMessage: "Entry deleted successfully",
+  },
+];
+
+beforeEach(() => vi.clearAllMocks());
+
+describe.each(HOOKS)(
+  "$name reports post-commit failures",
+  ({ spy, use, invoke, successMessage }) => {
+    it("shows a plain success when the server sent no warnings", async () => {
+      spy.mockResolvedValue({ item: entry });
+      const client = new QueryClient({
+        defaultOptions: { mutations: { retry: false } },
+      });
+
+      const { result } = renderHook(() => use(), {
+        wrapper: makeWrapper(client),
+      });
+      await invoke(result.current);
+
+      await waitFor(() =>
+        expect(successSpy).toHaveBeenCalledWith(successMessage)
+      );
+      expect(warningSpy).not.toHaveBeenCalled();
+    });
+
+    it("names the follow-up failure the server reported", async () => {
+      spy.mockResolvedValue({ item: entry, warnings });
+      const client = new QueryClient({
+        defaultOptions: { mutations: { retry: false } },
+      });
+
+      const { result } = renderHook(() => use(), {
+        wrapper: makeWrapper(client),
+      });
+      await invoke(result.current);
+
+      await waitFor(() => expect(warningSpy).toHaveBeenCalledOnce());
+      expect(warningSpy.mock.calls[0]?.[0]).toBe(
+        `${successMessage}, but 1 follow-up action failed`
+      );
+      // Still not an error: the row committed before the hook ran.
+      expect(successSpy).not.toHaveBeenCalled();
+    });
+
+    it("hands the entry, not the envelope, to onSuccess", async () => {
+      // The envelope is an internal detail of the hook. A consumer asked for
+      // the saved row, and widening that silently would break every caller.
+      spy.mockResolvedValue({ item: entry, warnings });
+      const onSuccess = vi.fn();
+      const client = new QueryClient({
+        defaultOptions: { mutations: { retry: false } },
+      });
+
+      const { result } = renderHook(() => use(onSuccess), {
+        wrapper: makeWrapper(client),
+      });
+      await invoke(result.current);
+
+      await waitFor(() => expect(onSuccess).toHaveBeenCalledWith(entry));
+    });
+  }
+);

--- a/packages/admin/src/hooks/queries/__tests__/useUpdateEntry.test.tsx
+++ b/packages/admin/src/hooks/queries/__tests__/useUpdateEntry.test.tsx
@@ -60,11 +60,15 @@ describe("useUpdateEntry", () => {
     // Cached without the flag, as the status-less optimistic merge leaves it.
     client.setQueryData(key, { id: "e1", status: "published", title: "old" });
     // The server's response to a status-less save DOES carry the flag.
+    // Wrapped in the mutation envelope the client returns, so the double is
+    // not looser than the thing it stands in for.
     updateSpy.mockResolvedValue({
-      id: "e1",
-      status: "published",
-      title: "new",
-      _isWorkingDraft: true,
+      item: {
+        id: "e1",
+        status: "published",
+        title: "new",
+        _isWorkingDraft: true,
+      },
     });
 
     const { result } = renderHook(
@@ -104,9 +108,7 @@ describe("useUpdateEntry", () => {
     });
     // Publishing returns the live document WITHOUT the synthetic flag.
     updateSpy.mockResolvedValue({
-      id: "e1",
-      status: "published",
-      title: "new",
+      item: { id: "e1", status: "published", title: "new" },
     });
 
     const { result } = renderHook(

--- a/packages/admin/src/hooks/queries/useCreateEntry.ts
+++ b/packages/admin/src/hooks/queries/useCreateEntry.ts
@@ -46,6 +46,10 @@ import {
   parseServerErrorMessage,
 } from "@admin/lib/errors/error-mapping";
 import {
+  toastMutationResult,
+  type MutationResult,
+} from "@admin/lib/mutation-warnings";
+import {
   entryApi,
   entryKeys,
   type CreateEntryPayload,
@@ -180,13 +184,16 @@ export function useCreateEntry<
 }: UseCreateEntryOptions<T, TFieldValues>) {
   const queryClient = useQueryClient();
 
-  return useMutation<T, Error, CreateEntryPayload>({
+  // The mutation resolves to the whole envelope so the success path can report
+  // what failed after the row committed; consumers still receive the entry.
+  return useMutation<MutationResult<T>, Error, CreateEntryPayload>({
     mutationFn: async (data: CreateEntryPayload) => {
       const result = await entryApi.create(collectionSlug, data);
-      return result as T;
+      return result as MutationResult<T>;
     },
 
-    onSuccess: data => {
+    onSuccess: result => {
+      const data = result.item;
       // Invalidate entry list queries for this collection
       void queryClient.invalidateQueries({
         queryKey: entryKeys.listsByCollection(collectionSlug),
@@ -201,7 +208,9 @@ export function useCreateEntry<
       void queryClient.invalidateQueries({ queryKey: ["dashboard"] });
 
       if (showToast) {
-        toast.success("Entry created successfully");
+        // The row IS written even when a post-commit hook failed, so this stays
+        // a success and names the follow-up failure beside it.
+        toastMutationResult("Entry created successfully", result.warnings);
       }
 
       onSuccess?.(data);

--- a/packages/admin/src/hooks/queries/useDeleteEntry.ts
+++ b/packages/admin/src/hooks/queries/useDeleteEntry.ts
@@ -28,6 +28,10 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 
 import { toast } from "@admin/components/ui";
+import {
+  toastMutationResult,
+  type MutationResult,
+} from "@admin/lib/mutation-warnings";
 import { entryApi, entryKeys } from "@admin/services/entryApi";
 import type { Entry } from "@admin/types/collection";
 
@@ -150,13 +154,16 @@ export function useDeleteEntry<T = Entry>({
 }: UseDeleteEntryOptions<T>) {
   const queryClient = useQueryClient();
 
-  return useMutation<T, Error, string>({
+  // The mutation resolves to the whole envelope so the success path can report
+  // what failed after the row committed; consumers still receive the entry.
+  return useMutation<MutationResult<T>, Error, string>({
     mutationFn: async (entryId: string) => {
       const result = await entryApi.delete(collectionSlug, entryId);
-      return result as T;
+      return result as MutationResult<T>;
     },
 
-    onSuccess: (data, entryId) => {
+    onSuccess: (result, entryId) => {
+      const data = result.item;
       // Invalidate entry list queries for this collection
       void queryClient.invalidateQueries({
         queryKey: entryKeys.listsByCollection(collectionSlug),
@@ -176,7 +183,9 @@ export function useDeleteEntry<T = Entry>({
       void queryClient.invalidateQueries({ queryKey: ["dashboard"] });
 
       if (showToast) {
-        toast.success("Entry deleted successfully");
+        // The row IS written even when a post-commit hook failed, so this stays
+        // a success and names the follow-up failure beside it.
+        toastMutationResult("Entry deleted successfully", result.warnings);
       }
 
       onSuccess?.(data);

--- a/packages/admin/src/hooks/queries/useUpdateEntry.ts
+++ b/packages/admin/src/hooks/queries/useUpdateEntry.ts
@@ -56,6 +56,10 @@ import {
   parseServerErrorMessage,
 } from "@admin/lib/errors/error-mapping";
 import {
+  toastMutationResult,
+  type MutationResult,
+} from "@admin/lib/mutation-warnings";
+import {
   entryApi,
   entryKeys,
   type UpdateEntryPayload,
@@ -242,7 +246,14 @@ export function useUpdateEntry<
     draft,
   });
 
-  return useMutation<T, Error, UpdateEntryPayload, UpdateContext<T>>({
+  // The mutation resolves to the whole envelope so the success path can report
+  // what failed after the row committed; consumers still receive the entry.
+  return useMutation<
+    MutationResult<T>,
+    Error,
+    UpdateEntryPayload,
+    UpdateContext<T>
+  >({
     mutationFn: async (data: UpdateEntryPayload) => {
       const result = await entryApi.update(
         collectionSlug,
@@ -250,7 +261,7 @@ export function useUpdateEntry<
         data,
         locale ? { locale, fallbackLocale } : undefined
       );
-      return result as T;
+      return result as MutationResult<T>;
     },
 
     // Optimistic update: immediately update cache before server responds
@@ -305,7 +316,8 @@ export function useUpdateEntry<
     },
 
     // On success, invalidate queries to ensure fresh data
-    onSuccess: data => {
+    onSuccess: result => {
+      const data = result.item;
       // Write the server's response into the detail cache the editor reads, so
       // fields it derives server-side are shown at once rather than only after
       // the invalidation below refetches (which may be slow or fail). The
@@ -345,7 +357,10 @@ export function useUpdateEntry<
       void queryClient.invalidateQueries({ queryKey: ["dashboard"] });
 
       if (showToast) {
-        toast.success("Entry updated successfully");
+        // The row IS saved even when a post-commit hook failed, so this stays a
+        // success and names the follow-up failure beside it. Reporting an error
+        // would have the user repeat a write that already took effect.
+        toastMutationResult("Entry updated successfully", result.warnings);
       }
 
       onSuccess?.(data);

--- a/packages/admin/src/lib/__tests__/mutation-warnings.test.tsx
+++ b/packages/admin/src/lib/__tests__/mutation-warnings.test.tsx
@@ -1,0 +1,126 @@
+/**
+ * A save whose follow-up failed must not look like a clean save.
+ *
+ * The row is durable either way, so the outcome is never an error: reporting
+ * one would have the user repeat a write that already took effect. What changes
+ * is that the toast says so, and says how many.
+ */
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+const { successSpy, warningSpy } = vi.hoisted(() => ({
+  successSpy: vi.fn(),
+  warningSpy: vi.fn(),
+}));
+
+vi.mock("@admin/components/ui", () => ({
+  toast: { success: successSpy, warning: warningSpy, error: vi.fn() },
+}));
+
+import { toastMutationResult, type HookWarning } from "../mutation-warnings";
+
+function warning(overrides: Partial<HookWarning> = {}): HookWarning {
+  return {
+    phase: "afterUpdate",
+    collection: "posts",
+    code: "INTERNAL_ERROR",
+    message: "The search index could not be updated.",
+    ...overrides,
+  };
+}
+
+beforeEach(() => vi.clearAllMocks());
+
+describe("toastMutationResult", () => {
+  it("reports a clean save as a success", () => {
+    toastMutationResult("Entry updated successfully", undefined);
+
+    expect(successSpy).toHaveBeenCalledWith("Entry updated successfully");
+    expect(warningSpy).not.toHaveBeenCalled();
+  });
+
+  it("treats an empty array as clean", () => {
+    // The server omits `warnings` when there are none, but a caller normalising
+    // the envelope may hand over `[]`. Those are the same outcome and must not
+    // read as "0 follow-up actions failed".
+    toastMutationResult("Entry updated successfully", []);
+
+    expect(successSpy).toHaveBeenCalledOnce();
+    expect(warningSpy).not.toHaveBeenCalled();
+  });
+
+  it("still reports the write as succeeded when a follow-up failed", () => {
+    toastMutationResult("Entry updated successfully", [warning()]);
+
+    // Not an error toast. The row IS saved, and saying otherwise invites the
+    // user to save again.
+    expect(successSpy).not.toHaveBeenCalled();
+    expect(warningSpy).toHaveBeenCalledOnce();
+    expect(warningSpy.mock.calls[0]?.[0]).toBe(
+      "Entry updated successfully, but 1 follow-up action failed"
+    );
+  });
+
+  it("counts the failures and pluralises", () => {
+    toastMutationResult("Entry updated successfully", [
+      warning(),
+      warning({ code: "EXTERNAL_SERVICE_ERROR" }),
+      warning({ phase: "afterCreate" }),
+    ]);
+
+    expect(warningSpy.mock.calls[0]?.[0]).toBe(
+      "Entry updated successfully, but 3 follow-up actions failed"
+    );
+  });
+
+  it("names the single failure without asking for a click", () => {
+    // A disclosure hiding one line costs an interaction and reveals nothing
+    // the headline could not have carried.
+    toastMutationResult("Entry created successfully", [
+      warning({ message: "The webhook could not be delivered." }),
+    ]);
+
+    const { description } = warningSpy.mock.calls[0]?.[1] as {
+      description: React.ReactElement;
+    };
+    render(description);
+
+    expect(
+      screen.getByText("The webhook could not be delivered.")
+    ).toBeInTheDocument();
+    expect(screen.queryByText("View details")).not.toBeInTheDocument();
+  });
+
+  it("lists every failure behind the disclosure", () => {
+    toastMutationResult("Entry updated successfully", [
+      warning({ message: "The search index could not be updated." }),
+      warning({ message: "The webhook could not be delivered." }),
+    ]);
+
+    const { description } = warningSpy.mock.calls[0]?.[1] as {
+      description: React.ReactElement;
+    };
+    render(description);
+
+    expect(screen.getByText("View details")).toBeInTheDocument();
+    // Present in the DOM even while collapsed, which is what makes the content
+    // reachable by find-in-page and announced on expand rather than fetched.
+    expect(
+      screen.getByText("The search index could not be updated.")
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("The webhook could not be delivered.")
+    ).toBeInTheDocument();
+  });
+
+  it("stays on screen long enough to be read", () => {
+    // This is the only place the failure is reported: it is not on the row, and
+    // the write has already committed. A default-duration toast that vanishes
+    // before the detail is open is the same as no warning at all.
+    toastMutationResult("Entry updated successfully", [warning(), warning()]);
+
+    const options = warningSpy.mock.calls[0]?.[1] as { duration: number };
+    expect(options.duration).toBeGreaterThanOrEqual(10_000);
+  });
+});

--- a/packages/admin/src/lib/mutation-warnings.tsx
+++ b/packages/admin/src/lib/mutation-warnings.tsx
@@ -1,0 +1,112 @@
+/**
+ * Reporting a write that succeeded while something after it did not.
+ *
+ * A post-commit hook (`afterCreate` / `afterUpdate` / `afterDelete`) runs once
+ * the row is already durable, so a handler failing there cannot un-save it. The
+ * server therefore answers success and carries the failure alongside as
+ * `warnings`. Until now the admin dropped that array at the API client, so a
+ * search index that was not updated, a webhook that was not delivered or a cache
+ * that was not purged looked exactly like a clean save.
+ *
+ * One owner for the toast, so the three mutation hooks cannot drift into three
+ * slightly different ways of saying the same thing.
+ *
+ * @module lib/mutation-warnings
+ */
+
+import { toast } from "@admin/components/ui";
+
+/**
+ * The public projection of a failed post-commit hook.
+ *
+ * Mirrors the server's `HookWarning`: the canonical code and the §13.8-safe
+ * public message only. It never carries identifiers, so it is safe to render.
+ */
+export interface HookWarning {
+  /** The lifecycle phase whose handler failed. */
+  phase: string;
+  /** The registry key the handler was registered against. */
+  collection: string;
+  /** The canonical error code, for a caller branching on the failure. */
+  code: string;
+  /** The public message. Never carries identifiers. */
+  message: string;
+  /** The row whose side effect failed, when the phase knows it. */
+  entryId?: string;
+}
+
+/** A mutation response: the durable result, plus anything that failed after it. */
+export interface MutationResult<T> {
+  item: T;
+  warnings?: HookWarning[];
+}
+
+/**
+ * Say what happened to the write, and separately what happened after it.
+ *
+ * The write is reported as the success it is -- the row IS saved, and telling
+ * the user otherwise would have them repeat an action that already took effect.
+ * The follow-up failure rides on the same toast rather than a second one,
+ * because two notifications for one action read as two outcomes.
+ */
+export function toastMutationResult(
+  successMessage: string,
+  warnings: readonly HookWarning[] | undefined
+): void {
+  if (!warnings || warnings.length === 0) {
+    toast.success(successMessage);
+    return;
+  }
+
+  toast.warning(
+    `${successMessage.replace(/\.$/, "")}, but ${describeCount(warnings.length)} failed`,
+    {
+      description: <WarningDetail warnings={warnings} />,
+      // Long enough to open the detail. A warning the user cannot finish reading
+      // is the same as no warning, and this is the only place the failure is
+      // reported: it is not on the row, and the write has already committed.
+      duration: 10_000,
+    }
+  );
+}
+
+/** "1 follow-up action" / "3 follow-up actions". */
+function describeCount(count: number): string {
+  return `${count} follow-up action${count === 1 ? "" : "s"}`;
+}
+
+/**
+ * The failures themselves, behind a disclosure.
+ *
+ * Collapsed by default: the headline is what most users act on, and the codes
+ * below are for whoever is going to retry or report the thing. `<details>` gives
+ * that for free with keyboard and screen-reader behaviour already correct,
+ * which a custom expander would have to reimplement.
+ *
+ * A single failure is rendered inline instead, since a disclosure that hides one
+ * line asks for a click and offers nothing for it.
+ */
+function WarningDetail({
+  warnings,
+}: {
+  warnings: readonly HookWarning[];
+}): React.ReactElement {
+  if (warnings.length === 1 && warnings[0]) {
+    return <span>{warnings[0].message}</span>;
+  }
+
+  return (
+    <details className="mt-1">
+      <summary className="cursor-pointer select-none underline-offset-2 hover:underline">
+        View details
+      </summary>
+      <ul className="mt-1 list-disc space-y-1 ps-4">
+        {warnings.map((warning, index) => (
+          <li key={`${warning.phase}-${warning.code}-${index}`}>
+            {warning.message}
+          </li>
+        ))}
+      </ul>
+    </details>
+  );
+}

--- a/packages/admin/src/services/__tests__/entryApi.mutation-warnings.test.ts
+++ b/packages/admin/src/services/__tests__/entryApi.mutation-warnings.test.ts
@@ -1,0 +1,74 @@
+/**
+ * The mutation clients return what the server sent, not only the row.
+ *
+ * `warnings` reports side effects that failed AFTER the write committed, and
+ * every client returned `result.item`, so the array was discarded here — one
+ * layer below anything that could have shown it.
+ *
+ * This layer needs its own coverage: the hook tests mock `entryApi` itself, so
+ * they stand in for exactly the code below and would pass with it reverted.
+ */
+
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+vi.mock("../../lib/api/protectedApi", () => ({
+  protectedApi: { post: vi.fn(), patch: vi.fn(), delete: vi.fn() },
+}));
+
+import { protectedApi } from "../../lib/api/protectedApi";
+import { entryApi } from "../entryApi";
+
+const post = protectedApi.post as unknown as ReturnType<typeof vi.fn>;
+const patch = protectedApi.patch as unknown as ReturnType<typeof vi.fn>;
+const del = protectedApi.delete as unknown as ReturnType<typeof vi.fn>;
+
+const item = { id: "e1", title: "Hello" };
+const warnings = [
+  {
+    phase: "afterUpdate",
+    collection: "posts",
+    code: "INTERNAL_ERROR",
+    message: "The search index could not be updated.",
+  },
+];
+
+/** Each write client, with the transport it uses. */
+const CLIENTS = [
+  {
+    name: "create",
+    transport: post,
+    call: () => entryApi.create("posts", { title: "Hello" }),
+  },
+  {
+    name: "update",
+    transport: patch,
+    call: () => entryApi.update("posts", "e1", { title: "Hello" }),
+  },
+  {
+    name: "delete",
+    transport: del,
+    call: () => entryApi.delete("posts", "e1"),
+  },
+];
+
+beforeEach(() => vi.clearAllMocks());
+
+describe.each(CLIENTS)("entryApi.$name", ({ transport, call }) => {
+  it("returns the warnings the response carried", async () => {
+    transport.mockResolvedValue({ message: "ok", item, warnings });
+
+    await expect(call()).resolves.toEqual({ item, warnings });
+  });
+
+  it("returns the row with no warnings key when the response had none", async () => {
+    // The server omits `warnings` entirely for a clean write, and the client
+    // must not invent an empty array — a caller branching on presence would
+    // then report a failure that did not happen.
+    transport.mockResolvedValue({ message: "ok", item });
+
+    const result = await call();
+
+    expect(result.item).toEqual(item);
+    expect(result.warnings).toBeUndefined();
+  });
+});

--- a/packages/admin/src/services/entryApi.ts
+++ b/packages/admin/src/services/entryApi.ts
@@ -22,7 +22,15 @@
 import { fetcher } from "../lib/api/fetcher";
 import { protectedApi } from "../lib/api/protectedApi";
 import type { BulkResponse, ListResponse } from "../lib/api/response-types";
+import type { HookWarning, MutationResult } from "../lib/mutation-warnings";
 import type { Entry, EntryValue, FieldDefinition } from "../types/collection";
+
+/** The canonical mutation envelope, exactly as the server sends it. */
+interface MutationResponse<T> {
+  message: string;
+  item: T;
+  warnings?: HookWarning[];
+}
 
 /**
  * Parameters for find operation
@@ -599,12 +607,15 @@ export const entryApi = {
   create: async (
     collectionSlug: string,
     data: CreateEntryPayload
-  ): Promise<Entry> => {
-    const result = await protectedApi.post<{ message: string; item: Entry }>(
+  ): Promise<MutationResult<Entry>> => {
+    // The whole envelope, not just `item`. `warnings` reports side effects that
+    // failed AFTER the row committed, and returning only the row is what made
+    // a save whose webhook never fired indistinguishable from a clean one.
+    const result = await protectedApi.post<MutationResponse<Entry>>(
       `/collections/${collectionSlug}/entries`,
       data
     );
-    return result.item;
+    return { item: result.item, warnings: result.warnings };
   },
 
   /**
@@ -628,18 +639,18 @@ export const entryApi = {
     id: string,
     data: UpdateEntryPayload,
     options?: Pick<FindParams, "locale" | "fallbackLocale">
-  ): Promise<Entry> => {
+  ): Promise<MutationResult<Entry>> => {
     // i18n M7: `?locale=de` updates only the German translatable values for this entry.
     const query = new URLSearchParams();
     if (options?.locale) query.set("locale", options.locale);
     if (options?.fallbackLocale)
       query.set("fallback-locale", options.fallbackLocale);
     const qs = query.toString();
-    const result = await protectedApi.patch<{ message: string; item: Entry }>(
+    const result = await protectedApi.patch<MutationResponse<Entry>>(
       `/collections/${collectionSlug}/entries/${id}${qs ? `?${qs}` : ""}`,
       data
     );
-    return result.item;
+    return { item: result.item, warnings: result.warnings };
   },
 
   /**
@@ -722,11 +733,14 @@ export const entryApi = {
    * const deleted = await entryApi.delete('posts', 'abc123');
    * ```
    */
-  delete: async (collectionSlug: string, id: string): Promise<Entry> => {
-    const result = await protectedApi.delete<{ message: string; item: Entry }>(
+  delete: async (
+    collectionSlug: string,
+    id: string
+  ): Promise<MutationResult<Entry>> => {
+    const result = await protectedApi.delete<MutationResponse<Entry>>(
       `/collections/${collectionSlug}/entries/${id}`
     );
-    return result.item;
+    return { item: result.item, warnings: result.warnings };
   },
 
   /**


### PR DESCRIPTION
## The problem

A post-commit hook (`afterCreate` / `afterUpdate` / `afterDelete`) runs once the row is already durable, so a handler failing there cannot un-save it. The server has always answered success and carried the failure alongside as `warnings` on the mutation envelope.

The admin dropped that array. `entryApi.create/update/delete` each ended with `return result.item`, one layer below anything that could have shown it — so a search index that was not reindexed, a webhook that was not delivered or a cache that was not purged looked **identical to a clean save**.

## What changes

The three entry clients return `{ item, warnings? }`, and one shared helper owns the toast.

- No warnings: `toast.success("Entry updated successfully")`, exactly as before.
- With warnings: `toast.warning("Entry updated successfully, but 2 follow-up actions failed")`, with the failures behind a `<details>` disclosure.

It stays a **success**, never an error. The row IS saved, and reporting a failure would invite the editor to repeat a write that already took effect.

Three judgements worth stating:

- **One owner for the toast**, not three copies in three hooks. The bug being fixed is literally "the same thing done per client, and one of them forgot".
- **A single failure renders inline**, without a disclosure. A `<details>` hiding one line costs a click and reveals nothing the headline could not have carried.
- **`<details>`, not a custom expander** — keyboard and screen-reader behaviour are already correct, and the content is in the DOM while collapsed, so find-in-page reaches it.

`toast.warning` is the admin's established "succeeded with caveats" signal (`CollectionTable`'s "Partially completed", both bulk-entry hooks), so this follows the existing vocabulary rather than inventing one. No hardcoded colours: the toast type and the semantic utility classes carry it, so both colour modes come from the tokens.

## Compatibility

`entryApi.create/update/delete` now resolve to `{ item, warnings? }`. Only the three hooks call them, and all three are updated.

**`onSuccess` still receives the entry**, on the hooks and on `useEntryForm` — the envelope is an internal detail. Widening that silently would have broken every caller, so a test pins it per hook.

## Verification

- New coverage at **both** layers. The hook tests mock `entryApi` itself, so they stand in for exactly the client-layer change and pass with it reverted — `entryApi.mutation-warnings.test.ts` covers that layer against a mocked transport, and fails on all three clients when the forwarding is removed.
- Reverting the empty-warnings branch fails 8 of 16; reverting the client forwarding fails 3 of 6. Each proven with `diff`.
- Two existing `useUpdateEntry` tests returned a bare entry from the mocked client. They now return the envelope, so the double is not looser than the thing it stands in for.
- Full `@nextlyhq/admin` suite diffed by failing-test **name set** against HEAD sources: **27 before, 27 after, none introduced**.

## Not in scope

Sonner's rich colours are not bound to the `--nx-*` tokens, so every warning/success/error toast in the admin already uses sonner's own palette. Pre-existing and affects all toast types, so re-theming them belongs in its own change rather than riding along here.