### PR TITLE
fix(blocks-react): clamp a stored list so a long one still renders

### DIFF
--- a/.changeset/list-items-cap.md
+++ b/.changeset/list-items-cap.md
@@ -4,6 +4,7 @@
 "@nextlyhq/admin": patch
 "@nextlyhq/admin-css": patch
 "@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
 "@nextlyhq/ui": patch
 "@nextlyhq/adapter-drizzle": patch
 "@nextlyhq/adapter-postgres": patch

--- a/.changeset/list-items-cap.md
+++ b/.changeset/list-items-cap.md
@@ -1,0 +1,29 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+Render a very long list instead of losing the block that holds it.
+
+`core/list` mapped its stored `items` with no cap. A document's own limits bound node count and depth but never the length of a prop array, so `items` arrives at whatever length was written — and past the renderer's inspection budget the normalizer refuses the whole output. An accidentally long list therefore cost the reader EVERY item and left a broken-block marker where the list should be, rather than costing only the items past the end.
+
+The items are clamped, and sliced before they are mapped so an oversized array is never walked in full: the work this bounds is the work of reading it, not only of rendering it. The cap sits far above any list a person writes and far below the budget, so nothing hand-authored reaches it and the block still has room for its wrapper.

--- a/packages/blocks-react/src/blocks/list-length.test.tsx
+++ b/packages/blocks-react/src/blocks/list-length.test.tsx
@@ -1,0 +1,86 @@
+/**
+ * `core/list` at lengths a document can hold but a person would not write.
+ *
+ * Its own file rather than an addition to the primitives suite, because the
+ * interesting assertion needs the BOUNDARY: the failure it guards against
+ * happens after the block's render returns, when the normalizer refuses an
+ * oversized output and the whole block becomes a placeholder.
+ */
+import { renderToReadableStream, renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import {
+  defineBlock,
+  type AnyBlockDefinition,
+  type BlockNode,
+} from "@nextlyhq/blocks-engine";
+
+import { BlockBoundary } from "../block-boundary";
+import type { BlockRenderArgs, PageContext } from "../context";
+import { createBlockResolver } from "../resolver";
+
+import { renderList } from "./list";
+
+const NODE: BlockNode = { id: "n1", type: "core/list", version: 1, props: {} };
+
+function context(): PageContext {
+  return {
+    entry: null,
+    data: { find: () => Promise.resolve({ items: [], total: 0 }) },
+    resolveMedia: () => Promise.resolve(null),
+    resolveEntryPath: () => Promise.resolve(null),
+  };
+}
+
+function args<P>(props: P): BlockRenderArgs<P> {
+  return {
+    props,
+    node: NODE,
+    className: "nx-n1",
+    ctx: context(),
+    renderSlot: () => null,
+  };
+}
+
+describe("core/list at length", () => {
+  it("renders an oversized list instead of losing the whole block", async () => {
+    // A stored array has no length of its own: the document's caps bound node
+    // count and depth, never a prop array. Past the renderer's inspection
+    // budget the normalizer refuses the output, so before the clamp an
+    // accidentally long list cost the reader EVERY item rather than the tail.
+    const items = Array.from({ length: 12_000 }, (_, index) => `item ${index}`);
+    const oversized = defineBlock({
+      name: "test/oversized-list",
+      version: 1,
+      description: "A list far past the inspection budget.",
+      example: { props: {} },
+      render: () => renderList(args({ items })),
+    });
+
+    const stream = await renderToReadableStream(
+      <BlockBoundary
+        node={{ id: "n1", type: "test/oversized-list", version: 1, props: {} }}
+        context={context()}
+        blocks={createBlockResolver([oversized as AnyBlockDefinition])}
+        classes={{ n1: "nx-node" }}
+      />
+    );
+    const html = await new Response(stream).text();
+
+    expect(html).not.toContain("data-nx-block-placeholder");
+    expect(html).toContain("item 0");
+    // The tail is traded for the body rather than the body for the tail.
+    expect(html).not.toContain("item 11999");
+  });
+
+  it("leaves a list nobody would call long alone", () => {
+    // The control. Without it the assertions above would pass on a clamp of any
+    // size, including one that silently truncated ordinary content.
+    const items = Array.from({ length: 250 }, (_, index) => `row ${index}`);
+    const out = renderToStaticMarkup(renderList(args({ items })));
+
+    expect(out).toContain("row 0");
+    expect(out).toContain("row 249");
+    expect(out.match(/<li>/g)).toHaveLength(250);
+  });
+});

--- a/packages/blocks-react/src/blocks/list.tsx
+++ b/packages/blocks-react/src/blocks/list.tsx
@@ -16,6 +16,22 @@ import { number, oneOf, text } from "./props";
 
 export const LIST_KINDS = ["unordered", "ordered"] as const;
 
+/**
+ * How many items are rendered from one stored list.
+ *
+ * A stored array has no length of its own — the document's caps bound node count
+ * and depth, never a prop array — so `items` arrives at whatever length was
+ * written. Past the renderer's own inspection budget the normalizer refuses the
+ * whole output, and the block becomes a broken-block placeholder: an
+ * accidentally long list loses EVERY item rather than the ones past the end.
+ *
+ * Clamping trades the tail for the body, which is the better failure by a wide
+ * margin. The number sits far above any list a person writes and far below the
+ * budget, so the block still has room for its wrapper and nothing hand-authored
+ * ever reaches it.
+ */
+const MAX_ITEMS = 1_000;
+
 export interface ListProps {
   /** Whether the order of the items is meaningful. */
   kind?: "unordered" | "ordered";
@@ -33,7 +49,11 @@ export function renderList({
   // as a child it cannot render. Coerced rather than dropped, so an item typed
   // as a number still appears where its author put it.
   const stored: unknown = props.items;
-  const items = Array.isArray(stored) ? stored.map(item => text(item)) : [];
+  // Sliced BEFORE the map, so an oversized array is never walked in full: the
+  // work this bounds is the work of reading it, not just of rendering it.
+  const items = Array.isArray(stored)
+    ? stored.slice(0, MAX_ITEMS).map(item => text(item))
+    : [];
   const children = items.map((item, index) => (
     // The index is the key because the items have no identity of their own:
     // they are strings in an array, and two identical strings are the same


### PR DESCRIPTION
Closes **C4** from the task-153 audit. Chosen because it is unblocked and collides with nothing: `list.tsx` is not in #609's diff, not in #601's, and not in the Phase 3 builder work.

## The failure

`core/list` mapped its stored `items` with no cap. A document's own limits bound node count and depth but **never the length of a prop array**, so `items` arrives at whatever length was written.

Past the renderer's inspection budget the normalizer refuses the entire output:

```
Expected a React node, received more than 10000 values,
which is past the point this renderer will inspect
```

So an accidentally long list cost the reader **every item** and left a broken-block marker where the list should be — rather than costing only the items past the end. Losing the tail is a far better failure than losing the block, and the reader currently gets the worse one.

## The fix

The items are clamped, following the clamp `collection-loop` already applies to its `limit`.

Sliced **before** the map, so an oversized array is never walked in full — the work this bounds is the work of reading it, not only of rendering it. The cap sits far above any list a person writes and far below the budget, so nothing hand-authored reaches it and the block still has room for its wrapper.

## Verification

The interesting assertion needs the **boundary**, because the failure happens after the block's render returns — calling `renderList` directly can never show it. That is the lesson C3 was filed for, so the test drives `BlockBoundary` and asserts no placeholder appears.

Put in its own `list-length.test.tsx` rather than added to the primitives suite, deliberately: that file is in #609's diff and the boundary imports it needs only exist on that branch, so adding to it would have created a conflict for no benefit.

**Control:** removing the clamp fails the test with the exact production symptom — `data-nx-block-placeholder="invalid-output"` carrying `received more than 10000 values`. The second test is the other half of the control: a 250-item list renders all 250, so a clamp of any smaller size could not ship quietly.

`blocks-react` full suite, check-types across both configs, and lint all clean.