### PR TITLE
test(plugin-seo): assert the withheld cause, not a leaked driver message

### DIFF
--- a/packages/plugin-seo/src/__tests__/extend.integration.test.ts
+++ b/packages/plugin-seo/src/__tests__/extend.integration.test.ts
@@ -70,11 +70,20 @@ describe("seoPlugin extend (integration)", () => {
 
     // Without the plugin the collection has no `seo` column, so the same write
     // that succeeds above is rejected here — proof the plugin is what adds it.
+    //
+    // What rejects it is the database refusing an unknown column, so the text
+    // naming `seo` is the driver's own. That text is withheld from the caller
+    // and reported to the operator instead, which is where this reads it from:
+    // asserting it on the public message would be asserting that raw driver
+    // output reaches a caller.
     await expect(
       current.nextly.create({
         collection: "pages",
         data: { slug: "home", title: "Home", seo: { metaTitle: "ignored" } },
       })
-    ).rejects.toThrow(/seo/i);
+    ).rejects.toMatchObject({
+      code: "INTERNAL_ERROR",
+      logContext: { legacyMessage: expect.stringMatching(/seo/i) },
+    });
   });
 });


### PR DESCRIPTION
Main is red. This is the only failing test, and it has been failing on every `main` run since #519 merged.

## What is actually broken

Nothing in the product. The test was asserting on a leak, and #519 closed it.

The write under test is rejected by the database, so the text naming the missing column is the driver's own. Probing the real error:

```
code:          INTERNAL_ERROR
status:        500
publicMessage: "An unexpected error occurred."
logContext:    { legacyMessage: "table dc_pages has no column named seo" }
```

#519 made a code-less failure answer with the generic sentence for its derived code, keeping the original text in `logContext` for the operator, precisely so driver output and internal paths do not reach the wire (spec 13.8). That is the contract working as intended. `rejects.toThrow(/seo/i)` was asserting the opposite.

## The change

The assertion now reads the driver text from the operator log, where it is deliberately kept, and still keys on the column name so the test proves what its name claims.

Verified by booting the same collection **with** the plugin and watching it fail — it is the absence of the column this detects, not merely that something threw.

Test-only, so no changeset.

## Worth a separate look

Writing an unknown field reaches the database and comes back as `INTERNAL_ERROR` / "An unexpected error occurred." A typo in a field name giving a developer no indication of which field is poor DX, and it is why this test had leaked driver text to assert on in the first place. Rejecting an unknown field during validation, with the field named, would be the real fix. Out of scope here — this PR only gets `main` green.
