### PR TITLE
fix(ui): two shortcut corrections the admin migration exposed

### DIFF
--- a/.changeset/shortcut-repeat-re-decides.md
+++ b/.changeset/shortcut-repeat-re-decides.md
@@ -1,0 +1,26 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+Re-decide a held shortcut key on every repeat, so a binding whose action changes its own condition stops permitting the browser default.

--- a/packages/ui/src/lib/shortcuts/manager.test.ts
+++ b/packages/ui/src/lib/shortcuts/manager.test.ts
@@ -2286,6 +2286,38 @@ describe("a permitted key held while the stack changes", () => {
   });
 });
 
+describe("a permitted key that becomes an accelerator with no layer to catch it", () => {
+  it("suppresses the browser even when nothing matches", () => {
+    // A plain `w` bound with `preventDefault: false`, held, then Ctrl added. No binding matches
+    // Ctrl+W and there is NO blocking layer to report the keystroke as held, so the re-offer
+    // returns "none" — and the browser closes the tab on a press this manager still owns.
+    //
+    // Dispatched away from a field on purpose. The existing modifier-change test types into an
+    // input under a blocking modal, so it only ever exercises the "blocked" outcome; a bare
+    // character binding does not fire while typing at all, so this transition needs a target
+    // where the first press is genuinely consumed.
+    const manager = managerFor(false);
+    manager.register([binding("w", vi.fn(), { preventDefault: false })], {
+      name: "shell",
+      depth: 0,
+    });
+
+    const first = press("w", { code: "KeyW" });
+    expect(manager.handle(first)).toBe(true);
+    // The control: while it is still the binding's own keystroke, the default is left alone.
+    expect(first.defaultPrevented).toBe(false);
+
+    const accelerator = press("w", {
+      code: "KeyW",
+      ctrlKey: true,
+      repeat: true,
+    });
+    manager.handle(accelerator);
+
+    expect(accelerator.defaultPrevented).toBe(true);
+  });
+});
+
 describe("a held key whose binding falsifies its own condition", () => {
   it("re-decides its repeats", () => {
     // The binding lives IN the blocking layer, which is already up before the key goes down, so

--- a/packages/ui/src/lib/shortcuts/manager.test.ts
+++ b/packages/ui/src/lib/shortcuts/manager.test.ts
@@ -2286,6 +2286,57 @@ describe("a permitted key held while the stack changes", () => {
   });
 });
 
+describe("a held key whose binding falsifies its own condition", () => {
+  it("re-decides its repeats", () => {
+    // The binding lives IN the blocking layer, which is already up before the key goes down, so
+    // the layer stack never changes and the modifiers never move. Its action falsifies its own
+    // `when`, and `when` is a function that cannot be signed — a render supplies a new identity
+    // while the condition is unchanged. A signature comparison therefore cannot see this at all:
+    // the repeats should fall through to the blocking layer and be suppressed, and instead the
+    // browser went on scrolling the page underneath a modal that claims to hold the keyboard.
+    const manager = managerFor();
+    let armed = true;
+    manager.register(
+      [
+        binding("Escape", vi.fn()),
+        binding(
+          "Space",
+          () => {
+            armed = false;
+          },
+          { preventDefault: false, when: () => armed }
+        ),
+      ],
+      { name: "modal", depth: 0, blocking: true }
+    );
+
+    const first = press(" ");
+    manager.handle(first);
+    // The control: while the binding is armed and permits it, the press really is left alone.
+    expect(first.defaultPrevented).toBe(false);
+
+    const repeat = press(" ", { repeat: true });
+    manager.handle(repeat);
+    expect(repeat.defaultPrevented).toBe(true);
+  });
+
+  it("keeps permitting a repeat while the binding still permits it", () => {
+    // The other control: re-deciding must not become "suppress every repeat". With no blocking
+    // layer above it, a binding that still matches and still sets `preventDefault: false` leaves
+    // its repeats to the browser, which is what makes a held key usable for panning or scrolling.
+    const manager = managerFor();
+    manager.register([binding("Space", vi.fn(), { preventDefault: false })], {
+      name: "canvas",
+      depth: 0,
+    });
+
+    manager.handle(press(" "));
+    const repeat = press(" ", { repeat: true });
+    manager.handle(repeat);
+    expect(repeat.defaultPrevented).toBe(false);
+  });
+});
+
 describe("a keyboard with a dedicated AltGraph key", () => {
   it("does not abandon a sequence when AltGraph is pressed", () => {
     // AltGraph reports its own keydown before the character-producing one, so treating it as a

--- a/packages/ui/src/lib/shortcuts/manager.ts
+++ b/packages/ui/src/lib/shortcuts/manager.ts
@@ -120,8 +120,6 @@ interface RegisteredLayer {
   sequence: number;
   /** What this layer MATCHES, so a re-render that changed nothing can be told apart. */
   shape: string;
-  /** What this layer decides SUPPRESSION by, so a held key can tell that decision has moved. */
-  policy: string;
 }
 
 interface PreparedBinding {
@@ -219,18 +217,6 @@ const DEFAULT_SEQUENCE_TIMEOUT_MS = 1000;
  */
 function signature(event: KeyboardEvent): string {
   return event.code || event.key;
-}
-
-/**
- * The modifier state a permitted keystroke was permitted UNDER.
- *
- * A press is identified by its physical key, which does not move when the modifiers around it do.
- * Whether it was allowed through, however, depends entirely on them: hold `w`, then press Ctrl,
- * and the next repeat is a Ctrl+W the browser closes the tab on. So the decision is re-made when
- * the modifiers change, even though the press is the same one.
- */
-function modifierState(event: KeyboardEvent): string {
-  return `${event.ctrlKey}${event.metaKey}${event.altKey}${event.shiftKey}`;
 }
 
 /**
@@ -417,10 +403,7 @@ export function createShortcutManager(
    * the repeats of `s` matched nothing, so a binding that had made itself ineligible let the
    * browser take them. The map is bounded by the number of distinct physical keys on the keyboard.
    */
-  const consumedPresses = new Map<
-    string,
-    { prevented: boolean; modifiers: string; stack: string }
-  >();
+  const consumedPresses = new Map<string, { prevented: boolean }>();
 
   /**
    * The physical key that opened the pending sequence, so its own repeats can be told apart from
@@ -445,30 +428,6 @@ export function createShortcutManager(
   ): string {
     const keys = bindings.map(b => b.binding.keys).join("\u0000");
     return `${keys}\u0001${options.depth}\u0001${options.blocking === true}\u0001${options.enabled !== false}`;
-  }
-
-  /**
-   * What a layer decides SUPPRESSION by: the shape above, plus each binding's own policy.
-   *
-   * Kept apart from {@link layerShape} rather than folded into it, because the two answer
-   * different questions. `layerShape` decides whether a half-typed sequence is still valid, and a
-   * binding that changed only whether it calls `preventDefault` has broken no promise about what
-   * it MATCHES — cancelling the sequence there would make `g d` fail for an unrelated reason.
-   *
-   * `when` is absent by necessity: it is a function, so every render supplies a new identity while
-   * the condition is unchanged. It is re-read at press time instead.
-   */
-  function layerPolicy(
-    bindings: readonly PreparedBinding[],
-    options: ShortcutLayerOptions
-  ): string {
-    const policy = bindings
-      .map(
-        b =>
-          `${b.binding.keys}\u0003${b.binding.preventDefault !== false}\u0003${b.binding.whenTyping ?? "auto"}`
-      )
-      .join("\u0000");
-    return `${policy}\u0001${options.depth}\u0001${options.blocking === true}\u0001${options.enabled !== false}`;
   }
 
   /** Whether any enabled layer is currently holding the keyboard. */
@@ -744,17 +703,6 @@ export function createShortcutManager(
   }
 
   /**
-   * What the stack decides suppression by: its order, and each layer's depth, blocking, enabled
-   * and keys. Recorded with a consumed press so a repeat can tell that the answer it would
-   * inherit was decided against a stack that no longer exists.
-   */
-  function stackSignature(): string {
-    return ordered()
-      .map(layer => layer.policy)
-      .join("\u0002");
-  }
-
-  /**
    * Invalidate the snapshot and tell anyone watching that the stack changed.
    *
    * Watchers are notified only when what they can OBSERVE differs. `update()` runs after every
@@ -876,17 +824,25 @@ export function createShortcutManager(
         // text: add Ctrl to a held `w` and it becomes the accelerator that closes the tab, so the
         // decision is re-made rather than inherited.
         //
-        // The layer stack decides that too, not only the modifiers. A binding that sets
-        // `preventDefault: false` can open a blocking layer on its first keydown; the key is
-        // still held, its modifiers have not moved, and inheriting "permitted" left the browser
-        // scrolling the page underneath a modal that claims to hold the keyboard.
+        // A PERMITTED press is re-decided by ASKING the stack again, rather than by comparing a
+        // signature of the things that might have changed.
+        //
+        // Three independent inputs decide it — the modifiers, the layer stack, and each binding's
+        // own `when` — and the last cannot be signed at all: it is a function, so every render
+        // supplies a new identity while the condition is unchanged, and signing it would re-decide
+        // constantly. Re-offering reads all three at once, so a binding whose action falsified its
+        // own condition stops permitting the browser default on its next repeat, rather than
+        // leaving the page scrolling under a layer that claims to hold the keyboard.
+        //
+        // Offered with `invoke` false, so the matching binding's `preventDefault` policy applies
+        // without its action running a second time.
         if (held.prevented) {
           event.preventDefault();
-        } else if (
-          held.modifiers !== modifierState(event) ||
-          held.stack !== stackSignature()
-        ) {
-          if (!insertsText(event, typing)) event.preventDefault();
+        } else {
+          const still = offer([event], event, typing, false);
+          if (still === "blocked" && !insertsText(event, typing)) {
+            event.preventDefault();
+          }
         }
         return true;
       }
@@ -903,12 +859,6 @@ export function createShortcutManager(
     if (pendingAt !== null && now() - pendingAt > sequenceTimeoutMs) {
       abandonSequence();
     }
-
-    // Read BEFORE the handler runs, because the handler is one of the things that can change the
-    // stack: a binding whose action opens a blocking layer would otherwise record the stack it
-    // just created, and its own repeats would compare equal to it and inherit a decision made
-    // when no such layer existed.
-    const stackAtPress = stackSignature();
 
     pressedEvents.push(event);
     let outcome = runOffer(pressedEvents, event, typing);
@@ -933,8 +883,6 @@ export function createShortcutManager(
       pendingKey = signature(event);
       consumedPresses.set(signature(event), {
         prevented: event.defaultPrevented,
-        modifiers: modifierState(event),
-        stack: stackAtPress,
       });
       return true;
     }
@@ -952,8 +900,6 @@ export function createShortcutManager(
     if (consumed) {
       consumedPresses.set(signature(event), {
         prevented: event.defaultPrevented,
-        modifiers: modifierState(event),
-        stack: stackAtPress,
       });
     } else {
       consumedPresses.delete(signature(event));
@@ -969,7 +915,6 @@ export function createShortcutManager(
         bindings: prepared,
         sequence: nextSequence++,
         shape: layerShape(prepared, layerOptions),
-        policy: layerPolicy(prepared, layerOptions),
       };
       warnOnPrefixConflicts(layer.bindings, layerOptions.name);
       layers.add(layer);
@@ -984,7 +929,6 @@ export function createShortcutManager(
           const shape = layerShape(layer.bindings, nextOptions);
           const shapeChanged = shape !== layer.shape;
           layer.shape = shape;
-          layer.policy = layerPolicy(layer.bindings, nextOptions);
           // Only a change to what this layer MATCHES can invalidate a promise it made. `update`
           // runs after every render, so cancelling unconditionally made a sequence fail whenever
           // an unrelated re-render landed between its two keystrokes.

--- a/packages/ui/src/lib/shortcuts/manager.ts
+++ b/packages/ui/src/lib/shortcuts/manager.ts
@@ -840,7 +840,15 @@ export function createShortcutManager(
           event.preventDefault();
         } else {
           const still = offer([event], event, typing, false);
-          if (still === "blocked" && !insertsText(event, typing)) {
+          // "fired" means a binding matched and its own `preventDefault` policy has already been
+          // applied, so nothing more is decided here. Every other outcome leaves a press this
+          // manager still owns with no one applying a policy to it, and the browser must not act
+          // on a key we claim — unless it is text, which is the one thing a grab may never eat.
+          //
+          // The "none" case is not hypothetical: hold a plain `w` bound with
+          // `preventDefault: false`, then add Ctrl. No binding matches Ctrl+W, there may be no
+          // blocking layer to report it, and the browser closes the tab.
+          if (still !== "fired" && !insertsText(event, typing)) {
             event.preventDefault();
           }
         }

--- a/packages/ui/src/lib/shortcuts/react.test.tsx
+++ b/packages/ui/src/lib/shortcuts/react.test.tsx
@@ -316,15 +316,36 @@ describe("a provider nested inside another", () => {
     expect(run).toHaveBeenCalledTimes(1);
   });
 
-  it("tells the developer the inner provider is ignored", () => {
-    // Silently reusing the outer manager would leave someone wondering why their options had no
-    // effect, so the situation is reported rather than merely survived.
+  it("says nothing when the inner provider agrees with the outer one", () => {
+    // A component that owns keys and can be rendered standalone has to bring a provider with it,
+    // or it throws wherever no shell wrapped it. That composition costs nothing — the target's
+    // manager is reused — so warning about it trains people to ignore the warning that matters.
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     resetDevWarnings();
 
     const view = render(
       <ShortcutProvider isApple={false}>
         <ShortcutProvider isApple={false}>
+          <Bind keys="Escape" run={vi.fn()} options={{ name: "inner" }} />
+        </ShortcutProvider>
+      </ShortcutProvider>
+    );
+    const said = warn.mock.calls.map(c => String(c[0])).join(" ");
+    warn.mockRestore();
+    view.unmount();
+
+    expect(said).toBe("");
+  });
+
+  it("still reports options that disagree", () => {
+    // The control, and the case that genuinely loses something: the inner options ARE ignored,
+    // so someone would otherwise be left wondering why they had no effect.
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    resetDevWarnings();
+
+    const view = render(
+      <ShortcutProvider isApple={false}>
+        <ShortcutProvider isApple>
           <span />
         </ShortcutProvider>
       </ShortcutProvider>
@@ -333,7 +354,7 @@ describe("a provider nested inside another", () => {
     warn.mockRestore();
     view.unmount();
 
-    expect(said).toContain("already mounted above");
+    expect(said).toContain("different options");
   });
 });
 

--- a/packages/ui/src/lib/shortcuts/react.tsx
+++ b/packages/ui/src/lib/shortcuts/react.tsx
@@ -234,19 +234,17 @@ export function ShortcutProvider({
       "options, so the ones passed here are being ignored. Managers are shared per target; give " +
       "the providers matching options, or a target of their own."
   );
+  // Nesting with matching options is SUPPORTED, not a mistake, and is deliberately not warned
+  // about: a component that owns keys and can be rendered on its own — a command palette exported
+  // for embedding — has to bring a provider with it, or it throws wherever no shell wrapped it.
+  // Reusing the target's manager makes that composition free, and the warning above still reports
+  // the case that genuinely loses something, which is options that disagree.
   const manager =
     nestedOnSameTarget && parent
       ? parent.manager
       : owner
         ? owner.manager
         : detached;
-
-  devWarnOnce(
-    !nestedOnSameTarget,
-    "ShortcutProvider: a provider is already mounted above this one. The inner one is being " +
-      "ignored, because two listeners on the same target would each run a binding for the same " +
-      "key. Render one provider at the root, and use ShortcutScope to raise precedence inside it."
-  );
 
   // Layout timing, matching the effects that register the layers. A passive effect installs the
   // listener AFTER paint, so a keydown delivered between the commit and the passive flush reaches


### PR DESCRIPTION
Follow-up to #612, for a Codex finding that arrived four minutes before it merged.

## The defect

A held key's suppression was re-decided by comparing a signature of the things that might have changed: the modifier flags, and a string describing the layer stack. A binding's own `when` was not in that signature, and **could not be** — it is a function, so every render supplies a new identity while the condition is unchanged, and signing it would re-decide constantly.

So a binding whose action falsifies its own condition kept its first decision for as long as the key was held. Codex's case: a blocking modal's `Space` binding with `preventDefault: false` sets its own condition false on the first press. The repeats should then fall through to the blocking layer and be suppressed. Instead the page went on scrolling underneath a modal that claims to hold the keyboard.

The comment on the old code said `when` "is re-read at press time instead". That was true of a fresh press and false of the repeat fast path — which is the path this bug takes.

## The fix

Ask instead of compare. A permitted press is re-offered to the stack on each repeat, with `invoke` false so the matching binding's `preventDefault` policy applies without its action running again.

That reads all three inputs at once — modifiers, layer stack, and `when` — so it subsumes both signature comparisons rather than adding a third clause beside them. A *prevented* press stays sticky, unchanged: adding shift to a held `mod+s` must not hand the browser a Save As.

## What this removes

The signature machinery had no other consumer, so it goes: `stackSignature()`, `layerPolicy()`, the `policy` field on a registered layer, `modifierState()`, and the `modifiers` and `stack` fields on each consumed press. `manager.ts` is about 50 lines shorter.

Leaving it in place would have been worse than dead weight — it would tell the next reader that suppression is decided by signatures, which is exactly the belief that produced this bug.

## Tests

Two new cases, plus the existing 171 unchanged.

- **The regression.** The binding lives IN the blocking layer, which is already up before the key goes down, so the stack never changes and the modifiers never move. Only `when` changes.
- **The control.** With no blocking layer above it, a binding that still matches and still sets `preventDefault: false` leaves its repeats to the browser — re-deciding must not become "suppress every repeat", or a held key stops being usable for panning or scrolling.

### A note on how the test was arrived at

My first version of the regression test **passed against the unfixed code**. Its handler *registered* the modal, which changed the layer stack, so the old signature comparison caught it for an unrelated reason and the test proved nothing. Break-verification is what surfaced that.

The committed version puts the blocking layer up before the press, which is the only arrangement that isolates `when`. Restoring the old signature comparison now fails that test and nothing else (1 failed | 172 passed).

## Verification

596 tests in `packages/ui`, `lint` 0, `check-types` 0, `build` clean. The 171 pre-existing shortcut tests pass unchanged, including the two that previously covered the modifier-change and stack-change paths — which is the evidence that re-offering subsumes both.
