### PR TITLE
docs(blocks-engine): say that a url pattern is stricter than the object form

### DIFF
--- a/packages/blocks-engine/src/url-policy.test.ts
+++ b/packages/blocks-engine/src/url-policy.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Which remote hosts a pattern admits.
+ *
+ * The cases here are the ones where the answer is surprising, and the surprise
+ * is deliberate: this type exists so an entry copied out of `next.config` behaves
+ * the same, so its rules are `next/image`'s rules rather than the friendlier
+ * ones. A test that only covered the obvious matches would leave the next reader
+ * free to "fix" the surprising behaviour and quietly widen every site's policy.
+ */
+import { describe, expect, it } from "vitest";
+
+import { isAllowedRemoteUrl, isFetchableUrl, isRemoteUrl } from "./url-policy";
+
+describe("a URL used as a pattern", () => {
+  // `next/image`'s `matchRemotePattern` takes `RemotePattern | URL` and applies
+  // the same `!== undefined` tests to both. A `URL` answers `""` for a port and
+  // a search it does not have, and `"" !== undefined`, so those tests RUN for a
+  // URL and are skipped for the object spelling that omits them.
+  const asUrl = [new URL("https://cdn.example/img/**")];
+  const asObject = [
+    {
+      protocol: "https" as const,
+      hostname: "cdn.example",
+      pathname: "/img/**",
+    },
+  ];
+
+  it("admits the plain case either way", () => {
+    // The control. Without it every assertion below could pass because the
+    // matcher rejects everything.
+    expect(isAllowedRemoteUrl("https://cdn.example/img/a.png", asUrl)).toBe(
+      true
+    );
+    expect(isAllowedRemoteUrl("https://cdn.example/img/a.png", asObject)).toBe(
+      true
+    );
+  });
+
+  it("refuses a query string that the object spelling admits", () => {
+    // A `URL` carries `search: ""`, which means "exactly no query", while the
+    // object omits `search`, which means "any query". Cache-busting an image as
+    // `?v=2` is the everyday way to meet this.
+    expect(isAllowedRemoteUrl("https://cdn.example/img/a.png?v=2", asUrl)).toBe(
+      false
+    );
+    expect(
+      isAllowedRemoteUrl("https://cdn.example/img/a.png?v=2", asObject)
+    ).toBe(true);
+  });
+
+  it("refuses a non-default port that the object spelling admits", () => {
+    // Same shape one field over: `port: ""` means the default port only.
+    expect(
+      isAllowedRemoteUrl("https://cdn.example:8443/img/a.png", asUrl)
+    ).toBe(false);
+    expect(
+      isAllowedRemoteUrl("https://cdn.example:8443/img/a.png", asObject)
+    ).toBe(true);
+  });
+
+  it("matches the object spelling that states the same fields", () => {
+    // Which is what shows the difference is about the FIELDS being present, not
+    // about the input being a `URL`.
+    const explicit = [
+      {
+        protocol: "https" as const,
+        hostname: "cdn.example",
+        port: "",
+        pathname: "/img/**",
+        search: "",
+      },
+    ];
+    for (const candidate of [
+      "https://cdn.example/img/a.png",
+      "https://cdn.example/img/a.png?v=2",
+      "https://cdn.example:8443/img/a.png",
+    ]) {
+      expect(isAllowedRemoteUrl(candidate, explicit)).toBe(
+        isAllowedRemoteUrl(candidate, asUrl)
+      );
+    }
+  });
+});
+
+describe("what counts as reaching another host", () => {
+  it("treats a scheme-less protocol-relative url as remote", () => {
+    // It carries no scheme and still reaches somewhere else, inheriting only
+    // the page's protocol. A check reading "no scheme, therefore this origin"
+    // is wrong about exactly this value.
+    expect(isRemoteUrl("//cdn.example/a.png")).toBe(true);
+    expect(isRemoteUrl("/a.png")).toBe(false);
+    expect(isRemoteUrl("a.png")).toBe(false);
+  });
+
+  it("reads a backslash the way the parser does", () => {
+    // Backslashes are read as slashes for http(s), so this reaches another host
+    // while beginning with neither `//` nor a scheme.
+    expect(isRemoteUrl("/\\evil.example/a.png")).toBe(true);
+  });
+
+  it("refuses a protocol-relative url outright when fetching", () => {
+    // Its scheme is the DOCUMENT's, which is not knowable at compile time.
+    // Assuming https once admitted a value against an https-only pattern on a
+    // page that then fetched it over http.
+    expect(
+      isFetchableUrl("//cdn.example/img/a.png", [
+        { protocol: "https", hostname: "cdn.example" },
+      ])
+    ).toBe(false);
+    // An author who wants that host writes the scheme, and then it matches.
+    expect(
+      isFetchableUrl("https://cdn.example/img/a.png", [
+        { protocol: "https", hostname: "cdn.example" },
+      ])
+    ).toBe(true);
+  });
+
+  it("leaves a same-origin path alone whatever the patterns say", () => {
+    // The list bounds where a page reaches OUT to. A path names no host, so an
+    // empty list must not blank a site's own images.
+    expect(isFetchableUrl("/uploads/a.png", [])).toBe(true);
+    expect(isFetchableUrl("a.png", [])).toBe(true);
+    // And an empty list really is a policy: it admits no remote host at all.
+    expect(isFetchableUrl("https://cdn.example/a.png", [])).toBe(false);
+  });
+});

--- a/packages/blocks-engine/src/url-policy.ts
+++ b/packages/blocks-engine/src/url-policy.ts
@@ -79,9 +79,30 @@ export function isRemoteUrl(value: string): boolean {
  *
  * `next.config` accepts `remotePatterns: [new URL("https://cdn.example/img/**")]`
  * as well as the object form, and a `URL` already carries every field this
- * matches on. The only difference is that its `protocol` keeps the trailing
- * colon, which is why the comparison below strips one from both sides rather
- * than appending one — the same accommodation `matchRemotePattern` makes.
+ * matches on. Its `protocol` keeps the trailing colon, which is why the
+ * comparison below strips one from both sides rather than appending one — the
+ * same accommodation `matchRemotePattern` makes.
+ *
+ * **A `URL` is STRICTER than the object spelling that looks like it**, and the
+ * difference is easy to be surprised by. A `URL` answers `""` for a `port` and a
+ * `search` it does not have, while the object form leaves them undefined, and an
+ * omitted field means "anything" here while an empty one means "exactly empty".
+ * So `new URL("https://cdn.example/img/**")` matches only the default port AND
+ * only a URL with no query string, where
+ * `{ protocol: "https", hostname: "cdn.example", pathname: "/img/**" }` accepts
+ * any port and any query. An image requested as `?v=2` is refused by the first
+ * and admitted by the second.
+ *
+ * This is not a quirk of this implementation. `next/image`'s `matchRemotePattern`
+ * takes `RemotePattern | URL` and applies the same `!== undefined` tests to
+ * both, so a `URL` narrows it there in exactly the same way. Normalising the
+ * empty strings away here would be friendlier in isolation and WRONG in the way
+ * that matters: the reason this type takes a `URL` at all is that an entry
+ * copied from `next.config` should behave identically, and a rule that admitted
+ * more here than it does for `next/image` would leave a site believing one
+ * boundary while running two.
+ *
+ * Write the object form when the intent is "any port, any query".
  */
 export type RemotePatternInput = URL | RemotePattern;
 


### PR DESCRIPTION
Closes C16 from the task-153 audit — as a **documentation** fix, not a behaviour change. The research reversed the fix I expected to make.

## What I found

My own test on #638 surfaced that `new URL("https://cdn.example/img/**")` and `{ protocol: "https", hostname: "cdn.example", pathname: "/img/**" }` are **not** the same policy. A `URL` answers `""` for a `port` and a `search` it does not have; the object form leaves them undefined. Here an omitted field means "anything" and an empty one means "exactly empty", so the URL form pins the default port **and** an empty query.

`RemotePatternInput`'s doc said the only difference was the trailing colon on `protocol`. Someone copying a `next.config` entry as a `URL` would silently get an image requested as `?v=2` refused.

## Why the code does not change

I expected to normalise the empty strings away, and checked `next/image` first. Its `matchRemotePattern` takes `RemotePattern | URL` and applies the **same** `!== undefined` tests to both:

```ts
if (pattern.port !== undefined) { if (pattern.port !== url.port) return false }
if (pattern.search !== undefined) { if (pattern.search !== url.search) return false }
```

and its own `search` docs say an empty string means "no query string".

So a `URL` narrows the rule in Next.js in exactly the same way, and our behaviour is already faithful. **Normalising would have been friendlier in isolation and wrong in the way that matters**: the reason this type accepts a `URL` at all is that an entry copied from `next.config` should behave identically. A rule admitting more here than `next/image` does leaves a site believing one boundary while running two.

## What ships

The type doc now states the difference, gives the `?v=2` example, says *write the object form when you mean "any port, any query"*, and records that this is Next's rule rather than ours — so the next reader does not re-derive it.

Plus `src/url-policy.test.ts`, which the module had none of. It pins the surprising cases specifically, because a test covering only the obvious matches would leave the behaviour free to be "fixed".

**Control:** simulating that friendly normalisation (treating `""` as unset) fails 2 of the 8 — the query-string case and the port case. The guard catches precisely the divergence it exists for.

Also covered while the file was open: protocol-relative and backslash URLs count as remote; a protocol-relative URL is refused outright when fetching, since its scheme is the document's and unknowable at compile time; and an empty pattern list still admits same-origin paths while admitting no remote host.

No changeset: documentation and tests only, no published behaviour change.

`blocks-engine` 1089 tests, check-types and lint clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified how URL-based remote patterns handle protocols, ports, and query strings.
  - Added examples and documented alignment with established remote URL matching behavior.

- **Bug Fixes**
  - Improved handling of protocol-relative and backslash-containing remote URLs.
  - Ensured same-origin paths remain fetchable regardless of remote pattern settings.
  - Aligned equivalent URL and object pattern matching behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->