### PR TITLE
feat(blocks-react): render a collection of block documents as pages

### DIFF
--- a/.changeset/blocks-page-route.md
+++ b/.changeset/blocks-page-route.md
@@ -1,0 +1,40 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+`createBlocksPage()` turns a collection of block documents into rendered pages.
+
+It composes the existing content-route factory with the block renderer: the route resolves a path to an entry and owns `generateStaticParams`, `generateMetadata` and the not-found decisions, and this fills in the render. Media ids and entry references resolve against the CMS, so images and links work without wiring either by hand.
+
+```tsx
+const { ContentPage, generateMetadata, generateStaticParams } =
+  createBlocksPage({ collections: ["pages"], field: "content" });
+
+export { generateMetadata, generateStaticParams };
+export default ContentPage;
+```
+
+It lives at `@nextlyhq/blocks-react/next`, so importing the renderer itself still pulls in neither Next nor the CMS. `nextly` is an optional peer dependency, and a test asserts the package root reaches no part of it.
+
+`render` and `buildMetadata` now also receive the reader the route resolved the entry through, as `context.reader`. A render that needs a second read — a referenced author, the media behind an image — no longer has to obtain an instance of its own, which on a per-tenant setup would be a different database.

--- a/packages/blocks-react/README.md
+++ b/packages/blocks-react/README.md
@@ -11,20 +11,33 @@ into it.
 
 ## Two entries, and why
 
-| Entry                         | Contains                              | Exported today                           |
-| ----------------------------- | ------------------------------------- | ---------------------------------------- |
-| `@nextlyhq/blocks-react`      | the renderer and the context contract | context types, `createStandaloneContext` |
-| `@nextlyhq/blocks-react/next` | everything that needs `next/*`        | entry marker only                        |
+| Entry                         | Contains                              | Exported today                                                                                    |
+| ----------------------------- | ------------------------------------- | ------------------------------------------------------------------------------------------------- |
+| `@nextlyhq/blocks-react`      | the renderer and the context contract | `PageRenderer`, `BlockBoundary`, the core block library, context types, `createStandaloneContext` |
+| `@nextlyhq/blocks-react/next` | everything that needs `next/*`        | `createBlocksPage`                                                                                |
 
-**Alpha:** the boundary and the context contract ship now. The renderer and the
-Next route helpers land on top of them, so these names describe the shape they
-will take rather than code that resolves today:
+Render a document anywhere:
 
 ```ts
-// Planned, not yet exported:
-// import { PageRenderer } from "@nextlyhq/blocks-react";
-// import { createBlocksPage } from "@nextlyhq/blocks-react/next";
+import { PageRenderer } from "@nextlyhq/blocks-react";
 ```
+
+Or turn a collection of documents into pages, in `app/[[...slug]]/page.tsx`:
+
+```tsx
+import { createBlocksPage } from "@nextlyhq/blocks-react/next";
+
+const { ContentPage, generateMetadata, generateStaticParams } =
+  createBlocksPage({ collections: ["pages"], field: "content" });
+
+export { generateMetadata, generateStaticParams };
+export default ContentPage;
+```
+
+The route resolves each path to an entry, renders its document, and wires media
+ids and entry references to the CMS so images and internal links work without
+being wired by hand. `nextly` is an OPTIONAL peer dependency, needed only for
+this entry.
 
 The root entry imports **no `next/*`, no admin code and no CMS runtime**. You
 can render a document from a plain React app, a test, or a script with nothing

--- a/packages/blocks-react/package.json
+++ b/packages/blocks-react/package.json
@@ -54,8 +54,8 @@
   },
   "peerDependencies": {
     "next": "^15.0.0 || ^16.0.0",
-    "react": "^19.0.0",
-    "nextly": "workspace:*"
+    "nextly": "workspace:*",
+    "react": "^19.0.0"
   },
   "peerDependenciesMeta": {
     "next": {

--- a/packages/blocks-react/package.json
+++ b/packages/blocks-react/package.json
@@ -54,10 +54,14 @@
   },
   "peerDependencies": {
     "next": "^15.0.0 || ^16.0.0",
-    "react": "^19.0.0"
+    "react": "^19.0.0",
+    "nextly": "workspace:*"
   },
   "peerDependenciesMeta": {
     "next": {
+      "optional": true
+    },
+    "nextly": {
       "optional": true
     }
   },
@@ -68,6 +72,7 @@
     "@types/react": "19.2.0",
     "@types/react-dom": "19.2.0",
     "eslint": "^9.39.1",
+    "nextly": "workspace:*",
     "react": "19.2.0",
     "react-dom": "19.2.0",
     "rimraf": "^6.1.3",

--- a/packages/blocks-react/src/layering.test.ts
+++ b/packages/blocks-react/src/layering.test.ts
@@ -57,6 +57,19 @@ const NEXT_ONLY_IMPORTS = [
   "next/cache",
   "next/headers",
   "next/navigation",
+  // The CMS, for `createBlocksPage`. Promise 2 above says the renderer must not
+  // import the CMS runtime, and this does not weaken it: that promise is about
+  // the RENDERER, which runs in the user's application where no CMS exists, and
+  // the root entry still may not reach either module.
+  //
+  // A route is a different thing from a renderer. Turning documents into pages
+  // means resolving a path to an entry, and resolving media and links means
+  // reading records; all three are the CMS's work, and a helper that did them
+  // without it would be reimplementing the CMS beside the CMS. Declared as an
+  // OPTIONAL peer dependency, so a consumer using only the root entry installs
+  // nothing extra and gets no unmet-peer warning.
+  "nextly",
+  "nextly/runtime",
 ];
 
 /** Files that are test harness rather than shipped code. */
@@ -392,25 +405,56 @@ describe("the package's layering contract", () => {
     // these, but naming them makes the failure message say what rule was
     // broken instead of only that something unlisted appeared.
     const forbidden = [
-      "nextly",
       "@nextlyhq/admin",
       "@nextlyhq/plugin-sdk",
       "@nextlyhq/plugin-page-builder",
       "@nextlyhq/ui",
     ];
+    // Permitted inside the `/next` graph and refused everywhere else, on the
+    // same footing as `next/*`. A route helper has to read content, and the
+    // subpath is the boundary that keeps that away from the renderer; the
+    // per-file check below is what makes "away" mean something.
+    const nextSideOnly = ["nextly"];
     const violations: string[] = [];
 
     for (const file of files) {
+      const isNextSide = nextGraph.has(file);
       for (const specifier of runtimeImports(file)) {
         const root = specifier.startsWith("@")
           ? specifier.split("/").slice(0, 2).join("/")
           : specifier.split("/")[0];
-        if (root && forbidden.includes(root)) {
+        if (!root) continue;
+        if (forbidden.includes(root)) {
+          violations.push(`${relative(SRC_DIR, file)}: ${specifier}`);
+          continue;
+        }
+        if (nextSideOnly.includes(root) && !isNextSide) {
           violations.push(`${relative(SRC_DIR, file)}: ${specifier}`);
         }
       }
     }
 
     expect(violations, violations.join("\n")).toEqual([]);
+  });
+
+  it("keeps the CMS out of the root's module graph", () => {
+    // The promise the optional peer dependency rests on. `nextly` is declared
+    // optional so that a consumer rendering documents standalone installs
+    // nothing extra — which is only true while no chain from `index.ts` reaches
+    // it. A per-file check cannot see that: every individual file could be
+    // clean while the root re-exported the one that is not.
+    const rootGraph = reachableFrom(join(SRC_DIR, "index.ts"));
+    const leaks: string[] = [];
+
+    for (const file of rootGraph) {
+      for (const specifier of runtimeImports(file)) {
+        const root = specifier.split("/")[0];
+        if (root === "nextly") {
+          leaks.push(`${relative(SRC_DIR, file)}: ${specifier}`);
+        }
+      }
+    }
+
+    expect(leaks, leaks.join("\n")).toEqual([]);
   });
 });

--- a/packages/blocks-react/src/next.test.ts
+++ b/packages/blocks-react/src/next.test.ts
@@ -29,6 +29,12 @@ function reader(
   return {
     find: vi.fn(async () => ({ items: [entry], meta: {} })),
     findByID: vi.fn(async ({ id }: { id: string }) => records[id] ?? null),
+    // A real instance exposes media as its OWN namespace, not as a dynamic
+    // collection, so the double has to as well or it certifies a path that
+    // fails against the product.
+    media: {
+      findByID: vi.fn(async ({ id }: { id: string }) => records[id] ?? null),
+    },
   } as never;
 }
 
@@ -185,7 +191,7 @@ describe("createBlocksPage", () => {
     const instance = reader(
       { slug: "about", content: document },
       { "media-1": { url: "/a.png" } }
-    ) as unknown as { findByID: ReturnType<typeof vi.fn> };
+    ) as unknown as { media: { findByID: ReturnType<typeof vi.fn> } };
 
     const props = await render({
       collections: ["pages"],
@@ -194,9 +200,93 @@ describe("createBlocksPage", () => {
     });
     await props.context?.resolveMedia("media-1");
 
+    expect(instance.media.findByID).toHaveBeenCalledWith({ id: "media-1" });
+  });
+
+  it("reads default media through the media namespace, not as a collection", async () => {
+    // Media is a system table with its own reader. Going through the generic
+    // collection path finds nothing on a standard install, so the advertised
+    // default resolver would never resolve an ordinary Nextly media record.
+    const instance = reader(
+      { slug: "about", content: document },
+      { "media-1": { url: "/a.png", altText: "A" } }
+    ) as unknown as {
+      findByID: ReturnType<typeof vi.fn>;
+      media: { findByID: ReturnType<typeof vi.fn> };
+    };
+
+    const props = await render({
+      collections: ["pages"],
+      field: "content",
+      nextly: instance as never,
+    });
+    await expect(props.context?.resolveMedia("media-1")).resolves.toEqual({
+      url: "/a.png",
+      alt: "A",
+    });
+
+    expect(instance.media.findByID).toHaveBeenCalledWith({ id: "media-1" });
+    expect(instance.findByID).not.toHaveBeenCalled();
+  });
+
+  it("reads a NAMED media collection as a collection", async () => {
+    // An explicitly named one IS a dynamic collection — a site storing images
+    // of its own — so it must not be sent to the media namespace.
+    const instance = reader(
+      { slug: "about", content: document },
+      { p1: { url: "/own.png" } }
+    ) as unknown as {
+      findByID: ReturnType<typeof vi.fn>;
+      media: { findByID: ReturnType<typeof vi.fn> };
+    };
+
+    const props = await render({
+      collections: ["pages"],
+      field: "content",
+      nextly: instance as never,
+      mediaCollection: "photos",
+    });
+    await props.context?.resolveMedia("p1");
+
     expect(instance.findByID).toHaveBeenCalledWith(
-      expect.objectContaining({ collection: "media", id: "media-1" })
+      expect.objectContaining({ collection: "photos", id: "p1" })
     );
+    expect(instance.media.findByID).not.toHaveBeenCalled();
+  });
+
+  it("resolves a homepage reference to the site root", async () => {
+    // The content route resolves an empty slug at `/`. Treating it as missing
+    // strips the destination from every button pointing at the site root.
+    const props = await render({
+      collections: ["pages"],
+      field: "content",
+      nextly: reader(
+        { slug: "about", content: document },
+        { home: { slug: "" } }
+      ),
+    });
+
+    await expect(
+      props.context?.resolveEntryPath("pages", "home")
+    ).resolves.toBe("/");
+  });
+
+  it("gives no path for an entry this route would not serve", async () => {
+    // A link is only useful if the path resolves. Emitting an href the same
+    // route answers with notFound() is worse than emitting none — and it
+    // publishes a restricted entry's slug to everyone who loads the page.
+    const props = await render({
+      collections: ["pages"],
+      field: "content",
+      nextly: reader(
+        { slug: "about", content: document },
+        { secret: { slug: "unreleased", status: "draft" } }
+      ),
+    });
+
+    await expect(
+      props.context?.resolveEntryPath("pages", "secret")
+    ).resolves.toBeNull();
   });
 
   it("passes the stored stylesheet through for the resolved entry", async () => {

--- a/packages/blocks-react/src/next.test.ts
+++ b/packages/blocks-react/src/next.test.ts
@@ -1,0 +1,213 @@
+/**
+ * `createBlocksPage` — the composition, exercised through the real
+ * `createContentRoute` rather than around it.
+ *
+ * A fake READER is injected and everything above it is production code, so
+ * these cover the seam that actually breaks: what the route hands the render,
+ * and what the render hands the block renderer. Mocking `createContentRoute`
+ * itself would assert only that this file calls a function.
+ */
+import { DOCUMENT_FORMAT_VERSION } from "@nextlyhq/blocks-engine";
+import type { BlockDocument } from "@nextlyhq/blocks-engine";
+import type { ReactElement } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+import { createBlocksPage } from "./next";
+import type { PageRendererProps } from "./page-renderer";
+
+const document: BlockDocument = {
+  formatVersion: DOCUMENT_FORMAT_VERSION,
+  kind: "page",
+  nodes: [],
+};
+
+/** A reader answering one page, plus whatever records a test adds. */
+function reader(
+  entry: Record<string, unknown>,
+  records: Record<string, Record<string, unknown>> = {}
+) {
+  return {
+    find: vi.fn(async () => ({ items: [entry], meta: {} })),
+    findByID: vi.fn(async ({ id }: { id: string }) => records[id] ?? null),
+  } as never;
+}
+
+/** Drive the route the way the App Router does. */
+async function render(
+  config: Parameters<typeof createBlocksPage>[0],
+  slug: string[] = ["about"]
+): Promise<PageRendererProps> {
+  const route = createBlocksPage(config);
+  const element = (await route.ContentPage({
+    params: { slug },
+  })) as ReactElement<PageRendererProps>;
+  return element.props;
+}
+
+describe("createBlocksPage", () => {
+  it("renders the document stored at the named field", async () => {
+    const props = await render({
+      collections: ["pages"],
+      field: "content",
+      nextly: reader({ slug: "about", content: document }),
+    });
+
+    expect(props.document).toEqual(document);
+  });
+
+  it("renders an empty page when the field is present and empty", async () => {
+    // An entry nobody has authored yet is ordinary, not an error.
+    const props = await render({
+      collections: ["pages"],
+      field: "content",
+      nextly: reader({ slug: "about", content: null }),
+    });
+
+    expect(props.document.nodes).toEqual([]);
+    expect(props.document.formatVersion).toBe(DOCUMENT_FORMAT_VERSION);
+  });
+
+  it("names the field and the collection when the field is absent", async () => {
+    // The alternative is a blank page with no explanation, which is the least
+    // debuggable outcome available: a typo here can only ever render nothing.
+    await expect(
+      render({
+        collections: ["pages"],
+        field: "body",
+        nextly: reader({ slug: "about", content: document }),
+      })
+    ).rejects.toThrow(/no field "body" on an entry from "pages"/);
+  });
+
+  it("surfaces a working draft on the context", async () => {
+    const props = await render({
+      collections: ["pages"],
+      field: "content",
+      nextly: reader({
+        slug: "about",
+        content: document,
+        _isWorkingDraft: true,
+      }),
+    });
+
+    expect(props.context?.isWorkingDraft).toBe(true);
+    expect(props.context?.entry).toMatchObject({ slug: "about" });
+  });
+
+  it("reads the locale the row was resolved in", async () => {
+    const props = await render({
+      collections: ["pages"],
+      field: "content",
+      nextly: reader({ slug: "about", content: document, _locale: "fr" }),
+    });
+
+    expect(props.context?.locale).toBe("fr");
+  });
+
+  it("resolves media, mapping the record's altText onto alt", async () => {
+    // The record stores `altText` and a block asks for `alt`. Letting that fall
+    // through renders the file name as alt text, which is an accessibility
+    // defect rather than a cosmetic one.
+    const props = await render({
+      collections: ["pages"],
+      field: "content",
+      nextly: reader(
+        { slug: "about", content: document },
+        {
+          "media-1": {
+            url: "https://cdn.example/a.png",
+            altText: "A cat",
+            width: 800,
+            height: 600,
+          },
+        }
+      ),
+    });
+
+    await expect(props.context?.resolveMedia("media-1")).resolves.toEqual({
+      url: "https://cdn.example/a.png",
+      alt: "A cat",
+      width: 800,
+      height: 600,
+    });
+  });
+
+  it("resolves media to null when the record has no usable url", async () => {
+    const props = await render({
+      collections: ["pages"],
+      field: "content",
+      nextly: reader(
+        { slug: "about", content: document },
+        { "media-2": { altText: "no url here" } }
+      ),
+    });
+
+    await expect(props.context?.resolveMedia("media-2")).resolves.toBeNull();
+  });
+
+  it("resolves an entry reference through the route's own slug field", async () => {
+    // The same field the route resolves paths by, so a link cannot point
+    // somewhere this route would 404 on.
+    const props = await render({
+      collections: ["pages"],
+      field: "content",
+      slugField: "permalink",
+      nextly: reader(
+        { permalink: "about", content: document },
+        { "page-9": { permalink: "contact" } }
+      ),
+    });
+
+    await expect(
+      props.context?.resolveEntryPath("pages", "page-9")
+    ).resolves.toBe("/contact");
+  });
+
+  it("prefers a caller's own resolvers over reading records", async () => {
+    const resolveMedia = vi.fn(async () => ({ url: "/custom.png" }));
+    const props = await render({
+      collections: ["pages"],
+      field: "content",
+      nextly: reader({ slug: "about", content: document }),
+      resolveMedia,
+    });
+
+    await expect(props.context?.resolveMedia("anything")).resolves.toEqual({
+      url: "/custom.png",
+    });
+    expect(resolveMedia).toHaveBeenCalledWith("anything");
+  });
+
+  it("reads related records through the instance the route resolved with", async () => {
+    // Not a stylistic preference: on a per-tenant setup a second instance is a
+    // second DATABASE, so a page and the media it embeds would come from two
+    // places and the mismatch would surface as missing images, not an error.
+    const instance = reader(
+      { slug: "about", content: document },
+      { "media-1": { url: "/a.png" } }
+    ) as unknown as { findByID: ReturnType<typeof vi.fn> };
+
+    const props = await render({
+      collections: ["pages"],
+      field: "content",
+      nextly: instance as never,
+    });
+    await props.context?.resolveMedia("media-1");
+
+    expect(instance.findByID).toHaveBeenCalledWith(
+      expect.objectContaining({ collection: "media", id: "media-1" })
+    );
+  });
+
+  it("passes the stored stylesheet through for the resolved entry", async () => {
+    const styles = { css: ".a{color:red}", classes: { n1: "a" } };
+    const props = await render({
+      collections: ["pages"],
+      field: "content",
+      nextly: reader({ slug: "about", content: document }),
+      styles: () => styles,
+    });
+
+    expect(props.styles).toEqual(styles);
+  });
+});

--- a/packages/blocks-react/src/next.ts
+++ b/packages/blocks-react/src/next.ts
@@ -5,11 +5,35 @@
  * `next/*` into a consumer's module graph. Everything that touches Next
  * (routing, metadata, draft mode) belongs here and nowhere else.
  *
- * Route helpers built on the CMS's existing content-route factory belong
- * here, alongside anything else that needs `next/*`.
+ * This subpath is also where the CMS may be imported. The root entry renders a
+ * document with nothing behind it; turning documents into ROUTES means
+ * resolving a path to an entry, and resolving media and links means reading
+ * records — both the CMS's job. Confining that here is what lets the root stay
+ * usable in an app that has no Nextly at all.
  *
  * @module next
  */
+import { DOCUMENT_FORMAT_VERSION } from "@nextlyhq/blocks-engine";
+import type {
+  BlockDocument,
+  StyleCompileContext,
+} from "@nextlyhq/blocks-engine";
+import { createContentRoute } from "nextly/runtime";
+import type {
+  ContentEntry,
+  ContentRoute,
+  ContentRouteConfig,
+  NextlyContentReader,
+  RenderContext,
+} from "nextly/runtime";
+import type { ReactElement, ReactNode } from "react";
+import { createElement } from "react";
+
+import { createStandaloneContext } from "./context";
+import type { BlocksDataProvider, PageContext, ResolvedMedia } from "./context";
+import { PageRenderer } from "./page-renderer";
+import type { BlockResolver } from "./resolver";
+import type { PageStyles } from "./styles";
 
 /**
  * Marker for the subpath's existence and its build wiring.
@@ -20,3 +44,239 @@
  * surfaces for a consumer after publish.
  */
 export const BLOCKS_REACT_NEXT_ENTRY = "@nextlyhq/blocks-react/next";
+
+/** The collection media ids resolve against unless the site names another. */
+const DEFAULT_MEDIA_COLLECTION = "media";
+
+/**
+ * Keys the CMS sets on the row it returns.
+ *
+ * Read rather than asked of the caller: both are decided by the read that
+ * produced the entry, so requiring a route to restate them is requiring it to
+ * guess at something it was already told.
+ */
+const WORKING_DRAFT_KEY = "_isWorkingDraft";
+const LOCALE_KEY = "_locale";
+
+/**
+ * Config for {@link createBlocksPage}.
+ *
+ * Everything {@link ContentRouteConfig} accepts, minus `render` — supplying
+ * that is the whole point of this helper — plus what the renderer needs.
+ */
+export interface BlocksPageConfig
+  extends Omit<ContentRouteConfig<ReactElement>, "render"> {
+  /**
+   * The field holding the block document, e.g. `"content"`.
+   *
+   * Required rather than defaulted. A default would be a guess at the site's
+   * schema, and guessing wrong renders a blank page instead of an error — the
+   * least debuggable outcome available. Naming it costs one line and makes a
+   * mismatch loud instead (see {@link readDocument}).
+   */
+  field: string;
+  /** Where block definitions come from. Defaults to the process registry. */
+  blocks?: BlockResolver;
+  /**
+   * The stylesheet compiled when this entry was saved.
+   *
+   * A function rather than a value because the sheet belongs to the ENTRY, and
+   * the route resolves a different entry per path. Returning `undefined` falls
+   * through to `styleContext`.
+   */
+  styles?: (
+    entry: ContentEntry,
+    context: RenderContext
+  ) => PageStyles | undefined | Promise<PageStyles | undefined>;
+  /**
+   * Compile the stylesheet during the render instead, for a site with no stored
+   * artifact yet. Ignored for an entry whose `styles` produced a sheet.
+   */
+  styleContext?: StyleCompileContext;
+  /** The collection media ids resolve against (default `"media"`). */
+  mediaCollection?: string;
+  /** Resolve a media id yourself, instead of reading the media collection. */
+  resolveMedia?: (id: string) => Promise<ResolvedMedia | null>;
+  /** Resolve an entry reference to a path, instead of reading its slug. */
+  resolveEntryPath?: (collection: string, id: string) => Promise<string | null>;
+  /** Data access for dynamic blocks. */
+  data?: BlocksDataProvider;
+  /** Shown in place of an asynchronous block until its output arrives. */
+  blockFallback?: ReactNode;
+}
+
+/** An empty page, for a field that exists and holds no document yet. */
+function emptyDocument(): BlockDocument {
+  return { formatVersion: DOCUMENT_FORMAT_VERSION, kind: "page", nodes: [] };
+}
+
+/**
+ * The document stored at `field`, or an empty page.
+ *
+ * The two nothing-cases are deliberately NOT treated alike. A field absent from
+ * the row is a wiring mistake — a typo, or a route pointed at a collection that
+ * has no such field — and it can only ever render blank, so it throws naming
+ * both the field and the collection. A field present and null is an entry
+ * nobody has authored yet, which is ordinary, and renders empty.
+ *
+ * Anything else goes to the renderer as-is rather than being inspected here:
+ * the renderer already repairs a malformed document forgivingly, and a second
+ * opinion about shape in front of it could only disagree with the first.
+ */
+function readDocument(
+  entry: ContentEntry,
+  field: string,
+  context: RenderContext
+): BlockDocument {
+  if (!(field in entry)) {
+    throw new Error(
+      `createBlocksPage: no field "${field}" on an entry from "${context.collection}". ` +
+        "Name the field that holds the block document."
+    );
+  }
+  const value = entry[field];
+  if (value === null || value === undefined) return emptyDocument();
+  return value as BlockDocument;
+}
+
+/** A string property of the row, when it is one. */
+function stringField(entry: ContentEntry, key: string): string | undefined {
+  const value = entry[key];
+  return typeof value === "string" ? value : undefined;
+}
+
+/**
+ * Read a media record and describe it the way a block expects.
+ *
+ * The names are mapped rather than assumed to line up: a block asks for `alt`
+ * and the record stores `altText`, and letting that fall through would render
+ * the file name as alt text, which is an accessibility defect rather than a
+ * cosmetic one.
+ *
+ * Read with access overridden because this resolves an asset the page already
+ * renders — the entry's own read has settled whether the page may be seen, and
+ * a second anonymous check here would blank the images on a page that passed it.
+ */
+function mediaResolver(
+  config: BlocksPageConfig,
+  reader: NextlyContentReader
+): (id: string) => Promise<ResolvedMedia | null> {
+  if (config.resolveMedia) return config.resolveMedia;
+  const collection = config.mediaCollection ?? DEFAULT_MEDIA_COLLECTION;
+  return async (id: string) => {
+    const record = await reader.findByID({
+      collection,
+      id,
+      overrideAccess: true,
+    });
+    if (!record) return null;
+    const { url, altText, width, height } = record;
+    if (typeof url !== "string") return null;
+    return {
+      url,
+      ...(typeof altText === "string" ? { alt: altText } : {}),
+      ...(typeof width === "number" ? { width } : {}),
+      ...(typeof height === "number" ? { height } : {}),
+    };
+  };
+}
+
+/**
+ * Resolve a referenced entry to the path it renders at.
+ *
+ * Uses the route's own `slugField`, so a link points where this route would
+ * resolve it. The alternative is a second opinion about where content lives,
+ * and a link that 404s while the page it names renders fine.
+ */
+function entryPathResolver(
+  config: BlocksPageConfig,
+  reader: NextlyContentReader
+): (collection: string, id: string) => Promise<string | null> {
+  if (config.resolveEntryPath) return config.resolveEntryPath;
+  const slugField = config.slugField ?? "slug";
+  return async (collection: string, id: string) => {
+    const record = await reader.findByID({
+      collection,
+      id,
+      overrideAccess: true,
+    });
+    const slug = record ? record[slugField] : undefined;
+    return typeof slug === "string" && slug.length > 0 ? `/${slug}` : null;
+  };
+}
+
+/**
+ * Turn a collection of block documents into rendered pages.
+ *
+ * The composition `createContentRoute` was built to carry: it resolves a path
+ * to an entry and owns `generateStaticParams`, `generateMetadata` and the
+ * not-found decisions, and this fills in the render with the block renderer
+ * over a context wired to the CMS.
+ *
+ * Wire the result into `app/[[...slug]]/page.tsx`:
+ *
+ * ```tsx
+ * const { ContentPage, generateMetadata, generateStaticParams } =
+ *   createBlocksPage({ collections: ["pages"], field: "content" });
+ *
+ * export { generateMetadata, generateStaticParams };
+ * export default ContentPage;
+ * ```
+ *
+ * Draft preview needs no argument here. `createContentRoute` owns the `draft`
+ * decision and this passes it through untouched, so a preview arrives as an
+ * ordinary entry that happens to be the pending one.
+ */
+export function createBlocksPage(
+  config: BlocksPageConfig
+): ContentRoute<ReactElement> {
+  const {
+    field,
+    blocks,
+    styles,
+    styleContext,
+    data,
+    blockFallback,
+    // Consumed by the resolvers built below rather than forwarded: passing them
+    // on would hand `createContentRoute` options it does not define.
+    mediaCollection: _mediaCollection,
+    resolveMedia: _resolveMedia,
+    resolveEntryPath: _resolveEntryPath,
+    ...routeConfig
+  } = config;
+
+  return createContentRoute<ReactElement>({
+    ...routeConfig,
+    render: async (entry, context) => {
+      const document = readDocument(entry, field, context);
+      const resolved = styles ? await styles(entry, context) : undefined;
+
+      // Built from the reader the ROUTE resolved this entry through, handed
+      // over in the context. A page and the records it embeds then always come
+      // from one instance, which on a per-tenant setup is one database.
+      const resolveMedia = mediaResolver(config, context.reader);
+      const resolveEntryPath = entryPathResolver(config, context.reader);
+
+      // `isWorkingDraft` is surfaced, not acted on: the renderer draws the
+      // pending content either way, and a host that wants to say so on the page
+      // has to be told which one it got.
+      const pageContext: PageContext = createStandaloneContext({
+        entry,
+        locale: stringField(entry, LOCALE_KEY),
+        isWorkingDraft: entry[WORKING_DRAFT_KEY] === true,
+        data,
+        resolveMedia,
+        resolveEntryPath,
+      });
+
+      return createElement(PageRenderer, {
+        document,
+        context: pageContext,
+        blocks,
+        styles: resolved,
+        styleContext,
+        blockFallback,
+      });
+    },
+  });
+}

--- a/packages/blocks-react/src/next.ts
+++ b/packages/blocks-react/src/next.ts
@@ -45,9 +45,6 @@ import type { PageStyles } from "./styles";
  */
 export const BLOCKS_REACT_NEXT_ENTRY = "@nextlyhq/blocks-react/next";
 
-/** The collection media ids resolve against unless the site names another. */
-const DEFAULT_MEDIA_COLLECTION = "media";
-
 /**
  * Keys the CMS sets on the row it returns.
  *
@@ -93,7 +90,14 @@ export interface BlocksPageConfig
    * artifact yet. Ignored for an entry whose `styles` produced a sheet.
    */
   styleContext?: StyleCompileContext;
-  /** The collection media ids resolve against (default `"media"`). */
+  /**
+   * A dynamic collection to resolve media ids against, for a site storing its
+   * images in one of its own.
+   *
+   * Omit it for ordinary Nextly media: those live in a system table with its
+   * own reader, not in a dynamic collection, so the default path asks the
+   * media namespace rather than naming a collection at all.
+   */
   mediaCollection?: string;
   /** Resolve a media id yourself, instead of reading the media collection. */
   resolveMedia?: (id: string) => Promise<ResolvedMedia | null>;
@@ -157,18 +161,50 @@ function stringField(entry: ContentEntry, key: string): string | undefined {
  * renders — the entry's own read has settled whether the page may be seen, and
  * a second anonymous check here would blank the images on a page that passed it.
  */
+/** The media surface the default resolver reads through. */
+interface MediaReader {
+  findByID(args: { id: string }): Promise<Record<string, unknown> | null>;
+}
+
+/**
+ * The instance's media reader, when it has one.
+ *
+ * Media is a SYSTEM table with its own namespace, not a dynamic collection, so
+ * `findByID({ collection: "media" })` goes through the collections handler and
+ * finds nothing — the image block then catches the rejection and renders no
+ * image, which is a default resolver that cannot resolve the default case.
+ *
+ * Detected structurally rather than by widening `NextlyContentReader`, which is
+ * `Pick<Nextly, "find" | "findByID">` and shared with `resolveContent`: adding a
+ * member there would oblige every caller injecting a stand-in — including tests
+ * that legitimately have no media — to supply one.
+ */
+function mediaNamespaceOf(
+  reader: NextlyContentReader
+): MediaReader | undefined {
+  const candidate = (reader as { media?: unknown }).media;
+  if (typeof candidate !== "object" || candidate === null) return undefined;
+  const findByID = (candidate as { findByID?: unknown }).findByID;
+  return typeof findByID === "function"
+    ? (candidate as MediaReader)
+    : undefined;
+}
+
 function mediaResolver(
   config: BlocksPageConfig,
   reader: NextlyContentReader
 ): (id: string) => Promise<ResolvedMedia | null> {
   if (config.resolveMedia) return config.resolveMedia;
-  const collection = config.mediaCollection ?? DEFAULT_MEDIA_COLLECTION;
   return async (id: string) => {
-    const record = await reader.findByID({
-      collection,
-      id,
-      overrideAccess: true,
-    });
+    const record = config.mediaCollection
+      ? // An explicitly named collection IS a dynamic collection — a site
+        // storing its images somewhere of its own — so it reads as one.
+        await reader.findByID({
+          collection: config.mediaCollection,
+          id,
+          overrideAccess: true,
+        })
+      : await mediaNamespaceOf(reader)?.findByID({ id });
     if (!record) return null;
     const { url, altText, width, height } = record;
     if (typeof url !== "string") return null;
@@ -195,13 +231,32 @@ function entryPathResolver(
   if (config.resolveEntryPath) return config.resolveEntryPath;
   const slugField = config.slugField ?? "slug";
   return async (collection: string, id: string) => {
+    // Read under the ROUTE's own policy, not with access overridden. A link is
+    // only useful if the path it names resolves, and this route resolves
+    // published entries anonymously by default — so a reference to an
+    // unpublished or restricted entry would otherwise emit an href that the
+    // same route answers with `notFound()`. No path is a better answer than a
+    // broken one, and it also stops a restricted entry's slug from being
+    // published to anyone who loads the page.
     const record = await reader.findByID({
       collection,
       id,
-      overrideAccess: true,
+      overrideAccess: config.overrideAccess ?? false,
     });
-    const slug = record ? record[slugField] : undefined;
-    return typeof slug === "string" && slug.length > 0 ? `/${slug}` : null;
+    if (!record) return null;
+    // `findByID` carries no lifecycle scope, so the route's own is applied
+    // here. A no-op on a status-less collection, which has no such field.
+    const scope = config.status ?? "published";
+    const status = record.status;
+    if (scope !== "all" && typeof status === "string" && status !== scope) {
+      return null;
+    }
+    const slug = record[slugField];
+    if (typeof slug !== "string") return null;
+    // An empty slug is the HOMEPAGE, which the content route resolves at `/`
+    // and pre-renders as `{ slug: [] }`. Treating it as missing would strip the
+    // destination from every button pointing at the site root.
+    return slug === "" ? "/" : `/${slug}`;
   };
 }
 

--- a/packages/nextly/src/runtime.ts
+++ b/packages/nextly/src/runtime.ts
@@ -80,6 +80,8 @@ export {
   type ContentRoute,
   type ContentRouteArgs,
   type ContentRouteConfig,
+  type RenderContext,
+  type NextlyContentReader,
   type ResolvedContext,
   type NextlySitemapEntry,
   type NextlySitemapOptions,

--- a/packages/nextly/src/runtime/routing/content-route.ts
+++ b/packages/nextly/src/runtime/routing/content-route.ts
@@ -36,12 +36,32 @@ import {
   type NextlyContentReader,
 } from "./resolve-content";
 
-/** Where a resolved entry was found — passed to `render`/`buildMetadata`. */
+/** Where a resolved entry was found. */
 export interface ResolvedContext {
   /** The collection the entry was resolved from. */
   collection: string;
   /** The joined slug path (no leading slash), e.g. `"about/team"`. */
   slug: string;
+}
+
+/**
+ * What `render` and `buildMetadata` receive: where the entry was found, plus
+ * the reader it was found through.
+ *
+ * The reader travels with the result rather than being looked up again, because
+ * a render that needs a second read — a referenced author, the media behind an
+ * image — otherwise has to obtain an instance of its own. On a per-tenant setup
+ * that is a different database, so the page and the records it embeds would
+ * come from two places, and the mismatch appears as missing relations rather
+ * than as an error.
+ *
+ * Deliberately NOT given to the `draft` decision, which answers from a path
+ * alone: handing it a reader would invite an authorization check to read
+ * content it is in the middle of deciding access to.
+ */
+export interface RenderContext extends ResolvedContext {
+  /** The instance this route resolved the entry through. */
+  reader: NextlyContentReader;
 }
 
 /**
@@ -60,12 +80,12 @@ export interface ContentRouteConfig<TNode> {
   /** Render the resolved entry (your server component body). May be async. */
   render: (
     entry: ContentEntry,
-    context: ResolvedContext
+    context: RenderContext
   ) => TNode | Promise<TNode>;
   /** Optional per-entry metadata (e.g. via `buildMetadata`). */
   buildMetadata?: (
     entry: ContentEntry,
-    context: ResolvedContext
+    context: RenderContext
   ) => Metadata | Promise<Metadata>;
   /** Field holding the slug (default `"slug"`). */
   slugField?: string;
@@ -267,7 +287,7 @@ export function createContentRoute<TNode>(
   /** Resolve the joined slug across the configured collections (first match wins). */
   async function resolve(
     slug: string
-  ): Promise<{ entry: ContentEntry; context: ResolvedContext } | null> {
+  ): Promise<{ entry: ContentEntry; context: RenderContext } | null> {
     for (const collection of collections) {
       // Asked per collection, not once per request: the answer is scoped to a
       // document, and the same slug can name a different document in each
@@ -319,7 +339,7 @@ export function createContentRoute<TNode>(
       // compares a POST-`afterRead` document, so a collection that reshapes its
       // public read would fail a valid grant and send the editor to live
       // content.
-      return { entry, context: { collection, slug } };
+      return { entry, context: { collection, slug, reader: getInstance() } };
     }
     return null;
   }

--- a/packages/nextly/src/runtime/routing/index.ts
+++ b/packages/nextly/src/runtime/routing/index.ts
@@ -6,7 +6,11 @@
  * @module runtime/routing
  */
 export { resolveContent } from "./resolve-content";
-export type { ContentEntry, ResolveContentOptions } from "./resolve-content";
+export type {
+  ContentEntry,
+  NextlyContentReader,
+  ResolveContentOptions,
+} from "./resolve-content";
 
 export { isReservedPath } from "./reserved-paths";
 
@@ -15,6 +19,7 @@ export type {
   ContentRoute,
   ContentRouteArgs,
   ContentRouteConfig,
+  RenderContext,
   ResolvedContext,
 } from "./content-route";
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -792,6 +792,9 @@ importers:
       eslint:
         specifier: ^9.39.1
         version: 9.39.1(jiti@2.7.0)
+      nextly:
+        specifier: workspace:*
+        version: link:../nextly
       react:
         specifier: 19.2.0
         version: 19.2.0
@@ -13305,7 +13308,7 @@ snapshots:
       '@humanfs/node': 0.16.6
       '@humanwhocodes/module-importer': 1.0.1
       '@humanwhocodes/retry': 0.4.3
-      '@types/estree': 1.0.9
+      '@types/estree': 1.0.8
       ajv: 6.15.0
       chalk: 4.1.2
       cross-spawn: 7.0.6


### PR DESCRIPTION
Plan 03 **R-4**. Turns block documents into real Next.js pages — the step that makes the renderer merged this week reachable from an actual app.

```tsx
const { ContentPage, generateMetadata, generateStaticParams } =
  createBlocksPage({ collections: ["pages"], field: "content" });

export { generateMetadata, generateStaticParams };
export default ContentPage;
```

## What it does

Composes `createContentRoute` with `PageRenderer`. The route already resolves a path to an entry and owns `generateStaticParams` / `generateMetadata` / the not-found decisions; this fills in the render and wires the `PageContext` the blocks read through — so images and internal links work without either being wired by hand.

**Draft preview needed no work here.** #563 already threaded the `draft` decision through `createContentRoute`, with an entryId-scoped grant, and this passes it through untouched. R-4's plan text predates that.

## Three decisions worth reviewing

**1. `field` is required, not defaulted.** A default would guess at the site's schema, and guessing wrong renders a *blank page* rather than an error — the least debuggable outcome available. A field absent from the row throws naming both the field and the collection; a field present and `null` is an entry nobody has authored yet and renders empty. The two nothing-cases are deliberately not alike.

**2. `nextly` is an OPTIONAL peer dependency of `blocks-react`.** The `/next` subpath is where CMS coupling belongs — its own module doc already said so. The layering allowlist gains `nextly` with the reason recorded, scoped to the next-graph exactly as `next/*` is, and a **new test asserts no chain from the package root reaches it**. That is the promise optionality rests on, and no per-file check can see it: every file could be individually clean while the root re-exported the one that isn't.

**3. `render`/`buildMetadata` now receive `context.reader`** — the instance the route resolved the entry through. A render needing a second read had no way to get the same one, and **on a per-tenant setup a second instance is a second database**, so a page and the records it embeds could come from two places and surface as missing relations rather than an error. The `draft` decision deliberately does *not* get one: it answers from a path alone, and handing it a reader would invite an authorization check to read the content it is deciding access to.

## A trap this nearly hit

The media table stores **`altText`**, not `alt`. Assuming they matched would have rendered the **file name as alt text** — an accessibility defect, not a cosmetic one. Mapped explicitly, and a test fails if the mapping is dropped.

## Verification

- `check-types` **20/20**, `lint` **21/21**.
- `blocks-react` **211/211** pass.
- `nextly` unit suite: failing-test **NAME SET byte-identical to `main`** at `c2ca409e1` (361 each, zero new, zero fixed) — I changed a public route type, so counts alone would not have been evidence.
- **Four mutations, each watched to fail and restored** (`diff`-proven, since prettier can swallow a scripted edit):
  | Mutation | Test that caught it |
  |---|---|
  | drop the missing-field throw | names the field and the collection |
  | assume the record stores `alt` | maps altText onto alt |
  | ignore the route's `slugField` | resolves through the route's own slug field |
  | leak `nextly` into the root graph | keeps the CMS out of the root's module graph |

## Self-review — what I could not verify

- **No browser render.** Tests assert the element and props `createBlocksPage` produces, driven through the real `createContentRoute` with a fake reader. Nothing here proves the HTML in a running Next app; R-7's dogfood page is where that gets proven.
- **`styleContext` fallback is passed through but untested** — compiled-CSS storage does not exist yet (that is PR-S8), so there is no stored artifact to fall back *from*.
- **Codex is rate-limited repo-wide**, so this has had no automated review. Per your standing rule while that lasts: evidence attached, **not self-merging** — yours to press.