### PR TITLE
fix(nextly): resolve a named preview grant by id, not by slug

### DIFF
--- a/.changeset/preview-by-id-resolve.md
+++ b/.changeset/preview-by-id-resolve.md
@@ -1,0 +1,30 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+Resolve a scoped preview link by the entry it names.
+
+A preview grant that names an entry is now read by that id and confirmed to live at the requested path, instead of resolving the path by slug and comparing ids afterwards. A slug is not unique, so the old order could find a different document, reject it, and fall back to published, showing an editor live content at a link they were given for a draft.
+
+When the named entry is gone or lives at another path, the request holds no draft authorization for that path and resolves published-only, so the widened lifecycle scope cannot surface a row the grant never named.

--- a/packages/nextly/src/runtime/routing/__tests__/content-route-by-id.test.ts
+++ b/packages/nextly/src/runtime/routing/__tests__/content-route-by-id.test.ts
@@ -1,0 +1,180 @@
+/**
+ * A preview grant that NAMES an entry resolves by that id, not by slug.
+ *
+ * The route used to resolve the path by slug and then compare the result's id
+ * against the grant. That comparison sits downstream of a lookup that can find
+ * the wrong document: a slug is not unique, and duplicates are settled by
+ * sorting on `id`, so a grant for one entry could land on another sharing its
+ * slug. The mismatch was then rejected and the path fell back to published,
+ * showing an editor LIVE content at a link they were given for a draft.
+ *
+ * Resolving by the granted id removes the comparison instead of hardening it.
+ * What has to stay is the confirmation in the other direction: the entry a
+ * grant names must still LIVE at the path being requested, or a preview cookie
+ * would turn every URL on the site into the previewed page.
+ *
+ * The reader here holds a row SET rather than a single row, because that is the
+ * only shape in which resolving by id and resolving by slug can disagree.
+ */
+import { describe, expect, it } from "vitest";
+
+import type {
+  FindArgs,
+  FindByIDArgs,
+} from "../../../direct-api/types/collections";
+import type { ListResult } from "../../../direct-api/types/shared";
+import { createContentRoute } from "../content-route";
+import type { ContentEntry, NextlyContentReader } from "../resolve-content";
+
+interface Row extends Record<string, unknown> {
+  id: string;
+  slug: string;
+  status: string;
+}
+
+function stubReader(rows: Row[]): {
+  reader: NextlyContentReader;
+  calls: FindArgs[];
+  byIdCalls: FindByIDArgs[];
+} {
+  const calls: FindArgs[] = [];
+  const byIdCalls: FindByIDArgs[] = [];
+
+  const reader: NextlyContentReader = {
+    find: async (args): Promise<ListResult<Record<string, unknown>>> => {
+      calls.push(args);
+      const slug = (args.where as { slug?: { equals?: unknown } } | undefined)
+        ?.slug?.equals;
+      // The lifecycle scope the query service applies, plus the deterministic
+      // `sort: "id"` the resolver relies on to settle duplicate slugs. Both
+      // matter: without the sort the shadowing case would be arbitrary rather
+      // than reproducible.
+      const items = rows
+        .filter(row => row.slug === slug)
+        .filter(row => args.status === "all" || row.status === "published")
+        .sort((left, right) => left.id.localeCompare(right.id))
+        .slice(0, 1);
+      return {
+        items,
+        meta: {
+          total: items.length,
+          page: 1,
+          limit: 1,
+          totalPages: 1,
+          hasNext: false,
+          hasPrev: false,
+        },
+      };
+    },
+    findByID: async (args): Promise<Record<string, unknown> | null> => {
+      byIdCalls.push(args);
+      const row = rows.find(candidate => candidate.id === args.id);
+      return row ? { ...row, _isWorkingDraft: true } : null;
+    },
+  };
+
+  return { reader, calls, byIdCalls };
+}
+
+function routeFor(reader: NextlyContentReader, entryId?: string) {
+  return createContentRoute({
+    collections: ["pages"],
+    nextly: reader,
+    render: (entry: ContentEntry) => entry,
+    buildMetadata: (entry: ContentEntry) => ({ title: String(entry.id) }),
+    draft: () => (entryId === undefined ? false : { entryId }),
+  });
+}
+
+const params = { params: { slug: ["a"] } };
+
+describe("a preview grant that names an entry", () => {
+  it("opens the entry it names, not the one that shadows its slug", async () => {
+    // `draft-first` sorts before `published-second` and has never been
+    // published, so the ordinary slug lookup under a widened status finds IT.
+    // The grant names the other one.
+    const { reader } = stubReader([
+      { id: "draft-first", slug: "a", status: "draft" },
+      { id: "published-second", slug: "a", status: "published" },
+    ]);
+
+    const entry = (await routeFor(reader, "published-second").ContentPage(
+      params
+    )) as ContentEntry;
+
+    expect(entry.id).toBe("published-second");
+    // And it is the DRAFT of that entry, not its live row: resolving by id is
+    // pointless if it drops the pending edits the link exists to show.
+    expect(entry._isWorkingDraft).toBe(true);
+  });
+
+  it("does not serve the granted entry at a path it does not live at", async () => {
+    // The trap this design exists to avoid. Resolving by the granted id alone
+    // would render that entry at EVERY url for the life of the session, which
+    // is worse than the duplicate-slug bug it fixes.
+    const { reader } = stubReader([
+      { id: "elsewhere", slug: "somewhere-else", status: "draft" },
+      { id: "here", slug: "a", status: "published" },
+    ]);
+
+    const entry = (await routeFor(reader, "elsewhere").ContentPage(
+      params
+    )) as ContentEntry;
+
+    expect(entry.id).toBe("here");
+    expect(entry._isWorkingDraft).toBeUndefined();
+  });
+
+  it("falls back to published when the grant names a deleted entry", async () => {
+    // A preview link outlives what it points at. Failing here would make a
+    // stale-but-valid link distinguishable from a forged one.
+    const { reader } = stubReader([
+      { id: "here", slug: "a", status: "published" },
+    ]);
+
+    const entry = (await routeFor(reader, "gone").ContentPage(
+      params
+    )) as ContentEntry;
+
+    expect(entry.id).toBe("here");
+    expect(entry._isWorkingDraft).toBeUndefined();
+  });
+
+  it("still opens the draft when a hook rewrites the entry's id", async () => {
+    // An `afterRead` hook's return REPLACES the document, so the old
+    // compare-the-id approach rejected a valid grant whenever a collection
+    // reshaped its public read. Nothing compares ids any more, so the read
+    // succeeds on its own terms.
+    const rows: Row[] = [{ id: "real", slug: "a", status: "published" }];
+    const { reader } = stubReader(rows);
+    const reshaping: NextlyContentReader = {
+      find: reader.find,
+      findByID: async args => {
+        const row = await reader.findByID(args);
+        return row === null ? null : { ...row, id: "reshaped-by-a-hook" };
+      },
+    };
+
+    const entry = (await routeFor(reshaping, "real").ContentPage(
+      params
+    )) as ContentEntry;
+
+    expect(entry._isWorkingDraft).toBe(true);
+    expect(entry.id).toBe("reshaped-by-a-hook");
+  });
+
+  it("reads by id before it reads by slug", async () => {
+    // The mechanism, not the symptom: a named grant must not spend a slug
+    // lookup first, because that lookup is the thing that can find the wrong
+    // document.
+    const { reader, calls, byIdCalls } = stubReader([
+      { id: "here", slug: "a", status: "published" },
+    ]);
+
+    await routeFor(reader, "here").ContentPage(params);
+
+    expect(byIdCalls).toHaveLength(1);
+    expect(byIdCalls[0]?.id).toBe("here");
+    expect(calls).toHaveLength(0);
+  });
+});

--- a/packages/nextly/src/runtime/routing/__tests__/content-route-draft.test.ts
+++ b/packages/nextly/src/runtime/routing/__tests__/content-route-draft.test.ts
@@ -218,49 +218,14 @@ describe("the content route's draft decision", () => {
     ]);
   });
 
-  it("discards a draft the grant did not name", async () => {
-    // A slug need not be unique — the resolver supports duplicates and settles
-    // them by sorting on `id` — so a grant scoped to one entry could otherwise
-    // open another that happens to share its slug. The grant names the
-    // document, and a resolve that lands on a different one falls back to
-    // published rather than serving what was never granted.
-    const { reader, byIdCalls } = stubReader();
-
-    const wrongEntry = await createContentRoute({
-      collections: ["pages"],
-      nextly: reader,
-      render: (entry: ContentEntry) => entry,
-      buildMetadata: (entry: ContentEntry) => ({ title: String(entry.id) }),
-      draft: () => ({ entryId: "some-other-entry" }),
-    }).ContentPage(params);
-
-    expect((wrongEntry as ContentEntry)._isWorkingDraft).toBeUndefined();
-
-    byIdCalls.length = 0;
-    const rightEntry = await createContentRoute({
-      collections: ["pages"],
-      nextly: reader,
-      render: (entry: ContentEntry) => entry,
-      buildMetadata: (entry: ContentEntry) => ({ title: String(entry.id) }),
-      draft: () => ({ entryId: "1" }),
-    }).ContentPage(params);
-
-    expect((rightEntry as ContentEntry)._isWorkingDraft).toBe(true);
-    expect(byIdCalls).toHaveLength(1);
-  });
-
-  it("refuses a grant when the resolved document has no comparable id", async () => {
-    // An `afterRead` hook's return value REPLACES the document, so a collection
-    // that reshapes its public read can hand back a row whose id is absent or
-    // structured. Stringifying those yields `"undefined"` and
-    // `"[object Object]"` — values a grant can carry literally.
-    //
-    // What that would cost is a disclosure, not a degraded preview: a grant the
-    // route honours is read with the lifecycle scope widened to `"all"`, so the
-    // row it matches by accident can be one that was NEVER published.
-    for (const id of [undefined, { nested: "1" }]) {
+  it("refuses a draft for an object grant that names no entry", async () => {
+    // The decision is app-supplied code, so the type is not a runtime
+    // guarantee. An object carrying no usable id must authorize nothing: the
+    // one combination that must not exist is a widened lifecycle scope with no
+    // entry named to bound it.
+    for (const grant of [{}, { entryId: "" }, { entryId: 42 }]) {
       const { reader, calls } = stubReader(
-        { id, slug: "a", status: "draft" },
+        { id: "1", slug: "a", status: "draft" },
         { enforceStatus: true }
       );
 
@@ -269,15 +234,14 @@ describe("the content route's draft decision", () => {
         nextly: reader,
         render: (row: ContentEntry) => row,
         buildMetadata: (row: ContentEntry) => ({ title: String(row.slug) }),
-        draft: () => ({ entryId: String(id) }),
+        draft: () => grant as never,
       });
 
-      // The never-published row is the only one there is, so refusing the grant
-      // leaves nothing to serve. Asserting the REFUSAL rather than the throw:
-      // the route re-read published-only, which is what a rejected grant does
-      // and what returning the row instead would have skipped.
+      // Nothing published lives at this path, so refusing the grant leaves
+      // nothing to serve. The read that happened is the assertion: published,
+      // not widened.
       await expect(route.ContentPage(params)).rejects.toThrow();
-      expect(calls.map(call => call.status)).toEqual(["all", "published"]);
+      expect(calls.map(call => call.status)).toEqual(["published"]);
     }
   });
 

--- a/packages/nextly/src/runtime/routing/content-route.ts
+++ b/packages/nextly/src/runtime/routing/content-route.ts
@@ -264,19 +264,6 @@ export function createContentRoute<TNode>(
     return typeof decision === "function" ? decision(context) : decision;
   }
 
-  /** Whether a grant covers the document the path actually resolved to. */
-  function grantCovers(grant: DraftGrant, entry: ContentEntry): boolean {
-    if (typeof grant === "boolean") return grant;
-    // Only a primitive id can be compared. An `afterRead` hook's return value
-    // REPLACES the document, so a collection that reshapes its public read can
-    // hand back a row whose id is absent or an object — and stringifying those
-    // yields `"undefined"` and `"[object Object]"`, values a grant could carry
-    // literally and thereby match a document it never named.
-    const id = entry.id;
-    if (typeof id !== "string" && typeof id !== "number") return false;
-    return String(id) === grant.entryId;
-  }
-
   /** Resolve the joined slug across the configured collections (first match wins). */
   async function resolve(
     slug: string
@@ -286,7 +273,23 @@ export function createContentRoute<TNode>(
       // document, and the same slug can name a different document in each
       // configured collection.
       const grant = await draftForThisPath({ collection, slug });
-      const draft = grant !== false;
+      // A grant that NAMES an entry is resolved by that id rather than by slug,
+      // so a duplicate slug cannot decide which document a preview opens. A
+      // bare `true` names nothing and keeps the ordinary lookup.
+      //
+      // An object grant carrying no usable id authorizes NOTHING. The decision
+      // is app-supplied code and the type is not a runtime guarantee, so a
+      // `{}` reaching here would otherwise widen the lifecycle scope while
+      // naming no entry to bound it, which is the one combination that must not
+      // exist.
+      const grantedEntryId =
+        typeof grant === "object" &&
+        grant !== null &&
+        typeof grant.entryId === "string" &&
+        grant.entryId !== ""
+          ? grant.entryId
+          : undefined;
+      const draft = grant === true || grantedEntryId !== undefined;
       const entry = await resolveContent(collection, slug, {
         nextly: config.nextly,
         slugField,
@@ -295,6 +298,7 @@ export function createContentRoute<TNode>(
         // switched on.
         ...(config.status ? { status: config.status } : {}),
         draft,
+        ...(grantedEntryId === undefined ? {} : { entryId: grantedEntryId }),
         depth,
         tags: config.tags,
         revalidate: config.revalidate,
@@ -307,26 +311,14 @@ export function createContentRoute<TNode>(
         overrideAccess: overrideAccess || draft,
       });
       if (!entry) continue;
-      if (draft && !grantCovers(grant, entry)) {
-        // The grant named a different document. A slug need not be unique, so
-        // this is where a token for one entry would otherwise have opened
-        // another that happens to share its slug — read again with no draft
-        // rather than serving the one that was never granted.
-        const published = await resolveContent(collection, slug, {
-          nextly: config.nextly,
-          slugField,
-          ...(config.status ? { status: config.status } : {}),
-          depth,
-          tags: config.tags,
-          revalidate: config.revalidate,
-          cacheScope: config.cacheScope,
-          overrideAccess,
-        });
-        if (published) {
-          return { entry: published, context: { collection, slug } };
-        }
-        continue;
-      }
+      // No identity check here, deliberately. Both halves a grant has to
+      // satisfy — that it names THIS entry, and that the entry lives at THIS
+      // path — are settled inside `resolveContent`, which reads by the granted
+      // id and confirms the slug, and resolves published-only when either fails.
+      // Re-comparing ids at this layer is what the by-id read replaced: it
+      // compares a POST-`afterRead` document, so a collection that reshapes its
+      // public read would fail a valid grant and send the editor to live
+      // content.
       return { entry, context: { collection, slug } };
     }
     return null;

--- a/packages/nextly/src/runtime/routing/resolve-content.ts
+++ b/packages/nextly/src/runtime/routing/resolve-content.ts
@@ -80,6 +80,26 @@ export interface ResolveContentOptions {
    * @default false
    */
   draft?: boolean;
+  /**
+   * The entry a preview grant NAMES, resolved by id instead of by slug.
+   *
+   * Only meaningful alongside `draft` on a trusted read. A slug is not unique:
+   * the ordinary lookup settles duplicates by sorting on `id`, so a grant for
+   * one entry can land on another that happens to share its slug, and the
+   * caller then rejects the mismatch and falls back to published. The editor
+   * sees LIVE content at a link they were given for a draft.
+   *
+   * Reading by the id the grant names removes that comparison rather than
+   * hardening it. The resolved entry's own slug is then confirmed against the
+   * requested one, which is what stops a preview session turning every path on
+   * the site into the previewed entry: without that check a cookie for one page
+   * would render that page at every URL for the life of the session.
+   *
+   * A grant that names a deleted entry, or one whose slug no longer matches the
+   * path, falls through to the ordinary slug resolution rather than failing. A
+   * preview link outlives what it points at.
+   */
+  entryId?: string;
   /** Relation population depth for rendering (default `1`). */
   depth?: number;
   /** Read a specific locale (localized collections). */
@@ -170,6 +190,7 @@ export async function resolveContent(
   const nextly = options.nextly ?? getNextly();
   const slugField = options.slugField ?? "slug";
   const draft = options.draft ?? false;
+  const grantedEntryId = options.entryId;
   const depth = options.depth ?? 1;
   const locale = options.locale;
   const overrideAccess = options.overrideAccess ?? false;
@@ -191,8 +212,68 @@ export async function resolveContent(
   const status =
     options.status ?? (draft && overrideAccess ? "all" : "published");
 
+  /** Whether a resolved entry is the one this path asked for. */
+  const answersThisPath = (entry: ContentEntry): boolean =>
+    entry[slugField] === slug;
+
+  /**
+   * Resolve this path with no draft authorization at all.
+   *
+   * Used when a named grant did not answer this path. Reading with the widened
+   * scope would surface a never-published row the grant never named, which is
+   * exactly the disclosure the grant is supposed to bound.
+   */
+  const publishedOnly = async (): Promise<ContentEntry | null> => {
+    const result = await nextly.find({
+      collection,
+      where: { [slugField]: { equals: slug } },
+      status: options.status ?? "published",
+      limit: 1,
+      sort: "id",
+      depth,
+      overrideAccess,
+      user,
+      ...(options.richTextFormat
+        ? { richTextFormat: options.richTextFormat }
+        : {}),
+      ...(locale ? { locale } : {}),
+    });
+    return result.items[0] ?? null;
+  };
+
   const read = async (): Promise<ContentEntry | null> => {
     try {
+      // A named grant resolves by id FIRST, so a duplicate slug cannot decide
+      // which document a preview opens. Trusted-only for the same reason the
+      // status widening is: an enforced read could not return an unpublished
+      // row anyway, and reading by an id the request supplied is exactly the
+      // shape that must not be reachable without the caller having authorized
+      // it.
+      if (draft && grantedEntryId !== undefined && overrideAccess) {
+        const granted = await readOverlay(() =>
+          nextly.findByID({
+            collection,
+            id: grantedEntryId,
+            draft: true,
+            depth,
+            overrideAccess,
+            user,
+            ...(options.richTextFormat
+              ? { richTextFormat: options.richTextFormat }
+              : {}),
+            ...(locale ? { locale } : {}),
+          })
+        );
+        if (granted !== null && answersThisPath(granted)) return granted;
+        // Deleted, or living at a different path than the one requested, so
+        // this request holds no draft authorization for THIS path. It resolves
+        // published-only from here, which is what makes the fall-through safe
+        // to take without a second identity check downstream: a named grant
+        // authorizes exactly one entry, and the widened lifecycle scope exists
+        // solely to reach it.
+        return publishedOnly();
+      }
+
       const result = await nextly.find({
         collection,
         where: { [slugField]: { equals: slug } },


### PR DESCRIPTION
Plan 03's **R-6**. Design written before implementation in `tasks/2026-08-05-r6-preview-draft-wiring-design.md`; this follows it, with one correction the tests forced.

## The defect

A grant that names an entry was checked by resolving the path **by slug** and then comparing the result's id. That comparison sits downstream of a lookup that can find the wrong document: a slug is not unique, and duplicates are settled by sorting on `id`. So a grant for one entry could land on another sharing its slug, be rejected, and fall back to published, showing an editor **live content at a link they were given for a draft**.

Resolving by the granted id removes the comparison instead of hardening it, and closes two findings deferred from #557 and #563 as one change rather than two patches.

## The trap that shapes it

**Resolving by the granted id alone would render the previewed entry at every URL on the site** for the life of the session. That is worse than the bug being fixed, and it is easy to write by accident because "resolve by id" sounds like the whole answer.

So the correspondence is confirmed rather than assumed: the entry is read by id, then its slug is checked against the requested path. That check lives in the read path, not in the app's `draft` decision, because the decision is app-supplied code and depending on every caller getting it right is exactly what `previewGrantsDraft` exists to avoid.

## The correction the tests forced

The design said keep `grantCovers` in the route as defence in depth. A test proved that wrong: the route was still comparing ids **after** the by-id read, so an `afterRead` hook that reshapes `id` failed the comparison and sent a valid preview back to live content, reintroducing the exact defect being removed.

The fix is a semantic one rather than an exception. When a named grant does not answer the path, the request holds **no draft authorization for that path**, so it resolves published-only. The widened lifecycle scope exists solely to reach the entry that was named, so withdrawing it withdraws the only thing that could leak. That makes the fall-through safe on its own terms, and `grantCovers` becomes unreachable and is deleted along with the mismatch-fallback branch.

An object grant carrying no usable `entryId` now authorizes nothing. The decision is app-supplied and the type is not a runtime guarantee, and a widened scope with no entry named to bound it is the one combination that must not exist.

## Not closed here

**Relation expansion at `depth: 1`** still uses the trusted lifecycle scope under a preview, so a granted page can include an unpublished related entry the token never named. That lives in `collection-query-service`, changes every trusted read in the product, and belongs to task 089, whose PR-2 already established that what propagates is the caller's intent rather than a status value. Stating it plainly rather than implying R-6 covered it.

## Verification

- **5 new tests** on a reader holding a row SET, which is the only shape in which resolving by id and by slug can disagree: the shadowed-slug case, the wrong-path case, a deleted entry, a hook that rewrites `id`, and that the by-id read happens *before* any slug lookup.
- **3 stub scenarios, all exact**: dropping the slug confirmation fails the wrong-path test; widening the fall-through fails the wrong-path and deleted-entry tests; accepting a malformed grant fails the malformed-grant test.
- Two tests from #563 that pinned the replaced mechanism are removed, and the properties they held are covered by the new file against a realistic reader rather than a stub that ignored ids.
- 54 routing tests, `check-types` (both projects) and `lint` clean.