### PR TITLE
fix(release): refuse to start a release a new package cannot finish

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,7 +114,14 @@ Before editing a package, read its README.md and check for a nested AGENTS.md.
   `0.0.0` placeholder containing no code (`package.json` + `README` only) to
   claim the name; it refuses to run when `CI` is set, so this never becomes a
   long-lived npm token in a workflow. Every real version still publishes only
-  from CI. Details: the `release-and-changesets` skill.
+  from CI. Claiming the name is only half of it: attach the package's Trusted
+  Publisher at npmjs.com (repository `nextlyhq/nextly`, workflow `release.yml`,
+  environment `Production`) and then add the package to
+  `scripts/release/first-publish-acknowledged.json` in the same PR that adds it.
+  Preflight refuses to start a release while a package carries only its
+  placeholder and is missing from that list, because a publish without a trusted
+  publisher answers 404 and would strand it after the rest of the train is
+  already live. Details: the `release-and-changesets` skill.
 
 ## Git and PR rules
 

--- a/scripts/release/first-publish-acknowledged.json
+++ b/scripts/release/first-publish-acknowledged.json
@@ -1,0 +1,22 @@
+{
+  "//": [
+    "Packages whose npm Trusted Publisher entry has been confirmed by a maintainer.",
+    "",
+    "A newly bootstrapped package exists on npm carrying only a 0.0.0 placeholder.",
+    "That proves its NAME is claimed; it does not prove the release workflow can",
+    "publish to it, because attaching a Trusted Publisher is a separate manual step",
+    "and npm answers a publish attempt without one with a 404 that looks identical",
+    "to the package not existing. A multi-package publish is not atomic, so the",
+    "train discovers this by stranding one package after the others are already",
+    "live.",
+    "",
+    "Add a package here in the same PR that adds the package, AFTER configuring its",
+    "Trusted Publisher at npmjs.com (repository nextlyhq/nextly, workflow",
+    "release.yml, environment Production). Preflight refuses to start a release",
+    "while any placeholder-only package is missing from this list.",
+    "",
+    "Once a package has published a real version the entry stops doing anything and",
+    "preflight will say so; remove it then."
+  ],
+  "packages": []
+}

--- a/scripts/release/lib.mjs
+++ b/scripts/release/lib.mjs
@@ -12,6 +12,12 @@ import { fileURLToPath } from "node:url";
 const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
 const PACKAGES_DIR = join(REPO_ROOT, "packages");
 const PRE_STATE_PATH = join(REPO_ROOT, ".changeset", "pre.json");
+const FIRST_PUBLISH_PATH = join(
+  REPO_ROOT,
+  "scripts",
+  "release",
+  "first-publish-acknowledged.json"
+);
 const REGISTRY = "https://registry.npmjs.org";
 
 /**
@@ -149,6 +155,37 @@ export function getExpectedDistTag(registryState, preState) {
 }
 
 /**
+ * The version `bootstrap-package.mjs` publishes to claim a name.
+ *
+ * A package sitting at exactly this and nothing else has had its NAME claimed
+ * and has never completed a real publish, which is a distinct state from both
+ * "unknown to npm" and "released": the trusted publisher may or may not have
+ * been attached, and nothing observable from here can tell the difference.
+ */
+export const PLACEHOLDER_VERSION = "0.0.0";
+
+/**
+ * Whether a package exists on the registry but has only ever been bootstrapped.
+ *
+ * npm requires a package to exist before a Trusted Publisher can be attached to
+ * it, so claiming the name and configuring the publisher are two separate acts
+ * by a human, and only the first leaves a trace the registry will show. A
+ * package in this state therefore has an UNPROVEN publish path: `npm publish`
+ * over OIDC answers 404 when the publisher is missing, and that answer is
+ * indistinguishable from the package not existing.
+ *
+ * It matters because a multi-package publish is not atomic. One package failing
+ * this way leaves every other package in the train already live, with no tag and
+ * no release describing them.
+ */
+export function isBootstrapPlaceholderOnly(state) {
+  if (state === null) return false;
+  return (
+    state.versions.length === 1 && state.versions[0] === PLACEHOLDER_VERSION
+  );
+}
+
+/**
  * Registry state for one package. Returns `null` when the package name has never
  * been published, which is a materially different situation from "published, but
  * not at this version": a first publish cannot authenticate through a trusted
@@ -170,6 +207,89 @@ export async function fetchRegistryState(name) {
   return {
     versions: Object.keys(body.versions ?? {}),
     distTags: body["dist-tags"] ?? {},
+  };
+}
+
+/**
+ * Packages a maintainer has confirmed are configured for trusted publishing.
+ *
+ * Read from a file in the repository rather than an environment variable so the
+ * acknowledgement arrives through review, in the same change that adds the
+ * package, instead of being typed once into a workflow run nobody can see
+ * afterwards.
+ */
+export function readFirstPublishAcknowledgements() {
+  if (!existsSync(FIRST_PUBLISH_PATH)) return [];
+  const contents = readJson(FIRST_PUBLISH_PATH);
+  return Array.isArray(contents.packages) ? contents.packages : [];
+}
+
+/**
+ * Everything preflight needs to decide whether a release may start.
+ *
+ * Pure, and separate from the script that prints it, so each rule can be tested
+ * against a constructed registry instead of against npm.
+ */
+export function classifyPreflight(
+  manifest,
+  registry,
+  expectedVersion,
+  acknowledged = []
+) {
+  const metadataErrors = [];
+  const versionMismatch = [];
+  const bootstrapNeeded = [];
+  const unprovenPublisher = [];
+  const staleAcknowledgements = [];
+  const alreadyPublished = [];
+  const toPublish = [];
+
+  for (const entry of manifest) {
+    const missing = findMissingPublishFields(entry.pkg);
+    if (missing.length > 0) {
+      metadataErrors.push({ name: entry.name, missing });
+    }
+
+    // Every publishable package shares one version through the Changesets
+    // `fixed` group; a package that drifts off it means the release is not the
+    // lockstep train the changelog and release notes will claim it is.
+    if (entry.version !== expectedVersion) {
+      versionMismatch.push({ name: entry.name, version: entry.version });
+    }
+
+    const state = registry.get(entry.name) ?? null;
+    const isAcknowledged = acknowledged.includes(entry.name);
+
+    if (state === null) {
+      bootstrapNeeded.push(entry.name);
+      continue;
+    }
+
+    if (isBootstrapPlaceholderOnly(state)) {
+      // Claimed but never really published: the publish path is unproven, and
+      // finding out by trying is what strands the rest of the train.
+      if (!isAcknowledged) unprovenPublisher.push(entry.name);
+    } else if (isAcknowledged) {
+      // The entry has done its job and now only invites confusion about which
+      // packages still need attention.
+      staleAcknowledgements.push(entry.name);
+    }
+
+    if (state.versions.includes(entry.version)) {
+      alreadyPublished.push(entry.name);
+    } else {
+      toPublish.push(entry.name);
+    }
+  }
+
+  return {
+    metadataErrors,
+    versionMismatch,
+    bootstrapNeeded,
+    unprovenPublisher,
+    staleAcknowledgements,
+    alreadyPublished,
+    toPublish,
   };
 }
 

--- a/scripts/release/preflight.mjs
+++ b/scripts/release/preflight.mjs
@@ -7,50 +7,11 @@
 // Exit codes: 0 = safe to publish, 1 = blocked.
 
 import {
+  classifyPreflight,
   fetchAllRegistryStates,
-  findMissingPublishFields,
   getReleaseManifest,
+  readFirstPublishAcknowledgements,
 } from "./lib.mjs";
-
-/** Groups every package by the reason it can or cannot be published right now. */
-function classify(manifest, registry, expectedVersion) {
-  const metadataErrors = [];
-  const versionMismatch = [];
-  const bootstrapNeeded = [];
-  const alreadyPublished = [];
-  const toPublish = [];
-
-  for (const entry of manifest) {
-    const missing = findMissingPublishFields(entry.pkg);
-    if (missing.length > 0) {
-      metadataErrors.push({ name: entry.name, missing });
-    }
-
-    // Every publishable package shares one version through the Changesets
-    // `fixed` group; a package that drifts off it means the release is not the
-    // lockstep train the changelog and release notes will claim it is.
-    if (entry.version !== expectedVersion) {
-      versionMismatch.push({ name: entry.name, version: entry.version });
-    }
-
-    const state = registry.get(entry.name);
-    if (state === null) {
-      bootstrapNeeded.push(entry.name);
-    } else if (state.versions.includes(entry.version)) {
-      alreadyPublished.push(entry.name);
-    } else {
-      toPublish.push(entry.name);
-    }
-  }
-
-  return {
-    metadataErrors,
-    versionMismatch,
-    bootstrapNeeded,
-    alreadyPublished,
-    toPublish,
-  };
-}
 
 async function main() {
   const manifest = getReleaseManifest();
@@ -65,9 +26,16 @@ async function main() {
     metadataErrors,
     versionMismatch,
     bootstrapNeeded,
+    unprovenPublisher,
+    staleAcknowledgements,
     alreadyPublished,
     toPublish,
-  } = classify(manifest, registry, expectedVersion);
+  } = classifyPreflight(
+    manifest,
+    registry,
+    expectedVersion,
+    readFirstPublishAcknowledgements()
+  );
 
   console.log(`Release preflight for ${expectedVersion}`);
   console.log(`  publishable packages: ${manifest.length}`);
@@ -120,6 +88,38 @@ async function main() {
           .join("\n") +
         "\n\n  See the release-and-changesets skill for the full procedure."
     );
+  }
+
+  // Claimed on npm, never actually published. The registry cannot show whether
+  // a Trusted Publisher was attached, and a publish attempt without one answers
+  // 404 — the same answer as a package that does not exist. Discovering that
+  // during `changeset publish` is what leaves the rest of the train live with
+  // no tag and no release, so it is settled here instead.
+  if (unprovenPublisher.length > 0) {
+    blocked = true;
+    console.error(
+      "\nBlocked: package exists on npm but has only its bootstrap placeholder"
+    );
+    for (const name of unprovenPublisher) {
+      console.error(`  ${name}`);
+    }
+    console.error(
+      "\n  Confirm each one's Trusted Publisher at npmjs.com (repository\n" +
+        "  nextlyhq/nextly, workflow release.yml, environment Production), then\n" +
+        "  add it to scripts/release/first-publish-acknowledged.json:\n" +
+        unprovenPublisher.map(name => `    "${name}"`).join("\n")
+    );
+  }
+
+  if (staleAcknowledgements.length > 0) {
+    // Not a failure: the acknowledgement did its job and now only obscures
+    // which packages still need one.
+    console.log(
+      "\nAcknowledgements no longer needed (these have published real versions):"
+    );
+    for (const name of staleAcknowledgements) {
+      console.log(`  ${name} — remove from first-publish-acknowledged.json`);
+    }
   }
 
   if (blocked) {

--- a/scripts/release/preflight.test.mjs
+++ b/scripts/release/preflight.test.mjs
@@ -1,0 +1,206 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  classifyPreflight,
+  isBootstrapPlaceholderOnly,
+  PLACEHOLDER_VERSION,
+} from "./lib.mjs";
+
+const VERSION = "0.0.2-alpha.52";
+
+/** A manifest entry whose publish metadata is complete, so only state matters. */
+function entry(name, version = VERSION) {
+  return {
+    name,
+    version,
+    dir: `/packages/${name}`,
+    manifestPath: `/packages/${name}/package.json`,
+    pkg: {
+      name,
+      version,
+      license: "MIT",
+      repository: { directory: `packages/${name}` },
+      publishConfig: { access: "public" },
+      engines: { node: ">=20.0.0" },
+    },
+  };
+}
+
+/** Registry state for a package that has published real versions. */
+function released(versions = [PLACEHOLDER_VERSION, "0.0.2-alpha.51"]) {
+  return { versions, distTags: { alpha: versions[versions.length - 1] } };
+}
+
+/** Registry state for a name that has only ever been bootstrapped. */
+function placeholderOnly() {
+  return {
+    versions: [PLACEHOLDER_VERSION],
+    distTags: { latest: PLACEHOLDER_VERSION },
+  };
+}
+
+function registryOf(pairs) {
+  return new Map(Object.entries(pairs));
+}
+
+describe("isBootstrapPlaceholderOnly", () => {
+  it("is true for a name carrying only the placeholder", () => {
+    expect(isBootstrapPlaceholderOnly(placeholderOnly())).toBe(true);
+  });
+
+  it("is false once a real version exists beside it", () => {
+    expect(isBootstrapPlaceholderOnly(released())).toBe(false);
+  });
+
+  it("is false for a name npm has never heard of", () => {
+    // A different situation with a different fix: that one needs the name
+    // claimed, this one needs its publisher configured.
+    expect(isBootstrapPlaceholderOnly(null)).toBe(false);
+  });
+
+  it("is false for a package whose only version is a real one", () => {
+    expect(isBootstrapPlaceholderOnly(released(["1.0.0"]))).toBe(false);
+  });
+});
+
+describe("classifyPreflight", () => {
+  it("refuses a package that carries only its bootstrap placeholder", () => {
+    const manifest = [entry("nextly"), entry("@nextlyhq/new-package")];
+    const registry = registryOf({
+      nextly: released(),
+      "@nextlyhq/new-package": placeholderOnly(),
+    });
+
+    const result = classifyPreflight(manifest, registry, VERSION);
+
+    expect(result.unprovenPublisher).toEqual(["@nextlyhq/new-package"]);
+    // And it is NOT confused with the unclaimed case, which needs a different fix.
+    expect(result.bootstrapNeeded).toEqual([]);
+  });
+
+  it("reproduces the partial-train scenario it exists to prevent", () => {
+    // Seventeen packages ready, one claimed but never published. Publishing
+    // would put the seventeen live and strand the last, with no tag and no
+    // release describing any of them.
+    const names = Array.from({ length: 17 }, (_, i) => `@nextlyhq/pkg-${i}`);
+    const manifest = [
+      ...names.map(name => entry(name)),
+      entry("@nextlyhq/late"),
+    ];
+    const registry = registryOf({
+      ...Object.fromEntries(names.map(name => [name, released()])),
+      "@nextlyhq/late": placeholderOnly(),
+    });
+
+    const result = classifyPreflight(manifest, registry, VERSION);
+
+    expect(result.unprovenPublisher).toEqual(["@nextlyhq/late"]);
+    expect(result.toPublish).toHaveLength(18);
+  });
+
+  it("allows a placeholder-only package once it is acknowledged", () => {
+    const manifest = [entry("@nextlyhq/new-package")];
+    const registry = registryOf({ "@nextlyhq/new-package": placeholderOnly() });
+
+    const result = classifyPreflight(manifest, registry, VERSION, [
+      "@nextlyhq/new-package",
+    ]);
+
+    expect(result.unprovenPublisher).toEqual([]);
+    // The first publish is exactly what the acknowledgement is for.
+    expect(result.toPublish).toEqual(["@nextlyhq/new-package"]);
+  });
+
+  it("reports an acknowledgement that has outlived its purpose", () => {
+    const manifest = [entry("@nextlyhq/settled")];
+    const registry = registryOf({ "@nextlyhq/settled": released() });
+
+    const result = classifyPreflight(manifest, registry, VERSION, [
+      "@nextlyhq/settled",
+    ]);
+
+    expect(result.staleAcknowledgements).toEqual(["@nextlyhq/settled"]);
+    // Reporting it must not block: the release itself is fine.
+    expect(result.unprovenPublisher).toEqual([]);
+  });
+
+  it("does not report a stale acknowledgement for a package still awaiting one", () => {
+    const manifest = [entry("@nextlyhq/new-package")];
+    const registry = registryOf({ "@nextlyhq/new-package": placeholderOnly() });
+
+    const result = classifyPreflight(manifest, registry, VERSION, [
+      "@nextlyhq/new-package",
+    ]);
+
+    expect(result.staleAcknowledgements).toEqual([]);
+  });
+
+  it("still refuses a name npm has never seen", () => {
+    const manifest = [entry("@nextlyhq/unclaimed")];
+    const registry = registryOf({ "@nextlyhq/unclaimed": null });
+
+    const result = classifyPreflight(manifest, registry, VERSION);
+
+    expect(result.bootstrapNeeded).toEqual(["@nextlyhq/unclaimed"]);
+    // An acknowledgement cannot substitute for the name existing.
+    const acknowledged = classifyPreflight(manifest, registry, VERSION, [
+      "@nextlyhq/unclaimed",
+    ]);
+    expect(acknowledged.bootstrapNeeded).toEqual(["@nextlyhq/unclaimed"]);
+  });
+
+  it("treats a package missing from the registry map as unclaimed", () => {
+    // `fetchAllRegistryStates` always populates every key, but a caller that
+    // built the map another way must not have the package silently skipped.
+    const result = classifyPreflight(
+      [entry("@nextlyhq/absent")],
+      new Map(),
+      VERSION
+    );
+    expect(result.bootstrapNeeded).toEqual(["@nextlyhq/absent"]);
+  });
+
+  it("separates what is already live from what still needs publishing", () => {
+    const manifest = [entry("a"), entry("b")];
+    const registry = registryOf({
+      a: released([PLACEHOLDER_VERSION, VERSION]),
+      b: released([PLACEHOLDER_VERSION, "0.0.2-alpha.51"]),
+    });
+
+    const result = classifyPreflight(manifest, registry, VERSION);
+
+    expect(result.alreadyPublished).toEqual(["a"]);
+    expect(result.toPublish).toEqual(["b"]);
+  });
+
+  it("catches a package that drifted off the lockstep version", () => {
+    const manifest = [entry("a"), entry("b", "0.0.2-alpha.51")];
+    const registry = registryOf({ a: released(), b: released() });
+
+    const result = classifyPreflight(manifest, registry, VERSION);
+
+    expect(result.versionMismatch).toEqual([
+      { name: "b", version: "0.0.2-alpha.51" },
+    ]);
+  });
+
+  it("names every missing publish field rather than the first", () => {
+    const incomplete = entry("a");
+    delete incomplete.pkg.license;
+    incomplete.pkg.publishConfig = { access: "restricted" };
+
+    const result = classifyPreflight(
+      [incomplete],
+      registryOf({ a: released() }),
+      VERSION
+    );
+
+    expect(result.metadataErrors).toHaveLength(1);
+    expect(result.metadataErrors[0].missing).toContain("license");
+    expect(
+      result.metadataErrors[0].missing.some(field =>
+        field.startsWith("publishConfig.access")
+      )
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
Closes the gap that produced the partial `v0.0.2-alpha.52` release.

## What happened

`@nextlyhq/blocks-react` was bootstrapped, so npm knew the name. Preflight checks `fetchRegistryState(name) === null` and saw a real package, so the release started. The publish then failed:

```
npm error 404 Not Found - PUT https://registry.npmjs.org/@nextlyhq%2fblocks-react
```

**17 packages went live, the 18th was stranded, and no tag or GitHub Release was created for any of them.**

The cause is that claiming a name and attaching a Trusted Publisher are two separate manual acts, and only the first leaves a trace the registry will show. A publish without a trusted publisher answers `404` — indistinguishable from the package not existing. `changeset publish` is not atomic, so the train finds out by stranding one package after the rest are already published.

## The fix

A package carrying **only** its `0.0.0` bootstrap placeholder is in a distinct state from both "unknown to npm" and "released": its publish path is unproven. Preflight now refuses to start while any such package is missing from `scripts/release/first-publish-acknowledged.json`, which a maintainer adds after configuring the publisher.

The acknowledgement lives in the repository rather than in a workflow input so it arrives through review, in the same PR that adds the package, instead of being typed once into a run nobody can inspect afterwards. Preflight also reports entries that have outlived their purpose, so the list does not silently accumulate.

Blocking rather than warning is deliberate: a warning in CI logs is missed, and the cost of being wrong is a stranded train — which has now been paid once.

## Structure

`classify` moves out of the script into `lib.mjs` as `classifyPreflight`, so each rule is tested against a constructed registry instead of against npm. The script keeps only I/O and formatting.

## Verification

- **11 new tests**, including one that reconstructs the exact failure: 17 released packages plus one placeholder-only, asserted blocked.
- Stub-verified: disabling the placeholder detection fails the scenario test; ignoring the acknowledgement fails the unblock test.
- Ran against the **live registry** — the current tree passes (`18 packages, nothing new to publish`), so this does not block the next real release.
- The stale-acknowledgement output path was exercised end to end by temporarily listing an already-released package.

No changeset: this is release tooling, not published package code.
