### PR TITLE
docs(plugin-page-builder): correct where the block registration seam runs

### DIFF
--- a/packages/plugin-page-builder/src/blocks/registration-service.ts
+++ b/packages/plugin-page-builder/src/blocks/registration-service.ts
@@ -16,13 +16,18 @@
  *
  * **What registration buys today, and what it does not.** A registered block is
  * known to `@nextlyhq/blocks-engine`: validation stops calling its type unknown,
- * and generation, manifests and tooling can see it. It is NOT yet rendered. The
- * renderer and the editor canvas resolve definitions from this package's own
- * earlier registry, which holds none of these, so a page containing a
- * registered type still draws the unknown-block placeholder. Bridging the two
- * is the renderer rewrite, not a line here — and registering blocks into the
- * engine before that bridge exists is deliberate, because validation and
- * tooling are worth having first.
+ * and generation, manifests and tooling can see it. It is also RENDERED on a
+ * published page — `PageRenderer` resolves through `registeredBlocks()`, which
+ * reads the engine registry this service writes to, so no bridging step stands
+ * between registering a block and it appearing.
+ *
+ * What it does not buy is the EDITOR. The canvas resolves definitions from this
+ * package's own `defaultBlockRegistry`, which holds none of these, so a
+ * contributed block cannot yet be inserted or drawn while editing. That half is
+ * the editor's own work, not a line here.
+ *
+ * So the seam runs between the published page and the canvas, not between
+ * registration and rendering.
  *
  * @module blocks/registration-service
  */

--- a/packages/plugin-page-builder/src/blocks/registration-service.ts
+++ b/packages/plugin-page-builder/src/blocks/registration-service.ts
@@ -16,18 +16,25 @@
  *
  * **What registration buys today, and what it does not.** A registered block is
  * known to `@nextlyhq/blocks-engine`: validation stops calling its type unknown,
- * and generation, manifests and tooling can see it. It is also RENDERED on a
- * published page — `PageRenderer` resolves through `registeredBlocks()`, which
- * reads the engine registry this service writes to, so no bridging step stands
- * between registering a block and it appearing.
+ * and generation, manifests and tooling can see it.
  *
- * What it does not buy is the EDITOR. The canvas resolves definitions from this
- * package's own `defaultBlockRegistry`, which holds none of these, so a
- * contributed block cannot yet be inserted or drawn while editing. That half is
- * the editor's own work, not a line here.
+ * Whether it RENDERS depends on which renderer, and there are two:
  *
- * So the seam runs between the published page and the canvas, not between
- * registration and rendering.
+ * - `PageRenderer` from **`@nextlyhq/blocks-react`** resolves through
+ *   `registeredBlocks()`, which reads the engine registry this service writes
+ *   to. A contributed block renders there with no bridging step.
+ * - `PageRenderer` from **`@nextlyhq/plugin-page-builder/render`** defaults to
+ *   this package's own `defaultBlockRegistry`, which holds none of them, so the
+ *   same block draws the unknown-block placeholder. A host may pass its own
+ *   `registry` prop, but the default does not reach the engine.
+ *
+ * The editor canvas is on that second side too — it reads `defaultBlockRegistry`
+ * — so a contributed block cannot yet be inserted or drawn while editing.
+ *
+ * So the seam does not sit between registration and rendering in general. It
+ * sits between the two registries, and a plugin author following THIS package's
+ * own documented render path is on the side that does not see contributed
+ * blocks.
  *
  * @module blocks/registration-service
  */


### PR DESCRIPTION
## What

`registration-service.ts`'s module doc is the only written record of where the block-contribution seam sits, and half of it expired with #574.

Task 153 finding C9.

## The claim, and what is actually true

> It is NOT yet rendered. The renderer and the editor canvas resolve definitions from this package's own earlier registry, which holds none of these, so a page containing a registered type still draws the unknown-block placeholder.

Both halves verified against `main` (`c0dd9fa4b`):

- **Renderer half — false.** `PageRenderer` resolves through `registeredBlocks()`, which is `{ get: getBlock }` from `@nextlyhq/blocks-engine` — the same registry this service writes to. A contributed block renders on a published page today, with no bridging step.
- **Canvas half — still true.** `CanvasNode.tsx` imports `defaultBlockRegistry` from `../../core/registry`, which holds none of them, so a contributed block cannot yet be inserted or drawn while editing.

So the seam runs between the **published page and the canvas**, not between registration and rendering. The doc now says that.

## Why it is worth a PR of its own

A plugin author reading this is told their block will not render and that they must wait for a "renderer rewrite". It renders. The cost of a stale doc here is someone not shipping something that already works, or building a workaround for a problem that no longer exists.

No behaviour change, so no changeset. Typecheck and lint clean.