### PR TITLE
feat(nextly): adopt translation columns the config cannot describe

### DIFF
--- a/.changeset/baseline-adopt-unknown.md
+++ b/.changeset/baseline-adopt-unknown.md
@@ -1,0 +1,30 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+`migrate:baseline --adopt-unknown` adopts a translation table holding columns your config no longer describes.
+
+Without the flag, adoption still refuses: such a column has no field stating what it holds, and the logical kind is what decides its column type, so it cannot be rendered from config at all. Adopting anyway would record a table shape the database does not have, and a rebuilt environment would come up missing translations.
+
+With it, the companion is rebuilt from the database instead of from config, reproducing every column exactly as it stands along with its composite key and its cascading foreign key. The columns simply have no field reading them.

--- a/packages/nextly/src/cli/commands/__tests__/migrate-baseline.transition.integration.test.ts
+++ b/packages/nextly/src/cli/commands/__tests__/migrate-baseline.transition.integration.test.ts
@@ -583,6 +583,75 @@ function runSuite(dialect: SupportedDialect): void {
     expect(files.filter(f => f.endsWith(".sql"))).toEqual([]);
   });
 
+  it("--adopt-unknown rebuilds the companion from the database, undescribed column and all", async () => {
+    // The escape hatch from the refusal above. The operator is mid-recovery and
+    // both other ways out are bad: re-declare a field they deliberately removed,
+    // or drop a column holding real translations. So the table is adopted as it
+    // stands, rendered from the live shape rather than from a config that cannot
+    // describe it.
+    await runDbSync(h, localizedConfig);
+    const companionTable = `${LOCALIZED_TABLE}_locales`;
+    expect(await tableExists(h, companionTable)).toBe(true);
+
+    const adopted = await baselineCore({
+      adapter: h.adapter,
+      db: h.db,
+      dialect: h.dialect,
+      migrationsDir: h.migrationsDir,
+      logger,
+      adoptUnknown: true,
+      localizedEntities: [
+        {
+          slug: LOCALIZED_SLUG,
+          tableName: LOCALIZED_TABLE,
+          fields: [text({ name: "summary", localized: true })],
+          status: false,
+          builtBy: "codeFirst" as const,
+        },
+      ],
+      defaultLocale: "en",
+    });
+    if (adopted.kind !== "baselined") throw new Error("expected a baseline");
+
+    const up = splitSqlStatements(
+      parseSqlSections(await readFile(adopted.sqlPath, "utf-8")).upSql
+    );
+    const companionSql = up.filter(st => st.includes(companionTable));
+    expect(companionSql).not.toEqual([]);
+    // `title` has no field describing it and is carried anyway.
+    expect(companionSql.join("\n")).toContain("title");
+    expect(companionSql.join("\n")).toMatch(/ON DELETE CASCADE/i);
+
+    // Asserted by EXECUTING the statement against a database that does not have
+    // the table and reading the result back, not by matching the text. The
+    // dialects disagree about where a key may sit and how a default is spelled,
+    // and only the server settles it.
+    const source = await introspectLiveSnapshot(h.db, h.dialect, [
+      companionTable,
+    ]);
+    const target = await makeHarness(h.dialect, "adopted");
+    try {
+      for (const stmt of up) {
+        await (target.adapter as unknown as DrizzleAdapter).executeQuery(stmt);
+      }
+
+      const rebuilt = await introspectLiveSnapshot(target.db, target.dialect, [
+        companionTable,
+      ]);
+      expect(rebuilt.tables).toEqual(source.tables);
+      // Named explicitly as well, because a deep-equal of two snapshots that
+      // both lost the composite key would still pass. It is what makes a
+      // companion row addressable per (document, locale).
+      const keyed = (rebuilt.tables[0]?.columns ?? [])
+        .filter(c => c.primaryKey === true)
+        .map(c => c.name)
+        .sort();
+      expect(keyed).toEqual(["_locale", "_parent"]);
+    } finally {
+      await target.dispose();
+    }
+  });
+
   it("rebuilds the same schema in an environment that has only the files", async () => {
     // The reason a baseline writes real SQL instead of a marker: a new
     // environment, a CI job, or `migrate:fresh` builds the schema from the

--- a/packages/nextly/src/cli/commands/migrate-baseline.ts
+++ b/packages/nextly/src/cli/commands/migrate-baseline.ts
@@ -33,6 +33,7 @@ import type { Command } from "commander";
 
 import { deriveCompanionSpec } from "../../domains/i18n/migration/derive-companion-spec";
 import {
+  buildCompanionCreateFromLive,
   buildCompanionCreateOnlySql,
   COMPANION_STATUS_COLUMN,
   COMPANION_STRUCTURAL_COLUMNS,
@@ -87,6 +88,7 @@ interface BaselineOptions {
   quiet?: boolean;
   cwd?: string;
   forceUnlock?: boolean;
+  adoptUnknown?: boolean;
 }
 
 /** The migration name used when the operator supplies none. */
@@ -216,6 +218,8 @@ function buildCompanionStatements(args: {
   entities: ResolvedEntity[];
   dialect: SupportedDialect;
   defaultLocale: string;
+  /** Rebuild a companion from the live table when config cannot describe it. */
+  adoptUnknown: boolean;
 }): {
   statements: string[];
   columnsByMain: Map<string, string[]>;
@@ -267,13 +271,36 @@ function buildCompanionStatements(args: {
       name => !COMPANION_STRUCTURAL_COLUMNS.has(name) && !described.has(name)
     );
     if (missing.length > 0) {
-      // Refused rather than skipped. A column standing in the database that
-      // the config no longer describes cannot be rendered faithfully — its
-      // logical kind is what decides the DDL type, and introspection recovers
-      // only the physical one — and emitting the companion without it would
-      // produce a baseline that rebuilds the table missing a column holding
-      // translations.
-      undescribed.push({ table: companionTable, columns: missing.sort() });
+      // A column standing in the database that the config no longer describes
+      // has no logical kind, and the kind is what decides the DDL type. So the
+      // spec-derived rendering cannot express it, and emitting the companion
+      // without it would produce a baseline that rebuilds the table missing a
+      // column holding translations.
+      //
+      // Refused by default, because adopting a schema nobody can describe
+      // should be a decision rather than a silent one. When the operator makes
+      // it, the table is rebuilt from what the database actually has, which
+      // reproduces every column including this one.
+      if (!args.adoptUnknown || !liveTable) {
+        undescribed.push({ table: companionTable, columns: missing.sort() });
+        continue;
+      }
+      statements.push(
+        buildCompanionCreateFromLive({
+          live: liveTable,
+          mainTable: entity.tableName,
+          dialect: args.dialect,
+        })
+      );
+      // Every translated column the companion holds, undescribed ones
+      // included: a later disable has to bring all of them home, and one it
+      // does not know about is one it strands.
+      columnsByMain.set(
+        entity.tableName,
+        [...liveColumns]
+          .filter(n => !COMPANION_STRUCTURAL_COLUMNS.has(n))
+          .sort()
+      );
       continue;
     }
 
@@ -337,6 +364,15 @@ export interface BaselineCoreDeps {
    * project that configured a shorter takeover for far longer than it asked.
    */
   ttlSeconds?: number;
+  /**
+   * Adopt a companion holding translated columns the config does not describe.
+   *
+   * Off by default: such a column cannot be rendered from its logical kind,
+   * so adopting one means recording a schema nobody can describe, which should
+   * be the operator's decision rather than a silent one. On, the companion is
+   * rebuilt from the live table instead of from the config's spec.
+   */
+  adoptUnknown?: boolean;
   /** Override the clock so a test can predict the filename. */
   now?: Date;
 }
@@ -473,6 +509,7 @@ export async function baselineCore(
         entities: deps.localizedEntities ?? [],
         dialect,
         defaultLocale: deps.defaultLocale ?? "en",
+        adoptUnknown: deps.adoptUnknown === true,
       });
       if (companionSql.undescribed.length > 0) {
         // Before anything is written. A baseline that silently omitted these
@@ -649,6 +686,7 @@ export async function runMigrateBaseline(
       defaultLocale: config.localization?.defaultLocale,
       ttlSeconds: config.db.migrateLockTtlSeconds,
       knownJunctions: resolved.knownJunctions,
+      adoptUnknown: options.adoptUnknown,
     });
 
     if (result.kind === "already-baselined") {
@@ -739,6 +777,10 @@ export function registerMigrateBaselineCommand(program: Command): void {
     .option(
       "--force-unlock",
       "Clear a stale migrate lock before taking it (use after a crashed run)"
+    )
+    .option(
+      "--adopt-unknown",
+      "Adopt translation tables holding columns your config no longer describes, rebuilding them from the database"
     )
     .action(async (opts: BaselineOptions, command: Command) => {
       const globalOpts = command.parent?.opts() ?? {};

--- a/packages/nextly/src/domains/i18n/migration/generate-up.ts
+++ b/packages/nextly/src/domains/i18n/migration/generate-up.ts
@@ -1,3 +1,8 @@
+import type { SupportedDialect } from "@nextlyhq/adapter-drizzle/types";
+
+import type { TableSpec } from "../../schema/pipeline/diff/types";
+import { createTableBody } from "../../schema/pipeline/sql-templates/create-table-body";
+
 import { ddlType, lit, q } from "./ddl-types";
 import type { CompanionCopyRef, CompanionMigrationSpec } from "./types";
 
@@ -66,6 +71,44 @@ function buildCompanionCreateStatement(
     `  PRIMARY KEY (${q("_parent", dialect)}, ${q("_locale", dialect)}),\n` +
     `  FOREIGN KEY (${q("_parent", dialect)}) REFERENCES ${q(mainTable, dialect)} (${q("id", dialect)}) ON DELETE CASCADE\n` +
     `)`
+  );
+}
+
+/**
+ * `CREATE TABLE` for a companion that already exists, rebuilt from what the
+ * database actually has.
+ *
+ * The spec-derived form above renders columns from their logical KIND, which is
+ * the right source when a field describes each one. A companion standing in a
+ * database being adopted may hold a column no field describes — and its logical
+ * kind is unrecoverable, while its physical type is right there. Rendering the
+ * introspected columns directly is therefore not a fallback but the more
+ * faithful path: it reproduces the table as it is, with no kind→type round trip
+ * to lose anything.
+ *
+ * Two things a snapshot cannot express are added back. The composite key comes
+ * free — introspection records `primaryKey` per column, so `createTableBody`
+ * emits `PRIMARY KEY (_parent, _locale)` from the live shape. The foreign key
+ * does not exist in the snapshot model at all, so it is spelled here, and
+ * INLINE: SQLite cannot add a constraint by `ALTER` at any point after the
+ * table is created.
+ */
+export function buildCompanionCreateFromLive(args: {
+  live: TableSpec;
+  mainTable: string;
+  dialect: SupportedDialect;
+}): string {
+  const { live, mainTable, dialect } = args;
+  const quote = (id: string): string => q(id, dialect);
+  const body = createTableBody(live, quote);
+  // `IF NOT EXISTS` for the same reason the spec-derived file form uses it: a
+  // baseline reaches databases that already have the companion, and the file is
+  // applied statement by statement with no enclosing transaction.
+  return (
+    `CREATE TABLE IF NOT EXISTS ${quote(live.name)} (\n` +
+    `${body},\n` +
+    `  FOREIGN KEY (${quote("_parent")}) REFERENCES ${quote(mainTable)} (${quote("id")}) ON DELETE CASCADE\n` +
+    `);`
   );
 }
 


### PR DESCRIPTION
Stacked on #551 — review that first; this PR's diff is the single commit `ee8b149fa`.

## The gap

#551 made `migrate:baseline` refuse when a localization companion holds a column no field describes. That refusal is right as a **default**: the column's logical kind is what decides its DDL type, introspection recovers only the physical one, and adopting anyway would record a table shape the database does not have.

It is wrong as the **only** option. Whoever hits it is already mid-recovery — the drift error walked them into editing config — and both remaining ways out are bad: re-declare a field they deliberately removed, or drop a column holding real translations.

## What this adds

`--adopt-unknown`. Default behaviour is unchanged.

With the flag, those companions are rendered from the **live table** rather than from the config's spec. That is not a fallback but the more faithful path: it reproduces the table as it is, with no kind→type round trip to lose anything. Two things a snapshot cannot express are added back:

- **The composite key** — free, since introspection records `primaryKey` per column (#553), so `createTableBody` emits `PRIMARY KEY (_parent, _locale)` from the live shape.
- **The foreign key with `ON DELETE CASCADE`** — spelled inline, because SQLite cannot add a constraint by `ALTER` at any point after the table exists.

`localizedColumns` records every translated column including the undescribed ones, since a later disable has to bring all of them home and one it does not know about is one it strands.

## Rejected

A `--force` that adopts the companion **without** the column. It records a shape the database does not have, so a rebuilt environment silently loses those translations — converting a loud stop into quiet data loss, which is the failure this command exists to prevent.

## Verification

The integration test **executes** the generated statements against a second database and compares the two by introspection, rather than asserting on SQL text — the #553 lesson, where text assertions missed missing primary keys, unquoted MySQL defaults and unparenthesised SQLite defaults alike.

Green on SQLite and PostgreSQL (18/18 on PG). Both halves mutation-verified: ignoring the flag, and dropping the cascade, each fail the test. `check-types` 20/20 and `lint` 21/21 clean.

## DX

The refusal names the flag, so finding it does not require the docs:

```
Some translation tables hold columns this project no longer describes.

  dc_posts_locales: title

...

To adopt them as they are, re-run with --adopt-unknown. The table is
then rebuilt from the database rather than from your config, so every
column is preserved -- these will simply have no field reading them.
```

Task file: `tasks/left-tasks/151-migrate-baseline-adopt-unknown-companion-columns.md`