### PR TITLE
fix(blocks-react): compile styles from a tree without the placeholder nodes

### DIFF
--- a/.changeset/renderer-style-timing.md
+++ b/.changeset/renderer-style-timing.md
@@ -1,0 +1,28 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+Stop shipping CSS compiled for blocks that render a placeholder.
+
+A node that resolves to a placeholder emits only a hidden marker, so every rule compiled for the markup it would have rendered matches nothing and ships anyway, carrying whatever those rules referenced. The stylesheet is now compiled from a tree with those nodes removed, while the render keeps them so their placeholders still appear.

--- a/packages/blocks-react/src/page-renderer.test.tsx
+++ b/packages/blocks-react/src/page-renderer.test.tsx
@@ -4095,6 +4095,42 @@ describe("PageRenderer", () => {
       expect(placeholderReasons(html)).toEqual(["invalid-output"]);
     });
 
+    it("recompiles without the placeholder node's own rules", async () => {
+      // Withholding the sheet is the fallback when there is nothing to
+      // recompile from. With a compile context present the sheet IS rebuilt,
+      // and rebuilding from a tree that still held the node would emit its
+      // rules again — so the style input is a tree with it removed, while the
+      // render keeps it to draw the placeholder.
+      //
+      // Both nodes carry styles, so the assertion can tell "the placeholder's
+      // rules are gone" from "no rules were compiled at all".
+      const ahead = doc(
+        node("a", "test/text", {
+          version: 9,
+          props: { value: "ahead" },
+          styles: { base: { base: { color: "#ff0000" } } },
+        }),
+        node("b", "test/text", {
+          props: { value: "healthy" },
+          styles: { base: { base: { color: "#00ff00" } } },
+        })
+      );
+
+      const html = await renderToHtml(
+        <PageRenderer
+          document={ahead}
+          blocks={createBlockResolver([text as AnyBlockDefinition])}
+          styleContext={{ limits: DEFAULT_LIMITS }}
+        />
+      );
+
+      expect(placeholderReasons(html)).toEqual(["version-ahead"]);
+      // The healthy node keeps its rule; the placeholder's is gone. Asserting
+      // both is what separates the prune from a sheet that failed to compile.
+      expect(html).toContain("#00ff00");
+      expect(html).not.toContain("#ff0000");
+    });
+
     it("does not trust a stored stylesheet when a node becomes a placeholder", async () => {
       // A knowable placeholder emits only a hidden marker, so a sheet compiled
       // for the markup it WOULD have rendered ships rules for content that is

--- a/packages/blocks-react/src/page-renderer.tsx
+++ b/packages/blocks-react/src/page-renderer.tsx
@@ -85,6 +85,62 @@ function rendersOwnMarkup(node: BlockNode, resolver: BlockResolver): boolean {
 }
 
 /**
+ * The tree a stylesheet should be compiled from.
+ *
+ * A node that resolves to a placeholder emits only a hidden marker, so every
+ * rule compiled for the markup it WOULD have rendered matches nothing and ships
+ * anyway, carrying whatever those rules referenced. Dropping the node from the
+ * style input is what stops that.
+ *
+ * It has to be a SEPARATE tree from the one that renders. The render still
+ * needs the node, because drawing its placeholder is how the failure becomes
+ * visible; only the stylesheet should pretend it was never there. Marking the
+ * document "repaired" is not enough on its own, because recompiling from a tree
+ * that still contains the node produces the same rules again.
+ *
+ * The subtree goes with it: a placeholder replaces the node entirely, so its
+ * children never reach the page either.
+ *
+ * Returns the ORIGINAL document when every node renders, so the common case
+ * allocates nothing and the caller can compare by identity.
+ */
+function pruneKnownPlaceholders(
+  document: BlockDocument,
+  resolver: BlockResolver
+): BlockDocument {
+  let changed = false;
+
+  const prune = (nodes: BlockNode[]): BlockNode[] => {
+    const kept: BlockNode[] = [];
+    for (const node of nodes) {
+      if (!rendersOwnMarkup(node, resolver)) {
+        changed = true;
+        continue;
+      }
+
+      const slots = node.slots;
+      if (slots === undefined) {
+        kept.push(node);
+        continue;
+      }
+
+      let slotsChanged = false;
+      const nextSlots: Record<string, BlockNode[]> = {};
+      for (const [name, children] of Object.entries(slots)) {
+        const pruned = prune(children);
+        if (pruned !== children) slotsChanged = true;
+        nextSlots[name] = pruned;
+      }
+      kept.push(slotsChanged ? { ...node, slots: nextSlots } : node);
+    }
+    return changed ? kept : nodes;
+  };
+
+  const nodes = prune(document.nodes);
+  return changed ? { ...document, nodes } : document;
+}
+
+/**
  * Renders a block document as React.
  *
  * A Server Component, and synchronous: nothing at this level needs to wait, so
@@ -105,22 +161,6 @@ function rendersOwnMarkup(node: BlockNode, resolver: BlockResolver): boolean {
  *    class, so the element carrying it has to exist or no rule matches
  *    anything.
  */
-/** Whether any node in the tree will be replaced by a knowable placeholder. */
-function hasKnownPlaceholder(
-  nodes: BlockNode[],
-  resolver: BlockResolver
-): boolean {
-  for (const node of nodes) {
-    if (!rendersOwnMarkup(node, resolver)) return true;
-    const slots = node.slots;
-    if (slots === undefined) continue;
-    for (const children of Object.values(slots)) {
-      if (hasKnownPlaceholder(children, resolver)) return true;
-    }
-  }
-  return false;
-}
-
 export function PageRenderer({
   document,
   context,
@@ -219,11 +259,15 @@ export function PageRenderer({
   // unchanged and the stale sheet would be trusted. Skipping the reservation
   // and then trusting the sheet is worse than either on its own, because the
   // colliding case previously repaired the tree and therefore recompiled.
+  // Compiled from a tree with the knowable placeholders removed, while the
+  // render keeps them so their placeholders still appear.
+  const styleInput = pruneKnownPlaceholders(visible, resolver);
+
   const repairedDocument =
     sanitized !== document ||
     pruned !== doc ||
     visible !== pruned ||
-    hasKnownPlaceholder(visible.nodes, resolver);
+    styleInput !== visible;
 
   // Recompiling after pruning must not lose what the stored artifact and the
   // renderer knew. `scope` lives on the artifact rather than in the compile
@@ -249,7 +293,7 @@ export function PageRenderer({
         };
 
   const { css, classes, scope } = resolvePageStyles(
-    visible,
+    styleInput,
     styles,
     compileContext,
     resolver,


### PR DESCRIPTION
The style half of the address/style timing problem, which the founder approved fixing properly. **The address half is not here, and the reason is new information — please read that section before deciding.**

## What this fixes

A node that resolves to a placeholder emits only a hidden marker, so every rule compiled for the markup it *would* have rendered matches nothing and ships anyway, carrying whatever those rules referenced.

#568 made a knowable placeholder mark the document "repaired", which triggers recompile-or-withhold. That closed the case where the sheet is **withheld**, but not the case where it is **recompiled**: rebuilding from a tree that still contains the node produces the same rules again.

The stylesheet is now compiled from a **separate tree** with those nodes and their subtrees removed. The render keeps them, because drawing the placeholder is how the failure stays visible. Two trees, one render.

## The address half, and why it is not here

The plan was "assign addresses after render". Implementing it required checking what that costs, and it costs something the renderer deliberately bought:

> *"An async component suspends, and a boundary that awaited unconditionally would suspend on every block — turning a page of forty ordinary sections into forty streaming chunks, each arriving after its own fallback. Only blocks that are actually asynchronous pay for being asynchronous."*
> — `block-boundary.tsx`

Assigning addresses after render means a **two-pass render**: render everything, collect which blocks actually produced host markup, then render again with addresses assigned. The first pass has to complete before the second can start, so **every async block must resolve before any markup is emitted**. A page with one slow block holds the entire page behind it. That is a real regression in exchange for a lost `#anchor`.

Three options, honestly:

1. **Leave the address half.** Cost: when a block throws or returns something unrenderable, a healthy sibling can lose an `#id` it wanted. Never wrong content, never a crash.
2. **Two-pass render.** Correct, and loses per-block streaming.
3. **Let each boundary write its own id when it produces a host root**, and stop pre-deduplicating DOM ids. Duplicates then reach the page only when the stored document genuinely has two visible nodes with the same id, which engine validation already rejects at write time. Keeps streaming, keeps correctness for valid documents, and is *less* code — but it stops being forgiving toward hand-edited documents.

**My recommendation is (3)**, and I did not do it unilaterally because it changes a stated posture ("the forgiving render path declining to reintroduce what a stored document may already hold") rather than just an implementation. Node-id deduplication would stay pre-render regardless: those are React keys, and a duplicate key is a wrong page rather than a missing anchor.

## Verification

- **170 tests** (169 + 1).
- **Stub-verified**, and the first version of the new test did not discriminate: it asserted the healthy node still rendered, which is true either way. It now gives both nodes real styles and asserts the placeholder's colour is absent while the healthy one's is present, which separates "the prune worked" from "no rules compiled at all". Reverting the prune fails both style tests.
- `check-types` and `lint` clean.