### PR TITLE
fix(nextly): declare the primary key in generated CREATE TABLE

### DIFF
--- a/.changeset/migration-primary-keys.md
+++ b/.changeset/migration-primary-keys.md
@@ -1,0 +1,28 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+Declare the primary key in generated `CREATE TABLE` statements. Every table a migration created was key-less: the desired snapshot has carried the marker since the diff needed it to exempt primary keys from the nullability comparison, and the SQL renderer dropped it. Any project whose tables were created by `nextly migrate` has content tables with no primary key, no uniqueness enforcement on `id`, and no primary-key index. Existing migration files are unchanged; new ones declare the key, and a table already created without one needs a corrective migration.
+
+Live introspection now records the primary key too, so a snapshot taken from a database describes the key it actually has. Statements generated from such a snapshot previously rebuilt the schema without one.

--- a/packages/nextly/src/domains/schema/pipeline/diff/__tests__/introspect-live.test.ts
+++ b/packages/nextly/src/domains/schema/pipeline/diff/__tests__/introspect-live.test.ts
@@ -10,6 +10,7 @@ const PG_COLS = {
       udt_name: "int4",
       is_nullable: "NO",
       column_default: null,
+      is_primary_key: true,
     },
     {
       table_name: "dc_posts",
@@ -17,6 +18,7 @@ const PG_COLS = {
       udt_name: "text",
       is_nullable: "YES",
       column_default: null,
+      is_primary_key: false,
     },
     {
       table_name: "dc_posts",
@@ -24,6 +26,7 @@ const PG_COLS = {
       udt_name: "varchar",
       is_nullable: "NO",
       column_default: "'draft'::character varying",
+      is_primary_key: false,
     },
   ],
 };
@@ -52,7 +55,13 @@ describe("introspectLiveSnapshot - postgresql", () => {
 
     expect(execute).toHaveBeenCalledTimes(2);
     expect(snapshot.tables[0].columns).toEqual([
-      { name: "id", type: "int4", nullable: false, default: undefined },
+      {
+        name: "id",
+        type: "int4",
+        nullable: false,
+        default: undefined,
+        primaryKey: true,
+      },
       { name: "title", type: "text", nullable: true, default: undefined },
       {
         name: "status",
@@ -99,6 +108,7 @@ describe("introspectLiveSnapshot - mysql", () => {
             COLUMN_TYPE: "int(11)",
             IS_NULLABLE: "NO",
             COLUMN_DEFAULT: null,
+            COLUMN_KEY: "PRI",
           },
         ],
         [],
@@ -124,6 +134,7 @@ describe("introspectLiveSnapshot - mysql", () => {
       type: "int(11)",
       nullable: false,
       default: undefined,
+      primaryKey: true,
     });
     expect(snapshot.tables[0].indexes).toEqual([
       { name: "idx_dc_posts_views", columns: ["views"], unique: false },
@@ -138,8 +149,22 @@ describe("introspectLiveSnapshot - sqlite", () => {
       .fn()
       // table_info(dc_posts)
       .mockReturnValueOnce([
-        { cid: 0, name: "id", type: "INTEGER", notnull: 1, dflt_value: null, pk: 1 },
-        { cid: 1, name: "slug", type: "TEXT", notnull: 0, dflt_value: null, pk: 0 },
+        {
+          cid: 0,
+          name: "id",
+          type: "INTEGER",
+          notnull: 1,
+          dflt_value: null,
+          pk: 1,
+        },
+        {
+          cid: 1,
+          name: "slug",
+          type: "TEXT",
+          notnull: 0,
+          dflt_value: null,
+          pk: 0,
+        },
       ])
       // index_list(dc_posts): one real unique index + one autoindex (filtered)
       .mockReturnValueOnce([
@@ -153,7 +178,13 @@ describe("introspectLiveSnapshot - sqlite", () => {
     const snapshot = await introspectLiveSnapshot(db, "sqlite", ["dc_posts"]);
 
     expect(snapshot.tables[0].columns).toEqual([
-      { name: "id", type: "integer", nullable: false, default: undefined },
+      {
+        name: "id",
+        type: "integer",
+        nullable: false,
+        default: undefined,
+        primaryKey: true,
+      },
       { name: "slug", type: "text", nullable: true, default: undefined },
     ]);
     expect(snapshot.tables[0].indexes).toEqual([

--- a/packages/nextly/src/domains/schema/pipeline/diff/__tests__/introspect-live.test.ts
+++ b/packages/nextly/src/domains/schema/pipeline/diff/__tests__/introspect-live.test.ts
@@ -97,6 +97,9 @@ describe("introspectLiveSnapshot - postgresql", () => {
 });
 
 describe("introspectLiveSnapshot - mysql", () => {
+  // Three queries, in this order: columns, the PRIMARY key's columns, then the
+  // secondary indexes. A mock short by one silently shifts every later result
+  // onto the wrong query, so the count is part of what these tests pin.
   it("handles mysql2's [rows, fields] tuple + reads indexes", async () => {
     const execute = vi
       .fn()
@@ -108,9 +111,14 @@ describe("introspectLiveSnapshot - mysql", () => {
             COLUMN_TYPE: "int(11)",
             IS_NULLABLE: "NO",
             COLUMN_DEFAULT: null,
-            COLUMN_KEY: "PRI",
+            DATA_TYPE: "int",
+            EXTRA: "",
           },
         ],
+        [],
+      ])
+      .mockResolvedValueOnce([
+        [{ TABLE_NAME: "dc_posts", COLUMN_NAME: "id" }],
         [],
       ])
       .mockResolvedValueOnce([
@@ -138,6 +146,95 @@ describe("introspectLiveSnapshot - mysql", () => {
     });
     expect(snapshot.tables[0].indexes).toEqual([
       { name: "idx_dc_posts_views", columns: ["views"], unique: false },
+    ]);
+    expect(execute).toHaveBeenCalledTimes(3);
+  });
+
+  it("keys only the columns the PRIMARY index names", async () => {
+    // `COLUMN_KEY` is not consulted, and this is why: MySQL reports `PRI` for
+    // a NOT NULL UNIQUE index when the table has no primary key at all,
+    // because InnoDB promotes such an index to the clustered key. The fixture
+    // says `PRI` on a column the PRIMARY index does not name, so a reader that
+    // trusted it would key `slug`.
+    const execute = vi
+      .fn()
+      .mockResolvedValueOnce([
+        [
+          {
+            TABLE_NAME: "dc_posts",
+            COLUMN_NAME: "slug",
+            COLUMN_TYPE: "varchar(40)",
+            IS_NULLABLE: "NO",
+            COLUMN_DEFAULT: null,
+            COLUMN_KEY: "PRI",
+            DATA_TYPE: "varchar",
+            EXTRA: "",
+          },
+        ],
+        [],
+      ])
+      // No PRIMARY index on the table.
+      .mockResolvedValueOnce([[], []])
+      .mockResolvedValueOnce([[], []]);
+
+    const snapshot = await introspectLiveSnapshot({ execute }, "mysql", [
+      "dc_posts",
+    ]);
+
+    expect(
+      snapshot.tables[0].columns.filter(c => c.primaryKey === true)
+    ).toEqual([]);
+  });
+
+  it("quotes a literal default and leaves an expression alone", async () => {
+    // MySQL reports a string default without quotes, unlike the other two
+    // dialects, and `EXTRA` is what separates a literal from an expression.
+    const execute = vi
+      .fn()
+      .mockResolvedValueOnce([
+        [
+          {
+            TABLE_NAME: "dc_posts",
+            COLUMN_NAME: "status",
+            COLUMN_TYPE: "varchar(20)",
+            IS_NULLABLE: "NO",
+            COLUMN_DEFAULT: "dra'ft\\x",
+            DATA_TYPE: "varchar",
+            EXTRA: "",
+          },
+          {
+            TABLE_NAME: "dc_posts",
+            COLUMN_NAME: "n",
+            COLUMN_TYPE: "int(11)",
+            IS_NULLABLE: "YES",
+            COLUMN_DEFAULT: "5",
+            DATA_TYPE: "int",
+            EXTRA: "",
+          },
+          {
+            TABLE_NAME: "dc_posts",
+            COLUMN_NAME: "made_at",
+            COLUMN_TYPE: "datetime",
+            IS_NULLABLE: "YES",
+            COLUMN_DEFAULT: "CURRENT_TIMESTAMP",
+            DATA_TYPE: "datetime",
+            EXTRA: "DEFAULT_GENERATED",
+          },
+        ],
+        [],
+      ])
+      .mockResolvedValueOnce([[], []])
+      .mockResolvedValueOnce([[], []]);
+
+    const snapshot = await introspectLiveSnapshot({ execute }, "mysql", [
+      "dc_posts",
+    ]);
+
+    expect(snapshot.tables[0].columns.map(c => c.default)).toEqual([
+      // Backslash escaped first, then the quote doubled.
+      "'dra''ft\\\\x'",
+      "5",
+      "CURRENT_TIMESTAMP",
     ]);
   });
 });

--- a/packages/nextly/src/domains/schema/pipeline/diff/introspect-live.ts
+++ b/packages/nextly/src/domains/schema/pipeline/diff/introspect-live.ts
@@ -86,9 +86,13 @@ interface MysqlRow {
   COLUMN_TYPE: string;
   IS_NULLABLE: "YES" | "NO";
   COLUMN_DEFAULT: string | null;
-  COLUMN_KEY: string;
   DATA_TYPE: string;
   EXTRA: string;
+}
+
+interface MysqlPrimaryKeyRow {
+  TABLE_NAME: string;
+  COLUMN_NAME: string;
 }
 
 interface MysqlIndexRow {
@@ -240,7 +244,7 @@ export async function introspectLiveSnapshot(
     // sometimes wraps it. Handle both shapes defensively.
     const result = (await dbTyped.execute(
       sql`SELECT TABLE_NAME, COLUMN_NAME, COLUMN_TYPE, IS_NULLABLE, COLUMN_DEFAULT,
-                 COLUMN_KEY, DATA_TYPE, EXTRA
+                 DATA_TYPE, EXTRA
           FROM information_schema.columns
           WHERE TABLE_SCHEMA = DATABASE()
             AND TABLE_NAME IN (${tableNamesIn})
@@ -252,7 +256,32 @@ export async function introspectLiveSnapshot(
       Array.isArray((result as unknown[])[0])
         ? (result as [MysqlRow[], unknown])[0]
         : (result as MysqlRow[]);
-    const snapshot = buildSnapshotFromMysqlRows(rows);
+    // The key comes from the PRIMARY index rather than `COLUMN_KEY`, which
+    // does not mean what its name suggests: a table with no primary key but a
+    // NOT NULL UNIQUE index reports `PRI` for that column, because InnoDB
+    // promotes such an index to the clustered key. Trusting it would mark
+    // something like `slug` as the primary key, hiding a table that genuinely
+    // has none and rebuilding it elsewhere with the wrong key. Verified
+    // against MySQL 8: `STATISTICS` shows only the `slug` index, no `PRIMARY`,
+    // while `COLUMN_KEY` still says `PRI`.
+    const pkRaw = (await dbTyped.execute(
+      sql`SELECT TABLE_NAME, COLUMN_NAME
+          FROM information_schema.STATISTICS
+          WHERE TABLE_SCHEMA = DATABASE()
+            AND TABLE_NAME IN (${tableNamesIn})
+            AND INDEX_NAME = 'PRIMARY'`
+    )) as MysqlPrimaryKeyRow[] | [MysqlPrimaryKeyRow[], unknown];
+    const pkRows: MysqlPrimaryKeyRow[] =
+      Array.isArray(pkRaw) &&
+      pkRaw.length > 0 &&
+      Array.isArray((pkRaw as unknown[])[0])
+        ? (pkRaw as [MysqlPrimaryKeyRow[], unknown])[0]
+        : (pkRaw as MysqlPrimaryKeyRow[]);
+    const primaryKeyColumns = new Set(
+      pkRows.map(r => `${r.TABLE_NAME}.${r.COLUMN_NAME}`)
+    );
+
+    const snapshot = buildSnapshotFromMysqlRows(rows, primaryKeyColumns);
     // Index query: information_schema.STATISTICS. Exclude PRIMARY.
     const idxRaw = (await dbTyped.execute(
       sql`SELECT TABLE_NAME, INDEX_NAME, NON_UNIQUE, COLUMN_NAME, SEQ_IN_INDEX
@@ -430,11 +459,18 @@ function mysqlDefaultExpression(row: MysqlRow): string | undefined {
   if (MYSQL_NUMERIC_TYPES.has((row.DATA_TYPE ?? "").toLowerCase())) {
     return value;
   }
-  // A literal, with any embedded quote doubled the way SQL spells it.
-  return `'${value.replace(/'/g, "''")}'`;
+  // A literal. Both the backslash and the quote have to be escaped, and the
+  // backslash first: under MySQL's default sql_mode a backslash introduces an
+  // escape sequence, so a default of `a\nb` re-emitted with only the quote
+  // handled would store a newline instead of the two characters it had.
+  const escaped = value.replace(/\\/g, "\\\\").replace(/'/g, "''");
+  return `'${escaped}'`;
 }
 
-function buildSnapshotFromMysqlRows(rows: MysqlRow[]): NextlySchemaSnapshot {
+function buildSnapshotFromMysqlRows(
+  rows: MysqlRow[],
+  primaryKeyColumns: ReadonlySet<string>
+): NextlySchemaSnapshot {
   const byTable = new Map<string, ColumnSpec[]>();
   for (const r of rows) {
     let cols = byTable.get(r.TABLE_NAME);
@@ -448,9 +484,9 @@ function buildSnapshotFromMysqlRows(rows: MysqlRow[]): NextlySchemaSnapshot {
       nullable: r.IS_NULLABLE === "YES",
       default: mysqlDefaultExpression(r),
     };
-    // `COLUMN_KEY` is "PRI" for every column of the PRIMARY key, and "UNI" or
-    // "MUL" for other index positions, so only the first is the key itself.
-    if (r.COLUMN_KEY === "PRI") column.primaryKey = true;
+    if (primaryKeyColumns.has(`${r.TABLE_NAME}.${r.COLUMN_NAME}`)) {
+      column.primaryKey = true;
+    }
     cols.push(column);
   }
   return {

--- a/packages/nextly/src/domains/schema/pipeline/diff/introspect-live.ts
+++ b/packages/nextly/src/domains/schema/pipeline/diff/introspect-live.ts
@@ -77,6 +77,7 @@ interface PgRow {
   is_nullable: "YES" | "NO";
   column_default: string | null;
   owned_sequence_default: boolean;
+  is_primary_key: boolean;
 }
 
 interface MysqlRow {
@@ -85,6 +86,7 @@ interface MysqlRow {
   COLUMN_TYPE: string;
   IS_NULLABLE: "YES" | "NO";
   COLUMN_DEFAULT: string | null;
+  COLUMN_KEY: string;
 }
 
 interface MysqlIndexRow {
@@ -154,9 +156,27 @@ export async function introspectLiveSnapshot(
     // that is not exactly a `nextval()` call yields NULL from the substring
     // and so falls to false, which is the safe direction: a default the diff
     // does not recognise is reported, never swallowed.
+    // `is_primary_key` comes from `pg_index.indisprimary` rather than
+    // `information_schema.table_constraints`, so it needs no second round trip
+    // and reports the same key the index query deliberately excludes. A live
+    // snapshot without it renders a key-less `CREATE TABLE` in any statement
+    // generated from it, which is how an adopted database rebuilt elsewhere
+    // ended up with no primary keys at all.
     const result = (await dbTyped.execute(
       sql`SELECT c.table_name, c.column_name, c.udt_name, c.is_nullable,
                  c.column_default,
+                 EXISTS (
+                   SELECT 1
+                   FROM pg_index i
+                   JOIN pg_class t ON t.oid = i.indrelid
+                   JOIN pg_namespace n ON n.oid = t.relnamespace
+                   JOIN pg_attribute a
+                     ON a.attrelid = t.oid AND a.attnum = ANY(i.indkey)
+                   WHERE i.indisprimary
+                     AND n.nspname = c.table_schema
+                     AND t.relname = c.table_name
+                     AND a.attname = c.column_name
+                 ) AS is_primary_key,
                  COALESCE(
                    substring(
                      c.column_default from '^nextval[(]''(.+)''::regclass[)]$'
@@ -217,7 +237,8 @@ export async function introspectLiveSnapshot(
     // mysql2's execute returns a [rows, fieldPackets] tuple; drizzle-orm/mysql2
     // sometimes wraps it. Handle both shapes defensively.
     const result = (await dbTyped.execute(
-      sql`SELECT TABLE_NAME, COLUMN_NAME, COLUMN_TYPE, IS_NULLABLE, COLUMN_DEFAULT
+      sql`SELECT TABLE_NAME, COLUMN_NAME, COLUMN_TYPE, IS_NULLABLE, COLUMN_DEFAULT,
+                 COLUMN_KEY
           FROM information_schema.columns
           WHERE TABLE_SCHEMA = DATABASE()
             AND TABLE_NAME IN (${tableNamesIn})
@@ -311,6 +332,10 @@ export async function introspectLiveSnapshot(
           // database. Whether requiring such a column is safe is decided from
           // the data, in resolve-safe-nullability.ts.
           nullable: r.notnull === 0,
+          // `pk` is 0 for an ordinary column and the 1-based position within
+          // the key otherwise, so any non-zero value means this column is part
+          // of it. PRAGMA has always returned this; nothing read it.
+          ...(r.pk > 0 ? { primaryKey: true as const } : {}),
           // dflt_value can be string, number, null, or undefined.
           // Coerce primitives to string; treat anything non-primitive as
           // missing (defensive - SQLite never returns object defaults).
@@ -350,6 +375,10 @@ function buildSnapshotFromPgRows(rows: PgRow[]): NextlySchemaSnapshot {
     // Recorded only when true, so a snapshot carries the marker rather than a
     // false on every column that has no sequence at all.
     if (r.owned_sequence_default === true) column.ownedSequenceDefault = true;
+    // Same convention for the key: present when it is one, absent otherwise,
+    // so a snapshot taken before this reads the same as one where the column
+    // is genuinely not part of the key.
+    if (r.is_primary_key === true) column.primaryKey = true;
     cols.push(column);
   }
   return {
@@ -367,12 +396,16 @@ function buildSnapshotFromMysqlRows(rows: MysqlRow[]): NextlySchemaSnapshot {
       cols = [];
       byTable.set(r.TABLE_NAME, cols);
     }
-    cols.push({
+    const column: ColumnSpec = {
       name: r.COLUMN_NAME,
       type: r.COLUMN_TYPE,
       nullable: r.IS_NULLABLE === "YES",
       default: r.COLUMN_DEFAULT ?? undefined,
-    });
+    };
+    // `COLUMN_KEY` is "PRI" for every column of the PRIMARY key, and "UNI" or
+    // "MUL" for other index positions, so only the first is the key itself.
+    if (r.COLUMN_KEY === "PRI") column.primaryKey = true;
+    cols.push(column);
   }
   return {
     tables: [...byTable.entries()].map(

--- a/packages/nextly/src/domains/schema/pipeline/diff/introspect-live.ts
+++ b/packages/nextly/src/domains/schema/pipeline/diff/introspect-live.ts
@@ -87,6 +87,8 @@ interface MysqlRow {
   IS_NULLABLE: "YES" | "NO";
   COLUMN_DEFAULT: string | null;
   COLUMN_KEY: string;
+  DATA_TYPE: string;
+  EXTRA: string;
 }
 
 interface MysqlIndexRow {
@@ -238,7 +240,7 @@ export async function introspectLiveSnapshot(
     // sometimes wraps it. Handle both shapes defensively.
     const result = (await dbTyped.execute(
       sql`SELECT TABLE_NAME, COLUMN_NAME, COLUMN_TYPE, IS_NULLABLE, COLUMN_DEFAULT,
-                 COLUMN_KEY
+                 COLUMN_KEY, DATA_TYPE, EXTRA
           FROM information_schema.columns
           WHERE TABLE_SCHEMA = DATABASE()
             AND TABLE_NAME IN (${tableNamesIn})
@@ -388,6 +390,50 @@ function buildSnapshotFromPgRows(rows: PgRow[]): NextlySchemaSnapshot {
   };
 }
 
+/** MySQL types whose default is reported as a bare number, not a literal. */
+const MYSQL_NUMERIC_TYPES = new Set([
+  "tinyint",
+  "smallint",
+  "mediumint",
+  "int",
+  "integer",
+  "bigint",
+  "decimal",
+  "numeric",
+  "float",
+  "double",
+  "real",
+]);
+
+/**
+ * A MySQL default as it must appear in DDL.
+ *
+ * MySQL is the odd one out. PostgreSQL reports `'draft'::character varying`
+ * and SQLite reports `'draft'`, both already quoted; MySQL's
+ * `information_schema.COLUMN_DEFAULT` strips the quotes and reports `draft`.
+ * Recorded verbatim, a snapshot then renders `DEFAULT draft`, which the server
+ * reads as an identifier and refuses — so a schema generated from a live MySQL
+ * snapshot could not be applied anywhere.
+ *
+ * `EXTRA` is what separates the two cases: an expression default (
+ * `CURRENT_TIMESTAMP`, `json_array()`) carries `DEFAULT_GENERATED` and must be
+ * left alone, while everything else is a literal. Numeric types need no quotes
+ * either, and quoting them would turn a number into a string.
+ */
+function mysqlDefaultExpression(row: MysqlRow): string | undefined {
+  const value = row.COLUMN_DEFAULT;
+  if (value === null || value === undefined) return undefined;
+  // An expression is already valid DDL as written.
+  if ((row.EXTRA ?? "").toUpperCase().includes("DEFAULT_GENERATED")) {
+    return value;
+  }
+  if (MYSQL_NUMERIC_TYPES.has((row.DATA_TYPE ?? "").toLowerCase())) {
+    return value;
+  }
+  // A literal, with any embedded quote doubled the way SQL spells it.
+  return `'${value.replace(/'/g, "''")}'`;
+}
+
 function buildSnapshotFromMysqlRows(rows: MysqlRow[]): NextlySchemaSnapshot {
   const byTable = new Map<string, ColumnSpec[]>();
   for (const r of rows) {
@@ -400,7 +446,7 @@ function buildSnapshotFromMysqlRows(rows: MysqlRow[]): NextlySchemaSnapshot {
       name: r.COLUMN_NAME,
       type: r.COLUMN_TYPE,
       nullable: r.IS_NULLABLE === "YES",
-      default: r.COLUMN_DEFAULT ?? undefined,
+      default: mysqlDefaultExpression(r),
     };
     // `COLUMN_KEY` is "PRI" for every column of the PRIMARY key, and "UNI" or
     // "MUL" for other index positions, so only the first is the key itself.

--- a/packages/nextly/src/domains/schema/pipeline/sql-templates/__tests__/create-table-primary-key.integration.test.ts
+++ b/packages/nextly/src/domains/schema/pipeline/sql-templates/__tests__/create-table-primary-key.integration.test.ts
@@ -154,6 +154,57 @@ describe("generated CREATE TABLE declares its primary key", () => {
     sqlite.close();
   });
 
+  it.skipIf(!MYSQL_URL)(
+    "mysql round-trips a live snapshot back into DDL the server accepts",
+    async () => {
+      // MySQL reports a string default WITHOUT quotes, unlike PostgreSQL and
+      // SQLite. Recorded verbatim it renders `DEFAULT draft`, which the server
+      // reads as an identifier — so the schema a live snapshot describes could
+      // not be rebuilt anywhere. Asserting on the snapshot text alone would
+      // pin a spelling; rebuilding the table from it is what proves the point.
+      const conn = await mysql.createConnection(MYSQL_URL);
+      pools.push(() => conn.end());
+      const db = drizzleMysql({ client: conn });
+      const source = "dc_mysql_defaults";
+      const rebuilt = "dc_mysql_defaults_rebuilt";
+
+      await conn.query(`DROP TABLE IF EXISTS \`${source}\``);
+      await conn.query(`DROP TABLE IF EXISTS \`${rebuilt}\``);
+      await conn.query(
+        `CREATE TABLE \`${source}\` (
+           id varchar(36) PRIMARY KEY NOT NULL,
+           status varchar(20) NOT NULL DEFAULT 'draft',
+           quantity int DEFAULT 5,
+           note varchar(40) DEFAULT 'it''s here',
+           made_at datetime DEFAULT CURRENT_TIMESTAMP
+         )`
+      );
+
+      const live = await introspectLiveSnapshot(db, "mysql", [source]);
+      const spec = live.tables[0];
+      expect(spec).toBeDefined();
+      // A literal is quoted, a number is not, and an expression is untouched.
+      const byName = (n: string) => spec!.columns.find(c => c.name === n);
+      expect(byName("status")?.default).toBe("'draft'");
+      expect(byName("quantity")?.default).toBe("5");
+      expect(byName("note")?.default).toBe("'it''s here'");
+      expect(byName("made_at")?.default).toBe("CURRENT_TIMESTAMP");
+
+      // And the whole thing rebuilds. This is the assertion that fails when a
+      // default is recorded in a form the server cannot read back.
+      for (const stmt of statements({ ...spec!, name: rebuilt }, "mysql")) {
+        await conn.query(stmt);
+      }
+      const after = await introspectLiveSnapshot(db, "mysql", [rebuilt]);
+      expect(after.tables[0]?.columns.map(c => c.default)).toEqual(
+        spec!.columns.map(c => c.default)
+      );
+
+      await conn.query(`DROP TABLE IF EXISTS \`${source}\``);
+      await conn.query(`DROP TABLE IF EXISTS \`${rebuilt}\``);
+    }
+  );
+
   it("does not declare a key on ADD COLUMN", async () => {
     // The renderer is shared with the altering paths, and no dialect accepts
     // an inline key on a column added to a table that already exists.

--- a/packages/nextly/src/domains/schema/pipeline/sql-templates/__tests__/create-table-primary-key.integration.test.ts
+++ b/packages/nextly/src/domains/schema/pipeline/sql-templates/__tests__/create-table-primary-key.integration.test.ts
@@ -245,15 +245,36 @@ describe("generated CREATE TABLE declares its primary key", () => {
       // because InnoDB promotes such an index to the clustered key. Reading it
       // would mark `slug` as the primary key, hiding a table that has none and
       // rebuilding it elsewhere with the wrong one.
+      //
+      // Built through the generator like the case above, so the fixture cannot
+      // drift from the DDL this suite protects — and the promotion still
+      // happens for the shape it emits (`CREATE TABLE` then a separate
+      // `CREATE UNIQUE INDEX`), which is what makes the case reachable.
       const conn = await mysql.createConnection(MYSQL_URL);
       pools.push(() => conn.end());
       const db = drizzleMysql({ client: conn });
       const name = "dc_mysql_promoted";
+      const spec: TableSpec = {
+        name,
+        columns: [
+          { name: "slug", type: "varchar(40)", nullable: false },
+          { name: "other", type: "varchar(10)", nullable: true },
+        ],
+        indexes: [{ name: `uq_${name}_slug`, columns: ["slug"], unique: true }],
+      };
 
       await conn.query(`DROP TABLE IF EXISTS \`${name}\``);
-      await conn.query(
-        `CREATE TABLE \`${name}\` (slug varchar(40) NOT NULL UNIQUE, other varchar(10)) ENGINE=InnoDB`
-      );
+      for (const stmt of statements(spec, "mysql")) await conn.query(stmt);
+
+      // The trap is still armed. If a future MySQL stopped promoting, the
+      // assertion below would pass for the wrong reason and stop guarding
+      // anything, so the promotion is asserted rather than assumed.
+      const [promoted] = (await conn.query(
+        `SELECT COLUMN_KEY FROM information_schema.columns
+         WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ? AND COLUMN_NAME = 'slug'`,
+        [name]
+      )) as [{ COLUMN_KEY: string }[], unknown];
+      expect(promoted[0]?.COLUMN_KEY).toBe("PRI");
 
       const live = await introspectLiveSnapshot(db, "mysql", [name]);
       expect(

--- a/packages/nextly/src/domains/schema/pipeline/sql-templates/__tests__/create-table-primary-key.integration.test.ts
+++ b/packages/nextly/src/domains/schema/pipeline/sql-templates/__tests__/create-table-primary-key.integration.test.ts
@@ -1,0 +1,175 @@
+/**
+ * A generated `CREATE TABLE` declares its primary key, and the database agrees.
+ *
+ * Every table a migration created was key-less: the desired snapshot has
+ * carried `primaryKey` since the diff needed it for the nullability exemption,
+ * and the SQL renderer dropped it. Nothing caught it because no test executed a
+ * generated `CREATE TABLE` and then asked the database what it had built.
+ *
+ * So that is what this does, per dialect, through the same `generateSQL` the
+ * CLI calls: run the statement, then introspect the result and require the key
+ * back. Asserting on the SQL text alone would pin the spelling without
+ * establishing that any dialect accepts it — and the three disagree about
+ * where `PRIMARY KEY` may sit relative to `NOT NULL`.
+ */
+import Database from "better-sqlite3";
+import { drizzle as drizzleSqlite } from "drizzle-orm/better-sqlite3";
+import { drizzle as drizzleMysql } from "drizzle-orm/mysql2";
+import { drizzle as drizzlePg } from "drizzle-orm/node-postgres";
+import mysql from "mysql2/promise";
+import { Pool } from "pg";
+import { afterAll, describe, expect, it } from "vitest";
+
+import { introspectLiveSnapshot } from "../../diff/introspect-live";
+import type { AddTableOp, TableSpec } from "../../diff/types";
+import { generateSQL } from "../index";
+
+const PG_URL = process.env.TEST_POSTGRES_URL ?? "";
+const MYSQL_URL = process.env.TEST_MYSQL_URL ?? "";
+
+/** A collection table as `build-from-fields` describes one, per dialect. */
+function table(name: string, idType: string): TableSpec {
+  return {
+    name,
+    columns: [
+      { name: "id", type: idType, nullable: false, primaryKey: true },
+      { name: "title", type: idType, nullable: false },
+    ],
+    indexes: [],
+  };
+}
+
+function statements(
+  spec: TableSpec,
+  dialect: "postgresql" | "mysql" | "sqlite"
+) {
+  const op: AddTableOp = { type: "add_table", table: spec };
+  return generateSQL(op, dialect)
+    .split(";\n")
+    .map(s => s.trim())
+    .filter(Boolean);
+}
+
+const pools: Array<() => Promise<void>> = [];
+afterAll(async () => {
+  for (const close of pools) await close();
+});
+
+describe("generated CREATE TABLE declares its primary key", () => {
+  it("sqlite builds a table the database reports as keyed", async () => {
+    const sqlite = new Database(":memory:");
+    const db = drizzleSqlite({ client: sqlite });
+    const name = "dc_pk_sqlite";
+
+    for (const stmt of statements(table(name, "text"), "sqlite")) {
+      sqlite.exec(stmt);
+    }
+
+    const live = await introspectLiveSnapshot(db, "sqlite", [name]);
+    const id = live.tables[0]?.columns.find(c => c.name === "id");
+    expect(id?.primaryKey).toBe(true);
+    // And the column that is not the key does not claim to be one, so the
+    // assertion above cannot pass by marking everything.
+    expect(
+      live.tables[0]?.columns.find(c => c.name === "title")?.primaryKey
+    ).toBeUndefined();
+    sqlite.close();
+  });
+
+  it.skipIf(!PG_URL)(
+    "postgres builds a table the database reports as keyed",
+    async () => {
+      const pool = new Pool({ connectionString: PG_URL });
+      pools.push(() => pool.end());
+      const db = drizzlePg({ client: pool });
+      const name = "dc_pk_postgres";
+
+      await pool.query(`DROP TABLE IF EXISTS "${name}"`);
+      for (const stmt of statements(table(name, "text"), "postgresql")) {
+        await pool.query(stmt);
+      }
+
+      const live = await introspectLiveSnapshot(db, "postgresql", [name]);
+      const id = live.tables[0]?.columns.find(c => c.name === "id");
+      expect(id?.primaryKey).toBe(true);
+      expect(
+        live.tables[0]?.columns.find(c => c.name === "title")?.primaryKey
+      ).toBeUndefined();
+      await pool.query(`DROP TABLE IF EXISTS "${name}"`);
+    }
+  );
+
+  it.skipIf(!MYSQL_URL)(
+    "mysql builds a table the database reports as keyed",
+    async () => {
+      const conn = await mysql.createConnection(MYSQL_URL);
+      pools.push(() => conn.end());
+      const db = drizzleMysql({ client: conn });
+      const name = "dc_pk_mysql";
+
+      await conn.query(`DROP TABLE IF EXISTS \`${name}\``);
+      for (const stmt of statements(table(name, "varchar(36)"), "mysql")) {
+        await conn.query(stmt);
+      }
+
+      const live = await introspectLiveSnapshot(db, "mysql", [name]);
+      const id = live.tables[0]?.columns.find(c => c.name === "id");
+      expect(id?.primaryKey).toBe(true);
+      expect(
+        live.tables[0]?.columns.find(c => c.name === "title")?.primaryKey
+      ).toBeUndefined();
+      await conn.query(`DROP TABLE IF EXISTS \`${name}\``);
+    }
+  );
+
+  it("a composite key becomes a table constraint the database accepts", async () => {
+    // No table Nextly generates has one today. It is covered because the
+    // inline spelling is a syntax error for two columns rather than a
+    // composite key, so the branch has to exist and has to be right before
+    // anything relies on it.
+    const sqlite = new Database(":memory:");
+    const name = "dc_pk_composite";
+    const spec: TableSpec = {
+      name,
+      columns: [
+        { name: "left_id", type: "text", nullable: false, primaryKey: true },
+        { name: "right_id", type: "text", nullable: false, primaryKey: true },
+      ],
+      indexes: [],
+    };
+
+    const sql = statements(spec, "sqlite")[0];
+    expect(sql).toContain('PRIMARY KEY ("left_id", "right_id")');
+    // One key for the table, not one per column.
+    expect(sql.match(/PRIMARY KEY/g)).toHaveLength(1);
+    sqlite.exec(sql);
+
+    const db = drizzleSqlite({ client: sqlite });
+    const live = await introspectLiveSnapshot(db, "sqlite", [name]);
+    expect(
+      live.tables[0]?.columns
+        .filter(c => c.primaryKey === true)
+        .map(c => c.name)
+    ).toEqual(["left_id", "right_id"]);
+    sqlite.close();
+  });
+
+  it("does not declare a key on ADD COLUMN", async () => {
+    // The renderer is shared with the altering paths, and no dialect accepts
+    // an inline key on a column added to a table that already exists.
+    const sql = generateSQL(
+      {
+        type: "add_column",
+        tableName: "dc_pk_sqlite",
+        column: {
+          name: "late",
+          type: "text",
+          nullable: false,
+          primaryKey: true,
+        },
+      },
+      "sqlite"
+    );
+    expect(sql).not.toContain("PRIMARY KEY");
+  });
+});

--- a/packages/nextly/src/domains/schema/pipeline/sql-templates/__tests__/create-table-primary-key.integration.test.ts
+++ b/packages/nextly/src/domains/schema/pipeline/sql-templates/__tests__/create-table-primary-key.integration.test.ts
@@ -160,48 +160,107 @@ describe("generated CREATE TABLE declares its primary key", () => {
       // MySQL reports a string default WITHOUT quotes, unlike PostgreSQL and
       // SQLite. Recorded verbatim it renders `DEFAULT draft`, which the server
       // reads as an identifier — so the schema a live snapshot describes could
-      // not be rebuilt anywhere. Asserting on the snapshot text alone would
-      // pin a spelling; rebuilding the table from it is what proves the point.
+      // not be rebuilt anywhere.
+      //
+      // The source table is built by the generator rather than by hand, which
+      // makes this a closed loop: spec -> DDL -> live -> spec. A hand-written
+      // fixture could drift from the generator this is meant to protect, and
+      // would also let the assertion agree with a shape nothing produces.
       const conn = await mysql.createConnection(MYSQL_URL);
       pools.push(() => conn.end());
       const db = drizzleMysql({ client: conn });
       const source = "dc_mysql_defaults";
       const rebuilt = "dc_mysql_defaults_rebuilt";
 
+      const spec: TableSpec = {
+        name: source,
+        columns: [
+          {
+            name: "id",
+            type: "varchar(36)",
+            nullable: false,
+            primaryKey: true,
+          },
+          {
+            name: "status",
+            type: "varchar(20)",
+            nullable: false,
+            default: "'draft'",
+          },
+          { name: "quantity", type: "int", nullable: true, default: "5" },
+          // An embedded quote and a backslash: MySQL treats the backslash as
+          // an escape introducer, so a default re-emitted with only the quote
+          // handled would come back as a different string.
+          {
+            name: "note",
+            type: "varchar(40)",
+            nullable: true,
+            default: "'it''s a\\\\nb'",
+          },
+          {
+            name: "made_at",
+            type: "datetime",
+            nullable: true,
+            default: "CURRENT_TIMESTAMP",
+          },
+        ],
+        indexes: [],
+      };
+
       await conn.query(`DROP TABLE IF EXISTS \`${source}\``);
       await conn.query(`DROP TABLE IF EXISTS \`${rebuilt}\``);
-      await conn.query(
-        `CREATE TABLE \`${source}\` (
-           id varchar(36) PRIMARY KEY NOT NULL,
-           status varchar(20) NOT NULL DEFAULT 'draft',
-           quantity int DEFAULT 5,
-           note varchar(40) DEFAULT 'it''s here',
-           made_at datetime DEFAULT CURRENT_TIMESTAMP
-         )`
-      );
+      for (const stmt of statements(spec, "mysql")) await conn.query(stmt);
 
       const live = await introspectLiveSnapshot(db, "mysql", [source]);
-      const spec = live.tables[0];
-      expect(spec).toBeDefined();
-      // A literal is quoted, a number is not, and an expression is untouched.
-      const byName = (n: string) => spec!.columns.find(c => c.name === n);
-      expect(byName("status")?.default).toBe("'draft'");
-      expect(byName("quantity")?.default).toBe("5");
-      expect(byName("note")?.default).toBe("'it''s here'");
-      expect(byName("made_at")?.default).toBe("CURRENT_TIMESTAMP");
+      const observed = live.tables[0];
+      expect(observed).toBeDefined();
+      // What the generator was given comes back unchanged, which is the
+      // property a snapshot needs to be rebuildable at all.
+      expect(observed!.columns.map(c => [c.name, c.default])).toEqual(
+        spec.columns.map(c => [c.name, c.default])
+      );
+      expect(observed!.columns.find(c => c.name === "id")?.primaryKey).toBe(
+        true
+      );
 
-      // And the whole thing rebuilds. This is the assertion that fails when a
-      // default is recorded in a form the server cannot read back.
-      for (const stmt of statements({ ...spec!, name: rebuilt }, "mysql")) {
+      // And it rebuilds from its own live snapshot.
+      for (const stmt of statements({ ...observed!, name: rebuilt }, "mysql")) {
         await conn.query(stmt);
       }
       const after = await introspectLiveSnapshot(db, "mysql", [rebuilt]);
       expect(after.tables[0]?.columns.map(c => c.default)).toEqual(
-        spec!.columns.map(c => c.default)
+        observed!.columns.map(c => c.default)
       );
 
       await conn.query(`DROP TABLE IF EXISTS \`${source}\``);
       await conn.query(`DROP TABLE IF EXISTS \`${rebuilt}\``);
+    }
+  );
+
+  it.skipIf(!MYSQL_URL)(
+    "mysql does not call a unique index the primary key",
+    async () => {
+      // `COLUMN_KEY` does not mean what its name suggests. A table with no
+      // primary key but a NOT NULL UNIQUE index reports `PRI` for that column,
+      // because InnoDB promotes such an index to the clustered key. Reading it
+      // would mark `slug` as the primary key, hiding a table that has none and
+      // rebuilding it elsewhere with the wrong one.
+      const conn = await mysql.createConnection(MYSQL_URL);
+      pools.push(() => conn.end());
+      const db = drizzleMysql({ client: conn });
+      const name = "dc_mysql_promoted";
+
+      await conn.query(`DROP TABLE IF EXISTS \`${name}\``);
+      await conn.query(
+        `CREATE TABLE \`${name}\` (slug varchar(40) NOT NULL UNIQUE, other varchar(10)) ENGINE=InnoDB`
+      );
+
+      const live = await introspectLiveSnapshot(db, "mysql", [name]);
+      expect(
+        live.tables[0]?.columns.filter(c => c.primaryKey === true)
+      ).toEqual([]);
+
+      await conn.query(`DROP TABLE IF EXISTS \`${name}\``);
     }
   );
 

--- a/packages/nextly/src/domains/schema/pipeline/sql-templates/create-table-body.ts
+++ b/packages/nextly/src/domains/schema/pipeline/sql-templates/create-table-body.ts
@@ -1,0 +1,81 @@
+/**
+ * The column list inside a generated `CREATE TABLE`.
+ *
+ * Shared by all three dialects because it was the same code in all three, and
+ * the one thing it had to say was missing from every copy: a column marked as
+ * the primary key was rendered as an ordinary `NOT NULL` column, so every table
+ * a migration created had no primary key at all. The desired snapshot has
+ * carried `primaryKey` since it was added for the diff's nullability exemption
+ * (`diff.ts`); only the renderer dropped it.
+ *
+ * `ALTER TABLE ... ADD COLUMN` deliberately does NOT come through here. No
+ * dialect accepts an inline `PRIMARY KEY` on an added column, and a table that
+ * already exists either has its key or needs a constraint statement rather than
+ * a column clause.
+ *
+ * @module domains/schema/pipeline/sql-templates/create-table-body
+ */
+import type { ColumnSpec, TableSpec } from "../diff/types";
+
+/** Quotes an identifier the way one dialect spells it. */
+export type QuoteIdentifier = (name: string) => string;
+
+/**
+ * One column, as it appears in a statement that is not creating the table.
+ *
+ * The primary key is not rendered here: this is what `ADD COLUMN` and the
+ * column-altering paths use, and none of them may declare a key.
+ */
+export function columnDefinition(c: ColumnSpec, q: QuoteIdentifier): string {
+  const nullable = c.nullable ? "" : " NOT NULL";
+  const def = c.default !== undefined ? ` DEFAULT ${c.default}` : "";
+  return `${q(c.name)} ${c.type}${nullable}${def}`;
+}
+
+/**
+ * One column, as it appears inside `CREATE TABLE`.
+ *
+ * `PRIMARY KEY` precedes `NOT NULL` to match the form drizzle-kit emits and
+ * the one `renderSystemColumnSql` already produces on the Builder path, so a
+ * table created by a migration and the same table created by the Builder read
+ * identically.
+ */
+function createTableColumn(c: ColumnSpec, q: QuoteIdentifier): string {
+  if (c.primaryKey !== true) return columnDefinition(c, q);
+  const nullable = c.nullable ? "" : " NOT NULL";
+  const def = c.default !== undefined ? ` DEFAULT ${c.default}` : "";
+  return `${q(c.name)} ${c.type} PRIMARY KEY${nullable}${def}`;
+}
+
+/**
+ * The full body of a `CREATE TABLE`: every column, and a table-level key when
+ * more than one column carries the marker.
+ *
+ * Every table Nextly generates today has a single-column key on `id`, which is
+ * why the inline form is the one that matches everything else. A composite key
+ * cannot be spelled inline at all — repeating `PRIMARY KEY` on two columns is
+ * a syntax error rather than a composite key — so it becomes a constraint. The
+ * two spellings are equivalent to the database; they are not equivalent to
+ * someone reading the file, which is why the common case keeps the short one.
+ */
+export function createTableBody(
+  table: TableSpec,
+  q: QuoteIdentifier,
+  indent = "  "
+): string {
+  const keyColumns = table.columns.filter(c => c.primaryKey === true);
+  const composite = keyColumns.length > 1;
+
+  const lines = table.columns.map(c =>
+    composite
+      ? `${indent}${columnDefinition(c, q)}`
+      : `${indent}${createTableColumn(c, q)}`
+  );
+
+  if (composite) {
+    const cols = keyColumns.map(c => q(c.name)).join(", ");
+    lines.push(`${indent}PRIMARY KEY (${cols})`);
+  }
+
+  return lines.join(",\n");
+}

--- a/packages/nextly/src/domains/schema/pipeline/sql-templates/mysql.ts
+++ b/packages/nextly/src/domains/schema/pipeline/sql-templates/mysql.ts
@@ -26,14 +26,13 @@ import type {
   RenameTableOp,
 } from "../diff/types";
 
+import { columnDefinition, createTableBody } from "./create-table-body";
 import { quoteIdent } from "./identifier-quoting";
 
 const q = (n: string) => quoteIdent(n, "mysql");
 
 function columnDef(c: ColumnSpec): string {
-  const nullable = c.nullable ? "" : " NOT NULL";
-  const def = c.default !== undefined ? ` DEFAULT ${c.default}` : "";
-  return `${q(c.name)} ${c.type}${nullable}${def}`;
+  return columnDefinition(c, q);
 }
 
 export function generateMysqlSQL(op: Operation): string {
@@ -85,7 +84,7 @@ function generateDropIndex(op: DropIndexOp): string {
 }
 
 function generateAddTable(op: AddTableOp): string {
-  const cols = op.table.columns.map(c => `  ${columnDef(c)}`).join(",\n");
+  const cols = createTableBody(op.table, q);
   const createTable = `CREATE TABLE ${q(op.table.name)} (\n${cols}\n)`;
   const indexStmts = (op.table.indexes ?? []).map(i =>
     createIndexStatement(op.table.name, i)

--- a/packages/nextly/src/domains/schema/pipeline/sql-templates/postgres.ts
+++ b/packages/nextly/src/domains/schema/pipeline/sql-templates/postgres.ts
@@ -21,14 +21,13 @@ import type {
   RenameTableOp,
 } from "../diff/types";
 
+import { columnDefinition, createTableBody } from "./create-table-body";
 import { quoteIdent } from "./identifier-quoting";
 
 const q = (n: string) => quoteIdent(n, "postgresql");
 
 function columnDef(c: ColumnSpec): string {
-  const nullable = c.nullable ? "" : " NOT NULL";
-  const def = c.default !== undefined ? ` DEFAULT ${c.default}` : "";
-  return `${q(c.name)} ${c.type}${nullable}${def}`;
+  return columnDefinition(c, q);
 }
 
 export function generatePgSQL(op: Operation): string {
@@ -79,7 +78,7 @@ function generateDropIndex(op: DropIndexOp): string {
 }
 
 function generateAddTable(op: AddTableOp): string {
-  const cols = op.table.columns.map(c => `  ${columnDef(c)}`).join(",\n");
+  const cols = createTableBody(op.table, q);
   const createTable = `CREATE TABLE ${q(op.table.name)} (\n${cols}\n)`;
   // Render the table's tracked indexes as separate statements after CREATE
   // TABLE. When `indexes` is undefined (pre-C1 sentinel) none are emitted.

--- a/packages/nextly/src/domains/schema/pipeline/sql-templates/sqlite.ts
+++ b/packages/nextly/src/domains/schema/pipeline/sql-templates/sqlite.ts
@@ -31,14 +31,13 @@ import type {
   RenameTableOp,
 } from "../diff/types";
 
+import { columnDefinition, createTableBody } from "./create-table-body";
 import { quoteIdent } from "./identifier-quoting";
 
 const q = (n: string) => quoteIdent(n, "sqlite");
 
 function columnDef(c: ColumnSpec): string {
-  const nullable = c.nullable ? "" : " NOT NULL";
-  const def = c.default !== undefined ? ` DEFAULT ${c.default}` : "";
-  return `${q(c.name)} ${c.type}${nullable}${def}`;
+  return columnDefinition(c, q);
 }
 
 export class SqliteUnsupportedOperationError extends Error {
@@ -108,7 +107,7 @@ function generateDropIndex(op: DropIndexOp): string {
 }
 
 function generateAddTable(op: AddTableOp): string {
-  const cols = op.table.columns.map(c => `  ${columnDef(c)}`).join(",\n");
+  const cols = createTableBody(op.table, q);
   const createTable = `CREATE TABLE ${q(op.table.name)} (\n${cols}\n)`;
   const indexStmts = (op.table.indexes ?? []).map(i =>
     createIndexStatement(op.table.name, i)


### PR DESCRIPTION
**P0.** Every table created by `nextly migrate` has no primary key. Found while chasing a Codex finding on #551; it is not a baselining bug and it predates that PR.

## Reproduction — a plain project, nothing to do with baselining

```
$ nextly migrate:create --name init
$ grep -c 'PRIMARY KEY' src/db/migrations/*init.sql
0

CREATE TABLE "dc_posts" (
  "id" text NOT NULL,      -- not a primary key
  ...
```

`generateSQL({type:"add_table"})` renders columns through a `columnDef` that emits `name type [NOT NULL] [DEFAULT ...]` and never `PRIMARY KEY` — identically in all three dialect modules. The desired snapshot has carried `ColumnSpec.primaryKey` since it was added for the diff's nullability exemption (`diff.ts:191`), and `build-from-fields` sets it on every collection, single and component `id`. **The information was always there; only the renderer dropped it.**

## Consequences

- **No uniqueness enforcement on `id`.** Two rows can carry the same id and nothing at the database level refuses it.
- **No primary-key index**, so every lookup by id is a scan.
- **No replica identity on PostgreSQL**, which breaks logical replication and CDC tooling.

## Why it survived this long

The Builder path was already correct — `renderSystemColumnSql` (`field-column-descriptor.ts:784`) emits `PRIMARY KEY`. `db:sync` and the Schema Builder produce keyed tables; only the migration path does not. The dev loop looks right and production does not.

## The fix

One `createTableBody` shared by all three dialects, because it was the same code in each and the same clause was missing from each.

- **Single key column → inline `PRIMARY KEY`**, matching drizzle-kit's canonical form and `renderSystemColumnSql`, so a table reads identically whichever path built it.
- **More than one → a table-level `PRIMARY KEY (...)` constraint.** Repeating the inline form is a syntax error, not a composite key. No table Nextly generates has one today; the branch exists because the alternative is invalid SQL rather than a wrong key.
- **`ALTER TABLE ... ADD COLUMN` keeps the key-less renderer.** No dialect accepts an inline key on a column added to a table that already exists.

Live introspection now records the key too — `pg_index.indisprimary`, MySQL's `COLUMN_KEY = 'PRI'`, and SQLite's `PRAGMA table_info.pk`, **which PRAGMA has always returned and nothing read**. A snapshot taken from a live database described a key-less schema, so anything generating statements from one rebuilt the schema without keys. This is also what unblocks #551.

## Verification

The per-dialect tests **execute the generated statement against a real database and introspect the result back**, rather than asserting on the SQL text — the three dialects disagree about where `PRIMARY KEY` may sit relative to `NOT NULL`, and only the database settles it. Passing on PostgreSQL 17, MySQL 8 and SQLite.

Mutation-checked: with the renderer reverted, 4 of the 5 tests fail on all three dialects. The one that stays green is the `ADD COLUMN` case, which is correct.

Unit-suite failing-test **name sets** compared against a worktree at `origin/main`: 341 on this branch vs 347 on main, and the only name not on main's list is a password-hashing test that passes in isolation and is unrelated.

One existing unit test changed. `introspect-live.test.ts` fed a SQLite fixture with `pk: 1` and then asserted the column came back **without** a key — it was pinning the defect. The PostgreSQL and MySQL fixtures in the same file omitted the key columns that a real driver always returns, so those were made realistic too rather than left permissive.

## Deliberately not in this PR

**Existing databases keep their key-less tables.** New migrations declare the key; nothing repairs a table already created without one. That is a decision, not a follow-up commit — adding a primary key to a populated table can fail on duplicate ids, and SQLite cannot add one by `ALTER` at all (task 127). Options are weighed in `tasks/left-tasks/142-generated-create-table-declares-no-primary-key.md`; my recommendation is to surface it in `migrate:check` first, then generate a corrective migration once an `add_primary_key` operation exists.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added primary-key support for PostgreSQL, MySQL, and SQLite schema introspection.
  * Generated table definitions now support single-column and composite primary keys.
  * MySQL defaults are preserved and correctly formatted, including strings, numbers, and expressions.

* **Bug Fixes**
  * Prevented unique indexes from being incorrectly reported as primary keys.
  * Ensured added columns do not incorrectly declare primary keys.

* **Tests**
  * Added cross-database integration coverage for primary keys, defaults, and schema round-tripping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->