### PR TITLE
refactor(blocks-engine): move the remote-host policy into the engine

### DIFF
--- a/.changeset/shared-host-matcher.md
+++ b/.changeset/shared-host-matcher.md
@@ -1,0 +1,32 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+Move the remote-host policy into the engine so one matcher can serve both the compiler and the renderer.
+
+Which hosts a page may fetch from is asked from two places that must not answer differently: the style compiler judging a `url()` in a stored value, and a React block judging an `img` or `iframe` source. Only the first could ask, because the matcher lived beside the page builder's own compiler. A second implementation for the renderer would be a second thing to be wrong, and two that drift apart fail silently, one permitting what the other refuses.
+
+`isFetchableUrl`, `isAllowedRemoteUrl`, `isRemoteUrl`, `normalizeUrl` and the `RemotePattern` types now live in `@nextlyhq/blocks-engine` and are exported from it. The page builder re-exports them, so every existing import is untouched and no behaviour changes.
+
+The engine's runtime-free allowlist gains `picomatch`, deliberately and with its reason recorded beside `css-tree`'s: it is the glob grammar `next/image`'s `remotePatterns` is written in, so reading the same patterns a Nextly app already declares means reading that grammar. Re-implementing it inside a security control to avoid a dependency would trade a known matcher for an unknown one. It has no dependencies of its own, imports no Node builtins, and already runs in a browser through the page builder's canvas.

--- a/packages/blocks-engine/package.json
+++ b/packages/blocks-engine/package.json
@@ -42,13 +42,15 @@
     "node": ">=20.0.0"
   },
   "dependencies": {
-    "css-tree": "^2.3.1"
+    "css-tree": "^2.3.1",
+    "picomatch": "^4.0.5"
   },
   "devDependencies": {
     "@nextlyhq/eslint-config": "workspace:*",
     "@nextlyhq/tsconfig": "workspace:*",
     "@types/css-tree": "^2.3.4",
     "@types/node": "^20.19.17",
+    "@types/picomatch": "^4.0.3",
     "eslint": "^9.39.1",
     "rimraf": "^6.1.3",
     "tsup": "^8.5.0",

--- a/packages/blocks-engine/src/index.ts
+++ b/packages/blocks-engine/src/index.ts
@@ -287,3 +287,14 @@ export type { SiteSheetArtifact, SiteSheetInput } from "./style/site-sheet";
 export { compileSiteSheet } from "./style/site-sheet";
 export { styleOrigin } from "./style/style-origin";
 export { BREAKPOINT_AXES } from "./style/breakpoint-axes";
+
+// The remote-host policy: which hosts a compiled page may fetch from. Exported
+// so the React renderer applies the SAME matcher the style compiler does.
+export {
+  isAllowedRemoteUrl,
+  isFetchableUrl,
+  isRemoteUrl,
+  normalizeUrl,
+  type RemotePattern,
+  type RemotePatternInput,
+} from "./url-policy";

--- a/packages/blocks-engine/src/runtime-free.test.ts
+++ b/packages/blocks-engine/src/runtime-free.test.ts
@@ -30,8 +30,14 @@ const SRC_DIR = dirname(fileURLToPath(import.meta.url));
  *   to be parsed to be made safe, and no seam moves that requirement
  *   elsewhere. Pure JavaScript, ships a browser build, and pulls in only
  *   `mdn-data` and `source-map-js`, so the "runs anywhere" promise holds.
+ * - `picomatch`: the glob grammar `next/image`'s `remotePatterns` is written
+ *   in. The remote-host policy has to read the same patterns a Nextly app
+ *   already declares for `next/image`, and re-implementing that grammar in a
+ *   SECURITY control to avoid a dependency would trade a known matcher for an
+ *   unknown one. Zero dependencies of its own, no Node builtins, and already
+ *   run in a browser by the page builder's canvas, so the promise holds.
  */
-const ALLOWED_RUNTIME_DEPENDENCIES = ["css-tree"];
+const ALLOWED_RUNTIME_DEPENDENCIES = ["css-tree", "picomatch"];
 
 /**
  * Files that are part of the test harness rather than the shipped engine.

--- a/packages/blocks-engine/src/url-policy.ts
+++ b/packages/blocks-engine/src/url-policy.ts
@@ -1,0 +1,198 @@
+/**
+ * Which remote hosts a compiled page may fetch from.
+ *
+ * Lives in the engine rather than beside any one renderer because the same
+ * question is asked from two places that must not answer it differently: the
+ * style compiler judging a `url()` in a stored value, and a React block judging
+ * an `img`/`iframe` source. A second implementation of a security check is a
+ * second thing to be wrong, and two that drift apart fail silently — the sheet
+ * permitting what the markup refuses, or the reverse.
+ *
+ * Deliberately the shape of `next/image`'s `images.remotePatterns`, because a
+ * Nextly app already declares the same hosts there and copying the entry across
+ * should just work.
+ *
+ * Runtime-free like the rest of this package: string and URL work only, no DOM
+ * and no Node builtins, so it runs in a server render, in a browser canvas, and
+ * in a test alike.
+ *
+ * @module url-policy
+ */
+import picomatch from "picomatch";
+
+/**
+ * The leading and trailing run the URL parser discards.
+ *
+ * "Remove any leading and trailing C0 control or space from input." C0 is
+ * U+0000 to U+001F, which `trim()` does not cover — U+0001 is not whitespace,
+ * so a scheme hidden behind one survives a trim while resolving to the same
+ * host. Scanned by code point rather than matched, because a regexp holding
+ * literal control characters is its own hazard to read and to lint.
+ */
+function trimControlsAndSpace(value: string): string {
+  let start = 0;
+  let end = value.length;
+  while (start < end && value.charCodeAt(start) <= 0x20) start += 1;
+  while (end > start && value.charCodeAt(end - 1) <= 0x20) end -= 1;
+  return value.slice(start, end);
+}
+
+/**
+ * A URL as the browser's parser will read it, rather than as it was written.
+ *
+ * The two removals are the first steps of the WHATWG basic URL parser, quoted
+ * beside each. Guessing at this produced two bypasses in the sanitizer — a tab
+ * inside a scheme, then a U+0001 in front of one — so it follows the algorithm
+ * rather than the cases anyone happened to think of.
+ */
+export function normalizeUrl(value: string): string {
+  const withoutBreaks = value
+    // "Remove all ASCII tab or newline from input."
+    .replace(/[\t\n\r]/g, "")
+    // Backslashes are read as slashes for http and https, so `/\\evil/a`
+    // reaches another host while beginning with neither `//` nor a scheme.
+    .replaceAll("\\", "/");
+  return trimControlsAndSpace(withoutBreaks);
+}
+
+/** Any `scheme:` prefix, tolerating the whitespace a value may carry. */
+const URL_SCHEME = /^[a-z][a-z0-9+.-]*:/i;
+
+/** Whether a URL reaches anywhere other than the document's own origin. */
+export function isRemoteUrl(value: string): boolean {
+  const normalized = normalizeUrl(value);
+  if (URL_SCHEME.test(normalized)) return true;
+  // No scheme, but still another host: `//evil.example/x.png` inherits the
+  // page's protocol and nothing else.
+  return normalized.startsWith("//");
+}
+
+/**
+ * One host a block image may be loaded from.
+ *
+ * Deliberately the shape of Next.js's `images.remotePatterns`, because a Nextly
+ * app already declares the same thing there for `next/image` and copying the
+ * entry across should just work.
+ */
+/**
+ * A pattern, or a `URL` standing in for one.
+ *
+ * `next.config` accepts `remotePatterns: [new URL("https://cdn.example/img/**")]`
+ * as well as the object form, and a `URL` already carries every field this
+ * matches on. The only difference is that its `protocol` keeps the trailing
+ * colon, which is why the comparison below strips one from both sides rather
+ * than appending one — the same accommodation `matchRemotePattern` makes.
+ */
+export type RemotePatternInput = URL | RemotePattern;
+
+export interface RemotePattern {
+  protocol?: "http" | "https";
+  /** A picomatch glob, as `next/image` reads it: `**.example.com`, `cdn.example`. */
+  hostname: string;
+  port?: string;
+  /** A picomatch glob. `/img/*` is one segment, `/img/**` is that path and below. */
+  pathname?: string;
+  search?: string;
+}
+
+/**
+ * Compiled matchers, keyed by the pattern text.
+ *
+ * `makeRe` is not cheap and a page compiles many values against the same few
+ * patterns, so each glob is compiled once. Keyed by text rather than by the
+ * pattern object, since callers build a fresh object per render.
+ */
+const globCache = new Map<string, RegExp>();
+
+function glob(pattern: string, dot = false): RegExp {
+  const key = `${dot ? "d:" : ":"}${pattern}`;
+  const cached = globCache.get(key);
+  if (cached !== undefined) return cached;
+  const compiled = picomatch.makeRe(pattern, dot ? { dot: true } : undefined);
+  globCache.set(key, compiled);
+  return compiled;
+}
+
+/**
+ * Whether a remote URL is one this site has declared it loads from.
+ *
+ * Closed by default: with no patterns configured, nothing off-origin is
+ * allowed. That is the same posture as `next/image`, and the posture the page
+ * builder needs, because a remote URL is a request whose firing can be made
+ * conditional by a custom-CSS selector — so an undeclared host is a channel
+ * out, not merely an unexpected image.
+ */
+export function isAllowedRemoteUrl(
+  url: string,
+  patterns: readonly RemotePatternInput[]
+): boolean {
+  let parsed: URL;
+  try {
+    parsed = new URL(normalizeUrl(url));
+  } catch {
+    return false;
+  }
+  // A pattern that names no protocol means "either of the two this type
+  // allows", not "any scheme at all". Checking here rather than per pattern so
+  // an omitted field cannot reopen it.
+  // Beyond what Next.js checks, and deliberately: `next/image` receives URLs
+  // that are already constrained, while this compiles whatever a style value
+  // holds. A pattern that names no protocol means "either of the two this type
+  // allows", not "any scheme".
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") return false;
+  return patterns.some(pattern => {
+    // Field order and glob options mirror `matchRemotePattern` in Next.js, and
+    // the matching is delegated to the same library it uses. This type says a
+    // `next.config` entry can be copied across, and that claim only holds if
+    // the globs mean the same thing: picomatch's `*` spans dots in a hostname,
+    // `/img/*` is one path segment, and a terminal `/img/**` matches `/img`
+    // itself. Any reimplementation is a second definition of those semantics,
+    // free to drift from the one the copied config was written against.
+    // Stripped from both sides: an object pattern writes `https`, a `URL`
+    // writes `https:`, and both mean the same scheme.
+    const scheme = (value: string): string => value.replace(/:$/, "");
+    if (
+      pattern.protocol !== undefined &&
+      pattern.protocol !== "" &&
+      scheme(pattern.protocol) !== scheme(parsed.protocol)
+    ) {
+      return false;
+    }
+    if (pattern.port !== undefined && pattern.port !== parsed.port) {
+      return false;
+    }
+    if (!glob(pattern.hostname).test(parsed.hostname)) return false;
+    if (pattern.search !== undefined && pattern.search !== parsed.search) {
+      return false;
+    }
+    return glob(pattern.pathname ?? "**", true).test(parsed.pathname);
+  });
+}
+
+/**
+ * Whether a URL written in a stylesheet may be fetched.
+ *
+ * A RELATIVE path is always allowed; anything carrying a scheme or a host needs
+ * a declared pattern. Note what that means and does not mean: an absolute URL
+ * naming the site's own host still needs an entry, because nothing here knows
+ * what the site's own host is — the stylesheet is compiled once and may be
+ * served from anywhere, so "same origin" is a property of the request rather
+ * than of the text. This is the same rule `next/image` applies, where
+ * `https://your-own-site.com/a.png` is refused until the host is in
+ * `remotePatterns` while `/a.png` needs nothing. Supplying an origin here
+ * instead would be a second way to express what one pattern entry already says.
+ *
+ * Protocol-relative is refused outright rather than resolved against a guess:
+ * `//cdn/a.png` inherits the DOCUMENT's protocol, which is not knowable when
+ * the stylesheet is compiled, and assuming https accepted it against an
+ * https-only pattern on a page that then fetched it over http. An author who
+ * wants that host can write the scheme.
+ */
+export function isFetchableUrl(
+  url: string,
+  patterns: readonly RemotePatternInput[]
+): boolean {
+  if (!isRemoteUrl(url)) return true;
+  if (normalizeUrl(url).startsWith("//")) return false;
+  return isAllowedRemoteUrl(url, patterns);
+}

--- a/packages/plugin-page-builder/src/core/url-policy.ts
+++ b/packages/plugin-page-builder/src/core/url-policy.ts
@@ -1,6 +1,5 @@
 import { asciiLower, decodeIdentifier } from "@nextlyhq/blocks-engine";
 import * as csstree from "css-tree";
-import picomatch from "picomatch";
 
 /**
  * Where a stylesheet this package emits is allowed to fetch from. React-free.
@@ -219,178 +218,19 @@ export function fetchableValues(
 }
 
 /**
- * The leading and trailing run the URL parser discards.
+ * The remote-host policy now lives in `@nextlyhq/blocks-engine`, where the
+ * renderer can reach it too, and is re-exported here so every caller in this
+ * package keeps the import it already had.
  *
- * "Remove any leading and trailing C0 control or space from input." C0 is
- * U+0000 to U+001F, which `trim()` does not cover — U+0001 is not whitespace,
- * so a scheme hidden behind one survives a trim while resolving to the same
- * host. Scanned by code point rather than matched, because a regexp holding
- * literal control characters is its own hazard to read and to lint.
+ * The CSS-AST scanning above stays: it answers "which strings in this value are
+ * fetched", which is a css-tree question this package owns. What moved is
+ * "may this URL be fetched", which both packages ask.
  */
-function trimControlsAndSpace(value: string): string {
-  let start = 0;
-  let end = value.length;
-  while (start < end && value.charCodeAt(start) <= 0x20) start += 1;
-  while (end > start && value.charCodeAt(end - 1) <= 0x20) end -= 1;
-  return value.slice(start, end);
-}
-
-/**
- * A URL as the browser's parser will read it, rather than as it was written.
- *
- * The two removals are the first steps of the WHATWG basic URL parser, quoted
- * beside each. Guessing at this produced two bypasses in the sanitizer — a tab
- * inside a scheme, then a U+0001 in front of one — so it follows the algorithm
- * rather than the cases anyone happened to think of.
- */
-export function normalizeUrl(value: string): string {
-  const withoutBreaks = value
-    // "Remove all ASCII tab or newline from input."
-    .replace(/[\t\n\r]/g, "")
-    // Backslashes are read as slashes for http and https, so `/\\evil/a`
-    // reaches another host while beginning with neither `//` nor a scheme.
-    .replaceAll("\\", "/");
-  return trimControlsAndSpace(withoutBreaks);
-}
-
-/** Any `scheme:` prefix, tolerating the whitespace a value may carry. */
-const URL_SCHEME = /^[a-z][a-z0-9+.-]*:/i;
-
-/** Whether a URL reaches anywhere other than the document's own origin. */
-export function isRemoteUrl(value: string): boolean {
-  const normalized = normalizeUrl(value);
-  if (URL_SCHEME.test(normalized)) return true;
-  // No scheme, but still another host: `//evil.example/x.png` inherits the
-  // page's protocol and nothing else.
-  return normalized.startsWith("//");
-}
-
-/**
- * One host a block image may be loaded from.
- *
- * Deliberately the shape of Next.js's `images.remotePatterns`, because a Nextly
- * app already declares the same thing there for `next/image` and copying the
- * entry across should just work.
- */
-/**
- * A pattern, or a `URL` standing in for one.
- *
- * `next.config` accepts `remotePatterns: [new URL("https://cdn.example/img/**")]`
- * as well as the object form, and a `URL` already carries every field this
- * matches on. The only difference is that its `protocol` keeps the trailing
- * colon, which is why the comparison below strips one from both sides rather
- * than appending one — the same accommodation `matchRemotePattern` makes.
- */
-export type RemotePatternInput = URL | RemotePattern;
-
-export interface RemotePattern {
-  protocol?: "http" | "https";
-  /** A picomatch glob, as `next/image` reads it: `**.example.com`, `cdn.example`. */
-  hostname: string;
-  port?: string;
-  /** A picomatch glob. `/img/*` is one segment, `/img/**` is that path and below. */
-  pathname?: string;
-  search?: string;
-}
-
-/**
- * Compiled matchers, keyed by the pattern text.
- *
- * `makeRe` is not cheap and a page compiles many values against the same few
- * patterns, so each glob is compiled once. Keyed by text rather than by the
- * pattern object, since callers build a fresh object per render.
- */
-const globCache = new Map<string, RegExp>();
-
-function glob(pattern: string, dot = false): RegExp {
-  const key = `${dot ? "d:" : ":"}${pattern}`;
-  const cached = globCache.get(key);
-  if (cached !== undefined) return cached;
-  const compiled = picomatch.makeRe(pattern, dot ? { dot: true } : undefined);
-  globCache.set(key, compiled);
-  return compiled;
-}
-
-/**
- * Whether a remote URL is one this site has declared it loads from.
- *
- * Closed by default: with no patterns configured, nothing off-origin is
- * allowed. That is the same posture as `next/image`, and the posture the page
- * builder needs, because a remote URL is a request whose firing can be made
- * conditional by a custom-CSS selector — so an undeclared host is a channel
- * out, not merely an unexpected image.
- */
-export function isAllowedRemoteUrl(
-  url: string,
-  patterns: readonly RemotePatternInput[]
-): boolean {
-  let parsed: URL;
-  try {
-    parsed = new URL(normalizeUrl(url));
-  } catch {
-    return false;
-  }
-  // A pattern that names no protocol means "either of the two this type
-  // allows", not "any scheme at all". Checking here rather than per pattern so
-  // an omitted field cannot reopen it.
-  // Beyond what Next.js checks, and deliberately: `next/image` receives URLs
-  // that are already constrained, while this compiles whatever a style value
-  // holds. A pattern that names no protocol means "either of the two this type
-  // allows", not "any scheme".
-  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") return false;
-  return patterns.some(pattern => {
-    // Field order and glob options mirror `matchRemotePattern` in Next.js, and
-    // the matching is delegated to the same library it uses. This type says a
-    // `next.config` entry can be copied across, and that claim only holds if
-    // the globs mean the same thing: picomatch's `*` spans dots in a hostname,
-    // `/img/*` is one path segment, and a terminal `/img/**` matches `/img`
-    // itself. Any reimplementation is a second definition of those semantics,
-    // free to drift from the one the copied config was written against.
-    // Stripped from both sides: an object pattern writes `https`, a `URL`
-    // writes `https:`, and both mean the same scheme.
-    const scheme = (value: string): string => value.replace(/:$/, "");
-    if (
-      pattern.protocol !== undefined &&
-      pattern.protocol !== "" &&
-      scheme(pattern.protocol) !== scheme(parsed.protocol)
-    ) {
-      return false;
-    }
-    if (pattern.port !== undefined && pattern.port !== parsed.port) {
-      return false;
-    }
-    if (!glob(pattern.hostname).test(parsed.hostname)) return false;
-    if (pattern.search !== undefined && pattern.search !== parsed.search) {
-      return false;
-    }
-    return glob(pattern.pathname ?? "**", true).test(parsed.pathname);
-  });
-}
-
-/**
- * Whether a URL written in a stylesheet may be fetched.
- *
- * A RELATIVE path is always allowed; anything carrying a scheme or a host needs
- * a declared pattern. Note what that means and does not mean: an absolute URL
- * naming the site's own host still needs an entry, because nothing here knows
- * what the site's own host is — the stylesheet is compiled once and may be
- * served from anywhere, so "same origin" is a property of the request rather
- * than of the text. This is the same rule `next/image` applies, where
- * `https://your-own-site.com/a.png` is refused until the host is in
- * `remotePatterns` while `/a.png` needs nothing. Supplying an origin here
- * instead would be a second way to express what one pattern entry already says.
- *
- * Protocol-relative is refused outright rather than resolved against a guess:
- * `//cdn/a.png` inherits the DOCUMENT's protocol, which is not knowable when
- * the stylesheet is compiled, and assuming https accepted it against an
- * https-only pattern on a page that then fetched it over http. An author who
- * wants that host can write the scheme.
- */
-export function isFetchableUrl(
-  url: string,
-  patterns: readonly RemotePatternInput[]
-): boolean {
-  if (!isRemoteUrl(url)) return true;
-  if (normalizeUrl(url).startsWith("//")) return false;
-  return isAllowedRemoteUrl(url, patterns);
-}
+export {
+  isAllowedRemoteUrl,
+  isFetchableUrl,
+  isRemoteUrl,
+  normalizeUrl,
+  type RemotePattern,
+  type RemotePatternInput,
+} from "@nextlyhq/blocks-engine";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -736,6 +736,9 @@ importers:
       css-tree:
         specifier: ^2.3.1
         version: 2.3.1
+      picomatch:
+        specifier: ^4.0.4
+        version: 4.0.5
     devDependencies:
       '@nextlyhq/eslint-config':
         specifier: workspace:*
@@ -749,6 +752,9 @@ importers:
       '@types/node':
         specifier: ^20.19.17
         version: 20.19.17
+      '@types/picomatch':
+        specifier: ^4.0.3
+        version: 4.0.3
       eslint:
         specifier: ^9.39.1
         version: 9.39.1(jiti@2.7.0)
@@ -12215,7 +12221,7 @@ snapshots:
       obug: 2.1.4
       std-env: 4.2.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.10(@types/node@20.19.17)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.9.0)(jsdom@27.1.0)(vite@7.3.6(@types/node@20.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.20.5)(yaml@2.8.3))
+      vitest: 4.1.10(@types/node@20.19.17)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.9.0)(jsdom@27.1.0)(vite@7.3.6(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
 
   '@vitest/expect@4.1.10':
     dependencies:
@@ -12285,7 +12291,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.1.0
-      vitest: 4.1.10(@types/node@20.19.17)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.9.0)(jsdom@27.1.0)(vite@7.3.6(@types/node@20.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.20.5)(yaml@2.8.3))
+      vitest: 4.1.10(@types/node@20.19.17)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.9.0)(jsdom@27.1.0)(vite@7.3.6(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
 
   '@vitest/utils@4.1.10':
     dependencies:
@@ -15940,7 +15946,7 @@ snapshots:
       std-env: 4.2.0
       tinybench: 2.9.0
       tinyexec: 1.2.4
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
       vite: 7.3.6(@types/node@20.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.20.5)(yaml@2.8.3)
       why-is-node-running: 2.3.0


### PR DESCRIPTION
## What

**PR A of three.** A pure move, no behaviour change, to make the next two possible.

Which hosts a page may fetch from is asked from two places that must not answer differently: the style compiler judging a `url()` in a stored value, and a React block judging an `img`/`iframe` source. Only the first could ask, because the matcher lived beside the page builder's own compiler.

`isFetchableUrl`, `isAllowedRemoteUrl`, `isRemoteUrl`, `normalizeUrl` and the `RemotePattern` types move to `@nextlyhq/blocks-engine`. `plugin-page-builder/src/core/url-policy.ts` re-exports them, so **every existing import is untouched**.

The CSS-AST scanning stays in the plugin. It answers *"which strings in this value are fetched"*, a css-tree question that package owns; what moved is *"may this URL be fetched"*, which both packages ask.

## The dependency, deliberately

The engine's `runtime-free.test.ts` allowlist gains `picomatch`, with its reason recorded beside `css-tree`'s — the guard's own doc says adding an entry is "a deliberate act with a reason recorded beside it".

I checked it against the bar `css-tree` sets rather than assuming:

- **zero dependencies** of its own
- **no Node builtins** (grepped its source)
- **already runs in a browser** in this repo — the page builder's canvas compiles styles through `url-policy.ts` today

It is the glob grammar `next/image`'s `remotePatterns` is written in. Reading the same patterns a Nextly app already declares means reading that grammar, and re-implementing it inside a security control to avoid one dependency would trade a known matcher for an unknown one.

## Proof this is a pure move

The plugin's existing tests are **unchanged** and pass against the moved implementation: **569 passing**, identical to `origin/main`.

Three plugin test FILES fail to load on both — `Cannot find package 'resend'` from `packages/nextly/dist` — which I baselined by stashing everything and re-running on clean `origin/main`: same three files, same cause, same 569 passing. Pre-existing, unrelated, not introduced here.

Engine: 1020 tests pass, both packages typecheck and lint, and `blocks-react` still typechecks against the rebuilt engine.

## What comes next

- **B** — the engine's CSS compiler consults the allowlist, and stops treating a protocol-relative URL as same-origin (**C11**: `checkUrlValue` applies its `http`/`https` allowlist only when a scheme is present, and its comment claims scheme-less values resolve to the page's own origin, which is false for `//cdn.example/a.png`).
- **C** — `BlockHostPolicy` gains the patterns; `core/image` and `core/embed` consult them. Per **C13**, the docs must say enforcement is per-renderer: `RenderNode` hands a block the patterns and cannot inspect what it returns, so a custom block must apply them itself.

Neither gap is reachable today — nothing renders production content through `blocks-react` — but all three land before R-4 `createBlocksPage()` makes it the published path.

**Note for #605:** that PR also touches `blocks-engine/src/index.ts`. This appends an export block at the end; the conflict should be both-sides-keep.