### PR TITLE
fix(blocks-react): harden the renderer against malformed documents and hostile output

### DIFF
--- a/.changeset/renderer-hardening.md
+++ b/.changeset/renderer-hardening.md
@@ -1,0 +1,30 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+Harden the block renderer against malformed stored documents and hostile block output.
+
+The document envelope is now checked before it is read, so a corrupt column holding a non-object renders a placeholder instead of throwing in the page component where no block boundary exists. A stored attribute bag with several case variants of `id` now reserves the value that will actually render, matching the last-write-wins rule the render path uses. A node stored ahead of its block definition no longer reserves a DOM id it will never emit.
+
+Block output is checked further: a `dangerouslySetInnerHTML.__html` value React cannot convert to a string is refused rather than left to throw during serialization, an object impersonating the `React.lazy` shape is refused, and a promise inside an element rejected for its own shape is now marked handled so a rejection cannot take the process down.

--- a/packages/blocks-react/src/page-renderer.test.tsx
+++ b/packages/blocks-react/src/page-renderer.test.tsx
@@ -13,6 +13,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   DEFAULT_LIMITS,
   DOCUMENT_FORMAT_VERSION,
+  nodeClassNames,
   NODE_CLASS_PREFIX,
   blockTypeClassName,
   defineBlock,
@@ -4030,6 +4031,112 @@ describe("PageRenderer", () => {
 
       expect(placeholderReasons(html)).toEqual(["invalid-output"]);
       expect(handlerAttached).toBe(true);
+    });
+
+    it("refuses inner HTML whose Symbol.toPrimitive is not callable", async () => {
+      // Coercion consults `Symbol.toPrimitive` BEFORE `toString`/`valueOf`, so
+      // an object carrying a non-callable one throws even though both of the
+      // others are inherited and callable.
+      const hostile = defineBlock({
+        name: "test/bad-to-primitive",
+        version: 1,
+        description: "Returns __html with a non-callable Symbol.toPrimitive.",
+        example: { props: {} },
+        defaultProps: {},
+        render: () => (
+          <div
+            dangerouslySetInnerHTML={
+              { __html: { [Symbol.toPrimitive]: 1 } } as unknown as {
+                __html: string;
+              }
+            }
+          />
+        ),
+      });
+
+      const html = await renderToHtml(
+        <PageRenderer
+          document={doc(node("a", "test/bad-to-primitive"))}
+          blocks={createBlockResolver([hostile as AnyBlockDefinition])}
+        />
+      );
+
+      expect(placeholderReasons(html)).toEqual(["invalid-output"]);
+    });
+
+    it("abandons an endless child rather than sweeping it forever", async () => {
+      // The refusal sweep marks promises inside a subtree nothing will render.
+      // Its budget makes each recursive call return, but the loop that FEEDS it
+      // must stop pulling too, or an endless generator child spins here instead
+      // of being abandoned.
+      const endless = defineBlock({
+        name: "test/endless-child",
+        version: 1,
+        description: "Puts an endless generator inside a void element.",
+        example: { props: {} },
+        defaultProps: {},
+        render: () => {
+          function* forever(): Generator<string> {
+            while (true) yield "x";
+          }
+          // `<br>` is void, so the element is refused for its own shape and the
+          // sweep is what walks this child.
+          return createElement("br", null, forever() as unknown as string);
+        },
+      });
+
+      const html = await renderToHtml(
+        <PageRenderer
+          document={doc(node("a", "test/endless-child"))}
+          blocks={createBlockResolver([endless as AnyBlockDefinition])}
+        />
+      );
+
+      expect(placeholderReasons(html)).toEqual(["invalid-output"]);
+    });
+
+    it("does not trust a stored stylesheet when a node becomes a placeholder", async () => {
+      // A knowable placeholder emits only a hidden marker, so a sheet compiled
+      // for the markup it WOULD have rendered ships rules for content that is
+      // not on the page. Identity alone misses it: the node is skipped by the
+      // address predicate, so with nothing else to repair the tree comes back
+      // unchanged and the stale sheet would be trusted.
+      const ahead = doc(
+        node("a", "test/text", { version: 9, props: { value: "ahead" } })
+      );
+      // The map has to cover every node id or the stored sheet is discarded for
+      // an unrelated reason, and the assertion below would hold either way.
+      const stored = {
+        css: ".nx-stale{color:red}",
+        classes: Object.fromEntries(nodeClassNames(["a"])),
+      };
+      // The fixture is only meaningful if this sheet WOULD otherwise be
+      // trusted, so pin that: a healthy document ships it.
+      const healthyDoc = doc(
+        node("a", "test/text", { props: { value: "fine" } })
+      );
+      const healthy = await renderToHtml(
+        <PageRenderer
+          document={healthyDoc}
+          blocks={createBlockResolver([text as AnyBlockDefinition])}
+          styles={{
+            css: ".nx-stale{color:red}",
+            classes: Object.fromEntries(nodeClassNames(["a"])),
+          }}
+        />
+      );
+      expect(healthy).toContain("nx-stale");
+
+      const html = await renderToHtml(
+        <PageRenderer
+          document={ahead}
+          blocks={createBlockResolver([text as AnyBlockDefinition])}
+          styles={stored}
+        />
+      );
+
+      expect(placeholderReasons(html)).toEqual(["version-ahead"]);
+      expect(html).not.toContain("nx-stale");
     });
   });
 });

--- a/packages/blocks-react/src/page-renderer.test.tsx
+++ b/packages/blocks-react/src/page-renderer.test.tsx
@@ -3870,4 +3870,166 @@ describe("PageRenderer", () => {
       expect(html).not.toContain("stale props");
     });
   });
+
+  describe("hostile stored input", () => {
+    it("refuses a document envelope that is not an object", async () => {
+      // The envelope is database input too, and it is read before any of the
+      // repair passes. `null` throws on the first property access, inside the
+      // page component, where no block boundary exists to contain it.
+      for (const stored of [null, undefined, 42, "a page", []]) {
+        const html = await renderToHtml(
+          <PageRenderer
+            document={stored as unknown as BlockDocument}
+            blocks={createBlockResolver([text as AnyBlockDefinition])}
+          />
+        );
+
+        expect(placeholderReasons(html)).toEqual(["unsupported-format"]);
+      }
+    });
+
+    it("reserves the id the attribute bag will actually render", async () => {
+      // The render path lowercases each attribute name into one bag, so the
+      // LAST string case-variant is what reaches the DOM. Reserving the first
+      // would hold an id the page never uses while letting the one it does use
+      // collide with a later node.
+      const html = await renderToHtml(
+        <PageRenderer
+          document={doc(
+            node("a", "test/text", {
+              props: { value: "first" },
+              attributes: { id: "old", ID: "hero" },
+            }),
+            node("b", "test/text", {
+              props: { value: "second" },
+              cssId: "hero",
+            })
+          )}
+          blocks={createBlockResolver([text as AnyBlockDefinition])}
+        />
+      );
+
+      // `hero` is claimed by the first node's rendered attribute, so the second
+      // renders without it. Exactly one `id="hero"` reaches the page.
+      expect(html.match(/id="hero"/g)).toHaveLength(1);
+      expect(html).not.toContain('id="old"');
+      expect(html).toContain("second");
+    });
+
+    it("does not let a version-ahead node reserve a DOM id", async () => {
+      // A node stored ahead of its definition renders a placeholder, which
+      // emits no modelled id — so reserving one would strip the anchor off a
+      // healthy node for nothing.
+      const html = await renderToHtml(
+        <PageRenderer
+          document={doc(
+            node("a", "test/text", { version: 9, cssId: "hero" }),
+            node("b", "test/text", {
+              props: { value: "healthy" },
+              cssId: "hero",
+            })
+          )}
+          blocks={createBlockResolver([text as AnyBlockDefinition])}
+        />
+      );
+
+      expect(placeholderReasons(html)).toEqual(["version-ahead"]);
+      expect(html).toContain('id="hero"');
+      expect(html).toContain("healthy");
+    });
+
+    it("refuses inner HTML React cannot convert to a string", async () => {
+      // React stringifies `__html` while serializing, after this boundary has
+      // returned, so a value that cannot be coerced throws uncontained.
+      const hostile = defineBlock({
+        name: "test/hostile-html",
+        version: 1,
+        description: "Returns an uncoercible __html value.",
+        example: { props: {} },
+        defaultProps: {},
+        render: () => (
+          <div
+            dangerouslySetInnerHTML={
+              { __html: { toString: null, valueOf: null } } as unknown as {
+                __html: string;
+              }
+            }
+          />
+        ),
+      });
+
+      const html = await renderToHtml(
+        <PageRenderer
+          document={doc(node("a", "test/hostile-html"))}
+          blocks={createBlockResolver([hostile as AnyBlockDefinition])}
+        />
+      );
+
+      expect(placeholderReasons(html)).toEqual(["invalid-output"]);
+    });
+
+    it("refuses a lazy wrapper that only impersonates the shape", async () => {
+      // What a lazy resolves to cannot be checked without calling `_init`, but
+      // React's own `lazy()` always sets `_payload` — so an object missing it is
+      // an impersonation, and one that resolves to a non-component throws
+      // "Element type is invalid" from inside React's render.
+      const forged = defineBlock({
+        name: "test/forged-lazy",
+        version: 1,
+        description: "Returns an object impersonating React.lazy.",
+        example: { props: {} },
+        defaultProps: {},
+        render: () =>
+          createElement({
+            $$typeof: Symbol.for("react.lazy"),
+            _init: () => 42,
+          } as unknown as Parameters<typeof createElement>[0]),
+      });
+
+      const html = await renderToHtml(
+        <PageRenderer
+          document={doc(node("a", "test/forged-lazy"))}
+          blocks={createBlockResolver([forged as AnyBlockDefinition])}
+        />
+      );
+
+      expect(placeholderReasons(html)).toEqual(["invalid-output"]);
+    });
+
+    it("marks a rejecting child of an element refused for its own shape", async () => {
+      // The element is judged by its own shape BEFORE its children are looked
+      // at, so refusing it returns before anything descends. A promise the
+      // block already started would be left with no handler, and Node's default
+      // `--unhandled-rejections=throw` turns that into a process exit: worse
+      // than the escape the refusal closed.
+      let handlerAttached = false;
+      const rejecting: PromiseLike<never> = {
+        then(_resolve, reject) {
+          if (typeof reject === "function") handlerAttached = true;
+          return rejecting as never;
+        },
+      };
+
+      const voidWithPromise = defineBlock({
+        name: "test/void-with-promise",
+        version: 1,
+        description: "Puts a rejecting promise inside a void element.",
+        example: { props: {} },
+        defaultProps: {},
+        // `<br>` is a void element and cannot have contents, so the element is
+        // refused for its own shape and its child is never inspected.
+        render: () => createElement("br", null, rejecting as unknown as string),
+      });
+
+      const html = await renderToHtml(
+        <PageRenderer
+          document={doc(node("a", "test/void-with-promise"))}
+          blocks={createBlockResolver([voidWithPromise as AnyBlockDefinition])}
+        />
+      );
+
+      expect(placeholderReasons(html)).toEqual(["invalid-output"]);
+      expect(handlerAttached).toBe(true);
+    });
+  });
 });

--- a/packages/blocks-react/src/page-renderer.tsx
+++ b/packages/blocks-react/src/page-renderer.tsx
@@ -4,6 +4,7 @@ import {
   PAGE_ROOT_CLASS,
   migrateDocument,
   type BlockDocument,
+  type BlockNode,
   type DocumentLimits,
   type StyleCompileContext,
 } from "@nextlyhq/blocks-engine";
@@ -58,6 +59,32 @@ export interface PageRendererProps {
 }
 
 /**
+ * Whether a node will render its own host markup, decided BEFORE rendering.
+ *
+ * Two passes need this answer early: address repair, which must not let a node
+ * that emits no `id` reserve one away from a healthy sibling, and the stylesheet
+ * decision, which must not publish rules compiled for markup that never ships.
+ *
+ * Only the placeholder outcomes that are knowable from the document and the
+ * resolver are covered — an unregistered type, a failed migration, and a node
+ * stored ahead of the definition that would render it. All three are pure
+ * comparisons.
+ *
+ * The rest are NOT knowable here, and deliberately so: whether a block throws,
+ * returns something unrenderable, or renders a given slot at all is only
+ * settled by calling it, which happens inside the boundary further down. A node
+ * that ends in one of those placeholders can still reserve an address it never
+ * uses. Closing that would mean deciding addresses after render, which is a
+ * different design than compiling the document once up front.
+ */
+function rendersOwnMarkup(node: BlockNode, resolver: BlockResolver): boolean {
+  if (node.migrationFailed === true) return false;
+  const definition = resolver.get(node.type);
+  if (definition === undefined) return false;
+  return node.version <= definition.version;
+}
+
+/**
  * Renders a block document as React.
  *
  * A Server Component, and synchronous: nothing at this level needs to wait, so
@@ -104,6 +131,24 @@ export function PageRenderer({
   // envelope itself may mean something different, so migrating and rendering
   // whatever sits under `nodes` shows content that was never authored this way
   // — worse than showing nothing, because nothing announces itself.
+  // The ENVELOPE is database input too, and it is read before any of the
+  // repair passes that make its contents safe. A corrupt JSON column holding
+  // `null` throws on the first property access below, in the page component
+  // itself, where no block boundary exists to contain it. (A primitive does
+  // not throw — it just reads `undefined` — but it is no more renderable, so
+  // both are refused the same way.)
+  if (
+    typeof document !== "object" ||
+    document === null ||
+    Array.isArray(document)
+  ) {
+    return (
+      <div className={PAGE_ROOT_CLASS}>
+        <BlockPlaceholder reason="unsupported-format" type="document" />
+      </div>
+    );
+  }
+
   if (document.formatVersion !== DOCUMENT_FORMAT_VERSION) {
     return (
       <div className={PAGE_ROOT_CLASS}>
@@ -137,12 +182,7 @@ export function PageRenderer({
   // dropped or stripped of its anchor, and the node it collided with would then
   // be pruned anyway.
   const visible = dedupeAddresses(pruned, node =>
-    // A node that will resolve to a placeholder emits no `id` of its own, so it
-    // must not reserve one: the healthy node it collided with would be stripped
-    // of an anchor that nothing else was going to use.
-    node.migrationFailed === true
-      ? false
-      : resolver.get(node.type) !== undefined
+    rendersOwnMarkup(node, resolver)
   );
 
   // Whether the tree that renders is the tree the stored stylesheet was

--- a/packages/blocks-react/src/page-renderer.tsx
+++ b/packages/blocks-react/src/page-renderer.tsx
@@ -105,6 +105,22 @@ function rendersOwnMarkup(node: BlockNode, resolver: BlockResolver): boolean {
  *    class, so the element carrying it has to exist or no rule matches
  *    anything.
  */
+/** Whether any node in the tree will be replaced by a knowable placeholder. */
+function hasKnownPlaceholder(
+  nodes: BlockNode[],
+  resolver: BlockResolver
+): boolean {
+  for (const node of nodes) {
+    if (!rendersOwnMarkup(node, resolver)) return true;
+    const slots = node.slots;
+    if (slots === undefined) continue;
+    for (const children of Object.values(slots)) {
+      if (hasKnownPlaceholder(children, resolver)) return true;
+    }
+  }
+  return false;
+}
+
 export function PageRenderer({
   document,
   context,
@@ -194,8 +210,20 @@ export function PageRenderer({
   // that is no longer on the page, and with duplicate node ids those rules
   // target the class the SURVIVING node now wears. So the sheet is recompiled
   // where it can be and withheld where it cannot, for any of the three.
+  //
+  // A knowable placeholder counts as a fourth. Such a node emits only a hidden
+  // marker, so a stored sheet compiled for the markup it WOULD have rendered
+  // ships rules for content that is not on the page, including whatever those
+  // rules reference. Identity alone misses it: the node is skipped by the
+  // predicate above, so when nothing else collided the tree comes back
+  // unchanged and the stale sheet would be trusted. Skipping the reservation
+  // and then trusting the sheet is worse than either on its own, because the
+  // colliding case previously repaired the tree and therefore recompiled.
   const repairedDocument =
-    sanitized !== document || pruned !== doc || visible !== pruned;
+    sanitized !== document ||
+    pruned !== doc ||
+    visible !== pruned ||
+    hasKnownPlaceholder(visible.nodes, resolver);
 
   // Recompiling after pruning must not lose what the stored artifact and the
   // renderer knew. `scope` lives on the artifact rather than in the compile

--- a/packages/blocks-react/src/renderable.ts
+++ b/packages/blocks-react/src/renderable.ts
@@ -347,10 +347,13 @@ function rendersOwnChildren(element: unknown): boolean {
  * effect would perform it twice.
  *
  * Primitives all coerce except a symbol, which throws. An object coerces
- * through `toString` or `valueOf`, so one of the two has to be reachable and
- * callable — a plain object inherits `Object.prototype.toString` and is fine
- * (React renders `[object Object]`), while `Object.create(null)` and an object
- * that nulls both inherit nothing and throw.
+ * through `Symbol.toPrimitive` if it has one and through `toString` or
+ * `valueOf` otherwise, so the order here mirrors the language's: a
+ * `Symbol.toPrimitive` that is present but not callable throws before either of
+ * the other two is consulted. A plain object inherits
+ * `Object.prototype.toString` and is fine (React renders `[object Object]`),
+ * while `Object.create(null)` and an object that nulls both inherit nothing and
+ * throw.
  *
  * The residual case is a REACHABLE method that throws when called. It cannot be
  * detected without calling it, and block code that wants to throw during render
@@ -361,7 +364,21 @@ function isStringable(value: unknown): boolean {
   if (value === null || typeof value !== "object") {
     return typeof value !== "function" || typeof value.toString === "function";
   }
-  const candidate = value as { toString?: unknown; valueOf?: unknown };
+  const candidate = value as {
+    toString?: unknown;
+    valueOf?: unknown;
+    [Symbol.toPrimitive]?: unknown;
+  };
+  // Reading a property can run a getter, so a throw here is an answer of "no"
+  // rather than something to propagate out of a predicate.
+  try {
+    const toPrimitive = candidate[Symbol.toPrimitive];
+    if (toPrimitive !== undefined && typeof toPrimitive !== "function") {
+      return false;
+    }
+  } catch {
+    return false;
+  }
   return (
     typeof candidate.toString === "function" ||
     typeof candidate.valueOf === "function"
@@ -830,13 +847,23 @@ export function normalizeRenderable(
     }
 
     if (Array.isArray(current)) {
-      for (const item of current) sweepThenables(item);
+      for (const item of current) {
+        if (sweepBudget <= 0) return;
+        sweepThenables(item);
+      }
       return;
     }
 
     if (!isIterable(current)) return;
     try {
-      for (const item of current) sweepThenables(item);
+      for (const item of current) {
+        // Checked BEFORE pulling the next value, not just inside the recursive
+        // call: an exhausted budget makes that call return immediately while
+        // this loop keeps asking the iterator for more, so an endless generator
+        // child would spin here forever rather than being abandoned.
+        if (sweepBudget <= 0) return;
+        sweepThenables(item);
+      }
     } catch {
       // A hostile iterator throwing mid-sweep must not replace the refusal that
       // is already on its way back with a different one.

--- a/packages/blocks-react/src/renderable.ts
+++ b/packages/blocks-react/src/renderable.ts
@@ -230,7 +230,22 @@ const ELEMENT_TYPE_SHAPE: ReadonlyMap<
   ],
   [
     Symbol.for("react.lazy"),
-    (type: object) => typeof (type as { _init?: unknown })._init === "function",
+    // Both fields React's own `lazy()` builds, not just the one React calls.
+    //
+    // What a lazy RESOLVES to cannot be checked here: React calls `_init` while
+    // rendering, long after this boundary has returned, and calling it here to
+    // find out would run the block author's loader twice and suspend outside
+    // any boundary. So a forged `{ _init: () => 42 }` reaches React and throws
+    // "Element type is invalid" uncontained.
+    //
+    // Requiring `_payload` narrows that to objects deliberately impersonating
+    // the full shape. React itself tolerates its absence, but nothing genuine
+    // lacks it — `lazy()` always sets both — so this refuses no real lazy while
+    // turning the accidental impersonation into a placeholder.
+    (type: object) => {
+      const lazyType = type as { _init?: unknown; _payload?: unknown };
+      return typeof lazyType._init === "function" && "_payload" in lazyType;
+    },
   ],
   [
     Symbol.for("react.consumer"),
@@ -323,6 +338,36 @@ function rendersOwnChildren(element: unknown): boolean {
  * React hardcodes the same list. Nothing has been added to it since `<wbr>`,
  * and a new one would be a change to HTML itself.
  */
+/**
+ * Whether React can convert a value to a string without throwing.
+ *
+ * Checked by SHAPE rather than by attempting the conversion, because a
+ * `toString` here is code the block author wrote: coercing to find out would
+ * run it once for the check and again for the render, and a method with a side
+ * effect would perform it twice.
+ *
+ * Primitives all coerce except a symbol, which throws. An object coerces
+ * through `toString` or `valueOf`, so one of the two has to be reachable and
+ * callable — a plain object inherits `Object.prototype.toString` and is fine
+ * (React renders `[object Object]`), while `Object.create(null)` and an object
+ * that nulls both inherit nothing and throw.
+ *
+ * The residual case is a REACHABLE method that throws when called. It cannot be
+ * detected without calling it, and block code that wants to throw during render
+ * can simply throw, which this boundary already contains.
+ */
+function isStringable(value: unknown): boolean {
+  if (typeof value === "symbol") return false;
+  if (value === null || typeof value !== "object") {
+    return typeof value !== "function" || typeof value.toString === "function";
+  }
+  const candidate = value as { toString?: unknown; valueOf?: unknown };
+  return (
+    typeof candidate.toString === "function" ||
+    typeof candidate.valueOf === "function"
+  );
+}
+
 const VOID_ELEMENTS: ReadonlySet<string> = new Set([
   "area",
   "base",
@@ -383,6 +428,15 @@ function hostPropReason(element: unknown): string | null {
     }
     if (children != null) {
       return `both \`children\` and \`dangerouslySetInnerHTML\` on <${type}>, which React refuses`;
+    }
+    // React STRINGIFIES `__html` while serializing, which is after this
+    // boundary has returned — so a value that cannot be coerced throws where
+    // nothing can contain it. Verified against React 19.2: a symbol and an
+    // object with no reachable `toString`/`valueOf` both throw, while a number,
+    // a boolean, an array and a plain object are all coerced without complaint.
+    const markup = (html as { __html?: unknown }).__html;
+    if (!isStringable(markup)) {
+      return `a \`dangerouslySetInnerHTML.__html\` value on <${type}> that React cannot convert to a string`;
     }
   }
 
@@ -587,7 +641,14 @@ export function normalizeRenderable(
 
     if (isValidElement(current)) {
       const elementReason = elementShapeReason(current);
-      if (elementReason !== null) return elementReason;
+      if (elementReason !== null) {
+        // Refused for its own shape, so nothing below descends. Any promise a
+        // block already started inside these children would be left with no
+        // handler at all.
+        sweepThenables(suspenseFallbackOf(current));
+        sweepThenables(childrenOf(current));
+        return elementReason;
+      }
       if (!rendersOwnChildren(current)) return null;
       // A Suspense fallback is rendered by React as surely as its children are,
       // just later, so an unrenderable one fails at the first suspension —
@@ -675,7 +736,11 @@ export function normalizeRenderable(
 
     if (isValidElement(current)) {
       const elementReason = elementShapeReason(current);
-      if (elementReason !== null) return { ok: false, reason: elementReason };
+      if (elementReason !== null) {
+        sweepThenables(suspenseFallbackOf(current));
+        sweepThenables(childrenOf(current));
+        return { ok: false, reason: elementReason };
+      }
       if (!rendersOwnChildren(current)) {
         return { ok: true, node: current as ReactNode, hasUnwrappedThenable };
       }
@@ -718,6 +783,64 @@ export function normalizeRenderable(
 
   const markHandled = (pending: PromiseLike<unknown>): void => {
     void Promise.resolve(pending).catch(() => undefined);
+  };
+
+  /**
+   * Budget for the refusal sweep below, separate from the inspection budget.
+   *
+   * Sharing one would mean a refusal discovered near the limit had nothing left
+   * to sweep with, which is exactly the case where an unhandled rejection is
+   * most likely.
+   */
+  let sweepBudget = MAX_CHECKED_VALUES;
+
+  /**
+   * Marks every thenable inside a subtree that is being refused.
+   *
+   * An element is judged by its OWN shape before its children are looked at, so
+   * refusing it returns before anything descends — and a promise a block had
+   * already started sits there with no handler attached. React never renders it
+   * (the element was replaced by a placeholder), so nothing else will attach one
+   * either, and Node's default `--unhandled-rejections=throw` turns that into a
+   * process exit: strictly worse than the escape the refusal closed.
+   *
+   * Marking is not swallowing. The placeholder is where the failure is
+   * reported; this only declines to let a value already refused kill the server.
+   *
+   * Consuming a single-use iterator here is deliberate and safe: this runs only
+   * on a subtree nothing will render.
+   */
+  const sweepThenables = (current: unknown): void => {
+    if (sweepBudget <= 0) return;
+    sweepBudget -= 1;
+    if (current === null || current === undefined) return;
+
+    const type = typeof current;
+    if (type !== "object" && type !== "function") return;
+
+    if (isThenable(current)) {
+      markHandled(current);
+      return;
+    }
+
+    if (isValidElement(current)) {
+      sweepThenables(suspenseFallbackOf(current));
+      sweepThenables(childrenOf(current));
+      return;
+    }
+
+    if (Array.isArray(current)) {
+      for (const item of current) sweepThenables(item);
+      return;
+    }
+
+    if (!isIterable(current)) return;
+    try {
+      for (const item of current) sweepThenables(item);
+    } catch {
+      // A hostile iterator throwing mid-sweep must not replace the refusal that
+      // is already on its way back with a different one.
+    }
   };
 
   try {

--- a/packages/blocks-react/src/sanitize.ts
+++ b/packages/blocks-react/src/sanitize.ts
@@ -131,6 +131,15 @@ export function sanitizeDocument(
  * case-insensitively because HTML treats them that way and the render path
  * lowercases before writing, so a stored `ID` becomes an `id` on the page.
  *
+ * Case variants resolve LAST-write-wins, mirroring the render path exactly: it
+ * lowercases each name into one bag, so `{ id: "old", ID: "hero" }` renders
+ * `hero`. Answering `old` here would reserve an id the page never uses and let
+ * the one it does use collide with a later node.
+ *
+ * Only STRING values count, and for the same reason: the render path skips a
+ * non-string after computing the key, so a later non-string variant does not
+ * displace an earlier string one.
+ *
  * The VALUE is compared exactly. Ids are case-sensitive in the DOM: `#Hero` and
  * `#hero` address different elements, and folding them together would strip an
  * id that was never ambiguous.
@@ -145,10 +154,13 @@ function renderedDomId(node: BlockNode): string | undefined {
   ) {
     return undefined;
   }
+  let rendered: string | undefined;
   for (const [name, value] of Object.entries(attributes)) {
-    if (name.toLowerCase() === "id" && typeof value === "string") return value;
+    if (name.toLowerCase() === "id" && typeof value === "string") {
+      rendered = value;
+    }
   }
-  return undefined;
+  return rendered;
 }
 
 /** A node with whatever supplied the given DOM id removed. */


### PR DESCRIPTION
Works the nine P2 findings left open on #545, which merged with them deliberately. Six are fixed here. Three share one root cause that this layer cannot reach, and they are written up below rather than half-fixed.

## Fixed

**The document envelope was read before it was checked.** `document.formatVersion` is the first property access in `PageRenderer`, and the envelope is database input like everything under it. A corrupt column holding `null` threw there, in the page component, where no block boundary exists to contain it. A primitive does not throw (it just reads `undefined`) but is no more renderable, so both are refused the same way.

**Address repair reserved an id the page would not render.** A stored bag like `{ id: "old", ID: "hero" }` renders `hero`: the render path lowercases each name into one object, so the last string value wins. Repair took the first match, reserved `old`, and then let a later node's `cssId: "hero"` through, putting two `id="hero"` on the page. It now mirrors the render rule exactly, including that the string check happens after the key is computed, so a later non-string variant does not displace an earlier string one.

**A version-ahead node reserved a DOM id it never emits.** `node.version > definition.version` renders a placeholder, and a placeholder emits no modelled id, so reserving one stripped the anchor off a healthy sibling for nothing. The prediction now lives in one helper, `rendersOwnMarkup`, next to an explicit statement of what it can and cannot know.

**`__html` values React cannot stringify.** React coerces `__html` while serializing, after the boundary has returned. Verified against React 19.2: a symbol, `Object.create(null)`, and an object nulling both `toString` and `valueOf` all throw, while a number, a boolean, an array and a plain object are coerced without complaint. The check is by shape rather than by attempting the conversion, because a `toString` here is the block author's code and coercing to find out would run it twice.

**Objects impersonating `React.lazy`.** `{ $$typeof: react.lazy, _init: () => 42 }` passed and then threw "Element type is invalid" from inside React's render. What a lazy resolves to genuinely cannot be checked here (calling `_init` would run the loader twice and suspend outside any boundary), but React's own `lazy()` always sets `_payload` and this did not. Requiring it refuses no real lazy, verified: React tolerates a missing `_payload`, so nothing legitimate depends on the tolerance.

**A promise child of an element refused for its own shape.** An element is judged by its own shape before its children are inspected, so refusing it returned before anything descended, leaving a promise the block had already started with no handler. Node's default `--unhandled-rejections=throw` turns that into a process exit, which is worse than the escape the refusal closed. Both refusal paths now sweep the subtree and mark thenables handled, on a budget separate from the inspection budget so a refusal discovered near the limit still has room to sweep.

## Not fixed, and why

Three findings are the same problem: **address and style decisions are made before render, but some placeholder outcomes are only settled by calling the block.**

- A registered, current node that **throws** or **returns something unrenderable** ends as a placeholder, having already reserved its address.
- Children under a slot the parent **never calls `renderSlot` for** consume addresses although they never reach the page.
- The stored stylesheet still ships rules compiled for any node that ends as a placeholder.

None is knowable from the document and the resolver, which is all this pass has. Closing them means either deciding addresses after render, or compiling styles from a tree with placeholder-only nodes removed. Both are design changes rather than guards, and the third has a wrinkle worth stating: setting the existing `repairedDocument` flag would not help, because recompiling from the same tree still includes the placeholder node's rules.

The failure direction is benign in all three: an anchor is lost or dead CSS ships. Nothing renders content it should not.

## Verification

- **145 tests** (139 existing plus 6).
- **6 stub scenarios, all exact:** each fix reverted in turn fails exactly its own test and nothing else.
- `check-types` and the full suite clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of malformed or unsupported page content with safe fallback placeholders.
  * Prevented invalid elements, lazy wrappers, and unsafe HTML values from causing rendering failures.
  * Preserved valid content while safely handling rejected promises in unsupported structures.
  * Improved duplicate ID handling, including case-insensitive attributes and consistent ownership.
* **Tests**
  * Added coverage for hostile input, unsupported versions, malformed documents, invalid HTML values, and promise rejection handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->