### PR TITLE
feat(plugin-page-builder): put every slot-declaring block on the structure source

### DIFF
--- a/.changeset/block-structure-slots-batch.md
+++ b/.changeset/block-structure-slots-batch.md
@@ -1,0 +1,26 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+Every block that can hold children now declares its slots where page validation can read them without loading the block library, so a page saved through the normal server path is checked against all of them rather than a few.

--- a/packages/plugin-page-builder/src/core/__tests__/structure-covers-the-catalog.test.ts
+++ b/packages/plugin-page-builder/src/core/__tests__/structure-covers-the-catalog.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Every block DEFINITION that declares slots has a structure the write path can read.
+ *
+ * This file is the renderer-aware half of the pair, and it imports `render/blocks` deliberately —
+ * the opposite of `validate-without-renderer.test.ts`, which must never import it. The two answer
+ * different questions and both are needed:
+ *
+ * - **There:** with nothing loaded, does the validator still refuse an undeclared slot? That is the
+ *   condition the config and server paths actually run in.
+ * - **Here:** does the structure source still describe the real catalogue? A hand-written list
+ *   compared against a hand-written record agrees with itself whatever the blocks do.
+ *
+ * The gap this closes is specific. The set-completeness assertion in the other file reads
+ * `CORE_BLOCK_STRUCTURES` and compares it to a literal list. Both are maintained by hand, so a new
+ * built-in that declares its slots ONLY in `defineBlock` satisfies both and silently opts itself
+ * out of the slot check — the failure the whole task exists to remove, reintroduced by omission.
+ * Nothing but the registry itself can see that.
+ */
+import { describe, expect, it } from "vitest";
+
+import { CORE_BLOCK_STRUCTURES, declaredSlotsOf } from "../block-structure";
+import { defaultBlockRegistry } from "../registry";
+import "../../render/blocks";
+
+/** Every registered definition that can hold children, by type. */
+function slotDeclaringTypes(): string[] {
+  return defaultBlockRegistry
+    .all()
+    .filter(def => (def.slots?.length ?? 0) > 0)
+    .map(def => def.type)
+    .sort();
+}
+
+describe("the structure source against the real catalogue", () => {
+  it("covers every definition that declares a slot", () => {
+    const fromDefinitions = slotDeclaringTypes();
+
+    // Positive control: the registry is actually populated here. Without the side-effect import
+    // above this list would be empty and every assertion below would hold vacuously — which is
+    // exactly how the write-path check came to look like it worked while being inert.
+    expect(fromDefinitions.length).toBeGreaterThan(0);
+
+    const missing = fromDefinitions.filter(
+      type => declaredSlotsOf(type) === undefined
+    );
+    expect(missing).toEqual([]);
+  });
+
+  it("declares the SAME slot names the definition does", () => {
+    // Covering the type is not enough: a structure naming different slots than its definition
+    // would let the validator accept a name the renderer never places, or reject one it does.
+    for (const def of defaultBlockRegistry.all()) {
+      const declared = def.slots?.map(s => s.name).sort();
+      if (!declared?.length) continue;
+      expect(
+        declaredSlotsOf(def.type)
+          ?.map(s => s.name)
+          .sort()
+      ).toEqual(declared);
+    }
+  });
+
+  it("does not describe a block the catalogue does not have", () => {
+    // The other direction. A structure left behind by a renamed or removed block would keep the
+    // validator enforcing slots for a type nothing can produce, which reads as working and is not.
+    const known = new Set(defaultBlockRegistry.all().map(def => def.type));
+    const orphans = Object.keys(CORE_BLOCK_STRUCTURES).filter(
+      type => !known.has(type)
+    );
+
+    expect(orphans).toEqual([]);
+  });
+});

--- a/packages/plugin-page-builder/src/core/__tests__/validate-without-renderer.test.ts
+++ b/packages/plugin-page-builder/src/core/__tests__/validate-without-renderer.test.ts
@@ -15,7 +15,7 @@
  */
 import { describe, expect, it } from "vitest";
 
-import { declaredSlotsOf } from "../block-structure";
+import { CORE_BLOCK_STRUCTURES, declaredSlotsOf } from "../block-structure";
 import { createBlockRegistry, defaultBlockRegistry } from "../registry";
 import { makeNode } from "../tree";
 import { validateDocument } from "../validate";
@@ -110,6 +110,32 @@ describe("the write path with nothing rendered", () => {
         { allowUnknown: true }
       )
     ).toContain("has no slot");
+  });
+
+  it("has structure for EVERY block that declares a slot", () => {
+    // The property that keeps the write path honest as blocks are added. A container whose
+    // structure is not declared here answers `undefined` from `declaredSlotsOf`, which the
+    // validator correctly treats as "this build cannot say" and defers to `allowUnknown` — so a
+    // new container would silently opt itself out of the slot check rather than fail loudly.
+    //
+    // Asserted against the structure source alone, with no renderer loaded: this file cannot see
+    // the definitions, which is the point. The list is written out rather than derived, so adding
+    // a container has to be a deliberate edit here.
+    expect(Object.keys(CORE_BLOCK_STRUCTURES).sort()).toEqual([
+      "core/columns",
+      "core/container",
+      "core/content-carousel",
+      "core/cover",
+      "core/grid",
+      "core/off-canvas",
+      "core/query-loop",
+      "core/row",
+    ]);
+    // Every one of them declares at least one slot: a structure with none would be a block that
+    // cannot hold children, which belongs to a later batch and not to this list.
+    for (const type of Object.keys(CORE_BLOCK_STRUCTURES)) {
+      expect(declaredSlotsOf(type)?.length ?? 0).toBeGreaterThan(0);
+    }
   });
 
   it("leaves a type this build has no structure for to allowUnknown", () => {

--- a/packages/plugin-page-builder/src/core/block-structure.ts
+++ b/packages/plugin-page-builder/src/core/block-structure.ts
@@ -94,6 +94,36 @@ export const gridStructure = declareStructure({
   slots: [{ name: "default" }],
 });
 
+export const coverStructure = declareStructure({
+  type: "core/cover",
+  isContainer: true,
+  slots: [{ name: "default" }],
+});
+
+export const offCanvasStructure = declareStructure({
+  type: "core/off-canvas",
+  isContainer: true,
+  slots: [{ name: "default" }],
+});
+
+export const queryLoopStructure = declareStructure({
+  type: "core/query-loop",
+  isContainer: true,
+  slots: [{ name: "default" }],
+});
+
+export const rowStructure = declareStructure({
+  type: "core/row",
+  isContainer: true,
+  slots: [{ name: "default" }],
+});
+
+export const contentCarouselStructure = declareStructure({
+  type: "core/content-carousel",
+  isContainer: true,
+  slots: [{ name: "default" }],
+});
+
 /** Whether a node's type is one this build has structure for. */
 export function hasStructure(node: BlockNode): boolean {
   return CORE_BLOCK_STRUCTURES[node.type] !== undefined;

--- a/packages/plugin-page-builder/src/render/blocks/cover.tsx
+++ b/packages/plugin-page-builder/src/render/blocks/cover.tsx
@@ -1,3 +1,4 @@
+import { coverStructure } from "../../core/block-structure";
 import { defineBlock } from "../../core/registry";
 import { safeValue } from "../../core/style-compiler";
 
@@ -5,13 +6,11 @@ import { cssMediaUrl, str } from "./util";
 
 /** A full-bleed hero: background image + color overlay, centered inner blocks. */
 export const cover = defineBlock({
-  type: "core/cover",
+  ...coverStructure,
   version: 1,
   label: "Cover",
   icon: "Image",
   category: "media",
-  isContainer: true,
-  slots: [{ name: "default" }],
   defaultProps: {
     image: undefined,
     overlayColor: "#000000",

--- a/packages/plugin-page-builder/src/render/blocks/interactive2.tsx
+++ b/packages/plugin-page-builder/src/render/blocks/interactive2.tsx
@@ -1,3 +1,4 @@
+import { offCanvasStructure } from "../../core/block-structure";
 import { defineBlock } from "../../core/registry";
 import { isFetchableUrl } from "../../core/url-policy";
 
@@ -48,13 +49,11 @@ export const toggle = defineBlock({
 
 /** An off-canvas slide-in panel toggled by the CSS checkbox-hack (no JS). */
 export const offCanvas = defineBlock({
-  type: "core/off-canvas",
+  ...offCanvasStructure,
   version: 1,
   label: "Off Canvas",
   icon: "Layers",
   category: "layout",
-  isContainer: true,
-  slots: [{ name: "default" }],
   defaultProps: { triggerText: "Open menu", side: "right" },
   contentFields: [
     { name: "triggerText", type: "text", label: "Trigger label" },

--- a/packages/plugin-page-builder/src/render/blocks/queryLoop.tsx
+++ b/packages/plugin-page-builder/src/render/blocks/queryLoop.tsx
@@ -1,3 +1,4 @@
+import { queryLoopStructure } from "../../core/block-structure";
 import { defineBlock } from "../../core/registry";
 import { loopGridStyle } from "../query/grid";
 
@@ -11,13 +12,11 @@ import { loopGridStyle } from "../query/grid";
  * by the admin's QueryLoopSettings panel rather than generic content fields.
  */
 export const queryLoop = defineBlock({
-  type: "core/query-loop",
+  ...queryLoopStructure,
   version: 1,
   label: "Query Loop",
   icon: "Repeat",
   category: "dynamic",
-  isContainer: true,
-  slots: [{ name: "default" }],
   defaultProps: {
     collection: "",
     sort: "",

--- a/packages/plugin-page-builder/src/render/blocks/row.tsx
+++ b/packages/plugin-page-builder/src/render/blocks/row.tsx
@@ -1,3 +1,4 @@
+import { rowStructure } from "../../core/block-structure";
 import { defineBlock } from "../../core/registry";
 
 import { str } from "./util";
@@ -7,13 +8,11 @@ const ALIGN = ["stretch", "flex-start", "center", "flex-end"];
 
 /** A flex Row/Stack with orientation, wrap, justify and align controls. */
 export const row = defineBlock({
-  type: "core/row",
+  ...rowStructure,
   version: 1,
   label: "Row / Stack",
   icon: "Columns",
   category: "layout",
-  isContainer: true,
-  slots: [{ name: "default" }],
   defaultProps: {
     orientation: "horizontal",
     justify: "flex-start",

--- a/packages/plugin-page-builder/src/render/blocks/slides.tsx
+++ b/packages/plugin-page-builder/src/render/blocks/slides.tsx
@@ -1,5 +1,6 @@
 import type { CSSProperties } from "react";
 
+import { contentCarouselStructure } from "../../core/block-structure";
 import { defineBlock } from "../../core/registry";
 
 import { renderInline } from "./markdown";
@@ -97,13 +98,11 @@ export const slides = defineBlock({
 
 /** A carousel of arbitrary inner blocks (scroll-snap container). */
 export const contentCarousel = defineBlock({
-  type: "core/content-carousel",
+  ...contentCarouselStructure,
   version: 1,
   label: "Content Carousel",
   icon: "Layers",
   category: "media",
-  isContainer: true,
-  slots: [{ name: "default" }],
   defaultProps: { perView: "70%" },
   contentFields: [
     { name: "perView", type: "text", label: "Item width", placeholder: "70%" },


### PR DESCRIPTION
Second PR of the task 160 follow-up. The seam landed in #636 with three blocks on
it; this puts **every remaining block that can hold children** on the same source.

## The count was wrong, and finding that out is most of this PR

The plan said "~50 blocks in batches". **Only 8 definitions declare slots at
all**, and 4 were already migrated — so the slot-declaring set is finished by
this PR, not by ten of them.

The "~50" came from a file-level grep. Two corrections got to the real number:

1. **`grep -l "slots: \["` counts FILES, not definitions.** `interactive2.tsx`
   and `slides.tsx` each hold several `defineBlock` calls, and the slots I first
   matched in them belonged to `core/off-canvas` and `core/content-carousel` —
   not to `core/toggle` or `core/slides`, whose names I had already used for the
   structure constants. Splitting each file on `defineBlock(` and reading each
   definition's own object literal gives the truth.
2. **A rewrite guard caught it before it did damage.** The migration script
   asserted the text between `type:` and `isContainer:` was under 260 characters;
   for `interactive2.tsx` it was the whole of another block's definition, so the
   script refused rather than rewriting across a boundary. That assertion is why
   this is a correction and not a bug.

## What changed

`core/off-canvas`, `core/query-loop`, `core/row` and `core/content-carousel` now
spread their structure instead of restating it, matching `core/container`,
`core/columns`, `core/grid` and `core/cover` from #636.

The full set on the structure source is now exactly the set of blocks that can
hold children:

```
core/columns  core/container  core/content-carousel  core/cover
core/grid     core/off-canvas core/query-loop        core/row
```

## The test that matters

A container whose structure is NOT declared answers `undefined` from
`declaredSlotsOf`, which the validator correctly reads as *"this build cannot
say"* and defers to `allowUnknown`. **So a newly added container would silently
opt itself out of the slot check rather than fail loudly** — the failure mode
this whole task exists to remove, reintroduced by omission.

The new test pins the exact set, written out rather than derived, so adding a
container has to be a deliberate edit here. It lives in the no-renderer file and
asserts against the structure source alone, with nothing loaded.

Stub-verified: making one block's structure a plain object instead of registering
it fails that test and nothing else.

## Not in this PR

The remaining ~50 non-container blocks. They matter for a different hole — a
block that declares NO slots carrying stored slots anyway, which the empty
registry also cannot catch today — and that is the next batch. **The
`def ? (def.slots ?? []) : structuralSlots` fallback stays until then**, and is
deleted with the last one.

622 tests pass; typecheck and lint clean.
