### PR TITLE
fix(plugin-page-builder): keep the class map on the side of the walk it came from

### DIFF
--- a/.changeset/node-class-ref-boundary.md
+++ b/.changeset/node-class-ref-boundary.md
@@ -1,0 +1,36 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+A reusable block keeps its own node classes.
+
+A resolved `core/ref` rendered its target using the containing document's class
+map. That map is keyed by node id, and a stored subtree can hold an id the
+document also holds, so a referenced node could take a class belonging to a
+different node and be styled by rules compiled for it. Referenced subtrees are
+outside the walk the map is built from, so they now take their plain class.
+
+The Query Loop sample preview in the editor renders the same template through the
+production renderer and was naming nodes the other way, so it disagreed with the
+editable template above it wherever a class had been disambiguated.

--- a/packages/plugin-page-builder/src/admin/canvas/CanvasQueryLoop.tsx
+++ b/packages/plugin-page-builder/src/admin/canvas/CanvasQueryLoop.tsx
@@ -23,7 +23,10 @@ export function QueryLoopSamplePreview({ node }: { node: BlockNode }) {
   // The sample rows render through the production `RenderNode`, so it needs the
   // same allowlist the published page uses. Left off, the preview drops images
   // the page will show and the sample stops representing the output.
-  const { remotePatterns } = useEditor();
+  // …and the same node-class map, for the same reason: the rows are compiled
+  // against the document's classes, so rendering them from a different naming
+  // drops the styles the editable template above them shows.
+  const { remotePatterns, nodeClasses } = useEditor();
   const collection =
     typeof node.props.collection === "string" ? node.props.collection : "";
   const sort =
@@ -74,6 +77,7 @@ export function QueryLoopSamplePreview({ node }: { node: BlockNode }) {
                   registry={defaultBlockRegistry}
                   item={item}
                   remotePatterns={remotePatterns}
+                  classes={nodeClasses}
                 />
               ))}
             </div>

--- a/packages/plugin-page-builder/src/render/RenderNode.bindings.test.tsx
+++ b/packages/plugin-page-builder/src/render/RenderNode.bindings.test.tsx
@@ -35,6 +35,46 @@ describe("RenderNode node classes", () => {
     expect(html).toContain("nx-pb-inner-from-map");
   });
 
+  it("does not carry the document's map into a referenced subtree", () => {
+    // A stored subtree can hold an id the document also holds — a block made
+    // reusable from a node that stayed put is the ordinary way. The map is keyed
+    // by id, so carrying it across the boundary hands the referenced node a
+    // class disambiguated for the OTHER node of that id, compiled from styles
+    // that are not its own. Outside the walk means outside the map.
+    const shared = "pb-shared-id";
+    const target = {
+      ...makeNode("core/heading", { text: "Reused", level: "h2" }),
+      id: shared,
+    };
+    const refNode = makeNode("core/ref", { refId: "r1" });
+    const root = makeNode("core/container", {}, undefined, {
+      default: [refNode],
+    });
+    const html = renderToStaticMarkup(
+      <RenderNode
+        node={root}
+        registry={defaultBlockRegistry}
+        refs={{ r1: target }}
+        classes={
+          new Map([
+            [root.id, "nx-pb-root-from-map"],
+            [refNode.id, "nx-pb-refnode-from-map"],
+            [shared, "nx-pb-collided-0"],
+          ])
+        }
+      />
+    );
+    // A resolved ref renders its target IN ITS PLACE and emits no element of
+    // its own, so the ref node's own class is not in the output at all — it is
+    // reached only by the missing-target placeholder.
+    expect(html).not.toContain("nx-pb-refnode-from-map");
+    // The target must not borrow the entry that its id happens to have here.
+    expect(html).not.toContain("nx-pb-collided-0");
+    expect(html).toContain(nodeClass(shared));
+    // The document's own nodes are still named from the map.
+    expect(html).toContain("nx-pb-root-from-map");
+  });
+
   it("falls back to the plain class for a node the map does not hold", () => {
     // A subtree reached through `core/ref` is not in the document walk, so it
     // is not in the map either. It still has to render with a class.

--- a/packages/plugin-page-builder/src/render/RenderNode.tsx
+++ b/packages/plugin-page-builder/src/render/RenderNode.tsx
@@ -129,7 +129,15 @@ export function RenderNode({
         budget={budget}
         refs={refs}
         refStack={[...(refStack ?? []), refId]}
-        classes={classes}
+        // Not this document's map. It is keyed by id, and a stored subtree can
+        // hold an id the document also holds — a block made reusable from a node
+        // that stayed put is the ordinary way — so passing it on would give the
+        // referenced node a class disambiguated for the OTHER node of that id,
+        // compiled from styles that are not its own. The referenced subtree is
+        // outside the walk the map is built from, so it has no entry to inherit
+        // and its nodes take the plain class, which is what the compiler would
+        // name them if it reached them.
+        classes={undefined}
       />
     );
   }


### PR DESCRIPTION
Follow-up to #570. Both findings from Codex's round on that PR, which merged before these landed.

## A referenced subtree took another node's class

`RenderNode` passed the containing document's class map across the `core/ref` boundary. The map is keyed by node id, and a stored subtree can hold an id the document also holds — a block made reusable from a node that stayed put is the ordinary way to get there. So a referenced node could take a class **disambiguated for a different node**, and be styled by rules compiled from that node's styles.

This contradicted the doc comment on `documentNodeClasses` in #570, which states that a referenced node keeps the plain class. The code and its stated design disagreed.

Reproduced before changing anything — a target whose root id matches an in-document id, rendered with a map in which that id was suffixed:

```
usesDocumentMapClass: true
usesPlainClass:       false
```

The map is now dropped at the boundary. A referenced subtree is outside the walk the map is built from, so it has no entry to inherit and its nodes take the plain class, which is what the compiler would name them if it reached them.

**Why not build a map for the referenced subtree** (the other option offered): that only becomes correct once the compiler walks the ref library, and today it emits no rules for those nodes at all — confirmed separately (`class in markup: true`, `style emitted: false`) and filed as left-task 149. A second map now would name nodes for a stylesheet that has nothing in it for them. Whether a reusable block carries its own styling is a product decision, so it belongs in that task rather than here.

## The Query Loop sample preview disagreed with its own template

`QueryLoopSamplePreview` renders the same template through the production `RenderNode` and was naming nodes the plain way while the editable template above it used the map — so the two disagreed wherever a class had been disambiguated. It already pulls `remotePatterns` off the editor context for exactly this reason, so `nodeClasses` comes from the same place rather than a second derivation beside it.

## Verification

573 plugin + 956 engine tests green, lint and types clean.

Stub-verified: restoring `classes={classes}` at the ref boundary fails exactly the new test. One assertion in my first draft was wrong — I expected the ref node's own mapped class in the output, but a resolved ref renders its target *in its place* and emits no element of its own, so that class is reached only by the missing-target placeholder. Corrected to assert what actually holds.
