### PR TITLE
feat: add the react renderer package boundary

### DIFF
--- a/.changeset/blocks-react-package.md
+++ b/.changeset/blocks-react-package.md
@@ -1,0 +1,40 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+feat(blocks-react): add the React renderer package boundary
+
+Adds `@nextlyhq/blocks-react`, the React/RSC renderer for Nextly block
+documents. This change lands the package and its layering guarantees; the
+renderer itself follows.
+
+The root entry imports no `next/*`, no admin code and no CMS runtime, so a
+document can be rendered from a plain React app, a test or a script. Everything
+Next-coupled lives at the `@nextlyhq/blocks-react/next` subpath, so importing
+the renderer never pulls Next into a consumer's module graph. Both rules are
+enforced by an allowlist-based import test rather than by convention.
+
+`PageContext` and `BlocksDataProvider` are also introduced: the seam through
+which data, media URLs and entry paths reach a block, so blocks never reach for
+a database directly.

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,6 +1,11 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@3.0.0/schema.json",
-  "changelog": ["@changesets/changelog-github", { "repo": "nextlyhq/nextly" }],
+  "changelog": [
+    "@changesets/changelog-github",
+    {
+      "repo": "nextlyhq/nextly"
+    }
+  ],
   "commit": false,
   "fixed": [
     [
@@ -9,6 +14,7 @@
       "@nextlyhq/admin",
       "@nextlyhq/admin-css",
       "@nextlyhq/blocks-engine",
+      "@nextlyhq/blocks-react",
       "@nextlyhq/ui",
       "@nextlyhq/adapter-drizzle",
       "@nextlyhq/adapter-postgres",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,6 +146,7 @@ jobs:
         run: >-
           pnpm turbo test
           --filter=@nextlyhq/blocks-engine
+          --filter=@nextlyhq/blocks-react
           --filter=@nextlyhq/plugin-page-builder
           --filter=@nextlyhq/plugin-form-builder
           --filter=@nextlyhq/plugin-seo

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -47,6 +47,7 @@ jobs:
             storage-vercel-blob
             storage-uploadthing
             blocks-engine
+            blocks-react
             plugin-form-builder
             plugin-page-builder
             plugin-seo

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,11 @@ for all published packages. Status: alpha, all packages version in lockstep.
 - `packages/admin` - the admin panel UI (`@nextlyhq/admin`).
 - `packages/adapter-{drizzle,postgres,mysql,sqlite}` - database adapters.
   `adapter-drizzle` is shared logic; the per-dialect adapters extend it.
+- `packages/blocks-engine` - the runtime-free block document model, validation
+  and style compiler. `packages/blocks-react` - the React/RSC renderer for those
+  documents; its root entry imports no `next/*`, no admin and no CMS runtime, so
+  it is usable standalone (enforced by `src/layering.test.ts`). Next-coupled
+  helpers live at the `/next` subpath.
 - `packages/plugin-sdk` - the ONLY stable import surface for plugin authors.
 - `packages/plugin-{form-builder,page-builder}` - first-party plugins.
 - `packages/storage-{s3,vercel-blob,uploadthing}` - media storage adapters.
@@ -69,7 +74,7 @@ Before editing a package, read its README.md and check for a nested AGENTS.md.
   `adapter-postgres`, `adapter-mysql`, `adapter-sqlite`, `adapter-drizzle`,
   `storage-s3`, `storage-vercel-blob`, `storage-uploadthing`,
   `plugin-form-builder`, `plugin-page-builder`, `plugin-seo`, `plugin-sdk`,
-  `blocks-engine`,
+  `blocks-engine`, `blocks-react`,
   `create-nextly-app`, `eslint-config`, `prettier-config`, `tsconfig`,
   `telemetry`, `client`) plus `playground`, `root`, `ci`, `docs`, `deps`,
   `release`. Scope is optional; the subject must not start with an uppercase

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -11,6 +11,7 @@ import { reactRules } from "@nextlyhq/eslint-config/react-internal";
 const REACT_FILES = [
   "packages/admin/**/*.{ts,tsx,js,jsx}",
   "packages/ui/**/*.{ts,tsx,js,jsx}",
+  "packages/blocks-react/**/*.{ts,tsx,js,jsx}",
   "apps/playground/**/*.{ts,tsx,js,jsx}",
 ];
 

--- a/packages/blocks-react/README.md
+++ b/packages/blocks-react/README.md
@@ -1,0 +1,48 @@
+# @nextlyhq/blocks-react
+
+The React renderer for Nextly block documents.
+
+A block document is plain JSON validated by
+[`@nextlyhq/blocks-engine`](../blocks-engine). This package turns one into a
+React tree, as Server Components, with no client JavaScript unless a block opts
+into it.
+
+> **Alpha.** The public surface is not yet stable.
+
+## Two entries, and why
+
+```ts
+import { PageRenderer } from "@nextlyhq/blocks-react"; // React only
+import { createBlocksPage } from "@nextlyhq/blocks-react/next"; // Next.js
+```
+
+The root entry imports **no `next/*`, no admin code and no CMS runtime**. You
+can render a document from a plain React app, a test, or a script with nothing
+else installed — the CMS is one way to produce documents, not a requirement for
+rendering them.
+
+Everything Next-coupled lives at `/next`, so importing the renderer never pulls
+Next into your module graph. `src/layering.test.ts` enforces both rules as a
+build failure rather than a convention.
+
+## Data, media and links
+
+Blocks never reach for a database. Anything from the outside world arrives
+through `PageContext`:
+
+```ts
+import { createStandaloneContext } from "@nextlyhq/blocks-react";
+
+const ctx = createStandaloneContext({
+  data: { find: async () => ({ items: myPosts }) },
+  resolveMediaUrl: id => `/uploads/${id}`,
+});
+```
+
+The CMS supplies an implementation backed by its own read path. Tests supply
+fixtures. The editor canvas supplies its own. One seam, four consumers.
+
+## Status
+
+`R-1` of implementation plan 03 lands the package boundary and its guarantees.
+`PageRenderer` arrives in `R-2`.

--- a/packages/blocks-react/README.md
+++ b/packages/blocks-react/README.md
@@ -47,5 +47,5 @@ fixtures. The editor canvas supplies its own. One seam, four consumers.
 
 ## Status
 
-`R-1` of implementation plan 03 lands the package boundary and its guarantees.
-`PageRenderer` arrives in `R-2`.
+Alpha. What ships today is the package boundary, its layering guarantees, and
+the `PageContext` contract. `PageRenderer` follows.

--- a/packages/blocks-react/README.md
+++ b/packages/blocks-react/README.md
@@ -11,9 +11,19 @@ into it.
 
 ## Two entries, and why
 
+| Entry                         | Contains                              | Exported today                           |
+| ----------------------------- | ------------------------------------- | ---------------------------------------- |
+| `@nextlyhq/blocks-react`      | the renderer and the context contract | context types, `createStandaloneContext` |
+| `@nextlyhq/blocks-react/next` | everything that needs `next/*`        | entry marker only                        |
+
+**Alpha:** the boundary and the context contract ship now. The renderer and the
+Next route helpers land on top of them, so these names describe the shape they
+will take rather than code that resolves today:
+
 ```ts
-import { PageRenderer } from "@nextlyhq/blocks-react"; // React only
-import { createBlocksPage } from "@nextlyhq/blocks-react/next"; // Next.js
+// Planned, not yet exported:
+// import { PageRenderer } from "@nextlyhq/blocks-react";
+// import { createBlocksPage } from "@nextlyhq/blocks-react/next";
 ```
 
 The root entry imports **no `next/*`, no admin code and no CMS runtime**. You
@@ -29,6 +39,8 @@ build failure rather than a convention.
 
 Blocks never reach for a database. Anything from the outside world arrives
 through `PageContext`:
+
+This part works today:
 
 ```ts
 import { createStandaloneContext } from "@nextlyhq/blocks-react";

--- a/packages/blocks-react/README.md
+++ b/packages/blocks-react/README.md
@@ -35,7 +35,10 @@ import { createStandaloneContext } from "@nextlyhq/blocks-react";
 
 const ctx = createStandaloneContext({
   data: { find: async () => ({ items: myPosts }) },
-  resolveMediaUrl: id => `/uploads/${id}`,
+  // Async, and a media object rather than a URL: an image block needs alt text
+  // and intrinsic dimensions to render without layout shift.
+  resolveMedia: async id => ({ url: `/uploads/${id}`, alt: "" }),
+  resolveEntryPath: async (collection, id) => `/${collection}/${id}`,
 });
 ```
 

--- a/packages/blocks-react/eslint.config.js
+++ b/packages/blocks-react/eslint.config.js
@@ -1,0 +1,7 @@
+// The renderer is a React package, so it layers the shared React rules over the
+// repository base. The root config scopes those rules by path; this per-package
+// config applies them unconditionally, matching how the other React packages
+// lint when run directly.
+import { config } from "@nextlyhq/eslint-config/react-internal";
+
+export default [...config];

--- a/packages/blocks-react/package.json
+++ b/packages/blocks-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nextlyhq/blocks-react",
   "version": "0.0.2-alpha.51",
-  "description": "Nextly blocks renderer — a React Server Component renderer for Nextly block documents, usable with or without the CMS.",
+  "description": "The React Server Component renderer for Nextly block documents, usable with or without the CMS.",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -60,9 +60,9 @@
     "@nextlyhq/eslint-config": "workspace:*",
     "@nextlyhq/tsconfig": "workspace:*",
     "@types/node": "^20.19.17",
-    "@types/react": "^19.2.2",
+    "@types/react": "19.2.0",
     "eslint": "^9.39.1",
-    "react": "^19.2.0",
+    "react": "19.2.0",
     "rimraf": "^6.1.3",
     "tsup": "^8.5.0",
     "typescript": "^5.9.3",

--- a/packages/blocks-react/package.json
+++ b/packages/blocks-react/package.json
@@ -1,0 +1,83 @@
+{
+  "name": "@nextlyhq/blocks-react",
+  "version": "0.0.2-alpha.51",
+  "description": "Nextly blocks renderer — a React Server Component renderer for Nextly block documents, usable with or without the CMS.",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/nextlyhq/nextly.git",
+    "directory": "packages/blocks-react"
+  },
+  "homepage": "https://nextlyhq.com/docs",
+  "bugs": {
+    "url": "https://github.com/nextlyhq/nextly/issues"
+  },
+  "type": "module",
+  "main": "dist/index.mjs",
+  "module": "dist/index.mjs",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs",
+      "default": "./dist/index.mjs"
+    },
+    "./next": {
+      "types": "./dist/next.d.ts",
+      "import": "./dist/next.mjs",
+      "default": "./dist/next.mjs"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "dev": "tsup --watch",
+    "check-types": "tsc --noEmit",
+    "lint": "eslint . --max-warnings 0",
+    "lint:fix": "eslint . --fix",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "clean": "rimraf dist"
+  },
+  "engines": {
+    "node": ">=20.0.0"
+  },
+  "dependencies": {
+    "@nextlyhq/blocks-engine": "workspace:*"
+  },
+  "peerDependencies": {
+    "next": "^14.0.0 || ^15.0.0 || ^16.0.0",
+    "react": "^18.0.0 || ^19.0.0"
+  },
+  "peerDependenciesMeta": {
+    "next": {
+      "optional": true
+    }
+  },
+  "devDependencies": {
+    "@nextlyhq/eslint-config": "workspace:*",
+    "@nextlyhq/tsconfig": "workspace:*",
+    "@types/node": "^20.19.17",
+    "@types/react": "^19.2.2",
+    "eslint": "^9.39.1",
+    "react": "^19.2.0",
+    "rimraf": "^6.1.3",
+    "tsup": "^8.5.0",
+    "typescript": "^5.9.3",
+    "vitest": "^4.1.0"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/",
+    "provenance": true
+  },
+  "keywords": [
+    "nextly",
+    "blocks",
+    "page-builder",
+    "react-server-components",
+    "renderer"
+  ]
+}

--- a/packages/blocks-react/src/context.ts
+++ b/packages/blocks-react/src/context.ts
@@ -44,6 +44,21 @@ export interface BlocksDataProvider {
 }
 
 /**
+ * A resolved media item.
+ *
+ * An object rather than a URL string because an image block needs alt text and
+ * intrinsic dimensions to render without layout shift, and those travel with
+ * the URL or they get looked up separately and inconsistently. This mirrors the
+ * shape the existing renderer already settled on.
+ */
+export interface ResolvedMedia {
+  url: string;
+  alt?: string;
+  width?: number;
+  height?: number;
+}
+
+/**
  * A provider that answers nothing.
  *
  * The default, so that rendering a document containing a dynamic block without
@@ -78,10 +93,23 @@ export interface PageContext {
   isWorkingDraft?: boolean;
   /** Data access for dynamic blocks. */
   data: BlocksDataProvider;
-  /** Resolve a media id to a URL, or `null` when it cannot be resolved. */
-  resolveMediaUrl(id: string): string | null;
-  /** Resolve an entry reference to a path, or `null` when it has none. */
-  resolveEntryPath(collection: string, id: string): string | null;
+  /**
+   * Resolve a media id, or `null` when it cannot be resolved.
+   *
+   * Async because a real host cannot answer synchronously: a CMS-backed
+   * context reads the media record from its database, and a storage adapter
+   * that issues signed URLs performs network work to produce one. A
+   * synchronous signature would force every such host to pre-resolve every
+   * media id on every render, or to lie.
+   */
+  resolveMedia(id: string): Promise<ResolvedMedia | null>;
+  /**
+   * Resolve an entry reference to a path, or `null` when it has none.
+   *
+   * Async for the same reason: the path depends on the referenced entry's slug
+   * and status, which is a read.
+   */
+  resolveEntryPath(collection: string, id: string): Promise<string | null>;
 }
 
 /** A context with nothing wired up: the standalone default. */
@@ -91,8 +119,8 @@ export function createStandaloneContext(
   return {
     entry: null,
     data: emptyDataProvider,
-    resolveMediaUrl: () => null,
-    resolveEntryPath: () => null,
+    resolveMedia: () => Promise.resolve(null),
+    resolveEntryPath: () => Promise.resolve(null),
     ...overrides,
   };
 }

--- a/packages/blocks-react/src/context.ts
+++ b/packages/blocks-react/src/context.ts
@@ -116,11 +116,21 @@ export interface PageContext {
 export function createStandaloneContext(
   overrides: Partial<PageContext> = {}
 ): PageContext {
-  return {
+  const defaults: PageContext = {
     entry: null,
     data: emptyDataProvider,
     resolveMedia: () => Promise.resolve(null),
     resolveEntryPath: () => Promise.resolve(null),
-    ...overrides,
   };
+
+  // Spreading `overrides` wholesale would let an explicit `undefined` replace a
+  // default: `exactOptionalPropertyTypes` is off, so
+  // `createStandaloneContext({ data: maybeProvider })` typechecks and then
+  // produces a context whose `data` is undefined, which crashes at the first
+  // dynamic block instead of falling back. Only defined values win.
+  const defined = Object.fromEntries(
+    Object.entries(overrides).filter(([, value]) => value !== undefined)
+  ) as Partial<PageContext>;
+
+  return { ...defaults, ...defined };
 }

--- a/packages/blocks-react/src/context.ts
+++ b/packages/blocks-react/src/context.ts
@@ -8,9 +8,10 @@
  * Everything the renderer needs from the outside world arrives through these
  * interfaces rather than through imports. That is what keeps the package usable
  * without the CMS, but the standalone case is the smaller half of the argument:
- * the canvas renders the same documents with different data access, tests want
- * fixtures instead of a database, and the binding system planned for a later
- * phase already assumes a provider. One seam serves all four.
+ * the canvas renders the same documents against different data access, and a
+ * test wants fixtures instead of a database. One seam serves every host, and a
+ * host that resolves data some other way is a different implementation of these
+ * interfaces rather than a change to the renderer.
  *
  * @module context
  */

--- a/packages/blocks-react/src/context.ts
+++ b/packages/blocks-react/src/context.ts
@@ -1,0 +1,98 @@
+/**
+ * What a block render receives, and where the renderer gets its data.
+ *
+ * `BlockRenderArgs<P, C>` in the engine leaves `ctx: C` deliberately unnamed —
+ * "what a context CONTAINS is the renderer's to say" — so defining it is this
+ * package's contractual obligation, not optional polish.
+ *
+ * Everything the renderer needs from the outside world arrives through these
+ * interfaces rather than through imports. That is what keeps the package usable
+ * without the CMS, but the standalone case is the smaller half of the argument:
+ * the canvas renders the same documents with different data access, tests want
+ * fixtures instead of a database, and the binding system planned for a later
+ * phase already assumes a provider. One seam serves all four.
+ *
+ * @module context
+ */
+
+/** A query the renderer asks its host to answer. Shapes stay deliberately
+ * narrow: this is the subset dynamic blocks need today, and widening it is a
+ * deliberate act rather than a side effect of a new block. */
+export interface BlocksQuery {
+  collection: string;
+  limit?: number;
+  offset?: number;
+  sort?: string;
+  locale?: string;
+}
+
+/** What a host returns for a {@link BlocksQuery}. */
+export interface BlocksResult {
+  items: ReadonlyArray<Record<string, unknown>>;
+  total?: number;
+}
+
+/**
+ * The data seam. The CMS supplies an implementation backed by its own read
+ * path; a standalone consumer or a test supplies fixtures.
+ *
+ * Async by contract even where a host could answer synchronously, because a
+ * host that later needs to await must not force every caller to change.
+ */
+export interface BlocksDataProvider {
+  find(query: BlocksQuery): Promise<BlocksResult>;
+}
+
+/**
+ * A provider that answers nothing.
+ *
+ * The default, so that rendering a document containing a dynamic block without
+ * a configured host produces an empty result rather than a crash — the
+ * forgiving-render posture the document model already takes for unknown block
+ * types.
+ */
+export const emptyDataProvider: BlocksDataProvider = {
+  find: () => Promise.resolve({ items: [], total: 0 }),
+};
+
+/**
+ * The context every block render receives.
+ *
+ * Resolver functions rather than raw maps: a host that resolves media through a
+ * CDN, a signed URL, or a local folder differs only in the function it passes,
+ * and none of that reaches a block author.
+ */
+export interface PageContext {
+  /**
+   * The entry the page renders, when there is one. `null` in standalone use,
+   * where a document is rendered with no surrounding record.
+   */
+  entry: Record<string, unknown> | null;
+  /** The locale being rendered, when the host is localized. */
+  locale?: string;
+  /**
+   * True when the entry being rendered is an unpublished working draft rather
+   * than its live content. Surfaced so a host can show a preview banner; the
+   * renderer itself does not change behaviour on it.
+   */
+  isWorkingDraft?: boolean;
+  /** Data access for dynamic blocks. */
+  data: BlocksDataProvider;
+  /** Resolve a media id to a URL, or `null` when it cannot be resolved. */
+  resolveMediaUrl(id: string): string | null;
+  /** Resolve an entry reference to a path, or `null` when it has none. */
+  resolveEntryPath(collection: string, id: string): string | null;
+}
+
+/** A context with nothing wired up: the standalone default. */
+export function createStandaloneContext(
+  overrides: Partial<PageContext> = {}
+): PageContext {
+  return {
+    entry: null,
+    data: emptyDataProvider,
+    resolveMediaUrl: () => null,
+    resolveEntryPath: () => null,
+    ...overrides,
+  };
+}

--- a/packages/blocks-react/src/index.ts
+++ b/packages/blocks-react/src/index.ts
@@ -17,5 +17,6 @@ export type {
   BlocksQuery,
   BlocksResult,
   PageContext,
+  ResolvedMedia,
 } from "./context";
 export { createStandaloneContext, emptyDataProvider } from "./context";

--- a/packages/blocks-react/src/index.ts
+++ b/packages/blocks-react/src/index.ts
@@ -7,8 +7,8 @@
  * helpers live at `@nextlyhq/blocks-react/next`, and `layering.test.ts` turns
  * that separation into a hard failure rather than a convention.
  *
- * R-1 lands the package boundary and its guarantees. The renderer itself
- * arrives in R-2.
+ * The renderer components are added on top of this boundary; what ships here
+ * is the boundary itself and the context contract every block renders against.
  *
  * @module index
  */

--- a/packages/blocks-react/src/index.ts
+++ b/packages/blocks-react/src/index.ts
@@ -1,0 +1,21 @@
+/**
+ * `@nextlyhq/blocks-react` — the React renderer for Nextly block documents.
+ *
+ * This entry renders documents with React alone. It imports no Next.js, no
+ * admin code, and no CMS runtime, so a document can be rendered from a plain
+ * React app, a test, or a script with nothing else installed. The Next-coupled
+ * helpers live at `@nextlyhq/blocks-react/next`, and `layering.test.ts` turns
+ * that separation into a hard failure rather than a convention.
+ *
+ * R-1 lands the package boundary and its guarantees. The renderer itself
+ * arrives in R-2.
+ *
+ * @module index
+ */
+export type {
+  BlocksDataProvider,
+  BlocksQuery,
+  BlocksResult,
+  PageContext,
+} from "./context";
+export { createStandaloneContext, emptyDataProvider } from "./context";

--- a/packages/blocks-react/src/layering.test.ts
+++ b/packages/blocks-react/src/layering.test.ts
@@ -90,7 +90,11 @@ function sourceFiles(dir: string = SRC_DIR): string[] {
  * documented workaround used elsewhere in this repo.
  */
 function runtimeImports(file: string): string[] {
-  const source = readFileSync(file, "utf8");
+  const raw = readFileSync(file, "utf8");
+  // Block comments become a single space so a comment sitting between tokens
+  // cannot hide a call from the matchers below, while token boundaries the
+  // patterns rely on are preserved.
+  const source = raw.replace(/\/\*[\s\S]*?\*\//g, " ");
   const specifiers: string[] = [];
 
   // `from "..."` in an import/export statement, and bare `import "..."`.
@@ -123,6 +127,10 @@ function runtimeImports(file: string): string[] {
   // argument does not start with a quote". `import("next/" + "headers")` starts
   // with a quote, so a first-character test waves it through while the literal
   // matcher above also skips it for the concatenation.
+  // `\s*` alone is not enough between the keyword and the parenthesis:
+  // `import /* webpackChunkName: "x" */ ("next/headers")` is valid and would
+  // be seen by neither matcher. Comments are stripped before matching so both
+  // forms are recognised.
   const anyDynamic = /(?<![.\w])(?:import|require)\s*\(([^)]*)\)/g;
   const singleLiteral = /^\s*["'][^"']*["']\s*$/;
   let dynamicMatch: RegExpExecArray | null;

--- a/packages/blocks-react/src/layering.test.ts
+++ b/packages/blocks-react/src/layering.test.ts
@@ -3,6 +3,7 @@ import { dirname, join, relative } from "node:path";
 import { fileURLToPath } from "node:url";
 import type { Dirent } from "node:fs";
 
+import ts from "typescript";
 import { describe, expect, it } from "vitest";
 
 /**
@@ -17,8 +18,7 @@ import { describe, expect, it } from "vitest";
  * 2. **Nothing imports the admin or the CMS runtime.** The renderer runs in the
  *    user's application, where neither exists.
  * 3. **Nothing imports the editor.** The rendering path and the editing path
- *    share a document format, not a module graph — the separation Plasmic
- *    maintains and the one the proof-of-concept already enforces for itself.
+ *    share a document format, not a module graph.
  *
  * The guard is an ALLOWLIST. A blocklist only stops what someone thought to
  * name, and the next dependency added without thought is exactly the one that
@@ -62,6 +62,15 @@ const NEXT_ONLY_IMPORTS = [
 /** Files that are test harness rather than shipped code. */
 const TEST_FILE = /\.test\.tsx?$/;
 
+/**
+ * Stand-in for a dynamic import whose target cannot be read from the source.
+ *
+ * It is deliberately not a real specifier, so it matches no allowlist entry and
+ * therefore fails: an unreadable route into the module graph is treated as a
+ * violation rather than waved through.
+ */
+const UNRESOLVABLE_SPECIFIER = "<computed-dynamic-import>";
+
 /** Every source file, with its path relative to `src`. */
 function sourceFiles(dir: string = SRC_DIR): string[] {
   const entries: Dirent[] = readdirSync(dir, { withFileTypes: true });
@@ -75,85 +84,84 @@ function sourceFiles(dir: string = SRC_DIR): string[] {
 }
 
 /**
- * Module specifiers a file imports at RUNTIME.
+ * Module specifiers a source text imports at RUNTIME.
  *
- * `import type` and `export type` are excluded because they erase at build and
- * cost a consumer nothing. Inline `import { type X }` still counts: the
- * statement itself is a runtime import even when one binding is a type.
+ * Read from TypeScript's own parse of the file rather than by pattern. What
+ * counts as an import is a question about syntax, and syntax has exactly one
+ * authority; a text scan has to re-derive comments, string boundaries and
+ * statement positions, and each of those is a way for a real import to go
+ * unseen. Every form below is one the parser answers directly:
  *
- * DYNAMIC imports count too. `await import("next/headers")` puts Next in the
- * module graph exactly as a static import does, and a guard that reads only
- * static syntax is bypassed by the one line most likely to be written when
- * someone wants to "just reach for it here" — which is precisely the moment
- * the boundary needs enforcing. `require()` is scanned for the same reason,
- * even though this package is ESM-only, because a lazy CommonJS resolve is the
- * documented workaround used elsewhere in this repo.
+ * - `import "x"` anywhere a statement may appear, including after another
+ *   statement on the same line.
+ * - `import type` / `export type`, which erase at build and so do not count.
+ *   Inline `import { type X }` still counts: the statement itself is a runtime
+ *   import even when one binding is a type.
+ * - `import("x")` and `require("x")`. A dynamic import puts a module in the
+ *   graph exactly as a static one does, and `import x = require("y")` is the
+ *   documented CommonJS-interop spelling.
+ * - `import("x").Foo` in type position, which is a type query and erases, so
+ *   it is correctly absent — it parses as a type node, not a call.
+ *
+ * A dynamic call whose argument is not a single string literal is reported as
+ * {@link UNRESOLVABLE_SPECIFIER}: `import(base + name)` cannot be checked here,
+ * and the guard exists so that no route into the graph opens without a
+ * deliberate act.
  */
-function runtimeImports(file: string): string[] {
-  const raw = readFileSync(file, "utf8");
-  // Comments become a single space so one sitting between tokens cannot hide a
-  // call from the matchers below, while the token boundaries the patterns rely
-  // on are preserved. Both forms are legal between `import` and its
-  // parenthesis, so both must go:
-  //
-  //   import /* annotation */ ("next/headers")
-  //   import // annotation
-  //   ("next/headers")
-  //
-  // String literals are left intact deliberately. A `//` inside a specifier is
-  // part of a URL, not a comment, and stripping it would corrupt the very
-  // value being checked; the cost is that a `//` inside a string could mask a
-  // later call on the same line, which no import statement produces.
-  const source = raw
-    .replace(/\/\*[\s\S]*?\*\//g, " ")
-    .replace(/(^|[^:"'`\\])\/\/[^\n]*/g, "$1 ");
+export function collectRuntimeImports(source: string, fileName: string) {
+  const parsed = ts.createSourceFile(
+    fileName,
+    source,
+    ts.ScriptTarget.ESNext,
+    // Parent pointers are unused, but omitting them costs nothing to set and
+    // makes any later node-relative query work rather than crash.
+    true,
+    fileName.endsWith(".tsx") ? ts.ScriptKind.TSX : ts.ScriptKind.TS
+  );
+
   const specifiers: string[] = [];
+  const push = (node: ts.Expression): void => {
+    specifiers.push(
+      ts.isStringLiteralLike(node) ? node.text : UNRESOLVABLE_SPECIFIER
+    );
+  };
 
-  // `from "..."` in an import/export statement, and bare `import "..."`.
-  const staticPattern =
-    /(?:^|\n)\s*(?:import|export)\s+(type\s+)?([^;'"]*?)\s*from\s*["']([^"']+)["']|(?:^|\n)\s*import\s+["']([^"']+)["']/g;
-
-  let match: RegExpExecArray | null;
-  while ((match = staticPattern.exec(source)) !== null) {
-    const isTypeOnly = Boolean(match[1]);
-    const specifier = match[3] ?? match[4];
-    if (!specifier || isTypeOnly) continue;
-    specifiers.push(specifier);
-  }
-
-  // `import("...")` and `require("...")`, with any whitespace. A preceding
-  // `.` is excluded so a method named `import` on some object is not counted.
-  const dynamicPattern =
-    /(?<![.\w])(?:import|require)\s*\(\s*["']([^"']+)["']\s*\)/g;
-  while ((match = dynamicPattern.exec(source)) !== null) {
-    const specifier = match[1];
-    if (specifier) specifiers.push(specifier);
-  }
-
-  // A dynamic import whose specifier is not a single literal cannot be checked
-  // here. Fail loudly rather than pass silently: the point of this guard is
-  // that a route into the module graph cannot be opened without a deliberate
-  // act.
-  //
-  // The test is "the argument is not EXACTLY one string literal", not "the
-  // argument does not start with a quote". `import("next/" + "headers")` starts
-  // with a quote, so a first-character test waves it through while the literal
-  // matcher above also skips it for the concatenation.
-  // `\s*` alone is not enough between the keyword and the parenthesis:
-  // `import /* webpackChunkName: "x" */ ("next/headers")` is valid and would
-  // be seen by neither matcher. Comments are stripped before matching so both
-  // forms are recognised.
-  const anyDynamic = /(?<![.\w])(?:import|require)\s*\(([^)]*)\)/g;
-  const singleLiteral = /^\s*["'][^"']*["']\s*$/;
-  let dynamicMatch: RegExpExecArray | null;
-  while ((dynamicMatch = anyDynamic.exec(source)) !== null) {
-    const argument = dynamicMatch[1] ?? "";
-    if (!singleLiteral.test(argument)) {
-      specifiers.push("<computed-dynamic-import>");
+  const visit = (node: ts.Node): void => {
+    if (ts.isImportDeclaration(node)) {
+      // No import clause is a bare side-effect import, which is a runtime
+      // import by definition and the form most likely to be overlooked.
+      if (!node.importClause?.isTypeOnly) push(node.moduleSpecifier);
+    } else if (ts.isExportDeclaration(node)) {
+      // A re-export without a specifier (`export { x }`) reaches no module.
+      if (node.moduleSpecifier && !node.isTypeOnly) push(node.moduleSpecifier);
+    } else if (
+      ts.isImportEqualsDeclaration(node) &&
+      ts.isExternalModuleReference(node.moduleReference)
+    ) {
+      if (!node.isTypeOnly) push(node.moduleReference.expression);
+    } else if (ts.isCallExpression(node)) {
+      const callee = node.expression;
+      // A bare `require` identifier only. `foo.require("x")` is a method on
+      // some object, not a module resolve.
+      const isModuleCall =
+        callee.kind === ts.SyntaxKind.ImportKeyword ||
+        (ts.isIdentifier(callee) && callee.text === "require");
+      if (isModuleCall) {
+        const argument = node.arguments[0];
+        if (argument) push(argument);
+        else specifiers.push(UNRESOLVABLE_SPECIFIER);
+      }
     }
-  }
+    ts.forEachChild(node, visit);
+  };
 
+  visit(parsed);
   return specifiers;
+}
+
+/** {@link collectRuntimeImports} for a file on disk. */
+function runtimeImports(file: string): string[] {
+  return collectRuntimeImports(readFileSync(file, "utf8"), file);
 }
 
 /** Relative specifiers are internal: not gated, but they ARE followed (below). */
@@ -195,7 +203,7 @@ function resolveRelative(fromFile: string, specifier: string): string | null {
  * The root's promise is about its MODULE GRAPH, not about one file: if
  * `index.ts` re-exports `./next`, importing the package root loads the
  * Next-coupled entry transitively and the promise is broken even though no
- * file named `next/*` directly. Checking files in isolation cannot see that.
+ * file names `next/*` directly. Checking files in isolation cannot see that.
  */
 function reachableFrom(entry: string): Set<string> {
   const seen = new Set<string>();
@@ -216,6 +224,92 @@ function reachableFrom(entry: string): Set<string> {
 function isNodeBuiltin(specifier: string): boolean {
   return specifier.startsWith("node:");
 }
+
+/**
+ * The scanner's own coverage.
+ *
+ * Every case here is a way a real import can reach the module graph while
+ * looking like something else in the file's text. They are asserted against
+ * source strings rather than files on disk so that adding one costs nothing
+ * and leaves no fixture behind.
+ */
+describe("the runtime-import scanner", () => {
+  const scan = (source: string) => collectRuntimeImports(source, "sample.ts");
+
+  it("sees a static import that follows another statement on the same line", () => {
+    // An import declaration is legal wherever a statement is, so a scan that
+    // expects one at the start of a line misses this while the module still
+    // enters the graph.
+    expect(scan('export const marker = true; import "next/headers";')).toEqual([
+      "next/headers",
+    ]);
+  });
+
+  it("sees imports regardless of surrounding comments", () => {
+    expect(
+      scan(
+        [
+          "/* import 'not-real' */",
+          "// import 'also-not-real'",
+          'import "next/cache";',
+          'import /* between */ "next/headers";',
+        ].join("\n")
+      )
+    ).toEqual(["next/cache", "next/headers"]);
+  });
+
+  it("ignores imports and requires that appear inside string literals", () => {
+    expect(
+      scan('const sample = `import "next/headers"; require("next")`;')
+    ).toEqual([]);
+  });
+
+  it("counts every dynamic form that reaches a module", () => {
+    expect(
+      scan(
+        [
+          'await import("next/headers");',
+          'const cache = require("next/cache");',
+          'import navigation = require("next/navigation");',
+        ].join("\n")
+      )
+    ).toEqual(["next/headers", "next/cache", "next/navigation"]);
+  });
+
+  it("refuses a dynamic import whose target it cannot read", () => {
+    expect(scan('await import("next/" + "headers");')).toEqual([
+      UNRESOLVABLE_SPECIFIER,
+    ]);
+    expect(scan("await import(chosen);")).toEqual([UNRESOLVABLE_SPECIFIER]);
+  });
+
+  it("does not count a method that happens to be named require", () => {
+    expect(scan('loader.require("next/headers");')).toEqual([]);
+  });
+
+  it("excludes type-only imports and exports, which erase at build", () => {
+    expect(
+      scan(
+        [
+          'import type { A } from "next/headers";',
+          'export type { B } from "next/cache";',
+          'type Later = import("next/navigation").Thing;',
+        ].join("\n")
+      )
+    ).toEqual([]);
+  });
+
+  it("counts a statement carrying an inline type binding", () => {
+    // `import { type A, b }` still emits an import at runtime for `b`.
+    expect(scan('import { type A, b } from "next/headers";')).toEqual([
+      "next/headers",
+    ]);
+  });
+
+  it("counts a bare side-effect import", () => {
+    expect(scan('import "next/headers";')).toEqual(["next/headers"]);
+  });
+});
 
 describe("the package's layering contract", () => {
   const files = sourceFiles();

--- a/packages/blocks-react/src/layering.test.ts
+++ b/packages/blocks-react/src/layering.test.ts
@@ -1,4 +1,4 @@
-import { readFileSync, readdirSync } from "node:fs";
+import { existsSync, readFileSync, readdirSync } from "node:fs";
 import { dirname, join, relative } from "node:path";
 import { fileURLToPath } from "node:url";
 import type { Dirent } from "node:fs";
@@ -125,9 +125,47 @@ function runtimeImports(file: string): string[] {
   return specifiers;
 }
 
-/** Relative specifiers are internal and never gated. */
+/** Relative specifiers are internal: not gated, but they ARE followed (below). */
 function isInternal(specifier: string): boolean {
   return specifier.startsWith(".") || specifier.startsWith("#");
+}
+
+/** Resolve a relative specifier to a file on disk, or null if it is not one. */
+function resolveRelative(fromFile: string, specifier: string): string | null {
+  if (!specifier.startsWith(".")) return null;
+  const base = join(dirname(fromFile), specifier);
+  for (const candidate of [
+    `${base}.ts`,
+    `${base}.tsx`,
+    join(base, "index.ts"),
+    join(base, "index.tsx"),
+  ]) {
+    if (existsSync(candidate)) return candidate;
+  }
+  return null;
+}
+
+/**
+ * Every file reachable from an entry by following relative imports.
+ *
+ * The root's promise is about its MODULE GRAPH, not about one file: if
+ * `index.ts` re-exports `./next`, importing the package root loads the
+ * Next-coupled entry transitively and the promise is broken even though no
+ * file named `next/*` directly. Checking files in isolation cannot see that.
+ */
+function reachableFrom(entry: string): Set<string> {
+  const seen = new Set<string>();
+  const queue = [entry];
+  while (queue.length > 0) {
+    const file = queue.pop();
+    if (!file || seen.has(file)) continue;
+    seen.add(file);
+    for (const specifier of runtimeImports(file)) {
+      const resolved = resolveRelative(file, specifier);
+      if (resolved && !seen.has(resolved)) queue.push(resolved);
+    }
+  }
+  return seen;
 }
 
 /** `node:fs` and friends: allowed nowhere in shipped code. */
@@ -164,6 +202,30 @@ describe("the package's layering contract", () => {
     }
 
     expect(violations, violations.join("\n")).toEqual([]);
+  });
+
+  it("keeps the next entry out of the root's module graph", () => {
+    // The guarantee is about what importing the package ROOT pulls in, so it
+    // is checked over the graph reachable from `index.ts` rather than file by
+    // file. A re-export of `./next` from the root would satisfy every
+    // per-file check while breaking the promise outright.
+    const rootGraph = reachableFrom(join(SRC_DIR, "index.ts"));
+    const nextEntry = join(SRC_DIR, "next.ts");
+
+    expect(
+      rootGraph.has(nextEntry),
+      "index.ts must not reach next.ts through any chain of relative imports"
+    ).toBe(false);
+
+    const leaks: string[] = [];
+    for (const file of rootGraph) {
+      for (const specifier of runtimeImports(file)) {
+        if (specifier === "next" || specifier.startsWith("next/")) {
+          leaks.push(`${relative(SRC_DIR, file)}: ${specifier}`);
+        }
+      }
+    }
+    expect(leaks, leaks.join("\n")).toEqual([]);
   });
 
   it("keeps next/* out of every file except the next entry", () => {

--- a/packages/blocks-react/src/layering.test.ts
+++ b/packages/blocks-react/src/layering.test.ts
@@ -80,22 +80,48 @@ function sourceFiles(dir: string = SRC_DIR): string[] {
  * `import type` and `export type` are excluded because they erase at build and
  * cost a consumer nothing. Inline `import { type X }` still counts: the
  * statement itself is a runtime import even when one binding is a type.
+ *
+ * DYNAMIC imports count too. `await import("next/headers")` puts Next in the
+ * module graph exactly as a static import does, and a guard that reads only
+ * static syntax is bypassed by the one line most likely to be written when
+ * someone wants to "just reach for it here" — which is precisely the moment
+ * the boundary needs enforcing. `require()` is scanned for the same reason,
+ * even though this package is ESM-only, because a lazy CommonJS resolve is the
+ * documented workaround used elsewhere in this repo.
  */
 function runtimeImports(file: string): string[] {
   const source = readFileSync(file, "utf8");
   const specifiers: string[] = [];
 
   // `from "..."` in an import/export statement, and bare `import "..."`.
-  const pattern =
+  const staticPattern =
     /(?:^|\n)\s*(?:import|export)\s+(type\s+)?([^;'"]*?)\s*from\s*["']([^"']+)["']|(?:^|\n)\s*import\s+["']([^"']+)["']/g;
 
   let match: RegExpExecArray | null;
-  while ((match = pattern.exec(source)) !== null) {
+  while ((match = staticPattern.exec(source)) !== null) {
     const isTypeOnly = Boolean(match[1]);
     const specifier = match[3] ?? match[4];
     if (!specifier || isTypeOnly) continue;
     specifiers.push(specifier);
   }
+
+  // `import("...")` and `require("...")`, with any whitespace. A preceding
+  // `.` is excluded so a method named `import` on some object is not counted.
+  const dynamicPattern =
+    /(?<![.\w])(?:import|require)\s*\(\s*["']([^"']+)["']\s*\)/g;
+  while ((match = dynamicPattern.exec(source)) !== null) {
+    const specifier = match[1];
+    if (specifier) specifiers.push(specifier);
+  }
+
+  // A dynamic import whose specifier is not a literal cannot be checked here.
+  // Fail loudly rather than pass silently: the point of this guard is that a
+  // route into the module graph cannot be opened without a deliberate act.
+  const computed = /(?<![.\w])(?:import|require)\s*\(\s*[^"')\s]/g;
+  if (computed.test(source)) {
+    specifiers.push("<computed-dynamic-import>");
+  }
+
   return specifiers;
 }
 

--- a/packages/blocks-react/src/layering.test.ts
+++ b/packages/blocks-react/src/layering.test.ts
@@ -1,0 +1,184 @@
+import { readFileSync, readdirSync } from "node:fs";
+import { dirname, join, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+import type { Dirent } from "node:fs";
+
+import { describe, expect, it } from "vitest";
+
+/**
+ * The package's layering contract, enforced rather than documented.
+ *
+ * Three promises, each broken by an import that is individually reasonable and
+ * collectively fatal:
+ *
+ * 1. **The root entry never touches Next.** A consumer importing the renderer
+ *    must not acquire `next/*` in their graph, and the renderer must stay
+ *    usable outside a Next app. `next.ts` is the one exception, by design.
+ * 2. **Nothing imports the admin or the CMS runtime.** The renderer runs in the
+ *    user's application, where neither exists.
+ * 3. **Nothing imports the editor.** The rendering path and the editing path
+ *    share a document format, not a module graph — the separation Plasmic
+ *    maintains and the one the proof-of-concept already enforces for itself.
+ *
+ * The guard is an ALLOWLIST. A blocklist only stops what someone thought to
+ * name, and the next dependency added without thought is exactly the one that
+ * breaks the promise. Adding an entry below is a deliberate act with a reason
+ * recorded beside it.
+ */
+
+// `import.meta.dirname` only exists from Node 20.11 and the package floor is
+// Node >=20.0, so derive the directory from the module URL instead.
+const SRC_DIR = dirname(fileURLToPath(import.meta.url));
+
+/**
+ * What the package may import at runtime, and why.
+ *
+ * - `react` / `react/jsx-runtime`: this is a React renderer. Declared as a peer
+ *   dependency so the consumer's copy is the only one in the tree.
+ * - `@nextlyhq/blocks-engine`: the document model, validation and style
+ *   compiler. Runtime-free itself, so depending on it costs the consumer
+ *   nothing beyond the engine's own bounded allowlist.
+ */
+const ALLOWED_RUNTIME_IMPORTS = [
+  "react",
+  "react/jsx-runtime",
+  "@nextlyhq/blocks-engine",
+];
+
+/**
+ * Modules only `src/next.ts` and its own imports may use.
+ *
+ * Kept separate from the allowlist above so that a `next/*` import appearing in
+ * any other file is a failure, not a pass — the whole point of the subpath
+ * split is that the boundary is checkable.
+ */
+const NEXT_ONLY_IMPORTS = [
+  "next",
+  "next/cache",
+  "next/headers",
+  "next/navigation",
+];
+
+/** Files that are test harness rather than shipped code. */
+const TEST_FILE = /\.test\.tsx?$/;
+
+/** Every source file, with its path relative to `src`. */
+function sourceFiles(dir: string = SRC_DIR): string[] {
+  const entries: Dirent[] = readdirSync(dir, { withFileTypes: true });
+  return entries.flatMap(entry => {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) return sourceFiles(full);
+    if (!/\.tsx?$/.test(entry.name)) return [];
+    if (TEST_FILE.test(entry.name)) return [];
+    return [full];
+  });
+}
+
+/**
+ * Module specifiers a file imports at RUNTIME.
+ *
+ * `import type` and `export type` are excluded because they erase at build and
+ * cost a consumer nothing. Inline `import { type X }` still counts: the
+ * statement itself is a runtime import even when one binding is a type.
+ */
+function runtimeImports(file: string): string[] {
+  const source = readFileSync(file, "utf8");
+  const specifiers: string[] = [];
+
+  // `from "..."` in an import/export statement, and bare `import "..."`.
+  const pattern =
+    /(?:^|\n)\s*(?:import|export)\s+(type\s+)?([^;'"]*?)\s*from\s*["']([^"']+)["']|(?:^|\n)\s*import\s+["']([^"']+)["']/g;
+
+  let match: RegExpExecArray | null;
+  while ((match = pattern.exec(source)) !== null) {
+    const isTypeOnly = Boolean(match[1]);
+    const specifier = match[3] ?? match[4];
+    if (!specifier || isTypeOnly) continue;
+    specifiers.push(specifier);
+  }
+  return specifiers;
+}
+
+/** Relative specifiers are internal and never gated. */
+function isInternal(specifier: string): boolean {
+  return specifier.startsWith(".") || specifier.startsWith("#");
+}
+
+/** `node:fs` and friends: allowed nowhere in shipped code. */
+function isNodeBuiltin(specifier: string): boolean {
+  return specifier.startsWith("node:");
+}
+
+describe("the package's layering contract", () => {
+  const files = sourceFiles();
+
+  it("has source files to check", () => {
+    // A traversal bug that returned nothing would make every assertion below
+    // vacuously true, which is the failure mode these tests exist to prevent.
+    expect(files.length).toBeGreaterThan(0);
+  });
+
+  it("imports nothing outside the allowlist", () => {
+    const violations: string[] = [];
+
+    for (const file of files) {
+      const isNextEntry = relative(SRC_DIR, file) === "next.ts";
+      for (const specifier of runtimeImports(file)) {
+        if (isInternal(specifier)) continue;
+
+        if (isNodeBuiltin(specifier)) {
+          violations.push(`${relative(SRC_DIR, file)}: ${specifier}`);
+          continue;
+        }
+        if (ALLOWED_RUNTIME_IMPORTS.includes(specifier)) continue;
+        if (isNextEntry && NEXT_ONLY_IMPORTS.includes(specifier)) continue;
+
+        violations.push(`${relative(SRC_DIR, file)}: ${specifier}`);
+      }
+    }
+
+    expect(violations, violations.join("\n")).toEqual([]);
+  });
+
+  it("keeps next/* out of every file except the next entry", () => {
+    const leaks: string[] = [];
+
+    for (const file of files) {
+      if (relative(SRC_DIR, file) === "next.ts") continue;
+      for (const specifier of runtimeImports(file)) {
+        if (specifier === "next" || specifier.startsWith("next/")) {
+          leaks.push(`${relative(SRC_DIR, file)}: ${specifier}`);
+        }
+      }
+    }
+
+    expect(leaks, leaks.join("\n")).toEqual([]);
+  });
+
+  it("imports neither the admin, the CMS runtime, nor the editor", () => {
+    // Named explicitly ON TOP of the allowlist. The allowlist already refuses
+    // these, but naming them makes the failure message say what rule was
+    // broken instead of only that something unlisted appeared.
+    const forbidden = [
+      "nextly",
+      "@nextlyhq/admin",
+      "@nextlyhq/plugin-sdk",
+      "@nextlyhq/plugin-page-builder",
+      "@nextlyhq/ui",
+    ];
+    const violations: string[] = [];
+
+    for (const file of files) {
+      for (const specifier of runtimeImports(file)) {
+        const root = specifier.startsWith("@")
+          ? specifier.split("/").slice(0, 2).join("/")
+          : specifier.split("/")[0];
+        if (root && forbidden.includes(root)) {
+          violations.push(`${relative(SRC_DIR, file)}: ${specifier}`);
+        }
+      }
+    }
+
+    expect(violations, violations.join("\n")).toEqual([]);
+  });
+});

--- a/packages/blocks-react/src/layering.test.ts
+++ b/packages/blocks-react/src/layering.test.ts
@@ -91,10 +91,22 @@ function sourceFiles(dir: string = SRC_DIR): string[] {
  */
 function runtimeImports(file: string): string[] {
   const raw = readFileSync(file, "utf8");
-  // Block comments become a single space so a comment sitting between tokens
-  // cannot hide a call from the matchers below, while token boundaries the
-  // patterns rely on are preserved.
-  const source = raw.replace(/\/\*[\s\S]*?\*\//g, " ");
+  // Comments become a single space so one sitting between tokens cannot hide a
+  // call from the matchers below, while the token boundaries the patterns rely
+  // on are preserved. Both forms are legal between `import` and its
+  // parenthesis, so both must go:
+  //
+  //   import /* annotation */ ("next/headers")
+  //   import // annotation
+  //   ("next/headers")
+  //
+  // String literals are left intact deliberately. A `//` inside a specifier is
+  // part of a URL, not a comment, and stripping it would corrupt the very
+  // value being checked; the cost is that a `//` inside a string could mask a
+  // later call on the same line, which no import statement produces.
+  const source = raw
+    .replace(/\/\*[\s\S]*?\*\//g, " ")
+    .replace(/(^|[^:"'`\\])\/\/[^\n]*/g, "$1 ");
   const specifiers: string[] = [];
 
   // `from "..."` in an import/export statement, and bare `import "..."`.

--- a/packages/blocks-react/src/layering.test.ts
+++ b/packages/blocks-react/src/layering.test.ts
@@ -133,14 +133,27 @@ function isInternal(specifier: string): boolean {
 /** Resolve a relative specifier to a file on disk, or null if it is not one. */
 function resolveRelative(fromFile: string, specifier: string): string | null {
   if (!specifier.startsWith(".")) return null;
-  const base = join(dirname(fromFile), specifier);
-  for (const candidate of [
-    `${base}.ts`,
-    `${base}.tsx`,
-    join(base, "index.ts"),
-    join(base, "index.tsx"),
-  ]) {
-    if (existsSync(candidate)) return candidate;
+
+  // `./next.js` is the standard ESM-TypeScript spelling and resolves to
+  // `next.ts` under both TypeScript's bundler resolution and esbuild. Probing
+  // only `next.js.ts` would treat that edge as unresolvable, and an
+  // unresolvable edge is silently dropped from the graph — which is exactly
+  // the re-export this walk exists to catch.
+  const withoutJsSuffix = specifier.replace(/\.(js|jsx|mjs|cjs)$/, "");
+  const bases = [
+    join(dirname(fromFile), specifier),
+    join(dirname(fromFile), withoutJsSuffix),
+  ];
+
+  for (const base of bases) {
+    for (const candidate of [
+      `${base}.ts`,
+      `${base}.tsx`,
+      join(base, "index.ts"),
+      join(base, "index.tsx"),
+    ]) {
+      if (existsSync(candidate)) return candidate;
+    }
   }
   return null;
 }

--- a/packages/blocks-react/src/layering.test.ts
+++ b/packages/blocks-react/src/layering.test.ts
@@ -114,12 +114,23 @@ function runtimeImports(file: string): string[] {
     if (specifier) specifiers.push(specifier);
   }
 
-  // A dynamic import whose specifier is not a literal cannot be checked here.
-  // Fail loudly rather than pass silently: the point of this guard is that a
-  // route into the module graph cannot be opened without a deliberate act.
-  const computed = /(?<![.\w])(?:import|require)\s*\(\s*[^"')\s]/g;
-  if (computed.test(source)) {
-    specifiers.push("<computed-dynamic-import>");
+  // A dynamic import whose specifier is not a single literal cannot be checked
+  // here. Fail loudly rather than pass silently: the point of this guard is
+  // that a route into the module graph cannot be opened without a deliberate
+  // act.
+  //
+  // The test is "the argument is not EXACTLY one string literal", not "the
+  // argument does not start with a quote". `import("next/" + "headers")` starts
+  // with a quote, so a first-character test waves it through while the literal
+  // matcher above also skips it for the concatenation.
+  const anyDynamic = /(?<![.\w])(?:import|require)\s*\(([^)]*)\)/g;
+  const singleLiteral = /^\s*["'][^"']*["']\s*$/;
+  let dynamicMatch: RegExpExecArray | null;
+  while ((dynamicMatch = anyDynamic.exec(source)) !== null) {
+    const argument = dynamicMatch[1] ?? "";
+    if (!singleLiteral.test(argument)) {
+      specifiers.push("<computed-dynamic-import>");
+    }
   }
 
   return specifiers;
@@ -188,6 +199,9 @@ function isNodeBuiltin(specifier: string): boolean {
 
 describe("the package's layering contract", () => {
   const files = sourceFiles();
+  // Everything the `/next` entry can reach. Membership, not filename, decides
+  // whether a module is allowed to import Next.
+  const nextGraph = reachableFrom(join(SRC_DIR, "next.ts"));
 
   it("has source files to check", () => {
     // A traversal bug that returned nothing would make every assertion below
@@ -199,7 +213,7 @@ describe("the package's layering contract", () => {
     const violations: string[] = [];
 
     for (const file of files) {
-      const isNextEntry = relative(SRC_DIR, file) === "next.ts";
+      const isNextSide = nextGraph.has(file);
       for (const specifier of runtimeImports(file)) {
         if (isInternal(specifier)) continue;
 
@@ -208,7 +222,10 @@ describe("the package's layering contract", () => {
           continue;
         }
         if (ALLOWED_RUNTIME_IMPORTS.includes(specifier)) continue;
-        if (isNextEntry && NEXT_ONLY_IMPORTS.includes(specifier)) continue;
+        // Any module reachable only from the `/next` entry may use Next, not
+        // just the entry file itself: splitting that entry into helpers must
+        // not require every helper to re-export through one file.
+        if (isNextSide && NEXT_ONLY_IMPORTS.includes(specifier)) continue;
 
         violations.push(`${relative(SRC_DIR, file)}: ${specifier}`);
       }
@@ -241,11 +258,11 @@ describe("the package's layering contract", () => {
     expect(leaks, leaks.join("\n")).toEqual([]);
   });
 
-  it("keeps next/* out of every file except the next entry", () => {
+  it("keeps next/* out of every file outside the next graph", () => {
     const leaks: string[] = [];
 
     for (const file of files) {
-      if (relative(SRC_DIR, file) === "next.ts") continue;
+      if (nextGraph.has(file)) continue;
       for (const specifier of runtimeImports(file)) {
         if (specifier === "next" || specifier.startsWith("next/")) {
           leaks.push(`${relative(SRC_DIR, file)}: ${specifier}`);

--- a/packages/blocks-react/src/next.ts
+++ b/packages/blocks-react/src/next.ts
@@ -1,0 +1,21 @@
+/**
+ * `@nextlyhq/blocks-react/next` — the Next.js-coupled surface.
+ *
+ * Separate from the package root so importing the renderer never pulls
+ * `next/*` into a consumer's module graph. Everything that touches Next
+ * (routing, metadata, draft mode) belongs here and nowhere else.
+ *
+ * `createBlocksPage()` lands in R-4, over the existing `createContentRoute`.
+ *
+ * @module next
+ */
+
+/**
+ * Marker for the subpath's existence and its build wiring.
+ *
+ * A real export rather than an empty file: an entry that exports nothing is
+ * dropped by treeshaking, so the subpath would build to nothing and its
+ * `exports` map would point at a missing file — a packaging error that only
+ * surfaces for a consumer after publish.
+ */
+export const BLOCKS_REACT_NEXT_ENTRY = "@nextlyhq/blocks-react/next";

--- a/packages/blocks-react/src/next.ts
+++ b/packages/blocks-react/src/next.ts
@@ -5,7 +5,8 @@
  * `next/*` into a consumer's module graph. Everything that touches Next
  * (routing, metadata, draft mode) belongs here and nowhere else.
  *
- * `createBlocksPage()` lands in R-4, over the existing `createContentRoute`.
+ * Route helpers built on the CMS's existing content-route factory belong
+ * here, alongside anything else that needs `next/*`.
  *
  * @module next
  */

--- a/packages/blocks-react/tsconfig.json
+++ b/packages/blocks-react/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "@nextlyhq/tsconfig/base-bundler.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "jsx": "react-jsx",
+    "lib": ["ES2022", "DOM"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules", "**/*.test.ts", "**/*.test.tsx"]
+}

--- a/packages/blocks-react/tsup.config.ts
+++ b/packages/blocks-react/tsup.config.ts
@@ -1,0 +1,29 @@
+import { defineConfig } from "tsup";
+
+/**
+ * Two entries, and the split is the package's central contract.
+ *
+ * `index` renders block documents with React alone: no Next.js, no CMS, no
+ * database. That is what lets the renderer be used standalone, and a test
+ * enforces it.
+ *
+ * `next` is the only Next-coupled surface. Keeping it in its own entry means a
+ * consumer who imports the renderer never pulls `next/*` into their graph, and
+ * bundlers can drop it entirely. Puck ships a separate `/rsc` bundle for the
+ * same reason: one bundle cannot serve both an editor-aware and a
+ * server-rendering consumer.
+ */
+export default defineConfig({
+  entry: ["src/index.ts", "src/next.ts"],
+  format: ["esm"],
+  dts: true,
+  clean: true,
+  sourcemap: true,
+  treeshake: true,
+  // React and Next are the consumer's; bundling either would produce a second
+  // copy of React in the tree, which breaks hooks and RSC alike.
+  external: ["react", "react/jsx-runtime", "next"],
+  outExtension() {
+    return { js: ".mjs" };
+  },
+});

--- a/packages/blocks-react/vitest.config.ts
+++ b/packages/blocks-react/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["src/**/*.test.ts", "src/**/*.test.tsx"],
+  },
+});

--- a/packages/blocks-react/vitest.config.ts
+++ b/packages/blocks-react/vitest.config.ts
@@ -1,5 +1,18 @@
 import { defineConfig } from "vitest/config";
 
+/**
+ * The suite is static analysis over source files, not rendering.
+ *
+ * `node` rather than a DOM environment because nothing here mounts a
+ * component: the layering checks read files and walk the import graph, and a
+ * DOM environment would add startup cost for capability none of them use. When
+ * renderer tests arrive they will need `jsdom`, and switching then is a
+ * deliberate change rather than an inherited default.
+ *
+ * `.tsx` is included alongside `.ts` because blocks are React components and
+ * their tests will live beside them.
+ */
+
 export default defineConfig({
   test: {
     environment: "node",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,7 +86,7 @@ importers:
         version: 6.9.1
       '@testing-library/react':
         specifier: ^16.3.0
-        version: 16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@19.2.0(@types/react@19.2.0))(@types/react@19.2.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: 16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@19.2.0(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@testing-library/user-event':
         specifier: ^14.6.1
         version: 14.6.1(@testing-library/dom@10.4.1)
@@ -752,6 +752,46 @@ importers:
       eslint:
         specifier: ^9.39.1
         version: 9.39.1(jiti@2.7.0)
+      rimraf:
+        specifier: ^6.1.3
+        version: 6.1.3
+      tsup:
+        specifier: ^8.5.0
+        version: 8.5.0(jiti@2.7.0)(postcss@8.5.23)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^4.1.0
+        version: 4.1.10(@types/node@20.19.17)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.9.0)(jsdom@27.1.0)(vite@7.3.6(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
+
+  packages/blocks-react:
+    dependencies:
+      '@nextlyhq/blocks-engine':
+        specifier: workspace:*
+        version: link:../blocks-engine
+      next:
+        specifier: ^16.2.12
+        version: 16.2.12(@babel/core@7.29.7)(@playwright/test@1.61.1)(@types/node@20.19.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+    devDependencies:
+      '@nextlyhq/eslint-config':
+        specifier: workspace:*
+        version: link:../eslint-config
+      '@nextlyhq/tsconfig':
+        specifier: workspace:*
+        version: link:../tsconfig
+      '@types/node':
+        specifier: ^20.19.17
+        version: 20.19.17
+      '@types/react':
+        specifier: ^19.2.2
+        version: 19.2.18
+      eslint:
+        specifier: ^9.39.1
+        version: 9.39.1(jiti@2.7.0)
+      react:
+        specifier: ^19.2.0
+        version: 19.2.0
       rimraf:
         specifier: ^6.1.3
         version: 6.1.3
@@ -4495,6 +4535,9 @@ packages:
   '@types/react@19.2.0':
     resolution: {integrity: sha512-1LOH8xovvsKsCBq1wnT4ntDUdCJKmnEakhsuoUSy6ExlHCkGP2hqnatagYTgFk6oeL0VU31u7SNjunPN+GchtA==}
 
+  '@types/react@19.2.18':
+    resolution: {integrity: sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w==}
+
   '@types/semver@7.7.1':
     resolution: {integrity: sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==}
 
@@ -5197,6 +5240,9 @@ packages:
 
   csstype@3.1.3:
     resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
+
+  csstype@3.2.3:
+    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
   culori@4.0.2:
     resolution: {integrity: sha512-1+BhOB8ahCn4O0cep0Sh2l9KCOfOdY+BXJnKMHFFzDEouSr/el18QwXEMRlOj9UY5nCeA8UN3a/82rUWRBeyBw==}
@@ -11191,6 +11237,16 @@ snapshots:
       '@types/react': 19.2.0
       '@types/react-dom': 19.2.0(@types/react@19.2.0)
 
+  '@testing-library/react@16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@19.2.0(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@testing-library/dom': 10.4.1
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
+    optionalDependencies:
+      '@types/react': 19.2.18
+      '@types/react-dom': 19.2.0(@types/react@19.2.18)
+
   '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1)':
     dependencies:
       '@testing-library/dom': 10.4.1
@@ -11336,9 +11392,18 @@ snapshots:
     dependencies:
       '@types/react': 19.2.0
 
+  '@types/react-dom@19.2.0(@types/react@19.2.18)':
+    dependencies:
+      '@types/react': 19.2.18
+    optional: true
+
   '@types/react@19.2.0':
     dependencies:
       csstype: 3.1.3
+
+  '@types/react@19.2.18':
+    dependencies:
+      csstype: 3.2.3
 
   '@types/semver@7.7.1': {}
 
@@ -11922,6 +11987,11 @@ snapshots:
       esbuild: 0.25.12
       load-tsconfig: 0.2.5
 
+  bundle-require@5.1.0(esbuild@0.28.1):
+    dependencies:
+      esbuild: 0.28.1
+      load-tsconfig: 0.2.5
+
   cac@6.7.14: {}
 
   call-bind-apply-helpers@1.0.2:
@@ -12152,6 +12222,8 @@ snapshots:
       lru-cache: 11.3.5
 
   csstype@3.1.3: {}
+
+  csstype@3.2.3: {}
 
   culori@4.0.2: {}
 
@@ -12704,7 +12776,7 @@ snapshots:
       '@humanfs/node': 0.16.6
       '@humanwhocodes/module-importer': 1.0.1
       '@humanwhocodes/retry': 0.4.3
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
       ajv: 6.15.0
       chalk: 4.1.2
       cross-spawn: 7.0.6
@@ -14962,22 +15034,22 @@ snapshots:
 
   tsup@8.5.0(jiti@2.6.1)(postcss@8.5.23)(tsx@4.20.5)(typescript@5.9.3)(yaml@2.8.3):
     dependencies:
-      bundle-require: 5.1.0(esbuild@0.25.12)
+      bundle-require: 5.1.0(esbuild@0.28.1)
       cac: 6.7.14
       chokidar: 4.0.3
       consola: 3.4.2
       debug: 4.4.3
-      esbuild: 0.25.12
+      esbuild: 0.28.1
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
       picocolors: 1.1.1
       postcss-load-config: 6.0.1(jiti@2.6.1)(postcss@8.5.23)(tsx@4.20.5)(yaml@2.8.3)
       resolve-from: 5.0.0
-      rollup: 4.60.1
+      rollup: 4.62.3
       source-map: 0.8.0-beta.0
       sucrase: 3.35.0
       tinyexec: 0.3.2
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.17
       tree-kill: 1.2.2
     optionalDependencies:
       postcss: 8.5.23
@@ -15322,7 +15394,7 @@ snapshots:
       std-env: 4.2.0
       tinybench: 2.9.0
       tinyexec: 1.2.4
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
       vite: 7.3.6(@types/node@20.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.20.5)(yaml@2.8.3)
       why-is-node-running: 2.3.0
@@ -15384,7 +15456,7 @@ snapshots:
       std-env: 4.2.0
       tinybench: 2.9.0
       tinyexec: 1.2.4
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
       vite: 7.3.6(@types/node@24.10.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.20.5)(yaml@2.8.3)
       why-is-node-running: 2.3.0
@@ -15415,7 +15487,7 @@ snapshots:
       std-env: 4.2.0
       tinybench: 2.9.0
       tinyexec: 1.2.4
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
       vite: 7.3.6(@types/node@24.10.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3)
       why-is-node-running: 2.3.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,7 +86,7 @@ importers:
         version: 6.9.1
       '@testing-library/react':
         specifier: ^16.3.0
-        version: 16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@19.2.0(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: 16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@19.2.0(@types/react@19.2.0))(@types/react@19.2.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@testing-library/user-event':
         specifier: ^14.6.1
         version: 14.6.1(@testing-library/dom@10.4.1)
@@ -784,13 +784,13 @@ importers:
         specifier: ^20.19.17
         version: 20.19.17
       '@types/react':
-        specifier: ^19.2.2
-        version: 19.2.18
+        specifier: 19.2.0
+        version: 19.2.0
       eslint:
         specifier: ^9.39.1
         version: 9.39.1(jiti@2.7.0)
       react:
-        specifier: ^19.2.0
+        specifier: 19.2.0
         version: 19.2.0
       rimraf:
         specifier: ^6.1.3
@@ -4535,9 +4535,6 @@ packages:
   '@types/react@19.2.0':
     resolution: {integrity: sha512-1LOH8xovvsKsCBq1wnT4ntDUdCJKmnEakhsuoUSy6ExlHCkGP2hqnatagYTgFk6oeL0VU31u7SNjunPN+GchtA==}
 
-  '@types/react@19.2.18':
-    resolution: {integrity: sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w==}
-
   '@types/semver@7.7.1':
     resolution: {integrity: sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==}
 
@@ -5237,9 +5234,6 @@ packages:
   cssstyle@6.2.0:
     resolution: {integrity: sha512-Fm5NvhYathRnXNVndkUsCCuR63DCLVVwGOOwQw782coXFi5HhkXdu289l59HlXZBawsyNccXfWRYvLzcDCdDig==}
     engines: {node: '>=20'}
-
-  csstype@3.1.3:
-    resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
@@ -11237,16 +11231,6 @@ snapshots:
       '@types/react': 19.2.0
       '@types/react-dom': 19.2.0(@types/react@19.2.0)
 
-  '@testing-library/react@16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@19.2.0(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
-    dependencies:
-      '@babel/runtime': 7.29.7
-      '@testing-library/dom': 10.4.1
-      react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
-    optionalDependencies:
-      '@types/react': 19.2.18
-      '@types/react-dom': 19.2.0(@types/react@19.2.18)
-
   '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1)':
     dependencies:
       '@testing-library/dom': 10.4.1
@@ -11392,16 +11376,7 @@ snapshots:
     dependencies:
       '@types/react': 19.2.0
 
-  '@types/react-dom@19.2.0(@types/react@19.2.18)':
-    dependencies:
-      '@types/react': 19.2.18
-    optional: true
-
   '@types/react@19.2.0':
-    dependencies:
-      csstype: 3.1.3
-
-  '@types/react@19.2.18':
     dependencies:
       csstype: 3.2.3
 
@@ -12220,8 +12195,6 @@ snapshots:
       '@csstools/css-syntax-patches-for-csstree': 1.1.3(css-tree@3.1.0)
       css-tree: 3.1.0
       lru-cache: 11.3.5
-
-  csstype@3.1.3: {}
 
   csstype@3.2.3: {}
 


### PR DESCRIPTION
**R-1 of implementation plan 03** (Renderer + Publishing, approved as PB-D22).

Adds `@nextlyhq/blocks-react` — the React/RSC renderer for Nextly block documents. This PR lands the **package boundary and its guarantees**; `PageRenderer` itself arrives in R-2.

## The boundary is the deliverable

Two entries, and the split is the contract:

- **root** — renders documents with React alone. No `next/*`, no admin, no CMS runtime. A document can be rendered from a plain React app, a test, or a script with nothing else installed.
- **`/next`** — the only Next-coupled surface. Importing the renderer never pulls Next into a consumer's module graph.

Puck ships a separate `/rsc` bundle for the same reason: one bundle cannot serve both an editor-aware and a server-rendering consumer.

## Enforced, not documented

`src/layering.test.ts` is an **allowlist**-based import scanner, not a blocklist — a blocklist only stops what someone thought to name, and the next unthinking dependency is exactly the one that breaks the promise. It asserts three rules: nothing outside the allowlist, no `next/*` outside `next.ts`, and no admin / CMS runtime / editor imports anywhere.

**Stub-verified against two violation classes**, because a guard that cannot detect a violation is worthless:

| Injected violation | Result |
|---|---|
| `import { draftMode } from "next/headers"` in `context.ts` | 2 tests fail, naming the file and specifier |
| `import { collections } from "nextly/config"` in `context.ts` | 2 tests fail, including the named CMS rule |

Restored from a copy and verified identical by diff.

## `PageContext` — the seam the engine assigns to this package

`BlockRenderArgs<P, C>` deliberately leaves `ctx: C` unnamed ("what a context CONTAINS is the renderer's to say"), so defining it is this package's obligation. `PageContext` + `BlocksDataProvider` are how data, media URLs and entry paths reach a block, so blocks never reach for a database.

The standalone case is the smaller half of why: the canvas renders the same documents with different data access, tests want fixtures instead of a database, and the binding system planned for a later phase already assumes a provider. One seam, four consumers.

## Also included

- `blocks-react` added to the PR-title allowed scopes and the AGENTS.md repo map — without the first, this PR's own title would fail CI.
- Added to the changeset fixed group (22 packages); changeset generated from config, never hand-typed.

## Verification

`build` emits both entries with types · `check-types` clean · `lint` clean (`--max-warnings 0`) · 4 layering tests pass and fail correctly when stubbed.

## Not in this PR

`PageRenderer`, `BlockBoundary`, `renderSlot`, the CSS injection path, and `createBlocksPage()` — R-2 and R-4.

---

## Merge precondition: npm name claim

`@nextlyhq/blocks-react` is a NEW publishable package and joins the Changesets `fixed` lockstep group. npm trusted publishing (OIDC) cannot perform a package's first publish, so the name must be claimed once by a maintainer before this merges:

```
npm login
node scripts/release/bootstrap-package.mjs @nextlyhq/blocks-react --publish
```

then add its Trusted Publisher entry on npmjs.com (environment name `Production`, matching the release workflow).

`scripts/release/preflight.mjs` already enforces this: it aborts the release BEFORE `changeset publish` runs, so the failure mode is a cleanly blocked release rather than a partial train. Verified on this branch — `never published: 1`, `Blocked: @nextlyhq/blocks-react`, `Release aborted before publishing. Nothing was pushed to npm.`
