### PR TITLE
fix(nextly): withdraw a preview grant's trust once it stops answering the path

### DIFF
--- a/.changeset/preview-grant-fallthrough-trust.md
+++ b/.changeset/preview-grant-fallthrough-trust.md
@@ -1,0 +1,26 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+A preview link that names one entry no longer widens access to the rest of its collection: when the granted entry does not live at the requested path, the published-only fall-through now reads with the caller's own access instead of the trust the draft decision forced on.

--- a/packages/nextly/src/runtime/routing/__tests__/content-route-by-id.test.ts
+++ b/packages/nextly/src/runtime/routing/__tests__/content-route-by-id.test.ts
@@ -30,6 +30,8 @@ interface Row extends Record<string, unknown> {
   id: string;
   slug: string;
   status: string;
+  /** Stands for a stored read rule that an anonymous caller does not satisfy. */
+  restricted?: boolean;
 }
 
 function stubReader(rows: Row[]): {
@@ -51,6 +53,10 @@ function stubReader(rows: Row[]): {
       // than reproducible.
       const items = rows
         .filter(row => row.slug === slug)
+        // What an enforced read does: a row the caller cannot see is not
+        // returned. `overrideAccess` short-circuits that constraint, so a query
+        // carrying it sees restricted rows too.
+        .filter(row => args.overrideAccess === true || row.restricted !== true)
         .filter(row => args.status === "all" || row.status === "published")
         .sort((left, right) => left.id.localeCompare(right.id))
         .slice(0, 1);
@@ -123,6 +129,29 @@ describe("a preview grant that names an entry", () => {
 
     expect(entry.id).toBe("here");
     expect(entry._isWorkingDraft).toBeUndefined();
+  });
+
+  it("withdraws the widened trust when the grant does not answer this path", async () => {
+    // The grant names an entry that lives somewhere else, so the by-id read
+    // cannot answer `/a` and the resolver falls through to a published-only
+    // read. That fall-through inherits the trust the draft decision forced on,
+    // so it must give it back: the widening exists to reach the NAMED entry,
+    // and once the grant misses, a preview link is just an anonymous request.
+    // Leaving it on turns one document-scoped grant into a collection-wide
+    // read that ignores the collection's own access rules.
+    const { reader, calls } = stubReader([
+      { id: "granted", slug: "somewhere-else", status: "draft" },
+      { id: "members-only", slug: "a", status: "published", restricted: true },
+    ]);
+
+    await expect(
+      routeFor(reader, "granted").ContentPage(params)
+    ).rejects.toThrow();
+
+    // And the reason it was not served is the enforced read, not luck: the
+    // fall-through query must carry the caller's own access, not the grant's.
+    const fallThrough = calls.at(-1);
+    expect(fallThrough?.overrideAccess).toBe(false);
   });
 
   it("falls back to published when the grant names a deleted entry", async () => {

--- a/packages/nextly/src/runtime/routing/content-route.ts
+++ b/packages/nextly/src/runtime/routing/content-route.ts
@@ -309,6 +309,11 @@ export function createContentRoute<TNode>(
         // silent no-op that makes preview look broken. The authorization that
         // justifies this lives in the `draft` decision itself.
         overrideAccess: overrideAccess || draft,
+        // ...but only for as long as the grant is answering this path. What the
+        // route itself authorized travels alongside, so the published-only
+        // fall-through can hand the widening back instead of reading every row
+        // in the collection as a trusted caller.
+        callerOverrideAccess: overrideAccess,
       });
       if (!entry) continue;
       // No identity check here, deliberately. Both halves a grant has to

--- a/packages/nextly/src/runtime/routing/resolve-content.ts
+++ b/packages/nextly/src/runtime/routing/resolve-content.ts
@@ -143,6 +143,15 @@ export interface ResolveContentOptions {
    * cached pages should read its public content with `overrideAccess: true`.
    */
   overrideAccess?: boolean;
+  /**
+   * What the CALLER authorized, before a draft decision widened it.
+   *
+   * A route forces `overrideAccess` on so a granted entry can be reached at
+   * all. That forcing is justified only while the grant is answering the path,
+   * so a read that runs after it stops answering uses this instead. Defaults to
+   * `overrideAccess`, leaving a caller that widened nothing where it was.
+   */
+  callerOverrideAccess?: boolean;
   /** User identity to evaluate access rules against (with `overrideAccess: false`). */
   user?: UserContext;
 }
@@ -194,6 +203,7 @@ export async function resolveContent(
   const depth = options.depth ?? 1;
   const locale = options.locale;
   const overrideAccess = options.overrideAccess ?? false;
+  const callerOverrideAccess = options.callerOverrideAccess ?? overrideAccess;
   const user = options.user;
 
   // Widening the lifecycle scope follows TRUST, not the draft flag.
@@ -222,6 +232,13 @@ export async function resolveContent(
    * Used when a named grant did not answer this path. Reading with the widened
    * scope would surface a never-published row the grant never named, which is
    * exactly the disclosure the grant is supposed to bound.
+   *
+   * Trust is withdrawn in BOTH dimensions, not just the lifecycle one. The
+   * access widening exists to reach the entry a grant NAMES; once the grant is
+   * not answering this path the request is an ordinary anonymous one, and
+   * carrying the widening here would let one document-scoped grant return any
+   * published row in the collection, including rows the collection's own
+   * access rules withhold from the caller.
    */
   const publishedOnly = async (): Promise<ContentEntry | null> => {
     const result = await nextly.find({
@@ -231,7 +248,7 @@ export async function resolveContent(
       limit: 1,
       sort: "id",
       depth,
-      overrideAccess,
+      overrideAccess: callerOverrideAccess,
       user,
       ...(options.richTextFormat
         ? { richTextFormat: options.richTextFormat }


### PR DESCRIPTION
## What

When a preview grant names an entry that does not live at the requested path, the published-only fall-through now reads with the caller's own access instead of the trust the draft decision forced on.

First of two fixes to the preview-link trust model found by the retro-audit of the unreviewed merge window (task 153, finding D1). The mint-side gap (D2 — minting is gated per collection while the token names a document) follows in a separate PR.

## The defect

`createContentRoute` forces `overrideAccess: overrideAccess || draft` so a granted entry can be reached at all. `resolveContent` then falls through to `publishedOnly()` when the granted entry's slug does not answer the requested path — and that fall-through inherited the forced value, even though its own docstring said it resolves "with no draft authorization at all". Only the *lifecycle* dimension was withdrawn (`status` stays `published`); the *access* dimension stayed wide open.

So an anonymous holder of any valid preview link for a collection could read every published row in it, including rows the collection's own access rules withhold from them. The widening exists to reach the entry a grant NAMES; once the grant stops answering, the request is an ordinary anonymous one.

## Reproduction

`content-route-by-id.test.ts` gained a case where the grant names an entry living at another path, and the requested path holds a restricted row. The stub now models an enforced read — a row the caller cannot see is not returned unless `overrideAccess` short-circuits the constraint, which is what the real access service does.

Before the fix, the test received the restricted row instead of a 404:

```
AssertionError: promise resolved "{ id: 'members-only', slug: 'a', …(2) }" instead of rejecting
```

## The fix

`callerOverrideAccess` carries what the route itself authorized, alongside the widened value. `publishedOnly` reads with it. It defaults to `overrideAccess`, so any caller that never widened anything is unaffected.

## Verification

- Revert-check performed: with `overrideAccess: callerOverrideAccess` reverted to `overrideAccess`, the new test fails with the output above; restored, 6/6 pass.
- `src/runtime/routing`: 9 files, 55 tests, all passing.
- `pnpm check-types` green from the repo root.
- Unit-level change on the read path; no DDL, so no dialect matrix applies.

## Notes

- One lockstep changeset, `patch`, generated from the `fixed` group in `.changeset/config.json`.
- The existing fall-through tests could not have caught this: their fixtures contain no row that an enforced read would withhold, so the widened access never changed the answer. That gap is finding D3 in task 153 and is addressed by the fixture added here.