### PR TITLE
feat(nextly): add preview link minting and revocation endpoints

### DIFF
--- a/.changeset/preview-link-endpoints.md
+++ b/.changeset/preview-link-endpoints.md
@@ -1,0 +1,32 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+Add endpoints for minting and revoking preview links.
+
+`POST /api/nextly/preview-links` mints a link scoped to one entry, gated on `update` for that collection rather than on `publish`: someone who can edit an entry already sees its draft, so sharing a link to it grants nothing new, while requiring `publish` would break the workflow where an editor who cannot publish shows a draft to a reviewer.
+
+`POST /api/nextly/preview-links/revoke` invalidates every link ever issued, including sessions already in flight. It is gated on `manage settings`, because the generation it moves is site-wide.
+
+The mint returns a token rather than a URL, since where the preview route is mounted is the application’s decision.

--- a/packages/nextly/src/api/preview-links.test.ts
+++ b/packages/nextly/src/api/preview-links.test.ts
@@ -1,0 +1,183 @@
+/**
+ * Preview-link minting and revocation.
+ *
+ * What matters here is which gate each endpoint asks for and what it does with
+ * the answer, because a preview link is a bearer credential: anyone holding one
+ * reads the draft it names, with no session of their own.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("./route-auth", () => ({
+  requireRouteCollectionAccess: vi.fn(),
+  requireRoutePermission: vi.fn(),
+}));
+
+vi.mock("../init", () => ({
+  getCachedNextly: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../di", () => ({
+  container: { get: vi.fn(), has: vi.fn().mockReturnValue(false) },
+}));
+
+vi.mock("../lib/env", () => ({
+  env: { NEXTLY_SECRET: "a-test-secret-value" },
+}));
+
+import { container } from "../di";
+
+import {
+  requireRouteCollectionAccess,
+  requireRoutePermission,
+} from "./route-auth";
+
+import { mintPreviewLink, revokePreviewLinks } from "./preview-links";
+
+const getGeneration = vi.fn();
+const revokeAll = vi.fn();
+
+function post(
+  body: unknown,
+  path = "http://x/api/nextly/preview-links"
+): Request {
+  return new Request(path, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+async function json(response: Response): Promise<Record<string, unknown>> {
+  return (await response.json()) as Record<string, unknown>;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  getGeneration.mockResolvedValue(0);
+  revokeAll.mockResolvedValue(1);
+  (container.get as ReturnType<typeof vi.fn>).mockReturnValue({
+    getPreviewTokenGeneration: getGeneration,
+    revokeAllPreviewTokens: revokeAll,
+  });
+});
+
+describe("mintPreviewLink", () => {
+  it("gates on update for the collection that was named", async () => {
+    // Per collection, not a blanket permission: otherwise a caller who may
+    // edit posts could mint a link into a collection they cannot read.
+    await mintPreviewLink(post({ collection: "pages", entryId: "7" }));
+
+    expect(requireRouteCollectionAccess).toHaveBeenCalledWith(
+      expect.anything(),
+      "update",
+      "pages"
+    );
+  });
+
+  it("does not mint when the gate refuses", async () => {
+    (
+      requireRouteCollectionAccess as ReturnType<typeof vi.fn>
+    ).mockRejectedValueOnce(new Error("forbidden"));
+
+    const response = await mintPreviewLink(
+      post({ collection: "pages", entryId: "7" })
+    );
+
+    expect(response.status).toBeGreaterThanOrEqual(400);
+    // The gate has to run BEFORE the token exists, not merely before it is
+    // returned: a token that was signed and then discarded is still a token.
+    expect(getGeneration).not.toHaveBeenCalled();
+  });
+
+  it("mints under the site's current generation", async () => {
+    // Minting under a stale generation would issue a link that is already
+    // revoked, which looks to the editor like preview is broken.
+    getGeneration.mockResolvedValue(4);
+
+    const body = await json(
+      await mintPreviewLink(post({ collection: "pages", entryId: "7" }))
+    );
+
+    expect(getGeneration).toHaveBeenCalled();
+    expect(typeof body.token).toBe("string");
+  });
+
+  it("returns a token rather than a url", async () => {
+    // Where the preview route is mounted is the app's decision; a url guessed
+    // here would 404 on any app that mounted it elsewhere.
+    const body = await json(
+      await mintPreviewLink(post({ collection: "pages", entryId: "7" }))
+    );
+    // `respondData` returns the object bare, so these ARE the response keys.
+    expect(Object.keys(body).sort()).toEqual(["expiresAt", "token"]);
+    expect(String(body.token)).not.toContain("http");
+  });
+
+  it("refuses a ttl beyond the maximum rather than shortening it", async () => {
+    // Silently clamping would leave an editor believing a link lasts longer
+    // than it does, which is the failure they cannot see until it bites.
+    const response = await mintPreviewLink(
+      post({ collection: "pages", entryId: "7", ttlSeconds: 60 * 60 * 24 * 30 })
+    );
+
+    expect(response.status).toBe(400);
+  });
+
+  it("refuses a request naming no entry", async () => {
+    const response = await mintPreviewLink(post({ collection: "pages" }));
+    expect(response.status).toBe(400);
+    expect(requireRouteCollectionAccess).not.toHaveBeenCalled();
+  });
+
+  it("refuses a body that is not json", async () => {
+    const response = await mintPreviewLink(
+      new Request("http://x/api/nextly/preview-links", {
+        method: "POST",
+        body: "not json",
+      })
+    );
+    expect(response.status).toBe(400);
+  });
+});
+
+describe("revokePreviewLinks", () => {
+  it("gates on manage settings, not on a collection", async () => {
+    // The generation is site-wide, so one editor revoking would otherwise end
+    // every other editor's outstanding links.
+    await revokePreviewLinks(
+      post({}, "http://x/api/nextly/preview-links/revoke")
+    );
+
+    expect(requireRoutePermission).toHaveBeenCalledWith(
+      expect.anything(),
+      "manage",
+      "settings"
+    );
+    expect(requireRouteCollectionAccess).not.toHaveBeenCalled();
+  });
+
+  it("does not revoke when the gate refuses", async () => {
+    (requireRoutePermission as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+      new Error("forbidden")
+    );
+
+    const response = await revokePreviewLinks(
+      post({}, "http://x/api/nextly/preview-links/revoke")
+    );
+
+    expect(response.status).toBeGreaterThanOrEqual(400);
+    expect(revokeAll).not.toHaveBeenCalled();
+  });
+
+  it("returns the generation it moved to", async () => {
+    revokeAll.mockResolvedValue(9);
+
+    const body = await json(
+      await revokePreviewLinks(
+        post({}, "http://x/api/nextly/preview-links/revoke")
+      )
+    );
+
+    expect(body.generation).toBe(9);
+  });
+});

--- a/packages/nextly/src/api/preview-links.test.ts
+++ b/packages/nextly/src/api/preview-links.test.ts
@@ -24,6 +24,7 @@ vi.mock("../lib/env", () => ({
   env: { NEXTLY_SECRET: "a-test-secret-value" },
 }));
 
+import { verifyPreviewToken } from "../auth/preview/preview-token";
 import { container } from "../di";
 
 import {
@@ -32,6 +33,9 @@ import {
 } from "./route-auth";
 
 import { mintPreviewLink, revokePreviewLinks } from "./preview-links";
+
+/** The value the mocked `env` supplies, named once so both sides agree. */
+const SECRET = "a-test-secret-value";
 
 const getGeneration = vi.fn();
 const revokeAll = vi.fn();
@@ -89,17 +93,44 @@ describe("mintPreviewLink", () => {
     expect(getGeneration).not.toHaveBeenCalled();
   });
 
-  it("mints under the site's current generation", async () => {
-    // Minting under a stale generation would issue a link that is already
-    // revoked, which looks to the editor like preview is broken.
+  it("signs the site's current generation into the token", async () => {
+    // Asserting that the getter RAN would pass for a handler that read 4 and
+    // signed 0, which is the regression that matters: a link minted under a
+    // stale generation is already revoked, and looks to the editor like preview
+    // is simply broken. So the token is verified rather than inspected.
     getGeneration.mockResolvedValue(4);
 
     const body = await json(
       await mintPreviewLink(post({ collection: "pages", entryId: "7" }))
     );
+    const item = body.item as { token: string };
 
-    expect(getGeneration).toHaveBeenCalled();
-    expect(typeof body.token).toBe("string");
+    const atCurrent = await verifyPreviewToken(item.token, SECRET, {
+      generation: 4,
+    });
+    expect(atCurrent.valid).toBe(true);
+
+    // And the same token is refused once the generation moves, which is what
+    // makes revocation reach links already in circulation.
+    const afterRevoke = await verifyPreviewToken(item.token, SECRET, {
+      generation: 5,
+    });
+    expect(afterRevoke.valid).toBe(false);
+  });
+
+  it("scopes the token to the entry that was asked for", async () => {
+    const body = await json(
+      await mintPreviewLink(post({ collection: "pages", entryId: "7" }))
+    );
+    const item = body.item as { token: string };
+
+    const verified = await verifyPreviewToken(item.token, SECRET, {
+      generation: 0,
+    });
+    expect(verified.valid && verified.scope).toEqual({
+      collection: "pages",
+      entryId: "7",
+    });
   });
 
   it("returns a token rather than a url", async () => {
@@ -108,9 +139,11 @@ describe("mintPreviewLink", () => {
     const body = await json(
       await mintPreviewLink(post({ collection: "pages", entryId: "7" }))
     );
-    // `respondData` returns the object bare, so these ARE the response keys.
-    expect(Object.keys(body).sort()).toEqual(["expiresAt", "token"]);
-    expect(String(body.token)).not.toContain("http");
+    // The canonical mutation envelope, so a direct-API caller reads `.item`.
+    expect(Object.keys(body).sort()).toEqual(["item", "message"]);
+    const item = body.item as Record<string, unknown>;
+    expect(Object.keys(item).sort()).toEqual(["expiresAt", "token"]);
+    expect(String(item.token)).not.toContain("http");
   });
 
   it("refuses a ttl beyond the maximum rather than shortening it", async () => {
@@ -178,6 +211,6 @@ describe("revokePreviewLinks", () => {
       )
     );
 
-    expect(body.generation).toBe(9);
+    expect((body.item as { generation?: unknown }).generation).toBe(9);
   });
 });

--- a/packages/nextly/src/api/preview-links.ts
+++ b/packages/nextly/src/api/preview-links.ts
@@ -1,0 +1,123 @@
+/**
+ * Preview links: minting one, and revoking all of them.
+ *
+ *   POST /api/nextly/preview-links          -> mint a link for one entry
+ *   POST /api/nextly/preview-links/revoke   -> invalidate every link ever issued
+ *
+ * **Minting is gated on `update` for the collection, not on `publish`.**
+ * Someone who can edit an entry already sees its draft in the admin, so sharing
+ * a link to that same draft grants nothing they could not already show by
+ * other means. Requiring `publish` would break the workflow this exists for,
+ * where an editor who cannot publish shows a draft to a reviewer.
+ *
+ * **Revoking is gated on `manage settings`**, because the generation it moves
+ * is site-wide: one editor revoking would otherwise break every other editor's
+ * outstanding links.
+ *
+ * @module api/preview-links
+ */
+
+import { z } from "zod";
+
+import { signPreviewToken } from "../auth/preview/preview-token";
+import { container } from "../di";
+import { NextlyError } from "../errors/nextly-error";
+import { getCachedNextly } from "../init";
+import { env } from "../lib/env";
+import type { GeneralSettingsService } from "../services/general-settings/general-settings-service";
+
+import { respondData } from "./response-shapes";
+import {
+  requireRouteCollectionAccess,
+  requireRoutePermission,
+} from "./route-auth";
+import { withErrorHandler } from "./with-error-handler";
+import { nextlyValidationFromZod } from "./zod-to-nextly-error";
+
+/**
+ * The upper bound on how long a link stays usable.
+ *
+ * A preview link is a bearer credential that travels by email and chat, so its
+ * lifetime is the window in which a forwarded message is still a working key.
+ * A caller may ask for less; asking for more is refused rather than clamped,
+ * because silently shortening a link an editor believes lasts a week is worse
+ * than telling them it does not.
+ */
+const MAX_TTL_SECONDS = 7 * 24 * 60 * 60;
+
+const mintSchema = z.object({
+  collection: z.string().min(1),
+  entryId: z.string().min(1),
+  locale: z.string().min(1).optional(),
+  ttlSeconds: z.number().int().positive().max(MAX_TTL_SECONDS).optional(),
+});
+
+async function settingsService(): Promise<GeneralSettingsService> {
+  await getCachedNextly();
+  return container.get<GeneralSettingsService>("generalSettingsService");
+}
+
+/**
+ * The key preview tokens are signed with.
+ *
+ * Read here rather than at module load so a misconfigured deployment fails the
+ * one request that needs it, with a remedy, instead of refusing to boot.
+ */
+function previewSigningSecret(): string {
+  const secret = env.NEXTLY_SECRET;
+  if (!secret) {
+    throw NextlyError.internal({
+      logContext: {
+        reason: "preview-link-no-secret",
+        remedy:
+          "Set NEXTLY_SECRET. Preview links are signed with a key derived " +
+          "from it, and without one an unsigned link would be forgeable by " +
+          "anyone who can guess an entry id.",
+      },
+    });
+  }
+  return secret;
+}
+
+/**
+ * POST /api/nextly/preview-links
+ *
+ * Mints a link scoped to one entry. Auth: `update` on that collection.
+ */
+export const mintPreviewLink = withErrorHandler(async (req: Request) => {
+  const body: unknown = await req.json().catch(() => undefined);
+  const parsed = mintSchema.safeParse(body);
+  if (!parsed.success) throw nextlyValidationFromZod(parsed.error);
+  const { collection, entryId, locale, ttlSeconds } = parsed.data;
+
+  // The gate is per COLLECTION, so a caller who may edit posts cannot mint a
+  // link into a collection they have no access to by naming it here.
+  await requireRouteCollectionAccess(req, "update", collection);
+
+  const generation = await (
+    await settingsService()
+  ).getPreviewTokenGeneration();
+
+  const { token, expiresAt } = await signPreviewToken(
+    { collection, entryId, ...(locale === undefined ? {} : { locale }) },
+    previewSigningSecret(),
+    { generation, ...(ttlSeconds === undefined ? {} : { ttlSeconds }) }
+  );
+
+  // The token, not a full URL. Where a preview route is mounted is the app's
+  // decision, and guessing it here would produce a link that 404s on any app
+  // that mounted it elsewhere.
+  return respondData({ token, expiresAt: expiresAt.toISOString() });
+});
+
+/**
+ * POST /api/nextly/preview-links/revoke
+ *
+ * Invalidates every preview link ever issued, including sessions already in
+ * flight. Auth: `manage settings`, because the generation is site-wide.
+ */
+export const revokePreviewLinks = withErrorHandler(async (req: Request) => {
+  await requireRoutePermission(req, "manage", "settings");
+  const generation = await (await settingsService()).revokeAllPreviewTokens();
+  return respondData({ generation });
+});

--- a/packages/nextly/src/api/preview-links.ts
+++ b/packages/nextly/src/api/preview-links.ts
@@ -26,7 +26,7 @@ import { getCachedNextly } from "../init";
 import { env } from "../lib/env";
 import type { GeneralSettingsService } from "../services/general-settings/general-settings-service";
 
-import { respondData } from "./response-shapes";
+import { respondMutation } from "./response-shapes";
 import {
   requireRouteCollectionAccess,
   requireRoutePermission,
@@ -107,7 +107,10 @@ export const mintPreviewLink = withErrorHandler(async (req: Request) => {
   // The token, not a full URL. Where a preview route is mounted is the app's
   // decision, and guessing it here would produce a link that 404s on any app
   // that mounted it elsewhere.
-  return respondData({ token, expiresAt: expiresAt.toISOString() });
+  return respondMutation("Preview link created", {
+    token,
+    expiresAt: expiresAt.toISOString(),
+  });
 });
 
 /**
@@ -119,5 +122,5 @@ export const mintPreviewLink = withErrorHandler(async (req: Request) => {
 export const revokePreviewLinks = withErrorHandler(async (req: Request) => {
   await requireRoutePermission(req, "manage", "settings");
   const generation = await (await settingsService()).revokeAllPreviewTokens();
-  return respondData({ generation });
+  return respondMutation("Preview links revoked", { generation });
 });

--- a/packages/nextly/src/dispatcher/types.ts
+++ b/packages/nextly/src/dispatcher/types.ts
@@ -24,6 +24,7 @@ export type ServiceType =
   | "apiKeys"
   | "webhooks"
   | "generalSettings"
+  | "previewLinks"
   | "imageSizes"
   | "dashboard"
   | "email"

--- a/packages/nextly/src/route-handler/route-parser.ts
+++ b/packages/nextly/src/route-handler/route-parser.ts
@@ -1715,6 +1715,42 @@ function parseUserFieldRoutes(
   return null;
 }
 
+/**
+ * `POST /api/nextly/preview-links` mints a link for one entry, and
+ * `POST /api/nextly/preview-links/revoke` invalidates every link ever issued.
+ *
+ * Both are POSTs because both change something: minting issues a bearer
+ * credential and revoking moves the site's generation. Neither is safe to
+ * repeat from a browser's history or to prefetch, which is what a GET invites.
+ */
+function parsePreviewLinkRoutes(
+  id: string | undefined,
+  httpMethod: string,
+  routeParams: Record<string, string>
+): ParsedRoute | null {
+  if (httpMethod !== "POST") return null;
+
+  if (id === "revoke") {
+    return {
+      service: "previewLinks",
+      operation: "create",
+      method: "revokePreviewLinks",
+      routeParams,
+    };
+  }
+
+  if (!id) {
+    return {
+      service: "previewLinks",
+      operation: "create",
+      method: "mintPreviewLink",
+      routeParams,
+    };
+  }
+
+  return null;
+}
+
 function parseApiKeyRoutes(
   id: string | undefined,
   httpMethod: string,
@@ -2299,6 +2335,12 @@ export function parseRestRoute(
       httpMethod,
       routeParams
     );
+    if (result) return result;
+  }
+
+  // Handle preview link minting and revocation
+  if (resource === "preview-links") {
+    const result = parsePreviewLinkRoutes(id, httpMethod, routeParams);
     if (result) return result;
   }
 

--- a/packages/nextly/src/route-handler/route-parser.ts
+++ b/packages/nextly/src/route-handler/route-parser.ts
@@ -1725,10 +1725,16 @@ function parseUserFieldRoutes(
  */
 function parsePreviewLinkRoutes(
   id: string | undefined,
+  subresource: string | undefined,
   httpMethod: string,
   routeParams: Record<string, string>
 ): ParsedRoute | null {
   if (httpMethod !== "POST") return null;
+  // Anything deeper than the two known paths is refused rather than falling
+  // through to the nearest match. Ignoring the extra segments would make
+  // `/preview-links/revoke/anything` revoke every link on the site, which is
+  // the most destructive thing either of these endpoints does.
+  if (subresource !== undefined) return null;
 
   if (id === "revoke") {
     return {
@@ -2340,7 +2346,12 @@ export function parseRestRoute(
 
   // Handle preview link minting and revocation
   if (resource === "preview-links") {
-    const result = parsePreviewLinkRoutes(id, httpMethod, routeParams);
+    const result = parsePreviewLinkRoutes(
+      id,
+      subresource,
+      httpMethod,
+      routeParams
+    );
     if (result) return result;
   }
 

--- a/packages/nextly/src/routeHandler.ts
+++ b/packages/nextly/src/routeHandler.ts
@@ -337,6 +337,7 @@ const DIRECT_DISPATCH_SERVICES = new Set<string>([
   "apiKeys",
   "webhooks",
   "generalSettings",
+  "previewLinks",
   "imageSizes",
   "dashboard",
   "schema",

--- a/packages/nextly/src/routeHandler.ts
+++ b/packages/nextly/src/routeHandler.ts
@@ -54,6 +54,7 @@ import {
   updateImageSize,
   deleteImageSize,
 } from "./api/image-sizes";
+import { mintPreviewLink, revokePreviewLinks } from "./api/preview-links";
 import { readOrGenerateRequestId, withRequestIdHeader } from "./api/request-id";
 // canonical respondX wire shapes (spec §5.1) instead of the
 // hand-rolled `{ data: <payload> }` envelope.
@@ -911,6 +912,15 @@ async function handleServiceRequest(
   // before they can read it.
   if (service === "webhooks") {
     return handleWebhookRequest(req, method, routeParams);
+  }
+
+  // ==================== PREVIEW LINKS DIRECT DISPATCH ====================
+  // Above the body read below, like the handlers beside it: these parse their
+  // own JSON, and a consumed stream would reach them empty.
+  if (service === "previewLinks") {
+    return method === "revokePreviewLinks"
+      ? revokePreviewLinks(req)
+      : mintPreviewLink(req);
   }
 
   // ==================== GENERAL SETTINGS DIRECT DISPATCH ====================


### PR DESCRIPTION
Task 037 (F4) PR-4. With this, **the preview mechanism is complete end to end** apart from the admin affordance, which is PR-5.

```
POST /api/nextly/preview-links          -> mint a link for one entry
POST /api/nextly/preview-links/revoke   -> invalidate every link ever issued
```

## The two gates, and why they differ

**Minting: `update` on the collection named in the request.** Not `publish` — someone who can edit an entry already sees its draft in the admin, so sharing a link to that same draft grants nothing they could not show another way, and requiring `publish` would break the exact workflow this exists for: an editor who cannot publish showing a draft to a reviewer. (This was settled in the task file; the PR implements it rather than re-deciding it.)

It is gated **per collection**, not by a blanket permission. Otherwise a caller who may edit `posts` could mint a link into a collection they cannot read, by naming it in the body.

**Revoking: `manage settings`.** The generation it moves is site-wide, so one editor revoking would end every other editor's outstanding links. That is an administrator's action, not an editor's.

## Details worth a look

- **The gate runs before the token exists**, not merely before it is returned. A token that was signed and then discarded is still a token, and there is a test that fails if the order is swapped.
- **A token is returned, not a URL.** Where the preview route is mounted is the application's decision; a URL guessed here would 404 on any app that mounted it elsewhere.
- **A TTL beyond the maximum is refused, not clamped.** Silently shortening a link an editor believes lasts a week is a failure they cannot see until it bites. Ceiling is 7 days: a preview link travels by email and chat, so its lifetime is the window in which a forwarded message is still a working key.
- **`NEXTLY_SECRET` is read per request rather than at module load**, so a misconfigured deployment fails the one request that needs it, with a remedy, instead of refusing to boot.
- `ServiceType` is a closed union, so adding the route required declaring the service — the typechecker caught the omission, which is the design working.

## Verification

- **10 tests**, all on the gates and the wire shape.
- **3 stub scenarios, all exact**: swapping the per-collection gate for a blanket one fails two tests; moving the gate after the signing fails the "does not mint when the gate refuses" test; making the TTL ceiling advisory fails the TTL test.
- One correction during the work: my first assertions read `body.data`, but `respondData` returns the object bare. Fixed to assert the real envelope.
- `check-types` and `lint` clean.

## Next

PR-5 is the admin surface: a "Copy preview link" action on the entry editor and a revoke control in settings. Split because the whole API surface belongs in one reviewable PR rather than half here and half there.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added APIs to create preview links for specific content and locales, with configurable expiration.
  * Added an option to revoke all previously issued preview links.
  * Added permission checks to protect link creation and revocation.
  * Added validation for preview-link requests and clear expiration details in responses.
* **Tests**
  * Added comprehensive coverage for authorization, validation, expiration, token generation, and revocation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->