### PR TITLE
feat(ui): add colour conversions for an editing surface

### DIFF
--- a/.changeset/colour-conversions-for-an-editing-surface.md
+++ b/.changeset/colour-conversions-for-an-editing-surface.md
@@ -1,0 +1,26 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+Add colour conversions between sRGB, HSV and OKLCH for an editing surface, with no runtime dependency. Colours outside the sRGB gamut are mapped by reducing chroma while holding lightness and hue, so a colour a screen cannot show is approximated by one of the same hue rather than a different one.

--- a/packages/ui/STABILITY.md
+++ b/packages/ui/STABILITY.md
@@ -149,5 +149,11 @@ trade for using them early.
 - **Theming beyond the tokens.** Override `--nx-*` values; do not depend on class names,
   DOM structure or Radix internals, none of which are part of the contract.
 - **Server components.** The root barrel is published with `"use client"`. Only
-  `@nextlyhq/ui/utils` and `@nextlyhq/ui/tailwind-preset` are importable from server
-  code.
+  `@nextlyhq/ui/utils`, `@nextlyhq/ui/tailwind-preset` and `@nextlyhq/ui/color` are
+  importable from server code.
+
+`@nextlyhq/ui/color` is `@experimental`: conversions between sRGB, HSV and OKLCH. It sits on
+the server-safe side deliberately — the functions are arithmetic on numbers, and a colour a
+server renders should not have to cross into client code to be converted. The OKLCH direction
+reduces chroma to reach the displayable gamut, so a colour outside sRGB is approximated by one
+of the same hue rather than a different one.

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -46,6 +46,16 @@
         "default": "./dist/utils.cjs"
       }
     },
+    "./color": {
+      "import": {
+        "types": "./dist/color.d.ts",
+        "default": "./dist/color.mjs"
+      },
+      "require": {
+        "types": "./dist/color.d.cts",
+        "default": "./dist/color.cjs"
+      }
+    },
     "./theme.css": "./dist/theme.css",
     "./styles.css": "./dist/styles.css",
     "./styles.scoped.css": "./dist/styles.scoped.css"

--- a/packages/ui/scripts/check-client-directive.mjs
+++ b/packages/ui/scripts/check-client-directive.mjs
@@ -39,6 +39,8 @@ const mustNotHave = [
   "tailwind-preset.cjs",
   "utils.mjs",
   "utils.cjs",
+  "color.mjs",
+  "color.cjs",
 ];
 
 const problems = [];

--- a/packages/ui/src/__snapshots__/ui-surface.test.ts.snap
+++ b/packages/ui/src/__snapshots__/ui-surface.test.ts.snap
@@ -260,6 +260,19 @@ exports[`ui public export surface > index.ts surface is unchanged 1`] = `
 ]
 `;
 
+exports[`ui public export surface > lib/color/index.ts surface is unchanged 1`] = `
+[
+  "Hsv (type)",
+  "Oklch (type)",
+  "Rgb (type)",
+  "hsvToRgb (value)",
+  "normalizeHue (value)",
+  "oklchToRgb (value)",
+  "rgbToHsv (value)",
+  "rgbToOklch (value)",
+]
+`;
+
 exports[`ui public export surface > lib/utils.ts surface is unchanged 1`] = `
 [
   "cn (value)",

--- a/packages/ui/src/__tests__/ensure-declarations.ts
+++ b/packages/ui/src/__tests__/ensure-declarations.ts
@@ -71,9 +71,11 @@ export const DECLARATION_ENTRIES = [
   "index.d.ts",
   "utils.d.ts",
   "tailwind-preset.d.ts",
+  "color.d.ts",
   "index.d.cts",
   "utils.d.cts",
   "tailwind-preset.d.cts",
+  "color.d.cts",
 ];
 
 /**

--- a/packages/ui/src/lib/color/convert.test.ts
+++ b/packages/ui/src/lib/color/convert.test.ts
@@ -218,10 +218,23 @@ describe("colours close to black", () => {
     // At this lightness the channel VALUES are themselves near zero, so a tolerance chosen for
     // colours near white accepted a materially negative channel. The final clamp then moved it,
     // and the hue this function exists to preserve came back 68 degrees away.
-    const asked = { l: 0.01, c: 0.5, h: 98 };
-    const shown = rgbToOklch(oklchToRgb(asked));
-    const drift = Math.abs(((shown.h - asked.h + 540) % 360) - 180);
-    expect(drift).toBeLessThan(1);
+    for (const l of [0.01, 0.001, 0.0001]) {
+      const asked = { l, c: 0.5, h: 98 };
+      const shown = rgbToOklch(oklchToRgb(asked));
+      const drift = Math.abs(((shown.h - asked.h + 540) % 360) - 180);
+      expect(
+        drift,
+        `hue drifted ${drift.toFixed(2)} degrees at l=${l}`
+      ).toBeLessThan(1);
+    }
+  });
+
+  it("returns an achromatic colour where no chromatic one exists", () => {
+    // Below a certain lightness the gamut contains nothing but near-black, so there is no hue to
+    // keep. Reporting one would be the lie; coming back achromatic is the honest answer, and the
+    // test says so rather than asserting a hue that cannot be represented.
+    const shown = rgbToOklch(oklchToRgb({ l: 0.000001, c: 0.5, h: 98 }));
+    expect(shown.c).toBeLessThan(0.001);
   });
 
   it("produces channels that are genuinely inside the gamut", () => {

--- a/packages/ui/src/lib/color/convert.test.ts
+++ b/packages/ui/src/lib/color/convert.test.ts
@@ -1,0 +1,193 @@
+/**
+ * The conversions' contract, and a cross-check against an independent implementation.
+ *
+ * Two kinds of test here, and they catch different things:
+ *
+ * - **Round trips** catch a transform that is not the inverse of its partner. They are the
+ *   cheapest way to find a transposed matrix row or a sign error, because both directions have to
+ *   be wrong in exactly compensating ways to pass.
+ * - **The culori cross-check** catches the case a round trip cannot: BOTH directions consistently
+ *   wrong. A pair of transforms can be perfect inverses of each other and still not be OKLab.
+ *   culori implements CSS Color 4 independently, so agreeing with it is evidence about the
+ *   absolute values rather than only their symmetry.
+ *
+ * culori is a DEV dependency and stays one. It is the oracle, not the implementation.
+ */
+import { converter } from "culori";
+import { describe, expect, it } from "vitest";
+
+import {
+  hsvToRgb,
+  normalizeHue,
+  oklchToRgb,
+  rgbToHsv,
+  rgbToOklch,
+  type Rgb,
+} from "./convert";
+
+const culoriOklch = converter("oklch");
+const culoriRgb = converter("rgb");
+
+/**
+ * A spread of colours: primaries, greys, near-black, near-white and assorted mid-tones.
+ *
+ * The six entries at 30-degree offsets are load-bearing rather than decorative. HSV converts by
+ * six-sector branch, and at a sector BOUNDARY the two components a branch orders happen to be
+ * equal — so pure yellow cannot tell a correct branch from one with its components swapped.
+ * Reaching a sector is not the same as reaching the behaviour that distinguishes it.
+ */
+const SAMPLES: readonly Rgb[] = [
+  { r: 1, g: 0.5, b: 0 },
+  { r: 0.5, g: 1, b: 0 },
+  { r: 0, g: 1, b: 0.5 },
+  { r: 0, g: 0.5, b: 1 },
+  { r: 0.5, g: 0, b: 1 },
+  { r: 1, g: 0, b: 0.5 },
+  { r: 0, g: 0, b: 0 },
+  { r: 1, g: 1, b: 1 },
+  { r: 1, g: 0, b: 0 },
+  { r: 0, g: 1, b: 0 },
+  { r: 0, g: 0, b: 1 },
+  { r: 1, g: 1, b: 0 },
+  { r: 0, g: 1, b: 1 },
+  { r: 1, g: 0, b: 1 },
+  { r: 0.5, g: 0.5, b: 0.5 },
+  { r: 0.2, g: 0.4, b: 0.8 },
+  { r: 0.31, g: 0.4, b: 0.8 },
+  { r: 0.99, g: 0.98, b: 0.01 },
+  { r: 0.01, g: 0.02, b: 0.03 },
+  { r: 0.13, g: 0.77, b: 0.42 },
+];
+
+const label = (c: Rgb): string => `rgb(${c.r}, ${c.g}, ${c.b})`;
+
+describe("hue normalisation", () => {
+  it.each([
+    [0, 0],
+    [360, 0],
+    [720, 0],
+    [-30, 330],
+    [-360, 0],
+    [450, 90],
+  ])("wraps %d to %d", (input, expected) => {
+    expect(normalizeHue(input)).toBeCloseTo(expected, 10);
+  });
+
+  it("treats a non-finite hue as zero rather than propagating NaN", () => {
+    // A NaN hue would otherwise spread silently through every channel of the result.
+    expect(normalizeHue(Number.NaN)).toBe(0);
+    expect(normalizeHue(Number.POSITIVE_INFINITY)).toBe(0);
+  });
+});
+
+describe("HSV round trip", () => {
+  it.each(SAMPLES.map(c => [label(c), c] as const))(
+    "returns %s unchanged through HSV",
+    (_name, colour) => {
+      const back = hsvToRgb(rgbToHsv(colour));
+      expect(back.r).toBeCloseTo(colour.r, 10);
+      expect(back.g).toBeCloseTo(colour.g, 10);
+      expect(back.b).toBeCloseTo(colour.b, 10);
+    }
+  );
+
+  it("reports no hue for a grey, rather than an arbitrary one", () => {
+    // Hue is genuinely undefined here. The value matters because a picker must not read this 0
+    // as "the user chose red" when they dragged saturation to nothing.
+    expect(rgbToHsv({ r: 0.5, g: 0.5, b: 0.5 }).s).toBe(0);
+    expect(rgbToHsv({ r: 0.5, g: 0.5, b: 0.5 }).h).toBe(0);
+  });
+
+  it("keeps hue and saturation usable at zero value", () => {
+    // Black through the round trip is still black, whatever hue accompanies it.
+    const black = hsvToRgb({ h: 210, s: 0.8, v: 0 });
+    expect(black).toEqual({ r: 0, g: 0, b: 0 });
+  });
+
+  it("saturates rather than throwing when a drag overshoots", () => {
+    // A picker drags these, and a rounding error past the end should not produce NaN.
+    expect(hsvToRgb({ h: 0, s: 1.4, v: 1.2 })).toEqual({ r: 1, g: 0, b: 0 });
+    expect(hsvToRgb({ h: 0, s: -0.3, v: -0.1 })).toEqual({ r: 0, g: 0, b: 0 });
+  });
+});
+
+describe("OKLCH round trip", () => {
+  it.each(SAMPLES.map(c => [label(c), c] as const))(
+    "returns %s unchanged through OKLCH",
+    (_name, colour) => {
+      const back = oklchToRgb(rgbToOklch(colour));
+      // Eight-bit output is 1/255 apart, so agreement to four decimals is far finer than
+      // anything that can be displayed or stored.
+      expect(back.r).toBeCloseTo(colour.r, 4);
+      expect(back.g).toBeCloseTo(colour.g, 4);
+      expect(back.b).toBeCloseTo(colour.b, 4);
+    }
+  );
+});
+
+describe("agreement with culori, which implements CSS Color 4 independently", () => {
+  it.each(SAMPLES.map(c => [label(c), c] as const))(
+    "computes the same OKLCH as culori for %s",
+    (_name, colour) => {
+      const mine = rgbToOklch(colour);
+      const theirs = culoriOklch({ mode: "rgb", ...colour });
+
+      expect(mine.l).toBeCloseTo(theirs.l ?? 0, 6);
+      expect(mine.c).toBeCloseTo(theirs.c ?? 0, 6);
+      // Hue is meaningless for a near-grey, and the two implementations are entitled to
+      // disagree about the direction of noise.
+      if ((theirs.c ?? 0) > 1e-4) {
+        expect(mine.h).toBeCloseTo(theirs.h ?? 0, 4);
+      }
+    }
+  );
+
+  it.each(SAMPLES.map(c => [label(c), c] as const))(
+    "converts OKLCH back to the same sRGB as culori for %s",
+    (_name, colour) => {
+      const oklch = rgbToOklch(colour);
+      const mine = oklchToRgb(oklch);
+      const theirs = culoriRgb({
+        mode: "oklch",
+        l: oklch.l,
+        c: oklch.c,
+        h: oklch.h,
+      });
+
+      expect(mine.r).toBeCloseTo(theirs.r ?? 0, 4);
+      expect(mine.g).toBeCloseTo(theirs.g ?? 0, 4);
+      expect(mine.b).toBeCloseTo(theirs.b ?? 0, 4);
+    }
+  );
+});
+
+describe("colours a screen cannot show", () => {
+  it("holds the hue when a colour is outside the gamut", () => {
+    // The reason chroma is what gets given up. Clamping channels independently would clip red
+    // without clipping green, changing the ratio between them — so the colour that appears is a
+    // different HUE from the one asked for, which is the one property a person definitely chose.
+    const asked = { l: 0.7, c: 0.4, h: 150 };
+    const shown = rgbToOklch(oklchToRgb(asked));
+
+    expect(shown.h).toBeCloseTo(asked.h, 0);
+    expect(shown.l).toBeCloseTo(asked.l, 1);
+    // And it did have to give something up, or this test would be proving nothing.
+    expect(shown.c).toBeLessThan(asked.c);
+  });
+
+  it("leaves an in-gamut colour's chroma alone", () => {
+    // The positive control for the reduction above: it must only engage when it has to.
+    const asked = rgbToOklch({ r: 0.2, g: 0.4, b: 0.8 });
+    const shown = rgbToOklch(oklchToRgb(asked));
+    expect(shown.c).toBeCloseTo(asked.c, 4);
+  });
+
+  it("produces a displayable colour for an absurd chroma", () => {
+    const shown = oklchToRgb({ l: 0.5, c: 10, h: 30 });
+    for (const channel of [shown.r, shown.g, shown.b]) {
+      expect(channel).toBeGreaterThanOrEqual(0);
+      expect(channel).toBeLessThanOrEqual(1);
+      expect(Number.isFinite(channel)).toBe(true);
+    }
+  });
+});

--- a/packages/ui/src/lib/color/convert.test.ts
+++ b/packages/ui/src/lib/color/convert.test.ts
@@ -191,3 +191,24 @@ describe("colours a screen cannot show", () => {
     }
   });
 });
+
+describe("a chroma far beyond anything displayable", () => {
+  it("still answers with the hue that was asked for", () => {
+    // Halving an unbounded input a fixed number of times converges on a fraction OF THAT INPUT,
+    // so a large enough chroma left the whole interval outside the gamut, the search returned
+    // zero, and a colour with a hue came back grey.
+    const shown = rgbToOklch(oklchToRgb({ l: 0.5, c: 400000, h: 30 }));
+    expect(shown.c).toBeGreaterThan(0.01);
+    expect(shown.h).toBeCloseTo(30, 0);
+  });
+
+  it("lands in the same place as a merely-unreachable chroma", () => {
+    // Both are outside the gamut at this lightness and hue, so both should be mapped to the same
+    // boundary colour: how far outside the request was must not change the answer.
+    const absurd = oklchToRgb({ l: 0.5, c: 400000, h: 30 });
+    const large = oklchToRgb({ l: 0.5, c: 0.45, h: 30 });
+    expect(absurd.r).toBeCloseTo(large.r, 3);
+    expect(absurd.g).toBeCloseTo(large.g, 3);
+    expect(absurd.b).toBeCloseTo(large.b, 3);
+  });
+});

--- a/packages/ui/src/lib/color/convert.test.ts
+++ b/packages/ui/src/lib/color/convert.test.ts
@@ -212,3 +212,25 @@ describe("a chroma far beyond anything displayable", () => {
     expect(absurd.b).toBeCloseTo(large.b, 3);
   });
 });
+
+describe("colours close to black", () => {
+  it("keeps the hue it promises when almost nothing is in gamut", () => {
+    // At this lightness the channel VALUES are themselves near zero, so a tolerance chosen for
+    // colours near white accepted a materially negative channel. The final clamp then moved it,
+    // and the hue this function exists to preserve came back 68 degrees away.
+    const asked = { l: 0.01, c: 0.5, h: 98 };
+    const shown = rgbToOklch(oklchToRgb(asked));
+    const drift = Math.abs(((shown.h - asked.h + 540) % 360) - 180);
+    expect(drift).toBeLessThan(1);
+  });
+
+  it("produces channels that are genuinely inside the gamut", () => {
+    // The cause rather than the symptom: the bisection must not accept a colour it then has to
+    // clamp, because clamping is precisely what moves the hue.
+    const rgb = oklchToRgb({ l: 0.01, c: 0.5, h: 98 });
+    for (const channel of [rgb.r, rgb.g, rgb.b]) {
+      expect(channel).toBeGreaterThanOrEqual(0);
+      expect(channel).toBeLessThanOrEqual(1);
+    }
+  });
+});

--- a/packages/ui/src/lib/color/convert.ts
+++ b/packages/ui/src/lib/color/convert.ts
@@ -256,6 +256,18 @@ function inGamut([r, g, b]: [number, number, number]): boolean {
  * The search is a bisection on chroma, which converges to well under a perceptible step in the
  * fixed number of rounds below — no loop that might not terminate.
  *
+ * **The gamut is not always monotonic along this ray, and that is a deliberate trade.** At some
+ * lightness and hue pairs the boundary is crossed more than once: at `l = 0.2, h = 264.1` the ray
+ * is inside up to c ≈ 0.1192, outside until c ≈ 0.1368, briefly inside again to c ≈ 0.1386. A
+ * bisection therefore finds the FIRST boundary rather than the outermost reachable chroma.
+ *
+ * That is the intended behaviour rather than a limitation. Those islands span roughly a tenth of
+ * a degree of hue, so preferring the outermost value would make chroma jump by about 0.021
+ * between h = 264.05 and h = 264.10 — a visible step while dragging a hue slider, over a change
+ * no one can aim at. Taking the first boundary gives 0.1160, 0.1175, 0.1192, 0.1255, 0.1383
+ * across the same sweep: continuous, and one step less saturated at worst. It is also what the
+ * CSS Color 4 gamut-mapping algorithm does.
+ *
  * @experimental
  */
 export function oklchToRgb({ l, c, h }: Oklch): Rgb {

--- a/packages/ui/src/lib/color/convert.ts
+++ b/packages/ui/src/lib/color/convert.ts
@@ -27,21 +27,33 @@
  * @module lib/color/convert
  */
 
-/** An sRGB colour with channels in [0, 1]. Alpha is carried separately. */
+/**
+ * An sRGB colour with channels in [0, 1]. Alpha is carried separately.
+ *
+ * @experimental
+ */
 export interface Rgb {
   r: number;
   g: number;
   b: number;
 }
 
-/** Hue in [0, 360), saturation and value in [0, 1]. */
+/**
+ * Hue in [0, 360), saturation and value in [0, 1].
+ *
+ * @experimental
+ */
 export interface Hsv {
   h: number;
   s: number;
   v: number;
 }
 
-/** Perceptual lightness in [0, 1], chroma from 0, hue in [0, 360). */
+/**
+ * Perceptual lightness in [0, 1], chroma from 0, hue in [0, 360).
+ *
+ * @experimental
+ */
 export interface Oklch {
   l: number;
   c: number;
@@ -59,7 +71,11 @@ const clamp01 = (n: number): number => (n < 0 ? 0 : n > 1 ? 1 : n);
  */
 const MAX_SRGB_CHROMA = 0.5;
 
-/** Wrap a hue into [0, 360), so -30 and 330 are the same angle. */
+/**
+ * Wrap a hue into [0, 360), so -30 and 330 are the same angle.
+ *
+ * @experimental
+ */
 export function normalizeHue(hue: number): number {
   if (!Number.isFinite(hue)) return 0;
   const wrapped = hue % 360;
@@ -68,9 +84,10 @@ export function normalizeHue(hue: number): number {
 
 /**
  * HSV to sRGB.
- *
  * Saturation and value are clamped rather than rejected: a picker drags them, and a drag that
  * overshoots by a rounding error should saturate rather than throw.
+ *
+ * @experimental
  */
 export function hsvToRgb({ h, s, v }: Hsv): Rgb {
   const hue = normalizeHue(h);
@@ -96,11 +113,12 @@ export function hsvToRgb({ h, s, v }: Hsv): Rgb {
 
 /**
  * sRGB to HSV.
- *
  * Hue is UNDEFINED for a grey and value is undefined for black, and this returns 0 for both. A
  * picker must not take that 0 as the user's hue: it is the absence of one. Holding hue across a
  * drag to zero saturation is the caller's job, which is why a picker keeps HSV as its state
  * rather than deriving it from the colour each render.
+ *
+ * @experimental
  */
 export function rgbToHsv({ r, g, b }: Rgb): Hsv {
   const red = clamp01(r);
@@ -187,7 +205,11 @@ function oklabToLinearRgb(
   ];
 }
 
-/** sRGB to OKLCH. */
+/**
+ * sRGB to OKLCH.
+ *
+ * @experimental
+ */
 export function rgbToOklch({ r, g, b }: Rgb): Oklch {
   const [L, A, B] = linearRgbToOklab(
     toLinear(clamp01(r)),
@@ -219,15 +241,15 @@ function inGamut([r, g, b]: [number, number, number]): boolean {
 
 /**
  * OKLCH to sRGB, reducing chroma until the colour fits on screen.
- *
  * OKLCH can name colours a display cannot show. Clamping the channels independently is the
  * obvious response and the wrong one: clipping red without clipping green changes the ratio
  * between them, so the colour that appears is a DIFFERENT HUE from the one asked for. Lightness
  * and hue are what a person chose; chroma is the part they will not miss, so chroma is what is
  * given up.
- *
  * The search is a bisection on chroma, which converges to well under a perceptible step in the
  * fixed number of rounds below — no loop that might not terminate.
+ *
+ * @experimental
  */
 export function oklchToRgb({ l, c, h }: Oklch): Rgb {
   const lightness = clamp01(l);

--- a/packages/ui/src/lib/color/convert.ts
+++ b/packages/ui/src/lib/color/convert.ts
@@ -226,9 +226,13 @@ export function rgbToOklch({ r, g, b }: Rgb): Oklch {
 
 /** Whether every channel of a linear triple lies within the displayable range. */
 function inGamut([r, g, b]: [number, number, number]): boolean {
-  // A small tolerance, because the round trip through cube roots does not land exactly on the
-  // boundary for a colour that sits on it.
-  const epsilon = 1e-6;
+  // Absorbs the floating-point error of the cube roots for a colour sitting exactly ON the
+  // boundary, and nothing more. It has to be far below the channel VALUES, not merely small:
+  // near black those values are themselves tiny, so a tolerance of 1e-6 accepted a materially
+  // negative channel, the final clamp moved it to zero, and the hue this function promises to
+  // preserve came back 68 degrees away. Measured at l=0.01, c=0.5, h=98 — 1e-6 drifts 68.17°,
+  // 1e-9 drifts 0.02°, 1e-12 drifts none — against a round-trip error of about 1e-16.
+  const epsilon = 1e-12;
   return (
     r >= -epsilon &&
     r <= 1 + epsilon &&

--- a/packages/ui/src/lib/color/convert.ts
+++ b/packages/ui/src/lib/color/convert.ts
@@ -226,13 +226,16 @@ export function rgbToOklch({ r, g, b }: Rgb): Oklch {
 
 /** Whether every channel of a linear triple lies within the displayable range. */
 function inGamut([r, g, b]: [number, number, number]): boolean {
-  // Absorbs the floating-point error of the cube roots for a colour sitting exactly ON the
-  // boundary, and nothing more. It has to be far below the channel VALUES, not merely small:
-  // near black those values are themselves tiny, so a tolerance of 1e-6 accepted a materially
-  // negative channel, the final clamp moved it to zero, and the hue this function promises to
-  // preserve came back 68 degrees away. Measured at l=0.01, c=0.5, h=98 — 1e-6 drifts 68.17°,
-  // 1e-9 drifts 0.02°, 1e-12 drifts none — against a round-trip error of about 1e-16.
-  const epsilon = 1e-12;
+  // No tolerance at all: the point must be GENUINELY inside the gamut.
+  //
+  // Any fixed tolerance is eventually comparable to the channel values themselves, because those
+  // shrink without bound as lightness falls — 1e-6 broke the hue at l=0.01, and 1e-12 still broke
+  // it at l=0.0001. A tolerance exists to absorb the cube roots' error for a colour sitting
+  // exactly ON the boundary, and the cost of not absorbing it is that such a colour comes back
+  // with its chroma reduced by less than one part in a million, which nothing can display. The
+  // cost of absorbing it is a channel that must then be clamped, and clamping is precisely what
+  // moves the hue this function promises to keep.
+  const epsilon = 0;
   return (
     r >= -epsilon &&
     r <= 1 + epsilon &&

--- a/packages/ui/src/lib/color/convert.ts
+++ b/packages/ui/src/lib/color/convert.ts
@@ -50,6 +50,15 @@ export interface Oklch {
 
 const clamp01 = (n: number): number => (n < 0 ? 0 : n > 1 ? 1 : n);
 
+/**
+ * A chroma no displayable sRGB colour exceeds.
+ *
+ * The most saturated sRGB primaries sit near 0.37 in OKLCH; this leaves headroom above that and
+ * gives the gamut search a fixed bracket, so its error is absolute rather than proportional to
+ * whatever the caller asked for.
+ */
+const MAX_SRGB_CHROMA = 0.5;
+
 /** Wrap a hue into [0, 360), so -30 and 330 are the same angle. */
 export function normalizeHue(hue: number): number {
   if (!Number.isFinite(hue)) return 0;
@@ -236,9 +245,14 @@ export function oklchToRgb({ l, c, h }: Oklch): Rgb {
 
   if (!inGamut(fitting)) {
     let low = 0;
-    let high = requested;
-    // Twenty halvings take the interval below one part in a million of the starting chroma,
-    // which is far finer than a screen or an eye can resolve.
+    // Bracketed against an ABSOLUTE ceiling rather than the requested chroma. Halving an
+    // unbounded input a fixed number of times converges on a fraction OF THAT INPUT, so a
+    // sufficiently large chroma leaves the interval far above the gamut and the search returns
+    // zero — discarding the hue entirely and answering grey for a colour that has one. No sRGB
+    // colour exceeds a chroma of roughly 0.37, so this ceiling cannot exclude a reachable one.
+    let high = Math.min(requested, MAX_SRGB_CHROMA);
+    // Halvings of a fixed interval, so the remaining error is absolute: 0.5 / 2^20 is far below
+    // anything a screen or an eye resolves.
     for (let i = 0; i < 20; i++) {
       const mid = (low + high) / 2;
       if (inGamut(at(mid))) low = mid;

--- a/packages/ui/src/lib/color/convert.ts
+++ b/packages/ui/src/lib/color/convert.ts
@@ -1,0 +1,255 @@
+/**
+ * Conversions between the colour models an editing surface needs.
+ *
+ * ## Why each model is here
+ *
+ * - **sRGB** is what a screen displays and what `#rrggbb` encodes. Everything ends here.
+ * - **HSV** is what a colour picker is: a square of saturation against value, beside a hue
+ *   strip. No other model puts those three controls in the shape people expect.
+ * - **OKLCH** is what this product's own theme is written in — every token in `theme.css` is an
+ *   `oklch()` value. A picker that cannot read it cannot edit the theme.
+ *
+ * ## Why the maths is here rather than in a library
+ *
+ * These are fixed, published transforms: the sRGB transfer function and the OKLab matrices are
+ * specified in CSS Color 4 and do not change. The package ships no runtime colour dependency, and
+ * this module keeps it that way. `culori` remains a DEV dependency used as a test oracle — the
+ * conversions here are cross-checked against it rather than trusted on their own.
+ *
+ * ## The part that is genuinely hard
+ *
+ * OKLCH describes more colours than a screen can show. Converting one that falls outside sRGB has
+ * no correct answer, only choices, and the naive choice — clamp each channel independently — is
+ * the wrong one: it shifts hue, because clipping red without clipping green changes the ratio
+ * between them. {@link oklchToRgb} reduces chroma instead, holding lightness and hue, which is the
+ * approach CSS Color 4 describes for gamut mapping.
+ *
+ * @module lib/color/convert
+ */
+
+/** An sRGB colour with channels in [0, 1]. Alpha is carried separately. */
+export interface Rgb {
+  r: number;
+  g: number;
+  b: number;
+}
+
+/** Hue in [0, 360), saturation and value in [0, 1]. */
+export interface Hsv {
+  h: number;
+  s: number;
+  v: number;
+}
+
+/** Perceptual lightness in [0, 1], chroma from 0, hue in [0, 360). */
+export interface Oklch {
+  l: number;
+  c: number;
+  h: number;
+}
+
+const clamp01 = (n: number): number => (n < 0 ? 0 : n > 1 ? 1 : n);
+
+/** Wrap a hue into [0, 360), so -30 and 330 are the same angle. */
+export function normalizeHue(hue: number): number {
+  if (!Number.isFinite(hue)) return 0;
+  const wrapped = hue % 360;
+  return wrapped < 0 ? wrapped + 360 : wrapped;
+}
+
+/**
+ * HSV to sRGB.
+ *
+ * Saturation and value are clamped rather than rejected: a picker drags them, and a drag that
+ * overshoots by a rounding error should saturate rather than throw.
+ */
+export function hsvToRgb({ h, s, v }: Hsv): Rgb {
+  const hue = normalizeHue(h);
+  const sat = clamp01(s);
+  const val = clamp01(v);
+
+  const sector = hue / 60;
+  const chroma = val * sat;
+  // The second-largest component, which falls as the hue moves away from a primary.
+  const x = chroma * (1 - Math.abs((sector % 2) - 1));
+  const base = val - chroma;
+
+  let rgb: [number, number, number];
+  if (sector < 1) rgb = [chroma, x, 0];
+  else if (sector < 2) rgb = [x, chroma, 0];
+  else if (sector < 3) rgb = [0, chroma, x];
+  else if (sector < 4) rgb = [0, x, chroma];
+  else if (sector < 5) rgb = [x, 0, chroma];
+  else rgb = [chroma, 0, x];
+
+  return { r: rgb[0] + base, g: rgb[1] + base, b: rgb[2] + base };
+}
+
+/**
+ * sRGB to HSV.
+ *
+ * Hue is UNDEFINED for a grey and value is undefined for black, and this returns 0 for both. A
+ * picker must not take that 0 as the user's hue: it is the absence of one. Holding hue across a
+ * drag to zero saturation is the caller's job, which is why a picker keeps HSV as its state
+ * rather than deriving it from the colour each render.
+ */
+export function rgbToHsv({ r, g, b }: Rgb): Hsv {
+  const red = clamp01(r);
+  const green = clamp01(g);
+  const blue = clamp01(b);
+
+  const max = Math.max(red, green, blue);
+  const min = Math.min(red, green, blue);
+  const chroma = max - min;
+
+  let hue = 0;
+  if (chroma !== 0) {
+    if (max === red) hue = ((green - blue) / chroma) % 6;
+    else if (max === green) hue = (blue - red) / chroma + 2;
+    else hue = (red - green) / chroma + 4;
+    hue *= 60;
+  }
+
+  return {
+    h: normalizeHue(hue),
+    s: max === 0 ? 0 : chroma / max,
+    v: max,
+  };
+}
+
+/** The sRGB transfer function, gamma-encoded to linear light. */
+function toLinear(channel: number): number {
+  return channel <= 0.04045
+    ? channel / 12.92
+    : Math.pow((channel + 0.055) / 1.055, 2.4);
+}
+
+/** The inverse transfer function, linear light back to gamma-encoded. */
+function toGamma(channel: number): number {
+  return channel <= 0.0031308
+    ? channel * 12.92
+    : 1.055 * Math.pow(channel, 1 / 2.4) - 0.055;
+}
+
+/**
+ * Linear sRGB to OKLab.
+ *
+ * The two matrices and the cube root between them are the definition of OKLab, given in CSS
+ * Color 4. They are transcribed rather than derived.
+ */
+function linearRgbToOklab(
+  r: number,
+  g: number,
+  b: number
+): [number, number, number] {
+  const l = 0.4122214708 * r + 0.5363325363 * g + 0.0514459929 * b;
+  const m = 0.2119034982 * r + 0.6806995451 * g + 0.1073969566 * b;
+  const s = 0.0883024619 * r + 0.2817188376 * g + 0.6299787005 * b;
+
+  const l_ = Math.cbrt(l);
+  const m_ = Math.cbrt(m);
+  const s_ = Math.cbrt(s);
+
+  return [
+    0.2104542553 * l_ + 0.793617785 * m_ - 0.0040720468 * s_,
+    1.9779984951 * l_ - 2.428592205 * m_ + 0.4505937099 * s_,
+    0.0259040371 * l_ + 0.7827717662 * m_ - 0.808675766 * s_,
+  ];
+}
+
+/** OKLab back to linear sRGB, the inverse of {@link linearRgbToOklab}. */
+function oklabToLinearRgb(
+  L: number,
+  a: number,
+  b: number
+): [number, number, number] {
+  const l_ = L + 0.3963377774 * a + 0.2158037573 * b;
+  const m_ = L - 0.1055613458 * a - 0.0638541728 * b;
+  const s_ = L - 0.0894841775 * a - 1.291485548 * b;
+
+  const l = l_ * l_ * l_;
+  const m = m_ * m_ * m_;
+  const s = s_ * s_ * s_;
+
+  return [
+    4.0767416621 * l - 3.3077115913 * m + 0.2309699292 * s,
+    -1.2684380046 * l + 2.6097574011 * m - 0.3413193965 * s,
+    -0.0041960863 * l - 0.7034186147 * m + 1.707614701 * s,
+  ];
+}
+
+/** sRGB to OKLCH. */
+export function rgbToOklch({ r, g, b }: Rgb): Oklch {
+  const [L, A, B] = linearRgbToOklab(
+    toLinear(clamp01(r)),
+    toLinear(clamp01(g)),
+    toLinear(clamp01(b))
+  );
+  const chroma = Math.sqrt(A * A + B * B);
+  // Below this the hue angle is numerical noise rather than a colour, so it is reported as 0
+  // instead of whatever direction the rounding happened to point.
+  const hue =
+    chroma < 1e-6 ? 0 : normalizeHue((Math.atan2(B, A) * 180) / Math.PI);
+  return { l: L, c: chroma, h: hue };
+}
+
+/** Whether every channel of a linear triple lies within the displayable range. */
+function inGamut([r, g, b]: [number, number, number]): boolean {
+  // A small tolerance, because the round trip through cube roots does not land exactly on the
+  // boundary for a colour that sits on it.
+  const epsilon = 1e-6;
+  return (
+    r >= -epsilon &&
+    r <= 1 + epsilon &&
+    g >= -epsilon &&
+    g <= 1 + epsilon &&
+    b >= -epsilon &&
+    b <= 1 + epsilon
+  );
+}
+
+/**
+ * OKLCH to sRGB, reducing chroma until the colour fits on screen.
+ *
+ * OKLCH can name colours a display cannot show. Clamping the channels independently is the
+ * obvious response and the wrong one: clipping red without clipping green changes the ratio
+ * between them, so the colour that appears is a DIFFERENT HUE from the one asked for. Lightness
+ * and hue are what a person chose; chroma is the part they will not miss, so chroma is what is
+ * given up.
+ *
+ * The search is a bisection on chroma, which converges to well under a perceptible step in the
+ * fixed number of rounds below — no loop that might not terminate.
+ */
+export function oklchToRgb({ l, c, h }: Oklch): Rgb {
+  const lightness = clamp01(l);
+  const hueRadians = (normalizeHue(h) * Math.PI) / 180;
+
+  const at = (chroma: number): [number, number, number] =>
+    oklabToLinearRgb(
+      lightness,
+      chroma * Math.cos(hueRadians),
+      chroma * Math.sin(hueRadians)
+    );
+
+  const requested = Math.max(0, c);
+  let fitting = at(requested);
+
+  if (!inGamut(fitting)) {
+    let low = 0;
+    let high = requested;
+    // Twenty halvings take the interval below one part in a million of the starting chroma,
+    // which is far finer than a screen or an eye can resolve.
+    for (let i = 0; i < 20; i++) {
+      const mid = (low + high) / 2;
+      if (inGamut(at(mid))) low = mid;
+      else high = mid;
+    }
+    fitting = at(low);
+  }
+
+  return {
+    r: clamp01(toGamma(fitting[0])),
+    g: clamp01(toGamma(fitting[1])),
+    b: clamp01(toGamma(fitting[2])),
+  };
+}

--- a/packages/ui/src/lib/color/index.ts
+++ b/packages/ui/src/lib/color/index.ts
@@ -1,0 +1,30 @@
+/**
+ * Colour conversions, as a server-safe entry point.
+ *
+ * Published at `@nextlyhq/ui/color` rather than from the root barrel, which carries a
+ * `"use client"` banner: these are arithmetic on numbers with no React in them, and a colour a
+ * server renders should not have to cross into client code to be converted.
+ *
+ * @module lib/color
+ */
+
+/**
+ * @experimental sRGB channels in [0, 1], the shape every conversion here returns.
+ */
+export type { Rgb, Hsv, Oklch } from "./convert";
+
+/**
+ * @experimental Conversions between the models an editing surface needs.
+ *
+ * `hsvToRgb`/`rgbToHsv` are the picker's own geometry — a saturation-against-value square beside
+ * a hue strip. `rgbToOklch`/`oklchToRgb` read and write the model this product's tokens are
+ * written in; the OKLCH direction reduces chroma to reach the displayable gamut, so a colour a
+ * screen cannot show is approximated by one of the SAME HUE rather than a different one.
+ */
+export {
+  hsvToRgb,
+  normalizeHue,
+  oklchToRgb,
+  rgbToHsv,
+  rgbToOklch,
+} from "./convert";

--- a/packages/ui/src/ui-surface.test.ts
+++ b/packages/ui/src/ui-surface.test.ts
@@ -28,7 +28,12 @@ const SRC = path.dirname(fileURLToPath(import.meta.url));
 const PKG_ROOT = path.join(SRC, "..");
 
 /** The entry points named in the package's `exports` map. */
-const ENTRY_POINTS = ["index.ts", "lib/utils.ts", "tailwind-preset.ts"];
+const ENTRY_POINTS = [
+  "index.ts",
+  "lib/utils.ts",
+  "tailwind-preset.ts",
+  "lib/color/index.ts",
+];
 
 /**
  * Strip comments before any structural check. Doc comments here legitimately

--- a/packages/ui/tsup.server-safe.config.ts
+++ b/packages/ui/tsup.server-safe.config.ts
@@ -15,7 +15,8 @@ const external = [
 
 /**
  * The exports that contain no React runtime: a Tailwind preset read by build
- * tooling and a pure class-name helper. They are built here, without the
+ * tooling, a pure class-name helper, and colour conversions that are arithmetic
+ * on numbers. They are built here, without the
  * component bundle's `"use client"` banner, so server code can import them.
  *
  * Built separately from the component bundle so the client banner does not
@@ -37,6 +38,7 @@ export default defineConfig({
     // foot of the entry for the same reasoning beside the code.
     "tailwind-preset": "src/tailwind-preset.ts",
     utils: "src/lib/utils.ts",
+    color: "src/lib/color/index.ts",
   },
   format: ["esm", "cjs"],
   dts: true,


### PR DESCRIPTION
## What

Conversions between the three colour models an editing surface needs, in a new `packages/ui/src/lib/color/` module. No runtime dependency added.

- **sRGB** — what a screen shows and what a hex string encodes.
- **HSV** — the shape a picker actually has: a saturation-against-value square beside a hue strip.
- **OKLCH** — what this product's own tokens are written in. Every value in `theme.css` is an `oklch()`.

## Why the maths is here rather than in a dependency

These are fixed, published transforms — the sRGB transfer function and the OKLab matrices are specified in CSS Color 4 and do not change. `packages/ui` ships no runtime colour dependency and this keeps it that way.

**`culori` stays a dev dependency and is used as a test oracle.** That distinction is load-bearing: a round trip proves two transforms are inverses *of each other*, and a pair can be perfect inverses and still not be OKLab. Agreeing with an independent implementation of the same specification is evidence about the absolute values rather than only their symmetry.

## The part that is genuinely hard

OKLCH can name colours a screen cannot show. Converting one has no correct answer, only choices — and the obvious choice is the wrong one. Clamping each channel independently clips red without clipping green, which changes the ratio between them, so **the colour that appears is a different hue from the one asked for**. Hue and lightness are what a person chose; chroma is what they will not miss, so chroma is what is given up, by a bisection with a fixed round count rather than a loop that might not terminate.

## Why this does not touch `styles/contrast/`

That directory contains the existing culori-based contrast code. Consolidating it onto this module is deliberately **not** in this PR: another session is mid-WCAG-audit and reported a theme's failure count moving 58 → 48 with the theme untouched, purely because that source changed underneath it. A measurement is only comparable while its instrument is fixed. The consolidation will follow, with a fixture corpus — including an `oklch()` with alpha and a `color-mix()` — proving identical ratios rather than intending a no-op.

## Tests

93 tests: HSV and OKLCH round trips, agreement with culori in both directions, gamut behaviour, and hue normalisation.

Every behavioural claim was verified by break. One of those breaks initially **passed**, which was the useful part: all six HSV sectors were covered, but sector 1 only by pure yellow — where the two components a branch orders happen to be equal, so a swapped branch is invisible. Reaching a sector is not reaching the behaviour that distinguishes it. Six colours at 30° offsets fixed the corpus, and the swap now fails, as does a realistic matrix typo and a dropped cube root.