### PR TITLE
fix(nextly): change nullability when a PostgreSQL repair also changes it

### DIFF
--- a/.changeset/repaired-column-carries-its-nullability.md
+++ b/.changeset/repaired-column-carries-its-nullability.md
@@ -4,6 +4,7 @@
 "@nextlyhq/admin": patch
 "@nextlyhq/admin-css": patch
 "@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
 "@nextlyhq/ui": patch
 "@nextlyhq/adapter-drizzle": patch
 "@nextlyhq/adapter-postgres": patch

--- a/.changeset/repaired-column-carries-its-nullability.md
+++ b/.changeset/repaired-column-carries-its-nullability.md
@@ -1,0 +1,25 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+A repaired legacy column that also becomes required, or stops being required, now carries that change on PostgreSQL. The repair converted the column's type and left its nullability as it was, so the applied schema contradicted the one the migration was generated from, and rolling back could not restore the original setting.

--- a/packages/nextly/src/domains/schema/migrate-create/__tests__/generate.test.ts
+++ b/packages/nextly/src/domains/schema/migrate-create/__tests__/generate.test.ts
@@ -567,10 +567,14 @@ describe("applyRenameDecisions (rename collapsing)", () => {
       previous as never
     );
 
+    // Five, in this order. The nullability op is here because this fixture's column also becomes
+    // required — PostgreSQL preserves nullability across a type change, so it needs its own
+    // statement.
     expect(out.map(o => o.type)).toEqual([
       "rename_column",
       "change_column_default",
       "change_column_type",
+      "change_column_nullable",
       "change_column_default",
     ]);
     // The old default is RECORDED on the drop, because buildInverseOperations inverts a default
@@ -578,7 +582,121 @@ describe("applyRenameDecisions (rename collapsing)", () => {
     // default a second time rather than restore it.
     expect(out[1]).toMatchObject({ fromDefault: "'{}'", toDefault: undefined });
     // And the desired default goes back on once the type is right.
-    expect(out[3]).toMatchObject({ toDefault: "'{}'::jsonb" });
+    expect(out[4]).toMatchObject({ toDefault: "'{}'::jsonb" });
+  });
+
+  it("changes PostgreSQL nullability when the repair coincides with becoming required", () => {
+    // PostgreSQL PRESERVES nullability across a type change, so nothing about converting the column
+    // makes it required — the UP would contradict the snapshot it was generated from, and the DOWN
+    // could not restore what was there. MySQL needs no equivalent because its MODIFY restates
+    // nullability with the type, which is why the same fact travels differently per dialect.
+    const ops = [
+      {
+        type: "drop_column" as const,
+        tableName: "dc_posts",
+        columnName: "_body",
+        columnType: "text",
+      },
+      {
+        type: "add_column" as const,
+        tableName: "dc_posts",
+        column: { name: "body", type: "jsonb", nullable: false },
+      },
+    ];
+    const decisions = [
+      {
+        candidate: {
+          tableName: "dc_posts",
+          fromColumn: "_body",
+          toColumn: "body",
+          fromType: "text",
+          toType: "jsonb",
+          typesCompatible: true,
+          defaultSuggestion: "rename" as const,
+        },
+        accepted: true,
+      },
+    ];
+    const previous = {
+      tables: [
+        {
+          name: "dc_posts",
+          columns: [{ name: "_body", type: "text", nullable: true }],
+          indexes: [],
+        },
+      ],
+    };
+
+    const out = applyRenameDecisionsForTest(
+      ops,
+      decisions,
+      "postgresql",
+      previous as never
+    );
+
+    const nullability = out.find(o => o.type === "change_column_nullable");
+    expect(nullability).toMatchObject({
+      columnName: "body",
+      fromNullable: true,
+      toNullable: false,
+    });
+
+    // Invertible, which is the point of emitting an operation rather than a statement: the DOWN
+    // restores the original setting rather than leaving the column as the UP left it.
+    const back = buildInverseOperations(out, previous as never).find(
+      o => o.type === "change_column_nullable"
+    );
+    expect(back).toMatchObject({ fromNullable: false, toNullable: true });
+  });
+
+  it("emits no nullability change when requiredness did not move", () => {
+    // The positive control. Emitting one unconditionally would add a pointless ALTER to every
+    // repair, and would assert a setting the snapshot never changed.
+    const ops = [
+      {
+        type: "drop_column" as const,
+        tableName: "dc_posts",
+        columnName: "_body",
+        columnType: "text",
+      },
+      {
+        type: "add_column" as const,
+        tableName: "dc_posts",
+        column: { name: "body", type: "jsonb", nullable: true },
+      },
+    ];
+    const decisions = [
+      {
+        candidate: {
+          tableName: "dc_posts",
+          fromColumn: "_body",
+          toColumn: "body",
+          fromType: "text",
+          toType: "jsonb",
+          typesCompatible: true,
+          defaultSuggestion: "rename" as const,
+        },
+        accepted: true,
+      },
+    ];
+    const previous = {
+      tables: [
+        {
+          name: "dc_posts",
+          columns: [{ name: "_body", type: "text", nullable: true }],
+          indexes: [],
+        },
+      ],
+    };
+
+    expect(
+      applyRenameDecisionsForTest(
+        ops,
+        decisions,
+        "postgresql",
+        previous as never
+      ).map(o => o.type)
+    ).not.toContain("change_column_nullable");
   });
 
   it("returns a MySQL column to its original definition on rollback", () => {

--- a/packages/nextly/src/domains/schema/pipeline/rename-conversion.ts
+++ b/packages/nextly/src/domains/schema/pipeline/rename-conversion.ts
@@ -115,6 +115,27 @@ export function conversionForRename(
     change,
   ];
 
+  // PostgreSQL preserves the column's nullability across a type change, so a repair that coincides
+  // with the field becoming required (or stopping being required) would leave the old setting behind
+  // — the UP contradicting the snapshot it was generated from, and the DOWN unable to restore what
+  // was there. MySQL needs no equivalent: its MODIFY restates nullability with the type, which is
+  // why the same fact travels on the op there and as its own statement here.
+  //
+  // Emitted as `change_column_nullable`, which the inverse builder already knows how to swap.
+  if (
+    context.source?.nullable !== undefined &&
+    context.target?.nullable !== undefined &&
+    context.source.nullable !== context.target.nullable
+  ) {
+    ops.push({
+      type: "change_column_nullable",
+      tableName: rename.tableName,
+      columnName: rename.toColumn,
+      fromNullable: context.source.nullable,
+      toNullable: context.target.nullable,
+    });
+  }
+
   // And the desired default goes back on after the type is right. Omitted when the target declares
   // none — an unconditional SET DEFAULT would invent one the schema never asked for.
   //


### PR DESCRIPTION
## Why this exists

🔴 **This is the last commit of #593, which did not reach main.**

#593 merged at `ec7aa8c51` taking head `15b2a5526`. My final push, `bba3e8383`, landed on the branch after that and was never included. Three of the PR's four commits are on main; this one is not.

Caught by verifying merged CONTENT rather than the merge state — the PR reads as merged with everything resolved, and `git log` on main looks complete. Only grepping for the marker showed it missing:

| marker | main after #593 | the branch |
|---|---|---|
| `conversionForRename` | 1 | 1 |
| `RenameConversionContext` | 2 | 2 |
| `fromColumnDefault` | 1 | 1 |
| **`change_column_nullable`** | **0** | **2** |

Cherry-picked onto current main, unchanged from what was reviewed and resolved on #593 (thread `PRRT_kwDOSYwUJs6X8wec`).

## What it fixes

PostgreSQL preserves a column's nullability across `ALTER COLUMN … TYPE`. So when a legacy repair coincided with the field becoming required — or stopping being required — the converted column kept its old setting: an UP contradicting the snapshot it was generated from, and a DOWN with nothing to restore. The collapsed `add_column`, the only record of what it should be, had already been consumed.

Emitted as `change_column_nullable`, which `buildInverseOperations` already inverts, and only when the two settings differ.

**MySQL needs no equivalent, and the asymmetry is deliberate:** its `MODIFY` restates nullability with the type, so there the fact travels on the op. PostgreSQL changes a type without disturbing it, so here it is its own statement. One fact, two shapes, because the engines disagree about what a type change touches.

## Verification

Build / check-types / lint / drizzle-guard all 0. Unit **361 failures / 7584 with zero new**, diffed at test-name level against a baseline freshly measured at `ec7aa8c51` (361 / 7582). Integration green on both dialects — PostgreSQL 224 files, MySQL 208.

Two cases, both proven load-bearing by breaking the code: a repair that also becomes required emits the change and the inverse restores the original setting; a repair where requiredness did not move emits none. Suppressing the emit fails both, plus the default test whose fixture also changes nullability.
