### PR TITLE
test(nextly): pin that the diff and the rename detector agree about one column

### DIFF
--- a/packages/nextly/src/domains/schema/__tests__/helpers/parse-generated-ddl.ts
+++ b/packages/nextly/src/domains/schema/__tests__/helpers/parse-generated-ddl.ts
@@ -1,0 +1,130 @@
+/**
+ * Reading the columns out of DDL a builder generated.
+ *
+ * Shared because two suites need the same answer and a second parser is exactly the failure both of
+ * them exist to catch. The column-conformance matrix compares what the builders emit against what
+ * the descriptor asks for; the rename-type ratchet needs the set of types those builders can put in
+ * a table. Each was a candidate for its own regex, and a regex that split `DECIMAL(10, 2)` on its
+ * comma or compared `TEXT` against `text` reported divergences that did not exist.
+ *
+ * The emitted SQL is read rather than any intermediate a generator happens to expose, because the
+ * SQL is what reaches the database and an intermediate can agree while the rendering does not.
+ *
+ * @module domains/schema/__tests__/helpers/parse-generated-ddl
+ */
+
+/**
+ * The text between the CREATE TABLE column list's own parentheses.
+ *
+ * Found by counting depth rather than by taking the last `)`, because a column can close its own
+ * parenthesis after the list's does not: `DECIMAL(10, 2)` and an inline CHECK both do.
+ */
+export function balancedBody(create: string): string {
+  const open = create.indexOf("(");
+  if (open < 0) return "";
+  let depth = 0;
+  for (let i = open; i < create.length; i++) {
+    if (create[i] === "(") depth++;
+    else if (create[i] === ")") {
+      depth--;
+      if (depth === 0) return create.slice(open + 1, i);
+    }
+  }
+  return create.slice(open + 1);
+}
+
+/**
+ * Split a column list on the commas that separate columns.
+ *
+ * A plain split on "," cuts `DECIMAL(10, 2)` in half and reports the fragment as the column's type,
+ * which reads as a real disagreement and is not one.
+ */
+export function splitTopLevel(body: string): string[] {
+  const parts: string[] = [];
+  let depth = 0;
+  let current = "";
+  for (const ch of body) {
+    if (ch === "(") depth++;
+    else if (ch === ")") depth--;
+    if (ch === "," && depth === 0) {
+      parts.push(current);
+      current = "";
+      continue;
+    }
+    current += ch;
+  }
+  if (current.trim()) parts.push(current);
+  return parts;
+}
+
+/** What one side says a column is. `null` means that side produces no column at all. */
+export interface Rendered {
+  type: string;
+  notNull: boolean;
+}
+
+/**
+ * The columns a generated CREATE TABLE declares.
+ *
+ * Reads the emitted SQL rather than any intermediate the generator happens to expose, because the
+ * SQL is what reaches the database and an intermediate can agree while the rendering does not.
+ */
+export function parseCreateTable(sql: string): Map<string, Rendered> {
+  const out = new Map<string, Rendered>();
+  const create = sql.split(";").find(s => /CREATE TABLE/i.test(s));
+  if (!create) return out;
+
+  for (const raw of splitTopLevel(balancedBody(create))) {
+    const line = raw.trim();
+    // Constraint and key clauses are not column declarations.
+    if (/^(CONSTRAINT|PRIMARY|FOREIGN|UNIQUE|KEY|INDEX)\b/i.test(line))
+      continue;
+    const m = line.match(/^["`]?([a-z0-9_]+)["`]?\s+(.+)$/i);
+    if (!m?.[1] || !m[2]) continue;
+    const rest = m[2].trim();
+    out.set(m[1], {
+      // Strip the clauses that qualify a column rather than name its type.
+      type: rest
+        .replace(/\b(NOT NULL|PRIMARY KEY|UNIQUE|AUTO_INCREMENT)\b/gi, "")
+        // To the end of the declaration, NOT to the next comma. `splitTopLevel` has already
+        // isolated one column, so every comma still present is inside the default's own
+        // parentheses: stopping at one leaves the tail of `DEFAULT (strftime('%s', 'now'))`
+        // attached to the type, which reads as a divergence and is not one.
+        .replace(/\bDEFAULT\s+.*/gi, "")
+        .replace(/\bREFERENCES\b.*/gi, "")
+        .trim(),
+      notNull: /\bNOT NULL\b/i.test(rest),
+    });
+  }
+  return out;
+}
+
+/**
+ * The columns an ALTER migration adds.
+ *
+ * A column created WITH its table and the same column added to an existing one are emitted by
+ * different code, and they are allowed to disagree without anything noticing: the ADD COLUMN path
+ * passes only a field's type and length, so anything a field says through its options or its
+ * validation is dropped on the way. That makes "created fresh" and "added later" two separate
+ * answers to one question, and both have to be measured.
+ */
+export function parseAddColumns(sql: string): Map<string, Rendered> {
+  const out = new Map<string, Rendered>();
+  for (const statement of sql.split(";")) {
+    const m = statement.match(
+      /ADD\s+COLUMN\s+["`]?([a-z0-9_]+)["`]?\s+([^;]+)/i
+    );
+    if (!m?.[1] || !m[2]) continue;
+    const rest = m[2].trim();
+    out.set(m[1], {
+      type: rest
+        .replace(/\b(NOT NULL|PRIMARY KEY|UNIQUE|AUTO_INCREMENT)\b/gi, "")
+        .replace(/\bDEFAULT\s+.*/gi, "")
+        .replace(/\bREFERENCES\b.*/gi, "")
+        .replace(/\bAFTER\b.*/gi, "")
+        .trim(),
+      notNull: /\bNOT NULL\b/i.test(rest),
+    });
+  }
+  return out;
+}

--- a/packages/nextly/src/domains/schema/pipeline/__tests__/rename-type-agreement.test.ts
+++ b/packages/nextly/src/domains/schema/pipeline/__tests__/rename-type-agreement.test.ts
@@ -22,6 +22,8 @@
 import { describe, expect, it } from "vitest";
 
 import { DynamicCollectionSchemaService } from "../../../dynamic-collections/services/dynamic-collection-schema-service";
+import { FieldGroupSchemaService } from "../../../field-groups/services/field-group-schema-service";
+import { parseCreateTable } from "../../__tests__/helpers/parse-generated-ddl";
 import { getColumnDescriptor } from "../../services/field-column-descriptor";
 import { normalizeType } from "../diff/normalize-type";
 import { isTypesCompatible } from "../rename-detector-type-families";
@@ -73,6 +75,27 @@ const SHAPES: Record<DynamicFieldType, Array<Record<string, unknown>>> = {
 };
 
 /**
+ * One field per shape in `SHAPES`, named so a generated table can hold them all at once.
+ *
+ * Named per shape rather than per type: two variations of one type are two different columns, and
+ * reusing a name would have the second overwrite the first in the parsed column map.
+ */
+function probeFields(): FieldDefinition[] {
+  const out: FieldDefinition[] = [];
+  for (const [type, shapes] of Object.entries(SHAPES) as Array<
+    [DynamicFieldType, Array<Record<string, unknown>>]
+  >) {
+    shapes.forEach((shape, i) => {
+      out.push({
+        name: `probe_${type.toLowerCase()}_${i}`,
+        ...shape,
+      } as unknown as FieldDefinition);
+    });
+  }
+  return out;
+}
+
+/**
  * Every column type the product can put in a table, for one dialect.
  *
  * Both sides are collected because a rename pairs them: the LIVE column carries whatever the builder
@@ -81,33 +104,64 @@ const SHAPES: Record<DynamicFieldType, Array<Record<string, unknown>>> = {
  */
 function reachableTypes(dialect: SupportedDialect): string[] {
   const found = new Set<string>();
-  const service = new DynamicCollectionSchemaService(undefined, dialect);
+  const collections = new DynamicCollectionSchemaService(undefined, dialect);
+  const fieldGroups = new FieldGroupSchemaService(dialect);
+  const probes = probeFields();
 
-  for (const [type, shapes] of Object.entries(SHAPES) as Array<
-    [DynamicFieldType, Array<Record<string, unknown>>]
-  >) {
-    for (const shape of shapes) {
-      const field = {
-        name: `probe_${type.toLowerCase()}`,
-        ...shape,
-      } as unknown as FieldDefinition;
+  for (const field of probes) {
+    const described = getColumnDescriptor(field, dialect, "collection");
+    if (described) found.add(described.dialectType);
 
-      const described = getColumnDescriptor(field, dialect, "collection");
-      if (described) found.add(described.dialectType);
-
-      // What a table built by that rendering REPORTS when introspected, which is the string the
-      // detector actually receives. The emitted DDL spelling is not it, and using it here invents
-      // pairs that no rename can produce.
-      const emitted = service.mapFieldTypeToSQL(
-        field.type,
-        undefined,
-        field.options,
-        field.validation
-      );
-      if (emitted) found.add(asIntrospected(emitted, dialect));
-    }
+    // What a table built by that rendering REPORTS when introspected, which is the string the
+    // detector actually receives. The emitted DDL spelling is not it, and using it here invents
+    // pairs that no rename can produce.
+    const emitted = collections.mapFieldTypeToSQL(
+      field.type,
+      undefined,
+      field.options,
+      field.validation
+    );
+    if (emitted) found.add(asIntrospected(emitted, dialect));
   }
+
+  for (const type of fieldGroupTypes(fieldGroups, probes, dialect)) {
+    found.add(type);
+  }
+
   return [...found];
+}
+
+/**
+ * The column types the OTHER builder puts in a table a rename can touch.
+ *
+ * A field group's storage is a `comp_` table built by `FieldGroupSchemaService`, and a rename inside
+ * one compares live columns that builder produced. It does not render every type the way the
+ * collection builder does — a single relationship reaches `UUID` on PostgreSQL and a date reaches
+ * `DATETIME` on MySQL, neither of which the collection builder emits — so a universe built from one
+ * builder leaves the pairs only the other can produce unmeasured.
+ *
+ * Read out of the generated DDL rather than from any table of declared types, because what the
+ * builder RENDERS is what reaches the database, and those two have already diverged once.
+ *
+ * Separate from `reachableTypes` so the test can assert this contributed anything at all. A parse
+ * that silently found nothing would leave every assertion below passing while measuring one builder
+ * instead of two, which is the failure this addition exists to fix.
+ */
+function fieldGroupTypes(
+  service: FieldGroupSchemaService,
+  probes: FieldDefinition[],
+  dialect: SupportedDialect
+): string[] {
+  const columns = parseCreateTable(
+    service.generateMigrationSQL(
+      "comp_probe",
+      probes as unknown as Parameters<
+        FieldGroupSchemaService["generateMigrationSQL"]
+      >[1],
+      {}
+    )
+  );
+  return [...columns.values()].map(c => asIntrospected(c.type, dialect));
 }
 
 /**
@@ -128,9 +182,15 @@ function reachableTypes(dialect: SupportedDialect): string[] {
 function asIntrospected(declared: string, dialect: SupportedDialect): string {
   if (dialect === "sqlite") return declared;
   if (dialect === "mysql") {
-    // The one declared spelling MySQL does not preserve. Everything else — int, varchar(n), text,
-    // json, decimal(p,s), datetime — is reported back as declared.
-    return /^bool(ean)?$/i.test(declared.trim()) ? "tinyint(1)" : declared;
+    const t = declared.trim();
+    // The two declared spellings MySQL does not preserve, both measured against a live server
+    // rather than inferred: a column declared `boolean` reads back as `tinyint(1)` because MySQL
+    // has no boolean type, and one declared `integer` reads back as `int` because that is the
+    // canonical name for the type. Everything else the builders emit — varchar(n), text, json,
+    // decimal(p,s), datetime, double — is reported exactly as declared.
+    if (/^bool(ean)?$/i.test(t)) return "tinyint(1)";
+    if (/^int(eger)?$/i.test(t)) return "int";
+    return declared;
   }
   // PostgreSQL: udt_name drops the modifier and names the underlying type, which is exactly what
   // `normalizeType` canonicalises to. Reusing it keeps one definition of that mapping rather than a
@@ -175,6 +235,20 @@ describe("the diff and the rename detector agree about what one column is", () =
       expect(types.length, "types reachable on this dialect").toBeGreaterThan(
         3
       );
+
+      // The second builder is IN the universe, not merely asked for. Its columns are read by
+      // parsing generated DDL, and a parse that stops matching what the builder emits fails silently
+      // — it returns nothing, every pair it would have contributed goes unmeasured, and the ratchet
+      // keeps passing while covering half of what it claims. That is how the divergence this file
+      // records went unnoticed in the first place.
+      expect(
+        fieldGroupTypes(
+          new FieldGroupSchemaService(dialect),
+          probeFields(),
+          dialect
+        ).length,
+        "columns read from the field-group builder's DDL"
+      ).toBeGreaterThan(3);
 
       const disagreements: string[] = [];
       for (const from of types) {

--- a/packages/nextly/src/domains/schema/pipeline/__tests__/rename-type-agreement.test.ts
+++ b/packages/nextly/src/domains/schema/pipeline/__tests__/rename-type-agreement.test.ts
@@ -1,0 +1,198 @@
+// Two implementations decide whether two type spellings mean one column, and they must not disagree.
+//
+//   normalizeType        the schema DIFF's answer — decides whether a column changed at all
+//   isTypesCompatible    the rename DETECTOR's answer — decides whether a rename keeps the data
+//
+// The invariant is one-directional and follows from what each is for. If the diff says two spellings
+// are the same column, then moving a column between them changes nothing about its storage, so the
+// detector must offer the rename that MOVES the data. When it does not, the only recovery on offer
+// drops the column and recreates it empty — for a column the database never needed to touch.
+//
+// The reverse is not required and is not asserted: the detector may accept a change the diff calls
+// real, which is how `text` into JSON is offered as a convertible rename.
+//
+// ## Why a matrix rather than a case
+//
+// This is the same failure the column-conformance matrix exists for, one layer down: a second
+// implementation of a question that already had an answer. It was found by measuring one field type
+// on one dialect, which is exactly how the generator/descriptor divergences were found one at a time
+// for a month. The types are therefore enumerated from what the product actually produces rather
+// than hand-listed, so a new field type or a changed rendering enters this comparison automatically.
+
+import { describe, expect, it } from "vitest";
+
+import { DynamicCollectionSchemaService } from "../../../dynamic-collections/services/dynamic-collection-schema-service";
+import { getColumnDescriptor } from "../../services/field-column-descriptor";
+import { normalizeType } from "../diff/normalize-type";
+import { isTypesCompatible } from "../rename-detector-type-families";
+
+import type { SupportedDialect } from "../../services/field-column-descriptor";
+import type {
+  DynamicFieldType,
+  FieldDefinition,
+} from "../../../../schemas/dynamic-collections";
+
+const DIALECTS: SupportedDialect[] = ["postgresql", "mysql", "sqlite"];
+
+const selectOptions = { options: [{ label: "One", value: "one" }] };
+
+/**
+ * One field shape per storage a column can reach.
+ *
+ * Keyed by the field-type union so a new type cannot be added without deciding what it stores, the
+ * same guard the column-conformance matrix uses. The variations are only those that change the
+ * physical column, because this file compares TYPES rather than field behaviour.
+ */
+const SHAPES: Record<DynamicFieldType, Array<Record<string, unknown>>> = {
+  text: [{ type: "text" }, { type: "text", options: { variant: "short" } }],
+  textarea: [{ type: "textarea" }],
+  richText: [{ type: "richText" }],
+  email: [{ type: "email" }],
+  password: [{ type: "password" }],
+  code: [{ type: "code" }],
+  number: [
+    { type: "number" },
+    { type: "number", dbType: "decimal", precision: 10, scale: 2 },
+    { type: "number", options: { format: "float" } },
+    { type: "number", hasMany: true },
+  ],
+  checkbox: [{ type: "checkbox" }],
+  date: [{ type: "date" }],
+  select: [{ type: "select", options: selectOptions }],
+  radio: [{ type: "radio", options: selectOptions }],
+  upload: [{ type: "upload" }, { type: "upload", hasMany: true }],
+  relationship: [
+    { type: "relationship", options: { target: "posts" } },
+    { type: "relationship", hasMany: true, options: { target: "posts" } },
+  ],
+  repeater: [{ type: "repeater", fields: [] }],
+  group: [{ type: "group", fields: [] }],
+  json: [{ type: "json" }],
+  component: [{ type: "component", options: { target: "hero" } }],
+  chips: [{ type: "chips" }],
+};
+
+/**
+ * Every column type the product can put in a table, for one dialect.
+ *
+ * Both sides are collected because a rename pairs them: the LIVE column carries whatever the builder
+ * once emitted, and the DESIRED column is what the descriptor asks for now. A comparison over only
+ * one side would miss precisely the pairs a legacy table produces.
+ */
+function reachableTypes(dialect: SupportedDialect): string[] {
+  const found = new Set<string>();
+  const service = new DynamicCollectionSchemaService(undefined, dialect);
+
+  for (const [type, shapes] of Object.entries(SHAPES) as Array<
+    [DynamicFieldType, Array<Record<string, unknown>>]
+  >) {
+    for (const shape of shapes) {
+      const field = {
+        name: `probe_${type.toLowerCase()}`,
+        ...shape,
+      } as unknown as FieldDefinition;
+
+      const described = getColumnDescriptor(field, dialect, "collection");
+      if (described) found.add(described.dialectType);
+
+      // The builder's own rendering, which is what an existing table actually holds.
+      const emitted = service.mapFieldTypeToSQL(
+        field.type,
+        undefined,
+        field.options,
+        field.validation
+      );
+      if (emitted) found.add(emitted);
+    }
+  }
+  return [...found];
+}
+
+/**
+ * A disagreement that exists today, is known, and is not this file's job to fix.
+ *
+ * Recorded rather than repaired so the ratchet can go green while the fixes are decided separately,
+ * and checked in BOTH directions: an entry describing a disagreement that no longer happens fails
+ * too, so resolving one forces its removal here and cannot be done silently.
+ *
+ * 🔴 Every entry below is a LIVE data-loss path, not a cosmetic mismatch. A rename between these
+ * spellings recreates the column empty, for a change the diff itself says is not a change.
+ */
+const ACCEPTED: Record<string, string> = {
+  // MySQL spells a boolean `tinyint(1)`. `normalizeType` knows this and collapses the two; the
+  // family table puts `tinyint` in the INTEGER family and `boolean` in the BOOLEAN family, so they
+  // never match. Consequence: renaming ANY checkbox field on MySQL drops the column.
+  "mysql:tinyint(1)->boolean":
+    "MySQL boolean synonym unknown to the family table",
+  "mysql:boolean->tinyint(1)":
+    "MySQL boolean synonym unknown to the family table",
+  // 🔴 `float8` is absent from the PostgreSQL family table entirely, so it is incompatible with
+  // ITSELF: `typeFamilyOf` answers null and every pair involving it falls to drop_and_add. `real`
+  // (float4) and `numeric` are both present, which is why this went unnoticed. Consequence:
+  // renaming a float number field on PostgreSQL drops the column.
+  "postgresql:float8->float8":
+    "float8 missing from the PostgreSQL family table",
+};
+
+const keyFor = (dialect: string, from: string, to: string): string =>
+  `${dialect}:${from}->${to}`;
+
+describe("the diff and the rename detector agree about what one column is", () => {
+  it.each(DIALECTS)(
+    "offers a data-preserving rename between spellings the diff calls identical — %s",
+    dialect => {
+      const types = reachableTypes(dialect);
+      // Guards against a vacuous pass: an empty or tiny universe would satisfy the assertion below
+      // while comparing nothing.
+      expect(types.length, "types reachable on this dialect").toBeGreaterThan(
+        3
+      );
+
+      const disagreements: string[] = [];
+      for (const from of types) {
+        for (const to of types) {
+          const sameColumn =
+            normalizeType(from) !== undefined &&
+            normalizeType(from) === normalizeType(to);
+          if (!sameColumn) continue;
+          if (isTypesCompatible(from, to, dialect)) continue;
+          if (ACCEPTED[keyFor(dialect, from, to)]) continue;
+          disagreements.push(
+            `${from} -> ${to}: the diff reads one column (${normalizeType(from)}), ` +
+              `the detector offers drop_and_add`
+          );
+        }
+      }
+
+      expect(
+        disagreements,
+        "a rename between these spellings recreates the column empty, for a change the diff says is not a change"
+      ).toEqual([]);
+    }
+  );
+
+  // The other direction of the ratchet. Without it, a fixed divergence leaves its entry behind and
+  // the list slowly stops describing the code — which is how a record of known problems becomes a
+  // record of problems someone once had.
+  it("keeps no accepted entry for a disagreement that no longer happens", () => {
+    const live = new Set<string>();
+    for (const dialect of DIALECTS) {
+      const types = reachableTypes(dialect);
+      for (const from of types) {
+        for (const to of types) {
+          const same =
+            normalizeType(from) !== undefined &&
+            normalizeType(from) === normalizeType(to);
+          if (same && !isTypesCompatible(from, to, dialect)) {
+            live.add(keyFor(dialect, from, to));
+          }
+        }
+      }
+    }
+
+    expect(
+      Object.keys(ACCEPTED).filter(k => !live.has(k)),
+      "this disagreement was resolved; delete its entry so the list keeps meaning what it says"
+    ).toEqual([]);
+  });
+});

--- a/packages/nextly/src/domains/schema/pipeline/__tests__/rename-type-agreement.test.ts
+++ b/packages/nextly/src/domains/schema/pipeline/__tests__/rename-type-agreement.test.ts
@@ -95,17 +95,47 @@ function reachableTypes(dialect: SupportedDialect): string[] {
       const described = getColumnDescriptor(field, dialect, "collection");
       if (described) found.add(described.dialectType);
 
-      // The builder's own rendering, which is what an existing table actually holds.
+      // What a table built by that rendering REPORTS when introspected, which is the string the
+      // detector actually receives. The emitted DDL spelling is not it, and using it here invents
+      // pairs that no rename can produce.
       const emitted = service.mapFieldTypeToSQL(
         field.type,
         undefined,
         field.options,
         field.validation
       );
-      if (emitted) found.add(emitted);
+      if (emitted) found.add(asIntrospected(emitted, dialect));
     }
   }
   return [...found];
+}
+
+/**
+ * The string introspection returns for a column that was created with `declared`.
+ *
+ * The live side of every rename comes from `introspect-live.ts`, not from the DDL that built the
+ * table, and the two are not the same string. PostgreSQL reports `udt_name`, which is the canonical
+ * token with no modifier: a `boolean` column reads back as `bool`, `integer` as `int4`,
+ * `double precision` as `float8`. MySQL reports `COLUMN_TYPE`, which is the type as the server
+ * stores it: a column declared `boolean` reads back as `tinyint(1)`, because MySQL has no separate
+ * boolean type. SQLite reports the declaration as written.
+ *
+ * 🔴 Modelling the emitted DDL instead of this manufactures disagreements that cannot happen. A
+ * checkbox rename on MySQL compares `tinyint(1)` against `tinyint(1)`; it never compares `boolean`
+ * against anything, because that spelling exists only in the CREATE statement and never survives a
+ * round trip through the database.
+ */
+function asIntrospected(declared: string, dialect: SupportedDialect): string {
+  if (dialect === "sqlite") return declared;
+  if (dialect === "mysql") {
+    // The one declared spelling MySQL does not preserve. Everything else — int, varchar(n), text,
+    // json, decimal(p,s), datetime — is reported back as declared.
+    return /^bool(ean)?$/i.test(declared.trim()) ? "tinyint(1)" : declared;
+  }
+  // PostgreSQL: udt_name drops the modifier and names the underlying type, which is exactly what
+  // `normalizeType` canonicalises to. Reusing it keeps one definition of that mapping rather than a
+  // second copy that can drift from the introspection this models.
+  return normalizeType(declared) ?? declared;
 }
 
 /**
@@ -119,13 +149,11 @@ function reachableTypes(dialect: SupportedDialect): string[] {
  * spellings recreates the column empty, for a change the diff itself says is not a change.
  */
 const ACCEPTED: Record<string, string> = {
-  // MySQL spells a boolean `tinyint(1)`. `normalizeType` knows this and collapses the two; the
-  // family table puts `tinyint` in the INTEGER family and `boolean` in the BOOLEAN family, so they
-  // never match. Consequence: renaming ANY checkbox field on MySQL drops the column.
-  "mysql:tinyint(1)->boolean":
-    "MySQL boolean synonym unknown to the family table",
-  "mysql:boolean->tinyint(1)":
-    "MySQL boolean synonym unknown to the family table",
+  // One entry, and it is worth saying why there is not a second. The family table also splits
+  // MySQL's `boolean` from `tinyint`, which looks like the same class of bug. That spelling never
+  // reaches the detector: a column declared `boolean` is reported by MySQL as `tinyint(1)`, so a
+  // checkbox rename compares `tinyint(1)` with itself and is already compatible.
+  //
   // 🔴 `float8` is absent from the PostgreSQL family table entirely, so it is incompatible with
   // ITSELF: `typeFamilyOf` answers null and every pair involving it falls to drop_and_add. `real`
   // (float4) and `numeric` are both present, which is why this went unnoticed. Consequence:

--- a/packages/nextly/src/domains/schema/services/__tests__/column-conformance-matrix.test.ts
+++ b/packages/nextly/src/domains/schema/services/__tests__/column-conformance-matrix.test.ts
@@ -49,6 +49,11 @@ import { describe, expect, it } from "vitest";
 import { DynamicCollectionSchemaService } from "../../../dynamic-collections/services/dynamic-collection-schema-service";
 import { FieldGroupSchemaService } from "../../../field-groups/services/field-group-schema-service";
 import { normalizeType } from "../../pipeline/diff/normalize-type";
+import {
+  parseAddColumns,
+  parseCreateTable,
+  type Rendered,
+} from "../../__tests__/helpers/parse-generated-ddl";
 import { getColumnDescriptor } from "../field-column-descriptor";
 
 // Both taken from the descriptor rather than from the database layer: it is the side under test
@@ -524,118 +529,6 @@ const ACCEPTED = byAspect([
     { origins: ["fieldGroup"], dialects: ["mysql"] }
   ),
 ]);
-
-/**
- * The text between the CREATE TABLE column list's own parentheses.
- *
- * Found by counting depth rather than by taking the last `)`, because a column can close its own
- * parenthesis after the list's does not: `DECIMAL(10, 2)` and an inline CHECK both do.
- */
-function balancedBody(create: string): string {
-  const open = create.indexOf("(");
-  if (open < 0) return "";
-  let depth = 0;
-  for (let i = open; i < create.length; i++) {
-    if (create[i] === "(") depth++;
-    else if (create[i] === ")") {
-      depth--;
-      if (depth === 0) return create.slice(open + 1, i);
-    }
-  }
-  return create.slice(open + 1);
-}
-
-/**
- * Split a column list on the commas that separate columns.
- *
- * A plain split on "," cuts `DECIMAL(10, 2)` in half and reports the fragment as the column's type,
- * which reads as a real disagreement and is not one.
- */
-function splitTopLevel(body: string): string[] {
-  const parts: string[] = [];
-  let depth = 0;
-  let current = "";
-  for (const ch of body) {
-    if (ch === "(") depth++;
-    else if (ch === ")") depth--;
-    if (ch === "," && depth === 0) {
-      parts.push(current);
-      current = "";
-      continue;
-    }
-    current += ch;
-  }
-  if (current.trim()) parts.push(current);
-  return parts;
-}
-
-/** What one side says a column is. `null` means that side produces no column at all. */
-interface Rendered {
-  type: string;
-  notNull: boolean;
-}
-
-/**
- * The columns a generated CREATE TABLE declares.
- *
- * Reads the emitted SQL rather than any intermediate the generator happens to expose, because the
- * SQL is what reaches the database and an intermediate can agree while the rendering does not.
- */
-function parseCreateTable(sql: string): Map<string, Rendered> {
-  const out = new Map<string, Rendered>();
-  const create = sql.split(";").find(s => /CREATE TABLE/i.test(s));
-  if (!create) return out;
-
-  for (const raw of splitTopLevel(balancedBody(create))) {
-    const line = raw.trim();
-    // Constraint and key clauses are not column declarations.
-    if (/^(CONSTRAINT|PRIMARY|FOREIGN|UNIQUE|KEY|INDEX)\b/i.test(line))
-      continue;
-    const m = line.match(/^["`]?([a-z0-9_]+)["`]?\s+(.+)$/i);
-    if (!m?.[1] || !m[2]) continue;
-    const rest = m[2].trim();
-    out.set(m[1], {
-      // Strip the clauses that qualify a column rather than name its type.
-      type: rest
-        .replace(/\b(NOT NULL|PRIMARY KEY|UNIQUE|AUTO_INCREMENT)\b/gi, "")
-        .replace(/\bDEFAULT\s+[^,]*/gi, "")
-        .replace(/\bREFERENCES\b.*/gi, "")
-        .trim(),
-      notNull: /\bNOT NULL\b/i.test(rest),
-    });
-  }
-  return out;
-}
-
-/**
- * The columns an ALTER migration adds.
- *
- * A column created WITH its table and the same column added to an existing one are emitted by
- * different code, and they are allowed to disagree without anything noticing: the ADD COLUMN path
- * passes only a field's type and length, so anything a field says through its options or its
- * validation is dropped on the way. That makes "created fresh" and "added later" two separate
- * answers to one question, and both have to be measured.
- */
-function parseAddColumns(sql: string): Map<string, Rendered> {
-  const out = new Map<string, Rendered>();
-  for (const statement of sql.split(";")) {
-    const m = statement.match(
-      /ADD\s+COLUMN\s+["`]?([a-z0-9_]+)["`]?\s+([^;]+)/i
-    );
-    if (!m?.[1] || !m[2]) continue;
-    const rest = m[2].trim();
-    out.set(m[1], {
-      type: rest
-        .replace(/\b(NOT NULL|PRIMARY KEY|UNIQUE|AUTO_INCREMENT)\b/gi, "")
-        .replace(/\bDEFAULT\s+.*/gi, "")
-        .replace(/\bREFERENCES\b.*/gi, "")
-        .replace(/\bAFTER\b.*/gi, "")
-        .trim(),
-      notNull: /\bNOT NULL\b/i.test(rest),
-    });
-  }
-  return out;
-}
 
 const PROBE_TABLE = "conformance_probe";
 


### PR DESCRIPTION
## The class of bug this catches

Two implementations decide whether two type spellings mean the same column:

| | used by | decides |
|---|---|---|
| `normalizeType` | the schema **diff** | whether a column changed at all |
| `isTypesCompatible` | the rename **detector** | whether a rename keeps the data |

The invariant is one-directional and follows from what each is for. **If the diff says two spellings are the same column, a rename between them changes nothing about storage, so the detector must offer the rename that MOVES the data.** When it does not, the only recovery on offer drops the column and recreates it **empty** — for a change the diff itself says is not a change.

The reverse is deliberately not asserted: the detector may accept a change the diff calls real, which is how `text` into JSON is offered as a convertible rename.

## It found a second live data-loss bug on its first run

One divergence was already known. The matrix found another that nobody had:

🔴 **`float8` is absent from the PostgreSQL family table entirely.** `typeFamilyOf` answers `null`, so `float8` is incompatible with **itself** and every pair involving it falls to drop-and-add. `real` (float4) and `numeric` are both present, which is why this went unnoticed.

**Consequence: renaming a float number field on PostgreSQL drops the column.**

Probed directly to scope it exactly:

```
postgresql: float8 -> float8            normalize=float8/float8   compatible=false
postgresql: double precision -> float8  normalize=float8/float8   compatible=false
postgresql: real -> real                normalize=float4/float4   compatible=true
postgresql: numeric -> numeric          normalize=numeric/numeric compatible=true
mysql:      double -> double            normalize=double/double   compatible=true
```

The known one is MySQL's boolean: `normalizeType` collapses `tinyint(1)` and `boolean`, while the family table puts `tinyint` in the **integer** family and `boolean` in the **boolean** family, so they never match. **Renaming any checkbox field on MySQL drops the column.**

Both are recorded as accepted entries rather than repaired, so the ratchet is green while the fixes are decided separately. Every accepted entry carries the mechanism and the user-facing consequence, because "accepted" without that is indistinguishable from "unnoticed".

## Why a matrix rather than two test cases

This is the same failure the column-conformance matrix exists for, one layer down: **a second implementation of a question that already had an answer.** The MySQL boolean case was found by measuring one field type on one dialect — exactly how the generator/descriptor divergences were found one at a time for a month.

So the types are **enumerated from what the product actually produces** rather than hand-listed: both the descriptor's desired column and the builder's emitted rendering, per dialect. A new field type or a changed rendering enters the comparison without anyone remembering to add it. `SHAPES` is keyed by `Record<DynamicFieldType, …>`, so a new field type is a compile error until it is covered — the same guard the conformance matrix uses.

Checked in **both directions**: an entry describing a disagreement that no longer happens fails too, so resolving one forces its removal and cannot be done silently.

## Verification

- `pnpm build` · `pnpm check-types --force` · `pnpm lint` (exit code) · `node scripts/check-drizzle-v1-legacy.cjs` — clean
- Unit: **361 failed / 7496** against a freshly measured baseline of **361 / 7492** at `63995c8f7`. Zero new; the +4 are this file's own tests.
- **Proven load-bearing in both directions.** Giving `float8` a family resolves a recorded divergence and fails the stale check with exactly `postgresql:float8->float8`. Splitting PG's `bool` and `boolean` into different families introduces a new one and fails the unaccepted check with `bool -> bool` and `bool -> boolean`.

🔴 One note on that proof: my first attempt at the second break put both spellings in the *same* new family, so no divergence existed and the test correctly stayed green. **A break that does not actually change behaviour proves nothing** — the valid break splits one normalized type across two families.

No changeset: test-only, no published code changes.