### PR TITLE
fix(create-nextly-app): match the diagnostics variable, not its prefix

### DIFF
--- a/.changeset/diagnostics-key-match.md
+++ b/.changeset/diagnostics-key-match.md
@@ -1,0 +1,35 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+`create-nextly-app` recognises the development-diagnostics setting however an existing `.env`
+spells it, and no longer mistakes a different variable for it.
+
+A substring test treated `NEXTLY_DEV_DIAGNOSTICS_BACKUP=1` as the setting already being present,
+so such a project was skipped and never told the real one exists. The check now matches an
+assignment at the start of a line, including the commented form and the `export KEY=value` form
+dotenv accepts so a file can also be sourced by a shell.
+
+The whitespace in that match is confined to the current line. Allowing it to cross newlines made
+the scan backtrack across the blank lines an `.env` is full of, which is quadratic on the common
+case of a file that does not contain the key at all.

--- a/packages/create-nextly-app/src/__tests__/generators.test.ts
+++ b/packages/create-nextly-app/src/__tests__/generators.test.ts
@@ -332,10 +332,20 @@ describe("generateEnv", () => {
       envExample: "file:./nextly.db",
     });
 
-    // Both files, since a contributor working from .env.example should get the
-    // same experience as the person who ran the scaffold.
-    for (const [, content] of mockWriteFile.mock.calls) {
-      const text = content as string;
+    // The two targets by NAME, not just two payloads: asserting only the
+    // contents passes if one file is written twice and the other skipped, which
+    // is the failure this is meant to catch.
+    const written = new Map(
+      mockWriteFile.mock.calls.map(([p, content]) => [
+        String(p).endsWith(".env.example") ? ".env.example" : ".env",
+        content as string,
+      ])
+    );
+    expect([...written.keys()].sort()).toEqual([".env", ".env.example"]);
+
+    // A contributor working from .env.example should get the same experience as
+    // the person who ran the scaffold.
+    for (const text of written.values()) {
       // Present and explained, so the setting is discoverable...
       expect(text).toContain("NEXTLY_DEV_DIAGNOSTICS");
       // ...and COMMENTED, so it is not enabled by a file that ships with the
@@ -413,6 +423,49 @@ describe("generateEnv", () => {
     expect(mockAppendFile).not.toHaveBeenCalled();
     // Should still update .env.example
     expect(mockWriteFile).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not mistake a similarly-named variable for the setting", async () => {
+    // A substring test treats `NEXTLY_DEV_DIAGNOSTICS_BACKUP` as the setting
+    // and skips the note, so a project that happens to use such a name never
+    // learns the real one exists.
+    mockPathExists.mockImplementation((async (path: unknown) =>
+      String(path).endsWith(".env")) as never);
+    mockReadFile.mockResolvedValue(
+      "DATABASE_URL=existing\nNEXTLY_DEV_DIAGNOSTICS_BACKUP=1\n" as never
+    );
+
+    const result = await generateEnv("/test/project", {
+      type: "sqlite",
+      adapter: "@nextlyhq/adapter-sqlite",
+      databaseDriver: "better-sqlite3",
+      connectionUrl: "file:./nextly.db",
+      envExample: "file:./nextly.db",
+    });
+
+    expect(result).toEqual({ created: false, updated: true });
+    expect(mockAppendFile).toHaveBeenCalledOnce();
+  });
+
+  it("leaves an already-commented setting alone", async () => {
+    // The commented form IS the note, so appending a second copy below it would
+    // be noise rather than help.
+    mockPathExists.mockImplementation((async (path: unknown) =>
+      String(path).endsWith(".env")) as never);
+    mockReadFile.mockResolvedValue(
+      "DATABASE_URL=existing\n# NEXTLY_DEV_DIAGNOSTICS=1\n" as never
+    );
+
+    const result = await generateEnv("/test/project", {
+      type: "sqlite",
+      adapter: "@nextlyhq/adapter-sqlite",
+      databaseDriver: "better-sqlite3",
+      connectionUrl: "file:./nextly.db",
+      envExample: "file:./nextly.db",
+    });
+
+    expect(result).toEqual({ created: false, updated: false });
+    expect(mockAppendFile).not.toHaveBeenCalled();
   });
 
   it("adds the diagnostics note to an already-configured .env", async () => {

--- a/packages/create-nextly-app/src/__tests__/generators.test.ts
+++ b/packages/create-nextly-app/src/__tests__/generators.test.ts
@@ -447,6 +447,57 @@ describe("generateEnv", () => {
     expect(mockAppendFile).toHaveBeenCalledOnce();
   });
 
+  it.each([
+    ["export form", "export NEXTLY_DEV_DIAGNOSTICS=1"],
+    ["commented export", "# export NEXTLY_DEV_DIAGNOSTICS=1"],
+    ["indented", "  NEXTLY_DEV_DIAGNOSTICS=1"],
+    ["spaced around =", "NEXTLY_DEV_DIAGNOSTICS = 1"],
+  ])("recognises the setting written as %s", async (_label, line) => {
+    // dotenv accepts `export KEY=value` so the same file can be sourced by a
+    // shell. A project written that way would otherwise be told the setting is
+    // absent and handed a duplicate block below the one it already has.
+    mockPathExists.mockImplementation((async (path: unknown) =>
+      String(path).endsWith(".env")) as never);
+    mockReadFile.mockResolvedValue(`DATABASE_URL=existing\n${line}\n` as never);
+
+    const result = await generateEnv("/test/project", {
+      type: "sqlite",
+      adapter: "@nextlyhq/adapter-sqlite",
+      databaseDriver: "better-sqlite3",
+      connectionUrl: "file:./nextly.db",
+      envExample: "file:./nextly.db",
+    });
+
+    expect(result).toEqual({ created: false, updated: false });
+    expect(mockAppendFile).not.toHaveBeenCalled();
+  });
+
+  it("scans a blank-line-heavy .env without backtracking", async () => {
+    // The whitespace classes are confined to the current line. With `\s` under
+    // the `m` flag they cross newlines, so each retry chews through the blank
+    // lines an .env is full of — quadratic on a file that does not contain the
+    // key at all, which is the common case.
+    mockPathExists.mockImplementation((async (path: unknown) =>
+      String(path).endsWith(".env")) as never);
+    mockReadFile.mockResolvedValue(
+      ("DATABASE_URL=existing\n" + "   \n".repeat(20000)) as never
+    );
+
+    const started = performance.now();
+    const result = await generateEnv("/test/project", {
+      type: "sqlite",
+      adapter: "@nextlyhq/adapter-sqlite",
+      databaseDriver: "better-sqlite3",
+      connectionUrl: "file:./nextly.db",
+      envExample: "file:./nextly.db",
+    });
+
+    // Generous by design: this fails on catastrophic backtracking, not on a
+    // slow machine. The pathological form takes orders of magnitude longer.
+    expect(performance.now() - started).toBeLessThan(2000);
+    expect(result).toEqual({ created: false, updated: true });
+  });
+
   it("leaves an already-commented setting alone", async () => {
     // The commented form IS the note, so appending a second copy below it would
     // be noise rather than help.

--- a/packages/create-nextly-app/src/generators/env.ts
+++ b/packages/create-nextly-app/src/generators/env.ts
@@ -20,9 +20,21 @@ function generateNextlySecret(): string {
  * and the like -- does not read as this one and silently suppress the note. A
  * commented form counts: the note is what is being added, and adding a second
  * copy of it below the first would be noise rather than help.
+ *
+ * `export KEY=value` counts too. dotenv accepts it so the same file can be
+ * sourced by a shell, and a project written that way would otherwise be told
+ * the setting is absent and handed a duplicate block.
+ *
+ * The horizontal-space classes are `[ \t]`, not `\s`. Under the `m` flag `\s`
+ * matches newlines, so the two around an optional `#` can each consume the
+ * blank lines an `.env` is full of, and the engine retries that from every
+ * line -- quadratic work on a file that simply does not contain the key.
+ * Confining them to the current line is what keeps the scan linear.
  */
 function mentionsDiagnostics(env: string): boolean {
-  return /^\s*#?\s*NEXTLY_DEV_DIAGNOSTICS\s*=/m.test(env);
+  return /^[ \t]*(?:#[ \t]*)?(?:export[ \t]+)?NEXTLY_DEV_DIAGNOSTICS[ \t]*=/m.test(
+    env
+  );
 }
 
 /**

--- a/packages/create-nextly-app/src/generators/env.ts
+++ b/packages/create-nextly-app/src/generators/env.ts
@@ -12,8 +12,18 @@ function generateNextlySecret(): string {
   return crypto.randomBytes(32).toString("base64");
 }
 
-/** The variable name, so presence is tested against one spelling. */
-const DIAGNOSTICS_KEY = "NEXTLY_DEV_DIAGNOSTICS";
+/**
+ * Whether a `.env` already mentions the diagnostics setting.
+ *
+ * Anchored to the start of a line and to the `=` that follows, so a DIFFERENT
+ * variable whose name merely starts the same way -- `NEXTLY_DEV_DIAGNOSTICS_URL`
+ * and the like -- does not read as this one and silently suppress the note. A
+ * commented form counts: the note is what is being added, and adding a second
+ * copy of it below the first would be noise rather than help.
+ */
+function mentionsDiagnostics(env: string): boolean {
+  return /^\s*#?\s*NEXTLY_DEV_DIAGNOSTICS\s*=/m.test(env);
+}
 
 /**
  * The diagnostics note, shared by the full template and the append-only path.
@@ -84,7 +94,7 @@ export async function generateEnv(
     // DATABASE_URL. Sharing that condition meant the setting only ever reached
     // brand-new apps, so the file the developer actually runs never mentioned
     // it while .env.example did.
-    if (!existingEnv.includes(DIAGNOSTICS_KEY)) {
+    if (!mentionsDiagnostics(existingEnv)) {
       await fs.appendFile(envPath, "\n" + DIAGNOSTICS_BLOCK, "utf-8");
       return { created: false, updated: true };
     }


### PR DESCRIPTION
Follow-up to #523, which merged with two CodeRabbit findings open. Both are real; neither is dangerous, so they land here rather than reopening that PR.

## 1. A substring test matched the wrong variable

`existingEnv.includes("NEXTLY_DEV_DIAGNOSTICS")` treats **`NEXTLY_DEV_DIAGNOSTICS_BACKUP=1`** as the setting already being present, so a project that happens to use such a name is silently skipped and never learns the real one exists.

Anchored to the start of a line and the `=` that follows:

```ts
function mentionsDiagnostics(env: string): boolean {
  return /^\s*#?\s*NEXTLY_DEV_DIAGNOSTICS\s*=/m.test(env);
}
```

A **commented** form still counts, deliberately: the commented line *is* the note being added, so appending a second copy below the first would be noise rather than help. That is now a test rather than an assumption.

## 2. A test that could pass while doing nothing

The diagnostics case looped over `mockWriteFile.mock.calls` and validated each payload — but never asserted **which** files were written. It passed if one target was written twice and the other skipped.

It now keys the writes by filename and asserts the pair:

```ts
expect([...written.keys()].sort()).toEqual([".env", ".env.example"]);
```

I isolated what this actually buys rather than asserting it. Running that case **alone**, with the assertion removed and `.env.example` never written: **passes**. Same scenario with the assertion: **fails**. So it closes a real hole in that test — a sibling case happens to cover the `.env.example` path separately, so this is a test-completeness fix, not an uncovered product bug. Worth stating plainly rather than implying more.

## Verification

Reverting the anchored match to `includes` fails the new similarly-named-variable case; proven with `diff`. `create-nextly-app` suite: 23 passed.