### PR TITLE
test(ui): derive the entry-point guards from the export map

### DIFF
--- a/packages/ui/scripts/check-client-directive.mjs
+++ b/packages/ui/scripts/check-client-directive.mjs
@@ -10,7 +10,10 @@
  * artifact settles it, so it is asserted here rather than assumed.
  */
 import { readFileSync } from "node:fs";
-import { serverSafeArtifacts } from "./published-entries.mjs";
+import {
+  clientArtifacts,
+  serverSafeArtifacts,
+} from "./published-entries.mjs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -32,7 +35,7 @@ function readClientDirective(file) {
   return /^["']use client["'];?$/.test(first.trim());
 }
 
-const mustHave = ["index.mjs", "index.cjs"];
+const mustHave = clientArtifacts();
 // The server-safe entries: build tooling and a pure helper, both of which
 // server code must be able to import.
 const mustNotHave = serverSafeArtifacts();

--- a/packages/ui/scripts/check-client-directive.mjs
+++ b/packages/ui/scripts/check-client-directive.mjs
@@ -10,6 +10,7 @@
  * artifact settles it, so it is asserted here rather than assumed.
  */
 import { readFileSync } from "node:fs";
+import { serverSafeArtifacts } from "./published-entries.mjs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -34,14 +35,7 @@ function readClientDirective(file) {
 const mustHave = ["index.mjs", "index.cjs"];
 // The server-safe entries: build tooling and a pure helper, both of which
 // server code must be able to import.
-const mustNotHave = [
-  "tailwind-preset.mjs",
-  "tailwind-preset.cjs",
-  "utils.mjs",
-  "utils.cjs",
-  "color.mjs",
-  "color.cjs",
-];
+const mustNotHave = serverSafeArtifacts();
 
 const problems = [];
 

--- a/packages/ui/scripts/published-entries.d.mts
+++ b/packages/ui/scripts/published-entries.d.mts
@@ -37,5 +37,5 @@ export function serverSafeBuildEntries(): Record<string, string>;
 /** Every subpath's source barrel, keyed by subpath. */
 export function sourcesBySubpath(): Record<string, string>;
 
-/** The build entry for the root barrel, as tsup expects it. */
-export function rootBuildEntry(): string[];
+/** The build entry for the root barrel, keyed by its published artifact name. */
+export function rootBuildEntry(): Record<string, string>;

--- a/packages/ui/scripts/published-entries.d.mts
+++ b/packages/ui/scripts/published-entries.d.mts
@@ -36,3 +36,6 @@ export function serverSafeBuildEntries(): Record<string, string>;
 
 /** Every subpath's source barrel, keyed by subpath. */
 export function sourcesBySubpath(): Record<string, string>;
+
+/** The build entry for the root barrel, as tsup expects it. */
+export function rootBuildEntry(): string[];

--- a/packages/ui/scripts/published-entries.d.mts
+++ b/packages/ui/scripts/published-entries.d.mts
@@ -1,0 +1,23 @@
+/**
+ * Types for the export-map derivation, which is plain ESM so a Node script and a Vitest suite can
+ * both read it without a build step.
+ */
+
+/** One published entry point. */
+export interface PublishedEntry {
+  /** The export key, such as `.` or `./color`. */
+  subpath: string;
+  /** The built file's base name, such as `index` or `color`. */
+  name: string;
+  /** Whether it is importable from server code. */
+  serverSafe: boolean;
+}
+
+/** Every published entry point that resolves to JavaScript. */
+export function publishedEntries(): PublishedEntry[];
+
+/** The built declaration files those entry points resolve to, in both module systems. */
+export function declarationFiles(): string[];
+
+/** The built JavaScript files that must not carry a `"use client"` banner. */
+export function serverSafeArtifacts(): string[];

--- a/packages/ui/scripts/published-entries.d.mts
+++ b/packages/ui/scripts/published-entries.d.mts
@@ -7,6 +7,10 @@
 export interface PublishedEntry {
   /** The export key, such as `.` or `./color`. */
   subpath: string;
+  /** The barrel it is built from, relative to the package root. */
+  source: string;
+  /** The build entry's key, such as `index` or `color`. */
+  name: string;
   /** The declaration files it resolves to, ESM then CJS. */
   declarations: string[];
   /** The JavaScript files it resolves to, ESM then CJS. */
@@ -21,5 +25,14 @@ export function publishedEntries(): PublishedEntry[];
 /** The built declaration files those entry points resolve to, in both module systems. */
 export function declarationFiles(): string[];
 
+/** The built JavaScript files that must carry a `"use client"` banner. */
+export function clientArtifacts(): string[];
+
 /** The built JavaScript files that must not carry a `"use client"` banner. */
 export function serverSafeArtifacts(): string[];
+
+/** The build entries for the server-safe subpaths, as tsup expects them. */
+export function serverSafeBuildEntries(): Record<string, string>;
+
+/** Every subpath's source barrel, keyed by subpath. */
+export function sourcesBySubpath(): Record<string, string>;

--- a/packages/ui/scripts/published-entries.d.mts
+++ b/packages/ui/scripts/published-entries.d.mts
@@ -7,8 +7,10 @@
 export interface PublishedEntry {
   /** The export key, such as `.` or `./color`. */
   subpath: string;
-  /** The built file's base name, such as `index` or `color`. */
-  name: string;
+  /** The declaration files it resolves to, ESM then CJS. */
+  declarations: string[];
+  /** The JavaScript files it resolves to, ESM then CJS. */
+  artifacts: string[];
   /** Whether it is importable from server code. */
   serverSafe: boolean;
 }

--- a/packages/ui/scripts/published-entries.d.mts
+++ b/packages/ui/scripts/published-entries.d.mts
@@ -19,23 +19,53 @@ export interface PublishedEntry {
   serverSafe: boolean;
 }
 
-/** Every published entry point that resolves to JavaScript. */
+/** A subpath's declared barrel, and which side of the React boundary it sits on. */
+export interface DeclaredBarrel {
+  /** The barrel it is built from, relative to the package root. */
+  source: string;
+  /** Whether it is client code, and so carries a `"use client"` banner. */
+  client: boolean;
+}
+
+/**
+ * The published entry points implied by an export map and a set of declared barrels.
+ *
+ * Takes both inputs rather than reading them, so the refusals can be exercised against a map this
+ * package does not have yet.
+ */
+export function derivePublishedEntries(
+  exportMap: Record<string, unknown>,
+  sources: Record<string, DeclaredBarrel>
+): PublishedEntry[];
+
+/** Every published entry point that resolves to JavaScript, read from this package. */
 export function publishedEntries(): PublishedEntry[];
 
-/** The built declaration files those entry points resolve to, in both module systems. */
-export function declarationFiles(): string[];
+/**
+ * The built declaration files those entry points resolve to, in both module systems.
+ *
+ * Each helper below takes the entries it derives from, defaulting to this package's own, so a
+ * caller can pass fixtures instead.
+ */
+export function declarationFiles(entries?: PublishedEntry[]): string[];
 
 /** The built JavaScript files that must carry a `"use client"` banner. */
-export function clientArtifacts(): string[];
+export function clientArtifacts(entries?: PublishedEntry[]): string[];
 
 /** The built JavaScript files that must not carry a `"use client"` banner. */
-export function serverSafeArtifacts(): string[];
+export function serverSafeArtifacts(entries?: PublishedEntry[]): string[];
 
 /** The build entries for the server-safe subpaths, as tsup expects them. */
-export function serverSafeBuildEntries(): Record<string, string>;
+export function serverSafeBuildEntries(
+  entries?: PublishedEntry[]
+): Record<string, string>;
 
 /** Every subpath's source barrel, keyed by subpath. */
-export function sourcesBySubpath(): Record<string, string>;
+export function sourcesBySubpath(
+  entries?: PublishedEntry[]
+): Record<string, string>;
 
-/** The build entry for the root barrel, keyed by its published artifact name. */
-export function rootBuildEntry(): Record<string, string>;
+/** The build entries for the client subpaths, keyed by published artifact name. */
+export function clientBuildEntries(
+  entries?: PublishedEntry[]
+): Record<string, string>;

--- a/packages/ui/scripts/published-entries.mjs
+++ b/packages/ui/scripts/published-entries.mjs
@@ -184,9 +184,14 @@ export function sourcesBySubpath() {
 }
 
 /**
- * The build entry for the root barrel, as tsup expects it.
+ * The build entry for the root barrel, KEYED by its published artifact name.
  *
- * @returns {string[]}
+ * Keyed rather than a bare path, because tsup names its output after the entry: an unnamed entry
+ * pointed at a differently named barrel emits files called after that barrel, and the export map
+ * still points at `dist/index.*`. The retarget this helper exists to support would then fail its
+ * own artifact checks.
+ *
+ * @returns {Record<string, string>}
  */
 export function rootBuildEntry() {
   const root = publishedEntries().find(entry => !entry.serverSafe);
@@ -196,5 +201,5 @@ export function rootBuildEntry() {
         "component build would be reading a path nothing publishes."
     );
   }
-  return [root.source];
+  return { [root.name]: root.source };
 }

--- a/packages/ui/scripts/published-entries.mjs
+++ b/packages/ui/scripts/published-entries.mjs
@@ -207,8 +207,8 @@ export function publishedEntries() {
  *
  * @returns {string[]}
  */
-export function declarationFiles() {
-  return publishedEntries().flatMap(entry => entry.declarations);
+export function declarationFiles(entries = publishedEntries()) {
+  return entries.flatMap(entry => entry.declarations);
 }
 
 /**
@@ -219,8 +219,8 @@ export function declarationFiles() {
  *
  * @returns {string[]}
  */
-export function clientArtifacts() {
-  return publishedEntries()
+export function clientArtifacts(entries = publishedEntries()) {
+  return entries
     .filter(entry => !entry.serverSafe)
     .flatMap(entry => entry.artifacts);
 }
@@ -230,8 +230,8 @@ export function clientArtifacts() {
  *
  * @returns {string[]}
  */
-export function serverSafeArtifacts() {
-  return publishedEntries()
+export function serverSafeArtifacts(entries = publishedEntries()) {
+  return entries
     .filter(entry => entry.serverSafe)
     .flatMap(entry => entry.artifacts);
 }
@@ -241,9 +241,9 @@ export function serverSafeArtifacts() {
  *
  * @returns {Record<string, string>}
  */
-export function serverSafeBuildEntries() {
+export function serverSafeBuildEntries(entries = publishedEntries()) {
   return Object.fromEntries(
-    publishedEntries()
+    entries
       .filter(entry => entry.serverSafe)
       .map(entry => [entry.name, entry.source])
   );
@@ -254,29 +254,33 @@ export function serverSafeBuildEntries() {
  *
  * @returns {Record<string, string>}
  */
-export function sourcesBySubpath() {
+export function sourcesBySubpath(entries = publishedEntries()) {
   return Object.fromEntries(
-    publishedEntries().map(entry => [entry.subpath, entry.source])
+    entries.map(entry => [entry.subpath, entry.source])
   );
 }
 
 /**
- * The build entry for the root barrel, KEYED by its published artifact name.
+ * The build entries for the client subpaths, as tsup expects them.
  *
- * Keyed rather than a bare path, because tsup names its output after the entry: an unnamed entry
- * pointed at a differently named barrel emits files called after that barrel, and the export map
- * still points at `dist/index.*`. The retarget this helper exists to support would then fail its
- * own artifact checks.
+ * EVERY client entry, not the first one found. Once a subpath can declare itself client code,
+ * selecting one means a second is emitted by neither config — the server-safe build excludes all
+ * client entries — while `clientArtifacts()` still requires its banner, so the build fails on a
+ * file nothing was asked to produce.
+ *
+ * Keyed by artifact name rather than given as bare paths, because tsup names its output after the
+ * entry: an unnamed entry pointed at a differently named barrel emits files called after that
+ * barrel, while the export map still points at `dist/index.*`.
  *
  * @returns {Record<string, string>}
  */
-export function rootBuildEntry() {
-  const root = publishedEntries().find(entry => !entry.serverSafe);
-  if (!root) {
+export function clientBuildEntries(entries = publishedEntries()) {
+  const client = entries.filter(entry => !entry.serverSafe);
+  if (client.length === 0) {
     throw new Error(
       "No client entry point was found. The root export has moved or changed shape, and the " +
         "component build would be reading a path nothing publishes."
     );
   }
-  return { [root.name]: root.source };
+  return Object.fromEntries(client.map(entry => [entry.name, entry.source]));
 }

--- a/packages/ui/scripts/published-entries.mjs
+++ b/packages/ui/scripts/published-entries.mjs
@@ -40,6 +40,15 @@ const SOURCES = {
 };
 
 /**
+ * Direct string targets the guards deliberately have nothing to say about.
+ *
+ * An allow-list of asset extensions rather than a list of JavaScript ones, so the unrecognised
+ * case fails closed. A deny-list would pass an extensionless target such as `./dist/motion`,
+ * which is JavaScript that no condition names — exactly what must not slip through.
+ */
+const ASSET_TARGET = /\.css$/;
+
+/**
  * One published entry point.
  *
  * @typedef {object} PublishedEntry
@@ -69,8 +78,24 @@ export function publishedEntries() {
   const entries = [];
 
   for (const [subpath, target] of Object.entries(pkg.exports ?? {})) {
-    // A stylesheet maps straight to a string; a JavaScript entry maps to conditions.
-    if (typeof target !== "object" || target === null) continue;
+    // A stylesheet maps straight to its file. Every other direct target is refused rather than
+    // skipped: a subpath published as a bare string names no `types` condition and no separate
+    // ESM and CommonJS files, so the guards have nothing to read, and passing over it in silence
+    // would recreate the very gap this module exists to close.
+    if (typeof target === "string") {
+      if (ASSET_TARGET.test(target)) continue;
+      throw new Error(
+        `The export "${subpath}" maps directly to "${target}". A JavaScript entry point must map ` +
+          "to `import` and `require` conditions so its declarations and its client directive can " +
+          "be checked; an asset must carry a recognised extension."
+      );
+    }
+    if (typeof target !== "object" || target === null) {
+      throw new Error(
+        `The export "${subpath}" is neither a conditions object nor a file path, so there is ` +
+          "nothing for the guards to check."
+      );
+    }
 
     // Every condition's OWN target is kept. Synthesising the other three from one basename
     // assumes they share it, and a map is free not to: the guards would then inspect files that
@@ -115,6 +140,20 @@ export function publishedEntries() {
     throw new Error(
       "No published JavaScript entry points were found. The export map has moved or changed " +
         "shape, and every guard reading this would now be passing vacuously."
+    );
+  }
+
+  // Checked in the other direction too. Every consumer derives its list from the published
+  // entries, so a key naming a subpath that is no longer published is dropped before any guard
+  // sees it: the retarget it describes would go unchecked while this map still claimed to
+  // describe it.
+  const unpublished = Object.keys(SOURCES).filter(
+    subpath => !entries.some(entry => entry.subpath === subpath)
+  );
+  if (unpublished.length > 0) {
+    throw new Error(
+      `SOURCES names ${unpublished.join(", ")}, which the export map does not publish. Remove ` +
+        "the stale key, or add the matching export."
     );
   }
 

--- a/packages/ui/scripts/published-entries.mjs
+++ b/packages/ui/scripts/published-entries.mjs
@@ -57,6 +57,18 @@ const SOURCES = {
 const ASSET_TARGET = /\.css$/;
 
 /**
+ * The export conditions this module knows how to follow, and the targets it reads inside each.
+ *
+ * Anything else is refused rather than ignored. A resolver picks the FIRST condition it matches,
+ * so a `react-server`, `browser` or top-level `default` key would be selected in the environment
+ * that matches it, ahead of the four targets below — and the artifact those consumers actually
+ * receive would have had neither its surface nor its client directive checked, while all three
+ * guards passed on the files nobody in that environment resolves to.
+ */
+const SUPPORTED_CONDITIONS = new Set(["import", "require"]);
+const SUPPORTED_TARGETS = new Set(["types", "default"]);
+
+/**
  * One published entry point.
  *
  * @typedef {object} PublishedEntry
@@ -104,6 +116,24 @@ export function derivePublishedEntries(exportMap, sources) {
         `The export "${subpath}" is neither a conditions object nor a file path, so there is ` +
           "nothing for the guards to check."
       );
+    }
+
+    for (const [condition, nested] of Object.entries(target)) {
+      if (!SUPPORTED_CONDITIONS.has(condition)) {
+        throw new Error(
+          `The export "${subpath}" has a "${condition}" condition, which these guards do not ` +
+            "follow. A resolver matching it would select a file whose surface and client " +
+            "directive were never checked. Add support for it here, or remove it."
+        );
+      }
+      for (const key of Object.keys(nested ?? {})) {
+        if (!SUPPORTED_TARGETS.has(key)) {
+          throw new Error(
+            `The export "${subpath}" has a "${condition}.${key}" target, which these guards do ` +
+              "not follow. Add support for it here, or remove it."
+          );
+        }
+      }
     }
 
     // Every condition's OWN target is kept. Synthesising the other three from one basename

--- a/packages/ui/scripts/published-entries.mjs
+++ b/packages/ui/scripts/published-entries.mjs
@@ -31,12 +31,20 @@ const pkgRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
  * The export map decides what ships; this decides where each shipped thing is built from. The two
  * are checked against each other, so a subpath without a source, or a source without a subpath,
  * is an error rather than a gap.
+ *
+ * `client` says which side of the React boundary the entry belongs to, and is DECLARED because
+ * nothing about a subpath reveals it. Deriving it from "everything except the root is server-safe"
+ * meant a client subpath added later would be built by the server-safe config, which adds no
+ * `"use client"` banner, while the directive guard demanded that same artifact stay unmarked —
+ * three green guards over an entry point React cannot use. Declaring it keeps enrolment automatic
+ * without guessing: a new subpath still cannot be added silently, because a missing entry here is
+ * an error.
  */
 const SOURCES = {
-  ".": "src/index.ts",
-  "./tailwind-preset": "src/tailwind-preset.ts",
-  "./utils": "src/lib/utils.ts",
-  "./color": "src/lib/color/index.ts",
+  ".": { source: "src/index.ts", client: true },
+  "./tailwind-preset": { source: "src/tailwind-preset.ts", client: false },
+  "./utils": { source: "src/lib/utils.ts", client: false },
+  "./color": { source: "src/lib/color/index.ts", client: false },
 };
 
 /**
@@ -61,23 +69,24 @@ const ASSET_TARGET = /\.css$/;
  */
 
 /**
- * Every published entry point that resolves to JavaScript.
+ * The published entry points implied by an export map and a set of declared barrels.
  *
  * Stylesheets are excluded: they are published as plain strings in the export map and none of the
  * three guards has anything to say about them.
  *
- * `serverSafe` is derived rather than listed. The root barrel is the component surface and is
- * published with a `"use client"` banner; every other JavaScript subpath exists precisely because
- * it carries no React runtime, which is the property that makes it importable from a server
- * component. Anything published from the root is client code by construction.
+ * Takes both inputs rather than reading them, so the refusals below can be exercised directly.
+ * Each one describes a map this package does not have yet — a client subpath, a bare JavaScript
+ * target, two subpaths sharing an artifact — and a check that can only ever run against the real
+ * `package.json` proves that today's map is acceptable, not that the check works.
  *
+ * @param {Record<string, unknown>} exportMap The `exports` field to read.
+ * @param {Record<string, {source: string, client: boolean}>} sources The declared barrels.
  * @returns {PublishedEntry[]}
  */
-export function publishedEntries() {
-  const pkg = JSON.parse(readFileSync(join(pkgRoot, "package.json"), "utf8"));
+export function derivePublishedEntries(exportMap, sources) {
   const entries = [];
 
-  for (const [subpath, target] of Object.entries(pkg.exports ?? {})) {
+  for (const [subpath, target] of Object.entries(exportMap ?? {})) {
     // A stylesheet maps straight to its file. Every other direct target is refused rather than
     // skipped: a subpath published as a bare string names no `types` condition and no separate
     // ESM and CommonJS files, so the guards have nothing to read, and passing over it in silence
@@ -118,13 +127,14 @@ export function publishedEntries() {
     }
 
     const file = value => value.replace(/^\.\//, "").replace(/^dist\//, "");
-    const source = SOURCES[subpath];
-    if (source === undefined) {
+    const declared = sources[subpath];
+    if (declared === undefined) {
       throw new Error(
         `The export "${subpath}" has no source barrel. Add one to SOURCES, so the build and the ` +
-          "surface snapshot read the same file."
+          "surface snapshot read the same file, and say whether it is client code."
       );
     }
+    const { source, client } = declared;
     const artifacts = [file(paths.importDefault), file(paths.requireDefault)];
     entries.push({
       subpath,
@@ -132,7 +142,7 @@ export function publishedEntries() {
       name: artifacts[0].replace(/\.[^.]+$/, ""),
       declarations: [file(paths.importTypes), file(paths.requireTypes)],
       artifacts,
-      serverSafe: subpath !== ".",
+      serverSafe: !client,
     });
   }
 
@@ -147,7 +157,7 @@ export function publishedEntries() {
   // entries, so a key naming a subpath that is no longer published is dropped before any guard
   // sees it: the retarget it describes would go unchecked while this map still claimed to
   // describe it.
-  const unpublished = Object.keys(SOURCES).filter(
+  const unpublished = Object.keys(sources).filter(
     subpath => !entries.some(entry => entry.subpath === subpath)
   );
   if (unpublished.length > 0) {
@@ -157,7 +167,35 @@ export function publishedEntries() {
     );
   }
 
+  // Two subpaths may resolve to one artifact only if they are built from one barrel. The build
+  // entries are keyed by artifact name, so a collision between DIFFERENT barrels keeps whichever
+  // came last and silently gives both subpaths its API — while the surface suite went on
+  // snapshotting the two declared sources separately and the file guards inspected the single
+  // shared output twice, leaving every check green.
+  const barrelsByName = new Map();
+  for (const entry of entries) {
+    const seen = barrelsByName.get(entry.name);
+    if (seen && seen.source !== entry.source) {
+      throw new Error(
+        `The exports "${seen.subpath}" and "${entry.subpath}" both resolve to the artifact ` +
+          `"${entry.name}", but are built from "${seen.source}" and "${entry.source}". One of ` +
+          "them would overwrite the other; give them separate artifacts, or one shared barrel."
+      );
+    }
+    if (!seen) barrelsByName.set(entry.name, entry);
+  }
+
   return entries;
+}
+
+/**
+ * Every published entry point that resolves to JavaScript, read from this package.
+ *
+ * @returns {PublishedEntry[]}
+ */
+export function publishedEntries() {
+  const pkg = JSON.parse(readFileSync(join(pkgRoot, "package.json"), "utf8"));
+  return derivePublishedEntries(pkg.exports, SOURCES);
 }
 
 /**

--- a/packages/ui/scripts/published-entries.mjs
+++ b/packages/ui/scripts/published-entries.mjs
@@ -3,15 +3,14 @@
  *
  * ## Why this exists
  *
- * Three separate guards protect a published entry point, and each held its own hand-written list:
- * the built declarations must carry a release tag, the source barrel must match a surface
- * snapshot, and a server-safe entry must not carry a client banner. Every one of those lists is
- * correct and every one is opt-in, so **a newly published subpath was unprotected by default in
- * all three at once** — and each omission was found separately, in a different review round.
+ * Three guards protect a published entry point: its built declarations must carry a release tag,
+ * its source barrel must match a surface snapshot, and a server-safe entry must not carry a
+ * client banner. Each guard reads a list of what to check, and a list written by hand is opt-in —
+ * so a newly published subpath is absent from it, every assertion stays green, and nothing
+ * reports that the new entry point is unchecked.
  *
- * The export map in `package.json` is the one place that already knows what ships. Deriving the
- * lists from it means adding an entry point enrols it in every check, so there is nothing left to
- * remember and nothing to keep in step.
+ * The export map is the one place that already knows what ships. Deriving the lists from it makes
+ * enrolment automatic, so there is no step to remember and no two lists to keep in step.
  *
  * @module scripts/published-entries
  */
@@ -26,7 +25,8 @@ const pkgRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
  *
  * @typedef {object} PublishedEntry
  * @property {string} subpath The export key, such as `.` or `./color`.
- * @property {string} name The built file's base name, such as `index` or `color`.
+ * @property {string[]} declarations The declaration files it resolves to, ESM then CJS.
+ * @property {string[]} artifacts The JavaScript files it resolves to, ESM then CJS.
  * @property {boolean} serverSafe Whether it is importable from server code.
  */
 
@@ -51,17 +51,33 @@ export function publishedEntries() {
     // A stylesheet maps straight to a string; a JavaScript entry maps to conditions.
     if (typeof target !== "object" || target === null) continue;
 
-    const types = target.import?.types;
-    if (typeof types !== "string") {
-      throw new Error(
-        `The export "${subpath}" has no import.types condition, so its declarations cannot be ` +
-          "checked. Give it one, or exclude it from the export map."
-      );
+    // Every condition's OWN target is kept. Synthesising the other three from one basename
+    // assumes they share it, and a map is free not to: the guards would then inspect files that
+    // are emitted but never selected, while the ones `import` and `require` actually resolve to
+    // go unchecked.
+    const paths = {
+      importTypes: target.import?.types,
+      requireTypes: target.require?.types,
+      importDefault: target.import?.default,
+      requireDefault: target.require?.default,
+    };
+
+    for (const [condition, value] of Object.entries(paths)) {
+      if (typeof value !== "string") {
+        throw new Error(
+          `The export "${subpath}" has no ${condition} target, so the file a consumer resolves ` +
+            "to cannot be checked. Give it one, or exclude the entry from the export map."
+        );
+      }
     }
 
-    // `./dist/color.d.ts` -> `color`
-    const name = types.replace(/^\.\/dist\//, "").replace(/\.d\.ts$/, "");
-    entries.push({ subpath, name, serverSafe: subpath !== "." });
+    const file = value => value.replace(/^\.\//, "").replace(/^dist\//, "");
+    entries.push({
+      subpath,
+      declarations: [file(paths.importTypes), file(paths.requireTypes)],
+      artifacts: [file(paths.importDefault), file(paths.requireDefault)],
+      serverSafe: subpath !== ".",
+    });
   }
 
   if (entries.length === 0) {
@@ -84,10 +100,7 @@ export function publishedEntries() {
  * @returns {string[]}
  */
 export function declarationFiles() {
-  return publishedEntries().flatMap(({ name }) => [
-    `${name}.d.ts`,
-    `${name}.d.cts`,
-  ]);
+  return publishedEntries().flatMap(entry => entry.declarations);
 }
 
 /**
@@ -98,5 +111,5 @@ export function declarationFiles() {
 export function serverSafeArtifacts() {
   return publishedEntries()
     .filter(entry => entry.serverSafe)
-    .flatMap(({ name }) => [`${name}.mjs`, `${name}.cjs`]);
+    .flatMap(entry => entry.artifacts);
 }

--- a/packages/ui/scripts/published-entries.mjs
+++ b/packages/ui/scripts/published-entries.mjs
@@ -21,10 +21,31 @@ import { fileURLToPath } from "node:url";
 const pkgRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
 
 /**
+ * The source barrel behind each published subpath.
+ *
+ * Declared here rather than in the build config, and read BY it, so a retarget happens once. When
+ * the build owned this and the surface snapshot kept its own copy, pointing an entry at a
+ * different barrel left the snapshot reading the old one — the new barrel published, and its
+ * exports never compared against anything.
+ *
+ * The export map decides what ships; this decides where each shipped thing is built from. The two
+ * are checked against each other, so a subpath without a source, or a source without a subpath,
+ * is an error rather than a gap.
+ */
+const SOURCES = {
+  ".": "src/index.ts",
+  "./tailwind-preset": "src/tailwind-preset.ts",
+  "./utils": "src/lib/utils.ts",
+  "./color": "src/lib/color/index.ts",
+};
+
+/**
  * One published entry point.
  *
  * @typedef {object} PublishedEntry
  * @property {string} subpath The export key, such as `.` or `./color`.
+ * @property {string} source The barrel it is built from, relative to the package root.
+ * @property {string} name The build entry's key, such as `index` or `color`.
  * @property {string[]} declarations The declaration files it resolves to, ESM then CJS.
  * @property {string[]} artifacts The JavaScript files it resolves to, ESM then CJS.
  * @property {boolean} serverSafe Whether it is importable from server code.
@@ -72,10 +93,20 @@ export function publishedEntries() {
     }
 
     const file = value => value.replace(/^\.\//, "").replace(/^dist\//, "");
+    const source = SOURCES[subpath];
+    if (source === undefined) {
+      throw new Error(
+        `The export "${subpath}" has no source barrel. Add one to SOURCES, so the build and the ` +
+          "surface snapshot read the same file."
+      );
+    }
+    const artifacts = [file(paths.importDefault), file(paths.requireDefault)];
     entries.push({
       subpath,
+      source,
+      name: artifacts[0].replace(/\.[^.]+$/, ""),
       declarations: [file(paths.importTypes), file(paths.requireTypes)],
-      artifacts: [file(paths.importDefault), file(paths.requireDefault)],
+      artifacts,
       serverSafe: subpath !== ".",
     });
   }
@@ -104,6 +135,20 @@ export function declarationFiles() {
 }
 
 /**
+ * The built JavaScript files that MUST carry a `"use client"` banner.
+ *
+ * The mirror of {@link serverSafeArtifacts}, and derived for the same reason: hard-coding the
+ * root's artifacts leaves the guard checking files a consumer may no longer resolve to.
+ *
+ * @returns {string[]}
+ */
+export function clientArtifacts() {
+  return publishedEntries()
+    .filter(entry => !entry.serverSafe)
+    .flatMap(entry => entry.artifacts);
+}
+
+/**
  * The built JavaScript files that must NOT carry a `"use client"` banner.
  *
  * @returns {string[]}
@@ -112,4 +157,28 @@ export function serverSafeArtifacts() {
   return publishedEntries()
     .filter(entry => entry.serverSafe)
     .flatMap(entry => entry.artifacts);
+}
+
+/**
+ * The build entries for the server-safe subpaths, as tsup expects them.
+ *
+ * @returns {Record<string, string>}
+ */
+export function serverSafeBuildEntries() {
+  return Object.fromEntries(
+    publishedEntries()
+      .filter(entry => entry.serverSafe)
+      .map(entry => [entry.name, entry.source])
+  );
+}
+
+/**
+ * Every subpath's source barrel, keyed by subpath.
+ *
+ * @returns {Record<string, string>}
+ */
+export function sourcesBySubpath() {
+  return Object.fromEntries(
+    publishedEntries().map(entry => [entry.subpath, entry.source])
+  );
 }

--- a/packages/ui/scripts/published-entries.mjs
+++ b/packages/ui/scripts/published-entries.mjs
@@ -1,0 +1,102 @@
+/**
+ * The package's published JavaScript entry points, read from the export map.
+ *
+ * ## Why this exists
+ *
+ * Three separate guards protect a published entry point, and each held its own hand-written list:
+ * the built declarations must carry a release tag, the source barrel must match a surface
+ * snapshot, and a server-safe entry must not carry a client banner. Every one of those lists is
+ * correct and every one is opt-in, so **a newly published subpath was unprotected by default in
+ * all three at once** — and each omission was found separately, in a different review round.
+ *
+ * The export map in `package.json` is the one place that already knows what ships. Deriving the
+ * lists from it means adding an entry point enrols it in every check, so there is nothing left to
+ * remember and nothing to keep in step.
+ *
+ * @module scripts/published-entries
+ */
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const pkgRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+/**
+ * One published entry point.
+ *
+ * @typedef {object} PublishedEntry
+ * @property {string} subpath The export key, such as `.` or `./color`.
+ * @property {string} name The built file's base name, such as `index` or `color`.
+ * @property {boolean} serverSafe Whether it is importable from server code.
+ */
+
+/**
+ * Every published entry point that resolves to JavaScript.
+ *
+ * Stylesheets are excluded: they are published as plain strings in the export map and none of the
+ * three guards has anything to say about them.
+ *
+ * `serverSafe` is derived rather than listed. The root barrel is the component surface and is
+ * published with a `"use client"` banner; every other JavaScript subpath exists precisely because
+ * it carries no React runtime, which is the property that makes it importable from a server
+ * component. Anything published from the root is client code by construction.
+ *
+ * @returns {PublishedEntry[]}
+ */
+export function publishedEntries() {
+  const pkg = JSON.parse(readFileSync(join(pkgRoot, "package.json"), "utf8"));
+  const entries = [];
+
+  for (const [subpath, target] of Object.entries(pkg.exports ?? {})) {
+    // A stylesheet maps straight to a string; a JavaScript entry maps to conditions.
+    if (typeof target !== "object" || target === null) continue;
+
+    const types = target.import?.types;
+    if (typeof types !== "string") {
+      throw new Error(
+        `The export "${subpath}" has no import.types condition, so its declarations cannot be ` +
+          "checked. Give it one, or exclude it from the export map."
+      );
+    }
+
+    // `./dist/color.d.ts` -> `color`
+    const name = types.replace(/^\.\/dist\//, "").replace(/\.d\.ts$/, "");
+    entries.push({ subpath, name, serverSafe: subpath !== "." });
+  }
+
+  if (entries.length === 0) {
+    throw new Error(
+      "No published JavaScript entry points were found. The export map has moved or changed " +
+        "shape, and every guard reading this would now be passing vacuously."
+    );
+  }
+
+  return entries;
+}
+
+/**
+ * The built declaration files a published entry point resolves to, in both module systems.
+ *
+ * Both, because each entry point has an `import.types` AND a `require.types` condition. Listing
+ * only the ESM side left the files served to CommonJS consumers unchecked while every assertion
+ * stayed green.
+ *
+ * @returns {string[]}
+ */
+export function declarationFiles() {
+  return publishedEntries().flatMap(({ name }) => [
+    `${name}.d.ts`,
+    `${name}.d.cts`,
+  ]);
+}
+
+/**
+ * The built JavaScript files that must NOT carry a `"use client"` banner.
+ *
+ * @returns {string[]}
+ */
+export function serverSafeArtifacts() {
+  return publishedEntries()
+    .filter(entry => entry.serverSafe)
+    .flatMap(({ name }) => [`${name}.mjs`, `${name}.cjs`]);
+}

--- a/packages/ui/scripts/published-entries.mjs
+++ b/packages/ui/scripts/published-entries.mjs
@@ -182,3 +182,19 @@ export function sourcesBySubpath() {
     publishedEntries().map(entry => [entry.subpath, entry.source])
   );
 }
+
+/**
+ * The build entry for the root barrel, as tsup expects it.
+ *
+ * @returns {string[]}
+ */
+export function rootBuildEntry() {
+  const root = publishedEntries().find(entry => !entry.serverSafe);
+  if (!root) {
+    throw new Error(
+      "No client entry point was found. The root export has moved or changed shape, and the " +
+        "component build would be reading a path nothing publishes."
+    );
+  }
+  return [root.source];
+}

--- a/packages/ui/scripts/published-entries.mjs
+++ b/packages/ui/scripts/published-entries.mjs
@@ -69,6 +69,22 @@ const SUPPORTED_CONDITIONS = new Set(["import", "require"]);
 const SUPPORTED_TARGETS = new Set(["types", "default"]);
 
 /**
+ * The file extension each condition's target must carry.
+ *
+ * A condition names the module system a consumer arrives through, and the extension decides what
+ * Node actually parses the file as. Pointing `require.default` at an `.mjs` builds cleanly, passes
+ * the client-directive check, and draws only a warning from publint — while `require()` of the
+ * package throws `ERR_REQUIRE_ESM` at the first consumer to try it, because CI ignores attw's
+ * `cjs-resolves-to-esm` rule. Checking the extension here is what makes that unshippable.
+ */
+const REQUIRED_EXTENSION = {
+  importTypes: ".d.ts",
+  requireTypes: ".d.cts",
+  importDefault: ".mjs",
+  requireDefault: ".cjs",
+};
+
+/**
  * One published entry point.
  *
  * @typedef {object} PublishedEntry
@@ -157,6 +173,33 @@ export function derivePublishedEntries(exportMap, sources) {
     }
 
     const file = value => value.replace(/^\.\//, "").replace(/^dist\//, "");
+
+    // Every target must carry the extension its condition requires, and all four must be the SAME
+    // build entry under those extensions. tsup names its output after the entry, so that is the
+    // only shape it can produce — and requiring it is what makes the collision check below
+    // complete. Derived from `import.default` alone, a map whose `require` targets borrowed
+    // ANOTHER entry's basename passed every guard while `require("./a")` resolved to `./b`'s API
+    // and `import "./a"` resolved to its own.
+    const buildNames = new Set();
+    for (const [condition, value] of Object.entries(paths)) {
+      const extension = REQUIRED_EXTENSION[condition];
+      if (!value.endsWith(extension)) {
+        throw new Error(
+          `The export "${subpath}" points ${condition} at "${value}", which does not end in ` +
+            `"${extension}". A consumer arriving through that condition would be handed a file ` +
+            "the wrong module system parses."
+        );
+      }
+      buildNames.add(file(value).slice(0, -extension.length));
+    }
+    if (buildNames.size !== 1) {
+      throw new Error(
+        `The export "${subpath}" resolves to more than one build entry ` +
+          `(${[...buildNames].sort().join(", ")}). Its four targets have to be one entry's ` +
+          "output, or the files a consumer receives depend on how they imported it."
+      );
+    }
+
     const declared = sources[subpath];
     if (declared === undefined) {
       throw new Error(
@@ -169,7 +212,7 @@ export function derivePublishedEntries(exportMap, sources) {
     entries.push({
       subpath,
       source,
-      name: artifacts[0].replace(/\.[^.]+$/, ""),
+      name: [...buildNames][0],
       declarations: [file(paths.importTypes), file(paths.requireTypes)],
       artifacts,
       serverSafe: !client,

--- a/packages/ui/src/__snapshots__/ui-surface.test.ts.snap
+++ b/packages/ui/src/__snapshots__/ui-surface.test.ts.snap
@@ -279,11 +279,6 @@ exports[`ui public export surface > src/lib/utils.ts surface is unchanged 1`] = 
 ]
 `;
 
-exports[`ui public export surface > src/lib/utils.ts surface is unchanged 2`] = `
-[
-  "cn (value)",
-]
-`;
 
 exports[`ui public export surface > src/tailwind-preset.ts surface is unchanged 1`] = `
 [

--- a/packages/ui/src/__snapshots__/ui-surface.test.ts.snap
+++ b/packages/ui/src/__snapshots__/ui-surface.test.ts.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`ui public export surface > src/index.ts surface is unchanged 1`] = `
+exports[`ui public export surface > . surface is unchanged 1`] = `
 [
   "Accordion (value)",
   "AccordionContent (value)",
@@ -260,7 +260,7 @@ exports[`ui public export surface > src/index.ts surface is unchanged 1`] = `
 ]
 `;
 
-exports[`ui public export surface > src/lib/color/index.ts surface is unchanged 1`] = `
+exports[`ui public export surface > ./color surface is unchanged 1`] = `
 [
   "Hsv (type)",
   "Oklch (type)",
@@ -273,16 +273,15 @@ exports[`ui public export surface > src/lib/color/index.ts surface is unchanged 
 ]
 `;
 
-exports[`ui public export surface > src/lib/utils.ts surface is unchanged 1`] = `
-[
-  "cn (value)",
-]
-`;
-
-
-exports[`ui public export surface > src/tailwind-preset.ts surface is unchanged 1`] = `
+exports[`ui public export surface > ./tailwind-preset surface is unchanged 1`] = `
 [
   "default (value)",
   "uiPreset (value)",
+]
+`;
+
+exports[`ui public export surface > ./utils surface is unchanged 1`] = `
+[
+  "cn (value)",
 ]
 `;

--- a/packages/ui/src/__snapshots__/ui-surface.test.ts.snap
+++ b/packages/ui/src/__snapshots__/ui-surface.test.ts.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`ui public export surface > index.ts surface is unchanged 1`] = `
+exports[`ui public export surface > src/index.ts surface is unchanged 1`] = `
 [
   "Accordion (value)",
   "AccordionContent (value)",
@@ -260,7 +260,7 @@ exports[`ui public export surface > index.ts surface is unchanged 1`] = `
 ]
 `;
 
-exports[`ui public export surface > lib/color/index.ts surface is unchanged 1`] = `
+exports[`ui public export surface > src/lib/color/index.ts surface is unchanged 1`] = `
 [
   "Hsv (type)",
   "Oklch (type)",
@@ -273,13 +273,19 @@ exports[`ui public export surface > lib/color/index.ts surface is unchanged 1`] 
 ]
 `;
 
-exports[`ui public export surface > lib/utils.ts surface is unchanged 1`] = `
+exports[`ui public export surface > src/lib/utils.ts surface is unchanged 1`] = `
 [
   "cn (value)",
 ]
 `;
 
-exports[`ui public export surface > tailwind-preset.ts surface is unchanged 1`] = `
+exports[`ui public export surface > src/lib/utils.ts surface is unchanged 2`] = `
+[
+  "cn (value)",
+]
+`;
+
+exports[`ui public export surface > src/tailwind-preset.ts surface is unchanged 1`] = `
 [
   "default (value)",
   "uiPreset (value)",

--- a/packages/ui/src/__tests__/ensure-declarations.ts
+++ b/packages/ui/src/__tests__/ensure-declarations.ts
@@ -43,6 +43,7 @@
  * shared directory this exists to stay out of.
  */
 import { execFileSync } from "node:child_process";
+import { declarationFiles } from "../../scripts/published-entries.mjs";
 import { existsSync, rmSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -59,24 +60,13 @@ const pkgRoot = join(here, "..", "..");
 const OUT_DIR = join(pkgRoot, "node_modules", ".cache", "surface-declarations");
 
 /**
- * Every declaration a published entry point resolves to.
+ * Every declaration a published entry point resolves to, derived from the export map.
  *
- * Both module systems, because `package.json` gives each entry point an
- * `import.types` AND a `require.types` condition. Listing only the ESM `.d.ts`
- * left the files served to CommonJS consumers unbuilt and unchecked for release
- * tags, so `index.d.cts` could be missing or untagged while every assertion
- * here stayed green.
+ * Derived rather than listed, because a hand-written copy is unprotected by default for anything
+ * added after it: a new subpath is simply absent, every assertion here stays green, and nothing
+ * says the new entry point is unchecked.
  */
-export const DECLARATION_ENTRIES = [
-  "index.d.ts",
-  "utils.d.ts",
-  "tailwind-preset.d.ts",
-  "color.d.ts",
-  "index.d.cts",
-  "utils.d.cts",
-  "tailwind-preset.d.cts",
-  "color.d.cts",
-];
+export const DECLARATION_ENTRIES: string[] = declarationFiles();
 
 /**
  * Build the declarations and return the directory holding them.

--- a/packages/ui/src/__tests__/published-entries.test.ts
+++ b/packages/ui/src/__tests__/published-entries.test.ts
@@ -1,0 +1,154 @@
+/**
+ * The export map is the enrolment list for three guards, so what it REFUSES is load-bearing.
+ *
+ * These run against fixtures rather than this package's own `package.json`. Every refusal below
+ * describes a map the package does not have yet — a client subpath beside the root, a bare
+ * JavaScript target, two subpaths sharing one artifact — and a check exercised only against the
+ * real map would be asserting that today's map is acceptable, which is a different claim.
+ */
+import { describe, expect, it } from "vitest";
+
+import { derivePublishedEntries } from "../../scripts/published-entries.mjs";
+
+/** The four conditions a JavaScript entry point has to name. */
+function conditions(name: string): Record<string, Record<string, string>> {
+  return {
+    import: { types: `./dist/${name}.d.ts`, default: `./dist/${name}.mjs` },
+    require: { types: `./dist/${name}.d.cts`, default: `./dist/${name}.cjs` },
+  };
+}
+
+const barrel = (source: string, client: boolean): object => ({
+  source,
+  client,
+});
+
+describe("which side of the React boundary an entry point sits on", () => {
+  it("reads the declaration rather than assuming anything but the root is server-safe", () => {
+    // Derived from `subpath !== "."`, a client subpath added later was built by the server-safe
+    // config — which adds no `"use client"` banner — while the directive guard demanded that same
+    // artifact stay unmarked. Three guards pass over an entry point React cannot use.
+    const entries = derivePublishedEntries(
+      {
+        ".": conditions("index"),
+        "./charts": conditions("charts"),
+        "./utils": conditions("utils"),
+      },
+      {
+        ".": barrel("src/index.ts", true),
+        "./charts": barrel("src/charts/index.ts", true),
+        "./utils": barrel("src/lib/utils.ts", false),
+      }
+    );
+
+    const serverSafe = entries
+      .filter(entry => entry.serverSafe)
+      .map(entry => entry.subpath);
+
+    // The control is `./utils` in the same map: a declared server-safe subpath is still one, so
+    // this is not passing by calling everything client code.
+    expect(serverSafe).toEqual(["./utils"]);
+  });
+});
+
+describe("two subpaths that resolve to one artifact", () => {
+  it("refuses them when they are built from different barrels", () => {
+    // The build entries are keyed by artifact name, so the second overwrites the first and both
+    // subpaths ship the later barrel's API — while the surface suite snapshots the two declared
+    // sources separately and the file guards inspect the one shared output twice.
+    expect(() =>
+      derivePublishedEntries(
+        { "./a": conditions("shared"), "./b": conditions("shared") },
+        {
+          "./a": barrel("src/a.ts", false),
+          "./b": barrel("src/b.ts", false),
+        }
+      )
+    ).toThrow(/both resolve to the artifact "shared"/);
+  });
+
+  it("allows them when they are aliases of one barrel", () => {
+    // The control: sharing an artifact is only a problem when the sources disagree. Refusing it
+    // outright would ban a deliberate alias.
+    expect(() =>
+      derivePublishedEntries(
+        { "./a": conditions("shared"), "./b": conditions("shared") },
+        {
+          "./a": barrel("src/shared.ts", false),
+          "./b": barrel("src/shared.ts", false),
+        }
+      )
+    ).not.toThrow();
+  });
+});
+
+describe("targets the guards cannot read", () => {
+  it("refuses a JavaScript subpath published as a bare string", () => {
+    expect(() =>
+      derivePublishedEntries(
+        { ".": conditions("index"), "./motion": "./dist/motion.mjs" },
+        { ".": barrel("src/index.ts", true) }
+      )
+    ).toThrow(/maps directly to "\.\/dist\/motion\.mjs"/);
+  });
+
+  it("refuses one with no extension at all", () => {
+    // The reason the test is an allow-list of asset extensions and not a list of JavaScript ones:
+    // a deny-list passes this, and it is still JavaScript no condition names.
+    expect(() =>
+      derivePublishedEntries(
+        { ".": conditions("index"), "./motion": "./dist/motion" },
+        { ".": barrel("src/index.ts", true) }
+      )
+    ).toThrow(/maps directly to "\.\/dist\/motion"/);
+  });
+
+  it("still passes over a stylesheet", () => {
+    // The control: stylesheets are published as bare strings too, and none of the guards has
+    // anything to say about one.
+    const entries = derivePublishedEntries(
+      { ".": conditions("index"), "./theme.css": "./dist/theme.css" },
+      { ".": barrel("src/index.ts", true) }
+    );
+    expect(entries.map(entry => entry.subpath)).toEqual(["."]);
+  });
+
+  it("refuses an entry missing one of its four conditions", () => {
+    const partial = conditions("index");
+    delete partial.require;
+    expect(() =>
+      derivePublishedEntries(
+        { ".": partial },
+        { ".": barrel("src/index.ts", true) }
+      )
+    ).toThrow(/has no requireTypes target/);
+  });
+});
+
+describe("the barrel declaration and the export map", () => {
+  it("refuses a published subpath with no declared barrel", () => {
+    expect(() =>
+      derivePublishedEntries({ ".": conditions("index") }, {})
+    ).toThrow(/has no source barrel/);
+  });
+
+  it("refuses a declared barrel the export map does not publish", () => {
+    // Consumers derive their lists from the published entries, so a stale key is dropped before
+    // any guard sees it: the retarget it describes would go unchecked.
+    expect(() =>
+      derivePublishedEntries(
+        { ".": conditions("index") },
+        {
+          ".": barrel("src/index.ts", true),
+          "./motion": barrel("src/lib/motion.ts", false),
+        }
+      )
+    ).toThrow(/SOURCES names \.\/motion/);
+  });
+
+  it("refuses an export map with no JavaScript entry points at all", () => {
+    expect(() =>
+      derivePublishedEntries({ "./theme.css": "./dist/theme.css" }, {})
+    ).toThrow(/passing vacuously/);
+  });
+});

--- a/packages/ui/src/__tests__/published-entries.test.ts
+++ b/packages/ui/src/__tests__/published-entries.test.ts
@@ -213,6 +213,53 @@ describe("export conditions the guards do not follow", () => {
   });
 });
 
+describe("a condition pointing at the wrong module format", () => {
+  it("refuses require resolving to ESM", () => {
+    // This builds cleanly, passes the client-directive check and draws only a publint warning,
+    // while `require()` of the package throws ERR_REQUIRE_ESM at the first consumer — CI ignores
+    // attw's `cjs-resolves-to-esm` rule, so the extension check here is what stops it shipping.
+    const target = conditions("index");
+    target.require = { ...target.require, default: "./dist/index.mjs" };
+    expect(() =>
+      derivePublishedEntries(
+        { ".": target },
+        { ".": barrel("src/index.ts", true) }
+      )
+    ).toThrow(/points requireDefault at ".\/dist\/index.mjs"/);
+  });
+
+  it("refuses a declaration whose extension does not match its condition", () => {
+    const target = conditions("index");
+    target.require = { ...target.require, types: "./dist/index.d.ts" };
+    expect(() =>
+      derivePublishedEntries(
+        { ".": target },
+        { ".": barrel("src/index.ts", true) }
+      )
+    ).toThrow(/points requireTypes at/);
+  });
+});
+
+describe("targets that belong to more than one build entry", () => {
+  it("refuses a subpath whose require targets borrow another entry's name", () => {
+    // Ownership used to be checked through the name derived from `import.default` alone, so this
+    // map passed: `./a` and `./b` had distinct import names, but `./a`'s require targets carried
+    // `./b`'s. The builds then emitted `shared.cjs` from `./b`, and `require("./a")` received
+    // `./b`'s API while `import "./a"` received its own.
+    const a = conditions("a");
+    a.require = { types: "./dist/shared.d.cts", default: "./dist/shared.cjs" };
+    expect(() =>
+      derivePublishedEntries(
+        { "./a": a, "./b": conditions("shared") },
+        {
+          "./a": barrel("src/a.ts", false),
+          "./b": barrel("src/shared.ts", false),
+        }
+      )
+    ).toThrow(/resolves to more than one build entry \(a, shared\)/);
+  });
+});
+
 describe("the barrel declaration and the export map", () => {
   it("refuses a published subpath with no declared barrel", () => {
     expect(() =>

--- a/packages/ui/src/__tests__/published-entries.test.ts
+++ b/packages/ui/src/__tests__/published-entries.test.ts
@@ -8,7 +8,11 @@
  */
 import { describe, expect, it } from "vitest";
 
-import { derivePublishedEntries } from "../../scripts/published-entries.mjs";
+import {
+  clientBuildEntries,
+  derivePublishedEntries,
+  serverSafeBuildEntries,
+} from "../../scripts/published-entries.mjs";
 
 /** The four conditions a JavaScript entry point has to name. */
 function conditions(name: string): Record<string, Record<string, string>> {
@@ -48,6 +52,45 @@ describe("which side of the React boundary an entry point sits on", () => {
     // The control is `./utils` in the same map: a declared server-safe subpath is still one, so
     // this is not passing by calling everything client code.
     expect(serverSafe).toEqual(["./utils"]);
+  });
+});
+
+describe("which tsup config builds what", () => {
+  it("builds every client entry, not only the first", () => {
+    // Selecting one client entry left a second emitted by NEITHER config — the server-safe build
+    // excludes all client entries — while the directive guard still required its banner, so the
+    // build failed on a file nothing had been asked to produce.
+    const entries = derivePublishedEntries(
+      {
+        ".": conditions("index"),
+        "./charts": conditions("charts"),
+        "./utils": conditions("utils"),
+      },
+      {
+        ".": barrel("src/index.ts", true),
+        "./charts": barrel("src/charts/index.ts", true),
+        "./utils": barrel("src/lib/utils.ts", false),
+      }
+    );
+
+    expect(clientBuildEntries(entries)).toEqual({
+      index: "src/index.ts",
+      charts: "src/charts/index.ts",
+    });
+    // The control: the two builds partition the entries, so nothing is emitted twice either.
+    expect(serverSafeBuildEntries(entries)).toEqual({
+      utils: "src/lib/utils.ts",
+    });
+  });
+
+  it("refuses an export map with no client entry at all", () => {
+    const entries = derivePublishedEntries(
+      { "./utils": conditions("utils") },
+      { "./utils": barrel("src/lib/utils.ts", false) }
+    );
+    expect(() => clientBuildEntries(entries)).toThrow(
+      /No client entry point was found/
+    );
   });
 });
 

--- a/packages/ui/src/__tests__/published-entries.test.ts
+++ b/packages/ui/src/__tests__/published-entries.test.ts
@@ -6,12 +6,17 @@
  * JavaScript target, two subpaths sharing one artifact — and a check exercised only against the
  * real map would be asserting that today's map is acceptable, which is a different claim.
  */
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
 import { describe, expect, it } from "vitest";
 
 import {
   clientBuildEntries,
   derivePublishedEntries,
   serverSafeBuildEntries,
+  type DeclaredBarrel,
 } from "../../scripts/published-entries.mjs";
 
 /** The four conditions a JavaScript entry point has to name. */
@@ -22,7 +27,7 @@ function conditions(name: string): Record<string, Record<string, string>> {
   };
 }
 
-const barrel = (source: string, client: boolean): object => ({
+const barrel = (source: string, client: boolean): DeclaredBarrel => ({
   source,
   client,
 });
@@ -168,6 +173,46 @@ describe("targets the guards cannot read", () => {
   });
 });
 
+describe("export conditions the guards do not follow", () => {
+  it("refuses a runtime condition it cannot traverse", () => {
+    // A resolver picks the FIRST condition it matches, so `react-server` would be selected ahead
+    // of `import`/`require` in that environment — and the file those consumers receive would have
+    // had neither its surface nor its client directive checked.
+    const target = {
+      "react-server": { types: "./dist/rsc.d.ts", default: "./dist/rsc.mjs" },
+      ...conditions("index"),
+    };
+    expect(() =>
+      derivePublishedEntries(
+        { ".": target },
+        { ".": barrel("src/index.ts", true) }
+      )
+    ).toThrow(/has a "react-server" condition/);
+  });
+
+  it("refuses an unfollowed target inside a condition it does follow", () => {
+    const target = conditions("index");
+    target.import = { ...target.import, browser: "./dist/index.browser.mjs" };
+    expect(() =>
+      derivePublishedEntries(
+        { ".": target },
+        { ".": barrel("src/index.ts", true) }
+      )
+    ).toThrow(/has a "import.browser" target/);
+  });
+
+  it("still accepts the four it does follow", () => {
+    // The control: the refusal is scoped to keys the guards cannot read, not to conditions in
+    // general — the ordinary dual-format entry must keep working.
+    expect(
+      derivePublishedEntries(
+        { ".": conditions("index") },
+        { ".": barrel("src/index.ts", true) }
+      )
+    ).toHaveLength(1);
+  });
+});
+
 describe("the barrel declaration and the export map", () => {
   it("refuses a published subpath with no declared barrel", () => {
     expect(() =>
@@ -193,5 +238,34 @@ describe("the barrel declaration and the export map", () => {
     expect(() =>
       derivePublishedEntries({ "./theme.css": "./dist/theme.css" }, {})
     ).toThrow(/passing vacuously/);
+  });
+});
+
+describe("the hand-written declaration beside the module", () => {
+  // A `.d.mts` maintained alongside a `.mjs` is a second list of the same facts, which is the
+  // shape this module exists to remove everywhere else. Nothing typechecks these tests today, so
+  // a declaration naming a function that no longer exists stayed green through a rename.
+  const scripts = path.join(
+    path.dirname(fileURLToPath(import.meta.url)),
+    "..",
+    "..",
+    "scripts"
+  );
+  const names = (file: string): string[] =>
+    [
+      ...readFileSync(path.join(scripts, file), "utf8").matchAll(
+        /^export function (\w+)/gm
+      ),
+    ]
+      .map(match => match[1]!)
+      .sort();
+
+  it("declares exactly the functions the module exports", () => {
+    const runtime = names("published-entries.mjs");
+    expect(
+      runtime.length,
+      "no exported functions were found to compare"
+    ).toBeGreaterThan(0);
+    expect(names("published-entries.d.mts")).toEqual(runtime);
   });
 });

--- a/packages/ui/src/ui-surface.test.ts
+++ b/packages/ui/src/ui-surface.test.ts
@@ -13,6 +13,7 @@
  * belong in a Node test process.
  */
 import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { publishedEntries } from "../scripts/published-entries.mjs";
 
 import {
   DECLARATION_ENTRIES,
@@ -27,7 +28,13 @@ import { beforeAll, describe, expect, it } from "vitest";
 const SRC = path.dirname(fileURLToPath(import.meta.url));
 const PKG_ROOT = path.join(SRC, "..");
 
-/** The entry points named in the package's `exports` map. */
+/**
+ * The SOURCE barrel behind each published entry point.
+ *
+ * Listed rather than derived, because the export map names built files and there is no convention
+ * mapping `dist/color` back to `src/lib/color/index.ts`. The list is instead tied to the export
+ * map by a completeness check below, so an entry point cannot be published without one.
+ */
 const ENTRY_POINTS = [
   "index.ts",
   "lib/utils.ts",
@@ -164,6 +171,17 @@ function documentedPublic(): { names: string[]; files: string[] } {
 }
 
 describe("ui public export surface", () => {
+  it("has a source barrel for every published entry point", () => {
+    // The one guard whose list cannot be derived, tied to the same source of truth by counting.
+    // Without this, publishing a subpath and forgetting to add its source here leaves its export
+    // names and value-versus-type kinds outside the snapshot, and every assertion stays green.
+    expect(
+      ENTRY_POINTS.length,
+      `package.json publishes ${publishedEntries().length} JavaScript entry points and ` +
+        `ENTRY_POINTS lists ${ENTRY_POINTS.length}. Add the new one's SOURCE barrel here.`
+    ).toBe(publishedEntries().length);
+  });
+
   it.each(ENTRY_POINTS)("%s surface is unchanged", file => {
     expect(exportedNames(file)).toMatchSnapshot();
   });

--- a/packages/ui/src/ui-surface.test.ts
+++ b/packages/ui/src/ui-surface.test.ts
@@ -222,6 +222,33 @@ describe("ui public export surface", () => {
 });
 
 describe("ui STABILITY.md ledger", () => {
+  it("classifies entry points the way the ledger promises", () => {
+    // The client/server split is DECLARED, and a declaration nothing checks is a comment. The
+    // ledger names the server-safe subpaths in prose, so the two are compared in both
+    // directions: misclassifying an entry builds it with the wrong config, and the directive
+    // guard then asserts the opposite of what that artifact needs.
+    const start = ledger.indexOf("- **Server components.**");
+    expect(
+      start,
+      "STABILITY.md no longer names the server-safe subpaths"
+    ).toBeGreaterThan(-1);
+    const bullet = ledger.slice(start, ledger.indexOf("\n\n", start));
+    const promised = [...bullet.matchAll(/`@nextlyhq\/ui\/([\w./-]+)`/g)]
+      .map(match => `./${match[1]}`)
+      .sort();
+    expect(
+      promised.length,
+      "the ledger bullet named no subpaths"
+    ).toBeGreaterThan(0);
+
+    expect(
+      publishedEntries()
+        .filter(entry => entry.serverSafe)
+        .map(entry => entry.subpath)
+        .sort()
+    ).toEqual(promised);
+  });
+
   it("promises no export the barrel does not ship", () => {
     const shipped = barrelNames();
     const missing = documentedPublic().names.filter(n => !shipped.has(n));

--- a/packages/ui/src/ui-surface.test.ts
+++ b/packages/ui/src/ui-surface.test.ts
@@ -41,8 +41,17 @@ const ENTRY_POINTS = Object.entries(sourcesBySubpath()).map(
   ([subpath, source]) => ({ subpath, source })
 );
 
-/** Just the source paths, for the checks that read files rather than compare identities. */
-const ENTRY_SOURCES = ENTRY_POINTS.map(entry => entry.source);
+/**
+ * `[subpath, source]` for the per-entry checks.
+ *
+ * Named by the SUBPATH rather than the file, so the snapshot records what a consumer of that
+ * subpath receives. Keyed by file, exchanging two entries' sources kept every snapshot matching
+ * the file it was named for, while the build paired each source with the other's artifact name —
+ * so the two subpaths shipped each other's API and nothing compared unequal.
+ */
+const ENTRY_CASES = ENTRY_POINTS.map(
+  entry => [entry.subpath, entry.source] as const
+);
 
 /**
  * Strip comments before any structural check. Doc comments here legitimately
@@ -197,16 +206,19 @@ describe("ui public export surface", () => {
     );
   });
 
-  it.each(ENTRY_SOURCES)("%s surface is unchanged", file => {
+  it.each(ENTRY_CASES)("%s surface is unchanged", (_subpath, file) => {
     expect(exportedNames(file)).toMatchSnapshot();
   });
 
   // The name/kind extractor cannot see through `export *` re-exports, so a star
   // export would add names to the public surface that the snapshots never
   // record. Fail loudly if one is introduced, so the guard stays complete.
-  it.each(ENTRY_SOURCES)("%s uses only named exports (no `export *`)", file => {
-    expect(sourceOf(file)).not.toMatch(/export\s+\*/);
-  });
+  it.each(ENTRY_CASES)(
+    "%s uses only named exports (no `export *`)",
+    (_subpath, file) => {
+      expect(sourceOf(file)).not.toMatch(/export\s+\*/);
+    }
+  );
 });
 
 describe("ui STABILITY.md ledger", () => {

--- a/packages/ui/src/ui-surface.test.ts
+++ b/packages/ui/src/ui-surface.test.ts
@@ -13,7 +13,10 @@
  * belong in a Node test process.
  */
 import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
-import { publishedEntries } from "../scripts/published-entries.mjs";
+import {
+  publishedEntries,
+  sourcesBySubpath,
+} from "../scripts/published-entries.mjs";
 
 import {
   DECLARATION_ENTRIES,
@@ -31,16 +34,12 @@ const PKG_ROOT = path.join(SRC, "..");
 /**
  * The SOURCE barrel behind each published entry point.
  *
- * Listed rather than derived, because the export map names built files and there is no convention
- * mapping `dist/color` back to `src/lib/color/index.ts`. The list is instead tied to the export
- * map by a completeness check below, so an entry point cannot be published without one.
+ * Read from the same map the build config consumes, so a retarget cannot leave this comparing the
+ * previous barrel while the new one ships unchecked.
  */
-const ENTRY_POINTS = [
-  { subpath: ".", source: "index.ts" },
-  { subpath: "./utils", source: "lib/utils.ts" },
-  { subpath: "./tailwind-preset", source: "tailwind-preset.ts" },
-  { subpath: "./color", source: "lib/color/index.ts" },
-] as const;
+const ENTRY_POINTS = Object.entries(sourcesBySubpath()).map(
+  ([subpath, source]) => ({ subpath, source })
+);
 
 /** Just the source paths, for the checks that read files rather than compare identities. */
 const ENTRY_SOURCES = ENTRY_POINTS.map(entry => entry.source);
@@ -58,7 +57,10 @@ function stripComments(source: string): string {
 }
 
 function sourceOf(file: string): string {
-  return stripComments(readFileSync(path.join(SRC, file), "utf8"));
+  // Resolved from the PACKAGE ROOT, because these paths are the ones the build config consumes
+  // and tsup entry paths are package-relative. Reading them from `src` instead would need a
+  // second spelling of the same path, which is what having one map is meant to prevent.
+  return stripComments(readFileSync(path.join(PKG_ROOT, file), "utf8"));
 }
 
 /**
@@ -102,7 +104,9 @@ function exportedNames(file: string): string[] {
 /** Names the barrel exports, without the kind suffix. */
 function barrelNames(): Set<string> {
   return new Set(
-    exportedNames("index.ts").map(entry => entry.replace(/ \(.*\)$/, ""))
+    exportedNames(sourcesBySubpath()["."]!).map(entry =>
+      entry.replace(/ \(.*\)$/, "")
+    )
   );
 }
 
@@ -112,7 +116,10 @@ function barrelNames(): Set<string> {
  * name in it. A group heading may sit between the tag and the clause.
  */
 function taggedPerSource(): { public: Set<string>; experimental: Set<string> } {
-  const source = readFileSync(path.join(SRC, "index.ts"), "utf8");
+  const source = readFileSync(
+    path.join(PKG_ROOT, sourcesBySubpath()["."]!),
+    "utf8"
+  );
   const tagged = { public: new Set<string>(), experimental: new Set<string>() };
 
   for (const m of source.matchAll(

--- a/packages/ui/src/ui-surface.test.ts
+++ b/packages/ui/src/ui-surface.test.ts
@@ -36,11 +36,14 @@ const PKG_ROOT = path.join(SRC, "..");
  * map by a completeness check below, so an entry point cannot be published without one.
  */
 const ENTRY_POINTS = [
-  "index.ts",
-  "lib/utils.ts",
-  "tailwind-preset.ts",
-  "lib/color/index.ts",
-];
+  { subpath: ".", source: "index.ts" },
+  { subpath: "./utils", source: "lib/utils.ts" },
+  { subpath: "./tailwind-preset", source: "tailwind-preset.ts" },
+  { subpath: "./color", source: "lib/color/index.ts" },
+] as const;
+
+/** Just the source paths, for the checks that read files rather than compare identities. */
+const ENTRY_SOURCES = ENTRY_POINTS.map(entry => entry.source);
 
 /**
  * Strip comments before any structural check. Doc comments here legitimately
@@ -172,24 +175,29 @@ function documentedPublic(): { names: string[]; files: string[] } {
 
 describe("ui public export surface", () => {
   it("has a source barrel for every published entry point", () => {
-    // The one guard whose list cannot be derived, tied to the same source of truth by counting.
-    // Without this, publishing a subpath and forgetting to add its source here leaves its export
-    // names and value-versus-type kinds outside the snapshot, and every assertion stays green.
+    // Compared by IDENTITY rather than by count. A change that renames or replaces one subpath
+    // leaves the total unchanged, so a count alone would keep passing while the new entry's
+    // exports and value-versus-type kinds sat outside the snapshots — which is the coverage gap
+    // this check exists to close.
     expect(
-      ENTRY_POINTS.length,
-      `package.json publishes ${publishedEntries().length} JavaScript entry points and ` +
-        `ENTRY_POINTS lists ${ENTRY_POINTS.length}. Add the new one's SOURCE barrel here.`
-    ).toBe(publishedEntries().length);
+      ENTRY_POINTS.map(entry => entry.subpath).sort(),
+      "the source barrels listed here and the subpaths package.json publishes have diverged; " +
+        "add or update the SOURCE barrel for the entry that changed"
+    ).toEqual(
+      publishedEntries()
+        .map(entry => entry.subpath)
+        .sort()
+    );
   });
 
-  it.each(ENTRY_POINTS)("%s surface is unchanged", file => {
+  it.each(ENTRY_SOURCES)("%s surface is unchanged", file => {
     expect(exportedNames(file)).toMatchSnapshot();
   });
 
   // The name/kind extractor cannot see through `export *` re-exports, so a star
   // export would add names to the public surface that the snapshots never
   // record. Fail loudly if one is introduced, so the guard stays complete.
-  it.each(ENTRY_POINTS)("%s uses only named exports (no `export *`)", file => {
+  it.each(ENTRY_SOURCES)("%s uses only named exports (no `export *`)", file => {
     expect(sourceOf(file)).not.toMatch(/export\s+\*/);
   });
 });

--- a/packages/ui/tsup.config.ts
+++ b/packages/ui/tsup.config.ts
@@ -1,6 +1,6 @@
 import { defineConfig } from "tsup";
 
-import { rootBuildEntry } from "./scripts/published-entries.mjs";
+import { clientBuildEntries } from "./scripts/published-entries.mjs";
 
 // Left to the consumer rather than bundled: React and Radix keep component
 // state and portals in module-level stores, so a second copy inside this
@@ -26,7 +26,7 @@ export default defineConfig({
   // Read from the same map the server-safe build and the surface snapshot use, so retargeting
   // the barrel moves all three together rather than leaving the snapshot describing a file the
   // build no longer produces.
-  entry: rootBuildEntry(),
+  entry: clientBuildEntries(),
   format: ["esm", "cjs"],
   dts: true,
   // Cleaning is done once by the build script, not per-config: the two configs

--- a/packages/ui/tsup.config.ts
+++ b/packages/ui/tsup.config.ts
@@ -1,5 +1,7 @@
 import { defineConfig } from "tsup";
 
+import { rootBuildEntry } from "./scripts/published-entries.mjs";
+
 // Left to the consumer rather than bundled: React and Radix keep component
 // state and portals in module-level stores, so a second copy inside this
 // bundle would not share that state with the host app's copy. lucide-react,
@@ -21,7 +23,10 @@ export default defineConfig({
   // use hooks, context, `forwardRef` or Radix, none of which a Server Component
   // can render. Build-time-only exports are built by tsup.preset.config.ts so
   // they stay importable from server code.
-  entry: ["src/index.ts"],
+  // Read from the same map the server-safe build and the surface snapshot use, so retargeting
+  // the barrel moves all three together rather than leaving the snapshot describing a file the
+  // build no longer produces.
+  entry: rootBuildEntry(),
   format: ["esm", "cjs"],
   dts: true,
   // Cleaning is done once by the build script, not per-config: the two configs

--- a/packages/ui/tsup.server-safe.config.ts
+++ b/packages/ui/tsup.server-safe.config.ts
@@ -1,5 +1,7 @@
 import { defineConfig } from "tsup";
 
+import { serverSafeBuildEntries } from "./scripts/published-entries.mjs";
+
 // Left to the consumer rather than bundled: React and Radix keep component
 // state and portals in module-level stores, so a second copy inside this
 // bundle would not share that state with the host app's copy. lucide-react,
@@ -27,19 +29,10 @@ export default defineConfig({
   // Named so the output stays flat: with plain paths tsup mirrors the source
   // tree from the common root and emits `dist/lib/utils.*`, which would not
   // match the exports map.
-  entry: {
-    // Builds with a "named and default exports together" warning, and that is
-    // the intended shape rather than an oversight. A preset is consumed as a
-    // value, so `require()` has to return it; CommonJS cannot express a
-    // default-only module without `module.exports =`, which makes the emitted
-    // declarations disagree with the runtime and trips attw's
-    // FalseExportDefault — a rule CI does NOT ignore. Silencing the warning
-    // with `output.exports` would change that shape back. See the export at the
-    // foot of the entry for the same reasoning beside the code.
-    "tailwind-preset": "src/tailwind-preset.ts",
-    utils: "src/lib/utils.ts",
-    color: "src/lib/color/index.ts",
-  },
+  // Read from the export-map derivation rather than declared here, so a subpath's source is
+  // stated once. When this config owned it and the surface snapshot kept a copy, retargeting an
+  // entry left the snapshot comparing the old barrel while the new one shipped unchecked.
+  entry: serverSafeBuildEntries(),
   format: ["esm", "cjs"],
   dts: true,
   clean: false,

--- a/turbo.jsonc
+++ b/turbo.jsonc
@@ -300,7 +300,14 @@
         "*.md",
         "package.json",
         "vitest.config.ts",
-        "tsconfig.json"
+        "tsconfig.json",
+        // Scripts and build configs are read BY tests, not only by builds: the ui suite derives
+        // its entry-point guards from `scripts/published-entries.mjs`, which the tsup configs
+        // also consume. Without these, retargeting a source barrel or changing an entry's
+        // client/server classification leaves the cache key untouched, so CI replays the previous
+        // pass precisely when the source of truth those guards read has changed.
+        "scripts/**",
+        "tsup*.config.ts"
       ],
       "outputs": ["coverage/**"], // Coverage reports
       "cache": true // Cache test results (only re-run if inputs change)


### PR DESCRIPTION
## The problem

Three guards protect a published entry point in `@nextlyhq/ui`:

| guard | checks |
|---|---|
| `DECLARATION_ENTRIES` | the built declarations carry a release tag |
| `ENTRY_POINTS` | the source barrel matches a surface snapshot, and uses no `export *` |
| `mustNotHave` | a server-safe entry carries no `"use client"` banner |

Each held its own hand-written list. Every one of them is correct, and every one is **opt-in** — so a newly published subpath was unprotected by default in all three at once.

That is not hypothetical: adding `@nextlyhq/ui/color` missed all three, and each omission was found **separately, in a different review round, on the same PR**. Missing the first was an oversight; missing three in a row is a property of the design.

## The change

The export map in `package.json` already knows what ships, so the lists come from there. Adding an entry point now enrols it in every check — which removes the thing there was to remember, rather than writing it down somewhere.

`scripts/published-entries.mjs` is plain ESM with a `.d.mts` beside it, because both a Node script and a Vitest suite have to read it without a build step.

**One list genuinely cannot be derived.** The export map names *built* files, and nothing maps `dist/color` back to `src/lib/color/index.ts`. That list stays explicit and is tied to the same source of truth by a completeness check, so an entry point cannot be published without a source barrel:

```
package.json publishes 5 JavaScript entry points and ENTRY_POINTS lists 4.
Add the new one's SOURCE barrel here.
```

`serverSafe` is also derived rather than listed: the root barrel is the component surface and ships with a client banner, and every other JavaScript subpath exists precisely because it carries no React runtime.

## Verification

Not "the tests still pass" — the point is what happens when someone adds an entry point. So I published a fake `./motion` subpath, changed nothing else, and checked each guard:

```
source-surface   NOTICES  expected 4 to be 5 — add the new one's SOURCE barrel here
client-directive NOTICES  motion.mjs / motion.cjs were not emitted by the build
declarations     NOTICES  motion.d.ts, motion.d.cts
```

Also guarded against passing vacuously: the helper throws if the export map yields no JavaScript entry points, since a shape change there would otherwise leave every guard reading it silently green.

No changeset: this is test and build tooling only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Build & Packaging**
  * Published package entry points are now derived consistently from the export configuration.
  * Client-safe and server-safe builds automatically stay aligned with published exports.
  * Newly published entry points are included automatically in generated declarations and build validation.

* **Bug Fixes**
  * Improved detection of missing, invalid, or mismatched package export entries.

* **Tests**
  * Expanded checks to validate source-to-package entry-point mappings and exported declarations across all configured entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->