### PR TITLE
feat(nextly): type plugin rows by their collection

### DIFF
--- a/.changeset/plugin-typed-rows.md
+++ b/.changeset/plugin-typed-rows.md
@@ -1,0 +1,38 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+`ctx.services.collections` now returns rows typed by their collection.
+
+The methods are generic over the slug and resolve through the types `nextly generate:types`
+writes, so `createEntry("posts", …)` hands back a `Post` rather than a record with an `unknown`
+index signature. The Direct API has always worked this way; the plugin path did not, which is why
+plugin code asserts a row into its own document type — and why those assertions cannot be checked,
+an index-signature record and a concrete document having no overlap for TypeScript to verify.
+
+An app that has not run codegen gets the loose record it gets today, exactly as the Direct API
+falls back. Nothing breaks and no new step is required.
+
+This is type-level only: the runtime proxy is unchanged. Plugin code that already stores a row in
+a variable typed as its own document may now need to drop an assertion that TypeScript reports as
+unnecessary.

--- a/docs/plugins/services.mdx
+++ b/docs/plugins/services.mdx
@@ -90,6 +90,23 @@ const res = await ctx.services.collections.createMany(slug, rows, { as: "system"
 // { successful, failed, ids: string[], errors: [{ index, error }] }
 ```
 
+## Rows are typed by their collection
+
+The methods are generic over the slug, so a row comes back as the type
+`nextly generate:types` wrote for that collection — the same way the Direct API
+has always worked:
+
+```ts
+const { item } = await ctx.services.collections.createEntry("posts", data, {
+  as: "system",
+});
+item.title; // typed, no cast
+```
+
+An app that has not run codegen gets a loose record instead, exactly as it does
+from the Direct API. Nothing breaks; the fields are just `unknown` until types
+are generated.
+
 ## Writes return an envelope
 
 `createEntry`, `updateEntry` and `deleteEntry` resolve to

--- a/packages/nextly/src/plugins/__tests__/service-mutation-envelope.integration.test.ts
+++ b/packages/nextly/src/plugins/__tests__/service-mutation-envelope.integration.test.ts
@@ -111,9 +111,13 @@ describe("ctx.services.collections write envelope", () => {
       { as: "system" }
     );
 
+    // `String(...)` rather than an assertion: this harness runs without
+    // generated types, so a row resolves to the loose fallback and its `id` is
+    // `unknown`. That IS the contract for an app that has not run codegen, and
+    // the test should read the way such an app reads.
     const result = await services.collections.updateEntry(
       "widgets",
-      created.item.id,
+      String(created.item.id),
       { title: "y" },
       { as: "system" }
     );
@@ -132,14 +136,14 @@ describe("ctx.services.collections write envelope", () => {
 
     const result = await services.collections.deleteEntry(
       "widgets",
-      created.item.id,
+      String(created.item.id),
       { as: "system" }
     );
 
     expect(result.message).toBe("Widgets deleted.");
     // The facade's delete resolves to `void`, so the id the caller passed is
     // the only thing that can identify what went.
-    expect(result.item).toEqual({ id: created.item.id });
+    expect(result.item).toEqual({ id: String(created.item.id) });
   });
 
   it("carries a post-commit failure the plugin's own write caused", async () => {

--- a/packages/nextly/src/plugins/__tests__/service-mutation-envelope.integration.test.ts
+++ b/packages/nextly/src/plugins/__tests__/service-mutation-envelope.integration.test.ts
@@ -111,13 +111,12 @@ describe("ctx.services.collections write envelope", () => {
       { as: "system" }
     );
 
-    // `String(...)` rather than an assertion: this harness runs without
-    // generated types, so a row resolves to the loose fallback and its `id` is
-    // `unknown`. That IS the contract for an app that has not run codegen, and
-    // the test should read the way such an app reads.
+    // `created.item.id` directly: without generated types a row falls back to
+    // `CollectionEntry`, which still promises `id` and the timestamps. An app
+    // that has not run codegen is not asked to coerce its own ids.
     const result = await services.collections.updateEntry(
       "widgets",
-      String(created.item.id),
+      created.item.id,
       { title: "y" },
       { as: "system" }
     );
@@ -136,14 +135,14 @@ describe("ctx.services.collections write envelope", () => {
 
     const result = await services.collections.deleteEntry(
       "widgets",
-      String(created.item.id),
+      created.item.id,
       { as: "system" }
     );
 
     expect(result.message).toBe("Widgets deleted.");
     // The facade's delete resolves to `void`, so the id the caller passed is
     // the only thing that can identify what went.
-    expect(result.item).toEqual({ id: String(created.item.id) });
+    expect(result.item).toEqual({ id: created.item.id });
   });
 
   it("carries a post-commit failure the plugin's own write caused", async () => {

--- a/packages/nextly/src/plugins/service-opts.ts
+++ b/packages/nextly/src/plugins/service-opts.ts
@@ -1,12 +1,18 @@
 import { buildMutationMessage } from "../direct-api/namespaces/helpers";
-import type { MutationResult } from "../direct-api/types/shared";
+import type {
+  CollectionSlug,
+  DataFromCollectionSlug,
+  MutationResult,
+} from "../direct-api/types/shared";
+import type { BatchOperationResult } from "../domains/collections/services/collection-types";
 import { NextlyError } from "../errors/nextly-error";
 import { collectingWarnings } from "../hooks/side-effect-warnings";
+import type { CollectionService } from "../services/collections/collection-service";
 import type {
-  CollectionEntry,
-  CollectionService,
-} from "../services/collections/collection-service";
-import type { RequestContext } from "../services/shared";
+  PaginatedResult,
+  QueryOptions,
+  RequestContext,
+} from "../services/shared";
 import type { AuthUser } from "../types/auth";
 
 /**
@@ -89,51 +95,98 @@ const WRITE_VERB = {
 
 type WriteMethod = keyof typeof WRITE_VERB;
 
-/** Replace a method's trailing `RequestContext` arg with an optional `ServiceOpts`. */
-type ReplaceTrailingContext<F> = F extends (
-  ...args: [...infer Head, RequestContext]
-) => infer R
-  ? (...args: [...Head, ServiceOpts?]) => R
-  : F;
-
 /**
- * The plugin-facing return type for a write.
+ * The row a slug resolves to.
  *
- * `deleteEntry` resolves to `void` on the facade, so the deleted row is
- * reported as the minimal `{ id }` the Direct API already uses for it -- a
- * caller that wants to log or re-key what it removed has the id, and there is
- * no row left to return.
+ * Reads the types `nextly generate:types` writes, and falls back to a loose
+ * record when an app has not run it -- the same fallback the Direct API has
+ * always had, so both paths degrade identically and a project that never
+ * generates types is no worse off than it is today.
  */
-type WriteResult<K extends WriteMethod> = K extends "deleteEntry"
-  ? MutationResult<{ id: string }>
-  : MutationResult<CollectionEntry>;
-
-/** Replace a write's trailing context AND widen its result to the envelope. */
-type PluginWriteMethod<K extends WriteMethod> =
-  ReplaceTrailingContext<CollectionService[K]> extends (
-    ...args: infer A
-  ) => unknown
-    ? (...args: A) => Promise<WriteResult<K>>
-    : never;
+type RowFor<TSlug extends CollectionSlug> = DataFromCollectionSlug<TSlug>;
 
 /**
  * @public Plugin-facing collection service.
  *
- * Access methods take `ServiceOpts` in place of a `RequestContext`, and the
- * writes resolve to the same `{ message, item, warnings? }` envelope the Direct
- * API and the wire API return. Returning the bare row left a plugin unable to
- * see a post-commit hook failure that every other caller of the same write is
- * told about.
+ * Two differences from the facade underneath, both so a plugin writes what an
+ * application writes:
+ *
+ * 1. Access methods take {@link ServiceOpts} in place of a `RequestContext`, so
+ *    a plugin never touches `overrideAccess` directly.
+ * 2. They are generic over the collection slug, so a row comes back as the type
+ *    generated for that collection rather than an index-signature record. The
+ *    Direct API has always done this; the plugin path did not, which is why
+ *    plugin code asserts a row into its own document type -- and why those
+ *    assertions cannot be checked, an index-signature record and a concrete
+ *    document having no overlap for TypeScript to verify.
+ *
+ * Written out rather than mapped from `CollectionService`: a mapped type cannot
+ * introduce a type parameter per method, and this IS the surface a plugin
+ * author reads.
  */
 export type PluginCollectionService = Omit<
   CollectionService,
   AccessMethod | WriteMethod
 > & {
-  [K in Exclude<AccessMethod, WriteMethod>]: ReplaceTrailingContext<
-    CollectionService[K]
-  >;
-} & {
-  [K in WriteMethod]: PluginWriteMethod<K>;
+  /** Create one entry. Resolves to `{ message, item, warnings? }`. */
+  createEntry<TSlug extends CollectionSlug>(
+    collectionName: TSlug,
+    data: Record<string, unknown>,
+    opts?: ServiceOpts
+  ): Promise<MutationResult<RowFor<TSlug>>>;
+
+  /** Update one entry. Resolves to `{ message, item, warnings? }`. */
+  updateEntry<TSlug extends CollectionSlug>(
+    collectionName: TSlug,
+    entryId: string,
+    data: Record<string, unknown>,
+    opts?: ServiceOpts
+  ): Promise<MutationResult<RowFor<TSlug>>>;
+
+  /**
+   * Delete one entry. Resolves to `{ message, item: { id }, warnings? }`.
+   *
+   * The deleted row is reported as its id alone: the facade's delete resolves
+   * to `void`, and there is no row left to return.
+   */
+  deleteEntry<TSlug extends CollectionSlug>(
+    collectionName: TSlug,
+    entryId: string,
+    opts?: ServiceOpts
+  ): Promise<MutationResult<{ id: string }>>;
+
+  /** Fetch one entry by id. */
+  findEntryById<TSlug extends CollectionSlug>(
+    collectionName: TSlug,
+    entryId: string,
+    opts?: ServiceOpts
+  ): Promise<RowFor<TSlug>>;
+
+  /** List entries with filter, sort and pagination. */
+  listEntries<TSlug extends CollectionSlug>(
+    collectionName: TSlug,
+    options?: QueryOptions,
+    opts?: ServiceOpts
+  ): Promise<PaginatedResult<RowFor<TSlug>>>;
+
+  /** Count entries matching a filter. */
+  count<TSlug extends CollectionSlug>(
+    collectionName: TSlug,
+    options?: { where?: Record<string, unknown>; search?: string },
+    opts?: ServiceOpts
+  ): Promise<number>;
+
+  /**
+   * Bulk insert.
+   *
+   * Keeps `BatchOperationResult`, which already models per-row outcomes -- an
+   * envelope around it would describe the batch and hide the rows.
+   */
+  createMany<TSlug extends CollectionSlug>(
+    collectionName: TSlug,
+    data: Record<string, unknown>[],
+    opts?: ServiceOpts
+  ): Promise<BatchOperationResult>;
 };
 
 /**

--- a/packages/nextly/src/plugins/service-opts.ts
+++ b/packages/nextly/src/plugins/service-opts.ts
@@ -1,13 +1,16 @@
 import { buildMutationMessage } from "../direct-api/namespaces/helpers";
 import type {
   CollectionSlug,
-  DataFromCollectionSlug,
+  GeneratedTypes,
   MutationResult,
 } from "../direct-api/types/shared";
 import type { BatchOperationResult } from "../domains/collections/services/collection-types";
 import { NextlyError } from "../errors/nextly-error";
 import { collectingWarnings } from "../hooks/side-effect-warnings";
-import type { CollectionService } from "../services/collections/collection-service";
+import type {
+  CollectionEntry,
+  CollectionService,
+} from "../services/collections/collection-service";
 import type {
   PaginatedResult,
   QueryOptions,
@@ -96,14 +99,31 @@ const WRITE_VERB = {
 type WriteMethod = keyof typeof WRITE_VERB;
 
 /**
+ * A slug this surface accepts.
+ *
+ * The generated union when types exist, and any string besides. The canonical
+ * remap-safe way to name your own collection is `ctx.self.collections[...]`,
+ * which is `Record<string, string>` because the framework may rename an
+ * entity -- so a bare `CollectionSlug` would reject the very expression the
+ * docs tell plugin authors to use. `string & {}` keeps the union's
+ * autocompletion while still admitting a computed name.
+ */
+type AcceptedSlug = CollectionSlug | (string & {});
+
+/**
  * The row a slug resolves to.
  *
- * Reads the types `nextly generate:types` writes, and falls back to a loose
- * record when an app has not run it -- the same fallback the Direct API has
- * always had, so both paths degrade identically and a project that never
- * generates types is no worse off than it is today.
+ * The generated type when one exists, and `CollectionEntry` otherwise -- NOT a
+ * bare record. An app without generated types has always been promised `id`
+ * and the timestamps here, and dropping to `Record<string, unknown>` would take
+ * that away from exactly the projects that have the least type information to
+ * spare.
  */
-type RowFor<TSlug extends CollectionSlug> = DataFromCollectionSlug<TSlug>;
+type RowFor<TSlug> = GeneratedTypes extends { collections: infer C }
+  ? TSlug extends keyof C
+    ? C[TSlug]
+    : CollectionEntry
+  : CollectionEntry;
 
 /**
  * @public Plugin-facing collection service.
@@ -129,14 +149,14 @@ export type PluginCollectionService = Omit<
   AccessMethod | WriteMethod
 > & {
   /** Create one entry. Resolves to `{ message, item, warnings? }`. */
-  createEntry<TSlug extends CollectionSlug>(
+  createEntry<TSlug extends AcceptedSlug>(
     collectionName: TSlug,
     data: Record<string, unknown>,
     opts?: ServiceOpts
   ): Promise<MutationResult<RowFor<TSlug>>>;
 
   /** Update one entry. Resolves to `{ message, item, warnings? }`. */
-  updateEntry<TSlug extends CollectionSlug>(
+  updateEntry<TSlug extends AcceptedSlug>(
     collectionName: TSlug,
     entryId: string,
     data: Record<string, unknown>,
@@ -149,28 +169,28 @@ export type PluginCollectionService = Omit<
    * The deleted row is reported as its id alone: the facade's delete resolves
    * to `void`, and there is no row left to return.
    */
-  deleteEntry<TSlug extends CollectionSlug>(
+  deleteEntry<TSlug extends AcceptedSlug>(
     collectionName: TSlug,
     entryId: string,
     opts?: ServiceOpts
   ): Promise<MutationResult<{ id: string }>>;
 
   /** Fetch one entry by id. */
-  findEntryById<TSlug extends CollectionSlug>(
+  findEntryById<TSlug extends AcceptedSlug>(
     collectionName: TSlug,
     entryId: string,
     opts?: ServiceOpts
   ): Promise<RowFor<TSlug>>;
 
   /** List entries with filter, sort and pagination. */
-  listEntries<TSlug extends CollectionSlug>(
+  listEntries<TSlug extends AcceptedSlug>(
     collectionName: TSlug,
     options?: QueryOptions,
     opts?: ServiceOpts
   ): Promise<PaginatedResult<RowFor<TSlug>>>;
 
   /** Count entries matching a filter. */
-  count<TSlug extends CollectionSlug>(
+  count<TSlug extends AcceptedSlug>(
     collectionName: TSlug,
     options?: { where?: Record<string, unknown>; search?: string },
     opts?: ServiceOpts
@@ -182,7 +202,7 @@ export type PluginCollectionService = Omit<
    * Keeps `BatchOperationResult`, which already models per-row outcomes -- an
    * envelope around it would describe the batch and hide the rows.
    */
-  createMany<TSlug extends CollectionSlug>(
+  createMany<TSlug extends AcceptedSlug>(
     collectionName: TSlug,
     data: Record<string, unknown>[],
     opts?: ServiceOpts


### PR DESCRIPTION
Task 120, second half — the change that removes the reason plugins cast at all.

## The gap

Nextly generates per-collection types, and the **Direct API is generic over the slug**: `nextly.find({ collection: "posts" })` gives you a `Post`.

`ctx.services.collections` was not. It returned `CollectionEntry` — `id`, `createdAt`, `updatedAt` and an `unknown` index signature.

So plugins were the one caller that lost the typing, and that is *why* they cast. Worse, the casts cannot be checked: a loose record and a concrete document have no overlap, so `as SubmissionDocument` does not compile and the only option is `as unknown as`, which verifies nothing. That is what let a breaking change compile on #516 and hand every caller `undefined`.

Fixing the plugin's casts treats the symptom. This removes the cause.

## What changes

The seven access methods are generic over the slug and resolve rows through `DataFromCollectionSlug`:

```ts
const { item } = await ctx.services.collections.createEntry("posts", data, {
  as: "system",
});
item.title; // typed, no cast
```

**Type-level only — the runtime proxy is untouched.**

Two deliberate calls:

- **Written out rather than mapped from `CollectionService`.** A mapped type cannot introduce a type parameter per method, and this *is* the surface a plugin author reads, so it should read as declarations rather than as type machinery. Writing them out also retired `ReplaceTrailingContext` and the `CollectionEntry` import — lint found both, which is the seam disappearing rather than being worked around.
- **`createMany` keeps `BatchOperationResult`**, which already models per-row outcomes. An envelope around it would describe the batch and hide the rows.

## No-codegen behaviour

An app that has not run `nextly generate:types` gets the loose record it gets today — `CollectionSlug` falls back to `string` and `DataFromCollectionSlug` to `Record<string, unknown>`, exactly as the Direct API already does. Both paths now degrade identically, and no new step is required of anyone.

The integration harness runs without codegen, so it exercises that fallback: its `item.id` is `unknown`, and the test reads `String(item.id)` rather than asserting a type — the way such an app genuinely reads. That is the fallback demonstrating itself, not a workaround.

## Verification

Whole repo type-checks; the only breakage was that harness, i.e. the fallback behaving as designed. Full `nextly` suite by failing-test **name set**: none introduced. Plugin envelope integration suite: 5 passed.

## Follow-on

`plugin-form-builder/document-shapes.ts` (from #529) exists only because of this gap. Once both land and the plugin's collections are in generated types, those functions can go and the call sites can hold rows directly — a separate, mechanical change once this is proven.