### PR TITLE
fix(nextly): stop verifying a shape the generators do not produce

### DIFF
--- a/packages/nextly/src/domains/schema/pipeline/pre-resolution/__tests__/drop-index-constraint.integration.test.ts
+++ b/packages/nextly/src/domains/schema/pipeline/pre-resolution/__tests__/drop-index-constraint.integration.test.ts
@@ -64,7 +64,12 @@ describe("pre-resolution drop_index — PostgreSQL constraint-backed uniques", (
         { name: "code", type: "text" },
         { name: "views", type: "number", index: true },
       ] as never,
-      "postgresql"
+      "postgresql",
+      // The provenance this fixture is about: its own header names form 1 as what the dynamic
+      // collection / component / user-ext schema services emit, and those are the Schema Builder's
+      // collection creator. A widthless text field resolves differently per builder, so the wrong
+      // answer here would build a table the templates under test never see.
+      { builtBy: "collection" }
     );
     await pool.query(generatePgSQL({ type: "add_table", table: spec }));
 


### PR DESCRIPTION
🔴 **#556 merged at `95948afb3`, two commits behind the branch head.** The two commits that were not
included are the ones that REMOVE a check which fails working operations, so main currently carries
two live regressions. This PR is those two commits, rebased onto main.

## Proven on merged main, not argued

Ran the branch's own regression guards against a worktree at `ccaa14089`, PostgreSQL and SQLite:

```
× keeps a create with a required upload applied
  Table "single_..._up" does not match this schema: hero is NOT NULL, expected nullable

× completes a localization enable sent with fields
  Table "single_..._enable" does not match this schema after the update:
    title is still NOT NULL but is no longer declared;
    slug is still NOT NULL but is no longer declared;
    headline is still NOT NULL but is no longer declared
```

### 1. A create with a required relationship or upload is recorded as `failed`

`field-column-descriptor.ts:230` reports every `fkSingle` column as nullable **on purpose** —
requiredness is enforced in application code — while the create DDL emits `NOT NULL`. The
nullability comparison therefore fails a table that was created correctly.

### 2. Enabling localization is recorded as `failed` AND strands content

This is the serious one. A field moving to the companion is legitimately still a `NOT NULL` column
on the main table until the companion transition seeds and drops it. The check runs first, sees
columns "no longer declared" — including the system `title` and `slug` — marks the migration failed,
and **skips the companion transition while `localized: true` has already been persisted.** Reads
then point at an unseeded companion while the content is still on main.

**A verification that strands data is worse than no verification.**

## Why removal rather than another narrowing

The check was narrowed twice already, dropping type and then index comparison. Each time the false
positives moved to whatever remained. The cause is structural: it compares against the diff engine's
**ideal** schema, and the Builder's own generators do not render that. Those divergences are real
and already tracked as their own work; a post-apply gate is not where they should be discovered.

Measured tally over the review of #556:

| the check broke | the check caught |
|---|---|
| float creates · unique creates · every field-group create · required relationship/upload creates · localization enables | nothing outside the repair scenarios written to exercise it |

## Also included: the write ordering returns to recording the outcome with the row

Writing the intent first is better only once something can finish an interrupted attempt. Without
that, the half-written row owns the slug and refuses every retry — worse than the orphan table it
prevents, because an orphan at least leaves the slug free. The ordering moves with the migration
lock that completes it.

Removed with it: the adoption branch, the atomic claim and the relaxed owner check. Nothing without
a caller is left behind.

**Kept:** planning before anything is persisted, so a request the generator refuses leaves nothing
at all. That was a genuine fix.

## What #556's work still delivers after this

The relocation itself (−356 lines from the handler), the extracted companion reconcile, the shared
statement runner that fixes the MySQL retry dead end, and 445 lines of integration tests proving a
create actually creates a table on all three dialects.

## Verification

Build clean · `check-types` 0 · `lint` 0 · drizzle gate passed · the create suite **16 passed on
PostgreSQL, 16 on MySQL** · dispatcher suites back to the main baseline exactly.

The three cases the check broke are kept as regression tests asserting they stay `applied`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved schema migration handling by surfacing rename conflicts instead of silently ignoring them.
  * Preserved existing schema metadata when migrations fail.
  * Prevented duplicate single-table ownership during creation.

* **New Features**
  * Added support and coverage for localization tables, required uploads, and schema updates.

* **Tests**
  * Expanded migration tests for conflicting column renames and schema-change scenarios.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->