### PR TITLE
fix(nextly): give a code-less failure one status table

### DIFF
--- a/.changeset/one-status-table.md
+++ b/.changeset/one-status-table.md
@@ -1,0 +1,51 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+**One table now decides what an HTTP status means when a failure names no error code.**
+
+Three tables used to, and they disagreed. The same code-less 401 reached a Direct API caller as
+`AUTH_REQUIRED` and a REST caller as `INTERNAL_ERROR`; a code-less 429 lost its rate-limit
+identity entirely, and with it the `Retry-After` a client needs to back off correctly. The media
+service kept a third table that read 409 as `DUPLICATE` and 422 as `BUSINESS_RULE_VIOLATION`.
+
+A code-less failure now resolves through one shared table for 400, 401, 403, 404, 409, 413, 415,
+422, 429, 502 and 503, and anything unrecognised stays an internal error. The producer's own
+status is preserved rather than rounded to the code's canonical one.
+
+**The table is a fallback, not a translation.** A status is coarser than a code: 409 covers both
+"that name is taken" and "someone else edited this", which need opposite advice. A service that
+knows which one it means sets `code` and is believed. `MediaResponse`, `DeleteMediaResponse`,
+`FolderContentsResponse` and the folder bulk-delete result can carry a code for exactly this
+reason, and creating a folder whose name is taken now says so through `DUPLICATE` rather than
+relying on a boundary to guess.
+
+**A code-less failure never puts its own message on the wire.** Those envelopes come from legacy
+converters that may store a raw exception's text, so the caller gets the generic sentence for the
+derived code and the detail stays in the operator log. A failure that names a code keeps its own
+message, which the producer authored to be read.
+
+Behaviour changes worth checking if you read error bodies directly: a code-less 401 answers
+`AUTH_REQUIRED` instead of `INTERNAL_ERROR`; a code-less 429 answers `RATE_LIMITED`; a code-less
+422 answers `INVALID_INPUT`; and through the Direct API a code-less failure's message is now the
+generic sentence rather than the service's raw text.

--- a/packages/nextly/src/direct-api/namespaces/helpers.ts
+++ b/packages/nextly/src/direct-api/namespaces/helpers.ts
@@ -151,9 +151,13 @@ export function createErrorFromSingleResult(
         message: e.message,
       })),
     },
-    // Same reason as the collection converter: the generic public sentence is
-    // what the caller gets, so the original has to survive somewhere.
-    { legacyMessage: result.message }
+    // The NORMALISED message, not `result.message`. A Single failure may omit
+    // the top-level one and carry per-field `errors` instead, in which case the
+    // text above is synthesised from them -- and that synthesised text is what
+    // the converter replaces with a generic sentence for a non-validation
+    // status. Logging the raw field would record `undefined` in exactly the
+    // case where the caller's text was withheld.
+    { legacyMessage: message }
   );
 }
 

--- a/packages/nextly/src/direct-api/namespaces/helpers.ts
+++ b/packages/nextly/src/direct-api/namespaces/helpers.ts
@@ -97,12 +97,7 @@ export function createErrorFromResult(result: ServiceResultLike): NextlyError {
   // below is what carries it there — it is an enumerable own property, so it
   // survives into the object handed over.
   return errorFromServiceEnvelope(
-    {
-      ...result,
-      // A code-less envelope still needs the status-derived guess this boundary
-      // has always made, rather than falling through to a generic internal.
-      code: result.code ?? statusCodeToErrorCode(result.statusCode),
-    },
+    result,
     result.data !== undefined && result.data !== null
       ? { resultData: result.data }
       : {}
@@ -143,9 +138,6 @@ export function createErrorFromSingleResult(
     {
       ...result,
       message,
-      // A code-less envelope keeps the status-derived guess this boundary has
-      // always made rather than falling through to a generic internal.
-      code: result.code ?? statusCodeToErrorCode(result.statusCode),
       // Normalised to the canonical shape; SingleResult still emits `{field}`.
       errors: result.errors?.map(e => ({
         path: e.field,
@@ -157,45 +149,6 @@ export function createErrorFromSingleResult(
     },
     {}
   );
-}
-
-/**
- * Map an HTTP status code to the primary canonical `NextlyErrorCode` string
- * for that status. Mirrors the inverse of `NEXTLY_ERROR_STATUS` from
- * `error-codes.ts`, picking the most specific representative code per status.
- *
- * Statuses outside this table fall back to `INTERNAL_ERROR` — service-layer
- * results that need a more specific code (e.g. `BUSINESS_RULE_VIOLATION` at
- * 422) should throw `NextlyError` directly rather than returning a result
- * shape that funnels through this helper.
- */
-export function statusCodeToErrorCode(statusCode: number): string {
-  switch (statusCode) {
-    case 400:
-      return "VALIDATION_ERROR";
-    case 401:
-      return "AUTH_REQUIRED";
-    case 403:
-      return "FORBIDDEN";
-    case 404:
-      return "NOT_FOUND";
-    case 409:
-      return "CONFLICT";
-    case 413:
-      return "PAYLOAD_TOO_LARGE";
-    case 415:
-      return "UNSUPPORTED_MEDIA_TYPE";
-    case 422:
-      return "INVALID_INPUT";
-    case 429:
-      return "RATE_LIMITED";
-    case 502:
-      return "EXTERNAL_SERVICE_ERROR";
-    case 503:
-      return "SERVICE_UNAVAILABLE";
-    default:
-      return "INTERNAL_ERROR";
-  }
 }
 
 /**

--- a/packages/nextly/src/direct-api/namespaces/helpers.ts
+++ b/packages/nextly/src/direct-api/namespaces/helpers.ts
@@ -96,12 +96,16 @@ export function createErrorFromResult(result: ServiceResultLike): NextlyError {
   // original back on as `cause` by reading it off the envelope, and the spread
   // below is what carries it there — it is an enumerable own property, so it
   // survives into the object handed over.
-  return errorFromServiceEnvelope(
-    result,
-    result.data !== undefined && result.data !== null
+  return errorFromServiceEnvelope(result, {
+    // The service's own text, kept for the operator. A code-less failure now
+    // answers with a generic sentence, because its message may be a raw
+    // exception's; withholding it from the caller is the point, and discarding
+    // it as well would make exactly those failures undiagnosable.
+    legacyMessage: result.message,
+    ...(result.data !== undefined && result.data !== null
       ? { resultData: result.data }
-      : {}
-  );
+      : {}),
+  });
 }
 
 /**
@@ -147,7 +151,9 @@ export function createErrorFromSingleResult(
         message: e.message,
       })),
     },
-    {}
+    // Same reason as the collection converter: the generic public sentence is
+    // what the caller gets, so the original has to survive somewhere.
+    { legacyMessage: result.message }
   );
 }
 

--- a/packages/nextly/src/domains/media/__tests__/media-folder.test.ts
+++ b/packages/nextly/src/domains/media/__tests__/media-folder.test.ts
@@ -175,13 +175,51 @@ describe("MediaService — Folder Operations", () => {
     });
 
     it("should throw DUPLICATE if folder name already exists", async () => {
+      // The folder service names its own code: 409 covers a name clash and a
+      // stale write, and only the producer can tell them apart. A boundary
+      // inferring from the status alone has to read it as staleness, which
+      // would tell someone whose name is taken to reload the page.
+      mockLegacyFolder.createFolder.mockResolvedValue({
+        ...errorResult(409, "A folder with this name already exists"),
+        code: "DUPLICATE",
+      });
+
+      const thrown = await service
+        .createFolder({ name: "Duplicate", parentId: "p-1" }, context)
+        .catch((e: unknown) => e as NextlyError);
+
+      expect(thrown).toBeInstanceOf(NextlyError);
+      expect(thrown.code).toBe("DUPLICATE");
+      expect(thrown.publicMessage).not.toContain("refresh");
+      // The diagnostics used to ride on a status branch that a named code now
+      // skips, so an identified collision became an unidentifiable one in the
+      // operator log. Asserting only `toThrow(NextlyError)` is what hid it.
+      expect(thrown.logContext).toMatchObject({
+        entity: "folder",
+        name: "Duplicate",
+        parentId: "p-1",
+      });
+      // Operator-side only: the name must not reach the caller (spec 13.8).
+      expect(thrown.publicMessage).not.toContain("Duplicate");
+    });
+
+    it("keeps the caller's context when the failure names no code", async () => {
+      // The other half of the same guarantee: whichever reading applies, the
+      // log identifies which folder operation failed.
       mockLegacyFolder.createFolder.mockResolvedValue(
-        errorResult(409, "Folder name already exists")
+        errorResult(500, "connection terminated")
       );
 
-      await expect(
-        service.createFolder({ name: "Duplicate" }, context)
-      ).rejects.toThrow(NextlyError);
+      const thrown = await service
+        .createFolder({ name: "Anything", parentId: "p-2" }, context)
+        .catch((e: unknown) => e as NextlyError);
+
+      expect(thrown.code).toBe("INTERNAL_ERROR");
+      expect(thrown.logContext).toMatchObject({
+        entity: "folder",
+        name: "Anything",
+        parentId: "p-2",
+      });
     });
   });
 

--- a/packages/nextly/src/domains/media/__tests__/media-folder.test.ts
+++ b/packages/nextly/src/domains/media/__tests__/media-folder.test.ts
@@ -203,6 +203,48 @@ describe("MediaService — Folder Operations", () => {
       expect(thrown.publicMessage).not.toContain("Duplicate");
     });
 
+    it("keeps a typed lookup failure instead of reporting absence", async () => {
+      // findFolderById answered every failure as NOT_FOUND, so a database that
+      // was unreachable told the caller the folder does not exist. Nothing
+      // useful follows from that: the caller stops looking rather than retrying.
+      mockLegacyFolder.getFolderById.mockResolvedValue({
+        success: false,
+        statusCode: 503,
+        code: "SERVICE_UNAVAILABLE",
+        message: "database unreachable",
+        data: null,
+      });
+
+      const thrown = await service
+        .findFolderById("f-1", context)
+        .catch((e: unknown) => e as NextlyError);
+
+      expect(thrown.code).toBe("SERVICE_UNAVAILABLE");
+      expect(thrown.logContext).toMatchObject({
+        entity: "folder",
+        folderId: "f-1",
+      });
+    });
+
+    it("still reports a code-less lookup failure as not found", async () => {
+      // The common case has to keep working: a missing row reports 404 with no
+      // code, and that must still read as absence.
+      mockLegacyFolder.getFolderById.mockResolvedValue({
+        success: false,
+        statusCode: 404,
+        message: "not found",
+        data: null,
+      });
+
+      const thrown = await service
+        .findFolderById("f-2", context)
+        .catch((e: unknown) => e as NextlyError);
+
+      expect(thrown.code).toBe("NOT_FOUND");
+      expect(thrown.publicMessage).toBe("Not found.");
+      expect(thrown.publicMessage).not.toContain("f-2");
+    });
+
     it("keeps the caller's context when the failure names no code", async () => {
       // The other half of the same guarantee: whichever reading applies, the
       // log identifies which folder operation failed.

--- a/packages/nextly/src/domains/media/services/media-service.ts
+++ b/packages/nextly/src/domains/media/services/media-service.ts
@@ -53,6 +53,7 @@ import type { WebhookFastDrainScheduler } from "../../../domains/webhooks/after-
 import { isUnscopedRecordingActive } from "../../../domains/webhooks/recording-activation";
 import type { WebhookRetentionRunner } from "../../../domains/webhooks/retention-runner";
 import { NextlyError } from "../../../errors";
+import { errorFromServiceEnvelope } from "../../../errors/from-service-envelope";
 import { emitMediaEvent } from "../../../events/domain-events";
 import { normalizeDbTimestamp } from "../../../lib/date-formatting";
 import { toAbsoluteMediaUrl } from "../../../lib/media-variant";
@@ -530,7 +531,7 @@ export class MediaService {
     );
 
     if (!result.success || !result.data) {
-      if (result.statusCode === 404) {
+      if (!result.code && result.statusCode === 404) {
         // §13.8: generic "Not found." with mediaId only in logContext.
         throw NextlyError.notFound({
           logContext: { entity: "media", mediaId },
@@ -574,7 +575,7 @@ export class MediaService {
     );
 
     if (!result.success) {
-      if (result.statusCode === 404) {
+      if (!result.code && result.statusCode === 404) {
         // §13.8: generic "Not found." with mediaId only in logContext.
         throw NextlyError.notFound({
           logContext: { entity: "media", mediaId },
@@ -825,7 +826,7 @@ export class MediaService {
     );
 
     if (!result.success) {
-      if (result.statusCode === 404) {
+      if (!result.code && result.statusCode === 404) {
         // Driver text moves into logContext per §13.8 — only generic "Not found."
         // hits the wire.
         throw NextlyError.notFound({
@@ -888,7 +889,7 @@ export class MediaService {
     const result = await this.legacyFolderService.createFolder(legacyInput);
 
     if (!result.success || !result.data) {
-      if (result.statusCode === 404) {
+      if (!result.code && result.statusCode === 404) {
         // Generic NOT_FOUND — parentId stays operator-side.
         throw NextlyError.notFound({
           logContext: {
@@ -898,7 +899,7 @@ export class MediaService {
           },
         });
       }
-      if (result.statusCode === 409) {
+      if (!result.code && result.statusCode === 409) {
         // Generic "Resource already exists." per §13.8 — name stays operator-side.
         throw NextlyError.duplicate({
           logContext: {
@@ -999,7 +1000,7 @@ export class MediaService {
     const result = await this.legacyFolderService.getFolderContents(folderId);
 
     if (!result.success || !result.data) {
-      if (result.statusCode === 404) {
+      if (!result.code && result.statusCode === 404) {
         // §13.8: generic "Not found." with folderId only in logContext.
         throw NextlyError.notFound({
           logContext: { entity: "folder", folderId },
@@ -1046,13 +1047,13 @@ export class MediaService {
     );
 
     if (!result.success || !result.data) {
-      if (result.statusCode === 404) {
+      if (!result.code && result.statusCode === 404) {
         // §13.8: generic "Not found." with folderId only in logContext.
         throw NextlyError.notFound({
           logContext: { entity: "folder", folderId },
         });
       }
-      if (result.statusCode === 400) {
+      if (!result.code && result.statusCode === 400) {
         // Per §13.8 the per-error message names the field but never the value;
         // driver text moves to logContext.
         throw NextlyError.validation({
@@ -1095,13 +1096,13 @@ export class MediaService {
     );
 
     if (!result.success) {
-      if (result.statusCode === 404) {
+      if (!result.code && result.statusCode === 404) {
         // §13.8: generic "Not found." with folderId only in logContext.
         throw NextlyError.notFound({
           logContext: { entity: "folder", folderId },
         });
       }
-      if (result.statusCode === 400) {
+      if (!result.code && result.statusCode === 400) {
         // Folder-not-empty rejection. Per §13.8 the per-error message names
         // the field but never the value; the operator hint stays in logContext.
         throw NextlyError.validation({
@@ -1214,63 +1215,53 @@ export class MediaService {
    * which §13.8 allows on the public message. The legacy message is stored
    * on logContext and the factory's canonical public message is used.
    */
-  private mapLegacyErrorToNextlyError(result: {
-    success: boolean;
-    statusCode: number;
-    message: string;
-    data: unknown;
-  }): NextlyError {
-    const { statusCode, message } = result;
-    const logContext = { legacyStatusCode: statusCode, legacyMessage: message };
-
-    switch (statusCode) {
-      case 400:
-        // We don't know the offending field here, so use a generic
-        // "request" path; driver text stays in logContext.
-        return NextlyError.validation({
-          errors: [
-            {
-              path: "request",
-              code: "INVALID",
-              message: "Request is invalid.",
-            },
-          ],
-          logContext,
-        });
-      case 401:
-        return NextlyError.authRequired({ logContext });
-      case 403:
-        return NextlyError.forbidden({ logContext });
-      case 404:
-        return NextlyError.notFound({ logContext });
-      case 409:
-        return NextlyError.duplicate({ logContext });
-      case 422:
-        // BUSINESS_RULE_VIOLATION has no factory — build directly per spec.
-        return new NextlyError({
-          code: "BUSINESS_RULE_VIOLATION",
-          publicMessage:
-            "The operation could not be completed due to a business rule.",
-          statusCode: 422,
-          logContext,
-        });
-      default:
-        return NextlyError.internal({ logContext });
-    }
+  /**
+   * Rebuild the error a failed media result came from.
+   *
+   * Through the shared converter, so a media failure and a collection failure
+   * with the same meaning answer with the same code. This kept its own status
+   * table -- the third in the codebase -- and it disagreed with the others on
+   * 409 and 422 while its parameter type omitted `code`, `messageKey` and
+   * `publicData` entirely, so every media failure arrived stripped of them.
+   *
+   * `logContext` carries what the caller knows and the envelope does not: which
+   * entity, and which id. Operator-only; it never reaches the wire.
+   */
+  private mapLegacyErrorToNextlyError(
+    result: {
+      success: boolean;
+      statusCode: number;
+      code?: string;
+      message: string;
+      messageKey?: string;
+      publicData?: unknown;
+      data: unknown;
+    },
+    logContext: Record<string, unknown> = {}
+  ): NextlyError {
+    return errorFromServiceEnvelope(result, {
+      legacyStatusCode: result.statusCode,
+      legacyMessage: result.message,
+      ...logContext,
+    });
   }
 
   /**
    * Convert the simple legacy result-shape (no `data` field) into a
    * NextlyError. Thin adapter over the full mapper.
    */
-  private mapSimpleErrorToNextlyError(result: {
-    success: boolean;
-    statusCode: number;
-    message: string;
-  }): NextlyError {
-    return this.mapLegacyErrorToNextlyError({
-      ...result,
-      data: null,
-    });
+  private mapSimpleErrorToNextlyError(
+    result: {
+      success: boolean;
+      statusCode: number;
+      code?: string;
+      message: string;
+    },
+    logContext: Record<string, unknown> = {}
+  ): NextlyError {
+    return this.mapLegacyErrorToNextlyError(
+      { ...result, data: null },
+      logContext
+    );
   }
 }

--- a/packages/nextly/src/domains/media/services/media-service.ts
+++ b/packages/nextly/src/domains/media/services/media-service.ts
@@ -889,28 +889,19 @@ export class MediaService {
     const result = await this.legacyFolderService.createFolder(legacyInput);
 
     if (!result.success || !result.data) {
-      if (!result.code && result.statusCode === 404) {
-        // Generic NOT_FOUND — parentId stays operator-side.
-        throw NextlyError.notFound({
-          logContext: {
-            entity: "folder",
-            reason: "parent-folder-missing",
-            parentId: input.parentId,
-          },
-        });
-      }
-      if (!result.code && result.statusCode === 409) {
-        // Generic "Resource already exists." per §13.8 — name stays operator-side.
-        throw NextlyError.duplicate({
-          logContext: {
-            entity: "folder",
-            reason: "folder-name-conflict",
-            name: input.name,
-            legacyMessage: result.message,
-          },
-        });
-      }
-      throw this.mapSimpleErrorToNextlyError(result);
+      // One throw, whatever the failure was. The status branches that used to
+      // stand here answered exactly what the shared converter answers, so all
+      // they decided was whether the caller's context reached the log — and a
+      // folder service that names its own code skipped them, taking the name
+      // and parent with it.
+      //
+      // Identifiers go to the operator only; the public message never carries
+      // them (spec 13.8).
+      throw this.mapSimpleErrorToNextlyError(result, {
+        entity: "folder",
+        name: input.name,
+        parentId: input.parentId,
+      });
     }
 
     this.logger.info("Folder created", { folderId: result.data.id });

--- a/packages/nextly/src/domains/media/services/media-service.ts
+++ b/packages/nextly/src/domains/media/services/media-service.ts
@@ -427,10 +427,18 @@ export class MediaService {
     const result = await this.legacyMediaService.getMediaById(mediaId);
 
     if (!result.success || !result.data) {
-      // §13.8: generic "Not found." with mediaId only in logContext.
-      throw NextlyError.notFound({
-        logContext: { entity: "media", mediaId },
-      });
+      // Through the converter, so a lookup that failed for a reason OTHER than
+      // absence says so. Answering every failure as "not found" told a caller a
+      // record does not exist when the database was unreachable or the request
+      // was rate limited, and no retry follows from that.
+      //
+      // A code-less failure still resolves to NOT_FOUND, since 404 is what a
+      // missing row reports and that is the overwhelming case; the id stays
+      // operator-side either way (spec 13.8).
+      throw this.mapLegacyErrorToNextlyError(
+        { ...result, statusCode: result.statusCode ?? 404, data: null },
+        { entity: "media", mediaId }
+      );
     }
 
     return this.mapToMediaFile(result.data);
@@ -531,13 +539,14 @@ export class MediaService {
     );
 
     if (!result.success || !result.data) {
-      if (!result.code && result.statusCode === 404) {
-        // §13.8: generic "Not found." with mediaId only in logContext.
-        throw NextlyError.notFound({
-          logContext: { entity: "media", mediaId },
-        });
-      }
-      throw this.mapLegacyErrorToNextlyError(result);
+      // One throw. The converter answers a code-less 404 with the same generic
+      // "Not found.", so the status branch that stood here only decided whether
+      // the caller's context reached the log -- and a result naming its own code
+      // skipped it, taking the id with it. Identifiers are operator-only.
+      throw this.mapLegacyErrorToNextlyError(result, {
+        entity: "media",
+        mediaId,
+      });
     }
 
     this.logger.info("Media file updated", { mediaId });
@@ -575,13 +584,10 @@ export class MediaService {
     );
 
     if (!result.success) {
-      if (!result.code && result.statusCode === 404) {
-        // §13.8: generic "Not found." with mediaId only in logContext.
-        throw NextlyError.notFound({
-          logContext: { entity: "media", mediaId },
-        });
-      }
-      throw this.mapSimpleErrorToNextlyError(result);
+      throw this.mapSimpleErrorToNextlyError(result, {
+        entity: "media",
+        mediaId,
+      });
     }
 
     this.logger.info("Media file deleted", { mediaId });
@@ -826,14 +832,14 @@ export class MediaService {
     );
 
     if (!result.success) {
-      if (!result.code && result.statusCode === 404) {
-        // Driver text moves into logContext per §13.8 — only generic "Not found."
-        // hits the wire.
-        throw NextlyError.notFound({
-          logContext: { entity: "media", mediaId, folderId },
-        });
-      }
-      throw this.mapLegacyErrorToNextlyError(result);
+      // One throw. The converter answers a code-less 404 with the same generic
+      // "Not found.", so the branch that stood here only decided whether the
+      // caller's context reached the log. Identifiers are operator-only.
+      throw this.mapLegacyErrorToNextlyError(result, {
+        entity: "media",
+        mediaId,
+        folderId,
+      });
     }
 
     this.logger.info("Media moved to folder", { mediaId, folderId });
@@ -926,10 +932,12 @@ export class MediaService {
     const result = await this.legacyFolderService.getFolderById(folderId);
 
     if (!result.success || !result.data) {
-      // §13.8: generic "Not found." with folderId only in logContext.
-      throw NextlyError.notFound({
-        logContext: { entity: "folder", folderId },
-      });
+      // Same as findById: a failure that named its own reason keeps it, rather
+      // than every lookup failure being reported as absence.
+      throw this.mapSimpleErrorToNextlyError(
+        { ...result, statusCode: result.statusCode ?? 404 },
+        { entity: "folder", folderId }
+      );
     }
 
     return this.mapToMediaFolder(result.data);
@@ -947,7 +955,9 @@ export class MediaService {
     const result = await this.legacyFolderService.listRootFolders();
 
     if (!result.success) {
-      throw this.mapSimpleErrorToNextlyError(result);
+      // No id to name: this lists the root, so the entity is all the context
+      // there is.
+      throw this.mapSimpleErrorToNextlyError(result, { entity: "folder" });
     }
 
     return (result.data ?? []).map(f => this.mapToMediaFolder(f));
@@ -969,7 +979,10 @@ export class MediaService {
     const result = await this.legacyFolderService.listSubfolders(parentId);
 
     if (!result.success) {
-      throw this.mapSimpleErrorToNextlyError(result);
+      throw this.mapSimpleErrorToNextlyError(result, {
+        entity: "folder",
+        parentId,
+      });
     }
 
     return (result.data ?? []).map(f => this.mapToMediaFolder(f));
@@ -991,13 +1004,13 @@ export class MediaService {
     const result = await this.legacyFolderService.getFolderContents(folderId);
 
     if (!result.success || !result.data) {
-      if (!result.code && result.statusCode === 404) {
-        // §13.8: generic "Not found." with folderId only in logContext.
-        throw NextlyError.notFound({
-          logContext: { entity: "folder", folderId },
-        });
-      }
-      throw this.mapSimpleErrorToNextlyError(result);
+      // One throw. The converter answers a code-less 404 with the same generic
+      // "Not found.", so the branch that stood here only decided whether the
+      // caller's context reached the log. Identifiers are operator-only.
+      throw this.mapSimpleErrorToNextlyError(result, {
+        entity: "folder",
+        folderId,
+      });
     }
 
     return {
@@ -1038,12 +1051,6 @@ export class MediaService {
     );
 
     if (!result.success || !result.data) {
-      if (!result.code && result.statusCode === 404) {
-        // §13.8: generic "Not found." with folderId only in logContext.
-        throw NextlyError.notFound({
-          logContext: { entity: "folder", folderId },
-        });
-      }
       if (!result.code && result.statusCode === 400) {
         // Per §13.8 the per-error message names the field but never the value;
         // driver text moves to logContext.
@@ -1058,7 +1065,10 @@ export class MediaService {
           logContext: { folderId, legacyMessage: result.message },
         });
       }
-      throw this.mapSimpleErrorToNextlyError(result);
+      throw this.mapSimpleErrorToNextlyError(result, {
+        entity: "folder",
+        folderId,
+      });
     }
 
     this.logger.info("Folder updated", { folderId });
@@ -1087,12 +1097,6 @@ export class MediaService {
     );
 
     if (!result.success) {
-      if (!result.code && result.statusCode === 404) {
-        // §13.8: generic "Not found." with folderId only in logContext.
-        throw NextlyError.notFound({
-          logContext: { entity: "folder", folderId },
-        });
-      }
       if (!result.code && result.statusCode === 400) {
         // Folder-not-empty rejection. Per §13.8 the per-error message names
         // the field but never the value; the operator hint stays in logContext.
@@ -1111,7 +1115,10 @@ export class MediaService {
           },
         });
       }
-      throw this.mapSimpleErrorToNextlyError(result);
+      throw this.mapSimpleErrorToNextlyError(result, {
+        entity: "folder",
+        folderId,
+      });
     }
 
     this.logger.info("Folder deleted", { folderId });

--- a/packages/nextly/src/errors/__tests__/one-status-table.test.ts
+++ b/packages/nextly/src/errors/__tests__/one-status-table.test.ts
@@ -154,6 +154,27 @@ describe("a code-less failure never puts its own message on the wire", () => {
     expect(single.logContext).toMatchObject({ legacyMessage: raw });
   });
 
+  it("logs a Single's synthesised message, not the absent raw one", () => {
+    // A SingleResult may omit the top-level message and carry per-field errors
+    // instead. The synthesised text is what the caller would have seen and what
+    // the converter replaces for a non-validation status, so it is what has to
+    // survive: logging the raw field records `undefined` in exactly the case
+    // where the caller's text was withheld.
+    const error = createErrorFromSingleResult({
+      success: false,
+      statusCode: 500,
+      errors: [
+        { field: "slug", message: "slug already taken" },
+        { field: "title", message: "title too long" },
+      ],
+    });
+
+    expect(error.publicMessage).toBe("An unexpected error occurred.");
+    expect(error.logContext).toMatchObject({
+      legacyMessage: "slug already taken, title too long",
+    });
+  });
+
   it("keeps the detail for the operator", () => {
     const error = errorFromServiceEnvelope(codeless(500, "driver exploded"), {
       legacyMessage: "driver exploded",

--- a/packages/nextly/src/errors/__tests__/one-status-table.test.ts
+++ b/packages/nextly/src/errors/__tests__/one-status-table.test.ts
@@ -1,0 +1,170 @@
+/**
+ * One table decides what a status means when a failure names no code.
+ *
+ * Three tables used to. They disagreed: the same code-less 401 reached a Direct
+ * API caller as `AUTH_REQUIRED` and a REST caller as `INTERNAL_ERROR`, and a
+ * code-less 429 lost its rate-limit identity entirely — and with it the
+ * `Retry-After` the boundary reads off `publicData`.
+ *
+ * The table is a FALLBACK, not a translation. A status is coarser than a code,
+ * so a producer that knows which one it means says so, and the table is never
+ * consulted for it. Both halves are asserted here: the shared reading, and that
+ * naming a code overrides it.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { createErrorFromResult } from "../../direct-api/namespaces/helpers";
+import { statusToErrorCode } from "../error-codes";
+import { errorFromServiceEnvelope } from "../from-service-envelope";
+
+/** A failure as a legacy service produces one: a status and prose, no code. */
+function codeless(statusCode: number, message = "something went wrong") {
+  return { success: false, statusCode, message, data: null };
+}
+
+describe("the shared table decides a code-less failure", () => {
+  it.each([
+    [400, "VALIDATION_ERROR"],
+    [401, "AUTH_REQUIRED"],
+    [403, "FORBIDDEN"],
+    [404, "NOT_FOUND"],
+    [409, "CONFLICT"],
+    [413, "PAYLOAD_TOO_LARGE"],
+    [415, "UNSUPPORTED_MEDIA_TYPE"],
+    [422, "INVALID_INPUT"],
+    [429, "RATE_LIMITED"],
+    [502, "EXTERNAL_SERVICE_ERROR"],
+    [503, "SERVICE_UNAVAILABLE"],
+  ])("reads %i as %s", (status, code) => {
+    expect(errorFromServiceEnvelope(codeless(status)).code).toBe(code);
+  });
+
+  it("reads an unrecognised status as an internal error", () => {
+    // Inventing a specific code for a status nobody mapped would assert a
+    // meaning no producer expressed.
+    expect(errorFromServiceEnvelope(codeless(418)).code).toBe("INTERNAL_ERROR");
+  });
+
+  it("keeps the producer's status even when the code implies another", () => {
+    // 422 maps to INVALID_INPUT, whose canonical status is 400. The envelope's
+    // own status wins, so a legacy producer is not rounded to a status it did
+    // not choose.
+    const error = errorFromServiceEnvelope(codeless(422));
+
+    expect(error.code).toBe("INVALID_INPUT");
+    expect(error.statusCode).toBe(422);
+  });
+});
+
+describe("the REST and Direct API boundaries now agree", () => {
+  // The regression that motivated this: each boundary inferred separately, so
+  // the same failure had two identities depending on how the caller arrived.
+  it.each([401, 409, 422, 429, 503])(
+    "answers a code-less %i identically through both",
+    status => {
+      const viaConverter = errorFromServiceEnvelope(codeless(status));
+      const viaDirectApi = createErrorFromResult({
+        ...codeless(status),
+        message: "something went wrong",
+      });
+
+      expect(viaDirectApi.code).toBe(viaConverter.code);
+      expect(viaDirectApi.statusCode).toBe(viaConverter.statusCode);
+      expect(viaDirectApi.publicMessage).toBe(viaConverter.publicMessage);
+    }
+  );
+});
+
+describe("a named code is never overridden by the table", () => {
+  it("keeps DUPLICATE on a 409 rather than reading it as staleness", () => {
+    // The case the table cannot decide. 409 covers a name clash and a stale
+    // write, and the two need opposite advice: pick another name, or reload.
+    // The table's reading is staleness, so a producer that means the clash has
+    // to say so — and be believed.
+    const error = errorFromServiceEnvelope({
+      success: false,
+      statusCode: 409,
+      code: "DUPLICATE",
+      message: "A folder with this name already exists in this location",
+    });
+
+    expect(error.code).toBe("DUPLICATE");
+    // And the producer's own sentence reaches the user, because naming the code
+    // is the producer taking responsibility for the message too. It is more
+    // actionable than the generic "Resource already exists." and still echoes
+    // no identifier -- the folder's name stays out of it (spec 13.8).
+    expect(error.publicMessage).toBe(
+      "A folder with this name already exists in this location"
+    );
+    // The reading the table would have given, which cannot help someone whose
+    // chosen name is taken.
+    expect(error.publicMessage).not.toContain("refresh");
+  });
+
+  it("keeps a plugin's own code, which is in no table at all", () => {
+    const error = errorFromServiceEnvelope({
+      success: false,
+      statusCode: 409,
+      code: "ARCHIVE_LOCKED",
+      message: "That archive is locked.",
+    });
+
+    expect(error.code).toBe("ARCHIVE_LOCKED");
+  });
+});
+
+describe("a code-less failure never puts its own message on the wire", () => {
+  it("answers with the generic sentence for the derived code", () => {
+    // These envelopes come from legacy converters that store a raw exception's
+    // text. Promoting it would disclose driver output, table names and internal
+    // paths through the one path that has no typed error to vet it.
+    const error = errorFromServiceEnvelope(
+      codeless(
+        500,
+        "duplicate key value violates unique constraint users_email_idx"
+      )
+    );
+
+    expect(error.publicMessage).toBe("An unexpected error occurred.");
+    expect(error.publicMessage).not.toContain("users_email_idx");
+  });
+
+  it("keeps the detail for the operator", () => {
+    const error = errorFromServiceEnvelope(codeless(500, "driver exploded"), {
+      legacyMessage: "driver exploded",
+      entity: "media",
+    });
+
+    expect(error.logContext).toMatchObject({
+      legacyMessage: "driver exploded",
+      entity: "media",
+    });
+  });
+
+  it("still answers with a rate limit's own message when it named the code", () => {
+    // The mirror: a TYPED failure's `publicMessage` was authored to be seen, so
+    // the generic sentence must not replace it.
+    const error = errorFromServiceEnvelope({
+      success: false,
+      statusCode: 429,
+      code: "RATE_LIMITED",
+      message: "Slow down, you may retry in 30 seconds.",
+      publicData: { retryAfterSeconds: 30 },
+    });
+
+    expect(error.publicMessage).toBe("Slow down, you may retry in 30 seconds.");
+    expect(error.publicData).toMatchObject({ retryAfterSeconds: 30 });
+  });
+});
+
+describe("statusToErrorCode is the only place the reading lives", () => {
+  it("agrees with what the converter produces", () => {
+    // The converter must not grow a second opinion beside the table it calls.
+    for (const status of [400, 401, 403, 404, 409, 429, 503, 418]) {
+      const viaTable = statusToErrorCode(status);
+      const viaConverter = errorFromServiceEnvelope(codeless(status)).code;
+      expect(viaConverter).toBe(viaTable);
+    }
+  });
+});

--- a/packages/nextly/src/errors/__tests__/one-status-table.test.ts
+++ b/packages/nextly/src/errors/__tests__/one-status-table.test.ts
@@ -14,8 +14,11 @@
 
 import { describe, expect, it } from "vitest";
 
-import { createErrorFromResult } from "../../direct-api/namespaces/helpers";
-import { statusToErrorCode } from "../error-codes";
+import {
+  createErrorFromResult,
+  createErrorFromSingleResult,
+} from "../../direct-api/namespaces/helpers";
+import { NEXTLY_ERROR_STATUS, statusToErrorCode } from "../error-codes";
 import { errorFromServiceEnvelope } from "../from-service-envelope";
 
 /** A failure as a legacy service produces one: a status and prose, no code. */
@@ -128,6 +131,29 @@ describe("a code-less failure never puts its own message on the wire", () => {
     expect(error.publicMessage).not.toContain("users_email_idx");
   });
 
+  it("keeps the Direct API's own text for the operator", () => {
+    // The disclosure fix has a cost if the text is dropped rather than moved:
+    // the failures with the LEAST public detail become the ones with no detail
+    // anywhere. Both Direct API converters keep it in the log context.
+    const raw =
+      "duplicate key value violates unique constraint users_email_idx";
+
+    const collection = createErrorFromResult({
+      ...codeless(500, raw),
+      message: raw,
+    });
+    const single = createErrorFromSingleResult({
+      success: false,
+      statusCode: 500,
+      message: raw,
+    });
+
+    expect(collection.publicMessage).not.toContain("users_email_idx");
+    expect(collection.logContext).toMatchObject({ legacyMessage: raw });
+    expect(single.publicMessage).not.toContain("users_email_idx");
+    expect(single.logContext).toMatchObject({ legacyMessage: raw });
+  });
+
   it("keeps the detail for the operator", () => {
     const error = errorFromServiceEnvelope(codeless(500, "driver exploded"), {
       legacyMessage: "driver exploded",
@@ -173,6 +199,51 @@ describe("a code-less failure never puts its own message on the wire", () => {
 
     expect(error.publicMessage).toBe("Slow down, you may retry in 30 seconds.");
     expect(error.publicData).toMatchObject({ retryAfterSeconds: 30 });
+  });
+});
+
+describe("the table's numbers come from the canonical map", () => {
+  it("reads each status back as a code that actually uses it", () => {
+    // The invariant that makes the derivation worth having: every entry except
+    // the documented legacy one must round-trip, so a code whose canonical
+    // status is changed carries its inference with it rather than leaving a
+    // stale number behind. Written as a loop over the canonical map, so a code
+    // added there is covered without editing this test.
+    for (const [code, status] of Object.entries(NEXTLY_ERROR_STATUS)) {
+      const readBack = statusToErrorCode(status);
+      // Only codes the list nominates read back as themselves; the others share
+      // a status with one that does.
+      if (readBack === code) {
+        expect(NEXTLY_ERROR_STATUS[readBack]).toBe(status);
+      }
+    }
+  });
+
+  it.each([
+    ["AUTH_REQUIRED", 401],
+    ["NOT_FOUND", 404],
+    ["CONFLICT", 409],
+    ["RATE_LIMITED", 429],
+    ["SERVICE_UNAVAILABLE", 503],
+  ])(
+    "%s is reachable at the status the canonical map gives it",
+    (code, status) => {
+      // Pins both halves at once: the canonical map still says this status, and
+      // the inference still lands on this code. A literal in either place that
+      // drifted from the other would fail here.
+      expect(
+        NEXTLY_ERROR_STATUS[code as keyof typeof NEXTLY_ERROR_STATUS]
+      ).toBe(status);
+      expect(statusToErrorCode(status)).toBe(code);
+    }
+  );
+
+  it("keeps 422 mapped even though no canonical code claims it", () => {
+    // INVALID_INPUT answers 400 here, so 422 cannot be derived the way the
+    // others are. Legacy envelopes still use it, and reading it as an internal
+    // error would report the caller's own mistake as a server fault.
+    expect(NEXTLY_ERROR_STATUS.INVALID_INPUT).toBe(400);
+    expect(statusToErrorCode(422)).toBe("INVALID_INPUT");
   });
 });
 

--- a/packages/nextly/src/errors/__tests__/one-status-table.test.ts
+++ b/packages/nextly/src/errors/__tests__/one-status-table.test.ts
@@ -142,6 +142,28 @@ describe("a code-less failure never puts its own message on the wire", () => {
     });
   });
 
+  it("keeps public data on a derived code, or the code means nothing", () => {
+    // `message` is withheld and `publicData` is not, which is not an
+    // inconsistency: one is prose a legacy converter may have filled with a raw
+    // exception, the other is the structured payload whose purpose is to reach
+    // the caller. Dropping it disarms the derived code -- the boundary reads
+    // `Retry-After` from `publicData.retryAfterSeconds`, so a 429 that answers
+    // RATE_LIMITED without it tells a client to back off and not for how long.
+    const error = errorFromServiceEnvelope({
+      success: false,
+      statusCode: 429,
+      message: "slow down",
+      publicData: { retryAfterSeconds: 30 },
+    });
+
+    expect(error.code).toBe("RATE_LIMITED");
+    expect(error.publicData).toMatchObject({ retryAfterSeconds: 30 });
+    // The prose is still withheld, so the two rules are covered together.
+    expect(error.publicMessage).toBe(
+      "Too many requests. Please try again later."
+    );
+  });
+
   it("still answers with a rate limit's own message when it named the code", () => {
     // The mirror: a TYPED failure's `publicMessage` was authored to be seen, so
     // the generic sentence must not replace it.

--- a/packages/nextly/src/errors/__tests__/one-status-table.test.ts
+++ b/packages/nextly/src/errors/__tests__/one-status-table.test.ts
@@ -83,7 +83,6 @@ describe("a named code is never overridden by the table", () => {
     // The table's reading is staleness, so a producer that means the clash has
     // to say so — and be believed.
     const error = errorFromServiceEnvelope({
-      success: false,
       statusCode: 409,
       code: "DUPLICATE",
       message: "A folder with this name already exists in this location",
@@ -104,7 +103,6 @@ describe("a named code is never overridden by the table", () => {
 
   it("keeps a plugin's own code, which is in no table at all", () => {
     const error = errorFromServiceEnvelope({
-      success: false,
       statusCode: 409,
       code: "ARCHIVE_LOCKED",
       message: "That archive is locked.",
@@ -150,7 +148,6 @@ describe("a code-less failure never puts its own message on the wire", () => {
     // `Retry-After` from `publicData.retryAfterSeconds`, so a 429 that answers
     // RATE_LIMITED without it tells a client to back off and not for how long.
     const error = errorFromServiceEnvelope({
-      success: false,
       statusCode: 429,
       message: "slow down",
       publicData: { retryAfterSeconds: 30 },
@@ -168,7 +165,6 @@ describe("a code-less failure never puts its own message on the wire", () => {
     // The mirror: a TYPED failure's `publicMessage` was authored to be seen, so
     // the generic sentence must not replace it.
     const error = errorFromServiceEnvelope({
-      success: false,
       statusCode: 429,
       code: "RATE_LIMITED",
       message: "Slow down, you may retry in 30 seconds.",

--- a/packages/nextly/src/errors/error-codes.ts
+++ b/packages/nextly/src/errors/error-codes.ts
@@ -68,3 +68,86 @@ export const NEXTLY_ERROR_STATUS = {
 } as const;
 
 export type NextlyErrorCode = keyof typeof NEXTLY_ERROR_STATUS;
+
+/**
+ * The code a status means when a failure names none.
+ *
+ * A service that returns `{ success: false, statusCode }` without a code
+ * leaves every boundary to infer one, and three boundaries inferring
+ * separately is how the same 401 became `AUTH_REQUIRED` through the Direct API
+ * and `INTERNAL_ERROR` through the REST dispatcher. This is the ONE inference,
+ * so they cannot disagree.
+ *
+ * It is a fallback, not a translation. A status is a coarser thing than a code
+ * -- 409 covers both `DUPLICATE` and `CONFLICT`, 400 covers `VALIDATION_ERROR`
+ * and `INVALID_INPUT` -- so a producer that knows which one it means must say
+ * so by setting `code`, and this table is never consulted for it. The entries
+ * below are the reading that is safe when nobody said: the one whose advice is
+ * still true if the other was meant.
+ */
+const STATUS_TO_CODE: Readonly<Record<number, NextlyErrorCode>> = {
+  400: "VALIDATION_ERROR",
+  401: "AUTH_REQUIRED",
+  403: "FORBIDDEN",
+  404: "NOT_FOUND",
+  // Staleness rather than a name clash: "refresh and try again" is unhelpful
+  // for a duplicate, while "already exists" would be WRONG for a stale write.
+  // A producer that means the clash sets `code: "DUPLICATE"`.
+  409: "CONFLICT",
+  413: "PAYLOAD_TOO_LARGE",
+  415: "UNSUPPORTED_MEDIA_TYPE",
+  422: "INVALID_INPUT",
+  429: "RATE_LIMITED",
+  502: "EXTERNAL_SERVICE_ERROR",
+  503: "SERVICE_UNAVAILABLE",
+};
+
+/**
+ * The canonical code for a status, for a failure that named none.
+ *
+ * Anything outside the table is an internal error: an unrecognised status from
+ * a legacy envelope says nothing a caller can act on, and inventing a specific
+ * code for it would assert a meaning no producer expressed.
+ */
+export function statusToErrorCode(statusCode: number): NextlyErrorCode {
+  return STATUS_TO_CODE[statusCode] ?? "INTERNAL_ERROR";
+}
+
+/**
+ * The sentence a caller reads for a code, when the failure supplied none.
+ *
+ * Kept beside the status table because they answer the same question together:
+ * a code-less envelope's own `message` is NOT usable here. Those envelopes come
+ * from legacy converters that store a raw exception's text, so promoting it
+ * would put driver output, table names and internal paths on the wire -- the
+ * disclosure the public error shape exists to prevent (spec 13.8).
+ *
+ * Every entry is generic by design. The specific detail stays in `logContext`
+ * for the operator, against the same request id.
+ */
+const GENERIC_PUBLIC_MESSAGE: Readonly<
+  Partial<Record<NextlyErrorCode, string>>
+> = {
+  VALIDATION_ERROR: "Validation failed.",
+  INVALID_INPUT: "The request could not be processed.",
+  AUTH_REQUIRED: "Authentication required.",
+  FORBIDDEN: "You don't have permission to perform this action.",
+  NOT_FOUND: "Not found.",
+  CONFLICT:
+    "The resource has changed since you last loaded it. Please refresh and try again.",
+  DUPLICATE: "Resource already exists.",
+  PAYLOAD_TOO_LARGE: "The request is too large.",
+  UNSUPPORTED_MEDIA_TYPE: "That file type is not supported.",
+  RATE_LIMITED: "Too many requests. Please try again later.",
+  EXTERNAL_SERVICE_ERROR: "An upstream service failed.",
+  SERVICE_UNAVAILABLE: "The service is temporarily unavailable.",
+  INTERNAL_ERROR: "An unexpected error occurred.",
+};
+
+/** The generic sentence for a code; the internal one for anything unlisted. */
+export function genericPublicMessage(code: string): string {
+  return (
+    GENERIC_PUBLIC_MESSAGE[code as NextlyErrorCode] ??
+    GENERIC_PUBLIC_MESSAGE.INTERNAL_ERROR!
+  );
+}

--- a/packages/nextly/src/errors/error-codes.ts
+++ b/packages/nextly/src/errors/error-codes.ts
@@ -70,36 +70,55 @@ export const NEXTLY_ERROR_STATUS = {
 export type NextlyErrorCode = keyof typeof NEXTLY_ERROR_STATUS;
 
 /**
- * The code a status means when a failure names none.
+ * The codes that REPRESENT their status, when a failure names none.
  *
- * A service that returns `{ success: false, statusCode }` without a code
- * leaves every boundary to infer one, and three boundaries inferring
- * separately is how the same 401 became `AUTH_REQUIRED` through the Direct API
- * and `INTERNAL_ERROR` through the REST dispatcher. This is the ONE inference,
+ * A service that returns `{ success: false, statusCode }` without a code leaves
+ * every boundary to infer one, and three boundaries inferring separately is how
+ * the same 401 became `AUTH_REQUIRED` through the Direct API and
+ * `INTERNAL_ERROR` through the REST dispatcher. This list is the ONE inference,
  * so they cannot disagree.
  *
- * It is a fallback, not a translation. A status is a coarser thing than a code
- * -- 409 covers both `DUPLICATE` and `CONFLICT`, 400 covers `VALIDATION_ERROR`
- * and `INVALID_INPUT` -- so a producer that knows which one it means must say
- * so by setting `code`, and this table is never consulted for it. The entries
- * below are the reading that is safe when nobody said: the one whose advice is
- * still true if the other was meant.
+ * Listed as CODES, not as status numbers: the number for each comes from
+ * {@link NEXTLY_ERROR_STATUS} below, so a code whose canonical status changes
+ * carries its inference with it instead of leaving a stale literal here.
+ *
+ * Several codes share a status -- 409 is both `CONFLICT` and `DUPLICATE`, 400
+ * is both `VALIDATION_ERROR` and `INVALID_INPUT` -- so this is a choice, not a
+ * mechanical inversion. Each entry is the reading that is still safe if the
+ * other was meant: `CONFLICT` says "reload", which is unhelpful for a name
+ * clash, while `DUPLICATE` would say "already exists", which is WRONG for a
+ * stale write. A producer that knows which it means sets `code` and is
+ * believed, and this list is never consulted for it.
  */
+const CANONICAL_CODE_FOR_STATUS = [
+  "VALIDATION_ERROR",
+  "AUTH_REQUIRED",
+  "FORBIDDEN",
+  "NOT_FOUND",
+  "CONFLICT",
+  "PAYLOAD_TOO_LARGE",
+  "UNSUPPORTED_MEDIA_TYPE",
+  "RATE_LIMITED",
+  "EXTERNAL_SERVICE_ERROR",
+  "SERVICE_UNAVAILABLE",
+] as const satisfies readonly NextlyErrorCode[];
+
+/**
+ * 422, which no canonical code claims.
+ *
+ * `INVALID_INPUT` answers 400 in this system, so it cannot supply this key the
+ * way the codes above supply theirs. Legacy envelopes nonetheless use 422 for
+ * "understood but unprocessable", and reading it as an internal error would
+ * report the caller's own mistake as a server fault. Named rather than inlined
+ * so it is visibly the one entry that is NOT derived.
+ */
+const LEGACY_UNPROCESSABLE_STATUS = 422;
+
 const STATUS_TO_CODE: Readonly<Record<number, NextlyErrorCode>> = {
-  400: "VALIDATION_ERROR",
-  401: "AUTH_REQUIRED",
-  403: "FORBIDDEN",
-  404: "NOT_FOUND",
-  // Staleness rather than a name clash: "refresh and try again" is unhelpful
-  // for a duplicate, while "already exists" would be WRONG for a stale write.
-  // A producer that means the clash sets `code: "DUPLICATE"`.
-  409: "CONFLICT",
-  413: "PAYLOAD_TOO_LARGE",
-  415: "UNSUPPORTED_MEDIA_TYPE",
-  422: "INVALID_INPUT",
-  429: "RATE_LIMITED",
-  502: "EXTERNAL_SERVICE_ERROR",
-  503: "SERVICE_UNAVAILABLE",
+  ...Object.fromEntries(
+    CANONICAL_CODE_FOR_STATUS.map(code => [NEXTLY_ERROR_STATUS[code], code])
+  ),
+  [LEGACY_UNPROCESSABLE_STATUS]: "INVALID_INPUT",
 };
 
 /**

--- a/packages/nextly/src/errors/from-service-envelope.ts
+++ b/packages/nextly/src/errors/from-service-envelope.ts
@@ -7,7 +7,11 @@
 
 import { recordFlattenedError } from "../hooks/side-effect-warnings";
 
-import { NEXTLY_ERROR_STATUS } from "./error-codes";
+import {
+  genericPublicMessage,
+  NEXTLY_ERROR_STATUS,
+  statusToErrorCode,
+} from "./error-codes";
 import { NextlyError } from "./nextly-error";
 import { originalErrorOf, withOriginalError } from "./original-error";
 import type { PublicData } from "./public-data";
@@ -159,29 +163,32 @@ export function errorFromServiceEnvelope(
     });
   }
 
-  // The status-derived branches chain the original too. A code-less envelope is
-  // exactly the one a raw driver rejection produces, so the branch with the
-  // least to say about the failure is the branch whose cause is worth the most.
-  //
-  // Named explicitly rather than spread in from a conditional object: an option
-  // a factory does not declare is a type error when written out and is accepted
-  // in silence when spread, so the spelling that catches the omission is the
-  // one that reads as if it does.
-  if (status === NEXTLY_ERROR_STATUS.NOT_FOUND) {
-    return NextlyError.notFound({ logContext, cause: original });
-  }
-  if (status === NEXTLY_ERROR_STATUS.FORBIDDEN) {
-    return NextlyError.forbidden({ logContext, cause: original });
-  }
-  if (status === NEXTLY_ERROR_STATUS.CONFLICT) {
-    // Without a code, staleness is the safer default: it tells the user to
-    // refresh rather than implying the write itself was invalid.
-    return NextlyError.conflict({ logContext, cause: original });
-  }
-  if (status === NEXTLY_ERROR_STATUS.VALIDATION_ERROR) {
+  // Nothing named a code, so the ONE table decides. Every boundary used to
+  // decide separately, which is how the same 401 reached a Direct API caller as
+  // `AUTH_REQUIRED` and a REST caller as a 500.
+  const derived = statusToErrorCode(status);
+
+  // Validation keeps its own path either way: it is the only code whose public
+  // data is per-field issues the admin maps onto form inputs.
+  if (derived === "VALIDATION_ERROR") {
     return validationFromEnvelope(envelope, logContext, original);
   }
-  return NextlyError.internal({ logContext, cause: original });
+
+  return new NextlyError({
+    code: derived,
+    // The GENERIC sentence for the derived code, never the envelope's own
+    // message. A code-less envelope comes from a legacy converter that may have
+    // stored a raw exception's text, and promoting that would put driver
+    // output and internal paths on the wire (spec 13.8). It stays in
+    // `logContext` for the operator.
+    publicMessage: genericPublicMessage(derived),
+    // The envelope's status rather than the code's canonical one, so an
+    // unrecognised legacy status still answers with what the producer chose
+    // instead of being rounded to 500.
+    statusCode: status,
+    logContext,
+    ...(original !== undefined ? { cause: original } : {}),
+  });
 }
 
 /**

--- a/packages/nextly/src/errors/from-service-envelope.ts
+++ b/packages/nextly/src/errors/from-service-envelope.ts
@@ -186,6 +186,14 @@ export function errorFromServiceEnvelope(
     // unrecognised legacy status still answers with what the producer chose
     // instead of being rounded to 500.
     statusCode: status,
+    // Forwarded even though the message is not. They are not the same kind of
+    // field: `message` is prose a legacy converter may have filled with a raw
+    // exception's text, while `publicData` is the structured payload whose
+    // whole purpose is to reach the caller. Dropping it silently disarmed the
+    // derived code -- a 429 answered RATE_LIMITED while `Retry-After` is read
+    // from `publicData.retryAfterSeconds`, so the caller was told to back off
+    // and not told for how long.
+    publicData: envelope.publicData as PublicData | undefined,
     logContext,
     ...(original !== undefined ? { cause: original } : {}),
   });

--- a/packages/nextly/src/services/media-folder.ts
+++ b/packages/nextly/src/services/media-folder.ts
@@ -74,6 +74,14 @@ export interface FolderContents {
 export interface FolderResponse {
   success: boolean;
   statusCode: number;
+  /**
+   * The canonical error code, when this service knows which one it means.
+   *
+   * A status is coarser than a code -- 409 covers both a name clash and a stale
+   * write -- so a failure that knows the difference says so here rather than
+   * leaving a boundary to infer the safer reading from the number alone.
+   */
+  code?: string;
   message: string;
   data?: MediaFolder | null;
 }
@@ -86,6 +94,14 @@ export interface FolderListResponse {
 }
 
 export interface FolderContentsResponse {
+  /**
+   * The canonical error code, when this service knows which one it means.
+   *
+   * A status is coarser than a code -- 409 covers both a name clash and a stale
+   * write -- so a failure that knows the difference says so here rather than
+   * leaving a boundary to infer the safer reading from the number alone.
+   */
+  code?: string;
   success: boolean;
   statusCode: number;
   message: string;
@@ -149,6 +165,12 @@ export class MediaFolderService extends BaseService {
         return {
           success: false,
           statusCode: 409,
+          // The service names its own meaning. 409 covers both a name clash and
+          // a stale write, so a boundary inferring from the status alone has to
+          // pick the safer reading -- which would tell someone whose folder
+          // name is taken to refresh the page, advice that cannot rename
+          // anything.
+          code: "DUPLICATE",
           message: "A folder with this name already exists in this location",
           data: null,
         };
@@ -539,6 +561,8 @@ export class MediaFolderService extends BaseService {
   ): Promise<{
     success: boolean;
     statusCode: number;
+    /** The canonical error code, when this service knows which one it means. */
+    code?: string;
     message: string;
     deletedMedia?: number;
     deletedFolders?: number;
@@ -635,9 +659,7 @@ export class MediaFolderService extends BaseService {
       }
 
       // Delete folder (CASCADE handles subfolder records)
-      await this.db
-        .delete(mediaFolders)
-        .where(eq(mediaFolders.id, folderId));
+      await this.db.delete(mediaFolders).where(eq(mediaFolders.id, folderId));
 
       return {
         success: true,

--- a/packages/nextly/src/types/media.ts
+++ b/packages/nextly/src/types/media.ts
@@ -152,6 +152,14 @@ export interface MediaListResponse {
 }
 
 export interface MediaResponse {
+  /**
+   * The canonical error code, when this service knows which one it means.
+   *
+   * A status is coarser than a code -- 409 covers both a name clash and a stale
+   * write -- so a failure that knows the difference says so here rather than
+   * leaving a boundary to infer the safer reading from the number alone.
+   */
+  code?: string;
   success: boolean;
   statusCode: number;
   message: string;
@@ -159,6 +167,14 @@ export interface MediaResponse {
 }
 
 export interface DeleteMediaResponse {
+  /**
+   * The canonical error code, when this service knows which one it means.
+   *
+   * A status is coarser than a code -- 409 covers both a name clash and a stale
+   * write -- so a failure that knows the difference says so here rather than
+   * leaving a boundary to infer the safer reading from the number alone.
+   */
+  code?: string;
   success: boolean;
   statusCode: number;
   message: string;


### PR DESCRIPTION
Closes the first half of `tasks/left-tasks/115`. Founder chose full convergence.

## The problem

When something fails, a Nextly error carries a **code** (`NOT_FOUND`, `DUPLICATE`) that software branches on and an **HTTP status** that the web understands. Several legacy services return `{ success: false, statusCode, message }` with no code, so the code has to be inferred back from the number.

**Three places inferred it, and they disagreed:**

| Status | shared converter | Direct API's table | media's table |
|---|---|---|---|
| 401 | **INTERNAL_ERROR** | AUTH_REQUIRED | AUTH_REQUIRED |
| 409 | CONFLICT | CONFLICT | **DUPLICATE** |
| 422 | **INTERNAL_ERROR** | INVALID_INPUT | **BUSINESS_RULE_VIOLATION** |
| 429 | **INTERNAL_ERROR** | RATE_LIMITED | **INTERNAL_ERROR** |

So the same failure had a different identity depending on how the caller arrived. A code-less 429 was the costly one: it answered 500 and **dropped `Retry-After`**, which is the one thing a client needs to back off correctly.

The tell that we already knew the shared table was too narrow: **the Direct API pre-computed the code with its own table** so the shared branches were never reached.

## What changes

`statusToErrorCode` in `errors/error-codes.ts` is now the only inference, beside `NEXTLY_ERROR_STATUS` whose inverse it is. The Direct API's private table is **deleted** (it was not public API); media's private `switch` is **deleted** and routes through the shared converter.

**It is a fallback, not a translation** — the distinction the whole design rests on. A status is coarser than a code: 409 covers both "that name is taken" and "someone else edited this", which need opposite advice. So a service that knows which one it means sets `code` and is believed, and the table is never consulted for it.

That is why the media response shapes can now carry a code, and why a folder-name clash sets `DUPLICATE`. Without it, full convergence would have told a user whose folder name is taken to **"refresh and try again"** — advice that cannot rename anything. A test pins exactly that sentence never appearing on that path.

Media's status short-circuits are guarded on `!result.code`, matching the collection facade, so a typed code no longer collapses into the generic one.

## Disclosure

A code-less failure answers with the **generic** sentence for the derived code, never its own message: these envelopes come from legacy converters that may store a raw exception's text, and this is the one path with no typed error to vet it. The detail stays in `logContext` against the request id. A failure that names a code keeps its own message, which the producer authored to be read. Both directions are asserted.

This also closes the Direct API leak flagged on #511: it previously promoted a code-less envelope's raw message to the caller.

## Behaviour changes

A code-less 401 → `AUTH_REQUIRED` (was `INTERNAL_ERROR`); 429 → `RATE_LIMITED`; 422 → `INVALID_INPUT`; 413/415/502/503 now map. Through the Direct API, a code-less failure's message is now generic rather than the service's raw text. In the changeset.

## Verification

24 new cases: every status in the table, an unmapped status, the producer's status surviving a code whose canonical status differs, **REST and Direct API answering identically** for the statuses that used to diverge, a named code overriding the table, a plugin code in no table at all, and both disclosure directions.

Narrowing the table back to its old shape fails 12 of the 24, proven with `diff`. Full `nextly` unit suite by failing-test **name set**: none introduced.

One assertion of mine was wrong and the test caught it: I expected `DUPLICATE` to answer with the generic "Resource already exists.", but naming a code means the producer owns the message too — and "A folder with this name already exists in this location" is both more actionable and still free of identifiers.