### PR TITLE
docs(plugin-page-builder): state what the remote allowlist actually covers

### DIFF
--- a/packages/plugin-page-builder/src/admin/store/EditorProvider.tsx
+++ b/packages/plugin-page-builder/src/admin/store/EditorProvider.tsx
@@ -90,10 +90,11 @@ export function EditorProvider({
    * `pageBuilder({ remotePatterns })` gets the same allowlist in the canvas
    * that the editor's compiler enforces.
    *
-   * A caller passing nothing still gets an empty list, and an empty list is
-   * STRICTER than an absent one: the canvas drops remote backgrounds rather
-   * than showing forbidden ones, so the failure costs preview fidelity and not
-   * safety. That is the deliberate direction for a value that did not arrive.
+   * An omitted value is normalised to the empty list here and again by the
+   * compiler, so the two are the same state: nothing remote is allowed. A
+   * caller that supplies none therefore gets a canvas that drops remote
+   * backgrounds rather than one that shows forbidden ones, which costs preview
+   * fidelity and not safety.
    */
   remotePatterns?: readonly RemotePatternInput[];
   /**

--- a/packages/plugin-page-builder/src/admin/store/EditorProvider.tsx
+++ b/packages/plugin-page-builder/src/admin/store/EditorProvider.tsx
@@ -84,14 +84,16 @@ export function EditorProvider({
    * exist.
    *
    * The registered surfaces — `PageBuilderEditView` and `PageBuilderField` —
-   * cannot supply this yet. Their props come from the admin's edit-view
-   * contract, and a plugin's own configuration has no route to a client
-   * component, so a host that configures `PageRenderer.remotePatterns` still
-   * gets an empty list in the canvas. The preview is then stricter than the
-   * page: it drops allowed remote backgrounds rather than showing forbidden
-   * ones, so the gap costs fidelity and not safety. Closing it needs a channel
-   * for plugin configuration to reach the client, which is a framework
-   * capability rather than something this component can reach for.
+   * supply it through `useRemotePatterns()`, which reads the plugin's own
+   * `clientConfig`. That channel is what carries server-side plugin
+   * configuration to a client component, so a host declaring
+   * `pageBuilder({ remotePatterns })` gets the same allowlist in the canvas
+   * that the editor's compiler enforces.
+   *
+   * A caller passing nothing still gets an empty list, and an empty list is
+   * STRICTER than an absent one: the canvas drops remote backgrounds rather
+   * than showing forbidden ones, so the failure costs preview fidelity and not
+   * safety. That is the deliberate direction for a value that did not arrive.
    */
   remotePatterns?: readonly RemotePatternInput[];
   /**

--- a/packages/plugin-page-builder/src/plugin.ts
+++ b/packages/plugin-page-builder/src/plugin.ts
@@ -33,22 +33,26 @@ export interface PageBuilderOptions {
    * only on `PageRenderer` because the canvas runs in the browser, where a
    * component prop from the host's server config cannot reach it.
    *
-   * **What this covers, exactly.** It is enforced by this package: the editor
-   * canvas, the style compiler that validates `url()` in custom CSS and style
-   * values, and the embed HTML sanitizer. Those are the surfaces that read it.
+   * Set the SAME value on `PageRenderer.remotePatterns` from
+   * `@nextlyhq/plugin-page-builder/render`. These are two assignments, not one:
+   * this configures the editor, and that renderer reads only its own prop.
+   * Setting one alone produces a mismatch in whichever direction you set it, so
+   * a shared constant in the host is what keeps them equal.
    *
-   * **What it does NOT cover.** `@nextlyhq/blocks-react` — the renderer the
-   * blocks pipeline is moving to — has no remote-host control at all. It
-   * allowlists URL SCHEMES (`http`/`https` only, with control characters and
+   * **What this covers.** Structured style values and block props, through
+   * `isFetchableUrl`; the embed HTML sanitizer; the editor canvas; and the CSP
+   * builder. **Not custom CSS** — `sanitizeCustomCss` takes no patterns and
+   * removes every off-origin URL unconditionally, so a CDN you allowlist here
+   * still disappears from hand-written CSS. That surface is stricter than this
+   * value, not governed by it.
+   *
+   * **What it does NOT reach.** `@nextlyhq/blocks-react`, the renderer the
+   * blocks pipeline is moving to, has no remote-host control and no such prop.
+   * It allowlists URL SCHEMES (`http`/`https`, with control characters and
    * quote-breaking characters refused), which stops a `javascript:` value but
    * not a third-party host: a `background` image pointed at any https origin
-   * compiles and ships. Verified against the engine's compiler, not inferred.
-   *
-   * So a page rendered through that renderer is not restricted by this value,
-   * and there is no second prop to set — an earlier version of this comment
-   * told the reader to mirror it onto `PageRenderer.remotePatterns`, which has
-   * never existed on either renderer. Do not assume a published page is bounded
-   * by what you configure here until that gap is closed.
+   * compiles and ships. Measured against the engine's compiler, not inferred.
+   * A page rendered through THAT renderer is not bounded by this value.
    *
    * Object patterns only. This value is serialized to the browser and a `URL`
    * does not survive that: it would arrive as a string. Converting one here

--- a/packages/plugin-page-builder/src/plugin.ts
+++ b/packages/plugin-page-builder/src/plugin.ts
@@ -34,25 +34,27 @@ export interface PageBuilderOptions {
    * component prop from the host's server config cannot reach it.
    *
    * Set the SAME value on `PageRenderer.remotePatterns` from
-   * `@nextlyhq/plugin-page-builder/render`. These are two assignments, not one:
-   * this configures the editor, and that renderer reads only its own prop.
-   * Setting one alone produces a mismatch in whichever direction you set it, so
-   * a shared constant in the host is what keeps them equal.
+   * `@nextlyhq/plugin-page-builder/render`, and pass it to `cspDirectives()` or
+   * `cspHeaderValue()`. Three assignments, not one: each reads only what it was
+   * given, and the CSP helpers default to an empty list, so a host that sets
+   * this alone emits a self-only policy that blocks the CDN the editor and the
+   * renderer both accept. A shared constant in the host is what keeps them equal.
    *
-   * **What this covers.** Structured style values and block props, through
-   * `isFetchableUrl`; the embed HTML sanitizer; the editor canvas; and the CSP
-   * builder. **Not custom CSS** — `sanitizeCustomCss` takes no patterns and
-   * removes every off-origin URL unconditionally, so a CDN you allowlist here
-   * still disappears from hand-written CSS. That surface is stricter than this
-   * value, not governed by it.
+   * **What reads it.** Structured style values and block props, through
+   * `isFetchableUrl`; the embed HTML sanitizer; the editor canvas.
    *
-   * **What it does NOT reach.** `@nextlyhq/blocks-react`, the renderer the
-   * blocks pipeline is moving to, has no remote-host control and no such prop.
-   * It allowlists URL SCHEMES (`http`/`https`, with control characters and
-   * quote-breaking characters refused), which stops a `javascript:` value but
-   * not a third-party host: a `background` image pointed at any https origin
-   * compiles and ships. Measured against the engine's compiler, not inferred.
-   * A page rendered through THAT renderer is not bounded by this value.
+   * **Custom CSS does not.** `sanitizeCustomCss` takes no patterns and drops
+   * every ABSOLUTE url, including one naming the site's own origin — compilation
+   * has no document origin to compare against, so a scheme is all it can see.
+   * Relative paths survive. That surface is stricter than this value rather than
+   * governed by it, and allowlisting a CDN here does not make it usable there.
+   *
+   * **`@nextlyhq/blocks-react` does not read it either**, and has no equivalent.
+   * Its two URL checks are narrower and unrelated to hosts: the engine's CSS
+   * compiler allows only `http` and `https` inside `url()`, while a block's
+   * attribute props reject `javascript:`, `vbscript:` and `data:` and admit any
+   * other scheme. Neither compares a host, so a page rendered through it is not
+   * bounded by this value.
    *
    * Object patterns only. This value is serialized to the browser and a `URL`
    * does not survive that: it would arrive as a string. Converting one here

--- a/packages/plugin-page-builder/src/plugin.ts
+++ b/packages/plugin-page-builder/src/plugin.ts
@@ -38,7 +38,14 @@ export interface PageBuilderOptions {
    * `cspHeaderValue()`. Three assignments, not one: each reads only what it was
    * given, and the CSP helpers default to an empty list, so a host that sets
    * this alone emits a self-only policy that blocks the CDN the editor and the
-   * renderer both accept. A shared constant in the host is what keeps them equal.
+   * renderer both accept.
+   *
+   * A shared constant aligns them as far as CSP can go, which is not all the
+   * way. A pattern constraining `pathname` or `search` is accepted here and by
+   * the renderer, but `cspDirectives()` omits its host rather than widening the
+   * policy to the whole origin — CSP cannot express a path constraint. Read
+   * `unexpressibleHosts()` to see what was refused and write that source
+   * yourself.
    *
    * **What reads it.** Structured style values and block props, through
    * `isFetchableUrl`; the embed HTML sanitizer; the editor canvas.
@@ -50,11 +57,13 @@ export interface PageBuilderOptions {
    * governed by it, and allowlisting a CDN here does not make it usable there.
    *
    * **`@nextlyhq/blocks-react` does not read it either**, and has no equivalent.
-   * Its two URL checks are narrower and unrelated to hosts: the engine's CSS
-   * compiler allows only `http` and `https` inside `url()`, while a block's
-   * attribute props reject `javascript:`, `vbscript:` and `data:` and admit any
-   * other scheme. Neither compares a host, so a page rendered through it is not
-   * bounded by this value.
+   * Its two URL checks are narrower and unrelated to hosts. The engine's CSS
+   * compiler limits an EXPLICIT scheme to `http` or `https`, and leaves a
+   * scheme-less value alone — so `//cdn.example/a.png`, which a browser fetches
+   * from `cdn.example`, passes. A block's attribute props reject `javascript:`,
+   * `vbscript:` and `data:` and admit every other scheme, including `blob:`.
+   * Neither compares a host, so a page rendered through it is not bounded by
+   * this value.
    *
    * Object patterns only. This value is serialized to the browser and a `URL`
    * does not survive that: it would arrive as a string. Converting one here

--- a/packages/plugin-page-builder/src/plugin.ts
+++ b/packages/plugin-page-builder/src/plugin.ts
@@ -51,8 +51,12 @@ export interface PageBuilderOptions {
    * **Not custom CSS.** `sanitizeCustomCss` takes no patterns and drops every
    * url naming a host, whether by scheme — including `https://site.example/a.png`,
    * the site's own origin, since compilation has no document origin to compare
-   * against — or by the scheme-less `//cdn.example/a.png`. Same-origin paths
-   * survive. That surface is stricter than this value, not governed by it.
+   * against — or by the scheme-less `//cdn.example/a.png`. What survives is a
+   * path naming no host: `/a.png`, `a.png`. That is a property of the stored
+   * TEXT, not of the eventual request — a cross-origin `<base href>` on the
+   * host document re-points every such path at another origin, which is a
+   * surface a parser cannot reach and one reason `cspDirectives()` emits
+   * `base-uri`. That surface is stricter than this value, not governed by it.
    *
    * **Not `@nextlyhq/blocks-react`**, which has no way to bound what a page
    * fetches. Its checks are about schemes: the engine's CSS compiler limits an

--- a/packages/plugin-page-builder/src/plugin.ts
+++ b/packages/plugin-page-builder/src/plugin.ts
@@ -33,17 +33,28 @@ export interface PageBuilderOptions {
    * only on `PageRenderer` because the canvas runs in the browser, where a
    * component prop from the host's server config cannot reach it.
    *
-   * Set the SAME value on `PageRenderer.remotePatterns`. These are two
-   * assignments, not one: this configures the editor, and `PageRenderer` reads
-   * only its own prop. Setting one alone produces a mismatch in whichever
-   * direction you set it, so a shared constant in the host is what keeps them
-   * equal.
+   * **What this covers, exactly.** It is enforced by this package: the editor
+   * canvas, the style compiler that validates `url()` in custom CSS and style
+   * values, and the embed HTML sanitizer. Those are the surfaces that read it.
    *
-   * Object patterns only, unlike `PageRenderer`, which also accepts a `URL`.
-   * This value is serialized to the browser and a `URL` does not survive that:
-   * it would arrive as a string. Converting one here would mean deciding what
-   * its default `pathname` of `"/"` means as a glob, and guessing at that in a
-   * security control is worse than declining the input.
+   * **What it does NOT cover.** `@nextlyhq/blocks-react` — the renderer the
+   * blocks pipeline is moving to — has no remote-host control at all. It
+   * allowlists URL SCHEMES (`http`/`https` only, with control characters and
+   * quote-breaking characters refused), which stops a `javascript:` value but
+   * not a third-party host: a `background` image pointed at any https origin
+   * compiles and ships. Verified against the engine's compiler, not inferred.
+   *
+   * So a page rendered through that renderer is not restricted by this value,
+   * and there is no second prop to set — an earlier version of this comment
+   * told the reader to mirror it onto `PageRenderer.remotePatterns`, which has
+   * never existed on either renderer. Do not assume a published page is bounded
+   * by what you configure here until that gap is closed.
+   *
+   * Object patterns only. This value is serialized to the browser and a `URL`
+   * does not survive that: it would arrive as a string. Converting one here
+   * would mean deciding what its default `pathname` of `"/"` means as a glob,
+   * and guessing at that in a security control is worse than declining the
+   * input.
    */
   remotePatterns?: readonly RemotePattern[];
 }

--- a/packages/plugin-page-builder/src/plugin.ts
+++ b/packages/plugin-page-builder/src/plugin.ts
@@ -35,35 +35,33 @@ export interface PageBuilderOptions {
    *
    * Set the SAME value on `PageRenderer.remotePatterns` from
    * `@nextlyhq/plugin-page-builder/render`, and pass it to `cspDirectives()` or
-   * `cspHeaderValue()`. Three assignments, not one: each reads only what it was
-   * given, and the CSP helpers default to an empty list, so a host that sets
-   * this alone emits a self-only policy that blocks the CDN the editor and the
-   * renderer both accept.
+   * `cspHeaderValue()`. Three assignments: each surface reads only what it was
+   * handed, and the CSP helpers default to an empty list.
    *
-   * A shared constant aligns them as far as CSP can go, which is not all the
-   * way. A pattern constraining `pathname` or `search` is accepted here and by
-   * the renderer, but `cspDirectives()` omits its host rather than widening the
-   * policy to the whole origin — CSP cannot express a path constraint. Read
-   * `unexpressibleHosts()` to see what was refused and write that source
-   * yourself.
+   * Even then the three are not identical. CSP cannot express a `pathname` or
+   * `search` constraint, so `cspDirectives()` omits such a host rather than
+   * widening the policy to its whole origin; `unexpressibleHosts()` reports what
+   * it refused so the host can write that source itself.
    *
-   * **What reads it.** Structured style values and block props, through
-   * `isFetchableUrl`; the embed HTML sanitizer; the editor canvas.
+   * **Enforced for** the built-in block renderers and structured style values,
+   * through `isFetchableUrl`; the embed HTML sanitizer; the editor canvas. A
+   * CUSTOM block is handed the patterns and must apply them itself — `RenderNode`
+   * passes them in and cannot inspect the element a block returns.
    *
-   * **Custom CSS does not.** `sanitizeCustomCss` takes no patterns and drops
-   * every ABSOLUTE url, including one naming the site's own origin — compilation
-   * has no document origin to compare against, so a scheme is all it can see.
-   * Relative paths survive. That surface is stricter than this value rather than
-   * governed by it, and allowlisting a CDN here does not make it usable there.
+   * **Not custom CSS.** `sanitizeCustomCss` takes no patterns and drops every
+   * url naming a host, whether by scheme — including `https://site.example/a.png`,
+   * the site's own origin, since compilation has no document origin to compare
+   * against — or by the scheme-less `//cdn.example/a.png`. Same-origin paths
+   * survive. That surface is stricter than this value, not governed by it.
    *
-   * **`@nextlyhq/blocks-react` does not read it either**, and has no equivalent.
-   * Its two URL checks are narrower and unrelated to hosts. The engine's CSS
-   * compiler limits an EXPLICIT scheme to `http` or `https`, and leaves a
-   * scheme-less value alone — so `//cdn.example/a.png`, which a browser fetches
-   * from `cdn.example`, passes. A block's attribute props reject `javascript:`,
-   * `vbscript:` and `data:` and admit every other scheme, including `blob:`.
-   * Neither compares a host, so a page rendered through it is not bounded by
-   * this value.
+   * **Not `@nextlyhq/blocks-react`**, which has no way to bound what a page
+   * fetches. Its checks are about schemes: the engine's CSS compiler limits an
+   * EXPLICIT scheme to `http`/`https` and leaves a scheme-less value alone, so
+   * `//cdn.example/a.png` passes; a block's attribute props reject
+   * `javascript:`, `vbscript:` and `data:` and admit every other scheme. It does
+   * compare hosts in one place — `hostPolicy.trustedFrameOrigins` decides
+   * whether an embed keeps its own origin — but that governs a sandbox
+   * permission, not whether the frame is loaded.
    *
    * Object patterns only. This value is serialized to the browser and a `URL`
    * does not survive that: it would arrive as a string. Converting one here


### PR DESCRIPTION
## What

Two comments about `remotePatterns` were wrong, in opposite directions. Task 153 finding C10.

### 1. `PageBuilderOptions.remotePatterns` told the reader to configure something that does not exist

> Set the SAME value on `PageRenderer.remotePatterns`.

**That prop has never existed** — not on `blocks-react`'s `PageRenderer`, not on `plugin-page-builder/render`'s. A host following the instruction believes they have restricted which remote hosts their published page loads from, and have not. Worse than an omission: it produces false confidence in a security control.

### 2. `EditorProvider.remotePatterns` described a limitation that has since been fixed

> The registered surfaces … cannot supply this yet … a host that configures `PageRenderer.remotePatterns` still gets an empty list in the canvas.

Both halves are stale. `PageBuilderEditView` and `PageBuilderField` now call `useRemotePatterns()`, which reads the plugin's `clientConfig` — the channel that carries server-side plugin config to a client component. The canvas gets the allowlist.

## What is actually true, verified not inferred

`remotePatterns` is enforced by **this package only**: the canvas, `core/style-compiler.ts` (custom CSS + style values, via `isFetchableUrl`), and `core/embed-sanitize.ts`.

**`@nextlyhq/blocks-react` has no remote-host control at all.** It allowlists URL *schemes* — `http`/`https`, with control characters and quote-breaking characters refused — which stops `javascript:` but not a third-party host. Measured against the engine's compiler with a positive control:

| `background.url` | result |
| --- | --- |
| own host (control) | compiles |
| `https://tracker.evil.example/pixel.png` | **ships** |

The control matters: my first probe used a property the catalog does not treat as a URL, so "blocked" meant "never compiled" rather than "refused".

## Scope, deliberately

**Doc-only.** No changeset.

The gap is real but **not live**: `blocks-react` is imported today only by the registration service and by tests, so nothing renders production content through it yet. It must be closed before that renderer becomes the published path (R-4 `createBlocksPage()`).

I did not add a partial control. A host allowlist that covers element attributes but not `url()` in the compiled sheet, shipped with a confident comment, is precisely the failure this PR is fixing. Closing it properly means one shared matcher used by both the engine's compiler and the renderer's blocks, so the two cannot disagree — which is the argument `core/url-policy.ts` already makes for itself, and it is a design decision spanning two packages rather than a patch.