### PR TITLE
fix(nextly): ask the data before converting a repaired column to JSON

### DIFF
--- a/.changeset/verify-json-before-converting.md
+++ b/.changeset/verify-json-before-converting.md
@@ -1,0 +1,26 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+A repaired legacy column is now checked for JSON contents before it is converted, and the repair refuses without changing anything when the check fails. A field originally declared as text carries the same legacy column shape as a repeater, so the repair could be offered for prose — failing mid-migration on PostgreSQL, and on MySQL leaving the column renamed but unconverted because MySQL commits schema changes as it makes them.

--- a/packages/nextly/src/domains/schema/pipeline/__tests__/precondition-classification.test.ts
+++ b/packages/nextly/src/domains/schema/pipeline/__tests__/precondition-classification.test.ts
@@ -1,0 +1,62 @@
+// A refusal must survive the trip out of the pipeline, or it may as well not carry a reason.
+//
+// The pre-resolution phase can decline to START — when the stored values would not survive a
+// conversion — and that answer names the column, says nothing has changed, and tells the operator
+// what to do instead. Every one of those facts is lost if the refusal is classified as a failed DDL
+// statement: the caller is told a statement failed, which is both untrue and unactionable, and the
+// message it carries is the deliberately generic "Validation failed."
+//
+// The distinction is not cosmetic. "Nothing ran, your schema is untouched, here is the column" and
+// "a statement failed partway" call for opposite responses from whoever reads them.
+
+import { describe, expect, it } from "vitest";
+
+import { NextlyError } from "../../../../errors";
+import { classifyError } from "../errors";
+
+describe("classifying a refused precondition", () => {
+  const refusal = () =>
+    NextlyError.validation({
+      errors: [
+        {
+          path: "posts._body",
+          code: "COLUMN_NOT_CONVERTIBLE",
+          message:
+            'Column "_body" on "posts" holds values that are not valid JSON.',
+        },
+      ],
+    });
+
+  it("is its own outcome, not a DDL failure", () => {
+    expect(classifyError(refusal()).code).toBe("PRECONDITION_FAILED");
+  });
+
+  it("carries the text that names the column, not the generic public message", () => {
+    // `NextlyError.validation` sets `publicMessage` to "Validation failed." and puts the substance
+    // in `publicData`. Reading `.message` here would compile, pass a "did it classify" test, and
+    // hand the operator a failure with no subject.
+    const classified = classifyError(refusal());
+    expect(classified.message).toContain("_body");
+    expect(classified.message).not.toBe("Validation failed.");
+  });
+
+  it("keeps the payload so a caller can render the column and code itself", () => {
+    expect(classifyError(refusal()).details).toMatchObject({
+      errors: [expect.objectContaining({ code: "COLUMN_NOT_CONVERTIBLE" })],
+    });
+  });
+
+  it("still degrades to the public message when the payload carries no text", () => {
+    // The control for the fallback branch: an empty error list must not produce an empty message.
+    const bare = NextlyError.validation({ errors: [] });
+    expect(classifyError(bare).message.length).toBeGreaterThan(0);
+  });
+
+  it("leaves an ordinary error classified as it was", () => {
+    // Without this, widening the classifier could quietly capture unrelated failures and report
+    // every one of them as "nothing ran" — the opposite of the truth.
+    expect(classifyError(new Error("boom")).code).not.toBe(
+      "PRECONDITION_FAILED"
+    );
+  });
+});

--- a/packages/nextly/src/domains/schema/pipeline/__tests__/pushschema-pipeline.test.ts
+++ b/packages/nextly/src/domains/schema/pipeline/__tests__/pushschema-pipeline.test.ts
@@ -21,6 +21,7 @@ import {
 
 import type { SupportedDialect } from "@nextlyhq/adapter-drizzle/types";
 
+import { NextlyError } from "../../../../errors";
 import {
   clearCachedSnapshot,
   clearLiveSnapshots,
@@ -1152,6 +1153,58 @@ describe("PushSchemaPipeline (Option E flow) - error paths", () => {
 
     expect(result.success).toBe(false);
     expect(result.error?.code).toBe("DDL_EXECUTION_FAILED");
+  });
+
+  it("returns a refused precondition as its own outcome, carrying the column", async () => {
+    // The pipeline builds its failure RESULT itself rather than going through `classifyError`, so
+    // teaching that function about preconditions is not enough on its own — this path had the right
+    // code and still reported the generic public message with the raw error as details.
+    //
+    // Both halves are asserted because either alone is satisfiable while the operator still cannot
+    // act: a correct code with no subject, or a subject under a code that says a statement failed.
+    const executePreResImpl = vi
+      .fn<
+        (
+          txOrDb: unknown,
+          ops: Operation[],
+          dialect: SupportedDialect
+        ) => Promise<number>
+      >()
+      .mockRejectedValue(
+        NextlyError.validation({
+          errors: [
+            {
+              path: "dc_posts._body",
+              code: "COLUMN_NOT_CONVERTIBLE",
+              message:
+                'Column "_body" on "dc_posts" holds values that are not valid JSON.',
+            },
+          ],
+        })
+      );
+
+    const { pipeline } = makePipeline({ executePreResImpl });
+
+    const result = await pipeline.apply({
+      desired: onePostsCollection,
+      db: {},
+      dialect: "postgresql",
+      source: "code",
+      promptChannel: "terminal",
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error?.code, "not a failed statement").toBe(
+      "PRECONDITION_FAILED"
+    );
+    expect(result.error?.message, "names the column").toContain("_body");
+    expect(
+      result.error?.message,
+      "and is not the generic public message"
+    ).not.toBe("Validation failed.");
+    expect(result.error?.details, "payload a caller can render").toMatchObject({
+      errors: [expect.objectContaining({ code: "COLUMN_NOT_CONVERTIBLE" })],
+    });
   });
 
   it("journals failure with success: false", async () => {

--- a/packages/nextly/src/domains/schema/pipeline/errors.ts
+++ b/packages/nextly/src/domains/schema/pipeline/errors.ts
@@ -8,10 +8,16 @@
 
 import { UnsupportedDialectVersionError } from "@nextlyhq/adapter-drizzle/version-check";
 
+import { NextlyError } from "../../../errors";
+
 export type SchemaApplyErrorCode =
   | "SCHEMA_VERSION_CONFLICT"
   | "PUSHSCHEMA_FAILED"
   | "DDL_EXECUTION_FAILED"
+  // The apply declined to start, because the database's CONTENTS could not survive it. Distinct
+  // from DDL_EXECUTION_FAILED in the fact that matters most to whoever reads it: nothing ran, so
+  // the schema is exactly as it was. Its `details` carry which column and what to do about it.
+  | "PRECONDITION_FAILED"
   | "CONFIRMATION_DECLINED"
   | "CONFIRMATION_REQUIRED_NO_TTY"
   | "CONNECTION_FAILED"
@@ -27,7 +33,43 @@ export interface ClassifiedError {
 // Translates an unknown thrown value into one of the typed codes.
 // Used by the apply pipeline to convert exceptions into the discriminated
 // failure branch of ApplyResult.
+/**
+ * The operator-facing text for a refused precondition.
+ *
+ * Reads the per-error messages the refusal carried and falls back to the generic public message
+ * only when there are none, so a payload shape this does not recognise degrades to today's
+ * behaviour rather than to an empty string.
+ */
+function preconditionMessage(err: NextlyError): string {
+  const data: unknown = err.publicData;
+  if (data && typeof data === "object" && "errors" in data) {
+    const { errors } = data;
+    if (Array.isArray(errors)) {
+      const texts = errors
+        .map(e =>
+          e && typeof e === "object" && "message" in e ? e.message : undefined
+        )
+        .filter((m): m is string => typeof m === "string" && m.length > 0);
+      if (texts.length > 0) return texts.join(" ");
+    }
+  }
+  return err.message;
+}
+
 export function classifyError(err: unknown): ClassifiedError {
+  // Checked before the generic Error branch: a refused precondition IS a NextlyError, and the
+  // generic branch would flatten it to its public message and lose the payload naming the column.
+  if (NextlyError.isValidation(err)) {
+    return {
+      code: "PRECONDITION_FAILED",
+      // NOT `err.message`: the validation factory sets a deliberately generic public message
+      // ("Validation failed.") and puts the substance in `publicData`. Passing the generic one here
+      // would hand the operator a failure with no subject, which is the whole defect being fixed.
+      message: preconditionMessage(err),
+      details: err.publicData,
+    };
+  }
+
   if (err instanceof UnsupportedDialectVersionError) {
     return {
       code: "UNSUPPORTED_DIALECT_VERSION",

--- a/packages/nextly/src/domains/schema/pipeline/errors.ts
+++ b/packages/nextly/src/domains/schema/pipeline/errors.ts
@@ -34,6 +34,22 @@ export interface ClassifiedError {
 // Used by the apply pipeline to convert exceptions into the discriminated
 // failure branch of ApplyResult.
 /**
+ * How a refused precondition is presented, wherever a failure is built from one.
+ *
+ * There are two places that turn a thrown value into a returned failure — `classifyError` here, and
+ * `PushSchemaPipeline`'s own catch, which constructs its result directly rather than calling this
+ * module. They classify DIFFERENT error families on purpose (the pipeline knows its own typed errors;
+ * this one reads drizzle-kit stack frames), so they are not merged. What they must not do is disagree
+ * about how THIS answer reads, which is why the presentation lives here and both ask for it.
+ */
+export function describePrecondition(err: NextlyError): {
+  message: string;
+  details: unknown;
+} {
+  return { message: preconditionMessage(err), details: err.publicData };
+}
+
+/**
  * The operator-facing text for a refused precondition.
  *
  * Reads the per-error messages the refusal carried and falls back to the generic public message
@@ -60,14 +76,7 @@ export function classifyError(err: unknown): ClassifiedError {
   // Checked before the generic Error branch: a refused precondition IS a NextlyError, and the
   // generic branch would flatten it to its public message and lose the payload naming the column.
   if (NextlyError.isValidation(err)) {
-    return {
-      code: "PRECONDITION_FAILED",
-      // NOT `err.message`: the validation factory sets a deliberately generic public message
-      // ("Validation failed.") and puts the substance in `publicData`. Passing the generic one here
-      // would hand the operator a failure with no subject, which is the whole defect being fixed.
-      message: preconditionMessage(err),
-      details: err.publicData,
-    };
+    return { code: "PRECONDITION_FAILED", ...describePrecondition(err) };
   }
 
   if (err instanceof UnsupportedDialectVersionError) {

--- a/packages/nextly/src/domains/schema/pipeline/pre-resolution/__tests__/conversion-domain.test.ts
+++ b/packages/nextly/src/domains/schema/pipeline/pre-resolution/__tests__/conversion-domain.test.ts
@@ -1,0 +1,107 @@
+// The apply path's conversions must stay inside what the convertibility probe can speak for.
+//
+// Two independent things keep a repaired column safe. The probe answers whether the stored values
+// survive the cast, and it answers that over rows which are NOT NULL — correct for a cast, wrong for
+// a NOT NULL. So the guarantee also depends on the apply path never emitting a statement the probe's
+// question does not cover.
+//
+// `executePreResolutionOps` secures that by calling `conversionForRename` WITHOUT a context, since
+// every nullability and default statement the function can emit is gated on one. That is a coupling
+// between two files held by an omitted argument, and this pins it.
+//
+// 🔴 This test would have been vacuous a day ago: nothing could emit a nullability change, so it
+// would have passed no matter what the code did — the fixture-never-reaches-the-mechanism failure.
+// It has teeth now because `conversionForRename` genuinely emits `change_column_nullable` when it is
+// given a context, which the second case below proves. A future context added at the executor's call
+// site fails here, at build time, instead of reaching a customer's migration.
+
+import { describe, expect, it, vi } from "vitest";
+
+import type { RenameColumnOp } from "../../diff/types";
+import { conversionForRename } from "../../rename-conversion";
+import { COVERED_CONVERSIONS, executePreResolutionOps } from "../executor";
+
+// Spied rather than replaced: the executor gets the real behaviour, and the arguments it passes
+// become observable. Asserting on those is the difference between checking the call site and
+// checking a copy of it — a test that rebuilt the argument list itself would keep passing after
+// someone changed the line it exists to watch.
+vi.mock("../../rename-conversion", async () => {
+  const actual = await vi.importActual<
+    typeof import("../../rename-conversion")
+  >("../../rename-conversion");
+  return { ...actual, conversionForRename: vi.fn(actual.conversionForRename) };
+});
+
+const rename: RenameColumnOp = {
+  type: "rename_column",
+  tableName: "posts",
+  fromColumn: "_body",
+  toColumn: "body",
+  fromType: "text",
+  toType: "jsonb",
+};
+
+// Read as plain strings. Compared at their literal types, TypeScript resolves the second case's
+// assertion statically and rejects it as a comparison that can never hold — which is a fair
+// complaint about the expression and not about the property, since what is being checked is the
+// CONTENTS of the list rather than its type.
+const covered: readonly string[] = COVERED_CONVERSIONS;
+
+describe("the conversions the apply path can emit", () => {
+  it("stay within what the probe covers, on every dialect", () => {
+    for (const dialect of ["postgresql", "mysql", "sqlite"] as const) {
+      // Called exactly as `executePreResolutionOps` calls it: no context.
+      const emitted = conversionForRename(rename, dialect).map(c => c.type);
+      const outside = emitted.filter(type => !covered.includes(type));
+      expect(
+        outside,
+        `${dialect} emitted a statement the probe cannot cover`
+      ).toEqual([]);
+    }
+  });
+
+  it("leave that set as soon as a context is supplied — the positive control", () => {
+    // Without this the test above proves only that the current call emits nothing uncovered, which a
+    // function that could NEVER emit anything uncovered would also satisfy. This shows the boundary
+    // is one argument away, so the assertion above is about the call and not about the callee.
+    const emitted = conversionForRename(rename, "postgresql", {
+      source: { nullable: true },
+      target: { nullable: false },
+    }).map(c => c.type);
+
+    expect(emitted).toContain("change_column_nullable");
+    expect(
+      covered,
+      "and it is deliberately outside the covered set"
+    ).not.toContain("change_column_nullable");
+  });
+
+  it("is asked for those conversions WITHOUT a context, by the executor itself", async () => {
+    // Observed at the real call site. `conversionForRename` emits nullability and default statements
+    // only when it is given a context, so the executor withholding one is what keeps the emitted set
+    // inside the probe's domain. Supplying a context there is a one-word edit with no local symptom,
+    // and this is what turns it into a failing build.
+    const spy = vi.mocked(conversionForRename);
+    spy.mockClear();
+
+    // Records instead of executing: the probe's SELECT resolves to no rows, so the column reads as
+    // convertible and the executor proceeds to the statements under test.
+    const statements: unknown[] = [];
+    const handle = {
+      execute: (query: unknown) => {
+        statements.push(query);
+        return Promise.resolve({ rows: [] });
+      },
+    };
+
+    await executePreResolutionOps(handle, [rename], "postgresql");
+
+    expect(spy).toHaveBeenCalled();
+    for (const call of spy.mock.calls) {
+      expect(
+        call[2],
+        "the executor must not hand conversionForRename a context"
+      ).toBeUndefined();
+    }
+  });
+});

--- a/packages/nextly/src/domains/schema/pipeline/pre-resolution/__tests__/json-convertibility.test.ts
+++ b/packages/nextly/src/domains/schema/pipeline/pre-resolution/__tests__/json-convertibility.test.ts
@@ -1,0 +1,119 @@
+// Where the SQLSTATE lives is a property of the DRIVER, and the driver is a property of the
+// deployment. These cover that dimension without a server.
+//
+// The probe distinguishes "this column holds values that are not JSON" from "the probe could not
+// run", and it does so by reading a SQLSTATE. Drizzle wraps the driver's error, so the code sits on
+// `cause` rather than on the object thrown — and how many wrappers sit between the two differs by
+// transport. A direct TCP connection nests it once; a serverless HTTP driver or a pooler can nest it
+// deeper. Getting that wrong fails in the safe direction, but it fails on the deployment target
+// rather than locally: a genuine bad-data migration would be reported as an infrastructure problem
+// on the production database and never in a local run.
+//
+// A live-server suite cannot cover this, because it can only produce the shape its own driver makes.
+
+import { describe, expect, it } from "vitest";
+
+import { columnHoldsOnlyJson } from "../json-convertibility";
+
+/** A handle whose every query fails with the given error. */
+function failingWith(error: unknown) {
+  return {
+    execute: () => Promise.reject(error),
+  };
+}
+
+/** The shape node-postgres produces, as Drizzle wraps it: one level down. */
+function wrappedOnce(code: string): Error {
+  const driverError = Object.assign(new Error("driver"), { code });
+  return Object.assign(new Error("Failed query"), { cause: driverError });
+}
+
+/** A deeper nesting, as a serverless HTTP driver or a pooler can produce. */
+function wrappedTwice(code: string): Error {
+  return Object.assign(new Error("Failed query"), { cause: wrappedOnce(code) });
+}
+
+/**
+ * Nested far deeper than any driver seen so far.
+ *
+ * The depth is the assertion. A walk bounded to some number of levels passes every shallow case and
+ * only fails here, so without this the difference between "walks the chain" and "walks a few links
+ * of it" is invisible — and that difference is exactly what a different transport would expose, in
+ * production, where the shallow cases all still pass.
+ */
+function wrappedDeeply(code: string, levels = 12): Error {
+  let error: Error = Object.assign(new Error("driver"), { code });
+  for (let i = 0; i < levels; i++) {
+    error = Object.assign(new Error(`wrapper ${i}`), { cause: error });
+  }
+  return error;
+}
+
+describe("columnHoldsOnlyJson — telling bad data apart from a probe that could not run", () => {
+  it("reads a data exception however deeply the driver nests it", async () => {
+    // 22P02 is what the malformed-JSON cast raises. The verdict must not depend on wrapper count.
+    for (const error of [
+      Object.assign(new Error("bare"), { code: "22P02" }),
+      wrappedOnce("22P02"),
+      wrappedTwice("22P02"),
+      wrappedDeeply("22P02"),
+    ]) {
+      await expect(
+        columnHoldsOnlyJson(failingWith(error), "t", "c", "postgresql")
+      ).resolves.toBe(false);
+    }
+  });
+
+  it("re-throws anything that is not a data exception, at every depth", async () => {
+    // 42P01 missing table, 55P03 lock not available, 08006 connection failure. None of these is a
+    // statement about the column's contents, and answering `false` for them would block a valid
+    // migration while telling the operator to go and look at their rows.
+    for (const code of ["42P01", "55P03", "08006"]) {
+      for (const error of [
+        wrappedOnce(code),
+        wrappedTwice(code),
+        wrappedDeeply(code),
+      ]) {
+        await expect(
+          columnHoldsOnlyJson(failingWith(error), "t", "c", "postgresql")
+        ).rejects.toBe(error);
+      }
+    }
+  });
+
+  it("re-throws an error carrying no SQLSTATE at all", async () => {
+    // A thrown string, or a bug in this package, must not be laundered into a verdict about data.
+    const plain = new Error("something else entirely");
+    await expect(
+      columnHoldsOnlyJson(failingWith(plain), "t", "c", "postgresql")
+    ).rejects.toBe(plain);
+  });
+
+  it("terminates on a cause chain that points back at itself", async () => {
+    // `cause` is an ordinary property and nothing stops it forming a cycle.
+    //
+    // This case is only able to FAIL rather than hang because the walk carries a link cap that
+    // throws. Without the cap, dropping the visited-set would spin in a synchronous loop and block
+    // the event loop, so vitest's timeout would never fire and the whole run would stall — an
+    // unfalsifiable guard. With the cap, the same removal ends in a thrown internal error and this
+    // assertion fails cleanly.
+    const looped: { code: string; cause?: unknown } = { code: "42P01" };
+    looped.cause = looped;
+    await expect(
+      columnHoldsOnlyJson(failingWith(looped), "t", "c", "postgresql")
+    ).rejects.toBe(looped);
+  });
+
+  it("asks nothing of SQLite, where JSON is stored as text", async () => {
+    // No cast happens, so no value can be rejected. The handle is deliberately one that would throw
+    // if it were used.
+    await expect(
+      columnHoldsOnlyJson(
+        failingWith(new Error("must not be queried")),
+        "t",
+        "c",
+        "sqlite"
+      )
+    ).resolves.toBe(true);
+  });
+});

--- a/packages/nextly/src/domains/schema/pipeline/pre-resolution/__tests__/rename-converts-type.integration.test.ts
+++ b/packages/nextly/src/domains/schema/pipeline/pre-resolution/__tests__/rename-converts-type.integration.test.ts
@@ -507,3 +507,114 @@ describe("a legacy column holding prose is not converted — MySQL", () => {
     await q.query(`DROP TABLE IF EXISTS \`${jsonTable}\``);
   });
 });
+
+/**
+ * What the probe must NOT refuse, and where it must look.
+ *
+ * The guard exists to stop one specific conversion running against values that cannot survive it.
+ * Two ways for it to be wrong in the other direction, both of which refuse work that was always
+ * valid — and a refusal is as damaging as a bad apply when it blocks every legitimate delta behind
+ * it.
+ */
+describe("the probe's scope — PostgreSQL", () => {
+  const scopeCtx = makeTestContext("postgresql");
+  if (!scopeCtx.available || !scopeCtx.url) {
+    it.skip("Skipping: TEST_POSTGRES_URL not set", () => {});
+    return;
+  }
+
+  let pool: Pool;
+  let db: ReturnType<typeof drizzlePg>;
+
+  beforeAll(async () => {
+    pool = new Pool({ connectionString: scopeCtx.url ?? undefined });
+    db = drizzlePg({ client: pool });
+  });
+
+  afterAll(async () => {
+    await pool.end();
+  });
+
+  it("does not run for a type change that is not into JSON", async () => {
+    // `conversionForRename` emits `change_column_type` for ANY change of type. Gating the probe on
+    // its mere presence asks "is this valid JSON?" of a column becoming `varchar(255)`, and prose
+    // answers no — refusing a rename that was never about JSON at all.
+    const table = `${scopeCtx.prefix}_widen`;
+    await pool.query(`DROP TABLE IF EXISTS "${table}" CASCADE`);
+    await pool.query(
+      `CREATE TABLE "${table}" ("id" text PRIMARY KEY, "_body" text)`
+    );
+    await pool.query(`INSERT INTO "${table}" VALUES ('r1', $1)`, [
+      "the quick brown fox",
+    ]);
+
+    await expect(
+      executePreResolutionOps(
+        db,
+        [
+          {
+            type: "rename_column",
+            tableName: table,
+            fromColumn: "_body",
+            toColumn: "body",
+            fromType: "text",
+            toType: "varchar(255)",
+          },
+        ] as Operation[],
+        "postgresql"
+      )
+    ).resolves.toBe(1);
+
+    const after = await pool.query<{ body: string }>(
+      `SELECT "body" FROM "${table}" WHERE id = 'r1'`
+    );
+    expect(after.rows[0]?.body, "the prose came with it").toBe(
+      "the quick brown fox"
+    );
+    await pool.query(`DROP TABLE IF EXISTS "${table}" CASCADE`);
+  });
+
+  it("asks the table its PRE-rename name when the table is renamed too", async () => {
+    // Column operations carry the table's post-rename name, because they normally run after
+    // `rename_table`. This preflight runs before everything, so the new name does not exist yet:
+    // probing it hits a missing table, and — correctly — that now propagates rather than being
+    // read as bad data, so the whole apply dies on a rename that was fine.
+    const oldName = `${scopeCtx.prefix}_before`;
+    const newName = `${scopeCtx.prefix}_after`;
+    await pool.query(`DROP TABLE IF EXISTS "${oldName}" CASCADE`);
+    await pool.query(`DROP TABLE IF EXISTS "${newName}" CASCADE`);
+    await pool.query(
+      `CREATE TABLE "${oldName}" ("id" text PRIMARY KEY, "_body" text)`
+    );
+    await pool.query(`INSERT INTO "${oldName}" VALUES ('r1', $1)`, [
+      JSON.stringify({ ok: 1 }),
+    ]);
+
+    await expect(
+      executePreResolutionOps(
+        db,
+        [
+          { type: "rename_table", fromName: oldName, toName: newName },
+          {
+            type: "rename_column",
+            tableName: newName,
+            fromColumn: "_body",
+            toColumn: "body",
+            fromType: "text",
+            toType: "jsonb",
+          },
+        ] as Operation[],
+        "postgresql"
+      )
+    ).resolves.toBe(2);
+
+    const shape = await pool.query<{ data_type: string }>(
+      `SELECT data_type FROM information_schema.columns WHERE table_name = $1 AND column_name = 'body'`,
+      [newName]
+    );
+    expect(shape.rows[0]?.data_type, "and the conversion still happened").toBe(
+      "jsonb"
+    );
+    await pool.query(`DROP TABLE IF EXISTS "${newName}" CASCADE`);
+  });
+});

--- a/packages/nextly/src/domains/schema/pipeline/pre-resolution/__tests__/rename-converts-type.integration.test.ts
+++ b/packages/nextly/src/domains/schema/pipeline/pre-resolution/__tests__/rename-converts-type.integration.test.ts
@@ -198,3 +198,312 @@ describe("a rename that also changes the column's type — MySQL", () => {
     ]);
   });
 });
+
+/**
+ * The same shape, holding prose instead of JSON — and the repair must refuse it.
+ *
+ * A leading underscore proves the old builder wrote the column. It does not prove what the column
+ * contains: the underscore affected every field type, so a field once declared as ordinary text
+ * carries `_body` too. Change that field to a repeater and the pair is indistinguishable from a
+ * genuine legacy repeater by name, by SQL type, and by anything else the schema records.
+ *
+ * On MySQL the refusal has to come BEFORE the rename. DDL commits implicitly there, so a conversion
+ * refused one statement later leaves the column renamed and unconverted with nothing able to take it
+ * back — which is why these assert the OLD name still resolves afterwards, not merely that the call
+ * rejected.
+ */
+describe("a legacy column holding prose is not converted — PostgreSQL", () => {
+  const proseCtx = makeTestContext("postgresql");
+  if (!proseCtx.available || !proseCtx.url) {
+    it.skip("Skipping: TEST_POSTGRES_URL not set", () => {});
+    return;
+  }
+
+  const table = `${proseCtx.prefix}_prose`;
+  let pool: Pool;
+  let db: ReturnType<typeof drizzlePg>;
+
+  beforeAll(async () => {
+    pool = new Pool({ connectionString: proseCtx.url ?? undefined });
+    db = drizzlePg({ client: pool });
+  });
+
+  afterAll(async () => {
+    await pool.query(`DROP TABLE IF EXISTS "${table}" CASCADE`);
+    await pool.end();
+  });
+
+  it("refuses, and leaves the column exactly as it was", async () => {
+    await pool.query(`DROP TABLE IF EXISTS "${table}" CASCADE`);
+    await pool.query(
+      `CREATE TABLE "${table}" ("id" text PRIMARY KEY, "_body" text)`
+    );
+    // Prose, which is what a text field held before someone changed it to a repeater.
+    await pool.query(`INSERT INTO "${table}" VALUES ('r1', $1)`, [
+      "the quick brown fox",
+    ]);
+
+    const ops: Operation[] = [
+      {
+        type: "rename_column",
+        tableName: table,
+        fromColumn: "_body",
+        toColumn: "body",
+        fromType: "text",
+        toType: "jsonb",
+      },
+    ];
+
+    // Asserted on the typed payload rather than the message: `NextlyError.validation` sets a generic
+    // public message and carries the detail in `publicData`, so matching on text would pass for any
+    // validation failure at all.
+    await expect(
+      executePreResolutionOps(db, ops, "postgresql")
+    ).rejects.toMatchObject({
+      code: "VALIDATION_ERROR",
+      publicData: {
+        errors: [expect.objectContaining({ code: "COLUMN_NOT_CONVERTIBLE" })],
+      },
+    });
+
+    // Nothing ran: the column still answers to its old name and still holds what it held.
+    const after = await pool.query<{ _body: string }>(
+      `SELECT "_body" FROM "${table}" WHERE id = 'r1'`
+    );
+    expect(after.rows[0]?._body).toBe("the quick brown fox");
+  });
+
+  it("refuses when only a LATER row is prose", async () => {
+    // The row order is the test. A probe that stops at the first row satisfying it — anything
+    // shaped `WHERE c::jsonb IS NOT NULL LIMIT 1` — reports this column convertible on the strength
+    // of row one and never reads row two, and the conversion then fails on the row the probe
+    // skipped. That is the mid-apply failure the guard exists to prevent, so it has to be the case
+    // the guard is measured against.
+    const mixed = `${proseCtx.prefix}_mixed`;
+    await pool.query(`DROP TABLE IF EXISTS "${mixed}" CASCADE`);
+    await pool.query(
+      `CREATE TABLE "${mixed}" ("id" text PRIMARY KEY, "_body" text)`
+    );
+    await pool.query(`INSERT INTO "${mixed}" VALUES ('r1', $1), ('r2', $2)`, [
+      JSON.stringify({ ok: 1 }),
+      "the quick brown fox",
+    ]);
+
+    await expect(
+      executePreResolutionOps(
+        db,
+        [
+          {
+            type: "rename_column",
+            tableName: mixed,
+            fromColumn: "_body",
+            toColumn: "body",
+            fromType: "text",
+            toType: "jsonb",
+          },
+        ] as Operation[],
+        "postgresql"
+      )
+    ).rejects.toMatchObject({
+      code: "VALIDATION_ERROR",
+      publicData: {
+        errors: [expect.objectContaining({ code: "COLUMN_NOT_CONVERTIBLE" })],
+      },
+    });
+
+    const after = await pool.query<{ column_name: string }>(
+      `SELECT column_name FROM information_schema.columns WHERE table_name = $1`,
+      [mixed]
+    );
+    expect(after.rows.map(r => r.column_name)).toContain("_body");
+    await pool.query(`DROP TABLE IF EXISTS "${mixed}" CASCADE`);
+  });
+
+  it("reports a probe that could not run as itself, not as bad data", async () => {
+    // A guard that reads every error as "unconvertible" gives the operator a confident, specific and
+    // wrong diagnosis: it names their data when the real cause is a missing table, a lock timeout or
+    // a permission. They then go looking in the rows. The probe raises SQLSTATE 22P02 for malformed
+    // JSON and 42P01 for a table that is not there, and only the data class may answer the question.
+    const missing = `${proseCtx.prefix}_absent`;
+
+    await expect(
+      executePreResolutionOps(
+        db,
+        [
+          {
+            type: "rename_column",
+            tableName: missing,
+            fromColumn: "_body",
+            toColumn: "body",
+            fromType: "text",
+            toType: "jsonb",
+          },
+        ] as Operation[],
+        "postgresql"
+      )
+      // Asserted on the cause, because Drizzle wraps the driver error and the SQLSTATE stays on the
+      // original underneath — which is also why the guard walks the chain rather than reading the
+      // top object.
+    ).rejects.toMatchObject({ cause: { code: "42P01" } });
+  });
+
+  it("still converts a column that does hold JSON", async () => {
+    // The positive control. A guard that refused everything would satisfy the cases above while
+    // breaking the repair this programme exists to provide.
+    const jsonTable = `${proseCtx.prefix}_json_ok`;
+    await pool.query(`DROP TABLE IF EXISTS "${jsonTable}" CASCADE`);
+    await pool.query(
+      `CREATE TABLE "${jsonTable}" ("id" text PRIMARY KEY, "_body" text)`
+    );
+    await pool.query(`INSERT INTO "${jsonTable}" VALUES ('r1', $1)`, [
+      JSON.stringify([{ label: "one" }]),
+    ]);
+
+    await executePreResolutionOps(
+      db,
+      [
+        {
+          type: "rename_column",
+          tableName: jsonTable,
+          fromColumn: "_body",
+          toColumn: "body",
+          fromType: "text",
+          toType: "jsonb",
+        },
+      ] as Operation[],
+      "postgresql"
+    );
+
+    const shape = await pool.query<{ data_type: string }>(
+      `SELECT data_type FROM information_schema.columns WHERE table_name = $1 AND column_name = 'body'`,
+      [jsonTable]
+    );
+    expect(shape.rows[0]?.data_type).toBe("jsonb");
+    await pool.query(`DROP TABLE IF EXISTS "${jsonTable}" CASCADE`);
+  });
+});
+
+/**
+ * The same refusal on MySQL, where getting it wrong is not recoverable.
+ *
+ * PostgreSQL runs the whole apply inside a transaction, so a conversion that fails mid-way rolls
+ * back and the operator is merely inconvenienced. MySQL commits DDL as it makes it: a rename that
+ * has already executed stays executed, and no rollback exists to undo it. That makes the ordering —
+ * ask first, then execute — the entire substance of the guard here rather than a nicety, and it can
+ * only be shown against a live server that really does auto-commit.
+ */
+describe("a legacy column holding prose is not converted — MySQL", () => {
+  if (!mysqlCtx.available || !mysqlCtx.url) {
+    it.skip("Skipping: TEST_MYSQL_URL not set", () => {});
+    return;
+  }
+
+  const table = `${mysqlCtx.prefix}_prose`;
+  let pool: MysqlPool;
+  // Held as the executor's own parameter type, for the reason given on the suite above: naming
+  // drizzle's generic makes two structurally identical instantiations collide under `check-types`.
+  let db: unknown;
+
+  beforeAll(() => {
+    pool = createPool({ uri: mysqlCtx.url as string });
+    db = drizzleMysql({ client: pool });
+  });
+
+  afterAll(async () => {
+    await pool.promise().query(`DROP TABLE IF EXISTS \`${table}\``);
+    await new Promise<void>(res => pool.end(() => res()));
+  });
+
+  it("refuses before renaming, so the column is left whole", async () => {
+    const q = pool.promise();
+    await q.query(`DROP TABLE IF EXISTS \`${table}\``);
+    await q.query(
+      `CREATE TABLE \`${table}\` (\`id\` varchar(36) PRIMARY KEY, \`_body\` text)`
+    );
+    await q.query(`INSERT INTO \`${table}\` VALUES ('r1', ?)`, [
+      "the quick brown fox",
+    ]);
+
+    await expect(
+      executePreResolutionOps(
+        db,
+        [
+          {
+            type: "rename_column",
+            tableName: table,
+            fromColumn: "_body",
+            toColumn: "body",
+            fromType: "text",
+            toType: "json",
+          },
+        ] as Operation[],
+        "mysql"
+      )
+    ).rejects.toMatchObject({
+      code: "VALIDATION_ERROR",
+      publicData: {
+        errors: [expect.objectContaining({ code: "COLUMN_NOT_CONVERTIBLE" })],
+      },
+    });
+
+    // The assertion the dialect exists for. A refusal raised one statement too late would still
+    // reject, and `_body` would already be gone with no transaction able to bring it back.
+    const [cols] = await q.query(
+      `SELECT COLUMN_NAME FROM information_schema.columns
+       WHERE table_schema = DATABASE() AND table_name = ?`,
+      [table]
+    );
+    const names = (cols as Array<{ COLUMN_NAME: string }>).map(
+      c => c.COLUMN_NAME
+    );
+    expect(names, "the rename did not run").toContain("_body");
+    expect(names).not.toContain("body");
+
+    const [rows] = await q.query(
+      `SELECT \`_body\` FROM \`${table}\` WHERE \`id\` = 'r1'`
+    );
+    expect((rows as Array<{ _body: string }>)[0]?._body).toBe(
+      "the quick brown fox"
+    );
+  });
+
+  it("still converts a column that does hold JSON", async () => {
+    // The positive control: without it, a guard that refused every MySQL conversion would pass the
+    // test above while removing the repair entirely.
+    const q = pool.promise();
+    const jsonTable = `${mysqlCtx.prefix}_json_ok`;
+    await q.query(`DROP TABLE IF EXISTS \`${jsonTable}\``);
+    await q.query(
+      `CREATE TABLE \`${jsonTable}\` (\`id\` varchar(36) PRIMARY KEY, \`_body\` text)`
+    );
+    await q.query(`INSERT INTO \`${jsonTable}\` VALUES ('r1', ?)`, [
+      JSON.stringify([{ label: "one" }]),
+    ]);
+
+    await expect(
+      executePreResolutionOps(
+        db,
+        [
+          {
+            type: "rename_column",
+            tableName: jsonTable,
+            fromColumn: "_body",
+            toColumn: "body",
+            fromType: "text",
+            toType: "json",
+          },
+        ] as Operation[],
+        "mysql"
+      )
+    ).resolves.toBe(1);
+
+    const [cols] = await q.query(
+      `SELECT COLUMN_NAME, DATA_TYPE FROM information_schema.columns
+       WHERE table_schema = DATABASE() AND table_name = ?`,
+      [jsonTable]
+    );
+    const columns = cols as Array<{ COLUMN_NAME: string; DATA_TYPE: string }>;
+    expect(columns.find(c => c.COLUMN_NAME === "body")?.DATA_TYPE).toBe("json");
+    await q.query(`DROP TABLE IF EXISTS \`${jsonTable}\``);
+  });
+});

--- a/packages/nextly/src/domains/schema/pipeline/pre-resolution/executor.ts
+++ b/packages/nextly/src/domains/schema/pipeline/pre-resolution/executor.ts
@@ -36,7 +36,7 @@ import { isPreResolutionOp, type Operation } from "../diff/types";
 import { conversionForRename } from "../rename-conversion";
 import { generateSQL } from "../sql-templates/index";
 
-import { columnHoldsOnlyJson } from "./json-convertibility";
+import { columnHoldsOnlyJson, isJsonTarget } from "./json-convertibility";
 
 interface AsyncExecuteHandle {
   execute(query: unknown): Promise<unknown>;
@@ -132,10 +132,25 @@ async function assertConversionsAreSafe(
   ordered: Operation[],
   dialect: SupportedDialect
 ): Promise<void> {
+  // The name each table answers to RIGHT NOW. Column ops carry the table's post-rename name,
+  // because they normally run after `rename_table` — but this runs before anything at all, so the
+  // new name does not exist yet and probing it would fail on a table that is merely about to be
+  // called that.
+  const currentTableName = new Map<string, string>();
+  for (const op of ordered) {
+    if (op.type === "rename_table")
+      currentTableName.set(op.toName, op.fromName);
+  }
+
   for (const op of ordered) {
     if (op.type !== "rename_column") continue;
     const conversions = conversionForRename(op, dialect);
-    const converts = conversions.some(c => c.type === "change_column_type");
+    // Only a conversion INTO json is a question this probe can answer. Any change of type at all
+    // produces `change_column_type`, so gating on its mere presence would run a JSON check against a
+    // column becoming `varchar(255)` or `bigint` and refuse an ordinary rename as unconvertible.
+    const converts = conversions.some(
+      c => c.type === "change_column_type" && isJsonTarget(c.toType)
+    );
     if (!converts) continue;
 
     // The probe reads rows that are NOT NULL, because a NULL cannot make a cast fail. It can make a
@@ -165,10 +180,12 @@ async function assertConversionsAreSafe(
       });
     }
 
-    // The column still answers to its OLD name: nothing has run yet.
+    // Both names as the database currently has them: nothing has run yet, so neither the table's
+    // new name nor the column's exists.
+    const liveTable = currentTableName.get(op.tableName) ?? op.tableName;
     const safe = await columnHoldsOnlyJson(
       txOrDb,
-      op.tableName,
+      liveTable,
       op.fromColumn,
       dialect
     );
@@ -177,10 +194,10 @@ async function assertConversionsAreSafe(
     throw NextlyError.validation({
       errors: [
         {
-          path: `${op.tableName}.${op.fromColumn}`,
+          path: `${liveTable}.${op.fromColumn}`,
           code: "COLUMN_NOT_CONVERTIBLE",
           message:
-            `Column "${op.fromColumn}" on "${op.tableName}" holds values that are not valid JSON, ` +
+            `Column "${op.fromColumn}" on "${liveTable}" holds values that are not valid JSON, ` +
             `so renaming it to "${op.toColumn}" as a JSON column would lose them. Nothing has been ` +
             `changed. Remove the field and add it again if the existing values are not needed, or ` +
             `correct the stored values first.`,

--- a/packages/nextly/src/domains/schema/pipeline/pre-resolution/executor.ts
+++ b/packages/nextly/src/domains/schema/pipeline/pre-resolution/executor.ts
@@ -27,6 +27,7 @@
 import type { SupportedDialect } from "@nextlyhq/adapter-drizzle/types";
 import { sql } from "drizzle-orm";
 
+import { NextlyError } from "../../../../errors";
 import { isPreResolutionOp, type Operation } from "../diff/types";
 // F11 PR 3: SQL-template generation moved to the shared sql-templates/
 // module (pipeline/sql-templates/) so both the apply pipeline (renames +
@@ -34,6 +35,8 @@ import { isPreResolutionOp, type Operation } from "../diff/types";
 // templates. Eliminates the byte-identical-SQL drift risk.
 import { conversionForRename } from "../rename-conversion";
 import { generateSQL } from "../sql-templates/index";
+
+import { columnHoldsOnlyJson } from "./json-convertibility";
 
 interface AsyncExecuteHandle {
   execute(query: unknown): Promise<unknown>;
@@ -58,6 +61,14 @@ export async function executePreResolutionOps(
   if (preOps.length === 0) return 0;
 
   const ordered = orderForExecution(preOps);
+
+  // Asked before anything executes, while every column still has the name it was found under.
+  //
+  // A conversion refused by the engine is recoverable on PostgreSQL, where the whole apply is in a
+  // transaction. On MySQL it is not: DDL commits implicitly, so a rename that has already run stays
+  // run, and the column is left renamed and unconverted with nothing able to take it back. The only
+  // safe moment to discover that the data will not convert is before the first statement.
+  await assertConversionsAreSafe(txOrDb, ordered, dialect);
 
   for (const op of ordered) {
     const sqlString = sqlForOp(op, dialect);
@@ -85,6 +96,92 @@ export async function executePreResolutionOps(
   }
 
   return ordered.length;
+}
+
+/**
+ * The conversion statements the convertibility probe's question actually covers.
+ *
+ * - `change_column_type` is the statement being guarded: the probe asks whether every stored value
+ *   survives it.
+ * - `change_column_default` touches no stored row. A default applies to writes that have not
+ *   happened, so no existing value can make it fail and the probe has nothing to say about it.
+ *
+ * Absent, deliberately: `change_column_nullable`, which fails on precisely the NULL rows the probe
+ * filters out.
+ */
+const COVERED_CONVERSIONS = [
+  "change_column_type",
+  "change_column_default",
+] as const;
+
+const PROBE_COVERS: ReadonlySet<string> = new Set(COVERED_CONVERSIONS);
+
+/**
+ * Refuse the whole apply when a repair would convert a column whose contents cannot survive it.
+ *
+ * The rename is offered on the strength of the column's NAME — a leading underscore only the old
+ * builder writes. That establishes the column is legacy and says nothing about what is in it, and
+ * the underscore affected every field type: a field once declared as ordinary text carries the same
+ * shape, holding prose rather than serialized JSON.
+ *
+ * Refusing here costs the operator a failed command and their data intact. Discovering it one
+ * statement later costs them a half-changed schema on MySQL.
+ */
+async function assertConversionsAreSafe(
+  txOrDb: unknown,
+  ordered: Operation[],
+  dialect: SupportedDialect
+): Promise<void> {
+  for (const op of ordered) {
+    if (op.type !== "rename_column") continue;
+    const conversions = conversionForRename(op, dialect);
+    const converts = conversions.some(c => c.type === "change_column_type");
+    if (!converts) continue;
+
+    // The probe reads rows that are NOT NULL, because a NULL cannot make a cast fail. It can make a
+    // NOT NULL fail, so a conversion carrying a nullability change would be guarded by a question
+    // asked over the wrong rows — and would still look guarded.
+    //
+    // Stated as what the probe DOES cover, so that an op kind added to `conversionForRename` later
+    // is refused until someone decides it is covered. A list of what to reject would instead be a
+    // list of the cases already thought of, and would say nothing about the one that does not exist
+    // yet: exactly how a check ends up silently permitting what it was built to catch.
+    const unguarded = conversions.find(c => !PROBE_COVERS.has(c.type));
+    if (unguarded) {
+      throw NextlyError.internal({
+        logContext: {
+          reason:
+            "a rename conversion carries a statement the convertibility probe does not cover",
+          operation: unguarded.type,
+          table: op.tableName,
+          column: op.fromColumn,
+        },
+      });
+    }
+
+    // The column still answers to its OLD name: nothing has run yet.
+    const safe = await columnHoldsOnlyJson(
+      txOrDb,
+      op.tableName,
+      op.fromColumn,
+      dialect
+    );
+    if (safe) continue;
+
+    throw NextlyError.validation({
+      errors: [
+        {
+          path: `${op.tableName}.${op.fromColumn}`,
+          code: "COLUMN_NOT_CONVERTIBLE",
+          message:
+            `Column "${op.fromColumn}" on "${op.tableName}" holds values that are not valid JSON, ` +
+            `so renaming it to "${op.toColumn}" as a JSON column would lose them. Nothing has been ` +
+            `changed. Remove the field and add it again if the existing values are not needed, or ` +
+            `correct the stored values first.`,
+        },
+      ],
+    });
+  }
 }
 
 // Returns ops sorted into the execution-safe order described above.

--- a/packages/nextly/src/domains/schema/pipeline/pre-resolution/executor.ts
+++ b/packages/nextly/src/domains/schema/pipeline/pre-resolution/executor.ts
@@ -109,7 +109,7 @@ export async function executePreResolutionOps(
  * Absent, deliberately: `change_column_nullable`, which fails on precisely the NULL rows the probe
  * filters out.
  */
-const COVERED_CONVERSIONS = [
+export const COVERED_CONVERSIONS = [
   "change_column_type",
   "change_column_default",
 ] as const;
@@ -155,6 +155,12 @@ async function assertConversionsAreSafe(
           operation: unguarded.type,
           table: op.tableName,
           column: op.fromColumn,
+          // Named so the obvious response is to widen the probe. A refusal that only says no gets
+          // resolved under deadline by deleting the check.
+          remedy:
+            `The probe reads only rows that are NOT NULL, so it cannot speak for "${unguarded.type}". ` +
+            `Widen columnHoldsOnlyJson to cover it and add it to COVERED_CONVERSIONS before this ` +
+            `op runs on this path.`,
         },
       });
     }

--- a/packages/nextly/src/domains/schema/pipeline/pre-resolution/json-convertibility.ts
+++ b/packages/nextly/src/domains/schema/pipeline/pre-resolution/json-convertibility.ts
@@ -37,9 +37,17 @@ interface SqliteRunHandle {
   all(query: unknown): unknown;
 }
 
-/** Quote an identifier for the dialect. */
-function q(name: string, dialect: SupportedDialect): string {
-  return dialect === "mysql" ? `\`${name}\`` : `"${name}"`;
+/**
+ * Whether a destination type is one this probe can speak for.
+ *
+ * The question asked here is "does this text parse as JSON", so it means something only when the
+ * column is BECOMING json. `conversionForRename` emits `change_column_type` for any change of type
+ * at all — `text` to `varchar(255)`, `integer` to `bigint` — and running a JSON check against a
+ * column becoming `varchar` would reject ordinary prose as unconvertible, refusing a rename that was
+ * always valid.
+ */
+export function isJsonTarget(toType: string): boolean {
+  return /^jsonb?$/i.test(toType.trim());
 }
 
 /**
@@ -88,15 +96,15 @@ export async function columnHoldsOnlyJson(
   // SQLite stores JSON as text, so nothing is reinterpreted and nothing can fail.
   if (dialect === "sqlite") return true;
 
-  const table = q(tableName, dialect);
-  const column = q(columnName, dialect);
+  // Composed with Drizzle's identifier primitive rather than interpolated into a string, so the
+  // dialect's own quoting rules apply and a table or column name can never be read as SQL.
+  const table = sql.identifier(tableName);
+  const column = sql.identifier(columnName);
 
   if (dialect === "mysql") {
     const handle = txOrDb as AsyncExecuteHandle;
     const rows = await handle.execute(
-      sql.raw(
-        `SELECT 1 FROM ${table} WHERE ${column} IS NOT NULL AND NOT JSON_VALID(${column}) LIMIT 1`
-      )
+      sql`SELECT 1 FROM ${table} WHERE ${column} IS NOT NULL AND NOT JSON_VALID(${column}) LIMIT 1`
     );
     return countedRows(rows) === 0;
   }
@@ -104,9 +112,7 @@ export async function columnHoldsOnlyJson(
   const handle = txOrDb as AsyncExecuteHandle;
   try {
     await handle.execute(
-      sql.raw(
-        `SELECT count(${column}::jsonb) FROM ${table} WHERE ${column} IS NOT NULL`
-      )
+      sql`SELECT count(${column}::jsonb) FROM ${table} WHERE ${column} IS NOT NULL`
     );
     return true;
   } catch (error) {

--- a/packages/nextly/src/domains/schema/pipeline/pre-resolution/json-convertibility.ts
+++ b/packages/nextly/src/domains/schema/pipeline/pre-resolution/json-convertibility.ts
@@ -1,0 +1,191 @@
+/**
+ * Whether a text column's contents survive being reinterpreted as JSON.
+ *
+ * ## Why a name cannot answer this
+ *
+ * The legacy repair is offered for a column pair shaped `_body` -> `body`, because a leading
+ * underscore can only have been written by the old builder — field names cannot start with one. That
+ * proves the column is LEGACY. It does not prove what the column CONTAINS.
+ *
+ * The underscore affected every field type, not only repeaters and groups. So a field originally
+ * declared as ordinary text also carries a `_body` column, and changing that field to a repeater
+ * during an upgrade produces exactly the same pair while the stored values are prose. Nothing in the
+ * schema distinguishes the two: snapshots and rename operations carry the SQL type, never the
+ * declared field type, and both cases read `text` -> `json`.
+ *
+ * The evidence is therefore in the data, and this asks it.
+ *
+ * ## Why it must run before the rename
+ *
+ * MySQL commits DDL implicitly. A conversion attempted after the rename and refused by the engine
+ * leaves the column renamed and unconverted, with no transaction able to take it back. So the
+ * question has to be answered while the column still has its old name and nothing has been changed.
+ *
+ * @module domains/schema/pipeline/pre-resolution/json-convertibility
+ */
+
+import type { SupportedDialect } from "@nextlyhq/adapter-drizzle/types";
+import { sql } from "drizzle-orm";
+
+import { NextlyError } from "../../../../errors";
+
+interface AsyncExecuteHandle {
+  execute(query: unknown): Promise<unknown>;
+}
+
+interface SqliteRunHandle {
+  all(query: unknown): unknown;
+}
+
+/** Quote an identifier for the dialect. */
+function q(name: string, dialect: SupportedDialect): string {
+  return dialect === "mysql" ? `\`${name}\`` : `"${name}"`;
+}
+
+/**
+ * Whether every non-null value in the column parses as JSON.
+ *
+ * The two servers answer differently, and both answers are exact rather than heuristic:
+ *
+ * - **MySQL** has `JSON_VALID`, so a single row matching `NOT JSON_VALID(c)` is a counterexample.
+ *   `LIMIT 1` is safe in that direction: the query stops at the first row that PROVES the column
+ *   unconvertible, and proving it convertible still requires reaching the end.
+ * - **PostgreSQL** has no version-independent predicate — `pg_input_is_valid` arrives in 16 and the
+ *   matrix tests 15 — so the cast itself is the test. `c::jsonb` RAISES on the first value it cannot
+ *   parse, and that raise is the answer. Catching it is not swallowing an error; it is reading the
+ *   only exact signal the server offers on every supported version.
+ *
+ * The PostgreSQL query must force the cast over EVERY row, which is why it aggregates rather than
+ * selecting with a `LIMIT`. A `SELECT ... WHERE c::jsonb IS NOT NULL LIMIT 1` stops as soon as one
+ * row satisfies it, so a column whose first row is valid JSON and whose second is prose answers
+ * "convertible" — and the conversion then fails on the row the probe never looked at, which is the
+ * exact mid-apply failure this exists to prevent. `count(c::jsonb)` has no early exit.
+ *
+ * A guess would not do here either. Deciding by a prefix like `^\s*[[{]` accepts `{oops` and would
+ * hand the operator a conversion that still fails.
+ *
+ * ## What this does NOT answer
+ *
+ * Both queries skip NULL rows, which is right for the cast and only for the cast: `NULL::jsonb` is
+ * NULL and raises nothing, so a NULL row cannot make a conversion fail. It would make a NOT NULL
+ * fail — so if a conversion ever carries a nullability change alongside the type change, the rows
+ * that break it are precisely the ones filtered out here and this probe would report safe.
+ *
+ * That is unreachable today: `executePreResolutionOps` calls `conversionForRename` without a
+ * context, and every nullability and default statement it can emit is gated on one.
+ *
+ * That coupling is enforced rather than described. The caller refuses outright if a conversion ever
+ * arrives carrying a nullability change, because the alternative is a probe that reads the wrong
+ * rows while still looking correct — and noticing that by hand requires the person changing the call
+ * site to first realise there is anything to notice.
+ */
+export async function columnHoldsOnlyJson(
+  txOrDb: unknown,
+  tableName: string,
+  columnName: string,
+  dialect: SupportedDialect
+): Promise<boolean> {
+  // SQLite stores JSON as text, so nothing is reinterpreted and nothing can fail.
+  if (dialect === "sqlite") return true;
+
+  const table = q(tableName, dialect);
+  const column = q(columnName, dialect);
+
+  if (dialect === "mysql") {
+    const handle = txOrDb as AsyncExecuteHandle;
+    const rows = await handle.execute(
+      sql.raw(
+        `SELECT 1 FROM ${table} WHERE ${column} IS NOT NULL AND NOT JSON_VALID(${column}) LIMIT 1`
+      )
+    );
+    return countedRows(rows) === 0;
+  }
+
+  const handle = txOrDb as AsyncExecuteHandle;
+  try {
+    await handle.execute(
+      sql.raw(
+        `SELECT count(${column}::jsonb) FROM ${table} WHERE ${column} IS NOT NULL`
+      )
+    );
+    return true;
+  } catch (error) {
+    // Only a DATA exception answers the question. SQLSTATE class 22 is exactly that class, and the
+    // malformed-JSON cast raises 22P02 within it.
+    //
+    // Anything else means the probe could not run rather than that the column is unconvertible: a
+    // missing table is 42P01, a lock timeout 55P03, a dropped connection class 08. Reporting those
+    // as bad data would block a legitimate migration and send the operator to look at their rows
+    // for a problem that is in their permissions or their cluster.
+    if (isDataException(error)) return false;
+    throw error;
+  }
+}
+
+/**
+ * Whether a driver error carries a SQLSTATE in class 22 — PostgreSQL's data-exception class.
+ *
+ * The chain is walked because Drizzle wraps the driver's error in a `DrizzleQueryError` and the
+ * SQLSTATE stays on the original underneath. Reading `code` off the top object alone finds nothing
+ * and would send every real cast failure past this check.
+ *
+ * It walks to the END of the chain rather than a fixed number of levels, because the wrapper count
+ * is a property of the deployment and not of this code: a serverless HTTP driver or a pooler can nest
+ * the driver's error deeper than a direct TCP connection does. A bound that fits the development
+ * database would quietly stop finding the code on the one the product is deployed against.
+ *
+ * Termination comes from remembering what has been visited, since `cause` is an ordinary property
+ * and nothing stops it pointing back. `MAX_CAUSE_LINKS` is a different quantity from the depth bound
+ * just described and exists for a different reason: it is not a limit on how deep a legitimate chain
+ * may go, it is the point past which the structure is malformed rather than deep. It THROWS instead
+ * of returning, because a walk that quietly stopped early would answer "not a data exception" and
+ * report a real bad-data column as an infrastructure failure — silence in the same place the rest of
+ * this module refuses to be silent.
+ */
+const MAX_CAUSE_LINKS = 100;
+
+function isDataException(error: unknown): boolean {
+  const seen = new Set<object>();
+  let current: unknown = error;
+  while (current && typeof current === "object" && !seen.has(current)) {
+    if (seen.size >= MAX_CAUSE_LINKS) {
+      throw NextlyError.internal({
+        cause: error instanceof Error ? error : undefined,
+        logContext: {
+          reason: "error cause chain exceeded its sanity limit",
+          maxCauseLinks: MAX_CAUSE_LINKS,
+        },
+      });
+    }
+    seen.add(current);
+    if ("code" in current) {
+      const { code } = current;
+      if (typeof code === "string" && code.startsWith("22")) return true;
+    }
+    current = "cause" in current ? current.cause : undefined;
+  }
+  return false;
+}
+
+/**
+ * How many rows a driver reported, across the shapes the two servers return.
+ *
+ * mysql2 hands back `[rows, fields]`; node-postgres hands back `{ rows }`. Reading `.length` off the
+ * wrong one silently answers zero, which here would report a column convertible when it is not.
+ */
+function countedRows(result: unknown): number {
+  if (Array.isArray(result)) {
+    const first = result[0];
+    return Array.isArray(first) ? first.length : result.length;
+  }
+  if (result && typeof result === "object" && "rows" in result) {
+    // `in` narrows the property into existence and TypeScript types it `unknown`, which is exactly
+    // what the Array.isArray guard below is for. No assertion needed.
+    const { rows } = result;
+    return Array.isArray(rows) ? rows.length : 0;
+  }
+  return 0;
+}
+
+/** Kept for the SQLite handle shape so the port stays honest about what it accepts. */
+export type ConvertibilityHandle = AsyncExecuteHandle | SqliteRunHandle;

--- a/packages/nextly/src/domains/schema/pipeline/pushschema-pipeline.ts
+++ b/packages/nextly/src/domains/schema/pipeline/pushschema-pipeline.ts
@@ -58,6 +58,7 @@ import {
 import { diffSnapshots } from "./diff/diff";
 import { introspectLiveSnapshot } from "./diff/introspect-live";
 import type { Operation, NextlySchemaSnapshot } from "./diff/types";
+import { describePrecondition } from "./errors";
 // Index restore uses the all-dialect templates, not ddl-emitter/: that module
 // is the PostgreSQL fast path and throws for the dialect this exists for.
 import {
@@ -1334,7 +1335,17 @@ export class PushSchemaPipeline {
       };
     } catch (err) {
       const code = this.classifyErrorCode(err);
-      const message = err instanceof Error ? err.message : String(err);
+      // A refused precondition carries its subject in the payload, not in the message: the
+      // validation factory sets a deliberately generic public message. Reading `err.message` here
+      // would report the correct CODE with no indication of which column, which is the half of the
+      // answer the operator cannot act on. Presentation comes from the shared describer so this
+      // result and `classifyError`'s cannot drift.
+      const described = NextlyError.isValidation(err)
+        ? describePrecondition(err)
+        : undefined;
+      const message =
+        described?.message ??
+        (err instanceof Error ? err.message : String(err));
       await this.deps.migrationJournal.recordEnd(journalId, {
         success: false,
         statementsExecuted: 0,
@@ -1360,8 +1371,8 @@ export class PushSchemaPipeline {
         renamesApplied: 0,
         error: {
           code,
-          message: err instanceof Error ? err.message : String(err),
-          details: err,
+          message,
+          details: described ? described.details : err,
         },
       };
     }

--- a/packages/nextly/src/domains/schema/pipeline/pushschema-pipeline.ts
+++ b/packages/nextly/src/domains/schema/pipeline/pushschema-pipeline.ts
@@ -25,6 +25,7 @@ import type { SupportedDialect } from "@nextlyhq/adapter-drizzle/types";
 import { dequal } from "dequal";
 
 import { getDialectTablesForPush } from "../../../database/index";
+import { NextlyError } from "../../../errors";
 import {
   getCachedSnapshot,
   getLiveSnapshot,
@@ -913,6 +914,11 @@ export class PushSchemaPipeline {
         try {
           await preResExecutor(tx, resolvedOps, dialect);
         } catch (err) {
+          // A refusal is not a failed statement. The pre-resolution phase can decline to start —
+          // when the stored values would not survive a conversion, for instance — and that answer
+          // carries the column, the reason and what to do about it. Wrapping it as a DDL failure
+          // replaces all of that with a generic message about a statement that never ran.
+          if (NextlyError.isValidation(err)) throw err;
           throw new DdlExecutionError(
             err instanceof Error ? err.message : String(err),
             err
@@ -1555,6 +1561,8 @@ export class PushSchemaPipeline {
   }
 
   private classifyErrorCode(err: unknown): string {
+    // Before the DDL branch: nothing ran, and saying so is the whole value of the distinction.
+    if (NextlyError.isValidation(err)) return "PRECONDITION_FAILED";
     if (err instanceof PushSchemaError) return "PUSHSCHEMA_FAILED";
     if (err instanceof DdlExecutionError) return "DDL_EXECUTION_FAILED";
     // PromptDispatcher signals - distinguish "user said no" from "no TTY


### PR DESCRIPTION
Closes the second half of what Codex raised after #593 merged (task 171, P1).

## The defect

The legacy repair offers a rename for a `_body` -> `body` pair, because field names cannot begin with an underscore, so a leading one can only have been written by the old builder. That proves the column is **legacy**. It does not prove what the column **holds**.

The underscore affected every field type. A field once declared as ordinary `text` carries a `_body` column too, and changing it to a repeater during an upgrade produces a pair that is indistinguishable from a genuine legacy repeater: same name shape, same SQL type, `text` -> `json` either way. Snapshots and rename operations carry the SQL type, never the declared field type, so nothing in the schema can tell them apart.

The conversion then runs against prose:

- **PostgreSQL** aborts the statement, and the apply is in a transaction, so nothing is lost.
- **MySQL** commits DDL implicitly. The rename has already happened by the time the conversion fails, leaving the column **renamed and unconverted**, with no transaction able to take it back.

## The fix

Ask the data, before the first statement runs, while every column still answers to the name it was found under. A refusal costs a failed command and leaves the schema untouched.

- **MySQL** — `NOT JSON_VALID(c)`. `LIMIT 1` is sound here because it hunts a **counterexample**.
- **PostgreSQL** — no version-independent predicate (`pg_input_is_valid` is 16+, the matrix tests 15), so the cast itself is the test.

## Three defects found in the guard during review, each fixed and proven by breaking

**1. The probe could pass a column it should refuse.** The first version was `... WHERE c IS NOT NULL AND c::jsonb IS NOT NULL LIMIT 1`. `LIMIT 1` stops at the first row that **satisfies** the predicate, and valid JSON satisfies it — so a column holding `{"ok":1}` then `the quick brown fox` answered "convertible" on row one and never evaluated row two. Confirmed against a live server:

```
SELECT 1 FROM t WHERE body IS NOT NULL AND body::jsonb IS NOT NULL LIMIT 1;  -> 1 row, no error
SELECT count(body::jsonb) FROM t WHERE body IS NOT NULL;                     -> ERROR 22P02
ALTER TABLE t ALTER COLUMN body TYPE jsonb USING body::jsonb;                -> ERROR 22P02
```

Now `count(c::jsonb)`, which has no early exit. **An existential search may short-circuit; a universal claim may not** — which is also why MySQL's identical-looking clause was correct all along.

**2. Any failure was reported as bad data.** A bare `catch` conflated `22P02` with `42P01`, `55P03` and class `08`, so a lock timeout or a permission error blocked a legitimate migration while telling the operator their rows were malformed. Narrowed to SQLSTATE class 22 — PostgreSQL's data-exception class — with everything else propagating. Implementing that **failed two previously-passing tests**, because Drizzle wraps the driver error and the SQLSTATE lives on `.cause`: they had been green on the strength of *some* error, never the right one.

**3. The probe's domain was documented rather than enforced.** It reads non-NULL rows, which is right for a cast and wrong for a `NOT NULL`. The caller now refuses any conversion statement outside `COVERED_CONVERSIONS`, stated as an allowlist so an op kind added later is refused until someone decides it is covered.

## Coverage

**Live, both servers** — prose refused with the old column intact; a later-row-prose case; a probe that cannot run reported as itself; and a positive control on each dialect proving a genuine JSON column still converts.

**Unit** — driver error shapes constructed directly (bare, wrapped once, twice, twelve deep, non-data SQLSTATEs at every depth, a self-referential cause). A live suite cannot cover this: it can only produce the shape its own driver makes, and wrapper depth differs by transport.

**Call-site observation** — the coupling that keeps the emitted statements inside the probe's domain is `executePreResolutionOps` calling `conversionForRename` **without** a context. Asserted by spying on the arguments the executor actually passes, not by rebuilding the same call in the test, which would keep passing after someone edited the line it exists to watch. Verified by breaking it with an **empty** context, which emits no extra op at all and still fails.

## TOCTOU, stated plainly

PostgreSQL runs the probe on the same handle inside the same transaction as the statements, so the window is closed. **MySQL cannot close it** — DDL auto-commits and no transaction contains the apply. That asymmetry is exactly why the check runs before the FIRST statement rather than beside each one.

## Verification

Run from the worktree root against `b19f8fb3f`:

- `pnpm build`, `pnpm check-types --force`, `pnpm lint`, `check-drizzle-v1-legacy.cjs` — all clean
- unit **361 failed / 7183 passed / 7592** — diffed at test-name level against a baseline freshly measured at `6b119f191` in its own installed and built worktree: **zero new, zero fixed**. The 361 is the known pre-existing baseline.
- integration **postgres17, mysql and sqlite all pass**

Follow-up filed as task 172 (a same-type rename still drops its attribute changes on every dialect; SQLite needs a table-rebuild operation that does not exist yet).
