### PR TITLE
fix(nextly): pass the required builder origin in the drop-index fixture

### DIFF
--- a/packages/nextly/src/domains/schema/pipeline/pre-resolution/__tests__/drop-index-constraint.integration.test.ts
+++ b/packages/nextly/src/domains/schema/pipeline/pre-resolution/__tests__/drop-index-constraint.integration.test.ts
@@ -64,7 +64,11 @@ describe("pre-resolution drop_index — PostgreSQL constraint-backed uniques", (
         { name: "code", type: "text" },
         { name: "views", type: "number", index: true },
       ] as never,
-      "postgresql"
+      "postgresql",
+      // Required, and not a formality: a text field with no stated width has no
+      // one right answer, so the desired shape depends on who built the table.
+      // This fixture stands in for the pipeline, which is `codeFirst`.
+      { builtBy: "codeFirst" }
     );
     await pool.query(generatePgSQL({ type: "add_table", table: spec }));
 


### PR DESCRIPTION
**`main` is red and has been since #395 merged.** Every open PR fails `Lint / Typecheck / Test / Build`, because CI typechecks the merge with `main`.

```
src/domains/schema/pipeline/pre-resolution/__tests__/drop-index-constraint.integration.test.ts(60,18):
  error TS2554: Expected 4 arguments, but got 3.
```

`buildDesiredTableFromFields` takes a required `options` argument (`builtBy` is not optional) and the fixture added by #395 passes three. `tsconfig.tests.json` covers that file, so the second `tsc` pass fails and takes the job with it.

## The value

`builtBy: "codeFirst"` — chosen from what the test is *for*, not from what compiles:

- the fixture's own comment says it builds the table "through the same helpers the pipeline uses for a new table";
- `reload-config.ts`, which *is* that pipeline, passes `builtBy: "codeFirst"` at all three of its call sites.

`hasStatus` is left off because the fixture declares no status field.

## Verified

`pnpm --filter nextly check-types` (both `tsc` passes) and `pnpm --filter nextly lint` clean on this branch.

Not my area — raising it because a red `main` blocks everyone, and the fix follows unambiguously from the fixture's stated intent. Happy for #395's author to take it over or correct the value if `codeFirst` is not what they meant.