### PR TITLE
fix(blocks-engine): name the class slot that was dropped

### DIFF
--- a/.changeset/named-class-duplicate-slot.md
+++ b/.changeset/named-class-duplicate-slot.md
@@ -1,0 +1,26 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+Report the class library slot that was dropped when the same class is listed twice. Only the first of two entries claiming one id or one name is written, and the warning explaining that named the entry rather than the slot — so a library built by reference, with one object in two slots, reported nothing at all and left an editor with no position to repair.

--- a/packages/blocks-engine/src/style/compile-page.ts
+++ b/packages/blocks-engine/src/style/compile-page.ts
@@ -48,7 +48,7 @@ import {
   namedClassName,
   orderedNamedClasses,
   orderedNamedClassPositions,
-  usableNamedClasses,
+  usableNamedClassPositions,
   MAX_NAMED_CLASS_NAME_LENGTH,
   NAMED_CLASS_SLUG_RE,
 } from "./named-class";
@@ -1034,7 +1034,7 @@ export function compilePageCss(
   // values. At one specificity the cascade is source order, so being emitted here IS what makes
   // a class beat the block default and lose to a local value.
   //
-  // `usableNamedClasses` decides which of them are written, and the class list handed back for
+  // `usableNamedClassPositions` decides which of them are written, and the class list handed
   // each node is built from that same call, so a class dropped here is dropped from both.
   //
   // Charged against an allowance of their own, one per class. A site's class library is one
@@ -1077,11 +1077,13 @@ export function compilePageCss(
       suggestion: "Store the class library as an array of classes.",
     });
   }
-  const usableClasses = usableNamedClasses(library);
-  // The entries themselves, not their ids. Two entries can carry ONE id, and only one of them is
-  // written: asking "was this id written" answers yes for the one that was dropped, and it goes
-  // unreported — the exact case this reporting exists to explain.
-  const written = new Set<unknown>(usableClasses);
+  // Which SLOTS were written, not which ids and not which entries. Two entries can carry one id,
+  // and one object can be supplied in two slots: asking "was this id written" answers yes for the
+  // entry that was dropped, and asking "was this ENTRY written" answers yes for the slot that was
+  // dropped. Both go unreported, which is the exact case this reporting exists to explain.
+  const writtenPositions = usableNamedClassPositions(library);
+  const written = new Set<number>(writtenPositions);
+  const usableClasses = writtenPositions.map(position => library[position]);
   // The ids the written classes claimed, so an entry dropped for sharing one can be told that
   // rather than being told its name collided.
   const usedIds = new Set(usableClasses.map(cls => cls.id));
@@ -1095,16 +1097,9 @@ export function compilePageCss(
   // two separate repairs, and a lookup keyed by the entry answers with the first position for
   // both, sending an editor to a class it has already fixed.
   const orderedPositions = orderedNamedClassPositions(library);
-  // Keyed by entry for the emission walk below, which sees only records that `usableNamedClasses`
-  // has already proven distinct — so no two of its keys can be the same value.
-  const libraryIndex = new Map<unknown, number>();
   for (const position of orderedPositions) {
     const cls = library[position];
-    if (!libraryIndex.has(cls)) libraryIndex.set(cls, position);
-  }
-  for (const position of orderedPositions) {
-    const cls = library[position];
-    if (written.has(cls)) continue;
+    if (written.has(position)) continue;
     // Reported once per entry the library could not use, naming which of the three reasons it
     // was. A usable record whose name is free is not reachable here, so the remaining case after
     // the two structural ones is a name another class already took.
@@ -1155,17 +1150,15 @@ export function compilePageCss(
       ...named,
     });
   }
-  for (const cls of usableClasses) {
+  for (const position of writtenPositions) {
+    const cls = library[position];
     rules.push(
       ...envelopeRules(
         cls.styles,
         `${pageRoot} .${escapeIdentifier(namedClassName(cls.slug))}`,
         // The envelope is stored under `styles`, so the pointer names it. Without that a warning
         // reads `/classes/0/base/base/bogus`, which resolves to nothing an editor can open.
-        pointer(
-          pointer("/classes", String(libraryIndex.get(cls) ?? 0)),
-          "styles"
-        ),
+        pointer(pointer("/classes", String(position)), "styles"),
         contexts,
         tokenPrefix,
         warnings,

--- a/packages/blocks-engine/src/style/named-class-emission.test.ts
+++ b/packages/blocks-engine/src/style/named-class-emission.test.ts
@@ -1008,3 +1008,24 @@ describe("a stored class library with holes in it", () => {
     expect(paths).toEqual(["/classes/0", "/classes/1"]);
   });
 });
+
+describe("one class object supplied in two library slots", () => {
+  it("reports the slot that was dropped", () => {
+    // A caller can build its library by reference, so the same object reaches two slots. Only the
+    // first is written; asking whether the ENTRY was written answers yes for the second too, and
+    // the slot an editor has to repair is never named.
+    const { warnings } = compile(doc({}), [card, card]);
+
+    const duplicate = warnings.find(
+      w => w.code === "duplicate-class-id" || w.code === "duplicate-class-name"
+    );
+    expect(duplicate).toBeDefined();
+    expect(duplicate?.path).toBe("/classes/1");
+  });
+
+  it("still writes the class once", () => {
+    const { css } = compile(doc({ classes: ["c1"] }), [card, card]);
+
+    expect(css.split(".nx-c-card").length - 1).toBe(1);
+  });
+});

--- a/packages/blocks-engine/src/style/named-class.ts
+++ b/packages/blocks-engine/src/style/named-class.ts
@@ -109,10 +109,28 @@ export function isUsableNamedClass(value: unknown): value is NamedClass {
 export function usableNamedClasses(
   classes: readonly NamedClass[]
 ): NamedClass[] {
+  return usableNamedClassPositions(classes).map(position => classes[position]);
+}
+
+/**
+ * The same list, as positions in the stored array rather than as entries.
+ *
+ * Which SLOT was written, not which value. A caller can supply one object in two slots, and only
+ * the first is written — asking "was this entry written" answers yes for the slot that was
+ * dropped, so the duplicate goes unreported and an editor is never told which slot to repair.
+ *
+ * Shares the ordering and the claim rules with `usableNamedClasses` rather than restating them,
+ * because the list of what is written and the list of where it was written have to be the same
+ * list.
+ */
+export function usableNamedClassPositions(
+  classes: readonly NamedClass[]
+): number[] {
   const takenSlugs = new Set<string>();
   const takenIds = new Set<string>();
-  const usable: NamedClass[] = [];
-  for (const cls of orderedNamedClasses(classes)) {
+  const usable: number[] = [];
+  for (const position of orderedNamedClassPositions(classes)) {
+    const cls = classes[position];
     if (!isUsableNamedClass(cls)) continue;
     if (takenSlugs.has(cls.slug)) continue;
     // An id claimed twice is as unusable as a name claimed twice, and quieter about it. A
@@ -123,7 +141,7 @@ export function usableNamedClasses(
     if (takenIds.has(cls.id)) continue;
     takenSlugs.add(cls.slug);
     takenIds.add(cls.id);
-    usable.push(cls);
+    usable.push(position);
   }
   return usable;
 }


### PR DESCRIPTION
Task 147, item 1 of 2. The other item was deliberately documented rather than changed and stays that way — see below.

## The gap

Only the first of two library entries claiming one id or one name is written; the rest are reported so an editor can go and repair them.

That report asked whether the **entry** had been written. A caller can build its library by reference, so one object reaches two slots — and then the answer is yes for both, the duplicate is never reported, and the slot needing the repair is never named.

## The fix

Track written **positions**, not written entries. `usableNamedClassPositions` is a sibling of the existing `usableNamedClassPositions`-style ordering function, and `usableNamedClasses` is now defined in terms of it — so the list of what is written and the list of where it was written come from one function and cannot disagree about either.

That also removed `libraryIndex`, a `Map` keyed by entry that existed only to answer "where did this come from" for the emission walk. The emission walk now iterates positions directly, so the question does not arise.

## Tests

Two cases: `reports the slot that was dropped` (asserting `/classes/1`, the position an editor can act on) and `still writes the class once`, since the point is to report the duplicate without emitting it twice.

Stub-verified by restoring entry-keyed tracking — the first test fails, the second does not, which is the right split.

1007 blocks-engine and 554 page-builder tests pass; typecheck, lint and a full build clean.

## Item 2 stays as documentation

The library cap slices the stored prefix before `orderIndex` is applied, so past 2,000 classes which entries survive depends on storage order. Deciding by `orderIndex` means reading every entry to know which to keep — and that read is exactly what the cap exists to bound, on site settings read at every page render. It is documented in `StyleCompileContext.namedClasses` and `MAX_NAMED_CLASSES`, and worth revisiting only if a real library approaches the cap, which would be the more interesting problem.

@codex please review this PR