### PR TITLE
feat(blocks-engine): answer which recorded declaration a node shows

### DIFF
--- a/.changeset/style-provenance-query.md
+++ b/.changeset/style-provenance-query.md
@@ -1,0 +1,26 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+Add a way to ask which recorded declaration a block is actually showing for one property, at one state and width. Reads the trace the compiler produced, so it reports what the stylesheet does rather than working it out a second time: a rule reaches a block through its own styles, a class it applies, its block type, or the page, and a rule that styles something inside a block also reaches down from an ancestor.

--- a/packages/blocks-engine/src/index.ts
+++ b/packages/blocks-engine/src/index.ts
@@ -279,4 +279,6 @@ export type { BreakpointAxis } from "./style/breakpoint-axes";
 // Where each emitted declaration came from, for an editor that has to tell an author which of
 // several tiers they are looking at. Produced only when `StyleCompileContext.trace` asks for it.
 export type { StyleOrigin, StyleTraceEntry } from "./style/style-trace";
+export type { StyleQuery, StyleSubject } from "./style/style-origin";
+export { styleOrigin } from "./style/style-origin";
 export { BREAKPOINT_AXES } from "./style/breakpoint-axes";

--- a/packages/blocks-engine/src/style/style-origin.test.ts
+++ b/packages/blocks-engine/src/style/style-origin.test.ts
@@ -1,0 +1,296 @@
+/**
+ * Which recorded declaration a node is showing.
+ *
+ * Every case here compiles a real document and asks about the trace that compile produced, rather
+ * than asserting against hand-built entries. The whole reason provenance is recorded instead of
+ * derived is that a second idea of what the compiler does can disagree with it; a test written
+ * against a hand-built trace would be exactly that second idea.
+ */
+import { describe, expect, it } from "vitest";
+
+import type { BlockDocument, NodeStyles } from "../document";
+import { FIXTURE_BREAKPOINTS } from "../validation.fixtures";
+
+import { compilePageCss } from "./compile-page";
+import type { NamedClass } from "./named-class";
+import { styleOrigin } from "./style-origin";
+import type { StyleSubject } from "./style-origin";
+import type { StyleTraceEntry } from "./style-trace";
+
+const styles = (
+  values: Record<string, unknown>,
+  breakpoint = "base"
+): NodeStyles => ({ base: { [breakpoint]: values } }) as unknown as NodeStyles;
+
+const card: NamedClass = {
+  id: "c1",
+  slug: "card",
+  orderIndex: 0,
+  styles: styles({ color: "blue" }),
+};
+
+function traceOf(
+  document: BlockDocument,
+  namedClasses: NamedClass[] = [],
+  blockBases: Record<string, NodeStyles> = {}
+): readonly StyleTraceEntry[] {
+  const { trace } = compilePageCss(document, {
+    breakpoints: FIXTURE_BREAKPOINTS,
+    namedClasses,
+    blockBases,
+    trace: true,
+  } as never);
+  // The suite is meaningless without one, and an absent trace would make every assertion below
+  // pass against nothing.
+  expect(trace).toBeDefined();
+  return trace ?? [];
+}
+
+const node = (extra: Record<string, unknown>, id = "n1") => ({
+  id,
+  type: "core/box",
+  version: 1,
+  props: {},
+  ...extra,
+});
+
+const page = (nodes: unknown[], settings?: unknown) =>
+  ({
+    formatVersion: 1,
+    kind: "page",
+    ...(settings === undefined ? {} : { settings }),
+    nodes,
+  }) as unknown as BlockDocument;
+
+const box: StyleSubject = { nodeId: "n1", blockType: "core/box" };
+const atBase = {
+  property: "color",
+  state: "base" as const,
+  breakpoints: ["base"],
+};
+
+describe("which tier a node is showing", () => {
+  it("prefers the node's own value over every other tier", () => {
+    const trace = traceOf(
+      page([node({ classes: ["c1"], styles: styles({ color: "red" }) })], {
+        styles: styles({ color: "black" }),
+      }),
+      [card],
+      { "core/box": styles({ color: "green" }) }
+    );
+
+    const showing = styleOrigin(trace, { ...box, classIds: ["c1"] }, atBase);
+
+    expect(showing?.value).toBe("red");
+    expect(showing?.origin).toEqual({ kind: "node", id: "n1" });
+  });
+
+  it("falls to the class when the node sets nothing", () => {
+    const trace = traceOf(
+      page([node({ classes: ["c1"] })], {
+        styles: styles({ color: "black" }),
+      }),
+      [card],
+      { "core/box": styles({ color: "green" }) }
+    );
+
+    const showing = styleOrigin(trace, { ...box, classIds: ["c1"] }, atBase);
+
+    expect(showing?.origin).toEqual({ kind: "class", id: "c1", slug: "card" });
+  });
+
+  it("falls to the block type when no class applies", () => {
+    const trace = traceOf(
+      page([node({})], { styles: styles({ color: "black" }) }),
+      [],
+      {
+        "core/box": styles({ color: "green" }),
+      }
+    );
+
+    const showing = styleOrigin(trace, box, atBase);
+
+    expect(showing?.origin).toEqual({ kind: "blockType", type: "core/box" });
+  });
+
+  it("falls to the page, which reaches a node that states nothing", () => {
+    const trace = traceOf(
+      page([node({})], { styles: styles({ color: "black" }) })
+    );
+
+    expect(styleOrigin(trace, box, atBase)?.origin).toEqual({ kind: "page" });
+  });
+
+  it("answers undefined when no tier wrote the property", () => {
+    const trace = traceOf(page([node({ styles: styles({ color: "red" }) })]));
+
+    expect(
+      styleOrigin(trace, box, { ...atBase, property: "width" })
+    ).toBeUndefined();
+  });
+});
+
+describe("what a rule is allowed to reach", () => {
+  it("does not report a class the node does not apply", () => {
+    const trace = traceOf(page([node({})]), [card]);
+
+    // The rule exists in the stylesheet; it just does not land on this element.
+    expect(trace.some(entry => entry.origin.kind === "class")).toBe(true);
+    expect(styleOrigin(trace, box, atBase)).toBeUndefined();
+  });
+
+  it("does not report another block type's default", () => {
+    const trace = traceOf(page([node({}, "n1")]), [], {
+      "core/text": styles({ color: "green" }),
+    });
+
+    expect(styleOrigin(trace, box, atBase)).toBeUndefined();
+  });
+
+  it("does not report another node's value", () => {
+    const trace = traceOf(
+      page([node({}), node({ styles: styles({ color: "red" }) }, "n2")])
+    );
+
+    expect(styleOrigin(trace, box, atBase)).toBeUndefined();
+  });
+});
+
+describe("a rule that styles something inside the block", () => {
+  const linkPage = () =>
+    traceOf(
+      page([
+        node({
+          styles: styles({ linkColor: "red" }),
+          slots: { default: [node({ classes: ["link"] }, "child")] },
+        }),
+      ]),
+      [
+        {
+          id: "link",
+          slug: "link",
+          orderIndex: 0,
+          styles: styles({ linkColor: "blue" }),
+        },
+      ]
+    );
+
+  const child: StyleSubject = {
+    nodeId: "child",
+    blockType: "core/box",
+    classIds: ["link"],
+    ancestors: [{ nodeId: "n1", blockType: "core/box" }],
+  };
+
+  it("reaches a descendant node from its ancestor", () => {
+    const showing = styleOrigin(linkPage(), child, {
+      ...atBase,
+      property: "color",
+    });
+
+    // `.n1 a` lands on this child's links directly, competing with the child's own class rule at
+    // equal specificity — so the later one wins, and node rules are written after class rules.
+    expect(showing?.origin).toEqual({ kind: "node", id: "n1" });
+    expect(showing?.descendant).toBe(" a");
+  });
+
+  it("does not reach a node that is not inside it", () => {
+    const sibling: StyleSubject = {
+      nodeId: "other",
+      blockType: "core/box",
+      ancestors: [],
+    };
+
+    expect(
+      styleOrigin(linkPage(), sibling, { ...atBase, property: "color" })
+    ).toBeUndefined();
+  });
+
+  it("lets a more specific descendant selector win over a later-written one", () => {
+    // The case where order and specificity DISAGREE, which is the only case that tests
+    // specificity at all. Inside one map the compiler emits by property name, so `linkColor`
+    // already precedes `linkColorHover` and taking the last would land on the right answer for
+    // the wrong reason.
+    //
+    // Split across tiers it comes apart: the class writes `a:hover`, the node writes `a`, and the
+    // node's rule is emitted LATER. On a hovered link both match, and the class's extra
+    // pseudo-class outranks the node's position.
+    const trace = traceOf(
+      page([
+        node({ classes: ["hover"], styles: styles({ linkColor: "blue" }) }),
+      ]),
+      [
+        {
+          id: "hover",
+          slug: "hover",
+          orderIndex: 0,
+          styles: styles({ linkColorHover: "red" }),
+        },
+      ]
+    );
+
+    const order = trace.map(entry => entry.descendant);
+    expect(order).toEqual([" a:hover", " a"]);
+
+    const showing = styleOrigin(
+      trace,
+      { ...box, classIds: ["hover"] },
+      { ...atBase, property: "color" }
+    );
+
+    expect(showing?.value).toBe("red");
+    expect(showing?.descendant).toBe(" a:hover");
+  });
+});
+
+describe("which breakpoints are live", () => {
+  const responsive = () =>
+    traceOf(
+      page([
+        node({
+          styles: {
+            base: { base: { color: "red" }, tablet: { color: "blue" } },
+          },
+        }),
+      ])
+    );
+
+  it("takes the narrower rule when the viewer is at that width", () => {
+    const showing = styleOrigin(responsive(), box, {
+      ...atBase,
+      breakpoints: ["base", "tablet"],
+    });
+
+    expect(showing?.value).toBe("blue");
+    expect(showing?.breakpoint).toBe("tablet");
+  });
+
+  it("ignores a breakpoint the viewer is not at", () => {
+    const showing = styleOrigin(responsive(), box, {
+      ...atBase,
+      breakpoints: ["base"],
+    });
+
+    expect(showing?.value).toBe("red");
+  });
+});
+
+describe("which state is being asked about", () => {
+  it("answers for the state asked, not whichever was written last", () => {
+    const trace = traceOf(
+      page([
+        node({
+          styles: {
+            base: { base: { color: "red" } },
+            hover: { base: { color: "blue" } },
+          },
+        }),
+      ])
+    );
+
+    expect(styleOrigin(trace, box, atBase)?.value).toBe("red");
+    expect(styleOrigin(trace, box, { ...atBase, state: "hover" })?.value).toBe(
+      "blue"
+    );
+  });
+});

--- a/packages/blocks-engine/src/style/style-origin.ts
+++ b/packages/blocks-engine/src/style/style-origin.ts
@@ -1,0 +1,136 @@
+// Which recorded declaration a node actually shows.
+//
+// The trace says what the compiler wrote and in what order. This says which of those entries the
+// browser is using for one node, one property, at one width — the question an inspector asks to
+// label a control "from the Card class" rather than leaving an author guessing whose value they
+// are looking at.
+//
+// Almost everything that makes this hard was settled by recording rather than re-deriving. The
+// trace holds only declarations that were EMITTED, in emission order, so tier order, both
+// breakpoint axes, states joining the base rules, a refused value, a refused map, a leaf refused
+// inside a composite, a class that lost its name to an earlier one, and two catalog keys writing
+// one CSS property are all already answered. None of them can be got wrong here because none of
+// them is decided here.
+//
+// Two things are left, and they are the only two.
+//
+// SCOPE. An entry was written under a selector, and a selector reaches some elements and not
+// others. A node is reached by its own rules, by the classes it applies, by its block type's
+// defaults, and by the page — and, for a property that styles something INSIDE a block, by any
+// ancestor's rule of the same kind, because `.ancestor a` lands on this node's links directly.
+//
+// SPECIFICITY. Everything is emitted at one specificity except the descendant selectors, which
+// carry whatever pseudo-classes the catalog gave them: a declaration on ` a:hover` outranks one
+// on ` a` however early it was written. Order decides only between equals.
+//
+// @module style/style-origin
+
+import type { StyleState } from "../document";
+
+import type { StyleTraceEntry } from "./style-trace";
+
+/**
+ * A node, and the ancestors whose rules can reach into it.
+ *
+ * The caller holds the document, so it names the node rather than this walking a tree it would
+ * have to be handed anyway. `ancestors` is outermost first; an empty list is a root node.
+ */
+export interface StyleSubject {
+  nodeId: string;
+  /** The block type, when the node has one the site supplies defaults for. */
+  blockType?: string;
+  /** The ids of the classes the node applies. Order is irrelevant: the trace already carries it. */
+  classIds?: readonly string[];
+  /** Outermost first. Only their descendant-selector rules can reach this node. */
+  ancestors?: readonly Omit<StyleSubject, "ancestors">[];
+}
+
+/** What is being asked about. */
+export interface StyleQuery {
+  /** The CSS property, as the trace records it — `color`, not the catalog key. */
+  property: string;
+  state: StyleState;
+  /**
+   * The breakpoints whose rules are live at the width being viewed.
+   *
+   * Supplied rather than derived because it is a fact about the viewer, not about the document:
+   * an editor simulating a narrow viewport inside a wide window is the normal case, and a page
+   * can respond to a viewport and a container at once. Everything else about breakpoints — which
+   * of two live rules wins — is already in the trace's order.
+   */
+  breakpoints: readonly string[];
+}
+
+/** How many pseudo-classes a descendant selector carries, which is what it adds to specificity. */
+function pseudoClassCount(descendant: string | undefined): number {
+  if (descendant === undefined) return 0;
+  return descendant.split(":").length - 1;
+}
+
+/**
+ * Whether an entry's origin reaches this node directly.
+ *
+ * Directly means the selector lands on the node's own element: its own rules, a class it applies,
+ * its block type's defaults, or the page root it sits under.
+ */
+function reachesNode(entry: StyleTraceEntry, subject: StyleSubject): boolean {
+  const origin = entry.origin;
+  switch (origin.kind) {
+    case "page":
+      return true;
+    case "node":
+      return origin.id === subject.nodeId;
+    case "blockType":
+      return origin.type === subject.blockType;
+    case "class":
+      return (subject.classIds ?? []).includes(origin.id);
+  }
+}
+
+/**
+ * Whether an entry's origin reaches this node through an ancestor.
+ *
+ * Only for a rule with a descendant selector. `.ancestor a` styles the links inside everything the
+ * ancestor contains, including this node, and competes with this node's own `a` rules at equal
+ * specificity — so it is not inheritance, and treating it as inheritance reports the wrong colour
+ * for a link inside a styled parent.
+ */
+function reachesThroughAncestor(
+  entry: StyleTraceEntry,
+  subject: StyleSubject
+): boolean {
+  if (entry.descendant === undefined) return false;
+  return (subject.ancestors ?? []).some(ancestor =>
+    reachesNode(entry, { ...ancestor, ancestors: [] })
+  );
+}
+
+/**
+ * The entry a node is showing for one property, or `undefined` when nothing wrote it.
+ *
+ * Undefined is a real answer and not a failure: a property no tier set is one the browser takes
+ * from its own defaults, and a control over it is genuinely empty.
+ */
+export function styleOrigin(
+  trace: readonly StyleTraceEntry[],
+  subject: StyleSubject,
+  query: StyleQuery
+): StyleTraceEntry | undefined {
+  const live = new Set(query.breakpoints);
+  let winner: StyleTraceEntry | undefined;
+  let winningSpecificity = -1;
+  for (const entry of trace) {
+    if (entry.property !== query.property) continue;
+    if (entry.state !== query.state) continue;
+    if (!live.has(entry.breakpoint)) continue;
+    if (!reachesNode(entry, subject) && !reachesThroughAncestor(entry, subject))
+      continue;
+    const specificity = pseudoClassCount(entry.descendant);
+    // Later beats earlier only at equal specificity, which is the cascade the compiler emits for:
+    // one class-worth for everything, plus whatever pseudo-classes a descendant selector adds.
+    if (specificity < winningSpecificity) continue;
+    winner = entry;
+    winningSpecificity = specificity;
+  }
+  return winner;
+}


### PR DESCRIPTION
Task 140, PR 2 of 2. Follows #572, which made the compiler record where each declaration came from. This reads that record.

## What recording bought

The archived resolver from #542 had to reproduce eleven things about the cascade, each discovered by a review round finding it wrong. Nine of them are now simply not decisions this code makes:

| what the old resolver had to reproduce | now |
|---|---|
| tier order within a node | emission order |
| both breakpoint axes, in emission order | emission order |
| states joining base rather than replacing it | emission order |
| whether the compiler writes a value at all | only emitted declarations are in the trace |
| ids claimed once across a library | only usable classes emit |
| leaf-level refusal inside a composite | only emitted declarations |
| two catalog keys writing one CSS property | the trace records the CSS property |
| a map refused as a whole | only emitted declarations |
| descendant rules ordered tier-major | emission order |
| **inheritance from ancestors** | **still decided here** |
| **selector specificity for descendant properties** | **still decided here** |

So this module answers two questions and no others.

**Scope.** A rule reaches a node through its own styles, a class it applies, its block type, or the page. A rule that styles something INSIDE a block also reaches down from an ancestor: `.ancestor a` lands on this node's links directly and competes with this node's own `a` rules at equal weight. That is not inheritance, and treating it as inheritance reports the wrong colour for a link inside a styled parent.

**Specificity.** Everything is emitted at one weight except descendant selectors, which carry whatever pseudo-classes the catalog gave them. ` a:hover` outranks ` a` however early it was written; order decides only between equals.

Which breakpoints are live is supplied by the caller rather than derived. It is a fact about the viewer — an editor simulating a narrow viewport inside a wide window is the normal case, and a page can respond to a viewport and a container at once.

## Tests

14 cases, every one compiling a real document and querying the trace that compile produced. Asserting against a hand-built trace would be a second idea of what the compiler does, which is the thing this design exists to avoid.

All five behaviours stub-verified. One is worth calling out: **my first specificity test could not fail.** Inside a single style map the compiler emits by property name, so `linkColor` already precedes `linkColorHover` and "take the last" lands on the right answer for the wrong reason. The fixture now splits them across tiers — the class writes ` a:hover`, the node writes ` a` and is emitted later — so order and specificity genuinely disagree, and the test asserts the emission order explicitly before asserting the winner. With the specificity comparison removed it now fails.

981 blocks-engine tests pass; typecheck, lint and a full build are clean.

@codex please review this PR