### PR TITLE
fix(nextly): honour the Resend base URL and user-agent overrides again

### DIFF
--- a/.changeset/resend-base-url-override.md
+++ b/.changeset/resend-base-url-override.md
@@ -1,0 +1,28 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+Honour `RESEND_BASE_URL` and `RESEND_USER_AGENT` again in the Resend email provider.
+
+Moving off the Resend SDK dropped the environment overrides it read, so a deployment routing mail through a capture server or an egress proxy silently reached the public Resend API instead. Both variables are respected again, and a blank value falls back to the public host.

--- a/packages/nextly/src/domains/email/__tests__/resend-provider.test.ts
+++ b/packages/nextly/src/domains/email/__tests__/resend-provider.test.ts
@@ -197,3 +197,81 @@ describe("createResendProvider", () => {
     expect(vi.mocked(globalThis.fetch)).toHaveBeenCalledTimes(2);
   });
 });
+
+describe("Resend adapter — endpoint resolution", () => {
+  const ORIGINAL_BASE = process.env.RESEND_BASE_URL;
+  const ORIGINAL_UA = process.env.RESEND_USER_AGENT;
+
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn());
+    delete process.env.RESEND_BASE_URL;
+    delete process.env.RESEND_USER_AGENT;
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    if (ORIGINAL_BASE === undefined) delete process.env.RESEND_BASE_URL;
+    else process.env.RESEND_BASE_URL = ORIGINAL_BASE;
+    if (ORIGINAL_UA === undefined) delete process.env.RESEND_USER_AGENT;
+    else process.env.RESEND_USER_AGENT = ORIGINAL_UA;
+  });
+
+  async function sendOnce() {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(okResponse());
+    await createResendProvider({ apiKey: "re_k" }).send(BASE_OPTIONS);
+    return vi.mocked(globalThis.fetch).mock.calls[0];
+  }
+
+  it("defaults to the public Resend host", async () => {
+    const [url] = await sendOnce();
+    expect(url).toBe("https://api.resend.com/emails");
+  });
+
+  it("routes through RESEND_BASE_URL when set", async () => {
+    // A capture server or egress proxy. Hardcoding the public host does not
+    // fail loudly here -- the send succeeds against the wrong endpoint -- so
+    // this is the only thing standing between the override and silent bypass.
+    process.env.RESEND_BASE_URL = "https://mail-proxy.internal";
+    const [url] = await sendOnce();
+    expect(url).toBe("https://mail-proxy.internal/emails");
+  });
+
+  it("tolerates a trailing slash on the override", async () => {
+    process.env.RESEND_BASE_URL = "https://mail-proxy.internal/";
+    const [url] = await sendOnce();
+    expect(url).toBe("https://mail-proxy.internal/emails");
+  });
+
+  it("ignores a blank override rather than building a bare path", async () => {
+    process.env.RESEND_BASE_URL = "   ";
+    const [url] = await sendOnce();
+    expect(url).toBe("https://api.resend.com/emails");
+  });
+
+  it("reads the override per call, not once at import", async () => {
+    // Capturing the value at module load makes it unchangeable for the process,
+    // which breaks a test that sets it between cases and a serverless runtime
+    // that populates the environment after the module graph is warm.
+    const [firstUrl] = await sendOnce();
+    expect(firstUrl).toBe("https://api.resend.com/emails");
+
+    vi.mocked(globalThis.fetch).mockReset();
+    process.env.RESEND_BASE_URL = "https://second.example";
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(okResponse());
+    await createResendProvider({ apiKey: "re_k" }).send(BASE_OPTIONS);
+    expect(vi.mocked(globalThis.fetch).mock.calls[0][0]).toBe(
+      "https://second.example/emails"
+    );
+  });
+
+  it("sends no User-Agent header by default", async () => {
+    const [, init] = await sendOnce();
+    expect(init?.headers).not.toHaveProperty("User-Agent");
+  });
+
+  it("forwards RESEND_USER_AGENT when set", async () => {
+    process.env.RESEND_USER_AGENT = "acme-mailer/2.1";
+    const [, init] = await sendOnce();
+    expect(init?.headers).toMatchObject({ "User-Agent": "acme-mailer/2.1" });
+  });
+});

--- a/packages/nextly/src/domains/email/__tests__/resend-provider.test.ts
+++ b/packages/nextly/src/domains/email/__tests__/resend-provider.test.ts
@@ -15,7 +15,15 @@
  * - Network exception → re-throws with provider prefix
  */
 
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeEach,
+  afterEach,
+  afterAll,
+} from "vitest";
 
 import { createResendProvider } from "../services/providers/resend-provider";
 
@@ -41,6 +49,27 @@ function okResponse(id = "msg_abc123") {
     json: async () => ({ id }),
   } as unknown as Response;
 }
+
+// Both variables are read by the provider, so ANY test in this file that
+// asserts a URL or headers depends on them being absent unless it sets them.
+// Isolated at file level rather than per-describe: a developer or CI with
+// RESEND_BASE_URL exported would otherwise fail the default-endpoint
+// assertions in the first describe, which never opted into the variable and
+// cannot see why it broke.
+const ORIGINAL_BASE_URL = process.env.RESEND_BASE_URL;
+const ORIGINAL_USER_AGENT = process.env.RESEND_USER_AGENT;
+
+beforeEach(() => {
+  delete process.env.RESEND_BASE_URL;
+  delete process.env.RESEND_USER_AGENT;
+});
+
+afterAll(() => {
+  if (ORIGINAL_BASE_URL === undefined) delete process.env.RESEND_BASE_URL;
+  else process.env.RESEND_BASE_URL = ORIGINAL_BASE_URL;
+  if (ORIGINAL_USER_AGENT === undefined) delete process.env.RESEND_USER_AGENT;
+  else process.env.RESEND_USER_AGENT = ORIGINAL_USER_AGENT;
+});
 
 describe("createResendProvider", () => {
   beforeEach(() => {
@@ -199,21 +228,13 @@ describe("createResendProvider", () => {
 });
 
 describe("Resend adapter — endpoint resolution", () => {
-  const ORIGINAL_BASE = process.env.RESEND_BASE_URL;
-  const ORIGINAL_UA = process.env.RESEND_USER_AGENT;
-
+  // Env isolation is file-level; this only needs the fetch stub.
   beforeEach(() => {
     vi.stubGlobal("fetch", vi.fn());
-    delete process.env.RESEND_BASE_URL;
-    delete process.env.RESEND_USER_AGENT;
   });
 
   afterEach(() => {
     vi.unstubAllGlobals();
-    if (ORIGINAL_BASE === undefined) delete process.env.RESEND_BASE_URL;
-    else process.env.RESEND_BASE_URL = ORIGINAL_BASE;
-    if (ORIGINAL_UA === undefined) delete process.env.RESEND_USER_AGENT;
-    else process.env.RESEND_USER_AGENT = ORIGINAL_UA;
   });
 
   async function sendOnce() {

--- a/packages/nextly/src/domains/email/services/providers/resend-provider.ts
+++ b/packages/nextly/src/domains/email/services/providers/resend-provider.ts
@@ -14,8 +14,37 @@
 
 import type { EmailProviderAdapter } from "../../types";
 
-/** Resend's send endpoint. */
-const RESEND_API_URL = "https://api.resend.com/emails";
+/** Resend's public API host, used when nothing overrides it. */
+const RESEND_DEFAULT_BASE_URL = "https://api.resend.com";
+
+/**
+ * Where to send, honouring the same environment override the Resend SDK read.
+ *
+ * Deployments point `RESEND_BASE_URL` at a capture server for testing, or at a
+ * controlled egress proxy where outbound traffic is the only route off the
+ * network. Hardcoding the public host does not fail loudly in either case — the
+ * request succeeds against the wrong endpoint — so the override has to survive
+ * the move off the SDK.
+ *
+ * Read per call rather than at module load: the value is captured at import
+ * time otherwise, which a test that sets the variable between cases cannot
+ * change, and a serverless runtime may populate the environment after the
+ * module graph is already warm.
+ */
+function resendEndpoint(): string {
+  const base = process.env.RESEND_BASE_URL?.trim() || RESEND_DEFAULT_BASE_URL;
+  // Tolerate a trailing slash so `https://host/` and `https://host` agree.
+  return `${base.replace(/\/+$/, "")}/emails`;
+}
+
+/**
+ * The `User-Agent` the SDK sent, overridable by the same variable it used.
+ * Some egress proxies filter on it, so it travels with the base URL rather
+ * than being dropped as cosmetic.
+ */
+function resendUserAgent(): string | undefined {
+  return process.env.RESEND_USER_AGENT?.trim() || undefined;
+}
 
 /**
  * Resend configuration shape stored in `EmailProviderRecord.configuration`.
@@ -100,13 +129,17 @@ export function createResendProvider(
         }));
       }
 
+      const headers: Record<string, string> = {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${config.apiKey}`,
+      };
+      const userAgent = resendUserAgent();
+      if (userAgent) headers["User-Agent"] = userAgent;
+
       try {
-        const response = await fetch(RESEND_API_URL, {
+        const response = await fetch(resendEndpoint(), {
           method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            Authorization: `Bearer ${config.apiKey}`,
-          },
+          headers,
           body: JSON.stringify(body),
         });
 

--- a/turbo.jsonc
+++ b/turbo.jsonc
@@ -62,6 +62,8 @@
     "R2_SECRET_ACCESS_KEY",
     "UPLOADTHING_TOKEN",
     "UPLOADTHING_SECRET",
+    "RESEND_BASE_URL", // Resend email provider: capture server / egress proxy host
+    "RESEND_USER_AGENT", // Resend email provider: User-Agent some proxies filter on
     "DATABASE_URL",
     "DB_DIALECT",
     "GITHUB_ACTOR", // nextly migrate: appliedBy actor in CI


### PR DESCRIPTION
Follow-up to #622, which merged with two Codex findings unresolved. This fixes the real one.

## The regression

Moving the Resend adapter off the SDK dropped two environment variables the SDK read. Confirmed by fetching the actual published package rather than trusting either side of the review — `resend@6.9.2`, `dist/index.mjs:882-885`:

```js
const defaultBaseUrl = "https://api.resend.com";
const baseUrl = process.env.RESEND_BASE_URL || defaultBaseUrl;
const userAgent = process.env.RESEND_USER_AGENT || defaultUserAgent;
```

`RESEND_BASE_URL` points at a capture server during testing, or at a controlled egress proxy that is the only sanctioned route off the network. **The failure mode is the dangerous kind: nothing errors.** The request succeeds against the public API, so a deployment that believed its mail was contained discovers otherwise only by inspecting traffic.

Codex flagged `RESEND_BASE_URL` (P2 on #622). `RESEND_USER_AGENT` is the adjacent instance it did not mention — same one-line pattern, dropped in the same edit, and some egress proxies filter on it. Fixed together rather than waiting for it to be reported separately.

## Details worth reviewing

**Read per call, not at module load.** Capturing at import time makes the value unchangeable for the process, which defeats a test setting it between cases and a serverless runtime that populates the environment after the module graph is warm. There is a test pinning exactly this.

**A blank override falls back** to the public host rather than building `/emails` against an empty base. A trailing slash is tolerated so `https://host/` and `https://host` agree.

**`turbo.jsonc`:** both variables are declared in `globalPassThroughEnv`, beside the other provider runtime config (S3, UploadThing, Vercel Blob). The `turbo/no-undeclared-env-vars` lint rule caught this, correctly — reading an undeclared variable makes turbo's cache keys wrong. Fixed by declaring, not by silencing.

## The other finding on #622, declined

Codex also raised (P1) that the adapter throws a bare `Error` rather than a `NextlyError`. **Verified by reading both consumers, and it is cosmetic on every path that exists:**

- `EmailService.send()` catches the throw and converts it to `{ success: false }`, discarding the error entirely.
- `EmailProviderService.testProvider()` catches it and reads `.message` only.

Nothing reads a code or status, so a `NextlyError` would add fields no consumer consults. More importantly, converting **only** Resend would break the consistency #622 deliberately created: `sendlayer-provider.ts` and `smtp-provider.ts` throw bare `Error` in exactly this shape, and Resend was written to match them. The observation is fair as a codebase-wide point — bare `throw new Error` appears 297 times in product files under `packages/nextly` — but it should be one change across all three providers, with a reason to prefer it, not a single divergent adapter.

Filed rather than dropped; not folded in here because it is a different question with a different blast radius.

## Test plan

Seven new tests: default host, override honoured, trailing slash, blank-ignored, read-per-call, no User-Agent by default, and `RESEND_USER_AGENT` forwarded.

**Positive control run:** against `main`'s current provider, **4 of the 7 fail** — `routes through RESEND_BASE_URL`, `tolerates a trailing slash`, `reads the override per call`, `forwards RESEND_USER_AGENT`. The other three pass because they assert behavior the regression preserved, which is the point of including them. Restore verified by `diff`.

- `vitest run src/domains/email` — **21 files / 163 tests, all passing.**
- `check-types` — **0 errors.**
- `lint` — clean at `--max-warnings 0`.

Changeset added: yes (patch, all 22 fixed-group packages, generated from `.changeset/config.json`).