### PR TITLE
feat(nextly): add migrate:baseline to adopt an existing database

### DIFF
--- a/.changeset/migrate-baseline-adoption.md
+++ b/.changeset/migrate-baseline-adoption.md
@@ -1,0 +1,44 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+Adopting an existing database into migrations no longer requires guesswork.
+
+A project built with `db:sync` has no migration snapshot, so its first
+`migrate:create` diffed the config against an empty baseline and emitted
+`CREATE TABLE` for every table that already existed. Once that project also had
+a pending config change, the generated migration bundled "adopt what exists"
+with "apply the change" — the live database matched neither side, `migrate`
+refused, and none of the three recoveries it suggested could succeed.
+
+`nextly migrate:baseline` records the live schema as the starting snapshot,
+changing nothing in the database. The next `migrate:create` then emits only the
+delta. This is the step Flyway (`baseline`), Django (`--fake-initial`), Alembic
+(`stamp head`) and Prisma (`migrate diff --from-database`) each provide; Nextly
+already shipped the second half of that flow in `migrate:resolve --applied`.
+
+The drift message now recognises this case. When every difference is a table
+that simply already exists and the migration expected to start from nothing,
+`migrate` names the un-adopted database and points at the one command that fixes
+it, instead of listing three recoveries that cannot work from that state.

--- a/packages/nextly/src/cli/commands/migrate-baseline.ts
+++ b/packages/nextly/src/cli/commands/migrate-baseline.ts
@@ -208,7 +208,16 @@ export function registerMigrateBaselineCommand(program: Command): void {
       "Clear a stale migrate lock before taking it",
       false
     )
-    .action(async (options: BaselineCommandOptions) => {
-      await runMigrateBaseline(options, createContext(options));
+    .action(async (cmdOptions: BaselineCommandOptions, cmd: Command) => {
+      // Merged with the program's globals, as every sibling migrate command
+      // does: `nextly --cwd /app migrate:baseline` puts `--cwd` on the PROGRAM,
+      // not the subcommand, so reading command-local options alone would load
+      // the config from — and write migrations into — the shell's directory
+      // instead of the project the operator named.
+      const globalOpts = cmd.optsWithGlobals();
+      await runMigrateBaseline(
+        { ...globalOpts, ...cmdOptions },
+        createContext(globalOpts)
+      );
     });
 }

--- a/packages/nextly/src/cli/commands/migrate-baseline.ts
+++ b/packages/nextly/src/cli/commands/migrate-baseline.ts
@@ -1,0 +1,214 @@
+/**
+ * `nextly migrate:baseline` — adopt an existing database into migrations.
+ *
+ * A project built with `db:sync` has no migration snapshot, so the first
+ * `migrate:create` diffs the config against an EMPTY baseline and emits
+ * `CREATE TABLE` for every table that already exists. That file can be applied
+ * while the config still matches the database, but the moment the project also
+ * has a pending config change the single generated migration bundles "adopt the
+ * existing tables" with "apply the change" — and the live database matches
+ * neither the empty baseline nor that combined target, so `migrate` reports
+ * drift and refuses. No recovery command helps from there.
+ *
+ * This records the live schema as the STARTING snapshot, with no config change
+ * folded into it. Everything downstream then works unchanged: the next
+ * `migrate:create` emits a minimal delta against this snapshot.
+ *
+ * The baseline's target snapshot IS the live schema, so the equivalence check
+ * `migrate:resolve --applied` runs passes by construction — this reuses that
+ * verification rather than introducing a second, weaker trust path.
+ *
+ * Unlike `migrate:create`, this command CONNECTS to the database; reading the
+ * live schema is the entire point. That is why it is a separate command:
+ * `migrate:create` documents "does NOT connect to a database" as an invariant
+ * that keeps it usable offline and in CI. The same split is what Flyway
+ * (`baseline`), Django (`--fake-initial`), Alembic (`stamp head`) and Prisma
+ * (`migrate diff --from-database` + `migrate resolve --applied`) all chose.
+ *
+ * **Runtime restriction (F11):** CLI-only; never import from runtime code.
+ *
+ * @module cli/commands/migrate-baseline
+ */
+import { mkdir, writeFile } from "node:fs/promises";
+import { resolve } from "node:path";
+
+import type { DrizzleAdapter } from "@nextlyhq/adapter-drizzle";
+import type { Command } from "commander";
+
+import { SchemaEventsRepository } from "../../domains/schema/events/schema-events-repository";
+import { createBaseline } from "../../domains/schema/migrate/baseline";
+import { resolveMigration } from "../../domains/schema/migrate/resolve";
+import { formatTimestamp } from "../../domains/schema/migrate-create/format-file";
+import {
+  loadLatestSnapshot,
+  writeSnapshot,
+} from "../../domains/schema/migrate-create/snapshot-io";
+import { introspectLiveSnapshot } from "../../domains/schema/pipeline/diff/introspect-live";
+import { withMigrateLock } from "../../domains/schema/pipeline/locks";
+import { isSnapshotComparableTable } from "../../domains/schema/pipeline/managed-tables";
+import { createContext, type CommandContext } from "../program";
+import {
+  createAdapter,
+  validateDatabaseEnv,
+  type CLIDatabaseAdapter,
+} from "../utils/adapter";
+import { loadConfig } from "../utils/config-loader";
+
+import { maybeForceUnlock } from "./migrate";
+
+interface BaselineCommandOptions {
+  config?: string;
+  cwd?: string;
+  verbose?: boolean;
+  /** Clear a stale migrate lock before taking it (operator escape hatch). */
+  forceUnlock?: boolean;
+}
+
+async function listManagedTables(
+  adapter: CLIDatabaseAdapter
+): Promise<string[]> {
+  let live: string[] = [];
+  try {
+    live = await (
+      adapter as unknown as { listTables: () => Promise<string[]> }
+    ).listTables();
+  } catch {
+    return [];
+  }
+  // Managed main tables only, filtered exactly as `migrate:resolve` filters
+  // them. A localized companion is migration-owned and never appears in a
+  // `migrate:create` snapshot, so including one here would produce a baseline
+  // that no later snapshot could match.
+  return live.filter(isSnapshotComparableTable);
+}
+
+export async function runMigrateBaseline(
+  options: BaselineCommandOptions,
+  context: CommandContext
+): Promise<void> {
+  const { logger } = context;
+
+  logger.header("Migrate Baseline");
+
+  const dbValidation = validateDatabaseEnv();
+  if (!dbValidation.valid || !dbValidation.dialect) {
+    for (const err of dbValidation.errors ?? []) logger.error(err);
+    process.exit(1);
+  }
+  const dialect = dbValidation.dialect;
+
+  const configResult = await loadConfig({
+    configPath: options.config,
+    cwd: options.cwd,
+    debug: options.verbose,
+  });
+  const cwd = options.cwd ?? process.cwd();
+  const migrationsDir = resolve(cwd, configResult.config.db.migrationsDir);
+  const metaDir = resolve(migrationsDir, "meta");
+
+  const adapter: CLIDatabaseAdapter = await createAdapter({
+    dialect,
+    databaseUrl: dbValidation.databaseUrl,
+    logger: options.verbose ? logger : undefined,
+  });
+
+  try {
+    const db = (adapter as unknown as DrizzleAdapter).getDrizzle();
+    await maybeForceUnlock(options, db, dialect);
+    const repo = new SchemaEventsRepository(db, dialect);
+
+    const result = await createBaseline({
+      existingSnapshot: () => loadLatestSnapshot(metaDir),
+      listManagedTables: () => listManagedTables(adapter),
+      introspect: tables => introspectLiveSnapshot(db, dialect, tables),
+      writeFiles: async ({ baseName, sqlContent, snapshot }) => {
+        const sqlPath = resolve(migrationsDir, `${baseName}.sql`);
+        await mkdir(migrationsDir, { recursive: true });
+        await writeFile(sqlPath, sqlContent, "utf-8");
+        // Paired snapshot written through the same helper `migrate:create`
+        // uses, so the hash and table ordering match what every other command
+        // expects to find.
+        const snapshotPath = await writeSnapshot(
+          metaDir,
+          baseName,
+          snapshot,
+          sqlContent
+        );
+        return { sqlPath, snapshotPath };
+      },
+      recordApplied: ({ filename, snapshot, tables }) =>
+        withMigrateLock(db, dialect, () =>
+          resolveMigration({
+            mode: "applied",
+            filename,
+            repo,
+            fileExists: () => Promise.resolve(true),
+            loadTargetSnapshot: () => Promise.resolve(snapshot),
+            introspectLive: () => introspectLiveSnapshot(db, dialect, tables),
+          })
+        ).then(r => r ?? { kind: "noop" }),
+      now: new Date(),
+      formatTimestamp,
+    });
+
+    if (result.kind === "already-managed") {
+      logger.error(
+        `This project already has a migration snapshot (${result.filename}).`
+      );
+      logger.newline();
+      logger.info(
+        "Baselining is for adopting a database that migrations do not manage yet. " +
+          "Run `nextly migrate:status` to see where this project stands."
+      );
+      process.exit(1);
+    }
+
+    if (result.kind === "empty-database") {
+      logger.error("No managed tables found in the database.");
+      logger.newline();
+      logger.info(
+        "Baselining adopts an EXISTING schema. On an empty database, run " +
+          "`nextly migrate:create <name>` and `nextly migrate` instead."
+      );
+      process.exit(1);
+    }
+
+    logger.newline();
+    logger.success(`Created baseline → ${result.sqlPath}`);
+    logger.success(`Snapshot → ${result.snapshotPath}`);
+    logger.keyValue("Tables adopted", result.tableCount);
+    if (result.note) logger.info(result.note);
+    logger.newline();
+    logger.divider();
+    logger.success("Database adopted into migrations.");
+    logger.newline();
+    logger.info("Next steps:");
+    logger.item("Commit the baseline .sql and its meta/ snapshot to git", 1);
+    logger.item(
+      "Run `nextly migrate:create <name>` for your next schema change",
+      1
+    );
+    logger.item("It will now emit only the delta, not the whole schema", 1);
+  } finally {
+    await adapter.disconnect();
+  }
+}
+
+export function registerMigrateBaselineCommand(program: Command): void {
+  program
+    .command("migrate:baseline")
+    .description(
+      "Adopt an existing (db:sync-managed) database into migrations by recording its schema as the starting snapshot"
+    )
+    .option("-c, --config <path>", "Path to nextly.config.ts")
+    .option("--cwd <path>", "Working directory")
+    .option("-v, --verbose", "Verbose output", false)
+    .option(
+      "--force-unlock",
+      "Clear a stale migrate lock before taking it",
+      false
+    )
+    .action(async (options: BaselineCommandOptions) => {
+      await runMigrateBaseline(options, createContext(options));
+    });
+}

--- a/packages/nextly/src/cli/program.ts
+++ b/packages/nextly/src/cli/program.ts
@@ -22,6 +22,7 @@ import { registerGenerateTypesCommand } from "./commands/generate-types";
 import { registerI18nRestoreCommand } from "./commands/i18n-restore";
 import { registerInitCommand } from "./commands/init";
 import { registerMigrateCommand } from "./commands/migrate";
+import { registerMigrateBaselineCommand } from "./commands/migrate-baseline";
 import { registerMigrateCheckCommand } from "./commands/migrate-check";
 import { registerMigrateCreateCommand } from "./commands/migrate-create";
 import { registerMigrateDownCommand } from "./commands/migrate-down";
@@ -214,6 +215,7 @@ function registerCommands(program: Command): void {
   registerMigrateCommand(program); // Imported from ./commands/migrate.js
   registerMigrateCreateCommand(program);
   registerMigrateCheckCommand(program); // F11 PR 4
+  registerMigrateBaselineCommand(program);
   registerMigrateStatusCommand(program);
   registerMigrateResolveCommand(program); // Plan C3 — recovery command
   registerPruneCommand(program); // P2b — drop orphaned plugin/code schema (D14)

--- a/packages/nextly/src/domains/schema/migrate/baseline.test.ts
+++ b/packages/nextly/src/domains/schema/migrate/baseline.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Adopting an existing database into migrations.
+ *
+ * The behaviour under test is an ORDER of decisions, not SQL: refuse a project
+ * that is already migration-managed, refuse an empty database, and otherwise
+ * record the LIVE schema — never the config's idea of it — as the starting
+ * snapshot. Driven through injected dependencies for the same reason
+ * `resolveMigration` is: none of these decisions need a database to be wrong.
+ *
+ * @module domains/schema/migrate/baseline.test
+ */
+import { describe, expect, it, vi } from "vitest";
+
+import type { NextlySchemaSnapshot } from "../pipeline/diff/types";
+
+import { createBaseline, type CreateBaselineArgs } from "./baseline";
+
+const LIVE: NextlySchemaSnapshot = {
+  tables: [{ name: "dc_posts" }, { name: "dc_categories" }],
+} as NextlySchemaSnapshot;
+
+const NOW = new Date("2026-08-05T10:20:30.000Z");
+
+function harness(over: Partial<CreateBaselineArgs> = {}): {
+  args: CreateBaselineArgs;
+  writeFiles: ReturnType<typeof vi.fn>;
+  recordApplied: ReturnType<typeof vi.fn>;
+  introspect: ReturnType<typeof vi.fn>;
+} {
+  const writeFiles = vi.fn(({ baseName }: { baseName: string }) =>
+    Promise.resolve({
+      sqlPath: `/m/${baseName}.sql`,
+      snapshotPath: `/m/meta/${baseName}.json`,
+    })
+  );
+  const recordApplied = vi.fn(() => Promise.resolve({ kind: "applied" }));
+  const introspect = vi.fn(() => Promise.resolve(LIVE));
+  const args: CreateBaselineArgs = {
+    existingSnapshot: () => Promise.resolve(null),
+    listManagedTables: () => Promise.resolve(["dc_posts", "dc_categories"]),
+    introspect,
+    writeFiles,
+    recordApplied,
+    now: NOW,
+    formatTimestamp: () => "20260805_102030_000",
+    ...over,
+  } as CreateBaselineArgs;
+  return { args, writeFiles, recordApplied, introspect };
+}
+
+describe("createBaseline", () => {
+  it("records the live schema and marks the baseline applied", async () => {
+    const { args, writeFiles, recordApplied, introspect } = harness();
+
+    const result = await createBaseline(args);
+
+    expect(result).toMatchObject({
+      kind: "created",
+      filename: "20260805_102030_000_baseline.sql",
+      tableCount: 2,
+    });
+    // The snapshot written is the one introspection returned — the LIVE schema.
+    // Deriving it from config instead is the whole defect being fixed.
+    expect(introspect).toHaveBeenCalledWith(["dc_posts", "dc_categories"]);
+    expect(writeFiles.mock.calls[0][0].snapshot).toBe(LIVE);
+    // Recorded applied, never executed: the schema is already there.
+    expect(recordApplied).toHaveBeenCalledTimes(1);
+    expect(recordApplied.mock.calls[0][0]).toMatchObject({
+      filename: "20260805_102030_000_baseline.sql",
+      snapshot: LIVE,
+    });
+  });
+
+  it("writes a migration body that applies nothing", async () => {
+    // If this ever emitted CREATE statements, `migrate:fresh` would execute them
+    // against an empty database and reproduce only what a snapshot can express.
+    const { args, writeFiles } = harness();
+
+    await createBaseline(args);
+
+    const sql = writeFiles.mock.calls[0][0].sqlContent as string;
+    expect(sql).toContain("-- Migration: baseline");
+    expect(sql).toContain("2 existing table(s)");
+    expect(sql.toUpperCase()).not.toContain("CREATE TABLE");
+    expect(sql.toUpperCase()).not.toContain("ALTER TABLE");
+  });
+
+  it("refuses a project that already has a snapshot, writing nothing", async () => {
+    // A second baseline records a second starting point, and every later
+    // migrate:create would diff against whichever snapshot sorts last.
+    const { args, writeFiles, recordApplied } = harness({
+      existingSnapshot: () =>
+        Promise.resolve({ filename: "20260101_000000_000_init.sql" }),
+    });
+
+    const result = await createBaseline(args);
+
+    expect(result).toEqual({
+      kind: "already-managed",
+      filename: "20260101_000000_000_init.sql",
+    });
+    expect(writeFiles).not.toHaveBeenCalled();
+    expect(recordApplied).not.toHaveBeenCalled();
+  });
+
+  it("refuses an empty database, writing nothing", async () => {
+    // Nothing to adopt. A snapshot claiming no tables is what an un-baselined
+    // project already has, only with a journal entry implying otherwise.
+    const { args, writeFiles, recordApplied } = harness({
+      listManagedTables: () => Promise.resolve([]),
+    });
+
+    const result = await createBaseline(args);
+
+    expect(result).toEqual({ kind: "empty-database" });
+    expect(writeFiles).not.toHaveBeenCalled();
+    expect(recordApplied).not.toHaveBeenCalled();
+  });
+
+  it("checks for an existing snapshot BEFORE reading the database", async () => {
+    // Order matters: an already-managed project must be refused without the
+    // command touching the database at all.
+    const seen: string[] = [];
+    const { args } = harness({
+      existingSnapshot: () => {
+        seen.push("snapshot");
+        return Promise.resolve({ filename: "init.sql" });
+      },
+      listManagedTables: () => {
+        seen.push("tables");
+        return Promise.resolve(["dc_posts"]);
+      },
+    });
+
+    await createBaseline(args);
+
+    expect(seen).toEqual(["snapshot"]);
+  });
+
+  it("surfaces an already-recorded baseline rather than reporting success blindly", async () => {
+    const { args } = harness({
+      recordApplied: () =>
+        Promise.resolve({ kind: "noop", reason: "already marked applied." }),
+    });
+
+    const result = await createBaseline(args);
+
+    expect(result).toMatchObject({
+      kind: "created",
+      note: "already marked applied.",
+    });
+  });
+});

--- a/packages/nextly/src/domains/schema/migrate/baseline.ts
+++ b/packages/nextly/src/domains/schema/migrate/baseline.ts
@@ -1,0 +1,128 @@
+/**
+ * Adopting an existing database into migrations (the `migrate:baseline` core).
+ *
+ * A project built with `db:sync` has no migration snapshot, so the first
+ * `migrate:create` diffs the config against an EMPTY baseline and emits
+ * `CREATE TABLE` for every table that already exists. Once that project also has
+ * a pending config change, the generated migration bundles "adopt what exists"
+ * with "apply the change", the live database matches neither side, and `migrate`
+ * refuses. Recording the live schema as the starting snapshot is what unsticks
+ * it — and it is the step Flyway (`baseline`), Django (`--fake-initial`),
+ * Alembic (`stamp head`) and Prisma (`migrate diff --from-database`) all have.
+ *
+ * The decisions live here rather than in the CLI shell for the same reason
+ * `resolveMigration` does: they are what is worth testing, and they should not
+ * require a database, a config file or a process to exercise.
+ *
+ * @module domains/schema/migrate/baseline
+ */
+import type { NextlySchemaSnapshot } from "../pipeline/diff/types";
+
+/** Where a baseline attempt ended up. The CLI maps these to output and exit codes. */
+export type BaselineResult =
+  | {
+      kind: "created";
+      filename: string;
+      sqlPath: string;
+      snapshotPath: string;
+      tableCount: number;
+      /** Set when recording the baseline applied was already done. */
+      note?: string;
+    }
+  /** A snapshot already exists: the project is migration-managed already. */
+  | { kind: "already-managed"; filename: string }
+  /** Nothing to adopt. */
+  | { kind: "empty-database" };
+
+export interface CreateBaselineArgs {
+  /** Existing starting snapshot, or null when the project has none. */
+  existingSnapshot: () => Promise<{ filename: string } | null>;
+  /** Live tables that a `migrate:create` snapshot would compare against. */
+  listManagedTables: () => Promise<string[]>;
+  /** Read the live schema of those tables. */
+  introspect: (tables: string[]) => Promise<NextlySchemaSnapshot>;
+  /** Persist the migration and its paired snapshot; returns their paths. */
+  writeFiles: (input: {
+    baseName: string;
+    sqlContent: string;
+    snapshot: NextlySchemaSnapshot;
+  }) => Promise<{ sqlPath: string; snapshotPath: string }>;
+  /** Record the baseline as applied WITHOUT executing it. */
+  recordApplied: (input: {
+    filename: string;
+    snapshot: NextlySchemaSnapshot;
+    tables: string[];
+  }) => Promise<{ kind: string; reason?: string }>;
+  /** Injected so the generated name is deterministic in tests. */
+  now: Date;
+  /** Timestamp prefix for the generated filename. */
+  formatTimestamp: (d: Date) => string;
+}
+
+/** The migration file's body. */
+export function formatBaselineFile(tableCount: number, now: Date): string {
+  // A comment, never DDL. The schema this describes ALREADY EXISTS, so emitting
+  // CREATE statements would make the file a claim about what it does that is
+  // false — and `migrate:fresh` would then execute it against an empty database
+  // and reproduce only the part a config-derived snapshot can express.
+  return [
+    "-- Migration: baseline",
+    `-- Generated: ${now.toISOString()}`,
+    "--",
+    `-- Adoption baseline: records ${tableCount} existing table(s) as the`,
+    "-- starting point for migrations. Intentionally empty — the schema it",
+    "-- describes was already in the database when this was generated, so",
+    "-- there is nothing to apply. The paired snapshot is what matters.",
+    "",
+  ].join("\n");
+}
+
+/**
+ * Record the live schema as the starting snapshot for migrations.
+ *
+ * Refuses in two states, both because proceeding would leave the project worse
+ * than it started:
+ *
+ * - **Already managed.** A second baseline records a second "starting point",
+ *   and every later `migrate:create` diffs against whichever snapshot sorts
+ *   last — silently changing what the next migration contains.
+ * - **Empty database.** There is nothing to adopt, and a snapshot claiming the
+ *   database holds no tables is exactly what an un-baselined project already
+ *   has, only now with a journal entry implying otherwise.
+ */
+export async function createBaseline(
+  args: CreateBaselineArgs
+): Promise<BaselineResult> {
+  const existing = await args.existingSnapshot();
+  if (existing) return { kind: "already-managed", filename: existing.filename };
+
+  const tables = await args.listManagedTables();
+  if (tables.length === 0) return { kind: "empty-database" };
+
+  const snapshot = await args.introspect(tables);
+  const baseName = `${args.formatTimestamp(args.now)}_baseline`;
+  const sqlContent = formatBaselineFile(tables.length, args.now);
+  const { sqlPath, snapshotPath } = await args.writeFiles({
+    baseName,
+    sqlContent,
+    snapshot,
+  });
+
+  const filename = `${baseName}.sql`;
+  // Recorded applied rather than executed: the schema is already there. The
+  // caller's recorder still verifies live against the snapshot just written
+  // from it, so this passes by construction and yet fails loudly if the
+  // database moved underneath the command.
+  const recorded = await args.recordApplied({ filename, snapshot, tables });
+
+  return {
+    kind: "created",
+    filename,
+    sqlPath,
+    snapshotPath,
+    tableCount: tables.length,
+    ...(recorded.kind === "noop" && recorded.reason
+      ? { note: recorded.reason }
+      : {}),
+  };
+}

--- a/packages/nextly/src/domains/schema/migrate/drift-error.test.ts
+++ b/packages/nextly/src/domains/schema/migrate/drift-error.test.ts
@@ -26,4 +26,46 @@ describe("migrationDriftError", () => {
       suggestedActions: ["A", "B", "C"],
     });
   });
+
+  it("names the un-adopted database instead of offering recoveries that cannot work", () => {
+    // The compound db:sync case: every difference is a table that already
+    // exists, and the migration expected to start from nothing. The generic
+    // message offers three recoveries, and on this state ALL THREE refuse —
+    // db:sync reports no changes, migrate:resolve fails the snapshot check,
+    // and migrate:create detects nothing to capture.
+    const err = migrationDriftError({
+      migration: "20260805_add_locales",
+      file: "src/db/migrations/20260805_add_locales.sql",
+      driftItems: [
+        { kind: "+", detail: "table 'dc_posts' present in DB" },
+        { kind: "+", detail: "table 'dc_categories' present in DB" },
+      ],
+      looksUnadopted: true,
+    });
+
+    expect(err.code).toBe("NEXTLY_MIGRATION_DRIFT");
+    expect(err.publicMessage).toContain("not managed by migrations yet");
+    expect(err.publicMessage).toContain("migrate:baseline");
+    expect(err.publicMessage).toContain("changes nothing in the database");
+    // The three recoveries are the wrong advice here and must not appear.
+    expect(err.publicMessage).not.toContain("migrate:resolve --applied");
+    expect(err.publicMessage).not.toContain("capture_drift");
+    expect(err.logContext).toMatchObject({ unadopted: true });
+  });
+
+  it("still gives the generic drift advice when a table is MISSING from the DB", () => {
+    // One `-` item means the database is not merely un-adopted: something the
+    // migration expected is absent, which baselining would not explain. The
+    // adoption message must not swallow this case.
+    const err = migrationDriftError({
+      migration: "20260805_mixed",
+      file: "src/db/migrations/20260805_mixed.sql",
+      driftItems: [
+        { kind: "+", detail: "table 'dc_posts' present in DB" },
+        { kind: "-", detail: "table 'dc_tags' absent from DB" },
+      ],
+    });
+    expect(err.publicMessage).toContain("schema drift detected");
+    expect(err.publicMessage).toContain("migrate:resolve --applied");
+  });
 });

--- a/packages/nextly/src/domains/schema/migrate/drift-error.ts
+++ b/packages/nextly/src/domains/schema/migrate/drift-error.ts
@@ -21,12 +21,60 @@ export interface MigrationDriftArgs {
   /** Repo-relative path to the .sql file. */
   file: string;
   driftItems: DriftItem[];
+  /**
+   * The database holds a schema migrations have never been told about — this
+   * migration expected to start from nothing and found tables already there,
+   * with every difference being one of them.
+   *
+   * Worth naming separately because the generic advice is actively wrong for
+   * it: none of the three recoveries below can succeed on an un-adopted
+   * database, so offering them leaves the operator trying each in turn and
+   * getting a different refusal from each.
+   */
+  looksUnadopted?: boolean;
 }
 
 export function migrationDriftError(args: MigrationDriftArgs): NextlyError {
   const lines = args.driftItems
     .map(d => `    ${d.kind} ${d.detail}`)
     .join("\n");
+
+  if (args.looksUnadopted) {
+    return new NextlyError({
+      code: "NEXTLY_MIGRATION_DRIFT",
+      statusCode: 409,
+      publicMessage: [
+        "Migration cannot be applied: this database is not managed by migrations yet",
+        "",
+        `  Migration:  ${args.migration}`,
+        `  File:       ${args.file}`,
+        "",
+        "  Every difference below is a table that EXISTS in your database but",
+        "  that migrations have no record of. That is what a project built with",
+        "  `db:sync` looks like: the schema is real, it simply has no starting",
+        "  snapshot to measure changes against.",
+        "",
+        `  Tables already present (${args.driftItems.length}):`,
+        lines,
+        "",
+        "  Fix — adopt the database, then create your migration again:",
+        "        pnpm nextly migrate:baseline",
+        `        pnpm nextly migrate:create --name ${args.migration}`,
+        "        pnpm nextly migrate",
+        "",
+        "  Baselining records the schema you already have as the starting",
+        "  point. It changes nothing in the database.",
+        "",
+        "  Details: https://docs.nextlyhq.com/guides/migration-drift",
+      ].join("\n"),
+      logContext: {
+        migration: args.migration,
+        file: args.file,
+        driftCount: args.driftItems.length,
+        unadopted: true,
+      },
+    });
+  }
 
   const publicMessage = [
     "Migration cannot be applied: schema drift detected",

--- a/packages/nextly/src/domains/schema/migrate/drift-reconcile.ts
+++ b/packages/nextly/src/domains/schema/migrate/drift-reconcile.ts
@@ -149,5 +149,18 @@ export async function reconcileFile(
 
   // DRIFT — live matches neither baseline nor target.
   const driftItems = diffSnapshots(before, live).map(toDriftItem);
-  throw migrationDriftError({ migration, file: file.path, driftItems });
+  // Adoption, not drift: this migration expected to start from an empty schema
+  // and every difference is a table that is simply already there. Derived from
+  // what is already in hand rather than from a journal read, so the diagnosis
+  // costs nothing on the path that reports a failure.
+  const looksUnadopted =
+    before.tables.length === 0 &&
+    driftItems.length > 0 &&
+    driftItems.every(item => item.kind === "+");
+  throw migrationDriftError({
+    migration,
+    file: file.path,
+    driftItems,
+    looksUnadopted,
+  });
 }


### PR DESCRIPTION
Task **076** (P1). The filing was corrected once after an end-to-end reproduction, so this implements what that corrected reproduction actually points at.

## The defect

A project built with `db:sync` has no migration snapshot. Its first `migrate:create` therefore diffs the config against an **empty** baseline and emits `CREATE TABLE` for every table that already exists — "Operations: 8" on the reproduction project.

In the pure case that file applies cleanly. The trap is the **compound** case, which is what a real project hits: once there is also a pending config change, the single generated migration bundles *adopt the existing tables* with *apply the change*. The live database matches neither the empty baseline nor that combined target, so `migrate` reports drift and refuses — and the reproduction proved **all three recoveries it suggests fail**:

- `db:sync && migrate` — db:sync reports no changes; migrate still refuses
- `migrate:resolve --applied` — `NEXTLY_MIGRATION_RESOLVE_DRIFT`
- `migrate:create --name capture_drift` — "No changes detected"

Three suggestions, none of which work, is worse DX than one that does.

## The fix

`nextly migrate:baseline` records the live schema as the starting snapshot, with no config change folded in. Everything downstream then works unchanged — the reproduction already proved a delta applies correctly once a baseline exists.

**The load-bearing insight:** the baseline's target snapshot *is* the live schema, so the equivalence check `resolveMigration` already performs passes by construction. This reuses that verification rather than introducing a second, weaker trust path — and it still fails loudly if the database moves underneath the command.

**Kept out of `migrate:create` deliberately.** That command's module header documents "does NOT connect to a database" as the invariant that keeps it usable offline and in CI; baselining must read the live schema. A separate command is also what Flyway (`baseline`), Django (`--fake-initial`), Alembic (`stamp head`) and Prisma (`migrate diff --from-database` + `migrate resolve --applied`) each chose. Nextly already shipped the second half of Prisma's flow; this adds the first.

**The generated file applies nothing.** It is a header comment. Emitting `CREATE TABLE` would make the file a false claim that `migrate:fresh` would then execute against an empty database.

**Refuses two states**, because proceeding leaves the project worse than it started: a project that already has a snapshot (a second "starting point" would silently change what later migrations contain), and an empty database (nothing to adopt, and the resulting snapshot would imply otherwise).

## The drift message

When every difference is a table that already exists **and** the migration expected to start from nothing, `migrate` now names the un-adopted database and points at `migrate:baseline`. Derived from the pre-baseline snapshot being empty plus every drift item being `+` — no journal read, so diagnosing costs nothing on the failure path. A single `-` item falls back to the generic message, since something *missing* is not explained by adoption.

## Structure

The decisions live in `domains/schema/migrate/baseline.ts`; the CLI is a thin shell, exactly as `migrate:resolve` is a thin shell over `resolveMigration`. That is what makes them testable without a database, a config file or a process — no CLI command in this repo had end-to-end coverage before, and the plumbing to add it would have been most of the work.

## Testing

**9 passed** — 6 in `baseline.test.ts`, 3 in `drift-error.test.ts`.

Covered: the live schema (never the config's) is what gets snapshotted; the body applies nothing; both refusals write nothing at all; the snapshot check happens *before* the database is touched; an already-recorded baseline is surfaced rather than reported as fresh success; the drift message swaps only in the adoption case and keeps the generic advice when a table is missing.

**Verified by break:** removing each guard fails exactly its own tests (3 failed / 3 passed).

Also green: `domains/schema/migrate` + `cli/commands` — 186 passed, 34 files. Registration confirmed against the built CLI (`nextly --help` lists the command).

## Not in scope

Changing `migrate:create` to connect to a database — it would break the offline and CI use its header promises.