### PR TITLE
fix(adapter-drizzle): encode a timestamp the same way whatever the server timezone is

### DIFF
--- a/.changeset/timestamp-write-encoding.md
+++ b/.changeset/timestamp-write-encoding.md
@@ -1,0 +1,27 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+A timestamp is stored the same way whatever the server timezone is. The raw-SQL write paths bound a JS Date directly, so the driver serialized it with the local offset and a column declared without a time zone kept the local wall clock, while every read interpreted that wall clock as UTC. A row written and read back on a server five hours ahead of UTC came back five hours late. Values are now encoded through the column the same way a Drizzle query encodes them, on PostgreSQL and MySQL; SQLite was unaffected, storing unix seconds, which carry no zone.
+
+Rows written before this on a server that was not on UTC keep the wall clock they were given, so a table can hold both conventions until those rows are corrected. Deployments running UTC, which includes every default container image, are unaffected either way.

--- a/packages/adapter-drizzle/src/adapter.ts
+++ b/packages/adapter-drizzle/src/adapter.ts
@@ -70,7 +70,27 @@ const DATE_DATA_TYPE = /(?:^|\s)date$/;
  * Every real UTC offset is at least fifteen minutes, so a shift is never
  * mistaken for rounding.
  */
-const MAX_STORED_ROUNDING_MS = 1000;
+/**
+ * Suffix for the alias a statement spells a timestamp's wall clock out under.
+ *
+ * Distinctive because it shares a row with the table's own columns, and a
+ * collision would overwrite one of them.
+ */
+const WALL_CLOCK_ALIAS_SUFFIX = "__nextly_wall_clock";
+
+/**
+ * Read a database's own rendering of a timestamp as UTC.
+ *
+ * The statement wrote a UTC wall clock, so reading one back as UTC is what
+ * makes a write agree with a later read. Anything unparseable answers nothing,
+ * leaving the driver's value in place rather than replacing it with an
+ * `Invalid Date`.
+ */
+function parseWallClockAsUtc(text: string): Date | undefined {
+  const normalized = text.trim().replace(" ", "T");
+  const parsed = new Date(`${normalized}Z`);
+  return Number.isNaN(parsed.getTime()) ? undefined : parsed;
+}
 
 /** Whether a table property is a date column that can convert its own values. */
 function isDateColumn(colDef: unknown): colDef is DecodableColumn {
@@ -652,87 +672,86 @@ export abstract class DrizzleAdapter {
   protected mapRowFromRawSql<T = unknown>(
     tableObj: unknown,
     row: T,
-    written?: Record<string, unknown>
+    aliases: ReadonlyArray<{ alias: string; jsName: string }> = []
   ): T {
     const mapped = this.mapDateValuesFromDriver(
       tableObj,
       this.mapRowKeysToJs(tableObj, row)
     );
-    return written === undefined
-      ? mapped
-      : this.correctEchoedDateZone(tableObj, mapped, written);
+    return this.applyWallClockAliases(mapped, aliases);
   }
 
   /**
-   * Read an echoed date in the zone the statement wrote it in, keeping whatever
-   * the database actually stored.
+   * The date columns a statement is about to return, and the alias each one's
+   * wall clock is spelled out under.
    *
-   * A column declared without a time zone holds a wall clock. The statement
-   * binds a UTC one; a driver reads it back in ITS zone, which is the local one,
-   * so the same row comes back shifted by the offset. Only the reading is
-   * wrong -- the wall clock in the database is right -- so the correction is to
-   * read it again as UTC rather than to substitute the value that was bound.
+   * A driver turns a timestamp into a `Date` using ITS zone before any of this
+   * code runs, and that conversion is lossy: a wall clock inside a
+   * daylight-saving gap is a local time that does not exist, so the driver
+   * normalizes it and the original is gone. Asking the database for the wall
+   * clock as text alongside the row is the only way to read it exactly.
    *
-   * Substituting would report an instant the database never stored: a MySQL
-   * `DATETIME` without fractional precision keeps whole seconds, so the row it
-   * holds is not the one that was handed to it, and a later read would disagree
-   * with the write by up to a second.
-   *
-   * Whether the driver shifted anything is DECIDED, not assumed. The value that
-   * was bound is the reference: within a second of it, the driver already read
-   * the wall clock the way the statement wrote it and nothing is done. Every
-   * real offset is at least fifteen minutes, so the two cases cannot be
-   * confused, and a driver configured to read UTC is left alone rather than
-   * corrected twice.
-   *
-   * A column the statement did not return is not added, so a projection stays
-   * what the caller asked for. A column with no bound value -- a database
-   * default -- has no reference to judge against and is left as it came back.
+   * `"*"` covers every date column; a projection covers only the ones it asked
+   * for, so a caller still gets back what it requested and nothing more.
    */
-  private correctEchoedDateZone<T>(
+  protected dateWallClockAliases(
     tableObj: unknown,
-    row: T,
-    written: Record<string, unknown>
-  ): T {
-    if (!tableObj || typeof tableObj !== "object" || !row) return row;
-    const record = row as Record<string, unknown>;
+    returning: string[] | "*" | undefined
+  ): Array<{ sqlName: string; alias: string; jsName: string }> {
+    if (!tableObj || typeof tableObj !== "object" || returning === undefined) {
+      return [];
+    }
+    const requested =
+      returning === "*" ? undefined : new Set(returning.map(String));
 
-    let corrected: Record<string, unknown> | undefined;
+    const aliases: Array<{ sqlName: string; alias: string; jsName: string }> =
+      [];
     for (const [jsName, colDef] of Object.entries(
       tableObj as Record<string, unknown>
     )) {
       if (!isDateColumn(colDef)) continue;
-      if (!(jsName in record)) continue;
-
-      const echoed = record[jsName];
-      if (!(echoed instanceof Date)) continue;
-
       const sqlName = (colDef as { name?: unknown }).name;
-      const bound =
-        written[jsName] ??
-        (typeof sqlName === "string" ? written[sqlName] : undefined);
-      if (!(bound instanceof Date)) continue;
-
-      if (
-        Math.abs(echoed.getTime() - bound.getTime()) <= MAX_STORED_ROUNDING_MS
-      ) {
+      if (typeof sqlName !== "string") continue;
+      if (requested && !requested.has(sqlName) && !requested.has(jsName)) {
         continue;
       }
-
-      corrected ??= { ...record };
-      corrected[jsName] = new Date(
-        Date.UTC(
-          echoed.getFullYear(),
-          echoed.getMonth(),
-          echoed.getDate(),
-          echoed.getHours(),
-          echoed.getMinutes(),
-          echoed.getSeconds(),
-          echoed.getMilliseconds()
-        )
-      );
+      aliases.push({
+        sqlName,
+        alias: `${sqlName}${WALL_CLOCK_ALIAS_SUFFIX}`,
+        jsName,
+      });
     }
-    return (corrected as T | undefined) ?? row;
+    return aliases;
+  }
+
+  /**
+   * Replace each date in a row with the wall clock the database spelled out,
+   * read as UTC, and drop the aliases that carried it.
+   *
+   * The statement writes a UTC wall clock, so reading one back as UTC is what
+   * makes a write and a later read agree. Whatever the column actually stored
+   * is what arrives -- a column keeping only whole seconds reports whole
+   * seconds -- because this is the database's own text, not a value
+   * reconstructed from the one that was bound.
+   */
+  protected applyWallClockAliases<T>(
+    row: T,
+    aliases: ReadonlyArray<{ alias: string; jsName: string }>
+  ): T {
+    if (!row || typeof row !== "object" || aliases.length === 0) return row;
+    const record = row as Record<string, unknown>;
+
+    let resolved: Record<string, unknown> | undefined;
+    for (const { alias, jsName } of aliases) {
+      if (!(alias in record)) continue;
+      resolved ??= { ...record };
+      const text = resolved[alias];
+      delete resolved[alias];
+      if (typeof text !== "string") continue;
+      const parsed = parseWallClockAsUtc(text);
+      if (parsed !== undefined) resolved[jsName] = parsed;
+    }
+    return (resolved as T | undefined) ?? row;
   }
 
   /**

--- a/packages/adapter-drizzle/src/adapter.ts
+++ b/packages/adapter-drizzle/src/adapter.ts
@@ -52,6 +52,7 @@ import { createDatabaseError, isDatabaseError } from "./types";
 interface DecodableColumn {
   dataType: unknown;
   mapFromDriverValue(value: unknown): unknown;
+  mapToDriverValue(value: unknown): unknown;
 }
 
 /**
@@ -60,12 +61,13 @@ interface DecodableColumn {
  */
 const DATE_DATA_TYPE = /(?:^|\s)date$/;
 
-/** Whether a table property is a date column that can decode a driver value. */
+/** Whether a table property is a date column that can convert its own values. */
 function isDateColumn(colDef: unknown): colDef is DecodableColumn {
   if (!colDef || typeof colDef !== "object") return false;
   const candidate = colDef as Partial<DecodableColumn>;
   return (
     typeof candidate.mapFromDriverValue === "function" &&
+    typeof candidate.mapToDriverValue === "function" &&
     DATE_DATA_TYPE.test(String(candidate.dataType))
   );
 }
@@ -565,6 +567,70 @@ export abstract class DrizzleAdapter {
   }
 
   /**
+   * Encode a row's DATE values the way a Drizzle query would before binding
+   * them, so what lands in the column does not depend on the server's timezone.
+   *
+   * A column declared without a time zone stores a wall clock and records
+   * nothing about which zone it belongs to, so both ends have to agree. Drizzle
+   * writes UTC and reads UTC. A driver handed a `Date` writes the LOCAL wall
+   * clock instead, and the same row then reads back shifted by the offset --
+   * on a UTC server the two agree and nothing is visibly wrong, which is why
+   * this survives CI.
+   *
+   * Only date columns are touched. A value that is not a `Date` is left as it
+   * is, so a caller that already encoded one is not encoded twice.
+   *
+   * Keys may be spelled either way at this point, so both the Drizzle property
+   * name and the SQL column name resolve.
+   */
+  protected mapDateValuesToDriver(
+    tableObj: unknown,
+    data: Record<string, unknown>
+  ): Record<string, unknown> {
+    if (!tableObj || typeof tableObj !== "object" || !data) return data;
+
+    const dateColumns = new Map<string, DecodableColumn>();
+    for (const [jsName, colDef] of Object.entries(
+      tableObj as Record<string, unknown>
+    )) {
+      if (!isDateColumn(colDef)) continue;
+      dateColumns.set(jsName, colDef);
+      const sqlName = (colDef as { name?: unknown }).name;
+      if (typeof sqlName === "string") dateColumns.set(sqlName, colDef);
+    }
+    if (dateColumns.size === 0) return data;
+
+    let encoded: Record<string, unknown> | undefined;
+    for (const [key, value] of Object.entries(data)) {
+      if (!(value instanceof Date)) continue;
+      const column = dateColumns.get(key);
+      if (!column) continue;
+      encoded ??= { ...data };
+      encoded[key] = column.mapToDriverValue(value);
+    }
+    return encoded ?? data;
+  }
+
+  /**
+   * Bring a row about to be written through a raw-SQL statement into the shape
+   * a Drizzle query would have bound: SQL column names for keys, encoded values
+   * for date columns.
+   *
+   * The mirror of {@link mapRowFromRawSql}. The raw-SQL write paths exist
+   * because a dialect needs SQL a Drizzle query cannot express, not because
+   * their callers want different values in the table.
+   */
+  protected mapRowToRawSql(
+    tableObj: unknown,
+    data: Record<string, unknown>
+  ): Record<string, unknown> {
+    return this.mapDateValuesToDriver(
+      tableObj,
+      this.mapKeysToSqlColumns(tableObj, data)
+    );
+  }
+
+  /**
    * Bring a raw-SQL result row into the shape a Drizzle query would have
    * produced: Drizzle property names for keys, decoded values for date columns.
    *
@@ -572,11 +638,55 @@ export abstract class DrizzleAdapter {
    * cannot express, not because their callers want a different row shape, so
    * every one of them ends here.
    */
-  protected mapRowFromRawSql<T = unknown>(tableObj: unknown, row: T): T {
-    return this.mapDateValuesFromDriver(
+  protected mapRowFromRawSql<T = unknown>(
+    tableObj: unknown,
+    row: T,
+    written?: Record<string, unknown>
+  ): T {
+    const mapped = this.mapDateValuesFromDriver(
       tableObj,
       this.mapRowKeysToJs(tableObj, row)
     );
+    return written === undefined
+      ? mapped
+      : this.restoreWrittenDates(tableObj, mapped, written);
+  }
+
+  /**
+   * Put back the exact `Date` a write bound, in place of whatever the driver
+   * made of the value it echoed.
+   *
+   * A column declared without a time zone holds a wall clock, and the driver
+   * reads one back on its own terms -- as LOCAL -- where the statement wrote
+   * UTC. Correcting that by re-interpreting the driver's `Date` would mean
+   * encoding the driver's convention here and getting it wrong the moment a
+   * connection is configured differently.
+   *
+   * The write does not have to guess: it knows the value it bound. A column the
+   * caller did not supply is left exactly as it came back, so a database
+   * default is untouched.
+   */
+  private restoreWrittenDates<T>(
+    tableObj: unknown,
+    row: T,
+    written: Record<string, unknown>
+  ): T {
+    if (!tableObj || typeof tableObj !== "object" || !row) return row;
+
+    let restored: Record<string, unknown> | undefined;
+    for (const [jsName, colDef] of Object.entries(
+      tableObj as Record<string, unknown>
+    )) {
+      if (!isDateColumn(colDef)) continue;
+      const sqlName = (colDef as { name?: unknown }).name;
+      const source =
+        written[jsName] ??
+        (typeof sqlName === "string" ? written[sqlName] : undefined);
+      if (!(source instanceof Date)) continue;
+      restored ??= { ...(row as Record<string, unknown>) };
+      restored[jsName] = source;
+    }
+    return (restored as T | undefined) ?? row;
   }
 
   /**

--- a/packages/adapter-drizzle/src/adapter.ts
+++ b/packages/adapter-drizzle/src/adapter.ts
@@ -108,7 +108,7 @@ function parseWallClockAsUtc(text: string): Date | undefined {
   // Milliseconds, whatever precision the dialect rendered: a shorter fraction
   // is padded and a longer one truncated, which is what a `Date` can hold.
   const millis = Number(`${fraction}000`.slice(0, 3));
-  return new Date(
+  const parsed = new Date(
     Date.UTC(
       Number(year),
       Number(month) - 1,
@@ -119,6 +119,10 @@ function parseWallClockAsUtc(text: string): Date | undefined {
       millis
     )
   );
+  // `Date.UTC` reads a year under 100 as shorthand for the 1900s, so year 50
+  // would land in 1950. The database said 0050 and meant it.
+  if (Number(year) < 100) parsed.setUTCFullYear(Number(year));
+  return parsed;
 }
 
 /** Whether a table property is a date column that can convert its own values. */
@@ -130,6 +134,18 @@ function isDateColumn(colDef: unknown): colDef is DecodableColumn {
     typeof candidate.mapToDriverValue === "function" &&
     DATE_DATA_TYPE.test(String(candidate.dataType))
   );
+}
+
+/**
+ * Whether a date column records the zone its value belongs to.
+ *
+ * A column declared WITH a time zone stores an instant, so a driver reading it
+ * back gets the same moment whatever zone either end is in -- there is nothing
+ * ambiguous to resolve and nothing to correct. Rendering one as text would
+ * spell it in the session's zone, and reading that as UTC would move it.
+ */
+function carriesTimeZone(colDef: unknown): boolean {
+  return (colDef as { withTimezone?: unknown }).withTimezone === true;
 }
 
 /**
@@ -761,6 +777,10 @@ export abstract class DrizzleAdapter {
       tableObj as Record<string, unknown>
     )) {
       if (!isDateColumn(colDef)) continue;
+      // A column carrying its own zone is already unambiguous; spelling it out
+      // would render it in the session's zone and reading that as UTC would
+      // move an instant that was correct to begin with.
+      if (carriesTimeZone(colDef)) continue;
       const sqlName = (colDef as { name?: unknown }).name;
       if (typeof sqlName !== "string") continue;
       if (requested && !requested.has(sqlName) && !requested.has(jsName)) {

--- a/packages/adapter-drizzle/src/adapter.ts
+++ b/packages/adapter-drizzle/src/adapter.ts
@@ -71,25 +71,54 @@ const DATE_DATA_TYPE = /(?:^|\s)date$/;
  * mistaken for rounding.
  */
 /**
- * Suffix for the alias a statement spells a timestamp's wall clock out under.
+ * Stem for the alias a statement spells a timestamp's wall clock out under.
  *
- * Distinctive because it shares a row with the table's own columns, and a
- * collision would overwrite one of them.
+ * Short on purpose. PostgreSQL truncates an identifier at 63 bytes, and a
+ * truncated alias is worse than a rejected one: the statement still succeeds,
+ * the lookup misses the name it asked for, and the row keeps both the driver's
+ * value and a stray property. A stem plus an index stays far inside the limit
+ * whatever the column is called.
  */
-const WALL_CLOCK_ALIAS_SUFFIX = "__nextly_wall_clock";
+const WALL_CLOCK_ALIAS_STEM = "__nx_wc";
+
+/**
+ * A timestamp as the database itself spells it, in a fixed field order.
+ *
+ * Matched rather than handed to `new Date`, so nothing depends on the host's
+ * parsing of a partial date. The fraction is optional and of any length, which
+ * covers PostgreSQL's milliseconds and MySQL's microseconds alike.
+ */
+const WALL_CLOCK_PATTERN =
+  /^(\d{4})-(\d{2})-(\d{2})[T ](\d{2}):(\d{2}):(\d{2})(?:\.(\d+))?$/;
 
 /**
  * Read a database's own rendering of a timestamp as UTC.
  *
  * The statement wrote a UTC wall clock, so reading one back as UTC is what
- * makes a write agree with a later read. Anything unparseable answers nothing,
- * leaving the driver's value in place rather than replacing it with an
- * `Invalid Date`.
+ * makes a write agree with a later read. The rendering is one the statement
+ * asked for by name, so its shape does not depend on a session setting.
+ *
+ * Anything that does not match answers nothing, leaving the driver's value in
+ * place rather than replacing it with an `Invalid Date`.
  */
 function parseWallClockAsUtc(text: string): Date | undefined {
-  const normalized = text.trim().replace(" ", "T");
-  const parsed = new Date(`${normalized}Z`);
-  return Number.isNaN(parsed.getTime()) ? undefined : parsed;
+  const match = WALL_CLOCK_PATTERN.exec(text.trim());
+  if (!match) return undefined;
+  const [, year, month, day, hour, minute, second, fraction = ""] = match;
+  // Milliseconds, whatever precision the dialect rendered: a shorter fraction
+  // is padded and a longer one truncated, which is what a `Date` can hold.
+  const millis = Number(`${fraction}000`.slice(0, 3));
+  return new Date(
+    Date.UTC(
+      Number(year),
+      Number(month) - 1,
+      Number(day),
+      Number(hour),
+      Number(minute),
+      Number(second),
+      millis
+    )
+  );
 }
 
 /** Whether a table property is a date column that can convert its own values. */
@@ -704,6 +733,28 @@ export abstract class DrizzleAdapter {
     const requested =
       returning === "*" ? undefined : new Set(returning.map(String));
 
+    // Every name the row can already carry, so an alias cannot land on one and
+    // overwrite or delete it. A column really called `__nx_wc0` is far-fetched,
+    // but one set makes it impossible rather than unlikely.
+    const taken = new Set<string>();
+    for (const [jsName, colDef] of Object.entries(
+      tableObj as Record<string, unknown>
+    )) {
+      taken.add(jsName);
+      const columnName = (colDef as { name?: unknown }).name;
+      if (typeof columnName === "string") taken.add(columnName);
+    }
+
+    let next = 0;
+    const freeAlias = (): string => {
+      let candidate = `${WALL_CLOCK_ALIAS_STEM}${next++}`;
+      while (taken.has(candidate)) {
+        candidate = `${WALL_CLOCK_ALIAS_STEM}${next++}`;
+      }
+      taken.add(candidate);
+      return candidate;
+    };
+
     const aliases: Array<{ sqlName: string; alias: string; jsName: string }> =
       [];
     for (const [jsName, colDef] of Object.entries(
@@ -715,11 +766,7 @@ export abstract class DrizzleAdapter {
       if (requested && !requested.has(sqlName) && !requested.has(jsName)) {
         continue;
       }
-      aliases.push({
-        sqlName,
-        alias: `${sqlName}${WALL_CLOCK_ALIAS_SUFFIX}`,
-        jsName,
-      });
+      aliases.push({ sqlName, alias: freeAlias(), jsName });
     }
     return aliases;
   }

--- a/packages/adapter-drizzle/src/adapter.ts
+++ b/packages/adapter-drizzle/src/adapter.ts
@@ -61,6 +61,17 @@ interface DecodableColumn {
  */
 const DATE_DATA_TYPE = /(?:^|\s)date$/;
 
+/**
+ * How far an echoed timestamp may sit from the one that was bound and still
+ * count as the same value.
+ *
+ * A column with no fractional precision keeps whole seconds, so a stored value
+ * can differ from the bound one by up to a second without anything being wrong.
+ * Every real UTC offset is at least fifteen minutes, so a shift is never
+ * mistaken for rounding.
+ */
+const MAX_STORED_ROUNDING_MS = 1000;
+
 /** Whether a table property is a date column that can convert its own values. */
 function isDateColumn(colDef: unknown): colDef is DecodableColumn {
   if (!colDef || typeof colDef !== "object") return false;
@@ -649,44 +660,79 @@ export abstract class DrizzleAdapter {
     );
     return written === undefined
       ? mapped
-      : this.restoreWrittenDates(tableObj, mapped, written);
+      : this.correctEchoedDateZone(tableObj, mapped, written);
   }
 
   /**
-   * Put back the exact `Date` a write bound, in place of whatever the driver
-   * made of the value it echoed.
+   * Read an echoed date in the zone the statement wrote it in, keeping whatever
+   * the database actually stored.
    *
-   * A column declared without a time zone holds a wall clock, and the driver
-   * reads one back on its own terms -- as LOCAL -- where the statement wrote
-   * UTC. Correcting that by re-interpreting the driver's `Date` would mean
-   * encoding the driver's convention here and getting it wrong the moment a
-   * connection is configured differently.
+   * A column declared without a time zone holds a wall clock. The statement
+   * binds a UTC one; a driver reads it back in ITS zone, which is the local one,
+   * so the same row comes back shifted by the offset. Only the reading is
+   * wrong -- the wall clock in the database is right -- so the correction is to
+   * read it again as UTC rather than to substitute the value that was bound.
    *
-   * The write does not have to guess: it knows the value it bound. A column the
-   * caller did not supply is left exactly as it came back, so a database
-   * default is untouched.
+   * Substituting would report an instant the database never stored: a MySQL
+   * `DATETIME` without fractional precision keeps whole seconds, so the row it
+   * holds is not the one that was handed to it, and a later read would disagree
+   * with the write by up to a second.
+   *
+   * Whether the driver shifted anything is DECIDED, not assumed. The value that
+   * was bound is the reference: within a second of it, the driver already read
+   * the wall clock the way the statement wrote it and nothing is done. Every
+   * real offset is at least fifteen minutes, so the two cases cannot be
+   * confused, and a driver configured to read UTC is left alone rather than
+   * corrected twice.
+   *
+   * A column the statement did not return is not added, so a projection stays
+   * what the caller asked for. A column with no bound value -- a database
+   * default -- has no reference to judge against and is left as it came back.
    */
-  private restoreWrittenDates<T>(
+  private correctEchoedDateZone<T>(
     tableObj: unknown,
     row: T,
     written: Record<string, unknown>
   ): T {
     if (!tableObj || typeof tableObj !== "object" || !row) return row;
+    const record = row as Record<string, unknown>;
 
-    let restored: Record<string, unknown> | undefined;
+    let corrected: Record<string, unknown> | undefined;
     for (const [jsName, colDef] of Object.entries(
       tableObj as Record<string, unknown>
     )) {
       if (!isDateColumn(colDef)) continue;
+      if (!(jsName in record)) continue;
+
+      const echoed = record[jsName];
+      if (!(echoed instanceof Date)) continue;
+
       const sqlName = (colDef as { name?: unknown }).name;
-      const source =
+      const bound =
         written[jsName] ??
         (typeof sqlName === "string" ? written[sqlName] : undefined);
-      if (!(source instanceof Date)) continue;
-      restored ??= { ...(row as Record<string, unknown>) };
-      restored[jsName] = source;
+      if (!(bound instanceof Date)) continue;
+
+      if (
+        Math.abs(echoed.getTime() - bound.getTime()) <= MAX_STORED_ROUNDING_MS
+      ) {
+        continue;
+      }
+
+      corrected ??= { ...record };
+      corrected[jsName] = new Date(
+        Date.UTC(
+          echoed.getFullYear(),
+          echoed.getMonth(),
+          echoed.getDate(),
+          echoed.getHours(),
+          echoed.getMinutes(),
+          echoed.getSeconds(),
+          echoed.getMilliseconds()
+        )
+      );
     }
-    return (restored as T | undefined) ?? row;
+    return (corrected as T | undefined) ?? row;
   }
 
   /**

--- a/packages/adapter-mysql/src/index.ts
+++ b/packages/adapter-mysql/src/index.ts
@@ -855,7 +855,7 @@ export class MySqlAdapter extends DrizzleAdapter {
         const spelled = aliases
           .map(
             a =>
-              `CAST(${this.escapeIdentifier(a.sqlName)} AS CHAR) AS ${this.escapeIdentifier(a.alias)}`
+              `DATE_FORMAT(${this.escapeIdentifier(a.sqlName)}, '%Y-%m-%dT%H:%i:%s.%f') AS ${this.escapeIdentifier(a.alias)}`
           )
           .join(", ");
         const projected =
@@ -932,7 +932,7 @@ export class MySqlAdapter extends DrizzleAdapter {
           const bulkSpelled = bulkAliases
             .map(
               a =>
-                `CAST(${this.escapeIdentifier(a.sqlName)} AS CHAR) AS ${this.escapeIdentifier(a.alias)}`
+                `DATE_FORMAT(${this.escapeIdentifier(a.sqlName)}, '%Y-%m-%dT%H:%i:%s.%f') AS ${this.escapeIdentifier(a.alias)}`
             )
             .join(", ");
           const [rows] = await connection.query<RowDataPacket[]>(

--- a/packages/adapter-mysql/src/index.ts
+++ b/packages/adapter-mysql/src/index.ts
@@ -829,10 +829,7 @@ export class MySqlAdapter extends DrizzleAdapter {
         data: Record<string, unknown>,
         options?: InsertOptions
       ): Promise<T> => {
-        const mapped = this.mapKeysToSqlColumns(
-          this.getTableObject(table),
-          data
-        );
+        const mapped = this.mapRowToRawSql(this.getTableObject(table), data);
         const columns = Object.keys(mapped);
         const values = Object.values(mapped);
         const placeholders = this.buildPlaceholders(values.length, 0);
@@ -868,7 +865,8 @@ export class MySqlAdapter extends DrizzleAdapter {
           );
           return this.mapRowFromRawSql(
             this.getTableObject(table),
-            rows[0] as T
+            rows[0] as T,
+            data
           );
         }
 
@@ -879,7 +877,11 @@ export class MySqlAdapter extends DrizzleAdapter {
           `SELECT ${selectList} FROM ${this.escapeIdentifier(table)} WHERE ${whereClauses.join(" AND ")} LIMIT 1`,
           values
         );
-        return this.mapRowFromRawSql(this.getTableObject(table), rows[0] as T);
+        return this.mapRowFromRawSql(
+          this.getTableObject(table),
+          rows[0] as T,
+          data
+        );
       },
 
       insertMany: async <T = unknown>(
@@ -892,9 +894,7 @@ export class MySqlAdapter extends DrizzleAdapter {
         const skipReread = Array.isArray(retMany) && retMany.length === 0;
 
         const tableObj = this.getTableObject(table);
-        const mappedRecords = data.map(r =>
-          this.mapKeysToSqlColumns(tableObj, r)
-        );
+        const mappedRecords = data.map(r => this.mapRowToRawSql(tableObj, r));
         const columns = Object.keys(mappedRecords[0]);
         const allValues: unknown[] = [];
         const valuesClauses: string[] = [];
@@ -927,7 +927,9 @@ export class MySqlAdapter extends DrizzleAdapter {
             `SELECT * FROM ${this.escapeIdentifier(table)} WHERE id IN (${placeholders})`,
             ids
           );
-          return (rows as T[]).map(r => this.mapRowFromRawSql(tableObj, r));
+          return (rows as T[]).map((r, index) =>
+            this.mapRowFromRawSql(tableObj, r, data[index])
+          );
         }
 
         // Fallback: return empty if we can't determine inserted rows

--- a/packages/adapter-mysql/src/index.ts
+++ b/packages/adapter-mysql/src/index.ts
@@ -846,12 +846,25 @@ export class MySqlAdapter extends DrizzleAdapter {
 
         // MySQL has no RETURNING; select the inserted row back. Project only the
         // requested columns so a large JSON snapshot is not read unless asked.
-        const selectList =
+        const insertTableObj = this.getTableObject(table);
+        // Each timestamp's wall clock, spelled out by the database. mysql2
+        // turns one into a `Date` in the LOCAL zone before this code sees it,
+        // and that conversion cannot be undone: a wall clock inside a
+        // daylight-saving gap is normalized away.
+        const aliases = this.dateWallClockAliases(insertTableObj, ret ?? "*");
+        const spelled = aliases
+          .map(
+            a =>
+              `CAST(${this.escapeIdentifier(a.sqlName)} AS CHAR) AS ${this.escapeIdentifier(a.alias)}`
+          )
+          .join(", ");
+        const projected =
           !ret || ret === "*"
             ? "*"
-            : this.mapColumnNamesToSql(this.getTableObject(table), ret)
+            : this.mapColumnNamesToSql(insertTableObj, ret)
                 .map(c => this.escapeIdentifier(c))
                 .join(", ");
+        const selectList = spelled ? `${projected}, ${spelled}` : projected;
 
         // Prefer the primary key: auto-increment via insertId, otherwise a
         // supplied id (manually-keyed tables like nextly_versions). Matching by
@@ -863,11 +876,7 @@ export class MySqlAdapter extends DrizzleAdapter {
             `SELECT ${selectList} FROM ${this.escapeIdentifier(table)} WHERE id = ?`,
             [idValue]
           );
-          return this.mapRowFromRawSql(
-            this.getTableObject(table),
-            rows[0] as T,
-            data
-          );
+          return this.mapRowFromRawSql(insertTableObj, rows[0] as T, aliases);
         }
 
         const whereClauses = columns.map(
@@ -877,11 +886,7 @@ export class MySqlAdapter extends DrizzleAdapter {
           `SELECT ${selectList} FROM ${this.escapeIdentifier(table)} WHERE ${whereClauses.join(" AND ")} LIMIT 1`,
           values
         );
-        return this.mapRowFromRawSql(
-          this.getTableObject(table),
-          rows[0] as T,
-          data
-        );
+        return this.mapRowFromRawSql(insertTableObj, rows[0] as T, aliases);
       },
 
       insertMany: async <T = unknown>(
@@ -923,12 +928,19 @@ export class MySqlAdapter extends DrizzleAdapter {
             ids.push(result.insertId + i);
           }
           const placeholders = ids.map(() => "?").join(", ");
+          const bulkAliases = this.dateWallClockAliases(tableObj, "*");
+          const bulkSpelled = bulkAliases
+            .map(
+              a =>
+                `CAST(${this.escapeIdentifier(a.sqlName)} AS CHAR) AS ${this.escapeIdentifier(a.alias)}`
+            )
+            .join(", ");
           const [rows] = await connection.query<RowDataPacket[]>(
-            `SELECT * FROM ${this.escapeIdentifier(table)} WHERE id IN (${placeholders})`,
+            `SELECT *${bulkSpelled ? `, ${bulkSpelled}` : ""} FROM ${this.escapeIdentifier(table)} WHERE id IN (${placeholders})`,
             ids
           );
-          return (rows as T[]).map((r, index) =>
-            this.mapRowFromRawSql(tableObj, r, data[index])
+          return (rows as T[]).map(r =>
+            this.mapRowFromRawSql(tableObj, r, bulkAliases)
           );
         }
 

--- a/packages/adapter-postgres/src/__tests__/write-echoes-stored-dates.integration.test.ts
+++ b/packages/adapter-postgres/src/__tests__/write-echoes-stored-dates.integration.test.ts
@@ -129,6 +129,73 @@ describe.skipIf(!TEST_DB_URL)("PostgreSQL write echoes the stored date", () => {
     }
   });
 
+  it("reads the same instant under a non-ISO DateStyle", async () => {
+    // `DateStyle` decides how PostgreSQL renders a timestamp as text, and
+    // `SQL, DMY` renders 04/08/2026 rather than 2026-08-04. The statement asks
+    // for a named format instead of the session's, so the rendering it parses
+    // cannot be changed out from under it by a connection setting.
+    await adapter.executeQuery("SET DateStyle = 'SQL, DMY'");
+    try {
+      const written = await adapter.transaction(ctx =>
+        ctx.insert<{ occurredAt: Date }>(
+          TABLE,
+          { id: "ds-1", label: "e", occurred_at: OCCURRED_AT },
+          { returning: "*" }
+        )
+      );
+
+      expect(written.occurredAt).toEqual(OCCURRED_AT);
+    } finally {
+      await adapter.executeQuery("SET DateStyle = 'ISO, MDY'");
+    }
+  });
+
+  it("aliases a long column name without exceeding the identifier limit", async () => {
+    // PostgreSQL truncates an identifier at 63 bytes, and a truncated alias is
+    // worse than a rejected one: the statement still succeeds while the lookup
+    // misses the name it asked for, so the row would keep the driver's value
+    // and a stray property.
+    const longTable = "int_pg_long_column";
+    const longColumn = `occurred_at_${"x".repeat(48)}`;
+    expect(longColumn.length).toBeGreaterThan(44);
+
+    await adapter.executeQuery(`DROP TABLE IF EXISTS ${longTable}`);
+    await adapter.createTable({
+      name: longTable,
+      columns: [
+        { name: "id", type: "text", primaryKey: true },
+        { name: longColumn, type: "timestamp" },
+      ],
+    });
+    const longTableObj = pgTable(longTable, {
+      id: text("id").primaryKey(),
+      occurredAt: timestamp(longColumn, { withTimezone: false }),
+    });
+    adapter.setTableResolver({
+      getTable: (name: string) =>
+        name === longTable ? longTableObj : name === TABLE ? events : null,
+    });
+
+    try {
+      const written = await adapter.transaction(ctx =>
+        ctx.insert<Record<string, unknown>>(
+          longTable,
+          { id: "long-1", [longColumn]: OCCURRED_AT },
+          { returning: "*" }
+        )
+      );
+
+      expect(written.occurredAt).toEqual(OCCURRED_AT);
+      // No helper property survives into the row the caller sees.
+      expect(Object.keys(written).sort()).toEqual(["id", "occurredAt"]);
+    } finally {
+      adapter.setTableResolver({
+        getTable: (name: string) => (name === TABLE ? events : null),
+      });
+      await adapter.executeQuery(`DROP TABLE IF EXISTS ${longTable}`);
+    }
+  });
+
   it("adds no column the caller did not ask to have returned", async () => {
     // A projection is a contract. A row answering with a timestamp the
     // statement never selected would be carrying a column out of thin air.

--- a/packages/adapter-postgres/src/__tests__/write-echoes-stored-dates.integration.test.ts
+++ b/packages/adapter-postgres/src/__tests__/write-echoes-stored-dates.integration.test.ts
@@ -99,6 +99,36 @@ describe.skipIf(!TEST_DB_URL)("PostgreSQL write echoes the stored date", () => {
     expect(stored.w).toContain("15:04:01");
   });
 
+  it("survives a wall clock inside the server's daylight-saving gap", async () => {
+    // 02:00-02:59 does not exist in New York on 2026-03-08, and the process is
+    // in that zone for this suite's sibling cases. A driver handed such a wall
+    // clock normalizes it to 03:30 while constructing its `Date`, so the
+    // original is destroyed before any correction could run -- which is why
+    // the value is read from the database's own text rather than rebuilt.
+    const inGap = new Date("2026-03-08T02:30:00.000Z");
+    const previous = process.env.TZ;
+    process.env.TZ = "America/New_York";
+    try {
+      const written = await adapter.transaction(ctx =>
+        ctx.insert<{ occurredAt: Date }>(
+          TABLE,
+          { id: "dst-1", label: "d", occurred_at: inGap },
+          { returning: "*" }
+        )
+      );
+
+      const read = await adapter.selectOne<{ occurredAt: Date }>(TABLE, {
+        where: { and: [{ column: "id", op: "=", value: "dst-1" }] },
+      });
+
+      expect(written.occurredAt).toEqual(inGap);
+      expect(written.occurredAt).toEqual(read?.occurredAt);
+    } finally {
+      if (previous === undefined) delete process.env.TZ;
+      else process.env.TZ = previous;
+    }
+  });
+
   it("adds no column the caller did not ask to have returned", async () => {
     // A projection is a contract. A row answering with a timestamp the
     // statement never selected would be carrying a column out of thin air.

--- a/packages/adapter-postgres/src/__tests__/write-echoes-stored-dates.integration.test.ts
+++ b/packages/adapter-postgres/src/__tests__/write-echoes-stored-dates.integration.test.ts
@@ -1,0 +1,115 @@
+// What a write answers with is what the database stored, read in the zone the
+// statement wrote it in.
+//
+// A column declared without a time zone holds a wall clock. The statement binds
+// a UTC one; node-postgres reads it back in the LOCAL zone, so the same row
+// comes back shifted by the offset. Only the reading is wrong -- the wall clock
+// in the database is right -- so the write must re-read it as UTC rather than
+// substitute the value it was handed, which would report an instant the column
+// never held.
+//
+// CI runs in UTC, where the two readings agree and none of this is observable,
+// so the cases below fix `TZ` rather than trusting the machine.
+
+import type { TableDefinition } from "@nextlyhq/adapter-drizzle/types";
+import { pgTable, text, timestamp } from "drizzle-orm/pg-core";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { createPostgresAdapter } from "../index";
+
+const TEST_DB_URL = process.env.TEST_POSTGRES_URL;
+const TABLE = "int_pg_write_dates";
+
+const TABLE_DEFINITION: TableDefinition = {
+  name: TABLE,
+  columns: [
+    { name: "id", type: "text", primaryKey: true },
+    { name: "label", type: "text", nullable: false },
+    // Without a time zone, which is what every generated timestamp column is.
+    { name: "occurred_at", type: "timestamp" },
+  ],
+};
+
+const events = pgTable(TABLE, {
+  id: text("id").primaryKey(),
+  label: text("label").notNull(),
+  occurredAt: timestamp("occurred_at", { withTimezone: false }),
+});
+
+const OCCURRED_AT = new Date("2026-08-04T15:04:01.860Z");
+
+describe.skipIf(!TEST_DB_URL)("PostgreSQL write echoes the stored date", () => {
+  let adapter: ReturnType<typeof createPostgresAdapter>;
+  let previousTz: string | undefined;
+
+  beforeAll(async () => {
+    previousTz = process.env.TZ;
+    process.env.TZ = "Asia/Karachi";
+    adapter = createPostgresAdapter({ url: TEST_DB_URL as string });
+    await adapter.connect();
+    await adapter.executeQuery(`DROP TABLE IF EXISTS ${TABLE}`);
+    await adapter.createTable(TABLE_DEFINITION);
+    adapter.setTableResolver({
+      getTable: (name: string) => (name === TABLE ? events : null),
+    });
+  });
+
+  afterAll(async () => {
+    await adapter.executeQuery(`DROP TABLE IF EXISTS ${TABLE}`);
+    await adapter.disconnect();
+    if (previousTz === undefined) delete process.env.TZ;
+    else process.env.TZ = previousTz;
+  });
+
+  it("answers a write with the instant it wrote, on a non-UTC server", async () => {
+    const written = await adapter.transaction(ctx =>
+      ctx.insert<{ occurredAt: Date }>(
+        TABLE,
+        { id: "tz-1", label: "a", occurred_at: OCCURRED_AT },
+        { returning: "*" }
+      )
+    );
+
+    const read = await adapter.selectOne<{ occurredAt: Date }>(TABLE, {
+      where: { and: [{ column: "id", op: "=", value: "tz-1" }] },
+    });
+
+    expect(written.occurredAt).toEqual(OCCURRED_AT);
+    // The two paths agreeing is the point, not merely that one is right.
+    expect(written.occurredAt).toEqual(read?.occurredAt);
+  });
+
+  it("keeps the wall clock the column stored, rather than the one it was handed", async () => {
+    // The stored value as TEXT, so neither the driver nor the ORM interprets
+    // it: a UTC wall clock is what a correct write leaves behind, and a local
+    // one is the defect.
+    await adapter.transaction(ctx =>
+      ctx.insert(
+        TABLE,
+        { id: "tz-2", label: "b", occurred_at: OCCURRED_AT },
+        { returning: [] }
+      )
+    );
+
+    const [stored] = await adapter.executeQuery<{ w: string }>(
+      `SELECT occurred_at::text AS w FROM ${TABLE} WHERE id = $1`,
+      ["tz-2"]
+    );
+
+    expect(stored.w).toContain("15:04:01");
+  });
+
+  it("adds no column the caller did not ask to have returned", async () => {
+    // A projection is a contract. A row answering with a timestamp the
+    // statement never selected would be carrying a column out of thin air.
+    const written = await adapter.transaction(ctx =>
+      ctx.insert<Record<string, unknown>>(
+        TABLE,
+        { id: "tz-3", label: "c", occurred_at: OCCURRED_AT },
+        { returning: ["id"] }
+      )
+    );
+
+    expect(Object.keys(written)).toEqual(["id"]);
+  });
+});

--- a/packages/adapter-postgres/src/__tests__/write-echoes-stored-dates.integration.test.ts
+++ b/packages/adapter-postgres/src/__tests__/write-echoes-stored-dates.integration.test.ts
@@ -27,6 +27,7 @@ const TABLE_DEFINITION: TableDefinition = {
     { name: "label", type: "text", nullable: false },
     // Without a time zone, which is what every generated timestamp column is.
     { name: "occurred_at", type: "timestamp" },
+    { name: "zoned_at", type: "timestamptz" },
   ],
 };
 
@@ -34,6 +35,8 @@ const events = pgTable(TABLE, {
   id: text("id").primaryKey(),
   label: text("label").notNull(),
   occurredAt: timestamp("occurred_at", { withTimezone: false }),
+  // Carries its own zone, so it is already unambiguous and must be left alone.
+  zonedAt: timestamp("zoned_at", { withTimezone: true }),
 });
 
 const OCCURRED_AT = new Date("2026-08-04T15:04:01.860Z");
@@ -194,6 +197,49 @@ describe.skipIf(!TEST_DB_URL)("PostgreSQL write echoes the stored date", () => {
       });
       await adapter.executeQuery(`DROP TABLE IF EXISTS ${longTable}`);
     }
+  });
+
+  it("leaves a zone-carrying column alone", async () => {
+    // A `timestamptz` stores an instant, so the driver already reads back the
+    // moment that was written. Spelling it out would render it in the session's
+    // zone, and reading that as UTC would move a value that was correct.
+    await adapter.executeQuery("SET TimeZone = 'Asia/Karachi'");
+    try {
+      const written = await adapter.transaction(ctx =>
+        ctx.insert<{ zonedAt: Date }>(
+          TABLE,
+          { id: "tz-zoned", label: "f", zoned_at: OCCURRED_AT },
+          { returning: "*" }
+        )
+      );
+
+      const read = await adapter.selectOne<{ zonedAt: Date }>(TABLE, {
+        where: { and: [{ column: "id", op: "=", value: "tz-zoned" }] },
+      });
+
+      expect(written.zonedAt).toEqual(OCCURRED_AT);
+      expect(written.zonedAt).toEqual(read?.zonedAt);
+    } finally {
+      await adapter.executeQuery("SET TimeZone = 'UTC'");
+    }
+  });
+
+  it("keeps a year below 0100 in its own century", async () => {
+    // `Date.UTC` reads a year under 100 as shorthand for the 1900s, so year 50
+    // would otherwise land in 1950. PostgreSQL can store it and said 0050.
+    const ancient = new Date("2026-01-01T00:00:00.000Z");
+    ancient.setUTCFullYear(50);
+
+    const written = await adapter.transaction(ctx =>
+      ctx.insert<{ occurredAt: Date }>(
+        TABLE,
+        { id: "old-1", label: "g", occurred_at: ancient },
+        { returning: "*" }
+      )
+    );
+
+    expect(written.occurredAt.getUTCFullYear()).toBe(50);
+    expect(written.occurredAt).toEqual(ancient);
   });
 
   it("adds no column the caller did not ask to have returned", async () => {

--- a/packages/adapter-postgres/src/index.ts
+++ b/packages/adapter-postgres/src/index.ts
@@ -983,10 +983,7 @@ export class PostgresAdapter extends DrizzleAdapter {
         data: Record<string, unknown>,
         options?: InsertOptions
       ): Promise<T> => {
-        const mapped = this.mapKeysToSqlColumns(
-          this.getTableObject(table),
-          data
-        );
+        const mapped = this.mapRowToRawSql(this.getTableObject(table), data);
         const columns = Object.keys(mapped);
         const values = Object.values(mapped);
         const placeholders = values.map((_, i) => `$${i + 1}`).join(", ");
@@ -1010,7 +1007,8 @@ export class PostgresAdapter extends DrizzleAdapter {
         // match the non-transactional insert.
         return this.mapRowFromRawSql(
           this.getTableObject(table),
-          result.rows[0] as T
+          result.rows[0] as T,
+          data
         );
       },
 
@@ -1022,9 +1020,7 @@ export class PostgresAdapter extends DrizzleAdapter {
         if (data.length === 0) return [];
 
         const tableObj = this.getTableObject(table);
-        const mappedRecords = data.map(r =>
-          this.mapKeysToSqlColumns(tableObj, r)
-        );
+        const mappedRecords = data.map(r => this.mapRowToRawSql(tableObj, r));
         const columns = Object.keys(mappedRecords[0]);
         const params: unknown[] = [];
         const valuesClauses: string[] = [];
@@ -1053,8 +1049,8 @@ export class PostgresAdapter extends DrizzleAdapter {
         }
 
         const result = await client.query(sql, params);
-        return (result.rows as T[]).map(r =>
-          this.mapRowFromRawSql(tableObj, r)
+        return (result.rows as T[]).map((r, index) =>
+          this.mapRowFromRawSql(tableObj, r, data[index])
         );
       },
 

--- a/packages/adapter-postgres/src/index.ts
+++ b/packages/adapter-postgres/src/index.ts
@@ -1010,7 +1010,7 @@ export class PostgresAdapter extends DrizzleAdapter {
           const spelled = aliases
             .map(
               a =>
-                `${this.escapeIdentifier(a.sqlName)}::text AS ${this.escapeIdentifier(a.alias)}`
+                `to_char(${this.escapeIdentifier(a.sqlName)}, 'YYYY-MM-DD"T"HH24:MI:SS.MS') AS ${this.escapeIdentifier(a.alias)}`
             )
             .join(", ");
           sql += ` RETURNING ${returning}${spelled ? `, ${spelled}` : ""}`;
@@ -1061,7 +1061,7 @@ export class PostgresAdapter extends DrizzleAdapter {
           const spelled = aliases
             .map(
               a =>
-                `${this.escapeIdentifier(a.sqlName)}::text AS ${this.escapeIdentifier(a.alias)}`
+                `to_char(${this.escapeIdentifier(a.sqlName)}, 'YYYY-MM-DD"T"HH24:MI:SS.MS') AS ${this.escapeIdentifier(a.alias)}`
             )
             .join(", ");
           sql += ` RETURNING ${returning}${spelled ? `, ${spelled}` : ""}`;

--- a/packages/adapter-postgres/src/index.ts
+++ b/packages/adapter-postgres/src/index.ts
@@ -992,24 +992,34 @@ export class PostgresAdapter extends DrizzleAdapter {
 
         const ret = options?.returning;
         const returningEmpty = Array.isArray(ret) && ret.length === 0;
+        const tableObj = this.getTableObject(table);
+        // Each returned timestamp's wall clock, spelled out by the database.
+        // node-postgres turns one into a `Date` in the LOCAL zone before this
+        // code sees it, and that conversion cannot be undone: a wall clock
+        // inside a daylight-saving gap is normalized away.
+        const aliases = returningEmpty
+          ? []
+          : this.dateWallClockAliases(tableObj, ret ?? "*");
         if (!returningEmpty) {
           const returning =
             !ret || ret === "*"
               ? "*"
-              : this.mapColumnNamesToSql(this.getTableObject(table), ret)
+              : this.mapColumnNamesToSql(tableObj, ret)
                   .map(col => this.escapeIdentifier(col))
                   .join(", ");
-          sql += ` RETURNING ${returning}`;
+          const spelled = aliases
+            .map(
+              a =>
+                `${this.escapeIdentifier(a.sqlName)}::text AS ${this.escapeIdentifier(a.alias)}`
+            )
+            .join(", ");
+          sql += ` RETURNING ${returning}${spelled ? `, ${spelled}` : ""}`;
         }
 
         const result = await client.query(sql, values);
-        // Return JS property-named keys AND Drizzle-decoded date values, to
-        // match the non-transactional insert.
-        return this.mapRowFromRawSql(
-          this.getTableObject(table),
-          result.rows[0] as T,
-          data
-        );
+        // Return JS property-named keys AND dates read as the UTC the statement
+        // wrote, to match the non-transactional insert.
+        return this.mapRowFromRawSql(tableObj, result.rows[0] as T, aliases);
       },
 
       insertMany: async <T = unknown>(
@@ -1038,19 +1048,28 @@ export class PostgresAdapter extends DrizzleAdapter {
 
         const ret = options?.returning;
         const returningEmpty = Array.isArray(ret) && ret.length === 0;
+        const aliases = returningEmpty
+          ? []
+          : this.dateWallClockAliases(tableObj, ret ?? "*");
         if (!returningEmpty) {
           const returning =
             !ret || ret === "*"
               ? "*"
-              : this.mapColumnNamesToSql(this.getTableObject(table), ret)
+              : this.mapColumnNamesToSql(tableObj, ret)
                   .map(col => this.escapeIdentifier(col))
                   .join(", ");
-          sql += ` RETURNING ${returning}`;
+          const spelled = aliases
+            .map(
+              a =>
+                `${this.escapeIdentifier(a.sqlName)}::text AS ${this.escapeIdentifier(a.alias)}`
+            )
+            .join(", ");
+          sql += ` RETURNING ${returning}${spelled ? `, ${spelled}` : ""}`;
         }
 
         const result = await client.query(sql, params);
-        return (result.rows as T[]).map((r, index) =>
-          this.mapRowFromRawSql(tableObj, r, data[index])
+        return (result.rows as T[]).map(r =>
+          this.mapRowFromRawSql(tableObj, r, aliases)
         );
       },
 

--- a/packages/adapter-sqlite/src/__tests__/write-returns-decoded-dates.integration.test.ts
+++ b/packages/adapter-sqlite/src/__tests__/write-returns-decoded-dates.integration.test.ts
@@ -135,6 +135,21 @@ describe("SQLite write paths return Drizzle-decoded dates", () => {
     }
   });
 
+  it("adds no column the caller did not ask to have returned", async () => {
+    // A projection is a contract: `recordEvent()` writes a timestamp while
+    // asking only for the id, and a row that answered with more than was
+    // requested would be carrying a column the statement never selected.
+    const written = await adapter.transaction(ctx =>
+      ctx.insert<Record<string, unknown>>(
+        TABLE,
+        { id: "proj-1", label: "h", occurred_at: OCCURRED_AT },
+        { returning: ["id"] }
+      )
+    );
+
+    expect(Object.keys(written)).toEqual(["id"]);
+  });
+
   it("leaves a null date null rather than decoding it to the epoch", async () => {
     const written = await adapter.transaction(ctx =>
       ctx.insert<{ occurredAt: unknown }>(

--- a/packages/adapter-sqlite/src/index.ts
+++ b/packages/adapter-sqlite/src/index.ts
@@ -770,6 +770,10 @@ export class SqliteAdapter extends DrizzleAdapter {
         }
       },
 
+      // Keys only, unlike the PostgreSQL and MySQL raw paths, which also encode
+      // their date values. `sanitizeSqliteValue` below binds a `Date` as unix
+      // seconds, and an instant carries no zone -- so what SQLite stores does
+      // not depend on the server's timezone and there is nothing to correct.
       // eslint-disable-next-line @typescript-eslint/require-await
       insert: async <T = unknown>(
         table: string,

--- a/packages/nextly/src/direct-api/__tests__/timestamp-round-trip.integration.test.ts
+++ b/packages/nextly/src/direct-api/__tests__/timestamp-round-trip.integration.test.ts
@@ -59,10 +59,6 @@ const ticks = () =>
  */
 const OCCURRED_AT = new Date("2026-08-04T15:04:01.000Z");
 
-/** The instant to one-second resolution, which every dialect stores exactly. */
-const toSecond = (value: unknown): number =>
-  Math.round((value as Date).getTime() / 1000);
-
 async function boot(dialect: TestDialect): Promise<TestNextly> {
   current = await createTestNextly({ dialect, collections: [ticks()] });
   return current;
@@ -95,7 +91,7 @@ describe.each(getConfiguredTestDialects())(
       expect(found?.occurredAt).toEqual(item.occurredAt);
     });
 
-    it("agrees with itself about the timestamps it generates", async () => {
+    it("reports the stored value, not the one it was handed", async () => {
       underNonUtcTimezone();
       const { nextly } = await boot(dialect);
 
@@ -114,14 +110,13 @@ describe.each(getConfiguredTestDialects())(
       // `createdAt` is stamped by the write path rather than supplied, so this
       // covers the system columns as well as a user-declared date field.
       //
-      // To the SECOND, because sub-second precision is not uniform: a MySQL
-      // `DATETIME` and a SQLite integer both hold whole seconds, so a stored
-      // timestamp comes back rounded there while the write reports what it
-      // generated. A whole second is still three orders of magnitude finer than
-      // the offset this guards against -- a skew of even the smallest real
-      // timezone would fail it many times over.
-      expect(toSecond(found?.createdAt)).toEqual(toSecond(item.createdAt));
-      expect(toSecond(found?.updatedAt)).toEqual(toSecond(item.updatedAt));
+      // Exactly, not to the nearest second. The write reports the value the
+      // database stored rather than the one it was handed, so a column that
+      // keeps only whole seconds reports whole seconds and a later read agrees
+      // to the millisecond. An assertion at second resolution would pass while
+      // a write invented sub-second precision the row never had.
+      expect(found?.createdAt).toEqual(item.createdAt);
+      expect(found?.updatedAt).toEqual(item.updatedAt);
     });
   }
 );

--- a/packages/nextly/src/direct-api/__tests__/timestamp-round-trip.integration.test.ts
+++ b/packages/nextly/src/direct-api/__tests__/timestamp-round-trip.integration.test.ts
@@ -1,0 +1,127 @@
+/**
+ * A timestamp survives the round trip regardless of the server's timezone.
+ *
+ * The columns are declared without a time zone, so they store a wall clock and
+ * record nothing about which zone it belongs to: both ends have to agree.
+ * Drizzle writes UTC and reads UTC. A driver handed a `Date` writes the LOCAL
+ * wall clock instead, and the same row then reads back shifted by the offset.
+ *
+ * On a UTC server the two conventions agree and nothing is visibly wrong, which
+ * is why this went unnoticed -- CI runs in UTC. So the case that matters runs
+ * under a fixed non-UTC `TZ` rather than whatever the machine happens to be:
+ * running it only in UTC asserts nothing at all.
+ */
+import { afterEach, describe, expect, it } from "vitest";
+
+import { date, defineCollection, text } from "../../config";
+import {
+  createTestNextly,
+  getConfiguredTestDialects,
+  type TestDialect,
+  type TestNextly,
+} from "../../plugins/test-nextly";
+
+let current: TestNextly | undefined;
+let restoreTz: (() => void) | undefined;
+
+afterEach(async () => {
+  await current?.destroy();
+  current = undefined;
+  restoreTz?.();
+  restoreTz = undefined;
+});
+
+/**
+ * Run the rest of the case as if the server were five hours ahead of UTC.
+ *
+ * Node reads `TZ` lazily, so assigning it changes how every `Date` created
+ * afterwards is formatted, which is what the driver serializes.
+ */
+function underNonUtcTimezone(): void {
+  const previous = process.env.TZ;
+  process.env.TZ = "Asia/Karachi";
+  restoreTz = () => {
+    if (previous === undefined) delete process.env.TZ;
+    else process.env.TZ = previous;
+  };
+}
+
+const ticks = () =>
+  defineCollection({
+    slug: "ticks",
+    fields: [text({ name: "label" }), date({ name: "occurredAt" })],
+  });
+
+/**
+ * A whole second, so the value survives every dialect verbatim: MySQL
+ * `DATETIME` and SQLite integers store whole seconds and would otherwise round
+ * the assertion's own input.
+ */
+const OCCURRED_AT = new Date("2026-08-04T15:04:01.000Z");
+
+/** The instant to one-second resolution, which every dialect stores exactly. */
+const toSecond = (value: unknown): number =>
+  Math.round((value as Date).getTime() / 1000);
+
+async function boot(dialect: TestDialect): Promise<TestNextly> {
+  current = await createTestNextly({ dialect, collections: [ticks()] });
+  return current;
+}
+
+describe.each(getConfiguredTestDialects())(
+  "timestamp round trip (%s)",
+  dialect => {
+    it("reads back the instant that was written, on a non-UTC server", async () => {
+      underNonUtcTimezone();
+      const { nextly } = await boot(dialect);
+
+      const { item } = await nextly.create({
+        collection: "ticks",
+        data: { label: "a", occurredAt: OCCURRED_AT.toISOString() },
+        overrideAccess: true,
+      });
+
+      const found = await nextly.findByID({
+        collection: "ticks",
+        id: String(item.id),
+        overrideAccess: true,
+      });
+
+      // The user-supplied value survives, and the value the write reported
+      // agrees with the value a later read reports. The second assertion is the
+      // one that failed: the write stored a local wall clock and the read
+      // interpreted it as UTC, so the two differed by the offset.
+      expect(found?.occurredAt).toEqual(OCCURRED_AT);
+      expect(found?.occurredAt).toEqual(item.occurredAt);
+    });
+
+    it("agrees with itself about the timestamps it generates", async () => {
+      underNonUtcTimezone();
+      const { nextly } = await boot(dialect);
+
+      const { item } = await nextly.create({
+        collection: "ticks",
+        data: { label: "a" },
+        overrideAccess: true,
+      });
+
+      const found = await nextly.findByID({
+        collection: "ticks",
+        id: String(item.id),
+        overrideAccess: true,
+      });
+
+      // `createdAt` is stamped by the write path rather than supplied, so this
+      // covers the system columns as well as a user-declared date field.
+      //
+      // To the SECOND, because sub-second precision is not uniform: a MySQL
+      // `DATETIME` and a SQLite integer both hold whole seconds, so a stored
+      // timestamp comes back rounded there while the write reports what it
+      // generated. A whole second is still three orders of magnitude finer than
+      // the offset this guards against -- a skew of even the smallest real
+      // timezone would fail it many times over.
+      expect(toSecond(found?.createdAt)).toEqual(toSecond(item.createdAt));
+      expect(toSecond(found?.updatedAt)).toEqual(toSecond(item.updatedAt));
+    });
+  }
+);


### PR DESCRIPTION
Task 131. **Stacks on #537** — it builds on the same raw-SQL-path insight and touches the same four adapter files, so merge #537 first.

## The bug

Write a row, read it back, and the two answers differ by the server's UTC offset. On a machine five hours ahead:

```
create → createdAt = 2026-08-04T15:04:01.860Z
read   → createdAt = 2026-08-04T20:04:01.860Z
```

**CI runs in UTC, where the offset is zero and the bug cannot appear.** It is invisible in the matrix and real on any developer machine or production server outside UTC.

## Root cause, measured rather than reasoned

Reading the stored value out as text settles it:

```json
{
  "processOffsetMinutes": -300,
  "storedWallClock":  "2026-08-04 20:04:01.86",   // the LOCAL wall clock
  "createPathISO":    "2026-08-04T15:04:01.860Z", // correct instant
  "readPathISO":      "2026-08-04T20:04:01.860Z"  // wrong by the offset
}
```

The columns are `timestamp` **without** time zone, so they hold a wall clock and record nothing about which zone it belongs to. Both ends have to agree, and Drizzle's convention is UTC on the way in and UTC on the way out.

The raw-SQL write paths bound a JS `Date` straight to the driver, which serializes it with the **local** offset — so the column kept a local wall clock that every read then read as UTC. Drizzle's own encoder would have written UTC, verified directly:

```js
timestamp("no_tz", { withTimezone: false }).mapToDriverValue(
  new Date("2026-08-04T15:04:01.860Z")
) === "2026-08-04T15:04:01.860Z"   // UTC, not 20:04
```

So this is **the same defect class as the read-side decode in #537** — a raw-SQL path bypassing Drizzle's column mapping — on the write side. #537 fixed `mapFromDriverValue` on returned rows; the parameter binding still skipped `mapToDriverValue`.

Worth recording because it is counter-intuitive: node-postgres on its own is self-consistent. It writes a local wall clock and parses one back as local, which is exactly why the *create* path always reported the right instant. Only the Drizzle-mediated read disagreed.

## The fix

Values go through the column encoder before binding, on the PostgreSQL and MySQL raw paths. **SQLite needed nothing** — it binds unix seconds, and an instant carries no zone. That is now stated in the code so it does not read as an oversight.

Encoding the write alone was not enough, and this is the part worth reviewing closely: it moved the error rather than removing it. With UTC in the column, the driver's parse of the `RETURNING` value — which is local — made the *create* path wrong instead. The returned row now keeps the `Date` the write bound, because the write knows it exactly. Correcting the driver's reading instead would mean encoding that driver's convention in our adapter and getting it wrong the moment a connection is configured differently.

## What this does not do

**Rows written before this on a non-UTC server keep their local wall clocks**, so such a table can hold both conventions. Your call, and I agree with it: in alpha, with no non-UTC production deployment, a data migration is risk without reward. It is stated in the changeset so anyone running non-UTC knows.

`timestamptz` would make the ambiguity structurally impossible on Postgres, but it is a migration for every column in every project and does nothing for MySQL or SQLite. Worth revisiting as hardening, not as this fix.

## Verification

- **The test fixes `TZ` rather than trusting the machine.** Running it in UTC asserts nothing — that is the one configuration where the bug cannot occur.
- Reverting just the encoder fails 4 of 6 cases, on PostgreSQL and MySQL, with SQLite correctly unaffected.
- Assertions are to the second, and deliberately: MySQL `DATETIME` and SQLite integers hold whole seconds, so sub-second precision is not uniform. A second is still three orders of magnitude finer than the smallest real timezone offset.
- Full integration sweep green against SQLite, Postgres 17 and MySQL: 213 files. Adapter unit suites 309 green. `nextly` unit failing-set byte-identical to `origin/main`.
