### PR TITLE
fix(nextly): refuse a permission an entity already owns

### DIFF
--- a/.changeset/permission-collision-at-boot.md
+++ b/.changeset/permission-collision-at-boot.md
@@ -1,0 +1,26 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+Refuse a plugin permission that collides with one a collection or single already owns, including for Schema Builder entities the config cannot see and for declarations that differ only in letter case. Honouring such a declaration hands the plugin a permission the role presets grant to editors, so the collection quietly stops being editable by them. An application already running such a plugin can set NEXTLY_ALLOW_PLUGIN_PERMISSION_OVERRIDE=1 to keep booting with a warning while it is fixed.

--- a/packages/nextly/src/di/register.ts
+++ b/packages/nextly/src/di/register.ts
@@ -96,7 +96,11 @@ import { createSanitizationHook } from "../hooks/sanitization-hooks";
 import type { PluginPermission, PluginRole } from "../plugins/contributions";
 import { getCoreVersion } from "../plugins/core-version";
 import { setInitializedPlugins } from "../plugins/initialized-plugins";
-import { collectCustomPermissions } from "../plugins/permissions/collect-permissions";
+import {
+  collectCustomPermissions,
+  collectUnresolvedPermissionTargets,
+  finalizePermissionTargets,
+} from "../plugins/permissions/collect-permissions";
 import type {
   PluginContext,
   PluginDefinition,
@@ -448,6 +452,16 @@ export async function registerServices(
   // only here; the list is re-derived + seeded in runPostInitTasks.
   collectCustomPermissions(transformedConfig, resolvedPlugins);
 
+  // The half of that check the config cannot answer. A CRUD action on a
+  // resource the config does not define may name a Schema Builder collection,
+  // whose permissions the seeder owns — or a resource the plugin owns
+  // outright, which is ordinary and legal. Only the database tells them apart,
+  // so the verdict waits for Builder slugs, the same way relation targets do.
+  const unresolvedPermissions = collectUnresolvedPermissionTargets(
+    transformedConfig,
+    resolvedPlugins
+  );
+
   // Fail fast on role-bundle collisions (D67). Validation only here; roles are
   // re-derived + seeded (resolving permission slugs→ids) in runPostInitTasks.
   collectRoles(transformedConfig, resolvedPlugins);
@@ -785,6 +799,21 @@ export async function registerServices(
       strict: isStrictPluginTargets(transformedConfig),
       logger: resolvedLogger,
     });
+
+    // Settled here, where both halves of the question are answerable, and
+    // before any service is registered or any route installed — so a refusal
+    // stops the boot rather than being discovered by a request.
+    finalizePermissionTargets(
+      unresolvedPermissions,
+      [
+        ...builderCollectionSlugs,
+        ...builderEntities.singles.map(single => single.slug),
+      ],
+      {
+        allowOverride: allowsPluginPermissionOverride(transformedConfig),
+        logger: resolvedLogger,
+      }
+    );
   }
 
   // F8 PR 3: SchemaChangeService + DrizzlePushService DI registration
@@ -2743,6 +2772,21 @@ export function clearServices(): void {
 }
 
 /** Strict plugin-target resolution — config flag OR env (CI/prod). */
+/**
+ * Whether a plugin may keep a permission that collides with an entity's own.
+ *
+ * Off by default: a collision is an authoring error, and honouring it takes a permission away
+ * from the roles the presets grant it. The escape hatch is for an application already running
+ * such a plugin, which would otherwise be unable to boot at all while it waits for a fix.
+ */
+function allowsPluginPermissionOverride(config: NextlyServiceConfig): boolean {
+  return (
+    (config as { allowPluginPermissionOverride?: boolean })
+      .allowPluginPermissionOverride === true ||
+    process.env.NEXTLY_ALLOW_PLUGIN_PERMISSION_OVERRIDE === "1"
+  );
+}
+
 function isStrictPluginTargets(config: NextlyServiceConfig): boolean {
   return (
     config.strictPluginTargets === true ||

--- a/packages/nextly/src/plugins/permissions/collect-permissions.test.ts
+++ b/packages/nextly/src/plugins/permissions/collect-permissions.test.ts
@@ -3,7 +3,11 @@ import { describe, expect, it } from "vitest";
 import type { NextlyServiceConfig } from "../../di/register";
 import type { PluginDefinition } from "../plugin-context";
 
-import { collectCustomPermissions } from "./collect-permissions";
+import {
+  collectCustomPermissions,
+  collectUnresolvedPermissionTargets,
+  finalizePermissionTargets,
+} from "./collect-permissions";
 
 const cfg = (
   collections: string[] = [],
@@ -319,5 +323,103 @@ describe("the publish lifecycle a plugin may already have declared", () => {
     ]);
 
     expect(out.map(p => p.slug)).toEqual(["publish-newsletter"]);
+  });
+});
+
+/**
+ * The collision code and reason a refusal carries.
+ *
+ * Asserted instead of the message: the public message is one sentence for every collision, so a
+ * test matching on it passes for a duplicate-permission refusal as readily as for this one.
+ */
+function collisionOf(run: () => void): { code: string; reason: unknown } {
+  try {
+    run();
+  } catch (error) {
+    const err = error as { code?: string; logContext?: { reason?: unknown } };
+    return { code: err.code ?? "", reason: err.logContext?.reason };
+  }
+  throw new Error("expected a collision, and nothing was thrown");
+}
+
+describe("a CRUD collision the config cannot see", () => {
+  const declaring = (action: string, resource: string) =>
+    collectUnresolvedPermissionTargets(cfg(["posts"]), [
+      plugin("@acme/reports", [{ action, resource }]),
+    ]);
+
+  it("defers a CRUD action on a resource the config does not define", () => {
+    // It may be a Builder collection or a resource the plugin owns outright. Both look the same
+    // here, so neither is refused yet.
+    expect(declaring("delete", "reports")).toEqual([
+      { action: "delete", resource: "reports", owner: "@acme/reports" },
+    ]);
+  });
+
+  it("defers a case-mismatched one too, since the seeder compares in lower case", () => {
+    expect(declaring("Delete", "Reports")).toHaveLength(1);
+  });
+
+  it("does not defer a resource the config already settled", () => {
+    // `collectCustomPermissions` threw on it, or allowed it; either way the answer is in.
+    expect(declaring("delete", "posts")).toEqual([]);
+  });
+
+  it("does not defer a non-CRUD action, which no seeder owns", () => {
+    expect(declaring("export", "reports")).toEqual([]);
+  });
+
+  it("refuses the declaration once the resource is known to be a Builder entity", () => {
+    const unresolved = declaring("delete", "reports");
+
+    expect(
+      collisionOf(() => finalizePermissionTargets(unresolved, ["reports"]))
+    ).toEqual({
+      code: "NEXTLY_PERMISSION_COLLISION",
+      reason: "crud-permission-reserved",
+    });
+  });
+
+  it("refuses it whatever case the declaration used", () => {
+    expect(
+      collisionOf(() =>
+        finalizePermissionTargets(declaring("Delete", "Reports"), ["reports"])
+      ).reason
+    ).toBe("crud-permission-reserved");
+  });
+
+  it("allows a resource no entity claims, which is the ordinary custom permission", () => {
+    expect(() =>
+      finalizePermissionTargets(declaring("delete", "reports"), ["invoices"])
+    ).not.toThrow();
+  });
+
+  it("warns instead of refusing only when an application opts in", () => {
+    const warnings: string[] = [];
+
+    expect(() =>
+      finalizePermissionTargets(declaring("delete", "reports"), ["reports"], {
+        allowOverride: true,
+        logger: { warn: message => warnings.push(message) },
+      })
+    ).not.toThrow();
+    // Silence would leave an application running with a permission taken from its own editors and
+    // nothing saying so.
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain("@acme/reports");
+  });
+});
+
+describe("a CRUD collision on a config entity", () => {
+  it("is refused whatever case the action was declared in", () => {
+    // `ensurePermission` matches an existing row with `LOWER(action) = LOWER(action)`, so a
+    // capitalised action reaches the same row — and reached it without passing this check.
+    expect(
+      collisionOf(() =>
+        collectCustomPermissions(cfg(["posts"]), [
+          plugin("@acme/x", [{ action: "Delete", resource: "Posts" }]),
+        ])
+      ).reason
+    ).toBe("crud-permission-reserved");
   });
 });

--- a/packages/nextly/src/plugins/permissions/collect-permissions.ts
+++ b/packages/nextly/src/plugins/permissions/collect-permissions.ts
@@ -134,9 +134,16 @@ export function collectCustomPermissions(
       return;
     }
 
+    // Compared in lower case, like the lifecycle check above and like `ensurePermission`, which
+    // matches an existing row with `LOWER(action) = LOWER(action)`. Left case-sensitive,
+    // `{ action: "Delete", resource: "Posts" }` walks past this reservation and is collected as a
+    // custom permission — and the seeder then patches an owner onto the collection's OWN
+    // `delete-posts` row, which `role-presets.ts` grants Editor on `!isSystem && !isPlugin`. The
+    // collection quietly stops being deletable by an editor.
+    const lowerAction = action.toLowerCase();
     if (
-      (CRUD_ACTIONS.has(action) && collectionSlugs.has(resource)) ||
-      (SINGLE_ACTIONS.has(action) && singleSlugs.has(resource))
+      (CRUD_ACTIONS.has(lowerAction) && lowerCollectionSlugs.has(entitySlug)) ||
+      (SINGLE_ACTIONS.has(lowerAction) && lowerSingleSlugs.has(entitySlug))
     ) {
       throw permissionCollisionError(
         action,
@@ -166,13 +173,114 @@ export function collectCustomPermissions(
     });
   };
 
-  // App-declared permissions first (owner "app"), then each plugin's.
-  for (const perm of config.permissions ?? []) consider(perm, "app");
-  for (const plugin of plugins) {
-    for (const perm of plugin.contributes?.permissions ?? []) {
-      consider(perm, plugin.name);
-    }
-  }
+  eachDeclaredPermission(config, plugins, consider);
 
   return out;
+}
+
+/**
+ * Every declared permission with the owner that declared it, app first then each plugin.
+ *
+ * One iterator, because two walks over the same declarations are two chances for them to
+ * disagree about what was declared — and the second walk here decides whether a boot is refused.
+ */
+function eachDeclaredPermission(
+  config: PermissionConfigSource,
+  plugins: PluginDefinition[],
+  visit: (perm: PluginPermission, owner: string) => void
+): void {
+  for (const perm of config.permissions ?? []) visit(perm, "app");
+  for (const plugin of plugins) {
+    for (const perm of plugin.contributes?.permissions ?? []) {
+      visit(perm, plugin.name);
+    }
+  }
+}
+
+/** A CRUD-shaped declaration whose resource the config cannot classify. */
+export interface UnresolvedPermission {
+  action: string;
+  resource: string;
+  owner: string;
+}
+
+/**
+ * @experimental Collect every CRUD-shaped declaration whose resource is NOT a config entity,
+ * WITHOUT throwing.
+ *
+ * A resource collected here may be a Schema Builder collection — which lives in
+ * `dynamic_collections` and is unknowable at fold time — or it may be a genuine custom resource a
+ * plugin owns outright, which is the ordinary case and entirely legal. The two are
+ * indistinguishable until Builder slugs load, so the verdict is deferred to
+ * {@link finalizePermissionTargets}.
+ *
+ * The same shape `collectUnresolvedRelationTargets` uses, for the same reason: config answers
+ * part of the question and the database answers the rest.
+ */
+export function collectUnresolvedPermissionTargets(
+  config: PermissionConfigSource,
+  plugins: PluginDefinition[]
+): UnresolvedPermission[] {
+  const configEntities = new Set([
+    ...(config.collections ?? []).map(c => c.slug.toLowerCase()),
+    ...(config.singles ?? []).map(s => s.slug.toLowerCase()),
+  ]);
+  const unresolved: UnresolvedPermission[] = [];
+  eachDeclaredPermission(config, plugins, (perm, owner) => {
+    const action = perm.action.toLowerCase();
+    if (!CRUD_ACTIONS.has(action) && !SINGLE_ACTIONS.has(action)) return;
+    // A resource the config knows was already settled by `collectCustomPermissions`, which threw
+    // if it collided. What is left is what only the database can classify.
+    if (configEntities.has(perm.resource.toLowerCase())) return;
+    unresolved.push({ action: perm.action, resource: perm.resource, owner });
+  });
+  return unresolved;
+}
+
+/**
+ * @experimental Settle deferred permission collisions once Builder slugs are known.
+ *
+ * A declaration that survived {@link collectUnresolvedPermissionTargets} and names a Builder
+ * entity is the same authoring error `crud-permission-reserved` already refuses for a config
+ * entity: the seeder owns that entity's CRUD permissions, so the declaration cannot be honoured
+ * as a custom permission. It is refused here rather than at fold time only because the config
+ * cannot see the entity.
+ *
+ * REFUSED rather than dropped, and refused rather than merely stripped of ownership, because
+ * both softer options end somewhere worse. Dropping it silently leaves the plugin's route
+ * guarded by a permission the collection also grants, so every editor reaches it. Withholding
+ * ownership does the same thing by a different route: `role-presets.ts` grants Editor on
+ * `!isSystem && !isPlugin`, so an unowned row is a granted row.
+ *
+ * `allowOverride` exists for an application already running such a plugin, which would otherwise
+ * have no way to boot while it waits for a fix. It is opt-in, and it says so in the warning.
+ */
+export function finalizePermissionTargets(
+  unresolved: readonly UnresolvedPermission[],
+  builderSlugs: Iterable<string>,
+  opts?: {
+    allowOverride?: boolean;
+    logger?: { warn?(message: string): void };
+  }
+): void {
+  if (unresolved.length === 0) return;
+  const builder = new Set<string>();
+  for (const slug of builderSlugs) builder.add(slug.toLowerCase());
+  for (const declaration of unresolved) {
+    if (!builder.has(declaration.resource.toLowerCase())) continue;
+    if (opts?.allowOverride !== true) {
+      throw permissionCollisionError(
+        declaration.action,
+        declaration.resource,
+        [declaration.owner],
+        "crud-permission-reserved"
+      );
+    }
+    opts.logger?.warn?.(
+      `[plugins] "${declaration.owner}" declares "${declaration.action}" on "${declaration.resource}", ` +
+        `which is a Schema Builder entity whose CRUD permissions the seeder owns. ` +
+        `Honouring it lets the plugin take that permission from the roles the presets grant it. ` +
+        `(unset NEXTLY_ALLOW_PLUGIN_PERMISSION_OVERRIDE to refuse this at boot instead)`
+    );
+  }
 }

--- a/turbo.jsonc
+++ b/turbo.jsonc
@@ -86,6 +86,7 @@
     "NEXTLY_SKIP_AUTO_SYNC",
     "NEXTLY_SKIP_SCHEMA_FILES",
     "NEXTLY_STRICT_PLUGIN_TARGETS", // P8: fail-fast on unresolvable plugin extend/relation targets
+    "NEXTLY_ALLOW_PLUGIN_PERMISSION_OVERRIDE", // let a plugin keep a permission an entity already owns
     "PERMISSION_CACHE_ENABLED",
     "PERMISSION_CACHE_MEMORY_SIZE",
     "PERMISSION_CACHE_TTL_SECONDS",


### PR DESCRIPTION
Task 146. Decided without a founder round, on the reasoning below.

## What was wrong

Three holes in one rule, all measured on `main` before changing anything:

```
{ action: "delete", resource: "posts"   }  config collection  -> refused (correct, already)
{ action: "Delete", resource: "Posts"   }  config collection  -> COLLECTED  ⚠
{ action: "delete", resource: "reports" }  Builder collection -> COLLECTED  ⚠
```

The consequence is not cosmetic. `ensurePermission` matches an existing row with `LOWER(action) = LOWER(action)`, so a collected declaration patches an `owner` onto the collection's OWN `delete-posts` row — and `role-presets.ts` grants Editor on `(!isSystem && !isPlugin)`. **The collection quietly stops being deletable by editors.** No Schema Builder needed for the case variant; it happens on ordinary config collections.

## Why refuse rather than soften

Two softer options were considered and both end somewhere worse.

**Drop the declaration silently.** The plugin's route guarded by `delete-posts` is then reachable by every editor, because the collection grants that permission normally. Widening access quietly is the worst failure mode available for authorization.

**Withhold ownership but keep the declaration.** Same destination by a different road: an unowned row is a granted row, because the preset grants on `!isPlugin`. This was tried in #555 and reverted for exactly this.

So the declaration itself has to go. That is also **the rule config collections have always followed** — this PR makes one rule apply consistently rather than introducing a new failure mode.

## Why an escape hatch, and why off by default

Precedent: **Spring Boot 2.1 flipped bean-definition overriding from silent to fail-fast**, for the same reason — silent overriding produced behaviour nobody could predict from the code — and shipped `spring.main.allow-bean-definition-overriding` for applications already relying on it ([Baeldung](https://www.baeldung.com/spring-boot-bean-definition-override-exception), [spring-boot#15037](https://github.com/spring-projects/spring-boot/issues/15037)).

Same shape here. Default refuses; `NEXTLY_ALLOW_PLUGIN_PERMISSION_OVERRIDE=1` (or `allowPluginPermissionOverride`) keeps an installed application booting with a warning that names the plugin, the permission and what it costs. Without it, upgrading would strand an app with no way to start while it waits on a plugin fix.

## Where it lives

Not a new seam — `registerServices` **already** fails fast on plugin permissions ([register.ts:449](https://github.com/nextlyhq/nextly/blob/main/packages/nextly/src/di/register.ts#L449)). What was missing is the half only the database can answer, and the codebase already solves that for relations twenty lines away:

```
collectUnresolvedRelationTargets(config)   →  finalizeRelationTargets(unresolved, builderSlugs, …)
collectUnresolvedPermissionTargets(config) →  finalizePermissionTargets(unresolved, builderSlugs, …)   ← new
```

Both settle where Builder slugs load, before any service is registered or route installed — so a refusal stops the boot rather than being found by a request. That answers the nine entry points task 146 enumerated: they were nine ways to reach a check placed too late, and this is placed before all of them.

One iterator now feeds both permission walks, so the two cannot disagree about what was declared.

## Tests

9 new cases. Four stub-verifications, each failing the right test: the finalizer never refusing; the config check back to case-sensitive; the deferred collector ignoring case; the opt-out warning silently.

`nextly` unit 377 passed / 2 failed, and **both failures are pre-existing** — `caching.test.ts`, which fails identically on `origin/main` (verified by running it there; it is in the known baseline and the error is `assertNoLegacyFieldGroupKey`, unrelated to permissions). Auth + permissions integration 57/57. Typecheck, lint and a full build clean.

Lint also caught the new env var missing from `turbo.jsonc`; added, and I checked the diff to confirm the neighbouring entry's comment survived the edit.

@codex please review this PR