### PR TITLE
fix(blocks-engine): match global names the way CSS compares them

### DIFF
--- a/.changeset/isolation-name-matching.md
+++ b/.changeset/isolation-name-matching.md
@@ -1,0 +1,31 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+Two corrections to how the page builder's isolation check reads names, both of
+which made it reject stylesheets that were correct.
+
+A font family is matched without regard to case, so a namespaced family spelled
+in capitals is the same family; a keyframe or a layer name is case-sensitive and
+still is. A comment is whitespace, so a comma inside one no longer splits one
+name into two.

--- a/packages/blocks-engine/docs/override-contract.md
+++ b/packages/blocks-engine/docs/override-contract.md
@@ -177,19 +177,25 @@ the builder emits, so repeating it adds nothing. Put an ancestor in front of it:
 /* The builder already emits this when the document has a scope: */
 /* .nx-pb-page.nx-pb-page.my-region .nx-pb-a1b2 { color: teal }  (0-4-0) */
 
-/* So this TIES, and loses on source order — the builder's inline
-   <style> comes after your stylesheet: */
+/* So this TIES, and a tie is settled by something this package does not
+   control — see the note below. Do not rely on it: */
 .my-region.nx-pb-page.nx-pb-page .nx-pb-a1b2 {
   color: rebeccapurple;
-} /* 0-4-0 — no */
+} /* 0-4-0 — unreliable */
 
-/* This wins: */
+/* This wins outright, whatever the order: */
 .my-theme .my-region.nx-pb-page.nx-pb-page .nx-pb-a1b2 {
   color: rebeccapurple;
 } /* 0-5-0 — yes */
 ```
 
-One exception to that tie, if you use `@scope`. Source order is not the next
+**Do not write a rule that ties.** This package compiles a stylesheet; it does
+not attach one. Where the compiled CSS lands relative to yours is the
+integrating renderer's decision, so whether a tie falls your way depends on
+something neither this package nor this document can promise. Beat the
+builder's specificity and the question does not arise.
+
+One further wrinkle on ties, if you use `@scope`. Source order is not the next
 tiebreaker after specificity — **scope proximity is**, and a rule with no
 scoping root counts as infinitely far away. So a tied rule of yours inside an
 `@scope` rooted near the element beats the builder's unscoped one, even though

--- a/packages/blocks-engine/src/style/isolation.test.ts
+++ b/packages/blocks-engine/src/style/isolation.test.ts
@@ -896,6 +896,48 @@ describe("names CSS resolves for the whole document", () => {
     ).toHaveLength(1);
   });
 
+  it("folds case for a family and not for an identifier", () => {
+    // A `<custom-ident>` is case-sensitive, so `FADE` and `fade` really are two
+    // animations. A family name is not, which is why `font-family: arial` finds
+    // a font installed as "Arial" — so one shared comparison rejects a family
+    // that CSS resolves as exactly the namespaced one it is.
+    const upper = ns("safe").toUpperCase();
+    expect(
+      findUnnamespacedGlobals(
+        `@font-face { font-family: ${upper}; src: url(a.woff2) }`,
+        SCOPE
+      )
+    ).toEqual([]);
+    // The identifier side must NOT fold, or two real animations become one.
+    expect(
+      findUnnamespacedGlobals(
+        `@keyframes ${ns("fade").toUpperCase()} { from { opacity: 0 } }`,
+        SCOPE
+      )
+    ).toHaveLength(1);
+    // And a family that is genuinely someone else's is still reported.
+    expect(
+      findUnnamespacedGlobals(
+        `@font-face { font-family: Host; src: url(a.woff2) }`,
+        SCOPE
+      )
+    ).toHaveLength(1);
+  });
+
+  it("does not split a name on a comma inside a comment", () => {
+    // A comment is whitespace to CSS, so this names ONE layer. Splitting on the
+    // comma reports the tail as a second, un-namespaced name.
+    expect(
+      findUnnamespacedGlobals(`@layer ${ns("theme")}/* retained, x */;`, SCOPE)
+    ).toEqual([]);
+    // Two real layers still split.
+    expect(
+      findUnnamespacedGlobals(`@layer base, components;`, SCOPE).map(
+        e => e.name
+      )
+    ).toEqual(["base", "components"]);
+  });
+
   it("reports every layer a prelude names", () => {
     // A host layer of the same name is the same layer, so two orderings that
     // were meant to be independent merge into one.

--- a/packages/blocks-engine/src/style/isolation.ts
+++ b/packages/blocks-engine/src/style/isolation.ts
@@ -78,6 +78,17 @@ interface AtRuleFacts {
   selectorless: boolean;
   /** The document-global names it defines, if it defines any. */
   globalNames?: (css: string, node: Atrule) => string[];
+  /**
+   * Its names are matched without regard to ASCII case.
+   *
+   * True for font families and false for everything else, and the split is not
+   * arbitrary: a `<custom-ident>` — a keyframe, a counter style, a layer — is
+   * case-SENSITIVE, so `Fade` and `fade` are two animations. A family name is
+   * not, which is why `font-family: arial` finds a font installed as "Arial".
+   * One shared comparison therefore rejects `NX…-SAFE` as un-namespaced when
+   * CSS resolves it as exactly the namespaced family it is.
+   */
+  caseInsensitiveNames?: boolean;
 }
 
 const AT_RULES: Record<string, AtRuleFacts> = {
@@ -98,11 +109,16 @@ const AT_RULES: Record<string, AtRuleFacts> = {
   "font-palette-values": { selectorless: true, globalNames: preludeName },
   "position-try": { selectorless: true, globalNames: preludeName },
   "color-profile": { selectorless: true, globalNames: preludeName },
-  "font-face": { selectorless: true, globalNames: fontFaceFamilies },
+  "font-face": {
+    selectorless: true,
+    globalNames: fontFaceFamilies,
+    caseInsensitiveNames: true,
+  },
   page: { selectorless: true, globalNames: pageNames },
   "font-feature-values": {
     selectorless: true,
     globalNames: featureValueFamilies,
+    caseInsensitiveNames: true,
   },
 };
 
@@ -336,8 +352,14 @@ function scopeToken(scopeClass: string): string {
 }
 
 /** Whether a name already carries this document's namespace. */
-function isNamespaced(name: string, scopeClass: string): boolean {
-  const prefix = `${scopeToken(scopeClass)}-`;
+function isNamespaced(
+  name: string,
+  scopeClass: string,
+  foldCase = false
+): boolean {
+  const raw = `${scopeToken(scopeClass)}-`;
+  const prefix = foldCase ? raw.toLowerCase() : raw;
+  if (foldCase) name = name.toLowerCase();
   // Both spellings, because a custom property carries `--` in front of the
   // namespace and the plain form does not.
   return name.startsWith(prefix) || name.startsWith(`--${prefix}`);
@@ -474,6 +496,16 @@ function splitTopLevel(text: string): string[] {
     }
     if (char === '"' || char === "'") {
       quote = char;
+      continue;
+    }
+    // A comment is whitespace to CSS, so a comma inside one separates nothing.
+    // `@layer x/* retained, comment */` names ONE layer, and splitting on that
+    // comma reports the tail as a second, un-namespaced name.
+    if (char === "/" && text[i + 1] === "*") {
+      const end = text.indexOf("*/", i + 2);
+      // An unterminated comment runs to the end, so nothing after it is a name.
+      if (end === -1) break;
+      i = end + 1;
       continue;
     }
     if (char === ",") {
@@ -622,8 +654,9 @@ export function findUnnamespacedGlobals(
       if (atRule === "layer" && ancestors.includes("layer")) return;
       const readNames = facts.globalNames;
       if (readNames === undefined) return;
+      const foldCase = facts.caseInsensitiveNames === true;
       for (const name of readNames(css, node)) {
-        if (isNamespaced(name, scopeClass)) continue;
+        if (isNamespaced(name, scopeClass, foldCase)) continue;
         found.push({
           atRule,
           name,


### PR DESCRIPTION
Follow-up to #503, which merged with three review comments outstanding. All three are here.

## Context

#503 added two isolation invariants to `blocks-engine`: nothing it emits may match outside the page root, and nothing it emits may define a document-global name that collides with the host's. It went through twelve review rounds and 33 findings. These are the last three, and two of them are the check **rejecting correct output** — the expensive direction, because an invariant that fails on valid stylesheets teaches people to stop reading it.

## 1. Case matters for some of these names and not others

One shared comparison cannot serve both, and it was serving neither correctly.

A `<custom-ident>` — a keyframe, a counter style, a layer — is case-**sensitive**. `FADE` and `fade` really are two animations, and folding them would let two documents share one.

A font family is **not**. That is why `font-family: arial` finds a font installed as "Arial". So a namespaced family spelled `NX…-SAFE` is exactly the namespaced family it looks like, and the shared case-sensitive check reported it as un-namespaced.

Which comparison applies is now recorded per at-rule, alongside the other facts about it:

```ts
"font-face": {
  selectorless: true,
  globalNames: fontFaceFamilies,
  caseInsensitiveNames: true,
},
```

That keeps it where the next person adding an at-rule has to answer it, rather than in a condition somewhere else that they will not think to look at. `@font-feature-values` carries the same flag, for the same reason.

Pinned in all three directions: an uppercase namespaced family is accepted, an uppercase keyframe name is still reported, and a family that genuinely belongs to someone else is still reported.

## 2. A comment is whitespace, so a comma inside one separates nothing

`@layer theme/* retained, comment */` names **one** layer. The prelude splitter reported the tail as a second, un-namespaced name.

The splitter already skipped strings — this is the same class of mistake one level over, and the third time on this PR that reading source text needed to account for something CSS treats as invisible. It skips comments now, and an unterminated one ends the search rather than yielding a name from inside it.

Two genuine layers still split, which is pinned alongside.

## 3. The engine cannot promise its stylesheet loads last

`override-contract.md` told integrations that a tied override loses on source order, because the builder's `<style>` comes later. `README.md` explicitly leaves stylesheet delivery and attachment to the renderer, so that is not the engine's to promise — and an external renderer that attaches the compiled sheet first inverts the outcome.

The worked example now marks the tie as unreliable rather than as a loss, and the document says why:

> **Do not write a rule that ties.** This package compiles a stylesheet; it does not attach one. Where the compiled CSS lands relative to yours is the integrating renderer's decision, so whether a tie falls your way depends on something neither this package nor this document can promise. Beat the builder's specificity and the question does not arise.

That is better advice than either outcome would have been, since a reader who ties is relying on something no one controls.

## Verification

`blocks-engine`: 747 tests pass, `tsc --noEmit` and `eslint --max-warnings 0` both exit 0.

Both code fixes stub-verified: removing the comment skip fails the comma test, and forcing `foldCase` off fails the case test.
