### PR TITLE
feat(blocks-engine): let a site say which hosts its styles may fetch

### DIFF
--- a/.changeset/style-url-host-policy.md
+++ b/.changeset/style-url-host-policy.md
@@ -1,0 +1,34 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+Let a site say which hosts its stylesheets may fetch from.
+
+A stylesheet is a fetching surface. `background-image: url(...)` makes the browser request whatever it names, on every page the rule applies to, and until now the only limit on that was the scheme allowlist. That allowlist answers whether a URL is `http(s)` rather than `javascript:`; it has never had anything to say about WHICH host is reached. A value carrying no scheme at all can still name one, because `//cdn.example/a.png` inherits the page's protocol and nothing else, so a check reading "no scheme, therefore this origin" was wrong about exactly the case that reaches somewhere else. The comment saying so has been corrected, and it is no longer the only thing marking the gap.
+
+`StyleCompileContext` now takes a `mayFetchUrl` predicate, forwarded to every URL a compile can emit. A PREDICATE rather than a list of patterns, so the engine holds no matching rules of its own and the caller keeps ONE answer for every channel it owns; which hosts a site trusts belongs to the site, not to the document format. Left undefined, nothing is asked and a compile behaves exactly as it did before, which is what every caller outside a configured site gets. The question is put last, to a value already known to be well formed, so a host rule is never the reason given for a value that was going to be refused anyway.
+
+Coverage is proved rather than asserted. The test walks the catalog for every leaf that can carry a URL, places a refused host at each one and checks none reach the stylesheet, with an allowed host in the SAME position as the control — without it a compiler emitting nothing for that property would pass by writing no CSS at all. Deriving the positions from the catalog is the point: a written list is a snapshot, and the property added next month would not be in it while the suite still reported full coverage.
+
+Two signatures grew a parameter and are now grouped rather than lengthened. `validateStyleValues` already took six positional arguments and `envelopeRules` ten, which is past where a call reads by position; a further optional would have sat beside one of a different type with nothing but that type to tell them apart, and a policy lost in a mis-slotted call leaves every URL in the document unasked about. `envelopeRules` takes a named object instead, so its arity goes down rather than up.

--- a/packages/blocks-engine/src/index.ts
+++ b/packages/blocks-engine/src/index.ts
@@ -170,7 +170,8 @@ export {
   // IS has to fold it the same way.
   asciiLower,
 } from "./style/css-value";
-export type { CssValueRejection } from "./style/css-value";
+export type { CssValueRejection, MayFetchUrl } from "./style/css-value";
+export type { StyleValueOptions } from "./style/validate-style-value";
 export {
   validateStyleValues,
   newStyleIssueBudget,

--- a/packages/blocks-engine/src/style/compile-page.ts
+++ b/packages/blocks-engine/src/style/compile-page.ts
@@ -41,6 +41,7 @@ import { isConditionGated } from "../visibility";
 import { BREAKPOINT_AXES } from "./breakpoint-axes";
 import type { BreakpointAxis } from "./breakpoint-axes";
 import { escapeIdentifier } from "./css-value";
+import type { MayFetchUrl } from "./css-value";
 import { compileStyleValues, DEFAULT_TOKEN_PREFIX } from "./declarations";
 import type { Declaration } from "./declarations";
 import type { NamedClass } from "./named-class";
@@ -73,6 +74,21 @@ import type { WarningAllowance } from "./warning-allowance";
 /** Everything site-level the compiler needs; the caller loads it. */
 export interface StyleCompileContext {
   breakpoints: BreakpointSet;
+  /**
+   * Which hosts this site will fetch from.
+   *
+   * A stylesheet is a fetching surface: `background-image: url(...)` makes the
+   * browser request whatever it names, on every page that rule applies to. The
+   * scheme allowlist below the compile refuses `javascript:` and friends but has
+   * nothing to say about WHICH http(s) host is reached, and a value carrying no
+   * scheme at all can still name one — `//cdn.example/a.png` inherits the page's
+   * protocol and nothing else.
+   *
+   * Left undefined, no host question is asked and the compile behaves exactly as
+   * it did before this existed. The engine ships no list of its own because
+   * which hosts a site trusts belongs to the site, not to the document format.
+   */
+  mayFetchUrl?: MayFetchUrl;
   /**
    * Base styles per block type, keyed by block name. One shared rule per type
    * rather than a copy inside every node: a page of forty default sections
@@ -506,6 +522,15 @@ function unknownBreakpointWarnings(
   }
 }
 
+/** What one envelope is, and what may be written from it. */
+interface EnvelopeContext {
+  origin: StyleOrigin;
+  /** Appended to as declarations are emitted; absent when no caller asked for a trace. */
+  trace?: StyleTraceEntry[];
+  /** Which hosts this site will fetch from; unasked when absent. */
+  mayFetchUrl?: MayFetchUrl;
+}
+
 /** Compile one styles envelope into rules under one selector. */
 function envelopeRules(
   styles: NodeStyles | undefined,
@@ -516,10 +541,18 @@ function envelopeRules(
   warnings: ValidationIssue[],
   budget: StyleIssueBudget,
   warningAllowance: WarningAllowance,
-  origin: StyleOrigin,
-  /** Appended to as declarations are emitted; absent when no caller asked for a trace. */
-  trace: StyleTraceEntry[] | undefined
+  /**
+   * What this envelope IS and what may be written from it, grouped rather than
+   * appended. Ten positional arguments was already past the point where a call
+   * reads by position, and the policy below had to arrive with them: as an
+   * eleventh optional in line it would have sat beside `trace` with nothing but
+   * its type to tell the two apart, and a policy dropped in a mis-slotted call
+   * leaves every URL in the document unasked about. Named fields cannot be
+   * mis-slotted, and grouping takes the arity DOWN rather than up.
+   */
+  about: EnvelopeContext
 ): CssRule[] {
+  const { origin, trace, mayFetchUrl } = about;
   if (styles === undefined) return [];
   // A stored envelope that is not an object — `[]`, a string, `null` — styles
   // nothing, and this compiler reads persisted data whether or not a caller
@@ -591,7 +624,8 @@ function envelopeRules(
         path,
         tokenPrefix,
         budget,
-        warningAllowance
+        warningAllowance,
+        { mayFetchUrl }
       );
       // Appended as they come. `compileStyleValues` holds this same allowance and charges
       // everything it returns against it exactly once, so charging again here would spend it
@@ -939,6 +973,7 @@ export function compilePageCss(
   const warningAllowance = newWarningAllowance();
   const contexts = breakpointContexts(ctx.breakpoints);
   const tokenPrefix = ctx.tokenPrefix ?? DEFAULT_TOKEN_PREFIX;
+  const mayFetchUrl = ctx.mayFetchUrl;
   const scope = scopeSelector(ctx.scope, warnings);
   const pageRoot = `${PAGE_ROOT_SELECTOR}${scope}`;
 
@@ -988,8 +1023,7 @@ export function compilePageCss(
       warnings,
       budget,
       warningAllowance,
-      { kind: "page" },
-      trace
+      { origin: { kind: "page" }, trace, mayFetchUrl }
     )
   );
 
@@ -1035,8 +1069,7 @@ export function compilePageCss(
         warnings,
         budget,
         warningAllowance,
-        { kind: "blockType", type },
-        trace
+        { origin: { kind: "blockType", type }, trace, mayFetchUrl }
       )
     );
   }
@@ -1180,8 +1213,11 @@ export function compilePageCss(
         // allowance, which is shared and is what actually caps the reporting.
         newStyleIssueBudget(),
         warningAllowance,
-        { kind: "class", id: cls.id, slug: cls.slug },
-        trace
+        {
+          origin: { kind: "class", id: cls.id, slug: cls.slug },
+          trace,
+          mayFetchUrl,
+        }
       )
     );
   }
@@ -1219,8 +1255,7 @@ export function compilePageCss(
         warnings,
         budget,
         warningAllowance,
-        { kind: "node", id: node.id },
-        trace
+        { origin: { kind: "node", id: node.id }, trace, mayFetchUrl }
       ),
       ...visibilityRules(
         node,

--- a/packages/blocks-engine/src/style/css-value.ts
+++ b/packages/blocks-engine/src/style/css-value.ts
@@ -32,10 +32,21 @@ export type CssValueRejection =
   | "unsafe-characters"
   | "unsafe-url-scheme"
   | "unsafe-url-characters"
+  | "url-host-not-allowed"
   | "too-deeply-nested"
   | "too-long"
   | "not-a-length"
   | "not-a-color";
+
+/**
+ * Whether this site will fetch a URL, asked of every URL a stylesheet emits.
+ *
+ * A PREDICATE rather than a list of patterns, so the engine stays free of the
+ * matching rules and the caller keeps one answer for every channel it owns. It
+ * is optional everywhere it appears: a caller with no host policy asks nothing
+ * and gets the scheme allowlist alone.
+ */
+export type MayFetchUrl = (url: string) => boolean;
 
 /**
  * Characters that must never reach a declaration, even inside a value that
@@ -56,8 +67,12 @@ const COMMENT_DELIMITERS = /\/\*|\*\//;
 /**
  * URL schemes allowed inside `url()`. An allowlist rather than a blocklist:
  * a blocklist has to predict every dangerous scheme, and misses the next one.
- * Relative paths, absolute paths and protocol-relative URLs carry no scheme and
- * are allowed by having none to reject.
+ *
+ * Having no scheme is not the same as naming no host. A relative or absolute
+ * path resolves against the page's own origin, but `//cdn.example/a.png` carries
+ * no scheme and still reaches ANOTHER host, inheriting only the page's protocol.
+ * This list cannot tell those apart, so which hosts may be reached is a separate
+ * question, asked of `mayFetchUrl` below.
  */
 const ALLOWED_URL_SCHEMES: readonly string[] = ["http", "https"];
 
@@ -994,9 +1009,12 @@ function unquotedUrlText(children: Iterable<CssNode>): string | null {
  * validator. Failing closed costs a value that was already at the limit; the
  * alternative turns a document write into a server error.
  */
-function nestedUrlRejection(ast: CssNode): CssValueRejection | null {
+function nestedUrlRejection(
+  ast: CssNode,
+  mayFetchUrl: MayFetchUrl | undefined
+): CssValueRejection | null {
   try {
-    return walkForUrlRejection(ast);
+    return walkForUrlRejection(ast, mayFetchUrl);
   } catch {
     return "too-deeply-nested";
   }
@@ -1004,17 +1022,23 @@ function nestedUrlRejection(ast: CssNode): CssValueRejection | null {
 
 function walkForUrlRejection(
   node: CssNode,
+  // Before the two defaulted parameters on purpose: a caller that slots an
+  // argument wrongly gets a type error rather than a predicate silently dropped,
+  // which would leave every URL in the value unasked about.
+  mayFetchUrl: MayFetchUrl | undefined,
   urlContext = false,
   depth = 0
 ): CssValueRejection | null {
   switch (node.type) {
     case "Url":
-      return checkUrlValue(node.value, "quoted");
+      return checkUrlValue(node.value, "quoted", mayFetchUrl);
     case "String":
       // A quoted string is a URL only where the function around it loads one.
       // The same string is a font family somewhere else, so the surrounding
       // context decides, not the node.
-      return urlContext ? checkUrlValue(node.value, "quoted") : null;
+      return urlContext
+        ? checkUrlValue(node.value, "quoted", mayFetchUrl)
+        : null;
     case "Raw": {
       // A custom property's fallback is kept unparsed, so it has to be read
       // back or `var(--x, url("javascript:…"))` reaches the page whenever the
@@ -1027,7 +1051,7 @@ function walkForUrlRejection(
       const parsed = parseValue(node.value);
       return parsed === null
         ? null
-        : walkForUrlRejection(parsed, urlContext, depth + 1);
+        : walkForUrlRejection(parsed, mayFetchUrl, urlContext, depth + 1);
     }
     default:
       break;
@@ -1047,7 +1071,7 @@ function walkForUrlRejection(
         const text = unquotedUrlText(node.children);
         return text === null
           ? "unsafe-url-characters"
-          : checkUrlValue(text, "raw");
+          : checkUrlValue(text, "raw", mayFetchUrl);
       }
     } else if (name !== "var" && name !== "env") {
       // A reference passes its context through to whatever stands in for it;
@@ -1057,7 +1081,7 @@ function walkForUrlRejection(
     }
   }
   for (const child of node.children) {
-    const rejection = walkForUrlRejection(child, inner, depth);
+    const rejection = walkForUrlRejection(child, mayFetchUrl, inner, depth);
     if (rejection !== null) return rejection;
   }
   return null;
@@ -1138,7 +1162,10 @@ function nestingDepth(value: string): number {
  * Check a CSS value for parseability and unsafe characters. Returns `null` when
  * the value is safe to emit.
  */
-export function checkCssValue(value: string): CssValueRejection | null {
+export function checkCssValue(
+  value: string,
+  mayFetchUrl?: MayFetchUrl
+): CssValueRejection | null {
   // The size cap goes first because it is the only constant-time check here:
   // trimming an oversized string scans and copies all of it before anything
   // decides the value was never going to be read.
@@ -1155,7 +1182,7 @@ export function checkCssValue(value: string): CssValueRejection | null {
   // the PARSED node rather than the raw text because the parser decodes CSS
   // escapes: `url("\6a avascript:...")` arrives here as `javascript:...`, which
   // a scan of the original string would not recognise.
-  return nestedUrlRejection(ast);
+  return nestedUrlRejection(ast, mayFetchUrl);
 }
 
 /**
@@ -1655,7 +1682,11 @@ type UrlContext = "raw" | "quoted";
  */
 export function checkUrlValue(
   value: string,
-  context: UrlContext = "raw"
+  context: UrlContext = "raw",
+  // Which hosts this site will fetch from, when the caller has an answer. A
+  // string is passed rather than a parsed URL because the emitted declaration
+  // carries the string, and re-serialising a parse would let the two differ.
+  mayFetchUrl?: MayFetchUrl
 ): CssValueRejection | null {
   // A dedicated URL property does not pass through the free-form value check,
   // so without this its own cap is the document byte limit: one stored value
@@ -1678,11 +1709,17 @@ export function checkUrlValue(
   }
   // Checked against the raw value, not a trimmed copy: trimming first would
   // quietly discard a trailing newline rather than refuse it, and the value
-  // emitted is the one stored, not the trimmed one. No scheme at all is a
-  // relative, absolute, or protocol-relative path, which resolves against the
-  // page's own origin and needs no allowlisting.
+  // emitted is the one stored, not the trimmed one.
   const unsafe =
     context === "quoted" ? UNSAFE_QUOTED_URL_CHARS : UNSAFE_URL_CHARS;
   if (unsafe.test(value)) return "unsafe-url-characters";
+  // Asked LAST, of a value already known to be well formed, so the host rule is
+  // never the reason given for a value that was going to be refused anyway. A
+  // caller with no host policy leaves this undefined and nothing changes: the
+  // scheme allowlist above is then the only limit, which is what every caller
+  // outside a configured site gets today.
+  if (mayFetchUrl !== undefined && !mayFetchUrl(value)) {
+    return "url-host-not-allowed";
+  }
   return null;
 }

--- a/packages/blocks-engine/src/style/declarations.ts
+++ b/packages/blocks-engine/src/style/declarations.ts
@@ -35,7 +35,10 @@ import {
   structuralAllowanceSpent,
   validateStyleValues,
 } from "./validate-style-value";
-import type { StyleIssueBudget } from "./validate-style-value";
+import type {
+  StyleIssueBudget,
+  StyleValueOptions,
+} from "./validate-style-value";
 import { newWarningAllowance, pushBoundedWarning } from "./warning-allowance";
 import type { WarningAllowance } from "./warning-allowance";
 
@@ -399,7 +402,11 @@ export function compileStyleValues(
   basePath: string,
   tokenPrefix?: string,
   suppliedBudget?: StyleIssueBudget,
-  suppliedAllowance?: WarningAllowance
+  suppliedAllowance?: WarningAllowance,
+  // Same object as validation takes, forwarded whole. This decides what reaches
+  // a page from what validation REPORTED, so a policy the two do not share is a
+  // policy the stylesheet does not have.
+  options?: StyleValueOptions
 ): CompiledDeclarations {
   // Strict, because this decides what reaches a page: a property this engine
   // does not know is preserved in the document and left out of the stylesheet,
@@ -428,7 +435,15 @@ export function compileStyleValues(
   // fresh one, so the diagnostics are bounded however this is reached.
   const allowance = suppliedAllowance ?? newWarningAllowance();
   const spentBefore = structuralAllowanceSpent(budget);
-  const issues = validateStyleValues(values, basePath, "strict", budget);
+  const issues = validateStyleValues(
+    values,
+    basePath,
+    "strict",
+    budget,
+    false,
+    undefined,
+    options
+  );
   const stopped =
     spentBefore ||
     structuralAllowanceSpent(budget) ||

--- a/packages/blocks-engine/src/style/url-host-policy.test.ts
+++ b/packages/blocks-engine/src/style/url-host-policy.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Every place a stored style value can name a host, and whether the site's host
+ * policy is asked about it.
+ *
+ * The positions are DERIVED from the catalog rather than listed here. A written
+ * list is a snapshot: the property added next month is not in it, its leaf is
+ * never exercised, and the suite still reports full coverage. Walking the
+ * catalog means a new URL-bearing leaf joins these assertions by existing.
+ */
+import { describe, expect, it } from "vitest";
+
+import { STYLE_CATALOG } from "./catalog";
+import type { StyleShape } from "./catalog-types";
+import { compilePageCss } from "./compile-page";
+import type { BlockDocument } from "../document";
+import { DOCUMENT_FORMAT_VERSION } from "../document";
+
+/** A value the leaf will accept, carrying `url` at the given host. */
+type UrlWriter = (url: string) => unknown;
+
+/**
+ * One writer per URL-bearing LEAF in this shape, each placing the URL at that
+ * leaf and nowhere else.
+ *
+ * Per leaf rather than per property, because a property can hold several: the
+ * background object carries a `url` beside two free-form values, and a walk
+ * that stopped at the first would leave the other two never exercised while
+ * still reporting the property covered.
+ */
+function urlWriters(shape: StyleShape): UrlWriter[] {
+  switch (shape.kind) {
+    case "url":
+      return [url => url];
+    case "cssValue":
+      return [url => `url("${url}")`];
+    case "logicalSides":
+      return nested(shape.sides);
+    case "logicalCorners":
+      return nested(shape.corners);
+    case "object":
+      return nested(shape.fields);
+    case "union":
+      // Each variant separately: they are alternative spellings of the same
+      // value, and a leaf reachable only through the second is still reachable.
+      return shape.of.flatMap(urlWriters);
+    default:
+      return [];
+  }
+}
+
+/** Writers for every URL-bearing leaf under a record of named members. */
+function nested(members: Readonly<Record<string, StyleShape>>): UrlWriter[] {
+  return Object.entries(members).flatMap(([name, inner]) =>
+    urlWriters(inner).map(write => (url: string) => ({ [name]: write(url) }))
+  );
+}
+
+/** Every leaf in the catalog that can carry a URL, with how to put one there. */
+const URL_BEARING = STYLE_CATALOG.flatMap(entry =>
+  urlWriters(entry.shape).map((write, leaf) => ({
+    property: entry.property,
+    leaf,
+    write,
+  }))
+);
+
+const ALLOWED = "https://cdn.allowed.test/a.png";
+const REFUSED = "https://cdn.refused.test/a.png";
+
+function compile(
+  property: string,
+  value: unknown,
+  host?: (url: string) => boolean
+) {
+  const doc: BlockDocument = {
+    formatVersion: DOCUMENT_FORMAT_VERSION,
+    kind: "page",
+    nodes: [
+      {
+        id: "n1",
+        type: "core/text",
+        version: 1,
+        props: {},
+        styles: { base: { base: { [property]: value } } },
+      },
+    ],
+  };
+  return compilePageCss(doc, {
+    breakpoints: { base: {} },
+    ...(host === undefined ? {} : { mayFetchUrl: host }),
+  });
+}
+
+describe("style values that name a host", () => {
+  it("finds the URL-bearing leaves rather than trusting a written list", () => {
+    // The precondition for everything below. Were the walk to return nothing —
+    // a renamed shape kind, a restructured catalog — every `it.each` beneath it
+    // would run zero cases and the file would report success having asserted
+    // nothing at all.
+    expect(URL_BEARING.length).toBeGreaterThanOrEqual(15);
+    const kinds = new Set(
+      STYLE_CATALOG.filter(entry =>
+        URL_BEARING.some(found => found.property === entry.property)
+      ).map(entry => entry.shape.kind)
+    );
+    // Both leaf kinds that reach `checkUrlValue` are represented, so a policy
+    // wired to one route and not the other cannot pass this file.
+    expect(kinds.size).toBeGreaterThan(1);
+  });
+
+  it.each(URL_BEARING)(
+    "$property leaf $leaf does not emit a refused host",
+    ({ property, write }) => {
+      const refused = compile(
+        property,
+        write(REFUSED),
+        url => !url.includes("refused")
+      );
+      expect(refused.css).not.toContain("cdn.refused.test");
+
+      // The positive control, in the SAME position. Without it a compiler that
+      // emitted nothing at all for this property — a shape this test writes
+      // wrongly, a property behind a `supports` flag — would pass the assertion
+      // above by writing no CSS whatsoever.
+      const allowed = compile(
+        property,
+        write(ALLOWED),
+        url => !url.includes("refused")
+      );
+      expect(allowed.css).toContain("cdn.allowed.test");
+    }
+  );
+
+  it.each(URL_BEARING)(
+    "$property leaf $leaf is unrestricted when no policy is supplied",
+    ({ property, write }) => {
+      // Absent means unasked, not allowed-nothing. A caller with no host policy
+      // must compile exactly as it did before the policy existed.
+      const compiled = compile(property, write(REFUSED));
+      expect(compiled.css).toContain("cdn.refused.test");
+    }
+  );
+
+  it("refuses a protocol-relative URL, which carries no scheme but names a host", () => {
+    // The case the scheme allowlist cannot see: `//host/x` has no scheme to
+    // reject and still reaches somewhere other than this origin.
+    const entry = URL_BEARING[0];
+    expect(entry).toBeDefined();
+    if (entry === undefined) return;
+    const compiled = compile(
+      entry.property,
+      entry.write("//cdn.refused.test/a.png"),
+      () => false
+    );
+    expect(compiled.css).not.toContain("cdn.refused.test");
+  });
+});

--- a/packages/blocks-engine/src/style/validate-style-value.ts
+++ b/packages/blocks-engine/src/style/validate-style-value.ts
@@ -33,7 +33,7 @@ import {
   splitCssTokens,
   trimCssWhitespace,
 } from "./css-value";
-import type { CssValueRejection } from "./css-value";
+import type { CssValueRejection, MayFetchUrl } from "./css-value";
 
 /** Human-readable reasons a value was refused, keyed by the safety check's verdict. */
 const REJECTION_MESSAGES = {
@@ -42,6 +42,7 @@ const REJECTION_MESSAGES = {
     "contains characters that are not allowed in a style value",
   "unsafe-url-scheme": "uses a URL scheme that is not allowed",
   "unsafe-url-characters": "contains characters that are not allowed in a URL",
+  "url-host-not-allowed": "loads from a host this site does not allow",
   "not-a-length": "is not a length",
   "not-a-color": "is not a color",
   "too-deeply-nested": "is nested too deeply",
@@ -500,7 +501,7 @@ function leafIssues(
   value: unknown,
   path: string,
   budget?: ReadyStyleIssueBudget,
-  tokens?: TokenLookup
+  check: ValueCheckContext = {}
 ): ValidationIssue[] {
   // A token reference substitutes for the whole leaf value, so it is checked
   // against the leaf's declared token kinds rather than its literal shape.
@@ -542,6 +543,7 @@ function leafIssues(
     // a token makes every document that used it unpublishable, and would arm
     // the trap where defining a site's FIRST token invalidates every other
     // reference in storage.
+    const { tokens } = check;
     if (tokens === undefined) return [];
     // The site allowance is spent HERE, at the reference, rather than once per
     // property. A property is a whole composite: charging only when it returns
@@ -685,7 +687,7 @@ function leafIssues(
       if (typeof value !== "string") {
         return [invalid(path, `${describeValue(value)} is not a string.`)];
       }
-      const rejection = checkCssValue(value);
+      const rejection = checkCssValue(value, check.mayFetchUrl);
       return rejection === null ? [] : rejected(path, value, rejection);
     }
     case "url": {
@@ -705,7 +707,7 @@ function leafIssues(
       ) {
         return [];
       }
-      const rejection = checkUrlValue(value);
+      const rejection = checkUrlValue(value, "raw", check.mayFetchUrl);
       return rejection === null ? [] : rejected(path, value, rejection);
     }
   }
@@ -741,6 +743,20 @@ function unionTokenKinds(shape: StyleShape): TokenKind[] {
   return kinds;
 }
 
+/**
+ * What a leaf needs besides the value itself.
+ *
+ * One object rather than one parameter apiece. These functions already carry
+ * seven positional arguments, several optional and several defaulted, and a
+ * second optional trailing parameter is the shape where a mis-slotted argument
+ * is silently accepted — here that would mean a URL policy quietly dropped and
+ * every URL in the document unasked about.
+ */
+interface ValueCheckContext {
+  tokens?: TokenLookup;
+  mayFetchUrl?: MayFetchUrl;
+}
+
 /** Validate a value against one named part of a composite shape. */
 function partIssues(
   parts: Readonly<Record<string, StyleShape>>,
@@ -750,7 +766,7 @@ function partIssues(
   budget?: ReadyStyleIssueBudget,
   spent = 0,
   spentBytes = 0,
-  tokens?: TokenLookup
+  check: ValueCheckContext = {}
 ): ValidationIssue[] {
   if (!isPlainRecord(value)) {
     return [
@@ -819,7 +835,7 @@ function partIssues(
       budget,
       spent + count,
       spentBytes + bytes,
-      tokens
+      check
     );
     for (const issue of nested) {
       if (isSiteIssue(issue)) continue;
@@ -839,9 +855,9 @@ function shapeIssues(
   budget?: ReadyStyleIssueBudget,
   spent = 0,
   spentBytes = 0,
-  tokens?: TokenLookup
+  check: ValueCheckContext = {}
 ): ValidationIssue[] {
-  if (isStyleLeaf(shape)) return leafIssues(shape, value, path, budget, tokens);
+  if (isStyleLeaf(shape)) return leafIssues(shape, value, path, budget, check);
   switch (shape.kind) {
     case "logicalSides":
       return partIssues(
@@ -852,7 +868,7 @@ function shapeIssues(
         budget,
         spent,
         spentBytes,
-        tokens
+        check
       );
     case "logicalCorners":
       return partIssues(
@@ -863,7 +879,7 @@ function shapeIssues(
         budget,
         spent,
         spentBytes,
-        tokens
+        check
       );
     case "object":
       return partIssues(
@@ -874,7 +890,7 @@ function shapeIssues(
         budget,
         spent,
         spentBytes,
-        tokens
+        check
       );
     case "union": {
       // A token is judged against every arm's kinds at once. Reporting the
@@ -888,6 +904,7 @@ function shapeIssues(
       // discard the answer. The lookup and reporting allowances are distinct
       // (a name already answered this run costs the caller nothing), so the
       // same guard the leaf reference uses bounds the ask here too.
+      const { tokens } = check;
       if (isTokenRef(value) && tokens !== undefined && !extraTokenKeys(value)) {
         const kinds = unionTokenKinds(shape);
         if (kinds.length > 0) {
@@ -927,7 +944,7 @@ function shapeIssues(
           speculativeBudget(budget),
           spent,
           spentBytes,
-          tokens
+          check
         );
         if (issues.length === 0) return [];
         // A variant that reports only warnings has ACCEPTED the value and
@@ -965,10 +982,22 @@ function shapeIssues(
         budget,
         spent,
         spentBytes,
-        tokens
+        check
       );
     }
   }
+}
+
+/** Caller-supplied policy for a validation run. */
+export interface StyleValueOptions {
+  /**
+   * Which hosts this site will fetch from.
+   *
+   * Absent by default, and absent means unasked rather than allowed: the engine
+   * ships no host list of its own, because which hosts a site trusts is the
+   * site operator's decision and not a property of the document format.
+   */
+  mayFetchUrl?: MayFetchUrl;
 }
 
 /**
@@ -987,7 +1016,13 @@ export function validateStyleValues(
   mode: ValidationMode,
   suppliedBudget?: StyleIssueBudget,
   skipValueParsing = false,
-  suppliedTokens?: TokenLookup
+  suppliedTokens?: TokenLookup,
+  // An OBJECT, where the six before it are positional. Six is already past the
+  // point where a call reads by position, and the next optional added in line
+  // would sit beside `suppliedTokens` with nothing but its type to tell them
+  // apart. A named field cannot be mis-slotted, and a caller who omits it gets
+  // exactly today's behaviour rather than a policy that silently did nothing.
+  options?: StyleValueOptions
 ): ValidationIssue[] {
   // The structural half of this shape has been public since it shipped, so a
   // caller may hand back an object that predates the site allowance. Filling it
@@ -1031,7 +1066,10 @@ export function validateStyleValues(
       // name resolves to cannot decide whether a document is valid, so running
       // out of room to report on names must not cut short the checks that can.
       issues.push(
-        ...shapeIssues(entry.shape, value, path, budget, 0, 0, tokens)
+        ...shapeIssues(entry.shape, value, path, budget, 0, 0, {
+          tokens,
+          mayFetchUrl: options?.mayFetchUrl,
+        })
       );
     }
     // Structural findings only: a site finding is charged at the reference that


### PR DESCRIPTION
## What

A stylesheet is a fetching surface. `background-image: url(...)` makes the browser request whatever it names, on every page the rule applies to, and the only limit on that was the scheme allowlist.

The scheme allowlist answers whether a URL is `http(s)` rather than `javascript:`. It has never had anything to say about WHICH host is reached. And a value carrying no scheme at all can still name one: `//cdn.example/a.png` inherits the page's protocol and nothing else, so the check reading "no scheme, therefore this origin" was wrong about exactly the case that reaches somewhere else.

`StyleCompileContext` now takes `mayFetchUrl`, forwarded to every URL a compile can emit.

## Why a predicate, not a pattern list

The engine holds no matching rules of its own, and the caller keeps ONE answer for every channel it owns. Which hosts a site trusts belongs to the site, not to the document format. `isFetchableUrl(url, patterns)` from the shared matcher closes over into exactly this shape.

Left undefined, nothing is asked and a compile behaves exactly as before — which is what every caller outside a configured site gets today. The question is put last, to a value already known to be well formed, so a host rule is never the reason given for a value that was going to be refused anyway.

## Coverage is proved, not asserted

The test walks the catalog for every leaf that can carry a URL — **15 of them**, one `url` and fourteen `cssValue` — places a refused host at each and checks none reach the stylesheet, with an allowed host in the SAME position as the control. Without that control, a compiler emitting nothing for a property would pass by writing no CSS at all.

The positions are derived from the catalog rather than listed. A written list is a snapshot: the property added next month would not be in it, its leaf would never be exercised, and the suite would still report full coverage.

Verified the test can fail: removing the one predicate consultation fails **16** cases (the 15 leaves plus protocol-relative) and leaves the 16 "no policy supplied" cases passing, which is the exact split it should produce.

## Signatures

Two functions needed the policy and were already long. `validateStyleValues` took six positional arguments, `envelopeRules` ten — past where a call reads by position. A further optional would have sat beside one of a different type with nothing but that type to tell them apart, and a policy lost in a mis-slotted call leaves every URL in the document unasked about.

`validateStyleValues` takes a named options object as its seventh. `envelopeRules` groups its trailing arguments instead, so its arity goes **down** from ten to nine while gaining the policy.

## Not in this PR

Nothing supplies the predicate yet. Wiring `plugin-page-builder`'s configured patterns into it, and having `core/image` and `core/embed` consult the same policy, is the next change.

## Verification

- `blocks-engine`: 1081 tests pass, typecheck clean, lint clean
- The new file is 32 cases; the fix-removed control is recorded above