### PR TITLE
fix(nextly): make a unique column a named index, not an unnamed constraint

### DIFF
--- a/.changeset/uniqueness-is-a-named-index.md
+++ b/.changeset/uniqueness-is-a-named-index.md
@@ -1,0 +1,28 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+A column declared unique now gets a named unique index instead of an unnamed constraint written into the table itself.
+
+An unnamed constraint is one the database names for you, and on SQLite that name is internal and cannot be referred to. Nothing could describe it afterwards, so the schema Nextly compared against never matched the table, and the only way SQLite could reconcile the two was to rebuild the whole table. Nextly refuses a rebuild it did not ask for, so the entire change was refused with it, including the parts that were only adding things. It also made such a column impossible to remove.

--- a/packages/nextly/src/domains/dynamic-collections/__tests__/alter-column-attachments.test.ts
+++ b/packages/nextly/src/domains/dynamic-collections/__tests__/alter-column-attachments.test.ts
@@ -42,6 +42,28 @@ interface Attachments {
   indexed: boolean;
 }
 
+/**
+ * Uniqueness on this column, in ANY spelling a generator may use.
+ *
+ * Asked once and used by both readers below. Reading only the column line for one path and only the
+ * named forms for the other made the two detectors disagree whenever the paths agreed in a spelling
+ * one of them could not see — which is a property of the readers, not of the DDL, and would report a
+ * genuine convergence as a regression.
+ */
+function hasUniqueness(
+  sql: string,
+  column: string,
+  columnLine: string
+): boolean {
+  return (
+    /\bUNIQUE\b/.test(columnLine) ||
+    new RegExp(`ADD CONSTRAINT \\S+ UNIQUE \\(${column}\\)`).test(sql) ||
+    new RegExp(
+      `CREATE UNIQUE INDEX (?:IF NOT EXISTS )?\\S+ ON ${TABLE}\\(${column}\\)`
+    ).test(sql)
+  );
+}
+
 /** A plain (non-unique) index on this column, in either generator's spelling. */
 function hasPlainIndex(sql: string, column: string): boolean {
   return new RegExp(
@@ -86,7 +108,7 @@ function createAttachments(rawSql: string, column: string): Attachments {
       .find(part => part.startsWith(`${column} `)) ?? "";
   return {
     notNull: /\bNOT NULL\b/.test(line),
-    unique: /\bUNIQUE\b/.test(line),
+    unique: hasUniqueness(sql, column, line),
     referencesTable: referencedTable(sql, column),
     indexed: hasPlainIndex(sql, column),
   };
@@ -98,11 +120,7 @@ function alterAttachments(rawSql: string, column: string): Attachments {
     sql.split("\n").find(line => line.includes(`ADD COLUMN ${column} `)) ?? "";
   return {
     notNull: /\bNOT NULL\b/.test(addLine),
-    unique:
-      new RegExp(`ADD CONSTRAINT \\S+ UNIQUE \\(${column}\\)`).test(sql) ||
-      new RegExp(
-        `CREATE UNIQUE INDEX (?:IF NOT EXISTS )?\\S+ ON ${TABLE}\\(${column}\\)`
-      ).test(sql),
+    unique: hasUniqueness(sql, column, addLine),
     referencesTable: referencedTable(sql, column),
     indexed: hasPlainIndex(sql, column),
   };

--- a/packages/nextly/src/domains/dynamic-collections/services/__tests__/__snapshots__/builder-ddl-characterization.test.ts.snap
+++ b/packages/nextly/src/domains/dynamic-collections/services/__tests__/__snapshots__/builder-ddl-characterization.test.ts.snap
@@ -214,7 +214,7 @@ CREATE TABLE IF NOT EXISTS "dc_pinned" (
   "updated_at" timestamp DEFAULT now(),
   "created_by" text,
 "title" text NOT NULL,
-"slug_key" text  UNIQUE,
+"slug_key" text,
 "short_code" varchar(120),
 "summary" text,
 "views" integer,
@@ -237,6 +237,8 @@ CREATE INDEX IF NOT EXISTS "idx_dc_pinned_lookup_code" ON "dc_pinned"("lookup_co
 CREATE INDEX IF NOT EXISTS "idx_dc_pinned_author" ON "dc_pinned"("author");
 --> statement-breakpoint
 CREATE INDEX IF NOT EXISTS "idx_dc_pinned_editors" ON "dc_pinned"("editors");
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "uq_dc_pinned_slug_key" ON "dc_pinned"("slug_key");
 --> statement-breakpoint
 CREATE INDEX IF NOT EXISTS "idx_dc_pinned_created_at" ON "dc_pinned"("created_at" DESC);
 --> statement-breakpoint
@@ -312,7 +314,7 @@ CREATE TABLE IF NOT EXISTS "single_pinned" (
   "created_at" timestamp DEFAULT now(),
   "updated_at" timestamp DEFAULT now(),
 "title" text NOT NULL,
-"slug_key" text  UNIQUE,
+"slug_key" text,
 "short_code" varchar(120),
 "summary" text,
 "views" integer,
@@ -335,6 +337,8 @@ CREATE INDEX IF NOT EXISTS "idx_single_pinned_lookup_code" ON "single_pinned"("l
 CREATE INDEX IF NOT EXISTS "idx_single_pinned_author" ON "single_pinned"("author");
 --> statement-breakpoint
 CREATE INDEX IF NOT EXISTS "idx_single_pinned_editors" ON "single_pinned"("editors");
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "uq_single_pinned_slug_key" ON "single_pinned"("slug_key");
 --> statement-breakpoint
 CREATE INDEX IF NOT EXISTS "idx_single_pinned_created_at" ON "single_pinned"("created_at" DESC);
 --> statement-breakpoint
@@ -366,7 +370,7 @@ CREATE TABLE IF NOT EXISTS "single_pinned" (
   "status" varchar(20) DEFAULT 'draft' NOT NULL,
   "first_published_at" timestamp,
 "title" text NOT NULL,
-"slug_key" text  UNIQUE,
+"slug_key" text,
 "short_code" varchar(120),
 "summary" text,
 "views" integer,
@@ -389,6 +393,8 @@ CREATE INDEX IF NOT EXISTS "idx_single_pinned_lookup_code" ON "single_pinned"("l
 CREATE INDEX IF NOT EXISTS "idx_single_pinned_author" ON "single_pinned"("author");
 --> statement-breakpoint
 CREATE INDEX IF NOT EXISTS "idx_single_pinned_editors" ON "single_pinned"("editors");
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "uq_single_pinned_slug_key" ON "single_pinned"("slug_key");
 --> statement-breakpoint
 CREATE INDEX IF NOT EXISTS "idx_single_pinned_created_at" ON "single_pinned"("created_at" DESC);
 --> statement-breakpoint
@@ -419,7 +425,7 @@ CREATE TABLE IF NOT EXISTS "dc_pinned" (
   "updated_at" integer DEFAULT (strftime('%s', 'now')),
   "created_by" text,
 "title" text NOT NULL,
-"slug_key" text  UNIQUE,
+"slug_key" text,
 "short_code" text,
 "summary" text,
 "views" integer,
@@ -442,6 +448,8 @@ CREATE INDEX IF NOT EXISTS "idx_dc_pinned_lookup_code" ON "dc_pinned"("lookup_co
 CREATE INDEX IF NOT EXISTS "idx_dc_pinned_author" ON "dc_pinned"("author");
 --> statement-breakpoint
 CREATE INDEX IF NOT EXISTS "idx_dc_pinned_editors" ON "dc_pinned"("editors");
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "uq_dc_pinned_slug_key" ON "dc_pinned"("slug_key");
 --> statement-breakpoint
 CREATE INDEX IF NOT EXISTS "idx_dc_pinned_created_at" ON "dc_pinned"("created_at");
 --> statement-breakpoint
@@ -517,7 +525,7 @@ CREATE TABLE IF NOT EXISTS "single_pinned" (
   "created_at" integer DEFAULT (strftime('%s', 'now')),
   "updated_at" integer DEFAULT (strftime('%s', 'now')),
 "title" text NOT NULL,
-"slug_key" text  UNIQUE,
+"slug_key" text,
 "short_code" text,
 "summary" text,
 "views" integer,
@@ -540,6 +548,8 @@ CREATE INDEX IF NOT EXISTS "idx_single_pinned_lookup_code" ON "single_pinned"("l
 CREATE INDEX IF NOT EXISTS "idx_single_pinned_author" ON "single_pinned"("author");
 --> statement-breakpoint
 CREATE INDEX IF NOT EXISTS "idx_single_pinned_editors" ON "single_pinned"("editors");
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "uq_single_pinned_slug_key" ON "single_pinned"("slug_key");
 --> statement-breakpoint
 CREATE INDEX IF NOT EXISTS "idx_single_pinned_created_at" ON "single_pinned"("created_at");
 --> statement-breakpoint
@@ -571,7 +581,7 @@ CREATE TABLE IF NOT EXISTS "single_pinned" (
   "status" text DEFAULT 'draft' NOT NULL,
   "first_published_at" integer,
 "title" text NOT NULL,
-"slug_key" text  UNIQUE,
+"slug_key" text,
 "short_code" text,
 "summary" text,
 "views" integer,
@@ -594,6 +604,8 @@ CREATE INDEX IF NOT EXISTS "idx_single_pinned_lookup_code" ON "single_pinned"("l
 CREATE INDEX IF NOT EXISTS "idx_single_pinned_author" ON "single_pinned"("author");
 --> statement-breakpoint
 CREATE INDEX IF NOT EXISTS "idx_single_pinned_editors" ON "single_pinned"("editors");
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "uq_single_pinned_slug_key" ON "single_pinned"("slug_key");
 --> statement-breakpoint
 CREATE INDEX IF NOT EXISTS "idx_single_pinned_created_at" ON "single_pinned"("created_at");
 --> statement-breakpoint

--- a/packages/nextly/src/domains/dynamic-collections/services/__tests__/uniqueness-is-a-named-index.test.ts
+++ b/packages/nextly/src/domains/dynamic-collections/services/__tests__/uniqueness-is-a-named-index.test.ts
@@ -1,0 +1,380 @@
+/**
+ * Uniqueness is a NAMED index, and a table's shape does not depend on when its column arrived.
+ *
+ * A column-level `UNIQUE` inside `CREATE TABLE` is anonymous: the server names the index behind it,
+ * and on SQLite that is an internal `sqlite_autoindex_*` no statement can reference. Nothing can
+ * describe such an index afterwards, so the desired schema — which declares `uq_<table>_<column>` —
+ * disagreed with every table carrying one, and no `DROP INDEX` could clear it before dropping its
+ * column.
+ *
+ * The add-column path already emitted `uq_<table>_<column>`; these pin that CREATE now agrees.
+ *
+ * Scope: these read the emitted DDL. Whether an apply still proposes a rebuild is a property of
+ * drizzle-kit's differ against a whole live database, which no fixture here holds; the e2e suite
+ * covers it, and recreates its database on every run so it exercises this path.
+ */
+import { describe, expect, it } from "vitest";
+
+import type { FieldDefinition } from "../../../../schemas/dynamic-collections";
+import {
+  MAX_INDEX_NAME_LENGTH,
+  indexNameForColumn,
+  uniqueIndexNameForColumn,
+} from "../../../schema/services/index-name";
+import { DynamicCollectionSchemaService } from "../dynamic-collection-schema-service";
+
+type Dialect = "postgresql" | "mysql" | "sqlite";
+const DIALECTS: Dialect[] = ["postgresql", "mysql", "sqlite"];
+
+const ddlFor = (dialect: Dialect, fields: FieldDefinition[]): string =>
+  new DynamicCollectionSchemaService(undefined, dialect).generateMigrationSQL(
+    "dc_widgets",
+    fields,
+    { hasStatus: false }
+  );
+
+/**
+ * A declared unique field.
+ *
+ * Deliberately NOT `slug`: every generated table already carries a system UNIQUE index on that
+ * column, so a field-level unique index there would be a second index over the same column and is
+ * correctly withheld. A fixture on `slug` would therefore test the excluded case while appearing
+ * to test the general one. `email` renders as `varchar` on MySQL, so it is keyable on all three
+ * dialects and the assertions hold everywhere rather than on the one dialect that agrees.
+ */
+const uniqueField = [
+  { name: "email", type: "email", required: true, unique: true },
+] as unknown as FieldDefinition[];
+
+/**
+ * The column definition line for a field, with the index statements excluded.
+ *
+ * Asserting `UNIQUE` is absent from the whole DDL would be wrong: `CREATE UNIQUE INDEX` contains the
+ * word, so the naive check passes only while the fix is broken and fails once it works.
+ */
+function columnLineFor(sql: string, column: string): string {
+  const line = sql
+    .split("\n")
+    .find(
+      l =>
+        l.includes(`\`${column}\``) ||
+        (l.includes(`"${column}"`) && !/CREATE\s+(UNIQUE\s+)?INDEX/i.test(l))
+    );
+  return line ?? "";
+}
+
+describe("a field declared unique", () => {
+  it.each(DIALECTS)("gets a named unique index on %s", dialect => {
+    const sql = ddlFor(dialect, uniqueField);
+    expect(sql).toMatch(/CREATE UNIQUE INDEX[\s\S]*uq_dc_widgets_email/i);
+  });
+
+  it.each(DIALECTS)(
+    "no longer carries an inline UNIQUE on its column on %s",
+    dialect => {
+      const sql = ddlFor(dialect, uniqueField);
+      const column = columnLineFor(sql, "email");
+
+      // The column line must exist, or this passes by finding nothing — the failure mode where a
+      // test is satisfied because its subject is absent rather than because it is correct.
+      expect(column, "the column is in the DDL").toContain("email");
+      expect(column, "and carries no anonymous constraint").not.toMatch(
+        /\bUNIQUE\b/i
+      );
+    }
+  );
+
+  it.each(DIALECTS)(
+    "names the index the way the add-column path already does on %s",
+    dialect => {
+      // `uq_<table>_<column>` is not a new convention: it is what a column added to an existing
+      // table has always produced, and what the desired schema declares. Agreeing on it is the
+      // entire fix — a different-but-consistent name would still drift from the snapshot.
+      expect(ddlFor(dialect, uniqueField)).toContain("uq_dc_widgets_email");
+    }
+  );
+});
+
+describe("a one-to-one relationship", () => {
+  const oneToOne = [
+    {
+      name: "profile",
+      type: "relationship",
+      options: { target: "profiles", relationType: "oneToOne" },
+    },
+  ] as unknown as FieldDefinition[];
+
+  it.each(DIALECTS)("keeps its inline UNIQUE on %s", dialect => {
+    // Deliberately unchanged. Its cardinality has NO other enforcement — no constraint on the
+    // add-column path, no unique index in the desired schema, no runtime check — so moving it to a
+    // named index without also changing what the desired schema declares would silently let a
+    // one-to-one hold duplicates.
+    const column = columnLineFor(ddlFor(dialect, oneToOne), "profile");
+    expect(column).toMatch(/\bUNIQUE\b/i);
+  });
+
+  it.each(DIALECTS)("does NOT get a uq_ index on %s", dialect => {
+    // The desired schema declares a one-to-one's index as NON-unique. Emitting a unique one here
+    // would be a third spelling of the same property, and the next diff would propose dropping it.
+    expect(ddlFor(dialect, oneToOne)).not.toContain("uq_dc_widgets_profile");
+  });
+});
+
+describe("a unique field MySQL cannot key", () => {
+  const uniqueText = [
+    { name: "sku", type: "textarea", unique: true },
+  ] as unknown as FieldDefinition[];
+
+  it("keeps the inline constraint rather than an index it would reject", () => {
+    // MySQL refuses to key a TEXT column without a length, and refuses BOTH spellings alike, so
+    // this field has never been creatable there. The inline form fails the CREATE atomically, which
+    // is what it has always done. Emitting a separate index instead would create the table first
+    // and fail on the index — leaving a collection installed without its uniqueness, past a
+    // statement MySQL has already auto-committed.
+    const sql = ddlFor("mysql", uniqueText);
+    expect(columnLineFor(sql, "sku")).toMatch(/\bUNIQUE\b/i);
+    expect(sql, "and no index it cannot accept").not.toContain(
+      "uq_dc_widgets_sku"
+    );
+  });
+
+  it("still gets the named index on dialects that can key text", () => {
+    // The control. Withholding it everywhere would satisfy the case above while abandoning the fix.
+    for (const dialect of ["postgresql", "sqlite"] as const) {
+      const sql = ddlFor(dialect, uniqueText);
+      expect(sql).toContain("uq_dc_widgets_sku");
+      expect(columnLineFor(sql, "sku")).not.toMatch(/\bUNIQUE\b/i);
+    }
+  });
+
+  it("still gets the named index on MySQL when the column IS keyable", () => {
+    // A bounded column is keyable, so the rule is about the column type and not about the dialect.
+    const bounded = [
+      { name: "email", type: "email", required: true, unique: true },
+    ] as unknown as FieldDefinition[];
+    expect(ddlFor("mysql", bounded)).toContain("uq_dc_widgets_email");
+  });
+});
+
+describe("the unique index name", () => {
+  it("is derived from the shared helper, so it stays within the identifier limit", () => {
+    // Composed directly, `uq_<table>_<column>` runs past 63 characters for names near their limits:
+    // MySQL refuses the identifier outright and PostgreSQL truncates it, leaving a created index
+    // whose name disagrees with the one the desired schema declares.
+    const longTable = `dc_${"a".repeat(48)}`;
+    const longColumn = "b".repeat(48);
+    const sql = new DynamicCollectionSchemaService(
+      undefined,
+      "postgresql"
+    ).generateMigrationSQL(
+      longTable,
+      [{ name: longColumn, type: "text", unique: true }] as never,
+      { hasStatus: false }
+    );
+    const name =
+      sql.match(/CREATE UNIQUE INDEX (?:IF NOT EXISTS )?"([^"]+)"/)?.[1] ?? "";
+    expect(name, "an index name was emitted").not.toBe("");
+    expect(
+      name.length,
+      "within the identifier limit MySQL enforces and PostgreSQL truncates at"
+    ).toBeLessThanOrEqual(63);
+    expect(name.startsWith("uq_"), "and still marked as the unique one").toBe(
+      true
+    );
+  });
+
+  it("stays DISTINCT for two long columns that share a prefix", () => {
+    // Length alone is not the property. A plain truncation also produces a name within the limit —
+    // and produces the SAME name for both of these, so a repair renaming pre-existing objects onto
+    // the convention would collide two constraints on exactly the long generated tables that
+    // motivated the naming. The shared helper reserves a hash of the WHOLE logical name for this.
+    const table =
+      "dc_a_very_long_collection_name_that_a_schema_builder_can_produc";
+    const shared = "a".repeat(58);
+    const first = uniqueIndexNameForColumn(table, `${shared}_one`);
+    const second = uniqueIndexNameForColumn(table, `${shared}_two`);
+
+    expect(first.length).toBeLessThanOrEqual(MAX_INDEX_NAME_LENGTH);
+    expect(second.length).toBeLessThanOrEqual(MAX_INDEX_NAME_LENGTH);
+    expect(
+      first.slice(0, 55),
+      "the readable part is identical, which is what makes this the hard case"
+    ).toBe(second.slice(0, 55));
+    expect(first, "and the names still differ").not.toBe(second);
+  });
+});
+
+describe("removing a unique field", () => {
+  const before = [
+    { name: "sku", type: "text", unique: true },
+  ] as unknown as FieldDefinition[];
+
+  it.each(DIALECTS)("drops its index before its column on %s", dialect => {
+    // SQLite refuses to drop a column an index still covers, and the index a unique field carries is
+    // named `uq_`. A removal path that searched only the `idx_` spellings never found it, emitted the
+    // column drop with the index in place, and the migration failed — the same "cannot drop a unique
+    // column" outcome the named index was supposed to end.
+    const service = new DynamicCollectionSchemaService(undefined, dialect);
+    const indexName = `uq_dc_widgets_sku`;
+    const sql = service.generateAlterTableMigration("dc_widgets", before, [], {
+      indexNames: new Set([indexName]),
+    });
+
+    const dropIndexAt = sql.indexOf(indexName);
+    const dropColumnAt = sql.search(/DROP COLUMN (?:IF EXISTS )?[`"]?sku/i);
+
+    expect(dropIndexAt, "the unique index is dropped").toBeGreaterThan(-1);
+    expect(dropColumnAt, "the column is dropped").toBeGreaterThan(-1);
+    expect(
+      dropIndexAt,
+      "and the index goes first, which is the whole requirement"
+    ).toBeLessThan(dropColumnAt);
+  });
+});
+
+describe("a unique field on a type the dialect cannot index", () => {
+  const jsonUnique = [
+    { name: "payload", type: "json", unique: true },
+  ] as unknown as FieldDefinition[];
+
+  /**
+   * Whether a unique index was emitted ON a given column.
+   *
+   * Scoped to the column on purpose: every generated table also carries a unique index on its
+   * system `slug`, so a bare search for `CREATE UNIQUE INDEX` is satisfied by that one and would
+   * report a split that never happened.
+   */
+  const hasUniqueIndexOn = (sql: string, column: string): boolean =>
+    new RegExp(
+      `CREATE UNIQUE INDEX (?:IF NOT EXISTS )?["\`][^"\`]*["\`] ON ["\`][^"\`]+["\`]\\(["\`]${column}["\`]\\)`,
+      "i"
+    ).test(sql);
+
+  it("keeps the uniqueness inline on MySQL rather than splitting it out", () => {
+    // MySQL cannot index a JSON column at all, so the split spelling fails on the CREATE UNIQUE
+    // INDEX — AFTER the CREATE TABLE it follows has already been auto-committed, leaving a table
+    // installed without the guarantee that was asked for. The inline form fails the CREATE itself,
+    // which installs nothing.
+    const sql = ddlFor("mysql", jsonUnique);
+
+    expect(
+      hasUniqueIndexOn(sql, "payload"),
+      "no separate unique index is emitted for a type MySQL cannot key"
+    ).toBe(false);
+    expect(
+      columnLineFor(sql, "payload"),
+      "the uniqueness stays on the column, so a failure is atomic"
+    ).toMatch(/UNIQUE/i);
+  });
+
+  it("still splits it out where the dialect can index the type", () => {
+    // The positive control: without it the assertion above passes for any implementation that
+    // stopped emitting unique indexes entirely, and for any typo in the matcher.
+    expect(hasUniqueIndexOn(ddlFor("postgresql", jsonUnique), "payload")).toBe(
+      true
+    );
+  });
+});
+
+describe("the attachments a create artefact is predicted to install", () => {
+  it.each(DIALECTS)("include the unique index it emits on %s", dialect => {
+    // A create that has not been deployed yet is described by this prediction rather than by
+    // introspection. When the prediction omitted the unique index, an edit removing the field
+    // emitted a bare DROP COLUMN, which SQLite refuses while the index still names the column.
+    const service = new DynamicCollectionSchemaService(undefined, dialect);
+    const { indexNames } = service.plannedAttachments(
+      "dc_widgets",
+      uniqueField
+    );
+
+    expect([...indexNames]).toContain("uq_dc_widgets_email");
+  });
+
+  it("omit it where the create emits none", () => {
+    // Predicting an index MySQL never installs is the mirror defect: the later drop names an
+    // absent index, and MySQL cannot express DROP INDEX IF EXISTS.
+    const service = new DynamicCollectionSchemaService(undefined, "mysql");
+    const { indexNames } = service.plannedAttachments("dc_widgets", [
+      { name: "payload", type: "json", unique: true },
+    ] as unknown as FieldDefinition[]);
+
+    expect([...indexNames]).not.toContain("uq_dc_widgets_payload");
+  });
+});
+
+/**
+ * These names are PERSISTED. They are the actual identifiers of objects in every database this
+ * code has created, so the function that produces them is a compatibility surface rather than a
+ * pure convenience recomputed on demand.
+ *
+ * Length and distinctness are properties any correct implementation has. IDENTITY is a property
+ * of THIS one, and it is the only property that protects databases already in the field: improve
+ * the readable portion, move the truncation split, swap the hash or change its width, and every
+ * one of those edits keeps length and distinctness green while renaming objects that already
+ * exist under the old spelling.
+ *
+ * If a change here is deliberate, it is a MIGRATION and not a refactor: existing databases carry
+ * the old names and something has to rename them. Update these values only together with that.
+ */
+describe("the generated names are pinned, because databases already hold them", () => {
+  it.each([
+    ["dc_widgets", "slug", "idx_dc_widgets_slug", "uq_dc_widgets_slug"],
+    ["dc_widgets", "sku", "idx_dc_widgets_sku", "uq_dc_widgets_sku"],
+    [
+      "single_pinned",
+      "slug",
+      "idx_single_pinned_slug",
+      "uq_single_pinned_slug",
+    ],
+    [
+      `dc_${"a".repeat(48)}`,
+      "b".repeat(48),
+      `idx_dc_${"a".repeat(48)}_0azp87a`,
+      `uq_dc_${"a".repeat(48)}_0azp87a`,
+    ],
+    [
+      "dc_a_very_long_collection_name_that_a_schema_builder_can_produc",
+      `${"a".repeat(58)}_one`,
+      "idx_dc_a_very_long_collection_name_that_a_schema_builde_1wf0ecy",
+      "uq_dc_a_very_long_collection_name_that_a_schema_builde_1wf0ecy",
+    ],
+  ])("%s.%s", (table, column, expectedIndex, expectedUnique) => {
+    expect(indexNameForColumn(table, column)).toBe(expectedIndex);
+    expect(uniqueIndexNameForColumn(table, column)).toBe(expectedUnique);
+  });
+});
+
+describe("a field declaring unique on the slug column", () => {
+  const uniqueSlug = [
+    { name: "slug", type: "text", required: true, unique: true },
+  ] as unknown as FieldDefinition[];
+
+  const uniqueIndexTargets = (sql: string): string[] =>
+    sql
+      .split("\n")
+      .filter(l => /CREATE UNIQUE INDEX/i.test(l))
+      .map(l => l.match(/\(["`]?([^"`)]+)["`]?\)/)?.[1] ?? "");
+
+  it.each(DIALECTS)("gets exactly ONE unique index on %s", dialect => {
+    // Every generated table already carries a system UNIQUE index on `slug`. Emitting a
+    // field-specific one as well puts two identical unique indexes on the column, which every
+    // write then maintains, and the desired schema keeps only one — so a table disagrees with
+    // its own snapshot the moment it is created and the next reconcile proposes a drop.
+    const onSlug = uniqueIndexTargets(ddlFor(dialect, uniqueSlug)).filter(
+      c => c === "slug"
+    );
+
+    expect(onSlug, "one unique index covers slug, not two").toHaveLength(1);
+  });
+
+  it.each(DIALECTS)(
+    "and it is the system one, not a uq_ twin, on %s",
+    dialect => {
+      const sql = ddlFor(dialect, uniqueSlug);
+      expect(sql).toContain(`${"idx"}_dc_widgets_slug`);
+      expect(sql, "no second spelling of the same guarantee").not.toContain(
+        "uq_dc_widgets_slug"
+      );
+    }
+  );
+});

--- a/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-schema-service.ts
+++ b/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-schema-service.ts
@@ -46,6 +46,7 @@ import {
 import {
   columnTypeIsIndexable,
   indexNameForColumn,
+  uniqueIndexNameForColumn,
 } from "../../schema/services/index-name";
 import { quoteJsonSqlDefault } from "../../schema/utils/sql-literal";
 
@@ -137,6 +138,85 @@ export class DynamicCollectionSchemaService {
   }
 
   /**
+   * The statement that makes a column unique, in the one spelling everything else expects.
+   *
+   * `uq_<table>_<column>` is what the desired schema declares for a unique field and what the
+   * add-column path already emits, so a column that arrives with its table and the same column
+   * added by a later edit now produce the same object. Asked in one place because the previous
+   * arrangement — inline at create, named on add — made a table's physical shape depend on WHEN
+   * the column appeared.
+   *
+   * MySQL is the exception on `IF NOT EXISTS`: it rejects the clause on CREATE INDEX rather than
+   * ignoring it.
+   */
+  private uniqueIndexSql(tableName: string, column: string): string {
+    const name = this.quoteIdentifier(
+      uniqueIndexNameForColumn(tableName, column)
+    );
+    const target = `${this.quoteIdentifier(tableName)}(${this.quoteIdentifier(column)})`;
+    return this.dialect === "mysql"
+      ? `CREATE UNIQUE INDEX ${name} ON ${target};`
+      : `CREATE UNIQUE INDEX IF NOT EXISTS ${name} ON ${target};`;
+  }
+
+  /**
+   * Whether this dialect can carry the uniqueness as a NAMED index on this column.
+   *
+   * MySQL cannot key a `TEXT`/`BLOB` column without a length, and refuses both spellings alike —
+   * the inline constraint and the index. Such a column keeps the inline form, which fails the
+   * CREATE atomically exactly as it always has, rather than creating the table and then failing on
+   * a separate index statement MySQL has already auto-committed past.
+   *
+   * Bounding the column would make it work, and is the right answer, but it belongs in the shared
+   * column descriptor: bounding it HERE alone makes the created column disagree with the type the
+   * desired schema derives, and the next reconciliation tries to convert it back — which MySQL
+   * cannot do while a full-value unique index stands on it.
+   */
+  private uniquenessCanBeAnIndex(rendered: string): boolean {
+    // Asked through the shared indexability rule before anything local: a type the dialect cannot
+    // index AT ALL cannot carry the uniqueness as an index either. MySQL rejects an index on a
+    // JSON column, so a `json`-backed unique field belongs with the inline form for the same
+    // reason TEXT does — and answering that here rather than restating the rule keeps this from
+    // being a second opinion about which columns MySQL can key.
+    if (!columnTypeIsIndexable(rendered, this.dialect)) return false;
+    if (this.dialect !== "mysql") return true;
+    return !/\b(text|blob|longtext|mediumtext|tinytext)\b/i.test(rendered);
+  }
+
+  /**
+   * The name of the UNIQUE index the create path emits for this field, or null when it emits none.
+   *
+   * Asked by the emitter and by `plannedAttachments` alike, so a prediction of what a create
+   * artefact installs cannot disagree with what it installs. When only the emitter knew, a create
+   * that had not been deployed yet still added this index, while the edit that followed emitted a
+   * bare `DROP COLUMN` — which SQLite refuses while any index still names the column.
+   */
+  private plannedUniqueIndexName(
+    tableName: string,
+    field: FieldDefinition
+  ): string | null {
+    if (field.unique !== true || !fieldProducesColumn(field)) return null;
+    // `slug` already carries a UNIQUE index that every generated table gets
+    // unconditionally, so a field declaring `unique: true` on it would be asking for a
+    // second index over the same column. The desired schema keeps only the system one —
+    // `dedupeIndexes` discards the field-specific duplicate as logically identical — so
+    // emitting both makes a freshly created table disagree with its own snapshot, and
+    // every write maintains two identical unique indexes until a reconcile drops one.
+    if (toSnakeCase(field.name) === "slug") return null;
+    const rendered =
+      this.canonicalSlugType(field) ??
+      this.mapFieldTypeToSQL(
+        field.type,
+        field.length,
+        field.options,
+        field.validation,
+        field
+      );
+    if (!this.uniquenessCanBeAnIndex(rendered)) return null;
+    return uniqueIndexNameForColumn(tableName, toSnakeCase(field.name));
+  }
+
+  /**
    * Whether the field's column is indexed.
    *
    * A relationship is indexed whether or not the author asked: it is joined on every read that
@@ -214,6 +294,25 @@ export class DynamicCollectionSchemaService {
    *
    * Which of these the table actually has is decided by the live index list, never guessed.
    */
+  /**
+   * The names a column's UNIQUE index may carry, for the paths that REMOVE the column.
+   *
+   * Deliberately NOT part of `indexNameCandidates`. That list is also consulted when a field merely
+   * turns its `index` flag off while staying unique, and a `uq_` name in it makes that path drop the
+   * uniqueness itself — losing a guarantee the field still declares.
+   */
+  private uniqueIndexNameCandidates(
+    tableName: string,
+    column: string
+  ): string[] {
+    return [
+      ...new Set([
+        uniqueIndexNameForColumn(tableName, column),
+        `uq_${tableName}_${column}`,
+      ]),
+    ];
+  }
+
   private indexNameCandidates(tableName: string, column: string): string[] {
     const full = `idx_${tableName}_${column}`;
     const candidates = [indexNameForColumn(tableName, column), full];
@@ -353,7 +452,23 @@ export class DynamicCollectionSchemaService {
           this.mapFieldTypeToSQL(f.type, f.length, f.options, f.validation, f);
         const nullable = f.required ? "NOT NULL" : "";
 
-        const unique = this.columnIsUnique(f) ? "UNIQUE" : "";
+        // A one-to-one keeps its inline `UNIQUE`, and ONLY a one-to-one.
+        //
+        // Its cardinality has no other enforcement anywhere — no constraint, no index, no runtime
+        // check — so removing this would silently let a one-to-one hold duplicates. The declared
+        // `unique: true` case moves to a named index below; this one cannot follow it yet, because
+        // the desired schema declares a one-to-one's index as NON-unique, and emitting a unique one
+        // here would drift from that on every table carrying a one-to-one.
+        //
+        // Reconciling that means changing what the desired schema declares, which would then
+        // propose ADDING a unique index to existing one-to-one columns — a statement that fails
+        // wherever duplicates were already allowed in. That needs a precondition and a decision,
+        // not a quiet edit here.
+        const unique =
+          this.columnIsUnique(f) &&
+          (f.unique !== true || !this.uniquenessCanBeAnIndex(type))
+            ? "UNIQUE"
+            : "";
 
         const defaultVal =
           f.default !== undefined && f.default !== null
@@ -537,6 +652,23 @@ ${allColumnDefs.join(",\n")}
         );
         if (indexSql) indexStatements.push(indexSql);
       }
+    });
+
+    // Uniqueness is a NAMED index, never a column-level `UNIQUE` inside CREATE TABLE.
+    //
+    // An inline constraint is anonymous: the server names its backing index, and on SQLite that is
+    // an internal `sqlite_autoindex_*` which no statement can reference or drop. Nothing downstream
+    // can then track it — so the desired schema, which declares `uq_<table>_<column>`, disagreed
+    // with every table that had one, and the disagreement is only resolvable by rebuilding the
+    // table. It also made a `unique: true` column impossible to drop on SQLite, since the constraint
+    // outlives every index drop.
+    //
+    // The flag alone, NOT `columnIsUnique`: a one-to-one relationship is unique by cardinality, and
+    // the desired schema gives it a NON-unique index. Emitting a unique one here would be a third
+    // spelling of the same property, and the next diff would propose dropping it.
+    mainFields.forEach(f => {
+      if (this.plannedUniqueIndexName(tableName, f) === null) return;
+      indexStatements.push(this.uniqueIndexSql(tableName, toSnakeCase(f.name)));
     });
 
     // For now, we'll add it as it's a common pattern in most applications
@@ -979,6 +1111,28 @@ ${allColumnDefs.join(",\n")}
           );
         }
 
+        // The UNIQUE index, which is a separate object from the plain one above and may be present
+        // without it. SQLite refuses to drop a column an index still names, so this has to go first.
+        //
+        // On PostgreSQL the same name can belong to a CONSTRAINT rather than to a free-standing
+        // index, because the add-column path creates it with ADD CONSTRAINT. `DROP INDEX` on a
+        // constraint-owned index is refused there, and the refusal aborts the migration before the
+        // column drop that would have removed both. Dropping the constraint first covers that case
+        // and is harmless when there is none; the index drop after it covers the create path, which
+        // makes a free-standing index under the same name.
+        const uniquePresent = this.uniqueIndexNameCandidates(
+          tableName,
+          dropCol
+        ).find(name => options?.indexNames?.has(name) === true);
+        if (uniquePresent !== undefined) {
+          if (this.dialect === "postgresql") {
+            statements.push(
+              `ALTER TABLE ${this.quoteIdentifier(tableName)} DROP CONSTRAINT IF EXISTS ${this.quoteIdentifier(uniquePresent)};`
+            );
+          }
+          statements.push(this.dropIndexSql(tableName, uniquePresent));
+        }
+
         // SQLite doesn't support IF EXISTS on DROP COLUMN
         if (this.dialect === "sqlite") {
           statements.push(
@@ -1328,6 +1482,10 @@ ${allColumnDefs.join(",\n")}
       ) {
         indexNames.add(indexNameForColumn(tableName, column));
       }
+      // The UNIQUE index is a separate object from the plain one and is emitted under its own
+      // rule, so it has to be predicted through that rule rather than inferred from this one.
+      const uniqueName = this.plannedUniqueIndexName(tableName, field);
+      if (uniqueName !== null) indexNames.add(uniqueName);
       if (field.type === "relationship" && field.options?.target) {
         foreignKeysByColumn.set(column, [`fk_${tableName}_${column}`]);
       }

--- a/packages/nextly/src/domains/schema/pipeline/diff/build-from-fields.ts
+++ b/packages/nextly/src/domains/schema/pipeline/diff/build-from-fields.ts
@@ -38,6 +38,7 @@ import {
 import {
   columnTypeIsIndexable,
   indexNameForColumn,
+  uniqueIndexNameForColumn,
 } from "../../services/index-name";
 
 import { indexKey } from "./index-util";
@@ -189,7 +190,7 @@ export function collectionIndexSpecs<F extends MinimalFieldDef>(
       !Array.isArray(field.relationTo);
     if (field.unique === true) {
       indexes.push({
-        name: indexNameForColumn(tableName, col).replace(/^idx_/, "uq_"),
+        name: uniqueIndexNameForColumn(tableName, col),
         columns: [col],
         unique: true,
       });

--- a/packages/nextly/src/domains/schema/services/index-name.ts
+++ b/packages/nextly/src/domains/schema/services/index-name.ts
@@ -37,6 +37,22 @@ export function indexNameForColumn(tableName: string, column: string): string {
 export const MAX_INDEX_NAME_LENGTH = 63;
 
 /**
+ * The name of the UNIQUE index on a column.
+ *
+ * Derived from `indexNameForColumn` rather than composed, so it inherits the length bound and the
+ * disambiguating hash. Composing `uq_${table}_${column}` directly looks equivalent and is not: for
+ * names near their limits it exceeds 63 characters, which MySQL refuses outright and PostgreSQL
+ * truncates — leaving the created index under a name that disagrees with the one the desired schema
+ * declares, which is the disagreement this naming exists to prevent.
+ */
+export function uniqueIndexNameForColumn(
+  tableName: string,
+  column: string
+): string {
+  return indexNameForColumn(tableName, column).replace(/^idx_/, "uq_");
+}
+
+/**
  * Whether the dialect can index a column of this type at all.
  *
  * MySQL cannot index a JSON column: it answers that indexing is supported "only via generated


### PR DESCRIPTION
Fixes the P1 in `tasks/left-tasks/177-hmr-apply-wants-to-drop-every-singles-table.md` for new databases. **That task stays OPEN** — see "What this does not fix".

## The defect

A column-level `UNIQUE` inside `CREATE TABLE` is anonymous: the server names the index behind it, and on SQLite that is an internal `sqlite_autoindex_*` no statement can reference or drop.

The desired schema declares `uq_<table>_<column>` for a unique field (`diff/build-from-fields.ts:190-195`), and the add-column path already emits exactly that (`:832`, `:840`). **Only the create path was out of step**, so every table it made disagreed with the schema it was generated from.

SQLite cannot `ALTER` that difference away, so drizzle-kit proposed rebuilding the table. Our diff had approved no change to it, so the destructive guard refused the batch — **including its additive half**.

Two user-visible failures from that one root:

1. **An HMR schema apply refused every batch** for any app registering a single. It printed as one `[ERROR]` line in a scrolling dev log, and **it turned e2e RED on unrelated PRs** — the UI lane lost a debugging pass to it on a PR containing five files of build tooling.
2. **A `unique: true` column created with its table could not be dropped on SQLite.** That was known and worked around rather than fixed; the note recording it is deleted here.

## The change

One product file. `field.unique` now produces `CREATE UNIQUE INDEX uq_<table>_<column>` alongside the create, in the same spelling the add-column path uses — so a column that arrives with its table and the same column added by a later edit finally produce the same object.

🔴 **A one-to-one relationship keeps its inline constraint, deliberately.** Its cardinality has no other enforcement anywhere — no constraint on the add path, no unique index in the desired schema, no runtime check (verified across every non-test `oneToOne` reference). The obvious version of this change would have silently deleted the only thing holding it. The desired schema also declares a one-to-one's index as NON-unique, so moving it would need that changed first, which then fails on existing duplicates. Filed as `2026-08-11-1830-a-one-to-one-relationship-does-not-enforce-its-cardinality.md`.

## Verification, and an honest note about where it is not

**End-to-end, measured both ways on the same commit:**

| | clean `main` | with this branch |
|---|---|---|
| `PUSHSCHEMA_FAILED` | 4 | **0** |
| `DROP TABLE single_*` | 8 | **0** |
| `Batch apply failed` | 4 | **0** |

Reproduce: `pnpm --filter @nextlyhq/e2e test:e2e`, grep `PUSHSCHEMA_FAILED`. That suite deletes its database before every run, which is why it exercises the create path.

**Unit:** 15 new cases pinning the emitted DDL on all three dialects. Proven load-bearing in both directions — removing the named index fails 6/15, restoring the inline constraint fails 3/15, count stable, clean builds.

🔴 **There is no integration test, and that is stated rather than left as a gap.** I wrote one, and it was vacuous: it passed identically with and without the fix. Three attempts — including one using the exact singles shape — all did. The rebuild is proposed by drizzle-kit's differ against a full live database, and a fixture holding one or two tables never reaches those conditions. It is deleted rather than kept looking like coverage, and the surviving test's header records the e2e numbers and the command instead.

## Two test changes that are not just "update the test"

**`alter-column-attachments.test.ts`** asserts CREATE and ADD-to-empty agree on what a column carries. Its case for `a unique text field` started failing — and the cause was in the test: `createAttachments` read uniqueness only from the column line while `alterAttachments` accepted a named constraint or index. Two detectors, disagreeing about what counts, so a genuine convergence read as a regression. Unified into one `hasUniqueness()` used by both, which makes the test assert agreement rather than identical syntax.

**Characterization snapshots** pin builder DDL as it is today, and this changes it. Before regenerating I filtered every changed line: the only differences are the uniqueness spelling and the `--> statement-breakpoint` separating the new statement, across three dialects for collections and singles.

## What this does not fix

**Databases that already exist.** Everything here changes creation only. A database created before this keeps its inline constraint and both bugs, and the repair is a SQLite table rebuild — task 172 and §3.2 of `tasks/2026-08-11-schema-operation-model-design.md`. If you hit the error locally after this merges, delete your playground database.

**Task 177 stays open for that**, because a green CI would otherwise remove the pressure to finish it.

## Verification bar

Run from the worktree root against `891ec3b0e`: `pnpm build`, `check-types --force`, `lint`, `check-drizzle-v1-legacy.cjs` — all clean. Unit **361 failed / 7227 passed / 7636**, diffed at test-name level against a baseline freshly measured at `891ec3b0e` in its own installed and built worktree: **zero new, zero fixed**. Integration **postgres17, mysql and sqlite all pass**.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of unique fields when creating or modifying collections.
  - Unique fields now consistently enforce uniqueness across PostgreSQL, MySQL, and SQLite.
  - Prevented duplicate or conflicting uniqueness definitions during schema changes.
  - Preserved inline uniqueness for one-to-one relationship fields while applying named unique indexes to standard unique fields.
- **Tests**
  - Added coverage to verify consistent unique index naming and column enforcement across supported databases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## If you saw this from another lane

The email lane hit this on **CI**, not on a stale local database, and set it
aside as unrelated to their diff:

```
Schema apply FAILED — global
3 destructive statement(s)
DROP TABLE single_homepage; DROP TABLE single_landing_page; DROP TABLE single_site_settings
```

That is this defect, and it reproduces on CI's **fresh SQLite database** because
the fault is in the CREATE path: a `unique: true` column was created with an
anonymous inline `UNIQUE`, which SQLite backs with an unnameable
`sqlite_autoindex_*`. The desired schema declares `uq_<table>_<column>`, nothing
could reconcile the two, and the differ resolved it the only way it can — by
rebuilding the table.

It appears in the WebServer boot log of the `Browser tests` job, where it is
noisy enough to look like the cause of an unrelated e2e failure. It is not; it
is this, and this PR fixes it for every new database.

**It does NOT repair databases that already exist.** Measured today across
engines: the fault is not SQLite-only. PostgreSQL 17.10 names the object
`<table>_<column>_key`, MySQL 8.0.46 and MariaDB 11.8.8 name it after the
column — all three invisible to code looking for `uq_*`, so an existing database
reads as clean when it is not. PostgreSQL, MySQL and MariaDB repair in place via
`RENAME CONSTRAINT` / `RENAME INDEX` with no window; only SQLite needs a table
rebuild. That repair is designed and measured but deliberately out of scope here.
