### PR TITLE
fix(blocks-react): supply the breakpoints a compile context requires

### DIFF
--- a/packages/blocks-react/src/page-renderer.test.tsx
+++ b/packages/blocks-react/src/page-renderer.test.tsx
@@ -4120,7 +4120,10 @@ describe("PageRenderer", () => {
         <PageRenderer
           document={ahead}
           blocks={createBlockResolver([text as AnyBlockDefinition])}
-          styleContext={{ limits: DEFAULT_LIMITS }}
+          styleContext={{
+            breakpoints: { viewport: [], container: [] },
+            limits: DEFAULT_LIMITS,
+          }}
         />
       );
 


### PR DESCRIPTION
**`main` is red and this is the one-line fix. It is my doing.**

```
src/page-renderer.test.tsx(4123,11): error TS2741:
  Property 'breakpoints' is missing in type '{ limits: DocumentLimits; }'
  but required in type 'StyleCompileContext'
```

`check-types` now runs the tests project, so this fails the whole job, and CI typechecks the merge with `main` — **every open PR in the repo will fail until this lands.**

## How it got in

Two of my own PRs, neither wrong alone:

- **#581** wired `tsc --noEmit -p tsconfig.tests.json` into `check-types`, so test files are typechecked for the first time.
- **#579** added a fixture passing `styleContext={{ limits: DEFAULT_LIMITS }}`, written *before* that guard existed and therefore never checked by it.

They merged in an order where neither branch ever contained the other, so nothing ran both together until both were on `main`. The same file already builds the correct shape in four other places; this one was simply never looked at.

## The fix

Supply the `breakpoints` the type requires, matching the four existing fixtures in the same file.

## Verification

- `check-types` clean on **both** projects, run against `origin/main` with this applied.
- 200 tests pass.
- `plugin-page-builder` typechecks, so nothing else is caught by the same interaction.

## Worth noting

This is the second red `main` today from the same shape: a guard and the thing it guards landing in separate PRs. It is an argument for the guard and its backlog fix travelling together, or for the guard landing last — recorded in the handoff.