### PR TITLE
feat(blocks-engine): compile the stylesheet a site shares

### DIFF
--- a/.changeset/site-sheet-artifact.md
+++ b/.changeset/site-sheet-artifact.md
@@ -1,0 +1,26 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+Add the stylesheet a whole site shares, compiled once from its design tokens, self-hosted fonts, named classes and block-type defaults, and named by a hash of the bytes it produced. Every page of a site repeats those rules today; a shared sheet is written once and cached until something in it actually changes. A token stored without any values is now reported and skipped rather than ending the compile, which would otherwise have taken down every page on the site.

--- a/packages/blocks-engine/src/index.ts
+++ b/packages/blocks-engine/src/index.ts
@@ -280,5 +280,9 @@ export type { BreakpointAxis } from "./style/breakpoint-axes";
 // several tiers they are looking at. Produced only when `StyleCompileContext.trace` asks for it.
 export type { StyleOrigin, StyleTraceEntry } from "./style/style-trace";
 export type { StyleQuery, StyleSubject } from "./style/style-origin";
+
+// The stylesheet every page of a site shares, compiled once and addressed by its content.
+export type { SiteSheetArtifact, SiteSheetInput } from "./style/site-sheet";
+export { compileSiteSheet } from "./style/site-sheet";
 export { styleOrigin } from "./style/style-origin";
 export { BREAKPOINT_AXES } from "./style/breakpoint-axes";

--- a/packages/blocks-engine/src/style/site-sheet.test.ts
+++ b/packages/blocks-engine/src/style/site-sheet.test.ts
@@ -180,6 +180,79 @@ describe("what the sheet declines to write", () => {
     expect(run().warnings.length).toBeGreaterThan(0);
   });
 
+  it("declares and references a token under the same prefix", () => {
+    // The two halves read the prefix from different places. Set one and not the other and the
+    // sheet declares `--site-color-primary` while the page asks for `var(--brand-color-primary)`:
+    // nothing errors, the reference resolves to nothing, and the colour silently does not apply.
+    const { css } = compileSiteSheet({
+      breakpoints: FIXTURE_BREAKPOINTS,
+      tokenPrefix: "--brand-",
+      tokens: {
+        tokens: [
+          {
+            name: "color.primary",
+            kind: "color" as const,
+            values: { light: "#123456" },
+          },
+        ],
+      },
+      blockBases: {
+        "core/box": {
+          base: { base: { color: { $token: "color.primary" } } },
+        } as unknown as NodeStyles,
+      },
+    });
+
+    expect(css).toContain("--brand-color-primary:#123456");
+    expect(css).toContain("var(--brand-color-primary)");
+    expect(css).not.toContain("--site-color-primary");
+  });
+
+  it("takes the prefix from the token set when no override is given", () => {
+    const { css } = compileSiteSheet({
+      breakpoints: FIXTURE_BREAKPOINTS,
+      tokens: {
+        prefix: "--brand-",
+        tokens: [
+          {
+            name: "color.primary",
+            kind: "color" as const,
+            values: { light: "#123456" },
+          },
+        ],
+      },
+      blockBases: {
+        "core/box": {
+          base: { base: { color: { $token: "color.primary" } } },
+        } as unknown as NodeStyles,
+      },
+    });
+
+    expect(css).toContain("--brand-color-primary:#123456");
+    expect(css).toContain("var(--brand-color-primary)");
+  });
+
+  it("refuses a token with no light value rather than writing undefined", () => {
+    // `light` is what a reader with no mode set resolves, so a token without one has no value at
+    // all. Accepted, it reached the sheet as the literal text `undefined` and warned about
+    // nothing.
+    const { css, warnings } = sheet({
+      tokens: {
+        tokens: [
+          { name: "color.a", kind: "color" as const, values: {} as never },
+          {
+            name: "color.b",
+            kind: "color" as const,
+            values: { dark: "#000000" } as never,
+          },
+        ],
+      },
+    });
+
+    expect(css).not.toContain("undefined");
+    expect(warnings.length).toBe(2);
+  });
+
   it("reports a font it refused rather than emitting it", () => {
     // Remote font sources are refused for privacy; the caller has to be told, or a missing
     // typeface has no explanation anywhere.

--- a/packages/blocks-engine/src/style/site-sheet.test.ts
+++ b/packages/blocks-engine/src/style/site-sheet.test.ts
@@ -1,0 +1,198 @@
+/**
+ * The stylesheet a whole site shares.
+ *
+ * Two properties carry it. The bytes must be identical to what a page would have inlined for the
+ * same tiers — otherwise a site that shares and a page that inlines render differently — and the
+ * hash must name exactly those bytes, so a change that alters nothing invalidates nothing and a
+ * change that alters anything cannot be missed.
+ */
+import { describe, expect, it } from "vitest";
+
+import type { NodeStyles } from "../document";
+import { FIXTURE_BREAKPOINTS } from "../validation.fixtures";
+
+import { compilePageCss } from "./compile-page";
+import type { NamedClass } from "./named-class";
+import { compileSiteSheet } from "./site-sheet";
+
+const styles = (values: Record<string, unknown>): NodeStyles =>
+  ({ base: { base: values } }) as unknown as NodeStyles;
+
+const card: NamedClass = {
+  id: "c1",
+  slug: "card",
+  orderIndex: 0,
+  styles: styles({ color: "blue" }),
+};
+
+const sheet = (over: Record<string, unknown> = {}) =>
+  compileSiteSheet({
+    breakpoints: FIXTURE_BREAKPOINTS,
+    classes: [card],
+    blockBases: { "core/box": styles({ color: "green" }) },
+    ...over,
+  });
+
+describe("what the shared sheet carries", () => {
+  it("emits every block type's default, not only the ones a page uses", () => {
+    // The difference from a page compile, and the reason this cannot just call it with the real
+    // document: a site sheet is shared, so it carries defaults for types this page never used.
+    const { css } = sheet({
+      blockBases: {
+        "core/box": styles({ color: "green" }),
+        "core/text": styles({ color: "black" }),
+      },
+    });
+
+    expect(css).toContain("color: green");
+    expect(css).toContain("color: black");
+  });
+
+  it("emits the named classes", () => {
+    expect(sheet().css).toContain(".nx-c-card");
+  });
+
+  it("emits tokens on the document root, not the page root", () => {
+    // A custom property is read by everything that inherits it, including markup this compiler
+    // never wrote. Scoped to the page root it would be unreadable outside a compiled page.
+    const { css } = sheet({
+      tokens: {
+        tokens: [
+          {
+            name: "color.primary",
+            kind: "color" as const,
+            values: { light: "#123456" },
+          },
+        ],
+      },
+    });
+
+    expect(css).toContain(":root");
+    expect(css).toContain("#123456");
+  });
+
+  it("emits self-hosted font faces", () => {
+    const { css } = sheet({
+      fonts: [{ family: "Inter", src: [{ url: "/fonts/inter.woff2" }] }],
+    });
+
+    expect(css).toContain("@font-face");
+    expect(css).toContain("Inter");
+  });
+
+  it("carries no node-level styling, which belongs to a page", () => {
+    // The synthetic nodes exist only to make each type present. If one of them ever contributed a
+    // rule, the shared sheet would carry a page's content.
+    expect(sheet().css).not.toContain("site-sheet-");
+  });
+});
+
+describe("the bytes agree with what a page would have inlined", () => {
+  it("emits the class tier exactly as the page compiler does", () => {
+    // The guarantee that lets a site share these tiers instead of every page repeating them. It
+    // holds because the same emitter produces both, and this is what would catch a second one.
+    const shared = compileSiteSheet({
+      breakpoints: FIXTURE_BREAKPOINTS,
+      classes: [card],
+      blockBases: {},
+    });
+    const asAPageWouldEmitIt = compilePageCss(
+      {
+        formatVersion: 1,
+        kind: "page",
+        nodes: [{ id: "n1", type: "core/box", version: 1, props: {} }],
+      } as never,
+      {
+        breakpoints: FIXTURE_BREAKPOINTS,
+        namedClasses: [card],
+        blockBases: {},
+      } as never
+    );
+
+    expect(shared.css).toBe(asAPageWouldEmitIt.css);
+  });
+});
+
+describe("the name the sheet is addressed by", () => {
+  it("is the same for the same input, compiled twice", () => {
+    expect(sheet().contentHash).toBe(sheet().contentHash);
+  });
+
+  it("is the same when an input is reordered but the output is not", () => {
+    // Addressing the BYTES rather than the inputs: a reorder the emitter normalizes away must not
+    // invalidate a cached sheet.
+    const a = sheet({
+      blockBases: {
+        "core/box": styles({ color: "green" }),
+        "core/text": styles({ color: "black" }),
+      },
+    });
+    const b = sheet({
+      blockBases: {
+        "core/text": styles({ color: "black" }),
+        "core/box": styles({ color: "green" }),
+      },
+    });
+
+    expect(b.css).toBe(a.css);
+    expect(b.contentHash).toBe(a.contentHash);
+  });
+
+  it("changes when a single declaration changes", () => {
+    const before = sheet();
+    const after = sheet({
+      blockBases: { "core/box": styles({ color: "red" }) },
+    });
+
+    expect(after.css).not.toBe(before.css);
+    expect(after.contentHash).not.toBe(before.contentHash);
+  });
+
+  it("names an empty sheet without failing", () => {
+    const empty = compileSiteSheet({ breakpoints: FIXTURE_BREAKPOINTS });
+
+    expect(empty.css).toBe("");
+    expect(empty.contentHash.length).toBeGreaterThan(0);
+  });
+});
+
+describe("what the sheet declines to write", () => {
+  it("reports a token with no values rather than failing the whole sheet", () => {
+    // Site tokens are one settings row read on every page render, and they arrive whether or not
+    // anything validated them. Reading through a missing field threw, so one corrupt row took
+    // down every page on the site instead of costing that one token.
+    const run = () =>
+      sheet({
+        tokens: {
+          tokens: [
+            { name: "color.primary", kind: "color" as const },
+            {
+              name: "color.ok",
+              kind: "color" as const,
+              values: { light: "#00ff00" },
+            },
+          ],
+        },
+      });
+
+    expect(run).not.toThrow();
+    expect(run().css).toContain("#00ff00");
+    expect(run().warnings.length).toBeGreaterThan(0);
+  });
+
+  it("reports a font it refused rather than emitting it", () => {
+    // Remote font sources are refused for privacy; the caller has to be told, or a missing
+    // typeface has no explanation anywhere.
+    const { css, warnings } = sheet({
+      fonts: [
+        {
+          family: "Remote",
+          src: [{ url: "https://fonts.example.com/a.woff2" }],
+        },
+      ],
+    });
+
+    expect(css).not.toContain("fonts.example.com");
+    expect(warnings.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/blocks-engine/src/style/site-sheet.ts
+++ b/packages/blocks-engine/src/style/site-sheet.ts
@@ -1,0 +1,130 @@
+// The stylesheet a whole site shares, compiled once.
+//
+// A page's own sheet carries what only that page knows: its settings and each node's own values.
+// Everything above that — the design tokens, the self-hosted fonts, the named classes, the block
+// types' defaults — is the same bytes on every page of the site. Inlining it per page repeats it
+// on every request; compiling it once gives one cacheable artifact addressed by its content.
+//
+// The tiers here are emitted by `compilePageCss`, not by a second emitter written beside it. That
+// is the load-bearing choice. The site sheet and a page's sheet have to agree exactly about what
+// a class or a block default looks like — one specificity, one order, one set of bytes — and two
+// emitters agree only until someone edits one of them. Feeding the page compiler a document that
+// uses every type and styles nothing keeps the guarantee structural rather than remembered.
+//
+// @module style/site-sheet
+
+import type { BlockDocument, BreakpointSet, NodeStyles } from "../document";
+import type { ValidationIssue } from "../validation";
+
+import { compilePageCss } from "./compile-page";
+import type { NamedClass } from "./named-class";
+import { hashId } from "./node-class";
+import type { FontFaceDef, SiteTokenSet } from "./site-tokens";
+import { emitFontFaces, emitTokenBlocks } from "./site-tokens";
+
+/** Everything the shared sheet is built from. All of it is site configuration, not document content. */
+export interface SiteSheetInput {
+  /** The site's design tokens, emitted as custom properties. */
+  tokens?: SiteTokenSet;
+  /** Self-hosted font faces. Remote sources are refused by `validateFontFace`, not here. */
+  fonts?: readonly FontFaceDef[];
+  /** The named-class library, emitted in library order. */
+  classes?: readonly NamedClass[];
+  /** Each block type's default look, keyed by type. */
+  blockBases?: Readonly<Record<string, NodeStyles>>;
+  /** The site's breakpoints, which decide the at-rules every tier is emitted under. */
+  breakpoints: BreakpointSet;
+  /** The custom-property prefix tokens are written under. */
+  tokenPrefix?: string;
+}
+
+/** The shared sheet and the name it is addressed by. */
+export interface SiteSheetArtifact {
+  css: string;
+  /**
+   * A stable name for these exact bytes.
+   *
+   * Same input, same hash, on every machine and every run: it is computed from the emitted CSS
+   * rather than from the inputs, so a change that does not alter a single byte of output does not
+   * invalidate a cache, and one that does cannot fail to.
+   *
+   * Not a cryptographic digest, and not used as one. A collision would serve a stale sheet, which
+   * is a caching fault rather than a safety one, and 53 bits is far past what a site's lifetime
+   * of revisions can reach.
+   */
+  contentHash: string;
+  /** What was left out of the sheet, and why. */
+  warnings: ValidationIssue[];
+}
+
+/**
+ * The selector site tokens are declared on.
+ *
+ * `:root` rather than the page root, because tokens are read by everything on the document —
+ * including admin surfaces and any markup outside a compiled page — and a custom property is
+ * inherited from wherever it is declared. Scoping them to the page root would leave a token
+ * unreadable to anything the compiler did not write.
+ */
+const TOKEN_SELECTOR = ":root";
+
+/**
+ * A document that uses every block type and styles nothing itself.
+ *
+ * `compilePageCss` emits a type's default only for a type present in the document, which is right
+ * for a page and wrong for a site sheet: the sheet is shared, so it carries every default the
+ * caller supplied. One styleless node per type says exactly that, and contributes no rules of its
+ * own — a node with no `styles` and no `visibility` emits nothing.
+ */
+function documentUsingEveryType(
+  blockBases: Readonly<Record<string, NodeStyles>>
+): BlockDocument {
+  return {
+    formatVersion: 1,
+    kind: "page",
+    nodes: Object.keys(blockBases)
+      .sort()
+      .map((type, index) => ({
+        id: `site-sheet-${index}`,
+        type,
+        version: 1,
+        props: {},
+      })),
+  } as unknown as BlockDocument;
+}
+
+/**
+ * Compile the stylesheet every page of a site shares.
+ *
+ * Order is the cascade, so it is fixed: font faces, then tokens, then the block-type defaults,
+ * then the named classes. A page's own sheet is appended after this one, which is what lets a
+ * node's own value beat a class and a class beat a block default.
+ */
+export function compileSiteSheet(input: SiteSheetInput): SiteSheetArtifact {
+  const warnings: ValidationIssue[] = [];
+  const blocks: string[] = [];
+
+  const fonts = emitFontFaces(input.fonts ?? []);
+  warnings.push(...fonts.issues);
+  if (fonts.css !== "") blocks.push(fonts.css);
+
+  if (input.tokens !== undefined) {
+    const tokens = emitTokenBlocks(input.tokens, TOKEN_SELECTOR);
+    warnings.push(...tokens.issues);
+    if (tokens.css !== "") blocks.push(tokens.css);
+  }
+
+  const blockBases = input.blockBases ?? {};
+  const tiers = compilePageCss(documentUsingEveryType(blockBases), {
+    breakpoints: input.breakpoints,
+    blockBases,
+    namedClasses: input.classes ?? [],
+    ...(input.tokenPrefix === undefined
+      ? {}
+      : { tokenPrefix: input.tokenPrefix }),
+  });
+  warnings.push(...tiers.warnings);
+  if (tiers.css !== "") blocks.push(tiers.css);
+
+  const css = blocks.join("\n");
+  return { css, contentHash: hashId(css), warnings };
+}

--- a/packages/blocks-engine/src/style/site-sheet.ts
+++ b/packages/blocks-engine/src/style/site-sheet.ts
@@ -107,8 +107,23 @@ export function compileSiteSheet(input: SiteSheetInput): SiteSheetArtifact {
   warnings.push(...fonts.issues);
   if (fonts.css !== "") blocks.push(fonts.css);
 
+  // ONE prefix, used to declare the custom properties and to reference them.
+  //
+  // The two halves read it from different places — `emitTokenBlocks` from the token set, the
+  // style compiler from its context — and a site that set one and not the other declared
+  // `--site-color-primary` while its pages asked for `var(--brand-color-primary)`. Nothing
+  // errors: the reference resolves to nothing and the value silently does not apply. Deriving it
+  // once here is what makes that impossible rather than merely unlikely.
+  const tokenPrefix = input.tokenPrefix ?? input.tokens?.prefix;
+
   if (input.tokens !== undefined) {
-    const tokens = emitTokenBlocks(input.tokens, TOKEN_SELECTOR);
+    const tokens = emitTokenBlocks(
+      {
+        ...input.tokens,
+        ...(tokenPrefix === undefined ? {} : { prefix: tokenPrefix }),
+      },
+      TOKEN_SELECTOR
+    );
     warnings.push(...tokens.issues);
     if (tokens.css !== "") blocks.push(tokens.css);
   }
@@ -118,9 +133,7 @@ export function compileSiteSheet(input: SiteSheetInput): SiteSheetArtifact {
     breakpoints: input.breakpoints,
     blockBases,
     namedClasses: input.classes ?? [],
-    ...(input.tokenPrefix === undefined
-      ? {}
-      : { tokenPrefix: input.tokenPrefix }),
+    ...(tokenPrefix === undefined ? {} : { tokenPrefix }),
   });
   warnings.push(...tiers.warnings);
   if (tiers.css !== "") blocks.push(tiers.css);

--- a/packages/blocks-engine/src/style/site-tokens.ts
+++ b/packages/blocks-engine/src/style/site-tokens.ts
@@ -629,10 +629,13 @@ export function emitTokenBlocks(
     // render and reach here whether or not anything validated them, so a missing field has to
     // cost the token rather than the render: reading through it throws, and one corrupt row would
     // take down every page on the site.
-    if (!isPlainRecord(token.values)) {
+    if (
+      !isPlainRecord(token.values) ||
+      typeof token.values.light !== "string"
+    ) {
       issues.push(
         tokenIssue(
-          `"${token.name}" has no values, so it was not written. A token needs at least a light value.`
+          `"${token.name}" has no light value, so it was not written. Every token needs one: it is what a reader with no mode set resolves.`
         )
       );
       continue;

--- a/packages/blocks-engine/src/style/site-tokens.ts
+++ b/packages/blocks-engine/src/style/site-tokens.ts
@@ -25,6 +25,7 @@
  *
  * @module style/site-tokens
  */
+import { isPlainRecord } from "../plain-record";
 import type { ValidationIssue } from "../validation";
 
 import type { TokenKind } from "./catalog-types";
@@ -620,6 +621,18 @@ export function emitTokenBlocks(
       issues.push(
         tokenIssue(
           `"${token.name}" is not a token name, so it was not written. A name is dot-separated words of letters, digits and dashes, like "color.primary".`
+        )
+      );
+      continue;
+    }
+    // A token with no values record at all. Site tokens are one settings row read on every page
+    // render and reach here whether or not anything validated them, so a missing field has to
+    // cost the token rather than the render: reading through it throws, and one corrupt row would
+    // take down every page on the site.
+    if (!isPlainRecord(token.values)) {
+      issues.push(
+        tokenIssue(
+          `"${token.name}" has no values, so it was not written. A token needs at least a light value.`
         )
       );
       continue;


### PR DESCRIPTION
PR-S8, part 2 of 2. Part 1 (PB-D25) merged as `b37551f5f`. This is `compileSiteSheet`.

## What it is

Every page of a site currently inlines the same design tokens, fonts, named classes and block-type defaults. This compiles them once into one artifact, addressed by a hash of its own bytes.

## The one decision worth reviewing

**The tiers are emitted by `compilePageCss`, not by a second emitter written beside it.**

A site sheet and a page sheet have to agree exactly about what a class or a block default looks like — one specificity, one order, one set of bytes. Two emitters agree only until somebody edits one of them, and #542 spent 24 rounds on exactly that failure mode in a different guise.

So the site sheet is *what the page compiler emits for a document that uses every block type and styles nothing itself*. It reads as indirect, and that is the trade: the guarantee is structural rather than remembered. There is a test asserting the class tier is byte-identical to a page compile, which is what would catch a second emitter appearing later.

One genuine difference from a page compile, and the reason this cannot simply pass the real document: `compilePageCss` emits a type's default only for a type present in the document, which is right for a page and wrong for a shared sheet.

## Details

- **Hash of the output, not the input.** A change that alters no bytes invalidates no cache; one that alters any cannot be missed. Reuses `hashId` — 53 bits, not cryptographic and not used as one. A collision serves a stale sheet, which is a caching fault rather than a safety one.
- **Tokens on `:root`, not the page root.** A custom property is read by everything that inherits it, including admin surfaces and markup this compiler never wrote. Scoped to the page root a token would be unreadable outside a compiled page.
- **Order is the cascade:** fonts, tokens, block-type defaults, named classes. A page's own sheet is appended after, which is what keeps a node's value above a class and a class above a block default.

## A crash this found

My first test fixture used the wrong token shape, and `emitTokenBlocks` **threw** on it — `token.values[mode]` on a token with no `values`.

That is not a fixture problem. Site tokens are one settings row read on every page render and reach that function whether or not anything validated them, and **this PR is what first puts it on a product path** (nothing outside its own tests called it before). One corrupt row would have taken down every page on the site rather than costing that one token. Now reported and skipped, with a test asserting the sheet still carries the tokens beside it.

## Tests

12 cases. Four stub-verifications: hashing the inputs instead of the bytes; emitting only the types a page used; putting tokens on the page root; and removing the missing-values guard.

1002 blocks-engine tests pass; typecheck, lint and a full build clean.

@codex please review this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for compiling a shared site stylesheet from fonts, design tokens, block defaults, named classes, and responsive breakpoints.
  * Added a content-derived hash for generated site stylesheets.
  * Exposed site stylesheet compilation types and functionality for broader integration.

* **Bug Fixes**
  * Improved handling of invalid design tokens and remote fonts by reporting warnings and continuing compilation.
  * Prevented malformed token values from causing rendering errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->