### PR TITLE
feat(ui): add a slider primitive for bounded numeric properties

### DIFF
--- a/.changeset/ui-slider-primitive.md
+++ b/.changeset/ui-slider-primitive.md
@@ -1,0 +1,39 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+Add `Slider` to `@nextlyhq/ui`, under the experimental tier.
+
+A bounded numeric property — opacity, blur radius, letter spacing, a colour's
+alpha — is the single most repeated control in an editing surface, and every
+plugin building one would otherwise reimplement it privately. `<input
+type="range">` is nearly unstyleable and cannot express two thumbs; a hand-rolled
+replacement gets pointer capture, step rounding and the per-thumb ARIA pattern
+wrong quietly. This wraps the Radix primitive, which is already the kit's
+vendor, so it adds no new dependency shape.
+
+`value` is an array even for a single thumb — that is what makes a range slider
+the same component rather than a second one. Commit expensive writes from
+`onValueCommit`, which fires once the drag settles, rather than `onValueChange`,
+which fires on every frame of it.

--- a/packages/ui/STABILITY.md
+++ b/packages/ui/STABILITY.md
@@ -88,7 +88,7 @@ Everything else the barrel exports, including: `Accordion`, `Alert`, `AlertDialo
 `TreeView`, the table state components, the layout primitives (`Stack`, `Grid`, `Stat`) and
 `Toaster`.
 
-`Slider` joins them for the inspector: a bounded numeric property — opacity, blur radius,
+`Slider` (with `SliderThumbProps`) joins them for the inspector: a bounded numeric property — opacity, blur radius,
 letter spacing, a colour's alpha — is the single most repeated control in an editing surface,
 and a hand-rolled one gets pointer capture, step rounding and the per-thumb ARIA pattern wrong
 quietly. Its `value` is an array even for one thumb, which is what makes a range slider the

--- a/packages/ui/STABILITY.md
+++ b/packages/ui/STABILITY.md
@@ -84,8 +84,15 @@ the published type advertised less than the component actually promised.
 Everything else the barrel exports, including: `Accordion`, `Alert`, `AlertDialog`,
 `Avatar`, `Card`, `Collapsible`, `Command`, `ContextMenu` and its family, `Popover`,
 `Progress`, `ResizablePanelGroup`/`ResizablePanel`/`ResizableHandle`, `Separator`,
-`Skeleton`, `Spinner`, `Table` and its family, `TableSearch`, `TableSkeleton`, `TreeView`, the
-table state components, the layout primitives (`Stack`, `Grid`, `Stat`) and `Toaster`.
+`Skeleton`, `Slider`, `Spinner`, `Table` and its family, `TableSearch`, `TableSkeleton`,
+`TreeView`, the table state components, the layout primitives (`Stack`, `Grid`, `Stat`) and
+`Toaster`.
+
+`Slider` joins them for the inspector: a bounded numeric property — opacity, blur radius,
+letter spacing, a colour's alpha — is the single most repeated control in an editing surface,
+and a hand-rolled one gets pointer capture, step rounding and the per-thumb ARIA pattern wrong
+quietly. Its `value` is an array even for one thumb, which is what makes a range slider the
+same component rather than a second one.
 
 The context menu and the resizable split are the editor-shell primitives: an editor needs
 a right-click menu and draggable regions, and both belong in the kit rather than inside

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -118,6 +118,7 @@
     "@radix-ui/react-radio-group": "^1.3.8",
     "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-separator": "^1.1.8",
+    "@radix-ui/react-slider": "^1.4.7",
     "@radix-ui/react-slot": "^1.2.4",
     "@radix-ui/react-switch": "^1.2.6",
     "@radix-ui/react-tabs": "^1.1.13",

--- a/packages/ui/src/__snapshots__/ui-surface.test.ts.snap
+++ b/packages/ui/src/__snapshots__/ui-surface.test.ts.snap
@@ -199,6 +199,7 @@ exports[`ui public export surface > index.ts surface is unchanged 1`] = `
   "SkeletonProps (type)",
   "Slider (value)",
   "SliderProps (type)",
+  "SliderThumbProps (type)",
   "SortInfo (type)",
   "Spinner (value)",
   "SpinnerProps (type)",

--- a/packages/ui/src/__snapshots__/ui-surface.test.ts.snap
+++ b/packages/ui/src/__snapshots__/ui-surface.test.ts.snap
@@ -197,6 +197,8 @@ exports[`ui public export surface > index.ts surface is unchanged 1`] = `
   "SheetTriggerProps (type)",
   "Skeleton (value)",
   "SkeletonProps (type)",
+  "Slider (value)",
+  "SliderProps (type)",
   "SortInfo (type)",
   "Spinner (value)",
   "SpinnerProps (type)",

--- a/packages/ui/src/components/slider.test.tsx
+++ b/packages/ui/src/components/slider.test.tsx
@@ -230,4 +230,39 @@ describe("Slider", () => {
       warn.mockRestore();
     }
   });
+
+  it("does not let a root labelledby outrank a thumb's own label", () => {
+    // The two naming attributes are alternatives, and `aria-labelledby` WINS
+    // name computation. Emitting the root's labelledby beside the thumb's own
+    // label would silently discard the caller's explicit name — and the
+    // same-attribute override test passes either way, so it cannot catch this.
+    const { container } = render(
+      <Slider
+        aria-labelledby="size-heading"
+        value={[40]}
+        onValueChange={() => {}}
+        thumbs={[{ "aria-label": "Opacity" }]}
+      />
+    );
+    const thumb = thumbsIn(container)[0];
+    expect(thumb.getAttribute("aria-label")).toBe("Opacity");
+    expect(thumb.hasAttribute("aria-labelledby")).toBe(false);
+  });
+
+  it("still falls back to the root when the thumb names itself in no way", () => {
+    // The positive control for the rule above: an all-or-nothing fallback that
+    // never fell back would pass the case above and break the documented
+    // single-thumb API.
+    const { container } = render(
+      <Slider
+        aria-labelledby="size-heading"
+        value={[40]}
+        onValueChange={() => {}}
+        thumbs={[{ "aria-valuetext": "40 percent" }]}
+      />
+    );
+    const thumb = thumbsIn(container)[0];
+    expect(thumb.getAttribute("aria-labelledby")).toBe("size-heading");
+    expect(thumb.getAttribute("aria-valuetext")).toBe("40 percent");
+  });
 });

--- a/packages/ui/src/components/slider.test.tsx
+++ b/packages/ui/src/components/slider.test.tsx
@@ -327,16 +327,20 @@ describe("Slider", () => {
   });
 
   describe("an empty value array", () => {
-    // Zero values is a state the control cannot represent, and the naive count arithmetic
-    // produced zero THUMBS from it: a track with no `slider` role in it at all. Nothing is
-    // focusable, arrow keys reach nothing, and a track click has no thumb to move — the control
-    // renders and is inert, which is the failure mode hardest to notice in review.
+    // Zero values is a state the control cannot represent. The naive count arithmetic produced
+    // zero THUMBS from it — a track with no `slider` role in it at all, inert and looking
+    // finished. The two ways out are not symmetric: the uncontrolled case has a correct value to
+    // fall back to, and the controlled case does not.
 
-    it("still renders an operable thumb for an empty controlled value", () => {
+    it("renders nothing at all for an empty controlled value", () => {
+      // Not merely "no thumb": a lone track is the inert bar this started as. And a thumb
+      // without a value would be worse still — Radix routes a track click through
+      // `getClosestValueIndex`, which answers -1 for an empty array and writes nowhere, so the
+      // control would look operable and move for no input at all.
       const { container } = render(
         <Slider aria-label="Opacity" value={[]} onValueChange={() => {}} />
       );
-      expect(thumbsIn(container)).toHaveLength(1);
+      expect(container.firstElementChild).toBeNull();
     });
 
     it("still renders an operable thumb for an empty defaultValue", () => {
@@ -359,18 +363,32 @@ describe("Slider", () => {
 
     it("does not seize state the caller owns when a controlled value is empty", () => {
       // The tempting repair — substituting a value — would either flip the control to
-      // uncontrolled or display a number the caller's state does not hold. A controlled slider
-      // must keep reporting the caller's state, however unusable that state is.
+      // uncontrolled or display a number the caller's state does not hold. Rendering nothing is
+      // what keeps a controlled slider from inventing state on the caller's behalf.
       const onValueChange = vi.fn();
       const { container } = render(
         <Slider aria-label="Opacity" value={[]} onValueChange={onValueChange} />
       );
-      const [thumb] = thumbsIn(container);
-      // A positive control: the empty defaultValue case above proves this assertion can read a
-      // number, so its absence here is the component staying out of the caller's state and not
-      // the query failing to find one.
-      expect(thumb.getAttribute("aria-valuenow")).toBeNull();
+      // Counting thumbs would NOT distinguish this from the original defect: a bare track has
+      // zero thumbs too, so the assertion would hold while the inert control was still there.
+      expect(container.firstElementChild).toBeNull();
       expect(onValueChange).not.toHaveBeenCalled();
+    });
+
+    it("returns to a working control once the value arrives", () => {
+      // The scenario this whole case exists for is a value that loads late, so the empty render
+      // has to be a passing phase rather than a dead end. Without this, "render nothing" could
+      // be satisfied by a component that never recovers.
+      const { container, rerender } = render(
+        <Slider aria-label="Opacity" value={[]} onValueChange={() => {}} />
+      );
+      expect(container.firstElementChild).toBeNull();
+
+      rerender(
+        <Slider aria-label="Opacity" value={[40]} onValueChange={() => {}} />
+      );
+      const [thumb] = thumbsIn(container);
+      expect(thumb?.getAttribute("aria-valuenow")).toBe("40");
     });
 
     it("reports the empty array rather than failing silently", () => {

--- a/packages/ui/src/components/slider.test.tsx
+++ b/packages/ui/src/components/slider.test.tsx
@@ -101,7 +101,10 @@ describe("Slider", () => {
       <Slider
         aria-label="Size range"
         defaultValue={[25, 75]}
-        thumbLabels={["Minimum size", "Maximum size"]}
+        thumbs={[
+          { "aria-label": "Minimum size" },
+          { "aria-label": "Maximum size" },
+        ]}
       />
     );
     const [lower, upper] = thumbsIn(container);
@@ -129,5 +132,49 @@ describe("Slider", () => {
     );
     const root = container.firstElementChild;
     expect(root?.className).toContain("py-2");
+  });
+
+  it("puts value-text and description on the thumb, where they are read", () => {
+    // The general form of the naming defect: every attribute assistive
+    // technology reads from a slider is read from the THUMB, and none are
+    // inherited from the root. Fixing only the name left the rest unreachable,
+    // since the thumbs are generated internally.
+    const { container } = render(
+      <Slider
+        value={[40]}
+        onValueChange={() => {}}
+        thumbs={[
+          {
+            "aria-label": "Opacity",
+            "aria-valuetext": "40 percent",
+            "aria-describedby": "opacity-help",
+          },
+        ]}
+      />
+    );
+    const thumb = thumbsIn(container)[0];
+    expect(thumb.getAttribute("aria-valuetext")).toBe("40 percent");
+    expect(thumb.getAttribute("aria-describedby")).toBe("opacity-help");
+  });
+
+  it("keeps the name off the roleless root", () => {
+    // A second copy on the root is not merely redundant: it is a name on an
+    // element nothing announces, which reads as correct in a DOM dump.
+    const { container } = render(
+      <Slider aria-label="Opacity" value={[40]} onValueChange={() => {}} />
+    );
+    expect(container.firstElementChild?.hasAttribute("aria-label")).toBe(false);
+  });
+
+  it("lets a thumb entry override the root name for a single thumb", () => {
+    const { container } = render(
+      <Slider
+        aria-label="Fallback"
+        value={[40]}
+        onValueChange={() => {}}
+        thumbs={[{ "aria-label": "Specific" }]}
+      />
+    );
+    expect(thumbsIn(container)[0].getAttribute("aria-label")).toBe("Specific");
   });
 });

--- a/packages/ui/src/components/slider.test.tsx
+++ b/packages/ui/src/components/slider.test.tsx
@@ -83,4 +83,51 @@ describe("Slider", () => {
     );
     expect(thumbsIn(container)[0].hasAttribute("data-disabled")).toBe(true);
   });
+
+  it("names the thumb, not the root, for a single-value slider", () => {
+    // The root is not focusable and carries no slider role; a name left there is
+    // announced by nothing. Screen readers meet the THUMB, so that is what has
+    // to carry the name.
+    const { container } = render(
+      <Slider aria-label="Opacity" value={[40]} onValueChange={() => {}} />
+    );
+    expect(thumbsIn(container)[0].getAttribute("aria-label")).toBe("Opacity");
+  });
+
+  it("gives a range's two thumbs distinct names", () => {
+    // A shared root name announces both ends identically, so nothing tells the
+    // user which one they are holding.
+    const { container } = render(
+      <Slider
+        aria-label="Size range"
+        defaultValue={[25, 75]}
+        thumbLabels={["Minimum size", "Maximum size"]}
+      />
+    );
+    const [lower, upper] = thumbsIn(container);
+    expect(lower.getAttribute("aria-label")).toBe("Minimum size");
+    expect(upper.getAttribute("aria-label")).toBe("Maximum size");
+  });
+
+  it("does not put a shared labelledby on both thumbs of a range", () => {
+    // One id cannot name two ends distinctly, so applying it to both would be
+    // worse than leaving them to `thumbLabels`.
+    const { container } = render(
+      <Slider aria-labelledby="size-heading" defaultValue={[25, 75]} />
+    );
+    for (const thumb of thumbsIn(container)) {
+      expect(thumb.hasAttribute("aria-labelledby")).toBe(false);
+    }
+  });
+
+  it("pads the root so the target clears the 24px minimum", () => {
+    // A 16px thumb on a 6px track is under WCAG 2.5.8, and on touch the gap
+    // between grabbing the thumb and missing the control is exactly this
+    // padding. The docs claimed it before the code did.
+    const { container } = render(
+      <Slider aria-label="Opacity" defaultValue={[10]} />
+    );
+    const root = container.firstElementChild;
+    expect(root?.className).toContain("py-2");
+  });
 });

--- a/packages/ui/src/components/slider.test.tsx
+++ b/packages/ui/src/components/slider.test.tsx
@@ -1,0 +1,86 @@
+// @vitest-environment jsdom
+/**
+ * A slider renders one thumb per VALUE, and the count comes from props rather than from children.
+ *
+ * Radix renders exactly the thumbs it is given, so a two-value slider handed one thumb drops the
+ * second silently: the value stays in state and no thumb can reach it. Nothing else reports that —
+ * the markup is valid, the first thumb works, and the control looks finished.
+ *
+ * The count is therefore measured here rather than assumed, in both directions (controlled and
+ * uncontrolled), because the two props are read on different code paths.
+ */
+import { render } from "@testing-library/react";
+import { beforeAll, describe, expect, it } from "vitest";
+
+import { Slider } from "./slider";
+
+beforeAll(() => {
+  // Radix measures the track, and jsdom has no ResizeObserver. A stub is enough: these
+  // assertions are about emitted roles and attributes, not about measured geometry.
+  class ResizeObserverStub {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+  (globalThis as Record<string, unknown>).ResizeObserver = ResizeObserverStub;
+});
+
+/**
+ * Thumbs within ONE render's container.
+ *
+ * This package's vitest setup does not unmount between tests, so a document-wide query counts
+ * every earlier render too and a per-test count assertion would drift upward as cases are added.
+ */
+const thumbsIn = (container: HTMLElement): Element[] =>
+  Array.from(container.querySelectorAll('[role="slider"]'));
+
+describe("Slider", () => {
+  it("renders one thumb for a single controlled value", () => {
+    const { container } = render(
+      <Slider aria-label="Opacity" value={[40]} onValueChange={() => {}} />
+    );
+    expect(thumbsIn(container)).toHaveLength(1);
+  });
+
+  it("renders two thumbs for a two-value range, from defaultValue", () => {
+    // The uncontrolled path reads a different prop than the controlled one, so a fix that
+    // consulted only `value` would leave this case broken.
+    const { container } = render(
+      <Slider aria-label="Size range" defaultValue={[25, 75]} />
+    );
+    expect(thumbsIn(container)).toHaveLength(2);
+  });
+
+  it("renders one thumb when neither value nor defaultValue is given", () => {
+    // The fallback matters: a slider with no initial value is still a usable control, and
+    // rendering zero thumbs would make it operable by nobody.
+    const { container } = render(<Slider aria-label="Blur" />);
+    expect(thumbsIn(container)).toHaveLength(1);
+  });
+
+  it("carries the bounds a screen reader announces", () => {
+    // A slider that announces only a position is not much use; the bounds are what make the
+    // number mean something.
+    const { container } = render(
+      <Slider
+        aria-label="Opacity"
+        value={[40]}
+        min={0}
+        max={200}
+        onValueChange={() => {}}
+      />
+    );
+    const thumb = thumbsIn(container)[0];
+    expect(thumb.getAttribute("aria-valuenow")).toBe("40");
+    expect(thumb.getAttribute("aria-valuemin")).toBe("0");
+    expect(thumb.getAttribute("aria-valuemax")).toBe("200");
+  });
+
+  it("marks the whole control disabled, not just its appearance", () => {
+    // Opacity alone would leave a control that looks unavailable and still responds to keys.
+    const { container } = render(
+      <Slider aria-label="Opacity" defaultValue={[10]} disabled />
+    );
+    expect(thumbsIn(container)[0].hasAttribute("data-disabled")).toBe(true);
+  });
+});

--- a/packages/ui/src/components/slider.test.tsx
+++ b/packages/ui/src/components/slider.test.tsx
@@ -10,7 +10,9 @@
  * uncontrolled), because the two props are read on different code paths.
  */
 import { render } from "@testing-library/react";
-import { beforeAll, describe, expect, it } from "vitest";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+
+import { resetDevWarnings } from "../lib/dev-warn";
 
 import { Slider } from "./slider";
 
@@ -33,6 +35,10 @@ beforeAll(() => {
  */
 const thumbsIn = (container: HTMLElement): Element[] =>
   Array.from(container.querySelectorAll('[role="slider"]'));
+
+afterEach(() => {
+  resetDevWarnings();
+});
 
 describe("Slider", () => {
   it("renders one thumb for a single controlled value", () => {
@@ -176,5 +182,52 @@ describe("Slider", () => {
       />
     );
     expect(thumbsIn(container)[0].getAttribute("aria-label")).toBe("Specific");
+  });
+
+  it("warns in development when a range names neither end", () => {
+    // The requirement the type system cannot express: how many thumbs there
+    // are is the length of an array. Documented and tested is not the same as
+    // enforced, and an unnamed range fails silently — the control renders and
+    // is unusable with a screen reader.
+    resetDevWarnings();
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      render(<Slider aria-label="Size" defaultValue={[25, 75]} />);
+      expect(warn).toHaveBeenCalledTimes(1);
+      expect(String(warn.mock.calls[0][0])).toContain(
+        "one `thumbs` entry per thumb"
+      );
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it("stays silent when the range names both ends", () => {
+    // The positive control. Without it, a warning that fired unconditionally
+    // would pass the case above and be useless.
+    resetDevWarnings();
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      render(
+        <Slider
+          defaultValue={[25, 75]}
+          thumbs={[{ "aria-label": "Minimum" }, { "aria-label": "Maximum" }]}
+        />
+      );
+      expect(warn).not.toHaveBeenCalled();
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it("stays silent for a single thumb named through the root", () => {
+    resetDevWarnings();
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      render(<Slider aria-label="Opacity" defaultValue={[40]} />);
+      expect(warn).not.toHaveBeenCalled();
+    } finally {
+      warn.mockRestore();
+    }
   });
 });

--- a/packages/ui/src/components/slider.test.tsx
+++ b/packages/ui/src/components/slider.test.tsx
@@ -325,4 +325,202 @@ describe("Slider", () => {
       warn.mockRestore();
     }
   });
+
+  describe("an empty value array", () => {
+    // Zero values is a state the control cannot represent, and the naive count arithmetic
+    // produced zero THUMBS from it: a track with no `slider` role in it at all. Nothing is
+    // focusable, arrow keys reach nothing, and a track click has no thumb to move — the control
+    // renders and is inert, which is the failure mode hardest to notice in review.
+
+    it("still renders an operable thumb for an empty controlled value", () => {
+      const { container } = render(
+        <Slider aria-label="Opacity" value={[]} onValueChange={() => {}} />
+      );
+      expect(thumbsIn(container)).toHaveLength(1);
+    });
+
+    it("still renders an operable thumb for an empty defaultValue", () => {
+      const { container } = render(
+        <Slider aria-label="Opacity" defaultValue={[]} />
+      );
+      expect(thumbsIn(container)).toHaveLength(1);
+    });
+
+    it("falls back to `min` when defaultValue is empty, rather than to nothing", () => {
+      // The uncontrolled case is repairable, and repairing it means landing on the value an
+      // omitted prop would have produced. Asserting the NUMBER rather than the thumb count is
+      // what separates a real fallback from a thumb rendered over no value at all.
+      const { container } = render(
+        <Slider aria-label="Opacity" defaultValue={[]} min={10} max={90} />
+      );
+      const [thumb] = thumbsIn(container);
+      expect(thumb.getAttribute("aria-valuenow")).toBe("10");
+    });
+
+    it("does not seize state the caller owns when a controlled value is empty", () => {
+      // The tempting repair — substituting a value — would either flip the control to
+      // uncontrolled or display a number the caller's state does not hold. A controlled slider
+      // must keep reporting the caller's state, however unusable that state is.
+      const onValueChange = vi.fn();
+      const { container } = render(
+        <Slider aria-label="Opacity" value={[]} onValueChange={onValueChange} />
+      );
+      const [thumb] = thumbsIn(container);
+      // A positive control: the empty defaultValue case above proves this assertion can read a
+      // number, so its absence here is the component staying out of the caller's state and not
+      // the query failing to find one.
+      expect(thumb.getAttribute("aria-valuenow")).toBeNull();
+      expect(onValueChange).not.toHaveBeenCalled();
+    });
+
+    it("reports the empty array rather than failing silently", () => {
+      resetDevWarnings();
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+      try {
+        render(
+          <Slider aria-label="Opacity" value={[]} onValueChange={() => {}} />
+        );
+        expect(warn).toHaveBeenCalledTimes(1);
+        expect(String(warn.mock.calls[0][0])).toContain("empty array");
+      } finally {
+        warn.mockRestore();
+      }
+    });
+  });
+
+  describe("an empty accessible name", () => {
+    // `aria-label={field.label}` before the label loads produces `aria-label=""`. The attribute
+    // is present, so a `!== undefined` check calls the thumb named; the accessible name computes
+    // to the empty string, so a screen reader announces a bare number. The warning existing at
+    // all is what made this worth catching — a safeguard that stays silent on the case it was
+    // built for is worse than none, because it certifies the defect.
+
+    it("reports a blank aria-label as unnamed", () => {
+      resetDevWarnings();
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+      try {
+        render(<Slider aria-label="   " defaultValue={[40]} />);
+        expect(warn).toHaveBeenCalledTimes(1);
+        expect(String(warn.mock.calls[0][0])).toContain("accessible name");
+      } finally {
+        warn.mockRestore();
+      }
+    });
+
+    it("reports a range whose second thumb is named with an empty string", () => {
+      resetDevWarnings();
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+      try {
+        render(
+          <Slider
+            defaultValue={[25, 75]}
+            thumbs={[{ "aria-label": "Minimum" }, { "aria-label": "" }]}
+          />
+        );
+        expect(warn).toHaveBeenCalledTimes(1);
+      } finally {
+        warn.mockRestore();
+      }
+    });
+
+    it("does not emit an empty naming attribute onto the thumb", () => {
+      // Present-and-empty is worse than absent: it states that a name was chosen. Omitting the
+      // attribute leaves the element honestly unnamed for anything auditing the DOM.
+      const { container } = render(
+        <Slider
+          defaultValue={[25, 75]}
+          thumbs={[{ "aria-label": "Min" }, { "aria-label": "" }]}
+        />
+      );
+      const thumbs = thumbsIn(container);
+      expect(thumbs[0].getAttribute("aria-label")).toBe("Min");
+      expect(thumbs[1].hasAttribute("aria-label")).toBe(false);
+    });
+
+    it("falls back to the root name when a single thumb's own label is blank", () => {
+      // A blank per-thumb label is not a name, so it must not suppress the root fallback the
+      // one-thumb API documents.
+      const { container } = render(
+        <Slider
+          aria-label="Opacity"
+          defaultValue={[40]}
+          thumbs={[{ "aria-label": "" }]}
+        />
+      );
+      const [thumb] = thumbsIn(container);
+      expect(thumb.getAttribute("aria-label")).toBe("Opacity");
+    });
+  });
+
+  describe("a vertical slider's length", () => {
+    // The cross-axis rules were written as `data-[orientation=vertical]:` variants, which compile
+    // to attribute selectors and therefore OUTRANK a plain utility passed in `className`. The
+    // caller's override lost the cascade silently, and the forced `h-full` collapsed to zero
+    // inside any auto-height parent — a slider with no track to drag along.
+
+    it("carries a length of its own rather than inheriting one", () => {
+      const { container } = render(
+        <Slider
+          aria-label="Opacity"
+          orientation="vertical"
+          defaultValue={[40]}
+        />
+      );
+      const root = container.firstElementChild;
+      expect(root?.className).toContain("h-44");
+      expect(root?.className).not.toContain("h-full");
+    });
+
+    it("lets a caller replace that length, including with h-full", () => {
+      // Both directions matter: a fixed override, and the fill-the-parent behaviour the default
+      // gives up. Neither can work while the wrapper's own class outranks the caller's.
+      const { container: fixed } = render(
+        <Slider
+          aria-label="A"
+          orientation="vertical"
+          defaultValue={[40]}
+          className="h-64"
+        />
+      );
+      expect(fixed.firstElementChild?.className).toContain("h-64");
+      expect(fixed.firstElementChild?.className).not.toContain("h-44");
+
+      const { container: filled } = render(
+        <Slider
+          aria-label="B"
+          orientation="vertical"
+          defaultValue={[40]}
+          className="h-full"
+        />
+      );
+      expect(filled.firstElementChild?.className).toContain("h-full");
+      expect(filled.firstElementChild?.className).not.toContain("h-44");
+    });
+
+    it("keeps the 24px target on the axis a vertical slider is thin in", () => {
+      const { container } = render(
+        <Slider
+          aria-label="Opacity"
+          orientation="vertical"
+          defaultValue={[40]}
+        />
+      );
+      expect(container.firstElementChild?.className).toContain("min-w-6");
+    });
+
+    it("still tells Radix which orientation it is", () => {
+      // Orientation drives the arrow keys a slider responds to. Reading it in JS to pick classes
+      // would be worthless if it stopped reaching the primitive that acts on it.
+      const { container } = render(
+        <Slider
+          aria-label="Opacity"
+          orientation="vertical"
+          defaultValue={[40]}
+        />
+      );
+      expect(
+        container.firstElementChild?.getAttribute("data-orientation")
+      ).toBe("vertical");
+    });
+  });
 });

--- a/packages/ui/src/components/slider.test.tsx
+++ b/packages/ui/src/components/slider.test.tsx
@@ -136,8 +136,11 @@ describe("Slider", () => {
     const { container } = render(
       <Slider aria-label="Opacity" defaultValue={[10]} />
     );
+    // Asserts the stated MINIMUM, not the padding that contributes to it:
+    // padding alone reached only 22px, and a test naming `py-2` passed while
+    // the documented 24px was never met.
     const root = container.firstElementChild;
-    expect(root?.className).toContain("py-2");
+    expect(root?.className).toContain("min-h-6");
   });
 
   it("puts value-text and description on the thumb, where they are read", () => {
@@ -264,5 +267,62 @@ describe("Slider", () => {
     const thumb = thumbsIn(container)[0];
     expect(thumb.getAttribute("aria-labelledby")).toBe("size-heading");
     expect(thumb.getAttribute("aria-valuetext")).toBe("40 percent");
+  });
+
+  it("keeps the uncontrolled thumb count fixed once Radix has captured it", () => {
+    // Radix captures an uncontrolled value array once, at mount. Recomputing
+    // the count from a later `defaultValue` drops a thumb while Radix still
+    // holds its value — an endpoint nothing can reach and nothing reports.
+    const { container, rerender } = render(
+      <Slider
+        defaultValue={[25, 75]}
+        thumbs={[{ "aria-label": "Min" }, { "aria-label": "Max" }]}
+      />
+    );
+    expect(thumbsIn(container)).toHaveLength(2);
+
+    rerender(
+      <Slider
+        defaultValue={[25]}
+        thumbs={[{ "aria-label": "Min" }, { "aria-label": "Max" }]}
+      />
+    );
+    expect(thumbsIn(container)).toHaveLength(2);
+  });
+
+  it("still follows a controlled value's length across rerenders", () => {
+    // The positive control: freezing BOTH paths would make a controlled range
+    // unable to change arity, which is a legitimate thing for a caller to do.
+    const { container, rerender } = render(
+      <Slider
+        value={[40]}
+        onValueChange={() => {}}
+        thumbs={[{ "aria-label": "One" }]}
+      />
+    );
+    expect(thumbsIn(container)).toHaveLength(1);
+
+    rerender(
+      <Slider
+        value={[25, 75]}
+        onValueChange={() => {}}
+        thumbs={[{ "aria-label": "Min" }, { "aria-label": "Max" }]}
+      />
+    );
+    expect(thumbsIn(container)).toHaveLength(2);
+  });
+
+  it("warns when a SINGLE thumb has no name anywhere", () => {
+    // Previously exempt: the check short-circuited on `count === 1`, so the
+    // simplest unnamed slider of all went unreported.
+    resetDevWarnings();
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      render(<Slider defaultValue={[40]} />);
+      expect(warn).toHaveBeenCalledTimes(1);
+      expect(String(warn.mock.calls[0][0])).toContain("accessible name");
+    } finally {
+      warn.mockRestore();
+    }
   });
 });

--- a/packages/ui/src/components/slider.tsx
+++ b/packages/ui/src/components/slider.tsx
@@ -46,6 +46,13 @@
  *   read from the thumb and inherited from nothing
  * - The root is padded so the target clears the 24px minimum (WCAG 2.5.8); the 16px thumb on a
  *   6px track does not on its own
+ * - An empty name does not count as a name: `aria-label=""` is reported the same as a missing one,
+ *   because the accessible name computes to nothing either way
+ *
+ * **Sizing**: a horizontal slider fills its container's width. A VERTICAL one carries a default
+ * height instead of filling, because `height: 100%` inside an auto-height parent collapses to a
+ * track with no length. Override it with an ordinary `className` — `h-64` for a longer control,
+ * `h-full` for the fill-the-parent behaviour.
  *
  * @example
  * ```tsx
@@ -147,12 +154,34 @@ export type SliderProps = Omit<
  * Radix renders only as many thumbs as it is given children, so a range slider whose caller
  * supplied two values but one thumb would silently drop the second — the value would still be in
  * state, and no thumb would be able to reach it.
+ *
+ * An EMPTY array floors to one rather than to zero. Zero thumbs is a track with nothing focusable
+ * in it: no `slider` role, no keyboard target, and no pointer target either, because Radix routes
+ * a track click to the nearest thumb. A control that cannot be operated at all is a worse outcome
+ * than one showing a fallback, and the empty array is reported separately.
  */
 function thumbCount(
   value: readonly number[] | undefined,
   defaultValue: readonly number[] | undefined
 ): number {
-  return value?.length ?? defaultValue?.length ?? 1;
+  return Math.max(1, value?.length ?? defaultValue?.length ?? 1);
+}
+
+/**
+ * Whether a naming attribute actually carries a name.
+ *
+ * A present-but-empty `aria-label` is the case a presence check misses: the attribute is there, so
+ * every `!== undefined` test says the thumb is named, while the accessible name computes to the
+ * empty string and assistive technology announces a bare number. It arises from ordinary code —
+ * `aria-label={field.label}` before the label loads, or a template over an absent value.
+ *
+ * The check is deliberately shallow for `aria-labelledby`: whether the referenced element exists
+ * and holds text is a property of a document this component cannot see at render, so an id that
+ * resolves to nothing still passes here. This catches the empty STRING, which is the case that is
+ * both common and knowable.
+ */
+function hasAccessibleName(value: string | undefined): boolean {
+  return value !== undefined && value.trim() !== "";
 }
 
 /**
@@ -170,6 +199,7 @@ const Slider = React.forwardRef<
       value,
       defaultValue,
       thumbs,
+      orientation = "horizontal",
       "aria-label": ariaLabel,
       "aria-labelledby": ariaLabelledBy,
       ...props
@@ -184,7 +214,30 @@ const Slider = React.forwardRef<
     const initialUncontrolledCount = React.useRef(
       thumbCount(undefined, defaultValue)
     ).current;
-    const count = value?.length ?? initialUncontrolledCount;
+    const count = Math.max(1, value?.length ?? initialUncontrolledCount);
+
+    // An empty array asks for a slider over no values, which is not a state this control can
+    // represent. The two cases differ in how far they can be repaired, so they are handled
+    // separately rather than with one blanket rule.
+    //
+    // UNCONTROLLED is fully repairable: an empty `defaultValue` is forwarded as absent, and Radix
+    // then applies its own `[min]` default. Substituting the vendor's default is exactly what an
+    // omitted prop would have done, so nothing downstream can tell the difference.
+    //
+    // CONTROLLED is NOT repairable here. Replacing an empty `value` would either flip the control
+    // to uncontrolled — handing Radix ownership of state the caller believes it holds — or display
+    // a number the caller's state does not contain, which would then never reconcile. The empty
+    // array is forwarded unchanged and reported instead; the fallback thumb keeps the control
+    // focusable, so the defect is visible rather than an inert bar.
+    const isEmptyDefault =
+      defaultValue !== undefined && defaultValue.length === 0;
+    devWarnOnce(
+      !isEmptyDefault && !(value !== undefined && value.length === 0),
+      "Slider: `value`/`defaultValue` must hold one number per thumb, and an empty array " +
+        "holds none — the control has nothing to slide. An empty `defaultValue` falls back to " +
+        "`min`; an empty `value` cannot be repaired without taking state the caller owns, so " +
+        "render nothing until the value is loaded rather than passing `[]`."
+    );
     // Everything assistive technology reads goes on the THUMB, which is what
     // carries the `slider` role and takes focus. Left on the root it is
     // announced by nothing.
@@ -202,10 +255,11 @@ const Slider = React.forwardRef<
     // check exists to report.
     const isNamed = (index: number): boolean => {
       const own = thumbs?.[index];
-      if (own?.["aria-label"] !== undefined) return true;
-      if (own?.["aria-labelledby"] !== undefined) return true;
+      if (hasAccessibleName(own?.["aria-label"])) return true;
+      if (hasAccessibleName(own?.["aria-labelledby"])) return true;
       return (
-        count === 1 && (ariaLabel !== undefined || ariaLabelledBy !== undefined)
+        count === 1 &&
+        (hasAccessibleName(ariaLabel) || hasAccessibleName(ariaLabelledBy))
       );
     };
     devWarnOnce(
@@ -218,24 +272,42 @@ const Slider = React.forwardRef<
 
     const ariaFor = (index: number): SliderThumbProps => {
       const supplied = thumbs?.[index] ?? {};
-      if (count !== 1) return supplied;
+      // An empty naming attribute is dropped rather than forwarded. Emitting `aria-label=""`
+      // states a name and supplies none, which reads to a name computation as a deliberate
+      // choice; omitting the attribute at least leaves the element honestly unnamed.
+      const ownLabel = hasAccessibleName(supplied["aria-label"])
+        ? supplied["aria-label"]
+        : undefined;
+      const ownLabelledBy = hasAccessibleName(supplied["aria-labelledby"])
+        ? supplied["aria-labelledby"]
+        : undefined;
+      if (count !== 1) {
+        return {
+          ...supplied,
+          "aria-label": ownLabel,
+          "aria-labelledby": ownLabelledBy,
+        };
+      }
       // The two naming attributes are ALTERNATIVES, not independent slots, so
       // the fallback is all-or-nothing. Filling each one separately can emit a
       // thumb `aria-label` alongside a root `aria-labelledby`, and since
       // accessible-name computation prefers `aria-labelledby`, the caller's
       // explicit per-thumb name would lose to the root's without saying so.
-      const namesItself =
-        supplied["aria-label"] !== undefined ||
-        supplied["aria-labelledby"] !== undefined;
+      const namesItself = ownLabel !== undefined || ownLabelledBy !== undefined;
       return {
-        "aria-label": namesItself ? supplied["aria-label"] : ariaLabel,
-        "aria-labelledby": namesItself
-          ? supplied["aria-labelledby"]
-          : ariaLabelledBy,
+        "aria-label": namesItself ? ownLabel : ariaLabel,
+        "aria-labelledby": namesItself ? ownLabelledBy : ariaLabelledBy,
         "aria-valuetext": supplied["aria-valuetext"],
         "aria-describedby": supplied["aria-describedby"],
       };
     };
+
+    // Orientation is a prop, so the branch belongs in JavaScript rather than in a
+    // `data-[orientation=vertical]:` variant. A variant compiles to an attribute selector, which
+    // outranks the plain utility a caller passes in `className` — `h-48` would lose to the
+    // wrapper's own height and the override would fail silently. Plain classes also let
+    // tailwind-merge do the job it is here for: same property, caller wins.
+    const isVertical = orientation === "vertical";
 
     return (
       // `aria-label`/`aria-labelledby` are destructured out above rather than
@@ -244,35 +316,41 @@ const Slider = React.forwardRef<
       <SliderPrimitive.Root
         ref={ref}
         className={cn(
-          "relative flex w-full touch-none select-none items-center",
-          // WCAG 2.5.8 wants 24px. Padding alone does not reach it: the thumb
-          // is absolutely positioned, so the cross-axis size is the 6px track
-          // plus the padding — 22px with `py-2`. An explicit minimum states
-          // the target rather than leaving it to arithmetic that moves
+          "relative flex touch-none select-none items-center",
+          // WCAG 2.5.8 wants a 24px target. Padding alone does not reach it: the
+          // thumb is absolutely positioned, so the cross-axis size is the 6px
+          // track plus the padding — 22px with `py-2`. An explicit minimum
+          // states the target rather than leaving it to arithmetic that moves
           // whenever the track thickness does.
-          "min-h-6 py-2",
-          "data-[orientation=vertical]:min-h-0 data-[orientation=vertical]:min-w-6",
-          "data-[orientation=vertical]:px-2 data-[orientation=vertical]:py-0",
-          "data-[orientation=vertical]:h-full data-[orientation=vertical]:w-auto",
-          "data-[orientation=vertical]:flex-col",
+          isVertical
+            ? // A vertical slider needs a LENGTH, and it cannot inherit one:
+              // `h-full` inside an auto-height parent resolves to zero, leaving
+              // a control with no track to drag along. A concrete default is
+              // usable everywhere and, being a plain utility, is replaced by a
+              // caller's own `h-*` — including `h-full`, for the fill-the-parent
+              // case this default gives up.
+              "h-44 min-w-6 flex-col px-2"
+            : "min-h-6 w-full py-2",
           "data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
           className
         )}
+        orientation={orientation}
         value={value}
-        defaultValue={defaultValue}
+        // An empty array is forwarded as absent so Radix applies its own `[min]`
+        // default; a populated one is passed through untouched.
+        defaultValue={isEmptyDefault ? undefined : defaultValue}
         {...props}
       >
         <SliderPrimitive.Track
           className={cn(
             "bg-secondary relative grow overflow-hidden rounded-full",
-            "h-1.5 w-full",
-            "data-[orientation=vertical]:h-full data-[orientation=vertical]:w-1.5"
+            isVertical ? "h-full w-1.5" : "h-1.5 w-full"
           )}
         >
           <SliderPrimitive.Range
             className={cn(
               "bg-primary absolute",
-              "h-full data-[orientation=vertical]:h-auto data-[orientation=vertical]:w-full"
+              isVertical ? "w-full" : "h-full"
             )}
           />
         </SliderPrimitive.Track>

--- a/packages/ui/src/components/slider.tsx
+++ b/packages/ui/src/components/slider.tsx
@@ -111,8 +111,12 @@ export interface SliderThumbProps {
  *
  * @experimental
  */
-export type SliderProps = React.ComponentPropsWithoutRef<
-  typeof SliderPrimitive.Root
+export type SliderProps = Omit<
+  React.ComponentPropsWithoutRef<typeof SliderPrimitive.Root>,
+  // The wrapper always supplies a track and at least one thumb, and Radix's
+  // Slot accepts exactly one composable child — so `asChild` here throws at
+  // render. Excluded from the type rather than left to fail at runtime.
+  "asChild"
 > & {
   /**
    * Assistive-technology attributes per thumb, in value order.
@@ -172,7 +176,15 @@ const Slider = React.forwardRef<
     },
     ref
   ) => {
-    const count = thumbCount(value, defaultValue);
+    // Radix captures an uncontrolled value array ONCE, at mount. Recomputing
+    // the count from a later `defaultValue` would drop a thumb while Radix
+    // still stores its value — an endpoint the user can no longer reach and
+    // nothing reports. Controlled sliders keep deriving from `value`, which is
+    // the prop Radix itself follows.
+    const initialUncontrolledCount = React.useRef(
+      thumbCount(undefined, defaultValue)
+    ).current;
+    const count = value?.length ?? initialUncontrolledCount;
     // Everything assistive technology reads goes on the THUMB, which is what
     // carries the `slider` role and takes focus. Left on the root it is
     // announced by nothing.
@@ -184,16 +196,24 @@ const Slider = React.forwardRef<
     // the length of an array, so nothing at compile time can insist a range
     // names both of its ends. Unmet, it fails silently — the control renders
     // and is unusable with a screen reader.
+    // Every thumb needs a name from somewhere: its own entry, or — for a
+    // single thumb only — the root's. A one-thumb slider with neither was
+    // previously exempt from this check, which is the same silent failure the
+    // check exists to report.
+    const isNamed = (index: number): boolean => {
+      const own = thumbs?.[index];
+      if (own?.["aria-label"] !== undefined) return true;
+      if (own?.["aria-labelledby"] !== undefined) return true;
+      return (
+        count === 1 && (ariaLabel !== undefined || ariaLabelledBy !== undefined)
+      );
+    };
     devWarnOnce(
-      count === 1 ||
-        Array.from({ length: count }).every(
-          (_, i) =>
-            thumbs?.[i]?.["aria-label"] ?? thumbs?.[i]?.["aria-labelledby"]
-        ),
-      "Slider: a range needs one `thumbs` entry per thumb with an accessible " +
-        "name. The root's name is not inherited by the thumbs, and two thumbs " +
-        "sharing one name are announced identically, so nothing says which " +
-        "end is held."
+      Array.from({ length: count }).every((_, i) => isNamed(i)),
+      "Slider: every thumb needs an accessible name. A single thumb may take " +
+        "it from the root's `aria-label`/`aria-labelledby`; a range needs one " +
+        "`thumbs` entry per thumb, because the root's name is not inherited " +
+        "and two thumbs sharing one name are announced identically."
     );
 
     const ariaFor = (index: number): SliderThumbProps => {
@@ -225,11 +245,14 @@ const Slider = React.forwardRef<
         ref={ref}
         className={cn(
           "relative flex w-full touch-none select-none items-center",
-          "py-2 data-[orientation=vertical]:px-2 data-[orientation=vertical]:py-0",
-          // A 16px thumb on a 6px track is under the 24px minimum target size
-          // (WCAG 2.5.8), and on touch the difference between "grabbed the thumb"
-          // and "missed the control" is exactly this padding.
-
+          // WCAG 2.5.8 wants 24px. Padding alone does not reach it: the thumb
+          // is absolutely positioned, so the cross-axis size is the 6px track
+          // plus the padding — 22px with `py-2`. An explicit minimum states
+          // the target rather than leaving it to arithmetic that moves
+          // whenever the track thickness does.
+          "min-h-6 py-2",
+          "data-[orientation=vertical]:min-h-0 data-[orientation=vertical]:min-w-6",
+          "data-[orientation=vertical]:px-2 data-[orientation=vertical]:py-0",
           "data-[orientation=vertical]:h-full data-[orientation=vertical]:w-auto",
           "data-[orientation=vertical]:flex-col",
           "data-[disabled]:pointer-events-none data-[disabled]:opacity-50",

--- a/packages/ui/src/components/slider.tsx
+++ b/packages/ui/src/components/slider.tsx
@@ -199,9 +199,19 @@ const Slider = React.forwardRef<
     const ariaFor = (index: number): SliderThumbProps => {
       const supplied = thumbs?.[index] ?? {};
       if (count !== 1) return supplied;
+      // The two naming attributes are ALTERNATIVES, not independent slots, so
+      // the fallback is all-or-nothing. Filling each one separately can emit a
+      // thumb `aria-label` alongside a root `aria-labelledby`, and since
+      // accessible-name computation prefers `aria-labelledby`, the caller's
+      // explicit per-thumb name would lose to the root's without saying so.
+      const namesItself =
+        supplied["aria-label"] !== undefined ||
+        supplied["aria-labelledby"] !== undefined;
       return {
-        "aria-label": supplied["aria-label"] ?? ariaLabel,
-        "aria-labelledby": supplied["aria-labelledby"] ?? ariaLabelledBy,
+        "aria-label": namesItself ? supplied["aria-label"] : ariaLabel,
+        "aria-labelledby": namesItself
+          ? supplied["aria-labelledby"]
+          : ariaLabelledBy,
         "aria-valuetext": supplied["aria-valuetext"],
         "aria-describedby": supplied["aria-describedby"],
       };

--- a/packages/ui/src/components/slider.tsx
+++ b/packages/ui/src/components/slider.tsx
@@ -84,6 +84,7 @@
 import * as SliderPrimitive from "@radix-ui/react-slider";
 import * as React from "react";
 
+import { devWarnOnce } from "../lib/dev-warn";
 import { cn } from "../lib/utils";
 
 /**
@@ -179,6 +180,22 @@ const Slider = React.forwardRef<
     // The single-thumb fallback keeps the documented one-thumb API working:
     // with one thumb the root's name is unambiguous, so it is forwarded. A
     // range has no such fallback — one name cannot distinguish two ends.
+    // The requirement TypeScript cannot express: how many thumbs there are is
+    // the length of an array, so nothing at compile time can insist a range
+    // names both of its ends. Unmet, it fails silently — the control renders
+    // and is unusable with a screen reader.
+    devWarnOnce(
+      count === 1 ||
+        Array.from({ length: count }).every(
+          (_, i) =>
+            thumbs?.[i]?.["aria-label"] ?? thumbs?.[i]?.["aria-labelledby"]
+        ),
+      "Slider: a range needs one `thumbs` entry per thumb with an accessible " +
+        "name. The root's name is not inherited by the thumbs, and two thumbs " +
+        "sharing one name are announced identically, so nothing says which " +
+        "end is held."
+    );
+
     const ariaFor = (index: number): SliderThumbProps => {
       const supplied = thumbs?.[index] ?? {};
       if (count !== 1) return supplied;

--- a/packages/ui/src/components/slider.tsx
+++ b/packages/ui/src/components/slider.tsx
@@ -61,8 +61,13 @@
  *
  * @example
  * ```tsx
- * // Two thumbs: the same component, because `value` was always an array
- * <Slider aria-label="Size range" defaultValue={[25, 75]} />
+ * // Two thumbs: the same component, because `value` was always an array.
+ * // A range needs `thumbLabels` — the root's name is not inherited, and two
+ * // thumbs sharing one name are announced identically.
+ * <Slider
+ *   defaultValue={[25, 75]}
+ *   thumbLabels={["Minimum size", "Maximum size"]}
+ * />
  * ```
  *
  * @module components/slider

--- a/packages/ui/src/components/slider.tsx
+++ b/packages/ui/src/components/slider.tsx
@@ -1,0 +1,148 @@
+/**
+ * Slider
+ *
+ * A value chosen by dragging along a track, built on `@radix-ui/react-slider`. An inspector is
+ * full of bounded numeric properties — opacity, blur radius, letter spacing, a colour's alpha —
+ * and each one is a value where the useful question is "more or less?" rather than "what number?".
+ *
+ * **Why a library rather than a range input**: `<input type="range">` is keyboard-accessible and
+ * nearly unstyleable, and it cannot express two thumbs. The parts that are genuinely hard are the
+ * ones a hand-rolled version gets wrong quietly — pointer capture that survives the cursor leaving
+ * the element, step rounding that does not accumulate floating-point drift, right-to-left
+ * direction, and the ARIA slider pattern for each thumb independently. Radix implements all of
+ * them and is already this kit's primitive vendor, so it adds no new dependency shape.
+ *
+ * **A slider is for magnitude, not precision.** Anything a person needs to type exactly wants a
+ * number input beside it; the slider is the coarse control and the input is the fine one. Pairing
+ * them is the caller's composition, deliberately: this kit does not decide that every slider earns
+ * a spinbox next to it.
+ *
+ * **Controlled and uncontrolled both work**, following Radix: pass `value` with `onValueChange` to
+ * control it, or `defaultValue` to let it own its state. `value` is an ARRAY even for a single
+ * thumb — that is what makes a range slider the same component rather than a second one, and it is
+ * the most common thing to get wrong on first use.
+ *
+ * **Commit on `onValueCommit`, not `onValueChange`**, whenever the write is expensive. The first
+ * fires once the drag settles; the second fires continuously while the pointer moves. Recompiling
+ * a stylesheet or writing to a server on every frame of a drag is the same mistake
+ * `ResizablePanelGroup` documents for layout persistence.
+ *
+ * **Design specifications**:
+ * - Track: 1.5 units thick, `bg-secondary`, fully rounded
+ * - Range: the filled portion, `bg-primary`
+ * - Thumb: 4x4, `border-primary` on `bg-background`, so it reads against both track halves
+ * - Focus: `focus-visible` ring on the thumb, which is the focusable element
+ * - Disabled: 50% opacity and `pointer-events-none`, matching the kit's other inputs
+ *
+ * **Accessibility**:
+ * - Each thumb is a `slider` with `aria-valuenow`/`aria-valuemin`/`aria-valuemax` from Radix
+ * - Arrow keys step, PageUp/PageDown jump, Home/End go to the bounds
+ * - `aria-label` or `aria-labelledby` is REQUIRED and not defaulted: an unlabelled slider
+ *   announces only a number, and this kit cannot invent a name that would be honest
+ * - The thumb is 16px with a larger touch target via padding on the root's vertical rhythm
+ *
+ * @example
+ * ```tsx
+ * // Single value, controlled, committing only when the drag settles
+ * <Slider
+ *   aria-label="Opacity"
+ *   value={[opacity]}
+ *   min={0}
+ *   max={100}
+ *   step={1}
+ *   onValueChange={([next]) => setPreview(next)}
+ *   onValueCommit={([next]) => save(next)}
+ * />
+ * ```
+ *
+ * @example
+ * ```tsx
+ * // Two thumbs: the same component, because `value` was always an array
+ * <Slider aria-label="Size range" defaultValue={[25, 75]} />
+ * ```
+ *
+ * @module components/slider
+ */
+"use client";
+
+import * as SliderPrimitive from "@radix-ui/react-slider";
+import * as React from "react";
+
+import { cn } from "../lib/utils";
+
+/**
+ * The slider's props, mirroring the Radix root.
+ *
+ * @experimental
+ */
+export type SliderProps = React.ComponentPropsWithoutRef<
+  typeof SliderPrimitive.Root
+>;
+
+/**
+ * One thumb per value, derived from whichever of `value`/`defaultValue` is present.
+ *
+ * Radix renders only as many thumbs as it is given children, so a range slider whose caller
+ * supplied two values but one thumb would silently drop the second — the value would still be in
+ * state, and no thumb would be able to reach it.
+ */
+function thumbCount(
+  value: readonly number[] | undefined,
+  defaultValue: readonly number[] | undefined
+): number {
+  return value?.length ?? defaultValue?.length ?? 1;
+}
+
+/**
+ * A bounded numeric value chosen by dragging.
+ *
+ * @experimental
+ */
+const Slider = React.forwardRef<
+  React.ElementRef<typeof SliderPrimitive.Root>,
+  SliderProps
+>(({ className, value, defaultValue, ...props }, ref) => (
+  <SliderPrimitive.Root
+    ref={ref}
+    className={cn(
+      "relative flex w-full touch-none select-none items-center",
+      "data-[orientation=vertical]:h-full data-[orientation=vertical]:w-auto",
+      "data-[orientation=vertical]:flex-col",
+      "data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      className
+    )}
+    value={value}
+    defaultValue={defaultValue}
+    {...props}
+  >
+    <SliderPrimitive.Track
+      className={cn(
+        "bg-secondary relative grow overflow-hidden rounded-full",
+        "h-1.5 w-full",
+        "data-[orientation=vertical]:h-full data-[orientation=vertical]:w-1.5"
+      )}
+    >
+      <SliderPrimitive.Range
+        className={cn(
+          "bg-primary absolute",
+          "h-full data-[orientation=vertical]:h-auto data-[orientation=vertical]:w-full"
+        )}
+      />
+    </SliderPrimitive.Track>
+    {Array.from({ length: thumbCount(value, defaultValue) }, (_, i) => (
+      <SliderPrimitive.Thumb
+        key={i}
+        className={cn(
+          "border-primary bg-background block h-4 w-4 rounded-full border-2",
+          "ring-offset-background transition-colors",
+          "focus-visible:ring-ring focus-visible:outline-none focus-visible:ring-2",
+          "focus-visible:ring-offset-2",
+          "disabled:pointer-events-none disabled:opacity-50"
+        )}
+      />
+    ))}
+  </SliderPrimitive.Root>
+));
+Slider.displayName = SliderPrimitive.Root.displayName;
+
+export { Slider };

--- a/packages/ui/src/components/slider.tsx
+++ b/packages/ui/src/components/slider.tsx
@@ -40,8 +40,10 @@
  * - A name is REQUIRED and not defaulted: an unlabelled slider announces only a number, and
  *   this kit cannot invent a name that would be honest. The name lands on the THUMB, which is
  *   what takes focus — `aria-label` on the root is inherited by nothing
- * - A RANGE needs `thumbLabels`, one per thumb: two thumbs sharing the root's name are
+ * - A RANGE needs `thumbs`, one entry per thumb: two thumbs sharing the root's name are
  *   announced identically, so nothing says which end is held
+ * - `aria-valuetext` and `aria-describedby` belong on `thumbs` too — like the name, they are
+ *   read from the thumb and inherited from nothing
  * - The root is padded so the target clears the 24px minimum (WCAG 2.5.8); the 16px thumb on a
  *   6px track does not on its own
  *
@@ -56,6 +58,8 @@
  *   step={1}
  *   onValueChange={([next]) => setPreview(next)}
  *   onValueCommit={([next]) => save(next)}
+ *   // The number alone does not say what it means; this is what gets spoken.
+ *   thumbs={[{ "aria-valuetext": `${opacity} percent` }]}
  * />
  * ```
  *
@@ -66,7 +70,10 @@
  * // thumbs sharing one name are announced identically.
  * <Slider
  *   defaultValue={[25, 75]}
- *   thumbLabels={["Minimum size", "Maximum size"]}
+ *   thumbs={[
+ *     { "aria-label": "Minimum size" },
+ *     { "aria-label": "Maximum size" },
+ *   ]}
  * />
  * ```
  *
@@ -80,6 +87,25 @@ import * as React from "react";
 import { cn } from "../lib/utils";
 
 /**
+ * The assistive-technology attributes a single thumb can carry.
+ *
+ * @experimental
+ */
+export interface SliderThumbProps {
+  /** The thumb's accessible name. */
+  "aria-label"?: string;
+  /** An element naming the thumb, when the name is already on screen. */
+  "aria-labelledby"?: string;
+  /**
+   * What the value MEANS, when the number alone does not say it — "40
+   * percent", "Medium". Announced in place of the raw number.
+   */
+  "aria-valuetext"?: string;
+  /** An element carrying help text for this thumb. */
+  "aria-describedby"?: string;
+}
+
+/**
  * The slider's props, mirroring the Radix root.
  *
  * @experimental
@@ -88,16 +114,26 @@ export type SliderProps = React.ComponentPropsWithoutRef<
   typeof SliderPrimitive.Root
 > & {
   /**
-   * An accessible name per thumb, in value order.
+   * Assistive-technology attributes per thumb, in value order.
    *
-   * Required for a RANGE, and the reason this prop exists: the focusable
-   * element is the thumb, not the root, and a name on the root is not
-   * inherited. Two thumbs named only by their shared root are announced
-   * identically, so nothing tells a screen-reader user which end they are
-   * holding. A single thumb falls back to the root's `aria-label`, so the
-   * one-thumb API stays as documented.
+   * The reason this exists at all: the focusable element with the `slider`
+   * role is the THUMB, and none of these attributes are inherited from the
+   * root. Anything a caller puts on the root is therefore announced by
+   * nothing, and the thumbs are generated internally so they cannot be
+   * reached any other way.
+   *
+   * Deliberately a curated set rather than the thumb's full prop type. This
+   * is the surface assistive technology reads; opening it to arbitrary props
+   * would let a caller replace the class names or the role the control
+   * depends on, and every escape hatch in a design system eventually gets
+   * used that way.
+   *
+   * Required for a RANGE: two thumbs sharing one name are announced
+   * identically, so nothing says which end is held. A single thumb falls back
+   * to the root's `aria-label`/`aria-labelledby`, so the one-thumb API stays
+   * as documented.
    */
-  thumbLabels?: readonly string[];
+  thumbs?: readonly SliderThumbProps[];
 };
 
 /**
@@ -128,7 +164,7 @@ const Slider = React.forwardRef<
       className,
       value,
       defaultValue,
-      thumbLabels,
+      thumbs,
       "aria-label": ariaLabel,
       "aria-labelledby": ariaLabelledBy,
       ...props
@@ -136,12 +172,28 @@ const Slider = React.forwardRef<
     ref
   ) => {
     const count = thumbCount(value, defaultValue);
-    // The name goes on the THUMB, which is what carries the `slider` role and
-    // takes focus. Left on the root it is announced by nothing.
-    const nameFor = (index: number): string | undefined =>
-      thumbLabels?.[index] ?? (count === 1 ? ariaLabel : undefined);
+    // Everything assistive technology reads goes on the THUMB, which is what
+    // carries the `slider` role and takes focus. Left on the root it is
+    // announced by nothing.
+    //
+    // The single-thumb fallback keeps the documented one-thumb API working:
+    // with one thumb the root's name is unambiguous, so it is forwarded. A
+    // range has no such fallback — one name cannot distinguish two ends.
+    const ariaFor = (index: number): SliderThumbProps => {
+      const supplied = thumbs?.[index] ?? {};
+      if (count !== 1) return supplied;
+      return {
+        "aria-label": supplied["aria-label"] ?? ariaLabel,
+        "aria-labelledby": supplied["aria-labelledby"] ?? ariaLabelledBy,
+        "aria-valuetext": supplied["aria-valuetext"],
+        "aria-describedby": supplied["aria-describedby"],
+      };
+    };
 
     return (
+      // `aria-label`/`aria-labelledby` are destructured out above rather than
+      // spread here: left on the root they would be a second, roleless copy
+      // of a name only the thumb is read for.
       <SliderPrimitive.Root
         ref={ref}
         className={cn(
@@ -177,10 +229,7 @@ const Slider = React.forwardRef<
         {Array.from({ length: count }, (_, i) => (
           <SliderPrimitive.Thumb
             key={i}
-            aria-label={nameFor(i)}
-            // Only meaningful for the single-thumb case: a range's thumbs need
-            // distinct names, which an id shared by both cannot give them.
-            aria-labelledby={count === 1 ? ariaLabelledBy : undefined}
+            {...ariaFor(i)}
             className={cn(
               "border-primary bg-background block h-4 w-4 rounded-full border-2",
               "ring-offset-background transition-colors",

--- a/packages/ui/src/components/slider.tsx
+++ b/packages/ui/src/components/slider.tsx
@@ -37,9 +37,13 @@
  * **Accessibility**:
  * - Each thumb is a `slider` with `aria-valuenow`/`aria-valuemin`/`aria-valuemax` from Radix
  * - Arrow keys step, PageUp/PageDown jump, Home/End go to the bounds
- * - `aria-label` or `aria-labelledby` is REQUIRED and not defaulted: an unlabelled slider
- *   announces only a number, and this kit cannot invent a name that would be honest
- * - The thumb is 16px with a larger touch target via padding on the root's vertical rhythm
+ * - A name is REQUIRED and not defaulted: an unlabelled slider announces only a number, and
+ *   this kit cannot invent a name that would be honest. The name lands on the THUMB, which is
+ *   what takes focus — `aria-label` on the root is inherited by nothing
+ * - A RANGE needs `thumbLabels`, one per thumb: two thumbs sharing the root's name are
+ *   announced identically, so nothing says which end is held
+ * - The root is padded so the target clears the 24px minimum (WCAG 2.5.8); the 16px thumb on a
+ *   6px track does not on its own
  *
  * @example
  * ```tsx
@@ -77,7 +81,19 @@ import { cn } from "../lib/utils";
  */
 export type SliderProps = React.ComponentPropsWithoutRef<
   typeof SliderPrimitive.Root
->;
+> & {
+  /**
+   * An accessible name per thumb, in value order.
+   *
+   * Required for a RANGE, and the reason this prop exists: the focusable
+   * element is the thumb, not the root, and a name on the root is not
+   * inherited. Two thumbs named only by their shared root are announced
+   * identically, so nothing tells a screen-reader user which end they are
+   * holding. A single thumb falls back to the root's `aria-label`, so the
+   * one-thumb API stays as documented.
+   */
+  thumbLabels?: readonly string[];
+};
 
 /**
  * One thumb per value, derived from whichever of `value`/`defaultValue` is present.
@@ -101,48 +117,78 @@ function thumbCount(
 const Slider = React.forwardRef<
   React.ElementRef<typeof SliderPrimitive.Root>,
   SliderProps
->(({ className, value, defaultValue, ...props }, ref) => (
-  <SliderPrimitive.Root
-    ref={ref}
-    className={cn(
-      "relative flex w-full touch-none select-none items-center",
-      "data-[orientation=vertical]:h-full data-[orientation=vertical]:w-auto",
-      "data-[orientation=vertical]:flex-col",
-      "data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
-      className
-    )}
-    value={value}
-    defaultValue={defaultValue}
-    {...props}
-  >
-    <SliderPrimitive.Track
-      className={cn(
-        "bg-secondary relative grow overflow-hidden rounded-full",
-        "h-1.5 w-full",
-        "data-[orientation=vertical]:h-full data-[orientation=vertical]:w-1.5"
-      )}
-    >
-      <SliderPrimitive.Range
+>(
+  (
+    {
+      className,
+      value,
+      defaultValue,
+      thumbLabels,
+      "aria-label": ariaLabel,
+      "aria-labelledby": ariaLabelledBy,
+      ...props
+    },
+    ref
+  ) => {
+    const count = thumbCount(value, defaultValue);
+    // The name goes on the THUMB, which is what carries the `slider` role and
+    // takes focus. Left on the root it is announced by nothing.
+    const nameFor = (index: number): string | undefined =>
+      thumbLabels?.[index] ?? (count === 1 ? ariaLabel : undefined);
+
+    return (
+      <SliderPrimitive.Root
+        ref={ref}
         className={cn(
-          "bg-primary absolute",
-          "h-full data-[orientation=vertical]:h-auto data-[orientation=vertical]:w-full"
+          "relative flex w-full touch-none select-none items-center",
+          "py-2 data-[orientation=vertical]:px-2 data-[orientation=vertical]:py-0",
+          // A 16px thumb on a 6px track is under the 24px minimum target size
+          // (WCAG 2.5.8), and on touch the difference between "grabbed the thumb"
+          // and "missed the control" is exactly this padding.
+
+          "data-[orientation=vertical]:h-full data-[orientation=vertical]:w-auto",
+          "data-[orientation=vertical]:flex-col",
+          "data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+          className
         )}
-      />
-    </SliderPrimitive.Track>
-    {Array.from({ length: thumbCount(value, defaultValue) }, (_, i) => (
-      <SliderPrimitive.Thumb
-        key={i}
-        className={cn(
-          "border-primary bg-background block h-4 w-4 rounded-full border-2",
-          "ring-offset-background transition-colors",
-          "focus-visible:ring-ring focus-visible:outline-none focus-visible:ring-2",
-          "focus-visible:ring-offset-2",
-          "disabled:pointer-events-none disabled:opacity-50"
-        )}
-      />
-    ))}
-  </SliderPrimitive.Root>
-));
+        value={value}
+        defaultValue={defaultValue}
+        {...props}
+      >
+        <SliderPrimitive.Track
+          className={cn(
+            "bg-secondary relative grow overflow-hidden rounded-full",
+            "h-1.5 w-full",
+            "data-[orientation=vertical]:h-full data-[orientation=vertical]:w-1.5"
+          )}
+        >
+          <SliderPrimitive.Range
+            className={cn(
+              "bg-primary absolute",
+              "h-full data-[orientation=vertical]:h-auto data-[orientation=vertical]:w-full"
+            )}
+          />
+        </SliderPrimitive.Track>
+        {Array.from({ length: count }, (_, i) => (
+          <SliderPrimitive.Thumb
+            key={i}
+            aria-label={nameFor(i)}
+            // Only meaningful for the single-thumb case: a range's thumbs need
+            // distinct names, which an id shared by both cannot give them.
+            aria-labelledby={count === 1 ? ariaLabelledBy : undefined}
+            className={cn(
+              "border-primary bg-background block h-4 w-4 rounded-full border-2",
+              "ring-offset-background transition-colors",
+              "focus-visible:ring-ring focus-visible:outline-none focus-visible:ring-2",
+              "focus-visible:ring-offset-2",
+              "disabled:pointer-events-none disabled:opacity-50"
+            )}
+          />
+        ))}
+      </SliderPrimitive.Root>
+    );
+  }
+);
 Slider.displayName = SliderPrimitive.Root.displayName;
 
 export { Slider };

--- a/packages/ui/src/components/slider.tsx
+++ b/packages/ui/src/components/slider.tsx
@@ -49,6 +49,11 @@
  * - An empty name does not count as a name: `aria-label=""` is reported the same as a missing one,
  *   because the accessible name computes to nothing either way
  *
+ * **An empty value array renders nothing.** A slider over no values is not a state this control
+ * can represent: an empty `defaultValue` falls back to `min`, and an empty `value` — which a
+ * controlled caller owns and this component must not overwrite — renders no control at all,
+ * rather than a thumb that carries no value and cannot be moved.
+ *
  * **Sizing**: a horizontal slider fills its container's width. A VERTICAL one carries a default
  * height instead of filling, because `height: 100%` inside an auto-height parent collapses to a
  * track with no length. Override it with an ordinary `className` — `h-64` for a longer control,
@@ -214,7 +219,9 @@ const Slider = React.forwardRef<
     const initialUncontrolledCount = React.useRef(
       thumbCount(undefined, defaultValue)
     ).current;
-    const count = Math.max(1, value?.length ?? initialUncontrolledCount);
+    // Both sources are already at least one: an empty controlled value returns before this is
+    // used, and `thumbCount` floors the uncontrolled side.
+    const count = value?.length ?? initialUncontrolledCount;
 
     // An empty array asks for a slider over no values, which is not a state this control can
     // represent. The two cases differ in how far they can be repaired, so they are handled
@@ -224,20 +231,27 @@ const Slider = React.forwardRef<
     // then applies its own `[min]` default. Substituting the vendor's default is exactly what an
     // omitted prop would have done, so nothing downstream can tell the difference.
     //
-    // CONTROLLED is NOT repairable here. Replacing an empty `value` would either flip the control
-    // to uncontrolled — handing Radix ownership of state the caller believes it holds — or display
-    // a number the caller's state does not contain, which would then never reconcile. The empty
-    // array is forwarded unchanged and reported instead; the fallback thumb keeps the control
-    // focusable, so the defect is visible rather than an inert bar.
+    // CONTROLLED is NOT repairable, so the control renders NOTHING. Substituting a value would
+    // either flip to uncontrolled — handing Radix ownership of state the caller believes it holds
+    // — or show a number the caller's state does not contain, which then never reconciles.
+    // Emitting a thumb anyway is worse than either: Radix resolves a track click through
+    // `getClosestValueIndex`, which returns -1 for an empty array and so writes nowhere. That
+    // thumb carries no `aria-valuenow`, cannot be dragged and cannot be moved by a key — a
+    // `slider` role that looks operable and is not, which is the one outcome worse than absence.
     const isEmptyDefault =
       defaultValue !== undefined && defaultValue.length === 0;
+    const isEmptyControlled = value !== undefined && value.length === 0;
     devWarnOnce(
-      !isEmptyDefault && !(value !== undefined && value.length === 0),
+      !isEmptyDefault && !isEmptyControlled,
       "Slider: `value`/`defaultValue` must hold one number per thumb, and an empty array " +
         "holds none — the control has nothing to slide. An empty `defaultValue` falls back to " +
-        "`min`; an empty `value` cannot be repaired without taking state the caller owns, so " +
-        "render nothing until the value is loaded rather than passing `[]`."
+        "`min`; an empty `value` renders nothing at all, because a controlled slider cannot be " +
+        "given a value without taking state the caller owns. Render nothing until the value is " +
+        "loaded rather than passing `[]`."
     );
+    // Placed after the warning so the defect is always reported, and after every hook so the
+    // early return cannot change the order they are called in.
+    if (isEmptyControlled) return null;
     // Everything assistive technology reads goes on the THUMB, which is what
     // carries the `slider` role and takes focus. Left on the root it is
     // announced by nothing.

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -475,5 +475,9 @@ export type { TreeNode, TreeViewProps } from "./components/tree-view";
  * for one thumb, which is what makes a range slider the same component rather than a second one.
  */
 export { Slider } from "./components/slider";
-/** @experimental The slider's props, mirroring the Radix root. */
-export type { SliderProps } from "./components/slider";
+/**
+ * @experimental The slider's props, and the per-thumb attributes assistive
+ * technology reads — which are read from the THUMB and inherited from nothing,
+ * so they cannot be passed through the root.
+ */
+export type { SliderProps, SliderThumbProps } from "./components/slider";

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -466,3 +466,14 @@ export {
 export { TreeView } from "./components/tree-view";
 /** @experimental The node shape a tree is built from, and the control's props. */
 export type { TreeNode, TreeViewProps } from "./components/tree-view";
+
+/**
+ * @experimental A bounded numeric value chosen by dragging.
+ *
+ * Every inspector is full of these — opacity, blur radius, letter spacing, a colour's alpha —
+ * and each is a property where "more or less?" is the useful question. `value` is an ARRAY even
+ * for one thumb, which is what makes a range slider the same component rather than a second one.
+ */
+export { Slider } from "./components/slider";
+/** @experimental The slider's props, mirroring the Radix root. */
+export type { SliderProps } from "./components/slider";

--- a/packages/ui/src/lib/dev-warn.test.ts
+++ b/packages/ui/src/lib/dev-warn.test.ts
@@ -1,0 +1,60 @@
+/**
+ * The warning utility's own contract.
+ *
+ * Each rule here exists because breaking it makes the warnings worse than
+ * useless: a warning on every frame of a drag trains people to ignore the
+ * console, and a warning that throws turns a degraded label into a blank page.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { devWarnOnce, resetDevWarnings } from "./dev-warn";
+
+let warn: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  resetDevWarnings();
+  warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  warn.mockRestore();
+});
+
+describe("devWarnOnce", () => {
+  it("says nothing while the requirement holds", () => {
+    devWarnOnce(true, "should not appear");
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("warns when the requirement is unmet, naming the kit", () => {
+    // The prefix matters in a console shared with the host app's own output:
+    // a bare sentence gives the reader nothing to search for.
+    devWarnOnce(false, "a range needs a name per thumb");
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(String(warn.mock.calls[0][0])).toContain("[@nextlyhq/ui]");
+    expect(String(warn.mock.calls[0][0])).toContain("a range needs a name");
+  });
+
+  it("emits the same message ONCE however many times it recurs", () => {
+    // A control re-rendering through a scrub would otherwise emit this on
+    // every frame, which buries the one line the developer needs to act on.
+    for (let i = 0; i < 60; i++) devWarnOnce(false, "same message");
+    expect(warn).toHaveBeenCalledTimes(1);
+  });
+
+  it("still reports a DIFFERENT defect after one has been emitted", () => {
+    // Deduplication that silenced everything after the first warning would
+    // hide the second defect entirely — the failure mode of a naive guard.
+    devWarnOnce(false, "first defect");
+    devWarnOnce(false, "second defect");
+    expect(warn).toHaveBeenCalledTimes(2);
+  });
+
+  it("reports a defect without throwing, so a missing label degrades", () => {
+    // The whole point is that an accessibility defect stays a defect rather
+    // than becoming a blank page: warning must never be the more damaging of
+    // the two outcomes.
+    expect(() => devWarnOnce(false, "unmet requirement")).not.toThrow();
+    expect(warn).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/ui/src/lib/dev-warn.test.ts
+++ b/packages/ui/src/lib/dev-warn.test.ts
@@ -50,6 +50,46 @@ describe("devWarnOnce", () => {
     expect(warn).toHaveBeenCalledTimes(2);
   });
 
+  it("stays silent in production", () => {
+    const original = process.env.NODE_ENV;
+    try {
+      process.env.NODE_ENV = "production";
+      devWarnOnce(false, "a production build must not say this");
+      expect(warn).not.toHaveBeenCalled();
+    } finally {
+      process.env.NODE_ENV = original;
+    }
+  });
+
+  it("stays silent when the environment cannot be identified", () => {
+    // The gate asks for a POSITIVE development signal rather than the absence of a production
+    // one. This package publishes ESM that keeps the check at runtime, and a bundle that never
+    // defines `process.env.NODE_ENV` would answer "not production" — so an `!== "production"`
+    // test would ship every warning to real users' consoles.
+    const original = process.env.NODE_ENV;
+    try {
+      delete process.env.NODE_ENV;
+      devWarnOnce(false, "an unidentified build must not say this either");
+      expect(warn).not.toHaveBeenCalled();
+    } finally {
+      process.env.NODE_ENV = original;
+    }
+  });
+
+  it("speaks in development", () => {
+    // The positive control for the two silences above: the same call, in an environment that
+    // does identify itself, must still produce the warning. Without this, the gate could be
+    // silencing everything and both tests would pass.
+    const original = process.env.NODE_ENV;
+    try {
+      process.env.NODE_ENV = "development";
+      devWarnOnce(false, "a development build says this");
+      expect(warn).toHaveBeenCalledTimes(1);
+    } finally {
+      process.env.NODE_ENV = original;
+    }
+  });
+
   it("reports a defect without throwing, so a missing label degrades", () => {
     // The whole point is that an accessibility defect stays a defect rather
     // than becoming a blank page: warning must never be the more damaging of

--- a/packages/ui/src/lib/dev-warn.ts
+++ b/packages/ui/src/lib/dev-warn.ts
@@ -16,8 +16,13 @@
  *
  * The rules this module exists to enforce:
  *
- * - **Development only.** The check is behind `process.env.NODE_ENV`, so a
- *   production bundle drops both the call and the message.
+ * - **Development only, proven rather than assumed.** The gate requires a
+ *   POSITIVE development signal. Asking instead whether the environment is
+ *   production fails open: this package publishes ESM that keeps the runtime
+ *   check, and a browser bundle that neither defines nor shims `process`
+ *   leaves the comparison false, so every warning would reach real users'
+ *   consoles. Silence in an unidentifiable environment is the cheaper mistake
+ *   of the two.
  * - **Once per message.** A control that re-renders through a drag would
  *   otherwise emit the same line on every frame, which trains people to ignore
  *   the console — the opposite of the point.
@@ -48,6 +53,29 @@ const emitted = new Set<string>();
 declare const process: { env?: { NODE_ENV?: string } | undefined } | undefined;
 
 /**
+ * The environments a warning is allowed to speak in.
+ *
+ * `test` is here alongside `development` because a suite asserting that a
+ * warning fires is checking the same contract a developer relies on; leaving
+ * it out would make every such test pass for the wrong reason.
+ */
+const SPEAKING_ENVIRONMENTS = new Set(["development", "test"]);
+
+/**
+ * Whether this runtime has positively identified itself as a development one.
+ *
+ * Deliberately not `!== "production"`. Bundlers replace `process.env.NODE_ENV`
+ * at build time, but nothing obliges them to: a build that leaves `process`
+ * undefined would answer "not production" and ship every warning to end users.
+ * An unrecognized environment is treated as one to stay quiet in.
+ */
+function isDevelopmentRuntime(): boolean {
+  if (typeof process === "undefined") return false;
+  const env = process?.env?.NODE_ENV;
+  return env !== undefined && SPEAKING_ENVIRONMENTS.has(env);
+}
+
+/**
  * Warn once, in development, about a requirement that is unmet.
  *
  * @param condition - The requirement. Nothing is emitted while this holds.
@@ -56,12 +84,7 @@ declare const process: { env?: { NODE_ENV?: string } | undefined } | undefined;
  */
 export function devWarnOnce(condition: boolean, message: string): void {
   if (condition) return;
-  if (
-    typeof process !== "undefined" &&
-    process?.env?.NODE_ENV === "production"
-  ) {
-    return;
-  }
+  if (!isDevelopmentRuntime()) return;
   if (emitted.has(message)) return;
   emitted.add(message);
   console.warn(`[@nextlyhq/ui] ${message}`);

--- a/packages/ui/src/lib/dev-warn.ts
+++ b/packages/ui/src/lib/dev-warn.ts
@@ -1,0 +1,78 @@
+/**
+ * Development-time warnings for requirements the type system cannot express.
+ *
+ * Some contracts in this kit depend on runtime facts — a range slider needs one
+ * accessible name per thumb, and how many thumbs there are is the length of an
+ * array. TypeScript cannot see that, a doc comment is not checked by anything,
+ * and the failure is silent: the control renders, looks finished, and is
+ * unusable with a screen reader.
+ *
+ * **This follows the layer beneath us rather than inventing a policy.** Radix
+ * Primitives warns when a Dialog is missing an accessible title or description;
+ * React Aria warns for missing labels; React itself warns for missing keys. A
+ * wrapper that stays silent about a defect the primitive underneath it reports
+ * is less safe than the thing it wraps, and quietly removes a signal consumers
+ * already had.
+ *
+ * The rules this module exists to enforce:
+ *
+ * - **Development only.** The check is behind `process.env.NODE_ENV`, so a
+ *   production bundle drops both the call and the message.
+ * - **Once per message.** A control that re-renders through a drag would
+ *   otherwise emit the same line on every frame, which trains people to ignore
+ *   the console — the opposite of the point.
+ * - **Never throws.** A missing label degrades; it must not take down the page
+ *   that contains it.
+ *
+ * @module lib/dev-warn
+ */
+
+/**
+ * Messages already emitted this session.
+ *
+ * Keyed by the message itself rather than by component instance: the same
+ * defect repeated across twenty instances is one thing for the developer to
+ * fix, and twenty identical lines make it harder to see, not easier.
+ */
+const emitted = new Set<string>();
+
+/**
+ * The one field this module reads, declared rather than pulled in with
+ * `@types/node`.
+ *
+ * This package targets the browser and deliberately carries no Node types;
+ * adding them to reach a single string would widen what every consumer's
+ * type-check sees. Bundlers replace `process.env.NODE_ENV` at build time, and
+ * `typeof` guards the case where nothing does.
+ */
+declare const process: { env?: { NODE_ENV?: string } | undefined } | undefined;
+
+/**
+ * Warn once, in development, about a requirement that is unmet.
+ *
+ * @param condition - The requirement. Nothing is emitted while this holds.
+ * @param message - What is wrong and what to do about it. Written for the
+ *   developer who will read it in a console with no other context.
+ */
+export function devWarnOnce(condition: boolean, message: string): void {
+  if (condition) return;
+  if (
+    typeof process !== "undefined" &&
+    process?.env?.NODE_ENV === "production"
+  ) {
+    return;
+  }
+  if (emitted.has(message)) return;
+  emitted.add(message);
+  console.warn(`[@nextlyhq/ui] ${message}`);
+}
+
+/**
+ * Forget which messages have been emitted.
+ *
+ * For tests, which need each case to observe its own warning rather than
+ * inheriting the suppression an earlier one caused.
+ */
+export function resetDevWarnings(): void {
+  emitted.clear();
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1536,6 +1536,9 @@ importers:
       '@radix-ui/react-separator':
         specifier: ^1.1.8
         version: 1.1.8(@types/react-dom@19.2.0(@types/react@19.2.0))(@types/react@19.2.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-slider':
+        specifier: ^1.4.7
+        version: 1.4.7(@types/react-dom@19.2.0(@types/react@19.2.0))(@types/react@19.2.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@radix-ui/react-slot':
         specifier: ^1.2.4
         version: 1.2.4(@types/react@19.2.0)(react@19.2.0)
@@ -3416,6 +3419,9 @@ packages:
   '@radix-ui/number@1.1.1':
     resolution: {integrity: sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==}
 
+  '@radix-ui/number@1.1.3':
+    resolution: {integrity: sha512-Road2bidD0uu/1BGDOWNdPI06g0lIRy6IF9GZcIrDK2KGItfor8IQwQa+yM2ERgHM1MmHxaxpTzk0/Jp42lNfA==}
+
   '@radix-ui/primitive@1.1.3':
     resolution: {integrity: sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==}
 
@@ -3963,6 +3969,19 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-slider@1.4.7':
+    resolution: {integrity: sha512-mTSLf1GC/C0moWjTbvCM6Qn/gBjvlFt1azuWF2v7MN5C3Zq2U2J2lN3ZEYkpujuOU5Ro7A28wkviSxaKnG0BYg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-slot@1.2.3':
     resolution: {integrity: sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==}
     peerDependencies:
@@ -4130,6 +4149,15 @@ packages:
 
   '@radix-ui/react-use-previous@1.1.1':
     resolution: {integrity: sha512-2dHfToCj/pzca2Ck724OZ5L0EVrr3eHRNsG/b3xQJLA2hZpVCS99bLAX+hm1IHXDEnzU6by5z/5MIY794/a8NQ==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-previous@1.1.4':
+    resolution: {integrity: sha512-XoSLhbRbqxFtgJoi2fNHA3C6pDlY34x508vUpUGoFZfvePfHXHbE1lC4FYFMnJWgiCRroSTw6fOsXQoVS9RwZg==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -10674,6 +10702,8 @@ snapshots:
 
   '@radix-ui/number@1.1.1': {}
 
+  '@radix-ui/number@1.1.3': {}
+
   '@radix-ui/primitive@1.1.3': {}
 
   '@radix-ui/primitive@1.1.7': {}
@@ -11240,6 +11270,25 @@ snapshots:
       '@types/react': 19.2.0
       '@types/react-dom': 19.2.0(@types/react@19.2.0)
 
+  '@radix-ui/react-slider@1.4.7(@types/react-dom@19.2.0(@types/react@19.2.0))(@types/react@19.2.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      '@radix-ui/number': 1.1.3
+      '@radix-ui/primitive': 1.1.7
+      '@radix-ui/react-collection': 1.1.15(@types/react-dom@19.2.0(@types/react@19.2.0))(@types/react@19.2.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-compose-refs': 1.1.5(@types/react@19.2.0)(react@19.2.0)
+      '@radix-ui/react-context': 1.2.2(@types/react@19.2.0)(react@19.2.0)
+      '@radix-ui/react-direction': 1.1.4(@types/react@19.2.0)(react@19.2.0)
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.0(@types/react@19.2.0))(@types/react@19.2.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-use-controllable-state': 1.2.6(@types/react@19.2.0)(react@19.2.0)
+      '@radix-ui/react-use-layout-effect': 1.1.4(@types/react@19.2.0)(react@19.2.0)
+      '@radix-ui/react-use-previous': 1.1.4(@types/react@19.2.0)(react@19.2.0)
+      '@radix-ui/react-use-size': 1.1.4(@types/react@19.2.0)(react@19.2.0)
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
+    optionalDependencies:
+      '@types/react': 19.2.0
+      '@types/react-dom': 19.2.0(@types/react@19.2.0)
+
   '@radix-ui/react-slot@1.2.3(@types/react@19.2.0)(react@19.2.0)':
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.0)(react@19.2.0)
@@ -11388,6 +11437,12 @@ snapshots:
       '@types/react': 19.2.0
 
   '@radix-ui/react-use-previous@1.1.1(@types/react@19.2.0)(react@19.2.0)':
+    dependencies:
+      react: 19.2.0
+    optionalDependencies:
+      '@types/react': 19.2.0
+
+  '@radix-ui/react-use-previous@1.1.4(@types/react@19.2.0)(react@19.2.0)':
     dependencies:
       react: 19.2.0
     optionalDependencies:
@@ -12193,7 +12248,7 @@ snapshots:
       obug: 2.1.4
       std-env: 4.2.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.10(@types/node@20.19.17)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.9.0)(jsdom@27.1.0)(vite@7.3.6(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.10(@types/node@24.10.0)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.9.0)(jsdom@27.1.0)(vite@7.3.6(@types/node@24.10.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
 
   '@vitest/expect@4.1.10':
     dependencies:
@@ -12263,7 +12318,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.1.0
-      vitest: 4.1.10(@types/node@20.19.17)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.9.0)(jsdom@27.1.0)(vite@7.3.6(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.10(@types/node@24.10.0)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.9.0)(jsdom@27.1.0)(vite@7.3.6(@types/node@24.10.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
 
   '@vitest/utils@4.1.10':
     dependencies:
@@ -15939,7 +15994,7 @@ snapshots:
       std-env: 4.2.0
       tinybench: 2.9.0
       tinyexec: 1.2.4
-      tinyglobby: 0.2.17
+      tinyglobby: 0.2.15
       tinyrainbow: 3.1.0
       vite: 7.3.6(@types/node@20.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.20.5)(yaml@2.8.3)
       why-is-node-running: 2.3.0
@@ -16001,7 +16056,7 @@ snapshots:
       std-env: 4.2.0
       tinybench: 2.9.0
       tinyexec: 1.2.4
-      tinyglobby: 0.2.17
+      tinyglobby: 0.2.15
       tinyrainbow: 3.1.0
       vite: 7.3.6(@types/node@24.10.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.20.5)(yaml@2.8.3)
       why-is-node-running: 2.3.0


### PR DESCRIPTION
First of the four missing **F7** primitives from the page-builder master plan (`@nextlyhq/ui` additions, PB-D17 D10-6). Foundation work for the builder, deliberately outside Plans 01/02/03 so it cannot collide with the page-builder program.

## Why this belongs in the kit

An inspector is mostly bounded numeric properties — opacity, blur radius, letter spacing, a colour's alpha. Every plugin that builds an editing surface needs the same control, and the page-builder proof of concept reimplemented it privately, which is exactly what F7 exists to prevent.

`<input type="range">` is keyboard-accessible and nearly unstyleable, and cannot express two thumbs. A hand-rolled replacement gets the quiet parts wrong: pointer capture that survives the cursor leaving the element, step rounding that does not accumulate float drift, RTL direction, and the ARIA slider pattern applied *per thumb*. This wraps `@radix-ui/react-slider` — Radix is already the kit's primitive vendor, so no new dependency shape enters.

## The one design decision worth reviewing

**Thumbs are derived from the value count**, not from children. Radix renders exactly the thumbs it is given, so a two-value slider handed one thumb drops the second *silently* — the value stays in state and no thumb can reach it. Nothing else reports that: the markup is valid, the first thumb works, and the control looks finished. `value` being an array even for one thumb is what makes a range slider the same component rather than a second one.

The docs also steer callers to `onValueCommit` over `onValueChange` for expensive writes — the same trap `ResizablePanelGroup` documents for layout persistence, since `onValueChange` fires on every frame of a drag.

## Testing

**5 tests**, and the full package suite is green: **286 passed, 17 files**.

Cases pin the things that fail silently: one thumb per controlled value, two per uncontrolled range (a different code path — a fix consulting only `value` would leave it broken), the no-value fallback, the bounds a screen reader announces, and that `disabled` reaches the control rather than only its appearance.

**Verified by break:** forcing `thumbCount` to 1 fails the range case specifically.

Two conventions I had to discover and matched rather than worked around: this package does not auto-clean the DOM between tests, so queries are scoped to each render's own container (a document-wide count drifts upward as cases are added); and jest-dom matchers are not wired in, so assertions use plain DOM reads.

## Package guards

The surface guard caught a real mistake: I first inserted the export *between* `TreeView`'s doc comment and its export statement, orphaning `TreeView`'s release tag. Fixed by placing the block after the tree-view exports.

It also enforces that the `@experimental` tag lives on the **declaration**, not the re-export — the bundler drops a comment attached to an export statement. `STABILITY.md` is updated, and the surface snapshot regenerated for the intentional addition.

## Not in this PR

The other three F7 primitives — colour picker, shortcut manager, breakpoint-manager dialog. Each is independent, and the colour picker in particular is substantial enough to deserve its own review rather than being bundled here.
