### PR TITLE
feat(plugin-page-builder): declare structure for every block in the catalogue

### DIFF
--- a/.changeset/block-structure-final-batch.md
+++ b/.changeset/block-structure-final-batch.md
@@ -1,0 +1,26 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+Page validation now refuses children stored under a slot on a block that holds none, not just on containers with the wrong slot name. Every block in the catalogue declares its structure where the check can read it without loading the block library.

--- a/packages/plugin-page-builder/src/core/__tests__/structure-covers-the-catalog.test.ts
+++ b/packages/plugin-page-builder/src/core/__tests__/structure-covers-the-catalog.test.ts
@@ -22,40 +22,38 @@ import { CORE_BLOCK_STRUCTURES, declaredSlotsOf } from "../block-structure";
 import { defaultBlockRegistry } from "../registry";
 import "../../render/blocks";
 
-/** Every registered definition that can hold children, by type. */
-function slotDeclaringTypes(): string[] {
-  return defaultBlockRegistry
-    .all()
-    .filter(def => (def.slots?.length ?? 0) > 0)
-    .map(def => def.type)
-    .sort();
-}
-
 describe("the structure source against the real catalogue", () => {
-  it("covers every definition that declares a slot", () => {
-    const fromDefinitions = slotDeclaringTypes();
+  it("covers EVERY registered definition, not only the slot-declaring ones", () => {
+    const everyType = defaultBlockRegistry.all().map(def => def.type);
 
     // Positive control: the registry is actually populated here. Without the side-effect import
     // above this list would be empty and every assertion below would hold vacuously — which is
     // exactly how the write-path check came to look like it worked while being inert.
-    expect(fromDefinitions.length).toBeGreaterThan(0);
+    expect(everyType.length).toBeGreaterThan(40);
 
-    const missing = fromDefinitions.filter(
+    // A type with no structure is one the validator leaves to `allowUnknown`, so a new block that
+    // skips the structure source opts itself out of the slot check silently. Coverage has to be
+    // total for the check to mean anything.
+    const missing = everyType.filter(
       type => declaredSlotsOf(type) === undefined
     );
     expect(missing).toEqual([]);
   });
 
-  it("declares the SAME slot names the definition does", () => {
+  it("declares the SAME slot names the definition does — including none", () => {
     // Covering the type is not enough: a structure naming different slots than its definition
     // would let the validator accept a name the renderer never places, or reject one it does.
+    // The empty case is compared too, deliberately: skipping slotless definitions left a
+    // structure that INVENTED a slot on a plain block invisible to this file, and the only test
+    // that caught it was the hand-maintained list — which someone editing both sides would edit
+    // together.
     for (const def of defaultBlockRegistry.all()) {
-      const declared = def.slots?.map(s => s.name).sort();
-      if (!declared?.length) continue;
+      const declared = (def.slots ?? []).map(s => s.name).sort();
       expect(
         declaredSlotsOf(def.type)
           ?.map(s => s.name)
-          .sort()
+          .sort(),
+        `slot names for ${def.type}`
       ).toEqual(declared);
     }
   });

--- a/packages/plugin-page-builder/src/core/__tests__/validate-without-renderer.test.ts
+++ b/packages/plugin-page-builder/src/core/__tests__/validate-without-renderer.test.ts
@@ -112,16 +112,14 @@ describe("the write path with nothing rendered", () => {
     ).toContain("has no slot");
   });
 
-  it("has structure for EVERY block that declares a slot", () => {
-    // The property that keeps the write path honest as blocks are added. A container whose
-    // structure is not declared here answers `undefined` from `declaredSlotsOf`, which the
-    // validator correctly treats as "this build cannot say" and defers to `allowUnknown` — so a
-    // new container would silently opt itself out of the slot check rather than fail loudly.
-    //
-    // Asserted against the structure source alone, with no renderer loaded: this file cannot see
-    // the definitions, which is the point. The list is written out rather than derived, so adding
-    // a container has to be a deliberate edit here.
-    expect(Object.keys(CORE_BLOCK_STRUCTURES).sort()).toEqual([
+  it("has structure for the ENTIRE catalogue, containers and plain blocks alike", () => {
+    // The property that keeps the write path honest as blocks are added. A type with NO structure
+    // is one the validator must leave to `allowUnknown` — so a new block that skips this list opts
+    // itself out of the slot check silently. The list is written out rather than derived, so
+    // adding a block has to be a deliberate edit here; the OTHER direction — that this record
+    // matches the real registry — is what `structure-covers-the-catalog.test.ts` asserts, because
+    // only the registry can see it and this file must never load it.
+    const containers = [
       "core/columns",
       "core/container",
       "core/content-carousel",
@@ -130,14 +128,84 @@ describe("the write path with nothing rendered", () => {
       "core/off-canvas",
       "core/query-loop",
       "core/row",
-    ]);
-    // Every one of them declares at least one slot: a structure with none would be a block that
-    // cannot hold children, which belongs to a later batch and not to this list.
-    for (const type of Object.keys(CORE_BLOCK_STRUCTURES)) {
+    ];
+    const plain = [
+      "core/accordion",
+      "core/anchor",
+      "core/badge",
+      "core/button",
+      "core/button-group",
+      "core/counter",
+      "core/countdown",
+      "core/cta-card",
+      "core/divider",
+      "core/embed",
+      "core/flip-box",
+      "core/form",
+      "core/gallery",
+      "core/heading",
+      "core/hotspot",
+      "core/icon",
+      "core/icon-box",
+      "core/icon-list",
+      "core/image",
+      "core/image-box",
+      "core/image-carousel",
+      "core/list",
+      "core/logo-carousel",
+      "core/logo-cloud",
+      "core/lottie",
+      "core/map",
+      "core/paragraph",
+      "core/price-list",
+      "core/pricing-table",
+      "core/progress-bar",
+      "core/rating",
+      "core/ref",
+      "core/reviews",
+      "core/rich-text",
+      "core/slides",
+      "core/social-icons",
+      "core/spacer",
+      "core/table",
+      "core/tabs",
+      "core/testimonial",
+      "core/testimonial-carousel",
+      "core/toggle",
+      "core/video",
+    ];
+
+    expect(Object.keys(CORE_BLOCK_STRUCTURES).sort()).toEqual(
+      [...containers, ...plain].sort()
+    );
+    // A container declares at least one slot; a plain block declares EXACTLY none. `slots: []` is
+    // a statement — "children are junk here" — not an omission.
+    for (const type of containers) {
       expect(declaredSlotsOf(type)?.length ?? 0).toBeGreaterThan(0);
+    }
+    for (const type of plain) {
+      expect(declaredSlotsOf(type)).toEqual([]);
     }
   });
 
+  it("REFUSES stored children on a block that holds none", () => {
+    // A block with no structure is one the validator leaves to `allowUnknown`, so junk slots on a
+    // LEAF pass the write check whenever the registry is empty — the ordinary state of the config
+    // and server paths. `slots: []` is what refuses them.
+    const error = validateDocument(
+      doc({
+        ...makeNode("core/heading", { text: "x", level: "h2" }),
+        slots: {
+          anything: [makeNode("core/paragraph", { text: "junk" })],
+        },
+      }),
+      defaultBlockRegistry,
+      { allowUnknown: true }
+    );
+
+    expect(error).toContain("anything");
+    expect(error).toContain("core/heading");
+  });
   it("leaves a type this build has no structure for to allowUnknown", () => {
     // A block from a plugin this process has not loaded. "No structure for that type" and "that
     // block declares no such slot" look identical from the lookup and only the second is a reason

--- a/packages/plugin-page-builder/src/core/block-structure.ts
+++ b/packages/plugin-page-builder/src/core/block-structure.ts
@@ -70,11 +70,12 @@ export function declaredSlotsOf(type: string): SlotSpec[] | undefined {
 }
 
 /**
- * The first migrated batch.
+ * Blocks that hold children, one constant each.
  *
  * Declared here rather than beside each `defineBlock` so this module can be imported without
  * reaching a `.tsx` file — which is the entire point: importing one block's structure must not pull
- * React in behind it.
+ * React in behind it. Each definition SPREADS its constant, so the slots a block draws and the
+ * slots the validator enforces are one statement rather than two that agree by discipline.
  */
 export const containerStructure = declareStructure({
   type: "core/container",
@@ -123,6 +124,68 @@ export const contentCarouselStructure = declareStructure({
   isContainer: true,
   slots: [{ name: "default" }],
 });
+
+/**
+ * Blocks that hold no children, declared as data in one list.
+ *
+ * `slots: []` is a statement, not an omission: a stored document can carry children under any slot
+ * name on any node, and a type with NO structure is one the validator must leave to `allowUnknown`
+ * — so before this list, junk slots on a heading or an image passed the write check whenever the
+ * registry was empty, which is the ordinary state of the config and server paths.
+ *
+ * No definition spreads these. There is nothing structural to share beyond the type name, and the
+ * correspondence is enforced from the other side: `structure-covers-the-catalog.test.ts` asserts
+ * every registered definition has a structure AND that their slot lists agree, so a block that
+ * later grows slots without moving to a container structure fails there, not silently here.
+ */
+const PLAIN_BLOCK_TYPES = [
+  "core/accordion",
+  "core/anchor",
+  "core/badge",
+  "core/button",
+  "core/button-group",
+  "core/counter",
+  "core/countdown",
+  "core/cta-card",
+  "core/divider",
+  "core/embed",
+  "core/flip-box",
+  "core/form",
+  "core/gallery",
+  "core/heading",
+  "core/hotspot",
+  "core/icon",
+  "core/icon-box",
+  "core/icon-list",
+  "core/image",
+  "core/image-box",
+  "core/image-carousel",
+  "core/list",
+  "core/logo-carousel",
+  "core/logo-cloud",
+  "core/lottie",
+  "core/map",
+  "core/paragraph",
+  "core/price-list",
+  "core/pricing-table",
+  "core/progress-bar",
+  "core/rating",
+  "core/ref",
+  "core/reviews",
+  "core/rich-text",
+  "core/slides",
+  "core/social-icons",
+  "core/spacer",
+  "core/table",
+  "core/tabs",
+  "core/testimonial",
+  "core/testimonial-carousel",
+  "core/toggle",
+  "core/video",
+] as const;
+for (const type of PLAIN_BLOCK_TYPES) {
+  declareStructure({ type, slots: [] });
+}
 
 /** Whether a node's type is one this build has structure for. */
 export function hasStructure(node: BlockNode): boolean {

--- a/packages/plugin-page-builder/src/core/validate.ts
+++ b/packages/plugin-page-builder/src/core/validate.ts
@@ -45,9 +45,9 @@ export function validateDocument(
     // none: a caller supplying its own definition is stating what its own renderer exposes, and
     // letting a built-in's structure fill the gap would admit children that renderer never draws.
     //
-    // Structure answers only when no definition is registered. That is the ordinary case for the
-    // config and server paths, where the registry is empty because populating it requires a
-    // side-effect import of the renderer that those paths do not perform.
+    // Structure answers when no definition is registered — the ordinary case for the config and
+    // server paths, where the registry is empty because populating it requires a side-effect
+    // import of the renderer that those paths do not perform.
     const structuralSlots = declaredSlotsOf(n.type);
     const declaredSlots = def ? (def.slots ?? []) : structuralSlots;
     const structural = def !== undefined || structuralSlots !== undefined;


### PR DESCRIPTION
Final batch of the task 160 follow-up. #636 built the seam, #640 put the eight
container definitions on it, and this puts **the whole catalogue** on it.

## The hole this closes

The earlier batches covered blocks that DECLARE slots. This one covers the
blocks that declare none — which had a hole of their own, in the opposite
direction.

`declaredSlotsOf` returns `undefined` for a type with no structure, and the
validator correctly reads that as *"this build cannot say"* and defers to
`allowUnknown`. So **junk slots stored on a leaf passed the write check** whenever
the registry was empty — the ordinary state of the config and server paths, which
is exactly where `pageBuilderField` runs.

Verified after the change: a `core/heading` carrying
`slots: { anything: [...] }` is now refused, naming the slot.

`slots: []` is therefore a statement, not an omission — *"children are junk
here"* — and 43 blocks now make it.

## The count, definitions not files

51 definitions in the catalogue: 8 containers (already spread from their
structure constants) and 43 plain blocks. Enumerated by splitting each file on
`defineBlock(` and reading each definition's own object literal — a file-level
grep gets this wrong, which is how "~50 blocks declare slots" entered the plan
when only 8 do.

## The check grew in the direction that was blind

`structure-covers-the-catalog.test.ts` compared slot names only for definitions
that declared some, and `continue`d past the rest. That left a structure which
**invents** a slot on a plain block invisible to the registry-backed test — its
only cover was the hand-maintained list in the other file, and someone editing
both sides would edit both.

Slot names are now compared for **every** definition, empty included, with the
block type in the assertion message.

| Stub | Failed |
|---|---|
| one plain type dropped from the list | all three completeness tests, including the new refusal |
| a plain structure grows a `default` slot | the hand-written-set test **and** (after the fix) the registry-backed name test |

## The fallback

`def ? (def.slots ?? []) : structuralSlots` **stays**, and its transitional
wording is gone. It is no longer a migration bridge: with the catalogue complete,
the structural branch is the *normal* answer for the config and server paths, and
the registry branch is what a caller supplying its own definition gets. That is
the permanent shape, so the comment now describes it as such — nothing in this
package still reads two declaration shapes.

626 tests pass; typecheck and lint clean.
