### PR TITLE
feat(nextly): store a revocation generation for preview links

### DIFF
--- a/.changeset/preview-token-generation.md
+++ b/.changeset/preview-token-generation.md
@@ -1,0 +1,30 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+Add a preview-link revocation generation to site settings.
+
+Every preview token records the generation it was minted under and is verified against the current one, so incrementing it invalidates every link ever issued, including sessions already in flight, with nothing to store, sweep or replicate per token.
+
+The counter is incremented by the database rather than read-then-written, so two revocations running at once cannot lose one another. It is excluded from the settings update surface because writing a lower value would re-validate links that a revoke had already invalidated.

--- a/packages/nextly/src/domains/schema/pipeline/__tests__/v1-golden/upgrade-sim-045.integration.test.ts
+++ b/packages/nextly/src/domains/schema/pipeline/__tests__/v1-golden/upgrade-sim-045.integration.test.ts
@@ -181,6 +181,19 @@ const addsWebhooksColumn = (stmt: string): boolean =>
     stmt.trim()
   );
 
+// The `preview_token_generation` column is additive on `site_settings`, which
+// predates this fixture, so a v1 upgrade of a schema captured before it emits
+// one `ADD COLUMN`. It is NOT NULL with a default of 0, which is data-preserving
+// on an existing row: 0 is the generation every preview link minted before any
+// revoke already carries, so the backfill leaves those links working rather than
+// refusing them all. Scoped to `site_settings` and to that column, so an
+// unrelated NOT NULL addition cannot ride in behind it. Tolerant of pg/MySQL
+// quoting and the optional COLUMN keyword.
+const addsPreviewGenerationColumn = (stmt: string): boolean =>
+  /^ALTER TABLE [`"]?site_settings[`"]? ADD (COLUMN )?[`"]?preview_token_generation[`"]?\b/i.test(
+    stmt.trim()
+  );
+
 // `activity_log` carried `user_id` with a cascading foreign key when this
 // fixture was captured, which meant deleting a user destroyed their entire
 // activity trail. Undoing that is a one-time migration on a table that predates
@@ -363,7 +376,8 @@ describe("existing-user upgrade sim (0.45 DDL → v1)", () => {
               addsRevalidateColumn(s) ||
               addsWebhooksColumn(s) ||
               migratesActivityLogActor(s) ||
-              addsAuditLogErasureStamp(s),
+              addsAuditLogErasureStamp(s) ||
+              addsPreviewGenerationColumn(s),
             `phantom diff: ${s}`
           ).toBe(true);
         }
@@ -441,7 +455,8 @@ describe("existing-user upgrade sim (0.45 DDL → v1)", () => {
               addsRevalidateColumn(s) ||
               addsWebhooksColumn(s) ||
               migratesActivityLogActor(s) ||
-              addsAuditLogErasureStamp(s),
+              addsAuditLogErasureStamp(s) ||
+              addsPreviewGenerationColumn(s),
             `unexpected reconcile statement shape: ${s}`
           ).toBe(true);
         }

--- a/packages/nextly/src/schemas/site-settings/mysql.ts
+++ b/packages/nextly/src/schemas/site-settings/mysql.ts
@@ -8,7 +8,7 @@
  * @since 1.0.0
  */
 
-import { mysqlTable, varchar, datetime } from "drizzle-orm/mysql-core";
+import { mysqlTable, varchar, datetime, int } from "drizzle-orm/mysql-core";
 
 export const siteSettingsMysql = mysqlTable("site_settings", {
   /** Always 'default' — enforces singleton pattern. */
@@ -43,6 +43,19 @@ export const siteSettingsMysql = mysqlTable("site_settings", {
 
   /** JSON object mapping plugin slugs to sidebar group overrides, e.g. {"form-builder":"collections"} */
   pluginPlacements: varchar("plugin_placements", { length: 4096 }),
+
+  /**
+   * Revocation generation for preview links. Every preview token records the
+   * generation it was minted under, and verification refuses a token whose
+   * generation is not the current one — so incrementing this invalidates every
+   * link ever issued, including sessions already in flight, with nothing to
+   * store, sweep or replicate per token.
+   *
+   * Monotonic by contract: it only ever moves forward. Lowering it would
+   * re-validate tokens that were already revoked, which is why the settings
+   * form cannot write it.
+   */
+  previewTokenGeneration: int("preview_token_generation").notNull().default(0),
 
   /** When the settings were last updated. */
   updatedAt: datetime("updated_at").notNull(),

--- a/packages/nextly/src/schemas/site-settings/postgres.ts
+++ b/packages/nextly/src/schemas/site-settings/postgres.ts
@@ -8,7 +8,13 @@
  * @since 1.0.0
  */
 
-import { pgTable, text, varchar, timestamp } from "drizzle-orm/pg-core";
+import {
+  pgTable,
+  text,
+  varchar,
+  timestamp,
+  integer,
+} from "drizzle-orm/pg-core";
 
 export const siteSettingsPg = pgTable("site_settings", {
   /** Always 'default' — enforces singleton pattern. */
@@ -43,6 +49,21 @@ export const siteSettingsPg = pgTable("site_settings", {
 
   /** JSON object mapping plugin slugs to sidebar group overrides, e.g. {"form-builder":"collections"} */
   pluginPlacements: text("plugin_placements"),
+
+  /**
+   * Revocation generation for preview links. Every preview token records the
+   * generation it was minted under, and verification refuses a token whose
+   * generation is not the current one — so incrementing this invalidates every
+   * link ever issued, including sessions already in flight, with nothing to
+   * store, sweep or replicate per token.
+   *
+   * Monotonic by contract: it only ever moves forward. Lowering it would
+   * re-validate tokens that were already revoked, which is why the settings
+   * form cannot write it.
+   */
+  previewTokenGeneration: integer("preview_token_generation")
+    .notNull()
+    .default(0),
 
   /** When the settings were last updated. */
   updatedAt: timestamp("updated_at", { withTimezone: false })

--- a/packages/nextly/src/schemas/site-settings/sqlite.ts
+++ b/packages/nextly/src/schemas/site-settings/sqlite.ts
@@ -44,6 +44,21 @@ export const siteSettingsSqlite = sqliteTable("site_settings", {
   /** JSON object mapping plugin slugs to sidebar group overrides, e.g. {"form-builder":"collections"} */
   pluginPlacements: text("plugin_placements"),
 
+  /**
+   * Revocation generation for preview links. Every preview token records the
+   * generation it was minted under, and verification refuses a token whose
+   * generation is not the current one — so incrementing this invalidates every
+   * link ever issued, including sessions already in flight, with nothing to
+   * store, sweep or replicate per token.
+   *
+   * Monotonic by contract: it only ever moves forward. Lowering it would
+   * re-validate tokens that were already revoked, which is why the settings
+   * form cannot write it.
+   */
+  previewTokenGeneration: integer("preview_token_generation")
+    .notNull()
+    .default(0),
+
   /** When the settings were last updated (Unix timestamp ms). */
   updatedAt: integer("updated_at", { mode: "timestamp" }).notNull(),
 });

--- a/packages/nextly/src/schemas/site-settings/types.ts
+++ b/packages/nextly/src/schemas/site-settings/types.ts
@@ -34,15 +34,26 @@ export interface GeneralSettingsRecord {
   customSidebarGroups: string | null;
   /** JSON object mapping plugin slugs to their sidebar placement group overrides. */
   pluginPlacements: string | null;
+  /**
+   * Revocation generation for preview links — the generation every preview
+   * token records and is verified against. Incrementing it invalidates every
+   * link ever issued. Monotonic: it only ever moves forward.
+   */
+  previewTokenGeneration: number;
   /** When the settings were last updated. */
   updatedAt: Date;
 }
 
 /**
  * Fields that can be updated via the settings form.
- * Excludes immutable `id` and auto-managed `updatedAt`.
+ *
+ * Excludes immutable `id` and auto-managed `updatedAt`, and
+ * `previewTokenGeneration`, which is a revocation counter rather than a
+ * setting: it must only ever be incremented by an explicit revoke, because
+ * writing a lower value would re-validate every preview link that revoke had
+ * already invalidated.
  */
 export type GeneralSettingsUpdate = Omit<
   GeneralSettingsRecord,
-  "id" | "updatedAt"
+  "id" | "updatedAt" | "previewTokenGeneration"
 >;

--- a/packages/nextly/src/services/general-settings/general-settings-service.ts
+++ b/packages/nextly/src/services/general-settings/general-settings-service.ts
@@ -10,7 +10,7 @@
  */
 
 import type { DrizzleAdapter } from "@nextlyhq/adapter-drizzle";
-import { eq } from "drizzle-orm";
+import { eq, sql } from "drizzle-orm";
 
 import { siteSettingsMysql } from "../../schemas/site-settings/mysql";
 import { siteSettingsPg } from "../../schemas/site-settings/postgres";
@@ -36,6 +36,7 @@ function emptyRecord(): GeneralSettingsRecord {
     logoUrl: null,
     customSidebarGroups: null,
     pluginPlacements: null,
+    previewTokenGeneration: 0,
     updatedAt: new Date(),
   };
 }
@@ -80,6 +81,14 @@ export class GeneralSettingsService extends BaseService {
       logoUrl: (row.logoUrl as string) ?? null,
       customSidebarGroups: (row.customSidebarGroups as string) ?? null,
       pluginPlacements: (row.pluginPlacements as string) ?? null,
+      // A database that predates the column reads back `undefined` until the
+      // reconcile adds it, and generation 0 is what every token minted before
+      // any revoke carries — so the default keeps those links working rather
+      // than refusing them all until the next migrate.
+      previewTokenGeneration:
+        typeof row.previewTokenGeneration === "number"
+          ? row.previewTokenGeneration
+          : 0,
       updatedAt:
         row.updatedAt instanceof Date
           ? row.updatedAt
@@ -92,10 +101,7 @@ export class GeneralSettingsService extends BaseService {
    * Returns an all-null record if the singleton row has not been saved yet.
    */
   async getSettings(): Promise<GeneralSettingsRecord> {
-    const rows = await this.db
-      .select()
-      .from(this.siteSettings)
-      .limit(1);
+    const rows = await this.db.select().from(this.siteSettings).limit(1);
 
     if (!rows || rows.length === 0) {
       return emptyRecord();
@@ -115,6 +121,51 @@ export class GeneralSettingsService extends BaseService {
   }
 
   /**
+   * The current preview-link revocation generation.
+   *
+   * Read on every mint and every verification, so a revoke reaches sessions
+   * already in flight rather than only new links.
+   */
+  async getPreviewTokenGeneration(): Promise<number> {
+    const settings = await this.getSettings();
+    return settings.previewTokenGeneration;
+  }
+
+  /**
+   * Invalidate every preview link ever issued, and return the new generation.
+   *
+   * The increment is computed by the DATABASE rather than read-then-written,
+   * so two administrators revoking at once cannot both write the same value
+   * and leave one of the two revocations undone.
+   *
+   * Creates the singleton row when it does not exist yet: an installation that
+   * has never opened the settings form still has to be able to revoke, and
+   * generation 1 correctly refuses tokens minted at the implicit 0.
+   */
+  async revokeAllPreviewTokens(): Promise<number> {
+    const existing = await this.db.select().from(this.siteSettings).limit(1);
+
+    if (!existing || existing.length === 0) {
+      await this.db.insert(this.siteSettings).values({
+        id: SETTINGS_ID,
+        previewTokenGeneration: 1,
+        updatedAt: new Date(),
+      });
+      return 1;
+    }
+
+    await this.db
+      .update(this.siteSettings)
+      .set({
+        previewTokenGeneration: sql`${this.siteSettings.previewTokenGeneration} + 1`,
+        updatedAt: new Date(),
+      })
+      .where(eq(this.siteSettings.id, SETTINGS_ID));
+
+    return this.getPreviewTokenGeneration();
+  }
+
+  /**
    * Upsert the general settings singleton row.
    * Only the provided fields are updated; omitted fields are left unchanged.
    * If the row doesn't exist yet, it is created with the provided values.
@@ -124,10 +175,7 @@ export class GeneralSettingsService extends BaseService {
   ): Promise<GeneralSettingsRecord> {
     const now = new Date();
 
-    const existing = await this.db
-      .select()
-      .from(this.siteSettings)
-      .limit(1);
+    const existing = await this.db.select().from(this.siteSettings).limit(1);
 
     const hasRow = existing && existing.length > 0;
 
@@ -197,5 +245,4 @@ export class GeneralSettingsService extends BaseService {
     await this.updateSettings({ customSidebarGroups: json });
     return groups;
   }
-
 }

--- a/packages/nextly/src/services/general-settings/preview-token-generation.integration.test.ts
+++ b/packages/nextly/src/services/general-settings/preview-token-generation.integration.test.ts
@@ -1,0 +1,108 @@
+/**
+ * The preview-link revocation generation, against a real database.
+ *
+ * Revocation for preview links is a counter rather than a per-token denylist:
+ * every token records the generation it was minted under, and verification
+ * refuses any token whose generation is not the current one. That buys
+ * `revoke-all` with nothing to store, sweep or replicate — but it puts the
+ * whole mechanism on one integer, so what matters is that the integer can only
+ * move forward and can never lose an increment.
+ *
+ * These run on a real database because both properties are the database's:
+ * whether concurrent updates serialize, and whether a row written before the
+ * column existed reads back as a usable generation.
+ */
+import { createTestNextly, type TestNextly } from "nextly/testing";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { GeneralSettingsService } from "./general-settings-service";
+
+let harness: TestNextly | undefined;
+
+function service(): GeneralSettingsService {
+  return new GeneralSettingsService(harness!.adapter, {
+    debug: () => {},
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+  });
+}
+
+afterEach(async () => {
+  await harness?.destroy();
+  harness = undefined;
+});
+
+beforeEach(async () => {
+  harness = await createTestNextly();
+});
+
+describe("preview token revocation generation (integration)", () => {
+  it("starts at zero on an installation that has never revoked", async () => {
+    // Tokens minted before any revoke carry generation 0, so the default has to
+    // BE 0 — a column defaulting to anything else would refuse every link that
+    // was already in circulation the moment it was added.
+    expect(await service().getPreviewTokenGeneration()).toBe(0);
+  });
+
+  it("creates the singleton row when revoking before any settings were saved", async () => {
+    // An installation that has never opened the settings form still has to be
+    // able to revoke. Generation 1 correctly refuses tokens minted at the
+    // implicit 0.
+    const settings = service();
+
+    expect(await settings.revokeAllPreviewTokens()).toBe(1);
+    expect(await settings.getPreviewTokenGeneration()).toBe(1);
+  });
+
+  it("keeps counting from an existing settings row", async () => {
+    const settings = service();
+    await settings.updateSettings({ applicationName: "Preview" });
+
+    expect(await settings.revokeAllPreviewTokens()).toBe(1);
+    expect(await settings.revokeAllPreviewTokens()).toBe(2);
+
+    // The revoke must not disturb the rest of the row: it shares a table with
+    // ordinary settings and writes through the same update.
+    const record = await settings.getSettings();
+    expect(record.applicationName).toBe("Preview");
+    expect(record.previewTokenGeneration).toBe(2);
+  });
+
+  it("loses no increment when revokes run concurrently", async () => {
+    // The increment is computed by the DATABASE (`generation + 1`) rather than
+    // read-then-written, so two administrators revoking at once cannot both
+    // compute the same next value and leave one of the two revocations undone.
+    // Read-modify-write would settle on 1 here.
+    const settings = service();
+    await settings.revokeAllPreviewTokens();
+
+    await Promise.all([
+      settings.revokeAllPreviewTokens(),
+      settings.revokeAllPreviewTokens(),
+      settings.revokeAllPreviewTokens(),
+    ]);
+
+    expect(await settings.getPreviewTokenGeneration()).toBe(4);
+  });
+
+  it("does not expose the generation to the settings form", async () => {
+    // `GeneralSettingsUpdate` omits the field, so this cannot be written in
+    // typed code — but `updateSettings` takes a partial and the admin API
+    // forwards a parsed body, so the runtime allow-list is what actually holds
+    // the line. Lowering the generation would re-validate every link a revoke
+    // had already invalidated.
+    const settings = service();
+    await settings.revokeAllPreviewTokens();
+    await settings.revokeAllPreviewTokens();
+
+    await settings.updateSettings({
+      applicationName: "Still fine",
+      ...({ previewTokenGeneration: 0 } as Partial<
+        Parameters<GeneralSettingsService["updateSettings"]>[0]
+      >),
+    });
+
+    expect(await settings.getPreviewTokenGeneration()).toBe(2);
+  });
+});


### PR DESCRIPTION
Gives preview-link revocation somewhere to live. Task 037 (F4) PR-3 of 4, following #554 (the token module) and #557 (the preview route).

## What and why

Revocation for preview links is a **generation counter**, not a per-token denylist. Every token records the generation it was minted under, and verification refuses any token whose generation is not the current one. That buys exactly the v1 scope (`copy` + `revoke-all`) with nothing to store, sweep or replicate per token, and it leaves sessions untouched.

The token module was written pure about where that number lives, so callers have been passing it in. This adds the store: a `preview_token_generation` column on `site_settings`, its accessors, and an atomic `revokeAllPreviewTokens()`.

It is not dead code: `PreviewRouteConfig.generation` already accepts `number | (() => number | Promise<number>)`, so the reader plugs straight in.

## Three things the audit changed

**The "3-dialect migration" is declarative, not hand-written DDL.** `site_settings` is already in `getCoreSchema` for all three dialects, so declaring the column is enough and the core reconcile carries it to existing databases.

**That only works because task 114's two-pass reconcile shipped.** Verified on main in `fresh-push.ts` rather than assumed: before it, a column added to a core table never reached an installation holding ordinary content, and `nextly migrate` reported success anyway. Worth stating explicitly, because this PR would have silently done nothing for every existing install three days ago.

**The counter must not be a setting.** `GeneralSettingsUpdate` is `Omit<GeneralSettingsRecord, "id" | "updatedAt">`, so adding the field to the record would have made it writable through the settings form, and writing a **lower** value re-validates every link a revoke had already killed. It is now omitted from the type as well. The runtime allow-list in `updateSettings` and the zod schema on the API were already closed, so this is the third layer, but the type is the one that makes the intent reviewable.

## Details worth a second look

- The increment is computed by the database (``sql`${column} + 1` ``, the same shape as `failedLoginAttempts`) rather than read-then-written, so two administrators revoking at once cannot both compute the same next value and leave one revocation undone.
- `revokeAllPreviewTokens()` creates the singleton row when it does not exist: an installation that never opened the settings form still has to be able to revoke, and generation 1 correctly refuses tokens minted at the implicit 0.
- `toRecord` defaults a missing column to 0 rather than failing. A database read between deploy and migrate reads back `undefined`, and 0 is what every already-circulating token carries, so the default keeps those links working instead of refusing all of them.

## Verification

- **5 integration tests, green on sqlite + postgres17 + mysql.**
- **2 stub scenarios, both exact:** replacing the DB-computed increment with read-modify-write fails only the concurrency test; allow-listing the field in `updateSettings` fails only the settings-form test.
- `check-types` (both projects) and `lint` clean.

## Next

PR-4 carries the product surface: the mint endpoint gated by `update` on the collection, the revoke-all endpoint, and the admin "Copy preview link" and revoke affordances. Split so the whole API surface lands in one reviewable PR rather than half here and half there.