### PR TITLE
feat(nextly): open a scoped draft session from a preview link

### DIFF
--- a/.changeset/preview-route.md
+++ b/.changeset/preview-route.md
@@ -1,0 +1,38 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+Draft previews no longer need an API key. A preview link now opens a draft session for
+exactly one entry: `createPreviewRoute` checks the token, turns on Next's draft mode, and carries
+the token onward in an httpOnly cookie so the rest of the request knows which document that session
+covers.
+
+The scope has to travel separately because Next's draft mode is a single boolean for the whole
+host — turning it on without it would let a link meant for one unpublished page unlock every
+unpublished page. `readPreviewScope` re-checks the token on every read rather than trusting that
+the route once said yes, so expiry and revocation reach sessions already in flight, and
+`previewGrantsDraft` answers the one question a read path should ask.
+
+Every refusal looks the same — a 404 with no cookie and no draft mode — so the endpoint cannot be
+used to discover which entries have drafts.

--- a/packages/nextly/src/auth/index.ts
+++ b/packages/nextly/src/auth/index.ts
@@ -66,3 +66,16 @@ export {
 
 export { routeAuthRequest } from "./handlers/router";
 export type { AuthRouterDeps } from "./handlers/router";
+
+// Preview tokens — minting and checking scoped, short-lived draft links. The
+// route that consumes them lives in `nextly/runtime`, since only that half
+// touches Next.
+export {
+  DEFAULT_PREVIEW_TTL_SECONDS,
+  previewTokenCovers,
+  signPreviewToken,
+  verifyPreviewToken,
+  type PreviewTokenScope,
+  type PreviewVerifyResult,
+  type SignPreviewTokenOptions,
+} from "./preview/preview-token";

--- a/packages/nextly/src/runtime.ts
+++ b/packages/nextly/src/runtime.ts
@@ -54,6 +54,19 @@ export {
   type SeoMetaInput,
 } from "./runtime/seo";
 
+// Draft previews — the route that turns a scoped preview link into a draft
+// session, and the reader a read path asks what that session may see. `next` is
+// not imported at all: the caller passes `draftMode` and `cookies` in, which
+// also keeps both testable without a request.
+export {
+  PREVIEW_SCOPE_COOKIE,
+  createPreviewRoute,
+  readPreviewScope,
+  previewGrantsDraft,
+  type PreviewRouteConfig,
+  type PreviewScopeReaderConfig,
+} from "./runtime/preview/preview-route";
+
 // Content routing + sitemap/robots delivery. `next`/`react` are type-only and
 // `next/navigation` resolves lazily, so importing these never forces them.
 export {

--- a/packages/nextly/src/runtime/preview/__tests__/preview-route.test.ts
+++ b/packages/nextly/src/runtime/preview/__tests__/preview-route.test.ts
@@ -134,6 +134,10 @@ describe("the preview route", () => {
 
       for (const target of [
         "//evil.example/x",
+        // A special scheme normalises a backslash to a slash, so these resolve
+        // to another host while still starting with a single "/".
+        "/\\evil.example/x",
+        "/\\\\evil.example/x",
         "https://evil.example/x",
         "javascript:alert(1)",
       ]) {
@@ -144,6 +148,50 @@ describe("the preview route", () => {
         expect(enable).not.toHaveBeenCalled();
       }
     });
+  });
+});
+
+describe("request input the reader must survive", () => {
+  it("treats a cookie that cannot be decoded as no session", async () => {
+    // A cookie is request input whoever wrote it, and "%" alone makes
+    // decodeURIComponent throw — which would answer a page request with a 500
+    // rather than simply no preview.
+    const scope = await readPreviewScope({
+      secret: TEST_SECRET,
+      generation: GENERATION,
+      cookies: () => Promise.resolve({ get: () => ({ value: "%" }) }),
+    });
+
+    expect(scope).toBeNull();
+  });
+
+  it("accepts synchronous cookies(), as Next 14 supplies", async () => {
+    // The peer range covers Next 14, where these helpers are synchronous.
+    const scope = await readPreviewScope({
+      secret: TEST_SECRET,
+      generation: GENERATION,
+      cookies: () => ({ get: () => undefined }),
+    });
+
+    expect(scope).toBeNull();
+  });
+
+  it("accepts a synchronous draftMode(), as Next 14 supplies", async () => {
+    const { token } = await signPreviewToken(SCOPE, TEST_SECRET, {
+      generation: GENERATION,
+    });
+    const enable = vi.fn();
+    const route = createPreviewRoute({
+      secret: TEST_SECRET,
+      generation: GENERATION,
+      redirectTo: () => "/pages/entry-1",
+      draftMode: () => ({ enable }),
+    });
+
+    const response = await route.GET(request(token));
+
+    expect(response.status).toBe(307);
+    expect(enable).toHaveBeenCalledOnce();
   });
 });
 

--- a/packages/nextly/src/runtime/preview/__tests__/preview-route.test.ts
+++ b/packages/nextly/src/runtime/preview/__tests__/preview-route.test.ts
@@ -6,6 +6,8 @@ import {
   createPreviewRoute,
   previewGrantsDraft,
   readPreviewScope,
+  type PreviewRouteConfig,
+  type PreviewScopeReaderConfig,
 } from "../preview-route";
 
 const TEST_SECRET = "preview-route-test-secret-at-least-32-chars!!";
@@ -140,14 +142,166 @@ describe("the preview route", () => {
         "/\\\\evil.example/x",
         "https://evil.example/x",
         "javascript:alert(1)",
+        // Not off-site, but not a path either: a bare relative target resolves
+        // against the ROUTE's own directory, so it would silently send the
+        // visitor somewhere under /api rather than where the app meant.
+        "pages/entry-1",
+        // No fixed sentinel origin can be named to slip past the check, because
+        // there is no fixed sentinel origin: the target is resolved against the
+        // request's own.
+        "//nextly.invalid/x",
+        "///nextly.invalid/x",
       ]) {
         const { route, enable } = routeFor({ redirectTo: () => target });
         const response = await route.GET(request(token));
 
         expect(response.status).toBe(404);
+        expect(response.headers.get("location")).toBeNull();
         expect(enable).not.toHaveBeenCalled();
       }
     });
+
+    it("refuses a link whose target cannot be resolved", async () => {
+      // A preview link outlives what it points at. When the entry has been
+      // deleted since the link was minted, the app's lookup rejects — and a 500
+      // here while every other failure answers 404 would make the endpoint an
+      // oracle again, separating entries that once existed from those that
+      // never did.
+      const { token } = await signPreviewToken(SCOPE, TEST_SECRET, {
+        generation: GENERATION,
+      });
+
+      for (const redirectTo of [
+        () => {
+          throw new Error("entry was deleted");
+        },
+        () => Promise.reject(new Error("entry was deleted")),
+        // Saying so without throwing, which is the shape an app should reach
+        // for first.
+        () => null,
+      ]) {
+        const { route, enable } = routeFor({ redirectTo });
+        const response = await route.GET(request(token));
+
+        expect(response.status).toBe(404);
+        expect(response.headers.get("set-cookie")).toBeNull();
+        expect(enable).not.toHaveBeenCalled();
+      }
+    });
+
+    it("sends the normalised target rather than the string it checked", async () => {
+      // CR, LF and NUL in a path — from a slug field, say — make the `Response`
+      // constructor throw when they reach a header raw. Emitting what the URL
+      // parser produced closes the gap between the value that was validated and
+      // the value that is used: the parser strips CR and LF and percent-encodes
+      // NUL, so the header cannot carry a second one.
+      const { token } = await signPreviewToken(SCOPE, TEST_SECRET, {
+        generation: GENERATION,
+      });
+      const CR = String.fromCharCode(13);
+      const LF = String.fromCharCode(10);
+      const NUL = String.fromCharCode(0);
+
+      for (const target of [
+        `/pages/a${CR}${LF}X-Injected: yes`,
+        `/pages/a${LF}X-Injected: yes`,
+        `/pages/a${NUL}b`,
+      ]) {
+        const { route, enable } = routeFor({ redirectTo: () => target });
+        const response = await route.GET(request(token));
+
+        expect(response.status).toBe(307);
+        const location = response.headers.get("location") ?? "";
+        expect(location).not.toContain(CR);
+        expect(location).not.toContain(LF);
+        expect(location).not.toContain(NUL);
+        expect(response.headers.get("x-injected")).toBeNull();
+        expect(enable).toHaveBeenCalledOnce();
+      }
+    });
+
+    it("keeps the query and fragment of a target it accepts", async () => {
+      // Normalising must not quietly drop the parts of a path a preview link
+      // needs — a locale query or an anchor into the page being reviewed.
+      const { token } = await signPreviewToken(SCOPE, TEST_SECRET, {
+        generation: GENERATION,
+      });
+      const { route } = routeFor({
+        redirectTo: () => "/pages/entry-1?locale=fr#section-2",
+      });
+
+      const response = await route.GET(request(token));
+
+      expect(response.headers.get("location")).toBe(
+        "/pages/entry-1?locale=fr#section-2"
+      );
+    });
+  });
+});
+
+/**
+ * The shape Next's own cookie store hands back: more than this reader needs,
+ * which is the point — the exported type has to accept it.
+ */
+interface NextRequestCookie {
+  name: string;
+  value: string;
+}
+const storedCookie: NextRequestCookie = {
+  name: PREVIEW_SCOPE_COOKIE,
+  value: "",
+};
+
+describe("the reader shapes both supported Next majors supply", () => {
+  // These are COMPILE-time assertions. Vitest does not typecheck, so a runtime
+  // test of a sync reader passes whatever the exported signature says; what
+  // makes these load-bearing is `tsc --noEmit -p tsconfig.tests.json`, which
+  // CI runs. An app on Next 14 gets synchronous helpers and one on Next 15 gets
+  // promises, and the peer range covers both, so a signature that required
+  // either alone would fail to typecheck in half the supported apps.
+  const next14Cookies: PreviewScopeReaderConfig["cookies"] = () => ({
+    get: (_name: string): NextRequestCookie | undefined => storedCookie,
+  });
+  const next15Cookies: PreviewScopeReaderConfig["cookies"] = () =>
+    Promise.resolve({
+      get: (_name: string): NextRequestCookie | undefined => storedCookie,
+    });
+  const next14Draft: PreviewRouteConfig["draftMode"] = () => ({
+    enable: () => undefined,
+  });
+  const next15Draft: PreviewRouteConfig["draftMode"] = () =>
+    Promise.resolve({ enable: () => undefined });
+
+  it("reads a cookie store from either major", async () => {
+    for (const cookies of [next14Cookies, next15Cookies]) {
+      // The stored value is empty, so this exercises the call rather than a
+      // grant; the assertion that matters is that both assignments above
+      // compile.
+      expect(
+        await readPreviewScope({
+          secret: TEST_SECRET,
+          generation: GENERATION,
+          cookies,
+        })
+      ).toBeNull();
+    }
+  });
+
+  it("enables draft mode from either major", async () => {
+    const { token } = await signPreviewToken(SCOPE, TEST_SECRET, {
+      generation: GENERATION,
+    });
+
+    for (const draftMode of [next14Draft, next15Draft]) {
+      const response = await createPreviewRoute({
+        secret: TEST_SECRET,
+        generation: GENERATION,
+        redirectTo: () => "/pages/entry-1",
+        draftMode,
+      }).GET(request(token));
+
+      expect(response.status).toBe(307);
+    }
   });
 });
 

--- a/packages/nextly/src/runtime/preview/__tests__/preview-route.test.ts
+++ b/packages/nextly/src/runtime/preview/__tests__/preview-route.test.ts
@@ -1,0 +1,214 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { signPreviewToken } from "../../../auth/preview/preview-token";
+import {
+  PREVIEW_SCOPE_COOKIE,
+  createPreviewRoute,
+  previewGrantsDraft,
+  readPreviewScope,
+} from "../preview-route";
+
+const TEST_SECRET = "preview-route-test-secret-at-least-32-chars!!";
+const GENERATION = 1;
+const SCOPE = { collection: "pages", entryId: "entry-1" };
+
+/** A draft-mode double that records whether the route enabled it. */
+function draftModeDouble() {
+  const enable = vi.fn();
+  return { enable, draftMode: () => Promise.resolve({ enable }) };
+}
+
+function routeFor(
+  overrides: Partial<Parameters<typeof createPreviewRoute>[0]> = {}
+) {
+  const draft = draftModeDouble();
+  const route = createPreviewRoute({
+    secret: TEST_SECRET,
+    generation: GENERATION,
+    redirectTo: scope => `/${scope.collection}/${scope.entryId}`,
+    draftMode: draft.draftMode,
+    ...overrides,
+  });
+  return { route, enable: draft.enable };
+}
+
+function request(token?: string): Request {
+  const url = new URL("https://site.example/api/preview");
+  if (token !== undefined) url.searchParams.set("token", token);
+  return new Request(url);
+}
+
+function cookiesFrom(response: Response) {
+  const header = response.headers.get("set-cookie") ?? "";
+  const value = /__nextly_preview=([^;]*)/.exec(header)?.[1];
+  return {
+    header,
+    get: (name: string) =>
+      name === PREVIEW_SCOPE_COOKIE && value !== undefined
+        ? { value }
+        : undefined,
+  };
+}
+
+describe("the preview route", () => {
+  it("starts a draft session and sends the visitor to the document", async () => {
+    const { token } = await signPreviewToken(SCOPE, TEST_SECRET, {
+      generation: GENERATION,
+    });
+    const { route, enable } = routeFor();
+
+    const response = await route.GET(request(token));
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get("location")).toBe("/pages/entry-1");
+    expect(enable).toHaveBeenCalledOnce();
+  });
+
+  it("carries the scope in an httpOnly cookie that dies with the token", async () => {
+    // Next's draft mode is one boolean for the whole host, so the cookie is
+    // what keeps a link meant for ONE page from unlocking every draft.
+    const { token, expiresAt } = await signPreviewToken(SCOPE, TEST_SECRET, {
+      generation: GENERATION,
+    });
+    const { route } = routeFor();
+
+    const header = cookiesFrom(await route.GET(request(token))).header;
+
+    expect(header).toContain("HttpOnly");
+    expect(header).toContain("SameSite=Lax");
+    expect(header).toContain("Secure");
+    expect(header).toContain(`Expires=${expiresAt.toUTCString()}`);
+  });
+
+  describe("refusals", () => {
+    const cases: Array<[string, () => Promise<Request>]> = [
+      ["no token at all", () => Promise.resolve(request())],
+      ["an empty token", () => Promise.resolve(request(""))],
+      ["a garbage token", () => Promise.resolve(request("not-a-jwt"))],
+      [
+        "a token signed with another secret",
+        async () =>
+          request(
+            (
+              await signPreviewToken(SCOPE, `${TEST_SECRET}-other`, {
+                generation: GENERATION,
+              })
+            ).token
+          ),
+      ],
+      [
+        "a revoked token",
+        async () =>
+          request(
+            (
+              await signPreviewToken(SCOPE, TEST_SECRET, {
+                generation: GENERATION - 1,
+              })
+            ).token
+          ),
+      ],
+    ];
+
+    for (const [label, build] of cases) {
+      it(`answers 404 to ${label}, and identically`, async () => {
+        const { route, enable } = routeFor();
+
+        const response = await route.GET(await build());
+
+        // Every failure looks the same: anything else makes the endpoint an
+        // oracle for which entries have unpublished drafts.
+        expect(response.status).toBe(404);
+        expect(response.headers.get("set-cookie")).toBeNull();
+        expect(response.headers.get("location")).toBeNull();
+        expect(enable).not.toHaveBeenCalled();
+      });
+    }
+
+    it("refuses to redirect anywhere but this site", async () => {
+      // The target comes from the app rather than the request, so this guards a
+      // mistake — but an open redirect wearing a preview link is worth making
+      // unreachable.
+      const { token } = await signPreviewToken(SCOPE, TEST_SECRET, {
+        generation: GENERATION,
+      });
+
+      for (const target of [
+        "//evil.example/x",
+        "https://evil.example/x",
+        "javascript:alert(1)",
+      ]) {
+        const { route, enable } = routeFor({ redirectTo: () => target });
+        const response = await route.GET(request(token));
+
+        expect(response.status).toBe(404);
+        expect(enable).not.toHaveBeenCalled();
+      }
+    });
+  });
+});
+
+describe("what a preview session may read", () => {
+  async function sessionFor(scope = SCOPE, generation = GENERATION) {
+    const { token } = await signPreviewToken(scope, TEST_SECRET, {
+      generation,
+    });
+    const { route } = routeFor();
+    return cookiesFrom(await route.GET(request(token)));
+  }
+
+  it("reports the document the link named", async () => {
+    const store = await sessionFor();
+
+    const scope = await readPreviewScope({
+      secret: TEST_SECRET,
+      generation: GENERATION,
+      cookies: () => Promise.resolve(store),
+    });
+
+    expect(scope).toEqual(SCOPE);
+  });
+
+  it("grants that document and refuses every other", async () => {
+    const store = await sessionFor();
+    const scope = await readPreviewScope({
+      secret: TEST_SECRET,
+      generation: GENERATION,
+      cookies: () => Promise.resolve(store),
+    });
+
+    expect(previewGrantsDraft(scope, SCOPE)).toBe(true);
+    expect(
+      previewGrantsDraft(scope, { collection: "pages", entryId: "entry-2" })
+    ).toBe(false);
+    expect(
+      previewGrantsDraft(scope, { collection: "posts", entryId: "entry-1" })
+    ).toBe(false);
+    // No session at all grants nothing, which is the default for every visitor.
+    expect(previewGrantsDraft(null, SCOPE)).toBe(false);
+  });
+
+  it("stops granting the moment the generation moves", async () => {
+    // The session is re-verified on every read rather than trusted because the
+    // route once said yes, so revoking reaches sessions already in flight.
+    const store = await sessionFor();
+
+    const scope = await readPreviewScope({
+      secret: TEST_SECRET,
+      generation: GENERATION + 1,
+      cookies: () => Promise.resolve(store),
+    });
+
+    expect(scope).toBeNull();
+    expect(previewGrantsDraft(scope, SCOPE)).toBe(false);
+  });
+
+  it("reports nothing when there is no cookie", async () => {
+    const scope = await readPreviewScope({
+      secret: TEST_SECRET,
+      generation: GENERATION,
+      cookies: () => Promise.resolve({ get: () => undefined }),
+    });
+
+    expect(scope).toBeNull();
+  });
+});

--- a/packages/nextly/src/runtime/preview/preview-route.ts
+++ b/packages/nextly/src/runtime/preview/preview-route.ts
@@ -137,10 +137,13 @@ export function createPreviewRoute(config: PreviewRouteConfig): {
 export interface PreviewScopeReaderConfig {
   secret: string;
   generation: number | (() => number | Promise<number>);
-  /** Reads the request's cookies. Injected so the reader is testable. */
-  cookies: () => Promise<{
-    get: (name: string) => { value: string } | undefined;
-  }>;
+  /**
+   * Reads the request's cookies. Injected so the reader is testable, and
+   * accepting a synchronous return for the same reason `draftMode` does.
+   */
+  cookies: () =>
+    | { get: (name: string) => { value: string } | undefined }
+    | Promise<{ get: (name: string) => { value: string } | undefined }>;
 }
 
 /**

--- a/packages/nextly/src/runtime/preview/preview-route.ts
+++ b/packages/nextly/src/runtime/preview/preview-route.ts
@@ -39,8 +39,15 @@ export interface PreviewRouteConfig {
    *
    * Supplied by the app because only it knows how its content is routed. The
    * returned value must be a site-relative path.
+   *
+   * Returning `null` refuses the link the same way an invalid token is
+   * refused. A preview link outlives what it points at — the entry can be
+   * deleted, unpublished or moved between minting and clicking — and this is
+   * how an app says so without having to throw.
    */
-  redirectTo: (scope: PreviewTokenScope) => string | Promise<string>;
+  redirectTo: (
+    scope: PreviewTokenScope
+  ) => string | null | Promise<string | null>;
   /**
    * Reads and enables Next's draft mode. Injected so the route is testable.
    *
@@ -52,27 +59,49 @@ export interface PreviewRouteConfig {
 }
 
 /**
- * Whether a redirect target is somewhere this site can send a visitor.
+ * A redirect target reduced to its site-relative form, or `null` if it is not
+ * one.
  *
  * The value comes from the app rather than the request, so this guards a
- * mistake rather than an attack — but an open redirect built out of a
- * preview link is worth making unreachable by construction. A protocol-relative
+ * mistake rather than an attack — but an open redirect built out of a preview
+ * link is worth making unreachable by construction. A protocol-relative
  * `//evil.example` is a URL to another host wearing a path's clothes, which is
  * why matching a leading slash is not enough on its own.
+ *
+ * Two decisions, both about closing the gap between what is checked and what is
+ * used:
+ *
+ * 1. **Resolved against the REQUEST's origin**, not a fixed sentinel. Any
+ *    constant used as the base is a host that passes the check, and a public
+ *    one is a host anybody can name: `//nextly.invalid/x` would be approved and
+ *    then sent, taking the visitor off the site. Resolving against the request
+ *    leaves exactly one origin that passes, and it is the site's own.
+ * 2. **Returns the parser's normalized form** rather than the string that was
+ *    checked, so the value that reaches the `Location` header is the value that
+ *    was validated. The parser strips CR and LF and percent-encodes NUL; the
+ *    raw string keeps them, and a header carrying one makes the `Response`
+ *    constructor throw — which would happen after draft mode had been enabled,
+ *    turning a refusal into a 500 with a session already granted.
+ *
+ * Resolution is the URL parser's job rather than this function's, because the
+ * spellings that escape an origin are its to know: `//host`, `/\host` and
+ * `/\\host` all reach another origin, since a special scheme normalises a
+ * backslash to a slash. Asking the same parser the browser will use is the only
+ * check that cannot fall behind the list.
  */
-function isSiteRelative(path: string): boolean {
-  if (!path.startsWith("/")) return false;
+function siteRelativeTarget(target: string, requestUrl: string): string | null {
+  // Tested before parsing rather than after. `https://elsewhere` and
+  // `javascript:` would be caught by the origin comparison below, but a bare
+  // `pages/x` resolves against the CURRENT path and would pass as a
+  // site-relative target the app never meant to write.
+  if (!target.startsWith("/")) return null;
   try {
-    // Resolved against a base rather than pattern-matched, because the
-    // spellings that escape an origin are the URL parser's to know and not
-    // this function's to guess: `//host`, `/\\host` and `/\\\\host` all resolve
-    // to another origin, since a special scheme normalises a backslash to a
-    // slash. Asking the same parser the browser will use is the only check
-    // that cannot fall behind the list.
-    const base = "https://nextly.invalid";
-    return new URL(path, base).origin === base;
+    const base = new URL(requestUrl);
+    const resolved = new URL(target, base);
+    if (resolved.origin !== base.origin) return null;
+    return `${resolved.pathname}${resolved.search}${resolved.hash}`;
   } catch {
-    return false;
+    return null;
   }
 }
 
@@ -104,15 +133,27 @@ export function createPreviewRoute(config: PreviewRouteConfig): {
       });
       if (!verified.valid) return refuse();
 
-      const target = await config.redirectTo(verified.scope);
-      if (!isSiteRelative(target)) return refuse();
+      // Everything that can fail happens before draft mode is enabled, so the
+      // request is never given a session it is then refused. A lookup here is
+      // the likeliest thing to reject: a link outlives what it points at, and
+      // the entry can be deleted between minting and clicking. Answering that
+      // with a 500 while every other failure answers 404 is what would make the
+      // endpoint an oracle again — a stranger could tell an entry that once
+      // existed from one that never did.
+      let target: string | null;
+      try {
+        target = await config.redirectTo(verified.scope);
+      } catch {
+        return refuse();
+      }
+      if (target === null) return refuse();
 
-      const draft = await config.draftMode();
-      draft.enable();
+      const location = siteRelativeTarget(target, request.url);
+      if (location === null) return refuse();
 
       const response = new Response(null, {
         status: 307,
-        headers: { location: target },
+        headers: { location },
       });
       // `httpOnly` because nothing in the browser needs to read this, and
       // `sameSite=lax` so the cookie survives following the link from an email
@@ -129,6 +170,14 @@ export function createPreviewRoute(config: PreviewRouteConfig): {
           `Expires=${verified.expiresAt.toUTCString()}`,
         ].join("; ")
       );
+
+      // Last, once the response it belongs to exists. Draft mode is a mutation
+      // on the outgoing request, and enabling it before a step that can still
+      // refuse would leave the visitor holding a draft session for a request
+      // that answered 404.
+      const draft = await config.draftMode();
+      draft.enable();
+
       return response;
     },
   };

--- a/packages/nextly/src/runtime/preview/preview-route.ts
+++ b/packages/nextly/src/runtime/preview/preview-route.ts
@@ -41,8 +41,14 @@ export interface PreviewRouteConfig {
    * returned value must be a site-relative path.
    */
   redirectTo: (scope: PreviewTokenScope) => string | Promise<string>;
-  /** Reads and enables Next's draft mode. Injected so the route is testable. */
-  draftMode: () => Promise<{ enable: () => void }>;
+  /**
+   * Reads and enables Next's draft mode. Injected so the route is testable.
+   *
+   * Accepts a synchronous return as well: `draftMode()` is sync on Next 14 and
+   * async from 15, and the peer range covers both, so requiring a promise would
+   * make the natural import fail to typecheck on the older one.
+   */
+  draftMode: () => { enable: () => void } | Promise<{ enable: () => void }>;
 }
 
 /**
@@ -55,7 +61,19 @@ export interface PreviewRouteConfig {
  * why matching a leading slash is not enough on its own.
  */
 function isSiteRelative(path: string): boolean {
-  return path.startsWith("/") && !path.startsWith("//");
+  if (!path.startsWith("/")) return false;
+  try {
+    // Resolved against a base rather than pattern-matched, because the
+    // spellings that escape an origin are the URL parser's to know and not
+    // this function's to guess: `//host`, `/\\host` and `/\\\\host` all resolve
+    // to another origin, since a special scheme normalises a backslash to a
+    // slash. Asking the same parser the browser will use is the only check
+    // that cannot fall behind the list.
+    const base = "https://nextly.invalid";
+    return new URL(path, base).origin === base;
+  } catch {
+    return false;
+  }
 }
 
 /**
@@ -145,11 +163,19 @@ export async function readPreviewScope(
       ? await config.generation()
       : config.generation;
 
-  const verified = await verifyPreviewToken(
-    decodeURIComponent(raw),
-    config.secret,
-    { generation }
-  );
+  // A cookie is request input whoever sent it, and `%` alone makes
+  // `decodeURIComponent` throw — which would answer a page request with a 500
+  // rather than simply no preview session.
+  let token: string;
+  try {
+    token = decodeURIComponent(raw);
+  } catch {
+    return null;
+  }
+
+  const verified = await verifyPreviewToken(token, config.secret, {
+    generation,
+  });
   return verified.valid ? verified.scope : null;
 }
 

--- a/packages/nextly/src/runtime/preview/preview-route.ts
+++ b/packages/nextly/src/runtime/preview/preview-route.ts
@@ -1,0 +1,169 @@
+import {
+  previewTokenCovers,
+  verifyPreviewToken,
+  type PreviewTokenScope,
+} from "../../auth/preview/preview-token";
+
+/**
+ * The route that turns a preview link into a draft-reading session, and the
+ * reader that tells the rest of the request what that session may see.
+ *
+ * **Why a cookie carries the token rather than a decision.** Next's draft mode
+ * is a single boolean: `draftMode().enable()` sets `__prerender_bypass` for the
+ * whole host, and nothing about it names a document. A preview token names
+ * exactly one. Enabling draft mode alone would therefore turn a link meant for
+ * one unpublished page into a key to every unpublished page on the site — the
+ * opposite of what the token was scoped for.
+ *
+ * So the scope travels beside it: the token itself is stored, httpOnly, and
+ * re-verified on every read. Storing the token rather than a decision derived
+ * from it means expiry and revocation keep applying for the life of the
+ * session, not just at the moment the link was clicked.
+ *
+ * @module runtime/preview/preview-route
+ */
+
+/** The cookie carrying the preview token for the rest of the session. */
+export const PREVIEW_SCOPE_COOKIE = "__nextly_preview";
+
+export interface PreviewRouteConfig {
+  /** The signing secret; the same `NEXTLY_SECRET` sessions use. */
+  secret: string;
+  /**
+   * The site's current revocation generation. Read per request so raising it
+   * ends existing preview sessions rather than only refusing new links.
+   */
+  generation: number | (() => number | Promise<number>);
+  /**
+   * Where to send the visitor once the link checks out.
+   *
+   * Supplied by the app because only it knows how its content is routed. The
+   * returned value must be a site-relative path.
+   */
+  redirectTo: (scope: PreviewTokenScope) => string | Promise<string>;
+  /** Reads and enables Next's draft mode. Injected so the route is testable. */
+  draftMode: () => Promise<{ enable: () => void }>;
+}
+
+/**
+ * Whether a redirect target is somewhere this site can send a visitor.
+ *
+ * The value comes from the app rather than the request, so this guards a
+ * mistake rather than an attack — but an open redirect built out of a
+ * preview link is worth making unreachable by construction. A protocol-relative
+ * `//evil.example` is a URL to another host wearing a path's clothes, which is
+ * why matching a leading slash is not enough on its own.
+ */
+function isSiteRelative(path: string): boolean {
+  return path.startsWith("/") && !path.startsWith("//");
+}
+
+/**
+ * A route handler that accepts a preview link and starts a draft session.
+ *
+ * Every failure answers exactly the same way: 404, no body, no cookie, no draft
+ * mode. A token that is expired, revoked, forged or simply absent must not be
+ * distinguishable from one naming a document that does not exist — otherwise
+ * the endpoint becomes an oracle for which entries are in draft.
+ */
+export function createPreviewRoute(config: PreviewRouteConfig): {
+  GET: (request: Request) => Promise<Response>;
+} {
+  const refuse = () => new Response(null, { status: 404 });
+
+  return {
+    async GET(request: Request): Promise<Response> {
+      const token = new URL(request.url).searchParams.get("token");
+      if (token === null || token.length === 0) return refuse();
+
+      const generation =
+        typeof config.generation === "function"
+          ? await config.generation()
+          : config.generation;
+
+      const verified = await verifyPreviewToken(token, config.secret, {
+        generation,
+      });
+      if (!verified.valid) return refuse();
+
+      const target = await config.redirectTo(verified.scope);
+      if (!isSiteRelative(target)) return refuse();
+
+      const draft = await config.draftMode();
+      draft.enable();
+
+      const response = new Response(null, {
+        status: 307,
+        headers: { location: target },
+      });
+      // `httpOnly` because nothing in the browser needs to read this, and
+      // `sameSite=lax` so the cookie survives following the link from an email
+      // or a chat client while staying off cross-site sub-requests. The cookie
+      // expires with the token rather than outliving it.
+      response.headers.append(
+        "set-cookie",
+        [
+          `${PREVIEW_SCOPE_COOKIE}=${encodeURIComponent(token)}`,
+          "Path=/",
+          "HttpOnly",
+          "SameSite=Lax",
+          "Secure",
+          `Expires=${verified.expiresAt.toUTCString()}`,
+        ].join("; ")
+      );
+      return response;
+    },
+  };
+}
+
+export interface PreviewScopeReaderConfig {
+  secret: string;
+  generation: number | (() => number | Promise<number>);
+  /** Reads the request's cookies. Injected so the reader is testable. */
+  cookies: () => Promise<{
+    get: (name: string) => { value: string } | undefined;
+  }>;
+}
+
+/**
+ * What the current request is allowed to preview, if anything.
+ *
+ * Re-verifies the stored token rather than trusting that the route once said
+ * yes. A session started an hour ago is refused the moment the token expires or
+ * the generation moves, which is what makes "revoke all preview links" mean
+ * something for sessions already in flight.
+ */
+export async function readPreviewScope(
+  config: PreviewScopeReaderConfig
+): Promise<PreviewTokenScope | null> {
+  const store = await config.cookies();
+  const raw = store.get(PREVIEW_SCOPE_COOKIE)?.value;
+  if (raw === undefined || raw.length === 0) return null;
+
+  const generation =
+    typeof config.generation === "function"
+      ? await config.generation()
+      : config.generation;
+
+  const verified = await verifyPreviewToken(
+    decodeURIComponent(raw),
+    config.secret,
+    { generation }
+  );
+  return verified.valid ? verified.scope : null;
+}
+
+/**
+ * Whether this request may read the named document's draft.
+ *
+ * The question a read path asks. Kept as a function over the scope rather than
+ * left to each caller to compare fields, so "a preview session exists" can
+ * never be mistaken for "this preview session covers what is being read" —
+ * which is the mistake that would turn one link into a key to every draft.
+ */
+export function previewGrantsDraft(
+  scope: PreviewTokenScope | null,
+  requested: PreviewTokenScope
+): boolean {
+  return scope !== null && previewTokenCovers(scope, requested);
+}


### PR DESCRIPTION
Foundation **F4** (task 037), PR-2. #554 landed the token; this makes a preview link actually open a draft session, and bounds what that session can see.

## The design problem, and why the cookie exists

Next's draft mode is **a single boolean for the whole host** — `draftMode().enable()` sets `__prerender_bypass` and nothing about it names a document. A preview token names exactly one. Enabling draft mode on its own would therefore turn a link meant for one unpublished page into a key to **every** unpublished page on the site, which is the opposite of what the token was scoped for.

So the scope travels beside it. The route stores **the token itself** in an httpOnly cookie, and `readPreviewScope` re-verifies it on every read.

Storing the token rather than a decision derived from it is the part worth reviewing: expiry and revocation then keep applying for the life of the session, not only at the instant the link was clicked. Raising the revocation generation ends sessions **already in flight**, which is what makes "revoke all preview links" mean anything.

## Surface

| | |
|---|---|
| `createPreviewRoute(config)` | verifies the token, enables draft mode, sets the cookie, redirects |
| `readPreviewScope(config)` | what this request may preview, re-verified, or `null` |
| `previewGrantsDraft(scope, requested)` | the one question a read path should ask |

`draftMode` and `cookies` are injected rather than imported, so neither half forces `next` at load and both are testable without a request.

## Security properties, each with a test

- **Every refusal is identical** — 404, no body, no cookie, no draft mode — for a missing, empty, garbage, wrong-secret or revoked token. Anything else makes the endpoint an oracle for which entries have unpublished drafts.
- **Redirects must be site-relative.** `//evil.example` is a URL to another host wearing a path's clothes, so a leading-slash check alone is not enough; `https://` and `javascript:` are refused too.
- **The session covers one document.** Cross-entry and cross-collection reads are refused, and no session grants nothing — the default for every visitor.
- **Cookie is `HttpOnly`, `Secure`, `SameSite=Lax`**, and expires with the token. Lax so the link still works when followed from an email or chat client, while staying off cross-site sub-requests.

12 tests. Each guard stub-verified: allowing a protocol-relative redirect, ignoring the current generation on read, and dropping the scope comparison each fail their test.

## Not in this PR

Wiring `previewGrantsDraft` into `createContentRoute`'s read path, and the admin "Copy preview link" affordance. Both are consumers of what this lands; keeping them separate keeps this reviewable as the security-shaped change it is.
