### PR TITLE
fix(nextly): let a repaired column carry its contents across a type change

### DIFF
--- a/.changeset/rename-carries-its-type.md
+++ b/.changeset/rename-carries-its-type.md
@@ -1,0 +1,26 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+Repairing a repeater or group column left over from an older table now keeps its contents. The only recovery offered before was to drop the column and recreate it empty, because the repair moved the column without converting it.

--- a/packages/nextly/src/domains/schema/migrate-create/__tests__/generate.test.ts
+++ b/packages/nextly/src/domains/schema/migrate-create/__tests__/generate.test.ts
@@ -454,6 +454,135 @@ describe("applyRenameDecisions (rename collapsing)", () => {
     expect(out[0].type).toBe("rename_column");
   });
 
+  it("carries the type change when the rename crosses types", () => {
+    // 🔴 A generated migration used to receive the rename ALONE. A rename moves the column without
+    // changing what it is, so the committed UP left `text` where the snapshot and the runtime expect
+    // JSON, and its DOWN omitted the reverse — a file that passes review and diverges at apply time.
+    const ops = [
+      {
+        type: "drop_column" as const,
+        tableName: "dc_posts",
+        columnName: "_body",
+        columnType: "text",
+      },
+      {
+        type: "add_column" as const,
+        tableName: "dc_posts",
+        column: { name: "body", type: "jsonb", nullable: true },
+      },
+    ];
+    const decisions = [
+      {
+        candidate: {
+          tableName: "dc_posts",
+          fromColumn: "_body",
+          toColumn: "body",
+          fromType: "text",
+          toType: "jsonb",
+          typesCompatible: true,
+          defaultSuggestion: "rename" as const,
+        },
+        accepted: true,
+      },
+    ];
+
+    const out = applyRenameDecisionsForTest(ops, decisions, "postgresql");
+
+    // Three, in this order. The DROP DEFAULT is not decoration: `ALTER COLUMN … TYPE jsonb USING …`
+    // converts stored ROWS and leaves the DEFAULT expression alone, so a text default on a column
+    // becoming JSON makes PostgreSQL reject the whole statement — every row can be valid JSON and
+    // the conversion still fails.
+    expect(out.map(o => o.type)).toEqual([
+      "rename_column",
+      "change_column_default",
+      "change_column_type",
+    ]);
+    expect(out[1]).toMatchObject({
+      columnName: "body",
+      toDefault: undefined,
+    });
+    // Against the NEW name: the conversion follows the rename, so the column no longer answers to
+    // the one it had.
+    expect(out[2]).toMatchObject({
+      tableName: "dc_posts",
+      columnName: "body",
+      toType: "jsonb",
+    });
+  });
+
+  it("emits no type change when the rename keeps the type", () => {
+    // The positive control. Without it, appending a conversion unconditionally would satisfy the
+    // case above while adding a pointless ALTER to every ordinary rename.
+    const ops = [
+      {
+        type: "drop_column" as const,
+        tableName: "dc_posts",
+        columnName: "_body",
+        columnType: "text",
+      },
+      {
+        type: "add_column" as const,
+        tableName: "dc_posts",
+        column: { name: "body", type: "text", nullable: true },
+      },
+    ];
+    const decisions = [
+      {
+        candidate: {
+          tableName: "dc_posts",
+          fromColumn: "_body",
+          toColumn: "body",
+          fromType: "text",
+          toType: "text",
+          typesCompatible: true,
+          defaultSuggestion: "rename" as const,
+        },
+        accepted: true,
+      },
+    ];
+
+    expect(
+      applyRenameDecisionsForTest(ops, decisions, "postgresql").map(o => o.type)
+    ).toEqual(["rename_column"]);
+  });
+
+  it("emits no type change on SQLite, which stores JSON as text", () => {
+    // Not an omission: SQLite has no ALTER that changes a column's type, and needs none here — the
+    // two sides of the one convertible change name the same storage. Asking for one would raise
+    // for a column that is already correct.
+    const ops = [
+      {
+        type: "drop_column" as const,
+        tableName: "dc_posts",
+        columnName: "_body",
+        columnType: "text",
+      },
+      {
+        type: "add_column" as const,
+        tableName: "dc_posts",
+        column: { name: "body", type: "jsonb", nullable: true },
+      },
+    ];
+    const decisions = [
+      {
+        candidate: {
+          tableName: "dc_posts",
+          fromColumn: "_body",
+          toColumn: "body",
+          fromType: "text",
+          toType: "jsonb",
+          typesCompatible: true,
+          defaultSuggestion: "rename" as const,
+        },
+        accepted: true,
+      },
+    ];
+
+    expect(
+      applyRenameDecisionsForTest(ops, decisions, "sqlite").map(o => o.type)
+    ).toEqual(["rename_column"]);
+  });
+
   it("leaves drop+add intact on decline", () => {
     const ops = [
       {

--- a/packages/nextly/src/domains/schema/migrate-create/__tests__/generate.test.ts
+++ b/packages/nextly/src/domains/schema/migrate-create/__tests__/generate.test.ts
@@ -19,6 +19,7 @@ import {
   generateMigration,
   type MinimalConfigEntity,
 } from "../generate";
+import { buildInverseOperations } from "../down-generator";
 import { writeSnapshot } from "../snapshot-io";
 
 const NOW = new Date("2026-04-29T15:45:00.123Z");
@@ -578,6 +579,69 @@ describe("applyRenameDecisions (rename collapsing)", () => {
     expect(out[1]).toMatchObject({ fromDefault: "'{}'", toDefault: undefined });
     // And the desired default goes back on once the type is right.
     expect(out[3]).toMatchObject({ toDefault: "'{}'::jsonb" });
+  });
+
+  it("returns a MySQL column to its original definition on rollback", () => {
+    // 🔴 The DOWN is where MySQL's MODIFY bites a second time. The inverse converts the type back,
+    // and restates the whole column while doing it — so a rollback that carried only the types would
+    // return the column to `text` while silently dropping the NOT NULL and default it originally
+    // had. Asserted through buildInverseOperations rather than by reading the forward op, because
+    // the forward op looking right is exactly what made this invisible.
+    const ops = [
+      {
+        type: "drop_column" as const,
+        tableName: "dc_posts",
+        columnName: "_body",
+        columnType: "text",
+      },
+      {
+        type: "add_column" as const,
+        tableName: "dc_posts",
+        column: { name: "body", type: "json", nullable: false },
+      },
+    ];
+    const decisions = [
+      {
+        candidate: {
+          tableName: "dc_posts",
+          fromColumn: "_body",
+          toColumn: "body",
+          fromType: "text",
+          toType: "json",
+          typesCompatible: true,
+          defaultSuggestion: "rename" as const,
+        },
+        accepted: true,
+      },
+    ];
+    const previous = {
+      tables: [
+        {
+          name: "dc_posts",
+          columns: [
+            { name: "_body", type: "text", nullable: false, default: "'{}'" },
+          ],
+          indexes: [],
+        },
+      ],
+    };
+
+    const forward = applyRenameDecisionsForTest(
+      ops,
+      decisions,
+      "mysql",
+      previous as never
+    );
+    const inverse = buildInverseOperations(forward, previous as never);
+
+    const back = inverse.find(o => o.type === "change_column_type");
+    expect(back).toMatchObject({
+      toType: "text",
+      // The definition the column is being returned TO, restated because MySQL deletes what a
+      // MODIFY omits.
+      nullable: false,
+      columnDefault: "'{}'",
+    });
   });
 
   it("carries requiredness into the MySQL conversion", () => {

--- a/packages/nextly/src/domains/schema/migrate-create/__tests__/generate.test.ts
+++ b/packages/nextly/src/domains/schema/migrate-create/__tests__/generate.test.ts
@@ -510,6 +510,118 @@ describe("applyRenameDecisions (rename collapsing)", () => {
     });
   });
 
+  it("keeps the target default and records the source one for rollback", () => {
+    // 🔴 The collapsed add_column is the ONLY statement of what the column must END UP being, and
+    // the previous snapshot is the only record of what it WAS. Discarding either leaves a generated
+    // migration whose UP drops a default the snapshot still declares, and whose DOWN emits a second
+    // DROP DEFAULT instead of putting the original back.
+    const ops = [
+      {
+        type: "drop_column" as const,
+        tableName: "dc_posts",
+        columnName: "_body",
+        columnType: "text",
+      },
+      {
+        type: "add_column" as const,
+        tableName: "dc_posts",
+        column: {
+          name: "body",
+          type: "jsonb",
+          nullable: false,
+          default: "'{}'::jsonb",
+        },
+      },
+    ];
+    const decisions = [
+      {
+        candidate: {
+          tableName: "dc_posts",
+          fromColumn: "_body",
+          toColumn: "body",
+          fromType: "text",
+          toType: "jsonb",
+          typesCompatible: true,
+          defaultSuggestion: "rename" as const,
+        },
+        accepted: true,
+      },
+    ];
+    const previous = {
+      tables: [
+        {
+          name: "dc_posts",
+          columns: [
+            { name: "_body", type: "text", nullable: true, default: "'{}'" },
+          ],
+          indexes: [],
+        },
+      ],
+    };
+
+    const out = applyRenameDecisionsForTest(
+      ops,
+      decisions,
+      "postgresql",
+      previous as never
+    );
+
+    expect(out.map(o => o.type)).toEqual([
+      "rename_column",
+      "change_column_default",
+      "change_column_type",
+      "change_column_default",
+    ]);
+    // The old default is RECORDED on the drop, because buildInverseOperations inverts a default
+    // change by assigning `toDefault: op.fromDefault`. Left undefined, the rollback would drop the
+    // default a second time rather than restore it.
+    expect(out[1]).toMatchObject({ fromDefault: "'{}'", toDefault: undefined });
+    // And the desired default goes back on once the type is right.
+    expect(out[3]).toMatchObject({ toDefault: "'{}'::jsonb" });
+  });
+
+  it("carries requiredness into the MySQL conversion", () => {
+    // MySQL spells the type change `MODIFY COLUMN <name> <type>`, which RESTATES the whole
+    // definition — so a required column becomes nullable unless its nullability travels with the
+    // type. There is no second statement that could put it back: change_column_nullable cannot be
+    // rendered for MySQL at all.
+    const ops = [
+      {
+        type: "drop_column" as const,
+        tableName: "dc_posts",
+        columnName: "_body",
+        columnType: "text",
+      },
+      {
+        type: "add_column" as const,
+        tableName: "dc_posts",
+        column: { name: "body", type: "json", nullable: false },
+      },
+    ];
+    const decisions = [
+      {
+        candidate: {
+          tableName: "dc_posts",
+          fromColumn: "_body",
+          toColumn: "body",
+          fromType: "text",
+          toType: "json",
+          typesCompatible: true,
+          defaultSuggestion: "rename" as const,
+        },
+        accepted: true,
+      },
+    ];
+
+    const out = applyRenameDecisionsForTest(ops, decisions, "mysql");
+
+    expect(out.map(o => o.type)).toEqual([
+      "rename_column",
+      "change_column_type",
+    ]);
+    expect(out[1]).toMatchObject({ nullable: false });
+  });
+
   it("emits no type change when the rename keeps the type", () => {
     // The positive control. Without it, appending a conversion unconditionally would satisfy the
     // case above while adding a pointless ALTER to every ordinary rename.

--- a/packages/nextly/src/domains/schema/migrate-create/down-generator.ts
+++ b/packages/nextly/src/domains/schema/migrate-create/down-generator.ts
@@ -75,6 +75,15 @@ function invertOne(op: Operation, prev: NextlySchemaSnapshot): Operation {
         columnName: op.columnName,
         fromType: op.toType,
         toType: op.fromType,
+        // The definition travels with the type, in both directions. MySQL renders this as
+        // `MODIFY COLUMN`, which restates the WHOLE column — so an inverse that swapped only the
+        // types would return the column to its old type while dropping the nullability and default
+        // it originally had.
+
+        nullable: op.fromNullable,
+        columnDefault: op.fromColumnDefault,
+        fromNullable: op.nullable,
+        fromColumnDefault: op.columnDefault,
       };
     case "change_column_nullable":
       return {

--- a/packages/nextly/src/domains/schema/migrate-create/generate.ts
+++ b/packages/nextly/src/domains/schema/migrate-create/generate.ts
@@ -43,6 +43,7 @@ import {
 } from "../pipeline/diff/build-from-fields";
 import { diffSnapshots } from "../pipeline/diff/diff";
 import type {
+  ColumnSpec,
   NextlySchemaSnapshot,
   Operation,
   RenameColumnOp,
@@ -230,7 +231,12 @@ export async function generateMigration(
       nonInteractive: args.nonInteractive,
       autoAccept: args.autoAcceptRenames,
     });
-    operations = applyRenameDecisions(operations, decisions, args.dialect);
+    operations = applyRenameDecisions(
+      operations,
+      decisions,
+      args.dialect,
+      previousSnapshot
+    );
   }
   if (operations.length === 0 && !hasCompanions) {
     return null;
@@ -662,7 +668,8 @@ export function buildDesiredSnapshotFromConfig(
 function applyRenameDecisions(
   ops: Operation[],
   decisions: RenameDecision[],
-  dialect: SupportedDialect
+  dialect: SupportedDialect,
+  previousSnapshot?: NextlySchemaSnapshot
 ): Operation[] {
   const accepted = decisions.filter(d => d.accepted);
   if (accepted.length === 0) return ops;
@@ -688,6 +695,11 @@ function applyRenameDecisions(
   // Filter out the matching drop_column / add_column pairs. TS narrows
   // `op` from the discriminated union via `op.type === "drop_column"`,
   // so no explicit cast is needed.
+  // The collapsed `add_column` is the ONLY statement of what the repaired column must end up being —
+  // its nullability and its default. Dropping it without keeping that is what let a generated repair
+  // leave the column nullable and defaultless while its own snapshot declared otherwise.
+  const consumedTarget = new Map<string, ColumnSpec>();
+
   const remaining: Operation[] = [];
   for (const op of ops) {
     if (op.type === "drop_column") {
@@ -697,6 +709,7 @@ function applyRenameDecisions(
     }
     if (op.type === "add_column") {
       if (acceptedAdds.has(`${op.tableName}::${op.column.name}`)) {
+        consumedTarget.set(`${op.tableName}::${op.column.name}`, op.column);
         continue;
       }
     }
@@ -728,7 +741,19 @@ function applyRenameDecisions(
     };
     renames.push(renameOp);
 
-    renames.push(...conversionForRename(renameOp, dialect));
+    const target = consumedTarget.get(`${c.tableName}::${c.toColumn}`);
+    renames.push(
+      ...conversionForRename(renameOp, dialect, {
+        target: target
+          ? { nullable: target.nullable, default: target.default }
+          : undefined,
+        // Read from the snapshot rather than from the drop, which records only a type. A generated
+        // DOWN needs the value to put back, and nothing else in the operation list carries it.
+        sourceDefault: previousSnapshot?.tables
+          .find(t => t.name === c.tableName)
+          ?.columns.find(col => col.name === c.fromColumn)?.default,
+      })
+    );
   }
 
   // Nothing was collapsed, so the diff's own ordering already holds and the
@@ -765,9 +790,10 @@ function applyRenameDecisions(
 export function applyRenameDecisionsForTest(
   ops: Operation[],
   decisions: RenameDecision[],
-  dialect: SupportedDialect = "postgresql"
+  dialect: SupportedDialect = "postgresql",
+  previousSnapshot?: NextlySchemaSnapshot
 ): Operation[] {
-  return applyRenameDecisions(ops, decisions, dialect);
+  return applyRenameDecisions(ops, decisions, dialect, previousSnapshot);
 }
 
 /**

--- a/packages/nextly/src/domains/schema/migrate-create/generate.ts
+++ b/packages/nextly/src/domains/schema/migrate-create/generate.ts
@@ -49,6 +49,7 @@ import type {
   TableSpec,
 } from "../pipeline/diff/types";
 import type { RenameCandidate } from "../pipeline/pushschema-pipeline-interfaces";
+import { conversionForRename } from "../pipeline/rename-conversion";
 import { RegexRenameDetector } from "../pipeline/rename-detector";
 import { generateSQL } from "../pipeline/sql-templates/index";
 
@@ -229,7 +230,7 @@ export async function generateMigration(
       nonInteractive: args.nonInteractive,
       autoAccept: args.autoAcceptRenames,
     });
-    operations = applyRenameDecisions(operations, decisions);
+    operations = applyRenameDecisions(operations, decisions, args.dialect);
   }
   if (operations.length === 0 && !hasCompanions) {
     return null;
@@ -660,7 +661,8 @@ export function buildDesiredSnapshotFromConfig(
  */
 function applyRenameDecisions(
   ops: Operation[],
-  decisions: RenameDecision[]
+  decisions: RenameDecision[],
+  dialect: SupportedDialect
 ): Operation[] {
   const accepted = decisions.filter(d => d.accepted);
   if (accepted.length === 0) return ops;
@@ -701,7 +703,18 @@ function applyRenameDecisions(
     remaining.push(op);
   }
 
-  // Append rename_column ops for each effective acceptance.
+  // Append rename_column ops for each effective acceptance, each followed by the type change it
+  // needs.
+  //
+  // 🔴 The conversion belongs here rather than only in the apply pipeline. A rename moves the column
+  // without changing what it is, so a generated migration carrying the rename alone leaves the old
+  // type under the new name — the UP writes `text` where the snapshot and the runtime expect JSON,
+  // and the DOWN omits the reverse. Emitted as an OPERATION rather than as SQL because everything
+  // downstream already understands one: `generateSQL` renders it for the dialect, and
+  // `buildInverseOperations` inverts it for the DOWN.
+  //
+  // `conversionForRename` is the same function the apply pipeline asks, so a repair written to a
+  // file and one applied against a live database cannot disagree about what the column becomes.
   const renames: Operation[] = [];
   for (const d of effectiveAccepts) {
     const c = d.candidate;
@@ -714,6 +727,8 @@ function applyRenameDecisions(
       toType: c.toType,
     };
     renames.push(renameOp);
+
+    renames.push(...conversionForRename(renameOp, dialect));
   }
 
   // Nothing was collapsed, so the diff's own ordering already holds and the
@@ -749,9 +764,10 @@ function applyRenameDecisions(
  */
 export function applyRenameDecisionsForTest(
   ops: Operation[],
-  decisions: RenameDecision[]
+  decisions: RenameDecision[],
+  dialect: SupportedDialect = "postgresql"
 ): Operation[] {
-  return applyRenameDecisions(ops, decisions);
+  return applyRenameDecisions(ops, decisions, dialect);
 }
 
 /**

--- a/packages/nextly/src/domains/schema/migrate-create/generate.ts
+++ b/packages/nextly/src/domains/schema/migrate-create/generate.ts
@@ -742,16 +742,20 @@ function applyRenameDecisions(
     renames.push(renameOp);
 
     const target = consumedTarget.get(`${c.tableName}::${c.toColumn}`);
+    const sourceColumn = previousSnapshot?.tables
+      .find(t => t.name === c.tableName)
+      ?.columns.find(col => col.name === c.fromColumn);
     renames.push(
       ...conversionForRename(renameOp, dialect, {
         target: target
           ? { nullable: target.nullable, default: target.default }
           : undefined,
         // Read from the snapshot rather than from the drop, which records only a type. A generated
-        // DOWN needs the value to put back, and nothing else in the operation list carries it.
-        sourceDefault: previousSnapshot?.tables
-          .find(t => t.name === c.tableName)
-          ?.columns.find(col => col.name === c.fromColumn)?.default,
+        // DOWN needs this to put the column back as it was, and nothing else in the operation list
+        // carries it.
+        source: sourceColumn
+          ? { nullable: sourceColumn.nullable, default: sourceColumn.default }
+          : undefined,
       })
     );
   }

--- a/packages/nextly/src/domains/schema/pipeline/__tests__/rename-detector.test.ts
+++ b/packages/nextly/src/domains/schema/pipeline/__tests__/rename-detector.test.ts
@@ -311,21 +311,38 @@ describe("RegexRenameDetector - a column left under a legacy spelling", () => {
       }
     }
 
-    // Recorded rather than asserted loosely: `repeater` and `group` were never in the builder's
-    // type map, so their legacy column is `text` where the descriptor asks for JSON, and the
-    // resolution offered is not the data-preserving one.
+    // `repeater` and `group` were never in the builder's type map, so their legacy column is `text`
+    // where the descriptor asks for JSON. That is a change of family and still keeps every value:
+    // a structured value held in a text column is already its own JSON serialization, so the
+    // database can reinterpret it where it lies. All five therefore offer the resolution that moves
+    // the data, and none offers the one that recreates the column empty.
     expect(outcomes).toEqual({
       "postgresql.text": "rename",
       "postgresql.date": "rename",
       "postgresql.number": "rename",
-      "postgresql.repeater": "drop_and_add",
-      "postgresql.group": "drop_and_add",
+      "postgresql.repeater": "rename",
+      "postgresql.group": "rename",
       "mysql.text": "rename",
       "mysql.date": "rename",
       "mysql.number": "rename",
-      "mysql.repeater": "drop_and_add",
-      "mysql.group": "drop_and_add",
+      "mysql.repeater": "rename",
+      "mysql.group": "rename",
     });
+  });
+
+  // The rename is only half the recovery: it moves the column, it does not change what the column
+  // is. Stated here because the detector's answer above is what makes the pair reach the executor
+  // at all, and a reader who stops at "rename" would reasonably assume the type followed.
+  it("does not treat an unrelated family change as recoverable", () => {
+    const candidates = detector.detect(
+      [
+        drop("dc_posts", "_count", "text"),
+        add("dc_posts", "count", "integer"),
+      ] as Operation[],
+      "postgresql"
+    );
+
+    expect(candidates[0]?.defaultSuggestion).toBe("drop_and_add");
   });
 });
 

--- a/packages/nextly/src/domains/schema/pipeline/__tests__/rename-detector.test.ts
+++ b/packages/nextly/src/domains/schema/pipeline/__tests__/rename-detector.test.ts
@@ -443,3 +443,52 @@ describe("RegexRenameDetector - the legacy column reached through the diff", () 
     }).toEqual({ drops: 1, adds: 1, others: 0 });
   });
 });
+
+describe("the text-to-JSON exception is scoped to the shape it repairs", () => {
+  const detector = new RegexRenameDetector();
+
+  it("offers the rename for the legacy underscore column", () => {
+    // The positive control, and the only shape the conversion has evidence for: a table built before
+    // the column-name fix holds `_body` where everything else addresses `body`, and the old builder
+    // is what wrote the JSON into it.
+    const candidates = detector.detect(
+      [
+        drop("dc_posts", "_body", "text"),
+        add("dc_posts", "body", "jsonb"),
+      ] as Operation[],
+      "postgresql"
+    );
+
+    expect(candidates[0]?.defaultSuggestion).toBe("rename");
+  });
+
+  it("does not offer it for two columns that merely share a table", () => {
+    // 🔴 The same two TYPES, and the answer has to differ. Nothing says this column holds serialized
+    // JSON — its text is whatever a user typed. Defaulting the operator into a conversion here fails
+    // on the first row of ordinary prose, and on MySQL the rename has already auto-committed by
+    // then, leaving a half-changed schema no transaction can take back.
+    const candidates = detector.detect(
+      [
+        drop("dc_posts", "summary", "text"),
+        add("dc_posts", "metadata", "jsonb"),
+      ] as Operation[],
+      "postgresql"
+    );
+
+    expect(candidates[0]?.defaultSuggestion).toBe("drop_and_add");
+  });
+
+  it("does not offer it when only the prefix is missing", () => {
+    // `body` -> `body_json` is not `_body` -> `body`. A rule keyed on "one name contains the other"
+    // would accept this; the rule is the exact underscore shape.
+    const candidates = detector.detect(
+      [
+        drop("dc_posts", "body", "text"),
+        add("dc_posts", "body_json", "jsonb"),
+      ] as Operation[],
+      "postgresql"
+    );
+
+    expect(candidates[0]?.defaultSuggestion).toBe("drop_and_add");
+  });
+});

--- a/packages/nextly/src/domains/schema/pipeline/diff/types.ts
+++ b/packages/nextly/src/domains/schema/pipeline/diff/types.ts
@@ -173,6 +173,16 @@ export interface ChangeColumnTypeOp {
    */
   nullable?: boolean;
   columnDefault?: string;
+  /**
+   * The same two facts about the column BEFORE the change.
+   *
+   * Carried for the same reason `fromType` is: an inverse operation has to restate the definition it
+   * is returning the column to, and on MySQL `MODIFY COLUMN` deletes whatever it does not restate.
+   * Without these a generated DOWN converts the type back and silently drops the `NOT NULL` and the
+   * default the column originally had.
+   */
+  fromNullable?: boolean;
+  fromColumnDefault?: string;
 }
 
 export interface ChangeColumnNullableOp {

--- a/packages/nextly/src/domains/schema/pipeline/diff/types.ts
+++ b/packages/nextly/src/domains/schema/pipeline/diff/types.ts
@@ -155,6 +155,24 @@ export interface ChangeColumnTypeOp {
   columnName: string;
   fromType: string;
   toType: string;
+  /**
+   * The nullability and default the column must still have afterwards, when the caller knows them.
+   *
+   * 🔴 Only MySQL needs these, and it needs them absolutely. Its type change is spelled
+   * `MODIFY COLUMN <name> <type>`, which RESTATES the whole definition — so a column that was
+   * `NOT NULL DEFAULT 0` becomes nullable with no default unless both travel with the type. There
+   * is no separate statement to put them back: `change_column_nullable` cannot be rendered for
+   * MySQL at all, by design, because it would need the type it does not carry.
+   *
+   * PostgreSQL ignores them: it changes a type without disturbing either, and expresses each as its
+   * own statement.
+   *
+   * Optional because a caller inside the apply pipeline does not need them — the schema push that
+   * follows reconciles nullability and defaults against the desired snapshot. A generated migration
+   * file has no such second pass, which is where omitting them silently changed the column.
+   */
+  nullable?: boolean;
+  columnDefault?: string;
 }
 
 export interface ChangeColumnNullableOp {

--- a/packages/nextly/src/domains/schema/pipeline/pre-resolution/__tests__/rename-converts-type.integration.test.ts
+++ b/packages/nextly/src/domains/schema/pipeline/pre-resolution/__tests__/rename-converts-type.integration.test.ts
@@ -1,0 +1,200 @@
+// Recovering a column that carries BOTH a legacy name and a legacy type, with its contents.
+//
+// A table created before the column-name fix can hold `_items` where everything else addresses
+// `items`, and for a repeater or a group it also holds `text` where the descriptor asks for JSON.
+// The recovery on offer is a rename, and a rename moves the column without changing what it is: run
+// alone it leaves a text column under the new name, which the runtime then reads through a schema
+// that says JSON.
+//
+// Only a live server can show the pair is accepted. PostgreSQL rejects `ALTER COLUMN ... TYPE jsonb`
+// outright without a USING clause, so a template that looks right can still fail at apply time, and
+// that is precisely the failure this suite exists to catch. The contents are written BEFORE the
+// repair and read back after, because a conversion that succeeds and empties the column would pass
+// every assertion about the column's type.
+
+import { drizzle as drizzleMysql } from "drizzle-orm/mysql2";
+import { drizzle as drizzlePg } from "drizzle-orm/node-postgres";
+import { createPool, type Pool as MysqlPool } from "mysql2";
+import { Pool } from "pg";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { makeTestContext } from "../../../../../database/__tests__/integration/helpers/test-db";
+import type { Operation } from "../../diff/types";
+import { executePreResolutionOps } from "../executor";
+
+const ctx = makeTestContext("postgresql");
+
+describe("a rename that also changes the column's type — PostgreSQL", () => {
+  if (!ctx.available || !ctx.url) {
+    it.skip("Skipping: TEST_POSTGRES_URL not set", () => {});
+    return;
+  }
+
+  const table = `${ctx.prefix}_legacy_repair`;
+  let pool: Pool;
+  let db: ReturnType<typeof drizzlePg>;
+
+  beforeAll(async () => {
+    pool = new Pool({ connectionString: ctx.url ?? undefined });
+    db = drizzlePg({ client: pool });
+  });
+
+  afterAll(async () => {
+    await pool.query(`DROP TABLE IF EXISTS "${table}" CASCADE`);
+    await pool.end();
+  });
+
+  it("moves the column, converts it, and keeps what was in it", async () => {
+    await pool.query(`DROP TABLE IF EXISTS "${table}" CASCADE`);
+    // The shape an affected table is actually in: the legacy NAME and the legacy TYPE together.
+    await pool.query(
+      `CREATE TABLE "${table}" ("id" text PRIMARY KEY, "_items" text)`
+    );
+    const stored = JSON.stringify([{ label: "one" }, { label: "two" }]);
+    await pool.query(`INSERT INTO "${table}" VALUES ('r1', $1)`, [stored]);
+
+    const ops: Operation[] = [
+      {
+        type: "rename_column",
+        tableName: table,
+        fromColumn: "_items",
+        toColumn: "items",
+        fromType: "text",
+        toType: "jsonb",
+      },
+    ];
+
+    await expect(executePreResolutionOps(db, ops, "postgresql")).resolves.toBe(
+      1
+    );
+
+    const shape = await pool.query<{ column_name: string; data_type: string }>(
+      `SELECT column_name, data_type FROM information_schema.columns WHERE table_name = $1`,
+      [table]
+    );
+    const items = shape.rows.find(r => r.column_name === "items");
+    expect(items, "the column reached its canonical name").toBeDefined();
+    expect(items?.data_type, "and its declared type").toBe("jsonb");
+    expect(
+      shape.rows.map(r => r.column_name),
+      "the legacy name is gone"
+    ).not.toContain("_items");
+
+    // The whole point. A conversion that dropped the contents would satisfy everything above.
+    const read = await pool.query<{ items: unknown }>(
+      `SELECT "items" FROM "${table}" WHERE "id" = 'r1'`
+    );
+    expect(read.rows[0]?.items, "the values survived the repair").toEqual([
+      { label: "one" },
+      { label: "two" },
+    ]);
+  });
+
+  // Same name, same type: the conversion must not fire, because emitting an ALTER TYPE for a column
+  // that already has that type is a rewrite of the whole table for nothing.
+  it("issues no conversion when only the name changes", async () => {
+    await pool.query(`DROP TABLE IF EXISTS "${table}" CASCADE`);
+    await pool.query(
+      `CREATE TABLE "${table}" ("id" text PRIMARY KEY, "_title" text)`
+    );
+    await pool.query(`INSERT INTO "${table}" VALUES ('r1', 'kept')`);
+
+    await expect(
+      executePreResolutionOps(
+        db,
+        [
+          {
+            type: "rename_column",
+            tableName: table,
+            fromColumn: "_title",
+            toColumn: "title",
+            fromType: "text",
+            toType: "text",
+          },
+        ] as Operation[],
+        "postgresql"
+      )
+    ).resolves.toBe(1);
+
+    const read = await pool.query<{ title: string }>(
+      `SELECT "title" FROM "${table}" WHERE "id" = 'r1'`
+    );
+    expect(read.rows[0]?.title).toBe("kept");
+  });
+});
+
+const mysqlCtx = makeTestContext("mysql");
+
+describe("a rename that also changes the column's type — MySQL", () => {
+  if (!mysqlCtx.available || !mysqlCtx.url) {
+    it.skip("Skipping: TEST_MYSQL_URL not set", () => {});
+    return;
+  }
+
+  const table = `${mysqlCtx.prefix}_legacy_repair`;
+  let pool: MysqlPool;
+  // Held as the executor's own parameter type. Naming drizzle's generic here instead makes two
+  // structurally identical instantiations of it collide under `check-types`, and the executor never
+  // looks at more than the call pattern anyway.
+  let db: unknown;
+
+  beforeAll(() => {
+    pool = createPool({ uri: mysqlCtx.url as string });
+    db = drizzleMysql({ client: pool });
+  });
+
+  afterAll(async () => {
+    await pool.promise().query(`DROP TABLE IF EXISTS \`${table}\``);
+    await new Promise<void>(res => pool.end(() => res()));
+  });
+
+  it("moves the column, converts it, and keeps what was in it", async () => {
+    const q = pool.promise();
+    await q.query(`DROP TABLE IF EXISTS \`${table}\``);
+    await q.query(
+      `CREATE TABLE \`${table}\` (\`id\` varchar(36) PRIMARY KEY, \`_items\` text)`
+    );
+    await q.query(`INSERT INTO \`${table}\` VALUES ('r1', ?)`, [
+      JSON.stringify([{ label: "one" }]),
+    ]);
+
+    await expect(
+      executePreResolutionOps(
+        db,
+        [
+          {
+            type: "rename_column",
+            tableName: table,
+            fromColumn: "_items",
+            toColumn: "items",
+            fromType: "text",
+            toType: "json",
+          },
+        ] as Operation[],
+        "mysql"
+      )
+    ).resolves.toBe(1);
+
+    const [cols] = await q.query(
+      `SELECT COLUMN_NAME, DATA_TYPE FROM information_schema.columns
+       WHERE table_schema = DATABASE() AND table_name = ?`,
+      [table]
+    );
+    const columns = cols as Array<{ COLUMN_NAME: string; DATA_TYPE: string }>;
+    expect(columns.map(c => c.COLUMN_NAME)).toContain("items");
+    expect(columns.map(c => c.COLUMN_NAME)).not.toContain("_items");
+    expect(columns.find(c => c.COLUMN_NAME === "items")?.DATA_TYPE).toBe(
+      "json"
+    );
+
+    // The whole point: a conversion that emptied the column would satisfy everything above.
+    const [rows] = await q.query(
+      `SELECT \`items\` FROM \`${table}\` WHERE \`id\` = 'r1'`
+    );
+    const value = (rows as Array<{ items: unknown }>)[0]?.items;
+    const parsed = typeof value === "string" ? JSON.parse(value) : value;
+    expect(parsed, "the values survived the repair").toEqual([
+      { label: "one" },
+    ]);
+  });
+});

--- a/packages/nextly/src/domains/schema/pipeline/pre-resolution/executor.ts
+++ b/packages/nextly/src/domains/schema/pipeline/pre-resolution/executor.ts
@@ -61,9 +61,46 @@ export async function executePreResolutionOps(
   for (const op of ordered) {
     const sqlString = sqlForOp(op, dialect);
     await runRaw(txOrDb, sqlString, dialect);
+
+    // A rename moves the column; it does not change what the column IS. When the two sides differ,
+    // the rename alone leaves the old type in place under the new name, so the schema the runtime
+    // reads through and the column it actually reads disagree from that moment on. The conversion
+    // is issued here, immediately after the rename and against the new name, because this is the
+    // only point that knows both the rename happened and which dialect has to carry it out.
+    const conversion = conversionAfterRename(op, dialect);
+    if (conversion) await runRaw(txOrDb, conversion, dialect);
   }
 
   return ordered.length;
+}
+
+/**
+ * The statement that finishes a rename whose type changed, or null when there is nothing to finish.
+ *
+ * Returns null for SQLite on purpose rather than by omission: it has no ALTER that changes a
+ * column's type, and it needs none here, because it stores JSON as text and so the two sides of the
+ * one convertible change name the same storage. Asking for a conversion there would raise
+ * `SqliteUnsupportedOperationError` for a column that is already correct.
+ */
+function conversionAfterRename(
+  op: Operation,
+  dialect: SupportedDialect
+): string | null {
+  if (op.type !== "rename_column") return null;
+  if (dialect === "sqlite") return null;
+  if (!op.fromType || !op.toType) return null;
+  if (op.fromType === op.toType) return null;
+
+  return generateSQL(
+    {
+      type: "change_column_type",
+      tableName: op.tableName,
+      columnName: op.toColumn,
+      fromType: op.fromType,
+      toType: op.toType,
+    },
+    dialect
+  );
 }
 
 // Returns ops sorted into the execution-safe order described above.

--- a/packages/nextly/src/domains/schema/pipeline/pre-resolution/executor.ts
+++ b/packages/nextly/src/domains/schema/pipeline/pre-resolution/executor.ts
@@ -32,6 +32,7 @@ import { isPreResolutionOp, type Operation } from "../diff/types";
 // module (pipeline/sql-templates/) so both the apply pipeline (renames +
 // drops) and migrate:create (all op types) consume the same per-dialect
 // templates. Eliminates the byte-identical-SQL drift risk.
+import { conversionForRename } from "../rename-conversion";
 import { generateSQL } from "../sql-templates/index";
 
 interface AsyncExecuteHandle {
@@ -61,46 +62,29 @@ export async function executePreResolutionOps(
   for (const op of ordered) {
     const sqlString = sqlForOp(op, dialect);
     await runRaw(txOrDb, sqlString, dialect);
+  }
 
-    // A rename moves the column; it does not change what the column IS. When the two sides differ,
-    // the rename alone leaves the old type in place under the new name, so the schema the runtime
-    // reads through and the column it actually reads disagree from that moment on. The conversion
-    // is issued here, immediately after the rename and against the new name, because this is the
-    // only point that knows both the rename happened and which dialect has to carry it out.
-    const conversion = conversionAfterRename(op, dialect);
-    if (conversion) await runRaw(txOrDb, conversion, dialect);
+  // A rename moves the column; it does not change what the column IS. When the two sides differ, the
+  // rename alone leaves the old type in place under the new name, so the schema the runtime reads
+  // through and the column it actually reads disagree from that moment on.
+  //
+  // 🔴 Issued as a pass AFTER every ordered op rather than beside each rename, and the ordering is
+  // the point. MySQL refuses to convert an indexed text column to JSON, and the index that covers it
+  // is dropped in a LATER bucket than the rename — so a conversion emitted next to its own rename
+  // runs while the index is still there and fails. Nothing in the buckets that follow can invalidate
+  // a conversion: the column's own table survives the rename by definition, and the drops target
+  // other objects.
+  //
+  // What to convert is decided by `conversionForRename`, which `migrate:create` also asks, so a
+  // repair applied here and one written to a migration file cannot disagree about it.
+  for (const op of ordered) {
+    if (op.type !== "rename_column") continue;
+    for (const conversion of conversionForRename(op, dialect)) {
+      await runRaw(txOrDb, generateSQL(conversion, dialect), dialect);
+    }
   }
 
   return ordered.length;
-}
-
-/**
- * The statement that finishes a rename whose type changed, or null when there is nothing to finish.
- *
- * Returns null for SQLite on purpose rather than by omission: it has no ALTER that changes a
- * column's type, and it needs none here, because it stores JSON as text and so the two sides of the
- * one convertible change name the same storage. Asking for a conversion there would raise
- * `SqliteUnsupportedOperationError` for a column that is already correct.
- */
-function conversionAfterRename(
-  op: Operation,
-  dialect: SupportedDialect
-): string | null {
-  if (op.type !== "rename_column") return null;
-  if (dialect === "sqlite") return null;
-  if (!op.fromType || !op.toType) return null;
-  if (op.fromType === op.toType) return null;
-
-  return generateSQL(
-    {
-      type: "change_column_type",
-      tableName: op.tableName,
-      columnName: op.toColumn,
-      fromType: op.fromType,
-      toType: op.toType,
-    },
-    dialect
-  );
 }
 
 // Returns ops sorted into the execution-safe order described above.

--- a/packages/nextly/src/domains/schema/pipeline/rename-conversion.ts
+++ b/packages/nextly/src/domains/schema/pipeline/rename-conversion.ts
@@ -48,13 +48,15 @@ export interface RenameConversionContext {
   /** The column spec the collapsed `add_column` declared. */
   target?: { nullable: boolean; default?: string };
   /**
-   * The default the ORIGINAL column had, read from the previous snapshot.
+   * What the ORIGINAL column was, read from the previous snapshot.
    *
-   * Recorded on the drop so a generated DOWN can put it back: `buildInverseOperations` inverts a
-   * default change by assigning `toDefault: op.fromDefault`, so leaving this undefined makes the
-   * rollback emit a second DROP DEFAULT instead of restoring what was there.
+   * Needed in both directions. A generated DOWN restores this definition, and on MySQL it must
+   * RESTATE it — `MODIFY COLUMN` deletes whatever it omits. On PostgreSQL the default is recorded on
+   * the drop so the inverse can put it back: `buildInverseOperations` inverts a default change by
+   * assigning `toDefault: op.fromDefault`, so leaving it undefined makes the rollback emit a second
+   * DROP DEFAULT instead of restoring what was there.
    */
-  sourceDefault?: string;
+  source?: { nullable?: boolean; default?: string };
 }
 
 export function conversionForRename(
@@ -83,6 +85,12 @@ export function conversionForRename(
       change.nullable = context.target.nullable;
       change.columnDefault = context.target.default;
     }
+    // The other direction, for the generated DOWN. Recorded here because this is the only point that
+    // has both definitions at once.
+    if (context.source) {
+      change.fromNullable = context.source.nullable;
+      change.fromColumnDefault = context.source.default;
+    }
     return [change];
   }
 
@@ -101,7 +109,7 @@ export function conversionForRename(
       type: "change_column_default",
       tableName: rename.tableName,
       columnName: rename.toColumn,
-      fromDefault: context.sourceDefault,
+      fromDefault: context.source?.default,
       toDefault: undefined,
     },
     change,

--- a/packages/nextly/src/domains/schema/pipeline/rename-conversion.ts
+++ b/packages/nextly/src/domains/schema/pipeline/rename-conversion.ts
@@ -23,7 +23,6 @@
 import type { SupportedDialect } from "@nextlyhq/adapter-drizzle/types";
 
 import type {
-  ChangeColumnDefaultOp,
   ChangeColumnTypeOp,
   Operation,
   RenameColumnOp,
@@ -37,9 +36,31 @@ import type {
  * convertible change name the same storage. Asking for a conversion there would raise
  * `SqliteUnsupportedOperationError` for a column that is already correct.
  */
+/**
+ * What the repaired column must still be afterwards, when the caller can say.
+ *
+ * A rename is produced by COLLAPSING a `drop_column` and an `add_column`, and the add carried the
+ * column's nullability and default. Collapsing them away discards that, so a caller which has the
+ * consumed pair passes it back in here. Without it the conversion can only restate the type, which
+ * on MySQL means the column silently loses its `NOT NULL` and its default.
+ */
+export interface RenameConversionContext {
+  /** The column spec the collapsed `add_column` declared. */
+  target?: { nullable: boolean; default?: string };
+  /**
+   * The default the ORIGINAL column had, read from the previous snapshot.
+   *
+   * Recorded on the drop so a generated DOWN can put it back: `buildInverseOperations` inverts a
+   * default change by assigning `toDefault: op.fromDefault`, so leaving this undefined makes the
+   * rollback emit a second DROP DEFAULT instead of restoring what was there.
+   */
+  sourceDefault?: string;
+}
+
 export function conversionForRename(
   rename: RenameColumnOp,
-  dialect: SupportedDialect
+  dialect: SupportedDialect,
+  context: RenameConversionContext = {}
 ): Operation[] {
   if (dialect === "sqlite") return [];
   if (!rename.fromType || !rename.toType) return [];
@@ -55,26 +76,52 @@ export function conversionForRename(
     toType: rename.toType,
   };
 
-  if (dialect !== "postgresql") return [change];
+  if (dialect === "mysql") {
+    // Carried on the op itself because MySQL has no other way to express them: MODIFY restates the
+    // whole definition and there is no renderable statement for nullability alone.
+    if (context.target) {
+      change.nullable = context.target.nullable;
+      change.columnDefault = context.target.default;
+    }
+    return [change];
+  }
 
-  // 🔴 PostgreSQL converts the ROWS, not the default.
+  // PostgreSQL from here.
   //
-  // `ALTER COLUMN … TYPE jsonb USING …` applies its USING expression to stored values and leaves the
-  // column's DEFAULT expression alone — so a text default that the old column legitimately carried
-  // (the `'{}'` left behind when a required repeater was added to a populated table) is still a text
-  // expression on a column that is now JSON, and PostgreSQL rejects the whole statement. Every row
-  // can be valid JSON and the conversion still fails.
+  // 🔴 It converts the ROWS, not the default. `ALTER COLUMN … TYPE jsonb USING …` applies its USING
+  // expression to stored values and leaves the DEFAULT expression alone — so a text default on a
+  // column becoming JSON is still a text expression, and PostgreSQL rejects the whole statement.
+  // Every row can be valid JSON and the conversion still fails. The old default therefore comes off
+  // first.
   //
-  // Dropped rather than translated: what the column's default SHOULD be is a property of the desired
-  // schema, not of the column being repaired, and the pass that follows this one already reconciles
-  // defaults. Translating it here would be this module inventing an answer another one owns.
-  const dropDefault: ChangeColumnDefaultOp = {
-    type: "change_column_default",
-    tableName: rename.tableName,
-    columnName: rename.toColumn,
-    fromDefault: undefined,
-    toDefault: undefined,
-  };
+  // `fromDefault` records what was there rather than `undefined`, because that is what a generated
+  // DOWN reads to put it back.
+  const ops: Operation[] = [
+    {
+      type: "change_column_default",
+      tableName: rename.tableName,
+      columnName: rename.toColumn,
+      fromDefault: context.sourceDefault,
+      toDefault: undefined,
+    },
+    change,
+  ];
 
-  return [dropDefault, change];
+  // And the desired default goes back on after the type is right. Omitted when the target declares
+  // none — an unconditional SET DEFAULT would invent one the schema never asked for.
+  //
+  // In the apply pipeline this is redundant: the schema push that follows reconciles defaults
+  // against the desired snapshot. In a generated migration file nothing follows, which is where its
+  // absence left the column without the default its own snapshot declares.
+  if (context.target?.default !== undefined) {
+    ops.push({
+      type: "change_column_default",
+      tableName: rename.tableName,
+      columnName: rename.toColumn,
+      fromDefault: undefined,
+      toDefault: context.target.default,
+    });
+  }
+
+  return ops;
 }

--- a/packages/nextly/src/domains/schema/pipeline/rename-conversion.ts
+++ b/packages/nextly/src/domains/schema/pipeline/rename-conversion.ts
@@ -1,0 +1,80 @@
+/**
+ * The type change a confirmed rename needs, decided once.
+ *
+ * A rename moves a column; it does not change what the column IS. When the two sides of a confirmed
+ * rename describe different types, the rename alone leaves the old type in place under the new name,
+ * and from that moment the schema the runtime reads through and the column it actually reads
+ * disagree.
+ *
+ * Two places act on a confirmed rename and both need this answer:
+ *
+ *   `executePreResolutionOps`   applies it against a live database
+ *   `migrate:create`            writes it into a migration file
+ *
+ * They had one answer between them — the apply path converted and the generated migration did not,
+ * so a repo-committed migration left `text` where the snapshot and the runtime expected JSON, and
+ * its DOWN omitted the reverse. This module is that answer, stated once, so the two cannot drift:
+ * the executor renders it to SQL, `migrate:create` carries it as an operation its own renderer and
+ * its inverse-builder already understand.
+ *
+ * @module domains/schema/pipeline/rename-conversion
+ */
+
+import type { SupportedDialect } from "@nextlyhq/adapter-drizzle/types";
+
+import type {
+  ChangeColumnDefaultOp,
+  ChangeColumnTypeOp,
+  Operation,
+  RenameColumnOp,
+} from "./diff/types";
+
+/**
+ * The operations a rename needs to finish, in order. Empty when it needs none.
+ *
+ * Empty for SQLite on purpose rather than by omission: it has no ALTER that changes a column's
+ * type, and it needs none here, because it stores JSON as text — so the two sides of the one
+ * convertible change name the same storage. Asking for a conversion there would raise
+ * `SqliteUnsupportedOperationError` for a column that is already correct.
+ */
+export function conversionForRename(
+  rename: RenameColumnOp,
+  dialect: SupportedDialect
+): Operation[] {
+  if (dialect === "sqlite") return [];
+  if (!rename.fromType || !rename.toType) return [];
+  if (rename.fromType === rename.toType) return [];
+
+  const change: ChangeColumnTypeOp = {
+    type: "change_column_type",
+    tableName: rename.tableName,
+    // The NEW name. The conversion runs after the rename, so the column no longer answers to the
+    // one it had.
+    columnName: rename.toColumn,
+    fromType: rename.fromType,
+    toType: rename.toType,
+  };
+
+  if (dialect !== "postgresql") return [change];
+
+  // 🔴 PostgreSQL converts the ROWS, not the default.
+  //
+  // `ALTER COLUMN … TYPE jsonb USING …` applies its USING expression to stored values and leaves the
+  // column's DEFAULT expression alone — so a text default that the old column legitimately carried
+  // (the `'{}'` left behind when a required repeater was added to a populated table) is still a text
+  // expression on a column that is now JSON, and PostgreSQL rejects the whole statement. Every row
+  // can be valid JSON and the conversion still fails.
+  //
+  // Dropped rather than translated: what the column's default SHOULD be is a property of the desired
+  // schema, not of the column being repaired, and the pass that follows this one already reconciles
+  // defaults. Translating it here would be this module inventing an answer another one owns.
+  const dropDefault: ChangeColumnDefaultOp = {
+    type: "change_column_default",
+    tableName: rename.tableName,
+    columnName: rename.toColumn,
+    fromDefault: undefined,
+    toDefault: undefined,
+  };
+
+  return [dropDefault, change];
+}

--- a/packages/nextly/src/domains/schema/pipeline/rename-detector-type-families.ts
+++ b/packages/nextly/src/domains/schema/pipeline/rename-detector-type-families.ts
@@ -158,13 +158,46 @@ export function typeFamilyOf(
 export function isTypesCompatible(
   fromType: string,
   toType: string,
-  dialect: SupportedDialect
+  dialect: SupportedDialect,
+  /**
+   * The columns the pair would move between, when the caller knows them.
+   *
+   * Only a CROSS-family answer depends on this, and only one such answer exists. Same-family
+   * compatibility is a property of the types alone and is unaffected. Omitting this therefore never
+   * widens what is accepted — it narrows it, which is the safe direction for a caller that cannot
+   * say which columns it is asking about.
+   */
+  columns?: { from: string; to: string }
 ): boolean {
   const fromFamily = typeFamilyOf(fromType, dialect);
   const toFamily = typeFamilyOf(toType, dialect);
   if (fromFamily === null || toFamily === null) return false;
   if (fromFamily === toFamily) return true;
-  return isConvertibleFamilyChange(fromFamily, toFamily);
+  if (!columns) return false;
+  return (
+    isConvertibleFamilyChange(fromFamily, toFamily) &&
+    isLegacyUnderscoreRepair(columns.from, columns.to)
+  );
+}
+
+/**
+ * Whether a pair is the legacy column the text-to-JSON conversion exists to repair.
+ *
+ * 🔴 The conversion is offered for a NAMED defect, not for text-to-JSON in general. A table created
+ * before the column-name fix holds `_items` where everything else addresses `items`, and for a
+ * repeater or a group it holds `text` where the descriptor asks for JSON. That pair is known to
+ * contain serialized JSON, because the old builder is what wrote it.
+ *
+ * Any other edit that happens to drop a text column and add a JSON one is not that: its text is
+ * whatever a user typed. Offering the rename there defaults the operator into a conversion that
+ * fails on the first row of ordinary prose — and on MySQL the rename has already auto-committed by
+ * then, leaving a half-changed schema no transaction can take back.
+ *
+ * So the shape is the evidence. Recognising it is what separates "this column is JSON that was
+ * stored as text" from "these two columns are both on this table".
+ */
+function isLegacyUnderscoreRepair(from: string, to: string): boolean {
+  return from === `_${to}`;
 }
 
 /**

--- a/packages/nextly/src/domains/schema/pipeline/rename-detector-type-families.ts
+++ b/packages/nextly/src/domains/schema/pipeline/rename-detector-type-families.ts
@@ -163,5 +163,30 @@ export function isTypesCompatible(
   const fromFamily = typeFamilyOf(fromType, dialect);
   const toFamily = typeFamilyOf(toType, dialect);
   if (fromFamily === null || toFamily === null) return false;
-  return fromFamily === toFamily;
+  if (fromFamily === toFamily) return true;
+  return isConvertibleFamilyChange(fromFamily, toFamily);
+}
+
+/**
+ * Whether a column can carry its contents across a change of family.
+ *
+ * Same-family is the ordinary case and needs no conversion. This covers the one pair that is not
+ * the same family and still holds every value it had: text into JSON. A structured value stored in
+ * a text column is already the JSON serialization of itself, so the database can reinterpret it in
+ * place, and refusing the rename means the only recovery on offer drops the column and recreates it
+ * empty.
+ *
+ * Deliberately one-directional. JSON back into text would also preserve the bytes, but nothing in
+ * this product moves that way, and a rule that answers a question no caller asks is a rule nobody
+ * maintains.
+ *
+ * 🔴 Offering the rename is only half of it. A rename does not convert on its own, so a caller that
+ * acts on this must also change the column's type; `executePreResolutionOps` is where that pairing
+ * is made.
+ */
+function isConvertibleFamilyChange(
+  fromFamily: TypeFamily,
+  toFamily: TypeFamily
+): boolean {
+  return fromFamily === "text" && toFamily === "json";
 }

--- a/packages/nextly/src/domains/schema/pipeline/rename-detector.ts
+++ b/packages/nextly/src/domains/schema/pipeline/rename-detector.ts
@@ -56,7 +56,10 @@ export class RegexRenameDetector implements RenameDetector {
           const compatible =
             fromType === ""
               ? false
-              : isTypesCompatible(fromType, toType, dialect);
+              : isTypesCompatible(fromType, toType, dialect, {
+                  from: drop.columnName,
+                  to: add.column.name,
+                });
           candidates.push({
             tableName,
             fromColumn: drop.columnName,

--- a/packages/nextly/src/domains/schema/pipeline/sql-templates/mysql.ts
+++ b/packages/nextly/src/domains/schema/pipeline/sql-templates/mysql.ts
@@ -118,7 +118,13 @@ function generateRenameColumn(op: RenameColumnOp): string {
 // dropped (operator must hand-edit if they need to preserve them).
 // Acceptable trade-off for v1.
 function generateChangeColumnType(op: ChangeColumnTypeOp): string {
-  return `ALTER TABLE ${q(op.tableName)} MODIFY COLUMN ${q(op.columnName)} ${op.toType}`;
+  // MODIFY restates the WHOLE definition, so anything the caller knows about the column has to be
+  // restated with it or MySQL drops it. A caller that knows neither gets the historical behaviour.
+  const nullability =
+    op.nullable === undefined ? "" : op.nullable ? " NULL" : " NOT NULL";
+  const columnDefault =
+    op.columnDefault === undefined ? "" : ` DEFAULT ${op.columnDefault}`;
+  return `ALTER TABLE ${q(op.tableName)} MODIFY COLUMN ${q(op.columnName)} ${op.toType}${nullability}${columnDefault}`;
 }
 
 // F11 PR 3 review fix #1: previously emitted SQL with a comment-as-


### PR DESCRIPTION
## The defect

A table created before the column-name fix can carry **both** a legacy name and a legacy type. For a `repeater` or `group` field the column is `text` where the schema asks for JSON, because those types were never in the builder's own type map.

The rename detector refused those pairs, since `text` and `json` are different families. So the only recovery on offer was **drop and re-add**, which recreates the column empty.

## Two halves, and the second one was the surprise

Making the detector offer a rename is necessary and **not sufficient**. Measured by building the op pair, applying a `rename` resolution, and printing the SQL that would run:

```
OPS AFTER RESOLUTION: rename_column
  SQL: ALTER TABLE "dc_x" RENAME COLUMN "_items" TO "items"
```

`applyResolutionsToOperations` builds an op carrying **both** `fromType` and `toType` (`apply-resolutions.ts:78-85`), and the templates then ignore both (`sql-templates/postgres.ts:134`, `mysql.ts:112`, `sqlite.ts:135`). The column keeps its old type under its new name.

🔴 **That is broader than this repair.** Any confirmed rename between differing types leaves the old type in place today.

## The fix

**Detector**: `text → json` is treated as convertible. Deliberately one-directional and deliberately narrow: a structured value held in a text column is already its own JSON serialization, so the database can reinterpret it where it lies. An unrelated family change such as `text → integer` still resolves as drop-and-add, and there is a test saying so.

**Executor**: the conversion is issued immediately after the rename, against the new name. That is the only point that knows both that the rename happened and which dialect has to carry it out — `applyResolutionsToOperations` is dialect-agnostic by design.

**SQLite returns null on purpose, not by omission.** It has no ALTER that changes a column's type, and it needs none here: it stores JSON as text, so both sides of this one convertible change name the same storage. Asking for a conversion there would raise `SqliteUnsupportedOperationError` for a column that is already correct.

No new SQL was written. `generateChangeColumnType` on PostgreSQL is already cast-aware (`ALTER COLUMN x TYPE t USING "x"::t`), which is what makes this work at all: PostgreSQL rejects `TYPE jsonb` outright without a `USING` clause.

## Verification

- `pnpm build` · `pnpm check-types --force` · `pnpm lint` (exit code) · `node scripts/check-drizzle-v1-legacy.cjs` — clean
- Unit: **361 failed / 7488** against a freshly measured baseline of **361 / 7478** at `6ca3f4506`. Zero new.
- Integration, full suite, both dialects: **PostgreSQL 1362 passed / 0 failed**, **MySQL 1282 passed / 0 failed**
- **Proven on live servers, both dialects.** The new suite builds the real legacy shape, writes contents, runs the repair, then asserts the column reached its canonical name, that its declared type is `jsonb` / `json`, and **that the values are still there** — a conversion that succeeded and emptied the column would satisfy every assertion about the type alone.
- **Proven load-bearing.** Removing the conversion fails the repair test while the name-only control still passes.

## One existing test changed, deliberately

`rename-detector.test.ts` recorded `repeater` and `group` as `drop_and_add`, with a comment noting "the resolution offered is not the data-preserving one." It was characterising the defect rather than protecting an invariant, so the recording is updated and its comment now explains why the change of family still keeps every value.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved schema migrations when renaming legacy columns while changing their data types.
  - PostgreSQL migrations now safely remove incompatible defaults before converting types.
  - MySQL conversions are applied to the renamed column while preserving existing values.
  - SQLite migrations avoid unnecessary type conversions for JSON-backed text storage.

- **Bug Fixes**
  - Restricted text-to-JSON rename detection to recognized legacy column patterns.
  - Prevented unrelated type changes from being incorrectly treated as renames.
  - Avoided unnecessary conversions when renamed columns already share the same type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->