### PR TITLE
feat(nextly): read pending edits through the content route

### DIFF
--- a/.changeset/content-route-working-draft.md
+++ b/.changeset/content-route-working-draft.md
@@ -32,8 +32,11 @@ The draft model is two-layered and they fail differently: `status` covers an
 entry that has never been published, while pending edits on an ALREADY-published
 entry live in a sidecar row that no `status` scope can see. Widening `status`
 alone therefore showed a published page live while the edits being previewed
-stayed invisible. Setting `draft` now widens `status` with it (an explicit
-`status` still wins) so the pair cannot be half-configured.
+stayed invisible. The two are gated differently: pending edits are judged
+per row by an update-capability probe, so asking for them is safe from anywhere,
+while never-published rows are judged by nothing. So `draft` widens `status`
+only on a trusted read (`overrideAccess: true`); an explicit `status` always
+wins.
 
 On the route the option is a per-request decision, because route config is
 captured once at module scope while whether a visitor is previewing is not:
@@ -42,10 +45,16 @@ captured once at module scope while whether a visitor is previewing is not:
 export const { ContentPage, generateMetadata, generateStaticParams } =
   createContentRoute({
     collections: ["pages"],
-    draft: async () => (await draftMode()).isEnabled,
+    draft: async ({ collection, slug }) => grantsDraftAt(collection, slug),
     render: page => <Page {...page} />,
   });
 ```
+
+The decision is handed the collection and slug being resolved, because Next's
+draft mode is one boolean for the whole host: `isEnabled` says a visitor opened
+a valid preview link, never which document it was for. Answering from that alone
+would turn a link scoped to one page into a key to every unpublished page in the
+configured collections.
 
 Returning `true` is an authorization decision rather than a display preference,
 so that request reads trusted — the route resolves anonymously and the overlay

--- a/.changeset/content-route-working-draft.md
+++ b/.changeset/content-route-working-draft.md
@@ -1,0 +1,56 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+thread the working-draft layer through the content route
+
+`resolveContent` and `createContentRoute` gain a `draft` option, so a preview
+can show pending unpublished edits instead of live content.
+
+The draft model is two-layered and they fail differently: `status` covers an
+entry that has never been published, while pending edits on an ALREADY-published
+entry live in a sidecar row that no `status` scope can see. Widening `status`
+alone therefore showed a published page live while the edits being previewed
+stayed invisible. Setting `draft` now widens `status` with it (an explicit
+`status` still wins) so the pair cannot be half-configured.
+
+On the route the option is a per-request decision, because route config is
+captured once at module scope while whether a visitor is previewing is not:
+
+```ts
+export const { ContentPage, generateMetadata, generateStaticParams } =
+  createContentRoute({
+    collections: ["pages"],
+    draft: async () => (await draftMode()).isEnabled,
+    render: page => <Page {...page} />,
+  });
+```
+
+Returning `true` is an authorization decision rather than a display preference,
+so that request reads trusted — the route resolves anonymously and the overlay
+is gated on an update-capability probe an anonymous read can never pass. Put the
+authorization in that function, never in a query parameter.
+
+A draft read is never cached, and `generateStaticParams` ignores the option
+entirely, so a draft is never baked into a pre-rendered path.

--- a/docs/guides/routing-and-seo.mdx
+++ b/docs/guides/routing-and-seo.mdx
@@ -38,6 +38,28 @@ draft translation under a published main row is never returned. On a status-less
 collection (no built-in Draft/Published lifecycle) the scope is a no-op and
 every row is live, so you can mix lifecycle and status-less collections freely.
 
+**Pending edits.** Publish state is only half the picture. An entry that has
+never been published is covered by `status`, but pending edits to an
+**already-published** entry are stored as a separate working draft that no
+`status` scope can see — the live row keeps serving until you publish. Pass
+`draft: true` to read those instead:
+
+```ts
+// The page as the editor last saved it, not as visitors see it.
+await resolveContent("posts", slug, { draft: true, overrideAccess: true });
+```
+
+Because a preview needs both layers, `draft: true` widens `status` to `"all"`
+unless you set `status` yourself. Widening only one of the two is the mistake
+this prevents: a preview that just set `status: "all"` would show a published
+page's **live** content while the edits being previewed stayed invisible.
+
+Two rules come with it. The working draft is only surfaced to a caller who could
+edit the document, so a draft read must be trusted (`overrideAccess: true`) or
+carry a `user` — otherwise you silently get the published row. And a draft read
+is **never cached**, because cache tags are busted by writes to the live row
+while a draft changes on every save.
+
 **Access.** By default `resolveContent` **enforces** the collection's read
 policy (`overrideAccess: false`). A rule-less (public) collection still renders;
 a collection with a stored member-only or role-based read rule is hidden from an
@@ -87,8 +109,8 @@ import { createContentRoute, buildMetadata } from "nextly/runtime";
 
 const route = createContentRoute({
   collections: ["pages"],
-  render: (entry) => <Page entry={entry} />,
-  buildMetadata: (entry) => buildMetadata(entry),
+  render: entry => <Page entry={entry} />,
+  buildMetadata: entry => buildMetadata(entry),
 });
 
 export const generateStaticParams = route.generateStaticParams;
@@ -108,6 +130,36 @@ This route always resolves **anonymously** — its config is captured once at
 module scope, so it cannot carry a per-request user. For a route that renders
 per-visitor member content, call `resolveContent` with the request's `user`
 inside your own page rather than using `createContentRoute`.
+
+### Previewing drafts
+
+Whether a visitor is previewing is a per-request fact, and route config is not —
+so `draft` takes a function the route asks on every request. Wire it to Next's
+draft mode:
+
+```ts
+import { draftMode } from "next/headers";
+
+const route = createContentRoute({
+  collections: ["pages"],
+  draft: async () => (await draftMode()).isEnabled,
+  render: page => <Page {...page} />,
+});
+```
+
+**Returning `true` is an authorization decision, not a display preference.** The
+route resolves anonymously and the working draft is only shown to a caller who
+could edit the document, so a request this returns `true` for is read trusted.
+Put the check inside that function — a verified preview cookie, a session — and
+never in a query parameter a visitor controls.
+
+`generateStaticParams` ignores `draft` entirely: it runs at build time, where
+there is no visitor to gate, and a draft baked into a static path would be
+published to everyone.
+
+A literal `draft: true` is accepted for a route mounted behind your own auth. It
+means **every** visitor sees unpublished content, which is almost never what a
+public site wants.
 
 > **Next 16 Cache Components:** an exported `generateStaticParams` must return at
 > least one entry under Cache Components. For a no-prerender or empty-site setup
@@ -164,7 +216,7 @@ export default nextlySitemap({
   tags: nextlyTags("posts"),
   entries: async () =>
     (await buildSitemapUrls(services, { collections: ["posts"], baseUrl })).map(
-      (u) => ({ url: u.loc, lastModified: u.lastModified })
+      u => ({ url: u.loc, lastModified: u.lastModified })
     ),
 });
 ```

--- a/docs/guides/routing-and-seo.mdx
+++ b/docs/guides/routing-and-seo.mdx
@@ -49,16 +49,21 @@ never been published is covered by `status`, but pending edits to an
 await resolveContent("posts", slug, { draft: true, overrideAccess: true });
 ```
 
-Because a preview needs both layers, `draft: true` widens `status` to `"all"`
-unless you set `status` yourself. Widening only one of the two is the mistake
-this prevents: a preview that just set `status: "all"` would show a published
-page's **live** content while the edits being previewed stayed invisible.
+The two layers are gated differently, and that difference is the important part:
 
-Two rules come with it. The working draft is only surfaced to a caller who could
-edit the document, so a draft read must be trusted (`overrideAccess: true`) or
-carry a `user` — otherwise you silently get the published row. And a draft read
-is **never cached**, because cache tags are busted by writes to the live row
-while a draft changes on every save.
+- **Pending edits** are judged per row, by an update-capability probe, so asking
+  for them is safe from anywhere. A caller who cannot edit the document gets the
+  published row instead.
+- **Never-published entries** are judged by nothing — the query simply returns
+  them. So `draft: true` widens `status` to `"all"` **only on a trusted read**
+  (`overrideAccess: true`). Without that, a draft read still sees published rows
+  and overlays their pending edits.
+
+That split exists because a `draft` flag wired from an untrusted request would
+otherwise publish unpublished pages. An explicit `status` always wins.
+
+A draft read is **never cached**, because cache tags are busted by writes to the
+live row while a draft changes on every save.
 
 **Access.** By default `resolveContent` **enforces** the collection's read
 policy (`overrideAccess: false`). A rule-less (public) collection still renders;
@@ -137,15 +142,27 @@ Whether a visitor is previewing is a per-request fact, and route config is not �
 so `draft` takes a function the route asks on every request. Wire it to Next's
 draft mode:
 
-```ts
-import { draftMode } from "next/headers";
+The function is handed the collection and slug being resolved, so the answer can
+be scoped to a document:
 
+```ts
 const route = createContentRoute({
   collections: ["pages"],
-  draft: async () => (await draftMode()).isEnabled,
+  draft: async ({ collection, slug }) => {
+    const scope = await readPreviewScope(previewConfig);
+    if (scope === null || scope.collection !== collection) return false;
+    return slug === (await slugOf(scope.collection, scope.entryId));
+  },
   render: page => <Page {...page} />,
 });
 ```
+
+**Use that argument.** Next's draft mode is a single boolean for the whole host:
+`draftMode().isEnabled` tells you a visitor opened _a_ valid preview link, never
+_which_ document it was for. Answering from it alone turns a link scoped to one
+unpublished page into a key to every unpublished page in the configured
+collections, for the life of the session — which is exactly what a preview
+token's scope exists to prevent.
 
 **Returning `true` is an authorization decision, not a display preference.** The
 route resolves anonymously and the working draft is only shown to a caller who

--- a/docs/guides/routing-and-seo.mdx
+++ b/docs/guides/routing-and-seo.mdx
@@ -148,14 +148,21 @@ be scoped to a document:
 ```ts
 const route = createContentRoute({
   collections: ["pages"],
-  draft: async ({ collection, slug }) => {
+  draft: async ({ collection }) => {
     const scope = await readPreviewScope(previewConfig);
     if (scope === null || scope.collection !== collection) return false;
-    return slug === (await slugOf(scope.collection, scope.entryId));
+    // Name the entry, do not just answer yes: slugs are not unique.
+    return { entryId: scope.entryId };
   },
   render: page => <Page {...page} />,
 });
 ```
+
+Return `{ entryId }` rather than `true` whenever a token is backing the
+decision. A slug need not be unique — the resolver supports duplicates and
+settles them by sorting on `id` — so a bare `true` grants whichever row the
+route happens to resolve, which may not be the one the token named. With an
+`entryId` the route discards the draft when the path resolved elsewhere.
 
 **Use that argument.** Next's draft mode is a single boolean for the whole host:
 `draftMode().isEnabled` tells you a visitor opened _a_ valid preview link, never

--- a/packages/nextly/src/runtime/routing/__tests__/content-route-draft.integration.test.ts
+++ b/packages/nextly/src/runtime/routing/__tests__/content-route-draft.integration.test.ts
@@ -20,6 +20,7 @@ import {
   type TestNextly,
 } from "../../../plugins/test-nextly";
 import { createContentRoute } from "../content-route";
+import { resolveContent } from "../resolve-content";
 import type { ContentEntry } from "../resolve-content";
 
 const pages = () =>
@@ -38,7 +39,12 @@ afterEach(async () => {
 
 function route(
   nextly: TestNextly["nextly"],
-  draft?: boolean | (() => boolean | Promise<boolean>)
+  draft?:
+    | boolean
+    | ((context: {
+        collection: string;
+        slug: string;
+      }) => boolean | Promise<boolean>)
 ) {
   return createContentRoute({
     collections: ["pages"],
@@ -95,6 +101,60 @@ describe("createContentRoute + draft layers (integration)", () => {
       params: { slug: ["unreleased"] },
     })) as ContentEntry;
     expect(previewPage.title).toBe("Unreleased");
+  });
+
+  it("grants a draft only at the path the decision names", async () => {
+    // The scope that a preview token carries has to survive the trip. Next's
+    // draft mode cannot express it — one boolean for the whole host — so a
+    // route answering from `isEnabled` alone would hand a link for one page the
+    // drafts of every other.
+    current = await createTestNextly({ collections: [pages()] });
+    for (const slug of ["granted", "other"]) {
+      const created = await current.nextly.create({
+        collection: "pages",
+        data: { slug, title: `${slug} live`, status: "published" },
+      });
+      await current.nextly.update({
+        collection: "pages",
+        id: String(created.item.id),
+        data: { title: `${slug} pending` },
+      });
+    }
+
+    const scoped = route(current.nextly, ({ slug }) => slug === "granted");
+
+    expect(
+      (
+        (await scoped.ContentPage({
+          params: { slug: ["granted"] },
+        })) as ContentEntry
+      ).title
+    ).toBe("granted pending");
+    expect(
+      (
+        (await scoped.ContentPage({
+          params: { slug: ["other"] },
+        })) as ContentEntry
+      ).title
+    ).toBe("other live");
+  });
+
+  it("does not publish a never-published entry to an untrusted draft read", async () => {
+    // Widening the lifecycle scope is gated by nothing per row, so it follows
+    // trust rather than the draft flag. `resolveContent` called with `draft`
+    // alone must not surface an entry that has never been published.
+    current = await createTestNextly({ collections: [pages()] });
+    await current.nextly.create({
+      collection: "pages",
+      data: { slug: "unreleased", title: "Unreleased", status: "draft" },
+    });
+
+    expect(
+      await resolveContent("pages", "unreleased", {
+        nextly: current.nextly,
+        draft: true,
+      })
+    ).toBeNull();
   });
 
   it("keeps drafts out of the paths a build pre-renders", async () => {

--- a/packages/nextly/src/runtime/routing/__tests__/content-route-draft.integration.test.ts
+++ b/packages/nextly/src/runtime/routing/__tests__/content-route-draft.integration.test.ts
@@ -1,0 +1,162 @@
+/**
+ * The draft layers a preview has to honour, against a real boot.
+ *
+ * The shipped model is two-layered and they fail differently:
+ *
+ * - `status` covers an entry that has NEVER been published.
+ * - The working draft covers pending edits on an ALREADY-published entry, which
+ *   live in a sidecar row the live table knows nothing about.
+ *
+ * A preview that only widened `status` would satisfy the first and silently
+ * fail the second — showing a published page's live content while the edits
+ * being previewed stay invisible. These prove both layers move together, and
+ * that neither reaches a visitor who is not previewing.
+ */
+import { afterEach, describe, expect, it } from "vitest";
+
+import { defineCollection, text } from "../../../config";
+import {
+  createTestNextly,
+  type TestNextly,
+} from "../../../plugins/test-nextly";
+import { createContentRoute } from "../content-route";
+import type { ContentEntry } from "../resolve-content";
+
+const pages = () =>
+  defineCollection({
+    slug: "pages",
+    status: true,
+    versions: { drafts: true },
+    fields: [text({ name: "slug" }), text({ name: "title" })],
+  });
+
+let current: TestNextly | undefined;
+afterEach(async () => {
+  await current?.destroy();
+  current = undefined;
+});
+
+function route(
+  nextly: TestNextly["nextly"],
+  draft?: boolean | (() => boolean | Promise<boolean>)
+) {
+  return createContentRoute({
+    collections: ["pages"],
+    nextly,
+    render: (entry: ContentEntry) => entry,
+    ...(draft === undefined ? {} : { draft }),
+  });
+}
+
+describe("createContentRoute + draft layers (integration)", () => {
+  it("shows pending edits to a preview and live content to everyone else", async () => {
+    current = await createTestNextly({ collections: [pages()] });
+    const created = await current.nextly.create({
+      collection: "pages",
+      data: { slug: "about", title: "Live", status: "published" },
+    });
+
+    // An update that names no status on a published document is
+    // non-destructive: the live row keeps its title and the edit becomes the
+    // working draft.
+    await current.nextly.update({
+      collection: "pages",
+      id: String(created.item.id),
+      data: { title: "Pending edit" },
+    });
+
+    const publicPage = (await route(current.nextly).ContentPage({
+      params: { slug: ["about"] },
+    })) as ContentEntry;
+    expect(publicPage.title).toBe("Live");
+    expect(publicPage._isWorkingDraft).toBeUndefined();
+
+    const previewPage = (await route(current.nextly, true).ContentPage({
+      params: { slug: ["about"] },
+    })) as ContentEntry;
+    expect(previewPage.title).toBe("Pending edit");
+    expect(previewPage._isWorkingDraft).toBe(true);
+  });
+
+  it("shows a never-published entry to a preview and 404s it publicly", async () => {
+    // The other layer. Widening `status` is what covers this one, and a
+    // preview needs both — hence `draft` widening the scope with it.
+    current = await createTestNextly({ collections: [pages()] });
+    await current.nextly.create({
+      collection: "pages",
+      data: { slug: "unreleased", title: "Unreleased", status: "draft" },
+    });
+
+    await expect(
+      route(current.nextly).ContentPage({ params: { slug: ["unreleased"] } })
+    ).rejects.toThrow();
+
+    const previewPage = (await route(current.nextly, true).ContentPage({
+      params: { slug: ["unreleased"] },
+    })) as ContentEntry;
+    expect(previewPage.title).toBe("Unreleased");
+  });
+
+  it("keeps drafts out of the paths a build pre-renders", async () => {
+    // `generateStaticParams` runs where there is no visitor to gate. A draft
+    // baked into a static path is published to everyone, permanently.
+    current = await createTestNextly({ collections: [pages()] });
+    await current.nextly.create({
+      collection: "pages",
+      data: { slug: "about", title: "About", status: "published" },
+    });
+    await current.nextly.create({
+      collection: "pages",
+      data: { slug: "unreleased", title: "Unreleased", status: "draft" },
+    });
+
+    const params = await route(current.nextly, true).generateStaticParams();
+
+    expect(params).toContainEqual({ slug: ["about"] });
+    expect(params).not.toContainEqual({ slug: ["unreleased"] });
+  });
+
+  it("follows the decision from request to request", async () => {
+    // The whole reason the decision is a function: one route object serves both
+    // the visitor and the editor, and the answer changes between them.
+    current = await createTestNextly({ collections: [pages()] });
+    const created = await current.nextly.create({
+      collection: "pages",
+      data: { slug: "about", title: "Live", status: "published" },
+    });
+    await current.nextly.update({
+      collection: "pages",
+      id: String(created.item.id),
+      data: { title: "Pending edit" },
+    });
+
+    let previewing = false;
+    const shared = route(current.nextly, () => previewing);
+
+    expect(
+      (
+        (await shared.ContentPage({
+          params: { slug: ["about"] },
+        })) as ContentEntry
+      ).title
+    ).toBe("Live");
+
+    previewing = true;
+    expect(
+      (
+        (await shared.ContentPage({
+          params: { slug: ["about"] },
+        })) as ContentEntry
+      ).title
+    ).toBe("Pending edit");
+
+    previewing = false;
+    expect(
+      (
+        (await shared.ContentPage({
+          params: { slug: ["about"] },
+        })) as ContentEntry
+      ).title
+    ).toBe("Live");
+  });
+});

--- a/packages/nextly/src/runtime/routing/__tests__/content-route-draft.test.ts
+++ b/packages/nextly/src/runtime/routing/__tests__/content-route-draft.test.ts
@@ -14,10 +14,15 @@ import type {
 } from "../../../direct-api/types/collections";
 import type { ListResult } from "../../../direct-api/types/shared";
 import { createContentRoute } from "../content-route";
+import type { ResolvedContext } from "../content-route";
 import type { ContentEntry, NextlyContentReader } from "../resolve-content";
 
 function stubReader(
-  row: Record<string, unknown> | null = { id: "1", slug: "a" }
+  row: Record<string, unknown> | null = {
+    id: "1",
+    slug: "a",
+    status: "published",
+  }
 ): {
   reader: NextlyContentReader;
   calls: FindArgs[];
@@ -150,6 +155,56 @@ describe("the content route's draft decision", () => {
     }).generateMetadata(params);
 
     expect(calls[0].status).toBe("published");
+  });
+
+  it("scopes the decision to the path being resolved", async () => {
+    // Next's draft mode is one boolean for the whole host: `isEnabled` says a
+    // visitor opened A valid preview link, never WHICH document it was for.
+    // Answering from that alone would turn a link scoped to one unpublished
+    // page into a key to every unpublished page in the configured collections.
+    // The collection and slug are handed in so the answer can be compared
+    // against what the token actually granted.
+    const { reader, byIdCalls } = stubReader();
+    const seen: ResolvedContext[] = [];
+    const route = createContentRoute({
+      collections: ["pages"],
+      nextly: reader,
+      render: (entry: ContentEntry) => entry,
+      buildMetadata: (entry: ContentEntry) => ({ title: String(entry.id) }),
+      draft: context => {
+        seen.push(context);
+        return context.slug === "granted";
+      },
+    });
+
+    await route.generateMetadata({ params: { slug: ["denied"] } });
+    expect(seen).toEqual([{ collection: "pages", slug: "denied" }]);
+    expect(byIdCalls).toHaveLength(0);
+
+    await route.generateMetadata({ params: { slug: ["granted"] } });
+    expect(seen[1]).toEqual({ collection: "pages", slug: "granted" });
+    expect(byIdCalls).toHaveLength(1);
+  });
+
+  it("asks per collection, since one slug can name a different document in each", async () => {
+    const { reader } = stubReader(null);
+    const seen: ResolvedContext[] = [];
+
+    await createContentRoute({
+      collections: ["pages", "docs"],
+      nextly: reader,
+      render: (entry: ContentEntry) => entry,
+      buildMetadata: (entry: ContentEntry) => ({ title: String(entry.id) }),
+      draft: context => {
+        seen.push(context);
+        return false;
+      },
+    }).generateMetadata(params);
+
+    expect(seen).toEqual([
+      { collection: "pages", slug: "a" },
+      { collection: "docs", slug: "a" },
+    ]);
   });
 
   it("never pre-renders draft paths", async () => {

--- a/packages/nextly/src/runtime/routing/__tests__/content-route-draft.test.ts
+++ b/packages/nextly/src/runtime/routing/__tests__/content-route-draft.test.ts
@@ -22,7 +22,14 @@ function stubReader(
     id: "1",
     slug: "a",
     status: "published",
-  }
+  },
+  /**
+   * Apply the lifecycle scope the way the query service does, so a
+   * never-published row is only returned to a read that widened `status`.
+   * Off by default: most cases here are about which arguments the route sends,
+   * and a stub that answers regardless keeps them independent of the filter.
+   */
+  options: { enforceStatus?: boolean } = {}
 ): {
   reader: NextlyContentReader;
   calls: FindArgs[];
@@ -33,7 +40,11 @@ function stubReader(
   const reader: NextlyContentReader = {
     find: async (args): Promise<ListResult<Record<string, unknown>>> => {
       calls.push(args);
-      const items = row ? [row] : [];
+      const withheld =
+        options.enforceStatus === true &&
+        args.status !== "all" &&
+        row?.status !== "published";
+      const items = row && !withheld ? [row] : [];
       return {
         items,
         meta: {
@@ -236,6 +247,38 @@ describe("the content route's draft decision", () => {
 
     expect((rightEntry as ContentEntry)._isWorkingDraft).toBe(true);
     expect(byIdCalls).toHaveLength(1);
+  });
+
+  it("refuses a grant when the resolved document has no comparable id", async () => {
+    // An `afterRead` hook's return value REPLACES the document, so a collection
+    // that reshapes its public read can hand back a row whose id is absent or
+    // structured. Stringifying those yields `"undefined"` and
+    // `"[object Object]"` — values a grant can carry literally.
+    //
+    // What that would cost is a disclosure, not a degraded preview: a grant the
+    // route honours is read with the lifecycle scope widened to `"all"`, so the
+    // row it matches by accident can be one that was NEVER published.
+    for (const id of [undefined, { nested: "1" }]) {
+      const { reader, calls } = stubReader(
+        { id, slug: "a", status: "draft" },
+        { enforceStatus: true }
+      );
+
+      const route = createContentRoute({
+        collections: ["pages"],
+        nextly: reader,
+        render: (row: ContentEntry) => row,
+        buildMetadata: (row: ContentEntry) => ({ title: String(row.slug) }),
+        draft: () => ({ entryId: String(id) }),
+      });
+
+      // The never-published row is the only one there is, so refusing the grant
+      // leaves nothing to serve. Asserting the REFUSAL rather than the throw:
+      // the route re-read published-only, which is what a rejected grant does
+      // and what returning the row instead would have skipped.
+      await expect(route.ContentPage(params)).rejects.toThrow();
+      expect(calls.map(call => call.status)).toEqual(["all", "published"]);
+    }
   });
 
   it("never pre-renders draft paths", async () => {

--- a/packages/nextly/src/runtime/routing/__tests__/content-route-draft.test.ts
+++ b/packages/nextly/src/runtime/routing/__tests__/content-route-draft.test.ts
@@ -1,0 +1,167 @@
+/**
+ * `createContentRoute`'s draft decision, against a stubbed reader (no DB).
+ *
+ * Route config is captured once at module scope while "is this visitor
+ * previewing" is a per-request fact, so the decision has to be a function the
+ * route asks on every resolve. These cover that it is asked, that its answer
+ * reaches the read, and that a build-time scan ignores it entirely.
+ */
+import { describe, expect, it } from "vitest";
+
+import type {
+  FindArgs,
+  FindByIDArgs,
+} from "../../../direct-api/types/collections";
+import type { ListResult } from "../../../direct-api/types/shared";
+import { createContentRoute } from "../content-route";
+import type { ContentEntry, NextlyContentReader } from "../resolve-content";
+
+function stubReader(
+  row: Record<string, unknown> | null = { id: "1", slug: "a" }
+): {
+  reader: NextlyContentReader;
+  calls: FindArgs[];
+  byIdCalls: FindByIDArgs[];
+} {
+  const calls: FindArgs[] = [];
+  const byIdCalls: FindByIDArgs[] = [];
+  const reader: NextlyContentReader = {
+    find: async (args): Promise<ListResult<Record<string, unknown>>> => {
+      calls.push(args);
+      const items = row ? [row] : [];
+      return {
+        items,
+        meta: {
+          total: items.length,
+          page: 1,
+          limit: 1,
+          totalPages: 1,
+          hasNext: false,
+          hasPrev: false,
+        },
+      };
+    },
+    findByID: async (args): Promise<Record<string, unknown> | null> => {
+      byIdCalls.push(args);
+      return { ...row, _isWorkingDraft: true };
+    },
+  };
+  return { reader, calls, byIdCalls };
+}
+
+function routeWith(
+  reader: NextlyContentReader,
+  draft?: boolean | (() => boolean | Promise<boolean>)
+) {
+  return createContentRoute({
+    collections: ["pages"],
+    nextly: reader,
+    render: (entry: ContentEntry) => entry,
+    buildMetadata: (entry: ContentEntry) => ({ title: String(entry.id) }),
+    ...(draft === undefined ? {} : { draft }),
+  });
+}
+
+const params = { params: { slug: ["a"] } };
+
+describe("the content route's draft decision", () => {
+  it("reads published content when nothing asks for a draft", async () => {
+    const { reader, calls, byIdCalls } = stubReader();
+
+    await routeWith(reader).generateMetadata(params);
+
+    expect(calls[0].status).toBe("published");
+    expect(calls[0].overrideAccess).toBe(false);
+    expect(byIdCalls).toHaveLength(0);
+  });
+
+  it("asks its decision function on every resolve", async () => {
+    // Config is captured once; the answer is not. A decision read at factory
+    // time would freeze the first visitor's answer for every later one.
+    const { reader } = stubReader();
+    let asked = 0;
+    const route = routeWith(reader, () => {
+      asked += 1;
+      return false;
+    });
+
+    await route.generateMetadata(params);
+    await route.generateMetadata(params);
+
+    expect(asked).toBe(2);
+  });
+
+  it("honours an answer that changes between requests", async () => {
+    const { reader, byIdCalls } = stubReader();
+    let previewing = false;
+    const route = routeWith(reader, () => previewing);
+
+    await route.generateMetadata(params);
+    expect(byIdCalls).toHaveLength(0);
+
+    previewing = true;
+    await route.generateMetadata(params);
+    expect(byIdCalls).toHaveLength(1);
+  });
+
+  it("accepts an async decision, as reading Next's draft mode requires", async () => {
+    // `draftMode()` is async from Next 15, so the natural wiring returns a
+    // promise; a synchronous-only signature would make it unusable.
+    const { reader, byIdCalls } = stubReader();
+
+    await routeWith(reader, async () => Promise.resolve(true)).generateMetadata(
+      params
+    );
+
+    expect(byIdCalls).toHaveLength(1);
+  });
+
+  it("reads trusted when the answer is yes", async () => {
+    // The route resolves anonymously and the overlay is gated on an
+    // update-capability probe, so an enforced draft read could only ever return
+    // the published row — preview would silently do nothing.
+    const { reader, calls, byIdCalls } = stubReader();
+
+    await routeWith(reader, true).generateMetadata(params);
+
+    expect(calls[0].overrideAccess).toBe(true);
+    expect(byIdCalls[0].overrideAccess).toBe(true);
+    expect(byIdCalls[0].draft).toBe(true);
+  });
+
+  it("widens the lifecycle scope with it, so both draft layers move together", async () => {
+    const { reader, calls } = stubReader();
+
+    await routeWith(reader, true).generateMetadata(params);
+
+    expect(calls[0].status).toBe("all");
+  });
+
+  it("leaves an explicitly configured lifecycle scope alone", async () => {
+    const { reader, calls } = stubReader();
+
+    await createContentRoute({
+      collections: ["pages"],
+      nextly: reader,
+      status: "published",
+      draft: true,
+      render: (entry: ContentEntry) => entry,
+      buildMetadata: (entry: ContentEntry) => ({ title: String(entry.id) }),
+    }).generateMetadata(params);
+
+    expect(calls[0].status).toBe("published");
+  });
+
+  it("never pre-renders draft paths", async () => {
+    // `generateStaticParams` runs at build time, where there is no visitor and
+    // no preview. Baking a draft into a static path would publish it to
+    // everyone, permanently, with no request to gate it.
+    const { reader, calls, byIdCalls } = stubReader();
+
+    await routeWith(reader, true).generateStaticParams();
+
+    expect(byIdCalls).toHaveLength(0);
+    expect(calls.every(call => call.status === "published")).toBe(true);
+    expect(calls.every(call => call.overrideAccess === false)).toBe(true);
+  });
+});

--- a/packages/nextly/src/runtime/routing/__tests__/content-route-draft.test.ts
+++ b/packages/nextly/src/runtime/routing/__tests__/content-route-draft.test.ts
@@ -207,6 +207,37 @@ describe("the content route's draft decision", () => {
     ]);
   });
 
+  it("discards a draft the grant did not name", async () => {
+    // A slug need not be unique — the resolver supports duplicates and settles
+    // them by sorting on `id` — so a grant scoped to one entry could otherwise
+    // open another that happens to share its slug. The grant names the
+    // document, and a resolve that lands on a different one falls back to
+    // published rather than serving what was never granted.
+    const { reader, byIdCalls } = stubReader();
+
+    const wrongEntry = await createContentRoute({
+      collections: ["pages"],
+      nextly: reader,
+      render: (entry: ContentEntry) => entry,
+      buildMetadata: (entry: ContentEntry) => ({ title: String(entry.id) }),
+      draft: () => ({ entryId: "some-other-entry" }),
+    }).ContentPage(params);
+
+    expect((wrongEntry as ContentEntry)._isWorkingDraft).toBeUndefined();
+
+    byIdCalls.length = 0;
+    const rightEntry = await createContentRoute({
+      collections: ["pages"],
+      nextly: reader,
+      render: (entry: ContentEntry) => entry,
+      buildMetadata: (entry: ContentEntry) => ({ title: String(entry.id) }),
+      draft: () => ({ entryId: "1" }),
+    }).ContentPage(params);
+
+    expect((rightEntry as ContentEntry)._isWorkingDraft).toBe(true);
+    expect(byIdCalls).toHaveLength(1);
+  });
+
   it("never pre-renders draft paths", async () => {
     // `generateStaticParams` runs at build time, where there is no visitor and
     // no preview. Baking a draft into a static path would publish it to

--- a/packages/nextly/src/runtime/routing/__tests__/resolve-content-draft-cache.test.ts
+++ b/packages/nextly/src/runtime/routing/__tests__/resolve-content-draft-cache.test.ts
@@ -25,7 +25,7 @@ vi.mock("../../cache/cached-find", () => ({
 }));
 
 function reader(): NextlyContentReader {
-  const row = { id: "1", title: "A" };
+  const row = { id: "1", title: "A", status: "published" };
   return {
     find: async (): Promise<ListResult<Record<string, unknown>>> => ({
       items: [row],
@@ -70,6 +70,11 @@ describe("caching a draft read", () => {
 
     expect(cachedFindSpy).not.toHaveBeenCalled();
     // And the read still happened — "not cached" must not mean "not read".
-    expect(result).toEqual({ id: "1", title: "A", _isWorkingDraft: true });
+    expect(result).toEqual({
+      id: "1",
+      title: "A",
+      status: "published",
+      _isWorkingDraft: true,
+    });
   });
 });

--- a/packages/nextly/src/runtime/routing/__tests__/resolve-content-draft-cache.test.ts
+++ b/packages/nextly/src/runtime/routing/__tests__/resolve-content-draft-cache.test.ts
@@ -1,0 +1,75 @@
+/**
+ * A draft read is never cached.
+ *
+ * Asserted as the MECHANISM — whether `cachedFind` is reached at all — rather
+ * than by reading twice and hoping to observe staleness. Outside a Next runtime
+ * `cachedFind` calls straight through, so a round-trip test would pass whether
+ * or not the rule existed.
+ *
+ * The rule matters because cache tags are busted by writes to the LIVE row
+ * while a working draft changes on every save: a cached draft would show an
+ * editor their previous save and call it a preview.
+ */
+import { describe, expect, it, vi } from "vitest";
+
+import type { ListResult } from "../../../direct-api/types/shared";
+import { resolveContent, type NextlyContentReader } from "../resolve-content";
+
+const { cachedFindSpy } = vi.hoisted(() => ({ cachedFindSpy: vi.fn() }));
+
+vi.mock("../../cache/cached-find", () => ({
+  cachedFind: (read: () => Promise<unknown>, options: unknown) => {
+    cachedFindSpy(options);
+    return read();
+  },
+}));
+
+function reader(): NextlyContentReader {
+  const row = { id: "1", title: "A" };
+  return {
+    find: async (): Promise<ListResult<Record<string, unknown>>> => ({
+      items: [row],
+      meta: {
+        total: 1,
+        page: 1,
+        limit: 1,
+        totalPages: 1,
+        hasNext: false,
+        hasPrev: false,
+      },
+    }),
+    findByID: async (): Promise<Record<string, unknown> | null> => ({
+      ...row,
+      _isWorkingDraft: true,
+    }),
+  };
+}
+
+describe("caching a draft read", () => {
+  it("caches a trusted published read", async () => {
+    // The baseline the next case is measured against. Without it, "not cached"
+    // could mean the rule works or that nothing here is ever cached.
+    cachedFindSpy.mockClear();
+
+    await resolveContent("posts", "a", {
+      nextly: reader(),
+      overrideAccess: true,
+    });
+
+    expect(cachedFindSpy).toHaveBeenCalledOnce();
+  });
+
+  it("never caches a draft read, even when it is trusted and userless", async () => {
+    cachedFindSpy.mockClear();
+
+    const result = await resolveContent("posts", "a", {
+      nextly: reader(),
+      overrideAccess: true,
+      draft: true,
+    });
+
+    expect(cachedFindSpy).not.toHaveBeenCalled();
+    // And the read still happened — "not cached" must not mean "not read".
+    expect(result).toEqual({ id: "1", title: "A", _isWorkingDraft: true });
+  });
+});

--- a/packages/nextly/src/runtime/routing/__tests__/resolve-content.test.ts
+++ b/packages/nextly/src/runtime/routing/__tests__/resolve-content.test.ts
@@ -5,7 +5,10 @@
  */
 import { describe, expect, it } from "vitest";
 
-import type { FindArgs } from "../../../direct-api/types/collections";
+import type {
+  FindArgs,
+  FindByIDArgs,
+} from "../../../direct-api/types/collections";
 import type { ListResult } from "../../../direct-api/types/shared";
 import { NextlyError } from "../../../errors/nextly-error";
 import { resolveContent, type NextlyContentReader } from "../resolve-content";
@@ -13,8 +16,15 @@ import { resolveContent, type NextlyContentReader } from "../resolve-content";
 function stubReader(behavior: {
   items?: Record<string, unknown>[];
   error?: unknown;
-}): { reader: NextlyContentReader; calls: FindArgs[] } {
+  /** What the by-id re-read returns; `null` models a row deleted mid-resolve. */
+  overlay?: Record<string, unknown> | null;
+}): {
+  reader: NextlyContentReader;
+  calls: FindArgs[];
+  byIdCalls: FindByIDArgs[];
+} {
   const calls: FindArgs[] = [];
+  const byIdCalls: FindByIDArgs[] = [];
   const reader: NextlyContentReader = {
     find: async (args): Promise<ListResult<Record<string, unknown>>> => {
       calls.push(args);
@@ -32,8 +42,15 @@ function stubReader(behavior: {
         },
       };
     },
+    findByID: async (args): Promise<Record<string, unknown> | null> => {
+      byIdCalls.push(args);
+      if (behavior.error) throw behavior.error;
+      return behavior.overlay === undefined
+        ? (behavior.items?.[0] ?? null)
+        : behavior.overlay;
+    },
   };
-  return { reader, calls };
+  return { reader, calls, byIdCalls };
 }
 
 describe("resolveContent (unit)", () => {
@@ -78,5 +95,116 @@ describe("resolveContent (unit)", () => {
   it("returns null on a genuine miss (no items)", async () => {
     const { reader } = stubReader({ items: [] });
     expect(await resolveContent("posts", "a", { nextly: reader })).toBeNull();
+  });
+});
+
+describe("resolveContent (working-draft layer)", () => {
+  it("does not re-read by id when no draft was asked for", async () => {
+    // The ordinary published read stays exactly one query.
+    const { reader, byIdCalls } = stubReader({ items: [{ id: "1" }] });
+    await resolveContent("posts", "a", { nextly: reader });
+    expect(byIdCalls).toHaveLength(0);
+  });
+
+  it("overlays the working draft on the row the slug resolved to", async () => {
+    // The overlay lives on the by-id read, not the list read, so a slug lookup
+    // cannot surface it without this second step.
+    const { reader, calls, byIdCalls } = stubReader({
+      items: [{ id: "1", title: "live" }],
+      overlay: { id: "1", title: "pending edit", _isWorkingDraft: true },
+    });
+
+    const result = await resolveContent("posts", "a", {
+      nextly: reader,
+      draft: true,
+      overrideAccess: true,
+    });
+
+    expect(result).toEqual({
+      id: "1",
+      title: "pending edit",
+      _isWorkingDraft: true,
+    });
+    expect(calls).toHaveLength(1);
+    expect(byIdCalls).toHaveLength(1);
+    expect(byIdCalls[0].id).toBe("1");
+    expect(byIdCalls[0].draft).toBe(true);
+    expect(byIdCalls[0].collection).toBe("posts");
+  });
+
+  it("widens the lifecycle scope so a never-published entry is found", async () => {
+    // Half-configuring preview is the failure this default exists to prevent: a
+    // published-only lookup finds nothing to overlay for an entry that has
+    // never gone live, so the page 404s while the editor is looking at it.
+    const { reader, calls } = stubReader({ items: [{ id: "1" }] });
+    await resolveContent("posts", "a", {
+      nextly: reader,
+      draft: true,
+      overrideAccess: true,
+    });
+    expect(calls[0].status).toBe("all");
+  });
+
+  it("still lets an explicit lifecycle scope win", async () => {
+    // Previewing pending edits on live pages only is a legitimate ask.
+    const { reader, calls } = stubReader({ items: [{ id: "1" }] });
+    await resolveContent("posts", "a", {
+      nextly: reader,
+      draft: true,
+      status: "published",
+      overrideAccess: true,
+    });
+    expect(calls[0].status).toBe("published");
+  });
+
+  it("carries the read context into the overlay read", async () => {
+    // The two reads must agree: an overlay fetched at a different depth or
+    // locale would render a page the slug lookup never described.
+    const { reader, byIdCalls } = stubReader({ items: [{ id: "1" }] });
+    await resolveContent("posts", "a", {
+      nextly: reader,
+      draft: true,
+      depth: 3,
+      locale: "fr",
+      richTextFormat: "html",
+      overrideAccess: true,
+      user: { id: "u1", role: "editor" },
+    });
+
+    expect(byIdCalls[0].depth).toBe(3);
+    expect(byIdCalls[0].locale).toBe("fr");
+    expect(byIdCalls[0].richTextFormat).toBe("html");
+    expect(byIdCalls[0].overrideAccess).toBe(true);
+    expect(byIdCalls[0].user).toEqual({ id: "u1", role: "editor" });
+  });
+
+  it("resolves to nothing when the row disappears between the two reads", async () => {
+    // Falling back to the copy already in hand would render a page that no
+    // longer exists.
+    const { reader } = stubReader({ items: [{ id: "1" }], overlay: null });
+    expect(
+      await resolveContent("posts", "a", {
+        nextly: reader,
+        draft: true,
+        overrideAccess: true,
+      })
+    ).toBeNull();
+  });
+
+  it("returns the row unchanged when its id is not addressable", async () => {
+    // A collection whose rows carry no usable id has nothing to re-read by;
+    // the live row is a truthful answer where a crash is not.
+    const { reader, byIdCalls } = stubReader({
+      items: [{ id: { nested: true }, title: "live" }],
+    });
+
+    const result = await resolveContent("posts", "a", {
+      nextly: reader,
+      draft: true,
+      overrideAccess: true,
+    });
+
+    expect(result).toEqual({ id: { nested: true }, title: "live" });
+    expect(byIdCalls).toHaveLength(0);
   });
 });

--- a/packages/nextly/src/runtime/routing/__tests__/resolve-content.test.ts
+++ b/packages/nextly/src/runtime/routing/__tests__/resolve-content.test.ts
@@ -18,6 +18,8 @@ function stubReader(behavior: {
   error?: unknown;
   /** What the by-id re-read returns; `null` models a row deleted mid-resolve. */
   overlay?: Record<string, unknown> | null;
+  /** What the by-id re-read throws, modelling the real API's error behaviour. */
+  overlayError?: unknown;
 }): {
   reader: NextlyContentReader;
   calls: FindArgs[];
@@ -44,6 +46,7 @@ function stubReader(behavior: {
     },
     findByID: async (args): Promise<Record<string, unknown> | null> => {
       byIdCalls.push(args);
+      if (behavior.overlayError) throw behavior.overlayError;
       if (behavior.error) throw behavior.error;
       return behavior.overlay === undefined
         ? (behavior.items?.[0] ?? null)
@@ -212,23 +215,39 @@ describe("resolveContent (working-draft layer)", () => {
     });
   });
 
-  it("treats a deletion race as a miss rather than an error", async () => {
-    // The real by-id read THROWS `NOT_FOUND` rather than answering null, so the
-    // overlay asks it not to: a row deleted between the two reads is a content
-    // miss, and the slug lookup answering nothing would simply have rendered
-    // the not-found page.
-    const { reader, byIdCalls } = stubReader({
+  it("treats a deleted row as a miss and a broken read as an error", async () => {
+    // The by-id read THROWS `NOT_FOUND` rather than answering null, so a row
+    // deleted between the two reads has to be caught — the slug lookup finding
+    // nothing would simply have rendered the not-found page.
+    //
+    // Caught by STATUS rather than with `disableErrors`, which returns null for
+    // every unsuccessful result: a database blip would become a permanently
+    // cached 404, the exact failure the rethrow exists to prevent. Both halves
+    // are asserted, because only the second separates the two.
+    const gone = stubReader({
       items: [{ id: "1", status: "published" }],
-      overlay: null,
+      overlayError: NextlyError.notFound(),
     });
+    expect(
+      await resolveContent("posts", "a", {
+        nextly: gone.reader,
+        draft: true,
+        overrideAccess: true,
+      })
+    ).toBeNull();
 
-    await resolveContent("posts", "a", {
-      nextly: reader,
-      draft: true,
-      overrideAccess: true,
+    const broken = NextlyError.internal();
+    const blip = stubReader({
+      items: [{ id: "1", status: "published" }],
+      overlayError: broken,
     });
-
-    expect(byIdCalls[0].disableErrors).toBe(true);
+    await expect(
+      resolveContent("posts", "a", {
+        nextly: blip.reader,
+        draft: true,
+        overrideAccess: true,
+      })
+    ).rejects.toBe(broken);
   });
 
   it("still lets an explicit lifecycle scope win", async () => {

--- a/packages/nextly/src/runtime/routing/__tests__/resolve-content.test.ts
+++ b/packages/nextly/src/runtime/routing/__tests__/resolve-content.test.ts
@@ -67,7 +67,9 @@ describe("resolveContent (unit)", () => {
   });
 
   it("forwards an explicit user and status, and a trusted override", async () => {
-    const { reader, calls } = stubReader({ items: [{ id: "1" }] });
+    const { reader, calls } = stubReader({
+      items: [{ id: "1", status: "published" }],
+    });
     await resolveContent("posts", "a", {
       nextly: reader,
       overrideAccess: true,
@@ -101,7 +103,9 @@ describe("resolveContent (unit)", () => {
 describe("resolveContent (working-draft layer)", () => {
   it("does not re-read by id when no draft was asked for", async () => {
     // The ordinary published read stays exactly one query.
-    const { reader, byIdCalls } = stubReader({ items: [{ id: "1" }] });
+    const { reader, byIdCalls } = stubReader({
+      items: [{ id: "1", status: "published" }],
+    });
     await resolveContent("posts", "a", { nextly: reader });
     expect(byIdCalls).toHaveLength(0);
   });
@@ -110,7 +114,7 @@ describe("resolveContent (working-draft layer)", () => {
     // The overlay lives on the by-id read, not the list read, so a slug lookup
     // cannot surface it without this second step.
     const { reader, calls, byIdCalls } = stubReader({
-      items: [{ id: "1", title: "live" }],
+      items: [{ id: "1", title: "live", status: "published" }],
       overlay: { id: "1", title: "pending edit", _isWorkingDraft: true },
     });
 
@@ -136,7 +140,9 @@ describe("resolveContent (working-draft layer)", () => {
     // Half-configuring preview is the failure this default exists to prevent: a
     // published-only lookup finds nothing to overlay for an entry that has
     // never gone live, so the page 404s while the editor is looking at it.
-    const { reader, calls } = stubReader({ items: [{ id: "1" }] });
+    const { reader, calls } = stubReader({
+      items: [{ id: "1", status: "published" }],
+    });
     await resolveContent("posts", "a", {
       nextly: reader,
       draft: true,
@@ -145,9 +151,91 @@ describe("resolveContent (working-draft layer)", () => {
     expect(calls[0].status).toBe("all");
   });
 
+  it("does not widen the lifecycle scope for an untrusted draft read", async () => {
+    // The two halves of a draft read are gated very differently. The overlay is
+    // judged per row by an update-capability probe, so asking for it is safe
+    // from anywhere; widening `status` is judged by nothing at all — the list
+    // read simply returns never-published rows. Tying the widening to the draft
+    // flag alone would let a preview flag wired from an untrusted request
+    // publish unpublished pages.
+    const { reader, calls } = stubReader({
+      items: [{ id: "1", status: "published" }],
+    });
+
+    await resolveContent("posts", "a", { nextly: reader, draft: true });
+
+    expect(calls[0].status).toBe("published");
+  });
+
+  it("still overlays pending edits on an untrusted read", async () => {
+    // Refusing the widening must not cost the half that IS safely gated: a
+    // published page's pending edits are still previewable, judged per row.
+    const { reader, byIdCalls } = stubReader({
+      items: [{ id: "1", status: "published" }],
+      overlay: { id: "1", title: "pending", _isWorkingDraft: true },
+    });
+
+    const result = await resolveContent("posts", "a", {
+      nextly: reader,
+      draft: true,
+      user: { id: "u1", role: "editor" },
+    });
+
+    expect(byIdCalls).toHaveLength(1);
+    expect(result).toEqual({
+      id: "1",
+      title: "pending",
+      _isWorkingDraft: true,
+    });
+  });
+
+  it("does not re-read a row that is not published", async () => {
+    // Only a published row can have pending edits beside it; an unpublished row
+    // already IS the draft. Skipping the second read there is also what keeps
+    // an enforced preview working, since a by-id read without trust filters to
+    // published and would answer 404 for exactly these rows.
+    const { reader, byIdCalls } = stubReader({
+      items: [{ id: "1", title: "never published", status: "draft" }],
+    });
+
+    const result = await resolveContent("posts", "a", {
+      nextly: reader,
+      draft: true,
+      overrideAccess: true,
+    });
+
+    expect(byIdCalls).toHaveLength(0);
+    expect(result).toEqual({
+      id: "1",
+      title: "never published",
+      status: "draft",
+    });
+  });
+
+  it("treats a deletion race as a miss rather than an error", async () => {
+    // The real by-id read THROWS `NOT_FOUND` rather than answering null, so the
+    // overlay asks it not to: a row deleted between the two reads is a content
+    // miss, and the slug lookup answering nothing would simply have rendered
+    // the not-found page.
+    const { reader, byIdCalls } = stubReader({
+      items: [{ id: "1", status: "published" }],
+      overlay: null,
+    });
+
+    await resolveContent("posts", "a", {
+      nextly: reader,
+      draft: true,
+      overrideAccess: true,
+    });
+
+    expect(byIdCalls[0].disableErrors).toBe(true);
+  });
+
   it("still lets an explicit lifecycle scope win", async () => {
     // Previewing pending edits on live pages only is a legitimate ask.
-    const { reader, calls } = stubReader({ items: [{ id: "1" }] });
+    const { reader, calls } = stubReader({
+      items: [{ id: "1", status: "published" }],
+    });
     await resolveContent("posts", "a", {
       nextly: reader,
       draft: true,
@@ -160,7 +248,9 @@ describe("resolveContent (working-draft layer)", () => {
   it("carries the read context into the overlay read", async () => {
     // The two reads must agree: an overlay fetched at a different depth or
     // locale would render a page the slug lookup never described.
-    const { reader, byIdCalls } = stubReader({ items: [{ id: "1" }] });
+    const { reader, byIdCalls } = stubReader({
+      items: [{ id: "1", status: "published" }],
+    });
     await resolveContent("posts", "a", {
       nextly: reader,
       draft: true,
@@ -181,7 +271,10 @@ describe("resolveContent (working-draft layer)", () => {
   it("resolves to nothing when the row disappears between the two reads", async () => {
     // Falling back to the copy already in hand would render a page that no
     // longer exists.
-    const { reader } = stubReader({ items: [{ id: "1" }], overlay: null });
+    const { reader } = stubReader({
+      items: [{ id: "1", status: "published" }],
+      overlay: null,
+    });
     expect(
       await resolveContent("posts", "a", {
         nextly: reader,
@@ -195,7 +288,7 @@ describe("resolveContent (working-draft layer)", () => {
     // A collection whose rows carry no usable id has nothing to re-read by;
     // the live row is a truthful answer where a crash is not.
     const { reader, byIdCalls } = stubReader({
-      items: [{ id: { nested: true }, title: "live" }],
+      items: [{ id: { nested: true }, title: "live", status: "published" }],
     });
 
     const result = await resolveContent("posts", "a", {
@@ -204,7 +297,11 @@ describe("resolveContent (working-draft layer)", () => {
       overrideAccess: true,
     });
 
-    expect(result).toEqual({ id: { nested: true }, title: "live" });
+    expect(result).toEqual({
+      id: { nested: true },
+      title: "live",
+      status: "published",
+    });
     expect(byIdCalls).toHaveLength(0);
   });
 });

--- a/packages/nextly/src/runtime/routing/__tests__/resolve-content.test.ts
+++ b/packages/nextly/src/runtime/routing/__tests__/resolve-content.test.ts
@@ -192,13 +192,13 @@ describe("resolveContent (working-draft layer)", () => {
     });
   });
 
-  it("does not re-read a row that is not published", async () => {
-    // Only a published row can have pending edits beside it; an unpublished row
-    // already IS the draft. Skipping the second read there is also what keeps
-    // an enforced preview working, since a by-id read without trust filters to
-    // published and would answer 404 for exactly these rows.
+  it("does not decide whether to overlay from the row's own status", async () => {
+    // An `afterRead` hook may reshape or drop `status` before it is read here,
+    // so gating the overlay on it made preview depend on a field the collection
+    // is free to redefine. The overlay is attempted for every row instead.
     const { reader, byIdCalls } = stubReader({
-      items: [{ id: "1", title: "never published", status: "draft" }],
+      items: [{ id: "1", title: "live" }],
+      overlay: { id: "1", title: "pending", _isWorkingDraft: true },
     });
 
     const result = await resolveContent("posts", "a", {
@@ -207,25 +207,27 @@ describe("resolveContent (working-draft layer)", () => {
       overrideAccess: true,
     });
 
-    expect(byIdCalls).toHaveLength(0);
+    expect(byIdCalls).toHaveLength(1);
     expect(result).toEqual({
       id: "1",
-      title: "never published",
-      status: "draft",
+      title: "pending",
+      _isWorkingDraft: true,
     });
   });
 
-  it("treats a deleted row as a miss and a broken read as an error", async () => {
-    // The by-id read THROWS `NOT_FOUND` rather than answering null, so a row
-    // deleted between the two reads has to be caught — the slug lookup finding
-    // nothing would simply have rendered the not-found page.
+  it("falls back to the live row when there is no overlay to be had", async () => {
+    // The overlay is an enhancement, so anything that means "no draft" leaves
+    // the live row standing: a row deleted between the two reads, or an
+    // enforced by-id read filtering it to published, both answer 404.
     //
-    // Caught by STATUS rather than with `disableErrors`, which returns null for
-    // every unsuccessful result: a database blip would become a permanently
-    // cached 404, the exact failure the rethrow exists to prevent. Both halves
-    // are asserted, because only the second separates the two.
+    // Caught around the OVERLAY read alone, and by status rather than with
+    // `disableErrors`. A handler over the whole read would turn a 404 from a
+    // mistyped collection into a silent content miss, and `disableErrors`
+    // returns null for every unsuccessful result — a database blip would become
+    // a permanently-cached 404. Both halves are asserted, because only the
+    // second separates the two.
     const gone = stubReader({
-      items: [{ id: "1", status: "published" }],
+      items: [{ id: "1", title: "live", status: "published" }],
       overlayError: NextlyError.notFound(),
     });
     expect(
@@ -234,7 +236,7 @@ describe("resolveContent (working-draft layer)", () => {
         draft: true,
         overrideAccess: true,
       })
-    ).toBeNull();
+    ).toEqual({ id: "1", title: "live", status: "published" });
 
     const broken = NextlyError.internal();
     const blip = stubReader({
@@ -248,6 +250,22 @@ describe("resolveContent (working-draft layer)", () => {
         overrideAccess: true,
       })
     ).rejects.toBe(broken);
+  });
+
+  it("still surfaces a 404 that came from the slug lookup", async () => {
+    // The overlay's handler must not reach this read. A mistyped collection —
+    // or schema or hook code beneath it — answers 404, and swallowing that
+    // would render an ordinary content miss with nothing to say why.
+    const notFound = NextlyError.notFound();
+    const { reader } = stubReader({ error: notFound });
+
+    await expect(
+      resolveContent("posts", "a", {
+        nextly: reader,
+        draft: true,
+        overrideAccess: true,
+      })
+    ).rejects.toBe(notFound);
   });
 
   it("still lets an explicit lifecycle scope win", async () => {
@@ -287,11 +305,11 @@ describe("resolveContent (working-draft layer)", () => {
     expect(byIdCalls[0].user).toEqual({ id: "u1", role: "editor" });
   });
 
-  it("resolves to nothing when the row disappears between the two reads", async () => {
-    // Falling back to the copy already in hand would render a page that no
-    // longer exists.
+  it("keeps the live row when the overlay read finds no draft", async () => {
+    // The overlay adds pending edits; its absence is the ordinary case, not a
+    // failure. Returning nothing here would 404 a page that resolved fine.
     const { reader } = stubReader({
-      items: [{ id: "1", status: "published" }],
+      items: [{ id: "1", title: "live", status: "published" }],
       overlay: null,
     });
     expect(
@@ -300,7 +318,7 @@ describe("resolveContent (working-draft layer)", () => {
         draft: true,
         overrideAccess: true,
       })
-    ).toBeNull();
+    ).toEqual({ id: "1", title: "live", status: "published" });
   });
 
   it("returns the row unchanged when its id is not addressable", async () => {

--- a/packages/nextly/src/runtime/routing/content-route.ts
+++ b/packages/nextly/src/runtime/routing/content-route.ts
@@ -115,7 +115,9 @@ export interface ContentRouteConfig<TNode> {
    *
    * @default false
    */
-  draft?: boolean | ((context: ResolvedContext) => boolean | Promise<boolean>);
+  draft?:
+    | boolean
+    | ((context: ResolvedContext) => DraftGrant | Promise<DraftGrant>);
   /** Relation depth for the resolved read (default `1`). */
   depth?: number;
   /** A booted Nextly instance (defaults to `getNextly()`). */
@@ -153,6 +155,20 @@ export interface ContentRouteConfig<TNode> {
    */
   staticParamsLimit?: number;
 }
+
+/**
+ * What a draft decision may answer.
+ *
+ * `true` grants the draft at this path unconditionally. `{ entryId }` grants it
+ * for ONE document, and the route discards the draft if the path resolved to a
+ * different one — which matters because a slug need not be unique: the resolver
+ * deliberately supports duplicates and settles them by sorting on `id`, so a
+ * token issued for one entry could otherwise reach another that shares its slug.
+ *
+ * A preview token names an entry, so `{ entryId: scope.entryId }` is the shape
+ * to return when one backs the decision.
+ */
+export type DraftGrant = boolean | { entryId: string };
 
 /** The optional-catch-all route arg: `{ params: Promise<{ slug?: string[] }> }`. */
 export interface ContentRouteArgs {
@@ -234,10 +250,18 @@ export function createContentRoute<TNode>(
   const getInstance = (): NextlyContentReader => config.nextly ?? getNextly();
 
   /** Whether this request may see unpublished edits at one collection + slug. */
-  async function draftForThisPath(context: ResolvedContext): Promise<boolean> {
+  async function draftForThisPath(
+    context: ResolvedContext
+  ): Promise<DraftGrant> {
     const decision = config.draft;
     if (decision === undefined) return false;
     return typeof decision === "function" ? decision(context) : decision;
+  }
+
+  /** Whether a grant covers the document the path actually resolved to. */
+  function grantCovers(grant: DraftGrant, entry: ContentEntry): boolean {
+    if (typeof grant === "boolean") return grant;
+    return String(entry.id) === grant.entryId;
   }
 
   /** Resolve the joined slug across the configured collections (first match wins). */
@@ -248,7 +272,8 @@ export function createContentRoute<TNode>(
       // Asked per collection, not once per request: the answer is scoped to a
       // document, and the same slug can name a different document in each
       // configured collection.
-      const draft = await draftForThisPath({ collection, slug });
+      const grant = await draftForThisPath({ collection, slug });
+      const draft = grant !== false;
       const entry = await resolveContent(collection, slug, {
         nextly: config.nextly,
         slugField,
@@ -268,7 +293,28 @@ export function createContentRoute<TNode>(
         // justifies this lives in the `draft` decision itself.
         overrideAccess: overrideAccess || draft,
       });
-      if (entry) return { entry, context: { collection, slug } };
+      if (!entry) continue;
+      if (draft && !grantCovers(grant, entry)) {
+        // The grant named a different document. A slug need not be unique, so
+        // this is where a token for one entry would otherwise have opened
+        // another that happens to share its slug — read again with no draft
+        // rather than serving the one that was never granted.
+        const published = await resolveContent(collection, slug, {
+          nextly: config.nextly,
+          slugField,
+          ...(config.status ? { status: config.status } : {}),
+          depth,
+          tags: config.tags,
+          revalidate: config.revalidate,
+          cacheScope: config.cacheScope,
+          overrideAccess,
+        });
+        if (published) {
+          return { entry: published, context: { collection, slug } };
+        }
+        continue;
+      }
+      return { entry, context: { collection, slug } };
     }
     return null;
   }

--- a/packages/nextly/src/runtime/routing/content-route.ts
+++ b/packages/nextly/src/runtime/routing/content-route.ts
@@ -75,6 +75,36 @@ export interface ContentRouteConfig<TNode> {
    * collections.
    */
   status?: "published" | "draft" | "all";
+  /**
+   * Whether THIS request may see pending unpublished edits.
+   *
+   * Almost always a function, because route config is captured once at module
+   * scope and whether a visitor is previewing is a per-request fact. The
+   * function is evaluated on every resolved read, so the natural wiring is
+   * Next's draft mode:
+   *
+   * ```ts
+   * draft: async () => (await draftMode()).isEnabled
+   * ```
+   *
+   * **Returning `true` is an authorization decision, not a display preference.**
+   * This route always resolves anonymously, and the working-draft overlay is
+   * gated on an update-capability probe that an anonymous read can never pass —
+   * so a request this returns `true` for is read TRUSTED, exactly as Payload
+   * pairs `draft: isDraftMode` with `overrideAccess: isDraftMode`. Put the
+   * authorization in this function (a verified preview cookie, a session
+   * check), never in a query parameter the visitor controls.
+   *
+   * A literal `true` is accepted for a route mounted behind the app's own auth,
+   * and means every visitor sees unpublished content. It is almost never what a
+   * public site wants.
+   *
+   * `generateStaticParams` ignores this entirely — draft paths are never
+   * pre-rendered.
+   *
+   * @default false
+   */
+  draft?: boolean | (() => boolean | Promise<boolean>);
   /** Relation depth for the resolved read (default `1`). */
   depth?: number;
   /** A booted Nextly instance (defaults to `getNextly()`). */
@@ -192,20 +222,37 @@ export function createContentRoute<TNode>(
 
   const getInstance = (): NextlyContentReader => config.nextly ?? getNextly();
 
+  /** Whether this request may see unpublished edits. Asked once per resolve. */
+  async function draftForThisRequest(): Promise<boolean> {
+    const decision = config.draft;
+    if (decision === undefined) return false;
+    return typeof decision === "function" ? decision() : decision;
+  }
+
   /** Resolve the joined slug across the configured collections (first match wins). */
   async function resolve(
     slug: string
   ): Promise<{ entry: ContentEntry; context: ResolvedContext } | null> {
+    const draft = await draftForThisRequest();
     for (const collection of collections) {
       const entry = await resolveContent(collection, slug, {
         nextly: config.nextly,
         slugField,
-        status,
+        // `status` is left to widen itself when a draft is asked for, so a
+        // route cannot end up previewing with only one of the two draft layers
+        // switched on.
+        ...(config.status ? { status: config.status } : {}),
+        draft,
         depth,
         tags: config.tags,
         revalidate: config.revalidate,
         cacheScope: config.cacheScope,
-        overrideAccess,
+        // A draft request reads trusted. The overlay is gated on an
+        // update-capability probe and this route resolves anonymously, so an
+        // enforced draft read could only ever return the published row — the
+        // silent no-op that makes preview look broken. The authorization that
+        // justifies this lives in the `draft` decision itself.
+        overrideAccess: overrideAccess || draft,
       });
       if (entry) return { entry, context: { collection, slug } };
     }

--- a/packages/nextly/src/runtime/routing/content-route.ts
+++ b/packages/nextly/src/runtime/routing/content-route.ts
@@ -76,35 +76,46 @@ export interface ContentRouteConfig<TNode> {
    */
   status?: "published" | "draft" | "all";
   /**
-   * Whether THIS request may see pending unpublished edits.
+   * Whether this request may see pending unpublished edits at THIS path.
    *
    * Almost always a function, because route config is captured once at module
-   * scope and whether a visitor is previewing is a per-request fact. The
-   * function is evaluated on every resolved read, so the natural wiring is
-   * Next's draft mode:
+   * scope while whether a visitor is previewing is a per-request fact. It is
+   * asked for every path the route resolves, and is handed the collection and
+   * slug being resolved so the answer can be scoped to a document.
+   *
+   * **The argument is the point, not a convenience.** Next's draft mode is a
+   * single boolean for the whole host — `draftMode().isEnabled` says a visitor
+   * opened *a* valid preview link, never *which* document it was for. Answering
+   * from that alone turns a link scoped to one unpublished page into a key to
+   * every unpublished page in the configured collections for the life of the
+   * session, which is precisely what the preview token's scope exists to
+   * prevent. Compare it against what the token actually granted:
    *
    * ```ts
-   * draft: async () => (await draftMode()).isEnabled
+   * draft: async ({ collection, slug }) => {
+   *   const scope = await readPreviewScope(previewConfig);
+   *   if (scope === null || scope.collection !== collection) return false;
+   *   return slug === (await slugOf(scope.collection, scope.entryId));
+   * }
    * ```
    *
-   * **Returning `true` is an authorization decision, not a display preference.**
-   * This route always resolves anonymously, and the working-draft overlay is
-   * gated on an update-capability probe that an anonymous read can never pass —
-   * so a request this returns `true` for is read TRUSTED, exactly as Payload
-   * pairs `draft: isDraftMode` with `overrideAccess: isDraftMode`. Put the
-   * authorization in this function (a verified preview cookie, a session
-   * check), never in a query parameter the visitor controls.
+   * **Returning `true` is an authorization decision, not a display
+   * preference.** This route always resolves anonymously, and the working-draft
+   * overlay is gated on an update-capability probe an anonymous read can never
+   * pass — so a request this returns `true` for is read TRUSTED, exactly as
+   * Payload pairs `draft: isDraftMode` with `overrideAccess: isDraftMode`. Put
+   * the authorization here, never in a query parameter the visitor controls.
    *
    * A literal `true` is accepted for a route mounted behind the app's own auth,
-   * and means every visitor sees unpublished content. It is almost never what a
-   * public site wants.
+   * and means every visitor sees unpublished content at every path. It is
+   * almost never what a public site wants.
    *
    * `generateStaticParams` ignores this entirely — draft paths are never
    * pre-rendered.
    *
    * @default false
    */
-  draft?: boolean | (() => boolean | Promise<boolean>);
+  draft?: boolean | ((context: ResolvedContext) => boolean | Promise<boolean>);
   /** Relation depth for the resolved read (default `1`). */
   depth?: number;
   /** A booted Nextly instance (defaults to `getNextly()`). */
@@ -222,19 +233,22 @@ export function createContentRoute<TNode>(
 
   const getInstance = (): NextlyContentReader => config.nextly ?? getNextly();
 
-  /** Whether this request may see unpublished edits. Asked once per resolve. */
-  async function draftForThisRequest(): Promise<boolean> {
+  /** Whether this request may see unpublished edits at one collection + slug. */
+  async function draftForThisPath(context: ResolvedContext): Promise<boolean> {
     const decision = config.draft;
     if (decision === undefined) return false;
-    return typeof decision === "function" ? decision() : decision;
+    return typeof decision === "function" ? decision(context) : decision;
   }
 
   /** Resolve the joined slug across the configured collections (first match wins). */
   async function resolve(
     slug: string
   ): Promise<{ entry: ContentEntry; context: ResolvedContext } | null> {
-    const draft = await draftForThisRequest();
     for (const collection of collections) {
+      // Asked per collection, not once per request: the answer is scoped to a
+      // document, and the same slug can name a different document in each
+      // configured collection.
+      const draft = await draftForThisPath({ collection, slug });
       const entry = await resolveContent(collection, slug, {
         nextly: config.nextly,
         slugField,

--- a/packages/nextly/src/runtime/routing/content-route.ts
+++ b/packages/nextly/src/runtime/routing/content-route.ts
@@ -95,9 +95,15 @@ export interface ContentRouteConfig<TNode> {
    * draft: async ({ collection, slug }) => {
    *   const scope = await readPreviewScope(previewConfig);
    *   if (scope === null || scope.collection !== collection) return false;
-   *   return slug === (await slugOf(scope.collection, scope.entryId));
+   *   if (slug !== (await slugOf(scope.collection, scope.entryId))) return false;
+   *   return { entryId: scope.entryId };
    * }
    * ```
+   *
+   * Name the entry rather than returning a bare `true`. A slug is not unique,
+   * so a boolean grants whichever row this route resolves the path to, which
+   * need not be the one the token was minted for; `{ entryId }` is checked
+   * against the document that was actually resolved.
    *
    * **Returning `true` is an authorization decision, not a display
    * preference.** This route always resolves anonymously, and the working-draft
@@ -261,7 +267,14 @@ export function createContentRoute<TNode>(
   /** Whether a grant covers the document the path actually resolved to. */
   function grantCovers(grant: DraftGrant, entry: ContentEntry): boolean {
     if (typeof grant === "boolean") return grant;
-    return String(entry.id) === grant.entryId;
+    // Only a primitive id can be compared. An `afterRead` hook's return value
+    // REPLACES the document, so a collection that reshapes its public read can
+    // hand back a row whose id is absent or an object — and stringifying those
+    // yields `"undefined"` and `"[object Object]"`, values a grant could carry
+    // literally and thereby match a document it never named.
+    const id = entry.id;
+    if (typeof id !== "string" && typeof id !== "number") return false;
+    return String(id) === grant.entryId;
   }
 
   /** Resolve the joined slug across the configured collections (first match wins). */

--- a/packages/nextly/src/runtime/routing/resolve-content.ts
+++ b/packages/nextly/src/runtime/routing/resolve-content.ts
@@ -23,12 +23,13 @@ import { markDynamic } from "./mark-dynamic";
 export type ContentEntry = Record<string, unknown>;
 
 /**
- * The booted-Nextly surface these helpers need: just a `find` reader. Typed
- * structurally (not as the Direct API class) so BOTH the internal singleton and
- * the public instance returned by `await getNextly(config)` satisfy it — the
- * public interface does not expose the Direct API's internal handlers.
+ * The booted-Nextly surface these helpers need: a `find` reader, plus
+ * `findByID` for the working-draft overlay. Typed structurally (not as the
+ * Direct API class) so BOTH the internal singleton and the public instance
+ * returned by `await getNextly(config)` satisfy it — the public interface does
+ * not expose the Direct API's internal handlers.
  */
-export type NextlyContentReader = Pick<Nextly, "find">;
+export type NextlyContentReader = Pick<Nextly, "find" | "findByID">;
 
 /** Options for {@link resolveContent}. */
 export interface ResolveContentOptions {
@@ -49,6 +50,31 @@ export interface ResolveContentOptions {
    * built-in lifecycle) it is a no-op — every row is live.
    */
   status?: "published" | "draft" | "all";
+  /**
+   * Return the pending working draft in place of the live row when one exists.
+   *
+   * The shipped draft model is TWO layers and a preview has to honour both.
+   * `status` covers an entry that has never been published; this covers pending
+   * edits on an ALREADY-published entry, which live in a sidecar row and are
+   * invisible to any `status` scope. Widening `status` alone therefore shows a
+   * published page's LIVE content while the edits being previewed stay hidden —
+   * the failure this option exists to prevent.
+   *
+   * Because the two belong together, `status` defaults to `"all"` when this is
+   * set (an explicit `status` still wins), so the common case cannot be
+   * half-configured.
+   *
+   * Effective only on a drafts-enabled, non-localized collection with the
+   * `status` lifecycle, and gated by an update-capability probe: a caller who
+   * cannot edit the document still gets the published row. A read that is
+   * neither trusted (`overrideAccess: true`) nor carrying a `user` can never
+   * pass that probe, so a draft read must be one or the other.
+   *
+   * A draft read is NEVER cached — see the caching note below.
+   *
+   * @default false
+   */
+  draft?: boolean;
   /** Relation population depth for rendering (default `1`). */
   depth?: number;
   /** Read a specific locale (localized collections). */
@@ -113,7 +139,12 @@ export async function resolveContent(
 ): Promise<ContentEntry | null> {
   const nextly = options.nextly ?? getNextly();
   const slugField = options.slugField ?? "slug";
-  const status = options.status ?? "published";
+  const draft = options.draft ?? false;
+  // A draft read that still filtered to published rows would miss an entry that
+  // has never been published — half of what "preview" means. An explicit
+  // `status` still wins, so a caller wanting only pending edits on live pages
+  // can still say `status: "published"`.
+  const status = options.status ?? (draft ? "all" : "published");
   const depth = options.depth ?? 1;
   const locale = options.locale;
   const overrideAccess = options.overrideAccess ?? false;
@@ -148,7 +179,37 @@ export async function resolveContent(
         // The content locale drives the localized read + fallback.
         ...(locale ? { locale } : {}),
       });
-      return result.items[0] ?? null;
+      const found = result.items[0] ?? null;
+      if (found === null || !draft) return found;
+
+      // The overlay lives on the by-id read, not the list read, so a slug
+      // lookup cannot surface it directly. Re-reading the resolved row by id is
+      // what turns "the live row whose slug matches" into "what an editor is
+      // about to publish"; the service still runs its update-capability probe,
+      // so this cannot widen who sees a draft.
+      //
+      // Consequence worth knowing: the lookup matches the LIVE row's slug. A
+      // draft that renamed its own slug is previewable at the published URL,
+      // not at the new one — resolve by id (the shape a preview link carries)
+      // when the new slug is what matters.
+      const id = found.id;
+      if (typeof id !== "string" && typeof id !== "number") return found;
+      const overlaid = await nextly.findByID({
+        collection,
+        id: String(id),
+        draft: true,
+        depth,
+        overrideAccess,
+        user,
+        ...(options.richTextFormat
+          ? { richTextFormat: options.richTextFormat }
+          : {}),
+        ...(locale ? { locale } : {}),
+      });
+      // A row deleted between the two reads resolves to nothing rather than
+      // falling back to the copy already in hand, which would render a page
+      // that no longer exists.
+      return overlaid ?? null;
     } catch (error) {
       // An access denial (403) means the read policy hides this entry from the
       // caller — treat it as absent (→ notFound), never as a transient error.
@@ -170,7 +231,15 @@ export async function resolveContent(
   // So caching requires `overrideAccess: true` AND no user; every enforced or
   // user-scoped read runs fresh per request. A public site that wants cached
   // pages reads its public content trusted (`overrideAccess: true`).
-  const cacheable = overrideAccess && !user;
+  //
+  // A DRAFT read is never cached either, and for a reason the key could not fix
+  // by being more specific: a working draft changes on every save while cache
+  // tags are busted by writes to the LIVE row, so a cached draft would show an
+  // editor their previous save and call it a preview. Serving it stale is the
+  // one thing a preview must not do, and per-request freshness is exactly what
+  // a preview wants. It also removes any path by which a draft entry could be
+  // handed to a request that never asked for one.
+  const cacheable = overrideAccess && !user && !draft;
   if (!cacheable) {
     // Bypassing `unstable_cache` alone does not opt out of Next's Full Route
     // Cache, so a page rendered while a policy was public could stay statically

--- a/packages/nextly/src/runtime/routing/resolve-content.ts
+++ b/packages/nextly/src/runtime/routing/resolve-content.ts
@@ -140,15 +140,26 @@ export async function resolveContent(
   const nextly = options.nextly ?? getNextly();
   const slugField = options.slugField ?? "slug";
   const draft = options.draft ?? false;
-  // A draft read that still filtered to published rows would miss an entry that
-  // has never been published — half of what "preview" means. An explicit
-  // `status` still wins, so a caller wanting only pending edits on live pages
-  // can still say `status: "published"`.
-  const status = options.status ?? (draft ? "all" : "published");
   const depth = options.depth ?? 1;
   const locale = options.locale;
   const overrideAccess = options.overrideAccess ?? false;
   const user = options.user;
+
+  // Widening the lifecycle scope follows TRUST, not the draft flag.
+  //
+  // The two halves of a draft read are gated very differently. The working-draft
+  // overlay is judged per row, by an update-capability probe, so asking for it
+  // is safe from anywhere. Widening `status` is not judged at all — the list
+  // read simply returns never-published rows — so tying it to `draft` alone
+  // would let a preview flag wired from an untrusted request publish
+  // unpublished pages.
+  //
+  // So an untrusted draft read still sees only published rows, and overlays
+  // their pending edits. Previewing an entry that has never been published
+  // needs `overrideAccess: true`, which is the caller stating they have already
+  // authorized it. An explicit `status` still wins either way.
+  const status =
+    options.status ?? (draft && overrideAccess ? "all" : "published");
 
   const read = async (): Promise<ContentEntry | null> => {
     try {
@@ -182,6 +193,17 @@ export async function resolveContent(
       const found = result.items[0] ?? null;
       if (found === null || !draft) return found;
 
+      // Only a PUBLISHED row can have pending edits beside it. The split keeps
+      // the live row published and stores the edit separately, so a row that is
+      // not published already IS the draft and there is nothing to overlay.
+      //
+      // Skipping the second read there is also what keeps an enforced preview
+      // working: a by-id read without `overrideAccess` filters to published, so
+      // it would answer 404 for exactly the rows that reached here unpublished.
+      // A status-less collection takes the same path, correctly — drafts
+      // require the status lifecycle, so it can never have one.
+      if (found.status !== "published") return found;
+
       // The overlay lives on the by-id read, not the list read, so a slug
       // lookup cannot surface it directly. Re-reading the resolved row by id is
       // what turns "the live row whose slug matches" into "what an editor is
@@ -201,6 +223,11 @@ export async function resolveContent(
         depth,
         overrideAccess,
         user,
+        // A row deleted between the two reads is a content miss, not an error.
+        // Without this the by-id read THROWS `NOT_FOUND` and the throw escapes
+        // as a 500, where the slug lookup answering nothing would simply have
+        // rendered the not-found page.
+        disableErrors: true,
         ...(options.richTextFormat
           ? { richTextFormat: options.richTextFormat }
           : {}),

--- a/packages/nextly/src/runtime/routing/resolve-content.ts
+++ b/packages/nextly/src/runtime/routing/resolve-content.ts
@@ -223,11 +223,6 @@ export async function resolveContent(
         depth,
         overrideAccess,
         user,
-        // A row deleted between the two reads is a content miss, not an error.
-        // Without this the by-id read THROWS `NOT_FOUND` and the throw escapes
-        // as a 500, where the slug lookup answering nothing would simply have
-        // rendered the not-found page.
-        disableErrors: true,
         ...(options.richTextFormat
           ? { richTextFormat: options.richTextFormat }
           : {}),
@@ -244,6 +239,18 @@ export async function resolveContent(
       // `NextlyError.is` matches across bundled package copies where a plain
       // `instanceof` would miss a differently-realmed error class.
       if (NextlyError.is(error) && error.statusCode === 403) {
+        return null;
+      }
+      // A row deleted between the slug lookup and the overlay read is a content
+      // miss too: the by-id read THROWS `NOT_FOUND`, and letting that escape
+      // would answer 500 where the slug lookup finding nothing would simply
+      // have rendered the not-found page.
+      //
+      // Narrowed to that one status rather than handled with `disableErrors`,
+      // which returns null for EVERY unsuccessful result — a database blip
+      // would become a permanently-cached 404, the exact failure the rethrow
+      // below exists to prevent.
+      if (NextlyError.is(error) && error.statusCode === 404) {
         return null;
       }
       throw error;

--- a/packages/nextly/src/runtime/routing/resolve-content.ts
+++ b/packages/nextly/src/runtime/routing/resolve-content.ts
@@ -61,8 +61,13 @@ export interface ResolveContentOptions {
    * the failure this option exists to prevent.
    *
    * Because the two belong together, `status` defaults to `"all"` when this is
-   * set (an explicit `status` still wins), so the common case cannot be
-   * half-configured.
+   * set on a TRUSTED read (`overrideAccess: true`), so the common case cannot
+   * be half-configured. An explicit `status` still wins. The widening is
+   * deliberately limited to trusted reads: the overlay is gated per row by an
+   * update-capability probe, but widening `status` is not gated by anything, so
+   * on an enforced read it would expose every never-published entry to whoever
+   * asked. An enforced draft read therefore stays published-only, and sees
+   * pending edits only through the (gated) overlay.
    *
    * Effective only on a drafts-enabled, non-localized collection with the
    * `status` lifecycle, and gated by an update-capability probe: a caller who

--- a/packages/nextly/src/runtime/routing/resolve-content.ts
+++ b/packages/nextly/src/runtime/routing/resolve-content.ts
@@ -132,6 +132,31 @@ export interface ResolveContentOptions {
  * if (!post) notFound();
  * ```
  */
+/**
+ * Runs the working-draft overlay read, answering `null` when there is no draft
+ * to be had rather than failing the page.
+ *
+ * Scoped to THIS read on purpose. A 404 here means the row went away between
+ * the slug lookup and this call, or that an enforced by-id read filtered it to
+ * published — both simply mean "no overlay", and the live row already in hand
+ * is the honest answer. Wrapping the slug lookup in the same handler would be
+ * much worse: a 404 from a mistyped collection, or from schema or hook code
+ * beneath it, would render as an ordinary content miss with nothing to say why.
+ *
+ * Every other failure still propagates, so a database blip stays a retryable
+ * error rather than becoming a permanently-cached 404.
+ */
+async function readOverlay(
+  read: () => Promise<ContentEntry | null>
+): Promise<ContentEntry | null> {
+  try {
+    return await read();
+  } catch (error) {
+    if (NextlyError.is(error) && error.statusCode === 404) return null;
+    throw error;
+  }
+}
+
 export async function resolveContent(
   collection: string,
   slug: string,
@@ -193,17 +218,6 @@ export async function resolveContent(
       const found = result.items[0] ?? null;
       if (found === null || !draft) return found;
 
-      // Only a PUBLISHED row can have pending edits beside it. The split keeps
-      // the live row published and stores the edit separately, so a row that is
-      // not published already IS the draft and there is nothing to overlay.
-      //
-      // Skipping the second read there is also what keeps an enforced preview
-      // working: a by-id read without `overrideAccess` filters to published, so
-      // it would answer 404 for exactly the rows that reached here unpublished.
-      // A status-less collection takes the same path, correctly — drafts
-      // require the status lifecycle, so it can never have one.
-      if (found.status !== "published") return found;
-
       // The overlay lives on the by-id read, not the list read, so a slug
       // lookup cannot surface it directly. Re-reading the resolved row by id is
       // what turns "the live row whose slug matches" into "what an editor is
@@ -216,22 +230,27 @@ export async function resolveContent(
       // when the new slug is what matters.
       const id = found.id;
       if (typeof id !== "string" && typeof id !== "number") return found;
-      const overlaid = await nextly.findByID({
-        collection,
-        id: String(id),
-        draft: true,
-        depth,
-        overrideAccess,
-        user,
-        ...(options.richTextFormat
-          ? { richTextFormat: options.richTextFormat }
-          : {}),
-        ...(locale ? { locale } : {}),
-      });
-      // A row deleted between the two reads resolves to nothing rather than
-      // falling back to the copy already in hand, which would render a page
-      // that no longer exists.
-      return overlaid ?? null;
+      // The overlay is an ENHANCEMENT, never a requirement. Deciding whether to
+      // attempt it from the row's own `status` was wrong twice over: an
+      // `afterRead` hook may reshape or drop that field before it is read here,
+      // and an unpublished row would be skipped even where it could be served.
+      // So it is always attempted, and anything answering "no draft" falls back
+      // to the live row already in hand.
+      const overlaid = await readOverlay(() =>
+        nextly.findByID({
+          collection,
+          id: String(id),
+          draft: true,
+          depth,
+          overrideAccess,
+          user,
+          ...(options.richTextFormat
+            ? { richTextFormat: options.richTextFormat }
+            : {}),
+          ...(locale ? { locale } : {}),
+        })
+      );
+      return overlaid ?? found;
     } catch (error) {
       // An access denial (403) means the read policy hides this entry from the
       // caller — treat it as absent (→ notFound), never as a transient error.
@@ -239,18 +258,6 @@ export async function resolveContent(
       // `NextlyError.is` matches across bundled package copies where a plain
       // `instanceof` would miss a differently-realmed error class.
       if (NextlyError.is(error) && error.statusCode === 403) {
-        return null;
-      }
-      // A row deleted between the slug lookup and the overlay read is a content
-      // miss too: the by-id read THROWS `NOT_FOUND`, and letting that escape
-      // would answer 500 where the slug lookup finding nothing would simply
-      // have rendered the not-found page.
-      //
-      // Narrowed to that one status rather than handled with `disableErrors`,
-      // which returns null for EVERY unsuccessful result — a database blip
-      // would become a permanently-cached 404, the exact failure the rethrow
-      // below exists to prevent.
-      if (NextlyError.is(error) && error.statusCode === 404) {
         return null;
       }
       throw error;


### PR DESCRIPTION
Splits the `draft`-option half out of Plan 03's R-4 so it can land now: it is pure core routing with no `blocks-react` dependency, and it is the gate on preview working end to end.

## The problem

The shipped draft model is **two-layered**, and the layers fail differently:

| Layer | Mechanism | Covers |
|---|---|---|
| Entry lifecycle | `status: "published" \| "draft" \| "all"` | an entry that has **never** been published |
| Working draft | sidecar row (`draft: true` → `includeWorkingDraft` → `_isWorkingDraft`) | pending edits on an **already-published** entry |

`createContentRoute` supported the first and had no plumbing for the second. A preview that widened `status` alone showed a published page's **live** content while the edits being previewed stayed invisible — because the live row is still published and still serving.

## What changed

`resolveContent` and `createContentRoute` take a `draft` option.

- **The two layers move together.** `draft: true` widens `status` to `"all"` unless one was set explicitly, so the pair cannot be half-configured.
- **The overlay lives on the by-id read**, not the list read, so a slug lookup cannot surface it. A draft read resolves the slug and re-reads that row by id — one extra query, on the preview path only. The service still runs its update-capability probe, so this cannot widen who sees a draft. A row deleted between the two reads resolves to nothing rather than falling back to the stale copy already in hand.
- **On the route the decision is per-request**, because config is captured once at module scope while whether a visitor is previewing is not:

  ```ts
  draft: async () => (await draftMode()).isEnabled
  ```

  Returning `true` is an **authorization decision**, not a display preference, so that request reads trusted. The route resolves anonymously and the overlay is gated on a probe an anonymous read can never pass, so an enforced draft read could only ever return the published row — the silent no-op that makes preview look broken. This mirrors Payload, which pairs `draft: isDraftMode` with `overrideAccess: isDraftMode`.
- **A draft read is never cached.** Cache tags are busted by writes to the *live* row while a working draft changes on every save, so a cached draft would show an editor their previous save and call it a preview.
- **`generateStaticParams` ignores it entirely** — it runs where there is no visitor to gate, and a draft baked into a static path is published to everyone, permanently.

## Tests

22 unit + 4 integration, all green. The integration suite is the one that matters: on a real drafts-enabled collection it proves a preview sees `"Pending edit"` while the public route sees `"Live"`, that a never-published entry 404s publicly and renders in preview, that drafts stay out of pre-rendered paths, and that one route object follows the decision as it changes between requests.

**7 stub scenarios, all exact** — each mechanism was broken in turn and only its own tests failed: removing the overlay, removing the status widening, allowing a draft read to be cached, dropping the trusted read, freezing the decision after the first request, letting the build-time scan inherit it, and falling back to the live row when the overlay read finds nothing.

The caching rule is asserted as a **mechanism** (whether `cachedFind` is reached) rather than by reading twice and hoping to observe staleness — outside a Next runtime `cachedFind` calls straight through, so a round-trip test would pass whether or not the rule existed.

## Notes

- `NextlyContentReader` widens to `Pick<Nextly, "find" | "findByID">`. Both real implementations already satisfy it; a hand-rolled reader now fails at compile time with a clear message, which is the right failure.
- Pre-existing unit baseline verified unchanged: 35 files / 363 tests fail identically with and without this branch.
- Follow-up worth noting: Payload exposes `draft` on `find` (list) as well; Nextly's overlay is single-entry only, which is why the two-step exists.