### PR TITLE
fix(nextly): let a failed email delivery reach the auth flow that depends on it

### DIFF
--- a/.changeset/email-delivery-failure-reaches-auth.md
+++ b/.changeset/email-delivery-failure-reaches-auth.md
@@ -1,0 +1,30 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+Report a failed email delivery to the auth flow that depends on it, and stop returning password-reset and verification tokens in production responses.
+
+A provider failure was converted into an unsuccessful result rather than an exception, and the auth convenience methods returned nothing, so a failed password-reset send was treated as a delivered one: the user received no email and no token. Those methods now return the send result, and the auth flows check it.
+
+Password-reset and email-verification tokens are no longer included in the API response when delivery fails in production. Outside production they still are, so a local install works before any email provider is configured.

--- a/packages/nextly/src/domains/auth/services/auth-service.ts
+++ b/packages/nextly/src/domains/auth/services/auth-service.ts
@@ -19,6 +19,7 @@ import type { MinimalUser } from "@nextly/types/auth";
 import { toDbError } from "../../../database/errors";
 import { NextlyError } from "../../../errors/nextly-error";
 import { emitAuthEvent } from "../../../events/domain-events";
+import { env } from "../../../lib/env";
 import { BaseService } from "../../../services/base-service";
 import type { EmailService } from "../../../services/email/email-service";
 import type { Logger } from "../../../services/shared";
@@ -159,6 +160,32 @@ export class AuthService extends BaseService {
   // Drizzle native on PG/MySQL and manual BEGIN/COMMIT on SQLite.
   // Do NOT override it here — the base class's dialect-aware routing
   // is what makes async transaction callbacks work on all three dialects.
+
+  /**
+   * What to return when a token could not be delivered by email.
+   *
+   * Outside production the raw token comes back, which is what makes a local
+   * install usable before any provider is configured. In production it does
+   * not: a reset or verification token is a credential, and OWASP's guidance
+   * is that it may only travel by the side channel it was minted for. Handing
+   * it to whoever called the endpoint turns a delivery outage into account
+   * takeover for every account an attacker cares to name.
+   *
+   * The gate is what makes detecting more failures safe. Recognising an
+   * unsuccessful send — rather than only a thrown one — necessarily routes
+   * more situations here, and without this that would have widened where a
+   * live token is handed back.
+   */
+  private undeliveredTokenFallback(rawToken: string): { token?: string } {
+    if (env.NODE_ENV === "production") {
+      this.logger.error(
+        "A token could not be delivered and is withheld from the response",
+        { event: "auth.token_delivery_failed", environment: "production" }
+      );
+      return {};
+    }
+    return { token: rawToken };
+  }
 
   /**
    * Register a new user with email and password.
@@ -445,34 +472,47 @@ export class AuthService extends BaseService {
       }
 
       if (this.emailService) {
+        let delivered = false;
         try {
-          await this.emailService.sendPasswordResetEmail(
+          // The result matters as much as the absence of a throw: a provider
+          // failure is converted to `{ success: false }` rather than raised, so
+          // awaiting alone would read a failed send as a delivered one and take
+          // the branch below that deliberately withholds the token.
+          const result = await this.emailService.sendPasswordResetEmail(
             normalizedEmail,
             { name: user.name, email: user.email },
             rawToken,
             { path: options?.redirectPath }
           );
+          delivered = result.success;
+          if (!delivered) {
+            this.logger.error("Password reset email was not delivered", {
+              event: "auth.password_reset.email_failed",
+              reason: "provider reported an unsuccessful send",
+            });
+          }
         } catch (emailError) {
-          // Email failure should not prevent token generation
-          console.warn(
-            "[AuthService] Failed to send password reset email:",
-            emailError instanceof Error
-              ? emailError.message
-              : String(emailError)
-          );
-          // Return token in response as dev fallback when email fails
-          return { token: rawToken };
+          this.logger.error("Failed to send password reset email", {
+            event: "auth.password_reset.email_failed",
+            error:
+              emailError instanceof Error
+                ? emailError.message
+                : String(emailError),
+          });
         }
 
-        // IMPORTANT: Email sent successfully — do NOT return token (security)
-        return {};
+        // Delivered: the token travelled by its side channel and must not also
+        // appear here.
+        if (delivered) return {};
+
+        return this.undeliveredTokenFallback(rawToken);
       }
 
-      // No email service configured — dev fallback: return token in response
-      console.warn(
-        "[AuthService] No email service configured. Returning password reset token in response. Configure an email provider for production use."
+      this.logger.warn(
+        "No email provider is configured, so the password reset token could not be delivered",
+        { event: "auth.password_reset.email_unconfigured" }
       );
-      return { token: rawToken };
+      return this.undeliveredTokenFallback(rawToken);
     } catch (error) {
       // DB errors are mapped to NextlyError. Generic public messages keep us
       // from leaking schema or driver text. Normalise raw driver errors via
@@ -662,34 +702,44 @@ export class AuthService extends BaseService {
       }
 
       if (this.emailService) {
+        let delivered = false;
         try {
-          await this.emailService.sendEmailVerificationEmail(
+          // Same reasoning as the password-reset path: a provider failure
+          // arrives as `{ success: false }`, not as a throw, so the result is
+          // the only evidence that nothing reached the user.
+          const result = await this.emailService.sendEmailVerificationEmail(
             email,
             { name: user.name, email: user.email },
             rawToken,
             { path: options?.redirectPath }
           );
+          delivered = result.success;
+          if (!delivered) {
+            this.logger.error("Email verification message was not delivered", {
+              event: "auth.email_verification.email_failed",
+              reason: "provider reported an unsuccessful send",
+            });
+          }
         } catch (emailError) {
-          // Email failure should not prevent token generation
-          console.warn(
-            "[AuthService] Failed to send email verification email:",
-            emailError instanceof Error
-              ? emailError.message
-              : String(emailError)
-          );
-          // Return token in response as dev fallback when email fails
-          return { token: rawToken };
+          this.logger.error("Failed to send email verification email", {
+            event: "auth.email_verification.email_failed",
+            error:
+              emailError instanceof Error
+                ? emailError.message
+                : String(emailError),
+          });
         }
 
-        // IMPORTANT: Email sent successfully — do NOT return token (security)
-        return {};
+        if (delivered) return {};
+
+        return this.undeliveredTokenFallback(rawToken);
       }
 
-      // No email service configured — dev fallback: return token in response
-      console.warn(
-        "[AuthService] No email service configured. Returning email verification token in response. Configure an email provider for production use."
+      this.logger.warn(
+        "No email provider is configured, so the verification token could not be delivered",
+        { event: "auth.email_verification.email_unconfigured" }
       );
-      return { token: rawToken };
+      return this.undeliveredTokenFallback(rawToken);
     } catch (error) {
       // Normalise raw driver errors so the DB kind is preserved.
       throw NextlyError.fromDatabaseError(toDbError(this.dialect, error));

--- a/packages/nextly/src/domains/email/__tests__/delivery-result-reaches-callers.test.ts
+++ b/packages/nextly/src/domains/email/__tests__/delivery-result-reaches-callers.test.ts
@@ -1,0 +1,186 @@
+/**
+ * Tests that a failed delivery is observable by the caller that needs to know.
+ *
+ * `EmailService.send()` converts a provider throw into `{ success: false }`
+ * rather than propagating it. That is the right contract for an application
+ * caller, but it means the three auth convenience wrappers — which returned
+ * `void` — discarded the only evidence that nothing was delivered. A caller
+ * whose next decision depends on delivery then treats a failed send as a
+ * completed one.
+ *
+ * The wrappers now return the send result. Widening `void` is deliberately
+ * additive: an existing caller that ignores the value keeps compiling and
+ * behaving identically, which matters for a published package.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+import type { EmailProviderAdapter } from "../types";
+
+import { EmailService } from "../services/email-service";
+
+// `lib/env` only re-exports this module, and `getBaseUrl` reaches the real one
+// directly — so mocking the re-export alone leaves env validation running.
+vi.mock("../../../shared/lib/env", () => ({
+  env: {
+    NEXTLY_SECRET: "test-secret-must-be-32chars-long!!",
+    DB_DIALECT: "sqlite",
+    DATABASE_URL: undefined,
+    NODE_ENV: "test",
+    NEXT_PUBLIC_APP_URL: "http://localhost:3000",
+  },
+}));
+
+const logger = {
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  debug: vi.fn(),
+};
+
+/** Minimal template service: always misses, so the code-first path is used. */
+function makeTemplateService() {
+  return {
+    getTemplateBySlug: vi.fn().mockResolvedValue(null),
+    getLayoutFor: vi.fn().mockResolvedValue(null),
+    renderWithLayout: vi.fn(),
+  };
+}
+
+/** Provider service with no DB providers, so code-first config is resolved. */
+function makeProviderService() {
+  return {
+    getProviderDecrypted: vi.fn(),
+    getDefaultProviderDecrypted: vi.fn().mockResolvedValue(null),
+  };
+}
+
+function makeService(adapter: EmailProviderAdapter) {
+  const emailConfig = {
+    providerConfig: { provider: "resend" as const, apiKey: "re_x" },
+    from: "App <noreply@example.com>",
+    templates: {
+      passwordReset: () => ({ subject: "Reset", html: "<p>reset</p>" }),
+      emailVerification: () => ({ subject: "Verify", html: "<p>verify</p>" }),
+      welcome: () => ({ subject: "Welcome", html: "<p>welcome</p>" }),
+    },
+  };
+
+  const service = new EmailService(
+    {} as never,
+    logger as never,
+    makeProviderService() as never,
+    makeTemplateService() as never,
+    emailConfig
+  );
+
+  // Resolve every provider to the adapter under test, so these tests exercise
+  // the wrapper -> sendWithTemplate -> send path and not provider resolution.
+  vi.spyOn(
+    service as unknown as {
+      resolveProvider: () => Promise<unknown>;
+    },
+    "resolveProvider"
+  ).mockResolvedValue({
+    adapter,
+    from: "App <noreply@example.com>",
+    providerType: "resend",
+  });
+
+  return service;
+}
+
+const USER = { name: "Ada", email: "ada@example.com" };
+
+describe("delivery failure reaches the caller", () => {
+  beforeEach(() => {
+    logger.warn.mockReset();
+    logger.error.mockReset();
+  });
+
+  it("reports success when the provider delivered", async () => {
+    const adapter: EmailProviderAdapter = {
+      send: vi.fn().mockResolvedValue({ success: true, messageId: "m1" }),
+    };
+
+    const result = await makeService(adapter).sendPasswordResetEmail(
+      USER.email,
+      USER,
+      "tok"
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.messageId).toBe("m1");
+  });
+
+  it("reports failure when the provider threw, instead of returning void", async () => {
+    // This is the defect: the adapter throws, send() swallows it into
+    // { success: false }, and the wrapper used to return undefined — so the
+    // caller could not tell this apart from a delivered message.
+    const adapter: EmailProviderAdapter = {
+      send: vi.fn().mockRejectedValue(new Error("SMTP 535 auth failed")),
+    };
+
+    const result = await makeService(adapter).sendPasswordResetEmail(
+      USER.email,
+      USER,
+      "tok"
+    );
+
+    expect(result.success).toBe(false);
+  });
+
+  it("reports failure when the provider returned an unsuccessful result", async () => {
+    const adapter: EmailProviderAdapter = {
+      send: vi.fn().mockResolvedValue({ success: false }),
+    };
+
+    const result = await makeService(adapter).sendPasswordResetEmail(
+      USER.email,
+      USER,
+      "tok"
+    );
+
+    expect(result.success).toBe(false);
+  });
+
+  it("reports failure from the email-verification wrapper too", async () => {
+    const adapter: EmailProviderAdapter = {
+      send: vi.fn().mockRejectedValue(new Error("network down")),
+    };
+
+    const result = await makeService(adapter).sendEmailVerificationEmail(
+      USER.email,
+      USER,
+      "tok"
+    );
+
+    expect(result.success).toBe(false);
+  });
+
+  it("reports failure from the welcome wrapper too", async () => {
+    const adapter: EmailProviderAdapter = {
+      send: vi.fn().mockRejectedValue(new Error("network down")),
+    };
+
+    const result = await makeService(adapter).sendWelcomeEmail(
+      USER.email,
+      USER
+    );
+
+    expect(result.success).toBe(false);
+  });
+
+  it("still resolves rather than throwing, so fire-and-forget callers are unaffected", async () => {
+    // user-mutation-service sends the welcome mail as a side effect and must
+    // not fail user creation because delivery did. Widening the return type
+    // must not turn a swallowed failure into a thrown one.
+    const adapter: EmailProviderAdapter = {
+      send: vi.fn().mockRejectedValue(new Error("boom")),
+    };
+
+    await expect(
+      makeService(adapter).sendWelcomeEmail(USER.email, USER)
+    ).resolves.toBeDefined();
+  });
+});

--- a/packages/nextly/src/domains/email/services/email-service.ts
+++ b/packages/nextly/src/domains/email/services/email-service.ts
@@ -452,13 +452,19 @@ export class EmailService extends BaseService {
    * 1. `options.path` (per-request override)
    * 2. `emailConfig.resetPasswordPath` (global config)
    * 3. `'/admin/reset-password'` (default)
+   *
+   * Returns the send result rather than `void`. `send()` converts a provider
+   * throw into `{ success: false }` instead of propagating it, so a caller that
+   * only awaits this cannot tell a failed delivery from a completed one — and
+   * for an auth flow that difference decides what the user is told. Callers
+   * that genuinely do not care may still ignore the value.
    */
   async sendPasswordResetEmail(
     to: string,
     user: { name: string | null; email: string },
     token: string,
     options?: { path?: string }
-  ): Promise<void> {
+  ): Promise<{ success: boolean; messageId?: string }> {
     const baseUrl = this.getBaseUrl();
     const path =
       options?.path ??
@@ -466,7 +472,7 @@ export class EmailService extends BaseService {
       "/admin/reset-password";
     const resetLink = `${baseUrl}${path}?token=${encodeURIComponent(token)}`;
 
-    await this.sendWithTemplate("password-reset", to, {
+    return this.sendWithTemplate("password-reset", to, {
       resetLink,
       expiresIn: "1 hour",
       appName: this.getAppName(),
@@ -487,13 +493,19 @@ export class EmailService extends BaseService {
    * 1. `options.path` (per-request override)
    * 2. `emailConfig.verifyEmailPath` (global config)
    * 3. `'/admin/verify-email'` (default)
+   *
+   * Returns the send result rather than `void`. `send()` converts a provider
+   * throw into `{ success: false }` instead of propagating it, so a caller that
+   * only awaits this cannot tell a failed delivery from a completed one — and
+   * for an auth flow that difference decides what the user is told. Callers
+   * that genuinely do not care may still ignore the value.
    */
   async sendEmailVerificationEmail(
     to: string,
     user: { name: string | null; email: string },
     token: string,
     options?: { path?: string }
-  ): Promise<void> {
+  ): Promise<{ success: boolean; messageId?: string }> {
     const baseUrl = this.getBaseUrl();
     const path =
       options?.path ??
@@ -501,7 +513,7 @@ export class EmailService extends BaseService {
       "/admin/verify-email";
     const verifyLink = `${baseUrl}${path}?token=${encodeURIComponent(token)}`;
 
-    await this.sendWithTemplate("email-verification", to, {
+    return this.sendWithTemplate("email-verification", to, {
       verifyLink,
       expiresIn: "24 hours",
       appName: this.getAppName(),
@@ -518,13 +530,19 @@ export class EmailService extends BaseService {
    * Uses the `welcome` template slug. When `verifyLink` is provided the
    * template includes a "Verify Email" button so the user can confirm
    * their address before logging in.
+   *
+   * Returns the send result rather than `void`. `send()` converts a provider
+   * throw into `{ success: false }` instead of propagating it, so a caller that
+   * only awaits this cannot tell a failed delivery from a completed one — and
+   * for an auth flow that difference decides what the user is told. Callers
+   * that genuinely do not care may still ignore the value.
    */
   async sendWelcomeEmail(
     to: string,
     user: { name: string | null; email: string },
     options?: { verifyLink?: string }
-  ): Promise<void> {
-    await this.sendWithTemplate("welcome", to, {
+  ): Promise<{ success: boolean; messageId?: string }> {
+    return this.sendWithTemplate("welcome", to, {
       userName: user.name ?? user.email,
       appName: this.getAppName(),
       userEmail: user.email,

--- a/packages/nextly/src/domains/users/services/user-mutation-service.ts
+++ b/packages/nextly/src/domains/users/services/user-mutation-service.ts
@@ -1295,14 +1295,32 @@ export class UserMutationService extends BaseService {
         }
       }
 
-      // ✅ Send welcome email if requested and service is available
+      // ✅ Send welcome email if requested and service is available.
+      // Deliberately fire-and-forget: a welcome message is a courtesy, and
+      // failing user creation because it could not be delivered would be worse
+      // than not sending it. Both failure shapes are logged rather than
+      // dropped, since the sender reports a provider failure as an
+      // unsuccessful result rather than by throwing.
       if (changes.sendWelcomeEmail && this.emailService) {
         await this.emailService
           .sendWelcomeEmail(user!.email, {
             name: user!.name ?? null,
             email: user!.email,
           })
-          .catch(() => undefined);
+          .then(result => {
+            if (!result.success) {
+              this.logger.warn("Welcome email was not delivered", {
+                event: "user.welcome_email_failed",
+                reason: "provider reported an unsuccessful send",
+              });
+            }
+          })
+          .catch((error: unknown) => {
+            this.logger.warn("Welcome email could not be sent", {
+              event: "user.welcome_email_failed",
+              error: error instanceof Error ? error.message : String(error),
+            });
+          });
       }
 
       return {


### PR DESCRIPTION
Closes left-task 159. Independent of #618 and #622 — no shared files.

## The defect

Three layers, each individually reasonable, lost the failure between them:

1. `send()` catches a provider throw and returns `{ success: false }` (`email-service.ts:420-438`).
2. The three auth convenience wrappers awaited that and **discarded it** — all were `Promise<void>`.
3. `AuthService` treated "did not throw" as "delivered" and ran the branch commented `// IMPORTANT: Email sent successfully — do NOT return token (security)`.

So the user received **no email and no token**, and an operator saw a `console.warn` at most.

**The failure boundary inverts the intuition.** `resolveProvider()` is called *outside* the `try`, so:

| Situation | Before |
|---|---|
| No provider configured at all | throws → caught → token returned → degrades correctly |
| **A provider configured but delivery failing** (rotated key, SMTP auth rejected, provider 5xx) | swallowed → reported as success |

The case that worked only happens on a fresh install. The case that broke is the ordinary production one.

## The fix

**Wrappers return the send result.** Widening `Promise<void>` is deliberately *additive*: an existing caller that ignores the value keeps compiling and behaving identically, which matters for a published package. Chosen over a throwing variant because `send()` itself does not throw — inventing a throw one layer up would make the wrapper's contract diverge from the layer it wraps, for no gain.

**The two auth flows now check `result.success`** and fall back when delivery did not happen, in addition to the existing `catch` for genuinely-thrown errors.

**`console.warn` → structured `this.logger` calls** with `event` keys (`auth.password_reset.email_failed`, etc.), so a delivery outage is greppable in a log aggregator instead of lost in stdout.

## The security half, which is not optional

Detecting more failures **necessarily routes more situations to the token-in-response fallback**. Shipping that alone would have widened where a live credential is handed back — which is exactly what task 159's own care note warned against.

So `undeliveredTokenFallback()` gates it: outside production the raw token is still returned (a local install must work before any provider is configured); in production it is withheld and the failure logged. [OWASP's Forgot Password guidance](https://cheatsheetseries.owasp.org/cheatsheets/Forgot_Password_Cheat_Sheet.html) is that a reset token may travel only by the side channel it was minted for — returning it to whoever called the endpoint turns a delivery outage into account takeover for any account an attacker names.

**This is a behaviour change in production** and the one thing worth reviewing hardest. Previously a production install with broken email returned the token to a Direct API caller; now it does not. The existing code already *called* this a "dev fallback" — it simply never checked. Public forgot-password handlers already discard the token and keep a generic anti-enumeration response, so no public route changes shape.

## Welcome email

Stays fire-and-forget: failing user creation because a courtesy message bounced would be worse than not sending it. But both failure shapes are now logged rather than dropped, since a provider failure arrives as an unsuccessful result and the previous `.catch(() => undefined)` would have ignored it silently either way.

## Test plan

Six new tests driving the wrapper → `sendWithTemplate` → `send` path with a stubbed adapter: delivered, provider-threw, provider-returned-unsuccessful, both other wrappers, and one pinning that a failure still *resolves* rather than throwing (so the fire-and-forget caller is unaffected).

Verified:

- **Failing test names compared, not counts.** Baseline 260 failures across `domains/auth` + `domains/email`; branch 260. **0 new, 0 newly-fixed — identically the same set.** Counts alone would hide a swap. This is the known pre-existing stale-mock baseline.
- Passes 314 → 320, exactly the 6 new tests.
- `domains/users` + `domains/email`: 26 files / 226 tests, all green.
- `check-types` clean apart from a pre-existing `@nextlyhq/blocks-engine` unbuilt-package resolution error in `block-manifest-engine-parity.test.ts`, present on `main`.
- `lint` clean at `--max-warnings 0`.

## Pre-existing issues, not introduced here

- The `block-manifest-engine-parity.test.ts` type error above.
- The ~260 stale-mock failures in `domains/auth`, unchanged by this PR.

Changeset added: yes (patch, all 22 fixed-group packages, generated from `.changeset/config.json`).