### PR TITLE
test(blocks-react): run the prune recompile against a real breakpoint

### DIFF
--- a/packages/blocks-react/src/page-renderer.test.tsx
+++ b/packages/blocks-react/src/page-renderer.test.tsx
@@ -4436,6 +4436,44 @@ describe("PageRenderer", () => {
       expect(html).not.toContain("#ff0000");
     });
 
+    it("recompiles a real breakpoint's rules without the placeholder's", async () => {
+      // Every other `styleContext` fixture declares empty breakpoint lists, so
+      // the recompile-after-prune path had never run with a breakpoint at all:
+      // a responsive rule belonging to a pruned node could have shipped inside
+      // its media query and no test would have looked there.
+      const ahead = doc(
+        node("a", "test/text", {
+          version: 9,
+          props: { value: "ahead" },
+          styles: { base: { narrow: { color: "#ff0000" } } },
+        }),
+        node("b", "test/text", {
+          props: { value: "healthy" },
+          styles: { base: { narrow: { color: "#00ff00" } } },
+        })
+      );
+
+      const html = await renderToHtml(
+        <PageRenderer
+          document={ahead}
+          blocks={createBlockResolver([text as AnyBlockDefinition])}
+          styleContext={{
+            breakpoints: {
+              viewport: [{ id: "narrow", label: "Narrow", maxWidth: 600 }],
+              container: [],
+            },
+            limits: DEFAULT_LIMITS,
+          }}
+        />
+      );
+
+      // The breakpoint really compiled, so the assertions below are about the
+      // prune rather than about a query that was never emitted.
+      expect(html).toContain("max-width: 600px");
+      expect(html).toContain("#00ff00");
+      expect(html).not.toContain("#ff0000");
+    });
+
     it("does not trust a stored stylesheet when a node becomes a placeholder", async () => {
       // A knowable placeholder emits only a hidden marker, so a sheet compiled
       // for the markup it WOULD have rendered ships rules for content that is


### PR DESCRIPTION
## What

Every `styleContext` fixture in `page-renderer.test.tsx` — all nine of them — declared empty breakpoint lists:

```ts
styleContext={{ breakpoints: { viewport: [], container: [] } }}
```

So the recompile-after-prune path had **never run with a breakpoint at all**. A responsive rule belonging to a pruned node could ship inside its media query and nothing would have looked there.

Task 153 finding C6, second half. Test-only, so no changeset.

## The test

A document with two nodes, both carrying a rule under a real `narrow` viewport breakpoint: one version-ahead (so it prunes to a placeholder), one healthy. It asserts three things, and the first is what makes the other two mean anything:

- `max-width: 600px` is present — the breakpoint really compiled, so this is about the prune rather than about a query that was never emitted
- the healthy node's rule ships
- the pruned node's rule does not

Stub-verified: neutering the prune fails exactly this test.

## Note

The fixture is typed rather than cast. `BreakpointDef` requires a `label`, and vitest passed without one while `tsc` did not — worth knowing, since running the suite alone would have let this through.

## Still open from C6

The first half of the finding is **confirmed and not fixed here**: `core/embed` with an empty `src` and `core/image` with no usable source render nothing, yet their node rules still ship. Verified with a positive control, since my first probe used a property that never compiles and produced a false negative:

| fixture | result |
| --- | --- |
| `core/image` **with** a source (control) | rule present |
| `core/image` with no source | **rule shipped** |
| `core/embed` with no source | **rule shipped** |

Fixing it needs a design decision rather than a patch: `rendersOwnMarkup` is deliberately generic (migration failure, unregistered type, version-ahead) and teaching it two block names by hand would couple the renderer to specific blocks. The clean shape is for a block to DECLARE that it renders nothing for given props, which is new surface on the block contract and belongs in its own PR.