### PR TITLE
feat(plugin-page-builder): offer to repair blocks the canvas cannot show

### DIFF
--- a/.changeset/invalid-slot-repair.md
+++ b/.changeset/invalid-slot-repair.md
@@ -1,0 +1,26 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+Page editor: a page holding blocks under a slot that no longer exists now says so and offers to clear them. Such blocks are invisible on the canvas (a block only draws the slots it declares), so until now the page simply refused to save with nothing to select and nothing to delete. A bar above the editor names each affected block and where it sits, and removing one is a per-block choice that undo can reverse. Nothing is discarded automatically.

--- a/packages/plugin-page-builder/src/admin/EditorSurface.tsx
+++ b/packages/plugin-page-builder/src/admin/EditorSurface.tsx
@@ -15,6 +15,7 @@ import { defaultBlockRegistry } from "../core/registry";
 
 import { Canvas } from "./canvas/Canvas";
 import { Monitor, Smartphone, Tablet } from "./icons";
+import { InvalidSlotBanner } from "./InvalidSlotBanner";
 import { dragLabel } from "./logic/dragLabel";
 import { planDrop } from "./logic/dropPlan";
 import { BlockLibrary } from "./panels/BlockLibrary";
@@ -72,6 +73,12 @@ export function EditorSurface() {
             ))}
           </div>
         </div>
+        {/*
+         * Above the panes rather than inside the canvas column: the blocks it reports are not
+         * drawn on the canvas at all, so anchoring the notice to the canvas would put it beside
+         * the one place that cannot show what it is about.
+         */}
+        <InvalidSlotBanner />
         <div className="nx-pb-body">
           <aside className="nx-pb-pane nx-pb-pane--left">
             <BlockLibrary />

--- a/packages/plugin-page-builder/src/admin/InvalidSlotBanner.test.tsx
+++ b/packages/plugin-page-builder/src/admin/InvalidSlotBanner.test.tsx
@@ -13,7 +13,10 @@
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
 
-import { findInvalidSlotEntries } from "../core/invalid-slots";
+import {
+  findInvalidSlotEntries,
+  repairInvalidSlot,
+} from "../core/invalid-slots";
 import { defaultBlockRegistry } from "../core/registry";
 import { makeNode } from "../core/tree";
 import { validateDocument } from "../core/validate";
@@ -71,6 +74,39 @@ describe("the repair banner", () => {
     expect(markupFor(docWith({ legacy: [heading("Only one")] }))).toContain(
       "1 block in a slot"
     );
+  });
+
+  it("shows a stale slot that is already empty, which holds no block to list", () => {
+    // The banner has to appear for a page whose only fault is a slot NAME. A surface that only
+    // ever counted blocks would render nothing here and leave the page unsaveable in silence.
+    const broken = docWith({ legacy: [] });
+
+    expect(
+      validateDocument(broken, defaultBlockRegistry, { allowUnknown: true })
+    ).toContain("has no slot");
+
+    const markup = markupFor(broken);
+    expect(markup).toContain("1 leftover");
+    expect(markup).not.toContain("1 block in a slot");
+  });
+
+  it("asks the reducer for exactly the repair the core prescribes", () => {
+    // Two switches on the same union, in two layers, which must not drift: the editor decides
+    // which ACTION a row dispatches, and the core decides which OPERATION a fault needs. Compared
+    // across every kind rather than trusted, because a wrong pairing still type-checks.
+    const broken = docWith({
+      legacy: [heading("Orphan")],
+      alsoStale: [],
+    });
+
+    const entries = findInvalidSlotEntries(broken.root, defaultBlockRegistry);
+    expect(entries.map(e => e.kind).sort()).toEqual(["block", "empty-slot"]);
+
+    for (const entry of entries) {
+      const viaEditor = editorReducer(initialState(broken), removalFor(entry));
+      const viaCore = repairInvalidSlot(broken.root, entry);
+      expect(viaEditor.document.root).toEqual(viaCore);
+    }
   });
 
   it("dispatches repairs that actually make the document save", () => {

--- a/packages/plugin-page-builder/src/admin/InvalidSlotBanner.test.tsx
+++ b/packages/plugin-page-builder/src/admin/InvalidSlotBanner.test.tsx
@@ -104,7 +104,11 @@ describe("the repair banner", () => {
 
     for (const entry of entries) {
       const viaEditor = editorReducer(initialState(broken), removalFor(entry));
-      const viaCore = repairInvalidSlot(broken.root, entry);
+      const viaCore = repairInvalidSlot(
+        broken.root,
+        entry,
+        defaultBlockRegistry
+      );
       expect(viaEditor.document.root).toEqual(viaCore);
     }
   });

--- a/packages/plugin-page-builder/src/admin/InvalidSlotBanner.test.tsx
+++ b/packages/plugin-page-builder/src/admin/InvalidSlotBanner.test.tsx
@@ -1,0 +1,107 @@
+/**
+ * The repair banner, and the loop it closes.
+ *
+ * Two separate claims, because either one alone can be true while the surface does nothing. The
+ * banner has to APPEAR for a document that cannot save, and the button it draws has to ask the
+ * reducer for the repair that actually makes the document save. A row naming the right block while
+ * dispatching the wrong slot would look right in any screenshot and fix nothing, so the second
+ * claim is followed all the way through the reducer to the validator.
+ *
+ * `render/blocks` is imported on purpose here: the admin is where this component runs, and there
+ * the registry is populated. The finder's own tests cover the opposite condition.
+ */
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { findInvalidSlotEntries } from "../core/invalid-slots";
+import { defaultBlockRegistry } from "../core/registry";
+import { makeNode } from "../core/tree";
+import { validateDocument } from "../core/validate";
+import "../render/blocks";
+
+import { InvalidSlotBanner, removalFor } from "./InvalidSlotBanner";
+import { EditorProvider } from "./store/EditorProvider";
+import { editorReducer, initialState } from "./store/editorStore";
+
+import type { BlockDocument, BlockNode } from "../core/types";
+
+function docWith(slots: Record<string, BlockNode[]>): BlockDocument {
+  return { version: 1, root: makeNode("core/container", {}, undefined, slots) };
+}
+
+const heading = (text: string) => makeNode("core/heading", { text });
+
+function markupFor(document: BlockDocument): string {
+  return renderToStaticMarkup(
+    <EditorProvider document={document} draftKey="nx-pb-test">
+      <InvalidSlotBanner />
+    </EditorProvider>
+  );
+}
+
+describe("the repair banner", () => {
+  it("says nothing about a document that saves", () => {
+    const clean = docWith({ default: [heading("Fine")] });
+
+    expect(
+      validateDocument(clean, defaultBlockRegistry, { allowUnknown: true })
+    ).toBe(true);
+    expect(markupFor(clean)).toBe("");
+  });
+
+  it("appears, and counts what the author cannot see", () => {
+    const broken = docWith({
+      default: [heading("Visible")],
+      legacy: [heading("Invisible"), heading("Also invisible")],
+    });
+
+    // Precondition: this really is a document the write path refuses. Without it the banner
+    // could be appearing for something that would have saved perfectly.
+    expect(
+      validateDocument(broken, defaultBlockRegistry, { allowUnknown: true })
+    ).toContain("has no slot");
+
+    const markup = markupFor(broken);
+    expect(markup).toContain("2 blocks in a slot");
+    expect(markup).toContain("will not save");
+    expect(markup).toContain("Review");
+  });
+
+  it("uses the singular for one block", () => {
+    expect(markupFor(docWith({ legacy: [heading("Only one")] }))).toContain(
+      "1 block in a slot"
+    );
+  });
+
+  it("dispatches repairs that actually make the document save", () => {
+    // Finder to button to reducer to validator, with nothing hand-written in between. This is the
+    // claim that a screenshot cannot make: the rows carry the slot they were found under, and the
+    // reducer removes that slot rather than merely the node inside it.
+    const broken = docWith({
+      default: [
+        heading("Visible"),
+        makeNode("core/row", {}, undefined, {
+          default: [heading("Also visible")],
+          removed: [heading("Orphan in a row")],
+        }),
+      ],
+      legacy: [heading("Orphan at the top")],
+    });
+
+    const entries = findInvalidSlotEntries(broken.root, defaultBlockRegistry);
+    expect(entries.length).toBeGreaterThan(0);
+
+    const repaired = entries.reduce(
+      (s, entry) => editorReducer(s, removalFor(entry)),
+      initialState(broken)
+    );
+
+    expect(
+      validateDocument(repaired.document, defaultBlockRegistry, {
+        allowUnknown: true,
+      })
+    ).toBe(true);
+    // And the banner stops showing, which is the author's signal that they are done.
+    expect(markupFor(repaired.document)).toBe("");
+  });
+});

--- a/packages/plugin-page-builder/src/admin/InvalidSlotBanner.tsx
+++ b/packages/plugin-page-builder/src/admin/InvalidSlotBanner.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+/**
+ * The repair surface for blocks the canvas cannot show and the author cannot save past.
+ *
+ * A block stored under a slot name its parent does not declare is invisible in the editor: the
+ * canvas builds what a definition declares, so nothing draws it. Saving is refused. Every surface
+ * that works by SELECTING a block is therefore useless here, which is why this is a banner over
+ * the document rather than an inspector panel or a marker on the canvas.
+ *
+ * Nothing is removed without a person choosing it, one block at a time. The alternative, repairing
+ * the document on load, would silently discard content whose only remaining copy is the row in the
+ * database.
+ */
+import { Button } from "@nextlyhq/ui";
+import { useState } from "react";
+
+import { findInvalidSlotEntries } from "../core/invalid-slots";
+import type { InvalidSlotEntry } from "../core/invalid-slots";
+import { defaultBlockRegistry } from "../core/registry";
+
+import { useEditor } from "./store/EditorProvider";
+import type { EditorAction } from "./store/editorStore";
+
+/** What the author is offered as the block's name: their own label if they gave it one. */
+function labelFor(entry: InvalidSlotEntry): string {
+  return entry.node.name?.trim() || entry.type;
+}
+
+/**
+ * Identifies the current problem, so dismissing it cannot hide a different one.
+ *
+ * Dismissal is a judgement about the blocks listed at that moment. If the set changes the banner
+ * has something new to say, and a flag that outlived the thing it referred to would hide a page
+ * that still refuses to save.
+ */
+function signatureOf(entries: InvalidSlotEntry[]): string {
+  return entries.map(e => e.node.id).join(",");
+}
+
+/**
+ * The action one Remove button dispatches.
+ *
+ * Separate from the button so the step between "what the finder reported" and "what the reducer
+ * is asked to do" can be exercised without a browser. A row that listed the right block and
+ * dispatched the wrong slot would look correct in every screenshot.
+ */
+export function removalFor(entry: InvalidSlotEntry): EditorAction {
+  return {
+    type: "REMOVE_FROM_SLOT",
+    parentId: entry.parentId,
+    slot: entry.slotName,
+    id: entry.node.id,
+  };
+}
+
+export function InvalidSlotBanner() {
+  const { state, dispatch } = useEditor();
+  const [dismissed, setDismissed] = useState<string | null>(null);
+  const [open, setOpen] = useState(false);
+
+  const entries = findInvalidSlotEntries(
+    state.document.root,
+    defaultBlockRegistry
+  );
+  const signature = signatureOf(entries);
+
+  if (entries.length === 0 || signature === dismissed) return null;
+
+  const count = entries.length;
+
+  return (
+    <div className="nx-pb-repair" role="status" aria-live="polite">
+      <div className="nx-pb-repair-bar">
+        <div className="nx-pb-repair-text">
+          <strong>
+            This page has {count} {count === 1 ? "block" : "blocks"} in a slot
+            that no longer exists.
+          </strong>{" "}
+          They are not drawn on the canvas, so you cannot select them, and the
+          page will not save while they are there.
+        </div>
+        <div className="nx-pb-repair-actions">
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            aria-expanded={open}
+            onClick={() => setOpen(o => !o)}
+          >
+            {open ? "Hide" : "Review"}
+          </Button>
+          <button
+            type="button"
+            className="nx-pb-repair-dismiss"
+            aria-label="Dismiss"
+            onClick={() => setDismissed(signature)}
+          >
+            ×
+          </button>
+        </div>
+      </div>
+
+      {open && (
+        <ul className="nx-pb-repair-list">
+          {entries.map(entry => (
+            <li key={entry.node.id} className="nx-pb-repair-item">
+              <div className="nx-pb-repair-item-text">
+                <span className="nx-pb-repair-item-name">
+                  {labelFor(entry)}
+                </span>
+                <span className="nx-pb-repair-item-where">
+                  in slot &ldquo;{entry.slotName}&rdquo; of {entry.parentType}
+                  {entry.path ? ` (${entry.path})` : ""}
+                  {entry.descendantCount > 0
+                    ? `, holding ${entry.descendantCount} more ${
+                        entry.descendantCount === 1 ? "block" : "blocks"
+                      }`
+                    : ""}
+                </span>
+              </div>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={() => dispatch(removalFor(entry))}
+              >
+                Remove
+              </Button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/packages/plugin-page-builder/src/admin/InvalidSlotBanner.tsx
+++ b/packages/plugin-page-builder/src/admin/InvalidSlotBanner.tsx
@@ -1,14 +1,19 @@
 "use client";
 
 /**
- * The repair surface for blocks the canvas cannot show and the author cannot save past.
+ * The repair surface for a page the canvas cannot show and the author cannot save.
  *
- * A block stored under a slot name its parent does not declare is invisible in the editor: the
+ * Anything stored under a slot name its parent does not declare is invisible in the editor: the
  * canvas builds what a definition declares, so nothing draws it. Saving is refused. Every surface
  * that works by SELECTING a block is therefore useless here, which is why this is a banner over
  * the document rather than an inspector panel or a marker on the canvas.
  *
- * Nothing is removed without a person choosing it, one block at a time. The alternative, repairing
+ * What it offers to remove is not always a block. Validation refuses a slot's NAME rather than its
+ * contents, and refuses a slots map on a non-container before it reads a key, so a page can be
+ * unsaveable with no block in it to remove. Each of those states gets its own row and its own
+ * repair, or the banner would report a problem with no action against it.
+ *
+ * Nothing is removed without a person choosing it, one row at a time. The alternative, repairing
  * the document on load, would silently discard content whose only remaining copy is the row in the
  * database.
  */
@@ -22,36 +27,76 @@ import { defaultBlockRegistry } from "../core/registry";
 import { useEditor } from "./store/EditorProvider";
 import type { EditorAction } from "./store/editorStore";
 
-/** What the author is offered as the block's name: their own label if they gave it one. */
+/** What a row calls the thing it offers to remove. */
 function labelFor(entry: InvalidSlotEntry): string {
-  return entry.node.name?.trim() || entry.type;
+  switch (entry.kind) {
+    case "block":
+      return entry.node.name?.trim() || entry.type;
+    case "empty-slot":
+      return `Empty slot "${entry.slotName}"`;
+    case "stray-slots":
+      return "Leftover slot data";
+  }
+}
+
+/** Where it sits, for someone who cannot click on it. */
+function whereFor(entry: InvalidSlotEntry): string {
+  const on = `on ${entry.parentType}${entry.path ? ` (${entry.path})` : ""}`;
+  switch (entry.kind) {
+    case "block": {
+      const held =
+        entry.descendantCount > 0
+          ? `, holding ${entry.descendantCount} more ${
+              entry.descendantCount === 1 ? "block" : "blocks"
+            }`
+          : "";
+      return `in slot "${entry.slotName}" ${on}${held}`;
+    }
+    case "empty-slot":
+      return `${on}, holding nothing`;
+    case "stray-slots":
+      return `${on}, which holds no slots at all`;
+  }
 }
 
 /**
  * Identifies the current problem, so dismissing it cannot hide a different one.
  *
- * Dismissal is a judgement about the blocks listed at that moment. If the set changes the banner
- * has something new to say, and a flag that outlived the thing it referred to would hide a page
- * that still refuses to save.
+ * Dismissal is a judgement about what was listed at that moment. If the set changes the banner has
+ * something new to say, and a flag that outlived the thing it referred to would hide a page that
+ * still refuses to save.
  */
 function signatureOf(entries: InvalidSlotEntry[]): string {
-  return entries.map(e => e.node.id).join(",");
+  return entries.map(e => e.key).join(",");
 }
 
 /**
  * The action one Remove button dispatches.
  *
- * Separate from the button so the step between "what the finder reported" and "what the reducer
- * is asked to do" can be exercised without a browser. A row that listed the right block and
- * dispatched the wrong slot would look correct in every screenshot.
+ * Separate from the button so the step between "what the finder reported" and "what the reducer is
+ * asked to do" can be exercised without a browser. A row that named the right thing while
+ * dispatching the wrong repair would look correct in every screenshot.
+ *
+ * Three kinds, three repairs: removing the block inside is only ever one of the three answers.
  */
 export function removalFor(entry: InvalidSlotEntry): EditorAction {
-  return {
-    type: "REMOVE_FROM_SLOT",
-    parentId: entry.parentId,
-    slot: entry.slotName,
-    id: entry.node.id,
-  };
+  switch (entry.kind) {
+    case "block":
+      return {
+        type: "REMOVE_FROM_SLOT",
+        parentId: entry.parentId,
+        slot: entry.slotName,
+        id: entry.node.id,
+      };
+    case "empty-slot":
+      return {
+        type: "REMOVE_SLOT",
+        parentId: entry.parentId,
+        slot: entry.slotName,
+      };
+    case "stray-slots":
+      return { type: "DROP_SLOTS", parentId: entry.parentId };
+  }
 }
 
 export function InvalidSlotBanner() {
@@ -68,17 +113,19 @@ export function InvalidSlotBanner() {
   if (entries.length === 0 || signature === dismissed) return null;
 
   const count = entries.length;
+  // An empty stale slot and a leftover slots map are faults with no block in them, so the
+  // block-counting sentence would be false whenever the list is not all blocks.
+  const headline = entries.every(e => e.kind === "block")
+    ? `This page has ${count} ${count === 1 ? "block" : "blocks"} in a slot that no longer exists.`
+    : `This page has ${count} ${count === 1 ? "leftover" : "leftovers"} from a slot that no longer exists.`;
 
   return (
     <div className="nx-pb-repair" role="status" aria-live="polite">
       <div className="nx-pb-repair-bar">
         <div className="nx-pb-repair-text">
-          <strong>
-            This page has {count} {count === 1 ? "block" : "blocks"} in a slot
-            that no longer exists.
-          </strong>{" "}
-          They are not drawn on the canvas, so you cannot select them, and the
-          page will not save while they are there.
+          <strong>{headline}</strong> None of it is drawn on the canvas, so
+          there is nothing to select, and the page will not save until it is
+          cleared.
         </div>
         <div className="nx-pb-repair-actions">
           <Button
@@ -104,19 +151,13 @@ export function InvalidSlotBanner() {
       {open && (
         <ul className="nx-pb-repair-list">
           {entries.map(entry => (
-            <li key={entry.node.id} className="nx-pb-repair-item">
+            <li key={entry.key} className="nx-pb-repair-item">
               <div className="nx-pb-repair-item-text">
                 <span className="nx-pb-repair-item-name">
                   {labelFor(entry)}
                 </span>
                 <span className="nx-pb-repair-item-where">
-                  in slot &ldquo;{entry.slotName}&rdquo; of {entry.parentType}
-                  {entry.path ? ` (${entry.path})` : ""}
-                  {entry.descendantCount > 0
-                    ? `, holding ${entry.descendantCount} more ${
-                        entry.descendantCount === 1 ? "block" : "blocks"
-                      }`
-                    : ""}
+                  {whereFor(entry)}
                 </span>
               </div>
               <Button

--- a/packages/plugin-page-builder/src/admin/store/editorStore.test.ts
+++ b/packages/plugin-page-builder/src/admin/store/editorStore.test.ts
@@ -275,3 +275,83 @@ describe("editorReducer", () => {
     expect(s.past.length).toBeLessThanOrEqual(50);
   });
 });
+
+describe("editorReducer — repairing a slot nothing declares", () => {
+  function docWithGhost(): {
+    doc: BlockDocument;
+    rootId: string;
+    ghostId: string;
+    keptId: string;
+  } {
+    const ghost = makeNode("core/heading", { text: "Invisible" });
+    const kept = makeNode("core/heading", { text: "On the canvas" });
+    const root = makeNode("core/container", {}, undefined, {
+      default: [kept],
+      legacy: [ghost],
+    });
+    return {
+      doc: { version: 1, root },
+      rootId: root.id,
+      ghostId: ghost.id,
+      keptId: kept.id,
+    };
+  }
+
+  it("REMOVE_FROM_SLOT drops the slot once its last child is gone", () => {
+    // The slot NAME is what refuses the save, so leaving an emptied key behind would leave the
+    // author with nothing to remove and a page that still will not save.
+    const { doc, rootId, ghostId } = docWithGhost();
+    const s = editorReducer(initialState(doc), {
+      type: "REMOVE_FROM_SLOT",
+      parentId: rootId,
+      slot: "legacy",
+      id: ghostId,
+    });
+
+    expect(s.document.root.slots?.legacy).toBeUndefined();
+    expect(findNode(s.document.root, ghostId)).toBeUndefined();
+    expect(s.dirty).toBe(true);
+  });
+
+  it("leaves the canvas selection alone, because the removed block was never on it", () => {
+    // `REMOVE` clears the selection unconditionally. Doing that here would take away the block
+    // the author is actually working on to discard one they cannot see.
+    const { doc, rootId, ghostId, keptId } = docWithGhost();
+    let s = editorReducer(initialState(doc), { type: "SELECT", id: keptId });
+    s = editorReducer(s, {
+      type: "REMOVE_FROM_SLOT",
+      parentId: rootId,
+      slot: "legacy",
+      id: ghostId,
+    });
+
+    expect(s.selectedId).toBe(keptId);
+  });
+
+  it("clears the selection when the removed subtree contained it", () => {
+    // The other direction: a selection pointing at a node that no longer exists.
+    const { doc, rootId, ghostId } = docWithGhost();
+    let s = editorReducer(initialState(doc), { type: "SELECT", id: ghostId });
+    s = editorReducer(s, {
+      type: "REMOVE_FROM_SLOT",
+      parentId: rootId,
+      slot: "legacy",
+      id: ghostId,
+    });
+
+    expect(s.selectedId).toBeNull();
+  });
+
+  it("is undoable, so a removal the author regrets is recoverable", () => {
+    const { doc, rootId, ghostId } = docWithGhost();
+    let s = editorReducer(initialState(doc), {
+      type: "REMOVE_FROM_SLOT",
+      parentId: rootId,
+      slot: "legacy",
+      id: ghostId,
+    });
+    s = editorReducer(s, { type: "UNDO" });
+
+    expect(findNode(s.document.root, ghostId)).toBeDefined();
+  });
+});

--- a/packages/plugin-page-builder/src/admin/store/editorStore.ts
+++ b/packages/plugin-page-builder/src/admin/store/editorStore.ts
@@ -195,10 +195,10 @@ export function editorReducer(
       // The discarded block was never on the canvas, so the author's selection is unrelated to it
       // and clearing it unconditionally would take away work they can see. It only has to go when
       // the removed subtree contained it.
-      const selectedId =
-        state.selectedId && !findNode(next, state.selectedId)
-          ? null
-          : state.selectedId;
+      const selectedId = keepValidSelection(
+        { ...state.document, root: next },
+        state.selectedId
+      );
       return commit(state, next, selectedId);
     }
 

--- a/packages/plugin-page-builder/src/admin/store/editorStore.ts
+++ b/packages/plugin-page-builder/src/admin/store/editorStore.ts
@@ -3,6 +3,7 @@
  * core tree ops, with bounded undo/redo history. Defaults for new nodes come from the
  * block registry — never a hard-coded list.
  */
+import { declaredSlotNames } from "../../core/invalid-slots";
 import type { MotionConfig } from "../../core/motion";
 import { defaultBlockRegistry } from "../../core/registry";
 import {
@@ -204,11 +205,24 @@ export function editorReducer(
     case "REMOVE_SLOT":
     case "DROP_SLOTS":
     case "REMOVE_FROM_SLOT": {
+      // The same slot names the core settles by, from the same registry: a container has to keep
+      // a home for every slot it declares or the canvas draws no drop zone for it.
+      const declared = declaredSlotNames(
+        root,
+        action.parentId,
+        defaultBlockRegistry
+      );
       const next =
         action.type === "REMOVE_FROM_SLOT"
-          ? removeFromSlot(root, action.parentId, action.slot, action.id)
+          ? removeFromSlot(
+              root,
+              action.parentId,
+              action.slot,
+              action.id,
+              declared
+            )
           : action.type === "REMOVE_SLOT"
-            ? removeSlot(root, action.parentId, action.slot)
+            ? removeSlot(root, action.parentId, action.slot, declared)
             : dropSlots(root, action.parentId);
       // The discarded block was never on the canvas, so the author's selection is unrelated to it
       // and clearing it unconditionally would take away work they can see. It only has to go when

--- a/packages/plugin-page-builder/src/admin/store/editorStore.ts
+++ b/packages/plugin-page-builder/src/admin/store/editorStore.ts
@@ -12,6 +12,7 @@ import {
   makeNode,
   moveNode,
   reidSubtree,
+  removeFromSlot,
   removeNode,
   updateNode,
 } from "../../core/tree";
@@ -62,6 +63,15 @@ export type EditorAction =
     }
   | { type: "MOVE"; id: string; parentId: string; slot: string; index: number }
   | { type: "REMOVE"; id: string }
+  /**
+   * Discard a block from a named slot, dropping the slot once nothing is left in it.
+   *
+   * Distinct from `REMOVE` because the block it addresses is one the canvas never drew: it sits
+   * under a slot name its parent does not declare, so there is no element to select and `REMOVE`
+   * — which searches every slot and keeps the emptied key — would leave behind the very thing
+   * that refuses the save.
+   */
+  | { type: "REMOVE_FROM_SLOT"; parentId: string; slot: string; id: string }
   | { type: "DUPLICATE"; id: string }
   | { type: "UPDATE_PROPS"; id: string; props: Record<string, unknown> }
   | {
@@ -173,6 +183,23 @@ export function editorReducer(
     case "REMOVE": {
       const next = removeNode(root, action.id);
       return { ...commit(state, next), selectedId: null };
+    }
+
+    case "REMOVE_FROM_SLOT": {
+      const next = removeFromSlot(
+        root,
+        action.parentId,
+        action.slot,
+        action.id
+      );
+      // The discarded block was never on the canvas, so the author's selection is unrelated to it
+      // and clearing it unconditionally would take away work they can see. It only has to go when
+      // the removed subtree contained it.
+      const selectedId =
+        state.selectedId && !findNode(next, state.selectedId)
+          ? null
+          : state.selectedId;
+      return commit(state, next, selectedId);
     }
 
     case "DUPLICATE":

--- a/packages/plugin-page-builder/src/admin/store/editorStore.ts
+++ b/packages/plugin-page-builder/src/admin/store/editorStore.ts
@@ -12,8 +12,10 @@ import {
   makeNode,
   moveNode,
   reidSubtree,
+  dropSlots,
   removeFromSlot,
   removeNode,
+  removeSlot,
   updateNode,
 } from "../../core/tree";
 import type {
@@ -72,6 +74,20 @@ export type EditorAction =
    * that refuses the save.
    */
   | { type: "REMOVE_FROM_SLOT"; parentId: string; slot: string; id: string }
+  /**
+   * Discard a whole slot a block does not declare, contents and all.
+   *
+   * The repair when such a slot is already empty: validation refuses its NAME, so there is no
+   * child to address and nothing to lose by dropping it.
+   */
+  | { type: "REMOVE_SLOT"; parentId: string; slot: string }
+  /**
+   * Take the slots map off a block that may not hold one.
+   *
+   * Validation refuses any slots object on a definition that is not a container before reading a
+   * key, so once the keys are gone the empty map is still the fault and has no narrower repair.
+   */
+  | { type: "DROP_SLOTS"; parentId: string }
   | { type: "DUPLICATE"; id: string }
   | { type: "UPDATE_PROPS"; id: string; props: Record<string, unknown> }
   | {
@@ -185,13 +201,15 @@ export function editorReducer(
       return { ...commit(state, next), selectedId: null };
     }
 
+    case "REMOVE_SLOT":
+    case "DROP_SLOTS":
     case "REMOVE_FROM_SLOT": {
-      const next = removeFromSlot(
-        root,
-        action.parentId,
-        action.slot,
-        action.id
-      );
+      const next =
+        action.type === "REMOVE_FROM_SLOT"
+          ? removeFromSlot(root, action.parentId, action.slot, action.id)
+          : action.type === "REMOVE_SLOT"
+            ? removeSlot(root, action.parentId, action.slot)
+            : dropSlots(root, action.parentId);
       // The discarded block was never on the canvas, so the author's selection is unrelated to it
       // and clearing it unconditionally would take away work they can see. It only has to go when
       // the removed subtree contained it.

--- a/packages/plugin-page-builder/src/core/__tests__/invalid-slots.test.ts
+++ b/packages/plugin-page-builder/src/core/__tests__/invalid-slots.test.ts
@@ -13,7 +13,11 @@
  */
 import { describe, expect, it } from "vitest";
 
-import { findInvalidSlotEntries, repairInvalidSlot } from "../invalid-slots";
+import {
+  declaredSlotNames,
+  findInvalidSlotEntries,
+  repairInvalidSlot,
+} from "../invalid-slots";
 import { createBlockRegistry, defaultBlockRegistry } from "../registry";
 import {
   dropSlots,
@@ -78,7 +82,7 @@ describe("finding blocks in a slot nothing declares", () => {
     expect(entries.length).toBeGreaterThan(0);
 
     const repaired = entries.reduce(
-      (tree, entry) => repairInvalidSlot(tree, entry),
+      (tree, entry) => repairInvalidSlot(tree, entry, defaultBlockRegistry),
       root
     );
 
@@ -104,9 +108,17 @@ describe("finding blocks in a slot nothing declares", () => {
       })
     ).toContain("has no slot");
 
-    const bySlot = removeFromSlot(root, root.id, "gone", only.id);
-    // The property goes, not just the key: an empty map is itself refused on a non-container.
-    expect(bySlot.slots).toBeUndefined();
+    const bySlot = removeFromSlot(
+      root,
+      root.id,
+      "gone",
+      only.id,
+      declaredSlotNames(root, root.id, defaultBlockRegistry)
+    );
+    // The stale key goes and the DECLARED one stays. The canvas builds a drop zone per stored key,
+    // so a container left holding none would render no drop target and stop accepting blocks —
+    // worst on the page root, whose declared slot is the whole page.
+    expect(bySlot.slots).toEqual({ default: [] });
     expect(
       validateDocument(doc(bySlot), defaultBlockRegistry, {
         allowUnknown: true,
@@ -121,7 +133,13 @@ describe("finding blocks in a slot nothing declares", () => {
     const second = heading("Second");
     const root = withSlots("core/container", { legacy: [first, second] });
 
-    const after = removeFromSlot(root, root.id, "legacy", first.id);
+    const after = removeFromSlot(
+      root,
+      root.id,
+      "legacy",
+      first.id,
+      declaredSlotNames(root, root.id, defaultBlockRegistry)
+    );
     expect(after.slots?.legacy?.map(n => n.id)).toEqual([second.id]);
   });
 
@@ -163,7 +181,13 @@ describe("finding blocks in a slot nothing declares", () => {
 
     // And the claim that made it safe to stop there: removing the one entry leaves a document
     // the validator accepts, nested undeclared slot and all.
-    const repaired = removeFromSlot(root, root.id, "gone", outer.id);
+    const repaired = removeFromSlot(
+      root,
+      root.id,
+      "gone",
+      outer.id,
+      declaredSlotNames(root, root.id, defaultBlockRegistry)
+    );
     expect(
       validateDocument(doc(repaired), defaultBlockRegistry, {
         allowUnknown: true,
@@ -195,7 +219,12 @@ describe("finding blocks in a slot nothing declares", () => {
     expect(entries).toHaveLength(1);
     expect(entries[0]?.kind).toBe("empty-slot");
 
-    const repaired = removeSlot(root, root.id, "legacy");
+    const repaired = removeSlot(
+      root,
+      root.id,
+      "legacy",
+      declaredSlotNames(root, root.id, defaultBlockRegistry)
+    );
     expect(
       validateDocument(doc(repaired), defaultBlockRegistry, {
         allowUnknown: true,

--- a/packages/plugin-page-builder/src/core/__tests__/invalid-slots.test.ts
+++ b/packages/plugin-page-builder/src/core/__tests__/invalid-slots.test.ts
@@ -1,0 +1,229 @@
+/**
+ * The finder behind the repair banner, checked against the thing it has to agree with.
+ *
+ * The banner offers to remove exactly the blocks that stop a page saving. That agreement is the
+ * property worth testing, and it cannot be tested by comparing the finder against a hand-written
+ * list of expected entries: that list and the finder would be two things maintained by the same
+ * person, agreeing with each other while both drift away from the validator. So the central test
+ * here runs the REAL validator, removes what the finder reports, and runs it again.
+ *
+ * 🔴 Like `validate-without-renderer.test.ts`, this file must not import `render/blocks`. The
+ * finder has to work where the registry is empty, which is the state the config and server paths
+ * are in, and a side-effect import would supply a precondition production does not have.
+ */
+import { describe, expect, it } from "vitest";
+
+import { findInvalidSlotEntries } from "../invalid-slots";
+import { createBlockRegistry, defaultBlockRegistry } from "../registry";
+import { makeNode, removeFromSlot, removeNode } from "../tree";
+import { validateDocument } from "../validate";
+
+import type { BlockNode } from "../types";
+
+const doc = (root: BlockNode) => ({ version: 1, root }) as never;
+
+const withSlots = (
+  type: string,
+  slots: Record<string, BlockNode[]>
+): BlockNode => ({ ...makeNode(type, {}), slots });
+
+const heading = (text: string) =>
+  makeNode("core/heading", { text, level: "h2" });
+
+describe("finding blocks in a slot nothing declares", () => {
+  it("has an EMPTY registry, which is the condition the finder has to work in", () => {
+    // The same precondition the validator's own test asserts. If an import ever populates the
+    // registry, this fails first and says why, instead of the assertions below passing because
+    // definitions arrived rather than because structure answered.
+    expect(defaultBlockRegistry.all()).toHaveLength(0);
+  });
+
+  it("reports nothing for a document that saves", () => {
+    // Positive control. Every assertion below is about a non-empty result, and a finder that
+    // reported everything would satisfy all of them.
+    const root = withSlots("core/container", { default: [heading("Fine")] });
+
+    expect(
+      validateDocument(doc(root), defaultBlockRegistry, { allowUnknown: true })
+    ).toBe(true);
+    expect(findInvalidSlotEntries(root, defaultBlockRegistry)).toEqual([]);
+  });
+
+  it("removing everything it reports is what makes the document save", () => {
+    // The agreement, end to end, with no expected-entry list in the middle of it. A document the
+    // validator refuses becomes one it accepts, and nothing but the reported nodes was removed.
+    const root = withSlots("core/container", {
+      default: [
+        heading("Visible"),
+        withSlots("core/row", {
+          default: [heading("Also visible")],
+          removed: [heading("Orphan inside a row")],
+        }),
+      ],
+      legacy: [heading("Orphan at the top")],
+    });
+
+    const before = validateDocument(doc(root), defaultBlockRegistry, {
+      allowUnknown: true,
+    });
+    expect(before).toContain("has no slot");
+
+    const entries = findInvalidSlotEntries(root, defaultBlockRegistry);
+    expect(entries.length).toBeGreaterThan(0);
+
+    const repaired = entries.reduce(
+      (tree, entry) =>
+        removeFromSlot(tree, entry.parentId, entry.slotName, entry.node.id),
+      root
+    );
+
+    expect(
+      validateDocument(doc(repaired), defaultBlockRegistry, {
+        allowUnknown: true,
+      })
+    ).toBe(true);
+  });
+
+  it("drops the emptied slot, because the NAME is what validation refuses", () => {
+    // The repair has to remove the slot and not just its contents. Taking the last child out with
+    // an ordinary delete leaves the key behind, and the key alone is refused — so an author who
+    // removed every block the banner listed would be refused again with nothing left to remove.
+    const only = heading("Last one out");
+    const root = withSlots("core/container", { gone: [only] });
+
+    const byNode = removeNode(root, only.id);
+    expect(byNode.slots).toEqual({ gone: [] });
+    expect(
+      validateDocument(doc(byNode), defaultBlockRegistry, {
+        allowUnknown: true,
+      })
+    ).toContain("has no slot");
+
+    const bySlot = removeFromSlot(root, root.id, "gone", only.id);
+    expect(bySlot.slots).toEqual({});
+    expect(
+      validateDocument(doc(bySlot), defaultBlockRegistry, {
+        allowUnknown: true,
+      })
+    ).toBe(true);
+  });
+
+  it("keeps a slot that still has children in it", () => {
+    // The other direction of the same rule: dropping the key on every removal would delete a
+    // sibling's home while it is still occupied.
+    const first = heading("First");
+    const second = heading("Second");
+    const root = withSlots("core/container", { legacy: [first, second] });
+
+    const after = removeFromSlot(root, root.id, "legacy", first.id);
+    expect(after.slots?.legacy?.map(n => n.id)).toEqual([second.id]);
+  });
+
+  it("descends through declared slots to reach an undeclared one further down", () => {
+    // The case that makes descent necessary: the offending slot belongs to a container nested
+    // inside perfectly valid ones, so a finder that only looked at the root would report nothing
+    // while the page stayed unsaveable.
+    const buried = heading("Buried");
+    const root = withSlots("core/container", {
+      default: [
+        withSlots("core/row", {
+          default: [withSlots("core/columns", { ghost: [buried] })],
+        }),
+      ],
+    });
+
+    const entries = findInvalidSlotEntries(root, defaultBlockRegistry);
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0]?.node.id).toBe(buried.id);
+    expect(entries[0]?.slotName).toBe("ghost");
+    expect(entries[0]?.parentType).toBe("core/columns");
+    expect(entries[0]?.path).toBe("core/container → core/row → core/columns");
+  });
+
+  it("reports only the outermost block of a branch, and counts what goes with it", () => {
+    // Entries are removal targets. A block already inside a reported block needs no separate
+    // decision, and offering one would mean a second Remove with nothing left to act on.
+    const inner = withSlots("core/row", { stale: [heading("Deeper orphan")] });
+    const outer = withSlots("core/container", { default: [inner] });
+    const root = withSlots("core/container", { gone: [outer] });
+
+    const entries = findInvalidSlotEntries(root, defaultBlockRegistry);
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0]?.node.id).toBe(outer.id);
+    // outer holds inner, which holds one heading.
+    expect(entries[0]?.descendantCount).toBe(2);
+
+    // And the claim that made it safe to stop there: removing the one entry leaves a document
+    // the validator accepts, nested undeclared slot and all.
+    const repaired = removeFromSlot(root, root.id, "gone", outer.id);
+    expect(
+      validateDocument(doc(repaired), defaultBlockRegistry, {
+        allowUnknown: true,
+      })
+    ).toBe(true);
+  });
+
+  it("lists siblings in document order", () => {
+    const first = heading("First");
+    const second = heading("Second");
+    const root = withSlots("core/container", { legacy: [first, second] });
+
+    expect(
+      findInvalidSlotEntries(root, defaultBlockRegistry).map(e => e.node.id)
+    ).toEqual([first.id, second.id]);
+  });
+
+  it("says nothing about a type this build has no structure for", () => {
+    // The validator leaves these to `allowUnknown`, so a page saved while a plugin is unloaded is
+    // not broken. If the finder disagreed, the banner would offer to delete blocks that save.
+    const root = withSlots("acme/not-loaded", {
+      whatever: [heading("Foreign")],
+    });
+
+    expect(
+      validateDocument(doc(root), defaultBlockRegistry, { allowUnknown: true })
+    ).toBe(true);
+    expect(findInvalidSlotEntries(root, defaultBlockRegistry)).toEqual([]);
+  });
+
+  it("reports children of a block whose structure declares no slots at all", () => {
+    // `slots: []` is a statement, not an omission: children are junk on a leaf. This is the
+    // neighbouring case to the one above and the two look identical at the lookup.
+    const junk = makeNode("core/paragraph", { text: "junk" });
+    const root: BlockNode = { ...heading("Leaf"), slots: { anything: [junk] } };
+
+    expect(findInvalidSlotEntries(root, defaultBlockRegistry)).toHaveLength(1);
+    expect(findInvalidSlotEntries(root, defaultBlockRegistry)[0]?.node.id).toBe(
+      junk.id
+    );
+  });
+
+  it("lets a registered definition's own slot list be the whole answer", () => {
+    // A definition that declares no slots is stating what its renderer exposes. Falling back to
+    // the built-in structure would clear a block the definition's own renderer never draws, so the
+    // finder branches on which source answered rather than coalescing them.
+    const own = createBlockRegistry();
+    own.register({
+      type: "core/container",
+      version: 1,
+      label: "Mine",
+      isContainer: true,
+      defaultProps: {},
+      render: () => null,
+    } as never);
+
+    const child = heading("Drawn by nobody");
+    const root = withSlots("core/container", { default: [child] });
+
+    // Positive control: against structure alone `default` is declared, so a fallback would report
+    // nothing here and the assertion below would be vacuous.
+    expect(findInvalidSlotEntries(root, defaultBlockRegistry)).toEqual([]);
+
+    const entries = findInvalidSlotEntries(root, own);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]?.node.id).toBe(child.id);
+    expect(entries[0]?.slotName).toBe("default");
+  });
+});

--- a/packages/plugin-page-builder/src/core/__tests__/invalid-slots.test.ts
+++ b/packages/plugin-page-builder/src/core/__tests__/invalid-slots.test.ts
@@ -13,9 +13,15 @@
  */
 import { describe, expect, it } from "vitest";
 
-import { findInvalidSlotEntries } from "../invalid-slots";
+import { findInvalidSlotEntries, repairInvalidSlot } from "../invalid-slots";
 import { createBlockRegistry, defaultBlockRegistry } from "../registry";
-import { makeNode, removeFromSlot, removeNode } from "../tree";
+import {
+  dropSlots,
+  makeNode,
+  removeFromSlot,
+  removeNode,
+  removeSlot,
+} from "../tree";
 import { validateDocument } from "../validate";
 
 import type { BlockNode } from "../types";
@@ -72,8 +78,7 @@ describe("finding blocks in a slot nothing declares", () => {
     expect(entries.length).toBeGreaterThan(0);
 
     const repaired = entries.reduce(
-      (tree, entry) =>
-        removeFromSlot(tree, entry.parentId, entry.slotName, entry.node.id),
+      (tree, entry) => repairInvalidSlot(tree, entry),
       root
     );
 
@@ -100,7 +105,8 @@ describe("finding blocks in a slot nothing declares", () => {
     ).toContain("has no slot");
 
     const bySlot = removeFromSlot(root, root.id, "gone", only.id);
-    expect(bySlot.slots).toEqual({});
+    // The property goes, not just the key: an empty map is itself refused on a non-container.
+    expect(bySlot.slots).toBeUndefined();
     expect(
       validateDocument(doc(bySlot), defaultBlockRegistry, {
         allowUnknown: true,
@@ -173,6 +179,70 @@ describe("finding blocks in a slot nothing declares", () => {
     expect(
       findInvalidSlotEntries(root, defaultBlockRegistry).map(e => e.node.id)
     ).toEqual([first.id, second.id]);
+  });
+
+  it("reports a stale slot that is ALREADY empty, which nothing else would offer", () => {
+    // `{ legacy: [] }` is refused by name, and there is no child to hang an entry on. A finder
+    // that only walked children would report nothing while the page stayed unsaveable, which is
+    // the precise state this whole surface exists to get an author out of.
+    const root = withSlots("core/container", { legacy: [] });
+
+    expect(
+      validateDocument(doc(root), defaultBlockRegistry, { allowUnknown: true })
+    ).toContain('has no slot "legacy"');
+
+    const entries = findInvalidSlotEntries(root, defaultBlockRegistry);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]?.kind).toBe("empty-slot");
+
+    const repaired = removeSlot(root, root.id, "legacy");
+    expect(
+      validateDocument(doc(repaired), defaultBlockRegistry, {
+        allowUnknown: true,
+      })
+    ).toBe(true);
+  });
+
+  it("reports a leftover slots map on a block that may hold none", () => {
+    // A registered non-container is refused for holding a slots object at all, before any key is
+    // read. With no keys there is nothing narrower to remove, so the map itself is the repair.
+    const own = createBlockRegistry();
+    own.register({
+      type: "core/heading",
+      version: 1,
+      label: "H",
+      isContainer: false,
+      defaultProps: {},
+      render: () => null,
+    } as never);
+
+    const root: BlockNode = { ...heading("Leaf"), slots: {} };
+
+    expect(validateDocument(doc(root), own, { allowUnknown: true })).toContain(
+      "cannot have slots"
+    );
+
+    const entries = findInvalidSlotEntries(root, own);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]?.kind).toBe("stray-slots");
+
+    expect(
+      validateDocument(doc(dropSlots(root, root.id)), own, {
+        allowUnknown: true,
+      })
+    ).toBe(true);
+  });
+
+  it("leaves an UNREGISTERED block's empty slots map alone, because it saves", () => {
+    // The neighbouring case, and the one direction that must not become a report: without a
+    // registered definition the validator never reaches the container check, so an empty map on
+    // an unknown block is fine and offering to strip it would be destroying valid data.
+    const root: BlockNode = { ...makeNode("acme/not-loaded", {}), slots: {} };
+
+    expect(
+      validateDocument(doc(root), defaultBlockRegistry, { allowUnknown: true })
+    ).toBe(true);
+    expect(findInvalidSlotEntries(root, defaultBlockRegistry)).toEqual([]);
   });
 
   it("says nothing about a type this build has no structure for", () => {

--- a/packages/plugin-page-builder/src/core/invalid-slots.ts
+++ b/packages/plugin-page-builder/src/core/invalid-slots.ts
@@ -22,7 +22,7 @@
  */
 import { declaredSlotsOf } from "./block-structure";
 import type { BlockRegistry } from "./registry";
-import { dropSlots, removeFromSlot, removeSlot } from "./tree";
+import { dropSlots, findNode, removeFromSlot, removeSlot } from "./tree";
 import type { BlockNode } from "./types";
 
 /** Where a fault sits, and how to say so to someone who cannot click on it. */
@@ -212,19 +212,39 @@ export function findInvalidSlotEntries(
  */
 export function repairInvalidSlot(
   root: BlockNode,
-  entry: InvalidSlotEntry
+  entry: InvalidSlotEntry,
+  registry: BlockRegistry
 ): BlockNode {
+  const declared = declaredSlotNames(root, entry.parentId, registry);
   switch (entry.kind) {
     case "block":
       return removeFromSlot(
         root,
         entry.parentId,
         entry.slotName,
-        entry.node.id
+        entry.node.id,
+        declared
       );
     case "empty-slot":
-      return removeSlot(root, entry.parentId, entry.slotName);
+      return removeSlot(root, entry.parentId, entry.slotName, declared);
     case "stray-slots":
       return dropSlots(root, entry.parentId);
   }
+}
+
+/**
+ * The slot names a node's definition declares, for settling its slots after a repair.
+ *
+ * `undefined` when nothing in this build describes the type, which is the same "leave it alone"
+ * answer the validator gives such a block. Exported because the editor's reducer has to settle the
+ * same way the core does, and deriving it twice is how the two would come to disagree.
+ */
+export function declaredSlotNames(
+  root: BlockNode,
+  parentId: string,
+  registry: BlockRegistry
+): readonly string[] | undefined {
+  const parent = findNode(root, parentId);
+  if (!parent) return undefined;
+  return declaredFor(parent, registry)?.map(spec => spec.name);
 }

--- a/packages/plugin-page-builder/src/core/invalid-slots.ts
+++ b/packages/plugin-page-builder/src/core/invalid-slots.ts
@@ -1,0 +1,100 @@
+/**
+ * Finding the blocks an author cannot see but cannot save past.
+ *
+ * A stored document can carry children under a slot name the block's own definition never
+ * declares — a slot a rename or a block update left behind. Saving such a page is now refused
+ * (`validate.ts`), and that is the point: the allowlist a definition puts on a slot is a promise,
+ * and an undeclared slot has no allowlist at all.
+ *
+ * The problem this module exists for is what the author experiences. Those children are
+ * **invisible in the editor**: the canvas builds every stored slot, but a block's `render` places
+ * only the slots it declares, so nothing draws them. The author sees a page that looks correct,
+ * presses save, and is refused — with no element to select and nothing to delete.
+ *
+ * So the editor needs a list of them that does not come from the canvas. This finds it.
+ *
+ * @module core/invalid-slots
+ */
+import { declaredSlotsOf } from "./block-structure";
+import type { BlockRegistry } from "./registry";
+import type { BlockNode } from "./types";
+
+/** One block sitting in a slot its parent does not declare. */
+export interface InvalidSlotEntry {
+  /** The child block itself — what a Remove action addresses. */
+  node: BlockNode;
+  /** The block type of the child, for the label. */
+  type: string;
+  /** The container holding it. */
+  parentId: string;
+  /** The container's type, so the label can say where the block sits. */
+  parentType: string;
+  /** The slot name its definition does not declare. */
+  slotName: string;
+  /**
+   * Human-readable path from the document root, e.g. `core/container → core/row`.
+   *
+   * The author cannot select these blocks, so a location they can read is the only orientation
+   * the banner can offer.
+   */
+  path: string;
+}
+
+/**
+ * Whether a node's slots are judged at all.
+ *
+ * A type this build has no structure for is one the validator leaves to `allowUnknown` — a page
+ * saved while a plugin is unloaded must not be reported as broken, because it is not. The reader
+ * and this finder therefore have to agree, or the banner would list blocks that save perfectly.
+ */
+function declaredFor(
+  node: BlockNode,
+  registry: BlockRegistry
+): readonly { name: string }[] | undefined {
+  const def = registry.get(node.type);
+  return def ? (def.slots ?? []) : declaredSlotsOf(node.type);
+}
+
+/**
+ * Every block stored in a slot its parent does not declare, in document order.
+ *
+ * Document order rather than grouped by parent: the banner lists them as the author would meet
+ * them going down the page, which is the only ordering they can map onto anything.
+ */
+export function findInvalidSlotEntries(
+  root: BlockNode,
+  registry: BlockRegistry
+): InvalidSlotEntry[] {
+  const found: InvalidSlotEntry[] = [];
+
+  const walk = (node: BlockNode, ancestry: string[]): void => {
+    const stored = node.slots;
+    if (stored) {
+      const declared = declaredFor(node, registry);
+      for (const [slotName, children] of Object.entries(stored)) {
+        const isDeclared =
+          declared === undefined ||
+          declared.some(spec => spec.name === slotName);
+        for (const child of children) {
+          if (!isDeclared) {
+            found.push({
+              node: child,
+              type: child.type,
+              parentId: node.id,
+              parentType: node.type,
+              slotName,
+              path: [...ancestry, node.type].join(" → "),
+            });
+          }
+          // Descend regardless: a declared slot can hold a container that has an undeclared one,
+          // and an undeclared slot's children can too. Reporting only the outermost would leave
+          // an author removing one block and being refused again by the next.
+          walk(child, [...ancestry, node.type]);
+        }
+      }
+    }
+  };
+
+  walk(root, []);
+  return found;
+}

--- a/packages/plugin-page-builder/src/core/invalid-slots.ts
+++ b/packages/plugin-page-builder/src/core/invalid-slots.ts
@@ -1,55 +1,91 @@
 /**
- * Finding the blocks an author cannot see but cannot save past.
+ * Finding what an author cannot see but cannot save past.
  *
- * A stored document can carry children under a slot name the block's own definition never
- * declares — a slot a rename or a block update left behind. Saving such a page is refused
- * (`validate.ts`), and that is the point: the allowlist a definition puts on a slot is a promise,
- * and an undeclared slot has no allowlist at all.
+ * A stored document can carry a slot name the block's own definition never declares — a slot a
+ * rename or a block update left behind. Saving such a page is refused (`validate.ts`), and that is
+ * the point: the allowlist a definition puts on a slot is a promise, and an undeclared slot has no
+ * allowlist at all.
  *
- * The problem this module exists for is what the author experiences. Those children are
+ * The problem this module exists for is what the author experiences. Anything under such a slot is
  * **invisible in the editor**: the canvas builds every stored slot, but a block's `render` places
- * only the slots it declares, so nothing draws them. The author sees a page that looks correct,
+ * only the slots it declares, so nothing draws it. The author sees a page that looks correct,
  * presses save, and is refused — with no element to select and nothing to delete.
  *
- * So the editor needs a list of them that does not come from the canvas. This finds it.
+ * So the editor needs a list that does not come from the canvas. This finds it.
+ *
+ * What is reported is whatever the write path refuses, and it is NOT always a block. Validation
+ * refuses a slot's NAME rather than its contents, and refuses a slots map on a non-container
+ * before it reads a single key, so a page can be unsaveable with nothing in it to remove. Each of
+ * those states needs its own repair or the banner reports a problem the author cannot act on.
  *
  * @module core/invalid-slots
  */
 import { declaredSlotsOf } from "./block-structure";
 import type { BlockRegistry } from "./registry";
+import { dropSlots, removeFromSlot, removeSlot } from "./tree";
 import type { BlockNode } from "./types";
 
-/** One block sitting in a slot its parent does not declare. */
-export interface InvalidSlotEntry {
-  /** The child block itself — what a Remove action addresses. */
-  node: BlockNode;
-  /** The block type of the child, for the label. */
-  type: string;
-  /** The container holding it. */
+/** Where a fault sits, and how to say so to someone who cannot click on it. */
+interface InvalidSlotLocation {
+  /** Stable identity for a list row, and for telling two faults apart. */
+  key: string;
+  /** The block holding the fault. */
   parentId: string;
-  /** The container's type, so the label can say where the block sits. */
+  /** Its type, so a row can say where the fault sits. */
   parentType: string;
-  /** The slot name its definition does not declare. */
-  slotName: string;
   /**
    * Human-readable path from the document root, e.g. `core/container → core/row`.
    *
-   * The author cannot select these blocks, so a location they can read is the only orientation
-   * the banner can offer.
+   * The author cannot select any of this, so a location they can read is the only orientation a
+   * row can offer.
    */
   path: string;
-  /**
-   * How many further blocks sit inside this one.
-   *
-   * Removing an entry removes its whole subtree, and a count of zero reads very differently from
-   * a count of forty. An author deciding whether to discard something they cannot look at is
-   * owed the size of it.
-   */
-  descendantCount: number;
 }
 
 /**
- * Whether a node's slots are judged at all.
+ * One thing standing between the document and a successful save.
+ *
+ * A union rather than one shape with optional fields: the three cases need three different
+ * repairs, and a `node` that is sometimes absent would let a caller forget which case it holds.
+ */
+export type InvalidSlotEntry =
+  | (InvalidSlotLocation & {
+      /** A block sitting in a slot its parent does not declare. */
+      kind: "block";
+      slotName: string;
+      node: BlockNode;
+      type: string;
+      /**
+       * How many further blocks sit inside this one.
+       *
+       * Removing it removes its whole subtree, and a count of zero reads very differently from a
+       * count of forty. Someone deciding whether to discard something they cannot look at is owed
+       * the size of it.
+       */
+      descendantCount: number;
+    })
+  | (InvalidSlotLocation & {
+      /**
+       * A slot nothing declares that holds nothing either.
+       *
+       * Still refused, because the name is what validation rejects. There is no child to address,
+       * so the repair is the slot itself — and removing it discards no content at all.
+       */
+      kind: "empty-slot";
+      slotName: string;
+    })
+  | (InvalidSlotLocation & {
+      /**
+       * A block that may hold no slots at all, carrying an empty slots map.
+       *
+       * Validation refuses any slots object on a definition that is not a container before it
+       * looks at the keys, so with no keys left there is no narrower thing to remove.
+       */
+      kind: "stray-slots";
+    });
+
+/**
+ * Whether a node's slot NAMES are judged at all.
  *
  * A type this build has no structure for is one the validator leaves to `allowUnknown` — a page
  * saved while a plugin is unloaded must not be reported as broken, because it is not. The reader
@@ -67,6 +103,20 @@ function declaredFor(
   return def ? (def.slots ?? []) : declaredSlotsOf(node.type);
 }
 
+/**
+ * Whether this block may hold no slots whatsoever.
+ *
+ * Only a REGISTERED definition can say so. Without one the validator never reaches that check, so
+ * an unregistered block carrying an empty map saves and must not be reported.
+ */
+function forbidsSlotsEntirely(
+  node: BlockNode,
+  registry: BlockRegistry
+): boolean {
+  const def = registry.get(node.type);
+  return def !== undefined && !def.isContainer;
+}
+
 /** Blocks beneath this one, not counting it. */
 function countDescendants(node: BlockNode): number {
   let total = 0;
@@ -77,17 +127,17 @@ function countDescendants(node: BlockNode): number {
 }
 
 /**
- * Every block stored in a slot its parent does not declare, in document order.
+ * Everything that makes a document unsaveable for slot reasons, in document order.
  *
- * Only the OUTERMOST such block in any branch is reported, because the entries are removal
- * targets and removing one takes its subtree with it. Reporting a block that already sits inside
- * a reported block would offer the author a second Remove that had nothing left to act on, and
- * would inflate the count with blocks nobody has to decide about separately. Descent therefore
- * continues through declared slots — where a nested container can hide an undeclared slot of its
- * own that no other entry would remove — and stops at each block that becomes an entry.
+ * Only the OUTERMOST offending block in any branch is reported, because entries are removal
+ * targets and removing one takes its subtree with it. Reporting a block that already sits inside a
+ * reported block would offer a second Remove with nothing left to act on, and would inflate the
+ * count with blocks nobody has to decide about separately. Descent therefore continues through
+ * declared slots — where a nested container can hide an undeclared slot of its own that no other
+ * entry would remove — and stops at each block that becomes an entry.
  *
- * Document order rather than grouped by parent: the banner lists them as the author would meet
- * them going down the page, which is the only ordering they can map onto anything.
+ * Document order rather than grouped by parent: a reader meets them as they would going down the
+ * page, which is the only ordering they can map onto anything.
  */
 export function findInvalidSlotEntries(
   root: BlockNode,
@@ -99,25 +149,49 @@ export function findInvalidSlotEntries(
     const stored = node.slots;
     if (!stored) return;
 
-    const declared = declaredFor(node, registry);
     const here = [...ancestry, node.type];
+    const path = here.join(" → ");
+    const at = { parentId: node.id, parentType: node.type, path };
+    const slotNames = Object.entries(stored);
 
-    for (const [slotName, children] of Object.entries(stored)) {
+    // A map with no keys left on a block that may hold none: refused, and with no key there is
+    // nothing narrower to address than the map itself.
+    if (slotNames.length === 0) {
+      if (forbidsSlotsEntirely(node, registry)) {
+        found.push({ ...at, key: `slots:${node.id}`, kind: "stray-slots" });
+      }
+      return;
+    }
+
+    const declared = declaredFor(node, registry);
+
+    for (const [slotName, children] of slotNames) {
       const isDeclared =
         declared === undefined || declared.some(spec => spec.name === slotName);
 
-      for (const child of children) {
-        if (isDeclared) {
-          walk(child, here);
-          continue;
-        }
+      if (isDeclared) {
+        for (const child of children) walk(child, here);
+        continue;
+      }
+
+      if (children.length === 0) {
         found.push({
+          ...at,
+          key: `slot:${node.id}:${slotName}`,
+          kind: "empty-slot",
+          slotName,
+        });
+        continue;
+      }
+
+      for (const child of children) {
+        found.push({
+          ...at,
+          key: `block:${child.id}`,
+          kind: "block",
+          slotName,
           node: child,
           type: child.type,
-          parentId: node.id,
-          parentType: node.type,
-          slotName,
-          path: here.join(" → "),
           descendantCount: countDescendants(child),
         });
       }
@@ -126,4 +200,31 @@ export function findInvalidSlotEntries(
 
   walk(root, []);
   return found;
+}
+
+/**
+ * Apply one entry's repair, returning a new tree.
+ *
+ * Lives beside the finder rather than in the editor because the mapping from a fault to its cure
+ * is a property of the fault: three kinds need three different operations, and a caller choosing
+ * for itself is a caller that can choose wrong. The editor's action for a row is checked against
+ * this, so the two cannot drift.
+ */
+export function repairInvalidSlot(
+  root: BlockNode,
+  entry: InvalidSlotEntry
+): BlockNode {
+  switch (entry.kind) {
+    case "block":
+      return removeFromSlot(
+        root,
+        entry.parentId,
+        entry.slotName,
+        entry.node.id
+      );
+    case "empty-slot":
+      return removeSlot(root, entry.parentId, entry.slotName);
+    case "stray-slots":
+      return dropSlots(root, entry.parentId);
+  }
 }

--- a/packages/plugin-page-builder/src/core/invalid-slots.ts
+++ b/packages/plugin-page-builder/src/core/invalid-slots.ts
@@ -2,7 +2,7 @@
  * Finding the blocks an author cannot see but cannot save past.
  *
  * A stored document can carry children under a slot name the block's own definition never
- * declares — a slot a rename or a block update left behind. Saving such a page is now refused
+ * declares — a slot a rename or a block update left behind. Saving such a page is refused
  * (`validate.ts`), and that is the point: the allowlist a definition puts on a slot is a promise,
  * and an undeclared slot has no allowlist at all.
  *
@@ -38,6 +38,14 @@ export interface InvalidSlotEntry {
    * the banner can offer.
    */
   path: string;
+  /**
+   * How many further blocks sit inside this one.
+   *
+   * Removing an entry removes its whole subtree, and a count of zero reads very differently from
+   * a count of forty. An author deciding whether to discard something they cannot look at is
+   * owed the size of it.
+   */
+  descendantCount: number;
 }
 
 /**
@@ -46,6 +54,10 @@ export interface InvalidSlotEntry {
  * A type this build has no structure for is one the validator leaves to `allowUnknown` — a page
  * saved while a plugin is unloaded must not be reported as broken, because it is not. The reader
  * and this finder therefore have to agree, or the banner would list blocks that save perfectly.
+ *
+ * The branch is on the SOURCE rather than a fallback: a registered definition is the whole answer
+ * about its own slots, including when it declares none, so a `??` here would let a built-in's
+ * structure answer for a definition that deliberately exposes nothing.
  */
 function declaredFor(
   node: BlockNode,
@@ -55,8 +67,24 @@ function declaredFor(
   return def ? (def.slots ?? []) : declaredSlotsOf(node.type);
 }
 
+/** Blocks beneath this one, not counting it. */
+function countDescendants(node: BlockNode): number {
+  let total = 0;
+  for (const children of Object.values(node.slots ?? {})) {
+    for (const child of children) total += 1 + countDescendants(child);
+  }
+  return total;
+}
+
 /**
  * Every block stored in a slot its parent does not declare, in document order.
+ *
+ * Only the OUTERMOST such block in any branch is reported, because the entries are removal
+ * targets and removing one takes its subtree with it. Reporting a block that already sits inside
+ * a reported block would offer the author a second Remove that had nothing left to act on, and
+ * would inflate the count with blocks nobody has to decide about separately. Descent therefore
+ * continues through declared slots — where a nested container can hide an undeclared slot of its
+ * own that no other entry would remove — and stops at each block that becomes an entry.
  *
  * Document order rather than grouped by parent: the banner lists them as the author would meet
  * them going down the page, which is the only ordering they can map onto anything.
@@ -69,28 +97,29 @@ export function findInvalidSlotEntries(
 
   const walk = (node: BlockNode, ancestry: string[]): void => {
     const stored = node.slots;
-    if (stored) {
-      const declared = declaredFor(node, registry);
-      for (const [slotName, children] of Object.entries(stored)) {
-        const isDeclared =
-          declared === undefined ||
-          declared.some(spec => spec.name === slotName);
-        for (const child of children) {
-          if (!isDeclared) {
-            found.push({
-              node: child,
-              type: child.type,
-              parentId: node.id,
-              parentType: node.type,
-              slotName,
-              path: [...ancestry, node.type].join(" → "),
-            });
-          }
-          // Descend regardless: a declared slot can hold a container that has an undeclared one,
-          // and an undeclared slot's children can too. Reporting only the outermost would leave
-          // an author removing one block and being refused again by the next.
-          walk(child, [...ancestry, node.type]);
+    if (!stored) return;
+
+    const declared = declaredFor(node, registry);
+    const here = [...ancestry, node.type];
+
+    for (const [slotName, children] of Object.entries(stored)) {
+      const isDeclared =
+        declared === undefined || declared.some(spec => spec.name === slotName);
+
+      for (const child of children) {
+        if (isDeclared) {
+          walk(child, here);
+          continue;
         }
+        found.push({
+          node: child,
+          type: child.type,
+          parentId: node.id,
+          parentType: node.type,
+          slotName,
+          path: here.join(" → "),
+          descendantCount: countDescendants(child),
+        });
       }
     }
   };

--- a/packages/plugin-page-builder/src/core/tree.ts
+++ b/packages/plugin-page-builder/src/core/tree.ts
@@ -87,6 +87,23 @@ export function removeNode(root: BlockNode, id: string): BlockNode {
 }
 
 /**
+ * Attach a slots map to a node, dropping the property entirely when nothing is left in it.
+ *
+ * An empty `slots` object is not the same as no slots. Validation refuses ANY slots object on a
+ * block whose definition is not a container, before it looks at a single key, so a repair that
+ * emptied the map but left it in place would swap one refusal for another and report success.
+ */
+function withSlots(
+  node: BlockNode,
+  slots: Record<string, BlockNode[]>
+): BlockNode {
+  if (Object.keys(slots).length > 0) return { ...node, slots };
+  const next = { ...node };
+  delete next.slots;
+  return next;
+}
+
+/**
  * Remove one child from a NAMED slot, dropping the slot itself once nothing is left in it.
  *
  * `removeNode` searches every slot and leaves the emptied key behind, which is correct for an
@@ -107,8 +124,37 @@ export function removeFromSlot(
     const slots = { ...n.slots };
     if (remaining.length > 0) slots[slot] = remaining;
     else delete slots[slot];
-    return { ...n, slots };
+    return withSlots(n, slots);
   });
+}
+
+/**
+ * Remove a whole slot from a node, contents and all.
+ *
+ * The repair for a slot nothing declares that is ALREADY empty: there is no child to address, and
+ * the slot's own name is what validation refuses.
+ */
+export function removeSlot(
+  root: BlockNode,
+  parentId: string,
+  slot: string
+): BlockNode {
+  return mapTree(root, n => {
+    if (n.id !== parentId || !n.slots) return n;
+    const slots = { ...n.slots };
+    delete slots[slot];
+    return withSlots(n, slots);
+  });
+}
+
+/**
+ * Take the whole `slots` property off a node.
+ *
+ * For a block whose definition is not a container, holding slots is itself the fault, so there is
+ * no individual name to remove — an empty map is refused exactly as a full one is.
+ */
+export function dropSlots(root: BlockNode, parentId: string): BlockNode {
+  return mapTree(root, n => (n.id === parentId ? withSlots(n, {}) : n));
 }
 
 /** True if `id` is `ancestorId` itself or nested anywhere inside it. */

--- a/packages/plugin-page-builder/src/core/tree.ts
+++ b/packages/plugin-page-builder/src/core/tree.ts
@@ -87,17 +87,31 @@ export function removeNode(root: BlockNode, id: string): BlockNode {
 }
 
 /**
- * Attach a slots map to a node, dropping the property entirely when nothing is left in it.
+ * Settle a node's slots after a repair: keep the homes it declares, drop the property otherwise.
  *
- * An empty `slots` object is not the same as no slots. Validation refuses ANY slots object on a
- * block whose definition is not a container, before it looks at a single key, so a repair that
- * emptied the map but left it in place would swap one refusal for another and report success.
+ * Two opposite mistakes are possible once a stale key is removed, and each breaks something the
+ * other fixes.
+ *
+ * Leaving an empty map behind breaks the WRITE path: validation refuses any slots object on a
+ * block whose definition is not a container, before it looks at a single key, so the page would
+ * still be refused with nothing left to remove.
+ *
+ * Deleting the property breaks the CANVAS: the editor builds a drop zone per STORED key, so a
+ * container left holding no keys draws no drop target and stops accepting blocks — worst on the
+ * page root, whose declared slot is the whole page.
+ *
+ * So a declared slot is restored as an empty array, and the property is dropped only when nothing
+ * declares anything. `declared` is required rather than optional because a caller that forgets it
+ * silently gets the canvas-breaking half.
  */
 function withSlots(
   node: BlockNode,
-  slots: Record<string, BlockNode[]>
+  slots: Record<string, BlockNode[]>,
+  declared: readonly string[] | undefined
 ): BlockNode {
-  if (Object.keys(slots).length > 0) return { ...node, slots };
+  const settled = { ...slots };
+  for (const name of declared ?? []) settled[name] ??= [];
+  if (Object.keys(settled).length > 0) return { ...node, slots: settled };
   const next = { ...node };
   delete next.slots;
   return next;
@@ -116,7 +130,8 @@ export function removeFromSlot(
   root: BlockNode,
   parentId: string,
   slot: string,
-  id: string
+  id: string,
+  declared: readonly string[] | undefined
 ): BlockNode {
   return mapTree(root, n => {
     if (n.id !== parentId || !n.slots) return n;
@@ -124,7 +139,7 @@ export function removeFromSlot(
     const slots = { ...n.slots };
     if (remaining.length > 0) slots[slot] = remaining;
     else delete slots[slot];
-    return withSlots(n, slots);
+    return withSlots(n, slots, declared);
   });
 }
 
@@ -137,13 +152,14 @@ export function removeFromSlot(
 export function removeSlot(
   root: BlockNode,
   parentId: string,
-  slot: string
+  slot: string,
+  declared: readonly string[] | undefined
 ): BlockNode {
   return mapTree(root, n => {
     if (n.id !== parentId || !n.slots) return n;
     const slots = { ...n.slots };
     delete slots[slot];
-    return withSlots(n, slots);
+    return withSlots(n, slots, declared);
   });
 }
 
@@ -154,7 +170,7 @@ export function removeSlot(
  * no individual name to remove — an empty map is refused exactly as a full one is.
  */
 export function dropSlots(root: BlockNode, parentId: string): BlockNode {
-  return mapTree(root, n => (n.id === parentId ? withSlots(n, {}) : n));
+  return mapTree(root, n => (n.id === parentId ? withSlots(n, {}, []) : n));
 }
 
 /** True if `id` is `ancestorId` itself or nested anywhere inside it. */

--- a/packages/plugin-page-builder/src/core/tree.ts
+++ b/packages/plugin-page-builder/src/core/tree.ts
@@ -86,6 +86,31 @@ export function removeNode(root: BlockNode, id: string): BlockNode {
   });
 }
 
+/**
+ * Remove one child from a NAMED slot, dropping the slot itself once nothing is left in it.
+ *
+ * `removeNode` searches every slot and leaves the emptied key behind, which is correct for an
+ * ordinary delete: a slot the block declares exists whether or not anything sits in it. It is the
+ * wrong shape for a slot the block does NOT declare, because validation refuses the slot's NAME
+ * rather than its contents — so emptying such a slot child by child ends with a document that is
+ * still refused and has nothing left to remove.
+ */
+export function removeFromSlot(
+  root: BlockNode,
+  parentId: string,
+  slot: string,
+  id: string
+): BlockNode {
+  return mapTree(root, n => {
+    if (n.id !== parentId || !n.slots) return n;
+    const remaining = (n.slots[slot] ?? []).filter(c => c.id !== id);
+    const slots = { ...n.slots };
+    if (remaining.length > 0) slots[slot] = remaining;
+    else delete slots[slot];
+    return { ...n, slots };
+  });
+}
+
 /** True if `id` is `ancestorId` itself or nested anywhere inside it. */
 function isSelfOrDescendant(
   root: BlockNode,

--- a/packages/plugin-page-builder/src/styles/editor.css
+++ b/packages/plugin-page-builder/src/styles/editor.css
@@ -409,3 +409,95 @@
   outline: 2px solid var(--nx-ring);
   outline-offset: 1px;
 }
+
+/* ------------------------------------------------- undeclared-slot repair */
+/*
+ * The bar sits between the toolbar and the three panes rather than inside the canvas column:
+ * the problem belongs to the document, not to one pane, and the 3-column grid would otherwise
+ * have to give up width to say so. `--nx-warning-foreground on --nx-warning` is a checked
+ * contrast pairing, so it holds in both modes without a hardcoded colour.
+ */
+.nx-pb-repair {
+  border-bottom: 1px solid var(--nx-border);
+  background: var(--nx-warning);
+  color: var(--nx-warning-foreground);
+}
+
+.nx-pb-repair-bar {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 8px 10px;
+}
+
+.nx-pb-repair-text {
+  flex: 1;
+  font-size: 13px;
+  line-height: 1.45;
+}
+
+.nx-pb-repair-actions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-shrink: 0;
+}
+
+.nx-pb-repair-dismiss {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  border: 0;
+  border-radius: var(--radius);
+  background: transparent;
+  color: inherit;
+  font-size: 18px;
+  line-height: 1;
+  cursor: pointer;
+}
+.nx-pb-repair-dismiss:hover {
+  background: color-mix(in srgb, var(--nx-warning-foreground) 15%, transparent);
+}
+.nx-pb-repair-dismiss:focus-visible {
+  outline: 2px solid var(--nx-warning-foreground);
+  outline-offset: 1px;
+}
+
+/* The rows carry the admin's own surface so the themed buttons on them read normally. */
+.nx-pb-repair-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  background: var(--nx-card);
+  color: var(--nx-card-foreground);
+  border-top: 1px solid var(--nx-border);
+  max-height: 220px;
+  overflow: auto;
+}
+
+.nx-pb-repair-item {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 6px 10px;
+}
+.nx-pb-repair-item + .nx-pb-repair-item {
+  border-top: 1px solid var(--nx-border-subtle);
+}
+
+.nx-pb-repair-item-text {
+  flex: 1;
+  min-width: 0;
+  font-size: 13px;
+}
+
+.nx-pb-repair-item-name {
+  font-weight: 600;
+}
+
+.nx-pb-repair-item-where {
+  color: var(--nx-muted-foreground);
+  margin-left: 6px;
+}


### PR DESCRIPTION
## What this fixes

A stored page can carry blocks under a slot name their parent's definition does not declare, left behind by a rename or a block update. Since the write-side slot check became live, saving such a page is refused. The blocks are also **invisible in the editor**: the canvas builds what a definition declares, so nothing draws them.

The author was therefore left with a page that looks correct, refuses to save, and offers nothing to select and nothing to delete. This adds the surface that gets them out of it.

## The surface

A bar above the editor panes, `role="status"`, saying how many blocks are affected. **Review** expands a list naming each one, where it sits, and how many blocks it holds inside it; each row has its own **Remove**. Dismiss is keyed to the set of blocks listed, so dismissing cannot hide a *different* problem that appears later.

Nothing is removed without a person choosing it, one block at a time, and every removal goes through the normal history so undo reverses it. Repairing on load was rejected: for these blocks the row in the database is the only remaining copy.

It sits above the panes rather than inside the canvas column because the blocks it reports are not on the canvas at all, and because a document-level notice should not make the three-column grid give up width.

## What execution changed about the plan

Two things were wrong in the design and were found by running it, not by reading it.

**1. Removing the blocks is not enough.** The validator refuses the slot's **name**, not its contents, so an ordinary `REMOVE` (which searches every slot and leaves the emptied key behind) would have left the author having removed every block the banner listed and still being refused, with nothing left to remove. Verified directly: after `removeNode`, `slots` is `{ gone: [] }` and validation still answers `core/container has no slot "gone"`; deleting the key is what makes it pass. Hence `removeFromSlot` and a distinct `REMOVE_FROM_SLOT` action rather than reuse of `REMOVE`.

**2. The finder reported too much.** It descended into blocks it had already reported, so a broken branch produced one entry per nested block. Those are not separate decisions — removing the outer block takes the subtree with it — so the extra rows would have been Removes with nothing left to act on, and the headline count would have been inflated. It now reports only the outermost block per branch and carries `descendantCount` so a row can say what the removal takes with it. Descent continues through *declared* slots, where a nested container can hide an undeclared slot no other entry would remove.

## Tests

The finder is checked **against the validator itself** rather than against a hand-written list of expected entries: a document the validator refuses has everything the finder reports removed, and is then accepted. Two things maintained by the same person agreeing with each other proves nothing; this cannot drift without failing.

The banner has the same treatment end to end — finder to the row's own action to the reducer to the validator — because a row naming the right block while dispatching the wrong slot would look correct in any screenshot.

Stub-verified, each restore confirmed by diff:

| Broken mechanism | Tests that failed |
|---|---|
| `removeFromSlot` keeps the emptied key | 3 |
| finder descends into an already-reported branch | `reports only the outermost block of a branch` |
| `declaredFor` coalesces with `??` instead of branching on the source | `lets a registered definition's own slot list be the whole answer` |
| banner never renders | `appears, and counts what the author cannot see`, `uses the singular for one block` |
| rows carry the wrong slot | `dispatches repairs that actually make the document save` |

`plugin-page-builder`: 68 files / 645 tests pass, `check-types` and `lint` clean.

## Not in this PR

`BlockNode.locked` says "block cannot be moved/deleted while true" and **nothing enforces it** — it is stored and shown in the navigator, and no path refuses a move or a delete. Measured, not assumed. It does not affect this surface (there is nothing to enforce against), but the comment is a claim the code does not keep. Recorded against the existing soft-lock task rather than fixed here.

## Not verified in a browser

The component is rendered and asserted through `renderToStaticMarkup`, and the repair loop is exercised through the real reducer and validator. The visual result has not been looked at in a running admin.
