### PR TITLE
fix(nextly): refuse identity on an audit write whose account is gone

### DIFF
--- a/.changeset/audit-log-late-write-identity.md
+++ b/.changeset/audit-log-late-write-identity.md
@@ -1,0 +1,36 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+Deleting an account no longer leaves its identifiers behind in the audit trail.
+
+`audit_log` rows carry an address and a client, and `actor_user_id` deliberately
+has no foreign key so the trail outlives the account. An attributed write that
+resolved its actor before a deletion but landed after that deletion AND its
+post-commit sweep kept those identifiers permanently: nothing revisits the row,
+and the account it names no longer exists for a later erasure to key on.
+
+The decision is now made as part of the write, the way the activity trail
+already made it, and both trails share one implementation so they cannot come to
+answer it differently. Unattributed events, which name nobody, are unaffected.

--- a/packages/nextly/src/domains/audit/__tests__/audit-log-late-write-erasure.integration.test.ts
+++ b/packages/nextly/src/domains/audit/__tests__/audit-log-late-write-erasure.integration.test.ts
@@ -1,0 +1,145 @@
+/**
+ * An audit write that lands after its actor's account is gone stores no identity.
+ *
+ * `audit_log.actor_user_id` carries no foreign key, deliberately, so the trail
+ * outlives the account. That is what creates the race: an attributed write
+ * resolves its actor, the account is deleted, the deletion's own erasure and its
+ * post-commit sweep both run, and only then does the write land. Nothing sweeps
+ * again, so an address and a client stored at that point are unreachable by any
+ * later erasure — the account they belong to no longer exists to key on.
+ *
+ * The window is narrow. The consequence is not, which is why this asserts on the
+ * ORDER that produces it rather than on a race it would have to win.
+ *
+ * Runs on every dialect the environment can reach. The writer swallows its own
+ * failures, so a botched fix here stops auth logging with nothing but a warning
+ * and a single-dialect suite would not notice.
+ */
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  createTestNextly,
+  getConfiguredTestDialects,
+  type TestNextly,
+} from "../../../plugins/test-nextly";
+import { buildAuditLogWriter } from "../audit-log-writer";
+
+let current: TestNextly | undefined;
+
+afterEach(async () => {
+  await current?.destroy();
+  current = undefined;
+});
+
+/** An `audit_log` row as read back (Drizzle camelCases the columns). */
+interface AuditRow {
+  kind: string;
+  actorUserId: string | null;
+  ipAddress: string | null;
+  userAgent: string | null;
+  identityErasedAt: unknown;
+  metadata: { marker?: string } | string | null;
+}
+
+const ACTOR = { id: "audit-late-write-actor", email: "late@example.test" };
+
+/** The rows this test wrote — `audit_log` is a fixed, unprefixed system table. */
+async function rowsFor(
+  handle: TestNextly,
+  marker: string
+): Promise<AuditRow[]> {
+  const all = await handle.adapter.select<AuditRow>("audit_log");
+  return all.filter(row => {
+    const meta =
+      typeof row.metadata === "string"
+        ? (JSON.parse(row.metadata) as { marker?: string })
+        : row.metadata;
+    return meta?.marker === marker;
+  });
+}
+
+describe.each(getConfiguredTestDialects())(
+  "audit-log identity on a late write (%s)",
+  dialect => {
+    it("keeps the address and client while the account exists", async () => {
+      // The control. Asserting only the erased case would pass just as well if
+      // the writer had stopped storing identifiers altogether.
+      current = await createTestNextly({ dialect });
+      await current.adapter.insert("users", {
+        id: ACTOR.id,
+        email: ACTOR.email,
+        is_active: true,
+      });
+      const marker = `present-${dialect}-${Date.now()}`;
+
+      await buildAuditLogWriter((name: string) =>
+        current!.getService(name as Parameters<TestNextly["getService"]>[0])
+      ).write({
+        kind: "login-succeeded",
+        actorUserId: ACTOR.id,
+        ipAddress: "203.0.113.7",
+        userAgent: "probe/1.0",
+        metadata: { marker },
+      });
+
+      const [row] = await rowsFor(current, marker);
+      expect(row).toBeDefined();
+      expect(row.ipAddress).toBe("203.0.113.7");
+      expect(row.userAgent).toBe("probe/1.0");
+      expect(row.identityErasedAt).toBeFalsy();
+    });
+
+    it("stores no address or client once the account is gone", async () => {
+      // The account is deleted BEFORE the write lands: the deletion's erasure
+      // and its post-commit sweep have both already run, so nothing will ever
+      // revisit this row. The identity has to be refused as it is written.
+      current = await createTestNextly({ dialect });
+      const marker = `erased-${dialect}-${Date.now()}`;
+
+      await buildAuditLogWriter((name: string) =>
+        current!.getService(name as Parameters<TestNextly["getService"]>[0])
+      ).write({
+        kind: "login-succeeded",
+        actorUserId: "audit-late-write-deleted-actor",
+        ipAddress: "203.0.113.9",
+        userAgent: "probe/2.0",
+        metadata: { marker },
+      });
+
+      const [row] = await rowsFor(current, marker);
+      expect(row).toBeDefined();
+      // The FACT survives — who it was attributed to, and that it happened.
+      expect(row.actorUserId).toBe("audit-late-write-deleted-actor");
+      expect(row.kind).toBe("login-succeeded");
+      // The person does not.
+      expect(row.ipAddress).toBeNull();
+      expect(row.userAgent).toBeNull();
+      // "Erased" and "never carried one" are different facts; only the stamp
+      // answers which this row is.
+      expect(row.identityErasedAt).toBeTruthy();
+    });
+
+    it("stores an unattributed event as it is, with no erasure stamp", async () => {
+      // A failed sign-in for an address that owns no account names nobody, so
+      // there is nothing to erase against. Stamping it would claim a person was
+      // removed from a row that never held one.
+      current = await createTestNextly({ dialect });
+      const marker = `anon-${dialect}-${Date.now()}`;
+
+      await buildAuditLogWriter((name: string) =>
+        current!.getService(name as Parameters<TestNextly["getService"]>[0])
+      ).write({
+        kind: "login-failed",
+        ipAddress: "203.0.113.11",
+        userAgent: "probe/3.0",
+        metadata: { marker },
+      });
+
+      const [row] = await rowsFor(current, marker);
+      expect(row).toBeDefined();
+      expect(row.actorUserId).toBeNull();
+      expect(row.ipAddress).toBe("203.0.113.11");
+      expect(row.identityErasedAt).toBeFalsy();
+    });
+  }
+);

--- a/packages/nextly/src/domains/audit/audit-log-writer.ts
+++ b/packages/nextly/src/domains/audit/audit-log-writer.ts
@@ -33,6 +33,7 @@
 
 import { randomUUID } from "crypto";
 
+import type { SupportedDialect } from "@nextlyhq/adapter-drizzle/types";
 import { getColumns } from "drizzle-orm";
 
 import { getDialectTables } from "../../database/index";
@@ -41,6 +42,11 @@ import { NextlyError } from "../../errors/nextly-error";
 import { getNextlyLogger } from "../../observability/logger";
 
 import { isAuditReason } from "./audit-reasons";
+import {
+  insertErasureAware,
+  type ErasureAwareDb,
+  type ErasureAwareInsert,
+} from "./erasure-aware-insert";
 
 export type AuditEventKind =
   | "csrf-failed"
@@ -319,14 +325,31 @@ export const NULL_AUDIT_LOG_WRITER: AuditLogWriter = {
  * undefined rather than guessing, because the caller must not fall back to the
  * environment: that is the coupling this exists to remove.
  */
-function adapterDialect(adapter: unknown): string | undefined {
+/** The dialects a row can be built for; anything else is not one we support. */
+const SUPPORTED_DIALECTS: readonly SupportedDialect[] = [
+  "postgresql",
+  "mysql",
+  "sqlite",
+];
+
+function isSupportedDialect(value: unknown): value is SupportedDialect {
+  return (
+    typeof value === "string" &&
+    (SUPPORTED_DIALECTS as readonly string[]).includes(value)
+  );
+}
+
+function adapterDialect(adapter: unknown): SupportedDialect | undefined {
   const candidate = adapter as {
     dialect?: unknown;
     getCapabilities?: () => { dialect?: unknown } | undefined;
   };
-  if (typeof candidate?.dialect === "string") return candidate.dialect;
+  // Narrowed against the supported set rather than accepted as any string: the
+  // row shape and the erasure decision are both chosen from this, so a value
+  // that is merely string-typed would pick a branch by accident.
+  if (isSupportedDialect(candidate?.dialect)) return candidate.dialect;
   const fromCapabilities = candidate?.getCapabilities?.()?.dialect;
-  return typeof fromCapabilities === "string" ? fromCapabilities : undefined;
+  return isSupportedDialect(fromCapabilities) ? fromCapabilities : undefined;
 }
 
 /**
@@ -401,6 +424,11 @@ function offersRetention(
   );
 }
 
+/** The write surface plus the transaction the lock has to be held inside. */
+interface TransactionalErasureDb extends ErasureAwareDb {
+  transaction<T>(work: (tx: ErasureAwareDb) => Promise<T>): Promise<T>;
+}
+
 export function buildAuditLogWriter(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   getService: (name: string) => any
@@ -429,21 +457,51 @@ export function buildAuditLogWriter(
         }
         const schema = getDialectTables(dialect);
         const table = (schema as { auditLog?: unknown }).auditLog;
-        if (!table) {
+        // The accounts table the attribution is checked against. Absent on the
+        // same older schema bundles that lack `auditLog`, and the erasure
+        // decision cannot be made without it.
+        const usersTable = (schema as { users?: unknown }).users;
+        if (!table || !usersTable) {
           // Dialect tables may not include auditLog if the consumer is
           // running against an older schema bundle. Don't throw.
           return;
         }
-        await db.insert(table).values({
-          id: randomUUID(),
-          kind: event.kind,
-          actorUserId: event.actorUserId ?? null,
-          targetUserId: event.targetUserId ?? null,
-          ipAddress: event.ipAddress ?? null,
-          userAgent: event.userAgent ?? null,
-          metadata: encodeMetadata(table, event.metadata),
-          createdAt: new Date(),
-        });
+        // The address and the client NAME the person, so they are decided by
+        // the write rather than stored unconditionally. An attributed event
+        // that resolves its actor before a deletion but lands after both that
+        // deletion and its post-commit sweep would otherwise keep the deleted
+        // person's identifiers permanently — the account they belong to no
+        // longer exists for any later erasure to key on. Unattributed events
+        // (a failed sign-in for an address owning no account) name nobody and
+        // are stored as they are.
+        const write = (executor: ErasureAwareDb): Promise<void> =>
+          insertErasureAware(executor, dialect, {
+            table: table as ErasureAwareInsert["table"],
+            users: usersTable as ErasureAwareInsert["users"],
+            row: {
+              id: randomUUID(),
+              kind: event.kind,
+              actorUserId: event.actorUserId ?? null,
+              targetUserId: event.targetUserId ?? null,
+              metadata: encodeMetadata(table, event.metadata),
+              createdAt: new Date(),
+            },
+            identity: {
+              ipAddress: event.ipAddress ?? null,
+              userAgent: event.userAgent ?? null,
+            },
+            actorUserId: event.actorUserId ?? null,
+          });
+
+        // The lock the decision rests on is only worth anything inside a
+        // transaction, and this writer owns none. SQLite takes no lock and its
+        // `BEGIN IMMEDIATE` would throw whenever another transaction is open,
+        // which here would become a silently missing audit entry.
+        if (dialect === "sqlite" || event.actorUserId == null) {
+          await write(db as ErasureAwareDb);
+        } else {
+          await (db as TransactionalErasureDb).transaction(tx => write(tx));
+        }
 
         // Offer a retention pass, for the same reason content writes do: there
         // is no scheduler to hang one off. Every other trigger is a content

--- a/packages/nextly/src/domains/audit/erasure-aware-insert.ts
+++ b/packages/nextly/src/domains/audit/erasure-aware-insert.ts
@@ -1,0 +1,159 @@
+/**
+ * Audit domain — writing a row whose identity may already have been erased.
+ *
+ * Both durable trails face the same race. A row attributed to an account can be
+ * written at the moment that account is being deleted: the deletion erases what
+ * already exists and a post-commit sweep catches the rest, so a write that lands
+ * after both keeps the deleted person's identifiers permanently, with nothing
+ * left to key a later erasure on.
+ *
+ * The decision has to be made INSIDE the write — never as a check followed by a
+ * separate insert, which leaves a durable row a second statement was still going
+ * to correct. Holding it here keeps the two trails from drifting apart on a
+ * question neither can afford to answer differently.
+ *
+ * @module domains/audit/erasure-aware-insert
+ */
+
+import type { SupportedDialect } from "@nextlyhq/adapter-drizzle/types";
+import { eq, sql, type Column, type Table } from "drizzle-orm";
+
+/**
+ * The Drizzle surface an erasure-aware write needs.
+ *
+ * Structural rather than the concrete types because the real ones are
+ * dialect-specific (NodePgDatabase / MySql2Database / BetterSQLite3Database),
+ * while the fluent API is identical.
+ */
+export interface ErasureAwareDb {
+  insert(table: unknown): { values(data: unknown): Promise<unknown> };
+  select(fields: unknown): {
+    from(table: unknown): {
+      where(condition: unknown): {
+        limit(count: number): Promise<Record<string, unknown>[]> & {
+          // `.for("share")` exists on the Postgres and MySQL builders. SQLite
+          // has no row lock and never reaches the call.
+          for(strength: "share"): Promise<Record<string, unknown>[]>;
+        };
+      };
+    };
+  };
+}
+
+/** One row to write, split into the parts erasure does and does not touch. */
+export interface ErasureAwareInsert {
+  /** The trail being written. Carries the erasure stamp. */
+  table: Table & { identityErasedAt: Column };
+  /** The accounts table the attribution is checked against. */
+  users: Table & { id: Column };
+  /** Columns erasure never touches — what happened, and when. */
+  row: Record<string, unknown>;
+  /**
+   * Columns that NAME the person: an address, a client, a display name. Stored
+   * as given while the account exists, and NULL once it does not.
+   */
+  identity?: Record<string, unknown>;
+  /**
+   * Identity columns whose value comes from the ACCOUNT rather than the caller,
+   * as trail column name to accounts column. Read under the same look that
+   * decides whether the account exists, so the value stored and the decision to
+   * store one cannot disagree.
+   */
+  identityFromAccount?: Record<string, Column>;
+  /**
+   * The account this row is attributed to. Null or absent means the row names
+   * nobody — a failed sign-in for an address that owns no account, a system
+   * write — so there is nothing to erase against and nothing to stamp.
+   */
+  actorUserId?: string | null;
+}
+
+/**
+ * Append one row, deciding what identity it may carry as part of the write.
+ *
+ * **Postgres and MySQL** take a SHARED lock on the account row first. The
+ * deletion takes an EXCLUSIVE lock before it erases anything, so the two cannot
+ * be in flight at once: either this lock is taken first and the deletion waits,
+ * so its erasure covers a row that already exists, or the deletion holds the row
+ * and this waits for its commit and then correctly finds the account gone. That
+ * closes the gap a single statement cannot — its subquery is answered when it
+ * STARTS while its row becomes visible when it COMMITS, so an insert spanning
+ * the deletion's commit satisfies neither the deletion's erasure nor its sweep.
+ * Shared rather than exclusive so concurrent writes naming the same person do
+ * not serialise against each other; only the deletion has to exclude them.
+ *
+ * **SQLite** has one writer, so its insert cannot interleave with the deletion
+ * at all and needs no lock. It decides inside the statement instead.
+ *
+ * The caller owns the transaction. On Postgres and MySQL the lock is only worth
+ * anything while one is open, so a caller that has none must supply one.
+ */
+export async function insertErasureAware(
+  db: ErasureAwareDb,
+  dialect: SupportedDialect,
+  input: ErasureAwareInsert
+): Promise<void> {
+  const { table, users, row, actorUserId } = input;
+  const identity = input.identity ?? {};
+  const fromAccount = input.identityFromAccount ?? {};
+
+  // A row naming nobody has no account to outlive. Storing an erasure stamp
+  // would claim a person was removed from a row that never held one.
+  if (actorUserId === undefined || actorUserId === null) {
+    await db
+      .insert(table)
+      .values({ ...row, ...identity, identityErasedAt: null });
+    return;
+  }
+
+  if (dialect === "sqlite") {
+    const now = new Date();
+    const actorIsGone = sql`NOT EXISTS (SELECT 1 FROM ${users} WHERE ${users.id} = ${actorUserId})`;
+    // Encoded through the column itself: the stamp is an epoch integer here,
+    // and an SQL fragment bypasses the mapping Drizzle would otherwise apply.
+    const erasedAt = table.identityErasedAt.mapToDriverValue(now);
+    const decided: Record<string, unknown> = {};
+    for (const [column, value] of Object.entries(identity)) {
+      decided[column] =
+        sql`CASE WHEN ${actorIsGone} THEN NULL ELSE ${value} END`;
+    }
+    for (const [column, source] of Object.entries(fromAccount)) {
+      decided[column] =
+        sql`CASE WHEN ${actorIsGone} THEN NULL ELSE (SELECT ${source} FROM ${users} WHERE ${users.id} = ${actorUserId}) END`;
+    }
+    await db.insert(table).values({
+      ...row,
+      ...decided,
+      identityErasedAt: sql`CASE WHEN ${actorIsGone} THEN ${erasedAt} ELSE NULL END`,
+    });
+    return;
+  }
+
+  const account = await db
+    .select({ id: users.id, ...fromAccount })
+    .from(users)
+    .where(eq(users.id, actorUserId))
+    .limit(1)
+    .for("share");
+  // Read AFTER the lock is granted. Acquiring it can wait out a whole deletion,
+  // and a stamp taken before the wait would claim the identity was erased at a
+  // moment that precedes the deletion it records.
+  const settled = new Date();
+  const stillExists = account.length > 0;
+  // Plain values, decided in JS: the lock makes the answer stable for the rest
+  // of this transaction. Deciding it in SQL instead would need the same CASE
+  // the SQLite path uses, whose untyped branches Postgres cannot infer a
+  // parameter type for.
+  const decided: Record<string, unknown> = {};
+  for (const column of Object.keys(identity)) {
+    decided[column] = stillExists ? identity[column] : null;
+  }
+  for (const column of Object.keys(fromAccount)) {
+    decided[column] = stillExists ? (account[0]?.[column] ?? null) : null;
+  }
+  await db.insert(table).values({
+    ...row,
+    ...decided,
+    identityErasedAt: stillExists ? null : settled,
+  });
+}

--- a/packages/nextly/src/services/dashboard/activity-log-service.ts
+++ b/packages/nextly/src/services/dashboard/activity-log-service.ts
@@ -14,13 +14,14 @@ import { randomUUID } from "crypto";
 
 import type { DrizzleAdapter } from "@nextlyhq/adapter-drizzle";
 import type { SqlParam } from "@nextlyhq/adapter-drizzle/types";
-import { eq, sql, type Column, type Table } from "drizzle-orm";
+import { type Column, type Table } from "drizzle-orm";
 
 import { toDbError } from "../../database/errors";
 // PR 4 migration: switched from ServiceError.fromDatabaseError to
 // NextlyError.fromDatabaseError. Public message stays generic per §13.8;
 // the underlying DbError is preserved as `cause` and rich DB context
 // (kind, dialect, code) flows into logContext automatically.
+import { insertErasureAware } from "../../domains/audit/erasure-aware-insert";
 import { NextlyError } from "../../errors";
 import { BaseService } from "../base-service";
 import type { Logger } from "../shared";
@@ -166,24 +167,18 @@ export class ActivityLogService extends BaseService {
   }
 
   /**
-   * The column values for one entry, given whatever decides its identity.
+   * The columns of one entry that erasure never touches.
    *
-   * One source for the column list, so the two write paths below cannot come
-   * to disagree about the shape of a row.
+   * The identity columns are decided by the write itself, against an account
+   * that may be being deleted at that moment, so they are supplied separately.
    */
   private entryValues(
     input: LogActivityInput,
-    createdAt: Date,
-    identity: {
-      userName: unknown;
-      userEmail: unknown;
-      identityErasedAt: unknown;
-    }
+    createdAt: Date
   ): Record<string, unknown> {
     return {
       id: randomUUID(),
       userId: input.userId,
-      ...identity,
       action: input.action,
       collection: input.collection,
       entryId: input.entryId ?? null,
@@ -267,70 +262,26 @@ export class ActivityLogService extends BaseService {
     db: ActivityWriteDb,
     input: LogActivityInput
   ): Promise<void> {
-    const tables = this.tables as ActivityWriteTables;
-    const { activityLog, users } = tables;
+    const { activityLog, users } = this.tables as ActivityWriteTables;
+    // The caller's identity when it supplied one, otherwise the account's own.
+    // Taking it from the account is what a caller holding only an actor id
+    // does: the write already looks at that row to decide whether the account
+    // exists, so the name comes from the same look as that decision.
+    const supplied: Record<string, unknown> = {};
+    const fromAccount: Record<string, Column> = {};
+    if (input.userName !== undefined) supplied.userName = input.userName;
+    else fromAccount.userName = users.name;
+    if (input.userEmail !== undefined) supplied.userEmail = input.userEmail;
+    else fromAccount.userEmail = users.email;
 
-    if (this.dialect === "sqlite") {
-      // Nothing to wait for here: SQLite takes no lock, so the statement
-      // runs at the moment this is read.
-      const now = new Date();
-      const actorIsGone = sql`NOT EXISTS (SELECT 1 FROM ${users} WHERE ${users.id} = ${input.userId})`;
-      // Encoded through the column itself: the stamp is an epoch integer
-      // here, and an SQL fragment bypasses the mapping Drizzle would
-      // otherwise apply to a plain value.
-      const erasedAt = activityLog.identityErasedAt.mapToDriverValue(now);
-      // A caller that supplied no identity takes it from the account row. The
-      // scalar subquery is answered in the same statement as the existence
-      // check above, so the name stored and the decision to store one cannot
-      // disagree about whether the account was there.
-      const nameSource =
-        input.userName !== undefined
-          ? sql`${input.userName}`
-          : sql`(SELECT ${users.name} FROM ${users} WHERE ${users.id} = ${input.userId})`;
-      const emailSource =
-        input.userEmail !== undefined
-          ? sql`${input.userEmail}`
-          : sql`(SELECT ${users.email} FROM ${users} WHERE ${users.id} = ${input.userId})`;
-      await db.insert(activityLog).values(
-        this.entryValues(input, now, {
-          userName: sql`CASE WHEN ${actorIsGone} THEN NULL ELSE ${nameSource} END`,
-          userEmail: sql`CASE WHEN ${actorIsGone} THEN NULL ELSE ${emailSource} END`,
-          identityErasedAt: sql`CASE WHEN ${actorIsGone} THEN ${erasedAt} ELSE NULL END`,
-        })
-      );
-      return;
-    }
-
-    const actor = await db
-      .select({ id: users.id, name: users.name, email: users.email })
-      .from(users)
-      .where(eq(users.id, input.userId))
-      .limit(1)
-      .for("share");
-    // Read AFTER the lock is granted. Acquiring it can wait out a whole
-    // deletion, and a stamp taken before the wait would claim the identity
-    // was erased at a moment that precedes the deletion it records.
-    const settled = new Date();
-    // Plain values, decided in JS: the lock makes the answer stable for the
-    // rest of this transaction, and the transaction makes the read and the
-    // write land together. Deciding it in SQL instead would need the same
-    // CASE the SQLite path uses, whose untyped branches Postgres cannot
-    // infer a parameter type for.
-    const actorStillExists = actor.length > 0;
-    // The caller's identity when it supplied one, otherwise the account's own,
-    // read under the lock that just answered whether the account exists.
-    const account = actor[0];
-    await db.insert(activityLog).values(
-      this.entryValues(input, settled, {
-        userName: actorStillExists
-          ? (input.userName ?? toNullableString(account?.name))
-          : null,
-        userEmail: actorStillExists
-          ? (input.userEmail ?? toNullableString(account?.email))
-          : null,
-        identityErasedAt: actorStillExists ? null : settled,
-      })
-    );
+    await insertErasureAware(db, this.dialect, {
+      table: activityLog,
+      users,
+      row: this.entryValues(input, new Date()),
+      identity: supplied,
+      identityFromAccount: fromAccount,
+      actorUserId: input.userId,
+    });
   }
 
   /**


### PR DESCRIPTION
Task **119 item A** — the highest-priority follow-up from #526/#535, and the only one with a privacy consequence.

## The defect

`audit_log` stores an address and a client, and `actor_user_id` deliberately carries **no foreign key** so the trail outlives the account it names. That is what creates the race:

1. An attributed write (`login-succeeded`, `password-changed`, `set-initial-password`) resolves its actor.
2. The account is deleted. The deletion erases the identifiers on rows that exist, and a post-commit sweep catches the rest.
3. **Only then does the write land.**

Nothing sweeps again, so that row keeps the deleted person's `ip_address` and `user_agent` permanently — and it is unreachable by any later erasure, because the account it belongs to no longer exists to key on.

The window is narrow. The consequence is not, which is why the tests assert on the **order** that produces it rather than on a race they would have to win.

## The fix

Decide the stored identity as part of the write, the way the activity trail already did — never a check followed by a separate insert, which leaves a durable row a second statement was still going to correct.

**Both trails now share one implementation** (`domains/audit/erasure-aware-insert.ts`). This is a question neither can afford to answer differently, and getting it right for `activity_log` took four review rounds and produced two dialect traps; a second hand-rolled copy is exactly how those come back:

- **Postgres/MySQL** — shared lock on the account row, then decide in JS. `deleteUser` takes an exclusive lock before erasing, so the two cannot interleave.
- **SQLite** — one writer, no lock, decided inside the statement.

Since the audit writer owns no transaction, it now supplies one for the dialects where the lock only means something inside one.

**Unattributed events are unchanged.** A failed sign-in for an address owning no account names nobody, so there is nothing to erase against and no stamp — claiming a person was removed from such a row would be its own kind of wrong.

## Testing

`domains/audit/__tests__/audit-log-late-write-erasure.integration.test.ts`, on **every configured dialect** — **9 passed** (3 cases x SQLite/Postgres/MySQL).

Per-dialect coverage is mandatory here: `buildAuditLogWriter` swallows its own failures, so a botched fix stops auth logging with nothing but a warning, and the identical `activity_log` fix previously failed *silently on Postgres* because coverage was SQLite-only.

**Verified by break:** forcing the erasure decision off fails `stores no address or client once the account is gone` on all 3 dialects (3 failed / 6 passed). The suite also carries a **control** — `keeps the address and client while the account exists` — so it cannot pass by the writer simply having stopped storing identifiers.

Also green: `domains/audit` + `domains/users` integration, 120 passed.

One pre-existing failure, unrelated and unchanged: `audit-log-write-pg > stores metadata as an object` fails with `relation "audit_log" does not exist` — the table is absent from the shared local Postgres database entirely, so the suite's own `SELECT` fails before any assertion. CI runs against a fresh database.

## Notes

`adapterDialect` now narrows against the supported set instead of accepting any string. Both the row shape and the erasure decision are chosen from that value, so a merely string-typed one could pick a branch by accident.

Remaining in task 119: **D** (actor-kind column, so API-key writes become attributable), **B** (the drifting fixture), **C** (operator prune), **E** (singles).