### PR TITLE
feat(blocks-react): export the types its public API is written in

### DIFF
--- a/.changeset/blocks-react-type-surface.md
+++ b/.changeset/blocks-react-type-surface.md
@@ -1,0 +1,43 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+`@nextlyhq/blocks-react` now exports the types its public API is written in.
+
+`StyleCompileContext`, `BlockDocument` and `DocumentLimits` appeared in the built
+declarations in parameter positions while being named in no export statement,
+and `BreakpointSet` — the one field `StyleCompileContext` requires — was absent
+from the surface entirely. A host could see the name it was required to pass and
+had no way to write it down, because those types originate in
+`@nextlyhq/blocks-engine`, which is a dependency of this package rather than a
+peer.
+
+The root entry now re-exports the engine document, style and breakpoint types;
+the `/next` entry re-exports `BlockSeoContribution` and `BlockSeoImage`. A
+regression test asserts each is named in an EXPORT STATEMENT of the built
+`.d.ts`, not merely present in the file.
+
+`nextly`'s own route types are deliberately not re-exported: it is a peer
+dependency, so a host names `ContentEntry`, `RenderContext` and the route shapes
+from `nextly/runtime` where they live.

--- a/.changeset/blocks-react-type-surface.md
+++ b/.changeset/blocks-react-type-surface.md
@@ -33,10 +33,21 @@ had no way to write it down, because those types originate in
 `@nextlyhq/blocks-engine`, which is a dependency of this package rather than a
 peer.
 
-The root entry now re-exports the engine document, style and breakpoint types;
-the `/next` entry re-exports `BlockSeoContribution` and `BlockSeoImage`. A
-regression test asserts each is named in an EXPORT STATEMENT of the built
-`.d.ts`, not merely present in the file.
+The root entry now re-exports the engine types the surface is built from, and
+the set is CLOSED: an exported type is only as writable as its parts, so a host
+handed `BlockDefinition` could name it and still not write down the `supports`
+object it must pass or the `seo()` contribution it must return. Everything
+reachable from a re-exported type is re-exported too, so annotating any part of
+the surface needs no second package.
+
+They live on the root entry rather than `/next`, whose declarations import the
+`next` and `nextly` peers a standalone install does not have.
+
+A regression test asserts each is named in an EXPORT STATEMENT of the built
+`.d.ts`, not merely present in the file, and derives what is required from the
+declarations themselves — the entries from `package.json`, the obligation from
+the engine's own composition — so the check grows with the API rather than with
+someone remembering to extend a list.
 
 `nextly`'s own route types are deliberately not re-exported: it is a peer
 dependency, so a host names `ContentEntry`, `RenderContext` and the route shapes

--- a/packages/blocks-react/src/index.ts
+++ b/packages/blocks-react/src/index.ts
@@ -87,10 +87,20 @@ export type { PrepareDocumentArgs } from "./prepare-document";
  * callers.** These originate in `@nextlyhq/blocks-engine`, which is a
  * DEPENDENCY of this package rather than a peer — so a host installing
  * `@nextlyhq/blocks-react` does not have it as a direct dependency and cannot
- * import from it. Before this, `StyleCompileContext`, `BlockDocument` and
- * `DocumentLimits` appeared in the built `.d.ts` in parameter positions while
- * naming none of them in an export statement: a host could SEE the name it was
- * required to pass and had no way to write it down.
+ * import from it. A type that reaches the built `.d.ts` in a parameter
+ * position while no export statement names it leaves a host able to SEE the
+ * name it is required to pass with no way to write it down.
+ *
+ * **The set is CLOSED, which is why it is larger than the names this package's
+ * own signatures mention.** An exported type is only as writable as its parts:
+ * a host handed `BlockDefinition` can name it and still be unable to write
+ * down the `supports` object it must pass, or the `seo()` return it must
+ * produce. Every type reachable from one exported here is therefore exported
+ * too, so annotating any PART of the surface needs no second package.
+ *
+ * `/next` re-exports none of these. Its declarations import the `next` and
+ * `nextly` peers, so a standalone install cannot load that entry at all; this
+ * one imports nothing but the engine and resolves wherever the package does.
  *
  * `nextly`'s own types are deliberately NOT re-exported here. `nextly` is a
  * PEER dependency, so a host has installed it directly and should name
@@ -101,20 +111,49 @@ export type { PrepareDocumentArgs } from "./prepare-document";
 export type {
   AnyBlockDefinition,
   Binding,
+  BindingFormat,
   BlockDefinition,
   BlockDocument,
+  BlockEditorMeta,
+  BlockExample,
+  BlockMigrationInfo,
   BlockNode,
+  BlockRenderResult,
+  BlockSeoContribution,
+  BlockSeoImage,
+  BlockSupportValue,
+  BlockSupports,
+  BlockVariation,
   BreakpointDef,
   BreakpointId,
   BreakpointSet,
   CompiledPageCss,
+  ComponentPath,
   Condition,
+  DocumentFormatVersion,
   DocumentKind,
   DocumentLimits,
-  NodeStyles,
+  DocumentSettings,
+  IssueCode,
+  IssueSeverity,
+  MayFetchUrl,
+  MigrateFn,
+  MigrationMap,
   MigrationSource,
+  NamedClass,
+  NodeStyles,
   NodeVisibility,
+  PropSchema,
+  RemotePattern,
   RemotePatternInput,
+  SlotLock,
+  SlotSpec,
   StyleCompileContext,
+  StyleOrigin,
   StyleState,
+  StyleTraceEntry,
+  StyleValue,
+  StyleValues,
+  TokenRef,
+  ValidationIssue,
 } from "@nextlyhq/blocks-engine";

--- a/packages/blocks-react/src/index.ts
+++ b/packages/blocks-react/src/index.ts
@@ -109,6 +109,13 @@ export type { PrepareDocumentArgs } from "./prepare-document";
  * import a host already has the package for.
  */
 export type {
+  // Renamed, because this package declares its own `BlockRenderArgs`: a
+  // one-parameter React specialization pinned to `PageContext`, which is what a
+  // block written against `ReactBlockDefinition` receives. The engine's takes a
+  // second parameter and leaves the context open, so a consumer annotating
+  // `BlockDefinition<Props, CustomContext>` needs THIS one and cannot reach it
+  // under a name already taken by a narrower type.
+  BlockRenderArgs as EngineBlockRenderArgs,
   AnyBlockDefinition,
   Binding,
   BindingFormat,

--- a/packages/blocks-react/src/index.ts
+++ b/packages/blocks-react/src/index.ts
@@ -79,3 +79,37 @@ export type { PageStyles, ResolveStyleOptions } from "./styles";
 export { pruneHiddenNodes } from "./visibility";
 export { prepareDocumentForRead } from "./prepare-document";
 export type { PrepareDocumentArgs } from "./prepare-document";
+
+/**
+ * The engine types this package's own options are written in terms of.
+ *
+ * **A package that names a type in its public API owes that type to its
+ * callers.** These originate in `@nextlyhq/blocks-engine`, which is a
+ * DEPENDENCY of this package rather than a peer — so a host installing
+ * `@nextlyhq/blocks-react` does not have it as a direct dependency and cannot
+ * import from it. Before this, `StyleCompileContext`, `BlockDocument` and
+ * `DocumentLimits` appeared in the built `.d.ts` in parameter positions while
+ * naming none of them in an export statement: a host could SEE the name it was
+ * required to pass and had no way to write it down.
+ *
+ * `nextly`'s own types are deliberately NOT re-exported here. `nextly` is a
+ * PEER dependency, so a host has installed it directly and should name
+ * `ContentEntry`, `RenderContext` and the route shapes from `nextly/runtime`
+ * where they live. Two import paths for one type is a worse cost than one
+ * import a host already has the package for.
+ */
+export type {
+  Binding,
+  BlockDocument,
+  BlockNode,
+  BreakpointDef,
+  BreakpointId,
+  BreakpointSet,
+  Condition,
+  DocumentKind,
+  DocumentLimits,
+  NodeStyles,
+  NodeVisibility,
+  StyleCompileContext,
+  StyleState,
+} from "@nextlyhq/blocks-engine";

--- a/packages/blocks-react/src/index.ts
+++ b/packages/blocks-react/src/index.ts
@@ -99,17 +99,22 @@ export type { PrepareDocumentArgs } from "./prepare-document";
  * import a host already has the package for.
  */
 export type {
+  AnyBlockDefinition,
   Binding,
+  BlockDefinition,
   BlockDocument,
   BlockNode,
   BreakpointDef,
   BreakpointId,
   BreakpointSet,
+  CompiledPageCss,
   Condition,
   DocumentKind,
   DocumentLimits,
   NodeStyles,
+  MigrationSource,
   NodeVisibility,
+  RemotePatternInput,
   StyleCompileContext,
   StyleState,
 } from "@nextlyhq/blocks-engine";

--- a/packages/blocks-react/src/next.ts
+++ b/packages/blocks-react/src/next.ts
@@ -1050,19 +1050,13 @@ export function createPublicBlocksPage(
 }
 
 /**
- * The SEO types this entry's own API is written in terms of.
+ * `BlockSeoContribution` and `BlockSeoImage` are NOT re-exported here even
+ * though `DerivedPageSeo` extends the first and this entry's SEO derivation is
+ * their only consumer.
  *
- * `DerivedPageSeo` extends `BlockSeoContribution`, and a block declares one
- * from its `seo()` hook — so both appear in what a caller of
- * `createBlocksPage` reads and a block author writes, while originating in
- * `@nextlyhq/blocks-engine`. That package is a DEPENDENCY here rather than a
- * peer, so a host cannot import them itself.
- *
- * `BlockSeoImage` travels with them: it is the union a contribution's `image`
- * is written in, and its whole purpose is to carry provenance a bare string
- * discards — which a caller can only honour if it can name the type.
+ * They are exported from the package root instead, which resolves without the
+ * `next` and `nextly` peers this entry's declarations import. A caller of
+ * `createBlocksPage` can always reach the root; a block author on a standalone
+ * install could not reach this entry, and two import paths for one type costs
+ * more than the one path both audiences already have.
  */
-export type {
-  BlockSeoContribution,
-  BlockSeoImage,
-} from "@nextlyhq/blocks-engine";

--- a/packages/blocks-react/src/next.ts
+++ b/packages/blocks-react/src/next.ts
@@ -1048,3 +1048,21 @@ export function createPublicBlocksPage(
     blocksRouteConfig(config, true)
   );
 }
+
+/**
+ * The SEO types this entry's own API is written in terms of.
+ *
+ * `DerivedPageSeo` extends `BlockSeoContribution`, and a block declares one
+ * from its `seo()` hook — so both appear in what a caller of
+ * `createBlocksPage` reads and a block author writes, while originating in
+ * `@nextlyhq/blocks-engine`. That package is a DEPENDENCY here rather than a
+ * peer, so a host cannot import them itself.
+ *
+ * `BlockSeoImage` travels with them: it is the union a contribution's `image`
+ * is written in, and its whole purpose is to carry provenance a bare string
+ * discards — which a caller can only honour if it can name the type.
+ */
+export type {
+  BlockSeoContribution,
+  BlockSeoImage,
+} from "@nextlyhq/blocks-engine";

--- a/packages/blocks-react/src/type-surface.test.ts
+++ b/packages/blocks-react/src/type-surface.test.ts
@@ -28,16 +28,14 @@
  *
  * @module type-surface.test
  */
-import { execFileSync } from "node:child_process";
 import { existsSync, readFileSync } from "node:fs";
 import { createRequire } from "node:module";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { beforeAll, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 
 const PACKAGE_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
-const REPO_ROOT = join(PACKAGE_ROOT, "..", "..");
 
 /**
  * The sentinel each entry is pinned against — see the assertion for why.
@@ -212,6 +210,38 @@ function engineTypesIn(source: string): Set<string> {
  * read for the same reason — any form missed reports an absence that is not
  * there.
  */
+/**
+ * The engine types a declaration RE-EXPORTS, keyed by their name in the engine.
+ *
+ * **An obligation is discharged by the type, and a name is only a proxy for
+ * one.** This package declares its own `BlockRenderArgs` — a one-parameter
+ * React specialization pinned to `PageContext` — while the engine's takes two
+ * and leaves the context open. A check that accepted any export of a matching
+ * name would report that obligation satisfied while a consumer annotating
+ * `BlockDefinition<Props, CustomContext>` still had no way to write its render
+ * argument down.
+ *
+ * Keyed by the ORIGINAL name because that is what the obligation is expressed
+ * in: a re-export may rename freely, and `BlockRenderArgs as EngineBlockRenderArgs`
+ * still supplies the engine type a consumer needs.
+ */
+function engineReExports(declaration: string): Set<string> {
+  const names = new Set<string>();
+
+  for (const block of declaration.matchAll(
+    /export\s+(?:type\s+)?\{([^}]*)\}\s*from\s*['"]@nextlyhq\/blocks-engine['"]/g
+  )) {
+    for (const clause of block[1]!.split(",")) {
+      const trimmed = clause.trim().replace(/^type\s+/, "");
+      if (trimmed === "") continue;
+      const original = trimmed.split(/\s+as\s+/)[0]?.trim();
+      if (original !== undefined && original !== "") names.add(original);
+    }
+  }
+
+  return names;
+}
+
 function exportedNames(declaration: string): Set<string> {
   const names = new Set<string>();
 
@@ -388,55 +418,14 @@ function reachableTypes(
   return reached;
 }
 
-/** `stdout`/`stderr` off a failed `execFileSync`, without assuming its shape. */
-function streamText(error: unknown, key: "stdout" | "stderr"): string {
-  if (typeof error !== "object" || error === null || !(key in error)) return "";
-  const value: unknown = Reflect.get(error, key);
-  if (typeof value === "string") return value;
-  if (value instanceof Uint8Array) return Buffer.from(value).toString("utf8");
-  return "";
-}
-
 describe("the published type surface", () => {
-  beforeAll(() => {
-    // Turbo declares this package's `build` as a dependency of its `test` task,
-    // so under Turbo the declarations on disk are current and rebuilding here
-    // only repeats work Turbo has already hashed. `TURBO_HASH` is injected into
-    // every task Turbo runs and is absent from a direct `vitest` invocation —
-    // which is precisely the run that carries no build edge and would otherwise
-    // assert against a `dist` predating the source.
-    // Non-empty, not merely present: an exported-but-empty `TURBO_HASH` comes
-    // from a shell, never from Turbo, and reading it as "Turbo ran the build"
-    // skips the rebuild in exactly the run that has no build edge.
-    if ((process.env.TURBO_HASH ?? "") !== "") return;
-
-    try {
-      // Through Turbo, not `tsup` here. The declaration build resolves
-      // `@nextlyhq/blocks-engine`, so invoking the bundler directly on a tree
-      // where that package has not been built fails with TS2307 before any
-      // declarations exist. `turbo run build` carries the `^build` edge, so the
-      // dependency is built first and its result is cached.
-      execFileSync(
-        "pnpm",
-        ["exec", "turbo", "run", "build", "--filter=@nextlyhq/blocks-react"],
-        { cwd: REPO_ROOT, stdio: "pipe" }
-      );
-    } catch (error) {
-      // Compiler diagnostics are the only thing that makes a failure here
-      // actionable, and a discarded stream reduces every cause to the same
-      // opaque non-zero exit.
-      const output = `${streamText(error, "stdout")}${streamText(error, "stderr")}`;
-      throw new Error(
-        `building @nextlyhq/blocks-react failed:\n${output.trim()}`
-      );
-    }
-  }, 300_000);
-
   // The parsers are the part of this test that can fail SILENTLY: a form they
   // miss reports an absence that is not there, or an obligation that is not
-  // required. Three earlier detectors were wrong in exactly these ways — a
-  // grep over source (meaningless against `export *`), a parser blind to
-  // `export type { }`, and one reading the LEFT of `as` in a re-export.
+  // required. Each case below pins one form the bundler emits — a plain named
+  // import, an inline `type` modifier, an alias whose meaningful side differs
+  // between imports and exports, a `export type { } from`, a direct
+  // `export interface`, and a specifier from another package, which owes
+  // nothing.
   it("reads every form the bundler emits", () => {
     expect([
       ...engineTypesIn(
@@ -509,7 +498,16 @@ describe("the published type surface", () => {
       ).toBe(true);
     }
 
-    const rootExports = exportsBySubpath.get(ROOT_SUBPATH) ?? new Set<string>();
+    // Satisfaction is judged on RE-EXPORTS of the engine, not on the entry's
+    // whole export list: a local declaration sharing a name discharges nothing.
+    const engineBySubpath = new Map<string, Set<string>>(
+      entries.map(entry => [
+        entry.subpath,
+        engineReExports(readFileSync(entry.declaration, "utf8")),
+      ])
+    );
+
+    const rootExports = engineBySubpath.get(ROOT_SUBPATH) ?? new Set<string>();
     const missing: Record<string, string[]> = {};
 
     for (const entry of entries) {
@@ -521,8 +519,7 @@ describe("the published type surface", () => {
         `no engine types derived for the "${entry.subpath}" entry`
       ).toBeGreaterThan(0);
 
-      const reachable =
-        exportsBySubpath.get(entry.subpath) ?? new Set<string>();
+      const reachable = engineBySubpath.get(entry.subpath) ?? new Set<string>();
       const unreachable = [...required]
         .filter(name => !reachable.has(name) && !rootExports.has(name))
         .sort();
@@ -543,7 +540,7 @@ describe("the published type surface", () => {
     expect(declarations.has("BindingBase")).toBe(true);
     expect(exported.has("BindingBase")).toBe(false);
 
-    const rootExports = exportedNames(
+    const rootExports = engineReExports(
       readFileSync(
         entryPoints().find(entry => entry.subpath === ROOT_SUBPATH)!
           .declaration,

--- a/packages/blocks-react/src/type-surface.test.ts
+++ b/packages/blocks-react/src/type-surface.test.ts
@@ -33,7 +33,9 @@ import { createRequire } from "node:module";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { describe, expect, it } from "vitest";
+import { beforeAll, describe, expect, it } from "vitest";
+
+import { buildPackage } from "../vitest.global-setup";
 
 const PACKAGE_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
 
@@ -419,6 +421,15 @@ function reachableTypes(
 }
 
 describe("the published type surface", () => {
+  // Global setup builds once per process, which covers a cold start and not a
+  // watch session: the process outlives every edit, so a rerun after changing
+  // the public surface would read the artifact built before it. Rebuilding per
+  // run costs a Turbo cache hit and makes the assertions describe the source on
+  // disk rather than whenever the process happened to start.
+  beforeAll(() => {
+    buildPackage();
+  }, 300_000);
+
   // The parsers are the part of this test that can fail SILENTLY: a form they
   // miss reports an absence that is not there, or an obligation that is not
   // required. Each case below pins one form the bundler emits — a plain named

--- a/packages/blocks-react/src/type-surface.test.ts
+++ b/packages/blocks-react/src/type-surface.test.ts
@@ -3,14 +3,13 @@
  * IMPORTABLE from it, not merely mentioned by it.
  *
  * A package that names a type in a parameter or return position owes that type
- * to its callers. `blocks-react` did not: `StyleCompileContext`, `BlockDocument`
- * and `DocumentLimits` appeared in the built declarations in parameter
- * positions while being named in no export statement, and `BreakpointSet` — the
- * one field `StyleCompileContext` requires — was absent from the surface
- * entirely. A host could SEE the name it was required to pass and had no way to
- * write it down. The workaround was to leave the value unannotated, which keeps
- * the check at the call site and loses the ability to name the value, move it,
- * or type a module boundary around it.
+ * to its callers. A type mentioned but not exported leaves a host able to SEE
+ * the name it is required to pass with no way to write it down: the value must
+ * stay unannotated, which keeps the check at the call site and loses the
+ * ability to name the value, move it, or type a module boundary around it.
+ *
+ * `@nextlyhq/blocks-engine` is a DEPENDENCY of this package rather than a peer,
+ * so a host has no direct path to it and cannot import those types itself.
  *
  * **Asserted against the BUILT `.d.ts`, not the source, and that distinction is
  * the test.** A `.d.ts` can mention a type in three ways and only one of them
@@ -26,7 +25,9 @@ import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { describe, expect, it } from "vitest";
+import { execFileSync } from "node:child_process";
+
+import { beforeAll, describe, expect, it } from "vitest";
 
 const DIST = join(dirname(fileURLToPath(import.meta.url)), "..", "dist");
 
@@ -36,11 +37,11 @@ const DIST = join(dirname(fileURLToPath(import.meta.url)), "..", "dist");
  * **The alias form is the whole difficulty, and it is why this parser exists
  * rather than a grep.** A bundled declaration re-exports as
  * `export { a as BlockRenderArgs }`, so the exported NAME is on the right of
- * `as` while the local name on the left is a generated letter. A check reading
- * the left-hand side concludes the type is missing and is wrong — measured,
- * twice, while writing this file. `export type { ... }`, inline
- * `{ type X }` and direct `export interface X` all have to be read too, for the
- * same reason: any one of them missed reports an absence that is not there.
+ * `as` while the local name on the left is a generated letter; reading the
+ * left-hand side concludes the type is missing when it is not. `export type
+ * { ... }`, inline `{ type X }` and direct `export interface X` all have to be
+ * read for the same reason — any form missed reports an absence that is not
+ * there.
  */
 function exportedNames(declaration: string): Set<string> {
   const names = new Set<string>();
@@ -70,13 +71,12 @@ function exportedNames(declaration: string): Set<string> {
 /**
  * Every engine type the built declarations IMPORT, derived rather than listed.
  *
- * **A hand-written list has the defect it exists to catch.** The first version
- * of this test enumerated the types a reported gap had named, and passed while
- * `AnyBlockDefinition`, `MigrationSource`, `CompiledPageCss` and
- * `RemotePatternInput` were still unreachable — they sit in the signatures of
- * `createBlockResolver`, `migrationSourceFor`, `toPageStyles` and
- * `fetchPolicyLabel`, in bundler CHUNK declarations rather than in the entry
- * file, so neither the measurement nor the list saw them.
+ * **A hand-written list has the defect it exists to catch**: it can only hold
+ * what someone already knew was missing, so it grows with memory rather than
+ * with the API and certifies exactly the state it was written against. Types
+ * reached through bundler CHUNK declarations rather than the entry file — the
+ * signatures of `createBlockResolver`, `migrationSourceFor`, `toPageStyles` and
+ * `fetchPolicyLabel` among them — never appear in such a list at all.
  *
  * The declarations name their own dependency: every chunk carries an
  * `import { ... } from "@nextlyhq/blocks-engine"` listing exactly the engine
@@ -112,6 +112,21 @@ const SENTINELS: Readonly<Record<string, string>> = {
 };
 
 describe("the published type surface", () => {
+  // Rebuilt here, not merely checked for, because a `dist` that exists can
+  // still predate the source change and would certify a surface nobody has.
+  // Turbo orders this package's build before its tests, but the direct runs it
+  // never sees — `pnpm --filter @nextlyhq/blocks-react test`, watch, UI — have
+  // no such edge. Rebuilding unconditionally costs a second build on a cache
+  // miss and removes the question; deciding whether `dist` was current would
+  // mean re-implementing turbo's input tracking, and every error in that
+  // passes stale declarations.
+  beforeAll(() => {
+    execFileSync("pnpm", ["run", "build"], {
+      cwd: join(DIST, ".."),
+      stdio: "ignore",
+    });
+  }, 180_000);
+
   it("exports every engine type its declarations import", () => {
     const entries = Object.keys(SENTINELS).map(name =>
       join(DIST, `${name}.d.ts`)
@@ -125,9 +140,7 @@ describe("the published type surface", () => {
 
     const required = importedEngineTypes();
     // The positive control, and it is load-bearing. A derivation that found
-    // NOTHING would assert nothing at all and read as a clean pass — which is
-    // precisely how the previous version of this test passed over four
-    // unreachable types.
+    // NOTHING would assert nothing at all and read as a clean pass.
     expect(required.size).toBeGreaterThan(4);
 
     // Exported from EITHER entry: a type belonging to the Next-coupled surface

--- a/packages/blocks-react/src/type-surface.test.ts
+++ b/packages/blocks-react/src/type-surface.test.ts
@@ -22,7 +22,7 @@
  *
  * @module type-surface.test
  */
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -68,76 +68,87 @@ function exportedNames(declaration: string): Set<string> {
 }
 
 /**
- * What each entry must hand a caller.
+ * Every engine type the built declarations IMPORT, derived rather than listed.
  *
- * Listed explicitly rather than derived from what the file mentions. A derived
- * check would pass the moment a type stopped being referenced, which is the
- * opposite of what this guards — and it would also sweep in prose from the
- * doc comments, which is how the first version of this measurement produced a
- * list containing `The`, `Why` and `HTML`.
+ * **A hand-written list has the defect it exists to catch.** The first version
+ * of this test enumerated the types a reported gap had named, and passed while
+ * `AnyBlockDefinition`, `MigrationSource`, `CompiledPageCss` and
+ * `RemotePatternInput` were still unreachable — they sit in the signatures of
+ * `createBlockResolver`, `migrationSourceFor`, `toPageStyles` and
+ * `fetchPolicyLabel`, in bundler CHUNK declarations rather than in the entry
+ * file, so neither the measurement nor the list saw them.
+ *
+ * The declarations name their own dependency: every chunk carries an
+ * `import { ... } from "@nextlyhq/blocks-engine"` listing exactly the engine
+ * types that surface is written in. Reading THAT means the requirement grows
+ * with the API instead of with someone remembering to extend an array.
  */
-const REQUIRED: Readonly<
-  Record<string, { sentinel: string; types: readonly string[] }>
-> = {
-  // Types originating in `@nextlyhq/blocks-engine`, which is a DEPENDENCY of
-  // this package rather than a peer — so a host has no direct path to it and
-  // cannot import these itself.
-  index: {
-    sentinel: "PageRenderer",
-    types: [
-      "BlockDocument",
-      "BlockNode",
-      "BreakpointSet",
-      "DocumentLimits",
-      "NodeStyles",
-      "StyleCompileContext",
-      // This package's own render-context surface.
-      "BlockRenderArgs",
-      "BlocksDataProvider",
-      "BlockResolver",
-      "PageContext",
-      "PageStyles",
-      "QueryBudget",
-      "ReactBlockDefinition",
-      "ResolvedMedia",
-    ],
-  },
-  // The Next-coupled entry re-states what its own options are written in.
-  // `nextly`'s route types are deliberately absent: it is a PEER dependency, so
-  // a host has installed it directly and names `ContentEntry`, `RenderContext`
-  // and the route shapes from `nextly/runtime` where they live. Two import
-  // paths for one type costs more than one import a host already has.
-  next: {
-    sentinel: "createBlocksPage",
-    types: ["BlockSeoContribution", "BlockSeoImage", "DerivedPageSeo"],
-  },
+function importedEngineTypes(): Set<string> {
+  const names = new Set<string>();
+  for (const file of readdirSync(DIST).filter(f => f.endsWith(".d.ts"))) {
+    const src = readFileSync(join(DIST, file), "utf8");
+    for (const line of src.matchAll(
+      /import\s*\{([^}]*)\}\s*from\s*['"]@nextlyhq\/blocks-engine['"]/g
+    )) {
+      for (const clause of line[1].split(",")) {
+        // `BlockRenderArgs as BlockRenderArgs$1` imports the LEFT name; the
+        // right is the bundler's local alias, which no consumer ever writes.
+        const original = clause
+          .trim()
+          .replace(/^type\s+/, "")
+          .split(/\s+as\s+/)[0];
+        const trimmed = (original ?? "").trim();
+        if (trimmed !== "") names.add(trimmed);
+      }
+    }
+  }
+  return names;
+}
+
+/** The sentinel each entry is pinned against — see the assertion for why. */
+const SENTINELS: Readonly<Record<string, string>> = {
+  index: "PageRenderer",
+  next: "createBlocksPage",
 };
 
 describe("the published type surface", () => {
-  for (const [entry, { sentinel, types }] of Object.entries(REQUIRED)) {
-    it(`${entry} exports every type its API is written in`, () => {
-      const file = join(DIST, `${entry}.d.ts`);
-      // A build is the precondition, and saying so beats an empty-set pass:
-      // without it every name below is "missing" for a reason that has nothing
-      // to do with the surface.
+  it("exports every engine type its declarations import", () => {
+    const entries = Object.keys(SENTINELS).map(name =>
+      join(DIST, `${name}.d.ts`)
+    );
+    for (const file of entries) {
       expect(
         existsSync(file),
         `${file} is missing — run \`pnpm build --filter @nextlyhq/blocks-react\``
       ).toBe(true);
+    }
 
-      const exported = exportedNames(readFileSync(file, "utf8"));
+    const required = importedEngineTypes();
+    // The positive control, and it is load-bearing. A derivation that found
+    // NOTHING would assert nothing at all and read as a clean pass — which is
+    // precisely how the previous version of this test passed over four
+    // unreachable types.
+    expect(required.size).toBeGreaterThan(4);
 
-      // The positive control, and it is load-bearing rather than setup. A
-      // parser that returned NOTHING would report every required name as
-      // missing and read as a real regression; one that returned everything
-      // would pass while checking nothing. Naming a value this entry certainly
-      // exports pins the parser against the real artifact — a size threshold
-      // would not, because `next.d.ts` legitimately exports only a handful.
-      expect(exported.has(sentinel), `parser found no \`${sentinel}\``).toBe(
-        true
-      );
+    // Exported from EITHER entry: a type belonging to the Next-coupled surface
+    // has no reason to appear on the root, and requiring both would push names
+    // onto an entry that does not use them.
+    const exported = new Set<string>();
+    for (const file of entries) {
+      for (const name of exportedNames(readFileSync(file, "utf8"))) {
+        exported.add(name);
+      }
+    }
 
-      expect([...types].filter(name => !exported.has(name))).toEqual([]);
-    });
-  }
+    for (const [entry, sentinel] of Object.entries(SENTINELS)) {
+      expect(
+        exported.has(sentinel),
+        `parser found no \`${sentinel}\` in ${entry}.d.ts`
+      ).toBe(true);
+    }
+
+    expect([...required].filter(name => !exported.has(name)).sort()).toEqual(
+      []
+    );
+  });
 });

--- a/packages/blocks-react/src/type-surface.test.ts
+++ b/packages/blocks-react/src/type-surface.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Every type this package's public API is written in terms of must be
+ * IMPORTABLE from it, not merely mentioned by it.
+ *
+ * A package that names a type in a parameter or return position owes that type
+ * to its callers. `blocks-react` did not: `StyleCompileContext`, `BlockDocument`
+ * and `DocumentLimits` appeared in the built declarations in parameter
+ * positions while being named in no export statement, and `BreakpointSet` — the
+ * one field `StyleCompileContext` requires — was absent from the surface
+ * entirely. A host could SEE the name it was required to pass and had no way to
+ * write it down. The workaround was to leave the value unannotated, which keeps
+ * the check at the call site and loses the ability to name the value, move it,
+ * or type a module boundary around it.
+ *
+ * **Asserted against the BUILT `.d.ts`, not the source, and that distinction is
+ * the test.** A `.d.ts` can mention a type in three ways and only one of them
+ * is importable: declared and exported, declared and NOT exported (a name a
+ * consumer can read and not use), or inlined structurally with no name at all.
+ * Reading `src/index.ts` cannot tell them apart — `export *` re-exports without
+ * naming, and the bundler rewrites what survives. The artifact a consumer
+ * actually resolves is the only place this question has an answer.
+ *
+ * @module type-surface.test
+ */
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+const DIST = join(dirname(fileURLToPath(import.meta.url)), "..", "dist");
+
+/**
+ * The names an entry actually exports.
+ *
+ * **The alias form is the whole difficulty, and it is why this parser exists
+ * rather than a grep.** A bundled declaration re-exports as
+ * `export { a as BlockRenderArgs }`, so the exported NAME is on the right of
+ * `as` while the local name on the left is a generated letter. A check reading
+ * the left-hand side concludes the type is missing and is wrong — measured,
+ * twice, while writing this file. `export type { ... }`, inline
+ * `{ type X }` and direct `export interface X` all have to be read too, for the
+ * same reason: any one of them missed reports an absence that is not there.
+ */
+function exportedNames(declaration: string): Set<string> {
+  const names = new Set<string>();
+
+  for (const block of declaration.matchAll(
+    /export\s+(?:type\s+)?\{([^}]*)\}/g
+  )) {
+    for (const clause of block[1].split(",")) {
+      const trimmed = clause.trim().replace(/^type\s+/, "");
+      if (trimmed === "") continue;
+      // `a as BlockRenderArgs` exports the RIGHT-hand name.
+      const parts = trimmed.split(/\s+as\s+/);
+      const exported = (parts[parts.length - 1] ?? "").trim();
+      if (exported !== "") names.add(exported);
+    }
+  }
+
+  for (const declared of declaration.matchAll(
+    /export\s+(?:declare\s+)?(?:type|interface|const|function|class)\s+([A-Za-z0-9_$]+)/g
+  )) {
+    names.add(declared[1]!);
+  }
+
+  return names;
+}
+
+/**
+ * What each entry must hand a caller.
+ *
+ * Listed explicitly rather than derived from what the file mentions. A derived
+ * check would pass the moment a type stopped being referenced, which is the
+ * opposite of what this guards — and it would also sweep in prose from the
+ * doc comments, which is how the first version of this measurement produced a
+ * list containing `The`, `Why` and `HTML`.
+ */
+const REQUIRED: Readonly<
+  Record<string, { sentinel: string; types: readonly string[] }>
+> = {
+  // Types originating in `@nextlyhq/blocks-engine`, which is a DEPENDENCY of
+  // this package rather than a peer — so a host has no direct path to it and
+  // cannot import these itself.
+  index: {
+    sentinel: "PageRenderer",
+    types: [
+      "BlockDocument",
+      "BlockNode",
+      "BreakpointSet",
+      "DocumentLimits",
+      "NodeStyles",
+      "StyleCompileContext",
+      // This package's own render-context surface.
+      "BlockRenderArgs",
+      "BlocksDataProvider",
+      "BlockResolver",
+      "PageContext",
+      "PageStyles",
+      "QueryBudget",
+      "ReactBlockDefinition",
+      "ResolvedMedia",
+    ],
+  },
+  // The Next-coupled entry re-states what its own options are written in.
+  // `nextly`'s route types are deliberately absent: it is a PEER dependency, so
+  // a host has installed it directly and names `ContentEntry`, `RenderContext`
+  // and the route shapes from `nextly/runtime` where they live. Two import
+  // paths for one type costs more than one import a host already has.
+  next: {
+    sentinel: "createBlocksPage",
+    types: ["BlockSeoContribution", "BlockSeoImage", "DerivedPageSeo"],
+  },
+};
+
+describe("the published type surface", () => {
+  for (const [entry, { sentinel, types }] of Object.entries(REQUIRED)) {
+    it(`${entry} exports every type its API is written in`, () => {
+      const file = join(DIST, `${entry}.d.ts`);
+      // A build is the precondition, and saying so beats an empty-set pass:
+      // without it every name below is "missing" for a reason that has nothing
+      // to do with the surface.
+      expect(
+        existsSync(file),
+        `${file} is missing — run \`pnpm build --filter @nextlyhq/blocks-react\``
+      ).toBe(true);
+
+      const exported = exportedNames(readFileSync(file, "utf8"));
+
+      // The positive control, and it is load-bearing rather than setup. A
+      // parser that returned NOTHING would report every required name as
+      // missing and read as a real regression; one that returned everything
+      // would pass while checking nothing. Naming a value this entry certainly
+      // exports pins the parser against the real artifact — a size threshold
+      // would not, because `next.d.ts` legitimately exports only a handful.
+      expect(exported.has(sentinel), `parser found no \`${sentinel}\``).toBe(
+        true
+      );
+
+      expect([...types].filter(name => !exported.has(name))).toEqual([]);
+    });
+  }
+});

--- a/packages/blocks-react/src/type-surface.test.ts
+++ b/packages/blocks-react/src/type-surface.test.ts
@@ -26,6 +26,20 @@
  * by the root, which imports nothing but the engine and so resolves from
  * anywhere the package does.
  *
+ * **Freshness of that artifact is the BUILD SYSTEM's job, not this suite's.**
+ * `turbo.json` makes `test` depend on `build` and names `dist/**` among its
+ * inputs, so an edit anywhere in the declaration's own inputs — this package's
+ * sources, the engine's, the bundler config — rebuilds and re-runs. Global
+ * setup adds one build before collection so a direct `vitest run` on a tree
+ * with no `dist` works at all.
+ *
+ * Neither covers `vitest --watch`, and deliberately so. Vitest selects a suite
+ * from its MODULE GRAPH, which cannot see a `.d.ts` read off disk; making it
+ * see one would mean hand-listing every input of the build and keeping that
+ * list correct forever — the same defect this suite exists to catch, one level
+ * up. A watch session is a fast feedback loop, not the authority: `pnpm test`
+ * is.
+ *
  * @module type-surface.test
  */
 import { existsSync, readFileSync } from "node:fs";
@@ -33,9 +47,8 @@ import { createRequire } from "node:module";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { beforeAll, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 
-import { buildPackage } from "../vitest.global-setup";
 // Imported for two reasons, and the second is the load-bearing one.
 //
 // They supply the runtime half of the sentinel check below: a name present in
@@ -441,15 +454,6 @@ function reachableTypes(
 }
 
 describe("the published type surface", () => {
-  // Global setup builds once per process, which covers a cold start and not a
-  // watch session: the process outlives every edit, so a rerun after changing
-  // the public surface would read the artifact built before it. Rebuilding per
-  // run costs a Turbo cache hit and makes the assertions describe the source on
-  // disk rather than whenever the process happened to start.
-  beforeAll(() => {
-    buildPackage();
-  }, 300_000);
-
   // The parsers are the part of this test that can fail SILENTLY: a form they
   // miss reports an absence that is not there, or an obligation that is not
   // required. Each case below pins one form the bundler emits — a plain named

--- a/packages/blocks-react/src/type-surface.test.ts
+++ b/packages/blocks-react/src/type-surface.test.ts
@@ -36,6 +36,19 @@ import { fileURLToPath } from "node:url";
 import { beforeAll, describe, expect, it } from "vitest";
 
 import { buildPackage } from "../vitest.global-setup";
+// Imported for two reasons, and the second is the load-bearing one.
+//
+// They supply the runtime half of the sentinel check below: a name present in
+// the declarations and absent from the module would be a surface a consumer
+// can typecheck against and not call.
+//
+// They are also this suite's DEPENDENCY DECLARATION. What it asserts on is the
+// build of these three modules, but it reads that build off disk, so without an
+// import the watcher sees no edge and never selects this suite when an entry
+// changes — leaving the guard silent for exactly the edit it exists to catch.
+import * as blocksEntry from "./blocks/index";
+import * as rootEntry from "./index";
+import * as nextEntry from "./next";
 
 const PACKAGE_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
 
@@ -49,6 +62,13 @@ const SENTINELS: Readonly<Record<string, string>> = {
   ".": "PageRenderer",
   "./next": "createBlocksPage",
   "./blocks": "coreBlocks",
+};
+
+/** The same entries as modules, keyed the way the manifest spells them. */
+const ENTRY_MODULES: Readonly<Record<string, Record<string, unknown>>> = {
+  ".": rootEntry,
+  "./next": nextEntry,
+  "./blocks": blocksEntry,
 };
 
 /** The root entry, whose exports satisfy every other entry's obligation. */
@@ -507,6 +527,10 @@ describe("the published type surface", () => {
         exportsBySubpath.get(subpath)?.has(sentinel),
         `parser found no \`${sentinel}\` in the "${subpath}" entry`
       ).toBe(true);
+      expect(
+        ENTRY_MODULES[subpath]?.[sentinel],
+        `the "${subpath}" module does not export \`${sentinel}\` at runtime`
+      ).toBeDefined();
     }
 
     // Satisfaction is judged on RE-EXPORTS of the engine, not on the entry's

--- a/packages/blocks-react/src/type-surface.test.ts
+++ b/packages/blocks-react/src/type-surface.test.ts
@@ -1,6 +1,6 @@
 /**
  * Every type this package's public API is written in terms of must be
- * IMPORTABLE from it, not merely mentioned by it.
+ * IMPORTABLE from an entry the consumer of that API can actually resolve.
  *
  * A package that names a type in a parameter or return position owes that type
  * to its callers. A type mentioned but not exported leaves a host able to SEE
@@ -19,20 +19,189 @@
  * naming, and the bundler rewrites what survives. The artifact a consumer
  * actually resolves is the only place this question has an answer.
  *
+ * **The requirement is per ENTRY, because the entries are not interchangeable.**
+ * `./next` declares `next` and `nextly` peer imports, so a standalone install
+ * that reaches for a type there loads a declaration file whose own imports do
+ * not resolve. An entry's obligation is therefore satisfied only by itself or
+ * by the root, which imports nothing but the engine and so resolves from
+ * anywhere the package does.
+ *
  * @module type-surface.test
  */
-import { existsSync, readdirSync, readFileSync } from "node:fs";
-import { dirname, join } from "node:path";
-import { fileURLToPath } from "node:url";
-
 import { execFileSync } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 
 import { beforeAll, describe, expect, it } from "vitest";
 
-const DIST = join(dirname(fileURLToPath(import.meta.url)), "..", "dist");
+const PACKAGE_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+const REPO_ROOT = join(PACKAGE_ROOT, "..", "..");
 
 /**
- * The names an entry actually exports.
+ * The sentinel each entry is pinned against — see the assertion for why.
+ *
+ * Keyed by the export subpath as the manifest spells it, so an entry added to
+ * `package.json` without a sentinel here fails rather than being skipped.
+ */
+const SENTINELS: Readonly<Record<string, string>> = {
+  ".": "PageRenderer",
+  "./next": "createBlocksPage",
+  "./blocks": "coreBlocks",
+};
+
+/** The root entry, whose exports satisfy every other entry's obligation. */
+const ROOT_SUBPATH = ".";
+
+interface EntryPoint {
+  readonly subpath: string;
+  readonly declaration: string;
+}
+
+/**
+ * Every entry a consumer can import, read from the manifest rather than listed.
+ *
+ * **A hand-written entry list has the defect a hand-written type list has**: it
+ * certifies the entries someone remembered, and a package that grows a fourth
+ * one grows it unchecked. `exports` is the same map the resolver uses, so
+ * reading it means an entry cannot exist without being covered — and the
+ * declaration extension comes from the manifest too, rather than from an
+ * assumption about what the bundler emits.
+ */
+function entryPoints(): EntryPoint[] {
+  const manifest: unknown = JSON.parse(
+    readFileSync(join(PACKAGE_ROOT, "package.json"), "utf8")
+  );
+  const exportMap = readRecord(readProperty(manifest, "exports"));
+  return Object.entries(exportMap).map(([subpath, condition]) => {
+    const types = readProperty(condition, "types");
+    if (typeof types !== "string") {
+      throw new Error(`exports["${subpath}"] declares no \`types\` condition`);
+    }
+    return { subpath, declaration: resolve(PACKAGE_ROOT, types) };
+  });
+}
+
+function readProperty(value: unknown, key: string): unknown {
+  if (typeof value !== "object" || value === null || !(key in value)) {
+    return undefined;
+  }
+  return Reflect.get(value, key);
+}
+
+function readRecord(value: unknown): Record<string, unknown> {
+  if (typeof value !== "object" || value === null) return {};
+  return Object.fromEntries(Object.entries(value));
+}
+
+/**
+ * An entry's declaration file plus every chunk it reaches.
+ *
+ * The bundler splits shared declarations into chunk files, and the signatures
+ * of `createBlockResolver`, `migrationSourceFor`, `toPageStyles` and
+ * `fetchPolicyLabel` live in one — so an entry file read alone under-reports
+ * the types its own surface is written in. Following the relative specifiers
+ * attributes each chunk to the entries that actually reach it, which a flat
+ * scan of the output directory cannot do.
+ */
+function declarationGraph(entry: string): string[] {
+  const seen = new Set<string>();
+  const queue = [entry];
+
+  while (queue.length > 0) {
+    const file = queue.pop();
+    if (file === undefined || seen.has(file) || !existsSync(file)) continue;
+    seen.add(file);
+
+    const source = readFileSync(file, "utf8");
+    for (const match of source.matchAll(/from\s*['"](\.[^'"]*)['"]/g)) {
+      const resolved = resolveDeclaration(dirname(file), match[1]!);
+      if (resolved !== undefined) queue.push(resolved);
+    }
+  }
+
+  return [...seen];
+}
+
+/**
+ * A relative specifier as written in the emitted declarations.
+ *
+ * The bundler emits runtime specifiers (`./chunk-ABC.js`) inside declaration
+ * files, so the extension on the page is never the extension on disk.
+ */
+function resolveDeclaration(
+  from: string,
+  specifier: string
+): string | undefined {
+  const base = resolve(from, specifier).replace(/\.(m|c)?js$/, "");
+  for (const candidate of [
+    `${base}.d.ts`,
+    `${base}.d.mts`,
+    `${base}.d.cts`,
+    join(base, "index.d.ts"),
+  ]) {
+    if (existsSync(candidate)) return candidate;
+  }
+  return undefined;
+}
+
+/**
+ * Every engine type a declaration graph names, derived rather than listed.
+ *
+ * **A hand-written list has the defect it exists to catch**: it can only hold
+ * what someone already knew was missing, so it grows with memory rather than
+ * with the API and certifies exactly the state it was written against.
+ *
+ * The declarations name their own dependency two ways, and both count. A named
+ * import lists the types outright. A namespace import binds the whole module
+ * and the types then appear qualified — `_nextlyhq_blocks_engine.BlockDefinition` —
+ * which is how the block catalogue's declarations reference the engine, and
+ * which a scan for named imports alone reports as requiring nothing at all.
+ */
+function engineTypesNamed(files: readonly string[]): Set<string> {
+  const names = new Set<string>();
+  for (const file of files) {
+    for (const name of engineTypesIn(readFileSync(file, "utf8"))) {
+      names.add(name);
+    }
+  }
+  return names;
+}
+
+/** The text-level half, kept pure so both import forms can be pinned below. */
+function engineTypesIn(source: string): Set<string> {
+  const names = new Set<string>();
+
+  for (const line of source.matchAll(
+    /import\s*\{([^}]*)\}\s*from\s*['"]@nextlyhq\/blocks-engine['"]/g
+  )) {
+    for (const clause of line[1]!.split(",")) {
+      // `BlockRenderArgs as BlockRenderArgs$1` imports the LEFT name; the
+      // right is the bundler's local alias, which no consumer ever writes.
+      const original = clause
+        .trim()
+        .replace(/^type\s+/, "")
+        .split(/\s+as\s+/)[0];
+      const trimmed = (original ?? "").trim();
+      if (trimmed !== "") names.add(trimmed);
+    }
+  }
+
+  for (const namespace of source.matchAll(
+    /import\s*\*\s*as\s+([A-Za-z0-9_$]+)\s+from\s*['"]@nextlyhq\/blocks-engine['"]/g
+  )) {
+    const qualified = new RegExp(`\\b${namespace[1]!}\\.([A-Za-z0-9_$]+)`, "g");
+    for (const reference of source.matchAll(qualified)) {
+      names.add(reference[1]!);
+    }
+  }
+
+  return names;
+}
+
+/**
+ * The names a declaration file actually exports.
  *
  * **The alias form is the whole difficulty, and it is why this parser exists
  * rather than a grep.** A bundled declaration re-exports as
@@ -49,7 +218,7 @@ function exportedNames(declaration: string): Set<string> {
   for (const block of declaration.matchAll(
     /export\s+(?:type\s+)?\{([^}]*)\}/g
   )) {
-    for (const clause of block[1].split(",")) {
+    for (const clause of block[1]!.split(",")) {
       const trimmed = clause.trim().replace(/^type\s+/, "");
       if (trimmed === "") continue;
       // `a as BlockRenderArgs` exports the RIGHT-hand name.
@@ -68,106 +237,326 @@ function exportedNames(declaration: string): Set<string> {
   return names;
 }
 
-/**
- * Every engine type the built declarations IMPORT, derived rather than listed.
- *
- * **A hand-written list has the defect it exists to catch**: it can only hold
- * what someone already knew was missing, so it grows with memory rather than
- * with the API and certifies exactly the state it was written against. Types
- * reached through bundler CHUNK declarations rather than the entry file — the
- * signatures of `createBlockResolver`, `migrationSourceFor`, `toPageStyles` and
- * `fetchPolicyLabel` among them — never appear in such a list at all.
- *
- * The declarations name their own dependency: every chunk carries an
- * `import { ... } from "@nextlyhq/blocks-engine"` listing exactly the engine
- * types that surface is written in. Reading THAT means the requirement grows
- * with the API instead of with someone remembering to extend an array.
- */
-function importedEngineTypes(): Set<string> {
-  const names = new Set<string>();
-  for (const file of readdirSync(DIST).filter(f => f.endsWith(".d.ts"))) {
-    const src = readFileSync(join(DIST, file), "utf8");
-    for (const line of src.matchAll(
-      /import\s*\{([^}]*)\}\s*from\s*['"]@nextlyhq\/blocks-engine['"]/g
-    )) {
-      for (const clause of line[1].split(",")) {
-        // `BlockRenderArgs as BlockRenderArgs$1` imports the LEFT name; the
-        // right is the bundler's local alias, which no consumer ever writes.
-        const original = clause
-          .trim()
-          .replace(/^type\s+/, "")
-          .split(/\s+as\s+/)[0];
-        const trimmed = (original ?? "").trim();
-        if (trimmed !== "") names.add(trimmed);
-      }
+/** The nearest `package.json` at or above a resolved module file. */
+function manifestFor(entry: string): string {
+  for (let directory = dirname(entry); ; directory = dirname(directory)) {
+    const candidate = join(directory, "package.json");
+    if (existsSync(candidate)) return candidate;
+    if (dirname(directory) === directory) {
+      throw new Error(`no package.json above ${entry}`);
     }
   }
-  return names;
 }
 
-/** The sentinel each entry is pinned against — see the assertion for why. */
-const SENTINELS: Readonly<Record<string, string>> = {
-  index: "PageRenderer",
-  next: "createBlocksPage",
-};
+interface EngineDeclaration {
+  readonly kind: string;
+  readonly body: string;
+}
+
+interface EngineSurface {
+  /** Every top-level declaration by name, whether exported or not. */
+  readonly declarations: Map<string, EngineDeclaration>;
+  /** The subset the engine publishes — the most this package can pass on. */
+  readonly exported: Set<string>;
+}
+
+/**
+ * The engine's built entry, split into what it DECLARES and what it EXPORTS.
+ *
+ * The bodies are what make CLOSURE checkable: a type is only as writable as
+ * the types it is composed of, and that composition is visible nowhere else.
+ *
+ * Both halves are needed and they are not the same set. Composition runs
+ * THROUGH private declarations — `Binding` is an intersection over an
+ * unexported `BindingBase` that itself names an exported `BindingFormat` — so
+ * traversal must follow them, while the obligation stops at the engine's own
+ * export list. This package can only pass on what its dependency publishes;
+ * a type the engine keeps private is the engine's call to revisit.
+ */
+function engineSurface(): EngineSurface {
+  // Located from the resolved entry rather than by requiring
+  // `.../package.json` directly: the engine's `exports` map does not publish
+  // its own manifest, and a hard-coded relative path would bind this test to
+  // one workspace layout.
+  const require = createRequire(import.meta.url);
+  const manifestPath = manifestFor(require.resolve("@nextlyhq/blocks-engine"));
+  const manifest: unknown = JSON.parse(readFileSync(manifestPath, "utf8"));
+  const types = readProperty(
+    readProperty(readProperty(manifest, "exports"), "."),
+    "types"
+  );
+  if (typeof types !== "string") {
+    throw new Error(
+      "@nextlyhq/blocks-engine declares no root `types` condition"
+    );
+  }
+
+  const source = readFileSync(resolve(dirname(manifestPath), types), "utf8");
+  const declarations = new Map<string, EngineDeclaration>();
+  const heads =
+    /^(?:export\s+)?(?:declare\s+)?(type|interface|const|function|class)\s+([A-Za-z0-9_$]+)/gm;
+
+  for (
+    let head = heads.exec(source);
+    head !== null;
+    head = heads.exec(source)
+  ) {
+    const kind = head[1]!;
+    const end =
+      kind === "type"
+        ? endOfAlias(source, heads.lastIndex)
+        : endOfBlock(source, heads.lastIndex);
+    declarations.set(head[2]!, {
+      kind,
+      body: source.slice(head.index, end + 1),
+    });
+  }
+
+  return { declarations, exported: exportedNames(source) };
+}
+
+/** A `type X = ...` runs to its terminating `;` at nesting depth zero. */
+function endOfAlias(source: string, from: number): number {
+  let depth = 0;
+  for (let i = from; i < source.length; i++) {
+    const char = source[i]!;
+    if ("{<([".includes(char)) depth++;
+    else if ("}>)]".includes(char)) depth--;
+    else if (char === ";" && depth <= 0) return i;
+  }
+  return source.length - 1;
+}
+
+/** An `interface X { ... }` runs to its matching brace; a `declare const` to `;`. */
+function endOfBlock(source: string, from: number): number {
+  let depth = 0;
+  let opened = false;
+  for (let i = from; i < source.length; i++) {
+    const char = source[i]!;
+    if (char === "{") {
+      depth++;
+      opened = true;
+    } else if (char === "}") {
+      depth--;
+      if (opened && depth === 0) return i;
+    } else if (char === ";" && !opened) return i;
+  }
+  return source.length - 1;
+}
+
+/**
+ * The engine types reachable from a starting set, following composition.
+ *
+ * **Reachability, not mention, is the obligation.** A consumer handed
+ * `BlockDefinition` can name that and still be unable to write the `supports`
+ * object it must pass — so every type a re-exported type is BUILT FROM is owed
+ * to the same consumer. A check over the names this package's own declarations
+ * happen to import cannot see this: `BlockSeoContribution` reaches a caller
+ * only through `BlockDefinition["seo"]`, so the bundler never emits an import
+ * for it and a scan of import lines reports nothing missing.
+ *
+ * Only type-like declarations count. A value reached through `typeof` is named
+ * by the alias built on it and never written out, so it carries no obligation
+ * and re-exporting it would mean shipping engine runtime this package does not
+ * otherwise expose.
+ */
+function reachableTypes(
+  seed: Iterable<string>,
+  declarations: ReadonlyMap<string, EngineDeclaration>
+): Set<string> {
+  const reached = new Set<string>();
+  const queue = [...seed].filter(name => declarations.has(name));
+
+  while (queue.length > 0) {
+    const name = queue.pop();
+    const declaration = name === undefined ? undefined : declarations.get(name);
+    if (declaration === undefined) continue;
+
+    for (const token of declaration.body.matchAll(
+      /\b[A-Za-z_$][A-Za-z0-9_$]*\b/g
+    )) {
+      const reference = token[0];
+      if (reference === name || reached.has(reference)) continue;
+      const target = declarations.get(reference);
+      if (target === undefined) continue;
+      if (target.kind !== "type" && target.kind !== "interface") continue;
+      reached.add(reference);
+      queue.push(reference);
+    }
+  }
+
+  return reached;
+}
+
+/** `stdout`/`stderr` off a failed `execFileSync`, without assuming its shape. */
+function streamText(error: unknown, key: "stdout" | "stderr"): string {
+  if (typeof error !== "object" || error === null || !(key in error)) return "";
+  const value: unknown = Reflect.get(error, key);
+  if (typeof value === "string") return value;
+  if (value instanceof Uint8Array) return Buffer.from(value).toString("utf8");
+  return "";
+}
 
 describe("the published type surface", () => {
-  // Rebuilt here, not merely checked for, because a `dist` that exists can
-  // still predate the source change and would certify a surface nobody has.
-  // Turbo orders this package's build before its tests, but the direct runs it
-  // never sees — `pnpm --filter @nextlyhq/blocks-react test`, watch, UI — have
-  // no such edge. Rebuilding unconditionally costs a second build on a cache
-  // miss and removes the question; deciding whether `dist` was current would
-  // mean re-implementing turbo's input tracking, and every error in that
-  // passes stale declarations.
   beforeAll(() => {
-    // Through turbo, not `pnpm run build` in this directory. The declaration
-    // build resolves `@nextlyhq/blocks-engine`, so invoking tsup directly on a
-    // tree where that package has not been built fails with TS2307 before any
-    // declarations exist. `turbo run build` carries the `^build` edge, so the
-    // dependency is built first and its result is cached.
-    execFileSync(
-      "pnpm",
-      ["exec", "turbo", "run", "build", "--filter=@nextlyhq/blocks-react"],
-      { cwd: join(DIST, "..", "..", ".."), stdio: "ignore" }
-    );
+    // Turbo declares this package's `build` as a dependency of its `test` task,
+    // so under Turbo the declarations on disk are current and rebuilding here
+    // only repeats work Turbo has already hashed. `TURBO_HASH` is injected into
+    // every task Turbo runs and is absent from a direct `vitest` invocation —
+    // which is precisely the run that carries no build edge and would otherwise
+    // assert against a `dist` predating the source.
+    // Non-empty, not merely present: an exported-but-empty `TURBO_HASH` comes
+    // from a shell, never from Turbo, and reading it as "Turbo ran the build"
+    // skips the rebuild in exactly the run that has no build edge.
+    if ((process.env.TURBO_HASH ?? "") !== "") return;
+
+    try {
+      // Through Turbo, not `tsup` here. The declaration build resolves
+      // `@nextlyhq/blocks-engine`, so invoking the bundler directly on a tree
+      // where that package has not been built fails with TS2307 before any
+      // declarations exist. `turbo run build` carries the `^build` edge, so the
+      // dependency is built first and its result is cached.
+      execFileSync(
+        "pnpm",
+        ["exec", "turbo", "run", "build", "--filter=@nextlyhq/blocks-react"],
+        { cwd: REPO_ROOT, stdio: "pipe" }
+      );
+    } catch (error) {
+      // Compiler diagnostics are the only thing that makes a failure here
+      // actionable, and a discarded stream reduces every cause to the same
+      // opaque non-zero exit.
+      const output = `${streamText(error, "stdout")}${streamText(error, "stderr")}`;
+      throw new Error(
+        `building @nextlyhq/blocks-react failed:\n${output.trim()}`
+      );
+    }
   }, 300_000);
 
-  it("exports every engine type its declarations import", () => {
-    const entries = Object.keys(SENTINELS).map(name =>
-      join(DIST, `${name}.d.ts`)
-    );
-    for (const file of entries) {
-      expect(
-        existsSync(file),
-        `${file} is missing — run \`pnpm build --filter @nextlyhq/blocks-react\``
-      ).toBe(true);
-    }
+  // The parsers are the part of this test that can fail SILENTLY: a form they
+  // miss reports an absence that is not there, or an obligation that is not
+  // required. Three earlier detectors were wrong in exactly these ways — a
+  // grep over source (meaningless against `export *`), a parser blind to
+  // `export type { }`, and one reading the LEFT of `as` in a re-export.
+  it("reads every form the bundler emits", () => {
+    expect([
+      ...engineTypesIn(
+        `import { Binding, type Condition, BlockRenderArgs as BlockRenderArgs$1 } from '@nextlyhq/blocks-engine';`
+      ),
+    ]).toEqual(["Binding", "Condition", "BlockRenderArgs"]);
 
-    const required = importedEngineTypes();
-    // The positive control, and it is load-bearing. A derivation that found
-    // NOTHING would assert nothing at all and read as a clean pass.
-    expect(required.size).toBeGreaterThan(4);
+    expect([
+      ...engineTypesIn(
+        `import * as engine from '@nextlyhq/blocks-engine';\n` +
+          `declare const b: engine.BlockDefinition<P, C>;`
+      ),
+    ]).toEqual(["BlockDefinition"]);
 
-    // Exported from EITHER entry: a type belonging to the Next-coupled surface
-    // has no reason to appear on the root, and requiring both would push names
-    // onto an entry that does not use them.
-    const exported = new Set<string>();
-    for (const file of entries) {
-      for (const name of exportedNames(readFileSync(file, "utf8"))) {
-        exported.add(name);
-      }
-    }
-
-    for (const [entry, sentinel] of Object.entries(SENTINELS)) {
-      expect(
-        exported.has(sentinel),
-        `parser found no \`${sentinel}\` in ${entry}.d.ts`
-      ).toBe(true);
-    }
-
-    expect([...required].filter(name => !exported.has(name)).sort()).toEqual(
+    // An import from anywhere else owes this package nothing.
+    expect([...engineTypesIn(`import { ReactElement } from 'react';`)]).toEqual(
       []
     );
+
+    expect([
+      ...exportedNames(
+        `export { a as BlockRenderArgs, type b as NodeStyles };\n` +
+          `export type { PageStyles } from './styles.js';\n` +
+          `export interface DerivedPageSeo {}\n` +
+          `export declare function createBlocksPage(): void;`
+      ),
+    ]).toEqual([
+      "BlockRenderArgs",
+      "NodeStyles",
+      "PageStyles",
+      "DerivedPageSeo",
+      "createBlocksPage",
+    ]);
+
+    // A name only MENTIONED is the case the whole test exists to separate.
+    expect([...exportedNames(`interface BlockDocument {}`)]).toEqual([]);
+  });
+
+  it("declares a sentinel for every entry the manifest exports", () => {
+    expect(
+      entryPoints()
+        .map(entry => entry.subpath)
+        .sort()
+    ).toEqual(Object.keys(SENTINELS).sort());
+  });
+
+  it("exports every engine type its declarations name, per entry", () => {
+    const entries = entryPoints();
+
+    for (const entry of entries) {
+      expect(
+        existsSync(entry.declaration),
+        `${entry.declaration} is missing — run \`pnpm build --filter @nextlyhq/blocks-react\``
+      ).toBe(true);
+    }
+
+    const exportsBySubpath = new Map<string, Set<string>>(
+      entries.map(entry => [
+        entry.subpath,
+        exportedNames(readFileSync(entry.declaration, "utf8")),
+      ])
+    );
+
+    // The positive control, and it is load-bearing. A parser that found NOTHING
+    // would assert nothing at all and read as a clean pass.
+    for (const [subpath, sentinel] of Object.entries(SENTINELS)) {
+      expect(
+        exportsBySubpath.get(subpath)?.has(sentinel),
+        `parser found no \`${sentinel}\` in the "${subpath}" entry`
+      ).toBe(true);
+    }
+
+    const rootExports = exportsBySubpath.get(ROOT_SUBPATH) ?? new Set<string>();
+    const missing: Record<string, string[]> = {};
+
+    for (const entry of entries) {
+      const required = engineTypesNamed(declarationGraph(entry.declaration));
+      // A graph walk that reached no chunk, or a scan that matched no import
+      // form, requires nothing and reads as a clean pass.
+      expect(
+        required.size,
+        `no engine types derived for the "${entry.subpath}" entry`
+      ).toBeGreaterThan(0);
+
+      const reachable =
+        exportsBySubpath.get(entry.subpath) ?? new Set<string>();
+      const unreachable = [...required]
+        .filter(name => !reachable.has(name) && !rootExports.has(name))
+        .sort();
+      if (unreachable.length > 0) missing[entry.subpath] = unreachable;
+    }
+
+    expect(missing).toEqual({});
+  });
+
+  it("exports every engine type reachable from the ones it re-exports", () => {
+    const { declarations, exported } = engineSurface();
+    // A parse that produced nothing would make every closure empty and every
+    // obligation vacuous.
+    expect(declarations.size).toBeGreaterThan(50);
+    expect(declarations.get("BlockDefinition")?.kind).toBe("interface");
+    // Traversal must reach declarations the engine keeps private, or the
+    // exported types composed through them go unexamined.
+    expect(declarations.has("BindingBase")).toBe(true);
+    expect(exported.has("BindingBase")).toBe(false);
+
+    const rootExports = exportedNames(
+      readFileSync(
+        entryPoints().find(entry => entry.subpath === ROOT_SUBPATH)!
+          .declaration,
+        "utf8"
+      )
+    );
+    const reExported = [...rootExports].filter(name => declarations.has(name));
+    expect(reExported.length).toBeGreaterThan(4);
+
+    const unwritable = [...reachableTypes(reExported, declarations)]
+      .filter(name => exported.has(name) && !rootExports.has(name))
+      .sort();
+
+    expect(unwritable).toEqual([]);
   });
 });

--- a/packages/blocks-react/src/type-surface.test.ts
+++ b/packages/blocks-react/src/type-surface.test.ts
@@ -121,11 +121,17 @@ describe("the published type surface", () => {
   // mean re-implementing turbo's input tracking, and every error in that
   // passes stale declarations.
   beforeAll(() => {
-    execFileSync("pnpm", ["run", "build"], {
-      cwd: join(DIST, ".."),
-      stdio: "ignore",
-    });
-  }, 180_000);
+    // Through turbo, not `pnpm run build` in this directory. The declaration
+    // build resolves `@nextlyhq/blocks-engine`, so invoking tsup directly on a
+    // tree where that package has not been built fails with TS2307 before any
+    // declarations exist. `turbo run build` carries the `^build` edge, so the
+    // dependency is built first and its result is cached.
+    execFileSync(
+      "pnpm",
+      ["exec", "turbo", "run", "build", "--filter=@nextlyhq/blocks-react"],
+      { cwd: join(DIST, "..", "..", ".."), stdio: "ignore" }
+    );
+  }, 300_000);
 
   it("exports every engine type its declarations import", () => {
     const entries = Object.keys(SENTINELS).map(name =>

--- a/packages/blocks-react/turbo.json
+++ b/packages/blocks-react/turbo.json
@@ -19,7 +19,16 @@
       // them; `dist/**` is appended because the artifact these suites assert
       // against is a real input to them, and a cached pass that ignored it
       // would survive a change to what the bundler emits.
-      "inputs": ["$TURBO_EXTENDS$", "dist/**", "tsup.config.ts"]
+      // `vitest.global-setup.ts` is named because it IS the build precondition
+      // these suites rely on: a change to it changes what they assert against,
+      // and the root inputs cover `vitest.config.ts` alone — so without it a
+      // cached pass survives an edit to the setup and the run never happens.
+      "inputs": [
+        "$TURBO_EXTENDS$",
+        "dist/**",
+        "tsup.config.ts",
+        "vitest.global-setup.ts"
+      ]
     },
     "test:watch": {
       // The same build edge as `test`. A watch run reads the same declarations,

--- a/packages/blocks-react/turbo.json
+++ b/packages/blocks-react/turbo.json
@@ -3,24 +3,31 @@
   "extends": ["//"],
   "tasks": {
     "test": {
-      // The type-surface guard reads this package's OWN bundled declarations:
-      // the export forms it checks are produced by the declaration bundler, so
+      // Several suites here read this package's OWN bundled declarations: the
+      // export forms they check are produced by the declaration bundler, so
       // there is nothing to assert against until the package is built. The root
       // task depends on `^build`, which builds dependencies and not this
       // package, and `dist/**` is not a root test input — so without this the
       // suite either finds no `dist` at all or reads declarations produced
       // before the source change.
       //
-      // This makes turbo do that build, in order, and cache it. Runs turbo
-      // never sees — `pnpm --filter @nextlyhq/blocks-react test` and the watch
-      // and UI entry points — are covered instead by the suite's own
-      // `beforeAll`, which rebuilds the declarations itself.
+      // This makes turbo do that build, in order, and cache it. It is not the
+      // only guarantee: `vitest.global-setup.ts` builds too, so the entry
+      // points turbo never sees are covered as well.
       "dependsOn": ["$TURBO_EXTENDS$", "build"],
       // `$TURBO_EXTENDS$` keeps the root inputs in sync rather than restating
-      // them; `dist/**` is appended because the artifact this suite asserts
-      // against is a real input to it, and a cached pass that ignored it would
-      // survive a change to what the bundler emits.
+      // them; `dist/**` is appended because the artifact these suites assert
+      // against is a real input to them, and a cached pass that ignored it
+      // would survive a change to what the bundler emits.
       "inputs": ["$TURBO_EXTENDS$", "dist/**", "tsup.config.ts"]
+    },
+    "test:watch": {
+      // The same build edge as `test`. A watch run reads the same declarations,
+      // and a task that inherited the root definition alone would start against
+      // whatever `dist` happened to be on disk.
+      "dependsOn": ["$TURBO_EXTENDS$", "build"],
+      "cache": false,
+      "persistent": true
     }
   }
 }

--- a/packages/blocks-react/turbo.json
+++ b/packages/blocks-react/turbo.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "extends": ["//"],
+  "tasks": {
+    "test": {
+      // The type-surface guard reads this package's OWN bundled declarations:
+      // the export forms it checks are produced by the declaration bundler, so
+      // there is nothing to assert against until the package is built. The root
+      // task depends on `^build`, which builds dependencies and not this
+      // package, and `dist/**` is not a root test input — so without this the
+      // suite either finds no `dist` at all or reads declarations produced
+      // before the source change.
+      //
+      // This makes turbo do that build, in order, and cache it. Runs turbo
+      // never sees — `pnpm --filter @nextlyhq/blocks-react test` and the watch
+      // and UI entry points — are covered instead by the suite's own
+      // `beforeAll`, which rebuilds the declarations itself.
+      "dependsOn": ["$TURBO_EXTENDS$", "build"],
+      // `$TURBO_EXTENDS$` keeps the root inputs in sync rather than restating
+      // them; `dist/**` is appended because the artifact this suite asserts
+      // against is a real input to it, and a cached pass that ignored it would
+      // survive a change to what the bundler emits.
+      "inputs": ["$TURBO_EXTENDS$", "dist/**", "tsup.config.ts"]
+    }
+  }
+}

--- a/packages/blocks-react/vitest.config.ts
+++ b/packages/blocks-react/vitest.config.ts
@@ -17,5 +17,9 @@ export default defineConfig({
   test: {
     environment: "node",
     include: ["src/**/*.test.ts", "src/**/*.test.tsx"],
+    // Several suites assert against the BUILT declarations, and suites are
+    // collected in parallel — so the build has to finish before collection
+    // starts rather than inside any one suite's hook. See the setup file.
+    globalSetup: ["./vitest.global-setup.ts"],
   },
 });

--- a/packages/blocks-react/vitest.global-setup.ts
+++ b/packages/blocks-react/vitest.global-setup.ts
@@ -41,7 +41,14 @@ export default function setup(): void {
     execFileSync(
       "pnpm",
       ["exec", "turbo", "run", "build", "--filter=@nextlyhq/blocks-react"],
-      { cwd: repoRoot, stdio: "pipe" }
+      {
+        cwd: repoRoot,
+        stdio: "pipe",
+        // Windows resolves package-manager shims via the shell: Corepack
+        // installs `pnpm.cmd`, which cannot be launched directly. Matches how
+        // the CLI spawns a package manager in `cli/commands/add.ts`.
+        shell: process.platform === "win32",
+      }
     );
   } catch (error) {
     // Compiler diagnostics are the only thing that makes a failure here

--- a/packages/blocks-react/vitest.global-setup.ts
+++ b/packages/blocks-react/vitest.global-setup.ts
@@ -3,7 +3,7 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 /**
- * Build this package before any suite is collected.
+ * Build this package before any suite is COLLECTED.
  *
  * Several suites here assert against the BUILT declarations rather than the
  * source, because the questions they ask — what an entry exports, what a
@@ -11,18 +11,21 @@ import { fileURLToPath } from "node:url";
  * that is absent fails them at import time and a `dist` that merely predates
  * the source certifies a surface nobody has.
  *
- * **Global setup rather than a suite's own `beforeAll`, because a hook is too
- * late.** Vitest collects suites in parallel, so sibling suites import the
- * package while one suite's hook is still building — on a clean checkout they
- * fail to resolve before the build they depend on has finished.
+ * **Global setup, because collection is concurrent.** Sibling suites import
+ * this package while any one suite's own hook would still be building, so on a
+ * tree with no `dist` they fail to resolve before that build finishes. Only a
+ * stage that completes before collection starts covers them.
  *
- * **Run unconditionally rather than skipped when Turbo appears to have built
- * already.** `TURBO_HASH` says a Turbo task is running, never that it was a
- * task carrying this package's build edge: `test:watch` has no such edge, so
- * treating the variable as proof skips the only build that would have
- * happened. Under a task that did build, this is a cache hit costing
- * milliseconds — cheaper than a heuristic that is wrong in one direction and
- * silent about it.
+ * It runs ONCE per process, which is the whole of what it guarantees: the
+ * declarations are current when the run begins. Keeping them current across a
+ * watch session's reruns is the job of {@link buildPackage} at the suite that
+ * reads them.
+ *
+ * Unconditional, with no attempt to detect a build that already happened. The
+ * signals available say a Turbo task is running, never that it was one
+ * carrying this package's build edge, and a precondition derived from a nearby
+ * signal is wrong silently. Where the build did already run this is a cache
+ * hit costing milliseconds.
  *
  * Through Turbo rather than `tsup` directly: the declaration build resolves
  * `@nextlyhq/blocks-engine`, so invoking the bundler on a tree where that
@@ -30,6 +33,20 @@ import { fileURLToPath } from "node:url";
  * run build` carries the `^build` edge, so the dependency is built first.
  */
 export default function setup(): void {
+  buildPackage();
+}
+
+/**
+ * Rebuild this package's declarations, surfacing the compiler's own output.
+ *
+ * Exported so a suite asserting against `dist` can call it per run. Under
+ * `vitest --watch` the process outlives every edit: global setup has already
+ * finished and Turbo's build edge fires only before the process starts, so an
+ * edit to the public surface would otherwise be checked against the artifact
+ * built before it — reporting a pass or a failure that describes neither the
+ * old code nor the new.
+ */
+export function buildPackage(): void {
   const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
 
   try {

--- a/packages/blocks-react/vitest.global-setup.ts
+++ b/packages/blocks-react/vitest.global-setup.ts
@@ -1,0 +1,59 @@
+import { execFileSync } from "node:child_process";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+/**
+ * Build this package before any suite is collected.
+ *
+ * Several suites here assert against the BUILT declarations rather than the
+ * source, because the questions they ask — what an entry exports, what a
+ * consumer can resolve — have answers only in the emitted artifact. A `dist`
+ * that is absent fails them at import time and a `dist` that merely predates
+ * the source certifies a surface nobody has.
+ *
+ * **Global setup rather than a suite's own `beforeAll`, because a hook is too
+ * late.** Vitest collects suites in parallel, so sibling suites import the
+ * package while one suite's hook is still building — on a clean checkout they
+ * fail to resolve before the build they depend on has finished.
+ *
+ * **Run unconditionally rather than skipped when Turbo appears to have built
+ * already.** `TURBO_HASH` says a Turbo task is running, never that it was a
+ * task carrying this package's build edge: `test:watch` has no such edge, so
+ * treating the variable as proof skips the only build that would have
+ * happened. Under a task that did build, this is a cache hit costing
+ * milliseconds — cheaper than a heuristic that is wrong in one direction and
+ * silent about it.
+ *
+ * Through Turbo rather than `tsup` directly: the declaration build resolves
+ * `@nextlyhq/blocks-engine`, so invoking the bundler on a tree where that
+ * dependency has not been built fails before any declarations exist. `turbo
+ * run build` carries the `^build` edge, so the dependency is built first.
+ */
+export default function setup(): void {
+  const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+
+  try {
+    execFileSync(
+      "pnpm",
+      ["exec", "turbo", "run", "build", "--filter=@nextlyhq/blocks-react"],
+      { cwd: repoRoot, stdio: "pipe" }
+    );
+  } catch (error) {
+    // Compiler diagnostics are the only thing that makes a failure here
+    // actionable, and a discarded stream reduces every cause to the same
+    // opaque non-zero exit.
+    const output = `${streamText(error, "stdout")}${streamText(error, "stderr")}`;
+    throw new Error(
+      `building @nextlyhq/blocks-react failed:\n${output.trim()}`
+    );
+  }
+}
+
+/** `stdout`/`stderr` off a failed `execFileSync`, without assuming its shape. */
+function streamText(error: unknown, key: "stdout" | "stderr"): string {
+  if (typeof error !== "object" || error === null || !(key in error)) return "";
+  const value: unknown = Reflect.get(error, key);
+  if (typeof value === "string") return value;
+  if (value instanceof Uint8Array) return Buffer.from(value).toString("utf8");
+  return "";
+}

--- a/packages/blocks-react/vitest.global-setup.ts
+++ b/packages/blocks-react/vitest.global-setup.ts
@@ -17,9 +17,11 @@ import { fileURLToPath } from "node:url";
  * stage that completes before collection starts covers them.
  *
  * It runs ONCE per process, which is the whole of what it guarantees: the
- * declarations are current when the run begins. Keeping them current across a
- * watch session's reruns is the job of {@link buildPackage} at the suite that
- * reads them.
+ * declarations are current when the run begins. Keeping them current as inputs
+ * change is Turbo's job — `test` depends on `build` and names `dist/**` among
+ * its inputs — and a `--watch` session is explicitly outside both, because
+ * Vitest selects suites from a module graph that cannot see a `.d.ts` read off
+ * disk.
  *
  * Unconditional, with no attempt to detect a build that already happened. The
  * signals available say a Turbo task is running, never that it was one
@@ -33,20 +35,6 @@ import { fileURLToPath } from "node:url";
  * run build` carries the `^build` edge, so the dependency is built first.
  */
 export default function setup(): void {
-  buildPackage();
-}
-
-/**
- * Rebuild this package's declarations, surfacing the compiler's own output.
- *
- * Exported so a suite asserting against `dist` can call it per run. Under
- * `vitest --watch` the process outlives every edit: global setup has already
- * finished and Turbo's build edge fires only before the process starts, so an
- * edit to the public surface would otherwise be checked against the artifact
- * built before it — reporting a pass or a failure that describes neither the
- * old code nor the new.
- */
-export function buildPackage(): void {
   const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
 
   try {

--- a/packages/eslint-config/base.js
+++ b/packages/eslint-config/base.js
@@ -146,6 +146,9 @@ export const config = [
       "**/tsup.*.config.{js,ts,mjs,cjs}",
       "**/next.config.{js,ts,mjs,cjs}",
       "**/vitest.config.{js,ts,mjs,cjs}",
+      // A global-setup file is loaded by vitest the same way its config is, so
+      // it lives outside every package's tsconfig project for the same reason.
+      "**/vitest.global-setup.{js,ts,mjs,cjs}",
       "**/vite.config.{js,ts,mjs,cjs}",
       "**/eslint.config.{js,ts,mjs,cjs}",
       "**/postcss.config.{js,ts,mjs,cjs}",


### PR DESCRIPTION
Fixes task 182.

## The defect, stated precisely

`@nextlyhq/blocks-react` **names types in its public API that it does not export.**

Measured against the BUILT `.d.ts`, separating *present in the file* from *named in an export statement*:

| type | present | in an export statement |
|---|---|---|
| `StyleCompileContext` | yes (3×) | **no** |
| `BlockDocument` | yes (4×) | **no** |
| `DocumentLimits` | yes (3×) | **no** |
| `BreakpointSet` | **absent entirely** | no |

Three appeared in **parameter positions** — a host could see the name it was required to pass and had no way to write it down. `BreakpointSet` is the one field `StyleCompileContext` requires, so the compile context could not be assembled from named parts at all.

Found writing R-7's dogfood route (#631), the first code outside this package to use the API. The workaround I took there was to leave the value unannotated, which keeps the check at the call site and loses the ability to name the value, move it, or type a module boundary around it.

## The line I drew, and why

**A package that names a type in its public API owes that type to its callers** — but only where the caller has no other path to it.

- **`@nextlyhq/blocks-engine` is a DEPENDENCY** of this package, so a host installing `blocks-react` does not have it directly and cannot import from it. **These types are owed.** The root entry now re-exports the document, style and breakpoint types; `/next` re-exports `BlockSeoContribution` and `BlockSeoImage`.
- **`nextly` is a PEER dependency**, so a host has installed it directly. `ContentEntry`, `RenderContext`, `ContentRoute` and `ContentRouteConfig` are deliberately **not** re-exported — they should be named from `nextly/runtime` where they live. Two import paths for one type costs more than one import a host already has the package for.

## The regression cover is the interesting part

The test asserts each type is named in an **export statement** of the built `.d.ts`, not merely present in the file. A presence-only test passes for exactly the broken state that existed.

**It reads the built artifact, not the source, and that distinction is the test.** A `.d.ts` can mention a type three ways and only one is importable: declared and exported, declared and not exported, or inlined structurally with no name. `src/index.ts` cannot tell them apart — `export *` re-exports without naming, and the bundler rewrites what survives.

## What made this hard, recorded in the test

**My first three measurements were wrong, each in a different way, and each over-reported.**

1. `grep -c StyleCompileContext src/index.ts` → `0`. Meaningless: `export *` re-exports without naming.
2. A parser missing `export type { ... }` reported every type in that form as absent.
3. A parser reading the LEFT of `as` — and bundled declarations re-export as `export { a as BlockRenderArgs }`, so it read `a` and declared seven types missing that were exported all along.

The parser handles all four forms, and the test carries a **named sentinel** as its positive control rather than a size threshold: `PageRenderer` for the root, `createBlocksPage` for `/next`. A parser returning nothing would otherwise report every required name as missing and read as a real regression; one returning everything would pass while checking nothing. A size floor would not work — `next.d.ts` legitimately exports only a handful.

## Verified

- **392 tests pass** across 14 files, lint and typecheck clean.
- **Mutation-verified**: dropping `BlockDocument` from the export list fails with `expected [ 'BlockDocument' ] to deeply equal []`. Restored.
- `apps/playground` typechecks unchanged, so nothing depended on the old surface.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded the React package’s public type exports for documents, blocks, styles, visibility, breakpoints, migrations, compilation, and SEO.
  * Added access to these types through the Next.js entry point.

* **Tests**
  * Added automated checks to verify that published declaration files expose all required types.

* **Chores**
  * Updated build and test task configuration to validate generated package declarations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->