### PR TITLE
fix(plugin-page-builder): let the page keep one primary landmark

### DIFF
--- a/.changeset/one-main-per-document.md
+++ b/.changeset/one-main-per-document.md
@@ -1,0 +1,27 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+---
+
+The page builder no longer renders a second `main` element. A page has one primary landmark, and the editor was adding another inside the admin’s own, which is invalid markup and gives screen readers two competing landmarks to choose between. The canvas pane is now a labelled region, so it is still announced and still reachable by landmark navigation.

--- a/packages/plugin-page-builder/src/admin/EditorSurface.tsx
+++ b/packages/plugin-page-builder/src/admin/EditorSurface.tsx
@@ -83,9 +83,16 @@ export function EditorSurface() {
           <aside className="nx-pb-pane nx-pb-pane--left">
             <BlockLibrary />
           </aside>
-          <main className="nx-pb-pane--center">
+          {/*
+           * A region, not a second `main`. HTML allows one non-hidden `main` per
+           * document and the admin already renders it, so a nested one is invalid
+           * markup, gives assistive technology two competing primary landmarks,
+           * and makes every strict `main` locator in the e2e suite ambiguous. The
+           * label is what keeps it a useful landmark rather than a bare wrapper.
+           */}
+          <section className="nx-pb-pane--center" aria-label="Canvas">
             <Canvas />
-          </main>
+          </section>
           <aside className="nx-pb-pane nx-pb-pane--right">
             <Inspector />
           </aside>

--- a/packages/plugin-page-builder/src/admin/one-main-per-document.test.ts
+++ b/packages/plugin-page-builder/src/admin/one-main-per-document.test.ts
@@ -1,0 +1,71 @@
+/**
+ * The editor contributes no `<main>`, because the page it mounts into already has one.
+ *
+ * HTML allows a single non-hidden `main` per document. A second one is invalid markup, gives
+ * assistive technology two competing primary landmarks, and makes every strict `main` locator
+ * ambiguous — which is how this surfaced: `e2e/tests/support/admin.ts` waits on
+ * `page.locator("main")`, and Playwright's strict mode fails a locator that resolves to two
+ * elements, so whole canvas specs died before reaching their own assertions.
+ *
+ * Asserted over the SOURCE of every admin component rather than by rendering one of them. The
+ * editor mounts a live drag-and-drop provider and an iframe canvas, so rendering the tree here
+ * would test the harness as much as the markup; and a render-based check only covers the
+ * components that particular fixture happens to reach, while a new pane added tomorrow is
+ * exactly the regression this exists to catch.
+ */
+import { readFileSync, readdirSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+const ADMIN_DIR = dirname(fileURLToPath(import.meta.url));
+
+/** Every component source under the admin surface. */
+function componentSources(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...componentSources(full));
+    else if (/\.tsx$/.test(entry.name) && !/\.test\.tsx$/.test(entry.name)) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+/**
+ * A `<main>` opening tag, whether bare or carrying attributes.
+ *
+ * `<main>` and `<main className=...>` both count; `<mainstay>` does not, which is what the
+ * boundary character rules out.
+ */
+const OPENS_A_MAIN = /<main[\s/>]/;
+
+describe("the editor adds no second landmark", () => {
+  const sources = componentSources(ADMIN_DIR);
+
+  it("reads the admin components, so the assertion is not vacuous", () => {
+    // Positive control. An empty list would satisfy the check below while proving nothing.
+    expect(sources.length).toBeGreaterThan(0);
+    expect(sources.some(f => f.endsWith("EditorSurface.tsx"))).toBe(true);
+  });
+
+  it("renders no <main> anywhere in the editor", () => {
+    const offenders = sources.filter(file =>
+      OPENS_A_MAIN.test(readFileSync(file, "utf8"))
+    );
+
+    expect(offenders).toEqual([]);
+  });
+
+  it("gives the canvas pane a labelled region instead", () => {
+    // The replacement is only an improvement if it stays a landmark: a bare `section` with no
+    // accessible name is not exposed as one, so dropping the label would quietly trade an
+    // invalid landmark for no landmark at all.
+    const surface = readFileSync(join(ADMIN_DIR, "EditorSurface.tsx"), "utf8");
+
+    expect(surface).toContain('<section className="nx-pb-pane--center"');
+    expect(surface).toContain('aria-label="Canvas"');
+  });
+});


### PR DESCRIPTION
## What this fixes

The page builder rendered `<main className="nx-pb-pane--center">` inside the admin, which already renders its own `<main>`. HTML allows one non-hidden `main` per document, so this was invalid markup, gave assistive technology two competing primary landmarks, and made every strict `main` locator ambiguous.

That last part is not theoretical. `e2e/tests/support/admin.ts:39` waits on `page.locator("main")`, and Playwright's strict mode fails a locator resolving to two elements:

```
Error: strict mode violation: locator('main') resolved to 2 elements:
  1) <main class="@container/content flex-1 overflow-y-auto bg-transparent">
  2) <main class="nx-pb-pane--center">
```

So whole specs died before reaching their own assertions — `canvas/checklist.spec.ts` and `canvas/coordinate-mapping.spec.ts` — **on other lanes' PRs**, which touched none of this.

The canvas pane is now `<section aria-label="Canvas">`. The label is load-bearing: a bare `section` with no accessible name is not exposed as a landmark at all, so dropping it would trade an invalid landmark for none.

## Provenance — no recent PR caused it

Two lanes each suspected their own change, so this was established by execution rather than by blame:

- It predates #648: `git cat-file -p 1ddda0ff4~1:...EditorSurface.tsx` still contains the `<main>`.
- Introduced by `da522a97e` *"feat(page-builder): native-styled shell + device-icon breakpoint switcher (stage 2)"*.

Latent since the editor shell landed; it only surfaces where a test drives a page that mounts the editor.

## 🔴 It is NOT the known flake

`canvas/checklist.spec.ts` "the innermost container owns the drop target" is recorded across this lane's notes as the **only** known e2e flake. It has two failure modes and this is the deterministic one. Anyone applying the flake heuristic re-runs, sees it fail again, and hunts in the wrong place. Grep a failing log for `strict mode violation` to separate them in one step. Filed as task 194 with that correction.

## A comment that reads like it anticipated this, and does not

`admin.ts:35-38` says the app "renders two of them, which no strict locator can resolve". **"Two of them" is the root div**, not `main` — it is the *reason* `main` was chosen, not a known second `main`. Read quickly it looks like the problem was already understood and half-fixed. It was not.

## The guard

A source-level assertion that no admin component opens a `<main>`, plus one that the pane keeps its label.

Asserted over source rather than by rendering: the editor mounts a live drag-and-drop provider and an iframe canvas, so a render-based check would test the harness as much as the markup — and would only cover the components that one fixture happens to reach, while a new pane added tomorrow is exactly the regression this exists to catch.

Stub-verified, each restore confirmed clean:

| Break | Tests that failed |
|---|---|
| reintroduce `<main>` in the editor | `renders no <main> anywhere in the editor`, `gives the canvas pane a labelled region instead` |
| remove only `aria-label`, keep `section` | `gives the canvas pane a labelled region instead` |

The second break was re-run after the first attempt was invalid — a mistyped restore path left the tree dirty, so it "failed" against an already-broken fixture and proved nothing. Redone against a verified-clean tree.

`plugin-page-builder`: 69 files / 653 tests pass, `check-types` clean, `lint` exit 0.

## Not verified in a browser

The markup change is asserted at source and the e2e suite is what exercises it for real. I have not watched the editor render.
