### PR TITLE
ci(root): stop a cancelled run from publishing a half-built turbo cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,13 +40,33 @@ jobs:
           cache: pnpm
           registry-url: https://registry.npmjs.org
 
-      - name: Cache Turbo
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      # Restore only. The matching save runs at the end of the job, gated on the
+      # job having succeeded.
+      #
+      # `actions/cache` saves in a post step that runs however the job ended, so a
+      # run cancelled mid-build — which `cancel-in-progress` above makes routine —
+      # can publish a `.turbo` holding a task entry whose recorded outputs are
+      # incomplete. A later run restores it, reports `cache hit, replaying logs`,
+      # and lays down a `dist/` missing files the rest of the build imports. The
+      # symptom is `Cannot find module '.../dist/chunk-<hash>.mjs'` in a package
+      # nobody changed.
+      #
+      # Re-running cannot clear it: the key is the commit SHA, so a second attempt
+      # scores an exact hit on the same entry. Splitting restore from save is the
+      # supported way to make the save conditional (`save-always` was deprecated
+      # for this).
+      #
+      # The `v2-` prefix retires every entry written under the old scheme in one
+      # step. Cache keys are immutable and `restore-keys` prefers the newest match,
+      # so entries already poisoned would otherwise keep being selected until they
+      # aged out.
+      - name: Restore Turbo cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: .turbo
-          key: turbo-${{ runner.os }}-${{ github.sha }}
+          key: turbo-v2-${{ runner.os }}-${{ github.sha }}
           restore-keys: |
-            turbo-${{ runner.os }}-
+            turbo-v2-${{ runner.os }}-
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -196,6 +216,16 @@ jobs:
         env:
           TURBO_CACHE_DIR: .turbo
 
+      # Only a job that finished its work publishes what it learned. A cancelled or
+      # failed run leaves the cache as it found it, so nothing it half-built can be
+      # restored by a later one.
+      - name: Save Turbo cache
+        if: success()
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: .turbo
+          key: turbo-v2-${{ runner.os }}-${{ github.sha }}
+
   # The admin, in a real browser, against a real server and a real database.
   # Covers the class of failure the unit and integration suites structurally
   # cannot: jsdom has no layout engine, so a column that grew to 1024px or a
@@ -229,13 +259,33 @@ jobs:
           node-version-file: .nvmrc
           cache: pnpm
 
-      - name: Cache Turbo
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      # Restore only. The matching save runs at the end of the job, gated on the
+      # job having succeeded.
+      #
+      # `actions/cache` saves in a post step that runs however the job ended, so a
+      # run cancelled mid-build — which `cancel-in-progress` above makes routine —
+      # can publish a `.turbo` holding a task entry whose recorded outputs are
+      # incomplete. A later run restores it, reports `cache hit, replaying logs`,
+      # and lays down a `dist/` missing files the rest of the build imports. The
+      # symptom is `Cannot find module '.../dist/chunk-<hash>.mjs'` in a package
+      # nobody changed.
+      #
+      # Re-running cannot clear it: the key is the commit SHA, so a second attempt
+      # scores an exact hit on the same entry. Splitting restore from save is the
+      # supported way to make the save conditional (`save-always` was deprecated
+      # for this).
+      #
+      # The `v2-` prefix retires every entry written under the old scheme in one
+      # step. Cache keys are immutable and `restore-keys` prefers the newest match,
+      # so entries already poisoned would otherwise keep being selected until they
+      # aged out.
+      - name: Restore Turbo cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: .turbo
-          key: turbo-${{ runner.os }}-${{ github.sha }}
+          key: turbo-v2-${{ runner.os }}-${{ github.sha }}
           restore-keys: |
-            turbo-${{ runner.os }}-
+            turbo-v2-${{ runner.os }}-
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -269,6 +319,16 @@ jobs:
           name: playwright-report
           path: e2e/.playwright/report
           retention-days: 7
+
+      # Only a job that finished its work publishes what it learned. A cancelled or
+      # failed run leaves the cache as it found it, so nothing it half-built can be
+      # restored by a later one.
+      - name: Save Turbo cache
+        if: success()
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: .turbo
+          key: turbo-v2-${{ runner.os }}-${{ github.sha }}
 
   # Cross-platform smoke test for the scaffolder. Catches Windows path
   # separator bugs and macOS-specific issues that only surface in fresh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,33 +40,35 @@ jobs:
           cache: pnpm
           registry-url: https://registry.npmjs.org
 
-      # Restore only. The matching save runs at the end of the job, gated on the
-      # job having succeeded.
+      # Scoped to the JOB, which is the part that matters. Six jobs across four
+      # workflows cache `.turbo`, they run concurrently on the same commit, and
+      # they build different filter sets — this one builds every package and app,
+      # `preview` builds only packages, `integration` builds five of them. Keyed on
+      # the commit alone they all wrote one entry, so whichever finished first
+      # decided what every later reader got.
       #
-      # `actions/cache` saves in a post step that runs however the job ended, so a
-      # run cancelled mid-build — which `cancel-in-progress` above makes routine —
-      # can publish a `.turbo` holding a task entry whose recorded outputs are
-      # incomplete. A later run restores it, reports `cache hit, replaying logs`,
-      # and lays down a `dist/` missing files the rest of the build imports. The
-      # symptom is `Cannot find module '.../dist/chunk-<hash>.mjs'` in a package
-      # nobody changed.
+      # A reader then restores a `.turbo` shaped by someone else's build, reports
+      # `cache hit, replaying logs`, and lays down a `dist/` that does not contain
+      # what its own tests import. The symptom is `Cannot find module
+      # '.../dist/chunk-<hash>.mjs'` in a package the pull request never touched.
+      # Re-running cannot clear it: the key is the commit, so a second attempt
+      # scores an exact hit on the same foreign entry.
       #
-      # Re-running cannot clear it: the key is the commit SHA, so a second attempt
-      # scores an exact hit on the same entry. Splitting restore from save is the
-      # supported way to make the save conditional (`save-always` was deprecated
-      # for this).
+      # `github.job` gives each job its own lineage. Nothing is lost — a job's own
+      # previous runs are what its cache was ever useful for, and turbo entries are
+      # content-addressed, so a narrower cache is a slower run and never a wrong
+      # one.
       #
-      # The `v2-` prefix retires every entry written under the old scheme in one
+      # The `v2-` prefix retires every entry written under the shared scheme in one
       # step. Cache keys are immutable and `restore-keys` prefers the newest match,
-      # so entries already poisoned would otherwise keep being selected until they
-      # aged out.
+      # so the entries already written would otherwise keep being selected.
       - name: Restore Turbo cache
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: .turbo
-          key: turbo-v2-${{ runner.os }}-${{ github.sha }}
+          key: turbo-v2-${{ runner.os }}-${{ github.job }}-${{ github.sha }}
           restore-keys: |
-            turbo-v2-${{ runner.os }}-
+            turbo-v2-${{ runner.os }}-${{ github.job }}-
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -217,14 +219,15 @@ jobs:
           TURBO_CACHE_DIR: .turbo
 
       # Only a job that finished its work publishes what it learned. A cancelled or
-      # failed run leaves the cache as it found it, so nothing it half-built can be
-      # restored by a later one.
+      # failed run leaves the cache as it found it — `actions/cache` saves in a post
+      # step that runs however the job ended, and splitting restore from save is the
+      # supported way to make that conditional (`save-always` was deprecated for it).
       - name: Save Turbo cache
         if: success()
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: .turbo
-          key: turbo-v2-${{ runner.os }}-${{ github.sha }}
+          key: turbo-v2-${{ runner.os }}-${{ github.job }}-${{ github.sha }}
 
   # The admin, in a real browser, against a real server and a real database.
   # Covers the class of failure the unit and integration suites structurally
@@ -259,33 +262,35 @@ jobs:
           node-version-file: .nvmrc
           cache: pnpm
 
-      # Restore only. The matching save runs at the end of the job, gated on the
-      # job having succeeded.
+      # Scoped to the JOB, which is the part that matters. Six jobs across four
+      # workflows cache `.turbo`, they run concurrently on the same commit, and
+      # they build different filter sets — this one builds every package and app,
+      # `preview` builds only packages, `integration` builds five of them. Keyed on
+      # the commit alone they all wrote one entry, so whichever finished first
+      # decided what every later reader got.
       #
-      # `actions/cache` saves in a post step that runs however the job ended, so a
-      # run cancelled mid-build — which `cancel-in-progress` above makes routine —
-      # can publish a `.turbo` holding a task entry whose recorded outputs are
-      # incomplete. A later run restores it, reports `cache hit, replaying logs`,
-      # and lays down a `dist/` missing files the rest of the build imports. The
-      # symptom is `Cannot find module '.../dist/chunk-<hash>.mjs'` in a package
-      # nobody changed.
+      # A reader then restores a `.turbo` shaped by someone else's build, reports
+      # `cache hit, replaying logs`, and lays down a `dist/` that does not contain
+      # what its own tests import. The symptom is `Cannot find module
+      # '.../dist/chunk-<hash>.mjs'` in a package the pull request never touched.
+      # Re-running cannot clear it: the key is the commit, so a second attempt
+      # scores an exact hit on the same foreign entry.
       #
-      # Re-running cannot clear it: the key is the commit SHA, so a second attempt
-      # scores an exact hit on the same entry. Splitting restore from save is the
-      # supported way to make the save conditional (`save-always` was deprecated
-      # for this).
+      # `github.job` gives each job its own lineage. Nothing is lost — a job's own
+      # previous runs are what its cache was ever useful for, and turbo entries are
+      # content-addressed, so a narrower cache is a slower run and never a wrong
+      # one.
       #
-      # The `v2-` prefix retires every entry written under the old scheme in one
+      # The `v2-` prefix retires every entry written under the shared scheme in one
       # step. Cache keys are immutable and `restore-keys` prefers the newest match,
-      # so entries already poisoned would otherwise keep being selected until they
-      # aged out.
+      # so the entries already written would otherwise keep being selected.
       - name: Restore Turbo cache
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: .turbo
-          key: turbo-v2-${{ runner.os }}-${{ github.sha }}
+          key: turbo-v2-${{ runner.os }}-${{ github.job }}-${{ github.sha }}
           restore-keys: |
-            turbo-v2-${{ runner.os }}-
+            turbo-v2-${{ runner.os }}-${{ github.job }}-
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -321,14 +326,15 @@ jobs:
           retention-days: 7
 
       # Only a job that finished its work publishes what it learned. A cancelled or
-      # failed run leaves the cache as it found it, so nothing it half-built can be
-      # restored by a later one.
+      # failed run leaves the cache as it found it — `actions/cache` saves in a post
+      # step that runs however the job ended, and splitting restore from save is the
+      # supported way to make that conditional (`save-always` was deprecated for it).
       - name: Save Turbo cache
         if: success()
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: .turbo
-          key: turbo-v2-${{ runner.os }}-${{ github.sha }}
+          key: turbo-v2-${{ runner.os }}-${{ github.job }}-${{ github.sha }}
 
   # Cross-platform smoke test for the scaffolder. Catches Windows path
   # separator bugs and macOS-specific issues that only surface in fresh

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -90,13 +90,33 @@ jobs:
           node-version-file: .nvmrc
           cache: pnpm
 
-      - name: Cache Turbo
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      # Restore only. The matching save runs at the end of the job, gated on the
+      # job having succeeded.
+      #
+      # `actions/cache` saves in a post step that runs however the job ended, so a
+      # run cancelled mid-build — which `cancel-in-progress` above makes routine —
+      # can publish a `.turbo` holding a task entry whose recorded outputs are
+      # incomplete. A later run restores it, reports `cache hit, replaying logs`,
+      # and lays down a `dist/` missing files the rest of the build imports. The
+      # symptom is `Cannot find module '.../dist/chunk-<hash>.mjs'` in a package
+      # nobody changed.
+      #
+      # Re-running cannot clear it: the key is the commit SHA, so a second attempt
+      # scores an exact hit on the same entry. Splitting restore from save is the
+      # supported way to make the save conditional (`save-always` was deprecated
+      # for this).
+      #
+      # The `v2-` prefix retires every entry written under the old scheme in one
+      # step. Cache keys are immutable and `restore-keys` prefers the newest match,
+      # so entries already poisoned would otherwise keep being selected until they
+      # aged out.
+      - name: Restore Turbo cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: .turbo
-          key: turbo-${{ runner.os }}-${{ github.sha }}
+          key: turbo-v2-${{ runner.os }}-${{ github.sha }}
           restore-keys: |
-            turbo-${{ runner.os }}-
+            turbo-v2-${{ runner.os }}-
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -135,6 +155,16 @@ jobs:
           TEST_MYSQL_URL: mysql://root:nextly@127.0.0.1:3306/nextly_test
           TURBO_CACHE_DIR: .turbo
 
+      # Only a job that finished its work publishes what it learned. A cancelled or
+      # failed run leaves the cache as it found it, so nothing it half-built can be
+      # restored by a later one.
+      - name: Save Turbo cache
+        if: success()
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: .turbo
+          key: turbo-v2-${{ runner.os }}-${{ github.sha }}
+
   # sqlite runs in-process against a throwaway file, so this job declares no
   # `services:` at all. Keeping it out of the matrix above means it never pulls
   # the postgres/mysql images it would not connect to, which removes its only
@@ -161,13 +191,33 @@ jobs:
           node-version-file: .nvmrc
           cache: pnpm
 
-      - name: Cache Turbo
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      # Restore only. The matching save runs at the end of the job, gated on the
+      # job having succeeded.
+      #
+      # `actions/cache` saves in a post step that runs however the job ended, so a
+      # run cancelled mid-build — which `cancel-in-progress` above makes routine —
+      # can publish a `.turbo` holding a task entry whose recorded outputs are
+      # incomplete. A later run restores it, reports `cache hit, replaying logs`,
+      # and lays down a `dist/` missing files the rest of the build imports. The
+      # symptom is `Cannot find module '.../dist/chunk-<hash>.mjs'` in a package
+      # nobody changed.
+      #
+      # Re-running cannot clear it: the key is the commit SHA, so a second attempt
+      # scores an exact hit on the same entry. Splitting restore from save is the
+      # supported way to make the save conditional (`save-always` was deprecated
+      # for this).
+      #
+      # The `v2-` prefix retires every entry written under the old scheme in one
+      # step. Cache keys are immutable and `restore-keys` prefers the newest match,
+      # so entries already poisoned would otherwise keep being selected until they
+      # aged out.
+      - name: Restore Turbo cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: .turbo
-          key: turbo-${{ runner.os }}-${{ github.sha }}
+          key: turbo-v2-${{ runner.os }}-${{ github.sha }}
           restore-keys: |
-            turbo-${{ runner.os }}-
+            turbo-v2-${{ runner.os }}-
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -181,3 +231,13 @@ jobs:
           pnpm turbo test:integration --filter=@nextlyhq/adapter-sqlite --filter=nextly --filter=@nextlyhq/plugin-page-builder
         env:
           TURBO_CACHE_DIR: .turbo
+
+      # Only a job that finished its work publishes what it learned. A cancelled or
+      # failed run leaves the cache as it found it, so nothing it half-built can be
+      # restored by a later one.
+      - name: Save Turbo cache
+        if: success()
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: .turbo
+          key: turbo-v2-${{ runner.os }}-${{ github.sha }}

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -90,33 +90,35 @@ jobs:
           node-version-file: .nvmrc
           cache: pnpm
 
-      # Restore only. The matching save runs at the end of the job, gated on the
-      # job having succeeded.
+      # Scoped to the JOB, which is the part that matters. Six jobs across four
+      # workflows cache `.turbo`, they run concurrently on the same commit, and
+      # they build different filter sets — this one builds every package and app,
+      # `preview` builds only packages, `integration` builds five of them. Keyed on
+      # the commit alone they all wrote one entry, so whichever finished first
+      # decided what every later reader got.
       #
-      # `actions/cache` saves in a post step that runs however the job ended, so a
-      # run cancelled mid-build — which `cancel-in-progress` above makes routine —
-      # can publish a `.turbo` holding a task entry whose recorded outputs are
-      # incomplete. A later run restores it, reports `cache hit, replaying logs`,
-      # and lays down a `dist/` missing files the rest of the build imports. The
-      # symptom is `Cannot find module '.../dist/chunk-<hash>.mjs'` in a package
-      # nobody changed.
+      # A reader then restores a `.turbo` shaped by someone else's build, reports
+      # `cache hit, replaying logs`, and lays down a `dist/` that does not contain
+      # what its own tests import. The symptom is `Cannot find module
+      # '.../dist/chunk-<hash>.mjs'` in a package the pull request never touched.
+      # Re-running cannot clear it: the key is the commit, so a second attempt
+      # scores an exact hit on the same foreign entry.
       #
-      # Re-running cannot clear it: the key is the commit SHA, so a second attempt
-      # scores an exact hit on the same entry. Splitting restore from save is the
-      # supported way to make the save conditional (`save-always` was deprecated
-      # for this).
+      # `github.job` gives each job its own lineage. Nothing is lost — a job's own
+      # previous runs are what its cache was ever useful for, and turbo entries are
+      # content-addressed, so a narrower cache is a slower run and never a wrong
+      # one.
       #
-      # The `v2-` prefix retires every entry written under the old scheme in one
+      # The `v2-` prefix retires every entry written under the shared scheme in one
       # step. Cache keys are immutable and `restore-keys` prefers the newest match,
-      # so entries already poisoned would otherwise keep being selected until they
-      # aged out.
+      # so the entries already written would otherwise keep being selected.
       - name: Restore Turbo cache
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: .turbo
-          key: turbo-v2-${{ runner.os }}-${{ github.sha }}
+          key: turbo-v2-${{ runner.os }}-${{ github.job }}-${{ github.sha }}
           restore-keys: |
-            turbo-v2-${{ runner.os }}-
+            turbo-v2-${{ runner.os }}-${{ github.job }}-
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -156,14 +158,15 @@ jobs:
           TURBO_CACHE_DIR: .turbo
 
       # Only a job that finished its work publishes what it learned. A cancelled or
-      # failed run leaves the cache as it found it, so nothing it half-built can be
-      # restored by a later one.
+      # failed run leaves the cache as it found it — `actions/cache` saves in a post
+      # step that runs however the job ended, and splitting restore from save is the
+      # supported way to make that conditional (`save-always` was deprecated for it).
       - name: Save Turbo cache
         if: success()
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: .turbo
-          key: turbo-v2-${{ runner.os }}-${{ github.sha }}
+          key: turbo-v2-${{ runner.os }}-${{ github.job }}-${{ github.sha }}
 
   # sqlite runs in-process against a throwaway file, so this job declares no
   # `services:` at all. Keeping it out of the matrix above means it never pulls
@@ -191,33 +194,35 @@ jobs:
           node-version-file: .nvmrc
           cache: pnpm
 
-      # Restore only. The matching save runs at the end of the job, gated on the
-      # job having succeeded.
+      # Scoped to the JOB, which is the part that matters. Six jobs across four
+      # workflows cache `.turbo`, they run concurrently on the same commit, and
+      # they build different filter sets — this one builds every package and app,
+      # `preview` builds only packages, `integration` builds five of them. Keyed on
+      # the commit alone they all wrote one entry, so whichever finished first
+      # decided what every later reader got.
       #
-      # `actions/cache` saves in a post step that runs however the job ended, so a
-      # run cancelled mid-build — which `cancel-in-progress` above makes routine —
-      # can publish a `.turbo` holding a task entry whose recorded outputs are
-      # incomplete. A later run restores it, reports `cache hit, replaying logs`,
-      # and lays down a `dist/` missing files the rest of the build imports. The
-      # symptom is `Cannot find module '.../dist/chunk-<hash>.mjs'` in a package
-      # nobody changed.
+      # A reader then restores a `.turbo` shaped by someone else's build, reports
+      # `cache hit, replaying logs`, and lays down a `dist/` that does not contain
+      # what its own tests import. The symptom is `Cannot find module
+      # '.../dist/chunk-<hash>.mjs'` in a package the pull request never touched.
+      # Re-running cannot clear it: the key is the commit, so a second attempt
+      # scores an exact hit on the same foreign entry.
       #
-      # Re-running cannot clear it: the key is the commit SHA, so a second attempt
-      # scores an exact hit on the same entry. Splitting restore from save is the
-      # supported way to make the save conditional (`save-always` was deprecated
-      # for this).
+      # `github.job` gives each job its own lineage. Nothing is lost — a job's own
+      # previous runs are what its cache was ever useful for, and turbo entries are
+      # content-addressed, so a narrower cache is a slower run and never a wrong
+      # one.
       #
-      # The `v2-` prefix retires every entry written under the old scheme in one
+      # The `v2-` prefix retires every entry written under the shared scheme in one
       # step. Cache keys are immutable and `restore-keys` prefers the newest match,
-      # so entries already poisoned would otherwise keep being selected until they
-      # aged out.
+      # so the entries already written would otherwise keep being selected.
       - name: Restore Turbo cache
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: .turbo
-          key: turbo-v2-${{ runner.os }}-${{ github.sha }}
+          key: turbo-v2-${{ runner.os }}-${{ github.job }}-${{ github.sha }}
           restore-keys: |
-            turbo-v2-${{ runner.os }}-
+            turbo-v2-${{ runner.os }}-${{ github.job }}-
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -233,11 +238,12 @@ jobs:
           TURBO_CACHE_DIR: .turbo
 
       # Only a job that finished its work publishes what it learned. A cancelled or
-      # failed run leaves the cache as it found it, so nothing it half-built can be
-      # restored by a later one.
+      # failed run leaves the cache as it found it — `actions/cache` saves in a post
+      # step that runs however the job ended, and splitting restore from save is the
+      # supported way to make that conditional (`save-always` was deprecated for it).
       - name: Save Turbo cache
         if: success()
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: .turbo
-          key: turbo-v2-${{ runner.os }}-${{ github.sha }}
+          key: turbo-v2-${{ runner.os }}-${{ github.job }}-${{ github.sha }}

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -44,33 +44,35 @@ jobs:
           node-version-file: .nvmrc
           cache: pnpm
 
-      # Restore only. The matching save runs at the end of the job, gated on the
-      # job having succeeded.
+      # Scoped to the JOB, which is the part that matters. Six jobs across four
+      # workflows cache `.turbo`, they run concurrently on the same commit, and
+      # they build different filter sets — this one builds every package and app,
+      # `preview` builds only packages, `integration` builds five of them. Keyed on
+      # the commit alone they all wrote one entry, so whichever finished first
+      # decided what every later reader got.
       #
-      # `actions/cache` saves in a post step that runs however the job ended, so a
-      # run cancelled mid-build — which `cancel-in-progress` above makes routine —
-      # can publish a `.turbo` holding a task entry whose recorded outputs are
-      # incomplete. A later run restores it, reports `cache hit, replaying logs`,
-      # and lays down a `dist/` missing files the rest of the build imports. The
-      # symptom is `Cannot find module '.../dist/chunk-<hash>.mjs'` in a package
-      # nobody changed.
+      # A reader then restores a `.turbo` shaped by someone else's build, reports
+      # `cache hit, replaying logs`, and lays down a `dist/` that does not contain
+      # what its own tests import. The symptom is `Cannot find module
+      # '.../dist/chunk-<hash>.mjs'` in a package the pull request never touched.
+      # Re-running cannot clear it: the key is the commit, so a second attempt
+      # scores an exact hit on the same foreign entry.
       #
-      # Re-running cannot clear it: the key is the commit SHA, so a second attempt
-      # scores an exact hit on the same entry. Splitting restore from save is the
-      # supported way to make the save conditional (`save-always` was deprecated
-      # for this).
+      # `github.job` gives each job its own lineage. Nothing is lost — a job's own
+      # previous runs are what its cache was ever useful for, and turbo entries are
+      # content-addressed, so a narrower cache is a slower run and never a wrong
+      # one.
       #
-      # The `v2-` prefix retires every entry written under the old scheme in one
+      # The `v2-` prefix retires every entry written under the shared scheme in one
       # step. Cache keys are immutable and `restore-keys` prefers the newest match,
-      # so entries already poisoned would otherwise keep being selected until they
-      # aged out.
+      # so the entries already written would otherwise keep being selected.
       - name: Restore Turbo cache
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: .turbo
-          key: turbo-v2-${{ runner.os }}-${{ github.sha }}
+          key: turbo-v2-${{ runner.os }}-${{ github.job }}-${{ github.sha }}
           restore-keys: |
-            turbo-v2-${{ runner.os }}-
+            turbo-v2-${{ runner.os }}-${{ github.job }}-
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -91,11 +93,12 @@ jobs:
         run: pnpm dlx pkg-pr-new publish --pnpm --commentWithSha './packages/*'
 
       # Only a job that finished its work publishes what it learned. A cancelled or
-      # failed run leaves the cache as it found it, so nothing it half-built can be
-      # restored by a later one.
+      # failed run leaves the cache as it found it — `actions/cache` saves in a post
+      # step that runs however the job ended, and splitting restore from save is the
+      # supported way to make that conditional (`save-always` was deprecated for it).
       - name: Save Turbo cache
         if: success()
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: .turbo
-          key: turbo-v2-${{ runner.os }}-${{ github.sha }}
+          key: turbo-v2-${{ runner.os }}-${{ github.job }}-${{ github.sha }}

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -44,13 +44,33 @@ jobs:
           node-version-file: .nvmrc
           cache: pnpm
 
-      - name: Cache Turbo
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      # Restore only. The matching save runs at the end of the job, gated on the
+      # job having succeeded.
+      #
+      # `actions/cache` saves in a post step that runs however the job ended, so a
+      # run cancelled mid-build — which `cancel-in-progress` above makes routine —
+      # can publish a `.turbo` holding a task entry whose recorded outputs are
+      # incomplete. A later run restores it, reports `cache hit, replaying logs`,
+      # and lays down a `dist/` missing files the rest of the build imports. The
+      # symptom is `Cannot find module '.../dist/chunk-<hash>.mjs'` in a package
+      # nobody changed.
+      #
+      # Re-running cannot clear it: the key is the commit SHA, so a second attempt
+      # scores an exact hit on the same entry. Splitting restore from save is the
+      # supported way to make the save conditional (`save-always` was deprecated
+      # for this).
+      #
+      # The `v2-` prefix retires every entry written under the old scheme in one
+      # step. Cache keys are immutable and `restore-keys` prefers the newest match,
+      # so entries already poisoned would otherwise keep being selected until they
+      # aged out.
+      - name: Restore Turbo cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: .turbo
-          key: turbo-${{ runner.os }}-${{ github.sha }}
+          key: turbo-v2-${{ runner.os }}-${{ github.sha }}
           restore-keys: |
-            turbo-${{ runner.os }}-
+            turbo-v2-${{ runner.os }}-
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -69,3 +89,13 @@ jobs:
       # push to the same PR.
       - name: Publish to pkg.pr.new
         run: pnpm dlx pkg-pr-new publish --pnpm --commentWithSha './packages/*'
+
+      # Only a job that finished its work publishes what it learned. A cancelled or
+      # failed run leaves the cache as it found it, so nothing it half-built can be
+      # restored by a later one.
+      - name: Save Turbo cache
+        if: success()
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: .turbo
+          key: turbo-v2-${{ runner.os }}-${{ github.sha }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,33 +67,35 @@ jobs:
       - name: Upgrade npm to >=11.5.1 for trusted publishing
         run: npm install -g npm@11.18.0
 
-      # Restore only. The matching save runs at the end of the job, gated on the
-      # job having succeeded.
+      # Scoped to the JOB, which is the part that matters. Six jobs across four
+      # workflows cache `.turbo`, they run concurrently on the same commit, and
+      # they build different filter sets — this one builds every package and app,
+      # `preview` builds only packages, `integration` builds five of them. Keyed on
+      # the commit alone they all wrote one entry, so whichever finished first
+      # decided what every later reader got.
       #
-      # `actions/cache` saves in a post step that runs however the job ended, so a
-      # run cancelled mid-build — which `cancel-in-progress` above makes routine —
-      # can publish a `.turbo` holding a task entry whose recorded outputs are
-      # incomplete. A later run restores it, reports `cache hit, replaying logs`,
-      # and lays down a `dist/` missing files the rest of the build imports. The
-      # symptom is `Cannot find module '.../dist/chunk-<hash>.mjs'` in a package
-      # nobody changed.
+      # A reader then restores a `.turbo` shaped by someone else's build, reports
+      # `cache hit, replaying logs`, and lays down a `dist/` that does not contain
+      # what its own tests import. The symptom is `Cannot find module
+      # '.../dist/chunk-<hash>.mjs'` in a package the pull request never touched.
+      # Re-running cannot clear it: the key is the commit, so a second attempt
+      # scores an exact hit on the same foreign entry.
       #
-      # Re-running cannot clear it: the key is the commit SHA, so a second attempt
-      # scores an exact hit on the same entry. Splitting restore from save is the
-      # supported way to make the save conditional (`save-always` was deprecated
-      # for this).
+      # `github.job` gives each job its own lineage. Nothing is lost — a job's own
+      # previous runs are what its cache was ever useful for, and turbo entries are
+      # content-addressed, so a narrower cache is a slower run and never a wrong
+      # one.
       #
-      # The `v2-` prefix retires every entry written under the old scheme in one
+      # The `v2-` prefix retires every entry written under the shared scheme in one
       # step. Cache keys are immutable and `restore-keys` prefers the newest match,
-      # so entries already poisoned would otherwise keep being selected until they
-      # aged out.
+      # so the entries already written would otherwise keep being selected.
       - name: Restore Turbo cache
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: .turbo
-          key: turbo-v2-${{ runner.os }}-${{ github.sha }}
+          key: turbo-v2-${{ runner.os }}-${{ github.job }}-${{ github.sha }}
           restore-keys: |
-            turbo-v2-${{ runner.os }}-
+            turbo-v2-${{ runner.os }}-${{ github.job }}-
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -231,11 +233,12 @@ jobs:
           cat "$NOTES_FILE" >> $GITHUB_STEP_SUMMARY
 
       # Only a job that finished its work publishes what it learned. A cancelled or
-      # failed run leaves the cache as it found it, so nothing it half-built can be
-      # restored by a later one.
+      # failed run leaves the cache as it found it — `actions/cache` saves in a post
+      # step that runs however the job ended, and splitting restore from save is the
+      # supported way to make that conditional (`save-always` was deprecated for it).
       - name: Save Turbo cache
         if: success()
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: .turbo
-          key: turbo-v2-${{ runner.os }}-${{ github.sha }}
+          key: turbo-v2-${{ runner.os }}-${{ github.job }}-${{ github.sha }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,13 +67,33 @@ jobs:
       - name: Upgrade npm to >=11.5.1 for trusted publishing
         run: npm install -g npm@11.18.0
 
-      - name: Cache Turbo
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      # Restore only. The matching save runs at the end of the job, gated on the
+      # job having succeeded.
+      #
+      # `actions/cache` saves in a post step that runs however the job ended, so a
+      # run cancelled mid-build — which `cancel-in-progress` above makes routine —
+      # can publish a `.turbo` holding a task entry whose recorded outputs are
+      # incomplete. A later run restores it, reports `cache hit, replaying logs`,
+      # and lays down a `dist/` missing files the rest of the build imports. The
+      # symptom is `Cannot find module '.../dist/chunk-<hash>.mjs'` in a package
+      # nobody changed.
+      #
+      # Re-running cannot clear it: the key is the commit SHA, so a second attempt
+      # scores an exact hit on the same entry. Splitting restore from save is the
+      # supported way to make the save conditional (`save-always` was deprecated
+      # for this).
+      #
+      # The `v2-` prefix retires every entry written under the old scheme in one
+      # step. Cache keys are immutable and `restore-keys` prefers the newest match,
+      # so entries already poisoned would otherwise keep being selected until they
+      # aged out.
+      - name: Restore Turbo cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: .turbo
-          key: turbo-${{ runner.os }}-${{ github.sha }}
+          key: turbo-v2-${{ runner.os }}-${{ github.sha }}
           restore-keys: |
-            turbo-${{ runner.os }}-
+            turbo-v2-${{ runner.os }}-
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -209,3 +229,13 @@ jobs:
             >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           cat "$NOTES_FILE" >> $GITHUB_STEP_SUMMARY
+
+      # Only a job that finished its work publishes what it learned. A cancelled or
+      # failed run leaves the cache as it found it, so nothing it half-built can be
+      # restored by a later one.
+      - name: Save Turbo cache
+        if: success()
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: .turbo
+          key: turbo-v2-${{ runner.os }}-${{ github.sha }}


### PR DESCRIPTION
CI is failing PRs on `Lint / Typecheck / Test / Build` with errors like:

```
Cannot find module '.../packages/adapter-drizzle/dist/version-check.mjs'
  imported from '.../packages/nextly/dist/chunk-EQL5KHCP.mjs'
Cannot find module '.../packages/nextly/dist/chunk-5YJCDDRX.mjs'
  imported from '.../packages/nextly/dist/index.mjs'
```

in packages the pull request never touched.

## The mechanism, with the evidence

**Six jobs across four workflows cache `.turbo` under one key**, `turbo-${{ runner.os }}-${{ github.sha }}`, with `restore-keys: turbo-${{ runner.os }}-`. On a pull request, `ci` (×2 jobs), `integration` (×2) and `preview` all run concurrently on the same commit — and they build **different filter sets**:

| job | builds |
| --- | --- |
| `ci` | `./packages/*` **and** `./apps/*` |
| `e2e` | `./packages/*` |
| `preview` | `./packages/*` |
| `integration`, `integration-sqlite` | five named packages |

One key, five concurrent writers, first one wins.

**The timestamps prove it happened.** #661's turbo cache was created at **11:12:36**. The `Preview release` workflow for that same commit ran 11:06:05→**11:12:39** — three seconds later. `CI` was still running (11:06:05→11:32:02) and had not reached its post step. The cache that `ci` later restored was written by `preview`.

A job then restores a `.turbo` shaped by someone else's build, reports `cache hit, replaying logs`, and lays down a `dist/` that does not contain what its own tests import. The failing build **never ran**: the log says `nextly:build → cache hit, replaying logs c587c5cd93b644a4`. Every package sets `clean: true`, so a build that *runs* cannot leave a partial `dist/` — which is what pointed at the cache in the first place.

And it cannot be cleared by hand: the key is the commit, so **re-running the failed job scores an exact hit on the same foreign entry**. That is the first thing anyone tries, and it is the one thing that cannot work.

## The fix

**Scope the key to the job** — `turbo-v2-${{ runner.os }}-${{ github.job }}-${{ github.sha }}`, restore-keys likewise. Each job restores its own lineage. Nothing is lost: a job's own previous runs are what its cache was ever useful for, and turbo entries are content-addressed, so a narrower cache is a slower run and never a wrong one.

**Split restore from save and gate the save on `success()`.** `actions/cache` saves in a post step that runs however the job ended; splitting is the supported way to make it conditional, now that `save-always` is deprecated. Independent of the sharing bug, and cheap.

**Bump the prefix to `turbo-v2-`.** Keys are immutable and `restore-keys` prefers the newest match, so the entries already written under the shared scheme would keep being selected. This retires them in one step and unblocks the PRs that are red right now.

The Playwright browser cache in `ci.yml` is deliberately untouched — it is keyed on the lockfile hash and is a different concern.

## A correction to my first pass

The first version of this PR blamed `cancel-in-progress` cancelling runs mid-build, and gated the save on that basis. Correlating every cache entry against its run showed caches being created **mid-run**, which cancellation does not explain and concurrent writers do. The save gating stayed because it is independently correct; the key scoping is the fix.

## Verification

- All four workflows parse. A structural check asserts, for each of the six jobs: exactly one restore and one save, save last in the job, identical keys, `path: .turbo`, `if: success()` present, and `${{ github.job }}` in both key and restore-keys.
- No monolithic `actions/cache@` remains for `.turbo`.

**No changeset** — CI-only, per AGENTS.md.
