### PR TITLE
fix(ui): report conflicting options between detached providers

### DIFF
--- a/.changeset/detached-provider-options.md
+++ b/.changeset/detached-provider-options.md
@@ -1,0 +1,26 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+Report conflicting shortcut-provider options when neither provider attaches a listener.

--- a/packages/ui/src/lib/shortcuts/react.test.tsx
+++ b/packages/ui/src/lib/shortcuts/react.test.tsx
@@ -337,6 +337,48 @@ describe("a provider nested inside another", () => {
     expect(said).toBe("");
   });
 
+  it("reports options that disagree between DETACHED providers too", () => {
+    // The per-target registry is a WeakMap keyed by the target, and `null` is not a key — so two
+    // nested providers that attach nothing have no entry to compare against. They still share a
+    // manager, and the inner one's options are still ignored, so the case that loses something
+    // has to be caught through the parent instead.
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    resetDevWarnings();
+
+    const view = render(
+      <ShortcutProvider isApple={false} target={null}>
+        <ShortcutProvider isApple target={null}>
+          <span />
+        </ShortcutProvider>
+      </ShortcutProvider>
+    );
+    const said = warn.mock.calls.map(c => String(c[0])).join(" ");
+    warn.mockRestore();
+    view.unmount();
+
+    expect(said).toContain("different options");
+  });
+
+  it("says nothing when two detached providers agree", () => {
+    // The control: a self-contained component nesting inside a host that also attaches nothing is
+    // the supported composition, and must stay silent.
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    resetDevWarnings();
+
+    const view = render(
+      <ShortcutProvider isApple={false} target={null}>
+        <ShortcutProvider isApple={false} target={null}>
+          <Bind keys="Escape" run={vi.fn()} options={{ name: "inner" }} />
+        </ShortcutProvider>
+      </ShortcutProvider>
+    );
+    const said = warn.mock.calls.map(c => String(c[0])).join(" ");
+    warn.mockRestore();
+    view.unmount();
+
+    expect(said).toBe("");
+  });
+
   it("still reports options that disagree", () => {
     // The control, and the case that genuinely loses something: the inner options ARE ignored,
     // so someone would otherwise be left wondering why they had no effect.

--- a/packages/ui/src/lib/shortcuts/react.tsx
+++ b/packages/ui/src/lib/shortcuts/react.tsx
@@ -69,6 +69,16 @@ interface ShortcutContextValue {
    * different while both attached a listener to it.
    */
   target: Pick<EventTarget, "addEventListener" | "removeEventListener"> | null;
+  /**
+   * The options the manager in use was built with, as a comparable string.
+   *
+   * Carried because the per-target registry cannot answer for a DETACHED provider: it is a
+   * WeakMap keyed by the target, and `null` is not a key, so a provider that attaches nothing has
+   * no entry to compare against. Two nested detached providers describe the same event stream and
+   * share a manager exactly as two attached ones do, and an inner one passing different options
+   * loses them the same way — with nothing in the registry to notice.
+   */
+  options: string;
 }
 
 const ShortcutContext = React.createContext<ShortcutContextValue | null>(null);
@@ -228,8 +238,13 @@ export function ShortcutProvider({
   // leaves a reservation nothing will ever clean up, and the next provider on that target adopts
   // its options silently. The mismatch is reported rather than hidden, because the symptom
   // otherwise is `mod` meaning the wrong key with nothing to point at.
+  // Checked against the PARENT as well as the registry. The registry answers for a shared target;
+  // the parent answers for the nested case, including the detached one the registry cannot see.
+  const adoptedDiffers =
+    (Boolean(owner) && owner?.options !== fingerprint) ||
+    (nestedOnSameTarget && parent !== null && parent.options !== fingerprint);
   devWarnOnce(
-    !owner || owner.options === fingerprint,
+    !adoptedDiffers,
     "ShortcutProvider: another provider is already listening on this target with different " +
       "options, so the ones passed here are being ignored. Managers are shared per target; give " +
       "the providers matching options, or a target of their own."
@@ -294,8 +309,8 @@ export function ShortcutProvider({
   // provider still outranks what surrounds it.
   const depth = nestedOnSameTarget && parent ? parent.depth : 0;
   const value = React.useMemo(
-    () => ({ manager, depth, target: resolvedTarget }),
-    [manager, depth, resolvedTarget]
+    () => ({ manager, depth, target: resolvedTarget, options: fingerprint }),
+    [manager, depth, resolvedTarget, fingerprint]
   );
   return (
     <ShortcutContext.Provider value={value}>
@@ -323,8 +338,11 @@ export function ShortcutScope({
       manager: parent.manager,
       depth: parent.depth + 1,
       target: parent.target,
+      // Inherited: a scope raises precedence, it does not build a manager, so the options in force
+      // are still the ones the provider above it used.
+      options: parent.options,
     }),
-    [parent.manager, parent.depth, parent.target]
+    [parent.manager, parent.depth, parent.target, parent.options]
   );
   return (
     <ShortcutContext.Provider value={value}>


### PR DESCRIPTION
Follow-up to #654, for a Codex finding that arrived as it merged.

## The defect

#654 removed a dev warning that fired whenever a provider was nested, because it fired whether or not anything was actually lost — and once a self-contained component brought its own provider, it fired on every admin page load. The reasoning was that the adjacent warning about **conflicting options** already covers the case that loses something.

That is true for providers sharing a DOM target, and false for detached ones. `ownersByTarget` is a `WeakMap` keyed by the target, and `null` is not a key, so a provider with `target={null}` has no registry entry to compare against. Two nested detached providers still share a manager, and the inner one's options are still ignored — with nothing to notice.

Concretely: `<ShortcutProvider isApple={false} target={null}>` wrapping `<ShortcutProvider isApple target={null}>` silently used the outer platform. `mod` means the wrong key, and nothing says so.

Detached providers are not a corner case here: the admin's own shared test render uses `target={null}` so no listener touches the shared jsdom document.

## The fix

The context now carries the options fingerprint of the manager in use, and the warning checks the **parent** as well as the registry — the registry answers for a shared target, the parent answers for the nested case including the detached one the registry cannot see.

`ShortcutScope` inherits the fingerprint rather than producing one: a scope raises precedence, it does not build a manager, so the options in force are still the provider's.

## Tests

- **the regression**: two nested detached providers with conflicting `isApple` now warn
- **the control**: two detached providers that AGREE stay silent, which is the composition #654 deliberately made free

Verified by break: narrowing the check back to the registry alone fails the regression test and leaves the control passing (1 failed | 28 passed).

## A near miss worth recording

My first version tested `owner !== undefined`. `owner` is `null` for a detached provider, not `undefined`, so the guard let it through and then read `.options` off it — crashing two existing tests rather than passing them. The suite caught it immediately, but a `!== undefined` check against a value that is sometimes `null` would have been an easy thing to leave in.

643 tests in `packages/ui`, lint and types clean.
