### PR TITLE
fix(blocks-react): stop an unrendered subtree from reserving node ids

### DIFF
--- a/.changeset/node-id-unrendered-subtree.md
+++ b/.changeset/node-id-unrendered-subtree.md
@@ -1,0 +1,32 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+Stop a block that never reaches the page from taking a node id off one that does.
+
+Node ids are made unique before anything renders, because they are also React's keys. That pass walked the whole stored tree, including the children of a node already known to be replaced by a placeholder. A placeholder replaces its node entirely, so those children were never going to be drawn, but they could still claim an id first and delete the later visible sibling that shared it. The reader lost real content and got a diagnostic for something that was never on the page.
+
+The descent now stops at a node that will not render its own markup. The node itself keeps its id, because its placeholder does render and still needs a key.
+
+This is the rule already applied to condition-gated nodes, and the one applied to DOM ids, extended to the one position that had been missed. Reaching it needs a document holding two nodes with the same id, which validation rejects at write time, so it can only arrive from a row edited outside the product.

--- a/packages/blocks-react/src/page-renderer.test.tsx
+++ b/packages/blocks-react/src/page-renderer.test.tsx
@@ -1324,6 +1324,50 @@ describe("PageRenderer", () => {
       }
     });
 
+    it("does not reserve a node id for a child that never reaches the page", async () => {
+      // The same rule one level down, for node ids rather than DOM ids. A
+      // placeholder replaces its node ENTIRELY, so the subtree under an unknown
+      // type never renders — but walking into it anyway let a child claim an id
+      // and delete the later visible sibling that shares it.
+      //
+      // `duplicate-node-id` is a write-time validation error, so this arrives
+      // only from a row edited outside the product. What matters is which side
+      // survives when it does: content over a diagnostic for something that was
+      // never going to be drawn.
+      for (const broken of [
+        node("wrapper", "test/missing", {
+          slots: {
+            main: [node("dup", "test/text", { props: { value: "buried" } })],
+          },
+        }),
+        node("wrapper", "test/text", {
+          props: { value: "stale" },
+          migrationFailed: true,
+          slots: {
+            main: [node("dup", "test/text", { props: { value: "buried" } })],
+          },
+        }),
+      ]) {
+        const html = await renderToHtml(
+          <PageRenderer
+            document={doc(
+              broken,
+              node("dup", "test/text", { props: { value: "healthy" } })
+            )}
+            blocks={createBlockResolver([text as AnyBlockDefinition])}
+          />
+        );
+
+        // The point of the test: the visible sibling is still on the page.
+        expect(html).toContain("healthy");
+        // And the child that took its id never was, so nothing was traded away.
+        expect(html).not.toContain("buried");
+        // The broken node still reports itself. Skipping the descent must not
+        // also skip the diagnostic that says why the subtree is gone.
+        expect(placeholderReasons(html)).toHaveLength(1);
+      }
+    });
+
     it("does not let attributes that never render force a placeholder", async () => {
       // The refusal is about DOM fields being LOST. `style` and `onClick` are
       // dropped by the allowlist whatever the root is, so a node carrying only

--- a/packages/blocks-react/src/page-renderer.tsx
+++ b/packages/blocks-react/src/page-renderer.tsx
@@ -237,7 +237,14 @@ export function PageRenderer({
   // take that address from a visible node for nothing: the visible one would be
   // dropped or stripped of its anchor, and the node it collided with would then
   // be pruned anyway.
-  const visible = dedupeNodeIds(pruned);
+  //
+  // The children of a node that is already known to placeholder are in the same
+  // position. The node itself still renders its marker and still needs a key,
+  // but a placeholder replaces the node entirely, so nothing below it reaches
+  // the page and nothing below it should hold an address.
+  const visible = dedupeNodeIds(pruned, node =>
+    rendersOwnMarkup(node, resolver)
+  );
 
   // Whether the tree that renders is the tree the stored stylesheet was
   // compiled from. Each pass returns its input unchanged when it had nothing to

--- a/packages/blocks-react/src/sanitize.ts
+++ b/packages/blocks-react/src/sanitize.ts
@@ -149,9 +149,20 @@ export function sanitizeDocument(
  * reaches the page, so letting it reserve an id would take that id from a
  * visible node for no benefit.
  *
+ * `rendersSubtree` extends that same rule one level down. A node the caller
+ * already knows will be replaced by a placeholder still renders — the
+ * placeholder is what makes the failure visible, and it needs a key — but its
+ * CHILDREN do not, because the placeholder replaces the node entirely. Walking
+ * into them anyway let a child that never reaches the page claim an id and
+ * drop a later visible sibling in exchange for nothing. Omitting the predicate
+ * walks everything, which is what a caller with no such knowledge should do.
+ *
  * Returns the ORIGINAL document when nothing collided.
  */
-export function dedupeNodeIds(document: BlockDocument): BlockDocument {
+export function dedupeNodeIds(
+  document: BlockDocument,
+  rendersSubtree?: (node: BlockNode) => boolean
+): BlockDocument {
   let changed = false;
   const seenIds = new Set<string>();
 
@@ -165,7 +176,9 @@ export function dedupeNodeIds(document: BlockDocument): BlockDocument {
       seenIds.add(node.id);
 
       const slots = node.slots;
-      if (slots === undefined) {
+      // The node keeps its id either way: it renders, as itself or as a
+      // placeholder, and React needs the key. Only the descent is skipped.
+      if (slots === undefined || rendersSubtree?.(node) === false) {
         result.push(node);
         continue;
       }


### PR DESCRIPTION
## What

Node ids are made unique before anything renders, because they double as React's keys. That pass walked the whole stored tree, including the children of a node already known to resolve to a placeholder.

A placeholder replaces its node **entirely**, so those children were never going to be drawn. They could still claim an id first, and the later *visible* sibling that shared it was dropped. The reader lost real content and kept a diagnostic for something that was never on the page.

Task 153 finding C7. Same failure mode #585 fixed for DOM ids, still live for node ids.

## The fix

`dedupeNodeIds` takes an optional predicate and stops descending into a node whose subtree will not render. The node itself still claims its id, because its placeholder *does* render and still needs a key.

This is not a new policy. It is the rule already stated for condition-gated nodes ("a hidden node never reaches the page, so letting it reserve an id would take that id from a visible node for no benefit") and already applied to DOM ids, extended to the one position that had been missed.

## Reachability

Low, and stated rather than implied. `duplicate-node-id` is a write-time validation **error** (`validation.ts:653`, severity `error`), so this shape can only arrive from a row edited outside the product. It is graded P3 for that reason. What it changes is which side survives when the defense does fire: content, over a diagnostic for something that was never going to be drawn.

## Test

Covers both routes to a knowable placeholder (unregistered type, `migrationFailed`) and asserts the thing that actually matters:

- the healthy visible sibling **is still on the page** (the assertion that fails today)
- the buried child never rendered, so nothing was traded away
- the broken node still reports itself, so skipping the descent did not also skip the diagnostic

Stub-verified in both directions: reverting the `sanitize.ts` half or the `page-renderer.tsx` wiring fails exactly this one test and nothing else.