### PR TITLE
fix(plugin-form-builder): describe the status the schema actually stores

### DIFF
--- a/.changeset/form-builder-document-shapes.md
+++ b/.changeset/form-builder-document-shapes.md
@@ -1,0 +1,35 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+`SubmissionDocument.status` now includes `"spam"`, and gains `spamReason`.
+
+The stored field has always offered `spam`, the admin has a Spam tab and filters its other views
+with `not_equals: "spam"`, the notification hook skips it, and marking something "Not spam" moves
+it back to `new`. Only the TypeScript type disagreed, so it described a shape the database cannot
+produce — narrowing on `status` could not see the case that actually reaches the UI.
+
+The conversions from a stored row to this plugin's document types now live in one module rather
+than at six call sites. They are still unchecked assertions, which the module says plainly:
+the services layer answers with a loose row and TypeScript has no overlap to verify. Nothing about
+runtime behaviour changes; the unchecked step is now in one place a reviewer can find.

--- a/packages/plugin-form-builder/src/__tests__/submit-form.integration.test.ts
+++ b/packages/plugin-form-builder/src/__tests__/submit-form.integration.test.ts
@@ -84,6 +84,12 @@ describe("submitForm end-to-end", () => {
     // is what let the result carry a mutation envelope here instead of the
     // document, handing every caller `undefined` for `submission.id`.
     expect(result.submission?.id).toEqual(expect.any(String));
+    // The status the schema stores. `spam` belongs to this union too — the
+    // stored field offers it and the admin has a tab for it — so a document
+    // type that omitted it was describing a shape the database cannot produce.
+    expect(["new", "read", "archived", "spam"]).toContain(
+      result.submission?.status
+    );
     expect(result.submission?.data).toMatchObject({ message: "hello" });
     expect(result.submission).not.toHaveProperty("item");
   });

--- a/packages/plugin-form-builder/src/document-shapes.ts
+++ b/packages/plugin-form-builder/src/document-shapes.ts
@@ -20,16 +20,7 @@
  *
  * The point of this module is therefore not safety it cannot provide. It is
  * that the unchecked step happens in ONE place a reviewer can find, rather than
- * at five call sites where it reads as ordinary code. It has already cost
- * something: a mutation envelope was once assigned straight into
- * `SubmissionDocument`, compiled, and handed every caller `undefined` for
- * `submission.id`.
- *
- * The real guarantee is meant to come from elsewhere. Nextly generates
- * per-collection types from the schema, and the Direct API is generic over the
- * collection slug, so `nextly.find({ collection: "posts" })` is typed. The
- * plugin-facing services are not generic yet; when they are, these functions
- * lose their reason to exist and the call sites can hold the row directly.
+ * at six call sites where it reads as ordinary code.
  *
  * @module document-shapes
  */

--- a/packages/plugin-form-builder/src/document-shapes.ts
+++ b/packages/plugin-form-builder/src/document-shapes.ts
@@ -1,0 +1,69 @@
+/**
+ * Reading a stored row as one of this plugin's documents.
+ *
+ * The services layer answers with a loose row -- `id`, `createdAt`, `updatedAt`
+ * and an `unknown` index signature -- while this plugin declares concrete
+ * documents. There is no overlap for TypeScript to check between the two, so
+ * the conversion goes through `unknown` and **nothing here is verified at
+ * compile time**. A single assertion does not compile:
+ *
+ * ```
+ * error TS2352: Conversion of type 'CollectionEntry' to type
+ * 'SubmissionDocument' may be a mistake because neither type sufficiently
+ * overlaps with the other.
+ * ```
+ *
+ * The parameters are therefore `unknown`, which is what the rows honestly are
+ * at this boundary. One assertion from `unknown` is legal where two from a
+ * partially-known shape were needed, so the widening removes a cast rather
+ * than adding one -- but it removes the notation, not the risk.
+ *
+ * The point of this module is therefore not safety it cannot provide. It is
+ * that the unchecked step happens in ONE place a reviewer can find, rather than
+ * at five call sites where it reads as ordinary code. It has already cost
+ * something: a mutation envelope was once assigned straight into
+ * `SubmissionDocument`, compiled, and handed every caller `undefined` for
+ * `submission.id`.
+ *
+ * The real guarantee is meant to come from elsewhere. Nextly generates
+ * per-collection types from the schema, and the Direct API is generic over the
+ * collection slug, so `nextly.find({ collection: "posts" })` is typed. The
+ * plugin-facing services are not generic yet; when they are, these functions
+ * lose their reason to exist and the call sites can hold the row directly.
+ *
+ * @module document-shapes
+ */
+
+import type { FormDocument, SubmissionDocument } from "./types";
+
+/**
+ * A row as the services layer hands it over.
+ *
+ * `unknown` rather than `Record<string, unknown>`: the read paths type their
+ * results loosely enough that a narrower parameter only moves the assertion to
+ * the call site, which is the thing this module exists to stop.
+ */
+type StoredRow = unknown;
+
+/**
+ * Read a stored row as a submission.
+ *
+ * Does not validate, and deliberately cannot throw: every caller is on a path
+ * where the row has already committed, so rejecting here would turn a saved
+ * submission into an error the visitor is invited to retry.
+ */
+export function asSubmissionDocument(row: StoredRow): SubmissionDocument {
+  return row as SubmissionDocument;
+}
+
+/** Read a list of stored rows as submissions. */
+export function asSubmissionDocuments(
+  rows: readonly StoredRow[]
+): SubmissionDocument[] {
+  return rows as SubmissionDocument[];
+}
+
+/** Read a stored row as a form. Same contract as {@link asSubmissionDocument}. */
+export function asFormDocument(row: StoredRow): FormDocument {
+  return row as FormDocument;
+}

--- a/packages/plugin-form-builder/src/handlers/submit-form.ts
+++ b/packages/plugin-form-builder/src/handlers/submit-form.ts
@@ -10,6 +10,7 @@
 
 import type { PluginContext } from "nextly";
 
+import { asFormDocument, asSubmissionDocument } from "../document-shapes";
 import type {
   FormDocument,
   SubmissionDocument,
@@ -336,12 +337,11 @@ export async function submitForm(
 
     return {
       success: true,
-      // The created ROW, not the envelope around it. The service's loose
-      // `CollectionEntry` and this declared document do not overlap enough for
-      // a checked assertion, so the conversion goes through `unknown` and
-      // TypeScript verifies nothing here — which is why the integration test
-      // reads `submission.id` off the result rather than only `success`.
-      submission: submission.item as unknown as SubmissionDocument,
+      // The created ROW, not the envelope around it. Through the shared
+      // conversion, which is where the unchecked step lives and says so; the
+      // integration test reads `submission.id` off the result because nothing
+      // at compile time will.
+      submission: asSubmissionDocument(submission.item),
       redirect,
     };
   } catch (error) {
@@ -387,7 +387,7 @@ export async function fetchFormBySlug(
     );
 
     const form = result.data?.[0];
-    return form ? (form as unknown as FormDocument) : null;
+    return form ? asFormDocument(form) : null;
   } catch {
     return null;
   }

--- a/packages/plugin-form-builder/src/plugin.ts
+++ b/packages/plugin-form-builder/src/plugin.ts
@@ -16,13 +16,16 @@ import type { CollectionConfig } from "nextly";
 
 import { formsCollection } from "./collections/forms";
 import { submissionsCollection } from "./collections/submissions";
+import {
+  asFormDocument,
+  asSubmissionDocument,
+  asSubmissionDocuments,
+} from "./document-shapes";
 import type {
   BeforeEmailFilterContext,
   FormNotification,
   FormBuilderPluginOptions,
   FormEmailNotification,
-  FormDocument,
-  SubmissionDocument,
   ResolvedFormBuilderConfig,
 } from "./types";
 import { evaluateSingleCondition } from "./utils/evaluate-conditions";
@@ -305,8 +308,8 @@ export function formBuilder(
             // The service returns parsed entries; the export helpers declare
             // the document shapes — the boundary cast is through unknown.
             const csv = exportToCSV(
-              items as unknown as SubmissionDocument[],
-              form as unknown as FormDocument
+              asSubmissionDocuments(items),
+              asFormDocument(form)
             );
             const filename = generateExportFilename(
               typeof form.slug === "string" ? form.slug : "form",
@@ -418,8 +421,8 @@ export function formBuilder(
             resolvedConfig.beforeEmail!({
               emails,
               // Boundary: loose runtime documents → the user's typed contract.
-              form: ctx.form as unknown as FormDocument,
-              submission: ctx.submission as unknown as SubmissionDocument,
+              form: asFormDocument(ctx.form),
+              submission: asSubmissionDocument(ctx.submission),
             })
         );
       }

--- a/packages/plugin-form-builder/src/types.ts
+++ b/packages/plugin-form-builder/src/types.ts
@@ -148,9 +148,19 @@ export interface SubmissionDocument {
   id: string;
   form: string | FormDocument;
   data: Record<string, unknown>;
-  status: "new" | "read" | "archived";
+  /**
+   * Where the submission sits in review.
+   *
+   * `spam` is one of them, not a separate flag: the stored field offers it, the
+   * admin has a Spam tab and filters the other views with `not_equals: "spam"`,
+   * the notification hook skips it, and marking something "Not spam" moves it
+   * back to `new`. `spamReason` records WHICH check flagged it.
+   */
+  status: "new" | "read" | "archived" | "spam";
   ipAddress?: string;
   userAgent?: string;
+  /** Which spam check flagged this, when one did. */
+  spamReason?: string | null;
   submittedAt: Date;
   createdAt: Date;
   updatedAt: Date;

--- a/packages/plugin-form-builder/src/types.ts
+++ b/packages/plugin-form-builder/src/types.ts
@@ -1125,8 +1125,17 @@ export interface FormSubmission {
   /** Submission data (JSON) */
   data: Record<string, unknown>;
 
-  /** Submission status */
-  status: "new" | "read" | "archived";
+  /**
+   * Submission status.
+   *
+   * `spam` is one of them, not a separate flag: the stored field offers it, the
+   * admin has a Spam tab and filters its other views with `not_equals: "spam"`,
+   * and marking something "Not spam" moves it back to `new`.
+   */
+  status: "new" | "read" | "archived" | "spam";
+
+  /** Which spam check flagged this, when one did. */
+  spamReason?: string | null;
 
   /** Internal notes (admin only) */
   notes?: string;


### PR DESCRIPTION
Task 120, first half. I filed this as needing a design decision about spam. **The audit says it does not** — the decision was made long ago and only one line of TypeScript missed it.

## `spam` is a status, and everything already agreed

- the stored field lists it: `{ label: "Spam", value: "spam" }`
- the admin has a **Spam tab**, and filters its other views with `not_equals: "spam"`
- the notification hook skips it: `if (submission.status === "spam") return;`
- the detail sheet moves a row **back to `new`** — that is the "Not spam" action
- `spamReason` records *which check* flagged it

`SubmissionDocument.status` said `"new" | "read" | "archived"`. So the type described a shape the database **cannot produce**, and narrowing on `status` could not reach the case the UI puts a whole tab in front of. `spamReason` was missing too.

## The conversions move into one module

Six places turned a stored row into one of this plugin's documents with `as unknown as`. They now go through `document-shapes.ts`.

**This does not make them safe, and the module says so.** The services layer answers with a loose row — `id`, `createdAt`, `updatedAt`, `unknown` index signature — and a concrete document has no overlap TypeScript can check, so a single assertion does not compile:

```
error TS2352: Conversion of type 'CollectionEntry' to type 'SubmissionDocument'
may be a mistake because neither type sufficiently overlaps with the other.
```

What changes is that the unchecked step happens **in one place a reviewer can find**, instead of at six call sites where it reads as ordinary code. That has already cost something: on #516 a mutation envelope was assigned straight into `SubmissionDocument`, compiled, and handed every caller `undefined` for `submission.id`.

Typing the parameters as `unknown` — which is what the rows honestly are — also means one assertion where two were needed. That removes the notation, not the risk.

## The real fix is the next step, and it already exists elsewhere

Nextly generates per-collection types, and the **Direct API is generic over the slug**, so `nextly.find({ collection: "posts" })` is typed. `ctx.services.collections` is not generic, which is why plugins cast at all.

Making the plugin facade generic the same way removes the reason these functions exist — for every plugin, not just this one. That is its own PR (agreed with the founder), falling back to a loose row when codegen has not run, exactly as the Direct API does today.

## Verification

`plugin-form-builder`: 89 passed. The integration test asserts the returned status against the four the schema stores, so a union that drifts from the field definition fails.

One process note: I said five call sites, from grepping the service call. There were **six** — `fetchFormBySlug` destructures differently — and `pnpm build` found it. Same miscount as #516, same cause: grepping for the call rather than the pattern.