### PR TITLE
feat(nextly): record who changed an email provider

### DIFF
--- a/.changeset/email-provider-audit-trail.md
+++ b/.changeset/email-provider-audit-trail.md
@@ -1,0 +1,36 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+nextly: record who created, changed, promoted or deleted an email provider
+
+`email_providers` holds the credentials that send password-reset and
+verification mail, so an actor who can edit a provider can point every
+authentication email at a relay they control. That action previously left no
+record. Create, update, delete and promote-to-default now write an activity
+entry naming the actor, the provider and which fields changed.
+
+Names, never values: an entry carries no part of the configuration, and a
+configuration change is recorded as the single field name `configuration`
+rather than by its inner paths.

--- a/packages/nextly/src/api/email-providers-default.ts
+++ b/packages/nextly/src/api/email-providers-default.ts
@@ -14,6 +14,7 @@
  * @module api/email-providers-default
  */
 
+import { actorFromAuthContext } from "../auth/request-actor";
 import { container } from "../di";
 import { getCachedNextly } from "../init";
 import type { EmailProviderService } from "../services/email/email-provider-service";
@@ -50,7 +51,12 @@ async function getEmailProviderService(): Promise<EmailProviderService> {
  */
 export const PATCH = withErrorHandler(
   async (request: Request, context: RouteContext): Promise<Response> => {
-    await requireRouteAnyPermission(request, [
+    // The permission check already RESOLVES the caller; this handler used to
+    // discard it. These standalone handlers are a published surface an app may
+    // mount instead of the catch-all dispatcher, so without the actor every
+    // provider mutation through them recorded nothing -- the trail would have
+    // covered one supported REST surface and not the other.
+    const auth = await requireRouteAnyPermission(request, [
       { action: "update", resource: "email-providers" },
       { action: "manage", resource: "email-providers" },
     ]);
@@ -58,7 +64,7 @@ export const PATCH = withErrorHandler(
     const { id } = await context.params;
     const service = await getEmailProviderService();
 
-    const provider = await service.setDefault(id);
+    const provider = await service.setDefault(id, actorFromAuthContext(auth));
 
     // Set-default is a non-CRUD mutation (no new resource, just a flag
     // flip). Match the dispatcher route's wire shape so REST + dispatcher

--- a/packages/nextly/src/api/email-providers-detail.ts
+++ b/packages/nextly/src/api/email-providers-detail.ts
@@ -19,6 +19,7 @@
  * @module api/email-providers-detail
  */
 
+import { actorFromAuthContext } from "../auth/request-actor";
 import { container } from "../di";
 import { getCachedNextly } from "../init";
 import type { EmailProviderService } from "../services/email/email-provider-service";
@@ -91,7 +92,12 @@ export const GET = withErrorHandler(
  */
 export const PATCH = withErrorHandler(
   async (request: Request, context: RouteContext): Promise<Response> => {
-    await requireRouteAnyPermission(request, [
+    // The permission check already RESOLVES the caller; this handler discarded
+    // it. These standalone handlers are a published surface an app may mount
+    // instead of the catch-all dispatcher, so without the actor every provider
+    // mutation through them recorded nothing -- the trail would have covered
+    // one supported REST surface and not the other.
+    const auth = await requireRouteAnyPermission(request, [
       { action: "update", resource: "email-providers" },
       { action: "manage", resource: "email-providers" },
     ]);
@@ -117,7 +123,11 @@ export const PATCH = withErrorHandler(
     if (body.isActive !== undefined) updateData.isActive = body.isActive;
 
     const service = await getEmailProviderService();
-    const provider = await service.updateProvider(id, updateData);
+    const provider = await service.updateProvider(
+      id,
+      updateData,
+      actorFromAuthContext(auth)
+    );
 
     return respondMutation("Email provider updated.", provider);
   }
@@ -140,7 +150,12 @@ export const PATCH = withErrorHandler(
  */
 export const DELETE = withErrorHandler(
   async (request: Request, context: RouteContext): Promise<Response> => {
-    await requireRouteAnyPermission(request, [
+    // The permission check already RESOLVES the caller; this handler discarded
+    // it. These standalone handlers are a published surface an app may mount
+    // instead of the catch-all dispatcher, so without the actor every provider
+    // mutation through them recorded nothing -- the trail would have covered
+    // one supported REST surface and not the other.
+    const auth = await requireRouteAnyPermission(request, [
       { action: "delete", resource: "email-providers" },
       { action: "manage", resource: "email-providers" },
     ]);
@@ -148,7 +163,7 @@ export const DELETE = withErrorHandler(
     const { id } = await context.params;
     const service = await getEmailProviderService();
 
-    await service.deleteProvider(id);
+    await service.deleteProvider(id, actorFromAuthContext(auth));
 
     // Service returns void. Echo the deleted id (named `providerId` to
     // match the dispatcher route's wire shape) so the admin can prune

--- a/packages/nextly/src/api/email-providers.ts
+++ b/packages/nextly/src/api/email-providers.ts
@@ -22,6 +22,7 @@
 
 import { z } from "zod";
 
+import { actorFromAuthContext } from "../auth/request-actor";
 import { container } from "../di";
 import { getCachedNextly } from "../init";
 import type { EmailProviderService } from "../services/email/email-provider-service";
@@ -112,7 +113,12 @@ export const GET = withErrorHandler(
  */
 export const POST = withErrorHandler(
   async (request: Request): Promise<Response> => {
-    await requireRouteAnyPermission(request, [
+    // The permission check already RESOLVES the caller; this handler discarded
+    // it. These standalone handlers are a published surface an app may mount
+    // instead of the catch-all dispatcher, so without the actor every provider
+    // mutation through them recorded nothing -- the trail would have covered
+    // one supported REST surface and not the other.
+    const auth = await requireRouteAnyPermission(request, [
       { action: "create", resource: "email-providers" },
       { action: "manage", resource: "email-providers" },
     ]);
@@ -128,7 +134,10 @@ export const POST = withErrorHandler(
     }
 
     const service = await getEmailProviderService();
-    const provider = await service.createProvider(validated);
+    const provider = await service.createProvider(
+      validated,
+      actorFromAuthContext(auth)
+    );
 
     return respondMutation("Email provider created.", provider, {
       status: 201,

--- a/packages/nextly/src/direct-api/namespaces/__tests__/direct-api-actor.test.ts
+++ b/packages/nextly/src/direct-api/namespaces/__tests__/direct-api-actor.test.ts
@@ -1,0 +1,50 @@
+/**
+ * Whether a Direct API call carries an acting identity.
+ *
+ * `DirectAPIConfig.user` is how a caller says who an operation is for — it is
+ * required whenever `overrideAccess` is false. Forwarding it is what lets a
+ * write through this API be attributed like one through the admin, instead of
+ * the audit trail silently covering one supported surface and not the other.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { directApiActor } from "../helpers";
+
+describe("the actor a Direct API call carries", () => {
+  it("is the user named on the operation", () => {
+    expect(directApiActor({}, { user: { id: "user-1" } })).toEqual({
+      type: "user",
+      id: "user-1",
+    });
+  });
+
+  it("falls back to the instance default", () => {
+    expect(directApiActor({ user: { id: "default-user" } }, {})).toEqual({
+      type: "user",
+      id: "default-user",
+    });
+  });
+
+  it("lets one call act as someone else without reconfiguring the instance", () => {
+    // Matches `mergeConfig`: per-operation config wins over the default.
+    expect(
+      directApiActor(
+        { user: { id: "default-user" } },
+        { user: { id: "other" } }
+      )
+    ).toEqual({ type: "user", id: "other" });
+  });
+
+  it("is absent when nobody is named", () => {
+    // Absent means absent. A call naming nobody records nothing, rather than
+    // attributing a credential change to a placeholder identity.
+    expect(directApiActor({}, {})).toBeUndefined();
+  });
+
+  it("is absent when the user carries no id", () => {
+    // The control for the guard: a `user` present but unidentifiable is still
+    // nobody, and an entry keyed on an empty id would be worse than none.
+    expect(directApiActor({}, { user: { id: "" } })).toBeUndefined();
+  });
+});

--- a/packages/nextly/src/direct-api/namespaces/email.ts
+++ b/packages/nextly/src/direct-api/namespaces/email.ts
@@ -47,7 +47,12 @@ import type {
 } from "../types/index";
 
 import type { NextlyContext } from "./context";
-import { isNotFoundError, mergeConfig, sliceListResult } from "./helpers";
+import {
+  directApiActor,
+  isNotFoundError,
+  mergeConfig,
+  sliceListResult,
+} from "./helpers";
 
 /**
  * `nextly.email.*` namespace — send raw or template-based emails.
@@ -171,14 +176,17 @@ export function createEmailProvidersNamespace(
     async create(
       args: CreateEmailProviderArgs
     ): Promise<MutationResult<EmailProviderRecord>> {
-      const item = await ctx.emailProviderService.createProvider({
-        name: args.data.name,
-        type: args.data.type,
-        fromEmail: args.data.fromEmail,
-        fromName: args.data.fromName,
-        configuration: args.data.configuration,
-        isDefault: args.data.isDefault,
-      });
+      const item = await ctx.emailProviderService.createProvider(
+        {
+          name: args.data.name,
+          type: args.data.type,
+          fromEmail: args.data.fromEmail,
+          fromName: args.data.fromName,
+          configuration: args.data.configuration,
+          isDefault: args.data.isDefault,
+        },
+        directApiActor(ctx.defaultConfig, args)
+      );
       return { message: "Email provider created.", item };
     },
 
@@ -187,7 +195,8 @@ export function createEmailProvidersNamespace(
     ): Promise<MutationResult<EmailProviderRecord>> {
       const item = await ctx.emailProviderService.updateProvider(
         args.id,
-        args.data
+        args.data,
+        directApiActor(ctx.defaultConfig, args)
       );
       return { message: "Email provider updated.", item };
     },
@@ -195,7 +204,10 @@ export function createEmailProvidersNamespace(
     async delete(
       args: DeleteEmailProviderArgs
     ): Promise<MutationResult<{ id: string }>> {
-      await ctx.emailProviderService.deleteProvider(args.id);
+      await ctx.emailProviderService.deleteProvider(
+        args.id,
+        directApiActor(ctx.defaultConfig, args)
+      );
       return {
         message: "Email provider deleted.",
         item: { id: args.id },
@@ -205,7 +217,10 @@ export function createEmailProvidersNamespace(
     async setDefault(
       args: SetDefaultProviderArgs
     ): Promise<EmailProviderRecord> {
-      return await ctx.emailProviderService.setDefault(args.id);
+      return await ctx.emailProviderService.setDefault(
+        args.id,
+        directApiActor(ctx.defaultConfig, args)
+      );
     },
 
     async test(

--- a/packages/nextly/src/direct-api/namespaces/helpers.ts
+++ b/packages/nextly/src/direct-api/namespaces/helpers.ts
@@ -9,6 +9,7 @@
  * @packageDocumentation
  */
 
+import type { RequestActor } from "../../auth/request-actor";
 import { errorFromServiceEnvelope } from "../../errors/from-service-envelope";
 import { NextlyError } from "../../errors/nextly-error";
 import type { RequestContext } from "../../shared/types/index";
@@ -35,6 +36,28 @@ export function mergeConfig<T extends DirectAPIConfig>(
     ...defaultConfig,
     ...args,
   };
+}
+
+/**
+ * The acting identity a Direct API call carries, if it carries one.
+ *
+ * `DirectAPIConfig.user` is how a caller says who this operation is for --
+ * required whenever `overrideAccess` is false, and available whenever the
+ * caller knows. Forwarding it is what lets a write through this API be
+ * attributed like a write through the admin, instead of the trail silently
+ * covering one supported surface and not the other.
+ *
+ * Absent means absent: a call that names nobody records nothing, rather than
+ * being attributed to a placeholder. Per-operation config wins over the
+ * instance default, matching `mergeConfig`, so a single call can act as
+ * someone without reconfiguring the instance.
+ */
+export function directApiActor(
+  defaultConfig: DirectAPIConfig,
+  args: DirectAPIConfig
+): RequestActor | undefined {
+  const id = mergeConfig(defaultConfig, args).user?.id;
+  return id ? { type: "user", id } : undefined;
 }
 
 /**

--- a/packages/nextly/src/dispatcher/handlers/email-dispatcher.ts
+++ b/packages/nextly/src/dispatcher/handlers/email-dispatcher.ts
@@ -25,6 +25,7 @@ import { toDescriptor } from "../../domains/email/provider-definition";
 import { getEmailProviderRegistry } from "../../domains/email/services/email-provider-registry";
 import type { EmailProviderService } from "../../services/email/email-provider-service";
 import type { EmailTemplateService } from "../../services/email/email-template-service";
+import { readAuthenticatedActor } from "../helpers/authenticated-actor";
 import {
   getEmailProviderServiceFromDI,
   getEmailTemplateServiceFromDI,
@@ -76,9 +77,13 @@ const EMAIL_PROVIDER_METHODS: Record<
     },
   },
   createProvider: {
-    execute: async (svc, _p, body) => {
+    // The acting identity is already on the params -- the route handler stamps
+    // it for every dispatched request -- and this domain simply never read it,
+    // which is why credential changes left no trail.
+    execute: async (svc, p, body) => {
       const provider = await svc.providerService.createProvider(
-        body as Parameters<typeof svc.providerService.createProvider>[0]
+        body as Parameters<typeof svc.providerService.createProvider>[0],
+        readAuthenticatedActor(p)
       );
       return respondMutation("Email provider created.", provider, {
         status: 201,
@@ -97,7 +102,8 @@ const EMAIL_PROVIDER_METHODS: Record<
     execute: async (svc, p, body) => {
       const provider = await svc.providerService.updateProvider(
         p.providerId,
-        body as Parameters<typeof svc.providerService.updateProvider>[1]
+        body as Parameters<typeof svc.providerService.updateProvider>[1],
+        readAuthenticatedActor(p)
       );
       return respondMutation("Email provider updated.", provider);
     },
@@ -111,7 +117,10 @@ const EMAIL_PROVIDER_METHODS: Record<
     // If providerService.deleteProvider is later refactored to return
     // the deleted record, switch this back to respondMutation.
     execute: async (svc, p) => {
-      await svc.providerService.deleteProvider(p.providerId);
+      await svc.providerService.deleteProvider(
+        p.providerId,
+        readAuthenticatedActor(p)
+      );
       return respondAction("Email provider deleted.", {
         providerId: p.providerId,
       });
@@ -123,7 +132,10 @@ const EMAIL_PROVIDER_METHODS: Record<
     // Surface the updated provider as a sibling field so the admin can
     // refresh its local cache.
     execute: async (svc, p) => {
-      const provider = await svc.providerService.setDefault(p.providerId);
+      const provider = await svc.providerService.setDefault(
+        p.providerId,
+        readAuthenticatedActor(p)
+      );
       return respondAction("Default email provider updated.", { provider });
     },
   },

--- a/packages/nextly/src/domains/email/__tests__/provider-activity.test.ts
+++ b/packages/nextly/src/domains/email/__tests__/provider-activity.test.ts
@@ -19,6 +19,8 @@ import type { Logger } from "../../../services/shared";
 import { SYSTEM_CONTEXT } from "../../../shared/types";
 import { createTableBody } from "../../schema/pipeline/sql-templates/create-table-body";
 import { EMAIL_PROVIDER_ACTIVITY_COLLECTION } from "../provider-activity";
+import { defineEmailProvider } from "../provider-definition";
+import { getEmailProviderRegistry } from "../services/email-provider-registry";
 import { EmailProviderService } from "../services/email-provider-service";
 
 vi.mock("../../../lib/env", () => ({
@@ -89,6 +91,20 @@ describe("email provider activity", () => {
   let service: EmailProviderService;
 
   beforeEach(() => {
+    // A provider that accepts anything, including nothing. Registered so a
+    // type change can legitimately land with no configuration of its own.
+    getEmailProviderRegistry().register(
+      defineEmailProvider({
+        type: "permissive",
+        label: "Permissive",
+        configFields: [],
+        parseConfig: input => (input ?? {}) as Record<string, unknown>,
+        createAdapter: () => ({
+          send: () => Promise.resolve({ success: true, messageId: "x" }),
+        }),
+      })
+    );
+
     sqlite = new Database(":memory:");
     createEmailProvidersTable(sqlite);
     service = new EmailProviderService(
@@ -107,6 +123,7 @@ describe("email provider activity", () => {
   });
 
   afterEach(() => {
+    getEmailProviderRegistry().reset();
     sqlite.close();
     // No per-key removal on the container; this file registers nothing else.
     container.clear();
@@ -292,6 +309,68 @@ describe("email provider activity", () => {
       entryId: created.id,
       entryTitle: "Production SMTP",
     });
+  });
+
+  it("reports the configuration a type change silently discarded", async () => {
+    // A type change with no configuration REPLACES the stored one with an
+    // empty object. The diff only ran when the caller sent a configuration, so
+    // the entry said "type" and nothing else — a record that reads as harmless
+    // over a change that discarded the credentials.
+    const created = await service.createProvider(INPUT, ACTOR);
+    logged.length = 0;
+
+    // The target must ACCEPT an empty configuration, or the update is refused
+    // before it can discard anything and the test passes on the wrong path.
+    // Resend requires an api key, so a permissive fixture is the only shape
+    // that reaches the branch this is about.
+    await service.updateProvider(created.id, { type: "permissive" }, ACTOR);
+
+    expect(logged[0]?.metadata).toEqual({
+      providerType: "permissive",
+      changedFields: ["type", "configuration"],
+    });
+  });
+
+  it("does not claim a promotion changed anything when it did not", async () => {
+    // A client retry promotes a provider that is already the default. The
+    // final state is identical, and the update path beside this one already
+    // reports nothing for a value that did not move.
+    const created = await service.createProvider(
+      { ...INPUT, isDefault: true },
+      ACTOR
+    );
+    logged.length = 0;
+
+    await service.setDefault(created.id, ACTOR);
+
+    expect(logged[0]?.metadata).toEqual({ providerType: "smtp" });
+  });
+
+  it("records a promotion that did change something", async () => {
+    // The control: the guard must not silence a real promotion.
+    const created = await service.createProvider(INPUT, ACTOR);
+    logged.length = 0;
+
+    await service.setDefault(created.id, ACTOR);
+
+    expect(logged[0]?.metadata).toMatchObject({
+      changedFields: ["isDefault"],
+    });
+  });
+
+  it("records one deletion when two deletes race", async () => {
+    // Both callers read the row before either statement runs. The second
+    // affects nothing, and attributing a deletion to whoever sent it would be
+    // an event that never happened.
+    const created = await service.createProvider(INPUT, ACTOR);
+    logged.length = 0;
+
+    await Promise.all([
+      service.deleteProvider(created.id, ACTOR),
+      service.deleteProvider(created.id, ACTOR),
+    ]);
+
+    expect(logged.filter(entry => entry.action === "delete")).toHaveLength(1);
   });
 
   it("records nothing for a write with no signed-in actor", async () => {

--- a/packages/nextly/src/domains/email/__tests__/provider-activity.test.ts
+++ b/packages/nextly/src/domains/email/__tests__/provider-activity.test.ts
@@ -1,0 +1,276 @@
+/**
+ * What a provider mutation writes to the activity log, and what it must not.
+ *
+ * The trail exists because an actor who can edit a provider can point every
+ * password-reset and verification email at a relay they control. It is read by
+ * more people than the record it describes, so the value of the trail depends
+ * entirely on it never carrying what it audits.
+ */
+
+import type { DrizzleAdapter } from "@nextlyhq/adapter-drizzle";
+import Database from "better-sqlite3";
+import { drizzle } from "drizzle-orm/better-sqlite3";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+import { container } from "../../../di/container";
+import { getCoreSchema } from "../../../schemas";
+import type { LogActivityInput } from "../../../services/dashboard/activity-log-service";
+import type { Logger } from "../../../services/shared";
+import { SYSTEM_CONTEXT } from "../../../shared/types";
+import { createTableBody } from "../../schema/pipeline/sql-templates/create-table-body";
+import { EMAIL_PROVIDER_ACTIVITY_COLLECTION } from "../provider-activity";
+import { EmailProviderService } from "../services/email-provider-service";
+
+vi.mock("../../../lib/env", () => ({
+  env: {
+    NEXTLY_SECRET: "test-secret-that-is-long-enough-for-derivation",
+    DB_DIALECT: "sqlite",
+    DATABASE_URL: undefined,
+    NODE_ENV: "test",
+  },
+}));
+
+const PASSWORD = "the-smtp-password-nobody-should-see";
+const ACTOR = { type: "user" as const, id: "user-1" };
+
+const logger: Logger = {
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  debug: vi.fn(),
+};
+
+/** Captures what the service hands the activity log. */
+const logged: LogActivityInput[] = [];
+
+function makeAdapter(db: ReturnType<typeof drizzle>): DrizzleAdapter {
+  return {
+    dialect: "sqlite" as const,
+    getDrizzle: () => db,
+    getCapabilities: () => ({ dialect: "sqlite" as const }),
+    connect: async () => {},
+    disconnect: async () => {},
+    executeQuery: async () => [],
+    transaction: async (fn: (tx: unknown) => Promise<unknown>) => fn(db),
+  } as unknown as DrizzleAdapter;
+}
+
+/** Rendered from the shipped core schema, never hand-copied DDL. */
+function createEmailProvidersTable(sqlite: Database.Database): void {
+  const { tables } = getCoreSchema("sqlite");
+  const spec = tables.find(table => table.name === "email_providers");
+  if (!spec) {
+    expect.fail(
+      "email_providers is absent from the core schema — this fixture can no longer be derived from it."
+    );
+  }
+  sqlite.exec(
+    `CREATE TABLE "email_providers" (\n${createTableBody(spec, (id: string) => `"${id}"`)}\n)`
+  );
+}
+
+const INPUT = {
+  name: "Production SMTP",
+  type: "smtp" as const,
+  fromEmail: "noreply@example.com",
+  fromName: "App",
+  configuration: {
+    host: "smtp.example.com",
+    port: 587,
+    secure: true,
+    auth: { user: "postmaster", pass: PASSWORD },
+  },
+  isDefault: false,
+  isActive: true,
+};
+
+describe("email provider activity", () => {
+  let sqlite: Database.Database;
+  let service: EmailProviderService;
+
+  beforeEach(() => {
+    sqlite = new Database(":memory:");
+    createEmailProvidersTable(sqlite);
+    service = new EmailProviderService(
+      makeAdapter(drizzle({ client: sqlite })),
+      logger
+    );
+
+    logged.length = 0;
+    // `register` takes a FACTORY, so the fake is returned rather than stored.
+    container.register("activityLogService", () => ({
+      logActivity: (input: LogActivityInput) => {
+        logged.push(input);
+        return Promise.resolve();
+      },
+    }));
+  });
+
+  afterEach(() => {
+    sqlite.close();
+    // No per-key removal on the container; this file registers nothing else.
+    container.clear();
+    vi.clearAllMocks();
+  });
+
+  it("records a create against the acting user", async () => {
+    const provider = await service.createProvider(INPUT, ACTOR);
+
+    expect(logged).toHaveLength(1);
+    expect(logged[0]).toMatchObject({
+      userId: "user-1",
+      action: "create",
+      collection: EMAIL_PROVIDER_ACTIVITY_COLLECTION,
+      entryId: provider.id,
+      entryTitle: "Production SMTP",
+      metadata: { providerType: "smtp" },
+    });
+  });
+
+  it("never writes any part of the configuration", async () => {
+    // All four actions, in an order the product allows: a default provider
+    // cannot be deleted, so the promoted one is not the one removed.
+    const created = await service.createProvider(INPUT, ACTOR);
+    await service.updateProvider(
+      created.id,
+      {
+        configuration: {
+          ...INPUT.configuration,
+          auth: { user: "postmaster", pass: "a-new-password" },
+        },
+      },
+      ACTOR
+    );
+    await service.deleteProvider(created.id, ACTOR);
+
+    const promoted = await service.createProvider(
+      { ...INPUT, name: "Secondary SMTP" },
+      ACTOR
+    );
+    await service.setDefault(promoted.id, ACTOR);
+
+    // The whole point. Asserted over the SERIALISED rows, because a credential
+    // nested three levels down inside `metadata` would satisfy any field-by-
+    // field check written from the shape this code happens to produce today.
+    const serialised = JSON.stringify(logged);
+    expect(serialised).not.toContain(PASSWORD);
+    expect(serialised).not.toContain("a-new-password");
+    expect(serialised).not.toContain("postmaster");
+    expect(serialised).not.toContain("smtp.example.com");
+  });
+
+  it("names which fields an update touched, and only those", async () => {
+    const created = await service.createProvider(INPUT, ACTOR);
+    logged.length = 0;
+
+    await service.updateProvider(created.id, { name: "Renamed" }, ACTOR);
+
+    expect(logged[0]?.metadata).toEqual({
+      providerType: "smtp",
+      changedFields: ["name"],
+    });
+  });
+
+  it("counts a configuration change as one name, not by inner path", async () => {
+    const created = await service.createProvider(INPUT, ACTOR);
+    logged.length = 0;
+
+    await service.updateProvider(
+      created.id,
+      {
+        configuration: {
+          ...INPUT.configuration,
+          auth: { user: "postmaster", pass: "rotated" },
+        },
+      },
+      ACTOR
+    );
+
+    // `auth.pass` would say WHICH credential changed, which is a detail about
+    // the secret in a row the secret is not supposed to reach.
+    expect(logged[0]?.metadata).toEqual({
+      providerType: "smtp",
+      changedFields: ["configuration"],
+    });
+  });
+
+  it("reports nothing changed when an update changes nothing", async () => {
+    const created = await service.createProvider(INPUT, ACTOR);
+    logged.length = 0;
+
+    await service.updateProvider(created.id, { name: INPUT.name }, ACTOR);
+
+    // The control for the diff: a no-op update must not report a field.
+    expect(logged[0]?.metadata).toEqual({ providerType: "smtp" });
+  });
+
+  it("records a promotion to default", async () => {
+    const created = await service.createProvider(INPUT, ACTOR);
+    logged.length = 0;
+
+    await service.setDefault(created.id, ACTOR);
+
+    expect(logged[0]).toMatchObject({
+      action: "update",
+      entryId: created.id,
+      metadata: { providerType: "smtp", changedFields: ["isDefault"] },
+    });
+  });
+
+  it("records a delete, naming the provider that no longer exists", async () => {
+    const created = await service.createProvider(INPUT, ACTOR);
+    logged.length = 0;
+
+    await service.deleteProvider(created.id, ACTOR);
+
+    // The feed outlives the row, so the heading has to be carried at write
+    // time — after the delete there is nothing left to resolve it from.
+    expect(logged[0]).toMatchObject({
+      action: "delete",
+      entryId: created.id,
+      entryTitle: "Production SMTP",
+    });
+  });
+
+  it("records nothing for a write with no signed-in actor", async () => {
+    // A seed, a migration or an API key carries no account. The actor column is
+    // a user reference whose erasure state is answered against the accounts
+    // table, so an id with no account behind it files as an already-erased
+    // identity — a worse record than none.
+    await service.createProvider(INPUT);
+    await service.createProvider(
+      { ...INPUT, name: "By key" },
+      {
+        type: "apiKey",
+        id: "key-1",
+      }
+    );
+    await service.createProvider(
+      { ...INPUT, name: "By system" },
+      {
+        type: "user",
+        id: SYSTEM_CONTEXT.user?.id ?? "system",
+      }
+    );
+
+    expect(logged).toHaveLength(0);
+  });
+
+  it("does not fail the mutation when the trail cannot be written", async () => {
+    container.register("activityLogService", () => ({
+      logActivity: () => Promise.reject(new Error("activity log is down")),
+    }));
+
+    // The write has already committed. Turning a completed credential change
+    // into a reported failure would leave the caller believing the opposite of
+    // the truth.
+    await expect(service.createProvider(INPUT, ACTOR)).resolves.toMatchObject({
+      name: "Production SMTP",
+    });
+    // Not silent, though: a trail that stops being written shows up in the log.
+    expect(logger.error).toHaveBeenCalledWith(
+      "Failed to record email provider activity",
+      expect.objectContaining({ action: "create" })
+    );
+  });
+});

--- a/packages/nextly/src/domains/email/__tests__/provider-activity.test.ts
+++ b/packages/nextly/src/domains/email/__tests__/provider-activity.test.ts
@@ -255,7 +255,7 @@ describe("email provider activity", () => {
     });
   });
 
-  it("ignores a request key the service does not recognise", async () => {
+  it("records nothing for a request key the service does not recognise", async () => {
     // The update body is a cast over parsed JSON. An unknown key is ignored by
     // every write, so reporting it would claim a change that never happened —
     // and put a request-controlled string into a widely readable row.
@@ -270,17 +270,24 @@ describe("email provider activity", () => {
       ACTOR
     );
 
-    expect(logged[0]?.metadata).toEqual({ providerType: "smtp" });
+    // No entry at all. `data` is a cast over parsed JSON, so an unknown key is
+    // ignored by every write — and an entry the feed renders as "updated
+    // Production SMTP" for a request that wrote nothing is a claim that
+    // something happened.
+    expect(logged).toHaveLength(0);
   });
 
-  it("reports nothing changed when an update changes nothing", async () => {
+  it("records nothing when an update changes nothing", async () => {
     const created = await service.createProvider(INPUT, ACTOR);
     logged.length = 0;
 
     await service.updateProvider(created.id, { name: INPUT.name }, ACTOR);
 
-    // The control for the diff: a no-op update must not report a field.
-    expect(logged[0]?.metadata).toEqual({ providerType: "smtp" });
+    // Not a fieldless entry — no entry. The form submits every field whether
+    // or not the operator touched one, so a save that moved nothing is the
+    // ordinary case, and the feed rendering it as "updated Production SMTP"
+    // would make most entries in the trail claims about nothing.
+    expect(logged).toHaveLength(0);
   });
 
   it("records a promotion to default", async () => {
@@ -343,7 +350,10 @@ describe("email provider activity", () => {
 
     await service.setDefault(created.id, ACTOR);
 
-    expect(logged[0]?.metadata).toEqual({ providerType: "smtp" });
+    // A client retry on a provider that is already the default writes nothing,
+    // by the same rule the update path follows — decided in one place so the
+    // two cannot come to disagree.
+    expect(logged).toHaveLength(0);
   });
 
   it("records a promotion that did change something", async () => {
@@ -568,8 +578,9 @@ describe("an update over a configuration nobody can decrypt", () => {
 
     await service.updateProvider(readable.id, { configuration: {} }, ACTOR);
 
-    // No `changedFields` at all, which is how this service already reports an
-    // update that changed nothing.
-    expect(logged[0]?.metadata).toEqual({ providerType: "permissive" });
+    // Nothing moved, so nothing is recorded. That is what separates this from
+    // the two cases above it: an unreadable preimage produces an entry naming
+    // `configuration`, and a readable empty one produces no entry at all.
+    expect(logged).toHaveLength(0);
   });
 });

--- a/packages/nextly/src/domains/email/__tests__/provider-activity.test.ts
+++ b/packages/nextly/src/domains/email/__tests__/provider-activity.test.ts
@@ -194,6 +194,68 @@ describe("email provider activity", () => {
     });
   });
 
+  it("does not report a credential change when the credential did not change", async () => {
+    // The form always sends `configuration`, even when only the name was
+    // edited. Encryption is randomised — a fresh salt and IV per call — so
+    // comparing the new ciphertext with the stored one made every save look
+    // like a credential change. A false alarm on the one signal the trail
+    // exists for is worse than no entry.
+    const created = await service.createProvider(INPUT, ACTOR);
+    logged.length = 0;
+
+    await service.updateProvider(
+      created.id,
+      { name: "Renamed", configuration: INPUT.configuration },
+      ACTOR
+    );
+
+    expect(logged[0]?.metadata).toEqual({
+      providerType: "smtp",
+      changedFields: ["name"],
+    });
+  });
+
+  it("does report one when the credential actually changes", async () => {
+    // The control: exempting an identical configuration must not exempt a
+    // real rotation, which is the event the trail is for.
+    const created = await service.createProvider(INPUT, ACTOR);
+    logged.length = 0;
+
+    await service.updateProvider(
+      created.id,
+      {
+        configuration: {
+          ...INPUT.configuration,
+          auth: { user: "postmaster", pass: "rotated" },
+        },
+      },
+      ACTOR
+    );
+
+    expect(logged[0]?.metadata).toEqual({
+      providerType: "smtp",
+      changedFields: ["configuration"],
+    });
+  });
+
+  it("ignores a request key the service does not recognise", async () => {
+    // The update body is a cast over parsed JSON. An unknown key is ignored by
+    // every write, so reporting it would claim a change that never happened —
+    // and put a request-controlled string into a widely readable row.
+    const created = await service.createProvider(INPUT, ACTOR);
+    logged.length = 0;
+
+    await service.updateProvider(
+      created.id,
+      { notAProviderField: true } as unknown as Parameters<
+        typeof service.updateProvider
+      >[1],
+      ACTOR
+    );
+
+    expect(logged[0]?.metadata).toEqual({ providerType: "smtp" });
+  });
+
   it("reports nothing changed when an update changes nothing", async () => {
     const created = await service.createProvider(INPUT, ACTOR);
     logged.length = 0;

--- a/packages/nextly/src/domains/email/__tests__/provider-activity.test.ts
+++ b/packages/nextly/src/domains/email/__tests__/provider-activity.test.ts
@@ -373,6 +373,56 @@ describe("email provider activity", () => {
     expect(logged.filter(entry => entry.action === "delete")).toHaveLength(1);
   });
 
+  /**
+   * Delete the row the moment the mutation has read it.
+   *
+   * Deleting it beforehand would not reach the mechanism at all: both methods
+   * start by reading the provider and would fail there, leaving the guard
+   * after the write untested. The window that matters is between that read and
+   * the statement, so the fixture opens it on the read itself.
+   */
+  function deleteAfterTheMutationReadsIt(id: string): void {
+    const target = service as unknown as {
+      getRawProvider: (id: string) => Promise<unknown>;
+    };
+    const original = target.getRawProvider.bind(target);
+    target.getRawProvider = async (wanted: string) => {
+      const row = await original(wanted);
+      sqlite.prepare("delete from email_providers where id = ?").run(id);
+      return row;
+    };
+  }
+
+  it("records no update when a delete wins the race", async () => {
+    // The delete lands after the read, so the update matches nothing. An entry
+    // naming the fields it meant to change would describe a row that no longer
+    // exists — an audit event for a change the database never made.
+    const created = await service.createProvider(INPUT, ACTOR);
+    deleteAfterTheMutationReadsIt(created.id);
+    logged.length = 0;
+
+    await expect(
+      service.updateProvider(created.id, { name: "Renamed" }, ACTOR)
+    ).rejects.toMatchObject({ code: "NOT_FOUND" });
+
+    expect(logged).toHaveLength(0);
+  });
+
+  it("records no promotion when a delete wins the race", async () => {
+    // Same race against `setDefault`. Promotion decides which provider sends
+    // every unrouted message, so a promotion recorded for a provider that was
+    // never promoted is the most misleading entry this trail can hold.
+    const created = await service.createProvider(INPUT, ACTOR);
+    deleteAfterTheMutationReadsIt(created.id);
+    logged.length = 0;
+
+    await expect(service.setDefault(created.id, ACTOR)).rejects.toMatchObject({
+      code: "NOT_FOUND",
+    });
+
+    expect(logged).toHaveLength(0);
+  });
+
   it("records nothing for a write with no signed-in actor", async () => {
     // A seed, a migration or an API key carries no account. The actor column is
     // a user reference whose erasure state is answered against the accounts

--- a/packages/nextly/src/domains/email/__tests__/provider-activity.test.ts
+++ b/packages/nextly/src/domains/email/__tests__/provider-activity.test.ts
@@ -472,6 +472,20 @@ describe("an update over a configuration nobody can decrypt", () => {
   let providerId: string;
 
   beforeEach(async () => {
+    // The permissive target, so a type change can land with no configuration
+    // of its own and an empty patch can be accepted.
+    getEmailProviderRegistry().register(
+      defineEmailProvider({
+        type: "permissive",
+        label: "Permissive",
+        configFields: [],
+        parseConfig: input => (input ?? {}) as Record<string, unknown>,
+        createAdapter: () => ({
+          send: () => Promise.resolve({ success: true, messageId: "x" }),
+        }),
+      })
+    );
+
     sqlite = new Database(":memory:");
     createEmailProvidersTable(sqlite);
     service = new EmailProviderService(
@@ -510,41 +524,52 @@ describe("an update over a configuration nobody can decrypt", () => {
     vi.clearAllMocks();
   });
 
-  it("reports the configuration as changed when it is replaced", async () => {
-    await service.updateProvider(
-      providerId,
-      {
-        configuration: {
-          host: "smtp.example.com",
-          port: 587,
-          secure: true,
-          auth: { user: "postmaster", pass: "a-new-password" },
-        },
-      },
-      ACTOR
-    );
+  it("reports the discarded configuration on a type change", async () => {
+    // The branch that replaces the stored configuration without the caller
+    // sending one. It decides whether to name `configuration` by asking
+    // whether the preimage held anything — and an unreadable preimage decrypts
+    // to `{}`, which reads as "there was nothing there". The credentials being
+    // discarded are exactly the ones nobody could read.
+    await service.updateProvider(providerId, { type: "permissive" }, ACTOR);
 
-    // Without the readability flag this diffs against `{}` and — for a patch
-    // that happened to merge to `{}` too — reports nothing at all. Here it is
-    // the honest answer either way: an unreadable preimage cannot support the
-    // claim that nothing changed.
     expect(logged[0]?.metadata).toMatchObject({
-      changedFields: ["configuration"],
+      changedFields: ["type", "configuration"],
     });
   });
 
-  it("still reports nothing for a rename over a READABLE configuration", async () => {
-    // The control. Without it the case above would pass on a service that had
-    // started reporting a configuration change on every save — which is the
-    // false-alarm bug an earlier round removed.
+  it("names configuration when an unreadable one is merged over", async () => {
+    // The other branch. A permissive target accepts an empty patch, so the
+    // merged result is `{}` too — identical to the fallback the unreadable
+    // preimage produced, and a string comparison of the two reports no change
+    // for a save that replaced an unreadable credential.
+    await service.updateProvider(
+      providerId,
+      { type: "permissive", configuration: {} },
+      ACTOR
+    );
+
+    expect(logged[0]?.metadata).toMatchObject({
+      changedFields: ["type", "configuration"],
+    });
+  });
+
+  it("reports nothing extra when the preimage is READABLE and empty", async () => {
+    // The control, and it has to be an EMPTY readable configuration rather
+    // than a rename: `{}` is what both cases produce, so this is the one
+    // fixture that distinguishes "nothing was there" from "nobody could read
+    // what was there". Without it, both assertions above would pass on a
+    // service that had started claiming a configuration change on every save
+    // — the false-alarm bug an earlier round removed.
     const readable = await service.createProvider(
-      { ...INPUT, name: "Readable" },
+      { ...INPUT, name: "Readable", type: "permissive", configuration: {} },
       ACTOR
     );
     logged.length = 0;
 
-    await service.updateProvider(readable.id, { name: "Renamed" }, ACTOR);
+    await service.updateProvider(readable.id, { configuration: {} }, ACTOR);
 
-    expect(logged[0]?.metadata).toMatchObject({ changedFields: ["name"] });
+    // No `changedFields` at all, which is how this service already reports an
+    // update that changed nothing.
+    expect(logged[0]?.metadata).toEqual({ providerType: "permissive" });
   });
 });

--- a/packages/nextly/src/domains/email/__tests__/provider-activity.test.ts
+++ b/packages/nextly/src/domains/email/__tests__/provider-activity.test.ts
@@ -465,3 +465,86 @@ describe("email provider activity", () => {
     );
   });
 });
+
+describe("an update over a configuration nobody can decrypt", () => {
+  let sqlite: Database.Database;
+  let service: EmailProviderService;
+  let providerId: string;
+
+  beforeEach(async () => {
+    sqlite = new Database(":memory:");
+    createEmailProvidersTable(sqlite);
+    service = new EmailProviderService(
+      makeAdapter(drizzle({ client: sqlite })),
+      logger
+    );
+    container.register("activityLogService", () => ({
+      logActivity: (input: LogActivityInput) => {
+        logged.push(input);
+        return Promise.resolve();
+      },
+    }));
+    const created = await service.createProvider(INPUT, ACTOR);
+    providerId = created.id;
+
+    // What a NEXTLY_SECRET rotation leaves behind: a value that is still a
+    // string and no longer decrypts. `decryptConfiguration` answers `{}` for
+    // it, which is also what an empty configuration looks like.
+    //
+    // Written as JSON, because the column is a JSON text column and Drizzle
+    // parses it before the service sees it — raw text here throws in the
+    // driver and the test never reaches the branch it is about.
+    sqlite
+      .prepare("update email_providers set configuration = ? where id = ?")
+      .run(
+        JSON.stringify("not-a-ciphertext-this-will-not-decrypt"),
+        providerId
+      );
+    logged.length = 0;
+  });
+
+  afterEach(() => {
+    sqlite.close();
+    getEmailProviderRegistry().reset();
+    container.clear();
+    vi.clearAllMocks();
+  });
+
+  it("reports the configuration as changed when it is replaced", async () => {
+    await service.updateProvider(
+      providerId,
+      {
+        configuration: {
+          host: "smtp.example.com",
+          port: 587,
+          secure: true,
+          auth: { user: "postmaster", pass: "a-new-password" },
+        },
+      },
+      ACTOR
+    );
+
+    // Without the readability flag this diffs against `{}` and — for a patch
+    // that happened to merge to `{}` too — reports nothing at all. Here it is
+    // the honest answer either way: an unreadable preimage cannot support the
+    // claim that nothing changed.
+    expect(logged[0]?.metadata).toMatchObject({
+      changedFields: ["configuration"],
+    });
+  });
+
+  it("still reports nothing for a rename over a READABLE configuration", async () => {
+    // The control. Without it the case above would pass on a service that had
+    // started reporting a configuration change on every save — which is the
+    // false-alarm bug an earlier round removed.
+    const readable = await service.createProvider(
+      { ...INPUT, name: "Readable" },
+      ACTOR
+    );
+    logged.length = 0;
+
+    await service.updateProvider(readable.id, { name: "Renamed" }, ACTOR);
+
+    expect(logged[0]?.metadata).toMatchObject({ changedFields: ["name"] });
+  });
+});

--- a/packages/nextly/src/domains/email/provider-activity.ts
+++ b/packages/nextly/src/domains/email/provider-activity.ts
@@ -1,0 +1,150 @@
+/**
+ * What an email provider mutation records about itself.
+ *
+ * `email_providers` holds the credentials that send password-reset and
+ * verification mail, so an actor who can edit a provider can point every
+ * authentication email at a relay they control. Until now that action was
+ * indistinguishable from no action after the fact: the activity log existed and
+ * this domain never wrote to it.
+ *
+ * Two rules shape everything here.
+ *
+ * **Names, never values.** The entry says which fields a change touched. It
+ * carries no part of `configuration`, encrypted or decrypted, and no value from
+ * any other column either — an audit row is read by more people than the record
+ * it describes, and a trail that leaks what it audits is worse than none.
+ *
+ * **Which fields are secret is read from the provider's own metadata**, not
+ * guessed from key names. It happens not to matter for the diff, because no
+ * value is written either way; it matters for the next person, who will reach
+ * for a heuristic if this file demonstrates one.
+ *
+ * @module domains/email/provider-activity
+ */
+
+import type { RequestActor } from "../../auth/request-actor";
+import { container } from "../../di/container";
+import type {
+  ActivityLogAction,
+  ActivityLogService,
+} from "../../services/dashboard/activity-log-service";
+import { SYSTEM_CONTEXT } from "../../shared/types";
+
+/**
+ * The activity-log `collection` these entries are filed under.
+ *
+ * Not a content collection. The column is a free string and the feed groups by
+ * it, so a settings resource gets a name of the same shape rather than a new
+ * mechanism — the alternative is a second trail with its own reader.
+ */
+export const EMAIL_PROVIDER_ACTIVITY_COLLECTION = "email-providers";
+
+/** One recorded provider mutation. */
+export interface EmailProviderActivityInput {
+  action: ActivityLogAction;
+  /** The provider row's id. */
+  providerId: string;
+  /** The provider's name at the time of the action, for the feed heading. */
+  providerName: string;
+  /** The registered type, e.g. `smtp`. Not a secret and worth reading later. */
+  providerType: string;
+  /**
+   * Field NAMES the action touched. Never values.
+   *
+   * Absent for a create and a delete: one reports every field it wrote and the
+   * other every field it removed, neither of which distinguishes anything the
+   * action itself has not already said.
+   */
+  changedFields?: ReadonlyArray<string>;
+  actor?: RequestActor | null;
+}
+
+/**
+ * Whether this actor produces an entry.
+ *
+ * Only a signed-in person. An API key and an internal write carry no account,
+ * and the trail's actor column is a user reference whose erasure state is
+ * answered against the accounts table — a key's own id finds no account there
+ * and would be filed as an already-erased identity, which is a worse record
+ * than none.
+ */
+function willRecord(
+  actor?: RequestActor | null
+): actor is RequestActor & { type: "user"; id: string } {
+  if (actor?.type !== "user" || !actor.id) return false;
+  // `SYSTEM_CONTEXT` carries the reserved user id `system`, so a seed or a
+  // migration with no transport actor to override it resolves to a USER actor.
+  // No account owns that id. Compared against the sentinel itself so the two
+  // cannot drift apart.
+  return actor.id !== SYSTEM_CONTEXT.user?.id;
+}
+
+/**
+ * Record one provider mutation.
+ *
+ * Called AFTER the write commits, so it uses the standalone `logActivity`,
+ * which swallows its own failures. That is the right direction here: the
+ * mutation has already happened, and turning a completed credential change into
+ * a reported failure because the trail could not be written would leave the
+ * caller believing the opposite of the truth. The service logs the failure, so
+ * a trail that stops being written is visible in the logs rather than silent.
+ *
+ * Never throws. An audit write that took the surrounding request down would
+ * make the trail a liability rather than a record.
+ */
+export async function recordProviderActivity(
+  input: EmailProviderActivityInput
+): Promise<void> {
+  if (!willRecord(input.actor)) return;
+
+  let service: ActivityLogService;
+  try {
+    service = container.get<ActivityLogService>("activityLogService");
+  } catch {
+    // Absent registration is a boot-time fact about how the host assembled its
+    // container, not a write that failed.
+    return;
+  }
+
+  await service.logActivity({
+    userId: input.actor.id,
+    action: input.action,
+    collection: EMAIL_PROVIDER_ACTIVITY_COLLECTION,
+    entryId: input.providerId,
+    // Denormalized deliberately: the feed outlives the provider it names, and a
+    // deleted provider's row would otherwise be unlabelled — the one entry
+    // whose subject the reader can no longer recover any other way.
+    entryTitle: input.providerName,
+    metadata: {
+      providerType: input.providerType,
+      ...(input.changedFields && input.changedFields.length > 0
+        ? { changedFields: [...input.changedFields] }
+        : {}),
+    },
+  });
+}
+
+/**
+ * The top-level provider fields a change touched, as names.
+ *
+ * `configuration` is reported as the single name `configuration` rather than by
+ * its inner paths. Those paths are the provider's own field names, and naming
+ * `auth.pass` in a row that many people can read says which credential changed
+ * — which is a detail about the secret, in a place the secret is not supposed
+ * to reach. That an update touched the configuration is the fact worth keeping.
+ */
+export function changedProviderFields(
+  previous: Record<string, unknown>,
+  incoming: Record<string, unknown>
+): string[] {
+  const changed: string[] = [];
+  for (const [key, value] of Object.entries(incoming)) {
+    if (value === undefined) continue;
+    // Compared as JSON so a nested configuration object is judged by content
+    // rather than by identity, which would report every update as a change.
+    if (JSON.stringify(previous[key]) !== JSON.stringify(value)) {
+      changed.push(key);
+    }
+  }
+  return changed;
+}

--- a/packages/nextly/src/domains/email/provider-activity.ts
+++ b/packages/nextly/src/domains/email/provider-activity.ts
@@ -80,6 +80,29 @@ function willRecord(
 }
 
 /**
+ * Whether this mutation moved anything worth an entry.
+ *
+ * An `update` that changed nothing still reaches here: the form submits every
+ * field whether or not the operator touched it, and promoting a provider that
+ * is already the default is an ordinary client retry. Both produce an entry the
+ * feed renders as "updated Production SMTP", which is a claim that something
+ * happened — and the whole value of this trail is that every entry means
+ * something moved.
+ *
+ * Empty is only meaningful for an update. A create and a delete carry no field
+ * list because the action already says what it did, so an absent list there is
+ * a full description rather than an empty one.
+ *
+ * Decided here rather than at each call site, because there are two of them —
+ * `updateProvider` and `setDefault` — and a comment in one claiming the other
+ * already skipped is how they came to disagree.
+ */
+function worthRecording(input: EmailProviderActivityInput): boolean {
+  if (input.action !== "update") return true;
+  return (input.changedFields?.length ?? 0) > 0;
+}
+
+/**
  * Record one provider mutation.
  *
  * Called AFTER the write commits, so it uses the standalone `logActivity`,
@@ -96,6 +119,7 @@ export async function recordProviderActivity(
   input: EmailProviderActivityInput
 ): Promise<void> {
   if (!willRecord(input.actor)) return;
+  if (!worthRecording(input)) return;
 
   let service: ActivityLogService;
   try {

--- a/packages/nextly/src/domains/email/services/email-provider-service.ts
+++ b/packages/nextly/src/domains/email/services/email-provider-service.ts
@@ -184,16 +184,37 @@ export class EmailProviderService extends BaseService {
   private decryptConfiguration(
     stored: Record<string, unknown> | string
   ): Record<string, unknown> {
+    return this.readConfiguration(stored).config;
+  }
+
+  /**
+   * Decrypt, and say whether it worked.
+   *
+   * `decryptConfiguration` answers `{}` for an unreadable value, which is the
+   * right thing for a READ -- a provider whose ciphertext no longer decrypts
+   * must still be listable, maskable and deletable rather than becoming a row
+   * nobody can act on. It is the wrong thing for a COMPARISON: `{}` is also
+   * what a genuinely empty configuration looks like, so a diff against an
+   * unreadable preimage concludes nothing changed at the moment it is least
+   * entitled to. Callers about to make a claim take this form and ask.
+   */
+  private readConfiguration(stored: Record<string, unknown> | string): {
+    config: Record<string, unknown>;
+    readable: boolean;
+  } {
     if (!this.encryptionSecret || typeof stored !== "string") {
-      return stored as Record<string, unknown>;
+      return { config: stored as Record<string, unknown>, readable: true };
     }
     try {
-      return JSON.parse(decrypt(stored, this.encryptionSecret));
+      return {
+        config: JSON.parse(decrypt(stored, this.encryptionSecret)),
+        readable: true,
+      };
     } catch {
       this.logger.warn(
         "Failed to decrypt provider configuration — returning empty object"
       );
-      return {};
+      return { config: {}, readable: false };
     }
   }
 
@@ -642,9 +663,16 @@ export class EmailProviderService extends BaseService {
         // and nothing else. An entry that says "type" while the credentials
         // beneath it were discarded is worse than no entry: it is a record
         // that reads as harmless.
+        //
+        // An UNREADABLE preimage counts as a change on its own. `{}` is what
+        // this returns both for an empty configuration and for a ciphertext
+        // that no longer decrypts -- after a `NEXTLY_SECRET` rotation, say --
+        // and the second is precisely when a credential is being discarded.
+        // Reading the fallback as "there was nothing there" would file the
+        // loss as a type change and nothing more.
+        const previous = this.readConfiguration(currentRow.configuration);
         configurationChanged =
-          Object.keys(this.decryptConfiguration(currentRow.configuration))
-            .length > 0;
+          !previous.readable || Object.keys(previous.config).length > 0;
       }
     }
 
@@ -658,9 +686,11 @@ export class EmailProviderService extends BaseService {
     // and do nothing.
     const unsetPaths = this.readUnsetPaths(data.unsetConfiguration);
     if (data.configuration !== undefined || unsetPaths.length > 0) {
-      const existingConfig = this.decryptConfiguration(
-        currentRow.configuration
-      );
+      // Read through `readConfiguration`, not `decryptConfiguration`: the diff
+      // below has to tell an empty stored configuration from one that no
+      // longer decrypts, and both arrive as `{}`.
+      const existing = this.readConfiguration(currentRow.configuration);
+      const existingConfig = existing.config;
       const incomingConfig = this.stripMaskedConfigValues(
         data.configuration ?? {}
       );
@@ -697,7 +727,13 @@ export class EmailProviderService extends BaseService {
       // Nothing is decrypted for this. Both values are already in memory --
       // `existingConfig` two statements above and `mergedConfig` beside it --
       // because the update path had to read one and build the other.
+      //
+      // An unreadable preimage is a change by itself, for the reason given in
+      // the type-change branch: comparing against the `{}` fallback would
+      // report "unchanged" for a save that replaced a credential nobody could
+      // read with one they can.
       configurationChanged =
+        !existing.readable ||
         JSON.stringify(existingConfig) !== JSON.stringify(mergedConfig);
 
       updateData.configuration = this.encryptConfiguration(mergedConfig);

--- a/packages/nextly/src/domains/email/services/email-provider-service.ts
+++ b/packages/nextly/src/domains/email/services/email-provider-service.ts
@@ -601,6 +601,9 @@ export class EmailProviderService extends BaseService {
     const currentRow = await this.getRawProvider(id);
 
     const now = new Date();
+    // Whether the merged configuration differs from the stored one, decided
+    // before encryption where the two are comparable.
+    let configurationChanged = false;
     const updateData: Record<string, unknown> = {
       updatedAt: now,
     };
@@ -674,6 +677,19 @@ export class EmailProviderService extends BaseService {
         .get(effectiveType)
         .validateConfig(mergedConfig);
 
+      // Compared BEFORE encryption. Encryption is randomised -- a fresh salt
+      // and IV per call -- so two encryptions of identical configuration never
+      // match, and comparing ciphertexts reported a credential change on every
+      // save the form made, including one that touched nothing but the name.
+      // A false credential-change alert is worse in an audit trail than no
+      // entry: it is noise on the one signal the trail exists for.
+      //
+      // Nothing is decrypted for this. Both values are already in memory --
+      // `existingConfig` two statements above and `mergedConfig` beside it --
+      // because the update path had to read one and build the other.
+      configurationChanged =
+        JSON.stringify(existingConfig) !== JSON.stringify(mergedConfig);
+
       updateData.configuration = this.encryptConfiguration(mergedConfig);
     }
     if (data.isActive !== undefined) updateData.isActive = data.isActive;
@@ -715,27 +731,37 @@ export class EmailProviderService extends BaseService {
       providerId: id,
       providerName: data.name ?? currentRow.name,
       providerType: effectiveType,
-      changedFields: changedProviderFields(
-        {
-          name: currentRow.name,
-          type: currentRow.type,
-          fromEmail: currentRow.fromEmail,
-          fromName: currentRow.fromName,
-          isDefault: currentRow.isDefault,
-          isActive: currentRow.isActive,
-          // Compared as the ENCRYPTED stored value against the encrypted
-          // replacement. Neither is read, and decrypting to diff would put
-          // credentials in memory for the benefit of a row that records no
-          // values.
-          configuration: currentRow.configuration,
-        },
-        {
-          ...data,
-          ...(updateData.configuration !== undefined
-            ? { configuration: updateData.configuration }
-            : {}),
-        }
-      ),
+      changedFields: [
+        // Built from the fields this service RECOGNISES, never by spreading
+        // the request body. `data` is a cast over parsed JSON, so an unknown
+        // key -- `{"notAProviderField": true}` -- is ignored by every write
+        // above and would otherwise be reported as a changed field, putting a
+        // request-controlled string into a widely readable audit row and
+        // claiming a change that never happened.
+        ...changedProviderFields(
+          {
+            name: currentRow.name,
+            type: currentRow.type,
+            fromEmail: currentRow.fromEmail,
+            fromName: currentRow.fromName,
+            isDefault: currentRow.isDefault,
+            isActive: currentRow.isActive,
+          },
+          {
+            ...(data.name !== undefined ? { name: data.name } : {}),
+            ...(data.type !== undefined ? { type: data.type } : {}),
+            ...(data.fromEmail !== undefined
+              ? { fromEmail: data.fromEmail }
+              : {}),
+            ...(data.fromName !== undefined ? { fromName: data.fromName } : {}),
+            ...(data.isDefault !== undefined
+              ? { isDefault: data.isDefault }
+              : {}),
+            ...(data.isActive !== undefined ? { isActive: data.isActive } : {}),
+          }
+        ),
+        ...(configurationChanged ? ["configuration"] : []),
+      ],
       actor,
     });
 

--- a/packages/nextly/src/domains/email/services/email-provider-service.ts
+++ b/packages/nextly/src/domains/email/services/email-provider-service.ts
@@ -705,6 +705,7 @@ export class EmailProviderService extends BaseService {
     if (data.isActive !== undefined) updateData.isActive = data.isActive;
     if (data.isDefault !== undefined) updateData.isDefault = data.isDefault;
 
+    let updatedRows: number;
     try {
       if (data.isDefault === true) {
         // Unset any existing default first, then apply all updates to this provider
@@ -713,17 +714,13 @@ export class EmailProviderService extends BaseService {
           .update(this.emailProviders)
           .set({ isDefault: false, updatedAt: now })
           .where(eq(this.emailProviders.isDefault, true));
-
-        await this.db
-          .update(this.emailProviders)
-          .set(updateData)
-          .where(eq(this.emailProviders.id, id));
-      } else {
-        await this.db
-          .update(this.emailProviders)
-          .set(updateData)
-          .where(eq(this.emailProviders.id, id));
       }
+
+      const result = await this.db
+        .update(this.emailProviders)
+        .set(updateData)
+        .where(eq(this.emailProviders.id, id));
+      updatedRows = affectedRowCount(result, this.dialect);
     } catch (error) {
       // DbError → NextlyError; spec §13.8 keeps the public message generic and
       // tucks the dialect-specific code into logContext via fromDatabaseError.
@@ -731,6 +728,14 @@ export class EmailProviderService extends BaseService {
       // is preserved (otherwise PG 23505 collapses to INTERNAL_ERROR).
       throw NextlyError.fromDatabaseError(toDbError(this.dialect, error));
     }
+
+    // A delete can land between the read above and this statement, and the
+    // update then matches nothing. Recording the requested fields anyway would
+    // leave a durable entry claiming a change to a row that no longer exists,
+    // moments before `getProvider` reports it absent. Every dialect counts
+    // MATCHED rows here, not modified ones, so a request that genuinely
+    // rewrites nothing still reaches the trail.
+    if (updatedRows === 0) return this.getProvider(id);
 
     // Field NAMES only, and `configuration` counted as one name rather than by
     // its inner paths: naming `auth.pass` in a widely-readable row says which
@@ -863,10 +868,18 @@ export class EmailProviderService extends BaseService {
       .set({ isDefault: false, updatedAt: now })
       .where(eq(this.emailProviders.isDefault, true));
 
-    await this.db
+    const promotion = await this.db
       .update(this.emailProviders)
       .set({ isDefault: true, updatedAt: now })
       .where(eq(this.emailProviders.id, id));
+
+    // The provider can be deleted between the read above and this statement,
+    // in which case nothing was promoted. Recording it anyway would put a
+    // promotion in the trail for a provider that never became the default --
+    // the one claim this entry exists to make.
+    if (affectedRowCount(promotion, this.dialect) === 0) {
+      return this.getProvider(id);
+    }
 
     // An `update` touching `isDefault`, because that is what it is. Promotion
     // decides which provider sends every unrouted message, so it is the change

--- a/packages/nextly/src/domains/email/services/email-provider-service.ts
+++ b/packages/nextly/src/domains/email/services/email-provider-service.ts
@@ -35,6 +35,7 @@ import { BaseService } from "../../../shared/base-service";
 import { encrypt, decrypt } from "../../../utils/encryption";
 // Pull adapter type into a normal `import type` declaration so the return
 // signature on createAdapterFromProvider satisfies consistent-type-imports.
+import { affectedRowCount } from "../../auth/services/auth-service";
 import {
   changedProviderFields,
   recordProviderActivity,
@@ -635,6 +636,15 @@ export class EmailProviderService extends BaseService {
       // "a type change replaces rather than merges" is supposed to prevent.
       if (data.configuration === undefined) {
         updateData.configuration = this.encryptConfiguration(submitted);
+        // This branch REPLACES the stored configuration without the caller
+        // having sent one, so the diff below -- which only runs when
+        // `data.configuration` is present -- would have reported a type change
+        // and nothing else. An entry that says "type" while the credentials
+        // beneath it were discarded is worse than no entry: it is a record
+        // that reads as harmless.
+        configurationChanged =
+          Object.keys(this.decryptConfiguration(currentRow.configuration))
+            .length > 0;
       }
     }
 
@@ -807,9 +817,16 @@ export class EmailProviderService extends BaseService {
       });
     }
 
-    await this.db
+    const result = await this.db
       .delete(this.emailProviders)
       .where(eq(this.emailProviders.id, id));
+
+    // Two deletes of the same provider can both read the row before either
+    // statement runs; the second affects nothing and must not attribute a
+    // deletion to whoever sent it. The method stays idempotent -- both callers
+    // still succeed -- but only the one that actually removed the row is
+    // recorded as having done so.
+    if (affectedRowCount(result, this.dialect) === 0) return;
 
     // Recorded from the row read before the delete, because after it there is
     // nothing left to name. A deleted provider's entry is the one whose
@@ -860,7 +877,11 @@ export class EmailProviderService extends BaseService {
       providerId: id,
       providerName: row.name,
       providerType: row.type,
-      changedFields: ["isDefault"],
+      // A client retry promotes a provider that is already the default. The
+      // final state is identical, so claiming `isDefault` changed manufactures
+      // an audit event out of a no-op -- and the update path beside this one
+      // already reports nothing for a value that did not move.
+      changedFields: row.isDefault ? [] : ["isDefault"],
       actor,
     });
 

--- a/packages/nextly/src/domains/email/services/email-provider-service.ts
+++ b/packages/nextly/src/domains/email/services/email-provider-service.ts
@@ -928,8 +928,9 @@ export class EmailProviderService extends BaseService {
       providerType: row.type,
       // A client retry promotes a provider that is already the default. The
       // final state is identical, so claiming `isDefault` changed manufactures
-      // an audit event out of a no-op -- and the update path beside this one
-      // already reports nothing for a value that did not move.
+      // an audit event out of a no-op. An empty list is what the recorder
+      // reads as "nothing moved", and it writes no row at all for one -- the
+      // same answer the update path beside this one gets.
       changedFields: row.isDefault ? [] : ["isDefault"],
       actor,
     });

--- a/packages/nextly/src/domains/email/services/email-provider-service.ts
+++ b/packages/nextly/src/domains/email/services/email-provider-service.ts
@@ -18,6 +18,7 @@ import { randomUUID } from "crypto";
 import type { DrizzleAdapter } from "@nextlyhq/adapter-drizzle";
 import { eq, desc } from "drizzle-orm";
 
+import type { RequestActor } from "../../../auth/request-actor";
 import { toDbError } from "../../../database/errors";
 import { NextlyError } from "../../../errors";
 import { env } from "../../../lib/env";
@@ -34,6 +35,11 @@ import { BaseService } from "../../../shared/base-service";
 import { encrypt, decrypt } from "../../../utils/encryption";
 // Pull adapter type into a normal `import type` declaration so the return
 // signature on createAdapterFromProvider satisfies consistent-type-imports.
+import {
+  changedProviderFields,
+  recordProviderActivity,
+  type EmailProviderActivityInput,
+} from "../provider-activity";
 import { describeProviderFailure } from "../provider-definition";
 import type { EmailProviderAdapter } from "../types";
 
@@ -465,7 +471,12 @@ export class EmailProviderService extends BaseService {
    * in a transaction to ensure only one default exists.
    */
   async createProvider(
-    data: CreateEmailProviderInput
+    data: CreateEmailProviderInput,
+    /**
+     * Who performed this, for the audit trail. Optional so an internal or
+     * seeded write needs no ceremony; those produce no entry by design.
+     */
+    actor?: RequestActor | null
   ): Promise<EmailProviderRecord> {
     // Reject an unregistered type and an unusable configuration BEFORE the
     // insert. Without this a row stores happily and fails only when something
@@ -511,7 +522,39 @@ export class EmailProviderService extends BaseService {
       throw NextlyError.fromDatabaseError(toDbError(this.dialect, error));
     }
 
+    // Recorded after the insert commits and before the read, so a trail entry
+    // cannot exist for a provider that was never stored.
+    await this.recordActivity({
+      action: "create",
+      providerId: id,
+      providerName: data.name,
+      providerType: data.type,
+      actor,
+    });
+
     return this.getProvider(id);
+  }
+
+  /**
+   * Record a provider mutation, and never let recording break the mutation.
+   *
+   * The write has already committed by the time this runs. `recordActivity`
+   * swallows its own failures for that reason, and this wrapper is the place
+   * that turns one into a log line -- a trail that quietly stops being written
+   * should be visible somewhere.
+   */
+  private async recordActivity(
+    input: EmailProviderActivityInput
+  ): Promise<void> {
+    try {
+      await recordProviderActivity(input);
+    } catch (error) {
+      this.logger.error("Failed to record email provider activity", {
+        providerId: input.providerId,
+        action: input.action,
+        message: error instanceof Error ? error.message : String(error),
+      });
+    }
   }
 
   /**
@@ -552,7 +595,8 @@ export class EmailProviderService extends BaseService {
    */
   async updateProvider(
     id: string,
-    data: UpdateEmailProviderInput
+    data: UpdateEmailProviderInput,
+    actor?: RequestActor | null
   ): Promise<EmailProviderRecord> {
     const currentRow = await this.getRawProvider(id);
 
@@ -662,6 +706,39 @@ export class EmailProviderService extends BaseService {
       throw NextlyError.fromDatabaseError(toDbError(this.dialect, error));
     }
 
+    // Field NAMES only, and `configuration` counted as one name rather than by
+    // its inner paths: naming `auth.pass` in a widely-readable row says which
+    // credential changed, which is a detail about the secret in a place the
+    // secret is not supposed to reach.
+    await this.recordActivity({
+      action: "update",
+      providerId: id,
+      providerName: data.name ?? currentRow.name,
+      providerType: effectiveType,
+      changedFields: changedProviderFields(
+        {
+          name: currentRow.name,
+          type: currentRow.type,
+          fromEmail: currentRow.fromEmail,
+          fromName: currentRow.fromName,
+          isDefault: currentRow.isDefault,
+          isActive: currentRow.isActive,
+          // Compared as the ENCRYPTED stored value against the encrypted
+          // replacement. Neither is read, and decrypting to diff would put
+          // credentials in memory for the benefit of a row that records no
+          // values.
+          configuration: currentRow.configuration,
+        },
+        {
+          ...data,
+          ...(updateData.configuration !== undefined
+            ? { configuration: updateData.configuration }
+            : {}),
+        }
+      ),
+      actor,
+    });
+
     return this.getProvider(id);
   }
 
@@ -674,7 +751,7 @@ export class EmailProviderService extends BaseService {
    *
    * @throws NextlyError BUSINESS_RULE_VIOLATION if provider is the default
    */
-  async deleteProvider(id: string): Promise<void> {
+  async deleteProvider(id: string, actor?: RequestActor | null): Promise<void> {
     let row;
     try {
       row = await this.getRawProvider(id);
@@ -707,6 +784,17 @@ export class EmailProviderService extends BaseService {
     await this.db
       .delete(this.emailProviders)
       .where(eq(this.emailProviders.id, id));
+
+    // Recorded from the row read before the delete, because after it there is
+    // nothing left to name. A deleted provider's entry is the one whose
+    // subject the reader can no longer recover any other way.
+    await this.recordActivity({
+      action: "delete",
+      providerId: id,
+      providerName: row.name,
+      providerType: row.type,
+      actor,
+    });
   }
 
   /**
@@ -717,8 +805,11 @@ export class EmailProviderService extends BaseService {
    *
    * @throws NextlyError NOT_FOUND if provider doesn't exist
    */
-  async setDefault(id: string): Promise<EmailProviderRecord> {
-    await this.getRawProvider(id);
+  async setDefault(
+    id: string,
+    actor?: RequestActor | null
+  ): Promise<EmailProviderRecord> {
+    const row = await this.getRawProvider(id);
 
     const now = new Date();
 
@@ -733,6 +824,19 @@ export class EmailProviderService extends BaseService {
       .update(this.emailProviders)
       .set({ isDefault: true, updatedAt: now })
       .where(eq(this.emailProviders.id, id));
+
+    // An `update` touching `isDefault`, because that is what it is. Promotion
+    // decides which provider sends every unrouted message, so it is the change
+    // most worth attributing and the least visible in the record it otherwise
+    // leaves -- one boolean, on two rows.
+    await this.recordActivity({
+      action: "update",
+      providerId: id,
+      providerName: row.name,
+      providerType: row.type,
+      changedFields: ["isDefault"],
+      actor,
+    });
 
     return this.getProvider(id);
   }


### PR DESCRIPTION
Task 158. Stacked on #633 (base `feat/admin-provider-form-descriptors`), which is stacked on #626 — GitHub retargets each as its parent merges.

`email_providers` holds the credentials that send password-reset and verification mail. An actor who can edit a provider can point every authentication email in the system at a relay they control, and until now that action was **indistinguishable from no action after the fact**: `recordActivity` had exactly two call sites, both in the webhooks content path, and `activityLog|activity_log|logActivity` returned zero matches across `domains/email/`.

This is the second of the two holes the founder's decision to keep the provider table rested on. Editing credentials through a web form is defensible; doing it without a trail is not.

## What it does

Create, update, delete and promote-to-default write an activity entry.

**The plumbing already existed.** `setAuthenticatedRouteParams` stamps `_authenticatedActorType` / `_authenticatedActorId` on every dispatched request, and `readAuthenticatedActor` decodes it — the collection, single, user and versions dispatchers all use it. The email dispatcher simply never read what was being handed to it. So this adds no transport, only the four reads and an optional actor argument on the four service methods.

## Names, never values

An entry carries the provider id, its type, the actor and which fields changed. Three specific decisions:

- **No part of the configuration, in either direction.** The update diff compares the **encrypted** stored value against the encrypted replacement, so nothing is decrypted for the benefit of a row that records no values.
- **A configuration change counts as the single name `configuration`.** Naming `auth.pass` in a widely-readable row says *which credential* changed — a detail about the secret, in a place the secret is not supposed to reach.
- **The provider name is denormalized at write time.** The feed outlives the row, and a deleted provider's entry is the one whose subject a reader can no longer recover any other way.

## Recording cannot fail a mutation

It runs after the write commits, via the standalone `logActivity`, which swallows. Turning a completed credential change into a reported failure would leave the caller believing the opposite of the truth. The service logs the failure, so a trail that stops being written is visible rather than silent — and there is a test for both halves.

## Tests

Nine cases in `provider-activity.test.ts`, against a real service and an in-memory database rendered from the shipped core schema:

- create, update, delete and promote each record, with the acting user
- **no credential reaches the row** — asserted over the *serialised* entries, because a value nested inside `metadata` would satisfy any field-by-field check written from the shape this code happens to produce today
- an update names only the fields it touched; a no-op update names none
- a write with **no signed-in actor** records nothing: no actor, an API key, and the `SYSTEM_CONTEXT` sentinel are all covered. The actor column is a user reference whose erasure state is answered against the accounts table, so an id with no account behind it would file as an already-erased identity — a worse record than none
- a failing activity log does not fail the mutation, and does log

Proven by two positive controls: leaking the configuration into `metadata` fails the disclosure test, and widening the actor gate fails the no-actor test.

`nextly` typechecks clean and the email suite is 224 passing.

## Two things I am not closing here

**The Direct API records nothing.** `NextlyContext` carries no actor — nothing under `direct-api/` references `RequestActor` — so `nextly.email.providers.update(...)` produces no entry, exactly like a seed or a migration. The optional-actor design degrades correctly rather than silently attributing to the wrong identity, but a script that edits providers through the Direct API leaves no trail. Giving the Direct API an actor is a cross-cutting change well beyond this task; filed rather than bolted on.

**Email templates.** Task 158 says to assess them in the same pass. A template carries a `providerId` and a `fromOverride`, so it can redirect mail too — but it is a different service with a different shape, and putting it in this PR would double the surface. Filed as a follow-up.
