### PR TITLE
feat(nextly): return the mutation envelope from plugin writes

### DIFF
--- a/.changeset/plugin-write-mutation-envelope.md
+++ b/.changeset/plugin-write-mutation-envelope.md
@@ -1,0 +1,55 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+**Breaking (plugin authors):** `ctx.services.collections.createEntry`, `updateEntry` and
+`deleteEntry` now resolve to `{ message, item, warnings? }` instead of the bare row.
+
+This is the same envelope the Direct API and the REST API already return, so the same failure is
+equally visible however the write was made. Previously a plugin was the ONLY caller of a write
+that could not see a post-commit hook failure: `afterCreate` / `afterUpdate` / `afterDelete` run
+once the row is durable, so a handler failing there cannot un-save it — the write reports success
+and the failure travels beside it as `warnings`. The plugin facade never opened a collector, so
+those failures were invisible to the plugin that caused them.
+
+Migration is one property access:
+
+```ts
+// Before
+const post = await ctx.services.collections.createEntry(slug, data, {
+  as: "system",
+});
+post.id;
+
+// After
+const { item, warnings } = await ctx.services.collections.createEntry(
+  slug,
+  data,
+  { as: "system" }
+);
+item.id;
+if (warnings) ctx.logger.warn("side effects failed", { id: item.id, warnings });
+```
+
+`deleteEntry` reports `item` as `{ id }`, since there is no row left to return. Reads
+(`listEntries`, `findEntryById`, `count`) and `createMany` are unchanged.

--- a/docs/plugins/api-reference.mdx
+++ b/docs/plugins/api-reference.mdx
@@ -79,8 +79,14 @@ interface PluginContext {
 // Acts as the current user (RBAC enforced):
 await ctx.services.collections.listEntries(slug, {}, { as: "user", user: ctx.user });
 // Privileged work — explicit, visible elevation:
-await ctx.services.collections.createEntry(slug, data, { as: "system" });
+const { item, warnings } = await ctx.services.collections.createEntry(slug, data, { as: "system" });
 ```
+
+Writes (`createEntry`, `updateEntry`, `deleteEntry`) resolve to the same
+`{ message, item, warnings? }` envelope the Direct API and the REST API return.
+`warnings` is present only when a post-commit hook failed: the row is already
+saved at that point, so the write succeeds and the failure travels beside it.
+Reads are unchanged and return their value directly.
 
 ## Hooks & events
 

--- a/docs/plugins/services.mdx
+++ b/docs/plugins/services.mdx
@@ -46,11 +46,11 @@ records should use `{ as: "user", user: ctx.user ?? undefined }`.
 
 | Method | Purpose |
 |---|---|
-| `createEntry(slug, data, opts?)` | Create one entry. |
+| `createEntry(slug, data, opts?)` | Create one entry. Returns `{ message, item, warnings? }`. |
 | `listEntries(slug, query?, opts?)` | List with filter/sort/pagination → `PaginatedResult`. |
 | `findEntryById(slug, id, opts?)` | Fetch one by id. |
-| `updateEntry(slug, id, data, opts?)` | Update one. |
-| `deleteEntry(slug, id, opts?)` | Delete one. |
+| `updateEntry(slug, id, data, opts?)` | Update one. Returns `{ message, item, warnings? }`. |
+| `deleteEntry(slug, id, opts?)` | Delete one. Returns `{ message, item: { id }, warnings? }`. |
 | `count(slug, where?, opts?)` | Count matching rows. |
 | `createMany(slug, rows, opts?)` | Bulk insert → `BatchOperationResult`. |
 
@@ -89,6 +89,29 @@ failure tells you exactly which rows failed:
 const res = await ctx.services.collections.createMany(slug, rows, { as: "system" });
 // { successful, failed, ids: string[], errors: [{ index, error }] }
 ```
+
+## Writes return an envelope
+
+`createEntry`, `updateEntry` and `deleteEntry` resolve to
+`{ message, item, warnings? }` — the same shape the Direct API and the REST API
+return, so the same failure is equally visible however the write was made.
+
+```ts
+const { item, warnings } = await ctx.services.collections.createEntry(
+  slug,
+  data,
+  { as: "system" }
+);
+
+if (warnings) {
+  // The row IS saved. A post-commit hook (`afterCreate` and friends) runs once
+  // the write has committed, so a handler failing there cannot un-save it —
+  // report it, don't retry the write.
+  ctx.logger.warn("side effects failed", { id: item.id, warnings });
+}
+```
+
+`deleteEntry` reports `item` as `{ id }`, since there is no row left to return.
 
 ## When to drop to `ctx.db`
 

--- a/packages/nextly/src/plugins/__tests__/secure-by-default.integration.test.ts
+++ b/packages/nextly/src/plugins/__tests__/secure-by-default.integration.test.ts
@@ -83,8 +83,11 @@ describe("secure-by-default write path (B3/T1, D35)", () => {
       { title: "y" },
       { as: "system" }
     );
-    expect(created).toBeTruthy();
-    expect((created as { title?: string }).title).toBe("y");
+    expect(created.item).toBeTruthy();
+    expect((created.item as { title?: string }).title).toBe("y");
+    // A clean write carries no `warnings` key at all, so a plugin branching on
+    // its presence is not told about a failure that did not happen.
+    expect(created.warnings).toBeUndefined();
     expect(beforeCreate.fired).toBeGreaterThanOrEqual(1);
   });
 });

--- a/packages/nextly/src/plugins/__tests__/service-d56-reads.integration.test.ts
+++ b/packages/nextly/src/plugins/__tests__/service-d56-reads.integration.test.ts
@@ -80,7 +80,7 @@ describe("ctx.services.collections reads/writes (D56, harness hook-wired)", () =
       { title: "x", kind: "q" },
       { as: "system" }
     );
-    expect((created as { id: string }).id).toBeDefined();
+    expect((created.item as { id: string }).id).toBeDefined();
     expect(
       await services.collections.count("widgets", {}, { as: "system" })
     ).toBe(1);

--- a/packages/nextly/src/plugins/__tests__/service-mutation-envelope.integration.test.ts
+++ b/packages/nextly/src/plugins/__tests__/service-mutation-envelope.integration.test.ts
@@ -77,7 +77,11 @@ async function boot(
   // rather than assumed: a harness that stopped calling `init` would otherwise
   // fail every case below on a property of `undefined`, which reads as a
   // regression in the code under test.
-  if (!services) throw new Error("plugin init did not run");
+  if (!services) {
+    throw NextlyError.internal({
+      logContext: { reason: "test-harness-init-did-not-run" },
+    });
+  }
   return services;
 }
 

--- a/packages/nextly/src/plugins/__tests__/service-mutation-envelope.integration.test.ts
+++ b/packages/nextly/src/plugins/__tests__/service-mutation-envelope.integration.test.ts
@@ -1,0 +1,166 @@
+/**
+ * A plugin write answers with the same envelope every other caller gets.
+ *
+ * `ctx.services.collections` returned the bare row, so a plugin was the one
+ * caller of a write that could not see a post-commit hook failure: the REST
+ * client gets `warnings` on the response, the Direct API gets it on
+ * `MutationResult`, and the plugin facade dropped it because it never opened a
+ * collector of its own.
+ *
+ * A plugin write is its own operation boundary -- `init` runs at boot, with no
+ * request around it -- so the scope has to open at the facade or nothing
+ * collects at all.
+ */
+import { afterEach, describe, expect, it } from "vitest";
+
+import { defineCollection, text } from "../../config";
+import { NextlyError } from "../../errors/nextly-error";
+import { definePlugin } from "../plugin-context";
+import { createTestNextly, type TestNextly } from "../test-nextly";
+
+let current: TestNextly | undefined;
+afterEach(async () => {
+  await current?.destroy();
+  current = undefined;
+});
+
+const widgets = () =>
+  defineCollection({
+    slug: "widgets",
+    fields: [text({ name: "title" })],
+  });
+
+/**
+ * Boot with an optional failing post-commit hook.
+ *
+ * The hook is registered by the plugin under test rather than on the
+ * collection, because the path being covered is a plugin observing a failure
+ * its OWN write caused.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+async function boot(failAfter?: "create" | "update" | "delete"): Promise<any> {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let services: any;
+  const probe = definePlugin({
+    name: "@test/mutation-envelope",
+    version: "1.0.0",
+    nextly: ">=0.0.0",
+    init: c => {
+      services = c.services;
+      if (!failAfter) return;
+      const phase = `after${failAfter[0]!.toUpperCase()}${failAfter.slice(1)}`;
+      // The registry's real signature. Registering through an indexed lookup
+      // with optional chaining would no-op silently, and the test would then
+      // prove only that a write with no failing hook reports no warnings.
+      c.hooks.on(phase as "afterCreate", "widgets", () => {
+        throw NextlyError.internal({
+          logContext: { reason: "test-post-commit-failure" },
+        });
+      });
+    },
+  });
+  current = await createTestNextly({
+    collections: [widgets()],
+    plugins: [probe],
+  });
+  return services;
+}
+
+describe("ctx.services.collections write envelope", () => {
+  it("returns { message, item } from a create", async () => {
+    const services = await boot();
+
+    const result = await services.collections.createEntry(
+      "widgets",
+      { title: "x" },
+      { as: "system" }
+    );
+
+    expect(result.message).toBe("Widgets created.");
+    expect(result.item.title).toBe("x");
+    expect(result.item.id).toBeDefined();
+    // Absent, not empty: a plugin branching on presence must not be told about
+    // a failure that did not happen.
+    expect(result.warnings).toBeUndefined();
+  });
+
+  it("returns { message, item } from an update", async () => {
+    const services = await boot();
+    const created = await services.collections.createEntry(
+      "widgets",
+      { title: "x" },
+      { as: "system" }
+    );
+
+    const result = await services.collections.updateEntry(
+      "widgets",
+      created.item.id,
+      { title: "y" },
+      { as: "system" }
+    );
+
+    expect(result.message).toBe("Widgets updated.");
+    expect(result.item.title).toBe("y");
+  });
+
+  it("reports the deleted row by id, since there is none left to return", async () => {
+    const services = await boot();
+    const created = await services.collections.createEntry(
+      "widgets",
+      { title: "x" },
+      { as: "system" }
+    );
+
+    const result = await services.collections.deleteEntry(
+      "widgets",
+      created.item.id,
+      { as: "system" }
+    );
+
+    expect(result.message).toBe("Widgets deleted.");
+    // The facade's delete resolves to `void`, so the id the caller passed is
+    // the only thing that can identify what went.
+    expect(result.item).toEqual({ id: created.item.id });
+  });
+
+  it("carries a post-commit failure the plugin's own write caused", async () => {
+    const services = await boot("create");
+
+    const result = await services.collections.createEntry(
+      "widgets",
+      { title: "x" },
+      { as: "system" }
+    );
+
+    // The row IS written -- the hook ran after the commit -- so the call
+    // resolves rather than rejecting, and the failure travels beside it.
+    expect(result.item.title).toBe("x");
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0]).toMatchObject({
+      phase: "afterCreate",
+      collection: "widgets",
+      code: "INTERNAL_ERROR",
+    });
+  });
+
+  it("does not open a scope for reads", async () => {
+    // The reads are deliberately untouched: nothing runs after them that could
+    // fail without failing the read, so wrapping them would only add a
+    // meaningless envelope to unwrap.
+    const services = await boot();
+    await services.collections.createEntry(
+      "widgets",
+      { title: "x" },
+      { as: "system" }
+    );
+
+    const list = await services.collections.listEntries(
+      "widgets",
+      {},
+      { as: "system" }
+    );
+
+    expect(list.message).toBeUndefined();
+    expect(list.data).toHaveLength(1);
+  });
+});

--- a/packages/nextly/src/plugins/__tests__/service-mutation-envelope.integration.test.ts
+++ b/packages/nextly/src/plugins/__tests__/service-mutation-envelope.integration.test.ts
@@ -15,8 +15,18 @@ import { afterEach, describe, expect, it } from "vitest";
 
 import { defineCollection, text } from "../../config";
 import { NextlyError } from "../../errors/nextly-error";
-import { definePlugin } from "../plugin-context";
+import { definePlugin, type PluginContext } from "../plugin-context";
 import { createTestNextly, type TestNextly } from "../test-nextly";
+
+/**
+ * The real plugin-facing services type, not `any`.
+ *
+ * These cases exist to pin the exported `PluginCollectionService` signature, so
+ * asserting against an untyped fixture would let a wrong signature compile
+ * while the runtime assertions still passed -- the suite would then prove only
+ * that the proxy returns an object with those keys.
+ */
+type PluginServices = PluginContext["services"];
 
 let current: TestNextly | undefined;
 afterEach(async () => {
@@ -37,10 +47,10 @@ const widgets = () =>
  * collection, because the path being covered is a plugin observing a failure
  * its OWN write caused.
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-async function boot(failAfter?: "create" | "update" | "delete"): Promise<any> {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  let services: any;
+async function boot(
+  failAfter?: "create" | "update" | "delete"
+): Promise<PluginServices> {
+  let services: PluginServices | undefined;
   const probe = definePlugin({
     name: "@test/mutation-envelope",
     version: "1.0.0",
@@ -63,6 +73,11 @@ async function boot(failAfter?: "create" | "update" | "delete"): Promise<any> {
     collections: [widgets()],
     plugins: [probe],
   });
+  // `init` has run by the time the harness resolves, so this is set. Asserted
+  // rather than assumed: a harness that stopped calling `init` would otherwise
+  // fail every case below on a property of `undefined`, which reads as a
+  // regression in the code under test.
+  if (!services) throw new Error("plugin init did not run");
   return services;
 }
 
@@ -135,18 +150,24 @@ describe("ctx.services.collections write envelope", () => {
     // The row IS written -- the hook ran after the commit -- so the call
     // resolves rather than rejecting, and the failure travels beside it.
     expect(result.item.title).toBe("x");
-    expect(result.warnings).toHaveLength(1);
-    expect(result.warnings[0]).toMatchObject({
-      phase: "afterCreate",
-      collection: "widgets",
-      code: "INTERNAL_ERROR",
-    });
+    expect(result.warnings).toEqual([
+      expect.objectContaining({
+        phase: "afterCreate",
+        collection: "widgets",
+        code: "INTERNAL_ERROR",
+      }),
+    ]);
   });
 
-  it("does not open a scope for reads", async () => {
+  it("leaves reads returning their value directly", async () => {
     // The reads are deliberately untouched: nothing runs after them that could
-    // fail without failing the read, so wrapping them would only add a
-    // meaningless envelope to unwrap.
+    // fail without failing the read, so wrapping them would only add an
+    // envelope to unwrap for no information.
+    //
+    // The paginated result is the whole return value, not something nested
+    // under `item` — checked at runtime as well as in the type, because the
+    // proxy decides this by name at run time and a write verb added for reads
+    // by mistake would still compile.
     const services = await boot();
     await services.collections.createEntry(
       "widgets",
@@ -160,7 +181,8 @@ describe("ctx.services.collections write envelope", () => {
       { as: "system" }
     );
 
-    expect(list.message).toBeUndefined();
     expect(list.data).toHaveLength(1);
+    expect(list).not.toHaveProperty("item");
+    expect(list).not.toHaveProperty("message");
   });
 });

--- a/packages/nextly/src/plugins/service-opts.ts
+++ b/packages/nextly/src/plugins/service-opts.ts
@@ -1,5 +1,11 @@
+import { buildMutationMessage } from "../direct-api/namespaces/helpers";
+import type { MutationResult } from "../direct-api/types/shared";
 import { NextlyError } from "../errors/nextly-error";
-import type { CollectionService } from "../services/collections/collection-service";
+import { collectingWarnings } from "../hooks/side-effect-warnings";
+import type {
+  CollectionEntry,
+  CollectionService,
+} from "../services/collections/collection-service";
 import type { RequestContext } from "../services/shared";
 import type { AuthUser } from "../types/auth";
 
@@ -67,6 +73,22 @@ const CONTEXT_INDEX: Record<AccessMethod, number> = {
   createMany: 2,
 };
 
+/**
+ * The write methods, and the verb each reports.
+ *
+ * A write is where a post-commit hook can fail after the row is already
+ * durable, so these are the methods whose result has something to say beyond
+ * the row itself. The reads are left exactly as they are: nothing runs after
+ * them that could fail without failing the read.
+ */
+const WRITE_VERB = {
+  createEntry: "created",
+  updateEntry: "updated",
+  deleteEntry: "deleted",
+} as const satisfies Record<string, "created" | "updated" | "deleted">;
+
+type WriteMethod = keyof typeof WRITE_VERB;
+
 /** Replace a method's trailing `RequestContext` arg with an optional `ServiceOpts`. */
 type ReplaceTrailingContext<F> = F extends (
   ...args: [...infer Head, RequestContext]
@@ -74,9 +96,44 @@ type ReplaceTrailingContext<F> = F extends (
   ? (...args: [...Head, ServiceOpts?]) => R
   : F;
 
-/** @public Plugin-facing collection service: access methods take `ServiceOpts`. */
-export type PluginCollectionService = Omit<CollectionService, AccessMethod> & {
-  [K in AccessMethod]: ReplaceTrailingContext<CollectionService[K]>;
+/**
+ * The plugin-facing return type for a write.
+ *
+ * `deleteEntry` resolves to `void` on the facade, so the deleted row is
+ * reported as the minimal `{ id }` the Direct API already uses for it -- a
+ * caller that wants to log or re-key what it removed has the id, and there is
+ * no row left to return.
+ */
+type WriteResult<K extends WriteMethod> = K extends "deleteEntry"
+  ? MutationResult<{ id: string }>
+  : MutationResult<CollectionEntry>;
+
+/** Replace a write's trailing context AND widen its result to the envelope. */
+type PluginWriteMethod<K extends WriteMethod> =
+  ReplaceTrailingContext<CollectionService[K]> extends (
+    ...args: infer A
+  ) => unknown
+    ? (...args: A) => Promise<WriteResult<K>>
+    : never;
+
+/**
+ * @public Plugin-facing collection service.
+ *
+ * Access methods take `ServiceOpts` in place of a `RequestContext`, and the
+ * writes resolve to the same `{ message, item, warnings? }` envelope the Direct
+ * API and the wire API return. Returning the bare row left a plugin unable to
+ * see a post-commit hook failure that every other caller of the same write is
+ * told about.
+ */
+export type PluginCollectionService = Omit<
+  CollectionService,
+  AccessMethod | WriteMethod
+> & {
+  [K in Exclude<AccessMethod, WriteMethod>]: ReplaceTrailingContext<
+    CollectionService[K]
+  >;
+} & {
+  [K in WriteMethod]: PluginWriteMethod<K>;
 };
 
 /**
@@ -98,6 +155,9 @@ export function wrapCollectionsForPlugin(
         prop as string
       ];
       if (idx === undefined) return fn.bind(target);
+      const verb = (WRITE_VERB as Record<string, string | undefined>)[
+        prop as string
+      ];
       return async (...args: unknown[]) => {
         const resolved = resolveServiceOpts((args[idx] as ServiceOpts) ?? {});
         const next = [...args];
@@ -105,10 +165,25 @@ export function wrapCollectionsForPlugin(
           user: resolved.user,
           overrideAccess: resolved.overrideAccess,
         };
-        return (fn as (...a: unknown[]) => Promise<unknown>).apply(
-          target,
-          next
-        );
+        const call = () =>
+          (fn as (...a: unknown[]) => Promise<unknown>).apply(target, next);
+
+        if (verb === undefined) return call();
+
+        // A plugin write is its own operation boundary: it may run during boot,
+        // with no request around it to open a collector. Opening one here is
+        // what lets the failure reach the plugin that caused it. A scope
+        // already open still receives the same failures, so an in-process write
+        // cannot hide one from the request waiting on it.
+        const { result, warnings } = await collectingWarnings(call);
+        return {
+          message: buildMutationMessage(args[0] as string, verb as "created"),
+          // `deleteEntry` resolves to `void`; the id the caller passed is the
+          // only thing left to identify what went, and it is the same minimal
+          // shape the Direct API reports for a delete.
+          item: result === undefined ? { id: args[1] as string } : result,
+          ...(warnings ? { warnings } : {}),
+        };
       };
     },
   }) as unknown as PluginCollectionService;

--- a/packages/plugin-form-builder/src/__tests__/submit-form.integration.test.ts
+++ b/packages/plugin-form-builder/src/__tests__/submit-form.integration.test.ts
@@ -77,6 +77,15 @@ describe("submitForm end-to-end", () => {
         .get()
         .services.collections.count("form-submissions", {}, { as: "system" })
     ).toBe(1);
+
+    // `submission` is the stored DOCUMENT, which the declared result type says
+    // and TypeScript cannot check: the conversion from the service's loose row
+    // shape goes through `unknown`. Asserting only `success` and the row count
+    // is what let the result carry a mutation envelope here instead of the
+    // document, handing every caller `undefined` for `submission.id`.
+    expect(result.submission?.id).toEqual(expect.any(String));
+    expect(result.submission?.data).toMatchObject({ message: "hello" });
+    expect(result.submission).not.toHaveProperty("item");
   });
 
   it("stores honeypot hits flagged as spam instead of dropping them", async () => {

--- a/packages/plugin-form-builder/src/handlers/submit-form.ts
+++ b/packages/plugin-form-builder/src/handlers/submit-form.ts
@@ -305,9 +305,22 @@ export async function submitForm(
 
     logger.info?.("Form submission created successfully", {
       formSlug,
-      submissionId: submission.id,
+      submissionId: submission.item.id,
       flaggedAsSpam: isContentSpam,
     });
+
+    // A post-commit hook cannot un-save the submission, so a failure there is
+    // logged against the row rather than turned into a failed submission: the
+    // notification email is the one that fails this way, and telling the
+    // visitor their submission did not go through would have them send it
+    // again.
+    if (submission.warnings) {
+      logger.warn?.("Form submission side effects failed", {
+        formSlug,
+        submissionId: submission.item.id,
+        warnings: submission.warnings,
+      });
+    }
 
     // Email notifications are sent via the afterCreate hook registered in
     // plugin.ts init(), so they fire for all submission paths (HTTP + direct).

--- a/packages/plugin-form-builder/src/handlers/submit-form.ts
+++ b/packages/plugin-form-builder/src/handlers/submit-form.ts
@@ -336,7 +336,12 @@ export async function submitForm(
 
     return {
       success: true,
-      submission: submission as unknown as SubmissionDocument,
+      // The created ROW, not the envelope around it. The service's loose
+      // `CollectionEntry` and this declared document do not overlap enough for
+      // a checked assertion, so the conversion goes through `unknown` and
+      // TypeScript verifies nothing here — which is why the integration test
+      // reads `submission.id` off the result rather than only `success`.
+      submission: submission.item as unknown as SubmissionDocument,
       redirect,
     };
   } catch (error) {


### PR DESCRIPTION
## The problem

A post-commit hook (`afterCreate` / `afterUpdate` / `afterDelete`) runs once the row is durable, so a handler failing there cannot un-save it. The write reports success and the failure travels beside it as `warnings`.

A REST client gets that on the response. A Direct API caller gets it on `MutationResult`. **A plugin got nothing** — `ctx.services.collections` returned the bare row and never opened a collector, so a plugin was the only caller of a write that could not see a failure its own write had caused.

## What changes

`createEntry`, `updateEntry` and `deleteEntry` on `ctx.services.collections` resolve to `{ message, item, warnings? }` — the same envelope the Direct API and the REST API already return.

**The scope opens at the facade**, using the existing `collectingWarnings`. That matters: a plugin write is its own operation boundary — `init` runs at boot, with no request around it — so if the scope doesn't open here, nothing collects at all. A scope already open still receives the same failures, so an in-process plugin write cannot hide one from the request waiting on it.

**Reads are deliberately untouched.** Nothing runs after a read that could fail without failing the read, so wrapping them would add an envelope to unwrap for no information. `createMany` keeps its `BatchOperationResult`, which already models per-row outcomes. A test pins that reads did not change.

`message` comes from the same `buildMutationMessage` the Direct API uses, so the two cannot drift into different wording for the same event.

## Breaking, and what moves with it

Migration is one property access. The changeset carries the before/after.

Everything affected is in this PR:

- **`plugin-form-builder`** — `submit-form.ts` read `submission.id`. Now reads `submission.item.id`, and logs `warnings` when the notification-email hook fails, rather than dropping it. My initial grep for `ctx.services.collections.` **missed this call site** (it destructures `collections` first); `pnpm build` caught it. `plugin-page-builder` and `plugin-seo` only read, so they need nothing.
- **Docs** — `docs/plugins/services.mdx` (method table + a new section) and `docs/plugins/api-reference.mdx`.
- **The plugin-sdk surface snapshot needs no update**, and that is worth flagging rather than passing over: it records exported *names*, not shapes, so it would not have caught this break. It is a rename guard, not a signature guard.

## Verification

- New integration suite covers all three writes, the `{ id }` delete shape, the warning path, and the untouched read.
- Reverting the wrapping fails 4 of the 5.
- **One test initially passed for the wrong reason.** I registered the failing hook as `c.hooks[phase]?.(...)`, but the registry's signature is `hooks.on(phase, collection, handler)` — the optional chaining made it a silent no-op, so the "carries a post-commit failure" case was really asserting that a write with no failing hook reports no warnings. It uses the real API now.
- Full `nextly` unit suite by failing-test **name set** against the pre-existing baseline: none introduced. Plugin integration suite: 102 passed, 6 skipped.