### PR TITLE
fix(nextly): carry the API key's own scope into every access-bearing operation

### DIFF
--- a/.changeset/direct-api-actor-seam.md
+++ b/.changeset/direct-api-actor-seam.md
@@ -1,0 +1,27 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+---
+
+A scoped API key is now judged on its own grants for every Direct API collection and single operation, not just some of them. Previously a key holding only update access could read through operations that forwarded the caller identity without the key scope, because the service fell back to the permissions of the user who issued the key.

--- a/packages/nextly/src/direct-api/__tests__/access-options-forwarding.test.ts
+++ b/packages/nextly/src/direct-api/__tests__/access-options-forwarding.test.ts
@@ -115,6 +115,39 @@ describe("Direct API access-options forwarding", () => {
     );
   });
 
+  it("keeps the caller's access on the read-back after a where-clause update", async () => {
+    mocks.collectionsHandler.bulkUpdateByQuery.mockResolvedValue({
+      successCount: 1,
+      successes: [{ id: "1" }],
+      failures: [],
+    });
+    mocks.collectionsHandler.getEntry.mockResolvedValue({
+      success: true,
+      statusCode: 200,
+      message: "OK",
+      data: { id: "1" },
+    });
+
+    await nextly.update({
+      collection: "posts",
+      where: { title: { equals: "t" } },
+      data: { title: "u" },
+      actor: UPDATE_ONLY_KEY,
+      overrideAccess: false,
+    });
+
+    // The write is correctly scoped, then the result is read back through a
+    // nested Direct API call. That nested call re-enters `mergeConfig`, so
+    // omitting the caller's access silently restores `overrideAccess: true` and
+    // hands an update-scoped key a row it has no read grant for.
+    expect(mocks.collectionsHandler.getEntry).toHaveBeenCalledWith(
+      expect.objectContaining({
+        authenticatedScope: UPDATE_ONLY_KEY,
+        overrideAccess: false,
+      })
+    );
+  });
+
   it("leaves the scope undefined for a session caller", async () => {
     mocks.collectionsHandler.listEntries.mockResolvedValue({
       success: true,

--- a/packages/nextly/src/direct-api/__tests__/access-options-forwarding.test.ts
+++ b/packages/nextly/src/direct-api/__tests__/access-options-forwarding.test.ts
@@ -1,0 +1,134 @@
+/**
+ * The caller's own scope must arrive at the service, not merely be accepted.
+ *
+ * `accessOptions` is spread into each handler's argument object, and a spread
+ * is exempt from TypeScript's excess-property check — so if a receiving option
+ * type ever drops `authenticatedScope`, the field is discarded silently and the
+ * build stays green. These assertions read what the handler was actually called
+ * with, which is the only evidence that the scope travels.
+ *
+ * The scope under test grants `update-posts` and withholds `read-posts`, the
+ * shape that leaks: its owner CAN read, so a service resolving permissions from
+ * the owner answers yes to a key that was never granted the read.
+ */
+import { describe, it, expect, beforeEach, afterAll } from "vitest";
+
+import type { AuthenticatedScope } from "../../auth/authenticated-scope";
+import type { Nextly } from "../nextly";
+
+import {
+  setupTestNextly,
+  resetMocks,
+  type TestMocks,
+} from "./helpers/test-setup";
+
+const UPDATE_ONLY_KEY: AuthenticatedScope = {
+  actorType: "apiKey",
+  permissions: ["update-posts"],
+};
+
+describe("Direct API access-options forwarding", () => {
+  let nextly: Nextly;
+  let mocks: TestMocks;
+  let cleanup: () => void;
+
+  beforeEach(() => {
+    const setup = setupTestNextly();
+    nextly = setup.nextly;
+    mocks = setup.mocks;
+    cleanup = setup.cleanup;
+    resetMocks(mocks);
+  });
+
+  afterAll(() => {
+    cleanup?.();
+  });
+
+  it("carries the key's own scope into a list read", async () => {
+    mocks.collectionsHandler.listEntries.mockResolvedValue({
+      success: true,
+      statusCode: 200,
+      message: "OK",
+      data: { docs: [], totalDocs: 0, limit: 10, page: 1, totalPages: 1 },
+    });
+
+    await nextly.find({ collection: "posts", actor: UPDATE_ONLY_KEY });
+
+    expect(mocks.collectionsHandler.listEntries).toHaveBeenCalledWith(
+      expect.objectContaining({ authenticatedScope: UPDATE_ONLY_KEY })
+    );
+  });
+
+  it("carries the key's own scope into a by-id read", async () => {
+    mocks.collectionsHandler.getEntry.mockResolvedValue({
+      success: true,
+      statusCode: 200,
+      message: "OK",
+      data: { id: "1" },
+    });
+
+    await nextly.findByID({
+      collection: "posts",
+      id: "1",
+      actor: UPDATE_ONLY_KEY,
+    });
+
+    expect(mocks.collectionsHandler.getEntry).toHaveBeenCalledWith(
+      expect.objectContaining({ authenticatedScope: UPDATE_ONLY_KEY })
+    );
+  });
+
+  it("carries the key's own scope into a count", async () => {
+    mocks.collectionsHandler.countEntries.mockResolvedValue({
+      success: true,
+      statusCode: 200,
+      message: "OK",
+      data: { count: 0 },
+    });
+
+    await nextly.count({ collection: "posts", actor: UPDATE_ONLY_KEY });
+
+    expect(mocks.collectionsHandler.countEntries).toHaveBeenCalledWith(
+      expect.objectContaining({ authenticatedScope: UPDATE_ONLY_KEY })
+    );
+  });
+
+  it("carries the key's own scope into a write", async () => {
+    mocks.collectionsHandler.createEntry.mockResolvedValue({
+      success: true,
+      statusCode: 201,
+      message: "OK",
+      data: { id: "1" },
+    });
+
+    await nextly.create({
+      collection: "posts",
+      data: { title: "t" },
+      actor: UPDATE_ONLY_KEY,
+    });
+
+    // The write path matters as much as the read: the leak is symmetric, and a
+    // key whose scope is dropped on create is judged by its owner there too.
+    expect(mocks.collectionsHandler.createEntry).toHaveBeenCalledWith(
+      expect.objectContaining({ authenticatedScope: UPDATE_ONLY_KEY }),
+      expect.anything()
+    );
+  });
+
+  it("leaves the scope undefined for a session caller", async () => {
+    mocks.collectionsHandler.listEntries.mockResolvedValue({
+      success: true,
+      statusCode: 200,
+      message: "OK",
+      data: { docs: [], totalDocs: 0, limit: 10, page: 1, totalPages: 1 },
+    });
+
+    await nextly.find({ collection: "posts" });
+
+    // Not merely "absent": a session caller must reach the service with no
+    // scope at all, so it resolves its grants the normal way. A stray empty
+    // scope would read as an API key holding nothing and deny everything.
+    const [call] = mocks.collectionsHandler.listEntries.mock.calls;
+    expect(call[0].authenticatedScope).toBeUndefined();
+  });
+});

--- a/packages/nextly/src/direct-api/__tests__/access-options-seam.test.ts
+++ b/packages/nextly/src/direct-api/__tests__/access-options-seam.test.ts
@@ -1,0 +1,77 @@
+/**
+ * The access-bearing fields must travel together, at every namespace operation.
+ *
+ * A service handed `user` without `authenticatedScope` resolves a scoped API
+ * key's permissions from its OWNER, so an update-only key issued by someone who
+ * can read is allowed to read. Spreading `accessOptions(config)` keeps the two
+ * inseparable; writing them inline is what let three of thirteen operations
+ * carry the scope while the rest silently authorized the key as its owner.
+ *
+ * TypeScript cannot catch the regression: a spread into an object literal is
+ * exempt from excess-property checking, and an omitted optional field is not an
+ * error either, so both directions of this mistake compile clean.
+ */
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const NAMESPACE_DIR = join(__dirname, "..", "namespaces");
+
+/**
+ * `helpers.ts` sits in this directory but exposes no operations — it is where
+ * `accessOptions` reads the config fields, and so the one place the inline pair
+ * is the definition rather than a bypass of it.
+ */
+const SEAM_DEFINITION = "helpers.ts";
+
+function namespaceSources(): { name: string; text: string }[] {
+  return readdirSync(NAMESPACE_DIR)
+    .filter(
+      name =>
+        name.endsWith(".ts") &&
+        !name.endsWith(".test.ts") &&
+        name !== SEAM_DEFINITION
+    )
+    .map(name => ({
+      name,
+      text: readFileSync(join(NAMESPACE_DIR, name), "utf8"),
+    }));
+}
+
+describe("the Direct API access seam", () => {
+  it("is exercised — there are namespace sources to scan", () => {
+    // Without this the two assertions below pass against an empty list, which
+    // is the shape of a guard that reports success because it found nothing.
+    const sources = namespaceSources();
+    expect(sources.length).toBeGreaterThan(5);
+    expect(sources.map(s => s.name)).toContain("collections.ts");
+  });
+
+  it("is the only way a namespace forwards the caller's identity", () => {
+    const offenders = namespaceSources()
+      .filter(({ text }) => /\buser:\s*config\.user\b/.test(text))
+      .map(({ name }) => name);
+
+    expect(
+      offenders,
+      "these namespaces forward `user` inline, so a scoped API key reaches the " +
+        "service without its own grants and is judged by its owner's. Spread " +
+        "`accessOptions(config)` instead."
+    ).toEqual([]);
+  });
+
+  it("is the only way a namespace forwards the access override", () => {
+    const offenders = namespaceSources()
+      .filter(({ text }) =>
+        /\boverrideAccess:\s*config\.overrideAccess\b/.test(text)
+      )
+      .map(({ name }) => name);
+
+    expect(
+      offenders,
+      "these namespaces forward `overrideAccess` inline; it belongs with the " +
+        "identity fields in `accessOptions(config)` so the three cannot drift."
+    ).toEqual([]);
+  });
+});

--- a/packages/nextly/src/direct-api/__tests__/access-options-seam.test.ts
+++ b/packages/nextly/src/direct-api/__tests__/access-options-seam.test.ts
@@ -61,6 +61,23 @@ describe("the Direct API access seam", () => {
     ).toEqual([]);
   });
 
+  it("is the only way a namespace forwards the caller's scope onward", () => {
+    // The nested-call direction. One namespace operation calling another must
+    // hand over `actor` through `callerAccess`, because a nested call that omits
+    // it re-enters `mergeConfig` and inherits `overrideAccess: true` from the
+    // instance defaults — discarding the caller's restrictions rather than
+    // keeping them.
+    const offenders = namespaceSources()
+      .filter(({ text }) => /\bactor:\s*config\.actor\b/.test(text))
+      .map(({ name }) => name);
+
+    expect(
+      offenders,
+      "these namespaces forward `actor` inline to a nested Direct API call; " +
+        "spread `callerAccess(config)` so the whole caller identity travels."
+    ).toEqual([]);
+  });
+
   it("is the only way a namespace forwards the access override", () => {
     const offenders = namespaceSources()
       .filter(({ text }) =>

--- a/packages/nextly/src/direct-api/namespaces/collections.ts
+++ b/packages/nextly/src/direct-api/namespaces/collections.ts
@@ -34,6 +34,7 @@ import type { NextlyContext } from "./context";
 import {
   accessOptions,
   buildMutationMessage,
+  callerAccess,
   createErrorFromResult,
   isNotFoundError,
   mergeConfig,
@@ -269,6 +270,11 @@ export async function update<TSlug extends CollectionSlug>(
     const updated = await findByID<TSlug>(ctx, {
       collection: args.collection,
       id: (bulkResult.successes[0] as { id: string }).id,
+      // The read-back is the caller's read, not the system's. Without these it
+      // re-enters `mergeConfig` and picks up the instance default of
+      // `overrideAccess: true`, handing an update-scoped caller a row it has no
+      // read grant for, with every field-level restriction skipped.
+      ...callerAccess(config),
     });
 
     if (!updated) {

--- a/packages/nextly/src/direct-api/namespaces/collections.ts
+++ b/packages/nextly/src/direct-api/namespaces/collections.ts
@@ -32,6 +32,7 @@ import type {
 
 import type { NextlyContext } from "./context";
 import {
+  accessOptions,
   buildMutationMessage,
   createErrorFromResult,
   isNotFoundError,
@@ -66,8 +67,7 @@ export async function find<TSlug extends CollectionSlug>(
     select: args.select,
     sort: args.sort,
     richTextFormat: config.richTextFormat,
-    overrideAccess: config.overrideAccess,
-    user: config.user,
+    ...accessOptions(config),
     // i18n M4: forward the content locale + fallback so localized fields resolve.
     locale: config.locale,
     fallbackLocale: config.fallbackLocale,
@@ -118,8 +118,7 @@ export async function findByID<TSlug extends CollectionSlug>(
       depth: config.depth,
       select: args.select,
       richTextFormat: config.richTextFormat,
-      overrideAccess: config.overrideAccess,
-      user: config.user,
+      ...accessOptions(config),
       // Overlay the pending working draft when the caller opts in; the service
       // still gates it on an update-capability probe.
       includeWorkingDraft: args.draft,
@@ -163,8 +162,7 @@ export async function create<TSlug extends CollectionSlug>(
     ctx.collectionsHandler.createEntry(
       {
         collectionName: args.collection,
-        overrideAccess: config.overrideAccess,
-        user: config.user,
+        ...accessOptions(config),
         // Forward the content locale so a localized write lands in the
         // requested language's companion row, not the default locale's.
         locale: config.locale,
@@ -215,8 +213,7 @@ export async function update<TSlug extends CollectionSlug>(
         {
           collectionName: args.collection,
           entryId,
-          overrideAccess: config.overrideAccess,
-          user: config.user,
+          ...accessOptions(config),
           // Forward the content locale so a localized update targets the requested
           // language's companion row, not the default locale's.
           locale: config.locale,
@@ -248,8 +245,7 @@ export async function update<TSlug extends CollectionSlug>(
           collectionName: args.collection,
           where,
           data: args.data,
-          overrideAccess: config.overrideAccess,
-          user: config.user,
+          ...accessOptions(config),
           context: config.context,
           disableRevalidate: config.disableRevalidate,
         },
@@ -328,8 +324,7 @@ export async function deleteEntry<
       ctx.collectionsHandler.deleteEntry({
         collectionName: args.collection,
         entryId,
-        overrideAccess: config.overrideAccess,
-        user: config.user,
+        ...accessOptions(config),
         context: config.context,
         disableRevalidate: config.disableRevalidate,
       })
@@ -355,8 +350,7 @@ export async function deleteEntry<
         {
           collectionName: args.collection,
           where,
-          overrideAccess: config.overrideAccess,
-          user: config.user,
+          ...accessOptions(config),
           context: config.context,
           disableRevalidate: config.disableRevalidate,
         },
@@ -401,8 +395,7 @@ export async function count(
   const result = await ctx.collectionsHandler.countEntries({
     collectionName: args.collection,
     where: args.where,
-    overrideAccess: config.overrideAccess,
-    user: config.user,
+    ...accessOptions(config),
     // i18n M4: parity with find() so locale-scoped counts match.
     locale: config.locale,
     fallbackLocale: config.fallbackLocale,
@@ -432,8 +425,7 @@ export async function bulkDelete(
     ctx.collectionsHandler.bulkDeleteEntries({
       collectionName: args.collection,
       ids: args.ids,
-      overrideAccess: config.overrideAccess,
-      user: config.user,
+      ...accessOptions(config),
       context: config.context,
       disableRevalidate: config.disableRevalidate,
     })
@@ -468,8 +460,7 @@ export async function duplicate<TSlug extends CollectionSlug>(
       collectionName: args.collection,
       entryId: args.id,
       overrides: args.overrides,
-      overrideAccess: config.overrideAccess,
-      user: config.user,
+      ...accessOptions(config),
       context: config.context,
       disableRevalidate: config.disableRevalidate,
     })

--- a/packages/nextly/src/direct-api/namespaces/helpers.ts
+++ b/packages/nextly/src/direct-api/namespaces/helpers.ts
@@ -59,7 +59,7 @@ export interface AccessOptions {
  *
  * Spread this rather than listing the fields inline: an operation that forwards
  * `user` but not `authenticatedScope` compiles, runs, and silently authorizes
- * the key as its owner. `no-inline-access-options.test.ts` fails the build if a
+ * the key as its owner. `access-options-seam.test.ts` fails the build if a
  * namespace hand-writes them instead.
  */
 export function accessOptions(config: DirectAPIConfig): AccessOptions {

--- a/packages/nextly/src/direct-api/namespaces/helpers.ts
+++ b/packages/nextly/src/direct-api/namespaces/helpers.ts
@@ -9,6 +9,7 @@
  * @packageDocumentation
  */
 
+import type { AuthenticatedScope } from "../../auth/authenticated-scope";
 import { errorFromServiceEnvelope } from "../../errors/from-service-envelope";
 import { NextlyError } from "../../errors/nextly-error";
 import type { RequestContext } from "../../shared/types/index";
@@ -19,6 +20,7 @@ import type {
   Permission,
   Role,
   SingleDefinition,
+  UserContext,
 } from "../types/index";
 
 /**
@@ -34,6 +36,37 @@ export function mergeConfig<T extends DirectAPIConfig>(
   return {
     ...defaultConfig,
     ...args,
+  };
+}
+
+/**
+ * Every field a service needs to decide whether this caller may see a row.
+ */
+export interface AccessOptions {
+  user?: UserContext;
+  overrideAccess?: boolean;
+  authenticatedScope?: AuthenticatedScope;
+}
+
+/**
+ * The access-bearing fields of a Direct API call, as one spreadable object.
+ *
+ * `user` says WHO is calling; `authenticatedScope` says what kind of caller and
+ * which grants the API KEY itself carries, which is what stops an update-only
+ * key from reading on the strength of its owner's permissions. The two travel
+ * together because a service that receives one without the other judges a
+ * scoped key by its owner — the exact leak this exists to close.
+ *
+ * Spread this rather than listing the fields inline: an operation that forwards
+ * `user` but not `authenticatedScope` compiles, runs, and silently authorizes
+ * the key as its owner. `no-inline-access-options.test.ts` fails the build if a
+ * namespace hand-writes them instead.
+ */
+export function accessOptions(config: DirectAPIConfig): AccessOptions {
+  return {
+    user: config.user,
+    overrideAccess: config.overrideAccess,
+    authenticatedScope: config.actor,
   };
 }
 

--- a/packages/nextly/src/direct-api/namespaces/helpers.ts
+++ b/packages/nextly/src/direct-api/namespaces/helpers.ts
@@ -71,6 +71,30 @@ export function accessOptions(config: DirectAPIConfig): AccessOptions {
 }
 
 /**
+ * The same three fields, for one namespace operation calling another.
+ *
+ * A nested Direct API call re-enters `mergeConfig`, so anything the caller
+ * leaves out is filled from the instance defaults — and `overrideAccess`
+ * defaults to `true`. An operation that omits these does not inherit the
+ * caller's restrictions, it discards them: a key scoped to update a row could
+ * update it under its own grants and then read the result back with access
+ * checks off entirely, past field redaction it was never allowed to see.
+ *
+ * Distinct from `accessOptions` because the boundary is different. A service
+ * takes the caller's scope as `authenticatedScope`; a Direct API operation
+ * takes it as `actor` and translates it itself.
+ */
+export function callerAccess(
+  config: DirectAPIConfig
+): Pick<DirectAPIConfig, "user" | "overrideAccess" | "actor"> {
+  return {
+    user: config.user,
+    overrideAccess: config.overrideAccess,
+    actor: config.actor,
+  };
+}
+
+/**
  * Build a RequestContext for downstream services from a Direct API call.
  *
  * Maps the narrow `DirectAPIConfig.user` shape to the richer `RequestContext`

--- a/packages/nextly/src/direct-api/namespaces/singles.ts
+++ b/packages/nextly/src/direct-api/namespaces/singles.ts
@@ -21,6 +21,7 @@ import type {
 
 import type { NextlyContext } from "./context";
 import {
+  accessOptions,
   buildMutationMessage,
   createErrorFromSingleResult,
   mergeConfig,
@@ -42,8 +43,7 @@ export async function findSingle<TSlug extends SingleSlug>(
     // field falls back to the default language, and a rule keyed on it sees
     // `undefined` when it is dropped here.
     fallbackLocale: config.fallbackLocale,
-    user: config.user,
-    overrideAccess: config.overrideAccess,
+    ...accessOptions(config),
     context: config.context,
   });
 
@@ -87,8 +87,7 @@ export async function updateSingle<TSlug extends SingleSlug>(
   const { result, warnings } = await collectingWarnings(() =>
     ctx.singleEntryService.update(args.slug, args.data, {
       locale: config.locale,
-      user: config.user,
-      overrideAccess: config.overrideAccess,
+      ...accessOptions(config),
       context: config.context,
       disableRevalidate: config.disableRevalidate,
     })
@@ -129,8 +128,7 @@ export async function findSingles(
         depth: config.depth,
         locale: config.locale,
         fallbackLocale: config.fallbackLocale,
-        user: config.user,
-        overrideAccess: config.overrideAccess,
+        ...accessOptions(config),
         context: config.context,
       });
 

--- a/packages/nextly/src/direct-api/types/shared.ts
+++ b/packages/nextly/src/direct-api/types/shared.ts
@@ -8,6 +8,7 @@
  */
 
 import type { PaginationMeta } from "../../api/response-shapes";
+import type { AuthenticatedScope } from "../../auth/authenticated-scope";
 import type { HookWarning } from "../../hooks/side-effect-warnings";
 import type { RichTextOutputFormat } from "../../lib/rich-text-html";
 
@@ -405,6 +406,19 @@ export interface DirectAPIConfig {
    * and role for permission checks.
    */
   user?: UserContext;
+
+  /**
+   * The authenticated caller's own scope, when it is an API key.
+   *
+   * Distinct from `user`, which says WHO the caller is. This says what KIND of
+   * caller it is and which grants the key itself carries. A scoped key is
+   * authorized on its own stamped permissions, not its owner's, so without this
+   * an update-only key issued by a reader-plus-publisher is judged by the
+   * owner's grants and reads what it was never given.
+   *
+   * Leave unset for session and system callers; they resolve grants normally.
+   */
+  actor?: AuthenticatedScope;
 
   /**
    * Request context passed to hooks.


### PR DESCRIPTION
## The leak

A scoped API key is authorized on its **own** stamped grants, not its owner's. The Direct API forwarded only `user` to the services that decide what a caller may see, so a key holding `update-posts` but **not** `read-posts`, issued by someone who can read, was judged by its owner and read what it was never granted.

The leak direction matters: a test asserting "the key is denied something it should not have" goes green against the broken code, because the owner's grants happen to allow it. What is wrong is that the key is still **granted** something only the owner had.

## Why a seam rather than thirteen edits

Each access-bearing operation in `collections.ts` and `singles.ts` hand-built its service-options object, so the scope had to be remembered thirteen separate times. Forwarding it per call site is what produced two consecutive P1s on #601: the option existed, three operations honoured it, and the rest silently authorized the key as its owner. **A shared security option honoured by only some operations is a false promise, worse than its absence.**

All thirteen now spread one `accessOptions(config)` carrying `user`, `overrideAccess` and `authenticatedScope` together.

## A correction to the plan this PR was scoped from

The plan of record said to fix this at `createRequestContext` in `helpers.ts`, where "all 19 `mergeConfig()` call sites across seven namespaces inherit it by construction". **Measured, both halves were false:**

```
namespace      mergeConfig  createRequestContext  user: config.user
collections         8              0                    10
singles             3              0                     3
email               4              0                     0
users               1              6                     0
forms               1              0                     0
field-groups        1              0                     0
media               1              9                     0
```

`createRequestContext` is called only by `users.ts` and `media.ts` — **zero** calls in the two namespaces that needed the fix. And neither `userService` nor `mediaService` accepts `authenticatedScope` at all, so wiring it there would have carried the scope into two services that ignore it.

The error was counting `mergeConfig` and reporting it as the access-bearing count. They are different populations: `email`, `forms` and `field-groups` call `mergeConfig` and never pass `user` anywhere. Real scope: **13 sites in 2 files**.

## The trap this had to survive

**A spread into an object literal is exempt from TypeScript's excess-property check.** `...accessOptions(config)` into a handler whose option type lacked `authenticatedScope` would compile clean and drop the field. An omitted optional field is not an error either — so *both* directions of this mistake typecheck.

Two tests close that, because the compiler cannot:

- **`access-options-seam.test.ts`** scans the namespace sources and fails if any operation hand-writes `user: config.user` or `overrideAccess: config.overrideAccess`, so operation fourteen cannot forget. It carries a precondition assertion first, so it cannot pass by finding nothing.
- **`access-options-forwarding.test.ts`** reads what the handler was actually *called* with, across a list read, a by-id read, a count and a write, plus a control pinning that a session caller still arrives with **no** scope rather than an empty one (an empty scope reads as a key holding nothing and would deny everything).

The receiving types already accept the scope all the way down: `CollectionsHandler` has 20 references to `authenticatedScope`, `collection-query-service` 18. Only this forwarding was missing.

## Verification

- `pnpm run check-types` (both tsc configs) exits 0.
- Both new suites stub-verified. Removing `authenticatedScope` from the seam fails **4 of 5** forwarding tests, and the 5th — the session control — correctly keeps passing. Reintroducing one inline site fails the seam guard, naming `collections.ts`, while its precondition test still passes.
- `src/direct-api` has **4 pre-existing failures** (2 in `collections.test.ts`, 2 in `media.test.ts`). A/B confirmed: the identical 4 fail with the directory checked out from `origin/main`, so they are the known baseline and not introduced here.

## Relationship to #601

This is the `actor` half, split out of #601 so that PR does not merge carrying a security option honoured by 3 of 19 operations. #601's API-key finding depends on this landing. **#601's relationship-expansion finding (finding 6) is deferred to task 186**, owned by the read-path lane, so we do not ship two contradicting bounds.
