### PR TITLE
feat(nextly): let a field access rule ask what the caller is granted

### DIFF
--- a/.changeset/builder-custom-css-permission.md
+++ b/.changeset/builder-custom-css-permission.md
@@ -1,0 +1,44 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+Field access rules can ask what the caller is granted, and custom CSS is now a privilege.
+
+A field's `access.create` / `access.read` / `access.update` function now receives
+`permissions` and `roles` alongside `req`, so a field can be gated on a permission
+rather than only on a role. Collection-level access already received these; field
+level did not, so "only these people may write this field" was not expressible.
+The grants are resolved once per operation and only when a rule actually runs, so
+an entity with no field rules makes no extra lookup. A rule that cannot read the
+grants denies rather than opens.
+
+`permissions` uses the same `resource:action` spelling collection-level access
+uses. Note this differs from the `action-resource` form the database and the
+admin's permission matrix show for the same row.
+
+The page builder's per-page and per-block custom CSS now requires a new
+`write-builder-custom-css` permission. Without it the CSS already on a page stays
+visible and keeps applying, but cannot be changed — the field is dropped from the
+write rather than the write being rejected, so everything else on the page saves
+normally. Grant it to any role that should keep authoring custom CSS.

--- a/packages/nextly/src/collections/fields/types/base.ts
+++ b/packages/nextly/src/collections/fields/types/base.ts
@@ -153,6 +153,22 @@ export type AccessFunction = (args: {
   id?: string;
   /** Document data being created or updated */
   data?: Record<string, unknown>;
+  /**
+   * The caller's effective permissions, as `resource:action` — the SAME
+   * spelling collection-level access control receives, so a rule reads the
+   * same string wherever it is written.
+   *
+   * Note that this is not how a permission is spelled in the database or in
+   * the admin's permission matrix, where it is `action-resource`. The two are
+   * composed from one row and mean the same thing; only the string differs.
+   *
+   * Empty for an unauthenticated caller, and empty if the lookup fails — a
+   * rule that asks for a permission therefore denies rather than opens when
+   * grants cannot be read.
+   */
+  permissions: string[];
+  /** The caller's role slugs, including roles inherited from other roles. */
+  roles: string[];
 }) => boolean | Promise<boolean>;
 
 /**

--- a/packages/nextly/src/shared/lib/__tests__/field-level-registry.test.ts
+++ b/packages/nextly/src/shared/lib/__tests__/field-level-registry.test.ts
@@ -10,8 +10,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 // rule's permission check is driven by the test rather than by a database, and
 // so the number of LOOKUPS is observable — the resolver promises to make one
 // per call however many rules ask.
-const listEffectivePermissions = vi.fn(async () => [] as string[]);
-const listRoleSlugsForUser = vi.fn(async () => [] as string[]);
+const listEffectivePermissions = vi.fn(
+  async (_userId: string) => [] as string[]
+);
+const listRoleSlugsForUser = vi.fn(async (_userId: string) => [] as string[]);
 vi.mock("../../../services/lib/permissions", () => ({
   listEffectivePermissions: (userId: string) =>
     listEffectivePermissions(userId),

--- a/packages/nextly/src/shared/lib/__tests__/field-level-registry.test.ts
+++ b/packages/nextly/src/shared/lib/__tests__/field-level-registry.test.ts
@@ -4,7 +4,19 @@
  * the database, so this registry restores them by capturing the live
  * config. A regression would silently disable field access rules and hooks.
  */
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// The registry resolves the caller's grants through these. Mocked so a field
+// rule's permission check is driven by the test rather than by a database, and
+// so the number of LOOKUPS is observable — the resolver promises to make one
+// per call however many rules ask.
+const listEffectivePermissions = vi.fn(async () => [] as string[]);
+const listRoleSlugsForUser = vi.fn(async () => [] as string[]);
+vi.mock("../../../services/lib/permissions", () => ({
+  listEffectivePermissions: (userId: string) =>
+    listEffectivePermissions(userId),
+  listRoleSlugsForUser: (userId: string) => listRoleSlugsForUser(userId),
+}));
 
 import { validateEntryData } from "../entry-validation";
 import {
@@ -19,6 +31,124 @@ import {
 } from "../field-level-registry";
 
 afterEach(() => clearFieldFunctions());
+
+describe("field access can ask what the caller is granted", () => {
+  beforeEach(() => {
+    listEffectivePermissions.mockReset().mockResolvedValue([]);
+    listRoleSlugsForUser.mockReset().mockResolvedValue([]);
+  });
+
+  const registerGated = (): void =>
+    registerFieldFunctions("collection", "pages", [
+      { name: "title" },
+      {
+        name: "customCss",
+        access: {
+          update: ({ permissions }: { permissions: string[] }) =>
+            permissions.includes("builder-custom-css:write"),
+        },
+      },
+    ]);
+
+  it("strips the field when the caller lacks the permission", async () => {
+    listEffectivePermissions.mockResolvedValue(["pages:update"]);
+    registerGated();
+    const data: Record<string, unknown> = { title: "Home", customCss: ".a{}" };
+    await applyFieldWriteAccess({
+      kind: "collection",
+      slug: "pages",
+      data,
+      operation: "update",
+      user: { id: "u1" },
+    });
+    // Silently stripped, not rejected: the rest of the write goes through and
+    // whatever CSS is stored stays as it was.
+    expect(data).toEqual({ title: "Home" });
+  });
+
+  it("keeps the field when the caller has it", async () => {
+    listEffectivePermissions.mockResolvedValue([
+      "pages:update",
+      "builder-custom-css:write",
+    ]);
+    registerGated();
+    const data: Record<string, unknown> = { title: "Home", customCss: ".a{}" };
+    await applyFieldWriteAccess({
+      kind: "collection",
+      slug: "pages",
+      data,
+      operation: "update",
+      user: { id: "u1" },
+    });
+    expect(data).toEqual({ title: "Home", customCss: ".a{}" });
+  });
+
+  it("resolves the grants once however many rules ask", async () => {
+    listEffectivePermissions.mockResolvedValue(["a:read"]);
+    registerFieldFunctions("collection", "pages", [
+      {
+        name: "one",
+        access: {
+          update: ({ permissions }: { permissions: string[] }) =>
+            permissions.length > 0,
+        },
+      },
+      {
+        name: "two",
+        access: {
+          update: ({ permissions }: { permissions: string[] }) =>
+            permissions.length > 0,
+        },
+      },
+      {
+        name: "three",
+        access: {
+          update: ({ permissions }: { permissions: string[] }) =>
+            permissions.length > 0,
+        },
+      },
+    ]);
+    await applyFieldWriteAccess({
+      kind: "collection",
+      slug: "pages",
+      data: { one: 1, two: 2, three: 3 },
+      operation: "update",
+      user: { id: "u1" },
+    });
+    // Three rules, one lookup. Field access runs on every authenticated write,
+    // so a per-rule lookup would multiply the cost by the field count.
+    expect(listEffectivePermissions).toHaveBeenCalledTimes(1);
+  });
+
+  it("makes no lookup at all when no rule runs", async () => {
+    registerFieldFunctions("collection", "pages", [
+      { name: "title", validate: () => true },
+    ]);
+    await applyFieldWriteAccess({
+      kind: "collection",
+      slug: "pages",
+      data: { title: "Home" },
+      operation: "update",
+      user: { id: "u1" },
+    });
+    expect(listEffectivePermissions).not.toHaveBeenCalled();
+  });
+
+  it("denies when the grant lookup fails", async () => {
+    listEffectivePermissions.mockRejectedValue(new Error("db down"));
+    registerGated();
+    const data: Record<string, unknown> = { title: "Home", customCss: ".a{}" };
+    await applyFieldWriteAccess({
+      kind: "collection",
+      slug: "pages",
+      data,
+      operation: "update",
+      user: { id: "u1" },
+    });
+    // Fail CLOSED: an unreadable grant set is not an open one.
+    expect(data).toEqual({ title: "Home" });
+  });
+});
 
 describe("field-level registry", () => {
   it("captures only function-bearing fields and replaces on re-register", () => {

--- a/packages/nextly/src/shared/lib/field-level-registry.ts
+++ b/packages/nextly/src/shared/lib/field-level-registry.ts
@@ -31,6 +31,10 @@ import { normalizeHookError } from "../../hooks/normalize-hook-error";
 import { singleHookNamespace } from "../../hooks/register-single-hooks";
 import { recordSideEffectWarning } from "../../hooks/side-effect-warnings";
 import type { FieldHookHandler } from "../../hooks/types";
+import {
+  listEffectivePermissions,
+  listRoleSlugsForUser,
+} from "../../services/lib/permissions";
 
 import { detachData } from "./detach";
 import type { ValidatableField } from "./entry-validation";
@@ -45,7 +49,57 @@ type FieldAccessFn = (args: {
   req: FieldRequestContext;
   id?: string;
   data?: Record<string, unknown>;
+  permissions: string[];
+  roles: string[];
 }) => MaybePromise<boolean>;
+
+/**
+ * The caller's grants, in the SAME spelling collection-level access uses.
+ *
+ * A field rule and a collection rule are written by the same person, minutes
+ * apart, and a permission that reads `pages:create` in one and something else
+ * in the other is a rule that silently denies. `listEffectivePermissions` is
+ * the single source for the string, so this carries what it returns rather
+ * than re-deriving it.
+ */
+interface CallerGrants {
+  permissions: string[];
+  roles: string[];
+}
+
+/**
+ * Resolve the caller's grants once, on the first rule that actually runs.
+ *
+ * Field access is evaluated on every authenticated write and read, and most
+ * entities declare no rule at all — so resolving eagerly would put a role and
+ * permission lookup on paths that never ask a question. Memoizing the PROMISE
+ * rather than the value also collapses the concurrent case: the rules at one
+ * level run in sequence but a nested container recurses first, and two levels
+ * asking at once must not become two lookups.
+ */
+function grantsResolver(
+  userId: string | undefined
+): () => Promise<CallerGrants> {
+  let pending: Promise<CallerGrants> | undefined;
+  return () => {
+    if (pending) return pending;
+    if (!userId) {
+      pending = Promise.resolve({ permissions: [], roles: [] });
+      return pending;
+    }
+    pending = Promise.all([
+      listEffectivePermissions(userId),
+      listRoleSlugsForUser(userId),
+    ])
+      .then(([permissions, roles]) => ({ permissions, roles }))
+      // Fail CLOSED on a lookup error: an empty grant set denies every rule
+      // that asks for a permission, which is the safe direction. Throwing here
+      // would instead be caught by the per-rule guard below and read as a
+      // denial anyway, but only for the rule that happened to ask first.
+      .catch(() => ({ permissions: [], roles: [] }));
+    return pending;
+  };
+}
 
 // The registry stores exactly what a field hook is declared as, so the shape
 // lives in one place rather than being restated here.
@@ -281,7 +335,11 @@ async function applyWriteAccessRec(
   data: Record<string, unknown>,
   fns: Record<string, FieldFunctions>,
   operation: "create" | "update",
-  ctx: { user?: Record<string, unknown>; id?: string }
+  ctx: {
+    user?: Record<string, unknown>;
+    id?: string;
+    grants: () => Promise<CallerGrants>;
+  }
 ): Promise<void> {
   // Taken BEFORE the recursion below, which rewrites nested containers in
   // place as it redacts them: a rule at this level that reads into a nested
@@ -303,10 +361,13 @@ async function applyWriteAccessRec(
     if (!fn) continue;
     let allowed = false;
     try {
+      const { permissions, roles } = await ctx.grants();
       allowed = await fn({
         req: { user: ctx.user },
         id: ctx.id,
         data: snapshot,
+        permissions,
+        roles,
       });
     } catch {
       // Fail-secure: an access rule that throws denies the field.
@@ -343,6 +404,9 @@ export async function applyFieldWriteAccess(opts: {
   await applyWriteAccessRec(opts.data, fns, opts.operation, {
     user: opts.user,
     id: opts.id,
+    grants: grantsResolver(
+      typeof opts.user.id === "string" ? opts.user.id : undefined
+    ),
   });
 }
 
@@ -467,7 +531,11 @@ function restoreReadAccessEvidence(
 async function applyReadAccessRec(
   entry: Record<string, unknown>,
   fns: Record<string, FieldFunctions>,
-  ctx: { user?: Record<string, unknown>; id?: string },
+  ctx: {
+    user?: Record<string, unknown>;
+    id?: string;
+    grants: () => Promise<CallerGrants>;
+  },
   redactions: ReadAccessRedactions,
   restoredByRow: RestoredByRow
 ): Promise<void> {
@@ -500,10 +568,13 @@ async function applyReadAccessRec(
     if (!fn) continue;
     let allowed = false;
     try {
+      const { permissions, roles } = await ctx.grants();
       allowed = await fn({
         req: { user: ctx.user },
         id: ctx.id,
         data: snapshot,
+        permissions,
+        roles,
       });
     } catch {
       // Fail-secure: an access rule that throws denies the field.
@@ -580,6 +651,12 @@ export async function applyFieldReadAccess(
     {
       user: opts.user,
       id: typeof opts.entry.id === "string" ? opts.entry.id : undefined,
+      // An unauthenticated read still runs the rules — this path, unlike the
+      // write one, does not bail without a user — so the resolver is handed the
+      // same absent id and answers with no grants rather than not being called.
+      grants: grantsResolver(
+        typeof opts.user?.id === "string" ? opts.user.id : undefined
+      ),
     },
     store,
     restoredByRow

--- a/packages/plugin-page-builder/src/collections/pages.test.ts
+++ b/packages/plugin-page-builder/src/collections/pages.test.ts
@@ -1,0 +1,77 @@
+/**
+ * The `pages` collection gates custom CSS on a permission.
+ *
+ * The rule and the declared permission are two halves of one thing: a rule
+ * reading a string nothing seeds denies forever, and a permission nothing reads
+ * grants nothing. Both are asserted here against the SAME exported constants,
+ * so the pair cannot drift.
+ */
+import { describe, expect, it } from "vitest";
+
+import { pageBuilder } from "../plugin";
+import {
+  CUSTOM_CSS_ACTION,
+  CUSTOM_CSS_GRANT,
+  CUSTOM_CSS_RESOURCE,
+} from "../permissions";
+
+import { PAGE_BUILDER_CUSTOM_CSS_FIELD } from "./pageBuilderEntry";
+import { pagesCollection } from "./pages";
+
+type AccessArgs = { permissions: string[] };
+type FieldWithAccess = {
+  name?: string;
+  access?: {
+    create?: (a: AccessArgs) => boolean;
+    read?: unknown;
+    update?: (a: AccessArgs) => boolean;
+  };
+};
+
+const cssField = (): FieldWithAccess => {
+  const field = (pagesCollection().fields as FieldWithAccess[]).find(
+    f => f.name === PAGE_BUILDER_CUSTOM_CSS_FIELD
+  );
+  if (!field) throw new Error("customCss field missing from pages");
+  return field;
+};
+
+describe("pages custom CSS permission", () => {
+  it("allows the write only with the grant", () => {
+    const { access } = cssField();
+    expect(access?.update?.({ permissions: [CUSTOM_CSS_GRANT] })).toBe(true);
+    expect(access?.create?.({ permissions: [CUSTOM_CSS_GRANT] })).toBe(true);
+    expect(access?.update?.({ permissions: [] })).toBe(false);
+    // A near miss must not pass: `pages:update` lets someone edit the page and
+    // is exactly what a user without this privilege already holds.
+    expect(access?.update?.({ permissions: ["pages:update"] })).toBe(false);
+  });
+
+  it("does not gate reading it", () => {
+    // Withholding the grant makes the field read-only, not invisible. Hiding
+    // it would show an empty editor over stored CSS and invite overwriting it.
+    expect(cssField().access?.read).toBeUndefined();
+  });
+
+  it("declares the permission the rule reads", () => {
+    const declared = pageBuilder().contributes?.permissions ?? [];
+    const match = declared.find(
+      p => p.action === CUSTOM_CSS_ACTION && p.resource === CUSTOM_CSS_RESOURCE
+    );
+    expect(match).toBeDefined();
+    // Author-written CSS reaching the published page is worth a warning.
+    expect(match?.danger).toBe(true);
+  });
+
+  it("spells the grant the way an access rule receives it", () => {
+    // The database and the admin matrix use `action-resource` for this same
+    // row. A rule written with that spelling matches nothing and denies
+    // silently, which is the whole reason the constant exists.
+    expect(CUSTOM_CSS_GRANT).toBe(
+      `${CUSTOM_CSS_RESOURCE}:${CUSTOM_CSS_ACTION}`
+    );
+    expect(CUSTOM_CSS_GRANT).not.toBe(
+      `${CUSTOM_CSS_ACTION}-${CUSTOM_CSS_RESOURCE}`
+    );
+  });
+});

--- a/packages/plugin-page-builder/src/collections/pages.ts
+++ b/packages/plugin-page-builder/src/collections/pages.ts
@@ -1,5 +1,7 @@
 import { defineCollection, text, code } from "nextly/config";
 
+import { CUSTOM_CSS_GRANT } from "../permissions";
+
 import { editorChoiceFields } from "./editorChoice";
 import { PAGE_BUILDER_CUSTOM_CSS_FIELD } from "./pageBuilderEntry";
 
@@ -27,7 +29,23 @@ export function pagesCollection() {
       text({ name: "slug", required: true, unique: true }),
       // The Elementor-style editor choice (select + Page Builder + normal rich text).
       ...editorChoiceFields(),
-      code({ name: PAGE_BUILDER_CUSTOM_CSS_FIELD, admin: { language: "css" } }),
+      code({
+        name: PAGE_BUILDER_CUSTOM_CSS_FIELD,
+        admin: { language: "css" },
+        // Writing custom CSS is gated; reading it is not. A user who may edit
+        // the page still needs to SEE the CSS already on it — the editor shows
+        // it, and hiding it would make the field look empty and invite it being
+        // overwritten with nothing. Withholding the grant makes it read-only,
+        // which is the intended shape of the privilege.
+        //
+        // A denied field is stripped from the write silently rather than
+        // rejected, so a user without the grant saves the rest of the page
+        // normally and the stored CSS is left as it was.
+        access: {
+          create: ({ permissions }) => permissions.includes(CUSTOM_CSS_GRANT),
+          update: ({ permissions }) => permissions.includes(CUSTOM_CSS_GRANT),
+        },
+      }),
     ],
     status: true,
     admin: { useAsTitle: "title" },

--- a/packages/plugin-page-builder/src/permissions.ts
+++ b/packages/plugin-page-builder/src/permissions.ts
@@ -1,15 +1,11 @@
 /**
  * The permissions this plugin declares, and the strings its rules read.
  *
- * One permission, not a vocabulary. A `publish` permission was declared here
- * once and nothing ever read it: granting it did nothing and withholding it
- * prevented nothing, so it was removed with the instruction to declare it again
- * alongside the check. That rule holds for every name the page-builder plans
- * eventually need — classes, tokens, patterns, components — so each arrives
- * with the surface that enforces it rather than ahead of it.
- *
- * Custom CSS is the one that has a surface today: the `pages` collection
- * carries a `customCss` field, so there is somewhere for a check to live.
+ * One permission, not a vocabulary. A permission is only worth declaring where
+ * something reads it: one that no check consults grants nothing when held and
+ * prevents nothing when withheld, while still appearing in the admin's matrix
+ * as though it protected something. Custom CSS has a check to attach to — the
+ * `pages` collection carries a `customCss` field — so it is declared here.
  *
  * @module permissions
  */

--- a/packages/plugin-page-builder/src/permissions.ts
+++ b/packages/plugin-page-builder/src/permissions.ts
@@ -1,0 +1,39 @@
+/**
+ * The permissions this plugin declares, and the strings its rules read.
+ *
+ * One permission, not a vocabulary. A `publish` permission was declared here
+ * once and nothing ever read it: granting it did nothing and withholding it
+ * prevented nothing, so it was removed with the instruction to declare it again
+ * alongside the check. That rule holds for every name the page-builder plans
+ * eventually need — classes, tokens, patterns, components — so each arrives
+ * with the surface that enforces it rather than ahead of it.
+ *
+ * Custom CSS is the one that has a surface today: the `pages` collection
+ * carries a `customCss` field, so there is somewhere for a check to live.
+ *
+ * @module permissions
+ */
+
+/**
+ * Custom CSS is a privilege, not an ordinary field.
+ *
+ * It is author-written CSS that reaches the published page. The compiler
+ * refuses a remote `url()` by default, but a site that has declared
+ * `remotePatterns` for its images has declared them for this too — and a
+ * selector can make such a request conditional, so what loads can be made to
+ * depend on what a page contains. It also styles a surface other people read.
+ * Neither is a reason to forbid it; both are reasons for it to be granted.
+ */
+export const CUSTOM_CSS_ACTION = "write";
+export const CUSTOM_CSS_RESOURCE = "builder-custom-css";
+
+/**
+ * The permission as an access RULE reads it: `resource:action`.
+ *
+ * Deliberately not spelled by hand at the call site. The database and the
+ * admin's permission matrix use `action-resource` for the same row, and the two
+ * are easy to confuse — a rule written with the database spelling silently
+ * matches nothing and denies. One exported constant means the rule and the
+ * declaration cannot drift apart.
+ */
+export const CUSTOM_CSS_GRANT = `${CUSTOM_CSS_RESOURCE}:${CUSTOM_CSS_ACTION}`;

--- a/packages/plugin-page-builder/src/plugin.ts
+++ b/packages/plugin-page-builder/src/plugin.ts
@@ -112,9 +112,9 @@ export const pageBuilder = (opts: PageBuilderOptions = {}) =>
       // could publish. Granting it did nothing and withholding it prevented
       // nothing. Declare it again alongside the check that reads it.
       //
-      // Custom CSS follows that rule rather than breaking it: the permission
-      // below ships WITH the field rule in `pagesCollection()` that reads it,
-      // so granting and withholding both do something the day it lands.
+      // The permission below is read by the `customCss` field rule in
+      // `pagesCollection()`, so granting and withholding it each change what a
+      // user can do.
       permissions: [
         {
           action: CUSTOM_CSS_ACTION,

--- a/packages/plugin-page-builder/src/plugin.ts
+++ b/packages/plugin-page-builder/src/plugin.ts
@@ -18,6 +18,7 @@ import { PAGE_BUILDER_FIELD_TYPE } from "./collections/pageBuilderEntry";
 import { pagesCollection } from "./collections/pages";
 import type { RemotePattern } from "./core/url-policy";
 import { BLOCKS_FIELD_TYPE } from "./fields/blocksField";
+import { CUSTOM_CSS_ACTION, CUSTOM_CSS_RESOURCE } from "./permissions";
 
 export interface PageBuilderOptions {
   /** Disable behavior while still applying schema. Default true. */
@@ -110,6 +111,27 @@ export const pageBuilder = (opts: PageBuilderOptions = {}) =>
       // `update-pages` already covers, and no code path asked whether the user
       // could publish. Granting it did nothing and withholding it prevented
       // nothing. Declare it again alongside the check that reads it.
+      //
+      // Custom CSS follows that rule rather than breaking it: the permission
+      // below ships WITH the field rule in `pagesCollection()` that reads it,
+      // so granting and withholding both do something the day it lands.
+      permissions: [
+        {
+          action: CUSTOM_CSS_ACTION,
+          resource: CUSTOM_CSS_RESOURCE,
+          label: "Write custom CSS",
+          description:
+            "Author per-page and per-block custom CSS in the page builder. Without it the CSS already on a page stays visible and applied, but cannot be changed.",
+          // No `group`: the admin files this under the plugin that declared it,
+          // and one permission does not need sorting into headings.
+          //
+          // `danger` because it is author-written CSS that reaches the
+          // published page. A site that declared `remotePatterns` for its
+          // images declared them for this too, and a selector can make such a
+          // request conditional on what a page contains.
+          danger: true,
+        },
+      ],
       admin: {
         // The canvas needs the allowlist and runs in the browser, so it
         // travels with the rest of the admin metadata. `remotePatterns` is


### PR DESCRIPTION
Page-builder foundation **F9**, built on what the research actually found rather than on the master plan's sketch.

## The blocker F9 was really sitting behind

The master plan lists F9 as a vocabulary: `builder:classes:create`, `builder:tokens:edit`, and so on. Three things made that impossible to build as written.

**1. The plugin already deleted a permission exactly like this**, and left the rule in the source:

> *"One was declared here and nothing ever read it… Granting it did nothing and withholding it prevented nothing. **Declare it again alongside the check that reads it.**"*

Four of the five names have no surface to gate — classes, tokens, patterns and components are Phase 4 UIs. Declaring them now would re-add the dead permission that was removed.

**2. Those names cannot be permission slugs.** Slugs are `${action}-${resource}` split on the first hyphen, so an action cannot contain one. Colons would be a second slug grammar.

**3. Field-level access could not check a permission at all.** `AccessFunction` received only `{ req, id, data }`, where `req.user` is `{id, email, role, roles}`. Collection-level `AccessControlFunction` already received `permissions: string[]`. So the one builder surface that exists today — the `customCss` field — had no way to be gated.

**(3) is the actual foundation work**, and it is what this PR does.

## What changed

`AccessFunction` now receives `permissions` and `roles`.

```ts
code({
  name: "customCss",
  access: {
    update: ({ permissions }) => permissions.includes(CUSTOM_CSS_GRANT),
  },
})
```

Any plugin can now gate any field on a permission. Design points:

- **Resolved lazily, memoized per operation.** Field access runs on every authenticated read and write, and most entities declare no rule. Zero lookups when no rule runs; exactly one when three rules ask. Both are tests.
- **Fails closed.** An unreadable grant set is empty, so a rule that asks for a permission denies. Tested.
- **One spelling.** `permissions` uses `resource:action`, the same string collection-level access already receives, rather than inventing a third form.

## The first real gate

`write-builder-custom-css`, declared **with** the rule that reads it. Custom CSS is a privilege per PB-D6: it is author-written CSS reaching the published page, and a site that declared `remotePatterns` for images declared them for this too, where a selector can make a request conditional on what a page contains. Marked `danger`.

**Reading is deliberately not gated** — a user who may edit the page still has to see the CSS on it, or the editor shows an empty box over stored CSS and invites overwriting it. Withholding the grant makes it read-only, which is the intended shape.

## Behaviour change

Custom CSS now needs the grant. Existing roles do not have it, so **grant `write-builder-custom-css` to any role that should keep authoring custom CSS**. Denied writes are stripped silently rather than rejected, so the rest of the page saves normally and stored CSS is untouched.

## Verification

323 core `shared/` + 558 plugin tests pass; lint and types clean on both packages.

Five stub-verifications, each breaking exactly one test: permissions withheld from rules; memoization removed; resolution made eager; fail-open on lookup error; the field gate deleted.

## Not in this PR

The other four builder permissions land with the Phase 4 surfaces that enforce them — following the rule the codebase already wrote down, rather than declaring them ahead of anything reading them.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added permission- and role-aware field access controls.
  * Added permission gating for page-builder custom CSS: authorized users can create or update CSS, while others can still view it.
  * Added a declared custom CSS write permission for administrators.

* **Bug Fixes**
  * Protected fields are now omitted when access checks fail or permission information cannot be retrieved.
  * Unrelated page updates continue successfully when custom CSS write access is denied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->