### PR TITLE
refactor(nextly): send Resend email over the REST API instead of the SDK

### DIFF
--- a/.changeset/resend-provider-fetch.md
+++ b/.changeset/resend-provider-fetch.md
@@ -1,0 +1,30 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+Send Resend email over the REST API directly, and drop the `resend` SDK dependency.
+
+Sending an email is one HTTP POST, but the SDK pulled in `svix` and `postal-mime` — webhook signature verification and inbound MIME parsing — which Nextly never called. Every install carried roughly 5 MB of unreachable code to make that request. The adapter now uses `fetch`, matching the SendLayer provider.
+
+No configuration changes: existing Resend providers keep working exactly as before.

--- a/packages/nextly/package.json
+++ b/packages/nextly/package.json
@@ -269,7 +269,6 @@
     "mime-types": "^3.0.2",
     "nodemailer": "^9.0.1",
     "picocolors": "^1.1.1",
-    "resend": "^6.9.2",
     "safe-regex2": "^5.1.1",
     "semver": "^7.6.0",
     "server-only": "^0.0.1",

--- a/packages/nextly/src/domains/email/__tests__/resend-provider-attachments.test.ts
+++ b/packages/nextly/src/domains/email/__tests__/resend-provider-attachments.test.ts
@@ -1,65 +1,142 @@
 /**
  * Attachment-forwarding tests for the Resend provider adapter.
  *
- * Resend SDK accepts `Buffer` directly (Node) or a base64 string for
- * `content`. We pass `Buffer` — no pre-encoding needed.
+ * Resend's REST API takes attachment content as a base64 STRING. This matters
+ * more than it looks: `JSON.stringify` turns a Buffer into
+ * `{"type":"Buffer","data":[...]}`, so handing the Buffer straight to the API
+ * produces a well-formed request carrying an object where bytes belong. These
+ * tests assert the encoded string on the wire, not the argument handed to a
+ * client library.
  */
 
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 import { createResendProvider } from "../services/providers/resend-provider";
 
-const mockSend = vi.hoisted(() => vi.fn());
+const BASE_OPTIONS = {
+  to: "u@e.com",
+  from: "a@b.c",
+  subject: "x",
+  html: "<p>x</p>",
+};
 
-vi.mock("resend", () => ({
-  Resend: class {
-    emails = { send: mockSend };
-  },
-}));
+function sentBody(): Record<string, unknown> {
+  const init = vi.mocked(globalThis.fetch).mock.calls[0][1];
+  return JSON.parse(String(init?.body)) as Record<string, unknown>;
+}
+
+function okResponse(id: string) {
+  return {
+    ok: true,
+    status: 200,
+    statusText: "OK",
+    json: async () => ({ id }),
+  } as unknown as Response;
+}
 
 describe("Resend adapter — attachments", () => {
-  it("forwards attachments as {filename, content: Buffer, contentType}", async () => {
-    mockSend.mockResolvedValue({ data: { id: "rsnd-1" }, error: null });
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("base64-encodes content and sends the wire field names", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(okResponse("rsnd-1"));
     const adapter = createResendProvider({ apiKey: "k" });
-    const content = Buffer.from("invoice-bytes");
 
     await adapter.send({
-      to: "u@e.com",
-      from: "a@b.c",
-      subject: "x",
-      html: "<p>x</p>",
+      ...BASE_OPTIONS,
       attachments: [
         {
           filename: "invoice.pdf",
           mimeType: "application/pdf",
-          content,
+          content: Buffer.from("invoice-bytes"),
         },
       ],
     });
 
-    expect(mockSend).toHaveBeenCalledWith(
-      expect.objectContaining({
-        attachments: [
-          {
-            filename: "invoice.pdf",
-            content,
-            contentType: "application/pdf",
-          },
-        ],
-      })
-    );
+    expect(sentBody().attachments).toEqual([
+      {
+        filename: "invoice.pdf",
+        content: Buffer.from("invoice-bytes").toString("base64"),
+        content_type: "application/pdf",
+      },
+    ]);
   });
 
-  it("passes attachments:undefined when none supplied", async () => {
-    mockSend.mockResolvedValue({ data: { id: "rsnd-2" }, error: null });
+  it("sends content that decodes back to the original bytes", async () => {
+    // The positive control. Asserting the field is "a string" would pass for
+    // any string; round-tripping proves the recipient can reconstruct the file.
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(okResponse("rsnd-2"));
     const adapter = createResendProvider({ apiKey: "k" });
+    const original = Buffer.from([0x00, 0xff, 0x10, 0x89, 0x50, 0x4e]);
+
     await adapter.send({
-      to: "u@e.com",
-      from: "a@b.c",
-      subject: "x",
-      html: "<p>x</p>",
+      ...BASE_OPTIONS,
+      attachments: [
+        { filename: "logo.png", mimeType: "image/png", content: original },
+      ],
     });
-    const call = mockSend.mock.calls.at(-1)?.[0];
-    expect(call?.attachments).toBeUndefined();
+
+    const attachments = sentBody().attachments as Array<{ content: string }>;
+    expect(Buffer.from(attachments[0].content, "base64")).toEqual(original);
+  });
+
+  it("never sends a serialized Buffer object in place of the bytes", async () => {
+    // Pins the specific failure this encoding exists to prevent: a body that
+    // is valid JSON and structurally plausible, but carries
+    // `{"type":"Buffer","data":[...]}` where the API reads a base64 string.
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(okResponse("rsnd-3"));
+    const adapter = createResendProvider({ apiKey: "k" });
+
+    await adapter.send({
+      ...BASE_OPTIONS,
+      attachments: [
+        {
+          filename: "doc.pdf",
+          mimeType: "application/pdf",
+          content: Buffer.from("bytes"),
+        },
+      ],
+    });
+
+    const init = vi.mocked(globalThis.fetch).mock.calls[0][1];
+    expect(String(init?.body)).not.toContain('"type":"Buffer"');
+  });
+
+  it("omits the attachments field entirely when none are supplied", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(okResponse("rsnd-4"));
+    const adapter = createResendProvider({ apiKey: "k" });
+
+    await adapter.send(BASE_OPTIONS);
+
+    expect(sentBody()).not.toHaveProperty("attachments");
+  });
+
+  it("forwards every attachment when several are supplied", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(okResponse("rsnd-5"));
+    const adapter = createResendProvider({ apiKey: "k" });
+
+    await adapter.send({
+      ...BASE_OPTIONS,
+      attachments: [
+        {
+          filename: "a.txt",
+          mimeType: "text/plain",
+          content: Buffer.from("a"),
+        },
+        {
+          filename: "b.txt",
+          mimeType: "text/plain",
+          content: Buffer.from("b"),
+        },
+      ],
+    });
+
+    const attachments = sentBody().attachments as unknown[];
+    expect(attachments).toHaveLength(2);
   });
 });

--- a/packages/nextly/src/domains/email/__tests__/resend-provider.test.ts
+++ b/packages/nextly/src/domains/email/__tests__/resend-provider.test.ts
@@ -1,27 +1,23 @@
 /**
  * Tests for the Resend email provider adapter.
  *
+ * The adapter posts to Resend's REST API with `fetch`, so these assert the
+ * REQUEST ITSELF — url, auth header, and JSON body keys. That is deliberate:
+ * the previous suite mocked the SDK and could only prove which arguments the
+ * SDK received, never what went on the wire. A wrong wire key (`replyTo` for
+ * `reply_to`, a Buffer where base64 is required) is exactly the failure an SDK
+ * mock cannot see, because the SDK was the thing translating it.
+ *
  * Covers:
  * - Successful send → returns success + messageId
- * - Resend SDK error response → throws with provider prefix
- * - SDK exception (network) → re-throws with provider prefix
+ * - Request shape: url, bearer auth, recipient list, optional fields
+ * - Resend error body → throws with provider prefix
+ * - Network exception → re-throws with provider prefix
  */
 
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 import { createResendProvider } from "../services/providers/resend-provider";
-
-// ── Hoist the mock fn so it's available before any imports ─────────────────
-const mockSend = vi.hoisted(() => vi.fn());
-
-// ── Mock the Resend SDK with a proper class constructor ────────────────────
-vi.mock("resend", () => ({
-  Resend: class {
-    emails = { send: mockSend };
-  },
-}));
-
-// ── Helpers ────────────────────────────────────────────────────────────────
 
 const BASE_OPTIONS = {
   to: "recipient@example.com",
@@ -30,18 +26,33 @@ const BASE_OPTIONS = {
   html: "<p>Hello World</p>",
 };
 
-// ── Tests ──────────────────────────────────────────────────────────────────
+/** The parsed JSON body of the single `fetch` call made. */
+function sentBody(): Record<string, unknown> {
+  const mockFetch = vi.mocked(globalThis.fetch);
+  const init = mockFetch.mock.calls[0][1];
+  return JSON.parse(String(init?.body)) as Record<string, unknown>;
+}
+
+function okResponse(id = "msg_abc123") {
+  return {
+    ok: true,
+    status: 200,
+    statusText: "OK",
+    json: async () => ({ id }),
+  } as unknown as Response;
+}
 
 describe("createResendProvider", () => {
   beforeEach(() => {
-    mockSend.mockReset();
+    vi.stubGlobal("fetch", vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
   });
 
   it("returns success and messageId on a successful send", async () => {
-    mockSend.mockResolvedValueOnce({
-      data: { id: "msg_abc123" },
-      error: null,
-    });
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(okResponse());
 
     const adapter = createResendProvider({ apiKey: "re_test_key" });
     const result = await adapter.send(BASE_OPTIONS);
@@ -50,40 +61,120 @@ describe("createResendProvider", () => {
     expect(result.messageId).toBe("msg_abc123");
   });
 
-  it("forwards all required fields to the Resend SDK", async () => {
-    mockSend.mockResolvedValueOnce({ data: { id: "x" }, error: null });
+  it("posts to Resend's send endpoint with bearer auth", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(okResponse());
 
     const adapter = createResendProvider({ apiKey: "re_test_key" });
     await adapter.send(BASE_OPTIONS);
 
-    expect(mockSend).toHaveBeenCalledOnce();
-    expect(mockSend).toHaveBeenCalledWith({
-      from: BASE_OPTIONS.from,
-      to: BASE_OPTIONS.to,
-      subject: BASE_OPTIONS.subject,
-      html: BASE_OPTIONS.html,
+    const [url, init] = vi.mocked(globalThis.fetch).mock.calls[0];
+    expect(url).toBe("https://api.resend.com/emails");
+    expect(init?.method).toBe("POST");
+    expect(init?.headers).toMatchObject({
+      Authorization: "Bearer re_test_key",
+      "Content-Type": "application/json",
     });
   });
 
-  it("throws a provider-prefixed error when Resend returns an error object", async () => {
-    mockSend.mockResolvedValueOnce({
-      data: null,
-      error: {
-        message: "Invalid API key",
-        name: "invalid_api_key",
-        statusCode: 403,
-      },
+  it("sends the recipient as a list, which the REST API requires", async () => {
+    // The SDK accepted a bare string and wrapped it. Passing a string straight
+    // through to the API would be rejected, and no SDK-level mock could catch
+    // that, because wrapping was the SDK's job.
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(okResponse());
+
+    const adapter = createResendProvider({ apiKey: "re_test_key" });
+    await adapter.send(BASE_OPTIONS);
+
+    expect(sentBody().to).toEqual(["recipient@example.com"]);
+  });
+
+  it("omits optional fields entirely rather than sending them null", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(okResponse());
+
+    const adapter = createResendProvider({ apiKey: "re_test_key" });
+    await adapter.send(BASE_OPTIONS);
+
+    const body = sentBody();
+    expect(body).not.toHaveProperty("reply_to");
+    expect(body).not.toHaveProperty("cc");
+    expect(body).not.toHaveProperty("bcc");
+    expect(body).not.toHaveProperty("attachments");
+    expect(body).not.toHaveProperty("text");
+  });
+
+  it("sends reply-to under the snake_case wire key", async () => {
+    // Guards the one-word difference that silently drops the header: the SDK
+    // took `replyTo`, the REST API reads `reply_to`.
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(okResponse());
+
+    const adapter = createResendProvider({ apiKey: "re_test_key" });
+    await adapter.send({ ...BASE_OPTIONS, replyTo: "reply@example.com" });
+
+    const body = sentBody();
+    expect(body.reply_to).toBe("reply@example.com");
+    expect(body).not.toHaveProperty("replyTo");
+  });
+
+  it("forwards text, cc and bcc when supplied", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(okResponse());
+
+    const adapter = createResendProvider({ apiKey: "re_test_key" });
+    await adapter.send({
+      ...BASE_OPTIONS,
+      text: "Hello World",
+      cc: ["cc@example.com"],
+      bcc: ["bcc@example.com"],
     });
+
+    const body = sentBody();
+    expect(body.text).toBe("Hello World");
+    expect(body.cc).toEqual(["cc@example.com"]);
+    expect(body.bcc).toEqual(["bcc@example.com"]);
+  });
+
+  it("throws a provider-prefixed error when Resend returns an error body", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce({
+      ok: false,
+      status: 403,
+      statusText: "Forbidden",
+      json: async () => ({
+        statusCode: 403,
+        name: "invalid_api_key",
+        message: "Invalid API key",
+      }),
+    } as unknown as Response);
 
     const adapter = createResendProvider({ apiKey: "re_bad_key" });
 
     await expect(adapter.send(BASE_OPTIONS)).rejects.toThrow(
-      "Resend provider error: Invalid API key"
+      "Resend provider error: HTTP 403: Invalid API key"
     );
   });
 
-  it("throws a provider-prefixed error when the SDK throws a network exception", async () => {
-    mockSend.mockRejectedValueOnce(new Error("ECONNREFUSED"));
+  it("falls back to the status line when the error body is not JSON", async () => {
+    // A gateway or proxy failure returns a status with no Resend envelope. The
+    // adapter must still report something an operator can act on rather than
+    // failing while trying to parse the failure.
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce({
+      ok: false,
+      status: 502,
+      statusText: "Bad Gateway",
+      json: async () => {
+        throw new Error("Unexpected token < in JSON");
+      },
+    } as unknown as Response);
+
+    const adapter = createResendProvider({ apiKey: "re_test_key" });
+
+    await expect(adapter.send(BASE_OPTIONS)).rejects.toThrow(
+      "Resend provider error: HTTP 502: Bad Gateway"
+    );
+  });
+
+  it("throws a provider-prefixed error when the request itself fails", async () => {
+    vi.mocked(globalThis.fetch).mockRejectedValueOnce(
+      new Error("ECONNREFUSED")
+    );
 
     const adapter = createResendProvider({ apiKey: "re_test_key" });
 
@@ -92,10 +183,10 @@ describe("createResendProvider", () => {
     );
   });
 
-  it("reuses the same Resend client instance across multiple send() calls", async () => {
-    mockSend
-      .mockResolvedValueOnce({ data: { id: "id1" }, error: null })
-      .mockResolvedValueOnce({ data: { id: "id2" }, error: null });
+  it("sends one request per send() call", async () => {
+    vi.mocked(globalThis.fetch)
+      .mockResolvedValueOnce(okResponse("id1"))
+      .mockResolvedValueOnce(okResponse("id2"));
 
     const adapter = createResendProvider({ apiKey: "re_test_key" });
     const r1 = await adapter.send(BASE_OPTIONS);
@@ -103,6 +194,6 @@ describe("createResendProvider", () => {
 
     expect(r1.messageId).toBe("id1");
     expect(r2.messageId).toBe("id2");
-    expect(mockSend).toHaveBeenCalledTimes(2);
+    expect(vi.mocked(globalThis.fetch)).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/nextly/src/domains/email/services/providers/resend-provider.ts
+++ b/packages/nextly/src/domains/email/services/providers/resend-provider.ts
@@ -1,17 +1,21 @@
 /**
  * Resend Email Provider Adapter
  *
- * Implements the `EmailProviderAdapter` interface using the Resend SDK.
- * The Resend client is created once in the factory closure and reused
- * across `send()` calls — no persistent connections, serverless-friendly.
+ * Implements the `EmailProviderAdapter` interface against the Resend REST API
+ * using native `fetch` — no SDK. Sending is a single POST, and the `resend`
+ * package pulls `svix` and `postal-mime` (webhook verification and inbound MIME
+ * parsing) that nothing here calls, so every install carried megabytes of
+ * unreachable code to make one HTTP request. Mirrors the SendLayer adapter,
+ * which has always worked this way.
  *
  * @module services/email/providers/resend-provider
  * @since 1.0.0
  */
 
-import { Resend } from "resend";
-
 import type { EmailProviderAdapter } from "../../types";
+
+/** Resend's send endpoint. */
+const RESEND_API_URL = "https://api.resend.com/emails";
 
 /**
  * Resend configuration shape stored in `EmailProviderRecord.configuration`.
@@ -22,10 +26,21 @@ interface ResendProviderConfig {
 }
 
 /**
+ * Error body Resend returns for a rejected send. Every field is optional
+ * because an error response is the one shape a caller cannot assume: a gateway
+ * or proxy failure yields a status without this envelope at all.
+ */
+interface ResendErrorBody {
+  statusCode?: number;
+  name?: string;
+  message?: string;
+}
+
+/**
  * Create a Resend email provider adapter.
  *
  * @param config - Decrypted Resend configuration from the email provider record
- * @returns An `EmailProviderAdapter` that sends emails via Resend
+ * @returns An `EmailProviderAdapter` that sends emails via the Resend REST API
  *
  * @example
  * ```typescript
@@ -44,35 +59,75 @@ interface ResendProviderConfig {
 export function createResendProvider(
   config: ResendProviderConfig
 ): EmailProviderAdapter {
-  const client = new Resend(config.apiKey);
-
   return {
     async send(options) {
+      // Built conditionally so unset fields are absent from the JSON rather
+      // than present and null, which Resend rejects for `reply_to`.
+      const body: Record<string, unknown> = {
+        from: options.from,
+        // The REST API takes a recipient LIST even for a single address; the
+        // SDK accepted a bare string and wrapped it.
+        to: [options.to],
+        subject: options.subject,
+        html: options.html,
+      };
+
+      if (options.text) {
+        body.text = options.text;
+      }
+
+      // Wire name is snake_case; the SDK's `replyTo` was its own camelCase
+      // surface, and sending that key here would silently drop the header.
+      if (options.replyTo) {
+        body.reply_to = options.replyTo;
+      }
+
+      if (options.cc && options.cc.length > 0) {
+        body.cc = options.cc;
+      }
+
+      if (options.bcc && options.bcc.length > 0) {
+        body.bcc = options.bcc;
+      }
+
+      if (options.attachments && options.attachments.length > 0) {
+        body.attachments = options.attachments.map(a => ({
+          filename: a.filename,
+          // Base64, not the Buffer itself: JSON.stringify turns a Buffer into
+          // `{"type":"Buffer","data":[...]}`, which is not what the API reads.
+          content: a.content.toString("base64"),
+          content_type: a.mimeType,
+        }));
+      }
+
       try {
-        const { data, error } = await client.emails.send({
-          from: options.from,
-          to: options.to,
-          subject: options.subject,
-          html: options.html,
-          text: options.text,
-          replyTo: options.replyTo,
-          cc: options.cc,
-          bcc: options.bcc,
-          attachments: options.attachments?.map(a => ({
-            filename: a.filename,
-            // Resend SDK accepts Buffer directly (Node) or base64 string.
-            content: a.content,
-            contentType: a.mimeType,
-          })),
+        const response = await fetch(RESEND_API_URL, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${config.apiKey}`,
+          },
+          body: JSON.stringify(body),
         });
 
-        if (error) {
-          throw new Error(error.message);
+        if (!response.ok) {
+          // Prefer Resend's own message; fall back to the status line when the
+          // body is absent or not JSON (a proxy or gateway failure).
+          let detail = response.statusText;
+          try {
+            const errorBody = (await response.json()) as ResendErrorBody;
+            if (errorBody.message) detail = errorBody.message;
+          } catch {
+            // Body was not JSON — the status line is all there is to report.
+          }
+          throw new Error(`HTTP ${response.status}: ${detail}`);
         }
+
+        const data = (await response.json()) as { id?: string };
 
         return {
           success: true,
-          messageId: data?.id,
+          messageId: data.id,
         };
       } catch (error) {
         const message =

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -976,9 +976,6 @@ importers:
       picocolors:
         specifier: ^1.1.1
         version: 1.1.1
-      resend:
-        specifier: ^6.9.2
-        version: 6.9.2
       safe-regex2:
         specifier: ^5.1.1
         version: 5.1.1
@@ -4524,9 +4521,6 @@ packages:
     resolution: {integrity: sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg==}
     engines: {node: '>=18.0.0'}
 
-  '@stablelib/base64@1.0.1':
-    resolution: {integrity: sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==}
-
   '@standard-schema/spec@1.0.0':
     resolution: {integrity: sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==}
 
@@ -6169,9 +6163,6 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
-  fast-sha256@1.3.0:
-    resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
-
   fast-uri@3.1.4:
     resolution: {integrity: sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==}
 
@@ -7449,9 +7440,6 @@ packages:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
 
-  postal-mime@2.7.3:
-    resolution: {integrity: sha512-MjhXadAJaWgYzevi46+3kLak8y6gbg0ku14O1gO/LNOuay8dO+1PtcSGvAdgDR0DoIsSaiIA8y/Ddw6MnrO0Tw==}
-
   postcss-load-config@6.0.1:
     resolution: {integrity: sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==}
     engines: {node: '>= 18'}
@@ -7674,15 +7662,6 @@ packages:
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
-
-  resend@6.9.2:
-    resolution: {integrity: sha512-uIM6CQ08tS+hTCRuKBFbOBvHIGaEhqZe8s4FOgqsVXSbQLAhmNWpmUhG3UAtRnmcwTWFUqnHa/+Vux8YGPyDBA==}
-    engines: {node: '>=20'}
-    peerDependencies:
-      '@react-email/render': '*'
-    peerDependenciesMeta:
-      '@react-email/render':
-        optional: true
 
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
@@ -7968,9 +7947,6 @@ packages:
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
-  standardwebhooks@1.0.0:
-    resolution: {integrity: sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==}
-
   std-env@4.2.0:
     resolution: {integrity: sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==}
 
@@ -8101,9 +8077,6 @@ packages:
   supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
-
-  svix@1.84.1:
-    resolution: {integrity: sha512-K8DPPSZaW/XqXiz1kEyzSHYgmGLnhB43nQCMeKjWGCUpLIpAMMM8kx3rVVOSm6Bo6EHyK1RQLPT4R06skM/MlQ==}
 
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
@@ -8444,10 +8417,6 @@ packages:
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
-
-  uuid@14.0.0:
-    resolution: {integrity: sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==}
-    hasBin: true
 
   validate-npm-package-name@5.0.1:
     resolution: {integrity: sha512-OljLrQ9SQdOUqTaQxqL5dEfZWrXExyyWsozYlAWFawPVNuD83igl7uJD2RTkNMbniIYgt8l81eCJGIdQF7avLQ==}
@@ -11688,8 +11657,6 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@stablelib/base64@1.0.1': {}
-
   '@standard-schema/spec@1.0.0': {}
 
   '@standard-schema/spec@1.0.0-beta.4': {}
@@ -12248,7 +12215,7 @@ snapshots:
       obug: 2.1.4
       std-env: 4.2.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.10(@types/node@24.10.0)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.9.0)(jsdom@27.1.0)(vite@7.3.6(@types/node@24.10.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.10(@types/node@20.19.17)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.9.0)(jsdom@27.1.0)(vite@7.3.6(@types/node@20.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.20.5)(yaml@2.8.3))
 
   '@vitest/expect@4.1.10':
     dependencies:
@@ -12318,7 +12285,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.1.0
-      vitest: 4.1.10(@types/node@24.10.0)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.9.0)(jsdom@27.1.0)(vite@7.3.6(@types/node@24.10.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.10(@types/node@20.19.17)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.9.0)(jsdom@27.1.0)(vite@7.3.6(@types/node@20.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.20.5)(yaml@2.8.3))
 
   '@vitest/utils@4.1.10':
     dependencies:
@@ -13501,8 +13468,6 @@ snapshots:
   fast-json-stable-stringify@2.1.0: {}
 
   fast-levenshtein@2.0.6: {}
-
-  fast-sha256@1.3.0: {}
 
   fast-uri@3.1.4: {}
 
@@ -14754,8 +14719,6 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
-  postal-mime@2.7.3: {}
-
   postcss-load-config@6.0.1(jiti@2.6.1)(postcss@8.5.23)(tsx@4.20.5)(yaml@2.8.3):
     dependencies:
       lilconfig: 3.1.3
@@ -14974,11 +14937,6 @@ snapshots:
   require-directory@2.1.1: {}
 
   require-from-string@2.0.2: {}
-
-  resend@6.9.2:
-    dependencies:
-      postal-mime: 2.7.3
-      svix: 1.84.1
 
   resolve-from@4.0.0: {}
 
@@ -15330,11 +15288,6 @@ snapshots:
 
   stackback@0.0.2: {}
 
-  standardwebhooks@1.0.0:
-    dependencies:
-      '@stablelib/base64': 1.0.1
-      fast-sha256: 1.3.0
-
   std-env@4.2.0: {}
 
   stdin-discarder@0.2.2: {}
@@ -15487,11 +15440,6 @@ snapshots:
       supports-color: 7.2.0
 
   supports-preserve-symlinks-flag@1.0.0: {}
-
-  svix@1.84.1:
-    dependencies:
-      standardwebhooks: 1.0.0
-      uuid: 14.0.0
 
   symbol-tree@3.2.4: {}
 
@@ -15871,8 +15819,6 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
-  uuid@14.0.0: {}
-
   validate-npm-package-name@5.0.1: {}
 
   vite-tsconfig-paths@5.1.4(typescript@5.9.3)(vite@7.3.6(@types/node@20.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.20.5)(yaml@2.8.3)):
@@ -16025,7 +15971,7 @@ snapshots:
       std-env: 4.2.0
       tinybench: 2.9.0
       tinyexec: 1.2.4
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
       vite: 7.3.6(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3)
       why-is-node-running: 2.3.0
@@ -16056,7 +16002,7 @@ snapshots:
       std-env: 4.2.0
       tinybench: 2.9.0
       tinyexec: 1.2.4
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
       vite: 7.3.6(@types/node@24.10.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.20.5)(yaml@2.8.3)
       why-is-node-running: 2.3.0


### PR DESCRIPTION
First PR of the email-extraction series. Independent of #618 — zero shared files.

## What and why

Sending an email through Resend is a single `POST https://api.resend.com/emails`. The `resend` package depends on `svix` (webhook signature verification) and `postal-mime` (inbound MIME parsing), neither of which Nextly ever calls. Every install carried them, and their subtree, to make that one request.

The adapter now uses `fetch`, matching `sendlayer-provider.ts`, which has always worked this way. Same exported factory, same `EmailProviderAdapter` contract, so the registry, the code-first path, and stored provider records are all untouched.

**Measured, not estimated.** The lockfile diff removes exactly `resend`, `svix` (4.0 MB), `postal-mime` (340 KB), `standardwebhooks`, `fast-sha256`, and `uuid@14` — and nothing else. Verified with `git diff pnpm-lock.yaml` filtered to non-Resend entries: empty.

`nodemailer` deliberately stays. Making SMTP's dependency optional is a separate, breaking change scheduled for the pre-1.0 window.

## Three wire details the SDK was hiding

Each of these would have been a silent production failure, and none is visible from the SDK's own signature:

1. **`to` is a list.** The REST API takes an array even for one recipient; the SDK accepted a bare string and wrapped it.
2. **`reply_to`, not `replyTo`.** The camelCase spelling was the SDK's surface. Sending it to the REST API drops the header without error.
3. **Attachment `content` is base64.** `JSON.stringify` turns a `Buffer` into `{"type":"Buffer","data":[...]}` — a well-formed request carrying an object where bytes belong.

Worth flagging on the third: Payload's own `@payloadcms/email-resend` passes the raw `Buffer` and `JSON.stringify`s it, so its attachment path appears to have exactly this bug. It was the obvious reference implementation to copy, and copying it would have imported the defect. Verified against Resend's API docs instead.

## Tests moved with the implementation

The old suite mocked the `resend` module, so it could only prove which arguments the SDK received — never what went on the wire, which is precisely where all three mistakes above live. The new suites stub `fetch` and assert the request: URL, bearer header, body keys, and that base64 content **decodes back to the original bytes** rather than merely being a string.

Added coverage that did not previously exist: optional fields omitted rather than sent null, `reply_to` spelling pinned, non-JSON error bodies falling back to the status line (a gateway failure returns a status with no Resend envelope), and a guard that the body never contains `"type":"Buffer"`.

Test count: 7 Resend tests on `main` (5 + 2) → 15 here (10 + 5).

## Test plan

On a fully built worktree:

- `vitest run src/domains/email` — **19 files / 144 tests, all passing.**
- `check-types` — **0 errors.**
- `lint` — clean at `--max-warnings 0`.

Baseline reconciliation, since a stash-based baseline is invalid here (stashing restores a `package.json` that imports `resend` while `node_modules` no longer has it, so its failures are an artifact of the measurement): the trustworthy `main` baseline is **19 files / 136 tests**, measured on a separately-built healthy worktree. `136 − 7 + 15 = 144`. Exact match, zero regressions.

## Note for reviewers on the CI environment

While preparing this I hit ~331 type errors and 7 failing email suites in a fresh worktree. They were **not** from this change — pristine `main` in the same worktree produced the identical 331. Root cause was an esbuild host/binary mismatch (`0.25.12` vs `0.28.1`) that stopped `@nextlyhq/adapter-drizzle` building, so `@nextlyhq/adapter-drizzle/types` could not resolve. A forced reinstall plus a full build fixed it, and every number above comes from the repaired tree. Flagging in case the same mismatch surfaces in CI.

Changeset added: yes (patch, all 22 fixed-group packages, generated from `.changeset/config.json`).