### PR TITLE
fix(blocks-react): emit prepared slots in declaration order

### DIFF
--- a/.changeset/blocks-react-declared-slot-order.md
+++ b/.changeset/blocks-react-declared-slot-order.md
@@ -1,0 +1,38 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+---
+
+`@nextlyhq/blocks-react` now emits a prepared document's slots in the order the
+block DEFINITION declares them, not the order they happen to be stored in.
+
+The renderer asks for its slots by calling `renderSlot` once per declaration,
+so declaration order is the order the page presents. This tree is documented as
+the render-equivalent one, so carrying stored order left its own key order
+describing a page nobody is served, and made two documents that render
+identically compare as different.
+
+A slot the definition declares but the document never stored stays ABSENT rather
+than being added as an empty array: an empty slot renders nothing either way,
+and adding it would rewrite every document that omits an optional slot.

--- a/packages/blocks-react/src/prepare-document.test.ts
+++ b/packages/blocks-react/src/prepare-document.test.ts
@@ -6,6 +6,7 @@ import type { BlockDocument, BlockNode } from "@nextlyhq/blocks-engine";
 import { describe, expect, it } from "vitest";
 
 import { coreBlocks } from "./blocks";
+import { defineBlock } from "./context";
 import { prepareDocumentForRead } from "./prepare-document";
 import { createBlockResolver } from "./resolver";
 
@@ -151,5 +152,84 @@ describe("prepareDocumentForRead", () => {
     });
 
     expect(prepared?.nodes.map(node => node.props.text)).toEqual(["Real"]);
+  });
+
+  describe("slot order", () => {
+    /**
+     * Two slots, so declaration order and stored order can disagree.
+     *
+     * Written here rather than borrowed from the catalogue because every core
+     * block declares exactly one slot, and a single-slot fixture cannot tell
+     * the two orders apart — it would pass whichever order the code emitted.
+     */
+    const panel = defineBlock({
+      name: "test/panel",
+      version: 1,
+      description: "Two slots, so the two orders can disagree.",
+      example: { props: {} },
+      slots: { header: {}, footer: {} },
+      render: () => null,
+    });
+
+    const resolver = createBlockResolver([...coreBlocks, panel]);
+
+    function panelWith(slots: Record<string, BlockNode[]>): BlockDocument {
+      return {
+        formatVersion: DOCUMENT_FORMAT_VERSION,
+        kind: "page",
+        nodes: [{ id: "1", type: "test/panel", version: 1, props: {}, slots }],
+      };
+    }
+
+    it("emits slots in the order the definition declares them", () => {
+      // The renderer asks for its slots by calling `renderSlot` once per
+      // declaration, so declaration order is the order the page presents. A
+      // tree documented as render-equivalent that carried stored order would
+      // describe a page nobody is served.
+      const prepared = prepareDocumentForRead(
+        panelWith({
+          footer: [heading("2", "Bottom")],
+          header: [heading("3", "Top")],
+        }),
+        { resolver }
+      );
+
+      expect(Object.keys(prepared?.nodes[0]?.slots ?? {})).toEqual([
+        "header",
+        "footer",
+      ]);
+    });
+
+    it("leaves a declared but unstored slot absent", () => {
+      // This pass repairs what a reader would mis-render, and an empty slot
+      // renders nothing whether its key is present or not. Adding it would
+      // rewrite every document that omits an optional slot.
+      const prepared = prepareDocumentForRead(
+        panelWith({ footer: [heading("2", "Bottom")] }),
+        { resolver }
+      );
+
+      expect(Object.keys(prepared?.nodes[0]?.slots ?? {})).toEqual(["footer"]);
+    });
+
+    it("still drops an undeclared slot while reordering the rest", () => {
+      // Reordering and pruning compose on one node rather than only being
+      // correct apart. The ghost sits BETWEEN two declared slots, so an
+      // implementation that filtered in place would have to reorder around a
+      // gap; this one selects by declaration and never sees it.
+      const prepared = prepareDocumentForRead(
+        panelWith({
+          footer: [heading("2", "Bottom")],
+          ghost: [heading("3", "Nowhere")],
+          header: [heading("4", "Top")],
+        }),
+        { resolver }
+      );
+
+      expect(Object.keys(prepared?.nodes[0]?.slots ?? {})).toEqual([
+        "header",
+        "footer",
+      ]);
+    });
   });
 });

--- a/packages/blocks-react/src/prepare-document.ts
+++ b/packages/blocks-react/src/prepare-document.ts
@@ -113,16 +113,40 @@ function pruneKnownPlaceholders(
       // for markup nobody receives. The SEO walk already refuses to descend
       // into them; this makes the tree itself say so, once, for every reader.
       const declared = resolver.get(node.type)?.slots ?? {};
+      const slotKeys = Object.keys(node.slots);
       let slotsChanged = false;
       const slots: Record<string, BlockNode[]> = {};
-      for (const [name, children] of Object.entries(node.slots)) {
-        if (!(name in declared)) {
-          slotsChanged = true;
-          continue;
-        }
+      // Iterated in DECLARATION order, not stored order. The renderer asks for
+      // its slots by calling `renderSlot` once per declaration, so declaration
+      // order is the order the page presents — and this tree is documented as
+      // the render-equivalent one. Emitting stored order instead leaves the
+      // tree's own key order describing a page nobody is served, and makes two
+      // documents that render identically compare as different.
+      for (const name of Object.keys(declared)) {
+        const children = node.slots[name];
+        // Declared but never stored. Left ABSENT rather than added as an empty
+        // array: this pass repairs what a reader would mis-render, and a slot
+        // with no children renders nothing whether the key is there or not.
+        // Adding it would rewrite every document that omits an optional slot.
+        if (children === undefined) continue;
         const next = walk(children);
         if (next !== children) slotsChanged = true;
         slots[name] = next;
+      }
+      // Undeclared slots are dropped by never being visited above, so the
+      // change is detected by comparing what survived against what was stored.
+      // Counting is enough: every surviving name came from `declared`, so an
+      // equal count means the same set.
+      if (Object.keys(slots).length !== Object.keys(node.slots).length) {
+        slotsChanged = true;
+      }
+      // A reorder is a change even when nothing was dropped or rewritten.
+      // Without this a stored order that merely DIFFERS from the declaration
+      // would compute the reordered object and then discard it.
+      else if (
+        Object.keys(slots).some((name, index) => name !== slotKeys[index])
+      ) {
+        slotsChanged = true;
       }
       if (slotsChanged) changed = true;
       kept.push(slotsChanged ? { ...node, slots } : node);


### PR DESCRIPTION
A prepared document now emits each node's slots in the order the block **definition** declares them, rather than the order they happen to be stored in.

## Why

The renderer asks for its slots by calling `renderSlot` once per declaration, so declaration order **is** the order the page presents. `prepareDocumentForRead` is documented as producing the render-equivalent tree, so carrying stored order left the tree's own key order describing a page nobody is served — and made two documents that render identically compare as different.

The style compiler already sorts slot names (`compile-page.ts:947`), so it was order-independent by design; this makes the tree itself canonical for every other reader.

## Decisions

- **A declared-but-unstored slot stays ABSENT**, not added as an empty array. An empty slot renders nothing either way, and adding it would rewrite every document that omits an optional slot.
- **Reordering counts as a change.** Without that, a stored order merely differing from the declaration would compute the reordered object and then discard it, returning the original node.
- **Dropping is detected by count.** Every surviving name came from `declared`, so an equal count means the same set.

## Verification

Three new tests, and each clause proven load-bearing by mutation:

| mutation | test that failed |
|---|---|
| iterate stored order instead of declared | `emits slots in the order the definition declares them` (+2 more) |
| remove the reorder detection | `emits slots in the order the definition declares them` |
| neutralise the drop detection | `drops a slot the block's definition does not declare` |

The fixture is a local two-slot block: every core block declares exactly one slot, and a single-slot fixture cannot tell the two orders apart — it would pass whichever order the code emitted.

445/445 tests, `check-types` and `lint` clean.