### PR TITLE
refactor(nextly): delete a single's storage and its row in one place

### DIFF
--- a/.changeset/single-delete-drops-storage.md
+++ b/.changeset/single-delete-drops-storage.md
@@ -1,0 +1,26 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+Deleting a Single now removes its storage and its registry entry as one operation, so an interrupted delete can no longer leave tables behind with nothing describing them.

--- a/packages/nextly/src/dispatcher/handlers/__tests__/single-dispatcher-delete.test.ts
+++ b/packages/nextly/src/dispatcher/handlers/__tests__/single-dispatcher-delete.test.ts
@@ -1,0 +1,161 @@
+/**
+ * What a delete is allowed to call a success.
+ *
+ * Deleting a Single is two removals — its storage, then its registry row — and only the second may
+ * be missing without that being a failure. A row another request already took is the state this
+ * asks for; storage that would not go away is not, however its driver phrases the refusal.
+ *
+ * The distinction is easy to lose because both arrive as an exception, and a handler that reads the
+ * MESSAGE cannot tell them apart: a dropped table that "does not exist" and a registry row that is
+ * already gone can word themselves the same way. Answering 200 to the first leaves the row present
+ * and the storage half removed, which is precisely the state the delete's ordering exists to avoid,
+ * and it leaves it while telling the caller the Single is gone.
+ *
+ * These drive the dispatcher rather than the service because the classification is the dispatcher's:
+ * it decides what reaches the caller.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../helpers/di", () => ({
+  getSingleRegistryFromDI: vi.fn(),
+  getSingleEntryServiceFromDI: vi.fn(),
+  getSingleMetadataServiceFromDI: vi.fn(),
+  getComponentRegistryFromDI: vi.fn().mockReturnValue(undefined),
+  getAdapterFromDI: vi.fn(),
+  getConfigFromDI: vi.fn(() => undefined),
+  getSchemaRegistryFromDI: vi.fn(() => undefined),
+}));
+
+vi.mock("../../../di/container", () => ({
+  container: {
+    has: vi.fn(() => false),
+    get: vi.fn(() => undefined),
+  },
+}));
+
+import { SingleMetadataService } from "../../../domains/singles/services/single-metadata-service";
+import type { SingleRegistryService } from "../../../domains/singles/services/single-registry-service";
+import { NextlyError } from "../../../errors";
+import type { Logger } from "../../../shared/types";
+import {
+  getSingleEntryServiceFromDI,
+  getSingleMetadataServiceFromDI,
+  getSingleRegistryFromDI,
+} from "../../helpers/di";
+import { dispatchSingles } from "../single-dispatcher";
+
+const SLUG = "site_settings";
+
+/**
+ * A registry reporting one unlocked Single, so the delete gets past its own preconditions and
+ * reaches the removal being tested.
+ */
+function wireRegistry(deleteSingle: () => Promise<void>) {
+  const registry = {
+    getSingleBySlug: vi.fn().mockResolvedValue({
+      slug: SLUG,
+      tableName: `single_${SLUG}`,
+      locked: false,
+    }),
+    deleteSingle: vi.fn(deleteSingle),
+  };
+  vi.mocked(getSingleRegistryFromDI).mockReturnValue(
+    registry as unknown as ReturnType<typeof getSingleRegistryFromDI>
+  );
+  vi.mocked(getSingleEntryServiceFromDI).mockReturnValue({
+    get: vi.fn(),
+    update: vi.fn(),
+  } as unknown as ReturnType<typeof getSingleEntryServiceFromDI>);
+  return registry;
+}
+
+function wireMetadata(deleteSingle: () => Promise<void>) {
+  const metadata = { deleteSingle: vi.fn(deleteSingle) };
+  vi.mocked(getSingleMetadataServiceFromDI).mockReturnValue(
+    metadata as unknown as ReturnType<typeof getSingleMetadataServiceFromDI>
+  );
+  return metadata;
+}
+
+beforeEach(() => {
+  vi.mocked(getSingleRegistryFromDI).mockReset();
+  vi.mocked(getSingleEntryServiceFromDI).mockReset();
+  vi.mocked(getSingleMetadataServiceFromDI).mockReset();
+});
+
+describe("deleteSingle reports what actually happened", () => {
+  it("removes the storage and the row when both succeed", async () => {
+    wireRegistry(async () => {});
+    const metadata = wireMetadata(async () => {});
+
+    await expect(
+      dispatchSingles("deleteSingle", { slug: SLUG }, {})
+    ).resolves.toBeDefined();
+
+    expect(metadata.deleteSingle).toHaveBeenCalledWith(SLUG, `single_${SLUG}`);
+  });
+
+  it("fails when the storage will not go away, however the failure is worded", async () => {
+    // Phrased the way a driver reports a missing object on purpose. The wording is the whole point:
+    // a handler classifying by message reads this as "already deleted" and answers success, leaving
+    // the registry row behind.
+    wireRegistry(async () => {});
+    wireMetadata(async () => {
+      throw new Error(`relation "single_${SLUG}" not found`);
+    });
+
+    await expect(
+      dispatchSingles("deleteSingle", { slug: SLUG }, {})
+    ).rejects.toThrow(/not found/);
+  });
+});
+
+/**
+ * The other half of the same rule, one layer down.
+ *
+ * Driven with no table name, which is the shape of a Single that never had storage: the teardown
+ * and the drop are skipped entirely, so what remains is the registry step alone and the tolerance
+ * can be observed without standing up a database to reach it.
+ */
+describe("the metadata service tolerates one failure and no others", () => {
+  const logger: Logger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  };
+
+  function serviceOver(deleteSingle: () => Promise<void>) {
+    const registry = { deleteSingle: vi.fn(deleteSingle) };
+    return {
+      registry,
+      service: new SingleMetadataService(
+        registry as unknown as SingleRegistryService,
+        logger
+      ),
+    };
+  }
+
+  it("completes when the row was already taken", async () => {
+    // `NextlyError.notFound` is what the registry raises for a row that is gone: a typed answer
+    // rather than a phrase, which is the only reason it can be told apart from a storage failure
+    // that happens to describe something missing.
+    const { registry, service } = serviceOver(async () => {
+      throw NextlyError.notFound({ logContext: { slug: SLUG } });
+    });
+
+    await expect(
+      service.deleteSingle(SLUG, undefined)
+    ).resolves.toBeUndefined();
+    expect(registry.deleteSingle).toHaveBeenCalled();
+  });
+
+  it("fails when the registry refuses for any other reason", async () => {
+    // The tolerance is for one code, not for the registry generally.
+    const { service } = serviceOver(async () => {
+      throw NextlyError.forbidden({ logContext: { slug: SLUG } });
+    });
+
+    await expect(service.deleteSingle(SLUG, undefined)).rejects.toThrow();
+  });
+});

--- a/packages/nextly/src/dispatcher/handlers/single-dispatcher.ts
+++ b/packages/nextly/src/dispatcher/handlers/single-dispatcher.ts
@@ -37,10 +37,8 @@ import {
 import type { FieldConfig } from "../../collections/fields/types";
 import { container } from "../../di/container";
 import { DynamicCollectionSchemaService } from "../../domains/dynamic-collections/services/dynamic-collection-schema-service";
-import { teardownEntityComponentData } from "../../domains/field-groups/services/teardown-entity-field-group-data";
 import { resolveLocalizedFieldNames } from "../../domains/i18n/classify-fields";
 import { assertLocalizationConfigured } from "../../domains/i18n/config/require-app-config";
-import { teardownEntityI18n } from "../../domains/i18n/migration/teardown-entity-i18n";
 import { buildCompanionRuntimeTable } from "../../domains/i18n/runtime/companion-registration";
 import { translatePipelinePreviewToLegacy } from "../../domains/schema/legacy-preview/translate";
 import { RealClassifier } from "../../domains/schema/pipeline/classifier/classifier";
@@ -725,37 +723,16 @@ const SINGLES_METHODS: Record<string, MethodHandler<SinglesServices>> = {
         );
       }
 
-      // Drop the data table FIRST so we don't leave orphans if deletion fails.
+      // The storage drop and the registry delete are one operation, so they are issued as one. Held
+      // apart, a failure between them loses the row that makes the tables findable.
       const tableName = single.tableName;
-      if (tableName && container.has("adapter")) {
-        const adapter = container.get<DrizzleAdapter>("adapter");
-        // Embedded component instances point back at this table by a plain string with
-        // no FK, so the drop below cascades nothing and would strand them. Sweep first.
-        await teardownEntityComponentData({ adapter, parentTable: tableName });
-
-        // Remove the companion `_locales` table and this single's archive rows before
-        // the main table. The companion holds an FK to `<main>.id`, so it must go first
-        // or the main drop orphans it (Postgres) / is rejected by the FK (MySQL).
-        await teardownEntityI18n({ adapter, slug, tableName, kind: "single" });
-
-        // Use dialect-appropriate quoting for the table name.
-        const dialect = adapter.dialect || "postgresql";
-        const quotedTableName =
-          dialect === "mysql" ? `\`${tableName}\`` : `"${tableName}"`;
-        // Postgres needs CASCADE to drop dependent objects: the companion's FK makes the
-        // main table an FK target, and a non-cascading drop of one raises. Failures
-        // propagate so a single that cannot be fully removed stays intact and retryable
-        // rather than losing its registry row while its tables survive.
-        const dropSql =
-          dialect === "postgresql"
-            ? `DROP TABLE IF EXISTS ${quotedTableName} CASCADE`
-            : `DROP TABLE IF EXISTS ${quotedTableName}`;
-        await adapter.executeQuery(dropSql);
-      }
-
-      // Delete the metadata from the dynamic_singles registry.
+      const metadata = getSingleMetadataServiceFromDI();
       try {
-        await svc.registry.deleteSingle(slug, { force: true });
+        if (metadata) {
+          await metadata.deleteSingle(slug, tableName);
+        } else {
+          await svc.registry.deleteSingle(slug, { force: true });
+        }
       } catch (deleteError) {
         const message =
           deleteError instanceof Error

--- a/packages/nextly/src/dispatcher/handlers/single-dispatcher.ts
+++ b/packages/nextly/src/dispatcher/handlers/single-dispatcher.ts
@@ -725,27 +725,12 @@ const SINGLES_METHODS: Record<string, MethodHandler<SinglesServices>> = {
 
       // The storage drop and the registry delete are one operation, so they are issued as one. Held
       // apart, a failure between them loses the row that makes the tables findable.
-      const tableName = single.tableName;
-      const metadata = getSingleMetadataServiceFromDI();
-      try {
-        if (metadata) {
-          await metadata.deleteSingle(slug, tableName);
-        } else {
-          await svc.registry.deleteSingle(slug, { force: true });
-        }
-      } catch (deleteError) {
-        const message =
-          deleteError instanceof Error
-            ? deleteError.message
-            : String(deleteError);
-        if (message.includes("not found")) {
-          console.log(
-            `[deleteSingle] Metadata already deleted for "${slug}", treating as success`
-          );
-        } else {
-          throw deleteError;
-        }
-      }
+      // No fallback and no catch. `dispatchSingles` refuses to run any method without a metadata
+      // service, so there is no path here where one is absent, and the service already treats a
+      // registry row another request took as the outcome asked for. Everything else it raises —
+      // storage that would not go away — is a failed delete and has to reach the caller, whatever
+      // words the driver chose for it.
+      await svc.metadata.deleteSingle(slug, single.tableName);
 
       // Spec divergence: spec §5.1 / §7.4 strictly maps delete to
       // respondMutation, but registry.deleteSingle returns void (no

--- a/packages/nextly/src/domains/singles/__tests__/single-delete-drops-storage.integration.test.ts
+++ b/packages/nextly/src/domains/singles/__tests__/single-delete-drops-storage.integration.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Deleting a Single removes its storage, not just its registry row.
+ *
+ * The two halves are ordered the opposite way from a create, and for the same reason. A create
+ * writes the row LAST so a failure cannot leave a row describing storage that was never made; a
+ * delete drops the storage FIRST so a failure cannot leave storage that no row describes. The row is
+ * what makes the tables findable, so losing it while the tables survive is the worse of the two
+ * states.
+ *
+ * Asserted against a real database because the ordering only matters to one: the companion holds a
+ * foreign key to the main table, so dropping them in the wrong order is rejected by MySQL and
+ * orphans on PostgreSQL. Neither failure is visible to a test that stops short of an engine.
+ *
+ * Self-skips per dialect on the standard rule: SQLite always runs, the servers run when their URL is
+ * set, and each dialect gets its own throwaway database.
+ */
+import { afterEach, describe, expect, it } from "vitest";
+
+import { dispatchSingles } from "../../../dispatcher/handlers/single-dispatcher";
+import {
+  createTestNextly,
+  getConfiguredTestDialects,
+  type TestNextly,
+} from "../../../plugins/test-nextly";
+
+let current: TestNextly | undefined;
+
+afterEach(async () => {
+  await current?.destroy();
+  current = undefined;
+});
+
+for (const dialect of getConfiguredTestDialects()) {
+  describe(`deleteSingle removes the storage — ${dialect}`, () => {
+    // Per-dialect slugs: the suites share one process, so a name reused across them turns a leaked
+    // row into a duplicate-slug rejection in a later suite rather than a failure where it leaked.
+    const plain = `sd_${dialect.slice(0, 2)}_plain`;
+    const localized = `sd_${dialect.slice(0, 2)}_loc`;
+
+    it("drops the table and removes the row", async () => {
+      current = await createTestNextly({ dialect });
+      const registry = current.getService("singleRegistryService");
+
+      await dispatchSingles(
+        "createSingle",
+        {},
+        {
+          slug: plain,
+          label: "Plain",
+          fields: [{ name: "body", type: "text" }],
+        }
+      );
+      // Proves the delete has something to remove. Without it, a delete that did nothing at all
+      // would satisfy every assertion below.
+      expect(await current.adapter.tableExists(`single_${plain}`)).toBe(true);
+
+      await dispatchSingles("deleteSingle", { slug: plain }, {});
+
+      expect(await current.adapter.tableExists(`single_${plain}`)).toBe(false);
+      expect(await registry.getSingleBySlug(plain)).toBeFalsy();
+    });
+
+    it("drops the companion too, and in an order the database accepts", async () => {
+      current = await createTestNextly({
+        dialect,
+        localization: { locales: ["en", "es"], defaultLocale: "en" },
+      });
+
+      await dispatchSingles(
+        "createSingle",
+        {},
+        {
+          slug: localized,
+          label: "Localized",
+          localized: true,
+          fields: [{ name: "headline", type: "text", localized: true }],
+        }
+      );
+      expect(
+        await current.adapter.tableExists(`single_${localized}_locales`)
+      ).toBe(true);
+
+      // The ordering assertion is that this RESOLVES. The companion holds a foreign key to the main
+      // table, so dropping the main one first is refused outright on MySQL.
+      await dispatchSingles("deleteSingle", { slug: localized }, {});
+
+      expect(await current.adapter.tableExists(`single_${localized}`)).toBe(
+        false
+      );
+      expect(
+        await current.adapter.tableExists(`single_${localized}_locales`)
+      ).toBe(false);
+    });
+  });
+}

--- a/packages/nextly/src/domains/singles/services/single-metadata-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-metadata-service.ts
@@ -44,6 +44,7 @@
 
 import type { DrizzleAdapter } from "@nextlyhq/adapter-drizzle";
 
+import { NextlyError } from "../../../errors";
 import type { FieldDefinition } from "../../../schemas/dynamic-collections";
 import type {
   DynamicSingleInsert,
@@ -198,19 +199,31 @@ export class SingleMetadataService {
       );
       await teardownEntityI18n({ adapter, slug, tableName, kind: "single" });
 
-      const dialect = adapter.getCapabilities().dialect;
-      const quoted =
-        dialect === "mysql" ? `\`${tableName}\`` : `"${tableName}"`;
       // PostgreSQL needs CASCADE to drop dependent objects: the companion's foreign key makes the
-      // main table a target, and a non-cascading drop raises rather than proceeding.
-      await adapter.executeQuery(
-        dialect === "postgresql"
-          ? `DROP TABLE IF EXISTS ${quoted} CASCADE`
-          : `DROP TABLE IF EXISTS ${quoted}`
-      );
+      // main table a target, and a non-cascading drop raises rather than proceeding. The other two
+      // dialects reject the keyword, so it is asked for only where it means something.
+      //
+      // The adapter renders this rather than a SQL string built here, because it already owns the
+      // two things such a string has to get right on every dialect: quoting the identifier, and
+      // turning a driver failure into the normalised database error the callers above expect.
+      await adapter.dropTable(tableName, {
+        ifExists: true,
+        cascade: adapter.getCapabilities().dialect === "postgresql",
+      });
     }
 
-    await this.registry.deleteSingle(slug, { force: true });
+    // A row a concurrent delete already took is the state this method exists to reach, so it
+    // completes rather than failing.
+    //
+    // The tolerance covers this one call and nothing above it. A teardown or a drop that fails has
+    // to surface even when its message mentions something missing, because answering "deleted" to
+    // it would leave the registry row present and the storage half removed — the exact state the
+    // ordering above is arranged to prevent.
+    try {
+      await this.registry.deleteSingle(slug, { force: true });
+    } catch (error) {
+      if (!NextlyError.isNotFound(error)) throw error;
+    }
   }
 
   /**

--- a/packages/nextly/src/domains/singles/services/single-metadata-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-metadata-service.ts
@@ -166,6 +166,54 @@ export class SingleMetadataService {
   }
 
   /**
+   * Remove a Single: its storage first, then its registry row.
+   *
+   * The order is the opposite of the create's and for the same reason. A create writes the row last
+   * so a failure cannot leave a row describing storage that was never made; a delete drops the
+   * storage first so a failure cannot leave storage that no row describes. Both put the registry
+   * write on the side where an interruption is visible rather than invisible.
+   *
+   * Failures propagate here rather than being recorded as a status. A single that cannot be fully
+   * removed stays intact and retryable, which is a better state than one whose row is gone while its
+   * tables survive: the row is what makes the tables findable.
+   */
+  async deleteSingle(
+    slug: string,
+    tableName: string | undefined
+  ): Promise<void> {
+    const adapter = this.adapter;
+    if (tableName && adapter) {
+      // Embedded field-group instances point back at this table by a plain string with no foreign
+      // key, so the drop below cascades nothing and would strand them. Sweep first.
+      const { teardownEntityComponentData } = await import(
+        "../../field-groups/services/teardown-entity-field-group-data"
+      );
+      await teardownEntityComponentData({ adapter, parentTable: tableName });
+
+      // Remove the companion `_locales` table and this single's archive rows before the main table.
+      // The companion holds a foreign key to `<main>.id`, so it must go first or the main drop
+      // orphans it on PostgreSQL and is rejected by the constraint on MySQL.
+      const { teardownEntityI18n } = await import(
+        "../../i18n/migration/teardown-entity-i18n"
+      );
+      await teardownEntityI18n({ adapter, slug, tableName, kind: "single" });
+
+      const dialect = adapter.getCapabilities().dialect;
+      const quoted =
+        dialect === "mysql" ? `\`${tableName}\`` : `"${tableName}"`;
+      // PostgreSQL needs CASCADE to drop dependent objects: the companion's foreign key makes the
+      // main table a target, and a non-cascading drop raises rather than proceeding.
+      await adapter.executeQuery(
+        dialect === "postgresql"
+          ? `DROP TABLE IF EXISTS ${quoted} CASCADE`
+          : `DROP TABLE IF EXISTS ${quoted}`
+      );
+    }
+
+    await this.registry.deleteSingle(slug, { force: true });
+  }
+
+  /**
    * Render the DDL and work out what the table must look like once it has run.
    *
    * Separated from the apply because the two have opposite contracts: this one is allowed to


### PR DESCRIPTION
## What moves, and why

Deleting a Single dropped its tables and removed its registry row from **two different layers**: the request handler issued the teardown and the `DROP TABLE`, and the registry service removed the row. A lock cannot cover a pair split that way, and a failure between the halves leaves tables that nothing has a record of.

Both halves now live in `SingleMetadataService`, beside the create that was relocated in #556. This is the same criterion-5 move, applied to the second of the three operations that change a Single's table.

## The ordering is deliberately the opposite of the create's

A **create** writes its registry row LAST, so a failure cannot leave a row describing storage that was never made.

A **delete** drops its storage FIRST, so a failure cannot leave storage that no row describes.

Both put the registry write on the side where an interruption is *visible*. The row is what makes the tables findable, so losing it while the tables survive is the worse of the two states, and that reasoning now lives with the code rather than only in a handler comment.

The teardown order inside the drop is preserved exactly, along with the reasons it is that order:

- field-group instances point back at the table by a plain string with **no foreign key**, so the drop cascades nothing and would strand them — they are swept first
- the companion `_locales` table holds a foreign key to `<main>.id`, so it must go before the main table or the drop orphans it on PostgreSQL and is **rejected outright** on MySQL
- PostgreSQL needs `CASCADE`, because the companion's foreign key makes the main table a target

Failures still propagate rather than being recorded as a status: a Single that cannot be fully removed stays intact and retryable.

## Verification

- `pnpm build` · `pnpm check-types --force` · `pnpm lint` (exit code) · `node scripts/check-drizzle-v1-legacy.cjs` — clean
- Unit: **361 failed / 7487** against a freshly measured baseline of **361 / 7478** at `6ca3f4506`. Zero new.
- Integration, full suite, both dialects: **PostgreSQL 1364 passed / 0 failed**, **MySQL 1285 passed / 0 failed**
- **Proven load-bearing on both dialects.** Removing the `DROP` fails all four cases of the new suite; restoring it passes them.

🔴 **A note on how that proof was obtained, because the first attempt was invalid.** Disabling the block with `if (false && …)` defeated TypeScript's narrowing and produced four *compile* errors — a build failure, not a test result, and it would have "proved" nothing. The valid break removes only the `DROP` statement, leaves the types intact, and then genuinely fails the tests.

The new suite asserts the table exists *before* deleting, because without that a delete which did nothing at all would satisfy every later assertion. The localized case's real assertion is that it **resolves** — the ordering hazard is a foreign key MySQL refuses, which no test stopping short of an engine can see.

Three failing tests in the touched areas were checked against the baseline rather than assumed either way; all three are pre-existing on main.