### PR TITLE
feat(nextly): record a login-succeeded audit event

### DIFF
--- a/.changeset/login-succeeded-audit.md
+++ b/.changeset/login-succeeded-audit.md
@@ -37,6 +37,14 @@ HTTP 200 instead would have the opposite fault: the challenge and
 password-change legs answer 200 while issuing no session, so a success would be
 reported for an account that was never reached.
 
+It is recorded last, after the post-login hooks. A hook that throws sends the
+handler into its failure path, which returns an error and records a failure, so
+the client receives neither the token body nor the cookies — a success recorded
+before that point would leave the trail asserting both outcomes for one attempt.
+Those hooks now run inside the same shared step for that reason: all three
+handlers ran the identical pair, and the order between them decides whether the
+trail can contradict itself.
+
 Unlike the failure event it is attributed to the account. Naming the account on
 a failure is the account-state leak the unified error response exists to avoid;
 on a success it is the whole value of the record.

--- a/.changeset/login-succeeded-audit.md
+++ b/.changeset/login-succeeded-audit.md
@@ -28,10 +28,14 @@ Failed logins have been recorded since the audit log shipped; successes were
 not. A trail of failures alone shows that someone tried and not whether they got
 in, which is the first question asked after a credential leak.
 
-The event is written only where a session actually exists. The multi-factor
-challenge and forced-password-change legs both return HTTP 200 without issuing
-one, so recording on status alone would report that an account was reached when
-it was not.
+The event is written where the session is issued, not where the flow began.
+Three handlers issue sessions — password login, second-factor resolution, and
+the forced first-sign-in password change — so recording it in the login handler
+alone would have left every user who completes a second factor absent from the
+success trail, which is the population most worth seeing in it. Recording on an
+HTTP 200 instead would have the opposite fault: the challenge and
+password-change legs answer 200 while issuing no session, so a success would be
+reported for an account that was never reached.
 
 Unlike the failure event it is attributed to the account. Naming the account on
 a failure is the account-state leak the unified error response exists to avoid;

--- a/.changeset/login-succeeded-audit.md
+++ b/.changeset/login-succeeded-audit.md
@@ -48,3 +48,15 @@ trail can contradict itself.
 Unlike the failure event it is attributed to the account. Naming the account on
 a failure is the account-state leak the unified error response exists to avoid;
 on a success it is the whole value of the record.
+
+Setup records it too. Creating the first administrator hands out a working
+session without going through the shared login path, so that account — the
+super-admin — was the one login absent from the trail.
+
+Also fixes an overstated token expiry on the login and setup responses. The
+`expiresAt` they return was derived from a fresh clock reading taken after the
+awaited work that follows signing, so it named a later moment than the token's
+own `exp` claim. `signAccessTokenWithExpiry` now returns the token together with
+the expiry it actually carries, computed once and set explicitly, so a caller
+reports the truth rather than a parallel calculation that drifts by however long
+that work takes — unbounded, since plugin `afterLogin` hooks run there.

--- a/.changeset/login-succeeded-audit.md
+++ b/.changeset/login-succeeded-audit.md
@@ -1,0 +1,38 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+Record a `login-succeeded` audit event when a session is issued.
+
+Failed logins have been recorded since the audit log shipped; successes were
+not. A trail of failures alone shows that someone tried and not whether they got
+in, which is the first question asked after a credential leak.
+
+The event is written only where a session actually exists. The multi-factor
+challenge and forced-password-change legs both return HTTP 200 without issuing
+one, so recording on status alone would report that an account was reached when
+it was not.
+
+Unlike the failure event it is attributed to the account. Naming the account on
+a failure is the account-state leak the unified error response exists to avoid;
+on a success it is the whole value of the record.

--- a/packages/nextly/src/auth/handlers/__tests__/challenge-resolve.test.ts
+++ b/packages/nextly/src/auth/handlers/__tests__/challenge-resolve.test.ts
@@ -71,6 +71,13 @@ describe("handleChallengeResolve (D71)", () => {
     expect(body.message).toBe("Logged in.");
     expect(body.user).toMatchObject({ id: "u1", email: "a@b.c" });
     expect(typeof body.accessToken).toBe("string");
+    // A user who always completes a second factor logs in through THIS handler,
+    // never through the one that first asked for the password. Recording the
+    // success only there would leave that population absent from the trail —
+    // which is the population an operator most wants to see in it.
+    expect(deps.auditLog.write).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: "login-succeeded", actorUserId: "u1" })
+    );
   });
 
   it("re-challenges with a fresh pending token on a wrong code", async () => {

--- a/packages/nextly/src/auth/handlers/__tests__/handler-shapes.test.ts
+++ b/packages/nextly/src/auth/handlers/__tests__/handler-shapes.test.ts
@@ -258,12 +258,13 @@ describe("login handler: respondAction shape", () => {
     );
   });
 
-  it("does not record a success when an afterLogin hook rejects", async () => {
-    // The hook runs after the session is created but before the client has the
-    // token body or cookies. If it throws, the handler returns an error and
-    // records a failure — so a success recorded earlier would leave the trail
-    // asserting both outcomes for one attempt, and claiming the user got in
-    // when nothing was ever delivered to them.
+  /**
+   * Drive a login whose `afterLogin` hook rejects with the given failure, and
+   * hand back what was recorded. The hook belongs to plugin code, so the
+   * failure it raises is whatever that author chose — which is why this is
+   * parameterised rather than fixed to one error type.
+   */
+  async function loginWithRejectingAfterLogin(failure: unknown) {
     const passwordHash = await hashPassword("Pass1234!");
     const fakeUser = {
       id: "u1",
@@ -291,7 +292,7 @@ describe("login handler: respondAction shape", () => {
     });
     pipeline.authHooks.add({
       afterLogin: () => {
-        throw new Error("afterLogin exploded");
+        throw failure;
       },
     } as never);
     const deps = {
@@ -313,22 +314,50 @@ describe("login handler: respondAction shape", () => {
       ...pipeline,
     };
 
-    const req = makeRequest("POST", {
-      email: "a@example.com",
-      password: "Pass1234!",
-    });
-    const res = await handleLogin(req, deps);
-    expect(res.status).toBeGreaterThanOrEqual(400);
+    const res = await handleLogin(
+      makeRequest("POST", {
+        email: "a@example.com",
+        password: "Pass1234!",
+      }),
+      deps
+    );
+    return { res, write: pipeline.auditLog.write };
+  }
 
-    const write = pipeline.auditLog.write;
-    expect(write).toHaveBeenCalledWith(
-      expect.objectContaining({ kind: "login-failed" })
-    );
-    // Exactly one outcome for one attempt.
-    expect(write).not.toHaveBeenCalledWith(
-      expect.objectContaining({ kind: "login-succeeded" })
-    );
-  });
+  // The hook runs after the session is created but before the client has the
+  // token body or cookies. If it throws, the handler returns an error and
+  // records a failure — so a success recorded earlier would leave the trail
+  // asserting both outcomes for one attempt, and claiming the account was
+  // reached when nothing was ever delivered to it.
+  //
+  // Both error shapes are covered because the handler's catch branches on them:
+  // a typed failure keeps its own status, while anything else is wrapped as an
+  // internal error. The invariant under test — exactly one outcome per attempt —
+  // must hold on both branches, and a plugin author is bound by neither our
+  // error convention nor our types.
+  it.each([
+    [
+      "an untyped failure, as third-party plugin code raises",
+      new Error("afterLogin exploded"),
+    ],
+    [
+      "a typed failure",
+      NextlyError.internal({ logContext: { from: "afterLogin" } }),
+    ],
+  ])(
+    "does not record a success when an afterLogin hook rejects with %s",
+    async (_label, failure) => {
+      const { res, write } = await loginWithRejectingAfterLogin(failure);
+
+      expect(res.status).toBeGreaterThanOrEqual(400);
+      expect(write).toHaveBeenCalledWith(
+        expect.objectContaining({ kind: "login-failed" })
+      );
+      expect(write).not.toHaveBeenCalledWith(
+        expect.objectContaining({ kind: "login-succeeded" })
+      );
+    }
+  );
 
   it("returns password_change_required with a pending token (no session) for a must-change account", async () => {
     const passwordHash = await hashPassword("Pass1234!");

--- a/packages/nextly/src/auth/handlers/__tests__/handler-shapes.test.ts
+++ b/packages/nextly/src/auth/handlers/__tests__/handler-shapes.test.ts
@@ -21,6 +21,7 @@
  * Every test also asserts the body has no `data` property, guarding
  * against accidental re-introduction of a `{ data: ... }` envelope.
  */
+import { jwtVerify } from "jose";
 import { describe, expect, it, vi } from "vitest";
 
 import { hashPassword } from "../../password";
@@ -41,6 +42,7 @@ import { NextlyError } from "../../../errors/nextly-error";
 import { handleSession } from "../session";
 import { handleSetup, handleSetupStatus } from "../setup";
 import { handleResendVerification, handleVerifyEmail } from "../verify-email";
+import { secretToKey } from "../../jwt/sign";
 import { hashRefreshToken } from "../../session/refresh";
 import { verifyCredentials } from "../../credentials/verify-credentials";
 import { AuthHookRegistry } from "../../pipeline/hooks";
@@ -670,6 +672,7 @@ describe("setup handler: respondAction shape", () => {
       fetchRoleIds: vi.fn().mockResolvedValue(["super-admin"]),
       seedPermissions: vi.fn().mockResolvedValue(undefined),
       storeRefreshToken: vi.fn().mockResolvedValue(undefined),
+      auditLog: { write: vi.fn().mockResolvedValue(undefined) },
     };
     const req = makeRequest("POST", {
       email: "a@example.com",
@@ -685,6 +688,22 @@ describe("setup handler: respondAction shape", () => {
     expect(typeof body.accessToken).toBe("string");
     expect(typeof body.refreshToken).toBe("string");
     expect(typeof body.expiresAt).toBe("string");
+    // The first administrator receives a working session, so the trail has to
+    // show it. Setup is the one session-issuing path that does not run through
+    // the shared login completion, which is exactly why it was missing.
+    expect(deps.auditLog.write).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: "login-succeeded", actorUserId: "u1" })
+    );
+    // The reported expiry must be the token's own, not a clock reading taken
+    // after the awaited work above. Asserting the signer in isolation would not
+    // catch a caller that ignores what it returns.
+    const { payload } = await jwtVerify(
+      body.accessToken as string,
+      secretToKey(SECRET)
+    );
+    expect(Date.parse(body.expiresAt as string)).toBe(
+      (payload.exp as number) * 1000
+    );
   });
 
   // Security: an unknown user count must never be treated as 0 -- a second

--- a/packages/nextly/src/auth/handlers/__tests__/handler-shapes.test.ts
+++ b/packages/nextly/src/auth/handlers/__tests__/handler-shapes.test.ts
@@ -258,6 +258,78 @@ describe("login handler: respondAction shape", () => {
     );
   });
 
+  it("does not record a success when an afterLogin hook rejects", async () => {
+    // The hook runs after the session is created but before the client has the
+    // token body or cookies. If it throws, the handler returns an error and
+    // records a failure — so a success recorded earlier would leave the trail
+    // asserting both outcomes for one attempt, and claiming the user got in
+    // when nothing was ever delivered to them.
+    const passwordHash = await hashPassword("Pass1234!");
+    const fakeUser = {
+      id: "u1",
+      email: "a@example.com",
+      name: "A",
+      passwordHash,
+      isActive: true,
+      emailVerified: true,
+      failedLoginAttempts: 0,
+      lockedUntil: null,
+      mustChangePassword: false,
+    };
+    const findUserByEmail = vi.fn().mockResolvedValue(fakeUser);
+    const incrementFailedAttempts = vi.fn().mockResolvedValue(undefined);
+    const lockAccount = vi.fn().mockResolvedValue(undefined);
+    const resetFailedAttempts = vi.fn().mockResolvedValue(undefined);
+    const pipeline = loginPipelineDeps({
+      findUserByEmail,
+      incrementFailedAttempts,
+      lockAccount,
+      resetFailedAttempts,
+      maxLoginAttempts: 5,
+      lockoutDurationSeconds: 900,
+      requireEmailVerification: true,
+    });
+    pipeline.authHooks.add({
+      afterLogin: () => {
+        throw new Error("afterLogin exploded");
+      },
+    } as never);
+    const deps = {
+      secret: SECRET,
+      accessTokenTTL: 900,
+      refreshTokenTTL: 604800,
+      loginStallTimeMs: 0,
+      requireEmailVerification: true,
+      allowedOrigins: ALLOWED_ORIGINS,
+      trustProxy: false,
+      trustedProxyIps: [],
+      findUserByEmail,
+      incrementFailedAttempts,
+      lockAccount,
+      resetFailedAttempts,
+      fetchRoleIds: vi.fn().mockResolvedValue(["super-admin"]),
+      fetchCustomFields: vi.fn().mockResolvedValue({}),
+      storeRefreshToken: vi.fn().mockResolvedValue(undefined),
+      ...pipeline,
+    };
+
+    const req = makeRequest("POST", {
+      email: "a@example.com",
+      password: "Pass1234!",
+    });
+    const res = await handleLogin(req, deps);
+    expect(res.status).toBeGreaterThanOrEqual(400);
+
+    const write = pipeline.auditLog.write;
+    expect(write).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: "login-failed" })
+    );
+    // Exactly one outcome for one attempt.
+    expect(write).not.toHaveBeenCalledWith(
+      expect.objectContaining({ kind: "login-succeeded" })
+    );
+  });
+
   it("returns password_change_required with a pending token (no session) for a must-change account", async () => {
     const passwordHash = await hashPassword("Pass1234!");
     const fakeUser = {

--- a/packages/nextly/src/auth/handlers/__tests__/handler-shapes.test.ts
+++ b/packages/nextly/src/auth/handlers/__tests__/handler-shapes.test.ts
@@ -193,6 +193,71 @@ describe("login handler: respondAction shape", () => {
     expect(Number.isFinite(Date.parse(body.expiresAt as string))).toBe(true);
   });
 
+  it("records a login-succeeded audit event once a session is issued", async () => {
+    // Failures are recorded already. Without the matching success an operator
+    // reading the trail after a credential leak can see that someone tried and
+    // not whether they got in, which is the question that actually matters.
+    const passwordHash = await hashPassword("Pass1234!");
+    const fakeUser = {
+      id: "u1",
+      email: "a@example.com",
+      name: "A",
+      passwordHash,
+      isActive: true,
+      emailVerified: true,
+      failedLoginAttempts: 0,
+      lockedUntil: null,
+      mustChangePassword: false,
+    };
+    const findUserByEmail = vi.fn().mockResolvedValue(fakeUser);
+    const incrementFailedAttempts = vi.fn().mockResolvedValue(undefined);
+    const lockAccount = vi.fn().mockResolvedValue(undefined);
+    const resetFailedAttempts = vi.fn().mockResolvedValue(undefined);
+    const pipeline = loginPipelineDeps({
+      findUserByEmail,
+      incrementFailedAttempts,
+      lockAccount,
+      resetFailedAttempts,
+      maxLoginAttempts: 5,
+      lockoutDurationSeconds: 900,
+      requireEmailVerification: true,
+    });
+    const deps = {
+      secret: SECRET,
+      accessTokenTTL: 900,
+      refreshTokenTTL: 604800,
+      loginStallTimeMs: 0,
+      requireEmailVerification: true,
+      allowedOrigins: ALLOWED_ORIGINS,
+      trustProxy: false,
+      trustedProxyIps: [],
+      findUserByEmail,
+      incrementFailedAttempts,
+      lockAccount,
+      resetFailedAttempts,
+      fetchRoleIds: vi.fn().mockResolvedValue(["super-admin"]),
+      fetchCustomFields: vi.fn().mockResolvedValue({}),
+      storeRefreshToken: vi.fn().mockResolvedValue(undefined),
+      ...pipeline,
+    };
+
+    const req = makeRequest("POST", {
+      email: "a@example.com",
+      password: "Pass1234!",
+    });
+    const res = await handleLogin(req, deps);
+    expect(res.status).toBe(200);
+
+    const write = pipeline.auditLog.write;
+    expect(write).toHaveBeenCalledTimes(1);
+    // Attributed, unlike a failure: a completed login names who completed it.
+    // A failure cannot, because saying which account was reached is the
+    // account-state leak the unified error shape exists to avoid.
+    expect(write).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: "login-succeeded", actorUserId: "u1" })
+    );
+  });
+
   it("returns password_change_required with a pending token (no session) for a must-change account", async () => {
     const passwordHash = await hashPassword("Pass1234!");
     const fakeUser = {
@@ -262,6 +327,12 @@ describe("login handler: respondAction shape", () => {
     expect(storeRefreshToken).not.toHaveBeenCalled();
     // No Set-Cookie for the access-token session.
     expect(res.headers.get("set-cookie") ?? "").not.toContain("nextly_session");
+    // And no successful-login record. This leg returns 200 with a pending
+    // token, so a success recorded on status alone would tell an operator the
+    // account was reached when no session exists.
+    expect(deps.auditLog.write).not.toHaveBeenCalledWith(
+      expect.objectContaining({ kind: "login-succeeded" })
+    );
   });
 });
 

--- a/packages/nextly/src/auth/handlers/challenge-resolve.ts
+++ b/packages/nextly/src/auth/handlers/challenge-resolve.ts
@@ -173,7 +173,6 @@ export async function handleChallengeResolve(
       image: u.image,
     };
     const response = await issueSession(user, deps, request, requestId);
-    await deps.authHooks.runAfterLogin(user, deps.pluginCtx);
     await stallResponse(startTime, deps.loginStallTimeMs);
     return response;
   } catch (err) {

--- a/packages/nextly/src/auth/handlers/issue-session.ts
+++ b/packages/nextly/src/auth/handlers/issue-session.ts
@@ -1,4 +1,5 @@
 import { respondAction } from "../../api/response-shapes";
+import type { AuditLogWriter } from "../../domains/audit/audit-log-writer";
 import type { PluginContext } from "../../plugins/plugin-context";
 import type { AuthUser } from "../../types/auth";
 import { getTrustedClientIp } from "../../utils/get-trusted-client-ip";
@@ -41,6 +42,12 @@ export interface IssueSessionDeps {
   authHooks: AuthHookRegistry;
   /** The plugin context handed to auth hooks. */
   pluginCtx: PluginContext;
+  /**
+   * Records the successful login. Required rather than optional: a session
+   * issued without one is a login absent from the audit trail, and the point of
+   * recording here is that no path can opt out by forgetting.
+   */
+  auditLog: AuditLogWriter;
 }
 
 /**
@@ -49,6 +56,13 @@ export interface IssueSessionDeps {
  * rotate-in a fresh refresh token, and respond with the canonical login body +
  * HttpOnly cookies (spec §7.6). Extracted from the login handler so the
  * challenge-resolve path issues sessions identically.
+ *
+ * It is also where a successful login is recorded, for that same reason. Three
+ * handlers issue sessions — password login, second-factor resolution, and the
+ * forced first-sign-in password change — and a user who always completes a
+ * second factor never passes through the first. Recording at each call site
+ * left that population out of the trail entirely, so the record belongs where
+ * the session is created rather than where the flow happened to begin.
  */
 export async function issueSession(
   user: AuthUser,
@@ -94,6 +108,20 @@ export async function issueSession(
       trustedProxyIps: deps.trustedProxyIps,
     }),
     expiresAt: new Date(Date.now() + deps.refreshTokenTTL * 1000),
+  });
+
+  // After the refresh token is durable: the session now exists, so the record
+  // describes something that happened rather than something about to. Attributed
+  // on purpose — naming the account is the account-state leak a FAILURE must
+  // avoid, and is the whole value of a success.
+  await deps.auditLog.write({
+    kind: "login-succeeded",
+    actorUserId: user.id,
+    ipAddress: getTrustedClientIp(request, {
+      trustProxy: deps.trustProxy,
+      trustedProxyIps: deps.trustedProxyIps,
+    }),
+    userAgent: request.headers.get("user-agent"),
   });
 
   const cookies = [

--- a/packages/nextly/src/auth/handlers/issue-session.ts
+++ b/packages/nextly/src/auth/handlers/issue-session.ts
@@ -6,7 +6,7 @@ import { getTrustedClientIp } from "../../utils/get-trusted-client-ip";
 import { setAccessTokenCookie } from "../cookies/access-token-cookie";
 import { setRefreshTokenCookie } from "../cookies/refresh-token-cookie";
 import { buildClaims } from "../jwt/claims";
-import { signAccessToken } from "../jwt/sign";
+import { signAccessTokenWithExpiry } from "../jwt/sign";
 import type { AuthHookRegistry } from "../pipeline/hooks";
 import {
   generateRefreshToken,
@@ -92,11 +92,8 @@ export async function issueSession(
     deps.pluginCtx
   );
 
-  const accessToken = await signAccessToken(
-    claims,
-    deps.secret,
-    deps.accessTokenTTL
-  );
+  const { token: accessToken, expiresAt: accessTokenExpiresAt } =
+    await signAccessTokenWithExpiry(claims, deps.secret, deps.accessTokenTTL);
 
   const rawRefreshToken = generateRefreshToken();
   const refreshTokenHash = hashRefreshToken(rawRefreshToken);
@@ -156,9 +153,9 @@ export async function issueSession(
       },
       accessToken,
       refreshToken: rawRefreshToken,
-      expiresAt: new Date(
-        Date.now() + deps.accessTokenTTL * 1000
-      ).toISOString(),
+      // The token's own expiry, not a fresh reading: the hooks and the audit
+      // write above are awaited, and a plugin hook is arbitrary code.
+      expiresAt: accessTokenExpiresAt.toISOString(),
     },
     {
       status: 200,

--- a/packages/nextly/src/auth/handlers/issue-session.ts
+++ b/packages/nextly/src/auth/handlers/issue-session.ts
@@ -57,12 +57,14 @@ export interface IssueSessionDeps {
  * HttpOnly cookies (spec §7.6). Extracted from the login handler so the
  * challenge-resolve path issues sessions identically.
  *
- * It is also where a successful login is recorded, for that same reason. Three
- * handlers issue sessions — password login, second-factor resolution, and the
- * forced first-sign-in password change — and a user who always completes a
- * second factor never passes through the first. Recording at each call site
- * left that population out of the trail entirely, so the record belongs where
- * the session is created rather than where the flow happened to begin.
+ * It also runs the post-login hooks and records the successful login, for that
+ * same reason. Three handlers complete a login — password login, second-factor
+ * resolution, and the forced first-sign-in password change — and each ran the
+ * identical pair of steps after issuing the session. A user who always completes
+ * a second factor never passes through the first, so recording at each call site
+ * left that population out of the trail entirely; and the ORDER of those steps
+ * decides whether the trail can contradict itself, which is not something three
+ * copies should each be trusted to get right.
  */
 export async function issueSession(
   user: AuthUser,
@@ -110,10 +112,19 @@ export async function issueSession(
     expiresAt: new Date(Date.now() + deps.refreshTokenTTL * 1000),
   });
 
-  // After the refresh token is durable: the session now exists, so the record
-  // describes something that happened rather than something about to. Attributed
-  // on purpose — naming the account is the account-state leak a FAILURE must
-  // avoid, and is the whole value of a success.
+  // Last, after the post-login hooks. A hook that throws sends the caller into
+  // its failure path, which returns an error and records a failure — the client
+  // never receives the token body or the cookies. Recording the success before
+  // that point left the trail asserting both outcomes for one attempt and
+  // claiming the account was reached when nothing was delivered.
+  //
+  // Running the hooks here rather than in each caller is what makes that
+  // ordering a property of the code instead of a convention: all three handlers
+  // ran exactly this pair, and one of them getting the order wrong is invisible
+  // until an audit is read.
+  await deps.authHooks.runAfterLogin(user, deps.pluginCtx);
+  // Attributed on purpose — naming the account is the account-state leak a
+  // FAILURE must avoid, and is the whole value of a success.
   await deps.auditLog.write({
     kind: "login-succeeded",
     actorUserId: user.id,

--- a/packages/nextly/src/auth/handlers/login.ts
+++ b/packages/nextly/src/auth/handlers/login.ts
@@ -182,22 +182,6 @@ export async function handleLogin(
 
     const response = await issueSession(afterAuth, deps, request, requestId);
     await deps.authHooks.runAfterLogin(afterAuth, deps.pluginCtx);
-    // Recorded only here, where a session actually exists. The challenge and
-    // forced-password-change legs above return without one, so treating them as
-    // successful logins would tell an operator an account was reached when it
-    // was not. Attributed, unlike the failure leg: naming the account is the
-    // account-state leak the unified error shape avoids on failure, and is
-    // precisely the value of the record on success — a failure trail alone
-    // shows that someone tried, not whether they got in.
-    await deps.auditLog.write({
-      kind: "login-succeeded",
-      actorUserId: afterAuth.id,
-      ipAddress: getTrustedClientIp(request, {
-        trustProxy: deps.trustProxy,
-        trustedProxyIps: deps.trustedProxyIps,
-      }),
-      userAgent: request.headers.get("user-agent"),
-    });
     await stallResponse(startTime, deps.loginStallTimeMs);
     return response;
   } catch (err) {

--- a/packages/nextly/src/auth/handlers/login.ts
+++ b/packages/nextly/src/auth/handlers/login.ts
@@ -181,7 +181,6 @@ export async function handleLogin(
     }
 
     const response = await issueSession(afterAuth, deps, request, requestId);
-    await deps.authHooks.runAfterLogin(afterAuth, deps.pluginCtx);
     await stallResponse(startTime, deps.loginStallTimeMs);
     return response;
   } catch (err) {

--- a/packages/nextly/src/auth/handlers/login.ts
+++ b/packages/nextly/src/auth/handlers/login.ts
@@ -182,6 +182,22 @@ export async function handleLogin(
 
     const response = await issueSession(afterAuth, deps, request, requestId);
     await deps.authHooks.runAfterLogin(afterAuth, deps.pluginCtx);
+    // Recorded only here, where a session actually exists. The challenge and
+    // forced-password-change legs above return without one, so treating them as
+    // successful logins would tell an operator an account was reached when it
+    // was not. Attributed, unlike the failure leg: naming the account is the
+    // account-state leak the unified error shape avoids on failure, and is
+    // precisely the value of the record on success — a failure trail alone
+    // shows that someone tried, not whether they got in.
+    await deps.auditLog.write({
+      kind: "login-succeeded",
+      actorUserId: afterAuth.id,
+      ipAddress: getTrustedClientIp(request, {
+        trustProxy: deps.trustProxy,
+        trustedProxyIps: deps.trustedProxyIps,
+      }),
+      userAgent: request.headers.get("user-agent"),
+    });
     await stallResponse(startTime, deps.loginStallTimeMs);
     return response;
   } catch (err) {

--- a/packages/nextly/src/auth/handlers/set-initial-password.ts
+++ b/packages/nextly/src/auth/handlers/set-initial-password.ts
@@ -167,7 +167,6 @@ export async function handleSetInitialPassword(
     });
 
     const response = await issueSession(user, deps, request, requestId);
-    await deps.authHooks.runAfterLogin(user, deps.pluginCtx);
     await stallResponse(startTime, deps.loginStallTimeMs);
     return response;
   } catch (err) {

--- a/packages/nextly/src/auth/handlers/setup.ts
+++ b/packages/nextly/src/auth/handlers/setup.ts
@@ -3,6 +3,7 @@
 // the legitimate first-admin form. See docs/auth/csrf.md.
 import { readOrGenerateRequestId } from "../../api/request-id";
 import { respondAction, respondData } from "../../api/response-shapes";
+import type { AuditLogWriter } from "../../domains/audit/audit-log-writer";
 import { NextlyError } from "../../errors";
 import { getNextlyLogger } from "../../observability/logger";
 import { getTrustedClientIp } from "../../utils/get-trusted-client-ip";
@@ -12,7 +13,7 @@ import { validatePasswordStrength } from "../credentials/password-strength";
 import { readCsrfCookie, readCsrfFromRequest } from "../csrf/csrf-cookie";
 import { validateCsrf } from "../csrf/validate";
 import { buildClaims } from "../jwt/claims";
-import { signAccessToken } from "../jwt/sign";
+import { signAccessTokenWithExpiry } from "../jwt/sign";
 // hashPassword not needed here -- seedSuperAdmin handles hashing internally
 import {
   generateRefreshToken,
@@ -27,6 +28,12 @@ import {
 } from "./handler-utils";
 
 export interface SetupHandlerDeps {
+  /**
+   * Records the session this hands out. Setup is account creation, but it
+   * returns a working session, so the trail must show it like any other
+   * completed login.
+   */
+  auditLog: AuditLogWriter;
   secret: string;
   isProduction: boolean;
   accessTokenTTL: number;
@@ -167,11 +174,8 @@ export async function handleSetup(
     image: null,
     roleIds,
   });
-  const accessToken = await signAccessToken(
-    claims,
-    deps.secret,
-    deps.accessTokenTTL
-  );
+  const { token: accessToken, expiresAt: accessTokenExpiresAt } =
+    await signAccessTokenWithExpiry(claims, deps.secret, deps.accessTokenTTL);
 
   const rawRefreshToken = generateRefreshToken();
   await deps.storeRefreshToken({
@@ -184,6 +188,20 @@ export async function handleSetup(
       trustedProxyIps: deps.trustedProxyIps,
     }),
     expiresAt: new Date(Date.now() + deps.refreshTokenTTL * 1000),
+  });
+
+  // Setup issues a real session, so it is a completed login and belongs in the
+  // trail like any other. It does not route through `issueSession` because it
+  // is account creation rather than authentication — different status, message,
+  // and no login hooks — but the session it hands out is the same thing.
+  await deps.auditLog.write({
+    kind: "login-succeeded",
+    actorUserId: user.id,
+    ipAddress: getTrustedClientIp(request, {
+      trustProxy: deps.trustProxy,
+      trustedProxyIps: deps.trustedProxyIps,
+    }),
+    userAgent: request.headers.get("user-agent"),
   });
 
   const cookies = [
@@ -205,10 +223,10 @@ export async function handleSetup(
       user: { id: user.id, email: user.email, name: user.name, roleIds },
       accessToken,
       refreshToken: rawRefreshToken,
-      // Authoritative server-side exp = accessToken JWT exp claim, not cookie max-age.
-      expiresAt: new Date(
-        Date.now() + deps.accessTokenTTL * 1000
-      ).toISOString(),
+      // Authoritative server-side exp = the accessToken JWT's own exp claim,
+      // not cookie max-age and not a fresh clock reading taken after the
+      // awaited work above.
+      expiresAt: accessTokenExpiresAt.toISOString(),
     },
     { status: 201, headers: buildCookieHeaders(cookies) }
   );

--- a/packages/nextly/src/auth/jwt/__tests__/jwt.test.ts
+++ b/packages/nextly/src/auth/jwt/__tests__/jwt.test.ts
@@ -2,7 +2,11 @@ import { jwtVerify } from "jose";
 import { describe, it, expect } from "vitest";
 
 import { buildClaims } from "../claims";
-import { signAccessToken, secretToKey } from "../sign";
+import {
+  signAccessToken,
+  signAccessTokenWithExpiry,
+  secretToKey,
+} from "../sign";
 import { verifyAccessToken } from "../verify";
 
 const TEST_SECRET = "test-secret-must-be-at-least-32-characters-long!!";
@@ -186,5 +190,62 @@ describe("verifyAccessToken", () => {
   it("should reject empty string", async () => {
     const result = await verifyAccessToken("", TEST_SECRET);
     expect(result.valid).toBe(false);
+  });
+});
+
+/**
+ * A caller that reports when the access token expires must report the token's
+ * OWN expiry. Deriving it from a second clock reading — after the awaits that
+ * follow signing — reports a later moment than the token actually holds, and a
+ * client trusting it keeps using a token the server has already rejected.
+ */
+describe("signAccessTokenWithExpiry", () => {
+  it("returns the expiry the token itself carries", async () => {
+    const claims = buildClaims({
+      userId: "user_123",
+      email: "test@example.com",
+      name: "Test User",
+      image: null,
+      roleIds: [],
+    });
+
+    const { token, expiresAt } = await signAccessTokenWithExpiry(
+      claims,
+      TEST_SECRET,
+      900
+    );
+
+    const key = secretToKey(TEST_SECRET);
+    const { payload } = await jwtVerify(token, key);
+    expect(expiresAt.getTime()).toBe((payload.exp as number) * 1000);
+  });
+
+  it("does not drift when the caller waits before reading the expiry", async () => {
+    const claims = buildClaims({
+      userId: "user_123",
+      email: "test@example.com",
+      name: "Test User",
+      image: null,
+      roleIds: [],
+    });
+
+    const { token, expiresAt } = await signAccessTokenWithExpiry(
+      claims,
+      TEST_SECRET,
+      1
+    );
+    // Stand in for the awaited work every session-issuing path does between
+    // signing and responding: storing the refresh token, running plugin
+    // afterLogin hooks, writing the audit record.
+    await new Promise(resolve => setTimeout(resolve, 1100));
+
+    const key = secretToKey(TEST_SECRET);
+    const { payload } = await jwtVerify(token, key).catch(() => ({
+      payload: null,
+    }));
+    // The token is expired by now, and the reported expiry says so rather than
+    // claiming validity the token no longer has.
+    expect(payload).toBeNull();
+    expect(expiresAt.getTime()).toBeLessThanOrEqual(Date.now());
   });
 });

--- a/packages/nextly/src/auth/jwt/sign.ts
+++ b/packages/nextly/src/auth/jwt/sign.ts
@@ -25,14 +25,42 @@ export async function signAccessToken(
   secret: string,
   ttlSeconds: number = 900
 ): Promise<string> {
+  const { token } = await signAccessTokenWithExpiry(claims, secret, ttlSeconds);
+  return token;
+}
+
+/**
+ * Sign an access token and report the expiry it actually carries.
+ *
+ * Every caller that returns an `expiresAt` to a client must use this rather
+ * than deriving one itself. Signing and responding are separated by awaited
+ * work — storing the refresh token, running plugin `afterLogin` hooks, writing
+ * the audit record — and a second clock reading taken after that work names a
+ * later moment than the token holds. The overstatement is unbounded, because a
+ * plugin hook is arbitrary code, and a client trusting it keeps sending a token
+ * the server has already rejected.
+ *
+ * The timestamps are computed once and set explicitly rather than left to a
+ * relative expression, so the returned `expiresAt` IS the `exp` claim rather
+ * than a parallel calculation that happens to agree.
+ */
+export async function signAccessTokenWithExpiry(
+  claims: Record<string, unknown>,
+  secret: string,
+  ttlSeconds: number = 900
+): Promise<{ token: string; expiresAt: Date }> {
   const key = secretToKey(secret);
   const jti = randomBytes(16).toString("hex");
+  // Whole seconds, because that is the resolution `exp` and `iat` are defined
+  // at; deriving the Date from the same integer keeps the two exact.
+  const issuedAt = Math.floor(Date.now() / 1000);
+  const expiresAt = issuedAt + ttlSeconds;
 
   const jwt = new SignJWT(claims)
     .setProtectedHeader({ alg: ALGORITHM })
-    .setIssuedAt()
-    .setExpirationTime(`${ttlSeconds}s`)
+    .setIssuedAt(issuedAt)
+    .setExpirationTime(expiresAt)
     .setJti(jti);
 
-  return jwt.sign(key);
+  return { token: await jwt.sign(key), expiresAt: new Date(expiresAt * 1000) };
 }

--- a/packages/nextly/src/domains/audit/audit-log-writer.ts
+++ b/packages/nextly/src/domains/audit/audit-log-writer.ts
@@ -35,6 +35,7 @@ import { getNextlyLogger } from "../../observability/logger";
 export type AuditEventKind =
   | "csrf-failed"
   | "login-failed"
+  | "login-succeeded"
   | "password-changed"
   | "role-assigned"
   | "role-revoked"


### PR DESCRIPTION
PR-3a of task 052 (roadmap item 7), per the signed design doc. Follows #512 and #513.

## Why

Failed logins have been recorded since the audit log shipped; successes have not.
A trail of failures alone shows that someone **tried** and not whether they **got
in**, which is the first question asked after a credential leak. Strapi records
both; we recorded half.

## The one decision worth reviewing

The event is written **only where a session actually exists** — after
`issueSession`, not on a 200 response. `handleLogin` has three non-failure
outcomes, and two of them return HTTP 200 without a session:

| Outcome | Session? | Recorded? |
|---|---|---|
| multi-factor challenge | no — pending token | no |
| forced password change (ASVS 6.4.1) | no — pending token | no |
| session issued | yes | **yes** |

Recording on status alone would tell an operator an account was reached when it
was not, which is worse than not recording at all.

It is **attributed** (`actorUserId`), unlike the failure event. Naming the account
on a failure is exactly the account-state leak the unified error wire shape exists
to avoid; on a success it is the entire value of the record.

## Tests, both directions

- The success case asserts the event is written once, with the kind and the actor.
  It failed RED before the change (`called 0 times`).
- The must-change-password case asserts the event is **not** written. That
  negative is the one that pins the placement, so I verified it is not vacuous by
  moving the write above that leg: it fails with
  `expected "vi.fn()" to not be called with arguments`. Restored, and green.

Green: 208 auth + audit unit tests, 5 audit integration, `check-types` and `lint`
clean, 0 behind `origin/main`.

## Deliberately not in this PR

`audit_log` identity erasure and its retention window are PR-3b. They need a new
column, a capability guard, and a decision about the free-form `metadata` field —
and `audit_log` has existing history with no pruning today, so introducing
retention deletes rows on upgrade. That deserves its own review rather than
riding along with an additive event kind.