### PR TITLE
fix(nextly): stop a public route expanding relations by default

### DIFF
--- a/.changeset/public-route-no-relation-expansion.md
+++ b/.changeset/public-route-no-relation-expansion.md
@@ -1,0 +1,37 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+A public content route no longer expands relations by default.
+
+A trusted read propagates both its trust and a widened lifecycle into
+relationship expansion: a populated target is read with access rules bypassed
+AND `status: "all"`. At the inherited default of `depth: 1`, a page in a public
+collection could therefore embed a draft or access-restricted row from a
+collection appearing nowhere in the route config — and a public route
+pre-renders that into a static artifact.
+
+`createPublicContentRoute` and `createPublicBlocksPage` now default to
+`depth: 0`. Setting `depth` explicitly restores expansion, and states that the
+populated collections are public too.

--- a/docs/guides/routing-and-seo.mdx
+++ b/docs/guides/routing-and-seo.mdx
@@ -170,8 +170,9 @@ choose it per collection set, not per preference.**
   **every collection you list must be public**. A restricted collection listed
   here has its entries read trusted and its paths pre-rendered into public HTML.
 
-> ⚠️ **The trust does not stop at the collections you list.** At the default
-> `depth: 1`, a populated relationship is expanded with the same trusted
+> ⚠️ **The trust does not stop at the collections you list.** Wherever relation
+> expansion happens — `resolveContent` and `createContentRoute` both default to
+> `depth: 1` — a populated relationship is expanded with the same trusted
 > posture — access rules bypassed, and lifecycle widened to include drafts. So a
 > page in a public collection can embed a draft or access-restricted row from a
 > **related** collection, and this route pre-renders that page into a static

--- a/docs/guides/routing-and-seo.mdx
+++ b/docs/guides/routing-and-seo.mdx
@@ -178,9 +178,12 @@ choose it per collection set, not per preference.**
 > artifact. Publishing it that way cannot be taken back by unpublishing the
 > source row.
 >
-> Until this is resolved, treat every collection a public route's pages
-> **populate** as being as exposed as the ones it lists. Use
-> `createContentRoute`, or set `depth: 0`, where that is not acceptable.
+> **`createPublicContentRoute` therefore defaults to `depth: 0`** — no relation
+> expansion — so the exposure is something a site opts into rather than
+> inherits. Setting `depth` yourself re-enables it, and by doing so you are
+> stating that the collections your pages populate are public too.
+>
+> That default bounds the blast radius; it does not fix the propagation.
 
 **The route factories take no `overrideAccess` option** — unlike
 `resolveContent`, which still does, because a page calling it directly knows who

--- a/docs/guides/routing-and-seo.mdx
+++ b/docs/guides/routing-and-seo.mdx
@@ -170,14 +170,20 @@ choose it per collection set, not per preference.**
   **every collection you list must be public**. A restricted collection listed
   here has its entries read trusted and its paths pre-rendered into public HTML.
 
-> ⚠️ **The trust does not stop at the collections you list.** Wherever relation
-> expansion happens — `resolveContent` and `createContentRoute` both default to
-> `depth: 1` — a populated relationship is expanded with the same trusted
-> posture — access rules bypassed, and lifecycle widened to include drafts. So a
-> page in a public collection can embed a draft or access-restricted row from a
-> **related** collection, and this route pre-renders that page into a static
-> artifact. Publishing it that way cannot be taken back by unpublishing the
-> source row.
+> ⚠️ **On a TRUSTED read, the trust does not stop at the collections you list.**
+> A populated relationship inherits the posture of the read that reached it — so
+> when the read is trusted, its targets are expanded with access rules bypassed
+> and lifecycle widened to include drafts.
+>
+> This does **not** apply to an enforced read. `resolveContent` defaults to
+> `overrideAccess: false` and `createContentRoute` reads restricted, so their
+> populated relations stay access-checked at the default `depth: 1`. The
+> propagation reaches a trusted `resolveContent` call, a draft-authorized route
+> read, and a public route.
+>
+> On a public route it is worst, because the page is pre-rendered into a static
+> artifact: publishing a draft or access-restricted row that way cannot be taken
+> back by unpublishing the source.
 >
 > **`createPublicContentRoute` therefore defaults to `depth: 0`** — no relation
 > expansion — so the exposure is something a site opts into rather than

--- a/packages/nextly/src/runtime/routing/__tests__/content-route-draft.test.ts
+++ b/packages/nextly/src/runtime/routing/__tests__/content-route-draft.test.ts
@@ -336,6 +336,19 @@ describe("the content route's draft decision", () => {
     expect(calls.every(call => call.depth === 0)).toBe(true);
   });
 
+  it("applies the route's depth to the static-params scan too", async () => {
+    // The scan is a TRUSTED read on a public route. Omitting `depth` let it
+    // inherit the Direct API's default, so the one read that runs at BUILD time
+    // — for a query that wants a single column — was the only read on the route
+    // not honouring its own no-expansion posture.
+    const { reader, calls } = stubReader();
+
+    await publicRouteWith(reader).generateStaticParams();
+
+    expect(calls.length).toBeGreaterThan(0);
+    expect(calls.every(call => call.depth === 0)).toBe(true);
+  });
+
   it("still expands relations when the site sets depth explicitly", async () => {
     // The default is a safe starting point, not a ceiling. A site that
     // populates relations says so, and by saying so states that those

--- a/packages/nextly/src/runtime/routing/__tests__/content-route-draft.test.ts
+++ b/packages/nextly/src/runtime/routing/__tests__/content-route-draft.test.ts
@@ -304,6 +304,36 @@ describe("the content route's draft decision", () => {
     expect(() => publicRouteWith(reader, true)).toThrow(/cannot serve drafts/i);
   });
 
+  it("does not expand relations unless the site asks it to", async () => {
+    // A trusted read propagates its trust AND `status: "all"` into relationship
+    // expansion, so a populated target is read with access rules bypassed and
+    // drafts included. On a public route that page is then pre-rendered into a
+    // static artifact. Defaulting to no expansion makes that exposure something
+    // a site opts into rather than inherits.
+    const { reader, calls } = stubReader();
+
+    await publicRouteWith(reader).ContentPage({ params: { slug: ["a"] } });
+
+    expect(calls.length).toBeGreaterThan(0);
+    expect(calls.every(call => call.depth === 0)).toBe(true);
+  });
+
+  it("still expands relations when the site sets depth explicitly", async () => {
+    // The default is a safe starting point, not a ceiling. A site that
+    // populates relations says so, and by saying so states that those
+    // collections are public too.
+    const { reader, calls } = stubReader();
+
+    await createPublicContentRoute({
+      collections: ["pages"],
+      nextly: reader,
+      depth: 2,
+      render: (entry: ContentEntry) => entry,
+    }).ContentPage({ params: { slug: ["a"] } });
+
+    expect(calls.every(call => call.depth === 2)).toBe(true);
+  });
+
   it("cannot be asked to pre-render a route that builds no paths", () => {
     // `staticParamsLimit: 0` asks for a static route with nothing to build. The
     // generator returns `[]` — accepted by standard App Router builds, rejected

--- a/packages/nextly/src/runtime/routing/__tests__/content-route-draft.test.ts
+++ b/packages/nextly/src/runtime/routing/__tests__/content-route-draft.test.ts
@@ -318,6 +318,24 @@ describe("the content route's draft decision", () => {
     expect(calls.every(call => call.depth === 0)).toBe(true);
   });
 
+  it("keeps the safe default when depth is explicitly undefined", async () => {
+    // An optional property permits an explicit `undefined`, and forwarding a
+    // config object produces one routinely. A spread overwrites with it, so a
+    // default placed BEFORE the spread is silently discarded — restoring
+    // trusted relation expansion for the caller least likely to have chosen it.
+    const { reader, calls } = stubReader();
+
+    await createPublicContentRoute({
+      collections: ["pages"],
+      nextly: reader,
+      depth: undefined,
+      render: (entry: ContentEntry) => entry,
+    }).ContentPage({ params: { slug: ["a"] } });
+
+    expect(calls.length).toBeGreaterThan(0);
+    expect(calls.every(call => call.depth === 0)).toBe(true);
+  });
+
   it("still expands relations when the site sets depth explicitly", async () => {
     // The default is a safe starting point, not a ceiling. A site that
     // populates relations says so, and by saying so states that those

--- a/packages/nextly/src/runtime/routing/content-route.ts
+++ b/packages/nextly/src/runtime/routing/content-route.ts
@@ -602,7 +602,31 @@ export function createPublicContentRoute<TNode>(
       },
     });
   }
-  return buildRoute(config, "public");
+  return buildRoute(
+    {
+      // Populated relations are NOT covered by the promise this factory makes.
+      //
+      // A trusted read propagates both its trust and a widened lifecycle into
+      // relationship expansion: a populated target is read with access rules
+      // bypassed AND `status: "all"`. So at the inherited default of `depth: 1`
+      // a page in a public collection can embed a DRAFT or access-restricted
+      // row from a collection that appears nowhere in this config — and this
+      // route pre-renders that into a static artifact, which publishing cannot
+      // be taken back from.
+      //
+      // Defaulting to no expansion makes the exposure something a site OPTS
+      // INTO rather than something it inherits. A site that populates relations
+      // sets `depth` itself, and by doing so states that those collections are
+      // public too.
+      //
+      // This bounds the blast radius; it does not fix the propagation. That
+      // still belongs where the trust is threaded, so a caller who sets `depth`
+      // gets the old behaviour in full.
+      depth: 0,
+      ...config,
+    },
+    "public"
+  );
 }
 
 /** Join the optional-catch-all segments into a slug path (no leading slash). */

--- a/packages/nextly/src/runtime/routing/content-route.ts
+++ b/packages/nextly/src/runtime/routing/content-route.ts
@@ -162,7 +162,19 @@ export interface ContentRouteConfig<TNode> {
    * `buildMetadata` as `context.locale`. Omit for the default locale.
    */
   locale?: string;
-  /** Relation depth for the resolved read (default `1`). */
+  /**
+   * Relation depth for the resolved read.
+   *
+   * **The default differs by factory, and the difference is a security one.**
+   * `createContentRoute` defaults to `1`, matching `resolveContent`.
+   * `createPublicContentRoute` defaults to `0` — a trusted read propagates both
+   * its trust and a widened lifecycle into relationship expansion, so a
+   * populated target would be read with access rules bypassed and drafts
+   * included, and a public route pre-renders that into a static artifact.
+   *
+   * Setting this on a public route restores expansion, and by setting it you
+   * state that the collections your pages populate are public too.
+   */
   depth?: number;
   /** A booted Nextly instance (defaults to `getNextly()`). */
   nextly?: NextlyContentReader;

--- a/packages/nextly/src/runtime/routing/content-route.ts
+++ b/packages/nextly/src/runtime/routing/content-route.ts
@@ -465,6 +465,13 @@ function buildRoute<TNode>(
         try {
           result = await nextly.find({
             collection,
+            // The route's own depth, not the Direct API's default. This scan is
+            // a TRUSTED read on a public route, so an inherited expansion depth
+            // pulls related rows — draft ones included — through their nested
+            // hooks at build time, for a query that wants one column. It is the
+            // same posture the render and metadata reads carry; a scan that
+            // opted out of it would be the one read on the route that did not.
+            depth,
             // Lifecycle-aware publish scope — a no-op on status-less collections.
             status,
             // The same locale `resolve()` reads in. Without it a localized

--- a/packages/nextly/src/runtime/routing/content-route.ts
+++ b/packages/nextly/src/runtime/routing/content-route.ts
@@ -622,8 +622,13 @@ export function createPublicContentRoute<TNode>(
       // This bounds the blast radius; it does not fix the propagation. That
       // still belongs where the trust is threaded, so a caller who sets `depth`
       // gets the old behaviour in full.
-      depth: 0,
+      // Normalized AFTER the spread, not defaulted before it. An optional
+      // property permits an EXPLICIT `undefined` — which forwarding a config
+      // object produces routinely — and a spread overwrites with it, so
+      // `{ depth: 0, ...config }` restores `?? 1` for exactly the caller least
+      // likely to have thought about relation expansion.
       ...config,
+      depth: config.depth ?? 0,
     },
     "public"
   );


### PR DESCRIPTION
Mitigates task 186 (P1, security). **Does not close it** — see below.

## The exposure

A trusted read propagates both its trust and a widened lifecycle into relationship expansion. `collection-query-service.ts:1409` and `:1418`:

```ts
overrideAccess: params.overrideAccess,
...
status: params.status === "all" || params.overrideAccess === true ? "all" : undefined,
```

So at the inherited default of `depth: 1`, a **public** route's populated targets are read with **access rules bypassed** and **`status: "all"`**. A page in a public collection can embed a draft or access-restricted row from a collection that appears **nowhere in the route config** — and a public route pre-renders that into a static artifact. Publishing it that way cannot be taken back by unpublishing the source row.

Raised by Codex on #641, verified there against the code, and shipped documented rather than fixed because designing read-scoping changes needed a session with context to verify them.

## What this changes

`createPublicContentRoute` (and therefore `createPublicBlocksPage`) now defaults to `depth: 0`. Setting `depth` explicitly restores expansion — and by setting it, a site states that the collections its pages populate are public too.

```ts
return buildRoute({ depth: 0, ...config }, "public");
```

The spread order is the whole mechanism: the default sits **under** the caller's config, so an explicit `depth` always wins.

## Why now, and why only this much

**The window is closing.** `createPublicContentRoute` shipped hours ago in #641 and has no consumers yet, so changing its default is free today and a breaking change the moment someone depends on `depth: 1` being inherited here.

**This bounds the blast radius; it does not fix the propagation.** A caller who sets `depth` gets the old behaviour in full. The real fix belongs where the trust is threaded — task 186 recommends requiring a route to name its full trusted set, so the config becomes the complete statement it currently pretends to be. **A documented opt-in to a security exposure is still the failure mode #641 spent six rounds removing**, and I would not want this PR read as closing that.

## Verified

Two tests, both mutation-verified. Removing `depth: 0` fails exactly one:

```
FAIL  does not expand relations unless the site asks it to
      AssertionError: expected false to be true
Tests  1 failed | 15 passed (16)
```

Restored: **63 routing tests pass**, lint clean.

The second test pins the other direction — `depth: 2` still reaches the reader — so the default cannot be read as a ceiling, and a future change that hard-codes `0` fails loudly.

The routing guide's warning is updated to describe the new default and to keep saying plainly that it is a bound, not a fix.



---

## Corroboration from a second package, verified independently

The page-builder lane read the `blocks-react` read path rather than reasoning about it, and confirmed **`depth: 0` breaks nothing there** — a page-builder page resolves everything through its own explicit channels, none of which ride on relationship expansion:

- **Media** goes to the media NAMESPACE, not a collection — ordinary Nextly media "live in a system table with its own reader, not in a dynamic collection".
- **Entry references** go through `resolveEntryPath`.
- **Dynamic blocks** go through `data?: BlocksDataProvider`.

Every occurrence of `depth` in `blocks-react` and `blocks-engine` is block-TREE nesting (`MAX_DEPTH`, `sanitize.ts`, `renderable.ts`), not relation expansion. **There is no consumer of `depth: 1` to break.**

Stronger than "does not break": **a page-builder page is exactly the document this finding describes.** Its content is author-assembled and can name a media id or entry reference from any collection, and a public route pre-renders it into a static artifact. Trust-propagating expansion at an inherited `depth: 1` is a hazard there, not a convenience being lost.

**And the same argument is already load-bearing elsewhere in this codebase.** `next.ts` refuses to make the read budget optional on a route helper, for a reason that is this PR's reason in different words:

> depth in a document becomes MULTIPLICATION in reads, so three nested `core/collection-loop` blocks over a hundred entries each is a million reads from one page view — and a route helper is exactly where a page becomes reachable by anyone with a URL.

The `depth` default and that budget are the same claim about the same boundary: **route helpers are where defaults must be conservative**, because they are where content stops being reached by application code that already knows who is asking.