### PR TITLE
fix(plugin-page-builder): name a reusable block's nodes from the block they live in

### DIFF
--- a/.changeset/ref-scoped-class-namespace.md
+++ b/.changeset/ref-scoped-class-namespace.md
@@ -1,0 +1,26 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+Render the styles saved on a reusable block. A block placed from the reusable library kept whatever colours, spacing and custom CSS were stored on it, and none of it reached the page; a reusable block that happened to share an id with a block on the page silently took that block's appearance instead. Every placement of one reusable block now shares one set of styles, so editing the block updates it everywhere it appears.

--- a/packages/plugin-page-builder/src/core/__tests__/ref-key-agreement.test.tsx
+++ b/packages/plugin-page-builder/src/core/__tests__/ref-key-agreement.test.tsx
@@ -1,0 +1,195 @@
+/**
+ * The compiler and the renderer must name a node the same way.
+ *
+ * Both derive a class from a KEY — a bare node id for the document's own nodes, a ref-scoped key
+ * for anything reached through `core/ref`. Sharing the hash is not proof they agree: the hash is
+ * one step, and the step before it composes the key. A site that composes it unscoped keeps the
+ * old bug while every other site is fixed, and the symptom is not a crash — the node silently
+ * wears another node's class and inherits its styles.
+ *
+ * So this asserts the property directly, over a corpus of ref shapes: **the set of classes the
+ * stylesheet writes is the set of classes the markup carries.** A class in the markup that the
+ * sheet never wrote is an unstyled node; a class in the sheet that no element carries is dead CSS.
+ * Neither is visible from one side alone, and neither shows up in a test that only checks one
+ * nesting depth.
+ *
+ * The two rows that matter most are a library block placed TWICE — which must resolve to one set
+ * of names, because that is what makes editing a reusable block update every placement — and a
+ * ref nested inside a ref, because a key composed from the path rather than from the owning block
+ * would name the same node differently depending on how it was reached.
+ */
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { defaultBlockRegistry } from "../registry";
+import { RenderNode } from "../../render/RenderNode";
+import "../../render/blocks";
+import {
+  compileDocumentBlockCss,
+  compileDocumentCss,
+  documentNodeClasses,
+  nodeClass,
+} from "../style-compiler";
+import { makeNode } from "../tree";
+
+import type { BlockNode } from "../types";
+
+/** Every `nx-pb-*` class the markup actually carries, with the stylesheet sliced off. */
+function classesInMarkup(html: string): Set<string> {
+  const markup = html.replace(/<style[\s\S]*?<\/style>/g, "");
+  return new Set(
+    [...markup.matchAll(/class="([^"]*)"/g)]
+      .flatMap(match => (match[1] ?? "").split(/\s+/))
+      .filter(name => name.startsWith("nx-pb-") && name !== "nx-pb-page")
+  );
+}
+
+/** Every `nx-pb-*` class the stylesheet writes a rule for. */
+function classesInSheet(css: string): Set<string> {
+  return new Set(
+    [...css.matchAll(/\.(nx-pb-[a-z0-9-]+)/g)]
+      .map(match => match[1] as string)
+      .filter(name => name !== "nx-pb-page")
+  );
+}
+
+const styled = (id: string, text: string, colour: string): BlockNode => ({
+  ...makeNode("core/heading", { text, level: "h2" }),
+  id,
+  style: { base: { color: colour } },
+});
+
+const ref = (id: string, refId: string): BlockNode => ({
+  ...makeNode("core/ref", { refId }),
+  id,
+});
+
+const container = (id: string, children: BlockNode[]): BlockNode => ({
+  ...makeNode("core/container", {}, undefined, { default: children }),
+  id,
+});
+
+/**
+ * Each row declares the keys its STYLED nodes should be named by, written out rather than derived.
+ *
+ * Derived expectations restate the implementation and agree with it by construction — including
+ * when both are wrong. Written out, the row is a claim about what the design SHOULD produce, and a
+ * change in key composition has to be defended here rather than silently absorbed.
+ *
+ * Only styled nodes: an unstyled container legitimately gets no rule, so requiring one for every
+ * class in the markup would fail on correct output.
+ */
+const CORPUS: [
+  string,
+  BlockNode,
+  Record<string, BlockNode>,
+  { placed: readonly string[]; onPage: number },
+][] = [
+  [
+    "one placement of one reusable block",
+    container("root", [styled("doc", "Doc", "#aa0001"), ref("p1", "r1")]),
+    { r1: styled("lib", "Lib", "#aa0002") },
+    { placed: ["doc", "2:r1lib"], onPage: 2 },
+  ],
+  [
+    "the SAME block placed twice",
+    container("root", [ref("p1", "r1"), ref("p2", "r1")]),
+    { r1: styled("lib", "Lib", "#aa0003") },
+    // ONE key for two placements: that is what makes editing the block update both.
+    { placed: ["2:r1lib"], onPage: 1 },
+  ],
+  [
+    "a library node sharing an id with a document node",
+    container("root", [styled("same", "Doc", "#aa0004"), ref("p1", "r1")]),
+    { r1: styled("same", "Lib", "#aa0005") },
+    // Two DIFFERENT keys for one id. This is the collision the scoping exists to close.
+    { placed: ["same", "2:r1same"], onPage: 2 },
+  ],
+  [
+    "a reusable block containing a subtree",
+    container("root", [ref("p1", "r1")]),
+    { r1: container("libroot", [styled("libchild", "Child", "#aa0006")]) },
+    { placed: ["2:r1libchild"], onPage: 1 },
+  ],
+  [
+    "a ref NESTED inside a reusable block",
+    container("root", [ref("p1", "r1")]),
+    {
+      r1: container("outer", [styled("a", "A", "#aa0007"), ref("inner", "r2")]),
+      r2: styled("b", "B", "#aa0008"),
+    },
+    // The nested block is named by the block it LIVES in, not by the path taken to reach it.
+    { placed: ["2:r1a", "2:r2b"], onPage: 2 },
+  ],
+  [
+    "a library block the document never places",
+    container("root", [styled("doc", "Doc", "#aa0009")]),
+    { unused: styled("never", "Never", "#aa0010") },
+    // Compiled but not on the page: its rule may exist, and no element carries it.
+    { placed: ["doc"], onPage: 1 },
+  ],
+];
+
+describe("what the sheet writes and what the markup carries", () => {
+  it.each(CORPUS)("%s", (_label, root, refs, expected) => {
+    const document = { root } as never;
+    const classes = documentNodeClasses(document, refs);
+    const css = [
+      compileDocumentCss(document, { classes, refs }),
+      compileDocumentBlockCss(document, classes, refs),
+    ].join("\n");
+    const html = renderToStaticMarkup(
+      <RenderNode
+        node={root}
+        registry={defaultBlockRegistry}
+        refs={refs}
+        classes={classes}
+      />
+    );
+
+    const inMarkup = classesInMarkup(html);
+    const inSheet = classesInSheet(css);
+
+    // Positive control: a fixture that rendered nothing, or compiled nothing, would satisfy every
+    // comparison below vacuously.
+    expect(inMarkup.size).toBeGreaterThan(0);
+    expect(inSheet.size).toBeGreaterThan(0);
+
+    const expectedClasses = expected.placed.map(
+      key => classes.get(key) ?? nodeClass(key)
+    );
+
+    for (const cls of expectedClasses) {
+      // Written by the compiler...
+      expect(inSheet.has(cls), `sheet never wrote ${cls}`).toBe(true);
+    }
+    // ...and carried by exactly the elements that should carry it. A node whose class the sheet
+    // wrote but the markup does not carry is dead CSS; the reverse is an unstyled node.
+    const onPage = expectedClasses.filter(cls => inMarkup.has(cls));
+    expect(onPage).toHaveLength(expected.onPage);
+  });
+
+  it("gives two placements of one block the SAME class", () => {
+    // This is what makes a reusable block reusable: one rule, every placement. Two classes here
+    // would mean editing the block updates one placement and not the other.
+    const root = container("root", [ref("p1", "r1"), ref("p2", "r1")]);
+    const refs = { r1: styled("lib", "Lib", "#bb0001") };
+    const document = { root } as never;
+    const classes = documentNodeClasses(document, refs);
+    const html = renderToStaticMarkup(
+      <RenderNode
+        node={root}
+        registry={defaultBlockRegistry}
+        refs={refs}
+        classes={classes}
+      />
+    );
+    const markup = html.replace(/<style[\s\S]*?<\/style>/g, "");
+
+    expect(markup.match(/Lib/g)).toHaveLength(2);
+    const libClass = classes.get(`${"r1".length}:r1lib`) as string;
+    expect(libClass).toBeDefined();
+    // Both placements carry it, so one rule serves both.
+    expect(markup.split(libClass).length - 1).toBe(2);
+  });
+});

--- a/packages/plugin-page-builder/src/core/style-compiler.ts
+++ b/packages/plugin-page-builder/src/core/style-compiler.ts
@@ -72,6 +72,23 @@ export interface CompileOptions {
    * node can know.
    */
   classes?: ReadonlyMap<string, string>;
+  /**
+   * The reusable-block library this page can reference, keyed by ref id.
+   *
+   * Supplied so a reusable block's OWN styles reach the page. Without it the compiler never sees
+   * those nodes — `walk` visits slots, and a library subtree is reached through `refs` rather than
+   * through the tree — so every style stored on a reusable block was silently dropped while the
+   * editor went on offering the controls that wrote it.
+   */
+  refs?: Record<string, BlockNode>;
+  /**
+   * The ref id whose library subtree is being compiled, when it is one.
+   *
+   * Absent for the document's own nodes. Present, a node is named from {@link refScopedKey}
+   * instead of its bare id, which is what keeps a library node that shares an id with a document
+   * node from wearing the document node's class — and its styles.
+   */
+  refScope?: string;
 }
 
 /**
@@ -121,11 +138,60 @@ export function compileTokensCss(
  */
 export { nodeClassName as nodeClass } from "@nextlyhq/blocks-engine";
 
+/**
+ * The key a node inside a reusable block is named by.
+ *
+ * A node reached through `core/ref` is not in the document's own id space. A block made reusable
+ * from a node that stayed put is the ordinary way to make one, so a library subtree very often
+ * holds an id the document also holds — and naming both from the id alone gives them the same
+ * class, so the referenced node silently wears the document node's styles.
+ *
+ * Length-prefixed rather than joined by a separator, because a separator has to be a character
+ * neither an id nor a ref id can contain, and nothing guarantees that: `("a", "b/c")` and
+ * `("a/b", "c")` would both spell `a/b/c` and two different nodes would share a class. The prefix
+ * makes the split unambiguous whatever the two strings contain.
+ *
+ * Scoped by the ref id rather than by the PLACEMENT, so a reusable block placed twice names its
+ * nodes the same both times and one rule serves every placement. That is what makes editing the
+ * block update everywhere it appears, which is the whole point of a reusable block. It also means
+ * a nested ref is named by the block it lives in, not by the path taken to reach it, so a block
+ * placed directly and through another block resolves to one set of names.
+ */
+export function refScopedKey(refId: string, nodeId: string): string {
+  return `${refId.length}:${refId}${nodeId}`;
+}
+
 /** Every node id in a document, in document order. */
 export function documentNodeIds(doc: BlockDocument): string[] {
   const ids: string[] = [];
   walk(doc.root, node => ids.push(node.id));
   return ids;
+}
+
+/**
+ * Every name a page can style: the document's own node ids, then one ref-scoped key per node of
+ * every reusable block the library holds.
+ *
+ * Both sets go through ONE {@link nodeClassNames} call, because the disambiguating suffix depends
+ * on the whole set. Naming the document from one call and the library from another would let a
+ * document id and a library key hash alike and each be told it was unique.
+ *
+ * The library is read whole rather than only the blocks this document places. A page that places
+ * a block conditionally would otherwise change every other node's disambiguation depending on
+ * which blocks happened to be referenced, so the same library node would be named differently on
+ * two pages and a shared stylesheet could not exist.
+ */
+export function pageStyleKeys(
+  doc: BlockDocument,
+  refs?: Record<string, BlockNode>
+): string[] {
+  const keys = documentNodeIds(doc);
+  for (const refId of Object.keys(refs ?? {}).sort()) {
+    const target = refs?.[refId];
+    if (!target) continue;
+    walk(target, node => keys.push(refScopedKey(refId, node.id)));
+  }
+  return keys;
 }
 
 /**
@@ -143,8 +209,11 @@ export function documentNodeIds(doc: BlockDocument): string[] {
  * on one side only is exactly the disagreement above. A referenced node keeps
  * the undisambiguated class {@link nodeClass} gives it, as it does today.
  */
-export function documentNodeClasses(doc: BlockDocument): Map<string, string> {
-  return nodeClassNames(documentNodeIds(doc));
+export function documentNodeClasses(
+  doc: BlockDocument,
+  refs?: Record<string, BlockNode>
+): Map<string, string> {
+  return nodeClassNames(pageStyleKeys(doc, refs));
 }
 
 /**
@@ -389,7 +458,14 @@ export function compileNodeCss(
 ): string {
   const bps = opts.breakpoints ?? DEFAULT_BREAKPOINTS;
   const remotePatterns = opts.remotePatterns ?? [];
-  const cls = opts.classes?.get(node.id) ?? nodeClassName(node.id);
+  // Named by the key it belongs to, so a library node and a document node holding the same id
+  // stay apart. Both sides derive the key the same way; a class the compiler invents that the
+  // renderer does not is a rule matching nothing.
+  const styleKey =
+    opts.refScope === undefined
+      ? node.id
+      : refScopedKey(opts.refScope, node.id);
+  const cls = opts.classes?.get(styleKey) ?? nodeClassName(styleKey);
   // The document's own class in front of the node's, when the caller supplies
   // one. A node class is a hash of the node id, and two documents can hold the
   // same id — a reusable block rendered in both is the ordinary way — so
@@ -462,39 +538,77 @@ export function compileDocumentCss(
 ): string {
   // Resolved once for the document and passed down, so every node in this
   // stylesheet is named by the same map the markup is named by.
-  const classes = opts.classes ?? documentNodeClasses(doc);
+  const classes = opts.classes ?? documentNodeClasses(doc, opts.refs);
   const nodeOpts = { ...opts, classes };
   const parts: string[] = [];
   walk(doc.root, n => {
     const css = compileNodeCss(n, nodeOpts);
     if (css) parts.push(css);
   });
+  // The library, after the document. A reusable block's own styles are the tier BELOW a
+  // placement's, so at one specificity source order is what makes a placement able to override
+  // the block it places — the same reason the tiers above are emitted whole, one after another.
+  for (const refId of Object.keys(opts.refs ?? {}).sort()) {
+    const target = opts.refs?.[refId];
+    if (!target) continue;
+    walk(target, n => {
+      const css = compileNodeCss(n, { ...nodeOpts, refScope: refId });
+      if (css) parts.push(css);
+    });
+  }
   return parts.join("\n");
 }
 
-/** Emit the shared motion keyframes once, if any node in the document animates. */
-export function compileDocumentMotionCss(doc: BlockDocument): string {
+/**
+ * Emit the shared motion keyframes once, if anything the page renders animates.
+ *
+ * The library counts. A reusable block that animates is on the page as much as a document node
+ * that does, and withholding the keyframes because only a referenced node uses them leaves its
+ * animation naming a rule nobody wrote.
+ */
+export function compileDocumentMotionCss(
+  doc: BlockDocument,
+  refs?: Record<string, BlockNode>
+): string {
   let any = false;
-  walk(doc.root, n => {
+  const check = (n: BlockNode): void => {
     if (n.motion?.entrance && n.motion.entrance !== "none") any = true;
-  });
+  };
+  walk(doc.root, check);
+  for (const target of Object.values(refs ?? {})) {
+    if (target) walk(target, check);
+  }
   return any ? MOTION_KEYFRAMES : "";
 }
 
 /** Collect every node's sanitized per-block custom CSS for the page <style> (spec §4.4). */
 export function compileDocumentBlockCss(
   doc: BlockDocument,
-  classes: ReadonlyMap<string, string> = documentNodeClasses(doc)
+  classes?: ReadonlyMap<string, string>,
+  refs?: Record<string, BlockNode>
 ): string {
+  const map = classes ?? documentNodeClasses(doc, refs);
   const parts: string[] = [];
-  walk(doc.root, n => {
-    if (n.customCss) {
-      const cls = classes.get(n.id) ?? nodeClassName(n.id);
-      const scoped = sanitizeBlockCss(n.customCss, cls);
-      // `.css`, not the result: the object is always truthy, so testing it
-      // would push an empty string for every block that has none.
-      if (scoped.css) parts.push(scoped.css);
-    }
-  });
+  // Named through the same key as every other tier, so a reusable block's custom CSS is anchored
+  // to the class its markup carries. Scoped by the ref it belongs to for the document's nodes as
+  // much as the library's: an unscoped spelling here would re-open the collision the scoped key
+  // exists to close, on this tier alone, and the symptom would be one block's custom CSS silently
+  // styling another.
+  const collect = (n: BlockNode, refScope?: string): void => {
+    if (!n.customCss) return;
+    const key = refScope === undefined ? n.id : refScopedKey(refScope, n.id);
+    const scoped = sanitizeBlockCss(
+      n.customCss,
+      map.get(key) ?? nodeClassName(key)
+    );
+    // `.css`, not the result: the object is always truthy, so testing it
+    // would push an empty string for every block that has none.
+    if (scoped.css) parts.push(scoped.css);
+  };
+  walk(doc.root, n => collect(n));
+  for (const refId of Object.keys(refs ?? {}).sort()) {
+    const target = refs?.[refId];
+    if (target) walk(target, n => collect(n, refId));
+  }
   return parts.join("\n");
 }

--- a/packages/plugin-page-builder/src/render/PageRenderer.tsx
+++ b/packages/plugin-page-builder/src/render/PageRenderer.tsx
@@ -74,17 +74,22 @@ export function PageRenderer({
   // One map for the whole render: the stylesheet below and the markup beneath
   // it must name each node identically, and a hash collision is only visible —
   // and only resolvable the same way twice — from the whole id set at once.
-  const classes = documentNodeClasses(document);
+  // The library is part of the name set, not an extra pass over it. A reusable block's nodes are
+  // named from the ref they belong to, and the disambiguating suffix depends on every name at
+  // once, so the document and the library have to be handed to this together or the two halves
+  // can each be told a colliding key was unique.
+  const classes = documentNodeClasses(document, refs);
   const css = [
     compileTokensCss(scope, tokens),
-    compileDocumentMotionCss(document),
+    compileDocumentMotionCss(document, refs),
     compileDocumentCss(document, {
       breakpoints,
       remotePatterns,
       scope,
       classes,
+      refs,
     }),
-    compileDocumentBlockCss(document, classes),
+    compileDocumentBlockCss(document, classes, refs),
     // `.css` alone: the sanitizer also returns what it removed, and this path
     // renders rather than edits, so there is nowhere to show a warning. The
     // editor reads the same result and displays them.

--- a/packages/plugin-page-builder/src/render/RenderNode.bindings.test.tsx
+++ b/packages/plugin-page-builder/src/render/RenderNode.bindings.test.tsx
@@ -2,7 +2,11 @@ import { describe, it, expect } from "vitest";
 import { renderToStaticMarkup } from "react-dom/server";
 
 import { defaultBlockRegistry } from "../core/registry";
-import { nodeClass } from "../core/style-compiler";
+import {
+  documentNodeClasses,
+  nodeClass,
+  refScopedKey,
+} from "../core/style-compiler";
 import { makeNode } from "../core/tree";
 
 import { RenderNode } from "./RenderNode";
@@ -35,44 +39,43 @@ describe("RenderNode node classes", () => {
     expect(html).toContain("nx-pb-inner-from-map");
   });
 
-  it("does not carry the document's map into a referenced subtree", () => {
-    // A stored subtree can hold an id the document also holds — a block made
-    // reusable from a node that stayed put is the ordinary way. The map is keyed
-    // by id, so carrying it across the boundary hands the referenced node a
-    // class disambiguated for the OTHER node of that id, compiled from styles
-    // that are not its own. Outside the walk means outside the map.
+  it("names a referenced node apart from a document node sharing its id", () => {
+    // A block made reusable from a node that stayed put is the ordinary way to make one, so a
+    // library subtree very often holds an id the document also holds. Naming both from the id
+    // alone gave them the SAME class — and the referenced node silently wore the document node's
+    // styles. Withholding the map did not fix that: for an id with no hash collision the plain
+    // class and the map's entry are the same string.
     const shared = "pb-shared-id";
     const target = {
       ...makeNode("core/heading", { text: "Reused", level: "h2" }),
       id: shared,
     };
+    const twin = {
+      ...makeNode("core/heading", { text: "Original", level: "h2" }),
+      id: shared,
+    };
     const refNode = makeNode("core/ref", { refId: "r1" });
     const root = makeNode("core/container", {}, undefined, {
-      default: [refNode],
+      default: [twin, refNode],
     });
+    const refs = { r1: target };
     const html = renderToStaticMarkup(
       <RenderNode
         node={root}
         registry={defaultBlockRegistry}
-        refs={{ r1: target }}
-        classes={
-          new Map([
-            [root.id, "nx-pb-root-from-map"],
-            [refNode.id, "nx-pb-refnode-from-map"],
-            [shared, "nx-pb-collided-0"],
-          ])
-        }
+        refs={refs}
+        classes={documentNodeClasses({ root } as never, refs)}
       />
     );
-    // A resolved ref renders its target IN ITS PLACE and emits no element of
-    // its own, so the ref node's own class is not in the output at all — it is
-    // reached only by the missing-target placeholder.
-    expect(html).not.toContain("nx-pb-refnode-from-map");
-    // The target must not borrow the entry that its id happens to have here.
-    expect(html).not.toContain("nx-pb-collided-0");
-    expect(html).toContain(nodeClass(shared));
-    // The document's own nodes are still named from the map.
-    expect(html).toContain("nx-pb-root-from-map");
+    const markup = html.replace(/<style[\s\S]*?<\/style>/g, "");
+
+    // Positive control: the document's own node of that id IS named, so a fixture that reached
+    // nothing could not satisfy the assertion below.
+    expect(markup).toContain(nodeClass(shared));
+    // The referenced node is named from its ref, not from the bare id.
+    expect(markup).toContain(nodeClass(refScopedKey("r1", shared)));
+    // And the two names differ, which is the whole point.
+    expect(nodeClass(refScopedKey("r1", shared))).not.toBe(nodeClass(shared));
   });
 
   it("falls back to the plain class for a node the map does not hold", () => {

--- a/packages/plugin-page-builder/src/render/RenderNode.tsx
+++ b/packages/plugin-page-builder/src/render/RenderNode.tsx
@@ -14,7 +14,7 @@ import { cloneElement, isValidElement, type ReactNode } from "react";
 
 import { resolveBindings } from "../core/bindings";
 import type { BlockRegistry } from "../core/registry";
-import { nodeClass } from "../core/style-compiler";
+import { nodeClass, refScopedKey } from "../core/style-compiler";
 import type { BlockNode } from "../core/types";
 import type { RemotePatternInput } from "../core/url-policy";
 
@@ -85,11 +85,22 @@ export interface RenderNodeProps {
    * stylesheet was compiled from, because a class disambiguated in one and not
    * the other names a selector the markup never carries.
    *
-   * A node reached through `core/ref` is not in it — the compiler does not walk
-   * the reusable-block library either — and falls back to its plain class,
-   * which is what both halves already give it.
+   * It spans the document's own ids AND one ref-scoped key per node of every
+   * reusable block, so a library node and a document node holding the same id
+   * are named apart rather than sharing a class.
    */
   classes?: ReadonlyMap<string, string>;
+  /**
+   * The ref id whose library subtree this node belongs to, when it belongs to
+   * one.
+   *
+   * Absent for the document's own nodes. Set at each `core/ref` boundary and
+   * carried down the subtree, so a node is named by the block it lives in
+   * rather than by the path taken to reach it — a nested reusable block
+   * resolves to the same names whether it was placed directly or through
+   * another block, and one rule serves every placement.
+   */
+  refScope?: string;
 }
 
 const REF_TYPE = "core/ref";
@@ -104,9 +115,14 @@ export function RenderNode({
   refs,
   refStack,
   classes,
+  refScope,
 }: RenderNodeProps): ReactNode {
+  // The same key the compiler names this node by. Deriving it differently on
+  // either side writes a stylesheet against a selector the markup never carries.
+  const styleKey =
+    refScope === undefined ? node.id : refScopedKey(refScope, node.id);
   const className = [
-    classes?.get(node.id) ?? nodeClass(node.id),
+    classes?.get(styleKey) ?? nodeClass(styleKey),
     node.customClass,
   ]
     .filter(Boolean)
@@ -129,15 +145,15 @@ export function RenderNode({
         budget={budget}
         refs={refs}
         refStack={[...(refStack ?? []), refId]}
-        // Not this document's map. It is keyed by id, and a stored subtree can
-        // hold an id the document also holds — a block made reusable from a node
-        // that stayed put is the ordinary way — so passing it on would give the
-        // referenced node a class disambiguated for the OTHER node of that id,
-        // compiled from styles that are not its own. The referenced subtree is
-        // outside the walk the map is built from, so it has no entry to inherit
-        // and its nodes take the plain class, which is what the compiler would
-        // name them if it reached them.
-        classes={undefined}
+        // The map DOES carry this subtree, under ref-scoped keys, so it is
+        // threaded rather than withheld. Withholding it was the previous answer
+        // and it did not work: for any id without a hash collision the plain
+        // class and the map's entry are the same string, so a referenced node
+        // sharing an id with a document node still wore that node's class.
+        // Naming it apart is what separates them; the scope below is what does
+        // the naming.
+        classes={classes}
+        refScope={refId}
       />
     );
   }
@@ -161,6 +177,7 @@ export function RenderNode({
           className={className}
           budget={budget ?? { n: 0 }}
           classes={classes}
+          refScope={refScope}
         />
       </BlockErrorBoundary>
     );
@@ -181,6 +198,11 @@ export function RenderNode({
           refs={refs}
           refStack={refStack}
           classes={classes}
+          // Carried down, not reset: a child of a library node is still inside that reusable
+          // block. Dropping it here would name the child from its bare id while its parent was
+          // named from the ref, so the child would collide with a document node of the same id
+          // and the parent would not — the original bug surviving one level down.
+          refScope={refScope}
         />
       ));
     }

--- a/packages/plugin-page-builder/src/render/query/QueryLoop.tsx
+++ b/packages/plugin-page-builder/src/render/query/QueryLoop.tsx
@@ -25,6 +25,14 @@ export interface QueryLoopProps {
   budget: QueryBudget;
   /** The document's node classes, threaded on to the loop template. */
   classes?: ReadonlyMap<string, string>;
+  /**
+   * The ref id whose reusable block this loop lives in, when it lives in one.
+   *
+   * Forwarded unchanged to the template it renders. A loop inside a reusable block is still inside
+   * it, and a template named from bare ids while its ancestors are named from the ref would put
+   * the collision back one level down.
+   */
+  refScope?: string;
 }
 
 export async function QueryLoop({
@@ -32,6 +40,7 @@ export async function QueryLoop({
   registry,
   dataProvider,
   remotePatterns,
+  refScope,
   className,
   budget,
   classes,
@@ -48,6 +57,7 @@ export async function QueryLoop({
       result={result}
       budget={budget}
       classes={classes}
+      refScope={refScope}
     />
   );
 }

--- a/packages/plugin-page-builder/src/render/query/QueryLoopView.tsx
+++ b/packages/plugin-page-builder/src/render/query/QueryLoopView.tsx
@@ -27,9 +27,18 @@ export interface QueryLoopViewProps {
   budget: QueryBudget;
   /** The document's node classes, threaded on to each rendered template node. */
   classes?: ReadonlyMap<string, string>;
+  /**
+   * The ref id whose reusable block this loop lives in, when it lives in one.
+   *
+   * Every template node rendered here is inside that block, so it is named from the ref exactly as
+   * the loop's own ancestors are. Stopping the scope at the loop would name the template from bare
+   * ids and put back the collision one level down.
+   */
+  refScope?: string;
 }
 
 export function QueryLoopView({
+  refScope,
   node,
   registry,
   dataProvider,
@@ -84,6 +93,7 @@ export function QueryLoopView({
               item={item}
               budget={budget}
               classes={classes}
+              refScope={refScope}
             />
           ))}
         </div>


### PR DESCRIPTION
Closes the styling half of task 149, and audit finding B8 with it — they turned out to be one bug.

## What was broken

A reusable block is a `core/ref` node holding a `refId`. Two independent failures met on it.

**1. A referenced node could wear a document node's class.** Both sides named a
node from its id alone. A reusable block is usually made from a node that stayed
put, so the library subtree and the document very often hold the same id — and
the same id gave the same class, so the referenced node inherited styles that
were not its own.

`classes={undefined}` at the boundary (#571) did not fix this. `nodeClassNames`
only appends a `-N` suffix when a hash bucket holds more than one distinct id, so
for any id without a collision the plain class and the map's entry are **the same
string**. That PR changed behaviour only in the disambiguated branch — the rare
one — and its test passed because it hand-built a map entry the real
`documentNodeClasses` can never produce.

**2. The compiler never walked the library at all.** `walk` visits `node.slots`,
and a library subtree is reached through `refs`, which the compiler was never
given. So every `style`, `customCss` and `motion` stored on a reusable block was
silently dropped while the editor went on offering the controls that wrote it.

## The fix

A library node is named from **the block it lives in**, not from its id:

```
refScopedKey(refId, nodeId) = `${refId.length}:${refId}${nodeId}`
```

- **Length-prefixed, not separator-joined.** A separator has to be a character
  neither an id nor a ref id can contain, and nothing guarantees one: `("a","b/c")`
  and `("a/b","c")` would both spell `a/b/c` and two nodes would share a class.
- **Hashed with the engine's existing `nodeClassName`** — no third digest. A
  second digest is a second thing to disagree.
- **Scoped by the OWNING block, not the placement.** A block placed twice keeps
  one set of names, so one rule serves both and editing the block updates every
  placement. A nested block is named by the block it lives in rather than the path
  taken to reach it, so placing it directly and through another block resolves to
  the same names.
- **One `nodeClassNames` call over document ids AND library keys.** The
  disambiguating suffix depends on the whole set; two calls could each be told a
  colliding key was unique.

The compiler now walks the library on all three tiers — node styles, custom CSS,
motion keyframes — and the library is emitted after the document, so at one
specificity a placement can still override the block it places.

## Verification

`ref-key-agreement.test.tsx` asserts the property rather than an instance: over a
corpus of ref shapes, the classes the sheet writes are the classes the markup
carries. Expectations are **written into each fixture**, not derived — a derived
expectation restates the implementation and agrees with it by construction,
including when both are wrong.

Rows include a block placed twice, a library node sharing an id with a document
node, a subtree inside a library block, a ref nested inside a ref, and a library
block the document never places. Every row carries a positive control, because a
fixture that rendered nothing would satisfy every set comparison vacuously.

**Three stubs, each failing only its own rows:**

| Stub | Failed |
|---|---|
| renderer drops the scope at the ref boundary | 6 of 7 |
| compiler stops walking the library | 5 of 7 |
| scope not carried through slots | exactly the 2 nesting rows |

That third one is not hypothetical — I shipped it. Threading the scope at the
`core/ref` boundary alone left every child of a library node named from its bare
id, so the collision survived one level down. The corpus caught it; a
single-depth test would not have.

### ⚠️ A previously passing test now asserts the opposite

`does not carry the document's map into a referenced subtree` encoded the old
behaviour and passed because of it. It is replaced by `names a referenced node
apart from a document node sharing its id`, which pins the same scenario with a
positive control. Flagging it because a reviewer seeing a flipped assertion would
reasonably assume a regression.

565 tests pass in the package; typecheck and lint clean.

## Deliberately NOT in this PR

**Making a ref PLACEMENT stylable.** A resolved `core/ref` renders its target *in
its place* and emits no element of its own, so a rule written for the placement's
class matches nothing. Fixing that is a rendering change, not a naming one, and
it is the remaining half of task 149. Named rather than dropped.
