### PR TITLE
feat(playground): render a blocks-engine document through a real route

### DIFF
--- a/apps/playground/nextly.config.ts
+++ b/apps/playground/nextly.config.ts
@@ -4,7 +4,7 @@
  * Internal contributor playground for the Nextly monorepo. NOT a
  * template for end-user projects — see templates/blog for that.
  *
- * Collections Posts, Categories, Tags (defined here) plus Media and
+ * Collections Posts, Categories, Tags, BlockPages (defined here) plus Media and
  * Users (core, registered automatically), three singles (Homepage,
  * LandingPage, SiteSettings) and the Seo field group. SiteSettings and Seo
  * are registered as a pair on purpose: SiteSettings embeds Seo through a
@@ -27,6 +27,7 @@ import { formBuilderPlugin } from "@nextlyhq/plugin-form-builder";
 import { pageBuilder } from "@nextlyhq/plugin-page-builder";
 import { defineConfig } from "nextly/config";
 
+import { BlockPages } from "./src/collections/block-pages";
 import { Categories } from "./src/collections/categories";
 import { Posts } from "./src/collections/posts";
 import { Tags } from "./src/collections/tags";
@@ -77,7 +78,7 @@ export default defineConfig({
     // Untranslated fields fall back to another locale's value on read (default true).
     fallback: true,
   },
-  collections: [Posts, Categories, Tags],
+  collections: [Posts, Categories, Tags, BlockPages],
   singles: [Homepage, LandingPage, SiteSettings],
   fieldGroups: [Seo],
   // Dev-harness plugins: page builder, form builder, and the styling fixture

--- a/apps/playground/package.json
+++ b/apps/playground/package.json
@@ -24,6 +24,7 @@
     "@nextlyhq/adapter-postgres": "workspace:^",
     "@nextlyhq/adapter-sqlite": "workspace:^",
     "@nextlyhq/admin": "workspace:^",
+    "@nextlyhq/blocks-react": "workspace:^",
     "@nextlyhq/plugin-form-builder": "workspace:^",
     "@nextlyhq/plugin-page-builder": "workspace:^",
     "@nextlyhq/plugin-sdk": "workspace:^",

--- a/apps/playground/src/app/blocks/[[...slug]]/page.tsx
+++ b/apps/playground/src/app/blocks/[[...slug]]/page.tsx
@@ -1,0 +1,86 @@
+/**
+ * Public route for the code-first blocks renderer.
+ *
+ * The whole route is `createBlocksPage` plus the three re-exports Next wants —
+ * there is no per-request wiring here, which is the point of the helper.
+ *
+ * The document this renders is a `@nextlyhq/blocks-engine` `BlockDocument`, NOT
+ * the page builder's `BlockNode`. They are different shapes (`styles` and a
+ * `visibility` that may carry conditions, against `style`/`styleHover` and a
+ * per-breakpoint boolean map), so this route and the page builder's
+ * `(site)/[...slug]` route are not interchangeable and neither can read the
+ * other's rows. That is why this reads its own collection.
+ */
+import { createBlockResolver } from "@nextlyhq/blocks-react";
+import { coreBlocks } from "@nextlyhq/blocks-react/blocks";
+import { createBlocksPage } from "@nextlyhq/blocks-react/next";
+import { getNextly } from "nextly";
+import type { NextlyContentReader } from "nextly/runtime";
+
+import nextlyConfig from "../../../../nextly.config";
+
+/**
+ * The route's reader, resolved per call.
+ *
+ * `createBlocksPage` otherwise falls back to the synchronous `getNextly()` from
+ * `nextly/runtime`, which returns the already-registered singleton and throws
+ * when nothing has registered it. A public page can be the FIRST request a cold
+ * server handles, so relying on that means the route works only once something
+ * else has booted the CMS — in this app, a visit to `/admin`.
+ *
+ * Async boot cannot happen where the config is captured (module scope), so the
+ * indirection is per call rather than a value. `getNextly` caches its instance,
+ * so every call after the first is a lookup.
+ */
+const reader: NextlyContentReader = {
+  find: async args => (await getNextly({ config: nextlyConfig })).find(args),
+  findByID: async args =>
+    (await getNextly({ config: nextlyConfig })).findByID(args),
+};
+
+/**
+ * Where this route is mounted, for canonical URLs.
+ *
+ * `derived.canonical` is the entry's path within its collection, already
+ * rooted (`/about/team`, or `/` for the collection's root entry), because the
+ * helper resolves slugs and does not know which segment of the app it was
+ * wired under. Prefixing is the host's job, and getting it wrong is how a page
+ * comes to claim it lives somewhere nothing is served.
+ */
+const MOUNT = "/blocks";
+
+/**
+ * The mount plus the entry's own path.
+ *
+ * The root entry's path is `/`, and concatenating it would emit `/blocks/` for
+ * a page Next serves at `/blocks` — a canonical that names a redirect rather
+ * than the page describing itself.
+ */
+function canonicalFor(path: string): string {
+  return path === "/" ? MOUNT : `${MOUNT}${path}`;
+}
+
+const { ContentPage, generateMetadata, generateStaticParams } =
+  createBlocksPage({
+    collections: ["block-pages"],
+    field: "content",
+    nextly: reader,
+    // An explicit set, not the process registry. `registeredBlocks()` reads the
+    // engine's global registry, which is populated by whatever booted the
+    // editor — so a public route depending on it renders the unknown-block
+    // placeholder whenever this request arrived before the admin did.
+    blocks: createBlockResolver(coreBlocks),
+    metadata: (entry, context, derived) => ({
+      title: derived.title ?? (entry.title as string | undefined),
+      description: derived.description,
+      ...(derived.canonical
+        ? { alternates: { canonical: canonicalFor(derived.canonical) } }
+        : {}),
+      ...(derived.image
+        ? { openGraph: { images: [{ url: derived.image }] } }
+        : {}),
+    }),
+  });
+
+export { generateMetadata, generateStaticParams };
+export default ContentPage;

--- a/apps/playground/src/app/blocks/[[...slug]]/page.tsx
+++ b/apps/playground/src/app/blocks/[[...slug]]/page.tsx
@@ -19,6 +19,41 @@ import type { NextlyContentReader } from "nextly/runtime";
 
 import nextlyConfig from "../../../../nextly.config";
 
+type NextlyInstance = Awaited<ReturnType<typeof getNextly>>;
+
+/**
+ * The site's breakpoints, and the reason this route compiles its own sheet.
+ *
+ * `PageRenderer` emits class NAMES unconditionally and CSS only when it is
+ * given either a stored `styles` artifact or a `styleContext` to compile from.
+ * This collection stores the document alone — there is no write path here
+ * producing a compiled sheet — so without a context every authored node style
+ * and every `visibility.devices` rule would resolve to a class that no rule
+ * ever defines, and the page would render structurally correct and visually
+ * bare.
+ *
+ * Declared by the host because breakpoints are a site decision: the engine
+ * never reads storage and ships no default set. Ids must be unique across both
+ * axes, and the base breakpoint carries no `maxWidth` — it is the fallback the
+ * others narrow.
+ *
+ * Left unannotated deliberately. `StyleCompileContext` is what
+ * `createBlocksPage` accepts, and `@nextlyhq/blocks-react` does not re-export
+ * it — naming the type here would mean taking a direct dependency on
+ * `@nextlyhq/blocks-engine` purely to label a config object. The shape is still
+ * fully checked where it is passed, so nothing is lost but the label.
+ */
+const STYLE_CONTEXT = {
+  breakpoints: {
+    viewport: [
+      { id: "base", label: "Base" },
+      { id: "tablet", label: "Tablet", maxWidth: 1024 },
+      { id: "mobile", label: "Mobile", maxWidth: 640 },
+    ],
+    container: [],
+  },
+};
+
 /**
  * The route's reader, resolved per call.
  *
@@ -32,10 +67,31 @@ import nextlyConfig from "../../../../nextly.config";
  * indirection is per call rather than a value. `getNextly` caches its instance,
  * so every call after the first is a lookup.
  */
-const reader: NextlyContentReader = {
-  find: async args => (await getNextly({ config: nextlyConfig })).find(args),
-  findByID: async args =>
-    (await getNextly({ config: nextlyConfig })).findByID(args),
+const instance = () => getNextly({ config: nextlyConfig });
+
+/**
+ * Just the media lookup `createBlocksPage` probes for.
+ *
+ * Narrower than the instance's whole `media` namespace on purpose: this reader
+ * exists to be READ from, and forwarding `upload`/`update`/`delete` would offer
+ * a public page route a write surface it has no reason to hold.
+ */
+type MediaLookup = Pick<NextlyInstance["media"], "findByID">;
+
+const reader: NextlyContentReader & { media: MediaLookup } = {
+  find: async args => (await instance()).find(args),
+  findByID: async args => (await instance()).findByID(args),
+  // The media namespace, forwarded rather than dropped.
+  //
+  // Ordinary Nextly media lives in a SYSTEM table with its own namespace, and
+  // `createBlocksPage` resolves an image's `mediaId` through `reader.media
+  // .findByID`. A wrapper exposing only `find` and `findByID` satisfies
+  // `NextlyContentReader` and silently loses that lookup, so every `core/image`
+  // storing a media id — rather than a literal `src` — resolves to null and
+  // draws nothing.
+  media: {
+    findByID: async args => (await instance()).media.findByID(args),
+  },
 };
 
 /**
@@ -86,6 +142,7 @@ const { ContentPage, generateMetadata } = createBlocksPage({
   // editor — so a public route depending on it renders the unknown-block
   // placeholder whenever this request arrived before the admin did.
   blocks: createBlockResolver(coreBlocks),
+  styleContext: STYLE_CONTEXT,
   metadata: (entry, context, derived) => ({
     title: derived.title ?? (entry.title as string | undefined),
     description: derived.description,

--- a/apps/playground/src/app/blocks/[[...slug]]/page.tsx
+++ b/apps/playground/src/app/blocks/[[...slug]]/page.tsx
@@ -60,27 +60,43 @@ function canonicalFor(path: string): string {
   return path === "/" ? MOUNT : `${MOUNT}${path}`;
 }
 
-const { ContentPage, generateMetadata, generateStaticParams } =
-  createBlocksPage({
-    collections: ["block-pages"],
-    field: "content",
-    nextly: reader,
-    // An explicit set, not the process registry. `registeredBlocks()` reads the
-    // engine's global registry, which is populated by whatever booted the
-    // editor — so a public route depending on it renders the unknown-block
-    // placeholder whenever this request arrived before the admin did.
-    blocks: createBlockResolver(coreBlocks),
-    metadata: (entry, context, derived) => ({
-      title: derived.title ?? (entry.title as string | undefined),
-      description: derived.description,
-      ...(derived.canonical
-        ? { alternates: { canonical: canonicalFor(derived.canonical) } }
-        : {}),
-      ...(derived.image
-        ? { openGraph: { images: [{ url: derived.image }] } }
-        : {}),
-    }),
-  });
+/**
+ * Rendered per request, never prerendered at build.
+ *
+ * The same reason `(site)/[...slug]` gives: this repository's build environment
+ * has no database, and `generateStaticParams` reads one to learn which paths
+ * exist. Without this the playground build fails with "Failed to collect page
+ * data" — not because the route is wrong, but because a build box has nothing
+ * to collect from.
+ *
+ * A deployed site whose build CAN reach its database wants the opposite, and
+ * `createBlocksPage` returns `generateStaticParams` for exactly that. It is not
+ * re-exported here because `force-dynamic` makes Next ignore it, and an export
+ * that does nothing invites the next reader to conclude that static generation
+ * was tried and did not work.
+ */
+export const dynamic = "force-dynamic";
 
-export { generateMetadata, generateStaticParams };
+const { ContentPage, generateMetadata } = createBlocksPage({
+  collections: ["block-pages"],
+  field: "content",
+  nextly: reader,
+  // An explicit set, not the process registry. `registeredBlocks()` reads the
+  // engine's global registry, which is populated by whatever booted the
+  // editor — so a public route depending on it renders the unknown-block
+  // placeholder whenever this request arrived before the admin did.
+  blocks: createBlockResolver(coreBlocks),
+  metadata: (entry, context, derived) => ({
+    title: derived.title ?? (entry.title as string | undefined),
+    description: derived.description,
+    ...(derived.canonical
+      ? { alternates: { canonical: canonicalFor(derived.canonical) } }
+      : {}),
+    ...(derived.image
+      ? { openGraph: { images: [{ url: derived.image }] } }
+      : {}),
+  }),
+});
+
+export { generateMetadata };
 export default ContentPage;

--- a/apps/playground/src/app/blocks/[[...slug]]/page.tsx
+++ b/apps/playground/src/app/blocks/[[...slug]]/page.tsx
@@ -1,8 +1,8 @@
 /**
  * Public route for the code-first blocks renderer.
  *
- * The whole route is `createBlocksPage` plus the three re-exports Next wants —
- * there is no per-request wiring here, which is the point of the helper.
+ * The whole route is `createBlocksPage` plus the re-exports Next wants — there
+ * is no per-request wiring here, which is the point of the helper.
  *
  * The document this renders is a `@nextlyhq/blocks-engine` `BlockDocument`, NOT
  * the page builder's `BlockNode`. They are different shapes (`styles` and a

--- a/apps/playground/src/collections/block-pages.ts
+++ b/apps/playground/src/collections/block-pages.ts
@@ -1,0 +1,35 @@
+import { defineCollection, json, text } from "nextly/config";
+
+// Pages rendered by the code-first blocks renderer (`@nextlyhq/blocks-react`),
+// served at /blocks/<slug> by apps/playground/src/app/blocks/[[...slug]]/page.tsx.
+//
+// Separate from the page builder's own `pages` collection because the two
+// renderers store DIFFERENT documents. `@nextlyhq/blocks-engine` nodes carry
+// `styles` (states x breakpoints) and a `visibility` object that can hold
+// conditions; the page builder's nodes carry `style`/`styleHover` and a
+// `visibility` that is only a per-breakpoint boolean map. A row written for one
+// renderer is not readable by the other, so pointing `createBlocksPage` at
+// `pages` would resolve rows it cannot draw.
+//
+// `title` and `slug` are declared explicitly so they replace Nextly's
+// auto-injected reserved columns of the same name. `id`, `createdAt` and
+// `updatedAt` are always auto-injected.
+export const BlockPages = defineCollection({
+  slug: "block-pages",
+  labels: { singular: "Block Page", plural: "Block Pages" },
+  // Draft/Published lifecycle. The route reads with the default `published`
+  // scope, so an unpublished row must 404 rather than render.
+  status: true,
+  fields: [
+    text({ name: "title", required: true }),
+    text({ name: "slug", required: true, unique: true }),
+    json({
+      name: "content",
+      label: "Block document",
+      admin: {
+        description:
+          "A @nextlyhq/blocks-engine BlockDocument. Rendered by blocks-react, not by the page builder.",
+      },
+    }),
+  ],
+});

--- a/e2e/tests/blocks-page.spec.ts
+++ b/e2e/tests/blocks-page.spec.ts
@@ -27,6 +27,8 @@
  */
 import { expect, test, type APIResponse } from "@playwright/test";
 
+import { STORAGE_STATE } from "../global-setup";
+
 test.describe.configure({ mode: "serial" });
 
 const ENTRIES = "/admin/api/collections/block-pages/entries";
@@ -123,36 +125,68 @@ const DOCUMENT = {
 };
 
 /** Fail with the server's message rather than with a bare status code. */
-async function expectCreated(response: APIResponse): Promise<void> {
+async function expectOk(response: APIResponse, what: string): Promise<void> {
   if (!response.ok()) {
     throw new Error(
-      `seed failed: ${response.status()} ${await response.text()}`
+      `${what} failed: ${response.status()} ${await response.text()}`
     );
   }
 }
 
-test("seeds a published and an unpublished block page", async ({ request }) => {
-  await expectCreated(
-    await request.post(ENTRIES, {
-      data: {
+/**
+ * Seeds the fixture rows, in a hook rather than in a test.
+ *
+ * As a test it was separately selectable, and every later test depended on it:
+ * `--grep` or a click in the UI picked one of them, skipped the seed, and ran
+ * against an empty database. A hook cannot be deselected.
+ *
+ * **Idempotent, and that is the half a hook alone would not fix.** `slug` is
+ * `unique: true`, and CI sets `retries: 1` over a `serial` group — so ONE later
+ * failure re-runs the whole group and the seed re-inserts. Measured before
+ * fixing: the retry did not merely die on the fixture, it reported a test that
+ * had PASSED as failed, because the group's first test is where the hook's
+ * error surfaces. A false failure in an unrelated test is worse than the
+ * original masking.
+ */
+test.beforeAll(async ({ playwright }, testInfo) => {
+  const baseURL = testInfo.project.use.baseURL;
+  if (baseURL === undefined) throw new Error("[e2e] No baseURL configured.");
+
+  // Its own context: `request` is test-scoped and cannot be taken by a
+  // `beforeAll`. The signed-in state is the same one every test runs with.
+  const api = await playwright.request.newContext({
+    baseURL,
+    storageState: STORAGE_STATE,
+  });
+
+  try {
+    for (const row of [
+      {
         title: "Dogfood",
         slug: PUBLISHED_SLUG,
         content: DOCUMENT,
         status: "published",
       },
-    })
-  );
-
-  await expectCreated(
-    await request.post(ENTRIES, {
-      data: {
+      {
         title: "Dogfood draft",
         slug: DRAFT_SLUG,
         content: DOCUMENT,
         status: "draft",
       },
-    })
-  );
+    ]) {
+      const created = await api.post(ENTRIES, { data: row });
+
+      // 409 IS the success case on a retry: the unique index on `slug` is what
+      // reports "this run already seeded me". Asking the list endpoint first
+      // looked tidier and was wrong — it answered without the draft row, so the
+      // check passed for one slug and not the other. The index is the authority
+      // on whether a slug is taken; nothing else has to agree with it.
+      if (created.status() === 409) continue;
+      await expectOk(created, `seeding ${row.slug}`);
+    }
+  } finally {
+    await api.dispose();
+  }
 });
 
 test("renders every block in the document", async ({ page }) => {

--- a/e2e/tests/blocks-page.spec.ts
+++ b/e2e/tests/blocks-page.spec.ts
@@ -1,0 +1,228 @@
+/**
+ * The code-first blocks renderer, served by a real route to a real browser.
+ *
+ * Everything about `createBlocksPage` was previously checked against intent —
+ * unit tests over the read pipeline, the SEO deriver and the resolvers, with a
+ * mocked CMS on the other side. Nothing had drawn a page. This boots the
+ * playground, writes a `@nextlyhq/blocks-engine` document through the ordinary
+ * write path, asks for the URL, and reads what came back.
+ *
+ * Four properties, in the order they can fail:
+ *
+ * 1. The document renders at all — the blocks reach markup, not the
+ *    unknown-block placeholder. The placeholder is asserted ABSENT because a
+ *    resolver that finds nothing still produces a page, and a test looking only
+ *    for "the route answered 200" passes against a page of placeholders.
+ * 2. A condition-gated node does not ship. `blocks-react` fails closed, and
+ *    this is the first time that has been observed in a browser rather than in
+ *    a tree filter. The assertion is over the response BODY, not over what is
+ *    visible: a node hidden by CSS is still served, and the whole point of the
+ *    conditions tier is that the markup never leaves the server.
+ * 3. The route's lifecycle scope holds — an unpublished entry 404s.
+ * 4. The metadata the blocks declared reaches the document head, including a
+ *    canonical carrying this route's mount point.
+ *
+ * Safe to write against: the suite owns its database and empties it before
+ * every run.
+ */
+import { expect, test, type APIResponse } from "@playwright/test";
+
+test.describe.configure({ mode: "serial" });
+
+const ENTRIES = "/admin/api/collections/block-pages/entries";
+
+const PUBLISHED_SLUG = "dogfood";
+const DRAFT_SLUG = "dogfood-draft";
+
+const PAGE_HEADING = "Rendered by blocks-react";
+const BUTTON_LABEL = "Read the docs";
+
+/**
+ * The first paragraph's text, which is also the page description.
+ *
+ * One value rather than two because `core/text` contributes its text as the
+ * description through `BlockDefinition.seo`. Asserting the same string in the
+ * body and in the head is what shows the block DECLARED the metadata, rather
+ * than something copying it off a field of the entry.
+ */
+const LEAD_PARAGRAPH = "A page assembled from core blocks.";
+
+/**
+ * Text that must never reach the client.
+ *
+ * Carried by a node whose `visibility.conditions` are set, which is the tier
+ * that omits a node from server output entirely (as opposed to `devices`, which
+ * hides a node that WAS served). Distinctive enough to be searched for in the
+ * raw HTML without matching anything else on the page.
+ */
+const GATED_TEXT = "vip-only-marker-8f21";
+
+/** A node id. Stable per fixture so a failure names the same node every run. */
+const id = (suffix: string) => `00000000-0000-4000-8000-0000000000${suffix}`;
+
+/**
+ * The fixture document.
+ *
+ * Written as the stored shape rather than built through a helper, because what
+ * this test is for is the path from STORED JSON to markup. A builder would
+ * assert that the builder and the renderer agree, which is a different and
+ * weaker claim.
+ */
+const DOCUMENT = {
+  formatVersion: 1,
+  kind: "page",
+  nodes: [
+    {
+      id: id("01"),
+      type: "core/section",
+      version: 1,
+      props: { as: "section", contained: true },
+      slots: {
+        children: [
+          {
+            id: id("02"),
+            type: "core/heading",
+            version: 1,
+            props: { text: PAGE_HEADING, level: "h1" },
+          },
+          {
+            id: id("03"),
+            type: "core/text",
+            version: 1,
+            props: { text: LEAD_PARAGRAPH },
+          },
+          {
+            id: id("04"),
+            type: "core/list",
+            version: 1,
+            props: {
+              kind: "unordered",
+              items: ["Schema in TypeScript", "Blocks in code"],
+            },
+          },
+          { id: id("05"), type: "core/divider", version: 1, props: {} },
+          {
+            id: id("06"),
+            type: "core/button",
+            version: 1,
+            props: { label: BUTTON_LABEL, href: "/blocks" },
+          },
+          {
+            id: id("07"),
+            type: "core/text",
+            version: 1,
+            props: { text: GATED_TEXT },
+            visibility: {
+              conditions: [[{ field: "tier", op: "eq", value: "vip" }]],
+            },
+          },
+        ],
+      },
+    },
+  ],
+};
+
+/** Fail with the server's message rather than with a bare status code. */
+async function expectCreated(response: APIResponse): Promise<void> {
+  if (!response.ok()) {
+    throw new Error(
+      `seed failed: ${response.status()} ${await response.text()}`
+    );
+  }
+}
+
+test("seeds a published and an unpublished block page", async ({ request }) => {
+  await expectCreated(
+    await request.post(ENTRIES, {
+      data: {
+        title: "Dogfood",
+        slug: PUBLISHED_SLUG,
+        content: DOCUMENT,
+        status: "published",
+      },
+    })
+  );
+
+  await expectCreated(
+    await request.post(ENTRIES, {
+      data: {
+        title: "Dogfood draft",
+        slug: DRAFT_SLUG,
+        content: DOCUMENT,
+        status: "draft",
+      },
+    })
+  );
+});
+
+test("renders every block in the document", async ({ page }) => {
+  const failed: string[] = [];
+  page.on("requestfailed", request =>
+    failed.push(`${request.method()} ${request.url()}`)
+  );
+
+  const response = await page.goto(`/blocks/${PUBLISHED_SLUG}`);
+  expect(response?.status()).toBe(200);
+
+  // One assertion per block type, so a failure names which block stopped
+  // rendering instead of reporting that "the page" is wrong.
+  await expect(page.getByRole("heading", { name: PAGE_HEADING })).toBeVisible();
+  await expect(page.getByText(LEAD_PARAGRAPH)).toBeVisible();
+  await expect(page.getByRole("listitem")).toHaveCount(2);
+  await expect(page.getByRole("link", { name: BUTTON_LABEL })).toBeVisible();
+  await expect(page.locator("hr")).toHaveCount(1);
+
+  // The container reached markup as a landmark and the blocks are INSIDE it —
+  // asserted as containment rather than as a count of `<section>` on the page,
+  // which would also pass if the section rendered empty beside its children.
+  await expect(
+    page.locator("section").getByRole("heading", { name: PAGE_HEADING })
+  ).toBeVisible();
+
+  // A resolver that resolves nothing still renders a page. Without this, every
+  // assertion above could be satisfied by placeholders carrying the same text.
+  await expect(page.getByText(/unknown block/i)).toHaveCount(0);
+
+  expect(failed).toEqual([]);
+});
+
+test("a condition-gated node is never sent to the client", async ({
+  request,
+}) => {
+  // Read as raw HTML rather than through the page: a node the renderer removed
+  // and a node CSS is hiding look identical to a visibility assertion, and only
+  // one of them is the guarantee conditions make.
+  const response = await request.get(`/blocks/${PUBLISHED_SLUG}`);
+  expect(response.status()).toBe(200);
+
+  const html = await response.text();
+  // The positive control. Without it, a fixture that failed to store its
+  // document at all satisfies "the gated text is absent" by serving an empty
+  // page, and reports clean.
+  expect(html).toContain(PAGE_HEADING);
+  expect(html).not.toContain(GATED_TEXT);
+});
+
+test("an unpublished entry is not served", async ({ page }) => {
+  const response = await page.goto(`/blocks/${DRAFT_SLUG}`);
+  expect(response?.status()).toBe(404);
+});
+
+test("block-declared metadata reaches the head", async ({ page }) => {
+  await page.goto(`/blocks/${PUBLISHED_SLUG}`);
+
+  // `core/heading` declares the title through its `seo` hook.
+  await expect(page).toHaveTitle(PAGE_HEADING);
+
+  await expect(page.locator('meta[name="description"]')).toHaveAttribute(
+    "content",
+    LEAD_PARAGRAPH
+  );
+
+  // The mount point is the host's to add: the helper resolves slugs within a
+  // collection and does not know which segment of the app it was wired under.
+  await expect(page.locator('link[rel="canonical"]')).toHaveAttribute(
+    "href",
+    new RegExp(`/blocks/${PUBLISHED_SLUG}$`)
+  );
+});

--- a/e2e/tests/blocks-page.spec.ts
+++ b/e2e/tests/blocks-page.spec.ts
@@ -164,6 +164,17 @@ test("renders every block in the document", async ({ page }) => {
   const response = await page.goto(`/blocks/${PUBLISHED_SLUG}`);
   expect(response?.status()).toBe(200);
 
+  // First, because it is what makes every assertion below mean anything: a
+  // resolver that resolves nothing still renders a page, so "the route answered
+  // 200" is not the same claim as "the blocks drew".
+  //
+  // Asserted on the attribute rather than on the placeholder's wording. The
+  // wording exists only in development — a production build renders the
+  // placeholder as an empty `hidden` div carrying the same attribute and no
+  // text at all, so a text assertion would quietly stop covering anything in
+  // exactly the build a performance measurement uses.
+  await expect(page.locator("[data-nx-block-placeholder]")).toHaveCount(0);
+
   // One assertion per block type, so a failure names which block stopped
   // rendering instead of reporting that "the page" is wrong.
   await expect(page.getByRole("heading", { name: PAGE_HEADING })).toBeVisible();
@@ -178,10 +189,6 @@ test("renders every block in the document", async ({ page }) => {
   await expect(
     page.locator("section").getByRole("heading", { name: PAGE_HEADING })
   ).toBeVisible();
-
-  // A resolver that resolves nothing still renders a page. Without this, every
-  // assertion above could be satisfied by placeholders carrying the same text.
-  await expect(page.getByText(/unknown block/i)).toHaveCount(0);
 
   expect(failed).toEqual([]);
 });

--- a/e2e/tests/blocks-page.spec.ts
+++ b/e2e/tests/blocks-page.spec.ts
@@ -59,6 +59,15 @@ const LEAD_PARAGRAPH = "A page assembled from core blocks.";
  */
 const GATED_TEXT = "vip-only-marker-8f21";
 
+/**
+ * An authored colour on one node.
+ *
+ * Deliberately not a colour anything else would produce, so the assertion
+ * cannot pass on an inherited or default value. Written in the form
+ * `getComputedStyle` reports so the comparison needs no parsing.
+ */
+const STYLED_HEADING_COLOR = "rgb(17, 85, 204)";
+
 /** A node id. Stable per fixture so a failure names the same node every run. */
 const id = (suffix: string) => `00000000-0000-4000-8000-0000000000${suffix}`;
 
@@ -86,6 +95,11 @@ const DOCUMENT = {
             type: "core/heading",
             version: 1,
             props: { text: PAGE_HEADING, level: "h1" },
+            // An authored node style, so the page has something a compiled
+            // stylesheet must carry. Documents in this collection store no
+            // compiled artifact, so the rule only exists if the route supplied
+            // a compile context — see the styles assertion below.
+            styles: { base: { base: { color: STYLED_HEADING_COLOR } } },
           },
           {
             id: id("03"),
@@ -225,6 +239,19 @@ test("renders every block in the document", async ({ page }) => {
   ).toBeVisible();
 
   expect(failed).toEqual([]);
+});
+
+test("an authored node style is compiled and applied", async ({ page }) => {
+  await page.goto(`/blocks/${PUBLISHED_SLUG}`);
+
+  const heading = page.getByRole("heading", { name: PAGE_HEADING });
+
+  // The class is emitted unconditionally, so its presence proves nothing about
+  // whether any rule defines it. The COMPUTED colour is the only thing that
+  // separates "a stylesheet was compiled and served" from "a class name was
+  // printed onto an unstyled page", which is what a route with no compiled
+  // artifact and no compile context produces.
+  await expect(heading).toHaveCSS("color", STYLED_HEADING_COLOR);
 });
 
 test("a condition-gated node is never sent to the client", async ({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -147,6 +147,9 @@ importers:
       '@nextlyhq/admin':
         specifier: workspace:^
         version: link:../../packages/admin
+      '@nextlyhq/blocks-react':
+        specifier: workspace:^
+        version: link:../../packages/blocks-react
       '@nextlyhq/plugin-form-builder':
         specifier: workspace:^
         version: link:../../packages/plugin-form-builder


### PR DESCRIPTION
## What

The first page ever rendered through `@nextlyhq/blocks-react` in a browser.

Everything about `createBlocksPage` had been checked against *intent* — 18 Codex
rounds over the read pipeline, the SEO deriver and the resolvers, with a mocked
CMS on the other side. Nothing had drawn a page. This wires a real route to a
real collection and reads back what the server sent.

- `apps/playground/src/collections/block-pages.ts` — a collection holding a
  `@nextlyhq/blocks-engine` `BlockDocument`.
- `apps/playground/src/app/blocks/[[...slug]]/page.tsx` — the whole route is
  `createBlocksPage` plus the three re-exports Next wants.
- `e2e/tests/blocks-page.spec.ts` — five specs.

It does **not** touch `(site)/[...slug]`, `(site)/home` or `(site)/blog/[slug]`.
Those are the page builder's renderer and another lane's package. The two store
different documents (`styles` + a `visibility` that can carry conditions, versus
`style`/`styleHover` + a per-breakpoint boolean map), so neither route can read
the other's rows — which is why this reads its own collection rather than `pages`.

## What the specs establish

1. **The blocks reach markup.** One assertion per block type, so a failure names
   which block stopped rendering.
2. **A condition-gated node never leaves the server.** Asserted over the raw
   response body, not over what is visible — a node hidden by CSS is still
   served, and the whole point of the conditions tier is that the markup does
   not ship. This is the first time `blocks-react`'s fail-closed behaviour has
   been observed in a browser rather than in a tree filter.
3. **The lifecycle scope holds** — an unpublished entry 404s.
4. **Block-declared metadata reaches the head**, including a canonical carrying
   the route's mount point.

## Mutation-verified

Every assertion was watched failing before it was trusted:

| Mutation | Result |
|---|---|
| `createBlockResolver(coreBlocks)` → `createBlockResolver([])` | render spec fails |
| `isUnconditional` → `true \|\| !isConditionGated(node)` | gated-node spec fails, `vip-only-marker-8f21` appears in the body |
| `canonicalFor` drops the mount prefix | metadata spec fails |
| route gains `status: "all"` | 404 spec fails |

**The first mutation caught a defect in my own test.** The placeholder assertion
read `getByText(/unknown block/i)`, and the placeholder's actual wording is
"No block is registered for this type" — so it matched nothing and would have
passed against a page made entirely of placeholders. It now asserts on
`[data-nx-block-placeholder]`, which is present in **both** dev and production
(a production build renders the placeholder as an empty `hidden` div with the
same attribute and no text), so it does not quietly stop covering anything in
the build a performance measurement would use.

## Two things the browser run surfaced, filed rather than fixed here

- **The playground's root layout is `"use client"` and ships ~40 admin chunks to
  every public page** — CodeMirror, dnd-kit, the media library, the role editor.
  It affects all four public routes equally, so no performance number taken in
  this app measures either renderer. Filed as task 178; R-7's Lighthouse number
  will be taken in a minimal app instead.
- **An HMR schema apply proposes `DROP TABLE` for all three singles tables.** The
  destructive-statement guard refused it and nothing was lost, but a refused
  batch also blocks the additive half. Filed as task 177, explicitly marked as
  not yet proven against a clean tree.

## Notes for review

- The route passes `nextly` explicitly. `createBlocksPage` otherwise falls back
  to the synchronous `getNextly()` from `nextly/runtime`, which throws when
  nothing has registered services — and a public page can be the first request a
  cold server handles.
- It passes `createBlockResolver(coreBlocks)` rather than the process registry,
  which is populated by whatever booted the editor.
- No changeset: playground and e2e are both private.

---

## R-7's Lighthouse number, and a P0 the production build turned up

Measured after this PR was opened, `next build && next start`, same route, same
document, same machine.

| Root layout | Desktop | Mobile | Page weight | Mobile LCP |
|---|---|---|---|---|
| Playground as shipped | 98 | 76 | 838 KiB | 6.1 s |
| Minimal server component | **100** | **99** | **151 KiB** | 2.0 s |

The only variable is the root layout. **687 KiB and 4.1s of mobile LCP are the
host app's layout choice, not the renderer** (task 178). The renderer's number
is the second row.

**And a P0, filed as task 179 — not fixed here, because it is in
`packages/nextly` and this PR is playground + e2e only.**

A `createBlocksPage` route whose collection is EMPTY at build time answers
**500 on every path**, not 404:

| collection at build | `overrideAccess` | result |
|---|---|---|
| empty | default (`false`) | **500 everywhere** |
| empty | `true` | 404, correct |
| populated | default | 200, route degraded to `ƒ` Dynamic |
| populated | `true` | 200 |

`overrideAccess` defaults to `false`, so no read is cacheable, so
`markDynamic()` → `unstable_noStore()` runs on every render. That throws in a
route Next classified as static — which is exactly what happens when
`generateStaticParams` returns nothing, because then nothing bails out to
degrade the route to dynamic.

So **the route's runtime behaviour depends on whether the database had rows when
the build ran**, and the ordinary deployment order for a new site (ship, then
author the first page) lands squarely in the 500 case.

Two things follow that this PR does not address:

- It does not reproduce in `next dev`. The e2e suite runs `pnpm dev:app`, so it
  structurally cannot catch this class of bug, and there is no production-build
  smoke job in `.github/workflows/`.
- `generateStaticParams` is inert under the default config — even with rows
  present the route builds as `ƒ`. The helper ships static generation and the
  default access posture silently switches it off.
