### PR TITLE
feat(ui): read and write the colour notation people type

### DIFF
--- a/.changeset/color-hex.md
+++ b/.changeset/color-hex.md
@@ -1,0 +1,26 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+Read and write hex colours from the server-safe colour entry point.

--- a/packages/ui/src/__snapshots__/ui-surface.test.ts.snap
+++ b/packages/ui/src/__snapshots__/ui-surface.test.ts.snap
@@ -282,11 +282,14 @@ exports[`ui public export surface > ./color surface is unchanged 1`] = `
   "Hsv (type)",
   "Oklch (type)",
   "Rgb (type)",
+  "Rgba (type)",
   "hsvToRgb (value)",
   "normalizeHue (value)",
   "oklchToRgb (value)",
+  "parseHex (value)",
   "rgbToHsv (value)",
   "rgbToOklch (value)",
+  "toHex (value)",
 ]
 `;
 

--- a/packages/ui/src/lib/color/hex.test.ts
+++ b/packages/ui/src/lib/color/hex.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Hex is what a person types, so the cases that matter are the ones a person produces: a partial
+ * string mid-keystroke, a pasted short form, mixed case, a stray space, and alpha.
+ */
+import { describe, expect, it } from "vitest";
+
+import { rgbToHsv, hsvToRgb } from "./convert";
+import { parseHex, toHex } from "./hex";
+
+/** Channel bytes, which is what a hex string actually carries. */
+const bytes = (hex: string): number[] => {
+  const parsed = parseHex(hex);
+  if (!parsed) throw new Error(`expected ${hex} to parse`);
+  return [parsed.r, parsed.g, parsed.b, parsed.alpha].map(n =>
+    Math.round(n * 255)
+  );
+};
+
+describe("reading a hex colour", () => {
+  it("reads the long form, with and without alpha", () => {
+    expect(bytes("#3b82f6")).toEqual([59, 130, 246, 255]);
+    expect(bytes("#3b82f680")).toEqual([59, 130, 246, 128]);
+  });
+
+  it("expands a short form by repeating each digit, not by padding", () => {
+    // `#abc` is `#aabbcc`. Padding with zero would make it `#a0b0c0`, under which `#fff` is not
+    // white — the one case that makes the difference impossible to miss.
+    expect(bytes("#fff")).toEqual([255, 255, 255, 255]);
+    expect(bytes("#abc")).toEqual(bytes("#aabbcc"));
+    expect(bytes("#abcd")).toEqual(bytes("#aabbccdd"));
+  });
+
+  it("accepts what people actually paste", () => {
+    expect(bytes("3B82F6")).toEqual(bytes("#3b82f6"));
+    expect(bytes("  #3b82f6  ")).toEqual(bytes("#3b82f6"));
+  });
+
+  it("returns null rather than guessing", () => {
+    // Mid-keystroke is the ordinary case for a field someone is typing into, so "not a colour yet"
+    // has to be answerable without an exception and without a silent black.
+    expect(parseHex("#3b8")).not.toBeNull();
+    for (const input of [
+      "",
+      "#",
+      "#3",
+      "#3b",
+      "#3b82f",
+      "#3b82f6g",
+      "blue",
+      "#3b82f6aa1",
+    ]) {
+      expect(parseHex(input), `${input} should not parse`).toBeNull();
+    }
+  });
+});
+
+describe("writing a hex colour", () => {
+  it("omits the alpha pair when the colour is opaque", () => {
+    // `#3b82f6ff` is the same colour, and the short form is what someone expects to read back out
+    // of a field they typed `#3b82f6` into.
+    expect(toHex({ r: 59 / 255, g: 130 / 255, b: 246 / 255 })).toBe("#3b82f6");
+    expect(toHex({ r: 1, g: 1, b: 1 }, 1)).toBe("#ffffff");
+  });
+
+  it("writes it when the colour is not", () => {
+    expect(toHex({ r: 0, g: 0, b: 0 }, 0)).toBe("#00000000");
+    expect(toHex({ r: 1, g: 1, b: 1 }, 128 / 255)).toBe("#ffffff80");
+  });
+
+  it("still produces a valid hex string when a channel is out of range", () => {
+    // Values wrong by a LOT, not by floating-point drift: drift rounds to the right byte on its
+    // own, so a near-boundary fixture passes with or without the clamp and proves nothing. A
+    // channel left in 0-255, or a computation that overshot, is what would otherwise emit
+    // something nothing downstream can parse.
+    expect(toHex({ r: 1.5, g: -0.5, b: 0.5 })).toBe("#ff0080");
+    expect(toHex({ r: 255, g: 0, b: 0 })).toBe("#ff0000");
+    expect(toHex({ r: 0, g: 0, b: 0 }, 4)).toBe("#000000");
+  });
+});
+
+describe("hex against the conversions it sits beside", () => {
+  it("survives a round trip through the picker's own geometry", () => {
+    // The pairing that matters in practice: a colour typed as hex, dragged on the saturation
+    // square, and written back. Byte-exact, because a picker that shifts a colour the user did not
+    // touch is the defect this guards.
+    for (const hex of ["#000000", "#ffffff", "#3b82f6", "#ff0000", "#7f7f7f"]) {
+      const parsed = parseHex(hex);
+      if (!parsed) throw new Error(`expected ${hex} to parse`);
+      expect(toHex(hsvToRgb(rgbToHsv(parsed)))).toBe(hex);
+    }
+  });
+
+  it("carries alpha through a round trip untouched", () => {
+    const parsed = parseHex("#3b82f640");
+    if (!parsed) throw new Error("expected the alpha form to parse");
+    expect(toHex(hsvToRgb(rgbToHsv(parsed)), parsed.alpha)).toBe("#3b82f640");
+  });
+});

--- a/packages/ui/src/lib/color/hex.test.ts
+++ b/packages/ui/src/lib/color/hex.test.ts
@@ -78,6 +78,34 @@ describe("writing a hex colour", () => {
   });
 });
 
+describe("a channel that is not a number at all", () => {
+  it("still produces a valid hex string", () => {
+    // `clamp01(NaN)` is NaN — both of its comparisons are false — and formatting that yields the
+    // three characters "NaN", producing `#NaN0000`. That is precisely the string this module
+    // documents itself as never returning, so the guarantee was false rather than merely untested.
+    expect(toHex({ r: NaN, g: 0, b: 0 })).toBe("#000000");
+    expect(toHex({ r: 0, g: Infinity, b: -Infinity })).toBe("#000000");
+    expect(toHex({ r: 1, g: 1, b: 1 }, NaN)).toBe("#ffffff");
+  });
+
+  it("treats a non-finite alpha as opaque, not as invisible", () => {
+    // A channel's neutral value is 0 and an alpha's is 1 — this parameter's own default. Falling
+    // back to 0 would turn a colour invisible on a stray NaN, silently, with nothing in the output
+    // to say why.
+    expect(toHex({ r: 0, g: 0, b: 0 }, NaN)).toBe("#000000");
+    expect(toHex({ r: 0, g: 0, b: 0 }, 0)).toBe("#00000000");
+  });
+
+  it("never emits a string a parser would reject", () => {
+    // The property the individual cases are examples of: whatever goes in, what comes out is a
+    // hex colour this module can read back.
+    for (const value of [NaN, Infinity, -Infinity, 1e9, -1e9]) {
+      const written = toHex({ r: value, g: value, b: value }, value);
+      expect(parseHex(written), `${value} produced ${written}`).not.toBeNull();
+    }
+  });
+});
+
 describe("hex against the conversions it sits beside", () => {
   it("survives a round trip through the picker's own geometry", () => {
     // The pairing that matters in practice: a colour typed as hex, dragged on the saturation

--- a/packages/ui/src/lib/color/hex.ts
+++ b/packages/ui/src/lib/color/hex.ts
@@ -30,7 +30,12 @@ const clamp01 = (n: number): number => (n < 0 ? 0 : n > 1 ? 1 : n);
 
 /** A channel byte as a two-digit lowercase pair. */
 function pair(channel: number): string {
-  return Math.round(clamp01(channel) * 255)
+  // A non-finite channel becomes 0 rather than passing through. `clamp01(NaN)` is NaN, because
+  // both of its comparisons are false, and formatting that yields the three characters "NaN" —
+  // producing `#NaN0000`, which is exactly the string this module documents itself as never
+  // returning.
+  const value = Number.isFinite(channel) ? clamp01(channel) : 0;
+  return Math.round(value * 255)
     .toString(16)
     .padStart(2, "0");
 }
@@ -85,6 +90,10 @@ export function parseHex(input: string): Rgba | null {
  * @experimental
  */
 export function toHex(color: Rgb, alpha = 1): string {
+  // A non-finite alpha falls back to 1, not to 0 as a channel does. Both are "nothing was
+  // specified", and for alpha that is this parameter's own default — where treating it as 0 would
+  // turn a colour invisible on a stray NaN, silently and with no way to tell from the output.
+  const opacity = Number.isFinite(alpha) ? clamp01(alpha) : 1;
   const opaque = `#${pair(color.r)}${pair(color.g)}${pair(color.b)}`;
-  return clamp01(alpha) === 1 ? opaque : `${opaque}${pair(alpha)}`;
+  return opacity === 1 ? opaque : `${opaque}${pair(opacity)}`;
 }

--- a/packages/ui/src/lib/color/hex.ts
+++ b/packages/ui/src/lib/color/hex.ts
@@ -1,0 +1,90 @@
+/**
+ * Hex is the notation people type, so it is the picker's front door.
+ *
+ * It lives beside the conversions rather than in the component that reads it, for the same reason
+ * they do: parsing `#3b82f6` is arithmetic on a string, a server rendering a token swatch needs it
+ * as much as an editing surface does, and pulling it into client code would put it behind the
+ * `"use client"` boundary for no benefit.
+ *
+ * @module lib/color/hex
+ */
+
+import type { Rgb } from "./convert";
+
+/**
+ * An sRGB colour with its alpha, which is what a hex string can carry and {@link Rgb} cannot.
+ *
+ * `alpha` is in [0, 1] like the channels, rather than 0-255, so it composes with the conversions
+ * without a second unit in play.
+ *
+ * @experimental
+ */
+export interface Rgba extends Rgb {
+  alpha: number;
+}
+
+/** `#rgb`, `#rgba`, `#rrggbb` or `#rrggbbaa`, with the hash optional and case ignored. */
+const HEX = /^#?(?:[0-9a-f]{3,4}|[0-9a-f]{6}|[0-9a-f]{8})$/i;
+
+const clamp01 = (n: number): number => (n < 0 ? 0 : n > 1 ? 1 : n);
+
+/** A channel byte as a two-digit lowercase pair. */
+function pair(channel: number): string {
+  return Math.round(clamp01(channel) * 255)
+    .toString(16)
+    .padStart(2, "0");
+}
+
+/**
+ * Read a hex colour, or `null` if the input is not one.
+ *
+ * Returns `null` rather than throwing or substituting black: this reads what someone is part-way
+ * through typing, where "not a colour yet" is the ordinary case and neither an exception nor a
+ * silent black is a useful answer. A caller decides whether to hold the last good value, show a
+ * message, or wait.
+ *
+ * Both short forms are accepted because both are what people paste. `#abc` expands by REPEATING
+ * each digit rather than padding with zero — `#abc` is `#aabbcc`, not `#a0b0c0` — which is what CSS
+ * does and the only expansion under which `#fff` is white.
+ *
+ * @experimental
+ */
+export function parseHex(input: string): Rgba | null {
+  const text = input.trim();
+  if (!HEX.test(text)) return null;
+
+  const digits = text.replace("#", "");
+  const short = digits.length < 6;
+  const size = short ? 1 : 2;
+  const channel = (index: number): number => {
+    const slice = digits.slice(index * size, index * size + size);
+    return parseInt(short ? slice + slice : slice, 16) / 255;
+  };
+
+  const hasAlpha = digits.length === 4 || digits.length === 8;
+  return {
+    r: channel(0),
+    g: channel(1),
+    b: channel(2),
+    alpha: hasAlpha ? channel(3) : 1,
+  };
+}
+
+/**
+ * Write a colour as `#rrggbb`, or `#rrggbbaa` when it is not fully opaque.
+ *
+ * The alpha pair is omitted at 1 rather than always written, because `#3b82f6ff` is the same colour
+ * and the shorter form is what someone expects to see in a field they typed `#3b82f6` into.
+ *
+ * Channels outside [0, 1] are clamped, so the result is always a valid six- or eight-digit hex
+ * string whatever a caller passes. Not for floating-point drift, which rounds to the right byte on
+ * its own: it is for a value that is wrong by a lot — a channel still in 0-255, or a computation
+ * that overshot — where the alternative is emitting `#17f00-80`, a string nothing downstream can
+ * parse and no error explains.
+ *
+ * @experimental
+ */
+export function toHex(color: Rgb, alpha = 1): string {
+  const opaque = `#${pair(color.r)}${pair(color.g)}${pair(color.b)}`;
+  return clamp01(alpha) === 1 ? opaque : `${opaque}${pair(alpha)}`;
+}

--- a/packages/ui/src/lib/color/index.ts
+++ b/packages/ui/src/lib/color/index.ts
@@ -14,6 +14,11 @@
 export type { Rgb, Hsv, Oklch } from "./convert";
 
 /**
+ * @experimental An sRGB colour with its alpha, which a hex string can carry and `Rgb` cannot.
+ */
+export type { Rgba } from "./hex";
+
+/**
  * @experimental Conversions between the models an editing surface needs.
  *
  * `hsvToRgb`/`rgbToHsv` are the picker's own geometry — a saturation-against-value square beside
@@ -28,3 +33,12 @@ export {
   rgbToHsv,
   rgbToOklch,
 } from "./convert";
+
+/**
+ * @experimental Reading and writing the notation people type.
+ *
+ * `parseHex` answers `null` for anything that is not a colour yet, which is the ordinary state of a
+ * field someone is part-way through typing into; `toHex` omits the alpha pair when the colour is
+ * opaque, so a value reads back the way it was entered.
+ */
+export { parseHex, toHex } from "./hex";


### PR DESCRIPTION
First increment toward the colour picker. `@nextlyhq/ui/color` could convert between sRGB, HSV and OKLCH, but had no way to read or write **hex** — which is the notation people actually type and paste.

## Why here rather than in the picker

Parsing `#3b82f6` is arithmetic on a string. It belongs beside the conversions for the reason they are there: a server rendering a token swatch needs it as much as an editing surface does, and putting it in the component would move it behind the `"use client"` boundary for no benefit.

`hex.ts` imports only `type { Rgb }`, so it stays clear of the server-safe layering guard in #656.

## API

```ts
parseHex(input: string): Rgba | null
toHex(color: Rgb, alpha = 1): string
```

`Rgba extends Rgb` with `alpha` in **[0, 1]**, matching the channels, so it composes with the existing conversions without a second unit in play.

## The decisions, and why

**`parseHex` returns `null` rather than throwing or substituting black.** This reads what someone is part-way through typing, where "not a colour yet" is the ordinary state — `#3b` is not an error, it is a person mid-keystroke. The caller decides whether to hold the last good value, show a message, or wait.

**A short form expands by REPEATING each digit, not padding.** `#abc` is `#aabbcc`, not `#a0b0c0`. That is what CSS does, and it is the only expansion under which `#fff` is white — which is the fixture that makes the difference impossible to miss.

**`toHex` omits the alpha pair when the colour is opaque.** `#3b82f6ff` is the same colour, but the short form is what someone expects to read back out of a field they typed `#3b82f6` into.

**Out-of-range channels are clamped**, so the output is always a valid six- or eight-digit string.

## Tests

Nine cases, covering what a person produces: partial input mid-keystroke, pasted short forms, missing hash, mixed case, stray whitespace, and alpha. Plus two round trips through the conversions this sits beside — hex to HSV and back, byte-exact, because a picker that shifts a colour the user did not touch is the defect worth guarding.

Each decision break-verified:

| break | result |
|---|---|
| pad the short form instead of repeating | `× expands a short form by repeating each digit` |
| always write the alpha pair | fails 3 tests including the round trip |
| accept anything the pattern rejects | `× returns null rather than guessing` |
| drop the clamp | `× still produces a valid hex string when a channel is out of range` |

### One of those breaks initially passed, and the fix was the comment

My first clamp test used `r: 1.0000000002`, justified in a comment as guarding floating-point drift. Dropping the clamp still passed it — because `Math.round(1.0000000002 * 255)` is already `255`. Drift rounds to the right byte on its own.

So the comment was asserting a reason that does not hold. The clamp is worth keeping, but for values wrong by a **lot** — a channel still in 0-255, or a computation that overshot — where the alternative is emitting a string nothing downstream can parse. Both the test and the comment now say that.

650 tests in `packages/ui`, lint, types and build clean. The `./color` surface snapshot picked up the three new exports and was updated deliberately; the diff is exactly those three names.
