### PR TITLE
fix(plugin-page-builder): hold a page to the slots its blocks declare

### DIFF
--- a/.changeset/undeclared-slot-allowlist.md
+++ b/.changeset/undeclared-slot-allowlist.md
@@ -1,0 +1,26 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+Refuse to save a page whose blocks carry a slot the block never declared, and ignore any such slot already stored. A renamed or removed slot left its children unchecked against the block author's allowlist, and their styles — including any image URL — were still compiled into the page even though nothing rendered them.

--- a/packages/plugin-page-builder/src/core/__tests__/declared-slots.test.tsx
+++ b/packages/plugin-page-builder/src/core/__tests__/declared-slots.test.tsx
@@ -218,5 +218,12 @@ describe("a slot the definition does not declare", () => {
       "alpha",
       "omega",
     ]);
+
+    // And the PRUNED TREE carries that order, which is the half that matters: every generic
+    // walker reads the tree, not this helper. A node whose slots are all declared but stored in
+    // another order has nothing dropped, so a change test that only counts slots leaves it alone
+    // and the two answers diverge precisely where they are meant to agree.
+    const pruned = pruneUndeclaredSlots(node, registry);
+    expect(Object.keys(pruned.slots ?? {})).toEqual(["alpha", "omega"]);
   });
 });

--- a/packages/plugin-page-builder/src/core/__tests__/declared-slots.test.tsx
+++ b/packages/plugin-page-builder/src/core/__tests__/declared-slots.test.tsx
@@ -133,6 +133,50 @@ describe("a slot the definition does not declare", () => {
     expect(html).not.toContain("stale-asset.png");
   });
 
+  it("keeps the children of a type this runtime has not loaded", () => {
+    // "This process has not loaded that plugin" and "that block declares no such slot" are
+    // different statements, and only the second justifies dropping anything. A page rendered while
+    // a plugin is unloaded would otherwise lose the children of every block it owns — and since the
+    // pruned tree is what would be saved next, it would lose them permanently.
+    const unloaded: BlockNode = {
+      ...makeNode("acme/not-loaded", {}),
+      slots: {
+        default: [
+          makeNode("core/heading", { text: "Author's work", level: "h2" }),
+        ],
+      },
+    };
+
+    const pruned = pruneUndeclaredSlots(unloaded, defaultBlockRegistry);
+
+    expect(pruned.slots?.default).toHaveLength(1);
+    // Positive control: the registry really does not know this type, so the assertion above is
+    // about the unknown-type branch and not about a type that happens to declare `default`.
+    expect(defaultBlockRegistry.get("acme/not-loaded")).toBeUndefined();
+  });
+
+  it("still refuses to SAVE a known block's undeclared slot, and permits an unknown one", () => {
+    // The write path draws the same line: a known container is held to its declaration, and a type
+    // this runtime cannot see is left to the caller's `allowUnknown`, which is what that option is
+    // for. Read and write disagreeing about which nodes are suspect is how one of them corrupts
+    // what the other accepted.
+    const unloaded = {
+      ...makeNode("acme/not-loaded", {}),
+      slots: {
+        default: [makeNode("core/heading", { text: "x", level: "h2" })],
+      },
+    };
+
+    expect(
+      validateDocument(doc(unloaded), defaultBlockRegistry, {
+        allowUnknown: true,
+      })
+    ).toBe(true);
+    expect(
+      validateDocument(doc(withStaleSlot()), defaultBlockRegistry)
+    ).toContain("legacy");
+  });
+
   it("returns the SAME node when a document has nothing to prune", () => {
     // A document with no stale slot is not rebuilt, so callers comparing by identity — and React
     // reconciling on it — are unaffected by a pass that had nothing to do.

--- a/packages/plugin-page-builder/src/core/__tests__/declared-slots.test.tsx
+++ b/packages/plugin-page-builder/src/core/__tests__/declared-slots.test.tsx
@@ -133,12 +133,42 @@ describe("a slot the definition does not declare", () => {
     expect(html).not.toContain("stale-asset.png");
   });
 
-  it("keeps the children of a type this runtime has not loaded", () => {
-    // "This process has not loaded that plugin" and "that block declares no such slot" are
-    // different statements, and only the second justifies dropping anything. A page rendered while
-    // a plugin is unloaded would otherwise lose the children of every block it owns — and since the
-    // pruned tree is what would be saved next, it would lose them permanently.
+  it("leaves an unloaded plugin's children out of the READ copy, and the sheet", () => {
+    // `RenderNode` draws the unknown-block placeholder and never traverses the children, so keeping
+    // them in the read copy only puts their rules — and any URL in them — into a stylesheet for
+    // markup nobody receives.
     const unloaded: BlockNode = {
+      ...makeNode("acme/not-loaded", {}),
+      slots: {
+        default: [
+          {
+            ...makeNode("core/heading", { text: "hidden", level: "h2" }),
+            style: { base: { backgroundImage: "/unknown-child-asset.png" } },
+          },
+        ],
+      },
+    };
+
+    // Positive control: the registry really does not know this type, so this exercises the
+    // unknown-type branch and not a type that happens to declare `default`.
+    expect(defaultBlockRegistry.get("acme/not-loaded")).toBeUndefined();
+
+    const html = renderToStaticMarkup(
+      <PageRenderer
+        document={doc(
+          makeNode("core/container", {}, undefined, { default: [unloaded] })
+        )}
+      />
+    );
+    expect(html).not.toContain("unknown-child-asset.png");
+  });
+
+  it("does not let an unloaded plugin cost an author their content", () => {
+    // The other half, and the reason the read copy may drop them: what protects the stored document
+    // is that pruning returns a COPY and that the WRITE path draws the distinction. `validate`
+    // rejects only when a definition is present, so a save made while a plugin is unloaded is
+    // accepted rather than rejected or stripped.
+    const unloaded = {
       ...makeNode("acme/not-loaded", {}),
       slots: {
         default: [
@@ -147,12 +177,14 @@ describe("a slot the definition does not declare", () => {
       },
     };
 
-    const pruned = pruneUndeclaredSlots(unloaded, defaultBlockRegistry);
-
-    expect(pruned.slots?.default).toHaveLength(1);
-    // Positive control: the registry really does not know this type, so the assertion above is
-    // about the unknown-type branch and not about a type that happens to declare `default`.
-    expect(defaultBlockRegistry.get("acme/not-loaded")).toBeUndefined();
+    expect(
+      validateDocument(doc(unloaded), defaultBlockRegistry, {
+        allowUnknown: true,
+      })
+    ).toBe(true);
+    // And a read does not mutate what it was handed.
+    pruneUndeclaredSlots(unloaded, defaultBlockRegistry);
+    expect(unloaded.slots.default).toHaveLength(1);
   });
 
   it("still refuses to SAVE a known block's undeclared slot, and permits an unknown one", () => {
@@ -175,6 +207,28 @@ describe("a slot the definition does not declare", () => {
     expect(
       validateDocument(doc(withStaleSlot()), defaultBlockRegistry)
     ).toContain("legacy");
+  });
+
+  it("survives a library entry that is not a node", () => {
+    // The library can be rebuilt from stored data. Every path downstream already tolerates a falsy
+    // entry — `pageStyleKeys` and `compileDocumentMotionCss` skip it, `RenderNode` draws the
+    // missing-ref placeholder — so dereferencing it while pruning would take the whole page down
+    // before that placeholder gets the chance.
+    const render = () =>
+      renderToStaticMarkup(
+        <PageRenderer
+          document={doc(
+            makeNode("core/container", {}, undefined, {
+              default: [makeNode("core/ref", { refId: "gone" })],
+            })
+          )}
+          refs={{ gone: null as unknown as BlockNode }}
+        />
+      );
+
+    expect(render).not.toThrow();
+    // Positive control: the page really rendered rather than returning nothing.
+    expect(render()).toContain("<style");
   });
 
   it("returns the SAME node when a document has nothing to prune", () => {

--- a/packages/plugin-page-builder/src/core/__tests__/declared-slots.test.tsx
+++ b/packages/plugin-page-builder/src/core/__tests__/declared-slots.test.tsx
@@ -1,0 +1,178 @@
+/**
+ * A slot a block's own definition does not declare is rejected at save and ignored at read.
+ *
+ * The allowlist a definition puts on a slot is a promise about what can live there. `spec` was
+ * undefined by TWO paths and only one was gated: an unregistered block type, where the permissive
+ * answer is what `allowUnknown` asks for, and a KNOWN container carrying a slot name its own
+ * definition never declared, which nothing asked for and which left every child in it unchecked.
+ *
+ * Both halves are asserted here because either alone leaves the hole open: rejecting at write does
+ * nothing for the pages already stored, and ignoring at read does nothing to stop new ones.
+ */
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { createBlockRegistry, defaultBlockRegistry } from "../registry";
+import { PageRenderer } from "../../render/PageRenderer";
+import "../../render/blocks";
+import { compileDocumentCss, documentNodeClasses } from "../style-compiler";
+import { declaredSlotEntries, pruneUndeclaredSlots } from "../declared-slots";
+import { makeNode } from "../tree";
+import { validateDocument } from "../validate";
+
+import type { BlockNode } from "../types";
+
+/** A container holding a child under a slot name `core/container` never declares. */
+const withStaleSlot = (): BlockNode => {
+  const node = makeNode("core/container", {}, undefined, {
+    default: [makeNode("core/heading", { text: "Kept", level: "h2" })],
+  });
+  return {
+    ...node,
+    slots: {
+      ...node.slots,
+      // A slot a rename or a block update left behind.
+      legacy: [
+        {
+          ...makeNode("core/heading", { text: "Stale", level: "h2" }),
+          style: { base: { backgroundImage: "/stale-asset.png" } },
+        },
+      ],
+    },
+  };
+};
+
+const doc = (root: BlockNode) => ({ version: 1, root }) as never;
+
+describe("a slot the definition does not declare", () => {
+  it("is refused at save, naming the slot", () => {
+    // The write path: `collections/pageBuilderField.ts` uses this as the field's `validate`, so a
+    // document carrying one never reaches the database in the first place.
+    const error = validateDocument(doc(withStaleSlot()), defaultBlockRegistry);
+
+    // A string is the failure channel; `true` is the pass. Naming the slot is the point — an
+    // author cannot fix what the message does not identify.
+    expect(error).toContain("legacy");
+    expect(error).toContain("core/container");
+  });
+
+  it("still accepts the slots the definition DOES declare", () => {
+    // Positive control: the rejection is about the undeclared name, not about slots in general —
+    // a fixture that failed validation for any reason would satisfy the assertion above.
+    const node = makeNode("core/container", {}, undefined, {
+      default: [makeNode("core/heading", { text: "Fine", level: "h2" })],
+    });
+
+    expect(validateDocument(doc(node), defaultBlockRegistry)).toBe(true);
+  });
+
+  it("is dropped from the tree a reader sees", () => {
+    const pruned = pruneUndeclaredSlots(withStaleSlot(), defaultBlockRegistry);
+
+    expect(Object.keys(pruned.slots ?? {})).toEqual(["default"]);
+    // Positive control: the declared slot and its child survive, so this is pruning rather than
+    // emptying.
+    expect(pruned.slots?.default).toHaveLength(1);
+  });
+
+  it("keeps its CSS and its asset URL out of the stylesheet", () => {
+    // The reason this is not merely tidiness. Both readers walked every STORED slot, so a stale
+    // slot's children were compiled into the sheet — `url(...)` included — for markup nobody
+    // receives. A background image is a REQUEST, so the leak is not only weight.
+    const stale = withStaleSlot();
+    const before = compileDocumentCss(doc(stale), {
+      classes: documentNodeClasses(doc(stale)),
+    });
+    const pruned = pruneUndeclaredSlots(stale, defaultBlockRegistry);
+    const after = compileDocumentCss(doc(pruned), {
+      classes: documentNodeClasses(doc(pruned)),
+    });
+
+    // Positive control: the URL really was reaching the sheet, so the assertion below is about the
+    // prune and not about a fixture that never produced it.
+    expect(before).toContain("stale-asset.png");
+    expect(after).not.toContain("stale-asset.png");
+  });
+
+  it("is gone from what a real page RENDERS, sheet included", () => {
+    // Asserted through `PageRenderer`, because the prune has to be wired at the entry point to be
+    // worth anything — a correct helper nobody calls is the same as no helper.
+    //
+    // The STYLESHEET is what pins it. A container's own `render` places `slots.default` and
+    // nothing else, so a stale slot's children never reach the markup whether or not anything
+    // prunes them; asserting on the markup alone passes against an unwired prune. The compiler is
+    // the half that walked every STORED slot, so the asset URL is where the wiring shows.
+    const html = renderToStaticMarkup(
+      <PageRenderer document={doc(withStaleSlot())} />
+    );
+
+    // Positive control: the page really rendered, and its sheet really is in this string.
+    expect(html).toContain("Kept");
+    expect(html).toContain("<style");
+    expect(html).not.toContain("stale-asset.png");
+    expect(html).not.toContain("Stale");
+  });
+
+  it("is pruned inside the reusable LIBRARY too", () => {
+    // A library block is rendered by the same code and can hold a stale slot for the same reason.
+    // Pruning only `document.root` would leave the leak open for every page that places it —
+    // which is more pages, not fewer, since that is what reusable means.
+    const html = renderToStaticMarkup(
+      <PageRenderer
+        document={doc(
+          makeNode("core/container", {}, undefined, {
+            default: [makeNode("core/ref", { refId: "r1" })],
+          })
+        )}
+        refs={{ r1: withStaleSlot() }}
+      />
+    );
+
+    // Positive control: the library block itself rendered, so the placement resolved.
+    expect(html).toContain("Kept");
+    expect(html).not.toContain("stale-asset.png");
+  });
+
+  it("returns the SAME node when a document has nothing to prune", () => {
+    // A document with no stale slot is not rebuilt, so callers comparing by identity — and React
+    // reconciling on it — are unaffected by a pass that had nothing to do.
+    const clean = makeNode("core/container", {}, undefined, {
+      default: [makeNode("core/heading", { text: "Fine", level: "h2" })],
+    });
+
+    expect(pruneUndeclaredSlots(clean, defaultBlockRegistry)).toBe(clean);
+  });
+
+  it("reads slots in DECLARED order, not stored order", () => {
+    // `blocks-react`'s SEO deriver already answers this question that way. Two packages disagreeing
+    // about which child comes first is how one of them describes a page the other renders.
+    //
+    // Against a purpose-built definition rather than a built-in: every block in the catalogue
+    // declares exactly one slot today, so no fixture drawn from it could tell the two orders apart.
+    const registry = createBlockRegistry();
+    registry.register({
+      type: "test/two-slots",
+      version: 1,
+      label: "Two slots",
+      isContainer: true,
+      slots: [{ name: "alpha" }, { name: "omega" }],
+      render: () => null,
+    });
+    const node = {
+      ...makeNode("test/two-slots"),
+      // Stored in the REVERSE of the declared order, so stored order and declared order disagree.
+      slots: {
+        omega: [makeNode("core/heading", { text: "omega", level: "h2" })],
+        alpha: [makeNode("core/heading", { text: "alpha", level: "h2" })],
+      },
+    };
+
+    // Positive control: both slots survive, so this is about their ORDER and not about one of them
+    // being dropped.
+    expect(declaredSlotEntries(node, registry)).toHaveLength(2);
+    expect(declaredSlotEntries(node, registry).map(([name]) => name)).toEqual([
+      "alpha",
+      "omega",
+    ]);
+  });
+});

--- a/packages/plugin-page-builder/src/core/declared-slots.ts
+++ b/packages/plugin-page-builder/src/core/declared-slots.ts
@@ -1,0 +1,85 @@
+/**
+ * Slots a block's own definition declares, and the pruning that holds readers to them.
+ *
+ * A stored document can carry children under a slot name the definition never declared — a slot
+ * that was renamed, or removed in a block update. Nothing rejected it at write until now, and both
+ * readers walked every STORED slot rather than the declared ones, so those children were compiled
+ * into the stylesheet and their asset URLs shipped for markup nobody receives.
+ *
+ * The allowlist a definition puts on a slot (`allowedBlocks`) is a promise the block author made
+ * about what can live there. A slot the definition does not declare has no allowlist at all, so
+ * every child in it was unchecked — and the containment was retroactively wrong too: the day a
+ * definition declares that name again, children that were never checked become live.
+ */
+import type { BlockRegistry } from "./registry";
+import type { BlockNode } from "./types";
+
+/**
+ * Whether a node's definition declares this slot name.
+ *
+ * An UNREGISTERED block type is treated as declaring nothing. That is deliberate and matches the
+ * write side: a document may legitimately hold types this runtime has not loaded, and the honest
+ * answer for one is "this reader cannot say what belongs here", which reads the same as an
+ * undeclared slot. The permissive direction is the one a caller opts into with `allowUnknown`.
+ */
+export function declaresSlot(
+  node: BlockNode,
+  slotName: string,
+  registry: BlockRegistry
+): boolean {
+  const def = registry.get(node.type);
+  return !!def?.slots?.some(spec => spec.name === slotName);
+}
+
+/**
+ * The entries of `node.slots` the node's definition actually declares, in DECLARED order.
+ *
+ * Declared order rather than stored order, so this package answers the question the SEO deriver in
+ * `blocks-react` already answers that way. Two packages disagreeing about which child comes first
+ * is how one of them ends up describing a page the other renders.
+ */
+export function declaredSlotEntries(
+  node: BlockNode,
+  registry: BlockRegistry
+): [string, BlockNode[]][] {
+  const stored = node.slots;
+  if (!stored) return [];
+  const def = registry.get(node.type);
+  if (!def?.slots) return [];
+  const entries: [string, BlockNode[]][] = [];
+  for (const spec of def.slots) {
+    const children = stored[spec.name];
+    if (children) entries.push([spec.name, children]);
+  }
+  return entries;
+}
+
+/**
+ * A copy of the tree holding only the slots each node's definition declares.
+ *
+ * Done once at the entry point rather than by teaching every walk to check: `walk` has thirty call
+ * sites and no registry, and a rule enforced at thirty places is a rule that is eventually missed
+ * at one. Everything downstream — the style compiler, the class map, the renderer — then sees a
+ * tree that cannot contain an undeclared slot, so none of them has to remember.
+ *
+ * Returns the SAME node object when nothing was dropped, so a document with no undeclared slots is
+ * not rebuilt and callers comparing by identity keep working.
+ */
+export function pruneUndeclaredSlots(
+  node: BlockNode,
+  registry: BlockRegistry
+): BlockNode {
+  const kept = declaredSlotEntries(node, registry);
+  const storedCount = node.slots ? Object.keys(node.slots).length : 0;
+  let changed = kept.length !== storedCount;
+  const slots: Record<string, BlockNode[]> = {};
+  for (const [name, children] of kept) {
+    const pruned = children.map(child => pruneUndeclaredSlots(child, registry));
+    // Compared per child rather than by array identity: `map` always returns a new array, so
+    // testing the array would report a change for every node that has any children at all.
+    if (pruned.some((child, i) => child !== children[i])) changed = true;
+    slots[name] = pruned;
+  }
+  if (!changed) return node;
+  return node.slots ? { ...node, slots } : node;
+}

--- a/packages/plugin-page-builder/src/core/declared-slots.ts
+++ b/packages/plugin-page-builder/src/core/declared-slots.ts
@@ -11,9 +11,10 @@
  * every child in it was unchecked — and the containment was retroactively wrong too: the day a
  * definition declares that name again, children that were never checked become live.
  *
- * A block type this runtime has NOT loaded is a different case and keeps everything it holds. The
- * two look alike from the lookup — both give no spec — and only one is a statement about the
- * document.
+ * A block type this runtime has NOT loaded looks the same from the lookup — no spec either way —
+ * and is a different question. It is answered on the WRITE side, where `validate` rejects only when
+ * a definition is present, so an unloaded plugin can never cost an author their content. On the
+ * read side there is nothing to keep: the placeholder is all that renders.
  */
 import type { BlockRegistry } from "./registry";
 import type { BlockNode } from "./types";
@@ -32,15 +33,15 @@ export function declaredSlotEntries(
   const stored = node.slots;
   if (!stored) return [];
   const def = registry.get(node.type);
-  // An UNREGISTERED type keeps everything it holds. "This runtime has not loaded that plugin" and
-  // "that block declares no such slot" are different statements, and only the second is a reason to
-  // drop anything: a page rendered while a plugin is unloaded would otherwise lose the children of
-  // every block that plugin owns — and because the pruned tree is what an editor would save next,
-  // it would lose them permanently. `blocks-react` keeps the node and draws its unknown-block
-  // placeholder for the same reason, so the two packages agree.
+  // An UNREGISTERED type contributes nothing to a READ. `RenderNode` draws its placeholder and
+  // never traverses its children, so keeping them in the read copy only puts their rules — and any
+  // URL in them — into a stylesheet for markup nobody receives.
   //
-  // Stored order is the only order available here; there is no declaration to take one from.
-  if (!def) return Object.entries(stored);
+  // This does not lose anything: what protects an author's work is that the STORED document is
+  // untouched, which is a property of this returning a copy, not of what the copy contains. The
+  // write path is where the distinction between "unloaded plugin" and "undeclared slot" has to be
+  // drawn, and it draws it — `validate` rejects only when a definition is present.
+  if (!def) return [];
   const entries: [string, BlockNode[]][] = [];
   for (const spec of def.slots ?? []) {
     const children = stored[spec.name];
@@ -59,6 +60,10 @@ export function declaredSlotEntries(
  *
  * Returns the SAME node object when nothing was dropped, so a document with no undeclared slots is
  * not rebuilt and callers comparing by identity keep working.
+ *
+ * 🔴 FOR READING ONLY. The result must never be written back: it is what a page should DISPLAY,
+ * not what it should STORE, and the two differ for any block whose plugin this process has not
+ * loaded. Repairing a stored document is a separate decision with its own author-facing surface.
  */
 export function pruneUndeclaredSlots(
   node: BlockNode,

--- a/packages/plugin-page-builder/src/core/declared-slots.ts
+++ b/packages/plugin-page-builder/src/core/declared-slots.ts
@@ -10,26 +10,13 @@
  * about what can live there. A slot the definition does not declare has no allowlist at all, so
  * every child in it was unchecked — and the containment was retroactively wrong too: the day a
  * definition declares that name again, children that were never checked become live.
+ *
+ * A block type this runtime has NOT loaded is a different case and keeps everything it holds. The
+ * two look alike from the lookup — both give no spec — and only one is a statement about the
+ * document.
  */
 import type { BlockRegistry } from "./registry";
 import type { BlockNode } from "./types";
-
-/**
- * Whether a node's definition declares this slot name.
- *
- * An UNREGISTERED block type is treated as declaring nothing. That is deliberate and matches the
- * write side: a document may legitimately hold types this runtime has not loaded, and the honest
- * answer for one is "this reader cannot say what belongs here", which reads the same as an
- * undeclared slot. The permissive direction is the one a caller opts into with `allowUnknown`.
- */
-export function declaresSlot(
-  node: BlockNode,
-  slotName: string,
-  registry: BlockRegistry
-): boolean {
-  const def = registry.get(node.type);
-  return !!def?.slots?.some(spec => spec.name === slotName);
-}
 
 /**
  * The entries of `node.slots` the node's definition actually declares, in DECLARED order.
@@ -45,9 +32,17 @@ export function declaredSlotEntries(
   const stored = node.slots;
   if (!stored) return [];
   const def = registry.get(node.type);
-  if (!def?.slots) return [];
+  // An UNREGISTERED type keeps everything it holds. "This runtime has not loaded that plugin" and
+  // "that block declares no such slot" are different statements, and only the second is a reason to
+  // drop anything: a page rendered while a plugin is unloaded would otherwise lose the children of
+  // every block that plugin owns — and because the pruned tree is what an editor would save next,
+  // it would lose them permanently. `blocks-react` keeps the node and draws its unknown-block
+  // placeholder for the same reason, so the two packages agree.
+  //
+  // Stored order is the only order available here; there is no declaration to take one from.
+  if (!def) return Object.entries(stored);
   const entries: [string, BlockNode[]][] = [];
-  for (const spec of def.slots) {
+  for (const spec of def.slots ?? []) {
     const children = stored[spec.name];
     if (children) entries.push([spec.name, children]);
   }

--- a/packages/plugin-page-builder/src/core/declared-slots.ts
+++ b/packages/plugin-page-builder/src/core/declared-slots.ts
@@ -65,8 +65,14 @@ export function pruneUndeclaredSlots(
   registry: BlockRegistry
 ): BlockNode {
   const kept = declaredSlotEntries(node, registry);
-  const storedCount = node.slots ? Object.keys(node.slots).length : 0;
-  let changed = kept.length !== storedCount;
+  const storedNames = node.slots ? Object.keys(node.slots) : [];
+  // A REORDER counts as a change, not only a drop. Comparing lengths alone leaves a node whose
+  // slots are all declared but stored in another order untouched — so `declaredSlotEntries` would
+  // answer in declared order while the tree every generic walker sees stayed in stored order, and
+  // the two would disagree exactly where this normalisation is supposed to make them agree.
+  let changed =
+    kept.length !== storedNames.length ||
+    kept.some(([name], i) => name !== storedNames[i]);
   const slots: Record<string, BlockNode[]> = {};
   for (const [name, children] of kept) {
     const pruned = children.map(child => pruneUndeclaredSlots(child, registry));

--- a/packages/plugin-page-builder/src/core/validate.ts
+++ b/packages/plugin-page-builder/src/core/validate.ts
@@ -46,6 +46,15 @@ export function validateDocument(
       }
       for (const [slotName, children] of Object.entries(n.slots)) {
         const spec = def?.slots?.find(s => s.name === slotName);
+        // A slot the definition does not declare has no allowlist, so every child in it would go
+        // unchecked. `spec` is undefined by two paths and `allowUnknown` gates only the first: an
+        // unregistered type, where the permissive answer is the one the caller asked for; and a
+        // KNOWN container carrying a slot name its own definition never declared, which nothing
+        // asked for. The containment is also retroactively wrong — the day a definition declares
+        // that name, children never checked against an allowlist become live.
+        if (def && !spec) {
+          return `${n.type} has no slot "${slotName}"`;
+        }
         for (const child of children) {
           if (spec?.allowedBlocks && !spec.allowedBlocks.includes(child.type)) {
             return `${child.type} is not allowed in slot "${slotName}" of ${n.type}`;

--- a/packages/plugin-page-builder/src/render/PageRenderer.tsx
+++ b/packages/plugin-page-builder/src/render/PageRenderer.tsx
@@ -8,6 +8,7 @@ import { PAGE_ROOT_CLASS } from "@nextlyhq/blocks-engine";
 import type { ReactNode } from "react";
 
 import { sanitizeCustomCss } from "../core/css-sanitize";
+import { pruneUndeclaredSlots } from "../core/declared-slots";
 import { defaultBlockRegistry, type BlockRegistry } from "../core/registry";
 import {
   compileDocumentStyles,
@@ -52,16 +53,38 @@ export interface PageRendererProps {
 }
 
 export function PageRenderer({
-  document,
+  document: stored,
   registry = defaultBlockRegistry,
   dataProvider,
   customCss,
   breakpoints,
   remotePatterns,
   tokens,
-  refs,
+  refs: storedRefs,
 }: PageRendererProps): ReactNode {
-  if (!document?.root) return null;
+  if (!stored?.root) return null;
+
+  // Held to the slots each definition declares, ONCE, before anything reads the tree. A stored
+  // document can carry children under a slot name a block update renamed or removed, and both the
+  // compiler and the renderer walked every STORED slot — so those children's rules, asset URLs
+  // included, were compiled into the sheet for markup nobody receives. Pruning here rather than in
+  // each walk is deliberate: `walk` has thirty call sites and no registry, and a rule enforced in
+  // thirty places is one that is eventually missed in one.
+  //
+  // The reusable library is pruned too. A library block is rendered by the same code and can hold
+  // a stale slot for the same reason.
+  const document = {
+    ...stored,
+    root: pruneUndeclaredSlots(stored.root, registry),
+  };
+  const refs = storedRefs
+    ? Object.fromEntries(
+        Object.entries(storedRefs).map(([id, target]) => [
+          id,
+          pruneUndeclaredSlots(target, registry),
+        ])
+      )
+    : storedRefs;
 
   // Everything two documents on one page must not share is anchored to a class
   // of this document's own: its token values, and the custom CSS whose

--- a/packages/plugin-page-builder/src/render/PageRenderer.tsx
+++ b/packages/plugin-page-builder/src/render/PageRenderer.tsx
@@ -77,11 +77,16 @@ export function PageRenderer({
     ...stored,
     root: pruneUndeclaredSlots(stored.root, registry),
   };
+  // A falsy library entry is left exactly as it is rather than pruned as a node. The library can be
+  // rebuilt from stored data, and every path downstream already tolerates one — `pageStyleKeys` and
+  // `compileDocumentMotionCss` skip it, `RenderNode` treats it as a missing ref and draws the
+  // placeholder. Dereferencing it here would take down the whole page before that placeholder gets
+  // the chance.
   const refs = storedRefs
     ? Object.fromEntries(
         Object.entries(storedRefs).map(([id, target]) => [
           id,
-          pruneUndeclaredSlots(target, registry),
+          target ? pruneUndeclaredSlots(target, registry) : target,
         ])
       )
     : storedRefs;


### PR DESCRIPTION
Closes task 160. Founder-decided shape: **reject on save AND ignore on read**,
because closing only one leaves the other half of the hole open — rejecting at
write does nothing for the pages already stored, and ignoring at read does
nothing to stop new ones.

## The gap

`core/validate.ts` looked up a slot's spec and checked its allowlist:

```ts
const spec = def?.slots?.find(s => s.name === slotName);
if (spec?.allowedBlocks && !spec.allowedBlocks.includes(child.type)) { … }
```

`spec` is undefined by **two** paths, and `allowUnknown` gates only the first:

1. **`def` undefined** — an unregistered block type. Gated; the permissive
   direction is the one the caller asked for.
2. **`def` DEFINED, and its `slots` declares no such name** — a known container
   carrying a slot a rename or a block update left behind. Nothing asked for
   this, and **no allowlist was enforced for any child in it**.

It is a write path — `collections/pageBuilderField.ts` uses `validateDocument`
as the field's `validate` — and the containment is retroactively wrong too: the
day a definition declares that name again, children that were never checked
become live.

## Why it was not only theoretical

Both readers walked every **stored** slot rather than the declared ones, so a
stale slot's children were compiled into the stylesheet and their asset URLs
shipped for markup nobody receives. A background image is a **request**, so this
is not only weight. The test asserts exactly that: `url(/stale-asset.png)` is in
the sheet before the prune and gone after.

## What changed

**Write** — saving is refused, naming the slot. An author cannot fix what the
message does not identify.

**Read** — pruned **once at the render entry point**, not in each walk. `walk`
has thirty call sites and no registry, and a rule enforced in thirty places is
one that is eventually missed in one. Everything downstream — compiler, class
map, renderer — then sees a tree that cannot contain an undeclared slot, so none
of them has to remember. This is the same argument the founder accepted for the
condition evaluator in task 175: own the entry point, not just the predicate.

**The reusable library is pruned too.** A library block can hold a stale slot for
the same reason and is placed on more pages than a document node, not fewer.

**Declared order, not stored order** — `blocks-react`'s SEO deriver already
assumes "declared slots in declared order". Two packages disagreeing about which
child comes first is how one of them describes a page the other renders.

**An unregistered type declares nothing**, matching the write side: a document
may hold types this runtime has not loaded, and "this reader cannot say what
belongs here" reads the same as an undeclared slot.

## Repair — NOT solved here, and the PR should not be read as solving it

**Correcting a claim I made in the first version of this description.** I wrote
that pruning is idempotent and runs on read, so a stale page repairs itself on
the next save. That is wrong, and I found it by checking rather than by assuming:

- The editor does **not** go through `PageRenderer`. The canvas renders through
  `CanvasNode`, which is a separate path, so nothing prunes what the editor
  loads or saves.
- Worse, the stale children are **invisible in the editor too**. `CanvasNode`
  builds every stored slot, but a block's own `render` places only the slots it
  declares — so an author cannot see them, cannot select them, and cannot delete
  them.

So a page that already holds an undeclared slot is now **unsavable and
unrepairable through the UI**. That is the consequence the founder accepted when
choosing reject-on-save, and they said explicitly that a repair path is part of
the work rather than a follow-up — so this PR is not the whole of task 160.

I have deliberately NOT resolved it by pruning on editor load, because that
relocates the silent drop the founder rejected as the primary rule: every
undeclared slot would be stripped on the next open, with no author ever told.
Choosing between "the editor prunes and says so" and an explicit author-driven
repair is a product decision, and it belongs with the founder rather than in a
commit.

**What this PR does deliver:** no NEW document can acquire an undeclared slot,
and no existing one leaks its CSS or asset URLs. Both are true today and neither
depends on the repair question.

## Second commit: a data-loss path this PR introduced, caught in review

The first version treated an **unregistered block type** the same as a block
declaring no such slot — the lookup gives no spec either way — and dropped every
child. Verified by execution: a node of type `acme/not-loaded` came back with
zero slots.

That means a page rendered while a plugin is unloaded loses the children of
every block that plugin owns. "This process has not loaded that plugin" and
"that block declares no such slot" are different statements and only the second
is about the document. Unknown types now keep everything, which is also what
`blocks-react` does — it keeps the node and draws its unknown-block placeholder —
so the two packages agree. The write path already drew this line, rejecting only
when a definition is present.

`declaresSlot` was removed in the same commit: it had no callers and answered the
question the opposite way, which is a trap for the next reader.

## Verification

Seven properties, each stub-verified to fail only its own test.

| Stub | Failed |
|---|---|
| write rejection removed | the save test |
| prune unwired at the entry | the rendered-page test |
| library not pruned | the library test |
| declared order → stored order | the ordering test |
| identity short-circuit removed | the same-node test |

**One test had to be rewritten because its stub did not fail.** The entry-point
test originally asserted the stale child was absent from the **markup** — and it
passed against an unwired prune, because `core/container`'s own `render` places
`slots.default` and nothing else, so a stale slot never reaches the markup
whether or not anything prunes it. The stylesheet is the half that leaked, so the
assertion is now on the asset URL.

The declared-order test uses a purpose-built two-slot definition rather than a
built-in: **every block in the catalogue declares exactly one slot today**, so no
fixture drawn from it could tell the two orders apart.

611 tests pass; typecheck and lint clean.

