### PR TITLE
fix(nextly): refuse to store email provider credentials without an encryption key

### DIFF
--- a/.changeset/email-provider-secret-required.md
+++ b/.changeset/email-provider-secret-required.md
@@ -1,0 +1,30 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+Refuse to save email provider credentials when `NEXTLY_SECRET` is not set, instead of storing them readable.
+
+A provider's configuration holds SMTP passwords and API keys. Without a secret to encrypt them under, Nextly previously wrote them to the database as plain JSON. Saving a provider in that state now fails with a message naming the variable to set, matching how webhook signing secrets have always behaved.
+
+Providers stored before this change remain readable, so an existing install can still open, rotate, or delete them.

--- a/packages/nextly/src/domains/email/__tests__/email-provider-secret-required.test.ts
+++ b/packages/nextly/src/domains/email/__tests__/email-provider-secret-required.test.ts
@@ -1,0 +1,188 @@
+/**
+ * Tests for EmailProviderService when `NEXTLY_SECRET` is absent.
+ *
+ * Lives in its own file because the env mock is hoisted per-file: the sibling
+ * suite pins a secret for every test it runs, and the behaviour under test here
+ * is what happens when there is none.
+ *
+ * A provider's `configuration` holds SMTP passwords and API keys. Without a
+ * secret to encrypt them under, the only two options are to refuse the write or
+ * to store the credential readable. The webhook domain already chose refusal for
+ * the same threat (`domains/webhooks/secret.ts`), and these tests pin email to
+ * the same posture.
+ */
+
+import type { DrizzleAdapter } from "@nextlyhq/adapter-drizzle";
+import Database from "better-sqlite3";
+import { drizzle } from "drizzle-orm/better-sqlite3";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+import { NextlyError } from "../../../errors";
+import { emailProvidersSqlite } from "../../../schemas/email-providers/sqlite";
+import type { Logger } from "../../../services/shared";
+import { EmailProviderService } from "../services/email-provider-service";
+
+// The whole point of this file: no secret is configured.
+vi.mock("../../../lib/env", () => ({
+  env: {
+    NEXTLY_SECRET: undefined,
+    DB_DIALECT: "sqlite",
+    DATABASE_URL: undefined,
+    NODE_ENV: "test",
+  },
+}));
+
+function makeAdapter(db: ReturnType<typeof drizzle>): DrizzleAdapter {
+  return {
+    dialect: "sqlite" as const,
+    getDrizzle: () => db,
+    getCapabilities: () => ({ dialect: "sqlite" as const }),
+    connect: async () => {},
+    disconnect: async () => {},
+    executeQuery: async () => [],
+    transaction: async (fn: (tx: unknown) => Promise<unknown>) => fn(db),
+  } as unknown as DrizzleAdapter;
+}
+
+const logger: Logger = {
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  debug: vi.fn(),
+};
+
+function createInMemoryDb() {
+  const sqlite = new Database(":memory:");
+  sqlite.exec(`
+    CREATE TABLE IF NOT EXISTS email_providers (
+      id            TEXT    PRIMARY KEY,
+      name          TEXT    NOT NULL,
+      type          TEXT    NOT NULL,
+      from_email    TEXT    NOT NULL,
+      from_name     TEXT,
+      configuration TEXT    NOT NULL,
+      is_default    INTEGER NOT NULL DEFAULT 0,
+      is_active     INTEGER NOT NULL DEFAULT 1,
+      created_at    INTEGER NOT NULL DEFAULT (strftime('%s','now') * 1000),
+      updated_at    INTEGER NOT NULL DEFAULT (strftime('%s','now') * 1000)
+    );
+  `);
+  // No `schema`/`relations` option: these tests only use `db.select()`, never
+  // the relational query API that a schema map exists to type.
+  const db = drizzle({ client: sqlite });
+  return { sqlite, db };
+}
+
+const INPUT = {
+  name: "SMTP",
+  type: "smtp" as const,
+  fromEmail: "noreply@example.com",
+  fromName: "App",
+  configuration: {
+    host: "smtp.example.com",
+    port: 587,
+    auth: { user: "u", pass: "super-secret-password" },
+  },
+  isDefault: false,
+  isActive: true,
+};
+
+describe("EmailProviderService without NEXTLY_SECRET", () => {
+  let sqlite: Database.Database;
+  let db: ReturnType<typeof drizzle>;
+  let service: EmailProviderService;
+
+  beforeEach(() => {
+    const made = createInMemoryDb();
+    sqlite = made.sqlite;
+    db = made.db;
+    service = new EmailProviderService(makeAdapter(db), logger);
+  });
+
+  afterEach(() => {
+    sqlite.close();
+  });
+
+  it("refuses to create a provider rather than storing the credential readable", async () => {
+    await expect(service.createProvider(INPUT)).rejects.toBeInstanceOf(
+      NextlyError
+    );
+  });
+
+  it("names the missing variable so the remedy does not require reading source", async () => {
+    // The operator hitting this is one environment variable away from working.
+    // A generic "unexpected error" would send them to the server logs for a
+    // fact the message can carry safely: `NEXTLY_SECRET` is a variable name,
+    // not a secret.
+    const error = await service.createProvider(INPUT).catch((e: unknown) => e);
+
+    expect(error).toBeInstanceOf(NextlyError);
+    expect((error as NextlyError).publicMessage).toContain("NEXTLY_SECRET");
+  });
+
+  it("writes no row when it refuses", async () => {
+    // A refusal that still inserted would be worse than the bug it replaces:
+    // a provider row that cannot be decrypted and that nothing will retry.
+    await service.createProvider(INPUT).catch(() => undefined);
+
+    const rows = await db.select().from(emailProvidersSqlite);
+    expect(rows).toHaveLength(0);
+  });
+
+  it("stores the credential nowhere the database can reveal it", async () => {
+    // The positive control for this whole file. Before the fix this test fails
+    // by FINDING the password, which is the exact defect; asserting only that
+    // an error was thrown would pass against a service that threw for some
+    // unrelated reason while still writing the row.
+    await service.createProvider(INPUT).catch(() => undefined);
+
+    const dump = JSON.stringify(
+      sqlite.prepare("SELECT * FROM email_providers").all()
+    );
+    expect(dump).not.toContain("super-secret-password");
+  });
+
+  it("refuses to update a provider's configuration for the same reason", async () => {
+    // Update re-encrypts a merged config, so it is a second write path to the
+    // same column and needs its own guard, not merely the one on create.
+    sqlite
+      .prepare(
+        `INSERT INTO email_providers
+           (id, name, type, from_email, configuration, is_default, is_active)
+         VALUES (?, ?, ?, ?, ?, 0, 1)`
+      )
+      .run("p1", "SMTP", "smtp", "noreply@example.com", JSON.stringify({}));
+
+    await expect(
+      service.updateProvider("p1", {
+        configuration: { auth: { user: "u", pass: "another-secret" } },
+      })
+    ).rejects.toBeInstanceOf(NextlyError);
+  });
+
+  it("still reads a provider that was stored before the guard existed", async () => {
+    // Installs that already wrote plaintext must stay readable. Refusing to
+    // decrypt them would convert an old security bug into new data loss, and
+    // would hide the very rows an operator needs to find and rotate.
+    sqlite
+      .prepare(
+        `INSERT INTO email_providers
+           (id, name, type, from_email, configuration, is_default, is_active)
+         VALUES (?, ?, ?, ?, ?, 0, 1)`
+      )
+      .run(
+        "legacy",
+        "Legacy",
+        "resend",
+        "old@example.com",
+        JSON.stringify({ apiKey: "re_stored_in_the_clear" })
+      );
+
+    const provider = await service.getProvider("legacy");
+    expect(provider.id).toBe("legacy");
+    // Masked on the public read path, as any provider is.
+    expect(JSON.stringify(provider.configuration)).not.toContain(
+      "re_stored_in_the_clear"
+    );
+  });
+});

--- a/packages/nextly/src/domains/email/__tests__/email-provider-secret-required.test.ts
+++ b/packages/nextly/src/domains/email/__tests__/email-provider-secret-required.test.ts
@@ -64,8 +64,12 @@ function createEmailProvidersTable(sqlite: Database.Database): void {
   const { tables } = getCoreSchema("sqlite");
   const spec = tables.find(t => t.name === "email_providers");
   if (!spec) {
-    throw new Error(
-      "email_providers is absent from the core schema — the fixture can no longer be derived from it."
+    // A vitest failure rather than a thrown error: the table vanishing from
+    // the core schema is a broken precondition of this fixture, not a runtime
+    // fault, and reporting it as the test failure it is names the file that
+    // needs updating. `expect.fail` returns `never`, so `spec` narrows below.
+    expect.fail(
+      "email_providers is absent from the core schema — this fixture can no longer be derived from it."
     );
   }
   const body = createTableBody(spec, (id: string) => `"${id}"`);

--- a/packages/nextly/src/domains/email/__tests__/email-provider-secret-required.test.ts
+++ b/packages/nextly/src/domains/email/__tests__/email-provider-secret-required.test.ts
@@ -19,7 +19,9 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 import { NextlyError } from "../../../errors";
 import { emailProvidersSqlite } from "../../../schemas/email-providers/sqlite";
+import { getCoreSchema } from "../../../schemas";
 import type { Logger } from "../../../services/shared";
+import { createTableBody } from "../../schema/pipeline/sql-templates/create-table-body";
 import { EmailProviderService } from "../services/email-provider-service";
 
 // The whole point of this file: no secret is configured.
@@ -51,22 +53,28 @@ const logger: Logger = {
   debug: vi.fn(),
 };
 
+/**
+ * Render `email_providers` from the same core schema the product ships, rather
+ * than hand-copying a CREATE TABLE. A security regression suite is exactly the
+ * one that must not certify a shape production no longer has: a fixture written
+ * by hand keeps passing after the real column list moves, and reports safety it
+ * never re-checked.
+ */
+function createEmailProvidersTable(sqlite: Database.Database): void {
+  const { tables } = getCoreSchema("sqlite");
+  const spec = tables.find(t => t.name === "email_providers");
+  if (!spec) {
+    throw new Error(
+      "email_providers is absent from the core schema — the fixture can no longer be derived from it."
+    );
+  }
+  const body = createTableBody(spec, (id: string) => `"${id}"`);
+  sqlite.exec(`CREATE TABLE "email_providers" (\n${body}\n)`);
+}
+
 function createInMemoryDb() {
   const sqlite = new Database(":memory:");
-  sqlite.exec(`
-    CREATE TABLE IF NOT EXISTS email_providers (
-      id            TEXT    PRIMARY KEY,
-      name          TEXT    NOT NULL,
-      type          TEXT    NOT NULL,
-      from_email    TEXT    NOT NULL,
-      from_name     TEXT,
-      configuration TEXT    NOT NULL,
-      is_default    INTEGER NOT NULL DEFAULT 0,
-      is_active     INTEGER NOT NULL DEFAULT 1,
-      created_at    INTEGER NOT NULL DEFAULT (strftime('%s','now') * 1000),
-      updated_at    INTEGER NOT NULL DEFAULT (strftime('%s','now') * 1000)
-    );
-  `);
+  createEmailProvidersTable(sqlite);
   // No `schema`/`relations` option: these tests only use `db.select()`, never
   // the relational query API that a schema map exists to type.
   const db = drizzle({ client: sqlite });
@@ -145,13 +153,17 @@ describe("EmailProviderService without NEXTLY_SECRET", () => {
   it("refuses to update a provider's configuration for the same reason", async () => {
     // Update re-encrypts a merged config, so it is a second write path to the
     // same column and needs its own guard, not merely the one on create.
-    sqlite
-      .prepare(
-        `INSERT INTO email_providers
-           (id, name, type, from_email, configuration, is_default, is_active)
-         VALUES (?, ?, ?, ?, ?, 0, 1)`
-      )
-      .run("p1", "SMTP", "smtp", "noreply@example.com", JSON.stringify({}));
+    await db.insert(emailProvidersSqlite).values({
+      id: "p1",
+      name: "SMTP",
+      type: "smtp",
+      fromEmail: "noreply@example.com",
+      configuration: {},
+      isDefault: false,
+      isActive: true,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
 
     await expect(
       service.updateProvider("p1", {
@@ -164,19 +176,19 @@ describe("EmailProviderService without NEXTLY_SECRET", () => {
     // Installs that already wrote plaintext must stay readable. Refusing to
     // decrypt them would convert an old security bug into new data loss, and
     // would hide the very rows an operator needs to find and rotate.
-    sqlite
-      .prepare(
-        `INSERT INTO email_providers
-           (id, name, type, from_email, configuration, is_default, is_active)
-         VALUES (?, ?, ?, ?, ?, 0, 1)`
-      )
-      .run(
-        "legacy",
-        "Legacy",
-        "resend",
-        "old@example.com",
-        JSON.stringify({ apiKey: "re_stored_in_the_clear" })
-      );
+    await db.insert(emailProvidersSqlite).values({
+      id: "legacy",
+      name: "Legacy",
+      type: "resend",
+      fromEmail: "old@example.com",
+      // The shape an install that wrote before the guard would hold: the
+      // configuration object itself, not a ciphertext string.
+      configuration: { apiKey: "re_stored_in_the_clear" },
+      isDefault: false,
+      isActive: true,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
 
     const provider = await service.getProvider("legacy");
     expect(provider.id).toBe("legacy");

--- a/packages/nextly/src/domains/email/services/email-provider-service.ts
+++ b/packages/nextly/src/domains/email/services/email-provider-service.ts
@@ -123,19 +123,42 @@ export class EmailProviderService extends BaseService {
 
   /**
    * Encrypt a configuration JSON object for storage.
-   * Returns the encrypted string, or the original object if no secret is configured.
+   *
+   * Refuses rather than degrading. A provider's configuration holds SMTP
+   * passwords and API keys, so with no secret to encrypt them under the only
+   * alternative is to write the credential readable to anyone with database
+   * access. `domains/webhooks/secret.ts` already refuses for the same threat;
+   * this keeps the two consistent instead of leaving the higher-value
+   * credential on the weaker policy.
+   *
+   * The message names the variable because the operator is one environment
+   * setting away from working, and a variable name is not itself a secret.
    */
-  private encryptConfiguration(
-    config: Record<string, unknown>
-  ): Record<string, unknown> | string {
+  private encryptConfiguration(config: Record<string, unknown>): string {
     if (!this.encryptionSecret) {
-      return config;
+      throw new NextlyError({
+        code: "BUSINESS_RULE_VIOLATION",
+        publicMessage:
+          "Email provider credentials cannot be saved because NEXTLY_SECRET is not set. " +
+          "Set it in the environment and restart — provider passwords and API keys are " +
+          "encrypted under it, and without it they would be stored readable.",
+        statusCode: 422,
+        logContext: { reason: "email-provider-no-encryption-key" },
+      });
     }
     return encrypt(JSON.stringify(config), this.encryptionSecret);
   }
 
   /**
    * Decrypt a stored configuration value back to a JSON object.
+   *
+   * Deliberately more permissive than its write counterpart: it still accepts a
+   * non-string stored value, which is what an install that wrote configuration
+   * before the write path refused would have. Refusing to read those rows would
+   * turn a credential stored in the clear into a provider nobody can open,
+   * rotate, or delete — hiding exactly the records an operator needs to find.
+   * The public read path masks them like any other, so tightening this would
+   * cost recoverability and buy no confidentiality.
    */
   private decryptConfiguration(
     stored: Record<string, unknown> | string


### PR DESCRIPTION
Closes left-task 157.

## What and why

`EmailProviderService.encryptConfiguration` returned its argument unchanged when `NEXTLY_SECRET` was unset, and both write paths stored that result. A provider's `configuration` holds SMTP passwords and API keys, so an install without the variable wrote credentials to `email_providers.configuration` as readable JSON. The method's `Record<string, unknown> | string` return type existed only to carry that branch; it is now `string`.

The webhook domain already refuses for the same threat (`domains/webhooks/secret.ts` throws rather than store a signing secret in the clear), so email was the weaker policy applied to the higher-value credential. That file's own header even claims webhook secrets are "protected exactly as email provider credentials already are" — this makes the claim true.

**Both write paths are guarded.** `updateProvider` re-encrypts a merged configuration, so it is a second write to the same column and needs its own coverage, not merely `createProvider`'s.

## Severity, stated honestly

The task was originally filed P1 and has been **revised down to P2**. `NEXTLY_SECRET` is already a hard production requirement enforced at boot (`shared/lib/env.ts:87-95`, min 32 chars), so the vulnerable branch is unreachable in a normal production deployment. What remains genuinely exposed, given `isProd = NODE_ENV === "production"`:

- every development and test database, where real API keys get pasted to test delivery;
- any deployment where `NODE_ENV` is not exactly `"production"` — `next start` sets it, so Vercel is covered, but a container running built output directly or a staging box on `NODE_ENV=staging` skips the boot gate *and* stores plaintext.

## Deliberate asymmetry between read and write

`decryptConfiguration` still accepts a non-string stored value. Refusing to read rows written before this guard would convert an old confidentiality bug into new data loss, leaving a provider nobody can open, rotate, or delete — hiding exactly the records an operator needs to find. Those rows are masked on the public read path like any other. A test pins this.

## Error shape

`BUSINESS_RULE_VIOLATION` / 422 with a public message naming `NEXTLY_SECRET`, rather than webhooks' opaque `NextlyError.internal`. Webhooks is a server-internal path with no UI; this one is reached from the admin provider form, where "An unexpected error occurred" would send a developer to the server logs for a fact the message can carry safely — a variable name is not a secret. This follows the precedent already set in this domain by `email-service.ts:657-662`.

## Test plan

Six tests in a new file (its own file because the env mock is hoisted per-file and the sibling suite pins a secret for every test it runs):

- refuses to create; refuses to update
- names the missing variable in the public message
- writes no row when it refuses
- **positive control:** dumps the raw table and asserts the password is absent. Before the fix this fails by *finding* `super-secret-password` in the row, which is the defect itself. Asserting only "an error was thrown" would pass against a service that threw for an unrelated reason while still writing.
- regression guard: a provider stored before the guard is still readable

Verified:

- `vitest run src/domains/email` — **baseline 19 files / 136 tests, this branch 20 / 142.** Exactly the 6 new tests, zero regressions.
- `check-types` — identical to baseline. The only error is a pre-existing `@nextlyhq/blocks-engine` unbuilt-package resolution failure in `block-manifest-engine-parity.test.ts`, present on `main` too.
- `lint` — clean at `--max-warnings 0`.

Worth noting: my first version of the test did not compile, and it only surfaced because new test files *are* typechecked. The sibling `email-provider-service.test.ts` makes the identical `drizzle({ client, schema })` call and passes solely because it sits on `tsconfig.tests.json`'s opt-out list. I fixed the call rather than adding myself to that list, since the file documents it as "an opt-out that shrinks". Under drizzle v1 the `schema` option was replaced by `relations`, and these tests only use `db.select()`.

## Pre-existing issues, not introduced here

- `block-manifest-engine-parity.test.ts` type error above (unbuilt package in a fresh worktree).
- Nothing seeds a provider at boot; every `createProvider`/`updateProvider` caller is an explicit user action via the dispatcher, REST, or Direct API. The refusal cannot fire during startup.

Changeset added: yes (patch, all 22 fixed-group packages, generated from `.changeset/config.json`).