### PR TITLE
fix(nextly): create the table on every field-group create transport

### DIFF
--- a/.changeset/field-group-transports-provision.md
+++ b/.changeset/field-group-transports-provision.md
@@ -24,3 +24,5 @@
 ---
 
 Creating a field group through `nextly.fieldGroups.create()` or the mounted `POST /api/field-groups` route now creates its table. Both previously answered success while writing only a registry row, leaving a field group whose storage did not exist and every read and write to it failing.
+
+Those two routes now also refuse a create whose table another field group already owns, which only the admin path checked before. Because a slug is normalised on its way to a table name, two slugs that differ only by hyphens and underscores name one table; such a request used to reach the schema change and rebind the existing field group's storage to the new field list. The mounted route additionally rejects a slug over 50 characters, the bound the rest of the product already validates against, instead of accepting it and provisioning a table under a name the database truncates or refuses.

--- a/.changeset/field-group-transports-provision.md
+++ b/.changeset/field-group-transports-provision.md
@@ -1,0 +1,26 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+Creating a field group through `nextly.fieldGroups.create()` or the mounted `POST /api/field-groups` route now creates its table. Both previously answered success while writing only a registry row, leaving a field group whose storage did not exist and every read and write to it failing.

--- a/packages/nextly/src/api/__tests__/field-group-route-delegates.test.ts
+++ b/packages/nextly/src/api/__tests__/field-group-route-delegates.test.ts
@@ -107,10 +107,10 @@ describe("the field-group create route", () => {
   });
 
   it("refuses a slug too long to survive becoming a table name", async () => {
-    // 51 characters: one past the bound the rest of the product validates against. `comp_` + this
-    // is 56, still inside what the engines accept — the bound is not the engine's, it is the
-    // product's, and it exists so a slug plus every prefix and companion suffix stays clear of the
-    // 63-byte ceiling where PostgreSQL stops rejecting and starts silently TRUNCATING.
+    // 48 characters: one past the bound. The bound is not the slug's own length limit, it is
+    // whatever leaves the LONGEST generated identifier legal — `idx_comp_<slug>_parent`, sixteen
+    // characters longer than this. At 48 that index name is 64: rejected by MySQL, and past the 63
+    // where PostgreSQL stops rejecting and starts silently truncating.
     const { POST } = await import("../field-groups");
 
     const response = await POST(
@@ -118,7 +118,7 @@ describe("the field-group create route", () => {
         method: "POST",
         headers: { "content-type": "application/json" },
         body: JSON.stringify({
-          slug: `a${"b".repeat(50)}`,
+          slug: `a${"b".repeat(47)}`,
           label: "Too long",
           fields: [{ name: "heading", type: "text" }],
         }),
@@ -142,7 +142,7 @@ describe("the field-group create route", () => {
         method: "POST",
         headers: { "content-type": "application/json" },
         body: JSON.stringify({
-          slug: `a${"b".repeat(49)}`,
+          slug: `a${"b".repeat(46)}`,
           label: "At the bound",
           fields: [{ name: "heading", type: "text" }],
         }),

--- a/packages/nextly/src/api/__tests__/field-group-route-delegates.test.ts
+++ b/packages/nextly/src/api/__tests__/field-group-route-delegates.test.ts
@@ -105,4 +105,51 @@ describe("the field-group create route", () => {
     expect(body.message).not.toBe("Field group created.");
     expect(body.message).toContain("could not be provisioned");
   });
+
+  it("refuses a slug too long to survive becoming a table name", async () => {
+    // 51 characters: one past the bound the rest of the product validates against. `comp_` + this
+    // is 56, still inside what the engines accept — the bound is not the engine's, it is the
+    // product's, and it exists so a slug plus every prefix and companion suffix stays clear of the
+    // 63-byte ceiling where PostgreSQL stops rejecting and starts silently TRUNCATING.
+    const { POST } = await import("../field-groups");
+
+    const response = await POST(
+      new Request("http://localhost/api/field-groups", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          slug: `a${"b".repeat(50)}`,
+          label: "Too long",
+          fields: [{ name: "heading", type: "text" }],
+        }),
+      })
+    );
+
+    expect(response.status).toBe(400);
+    // The point is WHERE it is refused. Accepted here, it reaches the DDL, provisions a table the
+    // verification then cannot find under the name it asked for, records the field group as failed,
+    // and still answers 201 for input the route declared valid.
+    expect(createFieldGroup).not.toHaveBeenCalled();
+  });
+
+  it("accepts a slug at the bound", async () => {
+    // The positive control. Without it, a rule that rejected everything would satisfy the case
+    // above while breaking every real create.
+    const { POST } = await import("../field-groups");
+
+    const response = await POST(
+      new Request("http://localhost/api/field-groups", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          slug: `a${"b".repeat(49)}`,
+          label: "At the bound",
+          fields: [{ name: "heading", type: "text" }],
+        }),
+      })
+    );
+
+    expect(response.status).toBe(201);
+    expect(createFieldGroup).toHaveBeenCalledTimes(1);
+  });
 });

--- a/packages/nextly/src/api/__tests__/field-group-route-delegates.test.ts
+++ b/packages/nextly/src/api/__tests__/field-group-route-delegates.test.ts
@@ -1,0 +1,108 @@
+// The REST create route reaches the service that owns the table, rather than writing the row itself.
+//
+// This route used to call `registerComponent` directly. That wrote a registry row and no table, so
+// it answered `201 Field group created.` for a field group whose `comp_<slug>` did not exist, and
+// every later read and write to it failed against the database.
+//
+// The half this file proves is the DELEGATION. The other half — that the service actually
+// provisions the table on a real engine — is proved against live databases in
+// `domains/field-groups/__tests__/field-group-create-transports.integration.test.ts`, through the
+// two transports the harness can reach without a session. This route is permission-gated and the
+// harness cannot authenticate a request, so proving it there would mean faking a session and
+// testing the fake. Split deliberately, and neither half stands alone: delegation without
+// provisioning proves nothing, and provisioning without delegation would leave this route still
+// writing its own row.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const createFieldGroup = vi.fn();
+const registerComponent = vi.fn();
+
+vi.mock("../../di", () => ({
+  getService: vi.fn((name: string) =>
+    name === "fieldGroupMetadataService"
+      ? { createFieldGroup }
+      : { registerComponent }
+  ),
+}));
+
+vi.mock("../../init", () => ({
+  getCachedNextly: vi.fn(async () => undefined),
+}));
+
+vi.mock("../route-auth", () => ({
+  requireRouteAnyPermission: vi.fn(async () => undefined),
+}));
+
+describe("the field-group create route", () => {
+  beforeEach(() => {
+    createFieldGroup.mockReset();
+    registerComponent.mockReset();
+    createFieldGroup.mockResolvedValue({
+      record: {
+        id: "fg-1",
+        slug: "hero",
+        label: "Hero",
+        tableName: "comp_hero",
+        fields: [],
+        migrationStatus: "applied",
+      },
+      migrationStatus: "applied",
+    });
+  });
+
+  it("creates through the service that owns the table, not the registry", async () => {
+    const { POST } = await import("../field-groups");
+
+    await POST(
+      new Request("http://localhost/api/field-groups", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          slug: "hero",
+          label: "Hero",
+          fields: [{ name: "heading", type: "text" }],
+        }),
+      })
+    );
+
+    expect(createFieldGroup).toHaveBeenCalledTimes(1);
+    // Stated as well as the positive, because the defect was not that the row went unwritten: it
+    // was that the row was written ALONE. A route that called both would look correct here.
+    expect(registerComponent).not.toHaveBeenCalled();
+    expect(createFieldGroup.mock.calls[0]?.[0]?.tableName).toBe("comp_hero");
+  });
+
+  it("says so when the table could not be provisioned", async () => {
+    createFieldGroup.mockResolvedValue({
+      record: {
+        id: "fg-2",
+        slug: "hero",
+        label: "Hero",
+        tableName: "comp_hero",
+        fields: [],
+        migrationStatus: "failed",
+      },
+      migrationStatus: "failed",
+    });
+    const { POST } = await import("../field-groups");
+
+    const response = await POST(
+      new Request("http://localhost/api/field-groups", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          slug: "hero",
+          label: "Hero",
+          fields: [{ name: "heading", type: "text" }],
+        }),
+      })
+    );
+    const body = (await response.json()) as { message?: string };
+
+    // An unqualified success for a create whose table was never made is what let this ship unnoticed
+    // for as long as it did.
+    expect(body.message).not.toBe("Field group created.");
+    expect(body.message).toContain("could not be provisioned");
+  });
+});

--- a/packages/nextly/src/api/field-groups.ts
+++ b/packages/nextly/src/api/field-groups.ts
@@ -25,11 +25,11 @@ import type {
   CreateFieldGroupInput,
   FieldGroupMetadataService,
 } from "../domains/field-groups/services/field-group-metadata-service";
+import { MAX_FIELD_GROUP_SLUG_LENGTH } from "../domains/field-groups/services/field-group-schema-service";
 import { calculateSchemaHash } from "../domains/schema/services/schema-hash";
 import { resolveComponentTableName } from "../domains/schema/utils/resolve-table-name";
 import { getCachedNextly } from "../init";
 import type { FieldGroupRegistryService } from "../services/field-groups/field-group-registry-service";
-import { MAX_SLUG_LENGTH } from "../shared/base-validator";
 import { requireBuilderEnabled } from "../shared/builder-access";
 
 import { assertValidFieldsPayload } from "./fields-payload";
@@ -59,11 +59,17 @@ const createComponentSchema = z.object({
   slug: z
     .string()
     .min(1, "Slug is required")
-    // The bound the rest of the product validates against, not the column width. A slug longer than
-    // this becomes a `comp_<slug>` identifier that PostgreSQL truncates and MySQL rejects, so a
-    // request accepted here would provision a table under a name it cannot then verify, record the
-    // field group as failed, and still answer 201.
-    .max(MAX_SLUG_LENGTH, `Slug must be ${MAX_SLUG_LENGTH} characters or less`)
+    // Bounded by the longest IDENTIFIER a field group generates, not by the slug itself and not by
+    // any column width. The slug is prefixed into a table name and that table name is prefixed and
+    // suffixed into `idx_comp_<slug>_parent`, sixteen characters longer than what the caller typed.
+    // The product's usual 50 therefore still yields a 66-character index name: MySQL rejects past
+    // 64, and PostgreSQL silently truncates past 63 — leaving an index under a name nothing can
+    // address. Accepted here, the table is created and the index creation fails, so the field group
+    // is recorded failed with an unbound table and the route still answers 201.
+    .max(
+      MAX_FIELD_GROUP_SLUG_LENGTH,
+      `Slug must be ${MAX_FIELD_GROUP_SLUG_LENGTH} characters or less`
+    )
     .regex(
       /^[a-z][a-z0-9-]*$/,
       "Slug must start with a letter and contain only lowercase letters, numbers, and hyphens"

--- a/packages/nextly/src/api/field-groups.ts
+++ b/packages/nextly/src/api/field-groups.ts
@@ -239,7 +239,7 @@ export const POST = withErrorHandler(async (request: Request) => {
   const message =
     migrationStatus === "applied"
       ? "Field group created."
-      : "Field group created, but its table could not be provisioned. Check the server logs and retry.";
+      : "Field group created, but its table could not be provisioned. The field group is recorded with a failed migration and holds its slug, so creating it again is refused as a duplicate: check the server logs, then delete this field group before creating it again.";
 
   return respondMutation(message, record, { status: 201 });
 });

--- a/packages/nextly/src/api/field-groups.ts
+++ b/packages/nextly/src/api/field-groups.ts
@@ -29,6 +29,7 @@ import { calculateSchemaHash } from "../domains/schema/services/schema-hash";
 import { resolveComponentTableName } from "../domains/schema/utils/resolve-table-name";
 import { getCachedNextly } from "../init";
 import type { FieldGroupRegistryService } from "../services/field-groups/field-group-registry-service";
+import { MAX_SLUG_LENGTH } from "../shared/base-validator";
 import { requireBuilderEnabled } from "../shared/builder-access";
 
 import { assertValidFieldsPayload } from "./fields-payload";
@@ -58,7 +59,11 @@ const createComponentSchema = z.object({
   slug: z
     .string()
     .min(1, "Slug is required")
-    .max(255, "Slug must be 255 characters or less")
+    // The bound the rest of the product validates against, not the column width. A slug longer than
+    // this becomes a `comp_<slug>` identifier that PostgreSQL truncates and MySQL rejects, so a
+    // request accepted here would provision a table under a name it cannot then verify, record the
+    // field group as failed, and still answer 201.
+    .max(MAX_SLUG_LENGTH, `Slug must be ${MAX_SLUG_LENGTH} characters or less`)
     .regex(
       /^[a-z][a-z0-9-]*$/,
       "Slug must start with a letter and contain only lowercase letters, numbers, and hyphens"

--- a/packages/nextly/src/api/field-groups.ts
+++ b/packages/nextly/src/api/field-groups.ts
@@ -21,6 +21,10 @@ import { z } from "zod";
 
 import { getService } from "../di";
 import { clampLimit } from "../domains/collections/query/query-parser";
+import type {
+  CreateFieldGroupInput,
+  FieldGroupMetadataService,
+} from "../domains/field-groups/services/field-group-metadata-service";
 import { calculateSchemaHash } from "../domains/schema/services/schema-hash";
 import { resolveComponentTableName } from "../domains/schema/utils/resolve-table-name";
 import { getCachedNextly } from "../init";
@@ -36,6 +40,18 @@ import { nextlyValidationFromZod } from "./zod-to-nextly-error";
 async function getComponentRegistry(): Promise<FieldGroupRegistryService> {
   await getCachedNextly();
   return getService("fieldGroupRegistryService");
+}
+
+/**
+ * The service that owns a field group's table and its registry row together.
+ *
+ * This route used to call the registry directly, which wrote the row and made no table: it answered
+ * 201 for a field group whose `comp_<slug>` did not exist, and every later read and write to it
+ * failed against the database.
+ */
+async function getFieldGroupMetadataService(): Promise<FieldGroupMetadataService> {
+  await getCachedNextly();
+  return getService("fieldGroupMetadataService");
 }
 
 const createComponentSchema = z.object({
@@ -164,7 +180,7 @@ export const POST = withErrorHandler(async (request: Request) => {
 
   // Boot services before the permission check (see GET) so lazy DI init does
   // not turn a valid caller's first request into a 403/503.
-  const registry = await getComponentRegistry();
+  const metadata = await getFieldGroupMetadataService();
 
   await requireRouteAnyPermission(request, [
     { action: "create", resource: "settings" },
@@ -190,13 +206,11 @@ export const POST = withErrorHandler(async (request: Request) => {
 
   // Validated by assertValidFieldsPayload above; cast through `unknown`
   // to the registry's config type while keeping the payload unstripped.
-  const fields = validated.fields as unknown as Parameters<
-    typeof registry.registerComponent
-  >[0]["fields"];
+  const fields = validated.fields as unknown as CreateFieldGroupInput["fields"];
 
   const schemaHash = calculateSchemaHash(fields);
 
-  const component = await registry.registerComponent({
+  const { record, migrationStatus } = await metadata.createFieldGroup({
     slug: validated.slug,
     label: validated.label,
     tableName,
@@ -208,5 +222,13 @@ export const POST = withErrorHandler(async (request: Request) => {
     schemaHash,
   });
 
-  return respondMutation("Field group created.", component, { status: 201 });
+  // The status is reported rather than swallowed. A create whose DDL failed still has a row
+  // describing what was attempted, and answering an unqualified success for it is what let a field
+  // group with no table look healthy.
+  const message =
+    migrationStatus === "applied"
+      ? "Field group created."
+      : "Field group created, but its table could not be provisioned. Check the server logs and retry.";
+
+  return respondMutation(message, record, { status: 201 });
 });

--- a/packages/nextly/src/di/register.ts
+++ b/packages/nextly/src/di/register.ts
@@ -46,6 +46,7 @@ import {
   getEmailProviderRegistry,
   resetEmailProviderRegistry,
 } from "../domains/email/services/email-provider-registry";
+import type { FieldGroupMetadataService } from "../domains/field-groups/services/field-group-metadata-service";
 import {
   resolveFieldGroupRegistryName,
   resolveKnownTypeColumns,
@@ -334,6 +335,7 @@ export interface ServiceMap {
   singleEntryService: SingleEntryService;
   /** Owns a Single's table change together with the registry write that records it. */
   singleMetadataService: SingleMetadataService;
+  fieldGroupMetadataService: FieldGroupMetadataService;
   fieldGroupRegistryService: FieldGroupRegistryService;
   fieldGroupSchemaService: FieldGroupSchemaService;
   fieldGroupDataService: FieldGroupDataService;

--- a/packages/nextly/src/di/registrations/register-components.ts
+++ b/packages/nextly/src/di/registrations/register-components.ts
@@ -6,6 +6,7 @@
  * resolution time) for component-field read/write support.
  */
 
+import { FieldGroupMetadataService } from "../../domains/field-groups/services/field-group-metadata-service";
 import type { CollectionRelationshipService } from "../../services/collections/collection-relationship-service";
 import {
   FieldGroupDataService,
@@ -30,6 +31,21 @@ export function registerComponentServices(ctx: RegistrationContext): void {
   container.registerSingleton<FieldGroupSchemaService>(
     "fieldGroupSchemaService",
     () => new FieldGroupSchemaService(adapter.getCapabilities().dialect)
+  );
+
+  // FieldGroupMetadataService — schema changes for a field group, holding the table change and the
+  // registry write together. Registered rather than built per request so one wrapper here governs
+  // every caller: the migration lock has to enclose both halves, and a lock applied at one call
+  // site leaves the others uncovered. That is the same reason the three create transports were
+  // allowed to disagree about whether the table gets made at all.
+  container.registerSingleton<FieldGroupMetadataService>(
+    "fieldGroupMetadataService",
+    () =>
+      new FieldGroupMetadataService(
+        container.get<FieldGroupRegistryService>("fieldGroupRegistryService"),
+        logger,
+        adapter
+      )
   );
 
   // FieldGroupDataService — CRUD for component instance data.

--- a/packages/nextly/src/direct-api/__tests__/field-groups-table-name.test.ts
+++ b/packages/nextly/src/direct-api/__tests__/field-groups-table-name.test.ts
@@ -26,7 +26,13 @@ describe("fieldGroups.create derives its table name", () => {
       warn: vi.fn(),
       error: vi.fn(),
     };
-    const registry = { registerComponent };
+    // Answers "no field group owns any table", which is the state a create starts from. The service
+    // refuses a table another field group already holds before it renders any DDL, so a double
+    // without this method describes a registry the create can no longer be performed against.
+    const registry = {
+      registerComponent,
+      getAllComponents: vi.fn().mockResolvedValue([]),
+    };
     const ctx = {
       fieldGroupRegistryService: registry,
       // The REAL service, with no adapter: the create then generates its statements and runs none,

--- a/packages/nextly/src/direct-api/__tests__/field-groups-table-name.test.ts
+++ b/packages/nextly/src/direct-api/__tests__/field-groups-table-name.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it, vi } from "vitest";
 
+import { FieldGroupMetadataService } from "../../domains/field-groups/services/field-group-metadata-service";
+import type { FieldGroupRegistryService } from "../../services/field-groups/field-group-registry-service";
+import type { Logger } from "../../shared/types";
 import { createFieldGroupsNamespace } from "../namespaces/field-groups";
 
 // fieldGroups.create() derives the physical table name through the canonical
@@ -17,9 +20,23 @@ describe("fieldGroups.create derives its table name", () => {
       source: "code",
       migrationStatus: "pending",
     });
+    const logger: Logger = {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    };
+    const registry = { registerComponent };
     const ctx = {
-      fieldGroupRegistryService: { registerComponent },
-      logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+      fieldGroupRegistryService: registry,
+      // The REAL service, with no adapter: the create then generates its statements and runs none,
+      // which is the configuration this product supports and the one that keeps this test about
+      // table-name derivation rather than about DDL.
+      fieldGroupMetadataService: new FieldGroupMetadataService(
+        registry as unknown as FieldGroupRegistryService,
+        logger
+      ),
+      logger,
     };
     return { ctx, registerComponent };
   }

--- a/packages/nextly/src/direct-api/namespaces/context.ts
+++ b/packages/nextly/src/direct-api/namespaces/context.ts
@@ -20,6 +20,7 @@ import type { PermissionService } from "../../domains/auth/services/permission-s
 import type { RBACAccessControlService } from "../../domains/auth/services/rbac-access-control-service";
 import type { RolePermissionService } from "../../domains/auth/services/role-permission-service";
 import type { RoleService } from "../../domains/auth/services/role-service";
+import type { FieldGroupMetadataService } from "../../domains/field-groups/services/field-group-metadata-service";
 import type { CollectionsHandler } from "../../services/collections-handler";
 import type { EmailProviderService } from "../../services/email/email-provider-service";
 import type { EmailService } from "../../services/email/email-service";
@@ -51,6 +52,7 @@ export interface NextlyContext {
   /** @internal */ readonly userService: UserService;
   /** @internal */ readonly mediaService: MediaService;
   /** @internal */ readonly fieldGroupRegistryService: FieldGroupRegistryService;
+  /** @internal */ readonly fieldGroupMetadataService: FieldGroupMetadataService;
   /** @internal */ readonly emailProviderService: EmailProviderService;
   /** @internal */ readonly emailTemplateService: EmailTemplateService;
   /** @internal */ readonly userFieldDefinitionService: UserFieldDefinitionService;

--- a/packages/nextly/src/direct-api/namespaces/field-groups.ts
+++ b/packages/nextly/src/direct-api/namespaces/field-groups.ts
@@ -194,7 +194,7 @@ export function createFieldGroupsNamespace(
         message:
           migrationStatus === "applied"
             ? "Field group created."
-            : "Field group created, but its table could not be provisioned. Check the server logs and retry.",
+            : "Field group created, but its table could not be provisioned. The field group is recorded with a failed migration and holds its slug, so creating it again is refused as a duplicate: check the server logs, then delete this field group before creating it again.",
         item: mapFieldGroupRecord(record),
       };
     },

--- a/packages/nextly/src/direct-api/namespaces/field-groups.ts
+++ b/packages/nextly/src/direct-api/namespaces/field-groups.ts
@@ -173,23 +173,29 @@ export function createFieldGroupsNamespace(
       });
       const tableName = resolveComponentTableName(args.slug);
 
-      const component = await ctx.fieldGroupRegistryService.registerComponent({
-        slug: args.slug,
-        label: args.label,
-        tableName,
-        description: args.description,
-        fields: fieldsTyped,
-        admin: args.admin,
-        source: "ui",
-        locked: false,
-        schemaHash,
-        schemaVersion: 1,
-        migrationStatus: "pending",
-      });
+      // Through the service that owns the table and the row together. Writing the row here
+      // directly is what made this path answer success for a field group whose comp_ table was
+      // never created, leaving the registry describing storage that did not exist.
+      const { record, migrationStatus } =
+        await ctx.fieldGroupMetadataService.createFieldGroup({
+          slug: args.slug,
+          label: args.label,
+          tableName,
+          description: args.description,
+          fields: fieldsTyped,
+          admin: args.admin,
+          source: "ui",
+          locked: false,
+          schemaHash,
+          schemaVersion: 1,
+        });
 
       return {
-        message: "Field group created.",
-        item: mapFieldGroupRecord(component),
+        message:
+          migrationStatus === "applied"
+            ? "Field group created."
+            : "Field group created, but its table could not be provisioned. Check the server logs and retry.",
+        item: mapFieldGroupRecord(record),
       };
     },
 

--- a/packages/nextly/src/direct-api/nextly.ts
+++ b/packages/nextly/src/direct-api/nextly.ts
@@ -57,6 +57,7 @@ import { PermissionService } from "../domains/auth/services/permission-service";
 import type { RBACAccessControlService } from "../domains/auth/services/rbac-access-control-service";
 import { RolePermissionService } from "../domains/auth/services/role-permission-service";
 import { RoleService } from "../domains/auth/services/role-service";
+import type { FieldGroupMetadataService } from "../domains/field-groups/services/field-group-metadata-service";
 import { NextlyError } from "../errors/nextly-error";
 import { buildPluginServicesNamespace } from "../plugins/services/plugin-services-registry";
 import type { CollectionsHandler } from "../services/collections-handler";
@@ -370,6 +371,13 @@ export class Nextly implements NextlyContext {
   public get fieldGroupRegistryService(): FieldGroupRegistryService {
     return container.get<FieldGroupRegistryService>(
       "fieldGroupRegistryService"
+    );
+  }
+
+  /** @internal */
+  public get fieldGroupMetadataService(): FieldGroupMetadataService {
+    return container.get<FieldGroupMetadataService>(
+      "fieldGroupMetadataService"
     );
   }
 

--- a/packages/nextly/src/dispatcher/handlers/__tests__/component-dispatcher-ddl.test.ts
+++ b/packages/nextly/src/dispatcher/handlers/__tests__/component-dispatcher-ddl.test.ts
@@ -19,6 +19,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("../../helpers/di", () => ({
   getComponentRegistryFromDI: vi.fn(),
+  getFieldGroupMetadataServiceFromDI: vi.fn(),
   getAdapterFromDI: vi.fn(),
   // Reached by the companion reconciliation a localized create runs. Omitted, calling it throws and
   // the handler catches that as a companion-provisioning failure — so the assertions below would
@@ -68,7 +69,14 @@ vi.mock("../../../di/container", () => ({
   },
 }));
 
-import { getAdapterFromDI, getComponentRegistryFromDI } from "../../helpers/di";
+import { FieldGroupMetadataService } from "../../../domains/field-groups/services/field-group-metadata-service";
+import type { FieldGroupRegistryService } from "../../../services/field-groups/field-group-registry-service";
+import type { Logger } from "../../../shared/types";
+import {
+  getAdapterFromDI,
+  getComponentRegistryFromDI,
+  getFieldGroupMetadataServiceFromDI,
+} from "../../helpers/di";
 import { dispatchComponents } from "../component-dispatcher";
 
 function wireRegistry() {
@@ -85,6 +93,24 @@ function wireRegistry() {
   };
   vi.mocked(getComponentRegistryFromDI).mockReturnValue(
     registry as unknown as ReturnType<typeof getComponentRegistryFromDI>
+  );
+  // The REAL service over the same doubles, because the create path's behaviour IS this service's
+  // behaviour: what the request forwards into the DDL is decided inside it, and a stub standing in
+  // for it would leave every assertion below describing the stub.
+  const silent: Logger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  };
+  vi.mocked(getFieldGroupMetadataServiceFromDI).mockReturnValue(
+    new FieldGroupMetadataService(
+      registry as unknown as FieldGroupRegistryService,
+      silent,
+      adapter as unknown as ConstructorParameters<
+        typeof FieldGroupMetadataService
+      >[2]
+    )
   );
   return registry;
 }
@@ -109,6 +135,7 @@ async function ddlFor(
 
 beforeEach(() => {
   vi.mocked(getComponentRegistryFromDI).mockReset();
+  vi.mocked(getFieldGroupMetadataServiceFromDI).mockReset();
   vi.mocked(getAdapterFromDI).mockReset();
 });
 

--- a/packages/nextly/src/dispatcher/handlers/__tests__/component-dispatcher-shapes.test.ts
+++ b/packages/nextly/src/dispatcher/handlers/__tests__/component-dispatcher-shapes.test.ts
@@ -12,6 +12,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("../../helpers/di", () => ({
   getComponentRegistryFromDI: vi.fn(),
+  getFieldGroupMetadataServiceFromDI: vi.fn(),
   getAdapterFromDI: vi.fn(),
 }));
 
@@ -22,7 +23,13 @@ vi.mock("../../../di/container", () => ({
   },
 }));
 
-import { getAdapterFromDI, getComponentRegistryFromDI } from "../../helpers/di";
+import { FieldGroupMetadataService } from "../../../domains/field-groups/services/field-group-metadata-service";
+import type { FieldGroupRegistryService } from "../../../services/field-groups/field-group-registry-service";
+import {
+  getAdapterFromDI,
+  getComponentRegistryFromDI,
+  getFieldGroupMetadataServiceFromDI,
+} from "../../helpers/di";
 import { dispatchComponents } from "../component-dispatcher";
 
 type Registry = {
@@ -57,6 +64,14 @@ function makeRegistry(overrides: Partial<Registry> = {}): Registry {
 function wireRegistry(registry: Registry) {
   vi.mocked(getComponentRegistryFromDI).mockReturnValue(
     registry as unknown as ReturnType<typeof getComponentRegistryFromDI>
+  );
+  // The real service with NO adapter, which is this suite's own premise: the create generates its
+  // statements and runs none, so these stay tests of the response shape rather than of DDL.
+  vi.mocked(getFieldGroupMetadataServiceFromDI).mockReturnValue(
+    new FieldGroupMetadataService(
+      registry as unknown as FieldGroupRegistryService,
+      { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+    )
   );
 }
 

--- a/packages/nextly/src/dispatcher/handlers/component-dispatcher.ts
+++ b/packages/nextly/src/dispatcher/handlers/component-dispatcher.ts
@@ -192,26 +192,8 @@ const COMPONENTS_METHODS: Record<string, MethodHandler<ComponentsServices>> = {
       // migrate:create paths, so the created table and the registry row agree.
       const tableName = resolveComponentTableName(b.slug);
 
-      // Refused before any DDL runs, and keyed on the TABLE NAME rather than the slug. The two are
-      // not the same key: a slug is normalised on its way to a table name, so `foo-bar` and
-      // `foo_bar` name one physical table while looking like two free slugs. Left to the registry's
-      // own check, which runs after the DDL, `CREATE TABLE IF NOT EXISTS` reports success against
-      // the table that already exists and the runtime registration then rebinds it to this
-      // request's fields — so a rejected create leaves the existing field group reading through a
-      // schema that does not describe it.
-      const owner = (await svc.registry.getAllComponents()).find(
-        c => c.tableName === tableName
-      );
-      if (owner) {
-        throw NextlyError.duplicate({
-          logContext: {
-            reason: "component-table-conflict",
-            slug: b.slug,
-            tableName,
-            ownedBy: owner.slug,
-          },
-        });
-      }
+      // The table-name conflict is refused inside the service, alongside the DDL it guards, so all
+      // three create transports get it rather than this one alone.
 
       // One service owns the table change and the registry write. This handler used to hold the
       // DDL itself, which is why the other two create transports could not perform the schema

--- a/packages/nextly/src/dispatcher/handlers/component-dispatcher.ts
+++ b/packages/nextly/src/dispatcher/handlers/component-dispatcher.ts
@@ -52,7 +52,6 @@ import {
 import { RegexRenameDetector } from "../../domains/schema/pipeline/rename-detector";
 import type { Resolution } from "../../domains/schema/pipeline/resolution/types";
 import type { DesiredFieldGroup } from "../../domains/schema/pipeline/types";
-import { applyMigrationStatements } from "../../domains/schema/services/apply-migration-statements";
 import { DrizzleStatementExecutor } from "../../domains/schema/services/drizzle-statement-executor";
 import type { FieldResolution } from "../../domains/schema/services/schema-change-types";
 import { calculateSchemaHash } from "../../domains/schema/services/schema-hash";
@@ -62,11 +61,11 @@ import { getProductionNotifier } from "../../runtime/notifications/index";
 import type { FieldDefinition } from "../../schemas/dynamic-collections";
 import { STORAGE_FORMAT } from "../../schemas/storage-format";
 import type { FieldGroupRegistryService } from "../../services/field-groups/field-group-registry-service";
-import { FieldGroupSchemaService } from "../../services/field-groups/field-group-schema-service";
 import { buildFullDesiredSchema } from "../helpers/desired-schema";
 import {
   getAdapterFromDI,
   getComponentRegistryFromDI,
+  getFieldGroupMetadataServiceFromDI,
   getMigrationJournalFromDI,
 } from "../helpers/di";
 import { requireParam, toNumber } from "../helpers/validation";
@@ -214,117 +213,33 @@ const COMPONENTS_METHODS: Record<string, MethodHandler<ComponentsServices>> = {
         });
       }
 
-      // Use FieldGroupSchemaService to generate tables with parent
-      // reference columns (_parent_id, _parent_table, _parent_field,
-      // _order, _component_type).
-      const adapter = getAdapterFromDI();
-      const dialect = adapter?.dialect || "postgresql";
-      const fieldGroupSchemaService = new FieldGroupSchemaService(dialect);
-
-      const migrationSQL = fieldGroupSchemaService.generateMigrationSQL(
-        tableName,
-        b.fields,
-        // i18n: omit translatable columns from the main comp_ table when localized — they live
-        // in the companion comp_<slug>_locales table (provisioned below).
-        { localized: isLocalized }
-      );
-
-      let migrationStatus: "pending" | "applied" | "failed" = "pending";
-
-      try {
-        if (container.has("adapter")) {
-          const diAdapter = container.get<DrizzleAdapter>("adapter");
-
-          await applyMigrationStatements(diAdapter, migrationSQL);
-
-          const tableExists = await diAdapter.tableExists(tableName);
-          if (tableExists) {
-            migrationStatus = "applied";
-            registerComponentRuntimeSchema(
-              diAdapter,
-              dialect,
-              tableName,
-              b.fields,
-              // 🔴 The constant, NOT a probe — and this is the one path where
-              // that inference is sound, so the reason is worth stating.
-              //
-              // This is the CREATE path for a new slug, and the statement
-              // executed above is the DDL generator's own, which writes
-              // `STORAGE_FORMAT.columns.type`. The storage migration cannot
-              // have moved a table that did not exist a moment ago, and a
-              // migrated table would carry the migrated PREFIX, so it could not
-              // be addressed by this name at all.
-              //
-              // Probing here can only hurt: a transient introspection failure
-              // is caught below, records the registry row as `failed`, and
-              // still returns 201 — leaving a created table with no runtime
-              // schema and its CRUD unavailable until a restart. Contrast the
-              // code-first sync path, where `CREATE TABLE IF NOT EXISTS` may
-              // no-op over a table that is years old; there the probe is
-              // required, and assuming the constant was a real defect.
-              STORAGE_FORMAT.columns.type,
-              // i18n: main runtime table omits translatable columns for a localized component.
-              isLocalized
-            );
-            // i18n: provision the companion comp_<slug>_locales table for a localized component.
-            try {
-              await reconcileComponentCompanion({
-                slug: b.slug,
-                tableName,
-                oldFields: [],
-                newFields: b.fields as unknown as FieldDefinition[],
-                localized: isLocalized,
-                // A brand-new component was never localized, so a localized create is a
-                // create-only companion rather than an enable transition.
-                wasLocalized: false,
-                adapter: diAdapter,
-              });
-            } catch (companionErr) {
-              migrationStatus = "failed";
-              const m =
-                companionErr instanceof Error
-                  ? companionErr.message
-                  : String(companionErr);
-              console.error(
-                `[Components] Companion provisioning failed for "${tableName}": ${m}`
-              );
-            }
-          } else {
-            migrationStatus = "failed";
-            console.error(
-              `[Components] Table "${tableName}" was not created after migration`
-            );
-          }
-        } else {
-          console.warn(
-            "[Components] No adapter found in container, migration not executed"
-          );
-        }
-      } catch (migrationError) {
-        migrationStatus = "failed";
-        const message =
-          migrationError instanceof Error
-            ? migrationError.message
-            : String(migrationError);
-        console.error("[Components] Migration execution failed:", message);
-        console.error("[Components] Migration SQL was:", migrationSQL);
+      // One service owns the table change and the registry write. This handler used to hold the
+      // DDL itself, which is why the other two create transports could not perform the schema
+      // half and shipped a registry row describing a table that was never made.
+      const metadata = getFieldGroupMetadataServiceFromDI();
+      if (!metadata) {
+        throw NextlyError.internal({
+          logContext: {
+            reason: "field-group-metadata-service-unavailable",
+            slug: b.slug,
+          },
+        });
       }
-
-      const created = await svc.registry.registerComponent({
-        slug: b.slug,
-        label: b.label || b.slug,
-        tableName,
-        fields: b.fields,
-        admin: b.admin,
-        description: b.description,
-        source: "ui",
-        locked: false,
-        // i18n: persist the Internationalization flag so the component reads/writes per language.
-        localized: isLocalized,
-        schemaHash,
-        schemaVersion: 1,
-        migrationStatus,
-      });
+      const { record: created, migrationStatus } =
+        await metadata.createFieldGroup({
+          slug: b.slug,
+          label: b.label || b.slug,
+          tableName,
+          fields: b.fields,
+          admin: b.admin,
+          description: b.description,
+          source: "ui",
+          locked: false,
+          // i18n: persist the Internationalization flag so the component reads/writes per language.
+          localized: isLocalized,
+          schemaHash,
+          schemaVersion: 1,
+        });
 
       // Migration status drives the toast copy so admins immediately
       // know whether the table was applied.

--- a/packages/nextly/src/dispatcher/handlers/component-dispatcher.ts
+++ b/packages/nextly/src/dispatcher/handlers/component-dispatcher.ts
@@ -27,13 +27,14 @@ import {
 import type { FieldConfig } from "../../collections/fields/types";
 import { container } from "../../di/container";
 import {
+  reconcileComponentCompanion,
+  registerComponentRuntimeSchema,
+} from "../../domains/field-groups/services/field-group-table-provisioning";
+import {
   resolveFieldGroupRegistryName,
   resolveTypeColumns,
 } from "../../domains/field-groups/storage/resolve-storage-names";
 import { assertLocalizationConfigured } from "../../domains/i18n/config/require-app-config";
-import { buildCompanionTransitionStatements } from "../../domains/i18n/migration/reconcile-companion";
-import { localizedColumnsOnMain } from "../../domains/i18n/runtime/companion-io";
-import { buildCompanionRuntimeTable } from "../../domains/i18n/runtime/companion-registration";
 import { translatePipelinePreviewToLegacy } from "../../domains/schema/legacy-preview/translate";
 import { RealClassifier } from "../../domains/schema/pipeline/classifier/classifier";
 import { extractDatabaseNameFromUrl } from "../../domains/schema/pipeline/database-url";
@@ -50,7 +51,6 @@ import {
 } from "../../domains/schema/pipeline/pushschema-pipeline-stubs";
 import { RegexRenameDetector } from "../../domains/schema/pipeline/rename-detector";
 import type { Resolution } from "../../domains/schema/pipeline/resolution/types";
-import { isIdempotencyError } from "../../domains/schema/pipeline/sql-statement-utils";
 import type { DesiredFieldGroup } from "../../domains/schema/pipeline/types";
 import { applyMigrationStatements } from "../../domains/schema/services/apply-migration-statements";
 import { DrizzleStatementExecutor } from "../../domains/schema/services/drizzle-statement-executor";
@@ -60,10 +60,6 @@ import { resolveComponentTableName } from "../../domains/schema/utils/resolve-ta
 import { NextlyError } from "../../errors";
 import { getProductionNotifier } from "../../runtime/notifications/index";
 import type { FieldDefinition } from "../../schemas/dynamic-collections";
-import {
-  getI18nArchiveDdl,
-  getI18nArchiveIndexRepairDdl,
-} from "../../schemas/nextly-i18n-archive";
 import { STORAGE_FORMAT } from "../../schemas/storage-format";
 import type { FieldGroupRegistryService } from "../../services/field-groups/field-group-registry-service";
 import { FieldGroupSchemaService } from "../../services/field-groups/field-group-schema-service";
@@ -71,9 +67,7 @@ import { buildFullDesiredSchema } from "../helpers/desired-schema";
 import {
   getAdapterFromDI,
   getComponentRegistryFromDI,
-  getConfigFromDI,
   getMigrationJournalFromDI,
-  getSchemaRegistryFromDI,
 } from "../helpers/di";
 import { requireParam, toNumber } from "../helpers/validation";
 import type { MethodHandler, Params } from "../types";
@@ -137,191 +131,9 @@ async function resolveComponentTypeColumn(
   return typeColumns.get(tableName) ?? STORAGE_FORMAT.columns.type;
 }
 
-function registerComponentRuntimeSchema(
-  adapter: DrizzleAdapter,
-  dialect: string,
-  tableName: string,
-  fields: FieldConfig[],
-  typeColumn: string,
-  // i18n: when localized, the main comp_ runtime table omits translatable columns and the
-  // companion comp_<slug>_locales runtime table is registered for per-language reads/writes.
-  localized = false
-): void {
-  try {
-    const fieldGroupSchemaService = new FieldGroupSchemaService(
-      dialect as ConstructorParameters<typeof FieldGroupSchemaService>[0]
-    );
-    const runtimeTable = fieldGroupSchemaService.generateRuntimeSchema(
-      tableName,
-      fields,
-      { localized, typeColumn }
-    );
-    const companion = localized
-      ? buildCompanionRuntimeTable({
-          slug: tableName,
-          tableName,
-          fields: fields as { name: string; type: string }[],
-          dialect: dialect as Parameters<
-            typeof buildCompanionRuntimeTable
-          >[0]["dialect"],
-          localized: true,
-          status: false,
-        })
-      : null;
-
-    const registry = getSchemaRegistryFromDI();
-    if (registry) {
-      registry.registerDynamicSchema(tableName, runtimeTable);
-      if (companion) {
-        registry.registerDynamicSchema(
-          companion.companionTableName,
-          companion.table
-        );
-      }
-      return;
-    }
-
-    // Fallback for paths where DI isn't wired (tests, CLI).
-    const resolver = (
-      adapter as unknown as {
-        tableResolver?: {
-          registerDynamicSchema?: (name: string, table: unknown) => void;
-        };
-      }
-    ).tableResolver;
-    if (resolver && typeof resolver.registerDynamicSchema === "function") {
-      resolver.registerDynamicSchema(tableName, runtimeTable);
-      return;
-    }
-
-    console.warn(
-      `[registerComponentRuntimeSchema] No SchemaRegistry available for ` +
-        `'${tableName}'. Component queries may reference old column names ` +
-        `until next server restart.`
-    );
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    console.warn(
-      `[registerComponentRuntimeSchema] In-memory schema refresh failed for ` +
-        `'${tableName}': ${msg}. Component queries may reference old ` +
-        `column names until next server restart.`
-    );
-  }
-}
-
-/**
- * Provision (create / ADD-DROP columns) the component's companion `comp_<slug>_locales` table
- * out-of-band after a schema change, then register its runtime table. The push pipeline excludes
- * companions, so every component create/update/apply path that changes the localized field set
- * goes through here. No-op when the component isn't localized. Mirrors reconcileSingleCompanion.
- * DDL throws on failure; runtime registration is best-effort. Does not move existing main-table
- * rows into the companion — that is the `nextly migrate` enable/disable path.
- */
-async function reconcileComponentCompanion(args: {
-  slug: string;
-  tableName: string;
-  oldFields: FieldDefinition[];
-  newFields: FieldDefinition[];
-  /** Localization state AFTER this save (requested). */
-  localized: boolean;
-  /** Localization state BEFORE this save (persisted). Drives enable/disable detection. */
-  wasLocalized: boolean;
-  adapter: DrizzleAdapter;
-}): Promise<void> {
-  const { slug, tableName, oldFields, newFields, localized, adapter } = args;
-  const wasLocalized = args.wasLocalized;
-  // Nothing to do when the component was and remains non-localized.
-  if (!wasLocalized && !localized) return;
-
-  const dialect = adapter.dialect;
-  const defaultLocale = getConfigFromDI()?.localization?.defaultLocale ?? "en";
-
-  const plan = buildCompanionTransitionStatements({
-    // The companion mirrors the main table, and a field group's builder reads a width from a different key.
-    builtBy: "fieldGroup" as const,
-    slug,
-    tableName,
-    dialect,
-    defaultLocale,
-    // Components are never Draft/Published — companion has no `_status`.
-    status: false,
-    // And never had one, so the disable restore has no status to carry back.
-    wasStatus: false,
-    wasLocalized,
-    isLocalized: localized,
-    oldFields,
-    newFields,
-    companionExists: await adapter.tableExists(`${tableName}_locales`),
-    // Which translatable columns the main table still carries. A disable must not re-add one that
-    // is already there, and must still restore it: presence says the column exists, never that its
-    // value is current, because every localized write went to the companion alone.
-    existingMainColumns: await localizedColumnsOnMain(
-      adapter,
-      tableName,
-      oldFields
-    ).then(cols => cols.map(c => c.name)),
-  });
-
-  // A disable archives non-default translations, so ensure `nextly_i18n_archive` exists first
-  // (Builder entities have no `nextly migrate` step to provision it). Idempotent.
-  if (plan.needsArchive) {
-    for (const stmt of getI18nArchiveDdl(dialect)) {
-      await adapter.executeQuery(stmt);
-    }
-    // MySQL's table DDL cannot restore an index the table is missing, and
-    // index-only drift produces no reconcile operations, so the repair runs
-    // here. Tolerated rather than checked first: attempting it and accepting
-    // "duplicate key name" is one round trip instead of two, and the same
-    // tolerance the schema executor already applies.
-    const indexRepair = getI18nArchiveIndexRepairDdl(dialect);
-    if (indexRepair) {
-      try {
-        await adapter.executeQuery(indexRepair);
-      } catch (err) {
-        if (!isIdempotencyError(err)) throw err;
-      }
-    }
-  }
-  // 🔴 STRICT on purpose: the companion does NOT tolerate a re-run.
-  //
-  // Tolerating it would make a half-finished localization ENABLE look like success. Interrupted
-  // after the companion is created but before the seed and the main-column drops, the retry is
-  // indistinguishable from an orphan repair — the planner cannot tell them apart, because the
-  // signal that separates them (`existingMainColumns`) is consumed only on the disable path — so
-  // the duplicate columns would be swallowed and the entity recorded as localized while its
-  // default-locale content is still stranded on the main table.
-  //
-  // A loud failure is the worse experience and the safer outcome. It costs the repair of a
-  // localized entity whose create half-failed; it prevents silently reporting a migration that did
-  // not happen.
-  for (const stmt of plan.statements) {
-    await adapter.executeQuery(stmt);
-  }
-
-  // The transition record describes a companion that no longer exists, so it stops being true
-  // the moment the disable succeeds. Left behind, it would refuse the next enable's real
-  // source locale — the check that protects a live transition would block a legitimate one.
-  if (plan.companionDropped) {
-    // The other half of "this companion is gone": readiness remembers only that one exists.
-    const { forgetCompanionReadiness } = await import(
-      "../../domains/i18n/runtime/companion-readiness"
-    );
-    forgetCompanionReadiness(adapter, `${tableName}_locales`);
-    const { resolveTransitionStore } = await import(
-      "../../domains/i18n/migration/transition-recorder"
-    );
-    const { forgetI18nTransition } = await import(
-      "../../domains/i18n/migration/transition-state"
-    );
-    await forgetI18nTransition(
-      await resolveTransitionStore(adapter),
-      "fieldGroup",
-      slug
-    );
-  }
-  // Runtime registration of the companion is handled by registerComponentRuntimeSchema(localized)
-  // in the calling handlers, so no separate registration is needed here.
-}
+// Both helpers now live beside the field-group schema service, so every transport that creates a
+// field group reaches the same table provisioning rather than only the one that happened to hold
+// them privately.
 
 const COMPONENTS_METHODS: Record<string, MethodHandler<ComponentsServices>> = {
   listComponents: {

--- a/packages/nextly/src/dispatcher/helpers/di.ts
+++ b/packages/nextly/src/dispatcher/helpers/di.ts
@@ -12,6 +12,7 @@ import type { DrizzleAdapter } from "@nextlyhq/adapter-drizzle";
 import type { SchemaRegistry } from "../../database/schema-registry";
 import { container } from "../../di/container";
 import type { NextlyServiceConfig } from "../../di/register";
+import type { FieldGroupMetadataService } from "../../domains/field-groups/services/field-group-metadata-service";
 import type { DrizzleMigrationJournal } from "../../domains/schema/journal/migration-journal";
 import type { SingleEntryService } from "../../domains/singles/services/single-entry-service";
 import type { SingleMetadataService } from "../../domains/singles/services/single-metadata-service";
@@ -78,6 +79,21 @@ export function getSingleMetadataServiceFromDI():
   try {
     if (container.has("singleMetadataService")) {
       return container.get<SingleMetadataService>("singleMetadataService");
+    }
+  } catch {
+    // DI not initialized
+  }
+  return undefined;
+}
+
+export function getFieldGroupMetadataServiceFromDI():
+  | FieldGroupMetadataService
+  | undefined {
+  try {
+    if (container.has("fieldGroupMetadataService")) {
+      return container.get<FieldGroupMetadataService>(
+        "fieldGroupMetadataService"
+      );
     }
   } catch {
     // DI not initialized

--- a/packages/nextly/src/domains/field-groups/__tests__/field-group-create-transports.integration.test.ts
+++ b/packages/nextly/src/domains/field-groups/__tests__/field-group-create-transports.integration.test.ts
@@ -95,5 +95,40 @@ for (const dialect of getConfiguredTestDialects()) {
       expect(row?.migrationStatus).toBe("applied");
       expect(await current.adapter.tableExists(`comp_${viaDirect}`)).toBe(true);
     });
+
+    it("refuses a create whose slug names a table another field group owns", async () => {
+      current = await createTestNextly({ dialect });
+
+      // Two DIFFERENT slugs naming ONE physical table, which is the case a slug-keyed check cannot
+      // see: a slug is normalised on its way to a table name, so these two are `comp_<...>_held`
+      // alike while looking like two free slugs.
+      const held = `fg_${dialect.slice(0, 2)}_held`;
+      const collides = held.replace(/_held$/, "-held");
+
+      await dispatchComponents(
+        "createComponent",
+        {},
+        { slug: held, label: "Holds the table", fields: FIELDS }
+      );
+
+      // Rejected for the reason that is true — a table conflict — rather than by whatever the
+      // database says when the unique index on `table_name` stops the insert. The distinction is
+      // the whole point: reaching the insert means the DDL and the runtime re-registration have
+      // already run, and the second of those rebinds the EXISTING field group to this request's
+      // fields.
+      await expect(
+        current.nextly.fieldGroups.create({
+          slug: collides,
+          label: "Wants the same table",
+          fields: [{ name: "different", type: "text" }],
+        })
+      ).rejects.toMatchObject({ code: "DUPLICATE" });
+
+      // The field group that owns the table is untouched, which is what a refusal before the DDL
+      // buys. Its own fields still describe it.
+      const row = await registryRow(current, held);
+      expect(row?.migrationStatus).toBe("applied");
+      expect(await current.adapter.tableExists(`comp_${held}`)).toBe(true);
+    });
   });
 }

--- a/packages/nextly/src/domains/field-groups/__tests__/field-group-create-transports.integration.test.ts
+++ b/packages/nextly/src/domains/field-groups/__tests__/field-group-create-transports.integration.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Every way a field group can be created has to leave one that actually works.
+ *
+ * ## The gap this closes
+ *
+ * A field group is creatable through three transports, and only the dispatcher made the table. The
+ * REST route answered `201 Field group created.` and the Direct API resolved normally, both having
+ * written a registry row describing a `comp_<slug>` that did not exist. Every later read and write
+ * to that field group then failed against the database.
+ *
+ * Nothing caught it because the coverage was per transport rather than per outcome: the dispatcher
+ * had tests, and they passed, while the other two were tested for their response shape and their
+ * table-name derivation — neither of which touches a database. So each transport was individually
+ * green and the product was broken.
+ *
+ * These assert the OUTCOME against a real database: the physical table exists. Written as one suite
+ * because the defect was precisely that the transports disagreed, and testing them apart is what
+ * let them.
+ *
+ * 🔴 The REST route is proved a level up rather than here, and the reason is worth stating plainly
+ * so nobody reads its absence as coverage. It is permission-gated, the test harness has no way to
+ * authenticate a request, and faking a session would test the fake. What matters is that all three
+ * transports now share ONE implementation: these cases prove that implementation provisions the
+ * table on a live database, and `field-group-route-delegates.test.ts` proves the route reaches it
+ * instead of writing the row itself. Neither half stands alone.
+ *
+ * Self-skips per dialect on the standard rule: SQLite always runs, the servers run when their URL
+ * is set, and each dialect gets its own throwaway database.
+ */
+import { afterEach, describe, expect, it } from "vitest";
+
+import { dispatchComponents } from "../../../dispatcher/handlers/component-dispatcher";
+import {
+  createTestNextly,
+  getConfiguredTestDialects,
+  type TestNextly,
+} from "../../../plugins/test-nextly";
+
+let current: TestNextly | undefined;
+
+afterEach(async () => {
+  await current?.destroy();
+  current = undefined;
+});
+
+/** The registry's own view of a slug, or undefined when it holds none. */
+async function registryRow(
+  instance: TestNextly,
+  slug: string
+): Promise<{ migrationStatus?: string; tableName?: string } | undefined> {
+  const registry = instance.getService("fieldGroupRegistryService");
+  return (await registry.getComponentBySlug(slug)) ?? undefined;
+}
+
+const FIELDS = [
+  { name: "heading", type: "text" },
+  { name: "weight", type: "number" },
+];
+
+for (const dialect of getConfiguredTestDialects()) {
+  describe(`every field-group create transport provisions its table — ${dialect}`, () => {
+    // Per-dialect slugs: the suites share one process, so a name reused across them turns a leaked
+    // row into a duplicate-slug rejection in a later suite rather than a failure where it leaked.
+    const viaDispatcher = `fg_${dialect.slice(0, 2)}_disp`;
+    const viaDirect = `fg_${dialect.slice(0, 2)}_direct`;
+
+    it("the dispatcher creates the table", async () => {
+      current = await createTestNextly({ dialect });
+
+      await dispatchComponents(
+        "createComponent",
+        {},
+        { slug: viaDispatcher, label: "Via dispatcher", fields: FIELDS }
+      );
+
+      const row = await registryRow(current, viaDispatcher);
+      // The recorded outcome FIRST: it names the problem, where a bare "table missing" only says
+      // the end state is wrong.
+      expect(row?.migrationStatus).toBe("applied");
+      expect(await current.adapter.tableExists(`comp_${viaDispatcher}`)).toBe(
+        true
+      );
+    });
+
+    it("the Direct API creates the table", async () => {
+      current = await createTestNextly({ dialect });
+
+      await current.nextly.fieldGroups.create({
+        slug: viaDirect,
+        label: "Via direct API",
+        fields: FIELDS,
+      });
+
+      const row = await registryRow(current, viaDirect);
+      expect(row?.migrationStatus).toBe("applied");
+      expect(await current.adapter.tableExists(`comp_${viaDirect}`)).toBe(true);
+    });
+  });
+}

--- a/packages/nextly/src/domains/field-groups/services/__tests__/field-group-metadata-apply-contract.test.ts
+++ b/packages/nextly/src/domains/field-groups/services/__tests__/field-group-metadata-apply-contract.test.ts
@@ -15,8 +15,24 @@
  */
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+/**
+ * Every table the runtime was pointed at, in order.
+ *
+ * Recorded rather than asserted through a spy on the module, because WHEN this happens is the
+ * behaviour under test: the list has to be empty for a create whose row was rejected.
+ */
+const bound: string[] = [];
+
+vi.mock("../field-group-table-provisioning", () => ({
+  registerComponentRuntimeSchema: vi.fn((_a, _d, tableName: string) => {
+    bound.push(tableName);
+  }),
+  reconcileComponentCompanion: vi.fn(async () => {}),
+}));
+
 import type { DrizzleAdapter } from "@nextlyhq/adapter-drizzle";
 
+import { NextlyError } from "../../../../errors";
 import type { Logger } from "../../../../shared/types";
 import type { FieldGroupRegistryService } from "../field-group-registry-service";
 import {
@@ -74,6 +90,7 @@ function serviceOver(
 
 beforeEach(() => {
   vi.clearAllMocks();
+  bound.length = 0;
 });
 
 describe("a field-group create records its outcome rather than raising it", () => {
@@ -129,5 +146,49 @@ describe("a field-group create records its outcome rather than raising it", () =
     // rebound the existing field group's storage to this request's fields.
     expect(adapter.executeQuery).not.toHaveBeenCalled();
     expect(registry.registerComponent).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * What separates two creates that both want the same table.
+ *
+ * The ownership check cannot exclude a write that has not happened yet, so two requests whose slugs
+ * normalise to one table can both pass it. The registry's `table_name` unique index is what actually
+ * decides between them — and that only helps if nothing irreversible has already happened.
+ *
+ * Binding the runtime schema is irreversible in the sense that matters: it describes the shared table
+ * to the running process. Done before the insert, the request that loses rebinds the winner's table
+ * to ITS field list and only then fails, leaving reads and writes going through a schema that
+ * describes the wrong field group until a restart. So the binding has to happen after the insert
+ * that would reject it.
+ */
+describe("a create that loses the race changes nothing", () => {
+  it("does not bind the runtime schema when the registry rejects the row", async () => {
+    const registry = registryDouble();
+    // Passes the ownership check — the state a racing pair is in, since neither row exists yet —
+    // and then fails at the INSERT, which is where the database serialises them.
+    registry.registerComponent.mockRejectedValue(
+      NextlyError.duplicate({ logContext: { reason: "table-name-unique" } })
+    );
+    const adapter = adapterDouble(async () => true);
+
+    await expect(
+      serviceOver(registry, adapter).createFieldGroup(INPUT)
+    ).rejects.toMatchObject({ code: "DUPLICATE" });
+
+    // The table itself was created, which is expected and harmless: the DDL is idempotent and the
+    // winner owns the same table. What must NOT have happened is the rebind.
+    expect(bound).toHaveLength(0);
+  });
+
+  it("binds the runtime schema when the row is written", async () => {
+    // The positive control. Without it, a service that never bound at all would satisfy the case
+    // above while leaving every successful create invisible to the running process.
+    const registry = registryDouble();
+    const adapter = adapterDouble(async () => true);
+
+    await serviceOver(registry, adapter).createFieldGroup(INPUT);
+
+    expect(bound).toEqual(["comp_hero"]);
   });
 });

--- a/packages/nextly/src/domains/field-groups/services/__tests__/field-group-metadata-apply-contract.test.ts
+++ b/packages/nextly/src/domains/field-groups/services/__tests__/field-group-metadata-apply-contract.test.ts
@@ -228,6 +228,61 @@ describe("a create whose generated names would not fit is refused", () => {
     expect(registry.registerComponent).not.toHaveBeenCalled();
   });
 
+  it("counts a unique index, which is named differently from a plain one", async () => {
+    // `uq_<table>_<column>`, emitted by its own loop. An enumeration that walked the fields looking
+    // for `index: true` missed this entirely, because a unique field need not set it.
+    const registry = registryDouble();
+    const adapter = adapterDouble(async () => true);
+
+    await expect(
+      serviceOver(registry, adapter).createFieldGroup({
+        ...INPUT,
+        tableName: longSlugTable,
+        fields: [{ name: "authorId", type: "text", unique: true }],
+      })
+    ).rejects.toMatchObject({ code: "VALIDATION_ERROR" });
+
+    expect(adapter.executeQuery).not.toHaveBeenCalled();
+  });
+
+  it("counts the column's own name, not only names derived from it", async () => {
+    // A column IS an identifier. A field named past the limit makes MySQL reject the CREATE TABLE
+    // itself — before any index exists to be named.
+    const registry = registryDouble();
+    const adapter = adapterDouble(async () => true);
+
+    await expect(
+      serviceOver(registry, adapter).createFieldGroup({
+        ...INPUT,
+        fields: [{ name: "a".repeat(65), type: "text" }],
+      })
+    ).rejects.toMatchObject({ code: "VALIDATION_ERROR" });
+
+    expect(adapter.executeQuery).not.toHaveBeenCalled();
+  });
+
+  it("does not count an index the renderer never emits", async () => {
+    // 🔴 A localized field's column lives in the companion, so the main table gets no index for it
+    // and no such name is ever generated. Rejecting this request would refuse a VALID create over an
+    // identifier that does not exist — a false refusal, which is worse than the miss it came from.
+    const registry = registryDouble();
+    const adapter = adapterDouble(async () => true);
+
+    const { migrationStatus } = await serviceOver(
+      registry,
+      adapter
+    ).createFieldGroup({
+      ...INPUT,
+      tableName: longSlugTable,
+      localized: true,
+      fields: [
+        { name: "authorId", type: "text", index: true, localized: true },
+      ],
+    });
+
+    expect(migrationStatus).toBe("applied");
+  });
+
   it("allows the same slug when no field derives a longer name", async () => {
     // The positive control. Without it, a rule that rejected every long slug would satisfy the case
     // above while refusing creates that are perfectly legal.

--- a/packages/nextly/src/domains/field-groups/services/__tests__/field-group-metadata-apply-contract.test.ts
+++ b/packages/nextly/src/domains/field-groups/services/__tests__/field-group-metadata-apply-contract.test.ts
@@ -192,3 +192,57 @@ describe("a create that loses the race changes nothing", () => {
     expect(bound).toEqual(["comp_hero"]);
   });
 });
+
+/**
+ * Names the database would not store intact are refused before anything runs.
+ *
+ * A slug bound cannot cover this. The generator names a field's index `idx_<tableName>_<columnName>`,
+ * so the longest identifier depends on the slug AND the longest indexed field name — two independent
+ * inputs, neither of which constrains the other. A slug inside its own limit, paired with an ordinary
+ * field name, still produces an index name past what MySQL accepts and PostgreSQL stores.
+ *
+ * The failure it prevents is a partial one: the table and its parent index are created, the field
+ * index fails, and the caller receives a record whose migration is recorded failed — a field group
+ * that exists and cannot be queried, made by a request that returned a success shape.
+ */
+describe("a create whose generated names would not fit is refused", () => {
+  const longSlugTable = `comp_${"a".repeat(47)}`;
+
+  it("counts the field's index name, not only the slug", async () => {
+    const registry = registryDouble();
+    const adapter = adapterDouble(async () => true);
+
+    // The slug is AT its own bound — `comp_<47>` is 52, and its parent index is exactly 63. What
+    // pushes it over is the field: `idx_comp_<47>_author_id` is 66.
+    await expect(
+      serviceOver(registry, adapter).createFieldGroup({
+        ...INPUT,
+        tableName: longSlugTable,
+        fields: [{ name: "authorId", type: "text", index: true }],
+      })
+    ).rejects.toMatchObject({ code: "VALIDATION_ERROR" });
+
+    // Before any DDL, which is the whole point: a refusal that has already run statements leaves
+    // exactly the half-made field group this exists to prevent.
+    expect(adapter.executeQuery).not.toHaveBeenCalled();
+    expect(registry.registerComponent).not.toHaveBeenCalled();
+  });
+
+  it("allows the same slug when no field derives a longer name", async () => {
+    // The positive control. Without it, a rule that rejected every long slug would satisfy the case
+    // above while refusing creates that are perfectly legal.
+    const registry = registryDouble();
+    const adapter = adapterDouble(async () => true);
+
+    const { migrationStatus } = await serviceOver(
+      registry,
+      adapter
+    ).createFieldGroup({
+      ...INPUT,
+      tableName: longSlugTable,
+      fields: [{ name: "body", type: "text" }],
+    });
+
+    expect(migrationStatus).toBe("applied");
+  });
+});

--- a/packages/nextly/src/domains/field-groups/services/__tests__/field-group-metadata-apply-contract.test.ts
+++ b/packages/nextly/src/domains/field-groups/services/__tests__/field-group-metadata-apply-contract.test.ts
@@ -1,0 +1,133 @@
+/**
+ * The apply half records its outcome instead of raising it, including when the CHECK fails.
+ *
+ * `createFieldGroup` runs the DDL and then writes a registry row carrying how far it got. That only
+ * works if the apply never throws: a rejection there takes the registry write with it and leaves a
+ * table that was just created with nothing describing it — findable only by guessing at names.
+ *
+ * The statements themselves were already inside a catch. The verification that follows them was
+ * not, and it is a query like any other: `tableExists` re-raises what the driver hands it, so a
+ * momentary connection failure at that instant orphaned the table it had just made. It is the
+ * confirmation step, so it fails exactly when the database is least healthy.
+ *
+ * Driven through doubles rather than an engine because the case being described is a query failure
+ * at one specific moment, which a real database will not reproduce on request.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { DrizzleAdapter } from "@nextlyhq/adapter-drizzle";
+
+import type { Logger } from "../../../../shared/types";
+import type { FieldGroupRegistryService } from "../field-group-registry-service";
+import {
+  FieldGroupMetadataService,
+  type CreateFieldGroupInput,
+} from "../field-group-metadata-service";
+
+const logger: Logger = {
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+};
+
+const INPUT: CreateFieldGroupInput = {
+  slug: "hero",
+  label: "Hero",
+  tableName: "comp_hero",
+  fields: [{ name: "heading", type: "text" }],
+  source: "ui",
+  locked: false,
+  // Required by the input type, and carried through to the row unchanged. Its value is irrelevant
+  // to what these assert; its presence is not, because the type is the registry's own insert shape
+  // and a subset would stop describing what a create actually writes.
+  schemaHash: "hash-for-the-fields-above",
+};
+
+/** A registry holding nothing, so the ownership check passes and the create proceeds. */
+function registryDouble() {
+  return {
+    getAllComponents: vi.fn().mockResolvedValue([]),
+    registerComponent: vi.fn(async (row: unknown) => row),
+  };
+}
+
+/** An adapter that runs DDL happily and answers the verification however the test needs. */
+function adapterDouble(tableExists: () => Promise<boolean>) {
+  return {
+    getCapabilities: () => ({ dialect: "postgresql" as const }),
+    executeQuery: vi.fn(async () => []),
+    tableExists: vi.fn(tableExists),
+  };
+}
+
+function serviceOver(
+  registry: ReturnType<typeof registryDouble>,
+  adapter: ReturnType<typeof adapterDouble>
+) {
+  return new FieldGroupMetadataService(
+    registry as unknown as FieldGroupRegistryService,
+    logger,
+    adapter as unknown as DrizzleAdapter
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("a field-group create records its outcome rather than raising it", () => {
+  it("records failed, and still writes the row, when the verification query fails", async () => {
+    const registry = registryDouble();
+    const adapter = adapterDouble(async () => {
+      throw new Error("connection terminated unexpectedly");
+    });
+
+    const { migrationStatus } = await serviceOver(
+      registry,
+      adapter
+    ).createFieldGroup(INPUT);
+
+    expect(migrationStatus).toBe("failed");
+    // The half that matters: a row exists describing what was attempted, so the table is not
+    // orphaned and the state is repairable.
+    expect(registry.registerComponent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tableName: "comp_hero",
+        migrationStatus: "failed",
+      })
+    );
+  });
+
+  it("records failed when the verification says the table is not there", async () => {
+    // The other way the same check can answer, kept alongside so a fix to the throwing case cannot
+    // quietly drop the answer this one depends on.
+    const registry = registryDouble();
+    const adapter = adapterDouble(async () => false);
+
+    const { migrationStatus } = await serviceOver(
+      registry,
+      adapter
+    ).createFieldGroup(INPUT);
+
+    expect(migrationStatus).toBe("failed");
+    expect(registry.registerComponent).toHaveBeenCalled();
+  });
+
+  it("refuses before running any DDL when another field group owns the table", async () => {
+    const registry = registryDouble();
+    registry.getAllComponents.mockResolvedValue([
+      { slug: "hero_legacy", tableName: "comp_hero" },
+    ]);
+    const adapter = adapterDouble(async () => true);
+
+    await expect(
+      serviceOver(registry, adapter).createFieldGroup(INPUT)
+    ).rejects.toMatchObject({ code: "DUPLICATE" });
+
+    // Nothing ran and nothing was written. A refusal that has already touched the table would have
+    // rebound the existing field group's storage to this request's fields.
+    expect(adapter.executeQuery).not.toHaveBeenCalled();
+    expect(registry.registerComponent).not.toHaveBeenCalled();
+  });
+});

--- a/packages/nextly/src/domains/field-groups/services/field-group-metadata-service.ts
+++ b/packages/nextly/src/domains/field-groups/services/field-group-metadata-service.ts
@@ -107,13 +107,15 @@ export class FieldGroupMetadataService {
   async createFieldGroup(
     input: CreateFieldGroupInput
   ): Promise<CreateFieldGroupResult> {
-    // 0. REFUSE what cannot be provisioned, before anything is executed.
-    await this.assertIdentifiersFit(input);
+    // 0. REFUSE a table another field group owns, before anything is executed.
     await this.assertTableUnowned(input);
 
     // 1. PLAN, before anything is persisted or executed. The generator validates as well as
     // renders, so a request it refuses leaves nothing behind at all.
     const migrationSQL = await this.planCreate(input);
+
+    // 1a. REFUSE names the database would not store, read from the statements themselves.
+    await this.assertIdentifiersFit(input, migrationSQL);
 
     // 2. APPLY. Never throws; a failure is reported as a status so the row can still record it.
     const migrationStatus = await this.applyCreateDdl(input, migrationSQL);
@@ -191,26 +193,31 @@ export class FieldGroupMetadataService {
    * reappearing one level up.
    */
   private async assertIdentifiersFit(
-    input: CreateFieldGroupInput
+    input: CreateFieldGroupInput,
+    migrationSQL: string
   ): Promise<void> {
     const { FieldGroupSchemaService, MAX_IDENTIFIER_LENGTH } = await import(
       "./field-group-schema-service"
     );
 
-    const tooLong = new FieldGroupSchemaService(this.dialect)
-      .generatedIdentifiers(input.tableName, input.fields, {
-        localized: input.localized === true,
-      })
-      .filter(name => name.length > MAX_IDENTIFIER_LENGTH);
+    const schema = new FieldGroupSchemaService(this.dialect);
+    // The rendered statements, plus the companion this create would provision alongside them. The
+    // companion's DDL is generated later and separately, so its name is the one identifier the scan
+    // cannot see.
+    const names = schema.identifiersIn(migrationSQL);
+    if (input.localized === true) {
+      names.push(`${input.tableName}${STORAGE_FORMAT.companionSuffix}`);
+    }
 
+    const tooLong = names.filter(name => name.length > MAX_IDENTIFIER_LENGTH);
     if (tooLong.length === 0) return;
 
     throw NextlyError.validation({
       errors: tooLong.map(name => ({
         path: "slug",
         code: "IDENTIFIER_TOO_LONG",
-        // The offending NAME, not just its length: the caller cannot otherwise tell which of the
-        // slug and a field name to shorten.
+        // The offending NAME, not just its length: a slug, a field name and the index derived from
+        // both all reach this, and the caller cannot otherwise tell which to shorten.
         message: `Generated database identifier "${name}" is ${name.length} characters; the limit is ${MAX_IDENTIFIER_LENGTH}. Shorten the field group's slug or the field name it derives from.`,
       })),
     });

--- a/packages/nextly/src/domains/field-groups/services/field-group-metadata-service.ts
+++ b/packages/nextly/src/domains/field-groups/services/field-group-metadata-service.ts
@@ -107,7 +107,8 @@ export class FieldGroupMetadataService {
   async createFieldGroup(
     input: CreateFieldGroupInput
   ): Promise<CreateFieldGroupResult> {
-    // 0. REFUSE a table another field group owns, before anything is executed.
+    // 0. REFUSE what cannot be provisioned, before anything is executed.
+    await this.assertIdentifiersFit(input);
     await this.assertTableUnowned(input);
 
     // 1. PLAN, before anything is persisted or executed. The generator validates as well as
@@ -170,6 +171,49 @@ export class FieldGroupMetadataService {
       STORAGE_FORMAT.columns.type,
       input.localized === true
     );
+  }
+
+  /**
+   * Refuse a create whose generated names the database would not store intact.
+   *
+   * 🔴 Checked over the NAMES rather than over the slug, because the slug is not the only input.
+   * A field's index is named `idx_<tableName>_<columnName>`, so the longest identifier depends on
+   * the slug AND the longest indexed field name — and no bound on one can constrain the other. A
+   * slug inside its limit paired with `authorId` still produces a 66-character index.
+   *
+   * Refused BEFORE any DDL because the failure is otherwise partial and silent-ish: the table and
+   * the parent index are created, the field index fails, and the caller gets back a record whose
+   * migration is recorded failed. Nothing is corrupted, but a field group exists that nothing can
+   * query, and the request that made it reported a success shape.
+   *
+   * Here rather than in a transport for the same reason the ownership check is: the mounted route
+   * bounded its slug and the other two transports did not, which is this service's founding defect
+   * reappearing one level up.
+   */
+  private async assertIdentifiersFit(
+    input: CreateFieldGroupInput
+  ): Promise<void> {
+    const { FieldGroupSchemaService, MAX_IDENTIFIER_LENGTH } = await import(
+      "./field-group-schema-service"
+    );
+
+    const tooLong = new FieldGroupSchemaService(this.dialect)
+      .generatedIdentifiers(input.tableName, input.fields, {
+        localized: input.localized === true,
+      })
+      .filter(name => name.length > MAX_IDENTIFIER_LENGTH);
+
+    if (tooLong.length === 0) return;
+
+    throw NextlyError.validation({
+      errors: tooLong.map(name => ({
+        path: "slug",
+        code: "IDENTIFIER_TOO_LONG",
+        // The offending NAME, not just its length: the caller cannot otherwise tell which of the
+        // slug and a field name to shorten.
+        message: `Generated database identifier "${name}" is ${name.length} characters; the limit is ${MAX_IDENTIFIER_LENGTH}. Shorten the field group's slug or the field name it derives from.`,
+      })),
+    });
   }
 
   /**

--- a/packages/nextly/src/domains/field-groups/services/field-group-metadata-service.ts
+++ b/packages/nextly/src/domains/field-groups/services/field-group-metadata-service.ts
@@ -123,7 +123,53 @@ export class FieldGroupMetadataService {
       migrationStatus,
     });
 
+    // 4. BIND the runtime schema, and only now.
+    //
+    // 🔴 The order here is what decides a race, so it is not arbitrary. Two creates whose slugs
+    // normalise to one table can both pass the ownership check above, because a read cannot exclude
+    // a write that has not happened yet. What separates them is the registry's own `table_name`
+    // unique index: the second INSERT is rejected by the database.
+    //
+    // That only helps if nothing irreversible has happened first. Binding before the insert meant
+    // the loser rebound the shared table to ITS field list and only then failed, leaving the winner
+    // reading through a schema that does not describe it until the process restarts. Binding after
+    // the insert means the loser never reaches this line.
+    //
+    // A lock spanning the check, the DDL and the insert would be stronger, and is what the migration
+    // lock will provide once it exists. It cannot be built here: MySQL commits DDL implicitly, so no
+    // transaction opened around this can cover the table change on all three dialects.
+    if (migrationStatus === "applied") {
+      await this.bindRuntimeSchema(input);
+    }
+
     return { record, migrationStatus };
+  }
+
+  /**
+   * Point the runtime at the table that was just created.
+   *
+   * Separated from the apply so it can run after the registry write rather than with the DDL. It
+   * describes the table to the running process; the DDL only makes it exist.
+   */
+  private async bindRuntimeSchema(input: CreateFieldGroupInput): Promise<void> {
+    const adapter = this.adapter;
+    if (!adapter) return;
+
+    const { registerComponentRuntimeSchema } = await import(
+      "./field-group-table-provisioning"
+    );
+    registerComponentRuntimeSchema(
+      adapter,
+      this.dialect,
+      input.tableName,
+      input.fields,
+      // The constant, NOT a probe, and this is the one path where that inference is sound: this is
+      // the CREATE path for a new slug, and the statements just executed are the DDL generator's
+      // own, which write this column. A table the storage migration had moved would carry the
+      // migrated prefix and could not be addressed by this name at all.
+      STORAGE_FORMAT.columns.type,
+      input.localized === true
+    );
   }
 
   /**
@@ -225,22 +271,8 @@ export class FieldGroupMetadataService {
       return "failed";
     }
 
-    const { reconcileComponentCompanion, registerComponentRuntimeSchema } =
-      await import("./field-group-table-provisioning");
-
-    registerComponentRuntimeSchema(
-      adapter,
-      this.dialect,
-      input.tableName,
-      input.fields,
-      // The constant, NOT a probe, and this is the one path where that inference is sound: this is
-      // the CREATE path for a new slug, and the statements just executed are the DDL generator's
-      // own, which write this column. A table the storage migration had moved would carry the
-      // migrated prefix and could not be addressed by this name at all. Probing here can only hurt,
-      // because a transient introspection failure would record the row as failed and still return
-      // success, leaving a created table with no runtime schema until a restart.
-      STORAGE_FORMAT.columns.type,
-      isLocalized
+    const { reconcileComponentCompanion } = await import(
+      "./field-group-table-provisioning"
     );
 
     // The companion is the other half of a localized field group's storage, so failing to provision

--- a/packages/nextly/src/domains/field-groups/services/field-group-metadata-service.ts
+++ b/packages/nextly/src/domains/field-groups/services/field-group-metadata-service.ts
@@ -1,0 +1,227 @@
+/**
+ * Schema changes for a Field Group, owned in one place with the registry write they belong to.
+ *
+ * ## Why this exists
+ *
+ * A field group can be created through three transports, and only one of them made the table. The
+ * dispatcher generated the DDL, ran it and wrote the registry row; `api/field-groups.ts` POST and
+ * the Direct API wrote the row and returned success. The registry then described a `comp_<slug>`
+ * table that did not exist, and every read and write to that field group failed against the
+ * database. The reason was structural rather than careless: the code that provisions the table was
+ * private to the dispatcher, so nothing else could reach it.
+ *
+ * One service owns both halves, and every transport goes through it.
+ *
+ * ## What it guarantees, and what it does not
+ *
+ * **NOT atomic.** MySQL commits DDL implicitly, so a table change and a row write cannot be made
+ * atomic there by any ordering or any transaction. The migration engine reached the same conclusion
+ * and says so in `field-groups/migration/steps.ts`. Promising atomicity would be a promise that
+ * silently does not hold on one of the three supported databases.
+ *
+ * The DDL runs first and the row is written last, carrying the outcome the apply reached. A crash
+ * between the two leaves a table nothing has a record of, and a DDL that FAILS still writes its row
+ * recording `failed`. Writing the intent first would trade the first cost for a worse one: a row
+ * persisted before the table is touched owns the slug from that moment, and nothing here can yet
+ * finish or discard an interrupted attempt, so a create killed mid-flight would block every retry.
+ * The ordering changes when a recovery path exists to release what an interrupted attempt claimed.
+ *
+ * 🔴 Everything that can REJECT a create runs before `createFieldGroup` is called, so a rejected
+ * request neither creates a table nor writes a row.
+ */
+
+import type { DrizzleAdapter } from "@nextlyhq/adapter-drizzle";
+
+import type { FieldDefinition } from "../../../schemas/dynamic-collections";
+import type {
+  DynamicFieldGroupInsert,
+  DynamicFieldGroupRecord,
+} from "../../../schemas/dynamic-field-groups/types";
+import { STORAGE_FORMAT } from "../../../schemas/storage-format";
+import type { Logger } from "../../../shared/types";
+
+import type { FieldGroupRegistryService } from "./field-group-registry-service";
+
+/**
+ * 🔴 The schema service and the table provisioning are loaded on demand, NOT at the top of this
+ * file.
+ *
+ * This service is registered in the DI container, and the registration module is imported during
+ * boot by anything that touches the container. A static import here would pull the whole schema and
+ * i18n machinery into that graph for every consumer, including every process that never creates a
+ * field group. `di/register.ts` avoids exactly this with its `await import()` calls covering these
+ * same modules, and a static import from a registration module quietly undoes that work.
+ */
+
+/** How far a schema change got. The registry stores this and the admin reads it back. */
+export type FieldGroupMigrationStatus = "pending" | "applied" | "failed";
+
+/**
+ * The registry row to create, minus the one field this service owns.
+ *
+ * Deliberately the registry's own insert type rather than a hand-listed subset: a bespoke input
+ * shape silently drops whatever it forgets, and that is not hypothetical — the singles equivalent
+ * listed its fields by hand and lost three of them, which nothing in the types or the tests caught.
+ */
+export type CreateFieldGroupInput = Omit<
+  DynamicFieldGroupInsert,
+  "migrationStatus"
+>;
+
+export interface CreateFieldGroupResult {
+  record: DynamicFieldGroupRecord;
+  migrationStatus: FieldGroupMigrationStatus;
+}
+
+export class FieldGroupMetadataService {
+  constructor(
+    private readonly registry: FieldGroupRegistryService,
+    private readonly logger: Logger,
+    /**
+     * Optional on purpose, and it changes what this service does rather than whether it works.
+     *
+     * With no adapter registered the statements are generated and never run, which is the behaviour
+     * the request handler had before this service existed. Demanding a connection here would turn a
+     * configuration this product supports into a crash.
+     */
+    private readonly adapter?: DrizzleAdapter
+  ) {}
+
+  /**
+   * The dialect the DDL is generated for.
+   *
+   * Read from the adapter that will RUN the statements, never from a default. `DB_DIALECT` is
+   * optional and falls back to `postgresql`, so an app configured with only a MySQL or SQLite URL
+   * would otherwise have its table created as PostgreSQL.
+   */
+  private get dialect(): "postgresql" | "mysql" | "sqlite" {
+    return this.adapter?.getCapabilities().dialect ?? "postgresql";
+  }
+
+  /**
+   * Create a field group's table and its registry row.
+   *
+   * The caller has already validated the input and established that no other field group owns this
+   * table name.
+   */
+  async createFieldGroup(
+    input: CreateFieldGroupInput
+  ): Promise<CreateFieldGroupResult> {
+    // 1. PLAN, before anything is persisted or executed. The generator validates as well as
+    // renders, so a request it refuses leaves nothing behind at all.
+    const migrationSQL = await this.planCreate(input);
+
+    // 2. APPLY. Never throws; a failure is reported as a status so the row can still record it.
+    const migrationStatus = await this.applyCreateDdl(input, migrationSQL);
+
+    // 3. RECORD, with the outcome already known.
+    const record = await this.registry.registerComponent({
+      ...input,
+      migrationStatus,
+    });
+
+    return { record, migrationStatus };
+  }
+
+  /** Render the DDL. Separated from the apply because this half is allowed to reject the request. */
+  private async planCreate(input: CreateFieldGroupInput): Promise<string> {
+    const { FieldGroupSchemaService } = await import(
+      "../../../services/field-groups/field-group-schema-service"
+    );
+    return new FieldGroupSchemaService(this.dialect).generateMigrationSQL(
+      input.tableName,
+      input.fields,
+      // i18n: translatable columns are omitted from the main comp_ table when localized; they live
+      // in the companion `comp_<slug>_locales`, provisioned below.
+      { localized: input.localized === true }
+    );
+  }
+
+  /**
+   * Run the create DDL, reporting how far it got.
+   *
+   * Never throws: a schema change that fails is recorded rather than raised, so the caller still has
+   * a row describing what was attempted. That is what makes the state repairable instead of lost.
+   */
+  private async applyCreateDdl(
+    input: CreateFieldGroupInput,
+    migrationSQL: string
+  ): Promise<FieldGroupMigrationStatus> {
+    const adapter = this.adapter;
+    if (!adapter) {
+      this.logger.warn(
+        "[FieldGroups] No adapter registered, migration not executed"
+      );
+      return "pending";
+    }
+
+    const isLocalized = input.localized === true;
+    const fields = input.fields as unknown as FieldDefinition[];
+
+    try {
+      const { applyMigrationStatements } = await import(
+        "../../schema/services/apply-migration-statements"
+      );
+      await applyMigrationStatements(adapter, migrationSQL);
+    } catch (error) {
+      this.logger.error(
+        `[FieldGroups] Migration execution failed for "${input.tableName}": ${
+          error instanceof Error ? error.message : String(error)
+        }`
+      );
+      return "failed";
+    }
+
+    // Observed, not assumed. "Applied" has to mean the table is there.
+    if (!(await adapter.tableExists(input.tableName))) {
+      this.logger.error(
+        `[FieldGroups] Table "${input.tableName}" was not created after migration`
+      );
+      return "failed";
+    }
+
+    const { reconcileComponentCompanion, registerComponentRuntimeSchema } =
+      await import("./field-group-table-provisioning");
+
+    registerComponentRuntimeSchema(
+      adapter,
+      this.dialect,
+      input.tableName,
+      input.fields,
+      // The constant, NOT a probe, and this is the one path where that inference is sound: this is
+      // the CREATE path for a new slug, and the statements just executed are the DDL generator's
+      // own, which write this column. A table the storage migration had moved would carry the
+      // migrated prefix and could not be addressed by this name at all. Probing here can only hurt,
+      // because a transient introspection failure would record the row as failed and still return
+      // success, leaving a created table with no runtime schema until a restart.
+      STORAGE_FORMAT.columns.type,
+      isLocalized
+    );
+
+    // The companion is the other half of a localized field group's storage, so failing to provision
+    // it leaves translatable values with nowhere to live. Reported as a failed migration rather than
+    // thrown: the main table exists and the row describes it, which is what makes a retry possible.
+    try {
+      await reconcileComponentCompanion({
+        slug: input.slug,
+        tableName: input.tableName,
+        oldFields: [],
+        newFields: fields,
+        localized: isLocalized,
+        // A brand-new field group was never localized, so a localized create is a create-only
+        // companion rather than an enable transition.
+        wasLocalized: false,
+        adapter,
+      });
+    } catch (error) {
+      this.logger.error(
+        `[FieldGroups] Companion provisioning failed for "${input.tableName}": ${
+          error instanceof Error ? error.message : String(error)
+        }`
+      );
+      return "failed";
+    }
+
+    return "applied";
+  }
+}

--- a/packages/nextly/src/domains/field-groups/services/field-group-metadata-service.ts
+++ b/packages/nextly/src/domains/field-groups/services/field-group-metadata-service.ts
@@ -32,6 +32,7 @@
 
 import type { DrizzleAdapter } from "@nextlyhq/adapter-drizzle";
 
+import { NextlyError } from "../../../errors";
 import type { FieldDefinition } from "../../../schemas/dynamic-collections";
 import type {
   DynamicFieldGroupInsert,
@@ -101,12 +102,14 @@ export class FieldGroupMetadataService {
   /**
    * Create a field group's table and its registry row.
    *
-   * The caller has already validated the input and established that no other field group owns this
-   * table name.
+   * The caller has already validated the input's shape.
    */
   async createFieldGroup(
     input: CreateFieldGroupInput
   ): Promise<CreateFieldGroupResult> {
+    // 0. REFUSE a table another field group owns, before anything is executed.
+    await this.assertTableUnowned(input);
+
     // 1. PLAN, before anything is persisted or executed. The generator validates as well as
     // renders, so a request it refuses leaves nothing behind at all.
     const migrationSQL = await this.planCreate(input);
@@ -121,6 +124,43 @@ export class FieldGroupMetadataService {
     });
 
     return { record, migrationStatus };
+  }
+
+  /**
+   * Refuse a create whose table another field group already owns.
+   *
+   * Keyed on the TABLE NAME rather than the slug, because the two are not the same key: a slug is
+   * normalised on its way to a table name, so `foo-bar` and `foo_bar` name one physical table while
+   * looking like two free slugs.
+   *
+   * It has to run before the DDL rather than after. `CREATE TABLE IF NOT EXISTS` reports success
+   * against a table that already exists, the runtime registration that follows then rebinds that
+   * table to THIS request's fields, and only afterwards does the registry reject the duplicate — so
+   * a refused create would leave the existing field group reading through a schema that does not
+   * describe it, until the process restarts.
+   *
+   * Here rather than in a request handler because all three create transports need it and only one
+   * of them had it. The same reason the DDL itself moved into this service.
+   *
+   * Two callers racing can still both pass this check; the registry table declares `table_name`
+   * unique, so the second insert is rejected by the database rather than by this.
+   */
+  private async assertTableUnowned(
+    input: CreateFieldGroupInput
+  ): Promise<void> {
+    const owner = (await this.registry.getAllComponents()).find(
+      existing => existing.tableName === input.tableName
+    );
+    if (!owner) return;
+
+    throw NextlyError.duplicate({
+      logContext: {
+        reason: "component-table-conflict",
+        slug: input.slug,
+        tableName: input.tableName,
+        ownedBy: owner.slug,
+      },
+    });
   }
 
   /** Render the DDL. Separated from the apply because this half is allowed to reject the request. */
@@ -158,24 +198,29 @@ export class FieldGroupMetadataService {
     const isLocalized = input.localized === true;
     const fields = input.fields as unknown as FieldDefinition[];
 
+    // The verification shares the statements' catch rather than following it. `tableExists`
+    // re-raises the query failures it meets, and left outside this it would reject the whole apply
+    // — breaking the one promise this method makes, that a schema change which fails is RECORDED
+    // rather than raised. A transient failure there would take the registry write with it and leave
+    // the table that was just created with nothing describing it.
     try {
       const { applyMigrationStatements } = await import(
         "../../schema/services/apply-migration-statements"
       );
       await applyMigrationStatements(adapter, migrationSQL);
+
+      // Observed, not assumed. "Applied" has to mean the table is there.
+      if (!(await adapter.tableExists(input.tableName))) {
+        this.logger.error(
+          `[FieldGroups] Table "${input.tableName}" was not created after migration`
+        );
+        return "failed";
+      }
     } catch (error) {
       this.logger.error(
         `[FieldGroups] Migration execution failed for "${input.tableName}": ${
           error instanceof Error ? error.message : String(error)
         }`
-      );
-      return "failed";
-    }
-
-    // Observed, not assumed. "Applied" has to mean the table is there.
-    if (!(await adapter.tableExists(input.tableName))) {
-      this.logger.error(
-        `[FieldGroups] Table "${input.tableName}" was not created after migration`
       );
       return "failed";
     }

--- a/packages/nextly/src/domains/field-groups/services/field-group-schema-service.ts
+++ b/packages/nextly/src/domains/field-groups/services/field-group-schema-service.ts
@@ -962,47 +962,28 @@ export class FieldGroupSchemaService {
   }
 
   /**
-   * Every identifier a create would put in front of the database, for this field group.
+   * The identifiers a rendered migration would put in front of the database, with their lengths.
    *
-   * 🔴 A slug bound cannot make this safe on its own, and that is not a matter of picking a smaller
-   * number. A field's index is named `idx_<tableName>_<columnName>`, so the longest identifier
-   * depends on the slug AND on the longest field name — two independent inputs. A slug at any bound
-   * can still be paired with a field name that pushes its index past the limit.
+   * 🔴 Read out of the SQL rather than re-derived from the field list, and the difference is not
+   * stylistic. An enumeration that walks the fields again is a SECOND transcription of the rules
+   * this renderer applies — which index names it emits, which fields it skips because they are
+   * localized and live in the companion, which get a `uq_` rather than an `idx_`, and that a column
+   * name is itself an identifier. A first attempt at that missed unique indexes and plain column
+   * names, and wrongly rejected localized fields for an index the renderer never emits. Three ways
+   * to be wrong, in rules that had already been written down once.
    *
-   * A method rather than a free function because it reads the same `toSnakeCase` and foreign-key
-   * predicate the rendering above uses. Deriving the names any other way would be a second
-   * implementation of the naming, drifting the moment either side changed.
-   *
-   * Returned rather than validated here so the caller decides what an over-long name means: this
-   * module renders SQL and does not own the product's error vocabulary.
+   * Scanning what was actually rendered cannot drift, because it IS the output. Every identifier
+   * this service emits is quoted with `this.q`, and no dialect uses that character for string
+   * literals — PostgreSQL and SQLite quote strings with `'`, MySQL identifiers are backticked — so
+   * the quoted tokens are identifiers and nothing else.
    */
-  generatedIdentifiers(
-    tableName: string,
-    fields: FieldConfig[],
-    options: { localized?: boolean } = {}
-  ): string[] {
-    const names = [
-      tableName,
-      `${STORAGE_FORMAT.indexPrefix}${tableName}_parent`,
-    ];
-
-    if (options.localized === true) {
-      names.push(`${tableName}${STORAGE_FORMAT.companionSuffix}`);
+  identifiersIn(sql: string): string[] {
+    const pattern = this.q === "`" ? /`([^`]+)`/g : /"([^"]+)"/g;
+    const found = new Set<string>();
+    for (const match of sql.matchAll(pattern)) {
+      if (match[1]) found.add(match[1]);
     }
-
-    for (const field of fields) {
-      if (!isDataField(field) && !isPluginDataField(field)) continue;
-      if (!("name" in field) || !field.name) continue;
-      const indexed =
-        ("index" in field && field.index === true) ||
-        this.fieldHasForeignKey(field);
-      if (!indexed) continue;
-      names.push(
-        `${STORAGE_FORMAT.indexPrefix}${tableName}_${this.toSnakeCase(field.name)}`
-      );
-    }
-
-    return names;
+    return [...found];
   }
 
   private fieldHasForeignKey(field: DataFieldConfig): boolean {

--- a/packages/nextly/src/domains/field-groups/services/field-group-schema-service.ts
+++ b/packages/nextly/src/domains/field-groups/services/field-group-schema-service.ts
@@ -961,6 +961,50 @@ export class FieldGroupSchemaService {
     return sqliteText(colName);
   }
 
+  /**
+   * Every identifier a create would put in front of the database, for this field group.
+   *
+   * 🔴 A slug bound cannot make this safe on its own, and that is not a matter of picking a smaller
+   * number. A field's index is named `idx_<tableName>_<columnName>`, so the longest identifier
+   * depends on the slug AND on the longest field name — two independent inputs. A slug at any bound
+   * can still be paired with a field name that pushes its index past the limit.
+   *
+   * A method rather than a free function because it reads the same `toSnakeCase` and foreign-key
+   * predicate the rendering above uses. Deriving the names any other way would be a second
+   * implementation of the naming, drifting the moment either side changed.
+   *
+   * Returned rather than validated here so the caller decides what an over-long name means: this
+   * module renders SQL and does not own the product's error vocabulary.
+   */
+  generatedIdentifiers(
+    tableName: string,
+    fields: FieldConfig[],
+    options: { localized?: boolean } = {}
+  ): string[] {
+    const names = [
+      tableName,
+      `${STORAGE_FORMAT.indexPrefix}${tableName}_parent`,
+    ];
+
+    if (options.localized === true) {
+      names.push(`${tableName}${STORAGE_FORMAT.companionSuffix}`);
+    }
+
+    for (const field of fields) {
+      if (!isDataField(field) && !isPluginDataField(field)) continue;
+      if (!("name" in field) || !field.name) continue;
+      const indexed =
+        ("index" in field && field.index === true) ||
+        this.fieldHasForeignKey(field);
+      if (!indexed) continue;
+      names.push(
+        `${STORAGE_FORMAT.indexPrefix}${tableName}_${this.toSnakeCase(field.name)}`
+      );
+    }
+
+    return names;
+  }
+
   private fieldHasForeignKey(field: DataFieldConfig): boolean {
     if (!isRelationshipField(field) && !isUploadField(field)) return false;
     return (
@@ -1153,8 +1197,17 @@ export class FieldGroupSchemaService {
  * Computed from the same constants the names are built from, so a change to either prefix or to the
  * suffix moves this bound with it instead of leaving a number behind that used to be right.
  */
+/**
+ * The longest identifier every supported dialect stores intact.
+ *
+ * PostgreSQL's 63 rather than MySQL's 64 because it is the tighter budget AND its failure is the
+ * worse one: PostgreSQL does not reject an over-long identifier, it silently TRUNCATES it, leaving
+ * an object under a name nothing else can address.
+ */
+export const MAX_IDENTIFIER_LENGTH = 63;
+
 export const MAX_FIELD_GROUP_SLUG_LENGTH =
-  63 -
+  MAX_IDENTIFIER_LENGTH -
   STORAGE_FORMAT.indexPrefix.length -
   STORAGE_FORMAT.tablePrefix.length -
   "_parent".length;

--- a/packages/nextly/src/domains/field-groups/services/field-group-schema-service.ts
+++ b/packages/nextly/src/domains/field-groups/services/field-group-schema-service.ts
@@ -1131,3 +1131,30 @@ export class FieldGroupSchemaService {
       .join("");
   }
 }
+
+/**
+ * The longest slug this generator can turn into a legal identifier on every dialect.
+ *
+ * Derived rather than chosen. A slug is not the identifier: it is prefixed into a table name and
+ * that table name is prefixed AND suffixed into an index name, so the longest thing the database
+ * actually sees is
+ *
+ *   `idx_` + `comp_` + <slug> + `_parent`
+ *
+ * which is sixteen characters longer than the slug the caller typed. Bounding the slug at the
+ * product's usual 50 therefore still produces a 66-character index name, and MySQL rejects any
+ * identifier past 64 — the table is created, the index creation fails, and the field group is left
+ * recorded as failed with an unbound table.
+ *
+ * The budget is PostgreSQL's 63 rather than MySQL's 64 because it is the tighter of the two, and
+ * because its failure is the worse one: PostgreSQL does not reject an over-long identifier, it
+ * silently TRUNCATES it, so the index it creates carries a name nothing else can address.
+ *
+ * Computed from the same constants the names are built from, so a change to either prefix or to the
+ * suffix moves this bound with it instead of leaving a number behind that used to be right.
+ */
+export const MAX_FIELD_GROUP_SLUG_LENGTH =
+  63 -
+  STORAGE_FORMAT.indexPrefix.length -
+  STORAGE_FORMAT.tablePrefix.length -
+  "_parent".length;

--- a/packages/nextly/src/domains/field-groups/services/field-group-table-provisioning.ts
+++ b/packages/nextly/src/domains/field-groups/services/field-group-table-provisioning.ts
@@ -1,0 +1,210 @@
+// Runtime registration and companion provisioning for a field group's table.
+//
+// Both were private to the components dispatcher, which is why the two other create transports
+// could not reuse the schema half and shipped a registry row describing a table that did not
+// exist. Moved here unchanged so one service can own the table change and the registry write
+// together; the bodies are byte-identical to the versions the dispatcher carried.
+
+import type { DrizzleAdapter } from "@nextlyhq/adapter-drizzle";
+
+import type { FieldConfig } from "../../../collections/fields/types";
+import {
+  getConfigFromDI,
+  getSchemaRegistryFromDI,
+} from "../../../dispatcher/helpers/di";
+import type { FieldDefinition } from "../../../schemas/dynamic-collections";
+import {
+  getI18nArchiveDdl,
+  getI18nArchiveIndexRepairDdl,
+} from "../../../schemas/nextly-i18n-archive";
+import { FieldGroupSchemaService } from "../../../services/field-groups/field-group-schema-service";
+import { buildCompanionTransitionStatements } from "../../i18n/migration/reconcile-companion";
+import { localizedColumnsOnMain } from "../../i18n/runtime/companion-io";
+import { buildCompanionRuntimeTable } from "../../i18n/runtime/companion-registration";
+import { isIdempotencyError } from "../../schema/pipeline/sql-statement-utils";
+
+export function registerComponentRuntimeSchema(
+  adapter: DrizzleAdapter,
+  dialect: string,
+  tableName: string,
+  fields: FieldConfig[],
+  typeColumn: string,
+  // i18n: when localized, the main comp_ runtime table omits translatable columns and the
+  // companion comp_<slug>_locales runtime table is registered for per-language reads/writes.
+  localized = false
+): void {
+  try {
+    const fieldGroupSchemaService = new FieldGroupSchemaService(
+      dialect as ConstructorParameters<typeof FieldGroupSchemaService>[0]
+    );
+    const runtimeTable = fieldGroupSchemaService.generateRuntimeSchema(
+      tableName,
+      fields,
+      { localized, typeColumn }
+    );
+    const companion = localized
+      ? buildCompanionRuntimeTable({
+          slug: tableName,
+          tableName,
+          fields: fields as { name: string; type: string }[],
+          dialect: dialect as Parameters<
+            typeof buildCompanionRuntimeTable
+          >[0]["dialect"],
+          localized: true,
+          status: false,
+        })
+      : null;
+
+    const registry = getSchemaRegistryFromDI();
+    if (registry) {
+      registry.registerDynamicSchema(tableName, runtimeTable);
+      if (companion) {
+        registry.registerDynamicSchema(
+          companion.companionTableName,
+          companion.table
+        );
+      }
+      return;
+    }
+
+    // Fallback for paths where DI isn't wired (tests, CLI).
+    const resolver = (
+      adapter as unknown as {
+        tableResolver?: {
+          registerDynamicSchema?: (name: string, table: unknown) => void;
+        };
+      }
+    ).tableResolver;
+    if (resolver && typeof resolver.registerDynamicSchema === "function") {
+      resolver.registerDynamicSchema(tableName, runtimeTable);
+      return;
+    }
+
+    console.warn(
+      `[registerComponentRuntimeSchema] No SchemaRegistry available for ` +
+        `'${tableName}'. Component queries may reference old column names ` +
+        `until next server restart.`
+    );
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.warn(
+      `[registerComponentRuntimeSchema] In-memory schema refresh failed for ` +
+        `'${tableName}': ${msg}. Component queries may reference old ` +
+        `column names until next server restart.`
+    );
+  }
+}
+
+/**
+ * Provision (create / ADD-DROP columns) the component's companion `comp_<slug>_locales` table
+ * out-of-band after a schema change, then register its runtime table. The push pipeline excludes
+ * companions, so every component create/update/apply path that changes the localized field set
+ * goes through here. No-op when the component isn't localized. Mirrors reconcileSingleCompanion.
+ * DDL throws on failure; runtime registration is best-effort. Does not move existing main-table
+ * rows into the companion — that is the `nextly migrate` enable/disable path.
+ */
+export async function reconcileComponentCompanion(args: {
+  slug: string;
+  tableName: string;
+  oldFields: FieldDefinition[];
+  newFields: FieldDefinition[];
+  /** Localization state AFTER this save (requested). */
+  localized: boolean;
+  /** Localization state BEFORE this save (persisted). Drives enable/disable detection. */
+  wasLocalized: boolean;
+  adapter: DrizzleAdapter;
+}): Promise<void> {
+  const { slug, tableName, oldFields, newFields, localized, adapter } = args;
+  const wasLocalized = args.wasLocalized;
+  // Nothing to do when the component was and remains non-localized.
+  if (!wasLocalized && !localized) return;
+
+  const dialect = adapter.dialect;
+  const defaultLocale = getConfigFromDI()?.localization?.defaultLocale ?? "en";
+
+  const plan = buildCompanionTransitionStatements({
+    // The companion mirrors the main table, and a field group's builder reads a width from a different key.
+    builtBy: "fieldGroup" as const,
+    slug,
+    tableName,
+    dialect,
+    defaultLocale,
+    // Components are never Draft/Published — companion has no `_status`.
+    status: false,
+    // And never had one, so the disable restore has no status to carry back.
+    wasStatus: false,
+    wasLocalized,
+    isLocalized: localized,
+    oldFields,
+    newFields,
+    companionExists: await adapter.tableExists(`${tableName}_locales`),
+    // Which translatable columns the main table still carries. A disable must not re-add one that
+    // is already there, and must still restore it: presence says the column exists, never that its
+    // value is current, because every localized write went to the companion alone.
+    existingMainColumns: await localizedColumnsOnMain(
+      adapter,
+      tableName,
+      oldFields
+    ).then(cols => cols.map(c => c.name)),
+  });
+
+  // A disable archives non-default translations, so ensure `nextly_i18n_archive` exists first
+  // (Builder entities have no `nextly migrate` step to provision it). Idempotent.
+  if (plan.needsArchive) {
+    for (const stmt of getI18nArchiveDdl(dialect)) {
+      await adapter.executeQuery(stmt);
+    }
+    // MySQL's table DDL cannot restore an index the table is missing, and
+    // index-only drift produces no reconcile operations, so the repair runs
+    // here. Tolerated rather than checked first: attempting it and accepting
+    // "duplicate key name" is one round trip instead of two, and the same
+    // tolerance the schema executor already applies.
+    const indexRepair = getI18nArchiveIndexRepairDdl(dialect);
+    if (indexRepair) {
+      try {
+        await adapter.executeQuery(indexRepair);
+      } catch (err) {
+        if (!isIdempotencyError(err)) throw err;
+      }
+    }
+  }
+  // 🔴 STRICT on purpose: the companion does NOT tolerate a re-run.
+  //
+  // Tolerating it would make a half-finished localization ENABLE look like success. Interrupted
+  // after the companion is created but before the seed and the main-column drops, the retry is
+  // indistinguishable from an orphan repair — the planner cannot tell them apart, because the
+  // signal that separates them (`existingMainColumns`) is consumed only on the disable path — so
+  // the duplicate columns would be swallowed and the entity recorded as localized while its
+  // default-locale content is still stranded on the main table.
+  //
+  // A loud failure is the worse experience and the safer outcome. It costs the repair of a
+  // localized entity whose create half-failed; it prevents silently reporting a migration that did
+  // not happen.
+  for (const stmt of plan.statements) {
+    await adapter.executeQuery(stmt);
+  }
+
+  // The transition record describes a companion that no longer exists, so it stops being true
+  // the moment the disable succeeds. Left behind, it would refuse the next enable's real
+  // source locale — the check that protects a live transition would block a legitimate one.
+  if (plan.companionDropped) {
+    // The other half of "this companion is gone": readiness remembers only that one exists.
+    const { forgetCompanionReadiness } = await import(
+      "../../i18n/runtime/companion-readiness"
+    );
+    forgetCompanionReadiness(adapter, `${tableName}_locales`);
+    const { resolveTransitionStore } = await import(
+      "../../i18n/migration/transition-recorder"
+    );
+    const { forgetI18nTransition } = await import(
+      "../../i18n/migration/transition-state"
+    );
+    await forgetI18nTransition(
+      await resolveTransitionStore(adapter),
+      "fieldGroup",
+      slug
+    );
+  }
+  // Runtime registration of the companion is handled by registerComponentRuntimeSchema(localized)
+  // in the calling handlers, so no separate registration is needed here.
+}

--- a/packages/nextly/src/shared/base-validator.ts
+++ b/packages/nextly/src/shared/base-validator.ts
@@ -146,6 +146,21 @@ export function isSQLKeyword(
 // ============================================================
 
 /**
+ * Longest slug the product accepts, for every resource that becomes a table.
+ *
+ * Bounded well below what the databases allow rather than at it. A slug is prefixed on its way to a
+ * physical name (`dc_`, `single_`, `comp_`) and a companion suffix can be appended after that, so
+ * the identifier that finally reaches the engine is longer than the slug by an amount the caller
+ * never sees. PostgreSQL silently TRUNCATES identifiers past 63 bytes and MySQL rejects past 64,
+ * and truncation is the worse of the two: the table is created under a name that no longer matches
+ * the one the caller asked about.
+ *
+ * Exported so the value is stated once. A route that re-declares its own bound is how an input this
+ * rejects reaches the DDL anyway.
+ */
+export const MAX_SLUG_LENGTH = 50;
+
+/**
  * Validate a slug against the standard Nextly rules: required, string,
  * length 1-50, pattern-conformant, not reserved, not a SQL keyword.
  *
@@ -187,10 +202,10 @@ export function validateSlugShared(
     });
   }
 
-  if (slug.length > 50) {
+  if (slug.length > MAX_SLUG_LENGTH) {
     errors.push({
       path,
-      message: `${ctx.entityLabel} slug must be at most 50 characters`,
+      message: `${ctx.entityLabel} slug must be at most ${MAX_SLUG_LENGTH} characters`,
       code: "SLUG_TOO_LONG",
     });
   }


### PR DESCRIPTION
## The defect (P1, live, reachable through the public API)

A field group is creatable through three transports. Only one made the table.

| transport | wrote the registry row | created the table |
|---|---|---|
| `component-dispatcher.ts` | yes | **yes** |
| `api/field-groups.ts` POST | yes | **no** |
| `direct-api/namespaces/field-groups.ts` create | yes | **no** |

Both of the last two answered success. The route returned `201 Field group created.`; the Direct API resolved normally. The registry then described a `comp_<slug>` table that did not exist, and every read and write to that field group failed against the database.

This is not a private path: `nextly.fieldGroups.create()` is the public programmatic surface, and `api/field-groups.ts` is exported for user apps to mount. Both routes already call `requireBuilderEnabled("create-component")`, so they were understood to BE schema operations. They just did not perform the schema half.

## Why it happened, and why the fix is a service

The code that provisions the table was **private to the dispatcher** — `registerComponentRuntimeSchema` and `reconcileComponentCompanion` were file-local functions. Nothing else could reach them, so the other transports could not have done the right thing even by trying. Copying the DDL block into them would have entrenched exactly the split this closes.

Three commits, each independently checkable:

1. **`fe6dda5a6`** — the two helpers move beside the field-group schema service. Proven a pure move: both bodies diffed **byte-identical** against main, the only difference being the depth of three dynamic-import paths.
2. **`0604a56fd`** — `FieldGroupMetadataService`: plan the DDL, apply it without throwing, write the row carrying the outcome. Registered in DI rather than built per request, so one wrapper governs every caller — which is what lets the migration lock (B1-9b) enclose both halves.
3. **`be3117eda`** — all three transports routed through it, plus the tests.

The input type is `Omit<DynamicFieldGroupInsert, "migrationStatus">` — the registry's **own** insert type, never a hand-listed subset. That is not stylistic: the singles equivalent listed its fields by hand and silently dropped three of them, and nothing in the types or the tests caught it.

## The coverage that was missing

Each transport was individually green and the product was broken, because the coverage was **per transport rather than per outcome**: the dispatcher had tests, and the other two were tested for their response shape and their table-name derivation — neither of which touches a database.

`field-group-create-transports.integration.test.ts` asserts the outcome against a real database: **the physical table exists**, per transport, per dialect.

🔴 **The REST route is proved a level up, and the test says so rather than leaving it implicit.** It is permission-gated and the harness cannot authenticate a request, so proving it there would mean faking a session and testing the fake. Instead the split is explicit: the integration suite proves the shared service provisions the table on live databases through the two transports the harness can reach, and `field-group-route-delegates.test.ts` proves the route reaches that service rather than writing the row itself. Neither half stands alone, and the file comment says so.

That delegation test also asserts the **negative**: `registerComponent` must not be called. The defect was never that the row went unwritten — it was that the row was written *alone*, so a route calling both would satisfy a positive-only assertion.

## Verification

- `pnpm build` · `pnpm check-types --force` · `pnpm lint` (exit code) · `node scripts/check-drizzle-v1-legacy.cjs` — clean
- Unit: **361 failed / 7489** against a freshly measured baseline of **361 / 7478** at `6ca3f4506`. Zero new.
- Integration, full suite, both dialects: **PostgreSQL 1364 passed / 0 failed**, **MySQL 1285 passed / 0 failed**
- **Proven load-bearing**: reverting the route to write the row directly fails both delegation tests.

Four existing suites needed rewiring. Each got the **real** service over the same doubles rather than a stub, so they keep describing the code instead of describing the stub.

One deliberate omission: the dispatcher keeps its original toast wording rather than adopting the routes' new message. Changing admin copy is not part of closing this P1.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Field-group creation now provisions the associated database tables and supporting localized storage automatically.
  - Creation results now indicate whether provisioning is complete, pending, or unsuccessful.
  - Component creation uses the same table-provisioning process for more consistent metadata and runtime behavior.

- **Bug Fixes**
  - Added clearer warnings when field-group metadata is created but table provisioning cannot be completed.
  - Improved handling of localized field-group table updates and cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->