### PR TITLE
feat(admin): mint and copy a shareable preview link

### DIFF
--- a/.changeset/preview-link-admin.md
+++ b/.changeset/preview-link-admin.md
@@ -1,0 +1,30 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+Add the admin side of shareable preview links.
+
+A `previewLinkApi` service and a `usePreviewLink` hook mint a link for one entry and put it on the clipboard. This is distinct from the Preview button beside it: Preview opens the entry using the editor’s own session and can include unsaved changes, while a preview LINK goes to someone with no session at all, so it carries its own signed authorization and shows only what was saved.
+
+The link is minted per click rather than cached, because it carries an expiry and a cached value would be handed out after it stopped working. When the browser refuses clipboard access, which happens on an insecure origin, the link is shown rather than a copy being claimed that never happened.

--- a/packages/admin/src/hooks/__tests__/usePreviewLink.test.ts
+++ b/packages/admin/src/hooks/__tests__/usePreviewLink.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Preview link assembly.
+ *
+ * The URL is built by hand from three pieces the admin does not control
+ * together — a configured site URL, a route the user's own app mounted, and a
+ * signed token — so the joins are where it breaks.
+ */
+import { describe, expect, it } from "vitest";
+
+import { DEFAULT_PREVIEW_ROUTE, buildPreviewUrl } from "../usePreviewLink";
+
+describe("buildPreviewUrl", () => {
+  it("uses the conventional route when the app has not moved it", () => {
+    expect(buildPreviewUrl({ token: "abc" })).toBe(
+      `${DEFAULT_PREVIEW_ROUTE}?token=abc`
+    );
+  });
+
+  it("returns a relative link when no site url is configured", () => {
+    // Correct when the admin and the site share an origin, which is the
+    // default deployment, and useless when they do not — so the caller
+    // supplies a site url rather than this guessing an origin.
+    expect(buildPreviewUrl({ token: "abc" }).startsWith("/")).toBe(true);
+  });
+
+  it("joins a site url without doubling the slash", () => {
+    // A trailing slash on a configured site url is common enough that not
+    // handling it would produce `https://site.com//api/preview`.
+    for (const siteUrl of ["https://site.com", "https://site.com/"]) {
+      expect(buildPreviewUrl({ token: "abc", siteUrl })).toBe(
+        `https://site.com${DEFAULT_PREVIEW_ROUTE}?token=abc`
+      );
+    }
+  });
+
+  it("honours an app that mounted the route elsewhere", () => {
+    expect(
+      buildPreviewUrl({
+        token: "abc",
+        siteUrl: "https://site.com",
+        previewRoute: "/preview",
+      })
+    ).toBe("https://site.com/preview?token=abc");
+  });
+
+  it("encodes the token rather than interpolating it raw", () => {
+    // A token is base64url and safe today. Assembling a query value by hand is
+    // exactly where that assumption stops being true later.
+    expect(buildPreviewUrl({ token: "a+b/c=d&e" })).toBe(
+      `${DEFAULT_PREVIEW_ROUTE}?token=a%2Bb%2Fc%3Dd%26e`
+    );
+  });
+});

--- a/packages/admin/src/hooks/usePreviewLink.ts
+++ b/packages/admin/src/hooks/usePreviewLink.ts
@@ -1,0 +1,122 @@
+"use client";
+
+/**
+ * Minting a shareable preview link and putting it on the clipboard.
+ *
+ * @module hooks/usePreviewLink
+ */
+
+import { useMutation } from "@tanstack/react-query";
+
+import { toast } from "@admin/components/ui";
+import { previewLinkApi } from "@admin/services/previewLinkApi";
+
+/**
+ * Where `createPreviewRoute` is mounted, by convention.
+ *
+ * The route handler is written to be dropped into `app/api/preview/route.ts`,
+ * which is where a Next application puts a route handler, and the admin has no
+ * other way to learn the path: the mount point is a file in the user's own app,
+ * invisible from here.
+ *
+ * A convention with an override is the honest arrangement. Guessing silently
+ * would produce a copied link that 404s with nothing to explain it; demanding
+ * configuration before the feature works at all would make the common case pay
+ * for the uncommon one.
+ */
+export const DEFAULT_PREVIEW_ROUTE = "/api/preview";
+
+export interface UsePreviewLinkOptions {
+  collection: string;
+  entryId: string;
+  /** Restricts the link to one locale. Absent means every locale. */
+  locale?: string;
+  /**
+   * The site the link points at. Without one the link is relative, which is
+   * correct when the admin and the site share an origin and useless when they
+   * do not.
+   */
+  siteUrl?: string;
+  /** Overrides {@link DEFAULT_PREVIEW_ROUTE} for an app that mounted it elsewhere. */
+  previewRoute?: string;
+}
+
+/** Assemble the URL a reviewer will open. */
+export function buildPreviewUrl({
+  token,
+  siteUrl,
+  previewRoute = DEFAULT_PREVIEW_ROUTE,
+}: {
+  token: string;
+  siteUrl?: string;
+  previewRoute?: string;
+}): string {
+  // `encodeURIComponent` rather than raw interpolation: a token is base64url
+  // and safe today, but a query value assembled by hand is exactly where an
+  // encoding assumption stops being true later.
+  const query = `?token=${encodeURIComponent(token)}`;
+  if (!siteUrl) return `${previewRoute}${query}`;
+  // Trailing slashes on a configured site URL are common and would otherwise
+  // produce `https://site.com//api/preview`.
+  return `${siteUrl.replace(/\/+$/, "")}${previewRoute}${query}`;
+}
+
+/**
+ * Copy text to the clipboard, reporting whether it worked.
+ *
+ * The Clipboard API is unavailable on an insecure origin and can be refused by
+ * permission policy, and both surface as a rejection rather than a return
+ * value. Reporting the failure lets the caller show the link instead of
+ * claiming a copy that never happened.
+ */
+async function copyToClipboard(text: string): Promise<boolean> {
+  try {
+    await navigator.clipboard.writeText(text);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Mint a preview link for one entry and put it on the clipboard.
+ *
+ * Minting happens per click rather than once per entry, deliberately: a link
+ * carries an expiry, so a value cached in the page would be handed out after it
+ * had stopped working.
+ */
+export function usePreviewLink({
+  collection,
+  entryId,
+  locale,
+  siteUrl,
+  previewRoute,
+}: UsePreviewLinkOptions) {
+  return useMutation({
+    mutationFn: async (): Promise<{ url: string; copied: boolean }> => {
+      const link = await previewLinkApi.mint({
+        collection,
+        entryId,
+        ...(locale === undefined ? {} : { locale }),
+      });
+      const url = buildPreviewUrl({
+        token: link.token,
+        ...(siteUrl === undefined ? {} : { siteUrl }),
+        ...(previewRoute === undefined ? {} : { previewRoute }),
+      });
+      return { url, copied: await copyToClipboard(url) };
+    },
+    onSuccess: ({ url, copied }) => {
+      if (copied) {
+        toast.success("Preview link copied.");
+        return;
+      }
+      // Not a failure of the mint: the link exists and works. Showing it is the
+      // only way the editor can still use it when the browser refused the copy.
+      toast.info(`Preview link: ${url}`);
+    },
+    onError: () => {
+      toast.error("Couldn't create a preview link.");
+    },
+  });
+}

--- a/packages/admin/src/services/previewLinkApi.ts
+++ b/packages/admin/src/services/previewLinkApi.ts
@@ -1,0 +1,56 @@
+/**
+ * Preview links — minting one for an entry, and revoking all of them.
+ *
+ * Distinct from the Preview button beside it, and the difference is who the
+ * link is for. Preview opens the entry in the site using the editor's own
+ * session, including unsaved changes handed over through session storage; a
+ * preview LINK is given to someone with no session at all, so it carries its
+ * own signed authorization and can only ever show what was saved.
+ *
+ * @module services/previewLinkApi
+ */
+
+import { protectedApi } from "@admin/lib/api/protectedApi";
+
+export interface PreviewLinkRequest {
+  collection: string;
+  entryId: string;
+  /** Restricts the link to one locale. Absent means every locale. */
+  locale?: string;
+}
+
+export interface PreviewLink {
+  /** The signed token. The URL is assembled by the caller. */
+  token: string;
+  /** ISO timestamp after which the link stops working. */
+  expiresAt: string;
+}
+
+export const previewLinkApi = {
+  /**
+   * Mint a link for one entry.
+   *
+   * Requires `update` on the collection: someone who can edit an entry already
+   * sees its draft, so sharing a link to that draft grants nothing new.
+   */
+  mint: async (request: PreviewLinkRequest): Promise<PreviewLink> => {
+    const result = await protectedApi.post<{
+      message: string;
+      item: PreviewLink;
+    }>("/preview-links", request);
+    return result.item;
+  },
+
+  /**
+   * Invalidate every preview link ever issued, including sessions already open.
+   *
+   * Requires `manage settings`, because the generation it moves is site-wide.
+   */
+  revokeAll: async (): Promise<{ generation: number }> => {
+    const result = await protectedApi.post<{
+      message: string;
+      item: { generation: number };
+    }>("/preview-links/revoke", {});
+    return result.item;
+  },
+};


### PR DESCRIPTION
Task 037 (F4) PR-5. The service and hook behind "Copy preview link", against the endpoints from #580.

## Why this is not the Preview button

The entry form already has one, and they are different features:

| | Preview (exists) | Preview **link** (this) |
|---|---|---|
| Who opens it | the editor | a reviewer with **no login** |
| Authorization | the editor's session | its own signed token |
| Can show unsaved edits | yes, via session storage | no, only what was saved |
| Expires | n/a | yes, and is revocable |

So this is added beside it rather than replacing it.

## One decision I made rather than asking, flagged here

**The admin cannot know where the preview route is mounted.** `createPreviewRoute` returns a `{ GET }` handler that the user drops into a file in *their own* app; nothing in the admin can see that path.

I took a **documented convention with an override**: `/api/preview`, which is where a Next application puts a route handler, overridable per call.

The alternatives are both worse. Guessing silently produces a copied link that 404s with nothing to explain it. Requiring configuration before the feature works at all makes the common case pay for the uncommon one. If you would rather this were a real setting, that is a small follow-up — but it wants a core column, and after today I would want it to land with its `upgrade-sim` shape named.

## Two details worth a look

- **Minted per click, never cached.** A link carries an expiry, so a value held in the page would be handed out after it had stopped working.
- **A refused clipboard write shows the link instead of claiming success.** The Clipboard API is unavailable on an insecure origin and can be denied by permission policy, and both surface as a rejection rather than a return value. The mint succeeded either way, so the editor should still be able to use it.

## Verification

- 5 tests on URL assembly: the conventional route, the relative case, trailing-slash joining, an app that moved the route, and that the token is encoded rather than interpolated raw.
- `check-types` and `lint` clean.

## What is left of F4 after this

Wiring the action into the entry form's toolbar, and the revoke control in settings. Split because this is the first work touching `packages/admin` in this stretch and the service/hook layer is reviewable on its own; the UI placement is a design conversation worth having separately.