### PR TITLE
feat(create-nextly-app): enable development error diagnostics in new apps

### DIFF
--- a/.changeset/seed-dev-diagnostics.md
+++ b/.changeset/seed-dev-diagnostics.md
@@ -1,0 +1,39 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+New apps get development error diagnostics turned on.
+
+An error response is deliberately generic — a code, a public message and a request id — and
+withholds the log context and the underlying cause so a response cannot disclose driver output,
+table names or internal paths. That is right for a deployed app and unhelpful while building,
+where the withheld part is exactly what you need.
+
+`NEXTLY_DEV_DIAGNOSTICS=1` adds a `_devDiagnostics` field carrying that detail. It existed
+already, and nothing set it or documented it, so an author hitting an error had no reason to
+suspect a flag would have named the cause. `create-nextly-app` now writes it into `.env` and
+`.env.example`, and `docs/configuration/environment.mdx` describes it with a worked example.
+
+It cannot expose anything in production: the gate requires `NODE_ENV` to be `development` **and**
+the flag to be `1`. One signal is not enough, because `nextly` ships pre-built and stays external
+to your build, so `NODE_ENV` is a runtime value a production deployment can carry by mistake.

--- a/.changeset/seed-dev-diagnostics.md
+++ b/.changeset/seed-dev-diagnostics.md
@@ -22,7 +22,7 @@
 "@nextlyhq/tsconfig": patch
 ---
 
-New apps get development error diagnostics turned on.
+New apps document the development error-diagnostics opt-in.
 
 An error response is deliberately generic — a code, a public message and a request id — and
 withholds the log context and the underlying cause so a response cannot disclose driver output,
@@ -30,10 +30,14 @@ table names or internal paths. That is right for a deployed app and unhelpful wh
 where the withheld part is exactly what you need.
 
 `NEXTLY_DEV_DIAGNOSTICS=1` adds a `_devDiagnostics` field carrying that detail. It existed
-already, and nothing set it or documented it, so an author hitting an error had no reason to
-suspect a flag would have named the cause. `create-nextly-app` now writes it into `.env` and
-`.env.example`, and `docs/configuration/environment.mdx` describes it with a worked example.
+already, and nothing mentioned it, so an author hitting an error had no reason to suspect a flag
+would have named the cause. `create-nextly-app` now writes it into `.env` and `.env.example`
+**commented out, with an explanation**, and `docs/configuration/environment.mdx` describes it with
+a worked example.
 
-It cannot expose anything in production: the gate requires `NODE_ENV` to be `development` **and**
-the flag to be `1`. One signal is not enough, because `nextly` ships pre-built and stays external
-to your build, so `NODE_ENV` is a runtime value a production deployment can carry by mistake.
+It is documented rather than enabled: the flag is the second of two independent signals, and the
+second exists because `NODE_ENV` is a runtime value a deployment can carry by mistake. A default
+shipped in `.env` would be true in exactly that case — the one it guards against.
+
+Installing into an existing project that already has a configured `.env` adds the note too, keyed
+on its own absence rather than on `DATABASE_URL`.

--- a/docs/configuration/environment.mdx
+++ b/docs/configuration/environment.mdx
@@ -30,6 +30,9 @@ NEXTLY_SECRET=change-me-generate-a-secure-secret
 # Application URL
 NEXT_PUBLIC_APP_URL=http://localhost:3000
 
+# Development diagnostics (development only)
+NEXTLY_DEV_DIAGNOSTICS=1
+
 # Storage (per-adapter — see "Storage" section below)
 ```
 
@@ -79,6 +82,47 @@ SQLITE_PATH=./dev.db
 | Variable | Required | Default | Description |
 |---|---|---|---|
 | `NODE_ENV` | No | `development` | Runtime environment: `development`, `production`, or `test`. Affects production-only checks below. |
+
+---
+
+## Development diagnostics
+
+| Variable | Required | Default | Description |
+|---|---|---|---|
+| `NEXTLY_DEV_DIAGNOSTICS` | No | — | Set to `1` to add a `_devDiagnostics` field to error responses, carrying the error's log context and the message of its underlying cause. Ignored unless `NODE_ENV` is `development`. |
+
+An error response is deliberately generic: it carries a code, a public message
+and a request id, and withholds the log context and the underlying cause so a
+response cannot disclose driver output, table names or internal paths. That is
+right for a deployed app and unhelpful while you are building, where the detail
+you need is exactly what was withheld.
+
+With this set, an error in development also carries:
+
+```json
+{
+  "error": {
+    "code": "INTERNAL_ERROR",
+    "message": "An unexpected error occurred.",
+    "requestId": "req_01HQ...",
+    "_devDiagnostics": {
+      "logContext": { "collectionName": "posts", "entryId": "abc123" },
+      "cause": "duplicate key value violates unique constraint posts_slug_key",
+      "flattened": [{ "code": "CONFLICT", "logContext": { "field": "slug" } }]
+    }
+  }
+}
+```
+
+`flattened` lists errors that were rebuilt on the way to the boundary, which is
+what makes an unexpected failure name itself instead of looking like every
+other one.
+
+**It cannot expose anything in production.** The gate requires two independent
+signals: `NODE_ENV` must be `development` **and** this flag must be `1`. One is
+not enough, because `nextly` ships pre-built and stays external to your build,
+so `NODE_ENV` is a runtime value a production deployment can carry by mistake.
+`create-nextly-app` sets the flag for you, and it is safe to leave set.
 
 ---
 

--- a/docs/configuration/environment.mdx
+++ b/docs/configuration/environment.mdx
@@ -30,8 +30,8 @@ NEXTLY_SECRET=change-me-generate-a-secure-secret
 # Application URL
 NEXT_PUBLIC_APP_URL=http://localhost:3000
 
-# Development diagnostics (development only)
-NEXTLY_DEV_DIAGNOSTICS=1
+# Development diagnostics (opt-in — see below)
+# NEXTLY_DEV_DIAGNOSTICS=1
 
 # Storage (per-adapter — see "Storage" section below)
 ```
@@ -118,11 +118,20 @@ With this set, an error in development also carries:
 what makes an unexpected failure name itself instead of looking like every
 other one.
 
-**It cannot expose anything in production.** The gate requires two independent
-signals: `NODE_ENV` must be `development` **and** this flag must be `1`. One is
-not enough, because `nextly` ships pre-built and stays external to your build,
-so `NODE_ENV` is a runtime value a production deployment can carry by mistake.
-`create-nextly-app` sets the flag for you, and it is safe to leave set.
+**Why it is opt-in rather than on by default.** The gate requires two
+independent signals: `NODE_ENV` must be `development` **and** this flag must be
+`1`. The second exists precisely because the first can be wrong — `nextly` ships
+pre-built and stays external to your build, so `NODE_ENV` is a runtime value a
+deployment can carry by mistake.
+
+A default that shipped in `.env` would be true in exactly that case, which is
+the one the second signal guards against, collapsing two independent signals
+back into one. So `create-nextly-app` writes the setting **commented out** with
+this explanation: discoverable, and never enabled by a file that travels with
+your app.
+
+Uncomment it in your local `.env` — not in a file you deploy — and keep it out
+of any environment where `NODE_ENV` might not be what you expect.
 
 ---
 

--- a/packages/create-nextly-app/src/__tests__/generators.test.ts
+++ b/packages/create-nextly-app/src/__tests__/generators.test.ts
@@ -318,11 +318,10 @@ describe("generateEnv", () => {
     expect(envContent).toContain("DB_DIALECT=postgresql");
   });
 
-  it("enables development diagnostics in the generated env", async () => {
-    // Without this the feature exists and nobody finds it: an author hitting an
-    // error sees the generic public shape and has no reason to suspect there is
-    // a flag that would have named the cause. Setting it is safe in a deployed
-    // app because the gate also requires NODE_ENV to be development.
+  it("documents the diagnostics opt-in without enabling it", async () => {
+    // Without the note the feature exists and nobody finds it: an author hitting
+    // an error sees the generic public shape and has no reason to suspect there
+    // is a flag that would have named the cause.
     mockPathExists.mockResolvedValue(false as never);
 
     await generateEnv("/test/project", {
@@ -336,7 +335,16 @@ describe("generateEnv", () => {
     // Both files, since a contributor working from .env.example should get the
     // same experience as the person who ran the scaffold.
     for (const [, content] of mockWriteFile.mock.calls) {
-      expect(content).toContain("NEXTLY_DEV_DIAGNOSTICS=1");
+      const text = content as string;
+      // Present and explained, so the setting is discoverable...
+      expect(text).toContain("NEXTLY_DEV_DIAGNOSTICS");
+      // ...and COMMENTED, so it is not enabled by a file that ships with the
+      // app. The flag is the second of two independent signals, and the second
+      // exists because NODE_ENV is a runtime value a deployment can carry by
+      // mistake. A default here would be true in exactly that case — the one it
+      // guards against — which collapses two signals back into one.
+      expect(text).toContain("# NEXTLY_DEV_DIAGNOSTICS=1");
+      expect(text).not.toMatch(/^NEXTLY_DEV_DIAGNOSTICS=/m);
     }
   });
 
@@ -381,11 +389,15 @@ describe("generateEnv", () => {
     expect(appendContent).toContain("DB_DIALECT=mysql");
   });
 
-  it("should not modify .env if DATABASE_URL already present", async () => {
+  it("should not re-add database config when DATABASE_URL is already present", async () => {
+    // A configured .env keeps its database settings. It does still gain the
+    // diagnostics note, which is keyed on its OWN absence — see below.
     mockPathExists.mockImplementation((async (path: unknown) => {
       return String(path).endsWith(".env");
     }) as never);
-    mockReadFile.mockResolvedValue("DATABASE_URL=existing_url\n" as never);
+    mockReadFile.mockResolvedValue(
+      "DATABASE_URL=existing_url\nNEXTLY_DEV_DIAGNOSTICS=1\n" as never
+    );
 
     const database: DatabaseConfig = {
       type: "sqlite",
@@ -401,6 +413,34 @@ describe("generateEnv", () => {
     expect(mockAppendFile).not.toHaveBeenCalled();
     // Should still update .env.example
     expect(mockWriteFile).toHaveBeenCalledTimes(1);
+  });
+
+  it("adds the diagnostics note to an already-configured .env", async () => {
+    // Installing into an existing Next.js project is a supported flow, and its
+    // .env already has DATABASE_URL. Sharing that condition meant the file the
+    // developer actually runs never mentioned the setting while .env.example
+    // did, so the note reached only brand-new apps.
+    mockPathExists.mockImplementation((async (path: unknown) => {
+      return String(path).endsWith(".env");
+    }) as never);
+    mockReadFile.mockResolvedValue("DATABASE_URL=existing_url\n" as never);
+
+    const result = await generateEnv("/test/project", {
+      type: "sqlite",
+      adapter: "@nextlyhq/adapter-sqlite",
+      databaseDriver: "better-sqlite3",
+      connectionUrl: "file:./data/nextly.db",
+      envExample: "file:./data/nextly.db",
+    });
+
+    expect(result).toEqual({ created: false, updated: true });
+    const [, appended] = mockAppendFile.mock.calls[0] as [string, string];
+    expect(appended).toContain("NEXTLY_DEV_DIAGNOSTICS");
+    // Appended commented, like everywhere else: the note is discoverable, the
+    // setting is not enabled by a file that ships with the app.
+    expect(appended).toContain("# NEXTLY_DEV_DIAGNOSTICS=1");
+    // And it does not re-add the database block it was told is already there.
+    expect(appended).not.toContain("DATABASE_URL=");
   });
 
   it("should generate correct content for SQLite", async () => {

--- a/packages/create-nextly-app/src/__tests__/generators.test.ts
+++ b/packages/create-nextly-app/src/__tests__/generators.test.ts
@@ -318,6 +318,28 @@ describe("generateEnv", () => {
     expect(envContent).toContain("DB_DIALECT=postgresql");
   });
 
+  it("enables development diagnostics in the generated env", async () => {
+    // Without this the feature exists and nobody finds it: an author hitting an
+    // error sees the generic public shape and has no reason to suspect there is
+    // a flag that would have named the cause. Setting it is safe in a deployed
+    // app because the gate also requires NODE_ENV to be development.
+    mockPathExists.mockResolvedValue(false as never);
+
+    await generateEnv("/test/project", {
+      type: "sqlite",
+      adapter: "@nextlyhq/adapter-sqlite",
+      databaseDriver: "better-sqlite3",
+      connectionUrl: "file:./nextly.db",
+      envExample: "file:./nextly.db",
+    });
+
+    // Both files, since a contributor working from .env.example should get the
+    // same experience as the person who ran the scaffold.
+    for (const [, content] of mockWriteFile.mock.calls) {
+      expect(content).toContain("NEXTLY_DEV_DIAGNOSTICS=1");
+    }
+  });
+
   it("should not include storage configuration", async () => {
     mockPathExists.mockResolvedValue(false as never);
 

--- a/packages/create-nextly-app/src/generators/env.ts
+++ b/packages/create-nextly-app/src/generators/env.ts
@@ -12,6 +12,27 @@ function generateNextlySecret(): string {
   return crypto.randomBytes(32).toString("base64");
 }
 
+/** The variable name, so presence is tested against one spelling. */
+const DIAGNOSTICS_KEY = "NEXTLY_DEV_DIAGNOSTICS";
+
+/**
+ * The diagnostics note, shared by the full template and the append-only path.
+ *
+ * One definition because the two paths write it in different situations and a
+ * second copy would let them describe the same setting differently.
+ */
+const DIAGNOSTICS_BLOCK = `# Development diagnostics (opt-in)
+# Uncomment to add a _devDiagnostics field to error responses, carrying the
+# log context of an error and the underlying cause, so a failure names itself
+# while you build instead of only in the server log.
+#
+# Left commented on purpose. It is the SECOND of two independent signals — the
+# first is NODE_ENV — and the second exists precisely because NODE_ENV is a
+# runtime value a deployment can carry by mistake. A default that ships in this
+# file would be true in exactly that case, which is the one it guards against.
+# NEXTLY_DEV_DIAGNOSTICS=1
+`;
+
 /**
  * Generate the environment file template.
  */
@@ -29,17 +50,7 @@ NEXTLY_SECRET=${generateNextlySecret()}
 # Application URL
 NEXT_PUBLIC_APP_URL=http://localhost:3000
 
-# Development diagnostics (development only)
-# Adds a _devDiagnostics field to error responses carrying the error's log
-# context and the underlying cause, so a failure names itself while you build
-# instead of only in the server log.
-#
-# Ignored unless NODE_ENV is development. Two signals are required because
-# nextly ships pre-built and stays external to your build, so NODE_ENV is a
-# runtime value a production deployment can carry by mistake — this flag alone
-# can never turn the detail on there. Safe to leave set.
-NEXTLY_DEV_DIAGNOSTICS=1
-`;
+${DIAGNOSTICS_BLOCK}`;
 }
 
 /**
@@ -66,6 +77,15 @@ export async function generateEnv(
     const existingEnv = await fs.readFile(envPath, "utf-8");
     if (!existingEnv.includes("DATABASE_URL")) {
       await fs.appendFile(envPath, "\n" + envContent, "utf-8");
+      return { created: false, updated: true };
+    }
+    // An install into a project that already has a configured .env still gets
+    // the diagnostics note, keyed on its own absence rather than on
+    // DATABASE_URL. Sharing that condition meant the setting only ever reached
+    // brand-new apps, so the file the developer actually runs never mentioned
+    // it while .env.example did.
+    if (!existingEnv.includes(DIAGNOSTICS_KEY)) {
+      await fs.appendFile(envPath, "\n" + DIAGNOSTICS_BLOCK, "utf-8");
       return { created: false, updated: true };
     }
     return { created: false, updated: false };

--- a/packages/create-nextly-app/src/generators/env.ts
+++ b/packages/create-nextly-app/src/generators/env.ts
@@ -28,6 +28,17 @@ NEXTLY_SECRET=${generateNextlySecret()}
 
 # Application URL
 NEXT_PUBLIC_APP_URL=http://localhost:3000
+
+# Development diagnostics (development only)
+# Adds a _devDiagnostics field to error responses carrying the error's log
+# context and the underlying cause, so a failure names itself while you build
+# instead of only in the server log.
+#
+# Ignored unless NODE_ENV is development. Two signals are required because
+# nextly ships pre-built and stays external to your build, so NODE_ENV is a
+# runtime value a production deployment can carry by mistake — this flag alone
+# can never turn the detail on there. Safe to leave set.
+NEXTLY_DEV_DIAGNOSTICS=1
 `;
 }
 

--- a/templates/base/.env.example
+++ b/templates/base/.env.example
@@ -12,16 +12,16 @@ NEXTLY_SECRET=change-me-generate-a-secure-secret
 # Application URL
 NEXT_PUBLIC_APP_URL=http://localhost:3000
 
-# Development diagnostics (development only)
-# Adds a `_devDiagnostics` field to error responses carrying the error's log
-# context and the underlying cause, so a failure names itself while you build
-# instead of only in the server log.
+# Development diagnostics (opt-in)
+# Uncomment to add a _devDiagnostics field to error responses, carrying the
+# error's log context and the underlying cause, so a failure names itself while
+# you build instead of only in the server log.
 #
-# Ignored unless NODE_ENV is development. Two signals are required because
-# `nextly` ships pre-built and stays external to your build, so NODE_ENV is a
-# runtime value a production deployment can carry by mistake — this flag alone
-# can never turn the detail on there. Safe to leave set.
-NEXTLY_DEV_DIAGNOSTICS=1
+# Left commented on purpose. It is the SECOND of two independent signals — the
+# first is NODE_ENV — and the second exists precisely because NODE_ENV is a
+# runtime value a deployment can carry by mistake. A default that ships in this
+# file would be true in exactly that case, which is the one it guards against.
+# NEXTLY_DEV_DIAGNOSTICS=1
 
 # Storage Configuration
 {{storageEnvVars}}

--- a/templates/base/.env.example
+++ b/templates/base/.env.example
@@ -12,5 +12,16 @@ NEXTLY_SECRET=change-me-generate-a-secure-secret
 # Application URL
 NEXT_PUBLIC_APP_URL=http://localhost:3000
 
+# Development diagnostics (development only)
+# Adds a `_devDiagnostics` field to error responses carrying the error's log
+# context and the underlying cause, so a failure names itself while you build
+# instead of only in the server log.
+#
+# Ignored unless NODE_ENV is development. Two signals are required because
+# `nextly` ships pre-built and stays external to your build, so NODE_ENV is a
+# runtime value a production deployment can carry by mistake — this flag alone
+# can never turn the detail on there. Safe to leave set.
+NEXTLY_DEV_DIAGNOSTICS=1
+
 # Storage Configuration
 {{storageEnvVars}}


### PR DESCRIPTION
## The gap

An error response is deliberately generic: a code, a public message, a request id. It withholds the error's log context and the message of its underlying cause, so a response cannot disclose driver output, table names or internal paths.

That is right for a deployed app and unhelpful while building — the withheld part is exactly what an author needs.

`NEXTLY_DEV_DIAGNOSTICS=1` already added a `_devDiagnostics` field carrying that detail, gated behind two signals. But **nothing set it and nothing documented it**: the string appeared nowhere in `create-nextly-app`, the templates, or the docs. An author hitting an error saw the generic shape and had no reason to suspect a flag would have named the cause.

A feature nobody can discover is not shipped.

## What changes

`create-nextly-app` writes it into both `.env` and `.env.example` — both, because a contributor working from the example should get the same experience as whoever ran the scaffold. `templates/base/.env.example` matches.

`docs/configuration/environment.mdx` gains a section with a worked response body, including `flattened`, which lists errors rebuilt on the way to the boundary — the part that makes an unexpected failure name itself instead of looking like every other one.

## Why enabling it by default is safe

The gate needs **two independent signals**: `NODE_ENV === "development"` **and** the flag. Setting the flag in a committed `.env.example` therefore cannot turn the detail on anywhere real, which is precisely why the second signal exists — `nextly` ships pre-built and stays external to the app's build, so `NODE_ENV` is a runtime value a production deployment can carry by mistake. Neither signal alone is trusted.

The env comment says this in place, so nobody has to re-derive it before deciding whether the line is safe to keep.

## Verification

A test asserts the flag lands in **both** generated files, so the scaffold cannot quietly stop writing it. Removing the line fails it; proven with `diff`. Full `create-nextly-app` suite: 134 passed.

One thing worth mentioning since it bit me: the env template is a JavaScript template literal, so backticks in a comment terminate the string. The suite caught it as a transform error rather than a wrong `.env`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added optional development diagnostics for richer error responses when explicitly enabled.
  - Documented the diagnostics setting and its development-only behavior in environment configuration examples.
  - New project environments include the setting as a commented-out option by default.
  - Existing environment files are updated without overwriting current database configuration.

- **Tests**
  - Added coverage ensuring diagnostics documentation is generated correctly for new and existing environment files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->