### PR TITLE
ci: let a dispatched review run without a progress comment

### DIFF
--- a/.github/workflows/nextly-review-bot.yml
+++ b/.github/workflows/nextly-review-bot.yml
@@ -107,7 +107,12 @@ jobs:
           # Explicit token skips the Anthropic GitHub App / OIDC exchange, which
           # is not needed with a third-party provider.
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          track_progress: true
+          # The progress comment needs an event that carries a conversation to
+          # post into, and a dispatch has none — the action refuses the whole
+          # run rather than skipping the comment. The review itself is posted
+          # through the gateway either way, so a dispatch simply runs without
+          # the running commentary.
+          track_progress: ${{ github.event_name == 'pull_request' }}
           prompt: |
             Read the file .github/review-prompt.md in the checked-out repository
             and execute it exactly, phase by phase.


### PR DESCRIPTION
## What

Makes `track_progress` conditional on the event, so a `workflow_dispatch` review actually runs.

## Why

Every dispatched run from #598 failed, all five, before the agent started:

```
Action failed with error: track_progress is only supported for events:
pull_request, issues, issue_comment, pull_request_review_comment,
pull_request_review. Current event: workflow_dispatch
```

The progress comment needs an event that carries a conversation to post into. A dispatch has none, and the action refuses the entire run rather than skipping the comment.

The resolve step added in #598 was fine — it produced the right PR number, head SHA and base on the dispatch path. What was never exercised was a real dispatched run end to end. #598's verification checked the resolve logic in isolation, which passes whether or not the run it feeds can start: the fixture did not reach the mechanism.

## How

`track_progress: ${{ github.event_name == 'pull_request' }}`. The review is posted through `.github/scripts/review-bot-gh.sh post-review` either way, so a dispatched run simply proceeds without the running commentary; nothing about the review output changes.

## Verification

Dispatched against a real PR after this lands — the check that #598 should have had. A dispatched run reaching the agent and posting a review is the only evidence that counts here, and it is what I will confirm before closing this out.

## Notes

- CI-only change: no changeset.