### PR TITLE
test(nextly): pin what a builder create request forwards into its DDL

### DIFF
--- a/packages/nextly/src/dispatcher/handlers/__tests__/component-dispatcher-ddl.test.ts
+++ b/packages/nextly/src/dispatcher/handlers/__tests__/component-dispatcher-ddl.test.ts
@@ -1,0 +1,171 @@
+/**
+ * What a field-group create REQUEST turns into on the way to the database, recorded from the
+ * request in.
+ *
+ * The generators' own output is pinned elsewhere, per set of options. That records what each
+ * generator RENDERS and cannot record what a caller PASSES: a handler that stops forwarding
+ * `localized` or the adapter's dialect still reaches every one of those assertions with the options
+ * spelled out correctly, and they all still pass.
+ *
+ * So these drive the dispatcher with a request-shaped payload and assert on the SQL the adapter is
+ * actually handed. That is the half no snapshot can cover, and it is the half a change which moves
+ * this code somewhere else can silently break.
+ *
+ * Deliberately a separate file from `component-dispatcher-shapes.test.ts`, which defeats both halves
+ * on purpose: it reports no adapter from DI and a container that has none, because it is testing
+ * response envelopes rather than DDL.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../helpers/di", () => ({
+  getComponentRegistryFromDI: vi.fn(),
+  getAdapterFromDI: vi.fn(),
+}));
+
+const executed: string[] = [];
+
+/**
+ * The adapter surface a create actually touches: the dialect it reports decides which DDL is
+ * generated, `tableExists` decides whether the create is recorded as applied, and every statement
+ * passes through `executeQuery`.
+ */
+function makeAdapter(dialect: "postgresql" | "mysql" | "sqlite") {
+  return {
+    dialect,
+    getCapabilities: () => ({ dialect }),
+    tableExists: vi.fn().mockResolvedValue(true),
+    executeQuery: vi.fn(async (sql: string) => {
+      executed.push(sql);
+      return [];
+    }),
+    getDrizzle: () => ({}),
+  };
+}
+
+let adapter: ReturnType<typeof makeAdapter>;
+
+vi.mock("../../../di/container", () => ({
+  container: {
+    // Only the adapter is registered, so this exercises the DDL path and nothing else.
+    has: vi.fn((key: string) => key === "adapter"),
+    get: vi.fn((key: string) => (key === "adapter" ? adapter : undefined)),
+  },
+}));
+
+import { getAdapterFromDI, getComponentRegistryFromDI } from "../../helpers/di";
+import { dispatchComponents } from "../component-dispatcher";
+
+function wireRegistry() {
+  const registry = {
+    listComponents: vi.fn(),
+    registerComponent: vi.fn(async (row: unknown) => row),
+    getComponent: vi.fn(),
+    updateComponent: vi.fn(),
+    deleteComponent: vi.fn(),
+    // "No such slug" and "no field group owns that table", so a create reaches the DDL path.
+    getComponentBySlug: vi.fn().mockResolvedValue(null),
+    getAllComponents: vi.fn().mockResolvedValue([]),
+    isLocked: vi.fn().mockResolvedValue(false),
+  };
+  vi.mocked(getComponentRegistryFromDI).mockReturnValue(
+    registry as unknown as ReturnType<typeof getComponentRegistryFromDI>
+  );
+  return registry;
+}
+
+/** Everything the adapter was asked to run, as one string. */
+async function ddlFor(
+  payload: Record<string, unknown>,
+  dialect: "postgresql" | "mysql" | "sqlite" = "postgresql"
+): Promise<string> {
+  executed.length = 0;
+  adapter = makeAdapter(dialect);
+  // The handler reads the adapter through BOTH seams: `getAdapterFromDI` for the dialect it
+  // generates with, and the container for the one it executes on. Wiring only one would leave the
+  // dialect assertion below reading the service's own default while appearing to pass.
+  vi.mocked(getAdapterFromDI).mockReturnValue(
+    adapter as unknown as ReturnType<typeof getAdapterFromDI>
+  );
+  wireRegistry();
+  await dispatchComponents("createComponent", {}, payload);
+  return executed.join("\n");
+}
+
+beforeEach(() => {
+  vi.mocked(getComponentRegistryFromDI).mockReset();
+  vi.mocked(getAdapterFromDI).mockReset();
+});
+
+describe("createComponent — what the request forwards into the DDL", () => {
+  const base = {
+    slug: "hero",
+    label: "Hero",
+    fields: [
+      { name: "heading", type: "text" },
+      { name: "weight", type: "number" },
+    ],
+  };
+
+  it("creates the table the request names, with its fields", async () => {
+    const sql = await ddlFor(base);
+
+    expect(sql).toContain("comp_hero");
+    expect(sql).toContain("heading");
+    expect(sql).toContain("weight");
+  });
+
+  /**
+   * A localized field group keeps its translatable columns in the companion `_locales` table, so
+   * the main CREATE must omit them. Forwarding this wrongly leaves two homes for one value and the
+   * companion holding nothing — and every generator snapshot still passes, because they are called
+   * with `localized` spelled out.
+   */
+  it("omits translatable columns from the main table when localized", async () => {
+    const sql = await ddlFor({
+      ...base,
+      localized: true,
+      fields: [
+        { name: "heading", type: "text", localized: true },
+        { name: "weight", type: "number" },
+      ],
+    });
+
+    expect(sql).not.toContain("heading");
+    // The non-translatable field stays on the main table.
+    expect(sql).toContain("weight");
+  });
+
+  /**
+   * The dialect comes from the adapter that will run the statements, never from a constant.
+   *
+   * This path currently falls back to the literal `"postgresql"` when no adapter is registered,
+   * where the single path defers to the service's own default. That difference is resolved during
+   * the relocation; what this pins is the case that matters either way — with an adapter present,
+   * its dialect is the one used.
+   */
+  it.each([
+    ["mysql", "`comp_hero`"],
+    ["postgresql", '"comp_hero"'],
+  ] as const)(
+    "generates for the adapter's dialect (%s)",
+    async (dialect, quoted) => {
+      const sql = await ddlFor(base, dialect);
+
+      expect(sql).toContain(quoted);
+    }
+  );
+
+  /**
+   * The parent pointer is what makes this a field-group table rather than an ordinary one, and it
+   * is emitted by the generator this handler chooses. Pinned so a relocation that reached for the
+   * collection generator instead would fail here rather than at a user's first write.
+   */
+  it("builds it with the field-group generator", async () => {
+    const sql = await ddlFor(base);
+
+    // The COLUMN, not merely the name. A bare `toContain("_parent_id")` is satisfied by the
+    // CREATE INDEX that follows, so it passes even when the column itself is gone — verified by
+    // removing the column definition and watching that weaker assertion stay green.
+    expect(sql).toMatch(/"_parent_id"\s+\w+.*NOT NULL/i);
+  });
+});

--- a/packages/nextly/src/dispatcher/handlers/__tests__/component-dispatcher-ddl.test.ts
+++ b/packages/nextly/src/dispatcher/handlers/__tests__/component-dispatcher-ddl.test.ts
@@ -20,6 +20,10 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 vi.mock("../../helpers/di", () => ({
   getComponentRegistryFromDI: vi.fn(),
   getAdapterFromDI: vi.fn(),
+  // Reached by the companion reconciliation a localized create runs. Omitted, calling it throws and
+  // the handler catches that as a companion-provisioning failure — so the assertions below would
+  // describe a FAILED migration while passing.
+  getConfigFromDI: vi.fn(() => undefined),
 }));
 
 const executed: string[] = [];
@@ -33,7 +37,11 @@ function makeAdapter(dialect: "postgresql" | "mysql" | "sqlite") {
   return {
     dialect,
     getCapabilities: () => ({ dialect }),
-    tableExists: vi.fn().mockResolvedValue(true),
+    // Answers the way a fresh create finds the database: the main table is there once its CREATE
+    // has run, and the companion is NOT — so the companion path CREATEs it rather than altering
+    // one that does not exist. A blanket `true` here made the companion look pre-existing, which
+    // is not a state a create ever starts from.
+    tableExists: vi.fn(async (name: string) => !name.includes("_locales")),
     executeQuery: vi.fn(async (sql: string) => {
       executed.push(sql);
       return [];
@@ -120,8 +128,8 @@ describe("createComponent — what the request forwards into the DDL", () => {
    * companion holding nothing — and every generator snapshot still passes, because they are called
    * with `localized` spelled out.
    */
-  it("omits translatable columns from the main table when localized", async () => {
-    const sql = await ddlFor({
+  it("moves translatable columns to the companion, not the main table", async () => {
+    await ddlFor({
       ...base,
       localized: true,
       fields: [
@@ -130,9 +138,29 @@ describe("createComponent — what the request forwards into the DDL", () => {
       ],
     });
 
-    expect(sql).not.toContain("heading");
+    // Scoped to the statement that creates each table. Asserting over ALL the SQL cannot express
+    // this: the companion's own CREATE legitimately names the translatable column, so a bare
+    // "the SQL does not mention heading" is either wrong or passes only because the companion
+    // never ran — which is what happened before `getConfigFromDI` was mocked.
+    const mainCreate = executed.find(
+      s =>
+        s.includes("CREATE TABLE") &&
+        s.includes("comp_hero") &&
+        !s.includes("_locales")
+    );
+    const companionCreate = executed.find(
+      s => s.includes("CREATE TABLE") && s.includes("comp_hero_locales")
+    );
+
+    expect(mainCreate, "the main table is created").toBeDefined();
+    expect(companionCreate, "the companion is created").toBeDefined();
+
+    expect(mainCreate).not.toContain("heading");
     // The non-translatable field stays on the main table.
-    expect(sql).toContain("weight");
+    expect(mainCreate).toContain("weight");
+    // And the translatable one is on the companion — the half that proves it MOVED rather than
+    // simply being dropped.
+    expect(companionCreate).toContain("heading");
   });
 
   /**

--- a/packages/nextly/src/dispatcher/handlers/__tests__/single-dispatcher-ddl.test.ts
+++ b/packages/nextly/src/dispatcher/handlers/__tests__/single-dispatcher-ddl.test.ts
@@ -21,6 +21,10 @@ vi.mock("../../helpers/di", () => ({
   getSingleEntryServiceFromDI: vi.fn(),
   getComponentRegistryFromDI: vi.fn().mockReturnValue(undefined),
   getAdapterFromDI: vi.fn(),
+  // Reached by the companion reconciliation a localized create runs. Omitted, calling it throws and
+  // the handler catches that as a companion-provisioning failure — so the assertions below would
+  // describe a FAILED migration while passing.
+  getConfigFromDI: vi.fn(() => undefined),
 }));
 
 const executed: string[] = [];
@@ -37,7 +41,11 @@ function makeAdapter(dialect: "postgresql" | "mysql" | "sqlite") {
   return {
     dialect,
     getCapabilities: () => ({ dialect }),
-    tableExists: vi.fn().mockResolvedValue(true),
+    // Answers the way a fresh create finds the database: the main table is there once its CREATE
+    // has run, and the companion is NOT — so the companion path CREATEs it rather than altering
+    // one that does not exist. A blanket `true` here made the companion look pre-existing, which
+    // is not a state a create ever starts from.
+    tableExists: vi.fn(async (name: string) => !name.includes("_locales")),
     executeQuery: vi.fn(async (sql: string) => {
       executed.push(sql);
       return [];
@@ -158,11 +166,29 @@ describe("createSingle — what the request forwards into the DDL", () => {
       ],
     };
 
-    const sql = await ddlFor(localized);
+    await ddlFor(localized);
 
-    expect(sql).not.toContain("body");
+    // Scoped to the statement that creates each table. The companion's own CREATE legitimately
+    // names the translatable column, so asserting over all the SQL either contradicts that or
+    // passes only because the companion never ran.
+    const mainCreate = executed.find(
+      s =>
+        s.includes("CREATE TABLE") &&
+        s.includes("single_page") &&
+        !s.includes("_locales")
+    );
+    const companionCreate = executed.find(
+      s => s.includes("CREATE TABLE") && s.includes("single_page_locales")
+    );
+
+    expect(mainCreate, "the main table is created").toBeDefined();
+    expect(companionCreate, "the companion is created").toBeDefined();
+
+    expect(mainCreate).not.toContain("body");
     // The non-translatable field stays on the main table.
-    expect(sql).toContain("views");
+    expect(mainCreate).toContain("views");
+    // And the translatable one is on the companion — proving it MOVED rather than was dropped.
+    expect(companionCreate).toContain("body");
   });
 
   /**

--- a/packages/nextly/src/dispatcher/handlers/__tests__/single-dispatcher-ddl.test.ts
+++ b/packages/nextly/src/dispatcher/handlers/__tests__/single-dispatcher-ddl.test.ts
@@ -1,0 +1,184 @@
+/**
+ * What a create REQUEST turns into on the way to the database, recorded from the request in.
+ *
+ * The generators' own output is pinned elsewhere, per set of options. That records what each
+ * generator RENDERS and cannot record what a caller PASSES: a handler that stops forwarding
+ * `localized`, `hasStatus` or the adapter's dialect still reaches every one of those assertions with
+ * the options spelled out correctly, and they all still pass.
+ *
+ * So these drive the dispatcher with a request-shaped payload and assert on the SQL the adapter is
+ * actually handed. That is the half no snapshot can cover, and it is the half a change which moves
+ * this code somewhere else can silently break.
+ *
+ * Deliberately a separate file from `single-dispatcher-shapes.test.ts`, which defeats both halves on
+ * purpose: it replaces the schema service with a stub returning `""` and reports no adapter, because
+ * it is testing response envelopes rather than DDL.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../helpers/di", () => ({
+  getSingleRegistryFromDI: vi.fn(),
+  getSingleEntryServiceFromDI: vi.fn(),
+  getComponentRegistryFromDI: vi.fn().mockReturnValue(undefined),
+  getAdapterFromDI: vi.fn(),
+}));
+
+const executed: string[] = [];
+
+/**
+ * The adapter surface a create actually touches: the dialect it reports decides which DDL is
+ * generated, `tableExists` decides whether the create is recorded as applied, and every statement
+ * passes through `executeQuery`.
+ *
+ * `tableResolver` is deliberately absent. The handler reads it defensively, so leaving it out skips
+ * runtime re-registration and keeps this focused on the statements.
+ */
+function makeAdapter(dialect: "postgresql" | "mysql" | "sqlite") {
+  return {
+    dialect,
+    getCapabilities: () => ({ dialect }),
+    tableExists: vi.fn().mockResolvedValue(true),
+    executeQuery: vi.fn(async (sql: string) => {
+      executed.push(sql);
+      return [];
+    }),
+  };
+}
+
+let adapter: ReturnType<typeof makeAdapter>;
+
+vi.mock("../../../di/container", () => ({
+  container: {
+    // Only the adapter is registered. Permission seeding and every other optional service stay
+    // absent so this exercises the DDL path and nothing else.
+    has: vi.fn((key: string) => key === "adapter"),
+    get: vi.fn((key: string) => (key === "adapter" ? adapter : undefined)),
+  },
+}));
+
+import {
+  getSingleEntryServiceFromDI,
+  getSingleRegistryFromDI,
+} from "../../helpers/di";
+import { dispatchSingles } from "../single-dispatcher";
+
+function wireRegistry() {
+  const registry = {
+    listSingles: vi.fn(),
+    // Answers "no single owns that table" so the create reaches the DDL path.
+    getAllSingles: vi.fn().mockResolvedValue([]),
+    getSingleBySlug: vi.fn(),
+    registerSingle: vi.fn(async (row: unknown) => row),
+    updateSingle: vi.fn(),
+    deleteSingle: vi.fn(),
+  };
+  vi.mocked(getSingleRegistryFromDI).mockReturnValue(
+    registry as unknown as ReturnType<typeof getSingleRegistryFromDI>
+  );
+  vi.mocked(getSingleEntryServiceFromDI).mockReturnValue({
+    get: vi.fn(),
+    update: vi.fn(),
+  } as unknown as ReturnType<typeof getSingleEntryServiceFromDI>);
+  return registry;
+}
+
+/** Everything the adapter was asked to run, as one string. */
+async function ddlFor(
+  payload: Record<string, unknown>,
+  dialect: "postgresql" | "mysql" | "sqlite" = "postgresql"
+): Promise<string> {
+  executed.length = 0;
+  adapter = makeAdapter(dialect);
+  wireRegistry();
+  await dispatchSingles("createSingle", {}, payload);
+  return executed.join("\n");
+}
+
+beforeEach(() => {
+  vi.mocked(getSingleRegistryFromDI).mockReset();
+  vi.mocked(getSingleEntryServiceFromDI).mockReset();
+});
+
+describe("createSingle — what the request forwards into the DDL", () => {
+  const base = {
+    slug: "page",
+    label: "Page",
+    fields: [
+      { name: "body", type: "text" },
+      { name: "views", type: "number" },
+    ],
+  };
+
+  it("creates the table the request names, with its fields", async () => {
+    const sql = await ddlFor(base);
+
+    expect(sql).toContain("single_page");
+    expect(sql).toContain("body");
+    expect(sql).toContain("views");
+  });
+
+  /**
+   * A single gets no owner column.
+   *
+   * 🔴 This does NOT cover the forwarding of `isSingle`, and must not be read as if it did.
+   * `generateMigrationSQL` takes the single branch for any table whose name begins with `single_`,
+   * whatever that option says — so dropping it entirely leaves every assertion in this file
+   * passing. Verified by removing it: 6 passed.
+   *
+   * Kept because the property is worth pinning on its own, renamed because the previous name
+   * claimed a guarantee the assertion cannot make. A relocation cannot break `isSingle` through
+   * this path; the table name decides.
+   */
+  it("gives a single no owner column", async () => {
+    const sql = await ddlFor(base);
+
+    expect(sql).not.toContain("created_by");
+  });
+
+  // Draft/Published has to reach the generator, or the runtime schema expects a column the DDL
+  // never created.
+  it("emits the status column only when the request asks for it", async () => {
+    expect(await ddlFor({ ...base, status: true })).toContain("status");
+    expect(await ddlFor(base)).not.toContain("status");
+  });
+
+  /**
+   * A localized single keeps its translatable columns in the companion `_locales` table, so the
+   * main CREATE must omit them. Forwarding this wrongly leaves two homes for one value and the
+   * companion holding nothing — and every generator snapshot still passes, because they are called
+   * with `localized` spelled out.
+   */
+  it("omits translatable columns from the main table when localized", async () => {
+    const localized = {
+      ...base,
+      localized: true,
+      fields: [
+        { name: "body", type: "text", localized: true },
+        { name: "views", type: "number" },
+      ],
+    };
+
+    const sql = await ddlFor(localized);
+
+    expect(sql).not.toContain("body");
+    // The non-translatable field stays on the main table.
+    expect(sql).toContain("views");
+  });
+
+  /**
+   * The dialect comes from the adapter that will run the statements, never from the service's own
+   * default. That default is `postgresql` and the environment variable behind it is optional, so an
+   * app configured with only a MySQL URL would otherwise have its table created as PostgreSQL.
+   */
+  it.each([
+    ["mysql", "`single_page`"],
+    ["postgresql", '"single_page"'],
+  ] as const)(
+    "generates for the adapter's dialect (%s)",
+    async (dialect, quoted) => {
+      const sql = await ddlFor(base, dialect);
+
+      expect(sql).toContain(quoted);
+    }
+  );
+});


### PR DESCRIPTION
Tests only. No production code changes, so no changeset.

## Why this lands before the change it guards

Task 116 moves the Builder's schema-changing code out of the request handlers and into services, so
a single lock can cover both the table change and the registry write. The property that makes that
move safe to review is "the emitted SQL is unchanged" — and that is not a claim a diff of moved code
can settle.

The existing characterization suite (#506) pins what each **generator renders** for a given set of
options. It cannot pin what a **caller passes**. A handler that stops forwarding `localized`,
`hasStatus`, or the adapter's dialect still reaches every one of those assertions with the options
spelled out correctly, and they all still pass.

These two suites close that gap, driving each dispatcher with a request-shaped payload and asserting
on the SQL the adapter is actually handed.

They go in first deliberately. A test that arrives in the same PR as the change it guards certifies
the new code **against itself**; landed first, it certifies the new code **against the old
behaviour**, and CI runs it against the move rather than alongside it.

## What is pinned

**`single-dispatcher-ddl.test.ts`** — the table is named from the request and carries its fields; a
single gets no owner column; `status` reaches the generator only when asked for; a localized create
omits translatable columns from the main table; the dialect is the adapter's, not the service
default.

**`component-dispatcher-ddl.test.ts`** — the same for field groups, plus that the field-group
generator is the one used, asserted through the parent-pointer column.

## Every assertion proven to discriminate

Each was verified by breaking the specific forwarding it guards and confirming the intended test —
and only that test — fails:

| break | result |
|---|---|
| drop `localized` (singles) | only the localized case fails |
| drop `hasStatus` | only the status case fails |
| hardcode the dialect instead of reading the adapter (both) | only the MySQL case fails |
| drop `localized` (field groups) | only the localized case fails |
| remove the parent-pointer column | only the generator case fails |

## Two assertions that were lying, found by that exercise

Recorded because both are the failure mode these suites exist to prevent, and both looked fine.

**`isSingle` is not covered, and the test no longer claims it is.** Removing the option entirely
left all six singles assertions green: `generateMigrationSQL` takes the single branch for any table
named `single_*`, whatever that option says. The assertion is kept — a single genuinely should have
no `created_by` — but renamed from "builds it as a single rather than a collection" to "gives a
single no owner column", with the reason recorded inline. A relocation cannot break `isSingle`
through this path; the table name decides.

**`toContain("_parent_id")` was satisfied by the wrong thing.** Removing the parent-pointer column
from the generator left it green, because the `CREATE INDEX` that follows also names the column. It
now matches the column definition, and the same break fails it.

## Also recorded, not attempted

A delete forwarding test was attempted as a unit test and abandoned. The delete path fans out into
the i18n teardown, the field-group data teardown and the version cleanup, each reaching further into
the adapter — `listTables()`, then `db.delete(...)`, then `db.execute(...)`. Several mock layers
deep, such a test stops proving anything about the database.

Delete's proof belongs in integration, and most of it already exists:
`entity-delete-teardown-dialects.integration.test.ts` proves the ordering on all three dialects, and
`entity-delete-field-group-data.integration.test.ts` covers the field-group half. What is missing is
that a delete driven from the REQUEST reaches those teardowns in order, which belongs beside those
suites rather than in the dispatcher unit folder. Noted in the task.

## Verification

Full `packages/nextly` unit run diffed at test-name level against a freshly measured baseline from
`98eb31554` in its own installed and built worktree: **397 vs 397, zero new, zero disappeared**.
Build clean · `check-types --force` 20/20 · `lint` exit 0.
