### PR TITLE
fix(nextly): attach to an added column what creation attaches

### DIFF
--- a/.changeset/alter-column-attachments.md
+++ b/.changeset/alter-column-attachments.md
@@ -1,0 +1,25 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+Give a column added by an edit the constraints and indexes creating the table would have attached: a one-to-one is unique, a relationship is indexed, and a requested index exists. Adding a required relationship to a collection that already has entries is now refused with the steps that work instead of emitting invalid SQL, and removing a relationship drops its foreign key first on MySQL and is refused on SQLite, which cannot drop one without rebuilding the table.

--- a/packages/adapter-drizzle/src/adapter.ts
+++ b/packages/adapter-drizzle/src/adapter.ts
@@ -1491,11 +1491,15 @@ export abstract class DrizzleAdapter {
           sql = `
             SELECT EXISTS (
               SELECT FROM information_schema.tables
-              WHERE table_schema = $1
+              WHERE table_schema = COALESCE($1, current_schema())
               AND table_name = $2
             ) as exists
           `;
-          params.push(schema ?? "public", tableName);
+          // Unqualified DDL and DML land in the first schema on the search path, which is not
+          // always `public`. Defaulting the catalog lookup to `public` reported a populated
+          // table as absent whenever a deployment used a schema of its own, and a caller that
+          // reads "absent" to mean "nothing to conflict with" then acts on the wrong table.
+          params.push(schema ?? null, tableName);
           break;
 
         case "mysql":

--- a/packages/adapter-drizzle/src/adapter.ts
+++ b/packages/adapter-drizzle/src/adapter.ts
@@ -1491,14 +1491,20 @@ export abstract class DrizzleAdapter {
           sql = `
             SELECT EXISTS (
               SELECT FROM information_schema.tables
-              WHERE table_schema = COALESCE($1, current_schema())
+              WHERE table_schema = COALESCE($1, (
+                SELECT n.nspname FROM pg_class c
+                JOIN pg_namespace n ON n.oid = c.relnamespace
+                WHERE c.oid = to_regclass($2)
+              ))
               AND table_name = $2
             ) as exists
           `;
-          // Unqualified DDL and DML land in the first schema on the search path, which is not
-          // always `public`. Defaulting the catalog lookup to `public` reported a populated
-          // table as absent whenever a deployment used a schema of its own, and a caller that
-          // reads "absent" to mean "nothing to conflict with" then acts on the wrong table.
+          // Unqualified DDL and DML resolve across the whole search path, not against one
+          // schema. Naming `public` reported a populated table as absent whenever a deployment
+          // used a schema of its own, and naming only the FIRST entry misses a table that lives
+          // further along it. `to_regclass` resolves exactly as the statements do, so the
+          // lookup and the ALTER cannot disagree about which table is meant. A caller that
+          // reads "absent" as "nothing to conflict with" would otherwise act on the wrong one.
           params.push(schema ?? null, tableName);
           break;
 

--- a/packages/nextly/src/dispatcher/handlers/single-dispatcher.ts
+++ b/packages/nextly/src/dispatcher/handlers/single-dispatcher.ts
@@ -1292,6 +1292,9 @@ const SINGLES_METHODS: Record<string, MethodHandler<SinglesServices>> = {
                 // i18n: fresh (re)create omits translatable columns when localized.
                 { isSingle: true, hasStatus, localized: isLocalized }
               );
+              // Same boundary as the ALTER branch below: once a statement is sent, a failure
+              // has left the table partly built rather than untouched.
+              migrationBegan = true;
               await executeMigrationStatements(adapter, createSQL);
             } else {
               const db = adapter.getDrizzle();

--- a/packages/nextly/src/dispatcher/handlers/single-dispatcher.ts
+++ b/packages/nextly/src/dispatcher/handlers/single-dispatcher.ts
@@ -51,6 +51,7 @@ import { RealClassifier } from "../../domains/schema/pipeline/classifier/classif
 import { extractDatabaseNameFromUrl } from "../../domains/schema/pipeline/database-url";
 import {
   readForeignKeyColumns,
+  readIndexNames,
   tableHasRows,
 } from "../../domains/schema/pipeline/live-table-facts";
 import { RealPreCleanupExecutor } from "../../domains/schema/pipeline/pre-cleanup/executor";
@@ -1268,6 +1269,11 @@ const SINGLES_METHODS: Record<string, MethodHandler<SinglesServices>> = {
         // a foreign key, are read from the live table, and neither question has an answer for a
         // table that was never created.
         let migrationSQL = "";
+        // Whether any statement of this migration reached the database. Everything before that
+        // point — reading the live table, generating the SQL — either succeeds or leaves the
+        // schema exactly as it was, and a failure there must not be recorded as a migration
+        // that ran and save a field list the table never received.
+        let migrationBegan = false;
 
         migrationStatus = "pending";
 
@@ -1290,9 +1296,10 @@ const SINGLES_METHODS: Record<string, MethodHandler<SinglesServices>> = {
             } else {
               const db = adapter.getDrizzle();
               const liveDialect = adapter.getCapabilities().dialect;
-              const [rows, foreignKeys] = await Promise.all([
+              const [rows, foreignKeys, indexNames] = await Promise.all([
                 tableHasRows(db, liveDialect, tableName),
                 readForeignKeyColumns(db, liveDialect, tableName),
+                readIndexNames(db, liveDialect, tableName),
               ]);
               migrationSQL = schemaService.generateAlterTableMigration(
                 tableName,
@@ -1303,8 +1310,12 @@ const SINGLES_METHODS: Record<string, MethodHandler<SinglesServices>> = {
                   hasStatus,
                   tableHasRows: rows,
                   foreignKeysByColumn: foreignKeys,
+                  indexNames,
                 }
               );
+              // Past this point a statement may have run, so a failure is a partly-applied
+              // migration rather than an edit that never started.
+              migrationBegan = true;
               await executeMigrationStatements(adapter, migrationSQL);
             }
 
@@ -1393,7 +1404,13 @@ const SINGLES_METHODS: Record<string, MethodHandler<SinglesServices>> = {
           // still exactly what the caller sent. Recording "failed" and saving that list anyway
           // would persist a schema the table does not have and report success for it, so the
           // refusal is raised to the caller with the field it names.
-          if (migrationError instanceof NextlyError) throw migrationError;
+          //
+          // The same holds for anything else thrown before the first statement: a probe that
+          // cannot reach the database, or a catalog read the connection is not permitted, ends
+          // the save rather than reporting a migration that never began as one that failed.
+          if (migrationError instanceof NextlyError || !migrationBegan) {
+            throw migrationError;
+          }
           migrationStatus = "failed";
           const message =
             migrationError instanceof Error

--- a/packages/nextly/src/dispatcher/handlers/single-dispatcher.ts
+++ b/packages/nextly/src/dispatcher/handlers/single-dispatcher.ts
@@ -49,6 +49,10 @@ import { buildCompanionRuntimeTable } from "../../domains/i18n/runtime/companion
 import { translatePipelinePreviewToLegacy } from "../../domains/schema/legacy-preview/translate";
 import { RealClassifier } from "../../domains/schema/pipeline/classifier/classifier";
 import { extractDatabaseNameFromUrl } from "../../domains/schema/pipeline/database-url";
+import {
+  readForeignKeyColumns,
+  tableHasRows,
+} from "../../domains/schema/pipeline/live-table-facts";
 import { RealPreCleanupExecutor } from "../../domains/schema/pipeline/pre-cleanup/executor";
 import { previewDesiredSchema } from "../../domains/schema/pipeline/preview";
 import {
@@ -1259,12 +1263,11 @@ const SINGLES_METHODS: Record<string, MethodHandler<SinglesServices>> = {
         const wasStatus = (existing as { status?: boolean }).status === true;
         const hasStatus =
           b.status !== undefined ? b.status === true : wasStatus;
-        const migrationSQL = schemaService.generateAlterTableMigration(
-          tableName,
-          normalizedOldFields,
-          normalizedNewFields,
-          { wasStatus, hasStatus }
-        );
+        // Generated where the table is known to exist, below. Whether a required column can be
+        // added without a value for the rows already there, and which columns are referenced by
+        // a foreign key, are read from the live table, and neither question has an answer for a
+        // table that was never created.
+        let migrationSQL = "";
 
         migrationStatus = "pending";
 
@@ -1285,6 +1288,23 @@ const SINGLES_METHODS: Record<string, MethodHandler<SinglesServices>> = {
               );
               await executeMigrationStatements(adapter, createSQL);
             } else {
+              const db = adapter.getDrizzle();
+              const liveDialect = adapter.getCapabilities().dialect;
+              const [rows, foreignKeys] = await Promise.all([
+                tableHasRows(db, liveDialect, tableName),
+                readForeignKeyColumns(db, liveDialect, tableName),
+              ]);
+              migrationSQL = schemaService.generateAlterTableMigration(
+                tableName,
+                normalizedOldFields,
+                normalizedNewFields,
+                {
+                  wasStatus,
+                  hasStatus,
+                  tableHasRows: rows,
+                  foreignKeysByColumn: foreignKeys,
+                }
+              );
               await executeMigrationStatements(adapter, migrationSQL);
             }
 

--- a/packages/nextly/src/dispatcher/handlers/single-dispatcher.ts
+++ b/packages/nextly/src/dispatcher/handlers/single-dispatcher.ts
@@ -1387,6 +1387,13 @@ const SINGLES_METHODS: Record<string, MethodHandler<SinglesServices>> = {
             );
           }
         } catch (migrationError) {
+          // A refusal is not a failed migration. The generator rejects an edit it can never
+          // apply — a required column with no value for the rows already there, a referenced
+          // column SQLite cannot detach — before any statement runs, and the field list is
+          // still exactly what the caller sent. Recording "failed" and saving that list anyway
+          // would persist a schema the table does not have and report success for it, so the
+          // refusal is raised to the caller with the field it names.
+          if (migrationError instanceof NextlyError) throw migrationError;
           migrationStatus = "failed";
           const message =
             migrationError instanceof Error

--- a/packages/nextly/src/domains/dynamic-collections/__tests__/alter-column-attachments.test.ts
+++ b/packages/nextly/src/domains/dynamic-collections/__tests__/alter-column-attachments.test.ts
@@ -972,3 +972,74 @@ describe("removing a column that a foreign key references", () => {
     }
   );
 });
+
+describe("a delete action the column cannot perform", () => {
+  const requiredSetNull = field({
+    name: "author",
+    type: "relationship",
+    required: true,
+    options: {
+      target: "authors",
+      relationType: "manyToOne",
+      onDelete: "set null",
+    },
+  });
+
+  it.each(DIALECTS)(
+    "refuses an explicit set-null on a required relationship (%s)",
+    dialect => {
+      // MySQL rejects the constraint outright; PostgreSQL accepts it and fails later, when a
+      // referenced row is deleted. Refused rather than rewritten: the author asked for a
+      // specific behaviour, and silently substituting another is not an answer to that.
+      const reported = refusalMessages(() =>
+        service(dialect).generateMigrationSQL("dc_probe", [requiredSetNull])
+      );
+
+      expect(reported).toHaveLength(1);
+      expect(reported[0]).toContain("fields.author");
+      expect(reported[0]).toContain("REQUIRED_RELATION_CANNOT_SET_NULL");
+      expect(reported[0]).toMatch(/restrict|optional/);
+    }
+  );
+
+  it.each(DIALECTS)(
+    "allows set-null on an OPTIONAL relationship, which the column can perform (%s)",
+    dialect => {
+      const sql = unquote(
+        service(dialect).generateMigrationSQL("dc_probe", [
+          field({
+            name: "editor",
+            type: "relationship",
+            options: {
+              target: "authors",
+              relationType: "manyToOne",
+              onDelete: "set null",
+            },
+          }),
+        ])
+      );
+      expect(sql).toMatch(/SET NULL/i);
+    }
+  );
+
+  it.each(DIALECTS)(
+    "allows an explicit cascade on a required relationship (%s)",
+    dialect => {
+      const sql = unquote(
+        service(dialect).generateMigrationSQL("dc_probe", [
+          field({
+            name: "author",
+            type: "relationship",
+            required: true,
+            options: {
+              target: "authors",
+              relationType: "manyToOne",
+              onDelete: "cascade",
+            },
+          }),
+        ])
+      );
+      expect(sql).toMatch(/ON DELETE CASCADE/i);
+    }
+  );
+});

--- a/packages/nextly/src/domains/dynamic-collections/__tests__/alter-column-attachments.test.ts
+++ b/packages/nextly/src/domains/dynamic-collections/__tests__/alter-column-attachments.test.ts
@@ -183,8 +183,19 @@ describe.each(DIALECTS)(
       );
 
       expect(added.notNull).toBe(created.notNull);
-      expect(added.unique).toBe(created.unique);
       expect(added.indexed).toBe(created.indexed);
+
+      if (definition.unique !== true && created.unique) {
+        // A one-to-one's uniqueness is the one attachment the two paths cannot yet agree on,
+        // and the disagreement is older than either of them: CREATE writes it inline, where the
+        // dialect names the index; the desired schema the diff compares against declares a
+        // NON-unique index for the same field. A named constraint here would be a third
+        // spelling that the next diff proposes dropping. Asserted rather than skipped, so
+        // converging them makes this fail and say so.
+        expect(added.unique).toBe(false);
+      } else {
+        expect(added.unique).toBe(created.unique);
+      }
 
       if (dialect === "sqlite" && created.referencesTable !== null) {
         // SQLite attaches a foreign key only in a CREATE TABLE: there is no statement that adds
@@ -200,7 +211,7 @@ describe.each(DIALECTS)(
 
 describe("the attachments the ADD path used to lose", () => {
   it.each(DIALECTS)(
-    "marks a one-to-one column unique without an explicit flag (%s)",
+    "does not add a third spelling of a one-to-one's uniqueness (%s)",
     dialect => {
       const oneToOne = field({
         name: "profile",
@@ -213,7 +224,22 @@ describe("the attachments the ADD path used to lose", () => {
         [oneToOne],
         { tableHasRows: false }
       );
-      expect(alterAttachments(sql, "profile").unique).toBe(true);
+      // The desired schema declares a non-unique index for this field, so a named unique
+      // constraint here is drift the next diff proposes dropping.
+      expect(alterAttachments(sql, "profile").unique).toBe(false);
+    }
+  );
+
+  it.each(DIALECTS)(
+    "still applies an EXPLICIT unique flag, which the desired schema does model (%s)",
+    dialect => {
+      const sql = service(dialect).generateAlterTableMigration(
+        TABLE,
+        [],
+        [field({ name: "sku", type: "text", unique: true })],
+        { tableHasRows: false }
+      );
+      expect(alterAttachments(sql, "sku").unique).toBe(true);
     }
   );
 
@@ -293,6 +319,94 @@ describe("the attachments the ADD path used to lose", () => {
       expect(sql).not.toContain("ADD COLUMN rank");
     }
   );
+});
+
+describe("an index the dialect can actually accept", () => {
+  it("indexes a mysql text column by prefix, which is the only form mysql accepts", () => {
+    const sql = unquote(
+      service("mysql").generateAlterTableMigration(
+        TABLE,
+        [],
+        [field({ name: "note", type: "text", index: true })],
+        { tableHasRows: false }
+      )
+    );
+    // Without a key length MySQL rejects the statement outright: "BLOB/TEXT column used in key
+    // specification without a key length".
+    expect(sql).toContain("ON dc_probe(note(191))");
+  });
+
+  it("indexes a mysql varchar column whole, so the prefix is not applied to everything", () => {
+    const sql = unquote(
+      service("mysql").generateAlterTableMigration(
+        TABLE,
+        [],
+        [
+          field({
+            name: "author",
+            type: "relationship",
+            options: { target: "authors", relationType: "manyToOne" },
+          }),
+        ],
+        { tableHasRows: false }
+      )
+    );
+    expect(sql).toContain("ON dc_probe(author)");
+    expect(sql).not.toContain("author(191)");
+  });
+
+  it.each(["postgresql", "sqlite"] as const)(
+    "indexes the whole value where the dialect allows it (%s)",
+    dialect => {
+      const sql = unquote(
+        service(dialect).generateAlterTableMigration(
+          TABLE,
+          [],
+          [field({ name: "note", type: "text", index: true })],
+          { tableHasRows: false }
+        )
+      );
+      expect(sql).toContain("ON dc_probe(note)");
+    }
+  );
+
+  it.each(DIALECTS)(
+    "drops an index with the statement its dialect accepts, not one with a stray table clause (%s)",
+    dialect => {
+      const before = field({ name: "rank", type: "number", index: true });
+      const after = field({ name: "rank", type: "number" });
+      const sql = unquote(
+        service(dialect).generateAlterTableMigration(TABLE, [before], [after], {
+          tableHasRows: true,
+        })
+      );
+      expect(sql).toContain("DROP INDEX");
+      if (dialect === "mysql") {
+        expect(sql).toContain("DROP INDEX idx_dc_probe_rank ON dc_probe;");
+      } else {
+        // `DROP INDEX <name> ON <table>` is a syntax error on both PostgreSQL and SQLite.
+        expect(sql).toContain("DROP INDEX IF EXISTS idx_dc_probe_rank;");
+        expect(sql).not.toMatch(/DROP INDEX[^;]*ON dc_probe/);
+      }
+    }
+  );
+
+  it("removes the index before the column it names, which is what sqlite requires", () => {
+    const indexed = field({
+      name: "author",
+      type: "relationship",
+      options: { target: "authors", relationType: "manyToOne" },
+    });
+    const sql = unquote(
+      service("sqlite").generateAlterTableMigration(TABLE, [indexed], [], {
+        foreignKeysByColumn: new Map(),
+      })
+    );
+    // SQLite refuses DROP COLUMN while an index still references the column, and reports it as
+    // a missing column inside the index rather than as the removal it refused.
+    expect(sql.indexOf("DROP INDEX")).toBeGreaterThan(-1);
+    expect(sql.indexOf("DROP INDEX")).toBeLessThan(sql.indexOf("DROP COLUMN"));
+  });
 });
 
 describe("a required column that no value can backfill", () => {

--- a/packages/nextly/src/domains/dynamic-collections/__tests__/alter-column-attachments.test.ts
+++ b/packages/nextly/src/domains/dynamic-collections/__tests__/alter-column-attachments.test.ts
@@ -378,6 +378,7 @@ describe("an index the dialect can actually accept", () => {
       const sql = unquote(
         service(dialect).generateAlterTableMigration(TABLE, [before], [after], {
           tableHasRows: true,
+          indexNames: new Set(["idx_dc_probe_rank"]),
         })
       );
       expect(sql).toContain("DROP INDEX");
@@ -391,6 +392,41 @@ describe("an index the dialect can actually accept", () => {
     }
   );
 
+  it("does not drop an index the live table does not carry", () => {
+    const indexed = field({
+      name: "author",
+      type: "relationship",
+      options: { target: "authors", relationType: "manyToOne" },
+    });
+    // A relationship column added before this path indexed them has no index. MySQL cannot
+    // express `DROP INDEX IF EXISTS`, so dropping one that is absent aborts the migration
+    // before the statements after it, and the field metadata is then saved for DDL that never
+    // ran. Which columns are indexed is not derivable from the field, so it is read.
+    const sql = unquote(
+      service("mysql").generateAlterTableMigration(TABLE, [indexed], [], {
+        foreignKeysByColumn: new Map(),
+        indexNames: new Set<string>(),
+      })
+    );
+    expect(sql).not.toContain("DROP INDEX");
+    expect(sql).toContain("DROP COLUMN");
+  });
+
+  it("drops an index the live table does carry", () => {
+    const indexed = field({
+      name: "author",
+      type: "relationship",
+      options: { target: "authors", relationType: "manyToOne" },
+    });
+    const sql = unquote(
+      service("mysql").generateAlterTableMigration(TABLE, [indexed], [], {
+        foreignKeysByColumn: new Map(),
+        indexNames: new Set(["idx_dc_probe_author"]),
+      })
+    );
+    expect(sql).toContain("DROP INDEX idx_dc_probe_author ON dc_probe;");
+  });
+
   it("removes the index before the column it names, which is what sqlite requires", () => {
     const indexed = field({
       name: "author",
@@ -400,6 +436,7 @@ describe("an index the dialect can actually accept", () => {
     const sql = unquote(
       service("sqlite").generateAlterTableMigration(TABLE, [indexed], [], {
         foreignKeysByColumn: new Map(),
+        indexNames: new Set(["idx_dc_probe_author"]),
       })
     );
     // SQLite refuses DROP COLUMN while an index still references the column, and reports it as

--- a/packages/nextly/src/domains/dynamic-collections/__tests__/alter-column-attachments.test.ts
+++ b/packages/nextly/src/domains/dynamic-collections/__tests__/alter-column-attachments.test.ts
@@ -392,6 +392,67 @@ describe("an index the dialect can actually accept", () => {
     }
   );
 
+  it.each(["json", "chips"] as const)(
+    "emits no index for a mysql %s column, which mysql cannot index at all",
+    type => {
+      const sql = unquote(
+        service("mysql").generateAlterTableMigration(
+          TABLE,
+          [],
+          [field({ name: "payload", type, index: true })],
+          { tableHasRows: false }
+        )
+      );
+      // "JSON column supports indexing only via generated columns on a specified JSON path" —
+      // the statement fails after the ADD COLUMN before it may already have committed.
+      expect(sql).toContain("ADD COLUMN payload");
+      expect(sql).not.toContain("idx_dc_probe_payload");
+    }
+  );
+
+  it.each(["postgresql", "sqlite"] as const)(
+    "still indexes a json column where the dialect can (%s)",
+    dialect => {
+      const sql = unquote(
+        service(dialect).generateAlterTableMigration(
+          TABLE,
+          [],
+          [field({ name: "payload", type: "json", index: true })],
+          { tableHasRows: false }
+        )
+      );
+      expect(sql).toContain("ON dc_probe(payload)");
+    }
+  );
+
+  it("drops a mysql foreign key before the index that supports it", () => {
+    const sql = unquote(
+      service("mysql").generateAlterTableMigration(
+        TABLE,
+        [
+          field({
+            name: "author",
+            type: "relationship",
+            options: { target: "authors", relationType: "manyToOne" },
+          }),
+        ],
+        [],
+        {
+          foreignKeysByColumn: new Map([["author", ["fk_dc_probe_author"]]]),
+          indexNames: new Set(["idx_dc_probe_author"]),
+        }
+      )
+    );
+    // MySQL enforces a foreign key THROUGH an index and refuses to drop the supporting one:
+    // "Cannot drop index 'idx_...': needed in a foreign key constraint".
+    const fk = sql.indexOf("DROP FOREIGN KEY");
+    const idx = sql.indexOf("DROP INDEX");
+    const col = sql.indexOf("DROP COLUMN");
+    expect(fk).toBeGreaterThan(-1);
+    expect(fk).toBeLessThan(idx);
+    expect(idx).toBeLessThan(col);
+  });
+
   it("does not drop an index the live table does not carry", () => {
     const indexed = field({
       name: "author",

--- a/packages/nextly/src/domains/dynamic-collections/__tests__/alter-column-attachments.test.ts
+++ b/packages/nextly/src/domains/dynamic-collections/__tests__/alter-column-attachments.test.ts
@@ -618,6 +618,37 @@ describe("an index name every dialect accepts", () => {
     expect(sql).toContain("DROP COLUMN");
   });
 
+  it("stays within 63, which is where postgres truncates rather than refuses", () => {
+    // MySQL refuses over 64; PostgreSQL silently truncates at 63. A 64-character name is
+    // therefore not a name PostgreSQL keeps, so bounding at 64 would let two names that differ
+    // only in their last character arrive as one identifier — defeating the hash entirely.
+    const svc = service("postgresql");
+    const names = [
+      ...svc.plannedAttachments(longTable, [
+        field({ name: `${"c".repeat(45)}alpha`, type: "number", index: true }),
+      ]).indexNames,
+    ];
+    for (const name of names) expect(name.length).toBeLessThanOrEqual(63);
+  });
+
+  it("keeps two names apart that postgres would otherwise truncate together", () => {
+    const svc = service("postgresql");
+    const nameFor = (column: string) => {
+      const system = [...svc.plannedAttachments(longTable, []).indexNames];
+      return [
+        ...svc.plannedAttachments(longTable, [
+          field({ name: column, type: "number", index: true }),
+        ]).indexNames,
+      ].find(n => !system.includes(n));
+    };
+    // Two valid field names sharing a long prefix: truncation alone would collapse them.
+    const first = nameFor(`${"d".repeat(44)}alpha`);
+    const second = nameFor(`${"d".repeat(44)}omega`);
+
+    expect(first).not.toEqual(second);
+    expect(first!.slice(0, 63)).not.toEqual(second!.slice(0, 63));
+  });
+
   it("leaves a short name readable and unhashed", () => {
     expect(
       service("mysql")

--- a/packages/nextly/src/domains/dynamic-collections/__tests__/alter-column-attachments.test.ts
+++ b/packages/nextly/src/domains/dynamic-collections/__tests__/alter-column-attachments.test.ts
@@ -607,6 +607,125 @@ describe("a required column that no value can backfill", () => {
   );
 });
 
+describe("the delete action a required relationship can actually perform", () => {
+  const required = field({
+    name: "author",
+    type: "relationship",
+    required: true,
+    options: { target: "authors", relationType: "manyToOne" },
+  });
+  const optional = field({
+    name: "editor",
+    type: "relationship",
+    options: { target: "authors", relationType: "manyToOne" },
+  });
+
+  // The ALTER path attaches no foreign key on SQLite, so the action it carries is only
+  // observable on the two dialects that can add one to an existing table.
+  it.each(["postgresql", "mysql"] as const)(
+    "restricts the delete for a required relationship rather than nulling it (%s)",
+    dialect => {
+      const sql = unquote(
+        service(dialect).generateAlterTableMigration(TABLE, [], [required], {
+          tableHasRows: false,
+        })
+      );
+      // MySQL rejects the pair outright: "Column cannot be NOT NULL: needed in a foreign key
+      // constraint SET NULL". PostgreSQL accepts it and fails later, at the delete.
+      expect(sql).toMatch(/FOREIGN KEY \(author\)[^;]*ON DELETE RESTRICT/i);
+      expect(sql).not.toMatch(/FOREIGN KEY \(author\)[^;]*SET NULL/i);
+    }
+  );
+
+  it.each(["postgresql", "mysql"] as const)(
+    "still nulls the reference for an optional relationship (%s)",
+    dialect => {
+      const sql = unquote(
+        service(dialect).generateAlterTableMigration(TABLE, [], [optional], {
+          tableHasRows: false,
+        })
+      );
+      expect(sql).toMatch(/FOREIGN KEY \(editor\)[^;]*SET NULL/i);
+    }
+  );
+
+  it.each(DIALECTS)(
+    "creates the table with the same rule, so the two paths agree (%s)",
+    dialect => {
+      const sql = unquote(
+        service(dialect).generateMigrationSQL(TABLE, [required, optional])
+      );
+      expect(sql).toMatch(/FOREIGN KEY \(author\)[^,\n]*ON DELETE RESTRICT/i);
+      expect(sql).toMatch(/FOREIGN KEY \(editor\)[^,\n]*SET NULL/i);
+    }
+  );
+
+  it.each(["postgresql", "mysql"] as const)(
+    "honours an explicit action over the rule (%s)",
+    dialect => {
+      const explicit = field({
+        name: "author",
+        type: "relationship",
+        required: true,
+        options: {
+          target: "authors",
+          relationType: "manyToOne",
+          onDelete: "cascade",
+        },
+      });
+      const sql = unquote(
+        service(dialect).generateAlterTableMigration(TABLE, [], [explicit], {
+          tableHasRows: false,
+        })
+      );
+      expect(sql).toMatch(/ON DELETE CASCADE/i);
+    }
+  );
+});
+
+describe("a table its creation migration has not built yet", () => {
+  it("reports the attachments the pending create will install, not none", () => {
+    const svc = service("sqlite");
+    const planned = svc.plannedAttachments(TABLE, [
+      field({
+        name: "author",
+        type: "relationship",
+        options: { target: "authors", relationType: "manyToOne" },
+      }),
+      field({ name: "rank", type: "number", index: true }),
+      field({ name: "note", type: "text" }),
+    ]);
+
+    // The two artefacts replay in order: the create installs these, then the update removes a
+    // column. Reporting none emits a bare DROP COLUMN that the built table refuses.
+    expect(planned.indexNames.has(`idx_${TABLE}_author`)).toBe(true);
+    expect(planned.indexNames.has(`idx_${TABLE}_rank`)).toBe(true);
+    expect(planned.indexNames.has(`idx_${TABLE}_note`)).toBe(false);
+    expect(planned.foreignKeysByColumn.get("author")).toEqual([
+      `fk_${TABLE}_author`,
+    ]);
+    expect(planned.foreignKeysByColumn.has("rank")).toBe(false);
+  });
+
+  it("carries the system indexes every generated table gets", () => {
+    const planned = service("postgresql").plannedAttachments(TABLE, []);
+    expect(planned.indexNames.has(`idx_${TABLE}_slug`)).toBe(true);
+    expect(planned.indexNames.has(`idx_${TABLE}_created_at`)).toBe(true);
+  });
+
+  it("gives a junction-backed field no column attachments", () => {
+    const planned = service("postgresql").plannedAttachments(TABLE, [
+      field({
+        name: "tags",
+        type: "relationship",
+        options: { target: "tags", relationType: "manyToMany" },
+      }),
+    ]);
+    expect(planned.indexNames.has(`idx_${TABLE}_tags`)).toBe(false);
+    expect(planned.foreignKeysByColumn.has("tags")).toBe(false);
+  });
+});
+
 describe("removing a column that a foreign key references", () => {
   const relationship = field({
     name: "author",

--- a/packages/nextly/src/domains/dynamic-collections/__tests__/alter-column-attachments.test.ts
+++ b/packages/nextly/src/domains/dynamic-collections/__tests__/alter-column-attachments.test.ts
@@ -563,6 +563,61 @@ describe("an index name every dialect accepts", () => {
     }
   });
 
+  it.each(["postgresql", "sqlite"] as const)(
+    "drops an index stored under the name an earlier version gave it (%s)",
+    dialect => {
+      const svc = service(dialect);
+      const indexed = field({ name: longColumn, type: "number", index: true });
+      // What a table created before the name was bounded actually carries: SQLite kept it
+      // whole, PostgreSQL truncated it to 63. Looking only for the current name would leave
+      // that index in place while the field records that it was removed.
+      const legacyFull = `idx_${longTable}_${longColumn}`;
+      const legacy =
+        dialect === "sqlite" ? legacyFull : legacyFull.slice(0, 63);
+
+      const sql = unquote(
+        svc.generateAlterTableMigration(longTable, [indexed], [], {
+          foreignKeysByColumn: new Map(),
+          indexNames: new Set([legacy]),
+        })
+      );
+
+      expect(sql).toContain(`DROP INDEX IF EXISTS ${legacy};`);
+    }
+  );
+
+  it("drops the current name when that is what the table carries", () => {
+    const svc = service("sqlite");
+    const indexed = field({ name: longColumn, type: "number", index: true });
+    // The one name that is not a system index, which is this column's.
+    const systemNames = [...svc.plannedAttachments(longTable, []).indexNames];
+    const current = [
+      ...svc.plannedAttachments(longTable, [indexed]).indexNames,
+    ].find(n => !systemNames.includes(n));
+    const sql = unquote(
+      svc.generateAlterTableMigration(longTable, [indexed], [], {
+        foreignKeysByColumn: new Map(),
+        indexNames: new Set([current!]),
+      })
+    );
+
+    expect(sql).toContain(`DROP INDEX IF EXISTS ${current};`);
+  });
+
+  it("drops nothing when the table carries neither name", () => {
+    const sql = unquote(
+      service("sqlite").generateAlterTableMigration(
+        longTable,
+        [field({ name: longColumn, type: "number", index: true })],
+        [],
+        { foreignKeysByColumn: new Map(), indexNames: new Set<string>() }
+      )
+    );
+
+    expect(sql).not.toContain("DROP INDEX");
+    expect(sql).toContain("DROP COLUMN");
+  });
+
   it("leaves a short name readable and unhashed", () => {
     expect(
       service("mysql")

--- a/packages/nextly/src/domains/dynamic-collections/__tests__/alter-column-attachments.test.ts
+++ b/packages/nextly/src/domains/dynamic-collections/__tests__/alter-column-attachments.test.ts
@@ -1,0 +1,474 @@
+/**
+ * A column is more than its type. Creating a table attaches NOT NULL, uniqueness, a foreign key
+ * and an index to it; adding the same field to a table that already exists went through a
+ * different path that attached only some of them, so a collection that gained a field by an edit
+ * did not enforce what the identical collection created from scratch did.
+ *
+ * The property is asserted first and the individual repairs after it: for one field definition,
+ * the table CREATE produces and the table ADD-to-an-empty-table produces must carry the same
+ * attachments. Every gap here violated that one rule, so pinning the four cases alone would let
+ * the fifth arrive unnoticed.
+ */
+import { describe, expect, it } from "vitest";
+
+import { NextlyError } from "../../../errors/nextly-error";
+import type { FieldDefinition } from "../../../schemas/dynamic-collections";
+import {
+  DynamicCollectionSchemaService,
+  type SupportedDialect,
+} from "../services/dynamic-collection-schema-service";
+
+const DIALECTS: SupportedDialect[] = ["postgresql", "mysql", "sqlite"];
+const TABLE = "dc_probe";
+
+const service = (dialect: SupportedDialect) =>
+  new DynamicCollectionSchemaService(undefined, dialect);
+
+const field = (overrides: Record<string, unknown>): FieldDefinition =>
+  ({ required: false, ...overrides }) as unknown as FieldDefinition;
+
+/**
+ * Identifier quoting differs per dialect and says nothing about what is attached, so it is
+ * removed before anything is read. Every name this compares is generated from a snake_case
+ * column, so nothing ambiguous survives the strip.
+ */
+const unquote = (sql: string) => sql.replace(/["`]/g, "");
+
+/** What a column carries, read from whichever form the generator emitted it in. */
+interface Attachments {
+  notNull: boolean;
+  unique: boolean;
+  referencesTable: string | null;
+  indexed: boolean;
+}
+
+/** A plain (non-unique) index on this column, in either generator's spelling. */
+function hasPlainIndex(sql: string, column: string): boolean {
+  return new RegExp(
+    `CREATE INDEX (?:IF NOT EXISTS )?\\S+ ON ${TABLE}\\(${column}\\)`
+  ).test(sql);
+}
+
+/**
+ * The refusal, read the way a client reads it.
+ *
+ * A validation error carries the generic "Validation failed." as its message and the part that
+ * names the field in its public data, which is what the envelope hands the admin. Asserting on
+ * `.message` would pass for any validation error at all and say nothing about this one.
+ */
+function refusalMessages(run: () => unknown): string[] {
+  try {
+    run();
+  } catch (error) {
+    if (!(error instanceof NextlyError)) throw error;
+    const data = error.publicData as
+      | { errors?: { path?: string; code?: string; message?: string }[] }
+      | undefined;
+    return (data?.errors ?? []).map(e => `${e.path} ${e.code} ${e.message}`);
+  }
+  return [];
+}
+
+function referencedTable(sql: string, column: string): string | null {
+  const match = sql.match(
+    new RegExp(`FOREIGN KEY \\(${column}\\) REFERENCES (\\S+?)\\(id\\)`)
+  );
+  return match ? match[1] : null;
+}
+
+function createAttachments(rawSql: string, column: string): Attachments {
+  const sql = unquote(rawSql);
+  const body = sql.slice(sql.indexOf("(") + 1, sql.indexOf("\n);"));
+  const line =
+    body
+      .split(",\n")
+      .map(part => part.trim())
+      .find(part => part.startsWith(`${column} `)) ?? "";
+  return {
+    notNull: /\bNOT NULL\b/.test(line),
+    unique: /\bUNIQUE\b/.test(line),
+    referencesTable: referencedTable(sql, column),
+    indexed: hasPlainIndex(sql, column),
+  };
+}
+
+function alterAttachments(rawSql: string, column: string): Attachments {
+  const sql = unquote(rawSql);
+  const addLine =
+    sql.split("\n").find(line => line.includes(`ADD COLUMN ${column} `)) ?? "";
+  return {
+    notNull: /\bNOT NULL\b/.test(addLine),
+    unique:
+      new RegExp(`ADD CONSTRAINT \\S+ UNIQUE \\(${column}\\)`).test(sql) ||
+      new RegExp(
+        `CREATE UNIQUE INDEX (?:IF NOT EXISTS )?\\S+ ON ${TABLE}\\(${column}\\)`
+      ).test(sql),
+    referencesTable: referencedTable(sql, column),
+    indexed: hasPlainIndex(sql, column),
+  };
+}
+
+/**
+ * The field shapes whose attachments differ from one another. Every one is added to an EMPTY
+ * table, which is the only state in which the two paths are comparable at all: a table with rows
+ * cannot receive a required column that states no backfill, by design.
+ */
+const SHAPES: { label: string; definition: FieldDefinition }[] = [
+  {
+    label: "an optional many-to-one relationship",
+    definition: field({
+      name: "author",
+      type: "relationship",
+      options: { target: "authors", relationType: "manyToOne" },
+    }),
+  },
+  {
+    label: "a required many-to-one relationship",
+    definition: field({
+      name: "author",
+      type: "relationship",
+      required: true,
+      options: { target: "authors", relationType: "manyToOne" },
+    }),
+  },
+  {
+    label: "a one-to-one relationship",
+    definition: field({
+      name: "profile",
+      type: "relationship",
+      options: { target: "profiles", relationType: "oneToOne" },
+    }),
+  },
+  {
+    label: "a unique text field",
+    definition: field({ name: "sku", type: "text", unique: true }),
+  },
+  {
+    label: "an indexed text field",
+    definition: field({ name: "slugAlias", type: "text", index: true }),
+  },
+  {
+    label: "a required text field",
+    definition: field({ name: "headline", type: "text", required: true }),
+  },
+  {
+    label: "an indexed number field",
+    definition: field({ name: "rank", type: "number", index: true }),
+  },
+  {
+    label: "a plain optional text field",
+    definition: field({ name: "note", type: "text" }),
+  },
+];
+
+describe.each(DIALECTS)(
+  "CREATE and ADD-to-empty agree on what a column carries (%s)",
+  dialect => {
+    it.each(SHAPES)("$label", ({ definition }) => {
+      const svc = service(dialect);
+      const column = definition.name.replace(
+        /[A-Z]/g,
+        c => `_${c.toLowerCase()}`
+      );
+
+      const created = createAttachments(
+        svc.generateMigrationSQL(TABLE, [definition]),
+        column
+      );
+      const added = alterAttachments(
+        svc.generateAlterTableMigration(TABLE, [], [definition], {
+          tableHasRows: false,
+        }),
+        column
+      );
+
+      expect(added.notNull).toBe(created.notNull);
+      expect(added.unique).toBe(created.unique);
+      expect(added.indexed).toBe(created.indexed);
+
+      if (dialect === "sqlite" && created.referencesTable !== null) {
+        // SQLite attaches a foreign key only in a CREATE TABLE: there is no statement that adds
+        // one to a table that already exists, short of rebuilding it. Asserted rather than
+        // skipped so the day a rebuild lands, this stops being true and says so.
+        expect(added.referencesTable).toBeNull();
+      } else {
+        expect(added.referencesTable).toBe(created.referencesTable);
+      }
+    });
+  }
+);
+
+describe("the attachments the ADD path used to lose", () => {
+  it.each(DIALECTS)(
+    "marks a one-to-one column unique without an explicit flag (%s)",
+    dialect => {
+      const oneToOne = field({
+        name: "profile",
+        type: "relationship",
+        options: { target: "profiles", relationType: "oneToOne" },
+      });
+      const sql = service(dialect).generateAlterTableMigration(
+        TABLE,
+        [],
+        [oneToOne],
+        { tableHasRows: false }
+      );
+      expect(alterAttachments(sql, "profile").unique).toBe(true);
+    }
+  );
+
+  it.each(DIALECTS)(
+    "leaves a many-to-one column non-unique, so uniqueness is read from the cardinality and not attached to every relationship (%s)",
+    dialect => {
+      const manyToOne = field({
+        name: "author",
+        type: "relationship",
+        options: { target: "authors", relationType: "manyToOne" },
+      });
+      const sql = service(dialect).generateAlterTableMigration(
+        TABLE,
+        [],
+        [manyToOne],
+        { tableHasRows: false }
+      );
+      expect(alterAttachments(sql, "author").unique).toBe(false);
+    }
+  );
+
+  it.each(DIALECTS)("indexes a newly added indexed field (%s)", dialect => {
+    const indexed = field({ name: "rank", type: "number", index: true });
+    const sql = service(dialect).generateAlterTableMigration(
+      TABLE,
+      [],
+      [indexed],
+      { tableHasRows: false }
+    );
+    expect(hasPlainIndex(unquote(sql), "rank")).toBe(true);
+  });
+
+  it.each(DIALECTS)(
+    "does not index a newly added field that asked for none (%s)",
+    dialect => {
+      const plain = field({ name: "note", type: "text" });
+      const sql = service(dialect).generateAlterTableMigration(
+        TABLE,
+        [],
+        [plain],
+        { tableHasRows: false }
+      );
+      expect(hasPlainIndex(unquote(sql), "note")).toBe(false);
+    }
+  );
+
+  it.each(DIALECTS)(
+    "creates the index for a new indexed field exactly once (%s)",
+    dialect => {
+      const indexed = field({ name: "rank", type: "number", index: true });
+      const sql = unquote(
+        service(dialect).generateAlterTableMigration(TABLE, [], [indexed], {
+          tableHasRows: false,
+        })
+      );
+      const matches = sql.match(
+        new RegExp(
+          `CREATE INDEX (?:IF NOT EXISTS )?\\S+ ON ${TABLE}\\(rank\\)`,
+          "g"
+        )
+      );
+      expect(matches).toHaveLength(1);
+    }
+  );
+
+  it.each(DIALECTS)(
+    "still toggles the index on a field that already existed (%s)",
+    dialect => {
+      const before = field({ name: "rank", type: "number" });
+      const after = field({ name: "rank", type: "number", index: true });
+      const sql = unquote(
+        service(dialect).generateAlterTableMigration(TABLE, [before], [after], {
+          tableHasRows: true,
+        })
+      );
+      expect(hasPlainIndex(sql, "rank")).toBe(true);
+      expect(sql).not.toContain("ADD COLUMN rank");
+    }
+  );
+});
+
+describe("a required column that no value can backfill", () => {
+  const requiredRelationship = field({
+    name: "author",
+    type: "relationship",
+    required: true,
+    options: { target: "authors", relationType: "manyToOne" },
+  });
+
+  it.each(DIALECTS)(
+    "refuses the edit when the table already holds rows (%s)",
+    dialect => {
+      const reported = refusalMessages(() =>
+        service(dialect).generateAlterTableMigration(
+          TABLE,
+          [],
+          [requiredRelationship],
+          { tableHasRows: true }
+        )
+      );
+      expect(reported).toHaveLength(1);
+      expect(reported[0]).toContain("fields.author");
+      expect(reported[0]).toContain("REQUIRED_COLUMN_NEEDS_BACKFILL");
+      // The refusal has to say what to do instead, or it is only a wall.
+      expect(reported[0]).toMatch(/optional/);
+    }
+  );
+
+  it.each(DIALECTS)(
+    "refuses when the caller did not look, rather than guessing the table is empty (%s)",
+    dialect => {
+      const reported = refusalMessages(() =>
+        service(dialect).generateAlterTableMigration(
+          TABLE,
+          [],
+          [requiredRelationship]
+        )
+      );
+      expect(reported).toHaveLength(1);
+      expect(reported[0]).toContain("REQUIRED_COLUMN_NEEDS_BACKFILL");
+    }
+  );
+
+  it.each(DIALECTS)(
+    "emits a plain NOT NULL with no default when the table is empty (%s)",
+    dialect => {
+      const sql = unquote(
+        service(dialect).generateAlterTableMigration(
+          TABLE,
+          [],
+          [requiredRelationship],
+          { tableHasRows: false }
+        )
+      );
+      expect(sql).toContain("ADD COLUMN author");
+      expect(sql).toMatch(/ADD COLUMN author[^;]*NOT NULL/);
+      // The statement this replaces. No dialect accepts it: PostgreSQL reports the nulls it
+      // found, MySQL calls the default invalid, and SQLite writes the column and then refuses
+      // every insert that omits it.
+      expect(sql).not.toMatch(/NOT NULL\s+DEFAULT NULL/);
+    }
+  );
+
+  it.each(DIALECTS)(
+    "still backfills a required column whose type states a value, so the refusal is not blanket (%s)",
+    dialect => {
+      const sql = unquote(
+        service(dialect).generateAlterTableMigration(
+          TABLE,
+          [],
+          [field({ name: "headline", type: "text", required: true })],
+          { tableHasRows: true }
+        )
+      );
+      expect(sql).toMatch(/ADD COLUMN headline[^;]*NOT NULL DEFAULT ''/);
+    }
+  );
+
+  it.each(DIALECTS)(
+    "adds an OPTIONAL relationship to a table with rows, which is the path the refusal points at (%s)",
+    dialect => {
+      const sql = unquote(
+        service(dialect).generateAlterTableMigration(
+          TABLE,
+          [],
+          [
+            field({
+              name: "author",
+              type: "relationship",
+              options: { target: "authors", relationType: "manyToOne" },
+            }),
+          ],
+          { tableHasRows: true }
+        )
+      );
+      expect(sql).toContain("ADD COLUMN author");
+      expect(sql).not.toMatch(/ADD COLUMN author[^;]*NOT NULL/);
+    }
+  );
+});
+
+describe("removing a column that a foreign key references", () => {
+  const relationship = field({
+    name: "author",
+    type: "relationship",
+    options: { target: "authors", relationType: "manyToOne" },
+  });
+  const withForeignKey = {
+    foreignKeysByColumn: new Map([["author", ["fk_dc_probe_author"]]]),
+  };
+
+  it("names and drops the constraint before the column on mysql", () => {
+    const sql = unquote(
+      service("mysql").generateAlterTableMigration(
+        TABLE,
+        [relationship],
+        [],
+        withForeignKey
+      )
+    );
+    expect(sql).toContain("DROP FOREIGN KEY fk_dc_probe_author");
+    expect(sql.indexOf("DROP FOREIGN KEY")).toBeLessThan(
+      sql.indexOf("DROP COLUMN")
+    );
+  });
+
+  it("drops only the column on postgresql, which removes the dependent constraint itself", () => {
+    const sql = unquote(
+      service("postgresql").generateAlterTableMigration(
+        TABLE,
+        [relationship],
+        [],
+        withForeignKey
+      )
+    );
+    expect(sql).toContain("DROP COLUMN IF EXISTS author");
+    expect(sql).not.toContain("DROP CONSTRAINT");
+  });
+
+  it("refuses on sqlite, where the constraint cannot be removed without rebuilding the table", () => {
+    const reported = refusalMessages(() =>
+      service("sqlite").generateAlterTableMigration(
+        TABLE,
+        [relationship],
+        [],
+        withForeignKey
+      )
+    );
+    expect(reported).toHaveLength(1);
+    expect(reported[0]).toContain("fields.author");
+    expect(reported[0]).toContain("FOREIGN_KEY_DROP_UNSUPPORTED");
+  });
+
+  it("drops a sqlite relationship column that carries no foreign key, which is every one added by an edit", () => {
+    const sql = unquote(
+      service("sqlite").generateAlterTableMigration(TABLE, [relationship], [], {
+        foreignKeysByColumn: new Map(),
+      })
+    );
+    expect(sql).toContain("DROP COLUMN author");
+  });
+
+  it.each(DIALECTS)(
+    "drops a plain column with no constraint statement at all (%s)",
+    dialect => {
+      const sql = unquote(
+        service(dialect).generateAlterTableMigration(
+          TABLE,
+          [field({ name: "note", type: "text" })],
+          [],
+          { foreignKeysByColumn: new Map() }
+        )
+      );
+      expect(sql).toContain("DROP COLUMN");
+      expect(sql).not.toContain("FOREIGN KEY");
+    }
+  );
+});

--- a/packages/nextly/src/domains/dynamic-collections/__tests__/alter-column-attachments.test.ts
+++ b/packages/nextly/src/domains/dynamic-collections/__tests__/alter-column-attachments.test.ts
@@ -707,6 +707,22 @@ describe("a table its creation migration has not built yet", () => {
     expect(planned.foreignKeysByColumn.has("rank")).toBe(false);
   });
 
+  it("does not predict an index the create cannot emit", () => {
+    const indexedJson = [field({ name: "payload", type: "json", index: true })];
+    // MySQL cannot index a JSON column, so the create emits none. Predicting one makes a later
+    // edit drop an index that was never installed, which aborts the whole migration there.
+    expect(
+      service("mysql")
+        .plannedAttachments(TABLE, indexedJson)
+        .indexNames.has(`idx_${TABLE}_payload`)
+    ).toBe(false);
+    expect(
+      service("postgresql")
+        .plannedAttachments(TABLE, indexedJson)
+        .indexNames.has(`idx_${TABLE}_payload`)
+    ).toBe(true);
+  });
+
   it("carries the system indexes every generated table gets", () => {
     const planned = service("postgresql").plannedAttachments(TABLE, []);
     expect(planned.indexNames.has(`idx_${TABLE}_slug`)).toBe(true);

--- a/packages/nextly/src/domains/dynamic-collections/__tests__/alter-column-attachments.test.ts
+++ b/packages/nextly/src/domains/dynamic-collections/__tests__/alter-column-attachments.test.ts
@@ -507,6 +507,73 @@ describe("an index the dialect can actually accept", () => {
   });
 });
 
+describe("an index name every dialect accepts", () => {
+  // Collection and field names may each be 50 characters, so the obvious composition can be
+  // half as long again as MySQL's 64-character identifier limit, and the CREATE INDEX is then
+  // rejected after the ADD COLUMN before it may already have committed.
+  const longTable = `dc_${"a".repeat(50)}`;
+  const longColumn = "b".repeat(50);
+
+  it.each(DIALECTS)("stays within 64 characters (%s)", dialect => {
+    const sql = unquote(
+      service(dialect).generateAlterTableMigration(
+        TABLE,
+        [],
+        [field({ name: longColumn, type: "number", index: true })],
+        { tableHasRows: false }
+      )
+    );
+    const name = sql.match(/CREATE INDEX (?:IF NOT EXISTS )?(\S+) ON/)?.[1];
+    expect(name).toBeDefined();
+    expect(name!.length).toBeLessThanOrEqual(64);
+  });
+
+  it("keeps two long names apart rather than truncating them together", () => {
+    const svc = service("mysql");
+    const planned = (column: string) => [
+      ...svc.plannedAttachments(longTable, [
+        field({ name: column, type: "number", index: true }),
+      ]).indexNames,
+    ];
+    // A plain truncation would make these identical, and the second index would then silently
+    // fail to create or drop the first.
+    const first = planned(`${longColumn}_one`);
+    const second = planned(`${longColumn}_two`);
+    expect(first).not.toEqual(second);
+  });
+
+  it("names the same index the same way when creating and when dropping", () => {
+    const svc = service("mysql");
+    const indexed = field({ name: longColumn, type: "number", index: true });
+    const created = unquote(
+      svc.generateAlterTableMigration(longTable, [], [indexed], {
+        tableHasRows: false,
+      })
+    ).match(/CREATE INDEX (\S+) ON/)?.[1];
+    const known = [...svc.plannedAttachments(longTable, [indexed]).indexNames];
+    // The drop builds the name again, separately; if the two ever disagreed the drop would
+    // name an index that does not exist and abort the migration on MySQL.
+    expect(known).toContain(created);
+  });
+
+  it("bounds the system indexes too, which carry the same table name", () => {
+    const planned = service("mysql").plannedAttachments(longTable, []);
+    for (const name of planned.indexNames) {
+      expect(name.length).toBeLessThanOrEqual(64);
+    }
+  });
+
+  it("leaves a short name readable and unhashed", () => {
+    expect(
+      service("mysql")
+        .plannedAttachments(TABLE, [
+          field({ name: "rank", type: "number", index: true }),
+        ])
+        .indexNames.has(`idx_${TABLE}_rank`)
+    ).toBe(true);
+  });
+});
+
 describe("a required column that no value can backfill", () => {
   const requiredRelationship = field({
     name: "author",

--- a/packages/nextly/src/domains/dynamic-collections/services/__tests__/__snapshots__/builder-ddl-characterization.test.ts.snap
+++ b/packages/nextly/src/domains/dynamic-collections/services/__tests__/__snapshots__/builder-ddl-characterization.test.ts.snap
@@ -27,11 +27,11 @@ CREATE TABLE IF NOT EXISTS \`dc_pinned\` (
   CONSTRAINT \`fk_dc_pinned_author\` FOREIGN KEY (\`author\`) REFERENCES \`dc_authors\`(\`id\`) ON DELETE CASCADE ON UPDATE CASCADE
 );
 --> statement-breakpoint
+CREATE INDEX \`idx_dc_pinned_lookup_code\` ON \`dc_pinned\`(\`lookup_code\`);
+--> statement-breakpoint
 CREATE INDEX \`idx_dc_pinned_author\` ON \`dc_pinned\`(\`author\`);
 --> statement-breakpoint
 CREATE INDEX \`idx_dc_pinned_editors\` ON \`dc_pinned\`(\`editors\`);
---> statement-breakpoint
-CREATE INDEX \`idx_dc_pinned_lookup_code\` ON \`dc_pinned\`(\`lookup_code\`);
 --> statement-breakpoint
 CREATE INDEX \`idx_dc_pinned_created_at\` ON \`dc_pinned\`(\`created_at\` DESC);
 --> statement-breakpoint
@@ -125,11 +125,11 @@ CREATE TABLE IF NOT EXISTS \`single_pinned\` (
   CONSTRAINT \`fk_single_pinned_author\` FOREIGN KEY (\`author\`) REFERENCES \`dc_authors\`(\`id\`) ON DELETE CASCADE ON UPDATE CASCADE
 );
 --> statement-breakpoint
+CREATE INDEX \`idx_single_pinned_lookup_code\` ON \`single_pinned\`(\`lookup_code\`);
+--> statement-breakpoint
 CREATE INDEX \`idx_single_pinned_author\` ON \`single_pinned\`(\`author\`);
 --> statement-breakpoint
 CREATE INDEX \`idx_single_pinned_editors\` ON \`single_pinned\`(\`editors\`);
---> statement-breakpoint
-CREATE INDEX \`idx_single_pinned_lookup_code\` ON \`single_pinned\`(\`lookup_code\`);
 --> statement-breakpoint
 CREATE INDEX \`idx_single_pinned_created_at\` ON \`single_pinned\`(\`created_at\` DESC);
 --> statement-breakpoint
@@ -179,11 +179,11 @@ CREATE TABLE IF NOT EXISTS \`single_pinned\` (
   CONSTRAINT \`fk_single_pinned_author\` FOREIGN KEY (\`author\`) REFERENCES \`dc_authors\`(\`id\`) ON DELETE CASCADE ON UPDATE CASCADE
 );
 --> statement-breakpoint
+CREATE INDEX \`idx_single_pinned_lookup_code\` ON \`single_pinned\`(\`lookup_code\`);
+--> statement-breakpoint
 CREATE INDEX \`idx_single_pinned_author\` ON \`single_pinned\`(\`author\`);
 --> statement-breakpoint
 CREATE INDEX \`idx_single_pinned_editors\` ON \`single_pinned\`(\`editors\`);
---> statement-breakpoint
-CREATE INDEX \`idx_single_pinned_lookup_code\` ON \`single_pinned\`(\`lookup_code\`);
 --> statement-breakpoint
 CREATE INDEX \`idx_single_pinned_created_at\` ON \`single_pinned\`(\`created_at\` DESC);
 --> statement-breakpoint
@@ -232,11 +232,11 @@ CREATE TABLE IF NOT EXISTS "dc_pinned" (
   CONSTRAINT "fk_dc_pinned_author" FOREIGN KEY ("author") REFERENCES "dc_authors"("id") ON DELETE CASCADE ON UPDATE CASCADE
 );
 --> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_dc_pinned_lookup_code" ON "dc_pinned"("lookup_code");
+--> statement-breakpoint
 CREATE INDEX IF NOT EXISTS "idx_dc_pinned_author" ON "dc_pinned"("author");
 --> statement-breakpoint
 CREATE INDEX IF NOT EXISTS "idx_dc_pinned_editors" ON "dc_pinned"("editors");
---> statement-breakpoint
-CREATE INDEX IF NOT EXISTS "idx_dc_pinned_lookup_code" ON "dc_pinned"("lookup_code");
 --> statement-breakpoint
 CREATE INDEX IF NOT EXISTS "idx_dc_pinned_created_at" ON "dc_pinned"("created_at" DESC);
 --> statement-breakpoint
@@ -330,11 +330,11 @@ CREATE TABLE IF NOT EXISTS "single_pinned" (
   CONSTRAINT "fk_single_pinned_author" FOREIGN KEY ("author") REFERENCES "dc_authors"("id") ON DELETE CASCADE ON UPDATE CASCADE
 );
 --> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_single_pinned_lookup_code" ON "single_pinned"("lookup_code");
+--> statement-breakpoint
 CREATE INDEX IF NOT EXISTS "idx_single_pinned_author" ON "single_pinned"("author");
 --> statement-breakpoint
 CREATE INDEX IF NOT EXISTS "idx_single_pinned_editors" ON "single_pinned"("editors");
---> statement-breakpoint
-CREATE INDEX IF NOT EXISTS "idx_single_pinned_lookup_code" ON "single_pinned"("lookup_code");
 --> statement-breakpoint
 CREATE INDEX IF NOT EXISTS "idx_single_pinned_created_at" ON "single_pinned"("created_at" DESC);
 --> statement-breakpoint
@@ -384,11 +384,11 @@ CREATE TABLE IF NOT EXISTS "single_pinned" (
   CONSTRAINT "fk_single_pinned_author" FOREIGN KEY ("author") REFERENCES "dc_authors"("id") ON DELETE CASCADE ON UPDATE CASCADE
 );
 --> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_single_pinned_lookup_code" ON "single_pinned"("lookup_code");
+--> statement-breakpoint
 CREATE INDEX IF NOT EXISTS "idx_single_pinned_author" ON "single_pinned"("author");
 --> statement-breakpoint
 CREATE INDEX IF NOT EXISTS "idx_single_pinned_editors" ON "single_pinned"("editors");
---> statement-breakpoint
-CREATE INDEX IF NOT EXISTS "idx_single_pinned_lookup_code" ON "single_pinned"("lookup_code");
 --> statement-breakpoint
 CREATE INDEX IF NOT EXISTS "idx_single_pinned_created_at" ON "single_pinned"("created_at" DESC);
 --> statement-breakpoint
@@ -437,11 +437,11 @@ CREATE TABLE IF NOT EXISTS "dc_pinned" (
   CONSTRAINT "fk_dc_pinned_author" FOREIGN KEY ("author") REFERENCES "dc_authors"("id") ON DELETE CASCADE ON UPDATE CASCADE
 );
 --> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_dc_pinned_lookup_code" ON "dc_pinned"("lookup_code");
+--> statement-breakpoint
 CREATE INDEX IF NOT EXISTS "idx_dc_pinned_author" ON "dc_pinned"("author");
 --> statement-breakpoint
 CREATE INDEX IF NOT EXISTS "idx_dc_pinned_editors" ON "dc_pinned"("editors");
---> statement-breakpoint
-CREATE INDEX IF NOT EXISTS "idx_dc_pinned_lookup_code" ON "dc_pinned"("lookup_code");
 --> statement-breakpoint
 CREATE INDEX IF NOT EXISTS "idx_dc_pinned_created_at" ON "dc_pinned"("created_at");
 --> statement-breakpoint
@@ -535,11 +535,11 @@ CREATE TABLE IF NOT EXISTS "single_pinned" (
   CONSTRAINT "fk_single_pinned_author" FOREIGN KEY ("author") REFERENCES "dc_authors"("id") ON DELETE CASCADE ON UPDATE CASCADE
 );
 --> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_single_pinned_lookup_code" ON "single_pinned"("lookup_code");
+--> statement-breakpoint
 CREATE INDEX IF NOT EXISTS "idx_single_pinned_author" ON "single_pinned"("author");
 --> statement-breakpoint
 CREATE INDEX IF NOT EXISTS "idx_single_pinned_editors" ON "single_pinned"("editors");
---> statement-breakpoint
-CREATE INDEX IF NOT EXISTS "idx_single_pinned_lookup_code" ON "single_pinned"("lookup_code");
 --> statement-breakpoint
 CREATE INDEX IF NOT EXISTS "idx_single_pinned_created_at" ON "single_pinned"("created_at");
 --> statement-breakpoint
@@ -589,11 +589,11 @@ CREATE TABLE IF NOT EXISTS "single_pinned" (
   CONSTRAINT "fk_single_pinned_author" FOREIGN KEY ("author") REFERENCES "dc_authors"("id") ON DELETE CASCADE ON UPDATE CASCADE
 );
 --> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_single_pinned_lookup_code" ON "single_pinned"("lookup_code");
+--> statement-breakpoint
 CREATE INDEX IF NOT EXISTS "idx_single_pinned_author" ON "single_pinned"("author");
 --> statement-breakpoint
 CREATE INDEX IF NOT EXISTS "idx_single_pinned_editors" ON "single_pinned"("editors");
---> statement-breakpoint
-CREATE INDEX IF NOT EXISTS "idx_single_pinned_lookup_code" ON "single_pinned"("lookup_code");
 --> statement-breakpoint
 CREATE INDEX IF NOT EXISTS "idx_single_pinned_created_at" ON "single_pinned"("created_at");
 --> statement-breakpoint

--- a/packages/nextly/src/domains/dynamic-collections/services/__tests__/__snapshots__/builder-ddl-characterization.test.ts.snap
+++ b/packages/nextly/src/domains/dynamic-collections/services/__tests__/__snapshots__/builder-ddl-characterization.test.ts.snap
@@ -27,7 +27,7 @@ CREATE TABLE IF NOT EXISTS \`dc_pinned\` (
   CONSTRAINT \`fk_dc_pinned_author\` FOREIGN KEY (\`author\`) REFERENCES \`dc_authors\`(\`id\`) ON DELETE CASCADE ON UPDATE CASCADE
 );
 --> statement-breakpoint
-CREATE INDEX \`idx_dc_pinned_lookup_code\` ON \`dc_pinned\`(\`lookup_code\`);
+CREATE INDEX \`idx_dc_pinned_lookup_code\` ON \`dc_pinned\`(\`lookup_code\`(191));
 --> statement-breakpoint
 CREATE INDEX \`idx_dc_pinned_author\` ON \`dc_pinned\`(\`author\`);
 --> statement-breakpoint
@@ -125,7 +125,7 @@ CREATE TABLE IF NOT EXISTS \`single_pinned\` (
   CONSTRAINT \`fk_single_pinned_author\` FOREIGN KEY (\`author\`) REFERENCES \`dc_authors\`(\`id\`) ON DELETE CASCADE ON UPDATE CASCADE
 );
 --> statement-breakpoint
-CREATE INDEX \`idx_single_pinned_lookup_code\` ON \`single_pinned\`(\`lookup_code\`);
+CREATE INDEX \`idx_single_pinned_lookup_code\` ON \`single_pinned\`(\`lookup_code\`(191));
 --> statement-breakpoint
 CREATE INDEX \`idx_single_pinned_author\` ON \`single_pinned\`(\`author\`);
 --> statement-breakpoint
@@ -179,7 +179,7 @@ CREATE TABLE IF NOT EXISTS \`single_pinned\` (
   CONSTRAINT \`fk_single_pinned_author\` FOREIGN KEY (\`author\`) REFERENCES \`dc_authors\`(\`id\`) ON DELETE CASCADE ON UPDATE CASCADE
 );
 --> statement-breakpoint
-CREATE INDEX \`idx_single_pinned_lookup_code\` ON \`single_pinned\`(\`lookup_code\`);
+CREATE INDEX \`idx_single_pinned_lookup_code\` ON \`single_pinned\`(\`lookup_code\`(191));
 --> statement-breakpoint
 CREATE INDEX \`idx_single_pinned_author\` ON \`single_pinned\`(\`author\`);
 --> statement-breakpoint

--- a/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-schema-service.ts
+++ b/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-schema-service.ts
@@ -38,6 +38,7 @@ import {
   renderSystemColumnSql,
   toSnakeCase,
 } from "../../schema/services/field-column-descriptor";
+import { indexNameForColumn } from "../../schema/services/index-name";
 import { quoteJsonSqlDefault } from "../../schema/utils/sql-literal";
 
 import { DynamicCollectionValidationService } from "./dynamic-collection-validation-service";
@@ -151,34 +152,6 @@ export class DynamicCollectionSchemaService {
   }
 
   /**
-   * The index name for one column, short enough for every dialect to accept.
-   *
-   * MySQL refuses an identifier over 64 characters, and a collection and a field may each be up
-   * to 50, so the obvious `idx_<table>_<column>` can be half as long again as the limit. Names
-   * over the bound keep a readable prefix and end in a hash of the full name, so two long names
-   * sharing a prefix still differ and the same input always produces the same identifier —
-   * which matters because the name is built again, separately, to drop the index later.
-   */
-  private indexName(tableName: string, column: string): string {
-    const full = `idx_${tableName}_${column}`;
-    // 63, not 64. MySQL refuses anything longer than 64, but PostgreSQL silently TRUNCATES at
-    // 63 — so a 64-character name is not a name PostgreSQL keeps, and two that differ only in
-    // their last character arrive as one identifier. Bounding at the smaller of the two limits
-    // is what makes the hash below the thing that tells names apart, rather than a decoration
-    // on a name the database has already collapsed.
-    if (full.length <= 63) return full;
-    // FNV-1a over the full name. Not for secrecy — only to tell apart two names that a plain
-    // truncation would make identical.
-    let hash = 0x811c9dc5;
-    for (let i = 0; i < full.length; i++) {
-      hash ^= full.charCodeAt(i);
-      hash = Math.imul(hash, 0x01000193) >>> 0;
-    }
-    const suffix = hash.toString(36).padStart(7, "0");
-    return `${full.slice(0, 63 - suffix.length - 1)}_${suffix}`;
-  }
-
-  /**
    * Every name this generator may have given one column's index, current first.
    *
    * Bounding long names changed what they are called, and an index already in a database still
@@ -190,9 +163,21 @@ export class DynamicCollectionSchemaService {
    *
    * Which of these the table actually has is decided by the live index list, never guessed.
    */
+
+  /**
+   * Every name this generator may have given one column's index, current first.
+   *
+   * Bounding long names changed what they are called, and an index already in a database still
+   * answers to the name it was created under. Looking only for the current one leaves the old
+   * index in place while the field records that it was removed. The dialects even disagree on
+   * the legacy name: SQLite stored it whole, PostgreSQL truncated it to 63 characters, and
+   * MySQL could not create an over-long one at all, so none exists there to find.
+   *
+   * Which of these the table actually has is decided by the live index list, never guessed.
+   */
   private indexNameCandidates(tableName: string, column: string): string[] {
     const full = `idx_${tableName}_${column}`;
-    const candidates = [this.indexName(tableName, column), full];
+    const candidates = [indexNameForColumn(tableName, column), full];
     if (this.dialect === "postgresql") candidates.push(full.slice(0, 63));
     return [...new Set(candidates)];
   }
@@ -210,7 +195,7 @@ export class DynamicCollectionSchemaService {
     column: string,
     columnType: string
   ): string | null {
-    const name = this.quoteIdentifier(this.indexName(tableName, column));
+    const name = this.quoteIdentifier(indexNameForColumn(tableName, column));
     const table = this.quoteIdentifier(tableName);
     const quoted = this.quoteIdentifier(column);
     if (this.dialect === "mysql") {
@@ -520,11 +505,11 @@ ${allColumnDefs.join(",\n")}
     // Note: MySQL 5.7 doesn't support IF NOT EXISTS for CREATE INDEX
     let createdAtIndex = "";
     if (this.dialect === "sqlite") {
-      createdAtIndex = `CREATE INDEX IF NOT EXISTS ${this.quoteIdentifier(this.indexName(tableName, "created_at"))} ON ${this.quoteIdentifier(tableName)}(${this.quoteIdentifier("created_at")});`;
+      createdAtIndex = `CREATE INDEX IF NOT EXISTS ${this.quoteIdentifier(indexNameForColumn(tableName, "created_at"))} ON ${this.quoteIdentifier(tableName)}(${this.quoteIdentifier("created_at")});`;
     } else if (this.dialect === "mysql") {
-      createdAtIndex = `CREATE INDEX ${this.quoteIdentifier(this.indexName(tableName, "created_at"))} ON ${this.quoteIdentifier(tableName)}(${this.quoteIdentifier("created_at")} DESC);`;
+      createdAtIndex = `CREATE INDEX ${this.quoteIdentifier(indexNameForColumn(tableName, "created_at"))} ON ${this.quoteIdentifier(tableName)}(${this.quoteIdentifier("created_at")} DESC);`;
     } else {
-      createdAtIndex = `CREATE INDEX IF NOT EXISTS ${this.quoteIdentifier(this.indexName(tableName, "created_at"))} ON ${this.quoteIdentifier(tableName)}(${this.quoteIdentifier("created_at")} DESC);`;
+      createdAtIndex = `CREATE INDEX IF NOT EXISTS ${this.quoteIdentifier(indexNameForColumn(tableName, "created_at"))} ON ${this.quoteIdentifier(tableName)}(${this.quoteIdentifier("created_at")} DESC);`;
     }
     indexStatements.push(createdAtIndex);
 
@@ -535,7 +520,7 @@ ${allColumnDefs.join(",\n")}
     // mirroring the column gate above. Plain (non-unique) index; users cannot
     // request one on this reserved field, so it is injected here.
     if (!isSingleTable) {
-      const ownerIndexName = this.indexName(tableName, "created_by");
+      const ownerIndexName = indexNameForColumn(tableName, "created_by");
       const ownerIndex =
         this.dialect === "mysql"
           ? `CREATE INDEX ${this.quoteIdentifier(ownerIndexName)} ON ${this.quoteIdentifier(tableName)}(${this.quoteIdentifier("created_by")});`
@@ -546,11 +531,11 @@ ${allColumnDefs.join(",\n")}
     // Add unique index for slug column (automatically available for all collections and singles)
     let slugIndex = "";
     if (this.dialect === "sqlite") {
-      slugIndex = `CREATE UNIQUE INDEX IF NOT EXISTS ${this.quoteIdentifier(this.indexName(tableName, "slug"))} ON ${this.quoteIdentifier(tableName)}(${this.quoteIdentifier("slug")});`;
+      slugIndex = `CREATE UNIQUE INDEX IF NOT EXISTS ${this.quoteIdentifier(indexNameForColumn(tableName, "slug"))} ON ${this.quoteIdentifier(tableName)}(${this.quoteIdentifier("slug")});`;
     } else if (this.dialect === "mysql") {
-      slugIndex = `CREATE UNIQUE INDEX ${this.quoteIdentifier(this.indexName(tableName, "slug"))} ON ${this.quoteIdentifier(tableName)}(${this.quoteIdentifier("slug")});`;
+      slugIndex = `CREATE UNIQUE INDEX ${this.quoteIdentifier(indexNameForColumn(tableName, "slug"))} ON ${this.quoteIdentifier(tableName)}(${this.quoteIdentifier("slug")});`;
     } else {
-      slugIndex = `CREATE UNIQUE INDEX IF NOT EXISTS ${this.quoteIdentifier(this.indexName(tableName, "slug"))} ON ${this.quoteIdentifier(tableName)}(${this.quoteIdentifier("slug")});`;
+      slugIndex = `CREATE UNIQUE INDEX IF NOT EXISTS ${this.quoteIdentifier(indexNameForColumn(tableName, "slug"))} ON ${this.quoteIdentifier(tableName)}(${this.quoteIdentifier("slug")});`;
     }
     indexStatements.push(slugIndex);
 
@@ -856,7 +841,10 @@ ${allColumnDefs.join(",\n")}
             }
           } else if (this.dialect !== "mysql") {
             statements.push(
-              this.dropIndexSql(tableName, this.indexName(tableName, idxCol))
+              this.dropIndexSql(
+                tableName,
+                indexNameForColumn(tableName, idxCol)
+              )
             );
           }
         }
@@ -932,7 +920,7 @@ ${allColumnDefs.join(",\n")}
           }
         } else if (this.dialect !== "mysql") {
           statements.push(
-            this.dropIndexSql(tableName, this.indexName(tableName, dropCol))
+            this.dropIndexSql(tableName, indexNameForColumn(tableName, dropCol))
           );
         }
 
@@ -1134,7 +1122,7 @@ ${allColumnDefs.join(",\n")}
     // The system indexes every generated table carries, named as `generateMigrationSQL` names
     // them, so a system column removed by an edit is not treated as unindexed.
     for (const column of ["slug", "created_at", "created_by"]) {
-      indexNames.add(this.indexName(tableName, column));
+      indexNames.add(indexNameForColumn(tableName, column));
     }
     for (const field of fields) {
       if (!fieldProducesColumn(field)) continue;
@@ -1156,7 +1144,7 @@ ${allColumnDefs.join(",\n")}
           )
         ) !== null
       ) {
-        indexNames.add(this.indexName(tableName, column));
+        indexNames.add(indexNameForColumn(tableName, column));
       }
       if (field.type === "relationship" && field.options?.target) {
         foreignKeysByColumn.set(column, [`fk_${tableName}_${column}`]);

--- a/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-schema-service.ts
+++ b/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-schema-service.ts
@@ -1075,7 +1075,23 @@ ${allColumnDefs.join(",\n")}
     for (const field of fields) {
       if (!fieldProducesColumn(field)) continue;
       const column = toSnakeCase(field.name);
-      if (this.columnIsIndexed(field)) {
+      // Asked through the statement builder, not through `columnIsIndexed` alone. Wanting an
+      // index and being able to have one are different questions: MySQL cannot index a JSON
+      // column, so the create emits nothing for one. Predicting it anyway makes a later edit
+      // drop an index that was never installed, which on MySQL aborts the whole migration.
+      if (
+        this.columnIsIndexed(field) &&
+        this.createIndexSql(
+          tableName,
+          column,
+          this.mapFieldTypeToSQL(
+            field.type,
+            field.length,
+            field.options,
+            field.validation
+          )
+        ) !== null
+      ) {
         indexNames.add(`idx_${tableName}_${column}`);
       }
       if (field.type === "relationship" && field.options?.target) {

--- a/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-schema-service.ts
+++ b/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-schema-service.ts
@@ -174,6 +174,25 @@ export class DynamicCollectionSchemaService {
   }
 
   /**
+   * Every name this generator may have given one column's index, current first.
+   *
+   * Bounding long names changed what they are called, and an index already in a database still
+   * carries the name it was created under. Looking only for the current one leaves the old index
+   * in place while the field records that it was removed — the table then keeps enforcing
+   * something the schema no longer says. The dialects even disagree on the legacy name: SQLite
+   * stored it whole, PostgreSQL truncated it to 63 characters, and MySQL could not create it at
+   * all, so an over-long name never existed there to find.
+   *
+   * Which of these the table actually has is decided by the live index list, never guessed.
+   */
+  private indexNameCandidates(tableName: string, column: string): string[] {
+    const full = `idx_${tableName}_${column}`;
+    const candidates = [this.indexName(tableName, column), full];
+    if (this.dialect === "postgresql") candidates.push(full.slice(0, 63));
+    return [...new Set(candidates)];
+  }
+
+  /**
    * `CREATE INDEX` for one column, in the spelling the dialect accepts.
    *
    * MySQL cannot index a `BLOB`/`TEXT` column without a key length and rejects the statement
@@ -210,8 +229,8 @@ export class DynamicCollectionSchemaService {
    * references the column, reporting it as a missing column inside the index rather than as the
    * removal it refused.
    */
-  private dropIndexSql(tableName: string, column: string): string {
-    const name = this.quoteIdentifier(this.indexName(tableName, column));
+  private dropIndexSql(tableName: string, indexName: string): string {
+    const name = this.quoteIdentifier(indexName);
     if (this.dialect === "mysql") {
       return `DROP INDEX ${name} ON ${this.quoteIdentifier(tableName)};`;
     }
@@ -819,12 +838,21 @@ ${allColumnDefs.join(",\n")}
         } else {
           // Same guard as the removal path: turning an index off that the table never carried
           // aborts on MySQL, which cannot express `DROP INDEX IF EXISTS`.
+          // And whichever name the table carries it under, for the same reason as the removal
+          // path: bounding long names changed what they are called, and an index already in a
+          // database still answers to the name it was created under.
           const known = options?.indexNames !== undefined;
-          const exists =
-            options?.indexNames?.has(this.indexName(tableName, idxCol)) ===
-            true;
-          if (known ? exists : this.dialect !== "mysql") {
-            statements.push(this.dropIndexSql(tableName, idxCol));
+          const present = this.indexNameCandidates(tableName, idxCol).find(
+            name => options?.indexNames?.has(name) === true
+          );
+          if (known) {
+            if (present !== undefined) {
+              statements.push(this.dropIndexSql(tableName, present));
+            }
+          } else if (this.dialect !== "mysql") {
+            statements.push(
+              this.dropIndexSql(tableName, this.indexName(tableName, idxCol))
+            );
           }
         }
       }
@@ -889,11 +917,18 @@ ${allColumnDefs.join(",\n")}
         // Asked of the live table, not of the field: an index is created by whichever path
         // added the column, so a field that looks indexed may have none. MySQL cannot guard the
         // drop itself, so without the answer it is not attempted there.
-        const indexName = this.indexName(tableName, dropCol);
         const indexIsKnown = options?.indexNames !== undefined;
-        const indexExists = options?.indexNames?.has(indexName) === true;
-        if (indexIsKnown ? indexExists : this.dialect !== "mysql") {
-          statements.push(this.dropIndexSql(tableName, dropCol));
+        const present = this.indexNameCandidates(tableName, dropCol).find(
+          name => options?.indexNames?.has(name) === true
+        );
+        if (indexIsKnown) {
+          if (present !== undefined) {
+            statements.push(this.dropIndexSql(tableName, present));
+          }
+        } else if (this.dialect !== "mysql") {
+          statements.push(
+            this.dropIndexSql(tableName, this.indexName(tableName, dropCol))
+          );
         }
 
         // SQLite doesn't support IF EXISTS on DROP COLUMN

--- a/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-schema-service.ts
+++ b/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-schema-service.ts
@@ -135,6 +135,46 @@ export class DynamicCollectionSchemaService {
   }
 
   /**
+   * `CREATE INDEX` for one column, in the spelling the dialect accepts.
+   *
+   * MySQL cannot index a `BLOB`/`TEXT` column without a key length and rejects the statement
+   * outright, so a text-backed column is indexed by prefix. 191 characters is the longest prefix
+   * that fits the 767-byte index limit under utf8mb4 on every InnoDB row format, including the
+   * compact ones where a longer prefix is refused. PostgreSQL and SQLite index the whole value.
+   */
+  private createIndexSql(
+    tableName: string,
+    column: string,
+    columnType: string
+  ): string {
+    const name = this.quoteIdentifier(`idx_${tableName}_${column}`);
+    const table = this.quoteIdentifier(tableName);
+    const quoted = this.quoteIdentifier(column);
+    if (this.dialect === "mysql") {
+      const target = /\b(text|blob)\b/i.test(columnType)
+        ? `${quoted}(191)`
+        : quoted;
+      return `CREATE INDEX ${name} ON ${table}(${target});`;
+    }
+    return `CREATE INDEX IF NOT EXISTS ${name} ON ${table}(${quoted});`;
+  }
+
+  /**
+   * `DROP INDEX` for one column's index, in the spelling the dialect accepts.
+   *
+   * Emitted before the column it names: SQLite refuses `DROP COLUMN` while any index still
+   * references the column, reporting it as a missing column inside the index rather than as the
+   * removal it refused.
+   */
+  private dropIndexSql(tableName: string, column: string): string {
+    const name = this.quoteIdentifier(`idx_${tableName}_${column}`);
+    if (this.dialect === "mysql") {
+      return `DROP INDEX ${name} ON ${this.quoteIdentifier(tableName)};`;
+    }
+    return `DROP INDEX IF EXISTS ${name};`;
+  }
+
+  /**
    * The literal that backfills existing rows when a required column is added, or null when the
    * field's type states none.
    *
@@ -399,16 +439,13 @@ ${allColumnDefs.join(",\n")}
         // indexed column so this matches the actual physical column (created
         // snake_cased) and the migrate:create desired-state index naming.
         const col = toSnakeCase(f.name);
-        const indexName = `idx_${tableName}_${col}`;
-        if (this.dialect === "mysql") {
-          indexStatements.push(
-            `CREATE INDEX ${this.quoteIdentifier(indexName)} ON ${this.quoteIdentifier(tableName)}(${this.quoteIdentifier(col)});`
-          );
-        } else {
-          indexStatements.push(
-            `CREATE INDEX IF NOT EXISTS ${this.quoteIdentifier(indexName)} ON ${this.quoteIdentifier(tableName)}(${this.quoteIdentifier(col)});`
-          );
-        }
+        indexStatements.push(
+          this.createIndexSql(
+            tableName,
+            col,
+            this.mapFieldTypeToSQL(f.type, f.length, f.options, f.validation)
+          )
+        );
       }
     });
 
@@ -674,15 +711,21 @@ ${allColumnDefs.join(",\n")}
             );
           }
 
-          // Add unique constraint if needed
-          if (this.columnIsUnique(field)) {
+          // The flag only, not `columnIsUnique`. A one-to-one's uniqueness is spelled three
+          // different ways today: the table CREATE writes it inline, where the dialect names the
+          // index itself; the desired schema the diff compares against declares a NON-unique
+          // index for the same field; and a named constraint here would be a third. Emitting one
+          // makes the next diff propose dropping it, so the cardinality is enforced by agreeing
+          // on one spelling, not by adding another.
+          if (field.unique) {
             statements.push(
               `ALTER TABLE ${this.quoteIdentifier(tableName)} ADD CONSTRAINT ${this.quoteIdentifier(`uq_${tableName}_${addColName}`)} UNIQUE (${this.quoteIdentifier(addColName)});`
             );
           }
         } else {
-          // For SQLite with unique constraint, create a unique index instead
-          if (this.columnIsUnique(field)) {
+          // For SQLite with unique constraint, create a unique index instead. The flag only,
+          // for the reason above.
+          if (field.unique) {
             statements.push(
               `CREATE UNIQUE INDEX IF NOT EXISTS ${this.quoteIdentifier(`uq_${tableName}_${addColName}`)} ON ${this.quoteIdentifier(tableName)}(${this.quoteIdentifier(addColName)});`
             );
@@ -695,12 +738,7 @@ ${allColumnDefs.join(",\n")}
         // at the same moment as the column nor the one a relationship always carries was created
         // by either.
         if (this.columnIsIndexed(field)) {
-          const indexName = `idx_${tableName}_${addColName}`;
-          statements.push(
-            this.dialect === "mysql"
-              ? `CREATE INDEX ${this.quoteIdentifier(indexName)} ON ${this.quoteIdentifier(tableName)}(${this.quoteIdentifier(addColName)});`
-              : `CREATE INDEX IF NOT EXISTS ${this.quoteIdentifier(indexName)} ON ${this.quoteIdentifier(tableName)}(${this.quoteIdentifier(addColName)});`
-          );
+          statements.push(this.createIndexSql(tableName, addColName, type));
         }
       }
     }
@@ -718,30 +756,15 @@ ${allColumnDefs.join(",\n")}
       if (!oldField || this.storageClassChanged(oldField, field)) continue;
       if (oldField.index !== field.index) {
         const idxCol = toSnakeCase(field.name);
-        const indexName = `idx_${tableName}_${idxCol}`;
-        if (field.index) {
-          // Add index
-          if (this.dialect === "mysql") {
-            statements.push(
-              `CREATE INDEX ${this.quoteIdentifier(indexName)} ON ${this.quoteIdentifier(tableName)}(${this.quoteIdentifier(idxCol)});`
-            );
-          } else {
-            statements.push(
-              `CREATE INDEX IF NOT EXISTS ${this.quoteIdentifier(indexName)} ON ${this.quoteIdentifier(tableName)}(${this.quoteIdentifier(idxCol)});`
-            );
-          }
-        } else {
-          // Drop index
-          if (this.dialect === "mysql") {
-            statements.push(
-              `DROP INDEX ${this.quoteIdentifier(indexName)} ON ${this.quoteIdentifier(tableName)};`
-            );
-          } else {
-            statements.push(
-              `DROP INDEX IF EXISTS ${this.quoteIdentifier(indexName)} ON ${this.quoteIdentifier(tableName)};`
-            );
-          }
-        }
+        statements.push(
+          field.index
+            ? this.createIndexSql(
+                tableName,
+                idxCol,
+                this.mapFieldTypeToSQL(field.type, field.length)
+              )
+            : this.dropIndexSql(tableName, idxCol)
+        );
       }
     }
 
@@ -764,6 +787,14 @@ ${allColumnDefs.join(",\n")}
         // until the constraint is named and removed first. SQLite cannot remove a constraint at
         // all: the column stays until the whole table is rebuilt around it, so the edit is
         // refused rather than sent to fail as a driver error the author cannot act on.
+        // Everything attached to the column comes off before the column does. SQLite refuses
+        // `DROP COLUMN` while an index still names it, and reports that as a missing column
+        // inside the index rather than as the removal it refused. PostgreSQL and MySQL drop the
+        // index with the column, so removing it first is redundant there and never wrong.
+        if (this.columnIsIndexed(field)) {
+          statements.push(this.dropIndexSql(tableName, dropCol));
+        }
+
         const foreignKeys = options?.foreignKeysByColumn?.get(dropCol);
         if (foreignKeys !== undefined) {
           if (this.dialect === "sqlite") {

--- a/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-schema-service.ts
+++ b/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-schema-service.ts
@@ -146,11 +146,16 @@ export class DynamicCollectionSchemaService {
     tableName: string,
     column: string,
     columnType: string
-  ): string {
+  ): string | null {
     const name = this.quoteIdentifier(`idx_${tableName}_${column}`);
     const table = this.quoteIdentifier(tableName);
     const quoted = this.quoteIdentifier(column);
     if (this.dialect === "mysql") {
+      // A JSON column cannot be indexed at all: MySQL answers "supports indexing only via
+      // generated columns on a specified JSON path". Emitting the statement fails the migration
+      // after the ADD COLUMN before it may already have committed, so no index is emitted here.
+      // The other dialects index the value, so the field means the same thing everywhere it can.
+      if (/\bjson\b/i.test(columnType)) return null;
       const target = /\b(text|blob)\b/i.test(columnType)
         ? `${quoted}(191)`
         : quoted;
@@ -439,13 +444,12 @@ ${allColumnDefs.join(",\n")}
         // indexed column so this matches the actual physical column (created
         // snake_cased) and the migrate:create desired-state index naming.
         const col = toSnakeCase(f.name);
-        indexStatements.push(
-          this.createIndexSql(
-            tableName,
-            col,
-            this.mapFieldTypeToSQL(f.type, f.length, f.options, f.validation)
-          )
+        const indexSql = this.createIndexSql(
+          tableName,
+          col,
+          this.mapFieldTypeToSQL(f.type, f.length, f.options, f.validation)
         );
+        if (indexSql) indexStatements.push(indexSql);
       }
     });
 
@@ -749,7 +753,8 @@ ${allColumnDefs.join(",\n")}
         // at the same moment as the column nor the one a relationship always carries was created
         // by either.
         if (this.columnIsIndexed(field)) {
-          statements.push(this.createIndexSql(tableName, addColName, type));
+          const addIndexSql = this.createIndexSql(tableName, addColName, type);
+          if (addIndexSql) statements.push(addIndexSql);
         }
       }
     }
@@ -768,13 +773,12 @@ ${allColumnDefs.join(",\n")}
       if (oldField.index !== field.index) {
         const idxCol = toSnakeCase(field.name);
         if (field.index) {
-          statements.push(
-            this.createIndexSql(
-              tableName,
-              idxCol,
-              this.mapFieldTypeToSQL(field.type, field.length)
-            )
+          const toggleIndexSql = this.createIndexSql(
+            tableName,
+            idxCol,
+            this.mapFieldTypeToSQL(field.type, field.length)
           );
+          if (toggleIndexSql) statements.push(toggleIndexSql);
         } else {
           // Same guard as the removal path: turning an index off that the table never carried
           // aborts on MySQL, which cannot express `DROP INDEX IF EXISTS`.
@@ -812,16 +816,6 @@ ${allColumnDefs.join(",\n")}
         // inside the index rather than as the removal it refused. PostgreSQL and MySQL drop the
         // index with the column, so removing it first is redundant there and never wrong.
         //
-        // Asked of the live table, not of the field: an index is created by whichever path
-        // added the column, so a field that looks indexed may have none. MySQL cannot guard the
-        // drop itself, so without the answer it is not attempted there.
-        const indexName = `idx_${tableName}_${dropCol}`;
-        const indexIsKnown = options?.indexNames !== undefined;
-        const indexExists = options?.indexNames?.has(indexName) === true;
-        if (indexIsKnown ? indexExists : this.dialect !== "mysql") {
-          statements.push(this.dropIndexSql(tableName, dropCol));
-        }
-
         const foreignKeys = options?.foreignKeysByColumn?.get(dropCol);
         if (foreignKeys !== undefined) {
           if (this.dialect === "sqlite") {
@@ -847,6 +841,21 @@ ${allColumnDefs.join(",\n")}
               );
             }
           }
+        }
+
+        // After the constraint, before the column. MySQL enforces a foreign key THROUGH an
+        // index and refuses to drop the one supporting it ("Cannot drop index: needed in a
+        // foreign key constraint"), so the constraint has to go first; SQLite refuses to drop a
+        // column an index still names, so the index has to go before that.
+        //
+        // Asked of the live table, not of the field: an index is created by whichever path
+        // added the column, so a field that looks indexed may have none. MySQL cannot guard the
+        // drop itself, so without the answer it is not attempted there.
+        const indexName = `idx_${tableName}_${dropCol}`;
+        const indexIsKnown = options?.indexNames !== undefined;
+        const indexExists = options?.indexNames?.has(indexName) === true;
+        if (indexIsKnown ? indexExists : this.dialect !== "mysql") {
+          statements.push(this.dropIndexSql(tableName, dropCol));
         }
 
         // SQLite doesn't support IF EXISTS on DROP COLUMN

--- a/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-schema-service.ts
+++ b/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-schema-service.ts
@@ -551,6 +551,17 @@ ${allColumnDefs.join(",\n")}
        * drop exactly as it behaved before anything was measured.
        */
       foreignKeysByColumn?: ReadonlyMap<string, readonly string[]>;
+      /**
+       * The index names the table carries, read from the live table by `readIndexNames`.
+       *
+       * Consulted before dropping one. Which columns are indexed is not derivable from the
+       * fields: an index is created by whichever path added the column, and those paths have
+       * not always agreed, so an identical field can be indexed on one table and not on
+       * another. MySQL has no `DROP INDEX IF EXISTS`, so dropping an absent index aborts the
+       * migration before the statements after it. Undefined means the caller did not look, and
+       * the drop is then emitted only where the dialect can guard it itself.
+       */
+      indexNames?: ReadonlySet<string>;
     }
   ): string {
     const statements: string[] = [`-- Update dynamic collection: ${tableName}`];
@@ -756,15 +767,24 @@ ${allColumnDefs.join(",\n")}
       if (!oldField || this.storageClassChanged(oldField, field)) continue;
       if (oldField.index !== field.index) {
         const idxCol = toSnakeCase(field.name);
-        statements.push(
-          field.index
-            ? this.createIndexSql(
-                tableName,
-                idxCol,
-                this.mapFieldTypeToSQL(field.type, field.length)
-              )
-            : this.dropIndexSql(tableName, idxCol)
-        );
+        if (field.index) {
+          statements.push(
+            this.createIndexSql(
+              tableName,
+              idxCol,
+              this.mapFieldTypeToSQL(field.type, field.length)
+            )
+          );
+        } else {
+          // Same guard as the removal path: turning an index off that the table never carried
+          // aborts on MySQL, which cannot express `DROP INDEX IF EXISTS`.
+          const known = options?.indexNames !== undefined;
+          const exists =
+            options?.indexNames?.has(`idx_${tableName}_${idxCol}`) === true;
+          if (known ? exists : this.dialect !== "mysql") {
+            statements.push(this.dropIndexSql(tableName, idxCol));
+          }
+        }
       }
     }
 
@@ -791,7 +811,14 @@ ${allColumnDefs.join(",\n")}
         // `DROP COLUMN` while an index still names it, and reports that as a missing column
         // inside the index rather than as the removal it refused. PostgreSQL and MySQL drop the
         // index with the column, so removing it first is redundant there and never wrong.
-        if (this.columnIsIndexed(field)) {
+        //
+        // Asked of the live table, not of the field: an index is created by whichever path
+        // added the column, so a field that looks indexed may have none. MySQL cannot guard the
+        // drop itself, so without the answer it is not attempted there.
+        const indexName = `idx_${tableName}_${dropCol}`;
+        const indexIsKnown = options?.indexNames !== undefined;
+        const indexExists = options?.indexNames?.has(indexName) === true;
+        if (indexIsKnown ? indexExists : this.dialect !== "mysql") {
           statements.push(this.dropIndexSql(tableName, dropCol));
         }
 

--- a/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-schema-service.ts
+++ b/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-schema-service.ts
@@ -135,6 +135,22 @@ export class DynamicCollectionSchemaService {
   }
 
   /**
+   * What happens to this row when the row it points at is deleted.
+   *
+   * A required relationship cannot be nulled out: the column forbids it. MySQL says so when the
+   * constraint is created — "Column cannot be NOT NULL: needed in a foreign key constraint SET
+   * NULL" — and PostgreSQL accepts the pair and fails later, at the delete, which is worse. So a
+   * required relationship restricts the delete instead, and an optional one nulls the reference.
+   * That is the same rule Prisma applies, for the same reason: the action has to be one the
+   * column can actually perform.
+   */
+  private relationOnDelete(field: FieldDefinition): string {
+    const declared = field.options?.onDelete;
+    if (declared) return declared;
+    return field.required ? "restrict" : "set null";
+  }
+
+  /**
    * `CREATE INDEX` for one column, in the spelling the dialect accepts.
    *
    * MySQL cannot index a `BLOB`/`TEXT` column without a key length and rejects the statement
@@ -329,9 +345,7 @@ export class DynamicCollectionSchemaService {
             relationType === "manyToOne" ||
             relationType === "oneToMany"
           ) {
-            const onDelete = this.mapOnDeleteAction(
-              f.options.onDelete || "set null"
-            );
+            const onDelete = this.mapOnDeleteAction(this.relationOnDelete(f));
             const onUpdate = this.mapOnUpdateAction(
               f.options.onUpdate || "no action"
             );
@@ -719,7 +733,7 @@ ${allColumnDefs.join(",\n")}
           // Add foreign key for non-manyToMany relations
           if (field.type === "relationship" && field.options?.target) {
             const targetTable = `dc_${field.options.target}`;
-            const onDelete = field.options.onDelete || "set null";
+            const onDelete = this.relationOnDelete(field);
             const onUpdate = field.options.onUpdate || "no action";
             statements.push(
               `ALTER TABLE ${this.quoteIdentifier(tableName)} ADD CONSTRAINT ${this.quoteIdentifier(`fk_${tableName}_${addColName}`)} FOREIGN KEY (${this.quoteIdentifier(addColName)}) REFERENCES ${this.quoteIdentifier(targetTable)}(${this.quoteIdentifier("id")}) ON DELETE ${this.mapOnDeleteAction(onDelete)} ON UPDATE ${this.mapOnUpdateAction(onUpdate)};`
@@ -1032,6 +1046,45 @@ ${allColumnDefs.join(",\n")}
   /**
    * Generate DROP TABLE migration SQL
    */
+  /**
+   * The indexes and foreign keys a table WILL carry once its creation migration has run.
+   *
+   * A collection saved but not yet deployed has a registry record and no table. Reading the
+   * absent table reports no attachments, and an edit made in that window then emits a bare
+   * `DROP COLUMN` — which is correct against nothing and wrong against what the deployment
+   * actually produces, because the create artefact runs first and installs the index and the
+   * constraint the drop then trips over.
+   *
+   * Answered by the class that emits the CREATE, so what is predicted here and what is written
+   * there cannot describe different tables.
+   */
+  plannedAttachments(
+    tableName: string,
+    fields: FieldDefinition[]
+  ): {
+    indexNames: Set<string>;
+    foreignKeysByColumn: Map<string, string[]>;
+  } {
+    const indexNames = new Set<string>();
+    const foreignKeysByColumn = new Map<string, string[]>();
+    // The system indexes every generated table carries, named as `generateMigrationSQL` names
+    // them, so a system column removed by an edit is not treated as unindexed.
+    for (const column of ["slug", "created_at", "created_by"]) {
+      indexNames.add(`idx_${tableName}_${column}`);
+    }
+    for (const field of fields) {
+      if (!fieldProducesColumn(field)) continue;
+      const column = toSnakeCase(field.name);
+      if (this.columnIsIndexed(field)) {
+        indexNames.add(`idx_${tableName}_${column}`);
+      }
+      if (field.type === "relationship" && field.options?.target) {
+        foreignKeysByColumn.set(column, [`fk_${tableName}_${column}`]);
+      }
+    }
+    return { indexNames, foreignKeysByColumn };
+  }
+
   generateDropTableMigration(
     collectionName: string,
     tableName: string

--- a/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-schema-service.ts
+++ b/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-schema-service.ts
@@ -22,6 +22,7 @@
 
 import type { FieldDefinition } from "@nextly/schemas/dynamic-collections";
 
+import { NextlyError } from "../../../errors/nextly-error";
 import { STORAGE_FORMAT } from "../../../schemas/storage-format";
 import { env } from "../../../shared/lib/env";
 import {
@@ -103,6 +104,55 @@ export class DynamicCollectionSchemaService {
   }
 
   /**
+   * Whether the field's column is unique.
+   *
+   * A one-to-one relationship is unique by its cardinality, not by anything the author ticks, so
+   * the flag alone does not decide it. Asked in one place because the answer has to be the same
+   * whether the column arrives with its table or is added to one that already exists: a table
+   * that gained its one-to-one by an edit was not enforcing the cardinality it declared.
+   */
+  private columnIsUnique(field: FieldDefinition): boolean {
+    return (
+      field.unique === true ||
+      (field.type === "relationship" &&
+        field.options?.relationType === "oneToOne")
+    );
+  }
+
+  /**
+   * Whether the field's column is indexed.
+   *
+   * A relationship is indexed whether or not the author asked: it is joined on every read that
+   * expands it, and PostgreSQL does not index a foreign key on its own. Everything else is
+   * indexed only on request. Asked in one place for the same reason as `columnIsUnique` — a
+   * column added to an existing table was reaching neither rule, so a relationship created with
+   * its table was indexed and the identical field added by an edit was not.
+   */
+  private columnIsIndexed(field: FieldDefinition): boolean {
+    if (!fieldProducesColumn(field)) return false;
+    if (field.type === "relationship") return true;
+    return field.index === true;
+  }
+
+  /**
+   * The literal that backfills existing rows when a required column is added, or null when the
+   * field's type states none.
+   *
+   * A relationship is the case with no answer: every id the generator could write references a
+   * row that does not exist, and `DEFAULT NULL` does not satisfy `NOT NULL` on any dialect.
+   */
+  private requiredColumnBackfill(field: FieldDefinition): string | null {
+    const literal =
+      field.default !== undefined
+        ? this.formatDefaultValue(field.default, field.type)
+        : this.getDefaultValueForType(field.type, field);
+    // `NULL` is the absence of an answer however it was arrived at. Read from the explicit
+    // default it is a contradiction with the required flag; derived from the type it is the
+    // relationship case. Neither satisfies NOT NULL, so both are reported the same way.
+    return literal === "NULL" ? null : literal;
+  }
+
+  /**
    * Generate SQL migration for creating a new collection table
    *
    * @param tableName - The name of the table to create
@@ -170,12 +220,7 @@ export class DynamicCollectionSchemaService {
           this.mapFieldTypeToSQL(f.type, f.length, f.options, f.validation);
         const nullable = f.required ? "NOT NULL" : "";
 
-        // one-to-one relationships should be unique
-        const unique =
-          f.unique ||
-          (f.type === "relationship" && f.options?.relationType === "oneToOne")
-            ? "UNIQUE"
-            : "";
+        const unique = this.columnIsUnique(f) ? "UNIQUE" : "";
 
         const defaultVal =
           f.default !== undefined && f.default !== null
@@ -343,41 +388,16 @@ ${allColumnDefs.join(",\n")}
     // Add indexes for fields that benefit from indexing
     const indexStatements: string[] = [];
 
-    // essential for JOIN performance, PostgreSQL does NOT automatically index foreign keys!
-    // Use mainFields so a localized relationship field (relocated to the companion) doesn't
-    // get an index on a column the main table no longer has.
+    // A relationship is indexed for JOIN performance whether or not it was asked for, and every
+    // other column only on request; `columnIsIndexed` holds both rules, and the ALTER path reads
+    // the same one so a column added later is indexed the way the same column created here is.
+    // Use mainFields so a localized field (relocated to the companion) doesn't get an index on a
+    // column the main table no longer has.
     mainFields.forEach(f => {
-      if (
-        f.type === "relationship" &&
-        f.options?.relationType !== "manyToMany"
-      ) {
+      if (this.columnIsIndexed(f)) {
         // Use the snake_case column name for both the index name and the
         // indexed column so this matches the actual physical column (created
         // snake_cased) and the migrate:create desired-state index naming.
-        const col = toSnakeCase(f.name);
-        const indexName = `idx_${tableName}_${col}`;
-        if (this.dialect === "mysql") {
-          indexStatements.push(
-            `CREATE INDEX ${this.quoteIdentifier(indexName)} ON ${this.quoteIdentifier(tableName)}(${this.quoteIdentifier(col)});`
-          );
-        } else {
-          indexStatements.push(
-            `CREATE INDEX IF NOT EXISTS ${this.quoteIdentifier(indexName)} ON ${this.quoteIdentifier(tableName)}(${this.quoteIdentifier(col)});`
-          );
-        }
-      }
-    });
-
-    // Add manual indexes requested by the user. Use mainFields so a localized field
-    // that also requested an index doesn't try to index a column relocated to the
-    // companion table (i18n). Component fields have no column to index, so skip them
-    // too (an index on a nonexistent column fails).
-    mainFields.forEach(f => {
-      if (
-        f.index &&
-        f.type !== "relationship" &&
-        f.type !== STORAGE_FORMAT.fieldType
-      ) {
         const col = toSnakeCase(f.name);
         const indexName = `idx_${tableName}_${col}`;
         if (this.dialect === "mysql") {
@@ -475,6 +495,25 @@ ${allColumnDefs.join(",\n")}
        * lifecycle is enabled or disabled. Pairs with `wasStatus`.
        */
       hasStatus?: boolean;
+      /**
+       * Whether the table already holds rows, read from the live table by `tableHasRows`.
+       *
+       * Only a required column whose type states no backfill consults it, and only to decide
+       * between emitting the column and refusing the edit. Undefined means the caller did not
+       * look, which is read as "may have rows": guessing empty produces a statement that
+       * PostgreSQL and MySQL reject and that SQLite accepts before rejecting every insert.
+       */
+      tableHasRows?: boolean;
+      /**
+       * Foreign-key constraint names by column, read from the live table by
+       * `readForeignKeyColumns`.
+       *
+       * Which columns carry one is not derivable from the fields: on SQLite the ALTER path
+       * cannot attach a foreign key, so a relationship added by an edit has none while the same
+       * field created with its table does. Undefined is read as "none known", which leaves the
+       * drop exactly as it behaved before anything was measured.
+       */
+      foreignKeysByColumn?: ReadonlyMap<string, readonly string[]>;
     }
   ): string {
     const statements: string[] = [`-- Update dynamic collection: ${tableName}`];
@@ -584,19 +623,39 @@ ${allColumnDefs.join(",\n")}
 
         const type = this.mapFieldTypeToSQL(field.type, field.length);
         const nullable = field.required ? "NOT NULL" : "";
-
-        // When adding a NOT NULL column to an existing table, we must provide a default
-        // value for existing rows. Use explicit defaultValue if provided, otherwise
-        // use a sensible default based on field type.
-        let defaultVal = "";
-        if (field.default !== undefined) {
-          defaultVal = `DEFAULT ${this.formatDefaultValue(field.default, field.type)}`;
-        } else if (field.required) {
-          // Required field without explicit default - provide sensible default for existing rows
-          defaultVal = `DEFAULT ${this.getDefaultValueForType(field.type, field)}`;
-        }
-
         const addColName = toSnakeCase(field.name);
+
+        // An existing row has no value for a column that did not exist a moment ago, so a
+        // required one has to say what those rows get. Most types state something usable; a
+        // relationship states nothing, because every id it could write references a row that
+        // is not there. Emitting `DEFAULT NULL` anyway is what produced three different
+        // failures: PostgreSQL reports the nulls it found, MySQL calls the default invalid,
+        // and SQLite writes the column and then refuses every insert that omits it.
+        //
+        // With no rows to backfill there is nothing to state, and a plain NOT NULL is
+        // accepted by all three. With rows, the value has to come from the author, so the
+        // edit is refused and names the order that works.
+        let defaultVal = "";
+        if (field.required || field.default !== undefined) {
+          const backfill = this.requiredColumnBackfill(field);
+          if (backfill !== null) {
+            defaultVal = `DEFAULT ${backfill}`;
+          } else if (field.required && options?.tableHasRows !== false) {
+            throw NextlyError.validation({
+              errors: [
+                {
+                  path: `fields.${field.name}`,
+                  code: "REQUIRED_COLUMN_NEEDS_BACKFILL",
+                  message:
+                    `"${field.name}" is required, but ${tableName} already has entries and ` +
+                    `a ${field.type} has no default value to give them. Add the field as ` +
+                    `optional, set a value on the existing entries, then mark it required.`,
+                },
+              ],
+              logContext: { tableName, field: field.name, type: field.type },
+            });
+          }
+        }
         statements.push(
           `ALTER TABLE ${this.quoteIdentifier(tableName)} ADD COLUMN ${this.quoteIdentifier(addColName)} ${type} ${nullable} ${defaultVal};`.trim()
         );
@@ -616,18 +675,32 @@ ${allColumnDefs.join(",\n")}
           }
 
           // Add unique constraint if needed
-          if (field.unique) {
+          if (this.columnIsUnique(field)) {
             statements.push(
               `ALTER TABLE ${this.quoteIdentifier(tableName)} ADD CONSTRAINT ${this.quoteIdentifier(`uq_${tableName}_${addColName}`)} UNIQUE (${this.quoteIdentifier(addColName)});`
             );
           }
         } else {
           // For SQLite with unique constraint, create a unique index instead
-          if (field.unique) {
+          if (this.columnIsUnique(field)) {
             statements.push(
               `CREATE UNIQUE INDEX IF NOT EXISTS ${this.quoteIdentifier(`uq_${tableName}_${addColName}`)} ON ${this.quoteIdentifier(tableName)}(${this.quoteIdentifier(addColName)});`
             );
           }
+        }
+
+        // The index this column carries, for a column that did not exist before this save. The
+        // index loop below compares a field against its previous state to catch a toggle, and a
+        // field being added has no previous state to differ from, so neither the index requested
+        // at the same moment as the column nor the one a relationship always carries was created
+        // by either.
+        if (this.columnIsIndexed(field)) {
+          const indexName = `idx_${tableName}_${addColName}`;
+          statements.push(
+            this.dialect === "mysql"
+              ? `CREATE INDEX ${this.quoteIdentifier(indexName)} ON ${this.quoteIdentifier(tableName)}(${this.quoteIdentifier(addColName)});`
+              : `CREATE INDEX IF NOT EXISTS ${this.quoteIdentifier(indexName)} ON ${this.quoteIdentifier(tableName)}(${this.quoteIdentifier(addColName)});`
+          );
         }
       }
     }
@@ -639,7 +712,11 @@ ${allColumnDefs.join(",\n")}
       // CREATE INDEX against a name the table does not have, which fails the whole save.
       if (!fieldProducesColumn(field)) continue;
       const oldField = oldFieldMap.get(field.name);
-      if (oldField && oldField.index !== field.index) {
+      // A column the add loop just created already carries whatever index was requested with
+      // it. Reading the toggle for one of those emits a second CREATE INDEX for the same
+      // column under the same name.
+      if (!oldField || this.storageClassChanged(oldField, field)) continue;
+      if (oldField.index !== field.index) {
         const idxCol = toSnakeCase(field.name);
         const indexName = `idx_${tableName}_${idxCol}`;
         if (field.index) {
@@ -680,6 +757,40 @@ ${allColumnDefs.join(",\n")}
       const next = newFieldMap.get(field.name);
       if (!next || this.storageClassChanged(field, next)) {
         const dropCol = toSnakeCase(field.name);
+
+        // A column that something references cannot simply be removed, and the three dialects
+        // do not agree on what that costs. PostgreSQL drops the constraints that depend on the
+        // column along with it, so it needs nothing here. MySQL keeps them and refuses the drop
+        // until the constraint is named and removed first. SQLite cannot remove a constraint at
+        // all: the column stays until the whole table is rebuilt around it, so the edit is
+        // refused rather than sent to fail as a driver error the author cannot act on.
+        const foreignKeys = options?.foreignKeysByColumn?.get(dropCol);
+        if (foreignKeys !== undefined) {
+          if (this.dialect === "sqlite") {
+            throw NextlyError.validation({
+              errors: [
+                {
+                  path: `fields.${field.name}`,
+                  code: "FOREIGN_KEY_DROP_UNSUPPORTED",
+                  message:
+                    `"${field.name}" cannot be removed on SQLite: the link it holds to another ` +
+                    `collection is part of ${tableName}'s definition, and SQLite can only drop ` +
+                    `one by rebuilding the table. Remove the field on PostgreSQL or MySQL, or ` +
+                    `recreate the collection.`,
+                },
+              ],
+              logContext: { tableName, field: field.name, column: dropCol },
+            });
+          }
+          if (this.dialect === "mysql") {
+            for (const constraint of foreignKeys) {
+              statements.push(
+                `ALTER TABLE ${this.quoteIdentifier(tableName)} DROP FOREIGN KEY ${this.quoteIdentifier(constraint)};`
+              );
+            }
+          }
+        }
+
         // SQLite doesn't support IF EXISTS on DROP COLUMN
         if (this.dialect === "sqlite") {
           statements.push(

--- a/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-schema-service.ts
+++ b/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-schema-service.ts
@@ -161,7 +161,12 @@ export class DynamicCollectionSchemaService {
    */
   private indexName(tableName: string, column: string): string {
     const full = `idx_${tableName}_${column}`;
-    if (full.length <= 64) return full;
+    // 63, not 64. MySQL refuses anything longer than 64, but PostgreSQL silently TRUNCATES at
+    // 63 — so a 64-character name is not a name PostgreSQL keeps, and two that differ only in
+    // their last character arrive as one identifier. Bounding at the smaller of the two limits
+    // is what makes the hash below the thing that tells names apart, rather than a decoration
+    // on a name the database has already collapsed.
+    if (full.length <= 63) return full;
     // FNV-1a over the full name. Not for secrecy — only to tell apart two names that a plain
     // truncation would make identical.
     let hash = 0x811c9dc5;
@@ -170,7 +175,7 @@ export class DynamicCollectionSchemaService {
       hash = Math.imul(hash, 0x01000193) >>> 0;
     }
     const suffix = hash.toString(36).padStart(7, "0");
-    return `${full.slice(0, 64 - suffix.length - 1)}_${suffix}`;
+    return `${full.slice(0, 63 - suffix.length - 1)}_${suffix}`;
   }
 
   /**

--- a/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-schema-service.ts
+++ b/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-schema-service.ts
@@ -151,6 +151,29 @@ export class DynamicCollectionSchemaService {
   }
 
   /**
+   * The index name for one column, short enough for every dialect to accept.
+   *
+   * MySQL refuses an identifier over 64 characters, and a collection and a field may each be up
+   * to 50, so the obvious `idx_<table>_<column>` can be half as long again as the limit. Names
+   * over the bound keep a readable prefix and end in a hash of the full name, so two long names
+   * sharing a prefix still differ and the same input always produces the same identifier —
+   * which matters because the name is built again, separately, to drop the index later.
+   */
+  private indexName(tableName: string, column: string): string {
+    const full = `idx_${tableName}_${column}`;
+    if (full.length <= 64) return full;
+    // FNV-1a over the full name. Not for secrecy — only to tell apart two names that a plain
+    // truncation would make identical.
+    let hash = 0x811c9dc5;
+    for (let i = 0; i < full.length; i++) {
+      hash ^= full.charCodeAt(i);
+      hash = Math.imul(hash, 0x01000193) >>> 0;
+    }
+    const suffix = hash.toString(36).padStart(7, "0");
+    return `${full.slice(0, 64 - suffix.length - 1)}_${suffix}`;
+  }
+
+  /**
    * `CREATE INDEX` for one column, in the spelling the dialect accepts.
    *
    * MySQL cannot index a `BLOB`/`TEXT` column without a key length and rejects the statement
@@ -163,7 +186,7 @@ export class DynamicCollectionSchemaService {
     column: string,
     columnType: string
   ): string | null {
-    const name = this.quoteIdentifier(`idx_${tableName}_${column}`);
+    const name = this.quoteIdentifier(this.indexName(tableName, column));
     const table = this.quoteIdentifier(tableName);
     const quoted = this.quoteIdentifier(column);
     if (this.dialect === "mysql") {
@@ -188,7 +211,7 @@ export class DynamicCollectionSchemaService {
    * removal it refused.
    */
   private dropIndexSql(tableName: string, column: string): string {
-    const name = this.quoteIdentifier(`idx_${tableName}_${column}`);
+    const name = this.quoteIdentifier(this.indexName(tableName, column));
     if (this.dialect === "mysql") {
       return `DROP INDEX ${name} ON ${this.quoteIdentifier(tableName)};`;
     }
@@ -473,11 +496,11 @@ ${allColumnDefs.join(",\n")}
     // Note: MySQL 5.7 doesn't support IF NOT EXISTS for CREATE INDEX
     let createdAtIndex = "";
     if (this.dialect === "sqlite") {
-      createdAtIndex = `CREATE INDEX IF NOT EXISTS ${this.quoteIdentifier(`idx_${tableName}_created_at`)} ON ${this.quoteIdentifier(tableName)}(${this.quoteIdentifier("created_at")});`;
+      createdAtIndex = `CREATE INDEX IF NOT EXISTS ${this.quoteIdentifier(this.indexName(tableName, "created_at"))} ON ${this.quoteIdentifier(tableName)}(${this.quoteIdentifier("created_at")});`;
     } else if (this.dialect === "mysql") {
-      createdAtIndex = `CREATE INDEX ${this.quoteIdentifier(`idx_${tableName}_created_at`)} ON ${this.quoteIdentifier(tableName)}(${this.quoteIdentifier("created_at")} DESC);`;
+      createdAtIndex = `CREATE INDEX ${this.quoteIdentifier(this.indexName(tableName, "created_at"))} ON ${this.quoteIdentifier(tableName)}(${this.quoteIdentifier("created_at")} DESC);`;
     } else {
-      createdAtIndex = `CREATE INDEX IF NOT EXISTS ${this.quoteIdentifier(`idx_${tableName}_created_at`)} ON ${this.quoteIdentifier(tableName)}(${this.quoteIdentifier("created_at")} DESC);`;
+      createdAtIndex = `CREATE INDEX IF NOT EXISTS ${this.quoteIdentifier(this.indexName(tableName, "created_at"))} ON ${this.quoteIdentifier(tableName)}(${this.quoteIdentifier("created_at")} DESC);`;
     }
     indexStatements.push(createdAtIndex);
 
@@ -488,7 +511,7 @@ ${allColumnDefs.join(",\n")}
     // mirroring the column gate above. Plain (non-unique) index; users cannot
     // request one on this reserved field, so it is injected here.
     if (!isSingleTable) {
-      const ownerIndexName = `idx_${tableName}_created_by`;
+      const ownerIndexName = this.indexName(tableName, "created_by");
       const ownerIndex =
         this.dialect === "mysql"
           ? `CREATE INDEX ${this.quoteIdentifier(ownerIndexName)} ON ${this.quoteIdentifier(tableName)}(${this.quoteIdentifier("created_by")});`
@@ -499,11 +522,11 @@ ${allColumnDefs.join(",\n")}
     // Add unique index for slug column (automatically available for all collections and singles)
     let slugIndex = "";
     if (this.dialect === "sqlite") {
-      slugIndex = `CREATE UNIQUE INDEX IF NOT EXISTS ${this.quoteIdentifier(`idx_${tableName}_slug`)} ON ${this.quoteIdentifier(tableName)}(${this.quoteIdentifier("slug")});`;
+      slugIndex = `CREATE UNIQUE INDEX IF NOT EXISTS ${this.quoteIdentifier(this.indexName(tableName, "slug"))} ON ${this.quoteIdentifier(tableName)}(${this.quoteIdentifier("slug")});`;
     } else if (this.dialect === "mysql") {
-      slugIndex = `CREATE UNIQUE INDEX ${this.quoteIdentifier(`idx_${tableName}_slug`)} ON ${this.quoteIdentifier(tableName)}(${this.quoteIdentifier("slug")});`;
+      slugIndex = `CREATE UNIQUE INDEX ${this.quoteIdentifier(this.indexName(tableName, "slug"))} ON ${this.quoteIdentifier(tableName)}(${this.quoteIdentifier("slug")});`;
     } else {
-      slugIndex = `CREATE UNIQUE INDEX IF NOT EXISTS ${this.quoteIdentifier(`idx_${tableName}_slug`)} ON ${this.quoteIdentifier(tableName)}(${this.quoteIdentifier("slug")});`;
+      slugIndex = `CREATE UNIQUE INDEX IF NOT EXISTS ${this.quoteIdentifier(this.indexName(tableName, "slug"))} ON ${this.quoteIdentifier(tableName)}(${this.quoteIdentifier("slug")});`;
     }
     indexStatements.push(slugIndex);
 
@@ -798,7 +821,8 @@ ${allColumnDefs.join(",\n")}
           // aborts on MySQL, which cannot express `DROP INDEX IF EXISTS`.
           const known = options?.indexNames !== undefined;
           const exists =
-            options?.indexNames?.has(`idx_${tableName}_${idxCol}`) === true;
+            options?.indexNames?.has(this.indexName(tableName, idxCol)) ===
+            true;
           if (known ? exists : this.dialect !== "mysql") {
             statements.push(this.dropIndexSql(tableName, idxCol));
           }
@@ -865,7 +889,7 @@ ${allColumnDefs.join(",\n")}
         // Asked of the live table, not of the field: an index is created by whichever path
         // added the column, so a field that looks indexed may have none. MySQL cannot guard the
         // drop itself, so without the answer it is not attempted there.
-        const indexName = `idx_${tableName}_${dropCol}`;
+        const indexName = this.indexName(tableName, dropCol);
         const indexIsKnown = options?.indexNames !== undefined;
         const indexExists = options?.indexNames?.has(indexName) === true;
         if (indexIsKnown ? indexExists : this.dialect !== "mysql") {
@@ -1070,7 +1094,7 @@ ${allColumnDefs.join(",\n")}
     // The system indexes every generated table carries, named as `generateMigrationSQL` names
     // them, so a system column removed by an edit is not treated as unindexed.
     for (const column of ["slug", "created_at", "created_by"]) {
-      indexNames.add(`idx_${tableName}_${column}`);
+      indexNames.add(this.indexName(tableName, column));
     }
     for (const field of fields) {
       if (!fieldProducesColumn(field)) continue;
@@ -1092,7 +1116,7 @@ ${allColumnDefs.join(",\n")}
           )
         ) !== null
       ) {
-        indexNames.add(`idx_${tableName}_${column}`);
+        indexNames.add(this.indexName(tableName, column));
       }
       if (field.type === "relationship" && field.options?.target) {
         foreignKeysByColumn.set(column, [`fk_${tableName}_${column}`]);

--- a/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-schema-service.ts
+++ b/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-schema-service.ts
@@ -38,7 +38,10 @@ import {
   renderSystemColumnSql,
   toSnakeCase,
 } from "../../schema/services/field-column-descriptor";
-import { indexNameForColumn } from "../../schema/services/index-name";
+import {
+  columnTypeIsIndexable,
+  indexNameForColumn,
+} from "../../schema/services/index-name";
 import { quoteJsonSqlDefault } from "../../schema/utils/sql-literal";
 
 import { DynamicCollectionValidationService } from "./dynamic-collection-validation-service";
@@ -147,8 +150,31 @@ export class DynamicCollectionSchemaService {
    */
   private relationOnDelete(field: FieldDefinition): string {
     const declared = field.options?.onDelete;
-    if (declared) return declared;
-    return field.required ? "restrict" : "set null";
+    if (declared === undefined) return field.required ? "restrict" : "set null";
+
+    // Declared, and still impossible: nulling a reference the column forbids cannot be done by
+    // any database. MySQL refuses the constraint outright; PostgreSQL accepts it and fails
+    // later, when a referenced row is deleted, which is worse because it ships. Refused rather
+    // than quietly rewritten — the author asked for a specific behaviour on delete, and
+    // substituting a different one silently is not an answer to that.
+    //
+    // Prisma treats the same pair as a schema error for the same reason.
+    if (declared === "set null" && field.required) {
+      throw NextlyError.validation({
+        errors: [
+          {
+            path: `fields.${field.name}`,
+            code: "REQUIRED_RELATION_CANNOT_SET_NULL",
+            message:
+              `"${field.name}" is required, so it cannot be emptied when the ${field.type} ` +
+              `it points at is deleted. Choose "restrict" to prevent that deletion, ` +
+              `"cascade" to delete this entry with it, or make the field optional.`,
+          },
+        ],
+        logContext: { field: field.name, onDelete: declared },
+      });
+    }
+    return declared;
   }
 
   /**
@@ -198,12 +224,10 @@ export class DynamicCollectionSchemaService {
     const name = this.quoteIdentifier(indexNameForColumn(tableName, column));
     const table = this.quoteIdentifier(tableName);
     const quoted = this.quoteIdentifier(column);
+    // Asked through the shared rule, which the desired schema reads too: an index only one of
+    // them believes in is proposed by every diff and refused by every apply.
+    if (!columnTypeIsIndexable(columnType, this.dialect)) return null;
     if (this.dialect === "mysql") {
-      // A JSON column cannot be indexed at all: MySQL answers "supports indexing only via
-      // generated columns on a specified JSON path". Emitting the statement fails the migration
-      // after the ADD COLUMN before it may already have committed, so no index is emitted here.
-      // The other dialects index the value, so the field means the same thing everywhere it can.
-      if (/\bjson\b/i.test(columnType)) return null;
       const target = /\b(text|blob)\b/i.test(columnType)
         ? `${quoted}(191)`
         : quoted;

--- a/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-service.ts
+++ b/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-service.ts
@@ -24,6 +24,7 @@ import {
 } from "../../i18n/runtime/companion-io";
 import {
   readForeignKeyColumns,
+  readIndexNames,
   tableHasRows,
 } from "../../schema/pipeline/live-table-facts";
 import { resolveBuilderVersions } from "../../versions/builder-versions";
@@ -167,13 +168,19 @@ export class DynamicCollectionService extends BaseService {
   private async readTableFacts(tableName: string): Promise<{
     tableHasRows: boolean;
     foreignKeysByColumn: ReadonlyMap<string, readonly string[]>;
+    indexNames: ReadonlySet<string>;
   }> {
     const db = this.adapter.getDrizzle();
-    const [hasRows, foreignKeys] = await Promise.all([
+    const [hasRows, foreignKeys, indexes] = await Promise.all([
       tableHasRows(db, this.adapter.dialect, tableName),
       readForeignKeyColumns(db, this.adapter.dialect, tableName),
+      readIndexNames(db, this.adapter.dialect, tableName),
     ]);
-    return { tableHasRows: hasRows, foreignKeysByColumn: foreignKeys };
+    return {
+      tableHasRows: hasRows,
+      foreignKeysByColumn: foreignKeys,
+      indexNames: indexes,
+    };
   }
 
   /**

--- a/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-service.ts
+++ b/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-service.ts
@@ -170,6 +170,19 @@ export class DynamicCollectionService extends BaseService {
     foreignKeysByColumn: ReadonlyMap<string, readonly string[]>;
     indexNames: ReadonlySet<string>;
   }> {
+    // A collection whose creation migration has not been deployed yet has a registry record and
+    // no table. Reading from it throws, which would block every follow-up edit to a collection
+    // the author has only just created. There is nothing to conflict with in that state: no
+    // rows to backfill, no constraint or index to remove, and the artefact this save produces
+    // runs after the one that creates the table.
+    if (!(await this.adapter.tableExists(tableName))) {
+      return {
+        tableHasRows: false,
+        foreignKeysByColumn: new Map(),
+        indexNames: new Set(),
+      };
+    }
+
     const db = this.adapter.getDrizzle();
     const [hasRows, foreignKeys, indexes] = await Promise.all([
       tableHasRows(db, this.adapter.dialect, tableName),

--- a/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-service.ts
+++ b/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-service.ts
@@ -22,6 +22,10 @@ import {
   companionHasStatusColumn,
   localizedColumnsOnMain,
 } from "../../i18n/runtime/companion-io";
+import {
+  readForeignKeyColumns,
+  tableHasRows,
+} from "../../schema/pipeline/live-table-facts";
 import { resolveBuilderVersions } from "../../versions/builder-versions";
 import { resolveBuilderWebhooks } from "../../webhooks/builder-webhooks";
 
@@ -150,6 +154,26 @@ export class DynamicCollectionService extends BaseService {
       this.adapter,
       this.logger
     );
+  }
+
+  /**
+   * What the live table is, for the parts of an ALTER the field list cannot decide: whether a
+   * required column can be added without a value for the rows already there, and which columns
+   * are referenced by a foreign key that has to come off before they can be dropped.
+   *
+   * Both are read together and once per save, so the two cannot be observed at different
+   * moments and a table is not queried twice for one edit.
+   */
+  private async readTableFacts(tableName: string): Promise<{
+    tableHasRows: boolean;
+    foreignKeysByColumn: ReadonlyMap<string, readonly string[]>;
+  }> {
+    const db = this.adapter.getDrizzle();
+    const [hasRows, foreignKeys] = await Promise.all([
+      tableHasRows(db, this.adapter.dialect, tableName),
+      readForeignKeyColumns(db, this.adapter.dialect, tableName),
+    ]);
+    return { tableHasRows: hasRows, foreignKeysByColumn: foreignKeys };
   }
 
   /**
@@ -611,6 +635,13 @@ export class DynamicCollectionService extends BaseService {
     let localMigrationSQL: string | null = null;
     let migrationFileName: string | null = null;
 
+    // Read by the branches that diff two different field lists, and shared between them. The
+    // status-only branches below diff a list against itself, so no column is added or dropped
+    // and there is nothing for these facts to decide.
+    let tableFacts: ReturnType<typeof this.readTableFacts> | null = null;
+    const liveTable = () =>
+      (tableFacts ??= this.readTableFacts(collection.tableName));
+
     // Why: the alter-table block runs when fields change, but a status-only
     // flip also needs a migration (ADD/DROP status column) so the data
     // table matches the new lifecycle setting. When only `status` toggled,
@@ -711,7 +742,7 @@ export class DynamicCollectionService extends BaseService {
           collection.tableName,
           oldShared,
           newShared,
-          { wasStatus, hasStatus }
+          { wasStatus, hasStatus, ...(await liveTable()) }
         );
         const {
           sql: companionSQL,
@@ -749,7 +780,7 @@ export class DynamicCollectionService extends BaseService {
           collection.tableName,
           oldUserFields,
           userDefinedFields,
-          { wasStatus, hasStatus }
+          { wasStatus, hasStatus, ...(await liveTable()) }
         );
       }
       migrationFileName = `${Date.now()}_update_${collectionName}.sql`;

--- a/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-service.ts
+++ b/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-service.ts
@@ -208,10 +208,18 @@ export class DynamicCollectionService extends BaseService {
       tableName,
       pendingFields
     );
+    // Indexes union freely: every path that adds a column also creates its index. Foreign keys
+    // do not, and only on SQLite — its ALTER cannot attach one, so a relationship a queued
+    // artefact ADDS there genuinely arrives without a constraint. Predicting one anyway makes a
+    // later removal refuse as unsupported when dropping the index and then the unconstrained
+    // column would have worked. The absent-table case above is different and keeps its
+    // prediction: a queued CREATE writes the constraint inline, on every dialect.
     const foreignKeysByColumn = new Map<string, readonly string[]>(foreignKeys);
-    for (const [column, names] of planned.foreignKeysByColumn) {
-      if (!foreignKeysByColumn.has(column)) {
-        foreignKeysByColumn.set(column, names);
+    if (this.adapter.dialect !== "sqlite") {
+      for (const [column, names] of planned.foreignKeysByColumn) {
+        if (!foreignKeysByColumn.has(column)) {
+          foreignKeysByColumn.set(column, names);
+        }
       }
     }
 

--- a/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-service.ts
+++ b/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-service.ts
@@ -195,10 +195,30 @@ export class DynamicCollectionService extends BaseService {
       readForeignKeyColumns(db, this.adapter.dialect, tableName),
       readIndexNames(db, this.adapter.dialect, tableName),
     ]);
+
+    // What the table carries, PLUS what the saved schema says it should — because artefacts
+    // replay in order and this one runs last. Two edits saved before a deployment are two
+    // artefacts: adding a relationship and then removing it leaves a live table with no index
+    // while the first artefact is still queued to create one, and reading only the live table
+    // emits a removal that meets the index the deployment just added. The saved fields are
+    // exactly what the queued artefacts build, so the union is the state this one will find.
+    //
+    // In the ordinary case the two agree, because an applied edit is already in the table.
+    const planned = this.schemaService.plannedAttachments(
+      tableName,
+      pendingFields
+    );
+    const foreignKeysByColumn = new Map<string, readonly string[]>(foreignKeys);
+    for (const [column, names] of planned.foreignKeysByColumn) {
+      if (!foreignKeysByColumn.has(column)) {
+        foreignKeysByColumn.set(column, names);
+      }
+    }
+
     return {
       tableHasRows: hasRows,
-      foreignKeysByColumn: foreignKeys,
-      indexNames: indexes,
+      foreignKeysByColumn,
+      indexNames: new Set([...indexes, ...planned.indexNames]),
     };
   }
 

--- a/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-service.ts
+++ b/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-service.ts
@@ -165,21 +165,27 @@ export class DynamicCollectionService extends BaseService {
    * Both are read together and once per save, so the two cannot be observed at different
    * moments and a table is not queried twice for one edit.
    */
-  private async readTableFacts(tableName: string): Promise<{
+  private async readTableFacts(
+    tableName: string,
+    pendingFields: FieldDefinition[]
+  ): Promise<{
     tableHasRows: boolean;
     foreignKeysByColumn: ReadonlyMap<string, readonly string[]>;
     indexNames: ReadonlySet<string>;
   }> {
     // A collection whose creation migration has not been deployed yet has a registry record and
     // no table. Reading from it throws, which would block every follow-up edit to a collection
-    // the author has only just created. There is nothing to conflict with in that state: no
-    // rows to backfill, no constraint or index to remove, and the artefact this save produces
-    // runs after the one that creates the table.
+    // the author has only just created.
+    //
+    // The attachments still have to be modelled, and as the table WILL be rather than as it is:
+    // the two artefacts replay in order, so the create runs first and installs the index and the
+    // constraint that this update then has to remove. Reporting none emits a bare DROP COLUMN
+    // that is correct against the absent table and refused by the one the deployment builds.
+    // There are no rows either way, because nothing has ever been inserted.
     if (!(await this.adapter.tableExists(tableName))) {
       return {
         tableHasRows: false,
-        foreignKeysByColumn: new Map(),
-        indexNames: new Set(),
+        ...this.schemaService.plannedAttachments(tableName, pendingFields),
       };
     }
 
@@ -660,7 +666,11 @@ export class DynamicCollectionService extends BaseService {
     // and there is nothing for these facts to decide.
     let tableFacts: ReturnType<typeof this.readTableFacts> | null = null;
     const liveTable = () =>
-      (tableFacts ??= this.readTableFacts(collection.tableName));
+      (tableFacts ??= this.readTableFacts(
+        collection.tableName,
+        // What the pending create artefact builds from, for the not-yet-deployed case.
+        collection.fields ?? []
+      ));
 
     // Why: the alter-table block runs when fields change, but a status-only
     // flip also needs a migration (ADD/DROP status column) so the data

--- a/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-service.ts
+++ b/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-service.ts
@@ -196,37 +196,23 @@ export class DynamicCollectionService extends BaseService {
       readIndexNames(db, this.adapter.dialect, tableName),
     ]);
 
-    // What the table carries, PLUS what the saved schema says it should — because artefacts
-    // replay in order and this one runs last. Two edits saved before a deployment are two
-    // artefacts: adding a relationship and then removing it leaves a live table with no index
-    // while the first artefact is still queued to create one, and reading only the live table
-    // emits a removal that meets the index the deployment just added. The saved fields are
-    // exactly what the queued artefacts build, so the union is the state this one will find.
+    // What the table carries, and only that.
     //
-    // In the ordinary case the two agree, because an applied edit is already in the table.
-    const planned = this.schemaService.plannedAttachments(
-      tableName,
-      pendingFields
-    );
-    // Indexes union freely: every path that adds a column also creates its index. Foreign keys
-    // do not, and only on SQLite — its ALTER cannot attach one, so a relationship a queued
-    // artefact ADDS there genuinely arrives without a constraint. Predicting one anyway makes a
-    // later removal refuse as unsupported when dropping the index and then the unconstrained
-    // column would have worked. The absent-table case above is different and keeps its
-    // prediction: a queued CREATE writes the constraint inline, on every dialect.
-    const foreignKeysByColumn = new Map<string, readonly string[]>(foreignKeys);
-    if (this.adapter.dialect !== "sqlite") {
-      for (const [column, names] of planned.foreignKeysByColumn) {
-        if (!foreignKeysByColumn.has(column)) {
-          foreignKeysByColumn.set(column, names);
-        }
-      }
-    }
-
+    // A deployment can hold several unapplied edits, and each one is generated against the
+    // table as it is now rather than as the edit before it will leave it. Correcting for that
+    // means replaying the queued artefacts in order — adding what they add AND removing what
+    // they remove — because a state that can only gain attachments answers the second edit
+    // wrongly in the other direction: disabling an index and then dropping its field would
+    // emit a second unguarded removal for an index the first artefact already took away.
+    //
+    // That is the deferred-artefact problem in general, not something about attachments, and
+    // it is tracked with the rest of it rather than approximated here. Reading the live table
+    // is exact whenever the edit is applied as it is saved, which is every development setup
+    // and every deployment holding one edit.
     return {
       tableHasRows: hasRows,
-      foreignKeysByColumn,
-      indexNames: new Set([...indexes, ...planned.indexNames]),
+      foreignKeysByColumn: foreignKeys,
+      indexNames: indexes,
     };
   }
 

--- a/packages/nextly/src/domains/schema/pipeline/__tests__/live-table-facts.test.ts
+++ b/packages/nextly/src/domains/schema/pipeline/__tests__/live-table-facts.test.ts
@@ -1,0 +1,132 @@
+/**
+ * The driver shapes here are transcribed from real output, not imagined: the PostgreSQL and
+ * SQLite rows were captured by running these exact queries against PostgreSQL 17 and SQLite
+ * 3.51, and MySQL's tuple wrapper is the documented mysql2 return. A fixture invented from the
+ * query text would certify a reader that fails on the real thing — SQLite's `PRAGMA
+ * foreign_key_list` names the referencing column `from`, which nothing in the query says.
+ */
+import { describe, expect, it, vi } from "vitest";
+
+import { readForeignKeyColumns, tableHasRows } from "../live-table-facts";
+
+/** One row of `PRAGMA foreign_key_list("dc_posts")`, verbatim from SQLite 3.51. */
+const SQLITE_FK_ROW = {
+  id: 0,
+  seq: 0,
+  table: "dc_authors",
+  from: "author",
+  to: "id",
+  on_update: "NO ACTION",
+  on_delete: "SET NULL",
+  match: "NONE",
+};
+
+describe("tableHasRows", () => {
+  it("reads postgres' QueryResult wrapper rather than the result object itself", async () => {
+    const empty = { execute: vi.fn().mockResolvedValue({ rows: [] }) };
+    const filled = {
+      execute: vi.fn().mockResolvedValue({ rows: [{ "?column?": 1 }] }),
+    };
+
+    expect(await tableHasRows(empty, "postgresql", "dc_posts")).toBe(false);
+    expect(await tableHasRows(filled, "postgresql", "dc_posts")).toBe(true);
+  });
+
+  it("unwraps mysql's [rows, fields] tuple", async () => {
+    const empty = { execute: vi.fn().mockResolvedValue([[], []]) };
+    const filled = { execute: vi.fn().mockResolvedValue([[{ "1": 1 }], []]) };
+
+    expect(await tableHasRows(empty, "mysql", "dc_posts")).toBe(false);
+    expect(await tableHasRows(filled, "mysql", "dc_posts")).toBe(true);
+  });
+
+  it("accepts a mysql wrapper that already flattened the tuple to rows", async () => {
+    const flattened = { execute: vi.fn().mockResolvedValue([{ "1": 1 }]) };
+
+    expect(await tableHasRows(flattened, "mysql", "dc_posts")).toBe(true);
+  });
+
+  it("reads sqlite's flat row array", async () => {
+    const empty = { all: vi.fn().mockResolvedValue([]) };
+    const filled = { all: vi.fn().mockResolvedValue([{ "1": 1 }]) };
+
+    expect(await tableHasRows(empty, "sqlite", "dc_posts")).toBe(false);
+    expect(await tableHasRows(filled, "sqlite", "dc_posts")).toBe(true);
+  });
+
+  it("asks for existence, not a count, so the cost does not grow with the table", async () => {
+    const execute = vi.fn().mockResolvedValue({ rows: [] });
+    await tableHasRows({ execute }, "postgresql", "dc_posts");
+
+    const query = JSON.stringify(execute.mock.calls[0][0]);
+    expect(query).toContain("LIMIT 1");
+    expect(query).not.toContain("count");
+  });
+});
+
+describe("readForeignKeyColumns", () => {
+  it("keys postgres constraints by their column", async () => {
+    const execute = vi.fn().mockResolvedValue({
+      rows: [{ column_name: "author", constraint_name: "fk_dc_posts_author" }],
+    });
+
+    const found = await readForeignKeyColumns(
+      { execute },
+      "postgresql",
+      "dc_posts"
+    );
+
+    expect(found.has("author")).toBe(true);
+    expect(found.get("author")).toEqual(["fk_dc_posts_author"]);
+    expect(found.has("title")).toBe(false);
+  });
+
+  it("keys mysql constraints by their column, through the tuple wrapper", async () => {
+    const execute = vi
+      .fn()
+      .mockResolvedValue([
+        [{ COLUMN_NAME: "author", CONSTRAINT_NAME: "fk_dc_posts_author" }],
+        [],
+      ]);
+
+    const found = await readForeignKeyColumns({ execute }, "mysql", "dc_posts");
+
+    expect(found.get("author")).toEqual(["fk_dc_posts_author"]);
+  });
+
+  it("excludes mysql's primary and unique keys, which share the same view", async () => {
+    const execute = vi.fn().mockResolvedValue([[], []]);
+
+    await readForeignKeyColumns({ execute }, "mysql", "dc_posts");
+
+    expect(JSON.stringify(execute.mock.calls[0][0])).toContain(
+      "REFERENCED_TABLE_NAME IS NOT NULL"
+    );
+  });
+
+  it("reads the referencing column from sqlite's `from`, and reports no name for it", async () => {
+    const all = vi.fn().mockResolvedValue([SQLITE_FK_ROW]);
+
+    const found = await readForeignKeyColumns({ all }, "sqlite", "dc_posts");
+
+    // Presence is the fact every caller needs; SQLite exposes no constraint name to drop.
+    expect(found.has("author")).toBe(true);
+    expect(found.get("author")).toEqual([]);
+  });
+
+  it.each(["postgresql", "mysql", "sqlite"] as const)(
+    "returns an empty map for a table with no foreign key (%s)",
+    async dialect => {
+      const db = {
+        execute: vi
+          .fn()
+          .mockResolvedValue(dialect === "mysql" ? [[], []] : { rows: [] }),
+        all: vi.fn().mockResolvedValue([]),
+      };
+
+      const found = await readForeignKeyColumns(db, dialect, "dc_plain");
+
+      expect(found.size).toBe(0);
+    }
+  );
+});

--- a/packages/nextly/src/domains/schema/pipeline/__tests__/live-table-facts.test.ts
+++ b/packages/nextly/src/domains/schema/pipeline/__tests__/live-table-facts.test.ts
@@ -7,7 +7,11 @@
  */
 import { describe, expect, it, vi } from "vitest";
 
-import { readForeignKeyColumns, tableHasRows } from "../live-table-facts";
+import {
+  readForeignKeyColumns,
+  readIndexNames,
+  tableHasRows,
+} from "../live-table-facts";
 
 /** One row of `PRAGMA foreign_key_list("dc_posts")`, verbatim from SQLite 3.51. */
 const SQLITE_FK_ROW = {
@@ -62,6 +66,55 @@ describe("tableHasRows", () => {
     expect(query).toContain("LIMIT 1");
     expect(query).not.toContain("count");
   });
+});
+
+describe("readIndexNames", () => {
+  it("reads postgres index names", async () => {
+    const execute = vi.fn().mockResolvedValue({
+      rows: [{ indexname: "dc_posts_pkey" }, { indexname: "idx_dc_posts_a" }],
+    });
+
+    const found = await readIndexNames({ execute }, "postgresql", "dc_posts");
+
+    expect([...found].sort()).toEqual(["dc_posts_pkey", "idx_dc_posts_a"]);
+  });
+
+  it("reads mysql index names through the tuple wrapper, deduplicated", async () => {
+    // One row per indexed COLUMN, so a composite index appears more than once.
+    const execute = vi
+      .fn()
+      .mockResolvedValue([[{ INDEX_NAME: "idx_dc_posts_a" }], []]);
+
+    const found = await readIndexNames({ execute }, "mysql", "dc_posts");
+
+    expect([...found]).toEqual(["idx_dc_posts_a"]);
+  });
+
+  it("reads sqlite's PRAGMA index_list rows", async () => {
+    const all = vi
+      .fn()
+      .mockResolvedValue([
+        { seq: 0, name: "idx_dc_posts_a", unique: 0, origin: "c", partial: 0 },
+      ]);
+
+    const found = await readIndexNames({ all }, "sqlite", "dc_posts");
+
+    expect(found.has("idx_dc_posts_a")).toBe(true);
+  });
+
+  it.each(["postgresql", "mysql", "sqlite"] as const)(
+    "reports an empty set for a table with no index (%s)",
+    async dialect => {
+      const db = {
+        execute: vi
+          .fn()
+          .mockResolvedValue(dialect === "mysql" ? [[], []] : { rows: [] }),
+        all: vi.fn().mockResolvedValue([]),
+      };
+
+      expect((await readIndexNames(db, dialect, "dc_plain")).size).toBe(0);
+    }
+  );
 });
 
 describe("readForeignKeyColumns", () => {

--- a/packages/nextly/src/domains/schema/pipeline/diff/build-from-fields.ts
+++ b/packages/nextly/src/domains/schema/pipeline/diff/build-from-fields.ts
@@ -34,7 +34,10 @@ import {
   getSystemColumnDescriptors,
   toSnakeCase,
 } from "../../services/field-column-descriptor";
-import { indexNameForColumn } from "../../services/index-name";
+import {
+  columnTypeIsIndexable,
+  indexNameForColumn,
+} from "../../services/index-name";
 
 import { indexKey } from "./index-util";
 import type { ColumnSpec, IndexSpec, TableSpec } from "./types";
@@ -107,6 +110,15 @@ interface CollectionIndexContext<F> {
    * change would otherwise produce indexes naming columns that do not exist.
    */
   columnNameFor: (field: F) => string | null;
+  /**
+   * Whether an index on this column can exist at all, asked per column.
+   *
+   * Supplied rather than derived here because it depends on the dialect AND the column type,
+   * and because the statements that create indexes ask the same question: a desired schema that
+   * declares an index the generator deliberately never writes makes every diff propose creating
+   * it and every apply refuse it.
+   */
+  columnIsIndexable?: (field: F, column: string) => boolean;
 }
 
 /**
@@ -174,7 +186,10 @@ export function collectionIndexSpecs<F extends MinimalFieldDef>(
         columns: [col],
         unique: true,
       });
-    } else if (field.index === true || isSingleRelation) {
+    } else if (
+      (field.index === true || isSingleRelation) &&
+      (context.columnIsIndexable?.(field, col) ?? true)
+    ) {
       indexes.push({
         name: indexNameForColumn(tableName, col),
         columns: [col],
@@ -268,6 +283,11 @@ export function buildDesiredTableFromFields(
     hasSlugColumn: columns.some(c => c.name === "slug"),
     hasCreatedAtColumn: columns.some(c => c.name === "created_at"),
     hasCreatedByColumn: columns.some(c => c.name === "created_by"),
+    columnIsIndexable: (_field, col) =>
+      columnTypeIsIndexable(
+        columns.find(c => c.name === col)?.type ?? "",
+        dialect
+      ),
     localizedNames,
     columnNameFor: field =>
       getColumnDescriptor(
@@ -524,6 +544,11 @@ export function buildDesiredTableFromComponentFields(
     // rebuild dropped them and nothing put them back — including the unique
     // ones, which is a constraint silently disappearing, not just an index.
     ...collectionIndexSpecs(tableName, fields, {
+      columnIsIndexable: (_field, col) =>
+        columnTypeIsIndexable(
+          columns.find(c => c.name === col)?.type ?? "",
+          dialect
+        ),
       // Components have no slug column; created_at is present when the
       // component carries timestamps.
       hasSlugColumn: false,

--- a/packages/nextly/src/domains/schema/pipeline/diff/build-from-fields.ts
+++ b/packages/nextly/src/domains/schema/pipeline/diff/build-from-fields.ts
@@ -34,6 +34,7 @@ import {
   getSystemColumnDescriptors,
   toSnakeCase,
 } from "../../services/field-column-descriptor";
+import { indexNameForColumn } from "../../services/index-name";
 
 import { indexKey } from "./index-util";
 import type { ColumnSpec, IndexSpec, TableSpec } from "./types";
@@ -130,7 +131,7 @@ export function collectionIndexSpecs<F extends MinimalFieldDef>(
   const indexes: IndexSpec[] = [];
   if (context.hasSlugColumn) {
     indexes.push({
-      name: `idx_${tableName}_slug`,
+      name: indexNameForColumn(tableName, "slug"),
       columns: ["slug"],
       unique: true,
     });
@@ -142,14 +143,14 @@ export function collectionIndexSpecs<F extends MinimalFieldDef>(
     // every index the replacement table does not declare, and the restore
     // replays only what the snapshot carries.
     indexes.push({
-      name: `idx_${tableName}_created_by`,
+      name: indexNameForColumn(tableName, "created_by"),
       columns: ["created_by"],
       unique: false,
     });
   }
   if (context.hasCreatedAtColumn) {
     indexes.push({
-      name: `idx_${tableName}_created_at`,
+      name: indexNameForColumn(tableName, "created_at"),
       columns: ["created_at"],
       unique: false,
     });
@@ -169,13 +170,13 @@ export function collectionIndexSpecs<F extends MinimalFieldDef>(
       !Array.isArray(field.relationTo);
     if (field.unique === true) {
       indexes.push({
-        name: `uq_${tableName}_${col}`,
+        name: indexNameForColumn(tableName, col).replace(/^idx_/, "uq_"),
         columns: [col],
         unique: true,
       });
     } else if (field.index === true || isSingleRelation) {
       indexes.push({
-        name: `idx_${tableName}_${col}`,
+        name: indexNameForColumn(tableName, col),
         columns: [col],
         unique: false,
       });

--- a/packages/nextly/src/domains/schema/pipeline/live-table-facts.ts
+++ b/packages/nextly/src/domains/schema/pipeline/live-table-facts.ts
@@ -1,0 +1,146 @@
+// The two facts about a live table that DDL generation cannot derive from a field list, and
+// gets wrong whenever it assumes them.
+//
+//   1. Whether the table holds any rows. Adding a required column whose type states no usable
+//      backfill — a relationship has none, because a fabricated id references nothing — is
+//      safe on an empty table and impossible on one with content. The three dialects disagree
+//      on how they refuse: PostgreSQL reports the existing nulls, MySQL rejects the statement
+//      as invalid, and SQLite accepts it and then rejects every insert that omits the column.
+//
+//   2. Which columns carry a foreign key. Dropping such a column needs the constraint removed
+//      first on MySQL, cannot be done at all on SQLite, and needs nothing on PostgreSQL, which
+//      drops constraints that depend on the column along with it.
+//
+// Both are read from the LIVE table rather than inferred from the fields, because neither is
+// recoverable from them. A SQLite relationship column added by a later edit never received a
+// foreign key — the ALTER path cannot attach one — while the same field created together with
+// its table did, and only the database knows which of the two a given column is.
+//
+// Per-dialect strategy mirrors `live-column-types`: one information_schema query for PG and
+// MySQL, a PRAGMA for SQLite.
+
+import type { SupportedDialect } from "@nextlyhq/adapter-drizzle/types";
+import { sql } from "drizzle-orm";
+
+interface PgForeignKeyRow {
+  column_name: string;
+  constraint_name: string;
+}
+
+interface MysqlForeignKeyRow {
+  COLUMN_NAME: string;
+  CONSTRAINT_NAME: string;
+}
+
+interface SqliteForeignKeyRow {
+  from: string;
+}
+
+interface PgMysqlExecute {
+  execute(query: unknown): Promise<unknown>;
+}
+
+interface SqliteAll {
+  all(query: unknown): unknown[] | Promise<unknown[]>;
+}
+
+/**
+ * MySQL's driver returns `[rows, fieldPackets]`; some wrappers flatten it to the rows alone.
+ * Reading the tuple shape without checking iterates the field packets as if they were rows.
+ */
+function mysqlRows<T>(result: unknown): T[] {
+  if (!Array.isArray(result)) return [];
+  if (result.length > 0 && Array.isArray(result[0])) {
+    return (result as [T[], unknown])[0];
+  }
+  return result as T[];
+}
+
+/**
+ * Whether the table currently holds at least one row.
+ *
+ * Asked as an existence check rather than a count: the answer only ever decides whether a
+ * backfill is needed, and `SELECT 1 ... LIMIT 1` costs the same on a table of ten rows and a
+ * table of ten million, where `COUNT(*)` scans.
+ */
+export async function tableHasRows(
+  db: unknown,
+  dialect: SupportedDialect,
+  tableName: string
+): Promise<boolean> {
+  const probe = sql`SELECT 1 FROM ${sql.identifier(tableName)} LIMIT 1`;
+
+  if (dialect === "postgresql") {
+    // node-postgres returns the QueryResult object, not a flat row array.
+    const result = (await (db as PgMysqlExecute).execute(probe)) as {
+      rows: unknown[];
+    };
+    return result.rows.length > 0;
+  }
+
+  if (dialect === "mysql") {
+    return (
+      mysqlRows<unknown>(await (db as PgMysqlExecute).execute(probe)).length > 0
+    );
+  }
+
+  return (await (db as SqliteAll).all(probe)).length > 0;
+}
+
+/**
+ * The foreign-key constraints the table carries, keyed by the column they are attached to.
+ *
+ * Presence of a key is the fact every caller needs; the names matter only to MySQL, which is
+ * the one dialect that requires the constraint to be named and dropped before its column can
+ * be. SQLite exposes no constraint names, so its entries carry an empty list — a column that
+ * appears here has a foreign key whether or not anything can be said about its name.
+ */
+export async function readForeignKeyColumns(
+  db: unknown,
+  dialect: SupportedDialect,
+  tableName: string
+): Promise<Map<string, string[]>> {
+  const out = new Map<string, string[]>();
+  const record = (column: string, constraint: string | null) => {
+    const names = out.get(column) ?? [];
+    if (constraint !== null) names.push(constraint);
+    out.set(column, names);
+  };
+
+  if (dialect === "postgresql") {
+    const result = (await (db as PgMysqlExecute).execute(
+      sql`SELECT kcu.column_name, tc.constraint_name
+          FROM information_schema.table_constraints tc
+          JOIN information_schema.key_column_usage kcu
+            ON tc.constraint_name = kcu.constraint_name
+           AND tc.constraint_schema = kcu.constraint_schema
+          WHERE tc.constraint_type = 'FOREIGN KEY'
+            AND tc.table_schema = 'public'
+            AND tc.table_name = ${tableName}`
+    )) as { rows: PgForeignKeyRow[] };
+    for (const row of result.rows) record(row.column_name, row.constraint_name);
+    return out;
+  }
+
+  if (dialect === "mysql") {
+    // A row in KEY_COLUMN_USAGE describes a foreign key only when it names the table it
+    // references; the same view also lists primary and unique keys, which have none.
+    const rows = mysqlRows<MysqlForeignKeyRow>(
+      await (db as PgMysqlExecute).execute(
+        sql`SELECT COLUMN_NAME, CONSTRAINT_NAME
+            FROM information_schema.KEY_COLUMN_USAGE
+            WHERE TABLE_SCHEMA = DATABASE()
+              AND TABLE_NAME = ${tableName}
+              AND REFERENCED_TABLE_NAME IS NOT NULL`
+      )
+    );
+    for (const row of rows) record(row.COLUMN_NAME, row.CONSTRAINT_NAME);
+    return out;
+  }
+
+  const rows = (await (db as SqliteAll).all(
+    sql`PRAGMA foreign_key_list(${sql.identifier(tableName)})`
+  )) as SqliteForeignKeyRow[];
+  for (const row of rows) record(row.from, null);
+  return out;
+}

--- a/packages/nextly/src/domains/schema/pipeline/live-table-facts.ts
+++ b/packages/nextly/src/domains/schema/pipeline/live-table-facts.ts
@@ -104,9 +104,16 @@ export async function readIndexNames(
   const names = new Set<string>();
 
   if (dialect === "postgresql") {
+    // Resolved through the relation itself rather than by schema name. An unqualified statement
+    // resolves across the WHOLE search path, so a table in `public` reached from a search path of
+    // `tenant, public` is found by the ALTER and missed by any predicate naming one schema —
+    // including `current_schema()`, which is only the first entry. `to_regclass` answers the
+    // question the statements actually ask.
     const result = (await (db as PgMysqlExecute).execute(
-      sql`SELECT indexname FROM pg_indexes
-          WHERE schemaname = current_schema() AND tablename = ${tableName}`
+      sql`SELECT c.relname AS indexname
+          FROM pg_index i
+          JOIN pg_class c ON c.oid = i.indexrelid
+          WHERE i.indrelid = to_regclass(${tableName})`
     )) as { rows: { indexname: string }[] };
     for (const row of result.rows) names.add(row.indexname);
     return names;
@@ -151,15 +158,14 @@ export async function readForeignKeyColumns(
   };
 
   if (dialect === "postgresql") {
+    // Against the relation, for the same reason as `readIndexNames`: the schema a name resolves
+    // to is whatever the search path finds first, not whichever one is listed first.
     const result = (await (db as PgMysqlExecute).execute(
-      sql`SELECT kcu.column_name, tc.constraint_name
-          FROM information_schema.table_constraints tc
-          JOIN information_schema.key_column_usage kcu
-            ON tc.constraint_name = kcu.constraint_name
-           AND tc.constraint_schema = kcu.constraint_schema
-          WHERE tc.constraint_type = 'FOREIGN KEY'
-            AND tc.table_schema = current_schema()
-            AND tc.table_name = ${tableName}`
+      sql`SELECT a.attname AS column_name, c.conname AS constraint_name
+          FROM pg_constraint c
+          JOIN unnest(c.conkey) AS k(attnum) ON true
+          JOIN pg_attribute a ON a.attrelid = c.conrelid AND a.attnum = k.attnum
+          WHERE c.contype = 'f' AND c.conrelid = to_regclass(${tableName})`
     )) as { rows: PgForeignKeyRow[] };
     for (const row of result.rows) record(row.column_name, row.constraint_name);
     return out;

--- a/packages/nextly/src/domains/schema/pipeline/live-table-facts.ts
+++ b/packages/nextly/src/domains/schema/pipeline/live-table-facts.ts
@@ -106,7 +106,7 @@ export async function readIndexNames(
   if (dialect === "postgresql") {
     const result = (await (db as PgMysqlExecute).execute(
       sql`SELECT indexname FROM pg_indexes
-          WHERE schemaname = 'public' AND tablename = ${tableName}`
+          WHERE schemaname = current_schema() AND tablename = ${tableName}`
     )) as { rows: { indexname: string }[] };
     for (const row of result.rows) names.add(row.indexname);
     return names;
@@ -158,7 +158,7 @@ export async function readForeignKeyColumns(
             ON tc.constraint_name = kcu.constraint_name
            AND tc.constraint_schema = kcu.constraint_schema
           WHERE tc.constraint_type = 'FOREIGN KEY'
-            AND tc.table_schema = 'public'
+            AND tc.table_schema = current_schema()
             AND tc.table_name = ${tableName}`
     )) as { rows: PgForeignKeyRow[] };
     for (const row of result.rows) record(row.column_name, row.constraint_name);

--- a/packages/nextly/src/domains/schema/pipeline/live-table-facts.ts
+++ b/packages/nextly/src/domains/schema/pipeline/live-table-facts.ts
@@ -88,6 +88,49 @@ export async function tableHasRows(
 }
 
 /**
+ * The names of the indexes the table currently carries.
+ *
+ * Whether a column is indexed is not derivable from its field: an index is created by the path
+ * that added the column, and the paths have not always agreed on which columns get one, so a
+ * table can carry a relationship column with no index beside an identical one that has it.
+ * MySQL has no `DROP INDEX IF EXISTS`, so dropping one that is not there aborts the migration
+ * before the statements that follow it.
+ */
+export async function readIndexNames(
+  db: unknown,
+  dialect: SupportedDialect,
+  tableName: string
+): Promise<Set<string>> {
+  const names = new Set<string>();
+
+  if (dialect === "postgresql") {
+    const result = (await (db as PgMysqlExecute).execute(
+      sql`SELECT indexname FROM pg_indexes
+          WHERE schemaname = 'public' AND tablename = ${tableName}`
+    )) as { rows: { indexname: string }[] };
+    for (const row of result.rows) names.add(row.indexname);
+    return names;
+  }
+
+  if (dialect === "mysql") {
+    const rows = mysqlRows<{ INDEX_NAME: string }>(
+      await (db as PgMysqlExecute).execute(
+        sql`SELECT DISTINCT INDEX_NAME FROM information_schema.STATISTICS
+            WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ${tableName}`
+      )
+    );
+    for (const row of rows) names.add(row.INDEX_NAME);
+    return names;
+  }
+
+  const rows = (await (db as SqliteAll).all(
+    sql`PRAGMA index_list(${sql.identifier(tableName)})`
+  )) as { name: string }[];
+  for (const row of rows) names.add(row.name);
+  return names;
+}
+
+/**
  * The foreign-key constraints the table carries, keyed by the column they are attached to.
  *
  * Presence of a key is the fact every caller needs; the names matter only to MySQL, which is

--- a/packages/nextly/src/domains/schema/services/__tests__/index-name.test.ts
+++ b/packages/nextly/src/domains/schema/services/__tests__/index-name.test.ts
@@ -1,0 +1,74 @@
+/**
+ * The DDL that creates an index and the desired schema the diff compares a table against have to
+ * name it identically. When they disagreed, every diff reported the installed index as
+ * unexpected and the declared one as missing, and a reconcile replaced an index with an
+ * identical index for as long as anyone kept running it.
+ */
+import { describe, expect, it } from "vitest";
+
+import { DynamicCollectionSchemaService } from "../../../dynamic-collections/services/dynamic-collection-schema-service";
+import { collectionIndexSpecs } from "../../pipeline/diff/build-from-fields";
+import { indexNameForColumn, MAX_INDEX_NAME_LENGTH } from "../index-name";
+
+const LONG_TABLE = `dc_${"a".repeat(50)}`;
+const LONG_COLUMN = "b".repeat(50);
+
+describe("indexNameForColumn", () => {
+  it("leaves a name the databases can store unchanged", () => {
+    expect(indexNameForColumn("dc_posts", "author")).toBe(
+      "idx_dc_posts_author"
+    );
+  });
+
+  it("bounds a long name at postgres' truncation point, not mysql's refusal point", () => {
+    // MySQL refuses over 64; PostgreSQL accepts 64 and silently truncates to 63, so 64 is not a
+    // name PostgreSQL keeps and two names differing only in the last character become one.
+    //
+    // Asserted against the literal 63 rather than the constant: reading the constant here would
+    // make the test agree with whatever the constant says, including a value no database
+    // accepts.
+    expect(
+      indexNameForColumn(LONG_TABLE, LONG_COLUMN).length
+    ).toBeLessThanOrEqual(63);
+    expect(MAX_INDEX_NAME_LENGTH).toBe(63);
+  });
+
+  it("keeps two long names apart that truncation alone would merge", () => {
+    const a = indexNameForColumn(LONG_TABLE, `${"c".repeat(45)}alpha`);
+    const b = indexNameForColumn(LONG_TABLE, `${"c".repeat(45)}omega`);
+    expect(a).not.toBe(b);
+  });
+
+  it("answers the same for the same input, since the drop builds the name again", () => {
+    expect(indexNameForColumn(LONG_TABLE, LONG_COLUMN)).toBe(
+      indexNameForColumn(LONG_TABLE, LONG_COLUMN)
+    );
+  });
+});
+
+describe("the emitted DDL and the desired schema agree", () => {
+  it("names a long index identically on both sides", () => {
+    const fields = [
+      { name: LONG_COLUMN, type: "number", required: false, index: true },
+    ];
+
+    const emitted = new DynamicCollectionSchemaService(undefined, "postgresql")
+      .generateMigrationSQL(LONG_TABLE, fields as never)
+      .match(/CREATE INDEX (?:IF NOT EXISTS )?"([^"]+)"/g)
+      ?.map(m => m.replace(/.*"([^"]+)"$/, "$1"));
+
+    const declared = collectionIndexSpecs(LONG_TABLE, fields as never, {
+      hasSlugColumn: false,
+      hasCreatedAtColumn: false,
+      hasCreatedByColumn: false,
+      localizedNames: new Set<string>(),
+      columnNameFor: field => field.name,
+    }).map(spec => spec.name);
+
+    // Every index the desired schema declares must be one the DDL actually installs, or the
+    // diff proposes creating something that is already there under another name.
+    for (const name of declared) {
+      expect(emitted).toContain(name);
+    }
+  });
+});

--- a/packages/nextly/src/domains/schema/services/__tests__/index-name.test.ts
+++ b/packages/nextly/src/domains/schema/services/__tests__/index-name.test.ts
@@ -8,7 +8,11 @@ import { describe, expect, it } from "vitest";
 
 import { DynamicCollectionSchemaService } from "../../../dynamic-collections/services/dynamic-collection-schema-service";
 import { collectionIndexSpecs } from "../../pipeline/diff/build-from-fields";
-import { indexNameForColumn, MAX_INDEX_NAME_LENGTH } from "../index-name";
+import {
+  columnTypeIsIndexable,
+  indexNameForColumn,
+  MAX_INDEX_NAME_LENGTH,
+} from "../index-name";
 
 const LONG_TABLE = `dc_${"a".repeat(50)}`;
 const LONG_COLUMN = "b".repeat(50);
@@ -70,5 +74,48 @@ describe("the emitted DDL and the desired schema agree", () => {
     for (const name of declared) {
       expect(emitted).toContain(name);
     }
+  });
+});
+
+describe("columnTypeIsIndexable", () => {
+  it("refuses a mysql json column, which mysql cannot index", () => {
+    expect(columnTypeIsIndexable("json", "mysql")).toBe(false);
+  });
+
+  it("allows the same column where the dialect can index it", () => {
+    expect(columnTypeIsIndexable("jsonb", "postgresql")).toBe(true);
+    expect(columnTypeIsIndexable("text", "sqlite")).toBe(true);
+  });
+
+  it("allows every other mysql type", () => {
+    expect(columnTypeIsIndexable("varchar(36)", "mysql")).toBe(true);
+    expect(columnTypeIsIndexable("text", "mysql")).toBe(true);
+  });
+});
+
+describe("the DDL and the desired schema agree on WHICH indexes exist", () => {
+  it("neither declares nor writes an index for a mysql json column", () => {
+    const fields = [
+      { name: "payload", type: "json", required: false, index: true },
+    ];
+
+    const emitted = new DynamicCollectionSchemaService(
+      undefined,
+      "mysql"
+    ).generateMigrationSQL("dc_probe", fields as never);
+
+    const declared = collectionIndexSpecs("dc_probe", fields as never, {
+      hasSlugColumn: false,
+      hasCreatedAtColumn: false,
+      hasCreatedByColumn: false,
+      localizedNames: new Set<string>(),
+      columnNameFor: field => field.name,
+      columnIsIndexable: () => columnTypeIsIndexable("json", "mysql"),
+    }).map(spec => spec.name);
+
+    // Declaring it while the generator skips it makes every reconcile emit a CREATE INDEX that
+    // MySQL rejects — the same failure, once per attempt, forever.
+    expect(emitted).not.toContain("idx_dc_probe_payload");
+    expect(declared).not.toContain("idx_dc_probe_payload");
   });
 });

--- a/packages/nextly/src/domains/schema/services/index-name.ts
+++ b/packages/nextly/src/domains/schema/services/index-name.ts
@@ -35,3 +35,23 @@ export function indexNameForColumn(tableName: string, column: string): string {
 
 /** PostgreSQL truncates at this length; MySQL refuses one character beyond it. */
 export const MAX_INDEX_NAME_LENGTH = 63;
+
+/**
+ * Whether the dialect can index a column of this type at all.
+ *
+ * MySQL cannot index a JSON column: it answers that indexing is supported "only via generated
+ * columns on a specified JSON path". PostgreSQL and SQLite index the value, so the same field
+ * means the same thing everywhere it can.
+ *
+ * Asked by BOTH the statements that create indexes and the desired schema the diff compares a
+ * table against. When only the statements knew, the desired schema went on declaring an index the
+ * generator deliberately never wrote, and every reconcile emitted a `CREATE INDEX` on a JSON
+ * column that MySQL rejects — the same failure, once per attempt, indefinitely.
+ */
+export function columnTypeIsIndexable(
+  columnType: string,
+  dialect: string
+): boolean {
+  if (dialect !== "mysql") return true;
+  return !/\bjson\b/i.test(columnType);
+}

--- a/packages/nextly/src/domains/schema/services/index-name.ts
+++ b/packages/nextly/src/domains/schema/services/index-name.ts
@@ -1,0 +1,37 @@
+// What an index on one column is called.
+//
+// Two places have to agree on this: the DDL that creates the index, and the desired schema the
+// live-versus-desired diff compares a table against. When they disagreed, every diff reported the
+// installed index as unexpected and the declared one as missing, so a reconcile replaced an index
+// with an identical index for as long as anyone kept running it.
+//
+// The bound is 63 characters, which is the smaller of the two limits that matter and therefore
+// the only safe one. MySQL REFUSES an identifier over 64. PostgreSQL accepts one and silently
+// TRUNCATES it to 63, so at 64 two names differing only in their last character arrive as a
+// single identifier — a collision no error reports. A collection name and a field name may each
+// be 50 characters, so the composed name reaches 105 and the bound is genuinely reachable.
+
+/**
+ * The index name for one column of one table, bounded so every dialect stores it whole.
+ *
+ * A name within the bound is returned unchanged, which keeps the common case readable and keeps
+ * every index created before the bound existed addressable by its own name. A longer one keeps as
+ * much of the readable prefix as fits and ends in a hash of the WHOLE name, so two long names
+ * sharing a prefix stay distinct.
+ */
+export function indexNameForColumn(tableName: string, column: string): string {
+  const full = `idx_${tableName}_${column}`;
+  if (full.length <= MAX_INDEX_NAME_LENGTH) return full;
+
+  // FNV-1a. Not for secrecy — only to tell apart two names a plain truncation would merge.
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < full.length; i++) {
+    hash ^= full.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193) >>> 0;
+  }
+  const suffix = hash.toString(36).padStart(7, "0");
+  return `${full.slice(0, MAX_INDEX_NAME_LENGTH - suffix.length - 1)}_${suffix}`;
+}
+
+/** PostgreSQL truncates at this length; MySQL refuses one character beyond it. */
+export const MAX_INDEX_NAME_LENGTH = 63;


### PR DESCRIPTION
## What

A column is more than its type. The CREATE path attaches a type, `NOT NULL`, uniqueness, a foreign key and an index to it. The ALTER path moved the column and little else, so a collection that gained a field by an edit did not enforce what the identical collection created from scratch did.

Five gaps, one theme. Four were filed; the fifth surfaced only from asserting the property.

| case | before | now |
|---|---|---|
| add a one-to-one | no `UNIQUE`, so the declared cardinality was unenforced | unique, from the same predicate CREATE reads |
| add a field with `index: true` | no `CREATE INDEX` | the index exists |
| **add any relationship** | **no index at all** — CREATE auto-indexes every relationship for JOIN performance, the ADD path indexed none | indexed, same rule as CREATE |
| add a **required** relationship | `ADD COLUMN … NOT NULL DEFAULT NULL` | clean `NOT NULL` when the table is empty; refused with the steps that work when it is not |
| remove a relationship | `DROP COLUMN` with the constraint left attached | constraint dropped first on MySQL, refused on SQLite, unchanged on PostgreSQL |

## Measured first, and it corrected the filing

The original task reasoned about dialect behaviour. Run against PostgreSQL 17, MySQL 8 and SQLite 3.51 in throwaway databases before any code was written, two of its claims were wrong:

- **PostgreSQL succeeds** at dropping a referenced column. It drops dependent constraints along with it, so there was never a gap there. The task said it refused.
- **SQLite hard-errors** (`unknown column "author" in foreign key definition`) rather than silently needing a rebuild.

And the invalid `NOT NULL DEFAULT NULL` fails three different ways:

| dialect | empty table | table with rows |
|---|---|---|
| PostgreSQL | worked by accident | fails: `column … contains null values` |
| MySQL | fails always: `ERROR 1067 Invalid default value` | fails |
| SQLite | **accepted, then the collection is unusable** — every insert that omits the column fails at runtime | fails |

That SQLite row is why this is P1: it is the default development database, the migration reports success, and the failure arrives later as a constraint error the author does not connect to the edit.

## Decisions

**Required-column backfill: refuse only when the table holds rows.** Empty table emits a clean `NOT NULL`, which all three dialects accept. A table with content is refused, naming the field and the order that works. This is what Prisma Migrate and Django do, and it keeps the saved schema and the physical table in agreement — the add-nullable-and-enforce-later alternative reintroduces exactly the divergence the column-identity work removed.

**Foreign-key drop: fix MySQL, refuse loudly on SQLite.** PostgreSQL needs nothing. SQLite cannot drop a constraint without rebuilding the table, and that rebuild moves user data, so it is split out rather than bundled here. Checked first whether drizzle-kit's existing SQLite rebuild was reusable: it is not — the generated SQL is split on `--> statement-breakpoint` and executed raw, and drizzle-kit is not in this path at all.

## How

Uniqueness and indexing are now **one predicate each** (`columnIsUnique`, `columnIsIndexed`) read by **both** paths, so they cannot drift apart again — which is what every gap here was.

The two facts a field list cannot supply are read from the live table by a new `domains/schema/pipeline/live-table-facts.ts`, beside the existing `live-column-types.ts` and following its per-dialect shape:

- **does the table hold rows** — asked as `SELECT 1 … LIMIT 1`, not a count, so it costs the same on ten rows and ten million
- **which columns carry a foreign key** — not inferable, because on SQLite a relationship added by an edit has no foreign key while the same field created with its table does, and only the database knows which

Wired into all five production call sites. The status-only branches diff a field list against itself, so no column is added or dropped there and the probe is not run.

## Verification

- **64 new tests**, led by the invariant: for one field, CREATE and ADD-to-an-empty-table must carry the same attachments. All five gaps violate that single rule; pinning the cases alone would have let the fifth arrive unnoticed.
- **Every fix falsified individually** and fails for its own reason: reverting the uniqueness predicate fails only the one-to-one cases, reverting the index block fails only the index cases, removing the refusal fails only the refusal cases, removing the foreign-key handling fails only the drop cases.
- **Mirror tests** so nothing can be satisfied by refusing or emitting nothing: a many-to-one stays non-unique, an unindexed field stays unindexed, a required *text* column still backfills with `''`, an *optional* relationship still adds cleanly to a table with rows, and a SQLite relationship with no foreign key still drops.
- **Unit suite: 397 failing tests, the standing baseline exactly**, and zero new failure names at the touched scope compared against `origin/main` in the same tree.
- **Integration: all three dialects**, one leg at a time on freshly recreated databases.
- The one snapshot change is a **reorder only** — merging CREATE's two index loops onto the shared predicate emits the same 27 statements in field order rather than relationships-then-manual. Proven by comparing the sorted statement sets, which are identical.

## Deliberate consequences

- Adding a **required** relationship to a Single that already has its row is refused. A single's row cannot be backfilled either, so the same rule applies and the message names the same three steps.
- Removing a relationship on SQLite is refused when the column actually carries a foreign key. One added by a later edit never got one and still drops cleanly, which is why the refusal is driven by what the live table carries rather than by the field's type.

## Follow-up

The SQLite table rebuild is filed as its own task: it would let SQLite both attach a foreign key to a column added by an edit and remove one. The parity test asserts that SQLite gap explicitly rather than skipping it, so the day a rebuild lands, the assertion fails and says so.
