### PR TITLE
feat(blocks-engine): record where each style declaration came from

### DIFF
--- a/.changeset/style-provenance-log.md
+++ b/.changeset/style-provenance-log.md
@@ -1,0 +1,26 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+Add an opt-in style trace: when a caller asks for it, compiling a page also returns every declaration that was written, in the order it was written, with the tier it came from — the page, a block type default, a named class, or the block itself. Recorded by the emitter from the declarations it emits, so it cannot describe a page the browser is not rendering. Nothing is produced for callers that do not ask, so a visitor page render is unchanged.

--- a/packages/blocks-engine/src/index.ts
+++ b/packages/blocks-engine/src/index.ts
@@ -275,4 +275,8 @@ export {
   NAMED_CLASS_SLUG_RE,
 } from "./style/named-class";
 export type { BreakpointAxis } from "./style/breakpoint-axes";
+
+// Where each emitted declaration came from, for an editor that has to tell an author which of
+// several tiers they are looking at. Produced only when `StyleCompileContext.trace` asks for it.
+export type { StyleOrigin, StyleTraceEntry } from "./style/style-trace";
 export { BREAKPOINT_AXES } from "./style/breakpoint-axes";

--- a/packages/blocks-engine/src/style/compile-page.ts
+++ b/packages/blocks-engine/src/style/compile-page.ts
@@ -59,6 +59,7 @@ import {
 } from "./node-class";
 import { serializeRules } from "./serialize";
 import type { CssRule } from "./serialize";
+import type { StyleOrigin, StyleTraceEntry } from "./style-trace";
 import type { StyleIssueBudget } from "./validate-style-value";
 import { newStyleIssueBudget } from "./validate-style-value";
 import {
@@ -123,6 +124,15 @@ export interface StyleCompileContext {
    * limits when the caller has no opinion.
    */
   limits?: DocumentLimits;
+  /**
+   * Whether to record where each emitted declaration came from.
+   *
+   * Off by default, and deliberately: a visitor's page render has no use for it, and building it
+   * there would put an editor-only structure on the path that matters most. An editor asks for it
+   * once per compile and indexes what it gets, so a control's question is a lookup rather than a
+   * walk over the page.
+   */
+  trace?: boolean;
 }
 
 /** A library entry's id, for a record that may not have one. */
@@ -160,6 +170,14 @@ export interface CompiledPageCss {
    * this value is what makes that tier do anything at all.
    */
   classes: Map<string, string>;
+  /**
+   * Every declaration written, in the order it was written, with its origin.
+   *
+   * Present only when the caller set `trace`. The order is the cascade: everything here is
+   * anchored at the page root at one specificity, so a later entry beats an earlier one wherever
+   * both match the same element.
+   */
+  trace?: readonly StyleTraceEntry[];
 }
 
 /**
@@ -478,7 +496,10 @@ function envelopeRules(
   tokenPrefix: string,
   warnings: ValidationIssue[],
   budget: StyleIssueBudget,
-  warningAllowance: WarningAllowance
+  warningAllowance: WarningAllowance,
+  origin: StyleOrigin,
+  /** Appended to as declarations are emitted; absent when no caller asked for a trace. */
+  trace: StyleTraceEntry[] | undefined
 ): CssRule[] {
   if (styles === undefined) return [];
   // A stored envelope that is not an object — `[]`, a string, `null` — styles
@@ -566,6 +587,21 @@ function envelopeRules(
           selector: `${selector}${STATE_SELECTORS[state]}${rule.descendant}`,
           declarations: rule.declarations,
         });
+        // Recorded here, from the same declarations that were just emitted, in the same loop.
+        // Anywhere else it would be a second reading of the document, and a second reading can
+        // disagree with the first — which is the one failure a provenance record must not have.
+        if (trace === undefined) continue;
+        for (const declaration of rule.declarations) {
+          trace.push({
+            origin,
+            property: declaration.property,
+            value: declaration.value,
+            ...(rule.descendant === "" ? {} : { descendant: rule.descendant }),
+            state,
+            breakpoint: context.id,
+            ...(context.atRule === undefined ? {} : { atRule: context.atRule }),
+          });
+        }
       }
     }
   }
@@ -889,6 +925,9 @@ export function compilePageCss(
   }
 
   const rules: CssRule[] = [];
+  // One array for the whole compile, appended to in emission order by every tier below.
+  const trace: StyleTraceEntry[] | undefined =
+    ctx.trace === true ? [] : undefined;
 
   // Page-scoped values, on the root every other selector is anchored to. First
   // because it is the outermost element: what it sets is what everything inside
@@ -902,7 +941,9 @@ export function compilePageCss(
       tokenPrefix,
       warnings,
       budget,
-      warningAllowance
+      warningAllowance,
+      { kind: "page" },
+      trace
     )
   );
 
@@ -947,7 +988,9 @@ export function compilePageCss(
         tokenPrefix,
         warnings,
         budget,
-        warningAllowance
+        warningAllowance,
+        { kind: "blockType", type },
+        trace
       )
     );
   }
@@ -1097,7 +1140,9 @@ export function compilePageCss(
         // library entry it never mentions. The tier's total output stays bounded by the warning
         // allowance, which is shared and is what actually caps the reporting.
         newStyleIssueBudget(),
-        warningAllowance
+        warningAllowance,
+        { kind: "class", id: cls.id, slug: cls.slug },
+        trace
       )
     );
   }
@@ -1133,7 +1178,9 @@ export function compilePageCss(
         tokenPrefix,
         warnings,
         budget,
-        warningAllowance
+        warningAllowance,
+        { kind: "node", id: node.id },
+        trace
       )
     );
     rules.push(
@@ -1298,5 +1345,8 @@ export function compilePageCss(
     css: serializeRules(rules),
     warnings,
     classes: attributeClasses,
+    // Omitted rather than empty when nobody asked, so a caller cannot mistake "not requested"
+    // for "nothing was written".
+    ...(trace === undefined ? {} : { trace }),
   };
 }

--- a/packages/blocks-engine/src/style/style-trace.test.ts
+++ b/packages/blocks-engine/src/style/style-trace.test.ts
@@ -1,0 +1,304 @@
+/**
+ * The trace against the stylesheet it describes.
+ *
+ * One property carries this design: a trace entry exists for exactly the declarations the
+ * compiler wrote, in exactly the order it wrote them. Everything an inspector later says about
+ * where a value came from rests on that, so it is asserted against the emitted CSS rather than
+ * against a second idea of what the compiler should have done.
+ */
+import { describe, expect, it } from "vitest";
+
+import type { BlockDocument, NodeStyles } from "../document";
+import { FIXTURE_BREAKPOINTS } from "../validation.fixtures";
+
+import { compilePageCss } from "./compile-page";
+import type { NamedClass } from "./named-class";
+
+const styles = (
+  values: Record<string, unknown>,
+  breakpoint = "base"
+): NodeStyles => ({ base: { [breakpoint]: values } }) as unknown as NodeStyles;
+
+const card: NamedClass = {
+  id: "c1",
+  slug: "card",
+  orderIndex: 0,
+  styles: styles({ color: "blue" }),
+};
+
+/** A document exercising all four tiers at once, so their relative order is observable. */
+const everyTier = {
+  formatVersion: 1,
+  kind: "page",
+  settings: { styles: styles({ color: "black" }) },
+  nodes: [
+    {
+      id: "n1",
+      type: "core/box",
+      version: 1,
+      props: {},
+      classes: ["c1"],
+      styles: styles({ color: "red" }),
+    },
+  ],
+} as unknown as BlockDocument;
+
+const compile = (document: BlockDocument, trace: boolean) =>
+  compilePageCss(document, {
+    breakpoints: FIXTURE_BREAKPOINTS,
+    namedClasses: [card],
+    blockBases: { "core/box": styles({ color: "green" }) },
+    trace,
+  } as never);
+
+/**
+ * The same, with no class library and no block defaults.
+ *
+ * For the cases that are about ONE node's own values: compiled against the shared fixture they
+ * would also carry the page, class and block-default declarations, and an assertion listing every
+ * entry would be asserting the fixture rather than the behaviour under test.
+ */
+const compileNodeOnly = (document: BlockDocument) =>
+  compilePageCss(document, {
+    breakpoints: FIXTURE_BREAKPOINTS,
+    namedClasses: [],
+    blockBases: {},
+    trace: true,
+  } as never);
+
+/**
+ * Every `property: value` in the stylesheet, in source order.
+ *
+ * Read back out of the CSS rather than out of the structures that built it: the trace is only
+ * worth anything if it matches what a browser will actually read.
+ */
+function declarationsInCss(css: string): string[] {
+  const found: string[] = [];
+  for (const line of css.split("\n")) {
+    const open = line.indexOf("{");
+    const close = line.lastIndexOf("}");
+    if (open === -1 || close <= open) continue;
+    const body = line.slice(open + 1, close).trim();
+    if (body === "") continue;
+    for (const declaration of body.split(";")) {
+      const text = declaration.trim();
+      if (text !== "") found.push(text);
+    }
+  }
+  return found;
+}
+
+describe("a trace is produced only when it is asked for", () => {
+  it("is absent by default, so a page render pays nothing for it", () => {
+    const { trace } = compilePageCss(everyTier, {
+      breakpoints: FIXTURE_BREAKPOINTS,
+      namedClasses: [card],
+      blockBases: {},
+    } as never);
+
+    // Absent rather than empty: a caller must not read "nothing was written" from "not asked".
+    expect(trace).toBeUndefined();
+  });
+
+  it("is present when asked for, and the CSS is identical either way", () => {
+    const off = compile(everyTier, false);
+    const on = compile(everyTier, true);
+
+    expect(on.trace).toBeDefined();
+    // Asking changes what is REPORTED, never what is written.
+    expect(on.css).toBe(off.css);
+    expect(on.warnings).toEqual(off.warnings);
+  });
+});
+
+describe("the trace accounts for the stylesheet", () => {
+  it("holds one entry per declaration, in the order they were written", () => {
+    const { css, trace } = compile(everyTier, true);
+
+    expect(trace?.map(entry => `${entry.property}: ${entry.value}`)).toEqual(
+      declarationsInCss(css)
+    );
+  });
+
+  it("names the tier each declaration came from, in cascade order", () => {
+    const { trace } = compile(everyTier, true);
+
+    // Page first, then the block type's default, then the class, then the node's own value. At
+    // one specificity that order IS which value the author sees, so it is the order an inspector
+    // reads to answer the question.
+    expect(trace?.map(entry => entry.origin)).toEqual([
+      { kind: "page" },
+      { kind: "blockType", type: "core/box" },
+      { kind: "class", id: "c1", slug: "card" },
+      { kind: "node", id: "n1" },
+    ]);
+  });
+
+  it("carries the state and breakpoint a declaration was stored under", () => {
+    const hovered = {
+      formatVersion: 1,
+      kind: "page",
+      nodes: [
+        {
+          id: "n1",
+          type: "core/box",
+          version: 1,
+          props: {},
+          styles: {
+            base: { tablet: { color: "red" } },
+            hover: { base: { color: "blue" } },
+          },
+        },
+      ],
+    } as unknown as BlockDocument;
+
+    const { trace } = compileNodeOnly(hovered);
+
+    // State is the outer loop and breakpoint the inner one, so every breakpoint of `base` is
+    // written before any of `hover`. That is what makes a hover value beat a base value at every
+    // width, and it is the order the trace has to carry for a later reader to see the same thing.
+    expect(
+      trace?.map(entry => `${entry.state}/${entry.breakpoint}=${entry.value}`)
+    ).toEqual(["base/tablet=red", "hover/base=blue"]);
+  });
+
+  it("carries the at-rule a breakpoint was emitted under", () => {
+    const narrow = {
+      formatVersion: 1,
+      kind: "page",
+      nodes: [
+        {
+          id: "n1",
+          type: "core/box",
+          version: 1,
+          props: {},
+          styles: styles({ color: "red" }, "tablet"),
+        },
+      ],
+    } as unknown as BlockDocument;
+
+    const { css, trace } = compileNodeOnly(narrow);
+    const atRule = trace?.[0]?.atRule;
+
+    expect(atRule).toBeDefined();
+    // The same at-rule the stylesheet opened, not a second rendering of the breakpoint.
+    expect(css).toContain(`${atRule} {`);
+  });
+
+  it("carries the descendant selector for a property that styles one", () => {
+    const linked = {
+      formatVersion: 1,
+      kind: "page",
+      nodes: [
+        {
+          id: "n1",
+          type: "core/box",
+          version: 1,
+          props: {},
+          styles: styles({ linkColor: "blue" }),
+        },
+      ],
+    } as unknown as BlockDocument;
+
+    const { trace } = compileNodeOnly(linked);
+
+    // Without it, a link colour and an element colour read as the same declaration on the same
+    // element — and they are two rules, on two elements, that do not compete.
+    expect(trace?.[0]?.descendant).toBe(" a");
+  });
+
+  it("holds each declaration once when one map writes two selectors", () => {
+    // A map mixing a property that styles the block with one that styles something inside it is
+    // emitted as TWO rules. The trace is built per rule, from the declarations that rule carries;
+    // built from the map instead it would record every declaration once per rule, and claim the
+    // page contains rules it does not.
+    const mixed = {
+      formatVersion: 1,
+      kind: "page",
+      nodes: [
+        {
+          id: "n1",
+          type: "core/box",
+          version: 1,
+          props: {},
+          styles: styles({ color: "red", linkColor: "blue" }),
+        },
+      ],
+    } as unknown as BlockDocument;
+
+    const { css, trace } = compileNodeOnly(mixed);
+
+    expect(trace?.map(entry => `${entry.property}: ${entry.value}`)).toEqual(
+      declarationsInCss(css)
+    );
+    expect(trace?.map(entry => entry.descendant)).toEqual([undefined, " a"]);
+  });
+
+  it("leaves the descendant absent for a property that styles the block itself", () => {
+    const { trace } = compile(everyTier, true);
+
+    expect(trace?.every(entry => entry.descendant === undefined)).toBe(true);
+  });
+});
+
+describe("the trace records what was written, not what was stored", () => {
+  it("omits a value the compiler refused", () => {
+    const refused = {
+      formatVersion: 1,
+      kind: "page",
+      nodes: [
+        {
+          id: "n1",
+          type: "core/box",
+          version: 1,
+          props: {},
+          styles: styles({ color: "not a color", width: "10px" }),
+        },
+      ],
+    } as unknown as BlockDocument;
+
+    const { css, trace } = compileNodeOnly(refused);
+
+    // The refusal is explained in `warnings`. What the trace answers is a different question —
+    // which value is on the page — so a value that never reached it has no entry.
+    expect(css).not.toContain("not a color");
+    expect(trace?.map(entry => entry.property)).toEqual(["width"]);
+  });
+
+  it("omits a class the stylesheet dropped", () => {
+    const twoClaimingOneName = {
+      formatVersion: 1,
+      kind: "page",
+      nodes: [
+        {
+          id: "n1",
+          type: "core/box",
+          version: 1,
+          props: {},
+          classes: ["c2"],
+        },
+      ],
+    } as unknown as BlockDocument;
+
+    const { trace } = compilePageCss(twoClaimingOneName, {
+      breakpoints: FIXTURE_BREAKPOINTS,
+      namedClasses: [
+        card,
+        {
+          id: "c2",
+          slug: "card",
+          orderIndex: 1,
+          styles: styles({ color: "green" }),
+        },
+      ],
+      blockBases: {},
+      trace: true,
+    } as never);
+
+    // Only the first of two classes claiming one name is written, so the second is not a source
+    // of anything — reporting it would name a rule the page does not have.
+    expect(trace?.map(entry => entry.origin)).toEqual([
+      { kind: "class", id: "c1", slug: "card" },
+    ]);
+  });
+});

--- a/packages/blocks-engine/src/style/style-trace.ts
+++ b/packages/blocks-engine/src/style/style-trace.ts
@@ -1,0 +1,61 @@
+// What the compiler wrote, and what made it write each thing.
+//
+// Once a style value can come from a class, a block type's default, the page, or the node itself,
+// an author looking at a control cannot tell whose value they are seeing — and if they cannot
+// tell, they change the wrong thing. Every builder that added shared styles had to answer this
+// with them.
+//
+// The answer is RECORDED here rather than derived beside the compiler. Deriving it means two
+// implementations of one cascade, and two implementations disagree: the indicator then describes
+// a page the browser is not rendering, which is worse than no indicator at all. A trace is
+// written by the emitter, from the same declarations it emits, in the same loop — so "what the
+// stylesheet says" and "what the trace says" cannot come apart without the emitter itself being
+// wrong.
+//
+// The order of the entries IS the cascade order. Everything the compiler emits sits at one
+// specificity and is anchored at the page root, so at equal specificity the later rule wins; the
+// array index carries that without a field that could drift from it.
+//
+// @module style/style-trace
+
+import type { StyleState } from "../document";
+
+/** Which tier emitted a declaration, and which member of that tier. */
+export type StyleOrigin =
+  /** The page's own settings, on the root everything else is anchored to. */
+  | { kind: "page" }
+  /** A block type's default look, shared by every node of that type. */
+  | { kind: "blockType"; type: string }
+  /**
+   * A named class the node applies.
+   *
+   * Carries the id as well as the slug because a document references a class by id and an author
+   * reads its name: an inspector offering to open the class needs the first, and a label needs
+   * the second.
+   */
+  | { kind: "class"; id: string; slug: string }
+  /** One node's own values. */
+  | { kind: "node"; id: string };
+
+/** One declaration the compiler wrote, and where it came from. */
+export interface StyleTraceEntry {
+  origin: StyleOrigin;
+  /** The CSS property, as written. */
+  property: string;
+  /** The CSS value, as written. */
+  value: string;
+  /**
+   * The selector this attaches to inside the block, for a property that styles something the
+   * block contains rather than the block itself — a link colour reaching `a`, say.
+   *
+   * Absent for the ordinary case. Present, it also carries the specificity: a declaration on
+   * ` a:hover` outranks one on ` a` wherever both match, which order alone does not express.
+   */
+  descendant?: string;
+  /** The stored state this came from. */
+  state: StyleState;
+  /** The breakpoint context it was emitted under. */
+  breakpoint: string;
+  /** The at-rule wrapping it, when the breakpoint has one. */
+  atRule?: string;
+}


### PR DESCRIPTION
Task 140, PR 1 of 2. Founder-decided 2026-08-05 after #542 was split: provenance is **recorded by the compiler**, not re-derived beside it.

## Why this shape

#542 carried a `resolveStyle` that answered "where did this value come from" by walking the cascade a second time, from local inputs. It took 13 review rounds and roughly 85 findings, and the large majority were places where the two walks disagreed — the resolver holding a smaller model of the cascade than `compilePageCss` holds. It was removed rather than shipped documented as approximate; it is preserved on `archive/provenance-resolver-v1` as a map of the rules provenance has to account for.

This records instead. `envelopeRules` appends a trace entry for each declaration **in the same loop that pushes the rule, from the same declarations array**. There is no second reading of the document, so there is nothing for a second reading to get wrong.

The order of the entries IS the cascade order: everything the compiler emits is anchored at the page root at one specificity, so at equal specificity the later rule wins, and the array index carries that without a field that could drift from it.

## Opt-in, deliberately

`StyleCompileContext.trace` asks for it; `CompiledPageCss.trace` returns it, and is **absent** rather than empty when nobody asked — so a caller cannot read "nothing was written" from "not requested".

A visitor page render has no use for provenance and should not build it. An editor asks once per compile and indexes what it gets, so a control's question becomes a lookup rather than a walk over the page.

## What is here and what is not

**Here:** the recording, the four tier origins (`page`, `blockType`, `class`, `node`), and the state, breakpoint, at-rule and descendant selector each declaration was written under.

**Not here:** the query side — "which entry wins for this node and this property". That is PR 2, and it is where the matching logic belongs. Splitting it keeps this PR incapable of disagreeing with the stylesheet: it only writes down what was emitted.

`node.visibility` is also out of scope. It is a separate stored field rather than a style value, and an inspector's visibility control reads it directly.

## Tests

`style-trace.test.ts`, 11 cases. The load-bearing one parses the declarations back **out of the emitted CSS** and asserts the trace matches them one for one, in order — the trace is only worth anything if it matches what a browser reads.

Three stub-verifications:

- building the trace from the style map rather than from the emitted rule → `holds each declaration once when one map writes two selectors` fails. This one needed a fixture with both a root property and a descendant property; with a single group the two sources are identical and the stub passed, so the first version of that test could not have caught it.
- dropping the descendant from the entry → `carries the descendant selector for a property that styles one` fails.
- ignoring the flag → `is absent by default` fails.

967 blocks-engine tests pass; typecheck, lint and a full build are clean.

@codex please review this PR