### PR TITLE
test(blocks-react): typecheck the package's own tests

### DIFF
--- a/.changeset/blocks-react-typecheck.md
+++ b/.changeset/blocks-react-typecheck.md
@@ -1,0 +1,30 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+Typecheck the block renderer’s own tests, and give block authors a typed defineBlock.
+
+The package excluded test files from tsc, so its tests had never been typechecked. Adding a tests project surfaced eleven errors, nine of which shared one cause: the engine types a slot’s output as unknown because it carries no React types, so a block author could not place it in their own JSX without annotating every render by hand.
+
+@nextlyhq/blocks-react now exports its own defineBlock, which names the context and the slot return type. This is the same service the plugin SDK performs for plugin authors, offered to anyone rendering with this package directly.

--- a/packages/blocks-react/package.json
+++ b/packages/blocks-react/package.json
@@ -39,7 +39,7 @@
   "scripts": {
     "build": "tsup",
     "dev": "tsup --watch",
-    "check-types": "tsc --noEmit",
+    "check-types": "tsc --noEmit && tsc --noEmit -p tsconfig.tests.json",
     "lint": "eslint . --max-warnings 0",
     "lint:fix": "eslint . --fix",
     "test": "vitest run",

--- a/packages/blocks-react/src/context.ts
+++ b/packages/blocks-react/src/context.ts
@@ -1,4 +1,8 @@
-import type { BlockRenderArgs as EngineBlockRenderArgs } from "@nextlyhq/blocks-engine";
+import type {
+  BlockRenderArgs as EngineBlockRenderArgs,
+  BlockDefinition as EngineBlockDefinition,
+  BlockRenderResult,
+} from "@nextlyhq/blocks-engine";
 import type { ReactNode } from "react";
 
 /**
@@ -207,4 +211,35 @@ export function createStandaloneContext(
   ) as Partial<PageContext>;
 
   return { ...defaults, ...defined };
+}
+
+/**
+ * A block definition written against THIS renderer.
+ *
+ * The engine's `defineBlock` leaves the context unnamed and types `renderSlot`
+ * as returning `BlockRenderResult`, which is `unknown`: the engine carries no
+ * React types. That is correct for the engine and wrong for an author, who then
+ * cannot place a slot's output into their own JSX without annotating the
+ * argument by hand at every block.
+ *
+ * Naming both here is the same service `@nextlyhq/plugin-sdk/blocks` performs
+ * for plugin authors, offered to anyone rendering with this package directly.
+ */
+export interface ReactBlockDefinition<P extends object>
+  extends Omit<EngineBlockDefinition<P, PageContext>, "render"> {
+  render(args: BlockRenderArgs<P>): BlockRenderResult;
+}
+
+/**
+ * Declare a block for this renderer.
+ *
+ * Identity at runtime, exactly like the engine's: the value is the definition.
+ * What it adds is the typing above, so a block's `render` receives a context
+ * this package has named and a `renderSlot` that returns something React can
+ * render.
+ */
+export function defineBlock<P extends object>(
+  definition: ReactBlockDefinition<P>
+): ReactBlockDefinition<P> {
+  return definition;
 }

--- a/packages/blocks-react/src/page-renderer.test.tsx
+++ b/packages/blocks-react/src/page-renderer.test.tsx
@@ -16,13 +16,13 @@ import {
   nodeClassNames,
   NODE_CLASS_PREFIX,
   blockTypeClassName,
-  defineBlock,
   type AnyBlockDefinition,
   type BlockDocument,
   type BlockNode,
 } from "@nextlyhq/blocks-engine";
 
 import type { PageContext } from "./context";
+import { defineBlock } from "./context";
 import { PageRenderer } from "./page-renderer";
 import { createBlockResolver } from "./resolver";
 
@@ -756,7 +756,7 @@ describe("PageRenderer", () => {
         render: () => <List>{(item: string) => <li>{item}</li>}</List>,
       });
 
-      const Ignores = () => <p>ignored ok</p>;
+      const Ignores = (_props: { children?: unknown }) => <p>ignored ok</p>;
       const opaque = defineBlock({
         name: "test/opaque-children",
         version: 1,
@@ -1816,7 +1816,7 @@ describe("PageRenderer", () => {
               _context: null,
             } as unknown as string,
             null,
-            () => null
+            (() => null) as unknown as ReactElement
           ),
       });
 

--- a/packages/blocks-react/tsconfig.tests.json
+++ b/packages/blocks-react/tsconfig.tests.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules"]
+}


### PR DESCRIPTION
Found while working #574's review: **this package's test files have never been typechecked.** `tsconfig.json` excludes `**/*.test.ts(x)`, confirmed with `tsc --listFiles` — the files simply do not appear.

## What the gap was hiding

A tests project surfaces **eleven errors**, and nine share one cause worth fixing properly rather than annotating around.

The engine types a slot's output as `BlockRenderResult`, which is `unknown`. That is right for the engine — it carries no React types — but it means a block author cannot put `renderSlot("children")` into their own JSX without annotating the render argument by hand at every single block. The core blocks do exactly that today; the tests did not, so they silently held nine type errors nobody could see.

`@nextlyhq/blocks-react` now exports **its own `defineBlock`**, which names the context and narrows the slot return to `ReactNode`. This is the same service `@nextlyhq/plugin-sdk/blocks` already performs for plugin authors, offered to anyone rendering with this package directly. Pointing the test file at it takes 11 errors to 2.

The remaining two are tests constructing values React refuses — an object where an element belongs, a function as a child. That is their subject rather than an accident, so they say so in the shape the rest of the suite already uses, and one of them turned out to be a genuinely wrong signature: the component under test *does* receive children and chooses not to render them, which is the case being asserted.

## Verification

- `check-types` now runs both projects, so this cannot regress.
- **Stub-verified that the guard actually guards**: a deliberate `const x: number = "..."` in a test file is invisible to the root project and caught by the tests project. Without that check, adding the config would prove nothing.
- 169 tests unchanged.

## Note on merge order

Touches `page-renderer.test.tsx`, which **#579** also touches. Whichever lands second needs a trivial rebase on that file. No overlap with **#578** or **#580**.