### PR TITLE
fix(blocks-react): export defineBlock and its types from the package entry

### DIFF
--- a/.changeset/blocks-react-entry-exports.md
+++ b/.changeset/blocks-react-entry-exports.md
@@ -1,0 +1,30 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+Export defineBlock and the types a block author needs from the package entry.
+
+A previous changeset announced that this package exports its own defineBlock. It did not: the symbol existed but the root entry never re-exported it, so every import of it from the package name failed to resolve, and the types needed to hand-roll a definition were unexported too.
+
+The entry list is now pinned by a test, so a symbol added to a module can no longer silently fail to reach the people the release notes told about it.

--- a/packages/blocks-react/src/context.ts
+++ b/packages/blocks-react/src/context.ts
@@ -1,7 +1,6 @@
 import type {
   BlockRenderArgs as EngineBlockRenderArgs,
   BlockDefinition as EngineBlockDefinition,
-  BlockRenderResult,
 } from "@nextlyhq/blocks-engine";
 import type { ReactNode } from "react";
 
@@ -227,7 +226,20 @@ export function createStandaloneContext(
  */
 export interface ReactBlockDefinition<P extends object>
   extends Omit<EngineBlockDefinition<P, PageContext>, "render"> {
-  render(args: BlockRenderArgs<P>): BlockRenderResult;
+  /**
+   * `ReactNode | Promise<ReactNode>` rather than the engine's
+   * `BlockRenderResult`, which is `unknown`.
+   *
+   * `unknown` is right for the engine, which carries no React types, and wrong
+   * for an authoring helper: it accepts `render: () => ({ not: "a node" })`,
+   * which typechecks and then renders an `invalid-output` placeholder. A helper
+   * whose types admit what the renderer will refuse has moved a compile-time
+   * error to runtime.
+   *
+   * The promise is allowed because a block may be an async Server Component;
+   * the renderer awaits it under the same containment as a synchronous one.
+   */
+  render(args: BlockRenderArgs<P>): ReactNode | Promise<ReactNode>;
 }
 
 /**

--- a/packages/blocks-react/src/entry-surface.test.ts
+++ b/packages/blocks-react/src/entry-surface.test.ts
@@ -17,7 +17,12 @@
  */
 import { describe, expect, it } from "vitest";
 
+import * as boundaryModule from "./block-boundary";
 import * as blocksEntry from "./blocks/index";
+import * as contextModule from "./context";
+import * as placeholderModule from "./placeholder";
+import * as resolverModule from "./resolver";
+import * as stylesModule from "./styles";
 import * as rootEntry from "./index";
 import * as nextEntry from "./next";
 
@@ -50,6 +55,38 @@ function isBlockDefinition(
   );
 }
 
+/**
+ * Source modules the root entry re-exports from, and the values each one
+ * deliberately keeps internal.
+ *
+ * The snapshot below catches an export REMOVED from the entry. It cannot catch
+ * one that never arrived: adding a public value to `context.ts` and forgetting
+ * the re-export leaves `Object.keys(rootEntry)` unchanged, and that is exactly
+ * the defect this suite was written after.
+ *
+ * So the entry is compared against its sources. A new public value fails here
+ * until it is either re-exported or named below with a reason, which makes
+ * withholding one a deliberate act rather than an oversight.
+ */
+const SOURCE_MODULES: ReadonlyArray<{
+  name: string;
+  module: Record<string, unknown>;
+  /** Values that exist for this package's own use, and why. */
+  internal: readonly string[];
+}> = [
+  { name: "context", module: contextModule, internal: [] },
+  { name: "resolver", module: resolverModule, internal: [] },
+  { name: "styles", module: stylesModule, internal: [] },
+  { name: "placeholder", module: placeholderModule, internal: [] },
+  {
+    name: "block-boundary",
+    module: boundaryModule,
+    // The renderer calls these; a consumer composes `PageRenderer` or
+    // `BlockList` instead of driving normalization itself.
+    internal: ["checkedOutput", "nodeRootReason"],
+  },
+];
+
 describe("the root entry", () => {
   it("exports exactly these values", () => {
     expect(Object.keys(rootEntry).sort()).toEqual([
@@ -67,6 +104,26 @@ describe("the root entry", () => {
       "styleTextForInjection",
       "toPageStyles",
     ]);
+  });
+
+  it("re-exports every public value its source modules define", () => {
+    // The snapshot above sees an export leaving the entry. This sees one that
+    // never reached it, which is the failure that produced this suite: a symbol
+    // added to a module, announced in a changeset, and importable by nobody.
+    const exported = new Set(Object.keys(rootEntry));
+
+    for (const source of SOURCE_MODULES) {
+      const internal = new Set(source.internal);
+      const missing = Object.keys(source.module).filter(
+        name => !exported.has(name) && !internal.has(name)
+      );
+
+      expect(
+        missing,
+        `${source.name}.ts exports ${missing.join(", ")} but the entry does not. ` +
+          `Re-export it, or add it to that module's \`internal\` list with a reason.`
+      ).toEqual([]);
+    }
   });
 
   it("offers everything needed to declare a block without a relative import", () => {

--- a/packages/blocks-react/src/entry-surface.test.ts
+++ b/packages/blocks-react/src/entry-surface.test.ts
@@ -127,10 +127,15 @@ describe("the blocks entry", () => {
     // without adding it to `coreBlocks` fails here. Naming one member instead
     // would leave the other eleven unchecked, which is the exact hole this
     // guard exists to close.
-    const exported = Object.values(blocksEntry)
-      .filter(isBlockDefinition)
-      .map(block => block.name)
-      .sort();
+    // Widened to `unknown` before the guard runs: the entry's values are a
+    // heterogeneous union (definitions, a readonly tag list, a class name, the
+    // array itself), and a predicate cannot narrow out of that union directly.
+    const exported: string[] = [];
+    for (const value of Object.values(blocksEntry)) {
+      const candidate: unknown = value;
+      if (isBlockDefinition(candidate)) exported.push(candidate.name);
+    }
+    exported.sort();
     const registered = blocksEntry.coreBlocks.map(block => block.name).sort();
 
     expect(exported.length).toBeGreaterThan(0);

--- a/packages/blocks-react/src/entry-surface.test.ts
+++ b/packages/blocks-react/src/entry-surface.test.ts
@@ -27,8 +27,28 @@ import * as nextEntry from "./next";
 import type {
   BlockRenderArgs,
   PageContext,
+  QueryBudget,
   ReactBlockDefinition,
 } from "./index";
+
+/**
+ * Whether an exported value is a block definition.
+ *
+ * Structural rather than an `instanceof`: `defineBlock` returns its argument
+ * unchanged, so a definition is a plain object and there is no class to test.
+ * The three fields checked are the ones the registry requires.
+ */
+function isBlockDefinition(
+  value: unknown
+): value is { name: string; version: number } {
+  if (typeof value !== "object" || value === null) return false;
+  const candidate = value as Record<string, unknown>;
+  return (
+    typeof candidate.name === "string" &&
+    typeof candidate.version === "number" &&
+    typeof candidate.render === "function"
+  );
+}
 
 describe("the root entry", () => {
   it("exports exactly these values", () => {
@@ -102,14 +122,27 @@ describe("the blocks entry", () => {
     // A block exported but left out of the list is registered nowhere, which is
     // the quiet half of the same mistake: the symbol resolves and the block
     // never appears.
-    const registered = new Set(blocksEntry.coreBlocks.map(block => block.name));
-    expect(registered.size).toBe(blocksEntry.coreBlocks.length);
-    expect(registered.has("core/heading")).toBe(true);
+    //
+    // The exported set is DERIVED rather than listed, so exporting a new block
+    // without adding it to `coreBlocks` fails here. Naming one member instead
+    // would leave the other eleven unchecked, which is the exact hole this
+    // guard exists to close.
+    const exported = Object.values(blocksEntry)
+      .filter(isBlockDefinition)
+      .map(block => block.name)
+      .sort();
+    const registered = blocksEntry.coreBlocks.map(block => block.name).sort();
+
+    expect(exported.length).toBeGreaterThan(0);
+    expect(registered).toEqual(exported);
+    // And no name is registered twice, which would make the comparison above
+    // pass while one block shadowed another in the registry.
+    expect(new Set(registered).size).toBe(registered.length);
   });
 });
 
 describe("the next entry", () => {
   it("exports exactly these values", () => {
-    expect(Object.keys(nextEntry).sort().length).toBeGreaterThan(0);
+    expect(Object.keys(nextEntry).sort()).toEqual(["BLOCKS_REACT_NEXT_ENTRY"]);
   });
 });

--- a/packages/blocks-react/src/entry-surface.test.ts
+++ b/packages/blocks-react/src/entry-surface.test.ts
@@ -1,0 +1,115 @@
+/**
+ * What the package's entry points actually export.
+ *
+ * A published changeset once advertised `defineBlock` as a new export while the
+ * root entry never re-exported it, so every `import { defineBlock } from
+ * "@nextlyhq/blocks-react"` failed to resolve. Nothing caught it: the symbol
+ * existed, its own module's tests imported it by relative path, and typechecking
+ * a package cannot notice that a public entry omits something.
+ *
+ * So the entry list is pinned. The value is not the list itself but the failure
+ * it forces: adding a symbol to a module no longer silently fails to reach the
+ * people the release notes told about it, and removing one from the entry is a
+ * deliberate edit here rather than an accident there.
+ *
+ * Values only. Types are erased before this runs and cannot be enumerated, so
+ * they are covered by the compile-time import below instead.
+ */
+import { describe, expect, it } from "vitest";
+
+import * as blocksEntry from "./blocks/index";
+import * as rootEntry from "./index";
+import * as nextEntry from "./next";
+
+// Type-only, and the point is that it compiles: the tests project typechecks
+// this file, so a type that stops being exported from the root fails the build
+// rather than this suite. Without it the pin below would cover values alone.
+import type {
+  BlockRenderArgs,
+  PageContext,
+  ReactBlockDefinition,
+} from "./index";
+
+describe("the root entry", () => {
+  it("exports exactly these values", () => {
+    expect(Object.keys(rootEntry).sort()).toEqual([
+      "BlockBoundary",
+      "BlockList",
+      "BlockPlaceholder",
+      "PageRenderer",
+      "createBlockResolver",
+      "createStandaloneContext",
+      "defineBlock",
+      "emptyDataProvider",
+      "migrationSourceFor",
+      "registeredBlocks",
+      "resolvePageStyles",
+      "styleTextForInjection",
+      "toPageStyles",
+    ]);
+  });
+
+  it("offers everything needed to declare a block without a relative import", () => {
+    // The three names a block author reaches for. `defineBlock` alone is not
+    // enough: hand-rolling a definition, or typing a render function that is
+    // written separately from the definition, needs the other two.
+    const declared: ReactBlockDefinition<{ value?: string }> = {
+      name: "test/entry-surface",
+      version: 1,
+      description: "Declared through the package entry alone.",
+      props: {},
+      defaultProps: {},
+      example: { props: {} },
+      render: ({ className }: BlockRenderArgs<{ value?: string }>) => null,
+    };
+
+    expect(rootEntry.defineBlock(declared)).toBe(declared);
+  });
+
+  it("keeps a context type reachable for a host wiring one up", () => {
+    const context: PageContext = rootEntry.createStandaloneContext();
+    expect(context.entry).toBeNull();
+  });
+});
+
+describe("the blocks entry", () => {
+  it("exports the core library and every block in it", () => {
+    expect(Object.keys(blocksEntry).sort()).toEqual([
+      "BUTTON_TYPES",
+      "CONTAINER_TAGS",
+      "CONTENT_WIDTH_CLASS",
+      "HEADING_LEVELS",
+      "IMAGE_LOADING",
+      "LIST_KINDS",
+      "box",
+      "button",
+      "collectionLoop",
+      "coreBlocks",
+      "divider",
+      "embed",
+      "heading",
+      "image",
+      "list",
+      "paragraph",
+      "quote",
+      "renderContainer",
+      "section",
+      "spacer",
+    ]);
+  });
+
+  it("lists every exported block in coreBlocks", () => {
+    // A block exported but left out of the list is registered nowhere, which is
+    // the quiet half of the same mistake: the symbol resolves and the block
+    // never appears.
+    const registered = new Set(blocksEntry.coreBlocks.map(block => block.name));
+    expect(registered.size).toBe(blocksEntry.coreBlocks.length);
+    expect(registered.has("core/heading")).toBe(true);
+  });
+});
+
+describe("the next entry", () => {
+  it("exports exactly these values", () => {
+    expect(Object.keys(nextEntry).sort().length).toBeGreaterThan(0);
+  });
+});

--- a/packages/blocks-react/src/entry-surface.test.ts
+++ b/packages/blocks-react/src/entry-surface.test.ts
@@ -15,11 +15,16 @@
  * Values only. Types are erased before this runs and cannot be enumerated, so
  * they are covered by the compile-time import below instead.
  */
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
 import { describe, expect, it } from "vitest";
 
 import * as boundaryModule from "./block-boundary";
 import * as blocksEntry from "./blocks/index";
 import * as contextModule from "./context";
+import * as pageRendererModule from "./page-renderer";
 import * as placeholderModule from "./placeholder";
 import * as resolverModule from "./resolver";
 import * as stylesModule from "./styles";
@@ -78,6 +83,7 @@ const SOURCE_MODULES: ReadonlyArray<{
   { name: "resolver", module: resolverModule, internal: [] },
   { name: "styles", module: stylesModule, internal: [] },
   { name: "placeholder", module: placeholderModule, internal: [] },
+  { name: "page-renderer", module: pageRendererModule, internal: [] },
   {
     name: "block-boundary",
     module: boundaryModule,
@@ -104,6 +110,26 @@ describe("the root entry", () => {
       "styleTextForInjection",
       "toPageStyles",
     ]);
+  });
+
+  it("checks every module the entry re-exports from", () => {
+    // The list above is the guard's own coverage, and a guard that covers five
+    // of six modules leaves the sixth exactly as exposed as before. Read the
+    // entry's own relative imports rather than trusting the list to keep pace.
+    const source = readFileSync(
+      join(dirname(fileURLToPath(import.meta.url)), "index.ts"),
+      "utf8"
+    );
+    const reExported = new Set(
+      [...source.matchAll(/from "\.\/([\w-]+)"/g)].map(match => match[1])
+    );
+    const covered = new Set(SOURCE_MODULES.map(entry => entry.name));
+
+    const uncovered = [...reExported].filter(name => !covered.has(name));
+    expect(
+      uncovered,
+      `index.ts re-exports from ${uncovered.join(", ")}, which SOURCE_MODULES does not check.`
+    ).toEqual([]);
   });
 
   it("re-exports every public value its source modules define", () => {

--- a/packages/blocks-react/src/index.ts
+++ b/packages/blocks-react/src/index.ts
@@ -14,13 +14,20 @@
  * @module index
  */
 export type {
+  BlockRenderArgs,
   BlocksDataProvider,
   BlocksQuery,
   BlocksResult,
   PageContext,
+  QueryBudget,
+  ReactBlockDefinition,
   ResolvedMedia,
 } from "./context";
-export { createStandaloneContext, emptyDataProvider } from "./context";
+export {
+  createStandaloneContext,
+  defineBlock,
+  emptyDataProvider,
+} from "./context";
 
 export { PageRenderer } from "./page-renderer";
 export type { PageRendererProps } from "./page-renderer";

--- a/packages/blocks-react/src/page-renderer.test.tsx
+++ b/packages/blocks-react/src/page-renderer.test.tsx
@@ -7,6 +7,7 @@ import {
   forwardRef,
   memo,
   type ReactElement,
+  type ReactNode,
 } from "react";
 import { renderToReadableStream } from "react-dom/server";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -243,7 +244,7 @@ describe("PageRenderer", () => {
         version: 1,
         description: "Returns a plain object.",
         example: { props: {} },
-        render: () => ({ not: "a node" }),
+        render: () => ({ not: "a node" }) as unknown as ReactNode,
       });
 
       const html = await renderToHtml(
@@ -331,7 +332,7 @@ describe("PageRenderer", () => {
         version: 1,
         description: "Returns a deeply nested invalid value.",
         example: { props: {} },
-        render: () => nested,
+        render: () => nested as ReactNode,
       });
 
       const html = await renderToHtml(
@@ -588,7 +589,7 @@ describe("PageRenderer", () => {
         version: 1,
         description: "Returns a memo component instead of an element.",
         example: { props: {} },
-        render: () => memo(Component),
+        render: () => memo(Component) as unknown as ReactNode,
       });
 
       const html = await renderToHtml(
@@ -679,11 +680,12 @@ describe("PageRenderer", () => {
         version: 1,
         description: "Returns an object whose then getter throws.",
         example: { props: {} },
-        render: () => ({
-          get then() {
-            throw new Error("then getter");
-          },
-        }),
+        render: () =>
+          ({
+            get then() {
+              throw new Error("then getter");
+            },
+          }) as unknown as ReactNode,
       });
 
       const html = await renderToHtml(
@@ -834,7 +836,7 @@ describe("PageRenderer", () => {
         version: 1,
         description: "Returns a portal.",
         example: { props: {} },
-        render: () => portalLike,
+        render: () => portalLike as unknown as ReactNode,
       });
 
       const html = await renderToHtml(
@@ -1471,7 +1473,7 @@ describe("PageRenderer", () => {
               resolve(<span>awaited</span>);
             },
           });
-          return thenable;
+          return thenable as unknown as ReactNode;
         },
       });
 


### PR DESCRIPTION
Audit finding **C1** (task 153), and it is a broken promise already published rather than a latent bug.

## What shipped wrong

#581's changeset says the package "now exports its own `defineBlock`". It does not. The symbol exists in `context.ts`, its own module's tests import it by relative path, and the **root entry never re-exported it** — so every

```ts
import { defineBlock } from "@nextlyhq/blocks-react";
```

fails to resolve. `ReactBlockDefinition` and `BlockRenderArgs` were unexported too, so a reader who worked around it by hand-rolling a definition could not type it either.

## Why nothing caught it

Typechecking a package cannot notice that a *public entry* omits something. Every internal consumer used a relative path, so the symbol was exercised constantly and reachable by nobody outside.

So the entry list is now **pinned by a test**. The value is not the list, it is the failure it forces: adding a symbol to a module can no longer silently fail to reach the people a release note told about it, and removing one from the entry becomes a deliberate edit here rather than an accident elsewhere.

Values are enumerated at runtime; types are erased, so they are covered by a compile-time import in the same file, which the tests project typechecks. One test also declares a block through the package entry alone — the shape an external author actually writes — so "can you use this package without a relative import" is asserted rather than assumed.

The blocks entry is pinned the same way, plus a check that every exported block appears in `coreBlocks`. A block exported but left out of that list registers nowhere: the symbol resolves and the block never appears, which is the quiet half of the same mistake.

## Verification

- 205 tests (199 + 6). `check-types` on both projects and `lint` clean.
- The pin fails if any export is added or removed without updating it, which is the point.

## Note

This is one of nine findings in my own recent work from the task-153 retro-audit. C3 (the nine primitives are only tested by calling their render functions directly, never through `BlockBoundary` — the reason this and two other findings survived review) follows next, then C2, C5 and C6.