### PR TITLE
ci(root): stop the test step rebuilding under running suites

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,9 +164,20 @@ jobs:
       #
       # ui / storage-s3 / storage-uploadthing have no test files yet; listed so
       # they gate automatically the moment they gain one.
+      # `--only` because the Build step above already built every package in this
+      # filter list. Without it turbo re-materialises each test's build
+      # dependencies from cache — 11 packages' `dist/` rewritten while sibling
+      # suites are already collecting against them. A test that resolves a
+      # dependency's entry mid-rewrite fails with `Cannot find module
+      # '.../dist/chunk-<hash>.mjs'` in a package the change never touched, and
+      # which package loses the race varies run to run.
+      #
+      # Safe because the filter list is a subset of `./packages/*`, which the
+      # Build step covers. A package added here but not built above would fail
+      # loudly at collection rather than silently skip.
       - name: Test
         run: >-
-          pnpm turbo test
+          pnpm turbo test --only
           --filter=@nextlyhq/blocks-engine
           --filter=@nextlyhq/blocks-react
           --filter=@nextlyhq/builder


### PR DESCRIPTION
PRs have been going red on `Lint / Typecheck / Test / Build` with errors like:

```
Cannot find module '.../packages/nextly/dist/chunk-OZJFLON7.mjs'
  imported from '.../packages/nextly/dist/index.mjs'
Failed to resolve entry for package "nextly".
```

in packages the change never touched, and in a *different* package each run.

## Cause, measured rather than argued

The `Test` step runs `pnpm turbo test --filter=…` **after** the `Build` step has already built every package. Because `test` declares `dependsOn: ["^build"]`, turbo re-materialises each test's build dependencies from cache — it rewrites their `dist/` directories while sibling suites are already collecting against them.

Measured on a fully built tree, three filters only:

| invocation | build replays triggered |
| --- | --- |
| `turbo test --filter=…` (what CI runs today) | **11** |
| `turbo test --only --filter=…` | **0** |

Eleven packages' `dist/` rewritten under running test processes. A suite that resolves a dependency's entry mid-rewrite sees `index.mjs` but not yet the chunk it imports. On a fast machine with a warm cache the window is tiny, which is why this never reproduces locally; in CI it is wide enough to lose, and which package loses varies run to run.

That accounts for every observation: no GitHub Actions cache is needed (a run with `Cache not found` failed identically), the missing artifact is logged as *built* minutes earlier, `main` sometimes gets lucky, and the failing package changes between runs.

## The fix

`--only` on the Test step: run the specified tasks, not their parents. The Build step immediately above already covers them.

Safe because the Test step's filter list is a subset of `./packages/*`, which the Build step builds. A package added to the test list but not built above would fail loudly at collection, not skip silently.

It composes with #651 rather than undoing it: `blocks-react` gains its build edge from `vitest.global-setup.ts` as well as from turbo, and that setup still runs.

## Scope, deliberately narrow

`integration.yml` has the same build-then-test shape and I did **not** change it. Those jobs are green today, I cannot run them locally without the database services, and changing something green on an analogy is how the last three attempts at this went wrong. If integration ever shows the symptom, the same one-word fix applies with its own evidence.

## Honesty about the path here

This is the fourth hypothesis for this failure. The first three — cancelled runs poisoning the turbo cache, concurrent workflows sharing a cache key, `tsup clean: true` racing a test — were each falsified by evidence, and one of them reached `main` as #667 before I could retract it. #667 is not harmful and its cache-save gating stands on its own, but it did not fix this.

What makes this one different is that it is measured, not inferred: 11 replays versus 0, on the same tree, one flag apart.

**No changeset** — CI-only, per AGENTS.md.
