### PR TITLE
fix(blocks-react): let each block claim its own DOM id at render

### DIFF
--- a/.changeset/dom-id-at-render.md
+++ b/.changeset/dom-id-at-render.md
@@ -1,0 +1,30 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+Let each block claim its own DOM id at render, instead of reserving ids in advance.
+
+Which node ends up writing an id is only knowable once a block has run: one that throws, or returns something with no host root, is replaced by a placeholder that emits no id at all. Reserving ids before rendering therefore meant a block that later failed had already taken the id, and the healthy node that wanted it rendered without one in exchange for nothing.
+
+Node ids are still made unique before rendering. Those are React keys, and a duplicate makes React reuse one block’s instance for another, which is a wrong page rather than a missing anchor.

--- a/packages/blocks-react/src/page-renderer.test.tsx
+++ b/packages/blocks-react/src/page-renderer.test.tsx
@@ -1233,12 +1233,49 @@ describe("PageRenderer", () => {
       expect(html).not.toContain("<span>second</span>");
     });
 
-    it("gives a repeated dom id to the first node that claims it", async () => {
-      // Two nodes can carry different node ids and the same `cssId`, and
-      // rendering both puts two `id` attributes in one page — which is what
-      // makes an anchor, a label's `for` and an `#id` selector ambiguous.
-      // Engine validation rejects the shape; the forgiving render path must not
-      // quietly reintroduce it.
+    it("keeps a healthy node's anchor when another node with that id fails", async () => {
+      // The reason DOM ids are not settled before rendering. A block that
+      // throws is replaced by a placeholder emitting no id at all, so reserving
+      // ids in advance meant the failing node had already taken `hero` and the
+      // healthy one was stripped in exchange for nothing.
+      const boom = defineBlock({
+        name: "test/boom",
+        version: 1,
+        description: "Throws.",
+        example: { props: {} },
+        defaultProps: {},
+        render: () => {
+          throw new Error("nope");
+        },
+      });
+
+      const html = await renderToHtml(
+        <PageRenderer
+          document={doc(
+            node("a", "test/boom", { cssId: "hero" }),
+            node("b", "test/text", {
+              props: { value: "healthy" },
+              cssId: "hero",
+            })
+          )}
+          blocks={createBlockResolver([
+            boom as AnyBlockDefinition,
+            text as AnyBlockDefinition,
+          ])}
+        />
+      );
+
+      expect(placeholderReasons(html)).toEqual(["render-error"]);
+      expect(html.match(/id="hero"/g)).toHaveLength(1);
+      expect(html).toContain("healthy");
+    });
+
+    it("lets a stored duplicate reach the page rather than repairing it", async () => {
+      // The cost of the above, stated rather than discovered. `duplicate-dom-id`
+      // is a write-time validation error, so this shape can only arrive from a
+      // row edited outside the product — and a browser resolves a duplicated id
+      // to the first match rather than failing, which is a smaller cost than
+      // silently unsticking an anchor on a page where nothing is wrong.
       const html = await renderToHtml(
         <PageRenderer
           document={doc(
@@ -1249,82 +1286,9 @@ describe("PageRenderer", () => {
         />
       );
 
-      // The id is dropped, not the content: the later node's body is fine.
+      expect(html.match(/id="dup"/g)).toHaveLength(2);
       expect(html).toContain("first");
       expect(html).toContain("second");
-      expect(html.match(/id="dup"/g)).toHaveLength(1);
-    });
-
-    it("drops a repeated dom id from a node that also has slots", async () => {
-      // The repaired copy is the one that has to reach the tree. Rebuilding a
-      // node's slots from the ORIGINAL would put the id back on exactly the
-      // nodes that can nest.
-      const box = defineBlock({
-        name: "test/dup-box",
-        version: 1,
-        description: "Renders one slot.",
-        example: { props: {} },
-        slots: { children: {} },
-        render: ({ className, renderSlot }) => (
-          <div className={className}>{renderSlot("children")}</div>
-        ),
-      });
-
-      const html = await renderToHtml(
-        <PageRenderer
-          document={doc(
-            node("a", "test/text", { props: { value: "first" }, cssId: "dup" }),
-            node("b", "test/dup-box", {
-              cssId: "dup",
-              slots: {
-                children: [
-                  node("c", "test/text", { props: { value: "nested" } }),
-                ],
-              },
-            })
-          )}
-          blocks={createBlockResolver([
-            box as AnyBlockDefinition,
-            text as AnyBlockDefinition,
-          ])}
-        />
-      );
-
-      expect(html.match(/id="dup"/g)).toHaveLength(1);
-      expect(html).toContain("first");
-      expect(html).toContain("nested");
-    });
-
-    it("counts an attribute id as the same address as a cssId", async () => {
-      // `id` is on the attribute allowlist, so the bag is a second way to write
-      // the same address. Reserving only `cssId` left the two able to collide
-      // with each other while each looked unique on its own.
-      const html = await renderToHtml(
-        <PageRenderer
-          document={doc(
-            node("a", "test/text", {
-              props: { value: "first" },
-              cssId: "hero",
-            }),
-            node("b", "test/text", {
-              props: { value: "second" },
-              attributes: { id: "hero" },
-            }),
-            node("c", "test/text", {
-              props: { value: "third" },
-              // Case variants of the NAME are the same attribute, since the
-              // render path lowercases before writing.
-              attributes: { ID: "hero" },
-            })
-          )}
-          blocks={createBlockResolver([text as AnyBlockDefinition])}
-        />
-      );
-
-      expect(html.match(/id="hero"/g)).toHaveLength(1);
-      for (const body of ["first", "second", "third"]) {
-        expect(html).toContain(body);
-      }
     });
 
     it("does not reserve a dom id for a node that renders a placeholder", async () => {
@@ -3889,32 +3853,24 @@ describe("PageRenderer", () => {
       }
     });
 
-    it("reserves the id the attribute bag will actually render", async () => {
+    it("renders the last string case-variant of an attribute id", async () => {
       // The render path lowercases each attribute name into one bag, so the
-      // LAST string case-variant is what reaches the DOM. Reserving the first
-      // would hold an id the page never uses while letting the one it does use
-      // collide with a later node.
+      // LAST string case-variant is what reaches the DOM. Worth pinning on its
+      // own: it decides which id an anchor resolves against.
       const html = await renderToHtml(
         <PageRenderer
           document={doc(
             node("a", "test/text", {
               props: { value: "first" },
               attributes: { id: "old", ID: "hero" },
-            }),
-            node("b", "test/text", {
-              props: { value: "second" },
-              cssId: "hero",
             })
           )}
           blocks={createBlockResolver([text as AnyBlockDefinition])}
         />
       );
 
-      // `hero` is claimed by the first node's rendered attribute, so the second
-      // renders without it. Exactly one `id="hero"` reaches the page.
-      expect(html.match(/id="hero"/g)).toHaveLength(1);
+      expect(html).toContain('id="hero"');
       expect(html).not.toContain('id="old"');
-      expect(html).toContain("second");
     });
 
     it("does not let a version-ahead node reserve a DOM id", async () => {

--- a/packages/blocks-react/src/page-renderer.tsx
+++ b/packages/blocks-react/src/page-renderer.tsx
@@ -18,7 +18,7 @@ import {
   migrationSourceFor,
   type BlockResolver,
 } from "./resolver";
-import { dedupeAddresses, sanitizeDocument } from "./sanitize";
+import { dedupeNodeIds, sanitizeDocument } from "./sanitize";
 import {
   resolvePageStyles,
   styleTextForInjection,
@@ -237,9 +237,7 @@ export function PageRenderer({
   // take that address from a visible node for nothing: the visible one would be
   // dropped or stripped of its anchor, and the node it collided with would then
   // be pruned anyway.
-  const visible = dedupeAddresses(pruned, node =>
-    rendersOwnMarkup(node, resolver)
-  );
+  const visible = dedupeNodeIds(pruned);
 
   // Whether the tree that renders is the tree the stored stylesheet was
   // compiled from. Each pass returns its input unchanged when it had nothing to

--- a/packages/blocks-react/src/sanitize.ts
+++ b/packages/blocks-react/src/sanitize.ts
@@ -123,100 +123,37 @@ export function sanitizeDocument(
 }
 
 /**
- * The DOM id a node will actually render with, if any.
+ * Makes every NODE ID in a document unique.
  *
- * `cssId` is the modelled field and the attribute bag is the escape hatch
- * beside it, so a node carrying both renders the modelled one — which means
- * that is the only value worth reserving. Attribute NAMES are matched
- * case-insensitively because HTML treats them that way and the render path
- * lowercases before writing, so a stored `ID` becomes an `id` on the page.
+ * Node ids are the document's addressing mechanism and the renderer's React
+ * keys. A duplicate makes React reuse one block's instance for another, which
+ * is a wrong page rather than a missing one, so it has to be settled before
+ * anything renders — the key is chosen by the caller, not by the block.
  *
- * Case variants resolve LAST-write-wins, mirroring the render path exactly: it
- * lowercases each name into one bag, so `{ id: "old", ID: "hero" }` renders
- * `hero`. Answering `old` here would reserve an id the page never uses and let
- * the one it does use collide with a later node.
+ * **DOM ids are deliberately NOT settled here.** Which node ends up writing an
+ * `id` is only knowable once a block has run: one that throws, or returns
+ * something with no host root, is replaced by a placeholder that emits no id at
+ * all. Reserving ids in advance therefore meant a block that later failed had
+ * already taken `#pricing`, and the healthy node that wanted it was stripped in
+ * exchange for nothing. Each boundary now writes its own id at the moment it
+ * successfully produces a host root, which is the only point at which the
+ * answer is known.
  *
- * Only STRING values count, and for the same reason: the render path skips a
- * non-string after computing the key, so a later non-string variant does not
- * displace an earlier string one.
- *
- * The VALUE is compared exactly. Ids are case-sensitive in the DOM: `#Hero` and
- * `#hero` address different elements, and folding them together would strip an
- * id that was never ambiguous.
- */
-function renderedDomId(node: BlockNode): string | undefined {
-  if (typeof node.cssId === "string") return node.cssId;
-  const attributes: unknown = node.attributes;
-  if (
-    typeof attributes !== "object" ||
-    attributes === null ||
-    Array.isArray(attributes)
-  ) {
-    return undefined;
-  }
-  let rendered: string | undefined;
-  for (const [name, value] of Object.entries(attributes)) {
-    if (name.toLowerCase() === "id" && typeof value === "string") {
-      rendered = value;
-    }
-  }
-  return rendered;
-}
-
-/** A node with whatever supplied the given DOM id removed. */
-function withoutDomId(node: BlockNode): BlockNode {
-  const stripped: BlockNode = { ...node };
-  delete stripped.cssId;
-  const attributes: unknown = stripped.attributes;
-  if (
-    typeof attributes === "object" &&
-    attributes !== null &&
-    !Array.isArray(attributes)
-  ) {
-    stripped.attributes = Object.fromEntries(
-      Object.entries(attributes).filter(([name]) => name.toLowerCase() !== "id")
-    );
-  }
-  return stripped;
-}
-
-/**
- * Makes every address in a document unique.
- *
- * Two kinds, both of which have to be unique only among nodes that will
- * actually render:
- *
- * - **Node ids** are the document's addressing mechanism and the renderer's
- *   React keys. A duplicate makes React reuse one block's instance for another,
- *   which is a wrong page rather than a missing one.
- * - **DOM ids** are what an anchor, a label's `for` and an `#id` selector
- *   resolve against. Two elements answering to one is the ambiguity `cssId`
- *   exists to prevent, and it can arrive through `cssId` or through the
- *   attribute bag.
+ * What that gives up is a repair for a document holding two identical DOM ids.
+ * Engine validation rejects that shape at write time (`duplicate-dom-id`), so
+ * it can only arrive from a row edited outside the product — and a browser
+ * resolves a duplicated id to the first match rather than failing, which is a
+ * smaller cost than silently unsticking an anchor on a healthy page.
  *
  * Run AFTER condition-gated nodes are pruned, deliberately. A hidden node never
- * reaches the page, so letting it reserve an address would take that address
- * away from a visible node for no benefit: the visible one would be dropped or
- * stripped, the hidden one would then be pruned, and the page would be missing
- * content or an anchor that was never in conflict with anything.
+ * reaches the page, so letting it reserve an id would take that id from a
+ * visible node for no benefit.
  *
- * Engine validation rejects both shapes at write time; this is the forgiving
- * render path declining to reintroduce what a stored document may already hold.
  * Returns the ORIGINAL document when nothing collided.
  */
-export function dedupeAddresses(
-  document: BlockDocument,
-  /**
-   * Whether a node will render its own markup. A node that resolves to a
-   * placeholder emits no `id`, so reserving one for it would strip the anchor
-   * off a healthy node in exchange for nothing. Defaults to assuming every node
-   * renders, which is the answer for a caller with no registry to ask.
-   */
-  rendersMarkup: (node: BlockNode) => boolean = () => true
-): BlockDocument {
+export function dedupeNodeIds(document: BlockDocument): BlockDocument {
   let changed = false;
   const seenIds = new Set<string>();
-  const seenDomIds = new Set<string>();
 
   const walk = (nodes: BlockNode[]): BlockNode[] => {
     const result: BlockNode[] = [];
@@ -227,22 +164,9 @@ export function dedupeAddresses(
       }
       seenIds.add(node.id);
 
-      let kept = node;
-      const domId = rendersMarkup(node) ? renderedDomId(node) : undefined;
-      if (domId !== undefined) {
-        if (seenDomIds.has(domId)) {
-          // The first node to claim an id keeps it; the later one renders
-          // without one rather than being dropped, since its content is fine.
-          changed = true;
-          kept = withoutDomId(node);
-        } else {
-          seenDomIds.add(domId);
-        }
-      }
-
-      const slots = kept.slots;
+      const slots = node.slots;
       if (slots === undefined) {
-        result.push(kept);
+        result.push(node);
         continue;
       }
 
@@ -253,7 +177,7 @@ export function dedupeAddresses(
         if (walked !== children) slotsChanged = true;
         nextSlots[name] = walked;
       }
-      result.push(slotsChanged ? { ...kept, slots: nextSlots } : kept);
+      result.push(slotsChanged ? { ...node, slots: nextSlots } : node);
     }
     return changed ? result : nodes;
   };


### PR DESCRIPTION
The address half of the renderer timing problem, implementing the option you chose. Completes what #579 started.

## The bug

Every block can carry a DOM id — `#pricing` — used by jump-links, `label for=`, and CSS. The renderer decided who got which id **before** drawing the page. If a block then failed, it had already taken the id, and the healthy node that wanted it was told "taken, render without one".

## The fix is a deletion

The boundary **already** wrote ids only for output with a host root: every placeholder path returns before `withNodeAttributes` is reached. So "each block claims its own id when it actually draws" was already true. The pre-render pass was second-guessing it.

This removes that pass. `dedupeAddresses` becomes `dedupeNodeIds`, and `renderedDomId` / `withoutDomId` / the `rendersMarkup` predicate all go with it — **net less code**, which is the shape a correct fix usually has here.

## What it gives up, stated rather than discovered

A stored document holding two identical DOM ids is no longer repaired; both reach the page.

I verified the premise before recommending this rather than assuming it: **`duplicate-dom-id` is a write-time validation error** (`blocks-engine/src/validation.fixtures.ts:559`), so that shape can only arrive from a row edited outside the product. And a browser resolves a duplicated id to the first match rather than failing — a smaller cost than silently unsticking an anchor on a page where nothing is wrong. There is a test asserting this new behaviour explicitly, so it is a documented trade rather than a regression someone finds later.

## Why not the alternative

Assigning ids after render needs a two-pass render, which requires every async block to resolve before any markup is emitted. `block-boundary.tsx` bought the opposite deliberately — *"only blocks that are actually asynchronous pay for being asynchronous"* — so a page with one slow block would stop streaming entirely. That is a visible speed regression to fix an invisible anchor bug.

**Node ids stay deduplicated before rendering.** Those are React keys, and a duplicate makes React reuse one block's instance for another: a wrong page, not a missing anchor. Different problem, different timing.

## Verification

- 199 tests. Four that pinned the removed behaviour are replaced by four that pin the new one, including **the regression this fixes**: a throwing block no longer takes the anchor from a healthy sibling.
- **Stub-verified**: restoring pre-render reservation fails exactly those four and nothing else.
- No stale references to the removed export anywhere in the monorepo; `check-types` (both projects), `lint`, and `plugin-page-builder` all clean.