### PR TITLE
fix(nextly): give an exact-decimal number field an exact column

### DIFF
--- a/.changeset/exact-decimal-collection-column.md
+++ b/.changeset/exact-decimal-collection-column.md
@@ -1,0 +1,26 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+A number field declared as an exact decimal now reaches an exact decimal column in a collection or single, on every database and whether the field is created with its table or added to an existing one. It previously became a whole-number column, so any amount with a fractional part lost it.

--- a/.changeset/exact-decimal-collection-column.md
+++ b/.changeset/exact-decimal-collection-column.md
@@ -23,4 +23,4 @@
 "@nextlyhq/tsconfig": patch
 ---
 
-A number field declared as an exact decimal now reaches an exact decimal column in a collection or single, on every database and whether the field is created with its table or added to an existing one. It previously became a whole-number column, so any amount with a fractional part lost it.
+A number field declared as an exact decimal now reaches a decimal column in a collection or single, whether the field is created with its table or added to an existing one. It previously became a whole-number column, so any amount with a fractional part lost it. Storage is exact on PostgreSQL and MySQL; on SQLite the column carries NUMERIC affinity, which is the closest that engine offers rather than a guarantee of exactness.

--- a/packages/nextly/src/domains/dynamic-collections/services/__tests__/collection-number-storage.test.ts
+++ b/packages/nextly/src/domains/dynamic-collections/services/__tests__/collection-number-storage.test.ts
@@ -366,3 +366,49 @@ describe("an ALTER changes only what actually changed", () => {
     expect(sql.toLowerCase()).toContain("numeric(12, 4)");
   });
 });
+
+/**
+ * Toggling requiredness is not a change of storage.
+ *
+ * The descriptor derives `nullable` from `required`, so comparing it as part of the column's SHAPE
+ * makes a requiredness toggle claim the type changed. On MySQL that rewrites the column through
+ * `MODIFY COLUMN` with the descriptor's type — the same truncation an index toggle caused, reached
+ * through a different edit, and on a table where nothing about the storage was touched.
+ */
+describe("requiredness alone does not rewrite a column's type", () => {
+  const alter = (
+    dialect: Dialect,
+    before: FieldDefinition,
+    after: FieldDefinition
+  ): string =>
+    new DynamicCollectionSchemaService(
+      undefined,
+      dialect
+    ).generateAlterTableMigration(TABLE, [before], [after], {
+      tableHasRows: false,
+    });
+
+  const sel = (extra: Record<string, unknown> = {}): FieldDefinition =>
+    ({
+      name: "category",
+      type: "select",
+      options: { options: [{ label: "One", value: "one" }] },
+      ...extra,
+    }) as unknown as FieldDefinition;
+
+  it("changes only the nullability — mysql", () => {
+    const sql = alter("mysql", sel(), sel({ required: true }));
+
+    // MySQL carries nullability in MODIFY, so the statement is expected — what must not appear is a
+    // type that differs from the column the generator created.
+    expect(sql).toMatch(/MODIFY COLUMN `category`[^;]*NOT NULL/i);
+    expect(sql).not.toMatch(/varchar\(255\)/i);
+  });
+
+  it("changes only the nullability — postgresql", () => {
+    const sql = alter("postgresql", sel(), sel({ required: true }));
+
+    expect(sql).toMatch(/ALTER COLUMN "category" SET NOT NULL/i);
+    expect(sql).not.toMatch(/ALTER COLUMN "category" TYPE/i);
+  });
+});

--- a/packages/nextly/src/domains/dynamic-collections/services/__tests__/collection-number-storage.test.ts
+++ b/packages/nextly/src/domains/dynamic-collections/services/__tests__/collection-number-storage.test.ts
@@ -9,14 +9,24 @@
 // table is created and the wrong one when it is added to a table that already exists, and the column
 // that results is the one the runtime has to read through.
 
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 
 import type { FieldDefinition } from "../../../../schemas/dynamic-collections";
+import {
+  clearFieldTypes,
+  registerFieldType,
+} from "../../../schema/field-types/field-type-registry";
 import { DynamicCollectionSchemaService } from "../dynamic-collection-schema-service";
 
 type Dialect = "postgresql" | "mysql" | "sqlite";
 
 const TABLE = "dc_number_storage";
+
+// A registered type leaks into every later file in the run, and this one deliberately registers a
+// number-storage type that would change what other suites measure.
+afterEach(() => {
+  clearFieldTypes();
+});
 
 function createdColumn(dialect: Dialect, field: FieldDefinition): string {
   const sql = new DynamicCollectionSchemaService(
@@ -237,5 +247,122 @@ describe("changing a number's storage on an existing table", () => {
     expect(alter("postgresql", whole("amount"), whole("amount"))).not.toMatch(
       /ALTER COLUMN "amount" TYPE/i
     );
+  });
+});
+
+/**
+ * What an ALTER must NOT do.
+ *
+ * `isFieldModified` answers true for an index or a unique constraint as well as for a change of
+ * storage, and those are not the same question. Rewriting the column type for an index toggle is not
+ * a harmless no-op, because the type written is the DESCRIPTOR's and the descriptor does not yet
+ * agree with the generator that created the column: a Builder `select` is created as unbounded
+ * `text`, so re-rendering it as `varchar(255)` truncates every stored value past 255 characters —
+ * for an edit that never touched its storage.
+ *
+ * MySQL adds a second way to lose data silently: `MODIFY COLUMN` restates the WHOLE definition, so
+ * anything omitted is dropped. Nullability and the default both have to travel with the type.
+ */
+describe("an ALTER changes only what actually changed", () => {
+  const alter = (
+    dialect: Dialect,
+    before: FieldDefinition,
+    after: FieldDefinition
+  ): string =>
+    new DynamicCollectionSchemaService(
+      undefined,
+      dialect
+    ).generateAlterTableMigration(TABLE, [before], [after], {
+      tableHasRows: false,
+    });
+
+  const select = (extra: Record<string, unknown> = {}): FieldDefinition =>
+    ({
+      name: "category",
+      type: "select",
+      options: { options: [{ label: "One", value: "one" }] },
+      ...extra,
+    }) as unknown as FieldDefinition;
+
+  it.each<[Dialect, RegExp]>([
+    ["mysql", /MODIFY COLUMN/i],
+    ["postgresql", /ALTER COLUMN "category" TYPE/i],
+  ])(
+    "does not rewrite a column's type when only its index changed — %s",
+    (dialect, rewrite) => {
+      const sql = alter(dialect, select(), select({ index: true }));
+
+      // The index itself still gets created; it is the TYPE rewrite that must not happen.
+      expect(sql).toMatch(/CREATE INDEX/i);
+      expect(sql).not.toMatch(rewrite);
+    }
+  );
+
+  it("keeps a default when modifying a column — mysql", () => {
+    const before = {
+      name: "amount",
+      type: "number",
+      default: 0,
+    } as unknown as FieldDefinition;
+    const after = {
+      name: "amount",
+      type: "number",
+      dbType: "decimal",
+      precision: 12,
+      scale: 4,
+      default: 0,
+    } as unknown as FieldDefinition;
+
+    const sql = alter("mysql", before, after);
+
+    expect(sql).toMatch(/MODIFY COLUMN `amount`/i);
+    // Omitted, MySQL drops the default the create path emitted, and later inserts that leave the
+    // field out write NULL or fail outright on a required column.
+    expect(sql).toMatch(/MODIFY COLUMN `amount`[^;]*DEFAULT 0/i);
+  });
+
+  it("ignores decimal properties on a field that is not the built-in number", () => {
+    // A plugin type persists as the `number` storage primitive, but `dbType`/`precision`/`scale` are
+    // the built-in number field's vocabulary. Honouring them here would give the plugin a decimal
+    // column while the descriptor still describes an integer, and would route around the dimension
+    // validation, which only inspects fields whose declared type IS `number`.
+    //
+    // 🔴 The type is REGISTERED, and that is the whole precondition. An unregistered type resolves
+    // to nothing, falls through to `text`, and satisfies both assertions below without the guard
+    // ever running — a test that passes for a reason unrelated to what it claims to prove.
+    registerFieldType({
+      type: "star-rating",
+      storage: "number",
+      component: "@acme/ratings/admin#StarRating",
+      surfaces: ["entries"],
+    });
+
+    const plugin = {
+      name: "rating",
+      type: "star-rating",
+      dbType: "decimal",
+      precision: 12,
+      scale: 4,
+    } as unknown as FieldDefinition;
+
+    const sql = new DynamicCollectionSchemaService(
+      undefined,
+      "postgresql"
+    ).generateMigrationSQL(TABLE, [plugin], {});
+
+    // Reaching the number branch at all is the precondition: an unresolved type would be `text`.
+    expect(sql.toLowerCase()).toContain("integer");
+    expect(sql.toLowerCase()).not.toContain("numeric(12, 4)");
+  });
+
+  it("still honours decimal properties on the built-in number", () => {
+    // The positive control for the guard above. Without it, dropping decimal support entirely would
+    // satisfy that case while breaking every real money field.
+    const sql = new DynamicCollectionSchemaService(
+      undefined,
+      "postgresql"
+    ).generateMigrationSQL(TABLE, [money("price")], {});
+
+    expect(sql.toLowerCase()).toContain("numeric(12, 4)");
   });
 });

--- a/packages/nextly/src/domains/dynamic-collections/services/__tests__/collection-number-storage.test.ts
+++ b/packages/nextly/src/domains/dynamic-collections/services/__tests__/collection-number-storage.test.ts
@@ -97,3 +97,65 @@ describe("a number field's storage", () => {
     expect(createdColumn("postgresql", field)).toContain("numeric(10, 2)");
   });
 });
+
+describe("an edit that changes a number's storage", () => {
+  const svc = (d: Dialect = "postgresql") =>
+    new DynamicCollectionSchemaService(undefined, d);
+
+  const plain = { name: "price", type: "number" } as unknown as FieldDefinition;
+
+  // The defect: the modification check listed the properties it compared, and none of the four that
+  // decide a number's storage were on that list. A field switched to exact decimal therefore
+  // produced no ALTER, so the registry described a decimal over an integer column.
+  it("notices a field switched to an exact decimal", () => {
+    expect(svc().isFieldModified(plain, money("price"))).toBe(true);
+  });
+
+  it("notices a precision change on a field that is already decimal", () => {
+    const before = {
+      name: "price",
+      type: "number",
+      dbType: "decimal",
+      precision: 10,
+      scale: 2,
+    } as unknown as FieldDefinition;
+
+    expect(svc().isFieldModified(before, money("price"))).toBe(true);
+  });
+
+  // Stated so the cases above cannot be satisfied by reporting every field as modified, which would
+  // rewrite columns on every save.
+  it("still reports an unchanged field as unchanged", () => {
+    expect(svc().isFieldModified(plain, { ...plain })).toBe(false);
+    expect(svc().isFieldModified(money("price"), money("price"))).toBe(false);
+  });
+});
+
+describe("decimal dimensions that cannot safely become SQL", () => {
+  // These arrive from a request payload on the Builder path, which validates names and plugin
+  // options but not these. Unchecked, the value is interpolated into the type verbatim.
+  const generate = (field: FieldDefinition): string =>
+    new DynamicCollectionSchemaService(
+      undefined,
+      "postgresql"
+    ).generateMigrationSQL(TABLE, [field], {});
+
+  it.each([
+    ["a non-integer precision", { precision: 2.5, scale: 1 }],
+    ["a scale larger than the precision", { precision: 2, scale: 8 }],
+    ["a precision out of range", { precision: 0, scale: 0 }],
+  ])("refuses %s", (_label, dims) => {
+    const field = {
+      name: "price",
+      type: "number",
+      dbType: "decimal",
+      ...dims,
+    } as unknown as FieldDefinition;
+
+    expect(() => generate(field)).toThrow();
+  });
+
+  it("accepts dimensions that are usable", () => {
+    expect(() => generate(money("price"))).not.toThrow();
+  });
+});

--- a/packages/nextly/src/domains/dynamic-collections/services/__tests__/collection-number-storage.test.ts
+++ b/packages/nextly/src/domains/dynamic-collections/services/__tests__/collection-number-storage.test.ts
@@ -1,0 +1,99 @@
+// What column a number field reaches, for each of the three ways one can ask.
+//
+// A number is not one column. `dbType: "decimal"` asks for EXACT fixed point, which is what a price
+// needs: a whole-number column silently discards the fraction entirely. `options.format === "float"`
+// asks for an ordinary fractional number. Silence asks for whole numbers.
+//
+// Pinned per dialect because the storage differs per dialect, and pinned on BOTH the create path and
+// the ADD COLUMN path because those are separate code: a field can reach the right column when its
+// table is created and the wrong one when it is added to a table that already exists, and the column
+// that results is the one the runtime has to read through.
+
+import { describe, expect, it } from "vitest";
+
+import type { FieldDefinition } from "../../../../schemas/dynamic-collections";
+import { DynamicCollectionSchemaService } from "../dynamic-collection-schema-service";
+
+type Dialect = "postgresql" | "mysql" | "sqlite";
+
+const TABLE = "dc_number_storage";
+
+function createdColumn(dialect: Dialect, field: FieldDefinition): string {
+  const sql = new DynamicCollectionSchemaService(
+    undefined,
+    dialect
+  ).generateMigrationSQL(TABLE, [field], {});
+  const line = sql
+    .split("\n")
+    .find(
+      l => l.includes(`"${field.name}"`) || l.includes(`\`${field.name}\``)
+    );
+  return (line ?? "").trim();
+}
+
+function addedColumn(dialect: Dialect, field: FieldDefinition): string {
+  const sql = new DynamicCollectionSchemaService(
+    undefined,
+    dialect
+  ).generateAlterTableMigration(TABLE, [], [field], { tableHasRows: false });
+  const line = sql.split("\n").find(l => /ADD COLUMN/i.test(l));
+  return (line ?? "").trim();
+}
+
+const money = (name: string): FieldDefinition =>
+  ({
+    name,
+    type: "number",
+    dbType: "decimal",
+    precision: 12,
+    scale: 4,
+  }) as unknown as FieldDefinition;
+
+describe("a number field's storage", () => {
+  // The defect this pins: `dbType` was never read on this path, so a price column was created as a
+  // whole number and every fractional amount written to it was lost.
+  it.each([
+    ["postgresql", "numeric(12, 4)"],
+    ["mysql", "decimal(12,4)"],
+    ["sqlite", "numeric"],
+  ] as const)(
+    "gives an exact-decimal field an exact column on %s",
+    (dialect, expected) => {
+      expect(createdColumn(dialect, money("price"))).toContain(expected);
+    }
+  );
+
+  it.each([
+    ["postgresql", "numeric(12, 4)"],
+    ["mysql", "decimal(12,4)"],
+    ["sqlite", "numeric"],
+  ] as const)(
+    "gives it the same column when it is ADDED to an existing table on %s",
+    (dialect, expected) => {
+      expect(addedColumn(dialect, money("price"))).toContain(expected);
+    }
+  );
+
+  // Stated so the exact cases above cannot be satisfied by making every number a decimal.
+  it("still gives a plain number a whole-number column", () => {
+    const field = {
+      name: "views",
+      type: "number",
+    } as unknown as FieldDefinition;
+
+    expect(createdColumn("postgresql", field)).toContain("integer");
+    expect(createdColumn("postgresql", field)).not.toContain("numeric");
+  });
+
+  // `precision` and `scale` are what let the column hold the values the field promises, so a default
+  // that silently ignored them would pass every assertion above that names no dimensions.
+  it("defaults an exact-decimal field that states no dimensions", () => {
+    const field = {
+      name: "amount",
+      type: "number",
+      dbType: "decimal",
+    } as unknown as FieldDefinition;
+
+    expect(createdColumn("postgresql", field)).toContain("numeric(10, 2)");
+  });
+});

--- a/packages/nextly/src/domains/dynamic-collections/services/__tests__/collection-number-storage.test.ts
+++ b/packages/nextly/src/domains/dynamic-collections/services/__tests__/collection-number-storage.test.ts
@@ -159,3 +159,83 @@ describe("decimal dimensions that cannot safely become SQL", () => {
     expect(() => generate(money("price"))).not.toThrow();
   });
 });
+
+/**
+ * The statement that CHANGES an existing column, which is a third path with its own answer.
+ *
+ * Detecting that a column must change and rendering what it becomes are two questions, and they were
+ * answered by different code: the comparison reads the descriptor, while the ALTER re-derived the
+ * type from a call that dropped `options` and `validation` on the way. A number switched to a
+ * fractional format was therefore correctly detected and then rewritten as a whole-number column.
+ *
+ * The statement's SHAPE is dialect-specific too. `ALTER COLUMN … TYPE` is PostgreSQL; MySQL spells it
+ * `MODIFY COLUMN` and restates the whole definition, so a column's NOT NULL has to travel with the
+ * type or the change quietly makes it nullable.
+ */
+describe("changing a number's storage on an existing table", () => {
+  const alter = (
+    dialect: Dialect,
+    before: FieldDefinition,
+    after: FieldDefinition
+  ): string =>
+    new DynamicCollectionSchemaService(
+      undefined,
+      dialect
+    ).generateAlterTableMigration(TABLE, [before], [after], {
+      tableHasRows: false,
+    });
+
+  const whole = (name: string): FieldDefinition =>
+    ({ name, type: "number" }) as unknown as FieldDefinition;
+
+  const float = (name: string): FieldDefinition =>
+    ({
+      name,
+      type: "number",
+      options: { format: "float" },
+    }) as unknown as FieldDefinition;
+
+  it("renders the fractional type it detected, not a whole-number one — postgresql", () => {
+    const sql = alter("postgresql", whole("amount"), float("amount"));
+
+    // The defect was silent: the ALTER ran, reported success, and left an integer column while the
+    // field metadata said float. Naming the wrong type keeps the failure legible.
+    expect(sql).not.toMatch(/TYPE\s+integer/i);
+    // `float8`, which is the DESCRIPTOR's answer for a fractional number on PostgreSQL. The old
+    // generator spelled it `decimal(10,2)`; taking the descriptor's is the point, because it is the
+    // column the runtime table and the diff both read through.
+    expect(sql).toMatch(/ALTER COLUMN "amount" TYPE float8/i);
+    // PostgreSQL refuses most cross-family changes without it, so its absence turned a migration
+    // that generated cleanly into one that failed at apply time.
+    expect(sql).toMatch(/USING "amount"::float8/i);
+  });
+
+  it("uses MODIFY COLUMN and keeps the column's nullability — mysql", () => {
+    const before = { ...whole("amount"), required: true } as FieldDefinition;
+    const after = { ...float("amount"), required: true } as FieldDefinition;
+    const sql = alter("mysql", before, after);
+
+    // PostgreSQL's spelling is a syntax error on MySQL, so the update failed before the type was
+    // ever applied.
+    expect(sql).not.toMatch(/ALTER COLUMN/i);
+    expect(sql).toMatch(/MODIFY COLUMN `amount`/i);
+    // MySQL's MODIFY replaces the definition. Without this the column silently becomes nullable.
+    expect(sql).toMatch(/MODIFY COLUMN `amount`[^;]*NOT NULL/i);
+  });
+
+  it("carries exact decimals through the change too — mysql", () => {
+    const sql = alter("mysql", whole("price"), money("price"));
+
+    // The dimensions `money` declares — 12 and 4 — not a fixed pair, so a change to the shared
+    // fixture cannot leave this asserting something the fixture no longer produces.
+    expect(sql).toMatch(/MODIFY COLUMN `price` decimal\(12,\s*4\)/i);
+  });
+
+  it("emits nothing when the storage did not change", () => {
+    // The positive control. A rule that emitted an ALTER for every field would satisfy all three
+    // cases above while rewriting every column on every save.
+    expect(alter("postgresql", whole("amount"), whole("amount"))).not.toMatch(
+      /ALTER COLUMN "amount" TYPE/i
+    );
+  });
+});

--- a/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-schema-service.ts
+++ b/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-schema-service.ts
@@ -1039,11 +1039,14 @@ ${allColumnDefs.join(",\n")}
           // with the generator that created the column. Enabling an index on a Builder `select`
           // would move it from the unbounded `text` it was created as to `varchar(255)`, truncating
           // every stored value past 255 characters — for an edit that never touched its storage.
+          // Nullability is deliberately NOT part of this. The descriptor derives `nullable` from
+          // `required`, so including it would make a requiredness toggle claim the column's TYPE
+          // changed and rewrite it — the same truncation the index case caused, reached through a
+          // different edit. It is tracked on its own below, where it belongs.
           const columnChanged =
             !before || !described
               ? before !== described
               : before.dialectType !== described.dialectType ||
-                before.nullable !== described.nullable ||
                 before.kind !== described.kind ||
                 before.name !== described.name;
           const nullabilityChanged = field.required !== oldField.required;
@@ -1061,8 +1064,27 @@ ${allColumnDefs.join(",\n")}
                 field.default !== undefined && field.default !== null
                   ? ` DEFAULT ${this.formatDefaultValue(field.default, field.type)}`
                   : "";
+              // 🔴 Which type a MODIFY restates depends on WHY it is being issued, and getting this
+              // wrong rewrites a column nobody asked to change.
+              //
+              // Changing the storage means asking for the descriptor's answer. Changing only the
+              // nullability means preserving what the column already is — and what it already is,
+              // for a table this service built, is what THIS generator renders. Restating the
+              // descriptor's answer instead would move a `select` created as unbounded `text` to
+              // `varchar(255)` and truncate stored values, for an edit that touched nothing but a
+              // required flag. MySQL leaves no third option: the type has to be restated or the
+              // column definition is lost.
+              const restated = columnChanged
+                ? type
+                : this.mapFieldTypeToSQL(
+                    field.type,
+                    field.length,
+                    field.options,
+                    field.validation,
+                    field
+                  );
               statements.push(
-                `ALTER TABLE ${this.quoteIdentifier(tableName)} MODIFY COLUMN ${this.quoteIdentifier(alterCol)} ${type}${nullability}${defaultClause};`
+                `ALTER TABLE ${this.quoteIdentifier(tableName)} MODIFY COLUMN ${this.quoteIdentifier(alterCol)} ${restated}${nullability}${defaultClause};`
               );
             }
           } else if (!columnChanged) {

--- a/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-schema-service.ts
+++ b/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-schema-service.ts
@@ -1011,6 +1011,11 @@ ${allColumnDefs.join(",\n")}
           // be judged modified by one definition and then rewritten by another: this call used to
           // drop `options` and `validation`, so a number switched to `format: "float"` was detected
           // and then re-emitted as `integer`.
+          const before = getColumnDescriptor(
+            oldField,
+            this.dialect,
+            "collection"
+          );
           const described = getColumnDescriptor(
             field,
             this.dialect,
@@ -1026,15 +1031,49 @@ ${allColumnDefs.join(",\n")}
               field
             );
 
+          // 🔴 Whether the COLUMN changed, which is not the same question as whether the FIELD did.
+          //
+          // `isFieldModified` also answers true for an index or a unique constraint, and neither is
+          // a property of the column's shape. Rewriting the type for one of those is not a harmless
+          // no-op: the type written here is the DESCRIPTOR's, and the descriptor does not yet agree
+          // with the generator that created the column. Enabling an index on a Builder `select`
+          // would move it from the unbounded `text` it was created as to `varchar(255)`, truncating
+          // every stored value past 255 characters — for an edit that never touched its storage.
+          const columnChanged =
+            !before || !described
+              ? before !== described
+              : before.dialectType !== described.dialectType ||
+                before.nullable !== described.nullable ||
+                before.kind !== described.kind ||
+                before.name !== described.name;
+          const nullabilityChanged = field.required !== oldField.required;
+
           if (this.dialect === "mysql") {
-            // MySQL restates the WHOLE definition, so nullability travels with the type or the
-            // column silently becomes nullable. That makes it one statement rather than two, and it
-            // is issued whenever the column changes — not only when `required` did — because the
-            // MODIFY would otherwise drop a NOT NULL nobody asked to remove.
-            const nullability = field.required ? " NOT NULL" : " NULL";
-            statements.push(
-              `ALTER TABLE ${this.quoteIdentifier(tableName)} MODIFY COLUMN ${this.quoteIdentifier(alterCol)} ${type}${nullability};`
-            );
+            // MySQL restates the WHOLE definition, so everything the column carries travels with
+            // the type or it is dropped: nullability, and the default the create path emits from
+            // `field.default`. A MODIFY that omits either silently removes it.
+            //
+            // Issued when the column's shape changed OR its nullability did, because on this dialect
+            // one statement carries both.
+            if (columnChanged || nullabilityChanged) {
+              const nullability = field.required ? " NOT NULL" : " NULL";
+              const defaultClause =
+                field.default !== undefined && field.default !== null
+                  ? ` DEFAULT ${this.formatDefaultValue(field.default, field.type)}`
+                  : "";
+              statements.push(
+                `ALTER TABLE ${this.quoteIdentifier(tableName)} MODIFY COLUMN ${this.quoteIdentifier(alterCol)} ${type}${nullability}${defaultClause};`
+              );
+            }
+          } else if (!columnChanged) {
+            // Nothing about the column moved. Nullability is still handled below.
+            if (nullabilityChanged) {
+              statements.push(
+                field.required
+                  ? `ALTER TABLE ${this.quoteIdentifier(tableName)} ALTER COLUMN ${this.quoteIdentifier(alterCol)} SET NOT NULL;`
+                  : `ALTER TABLE ${this.quoteIdentifier(tableName)} ALTER COLUMN ${this.quoteIdentifier(alterCol)} DROP NOT NULL;`
+              );
+            }
           } else {
             // Rendered by the shared template rather than written out here, so this path and
             // `migrate:create` emit the same statement. It also carries the `USING` clause
@@ -1045,16 +1084,14 @@ ${allColumnDefs.join(",\n")}
                   type: "change_column_type",
                   tableName,
                   columnName: alterCol,
-                  fromType:
-                    getColumnDescriptor(oldField, this.dialect, "collection")
-                      ?.dialectType ?? type,
+                  fromType: before?.dialectType ?? type,
                   toType: type,
                 },
                 this.dialect
               )};`
             );
 
-            if (field.required !== oldField.required) {
+            if (nullabilityChanged) {
               if (field.required) {
                 statements.push(
                   `ALTER TABLE ${this.quoteIdentifier(tableName)} ALTER COLUMN ${this.quoteIdentifier(alterCol)} SET NOT NULL;`
@@ -1499,12 +1536,23 @@ ${this.dialect === "mysql" ? "CREATE INDEX" : "CREATE INDEX IF NOT EXISTS"} ${th
     // and the missing-column scan already make.
     const type = storageTypeToken({ type: declaredType }) ?? declaredType;
 
+    // 🔴 Only a field DECLARED as the built-in number states how a number is stored.
+    //
+    // A plugin type resolves to the `number` storage primitive above, but `dbType`, `precision` and
+    // `scale` are the built-in number field's own vocabulary — a plugin's payload carrying them
+    // means something to the plugin, not to this map. Honouring them would give the plugin a decimal
+    // column while `getColumnDescriptor` still describes its storage primitive as an integer, so the
+    // ORM would bind a different shape than the table has and every diff would propose the change
+    // again. It also routes around the dimension validation, which only inspects fields whose type
+    // IS `number` and would never see the values being interpolated here.
+    const storage = declaredType === "number" ? numberStorage : undefined;
+
     if (this.dialect === "sqlite") {
       // SQLite type mapping. SQLite has dynamic typing, so types are simplified.
       const sqliteTypeMap: Record<string, string> = {
         text: "text",
         textarea: "text",
-        number: this.numberColumnType(options, numberStorage),
+        number: this.numberColumnType(options, storage),
         checkbox: "integer", // SQLite uses 0/1 for boolean
         date: "integer", // Store as Unix timestamp
         email: "text",
@@ -1526,7 +1574,7 @@ ${this.dialect === "mysql" ? "CREATE INDEX" : "CREATE INDEX IF NOT EXISTS"} ${th
             ? `varchar(${validation?.maxLength || 255})`
             : "text",
         textarea: "text",
-        number: this.numberColumnType(options, numberStorage),
+        number: this.numberColumnType(options, storage),
         checkbox: "boolean",
         date: "timestamp",
         email: `varchar(${validation?.maxLength || 255})`,
@@ -1547,7 +1595,7 @@ ${this.dialect === "mysql" ? "CREATE INDEX" : "CREATE INDEX IF NOT EXISTS"} ${th
           ? `varchar(${validation?.maxLength || 255})`
           : "text",
       textarea: "text",
-      number: this.numberColumnType(options, numberStorage),
+      number: this.numberColumnType(options, storage),
       checkbox: "boolean",
       date: "timestamp",
       email: `varchar(${validation?.maxLength || 255})`,

--- a/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-schema-service.ts
+++ b/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-schema-service.ts
@@ -24,6 +24,10 @@ import type { FieldDefinition } from "@nextly/schemas/dynamic-collections";
 
 import { NextlyError } from "../../../errors/nextly-error";
 import { STORAGE_FORMAT } from "../../../schemas/storage-format";
+import {
+  validateNumberDecimalDimensionsShared,
+  type BaseValidationError,
+} from "../../../shared/base-validator";
 import { env } from "../../../shared/lib/env";
 import {
   pluginEmptyColumnDefault,
@@ -37,8 +41,6 @@ import {
   getSystemColumnDescriptors,
   renderSystemColumnSql,
   toSnakeCase,
-  DEFAULT_DECIMAL_PRECISION,
-  DEFAULT_DECIMAL_SCALE,
 } from "../../schema/services/field-column-descriptor";
 import {
   columnTypeIsIndexable,
@@ -314,6 +316,9 @@ export class DynamicCollectionSchemaService {
       localized?: boolean;
     }
   ): string {
+    // Refuse an unusable decimal shape before any of it becomes SQL.
+    this.assertDecimalDimensions(fields);
+
     const constraints: string[] = [];
     const checks: string[] = [];
     const junctionTables: string[] = [];
@@ -648,6 +653,9 @@ ${allColumnDefs.join(",\n")}
       indexNames?: ReadonlySet<string>;
     }
   ): string {
+    // The added columns become SQL here too, so the same refusal applies.
+    this.assertDecimalDimensions(newFields);
+
     const statements: string[] = [`-- Update dynamic collection: ${tableName}`];
 
     // Status system column flip (enable / disable Draft/Published). When
@@ -1029,16 +1037,39 @@ ${allColumnDefs.join(",\n")}
   /**
    * Check if a field definition has been modified
    */
+  /**
+   * Whether an edit changes the physical column, and therefore needs an ALTER.
+   *
+   * The column is compared through the descriptor rather than by listing the properties that
+   * happen to affect it. A list is a claim about which properties matter, and it goes stale the
+   * moment a new one is added: `dbType`, `precision`, `scale` and `options.format` all decide a
+   * number's storage and none of them were listed, so changing a field to an exact decimal or
+   * widening its precision produced no ALTER at all — the registry described a decimal while the
+   * column stayed an integer, and every fractional write was still truncated.
+   *
+   * Asking the descriptor makes that class of omission impossible: whatever decides a column today
+   * or later is, by construction, what this compares.
+   *
+   * `unique` and `index` are compared separately because they are not properties of the column's
+   * shape. Two columns can be identical and differ in whether an index covers them.
+   */
   isFieldModified(
     oldField: FieldDefinition,
     newField: FieldDefinition
   ): boolean {
+    if (oldField.unique !== newField.unique) return true;
+    if (oldField.index !== newField.index) return true;
+
+    const before = getColumnDescriptor(oldField, this.dialect, "collection");
+    const after = getColumnDescriptor(newField, this.dialect, "collection");
+    // One producing no column and the other producing one is itself a change of storage class.
+    if (!before || !after) return before !== after;
+
     return (
-      oldField.type !== newField.type ||
-      oldField.length !== newField.length ||
-      oldField.required !== newField.required ||
-      oldField.unique !== newField.unique ||
-      oldField.index !== newField.index
+      before.name !== after.name ||
+      before.dialectType !== after.dialectType ||
+      before.nullable !== after.nullable ||
+      before.kind !== after.kind
     );
   }
 
@@ -1332,9 +1363,15 @@ ${this.dialect === "mysql" ? "CREATE INDEX" : "CREATE INDEX IF NOT EXISTS"} ${th
    * The column a number field reaches, for the dialect this service builds for.
    *
    * Two independent things can ask for fractions and they mean different storage. `dbType:
-   * "decimal"` asks for EXACT fixed point, which is what money needs and what nothing else should
+   * "decimal"` asks for exact fixed point, which is what money needs and what nothing else should
    * use; `options.format === "float"` is the UI's way of asking for an ordinary fractional number.
    * Silence means whole numbers.
+   *
+   * 🔴 "Exact" holds on PostgreSQL and MySQL, which have a real fixed-point type. SQLite has only
+   * NUMERIC affinity: it stores what it can as an exact value and falls back to binary floating
+   * point, and this package reads number columns back as JavaScript numbers either way. The column
+   * is therefore the best storage SQLite offers rather than a guarantee, which is the same caveat
+   * `NumberFieldConfig` already carries.
    *
    * Read here rather than inline in each dialect map because the same three-way answer is needed
    * three times, and a map that answered it per dialect is how one of the three came to be missing
@@ -1345,20 +1382,59 @@ ${this.dialect === "mysql" ? "CREATE INDEX" : "CREATE INDEX IF NOT EXISTS"} ${th
     storage: Pick<FieldDefinition, "dbType" | "precision" | "scale"> | undefined
   ): string {
     if (storage?.dbType === "decimal") {
-      const precision = storage.precision ?? DEFAULT_DECIMAL_PRECISION;
-      const scale = storage.scale ?? DEFAULT_DECIMAL_SCALE;
-      // Rendered the way the column descriptor renders it for each dialect, so a table built here
-      // and the runtime schema that reads it describe one column. SQLite has no sized numeric and
-      // stores the value with full fidelity either way.
-      if (this.dialect === "sqlite") return "numeric";
-      return this.dialect === "mysql"
-        ? `decimal(${precision},${scale})`
-        : `numeric(${precision}, ${scale})`;
+      // 🔴 Asked, not restated. The descriptor owns the decimal defaults and the per-dialect
+      // spelling, and both are read by the runtime table and the schema diff. Copying them here
+      // would be a second source of truth for the very question whose two answers produced this
+      // defect: a later change to a default or a dialect rendering would make a newly created
+      // table disagree with the schema that binds it, silently and only on one path.
+      //
+      // The dimensions are validated before this point, so what reaches the descriptor is a shape
+      // it can render rather than whatever a request happened to carry.
+      const described = getColumnDescriptor(
+        {
+          name: "n",
+          type: "number",
+          dbType: "decimal",
+          precision: storage.precision,
+          scale: storage.scale,
+        },
+        this.dialect,
+        "collection"
+      );
+      if (described) return described.dialectType;
     }
     if (options?.format === "float") {
       return this.dialect === "sqlite" ? "real" : "decimal(10,2)";
     }
     return "integer";
+  }
+
+  /**
+   * Refuse decimal dimensions that cannot safely become part of a type.
+   *
+   * `precision` and `scale` are interpolated into DDL, and on this path they arrive from a request
+   * payload that is only name- and plugin-validated. A value that is not an integer therefore
+   * reaches the template verbatim, which at best renders a migration no engine accepts and at worst
+   * carries whatever the string contains into a statement.
+   *
+   * The same rule the code-first config already enforces, reused rather than restated: the ranges
+   * and the scale-not-greater-than-precision check are one definition, so the Schema Builder cannot
+   * accept a shape `defineCollection` rejects.
+   */
+  private assertDecimalDimensions(fields: FieldDefinition[]): void {
+    const errors: BaseValidationError[] = [];
+    fields.forEach((field, index) => {
+      validateNumberDecimalDimensionsShared(field, `fields[${index}]`, errors);
+    });
+    if (errors.length > 0) {
+      throw NextlyError.validation({
+        errors: errors.map(e => ({
+          path: e.path,
+          code: e.code,
+          message: e.message,
+        })),
+      });
+    }
   }
 
   mapFieldTypeToSQL(

--- a/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-schema-service.ts
+++ b/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-schema-service.ts
@@ -37,6 +37,8 @@ import {
   getSystemColumnDescriptors,
   renderSystemColumnSql,
   toSnakeCase,
+  DEFAULT_DECIMAL_PRECISION,
+  DEFAULT_DECIMAL_SCALE,
 } from "../../schema/services/field-column-descriptor";
 import {
   columnTypeIsIndexable,
@@ -342,7 +344,7 @@ export class DynamicCollectionSchemaService {
 
         const type =
           this.canonicalSlugType(f) ??
-          this.mapFieldTypeToSQL(f.type, f.length, f.options, f.validation);
+          this.mapFieldTypeToSQL(f.type, f.length, f.options, f.validation, f);
         const nullable = f.required ? "NOT NULL" : "";
 
         const unique = this.columnIsUnique(f) ? "UNIQUE" : "";
@@ -525,7 +527,7 @@ ${allColumnDefs.join(",\n")}
         const indexSql = this.createIndexSql(
           tableName,
           col,
-          this.mapFieldTypeToSQL(f.type, f.length, f.options, f.validation)
+          this.mapFieldTypeToSQL(f.type, f.length, f.options, f.validation, f)
         );
         if (indexSql) indexStatements.push(indexSql);
       }
@@ -751,7 +753,13 @@ ${allColumnDefs.join(",\n")}
           continue;
         }
 
-        const type = this.mapFieldTypeToSQL(field.type, field.length);
+        const type = this.mapFieldTypeToSQL(
+          field.type,
+          field.length,
+          undefined,
+          undefined,
+          field
+        );
         const nullable = field.required ? "NOT NULL" : "";
         const addColName = toSnakeCase(field.name);
 
@@ -854,7 +862,13 @@ ${allColumnDefs.join(",\n")}
           const toggleIndexSql = this.createIndexSql(
             tableName,
             idxCol,
-            this.mapFieldTypeToSQL(field.type, field.length)
+            this.mapFieldTypeToSQL(
+              field.type,
+              field.length,
+              undefined,
+              undefined,
+              field
+            )
           );
           if (toggleIndexSql) statements.push(toggleIndexSql);
         } else {
@@ -983,7 +997,13 @@ ${allColumnDefs.join(",\n")}
         if (oldField && this.storageClassChanged(oldField, field)) continue;
         if (oldField && this.isFieldModified(oldField, field)) {
           const alterCol = toSnakeCase(field.name);
-          const type = this.mapFieldTypeToSQL(field.type, field.length);
+          const type = this.mapFieldTypeToSQL(
+            field.type,
+            field.length,
+            undefined,
+            undefined,
+            field
+          );
           statements.push(
             `ALTER TABLE ${this.quoteIdentifier(tableName)} ALTER COLUMN ${this.quoteIdentifier(alterCol)} TYPE ${type};`
           );
@@ -1172,7 +1192,8 @@ ${allColumnDefs.join(",\n")}
             field.type,
             field.length,
             field.options,
-            field.validation
+            field.validation,
+            field
           )
         ) !== null
       ) {
@@ -1307,11 +1328,54 @@ ${this.dialect === "mysql" ? "CREATE INDEX" : "CREATE INDEX IF NOT EXISTS"} ${th
    * outright. Converging the rest belongs with the column-descriptor
    * consolidation rather than with a per-column patch.
    */
+  /**
+   * The column a number field reaches, for the dialect this service builds for.
+   *
+   * Two independent things can ask for fractions and they mean different storage. `dbType:
+   * "decimal"` asks for EXACT fixed point, which is what money needs and what nothing else should
+   * use; `options.format === "float"` is the UI's way of asking for an ordinary fractional number.
+   * Silence means whole numbers.
+   *
+   * Read here rather than inline in each dialect map because the same three-way answer is needed
+   * three times, and a map that answered it per dialect is how one of the three came to be missing
+   * from all of them.
+   */
+  private numberColumnType(
+    options: FieldDefinition["options"],
+    storage: Pick<FieldDefinition, "dbType" | "precision" | "scale"> | undefined
+  ): string {
+    if (storage?.dbType === "decimal") {
+      const precision = storage.precision ?? DEFAULT_DECIMAL_PRECISION;
+      const scale = storage.scale ?? DEFAULT_DECIMAL_SCALE;
+      // Rendered the way the column descriptor renders it for each dialect, so a table built here
+      // and the runtime schema that reads it describe one column. SQLite has no sized numeric and
+      // stores the value with full fidelity either way.
+      if (this.dialect === "sqlite") return "numeric";
+      return this.dialect === "mysql"
+        ? `decimal(${precision},${scale})`
+        : `numeric(${precision}, ${scale})`;
+    }
+    if (options?.format === "float") {
+      return this.dialect === "sqlite" ? "real" : "decimal(10,2)";
+    }
+    return "integer";
+  }
+
   mapFieldTypeToSQL(
     declaredType: string,
     length?: number,
     options?: FieldDefinition["options"],
-    validation?: FieldDefinition["validation"]
+    validation?: FieldDefinition["validation"],
+    /**
+     * What a number field says about how it wants to be stored.
+     *
+     * Passed as its own argument because this map is reached from six call
+     * sites and four of them used to hand over only a type and a length, which
+     * is why an exact-decimal field silently became a whole-number column: the
+     * facts that decide it never arrived. Optional so a caller that genuinely
+     * has no field (a storage token resolved from a plugin type) is unchanged.
+     */
+    numberStorage?: Pick<FieldDefinition, "dbType" | "precision" | "scale">
   ): string {
     // A contributed type persists as its storage primitive, and this map has
     // never heard of the token it is declared under. Left unresolved it falls
@@ -1325,7 +1389,7 @@ ${this.dialect === "mysql" ? "CREATE INDEX" : "CREATE INDEX IF NOT EXISTS"} ${th
       const sqliteTypeMap: Record<string, string> = {
         text: "text",
         textarea: "text",
-        number: options?.format === "float" ? "real" : "integer",
+        number: this.numberColumnType(options, numberStorage),
         checkbox: "integer", // SQLite uses 0/1 for boolean
         date: "integer", // Store as Unix timestamp
         email: "text",
@@ -1347,7 +1411,7 @@ ${this.dialect === "mysql" ? "CREATE INDEX" : "CREATE INDEX IF NOT EXISTS"} ${th
             ? `varchar(${validation?.maxLength || 255})`
             : "text",
         textarea: "text",
-        number: options?.format === "float" ? "decimal(10,2)" : "integer",
+        number: this.numberColumnType(options, numberStorage),
         checkbox: "boolean",
         date: "timestamp",
         email: `varchar(${validation?.maxLength || 255})`,
@@ -1368,7 +1432,7 @@ ${this.dialect === "mysql" ? "CREATE INDEX" : "CREATE INDEX IF NOT EXISTS"} ${th
           ? `varchar(${validation?.maxLength || 255})`
           : "text",
       textarea: "text",
-      number: options?.format === "float" ? "decimal(10,2)" : "integer",
+      number: this.numberColumnType(options, numberStorage),
       checkbox: "boolean",
       date: "timestamp",
       email: `varchar(${validation?.maxLength || 255})`,

--- a/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-schema-service.ts
+++ b/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-schema-service.ts
@@ -34,6 +34,7 @@ import {
   storageTypeToken,
 } from "../../../shared/lib/plugin-storage";
 import { resolveLocalizedFieldNames } from "../../i18n/classify-fields";
+import { generateSQL } from "../../schema/pipeline/sql-templates/index";
 import {
   fieldProducesColumn,
   usesJunctionTable,
@@ -1005,26 +1006,64 @@ ${allColumnDefs.join(",\n")}
         if (oldField && this.storageClassChanged(oldField, field)) continue;
         if (oldField && this.isFieldModified(oldField, field)) {
           const alterCol = toSnakeCase(field.name);
-          const type = this.mapFieldTypeToSQL(
-            field.type,
-            field.length,
-            undefined,
-            undefined,
-            field
+          // The descriptor decides the target column, the same answer the comparison above used to
+          // decide there was a change at all. Asking a different renderer here is what let a field
+          // be judged modified by one definition and then rewritten by another: this call used to
+          // drop `options` and `validation`, so a number switched to `format: "float"` was detected
+          // and then re-emitted as `integer`.
+          const described = getColumnDescriptor(
+            field,
+            this.dialect,
+            "collection"
           );
-          statements.push(
-            `ALTER TABLE ${this.quoteIdentifier(tableName)} ALTER COLUMN ${this.quoteIdentifier(alterCol)} TYPE ${type};`
-          );
+          const type =
+            described?.dialectType ??
+            this.mapFieldTypeToSQL(
+              field.type,
+              field.length,
+              field.options,
+              field.validation,
+              field
+            );
 
-          if (field.required !== oldField.required) {
-            if (field.required) {
-              statements.push(
-                `ALTER TABLE ${this.quoteIdentifier(tableName)} ALTER COLUMN ${this.quoteIdentifier(alterCol)} SET NOT NULL;`
-              );
-            } else {
-              statements.push(
-                `ALTER TABLE ${this.quoteIdentifier(tableName)} ALTER COLUMN ${this.quoteIdentifier(alterCol)} DROP NOT NULL;`
-              );
+          if (this.dialect === "mysql") {
+            // MySQL restates the WHOLE definition, so nullability travels with the type or the
+            // column silently becomes nullable. That makes it one statement rather than two, and it
+            // is issued whenever the column changes — not only when `required` did — because the
+            // MODIFY would otherwise drop a NOT NULL nobody asked to remove.
+            const nullability = field.required ? " NOT NULL" : " NULL";
+            statements.push(
+              `ALTER TABLE ${this.quoteIdentifier(tableName)} MODIFY COLUMN ${this.quoteIdentifier(alterCol)} ${type}${nullability};`
+            );
+          } else {
+            // Rendered by the shared template rather than written out here, so this path and
+            // `migrate:create` emit the same statement. It also carries the `USING` clause
+            // PostgreSQL requires for cross-family changes, which the hand-written form omitted.
+            statements.push(
+              `${generateSQL(
+                {
+                  type: "change_column_type",
+                  tableName,
+                  columnName: alterCol,
+                  fromType:
+                    getColumnDescriptor(oldField, this.dialect, "collection")
+                      ?.dialectType ?? type,
+                  toType: type,
+                },
+                this.dialect
+              )};`
+            );
+
+            if (field.required !== oldField.required) {
+              if (field.required) {
+                statements.push(
+                  `ALTER TABLE ${this.quoteIdentifier(tableName)} ALTER COLUMN ${this.quoteIdentifier(alterCol)} SET NOT NULL;`
+                );
+              } else {
+                statements.push(
+                  `ALTER TABLE ${this.quoteIdentifier(tableName)} ALTER COLUMN ${this.quoteIdentifier(alterCol)} DROP NOT NULL;`
+                );
+              }
             }
           }
         }

--- a/packages/nextly/src/domains/schema/services/__tests__/column-conformance-matrix.test.ts
+++ b/packages/nextly/src/domains/schema/services/__tests__/column-conformance-matrix.test.ts
@@ -334,17 +334,6 @@ const ACCEPTED = byAspect([
     { origins: ["fieldGroup"] }
   ),
 
-  // --- 🔴 Fixed-point numbers ----------------------------------------------
-  // The field-group generator honours `dbType: "decimal"`; the collection generator never reads it
-  // and emits a whole-number column, so a money field loses its fraction. The generator moves.
-  ...everywhere(
-    ["number"],
-    ["decimal"],
-    "type",
-    "collection generator ignores dbType and emits an integer column; descriptor says exact decimal",
-    { origins: ["collection"] }
-  ),
-
   // --- Required foreign keys: nullability ----------------------------------
   // The descriptor states that every FK column is nullable and that requiredness is enforced above
   // the database. Both generators emit NOT NULL, so a row the application would have rejected with


### PR DESCRIPTION
## The defect

A number field declared as exact decimal — `{ type: "number", dbType: "decimal", precision, scale }` — was created as a **whole-number column** in a collection or single. Every amount with a fractional part lost it on write.

The same field definition in a **field group** got `decimal(10,2)` correctly. `FieldGroupSchemaService` has always honoured the flag; `DynamicCollectionSchemaService` had **zero references to `dbType`**. Meanwhile the column descriptor — which the runtime Drizzle table and the schema diff both read — described the column as exact either way, so the ORM was binding an exact column over an integer one.

**Reachability, stated honestly:** `dbType` has zero references in `packages/admin`, so this is not reachable by clicking. It is reachable through the programmatic API and a hand-written create payload. A correctness gap rather than a live fire, which is why it is a small PR rather than a hotfix.

## The fix

The three number storages are decided in **one place** instead of being restated in each dialect map:

| the field says | column |
|---|---|
| `dbType: "decimal"` | exact fixed point, sized by `precision`/`scale` |
| `options.format === "float"` | ordinary fractional |
| neither | whole number |

Rendered per dialect exactly as the descriptor renders it (`numeric(p, s)` on Postgres, `decimal(p,s)` on MySQL, `numeric` on SQLite), so the table and the schema that reads it describe one column.

`mapFieldTypeToSQL` now also takes the field it is describing. **Four of its six call sites passed only a type and a length**, which is the mechanical reason the facts that decide a number's storage never arrived. Threading the field means a future field property cannot be silently dropped on the way in the same way.

## Scope, proven mechanically rather than asserted

This branch changes emitted DDL, so "did I widen scope?" is answered by the column-conformance ratchet on `main` rather than by my reading of the diff. Running it reported **exactly six resolved entries and nothing else**:

```
collection/postgresql/number/decimal/type
collection/mysql/number/decimal/type
collection/sqlite/number/decimal/type
collection-alter/postgresql/number/decimal/type
collection-alter/mysql/number/decimal/type
collection-alter/sqlite/number/decimal/type
```

Those six entries are deleted here, which is the ratchet working as designed: a resolved divergence fails the build until its entry is removed, so this cannot be done silently. Every other recorded divergence is untouched — in particular the ADD COLUMN path still drops a field's options and validation, so short text and float remain accepted and are not quietly changed by this PR.

## Verification

- `pnpm build` · `pnpm check-types --force` · `pnpm lint` (exit code) · `node scripts/check-drizzle-v1-legacy.cjs` — clean
- Unit: **361 failed / 7486** against a freshly measured baseline of **361 / 7478** at `6ca3f4506`. Zero new, zero disappeared; the +8 are this PR's own tests.
- Integration, full suite, both dialects: **PostgreSQL 1360 passed / 0 failed**, **MySQL 1281 passed / 0 failed**
- **Proven load-bearing.** Restoring the defect (stop reading `dbType`) fails 7 of the 8 new tests plus the ratchet's unaccepted check, with the "a plain number is still a whole number" control correctly still passing. Test count held at 11.

The new suite pins all three storages per dialect, on **both** the create path and the ADD COLUMN path, because those are separate code and a field can reach the right column one way and the wrong one the other.