### PR TITLE
fix(nextly): ask one rule whether a unique column can be an index

### DIFF
--- a/.changeset/uniqueness-described-once.md
+++ b/.changeset/uniqueness-described-once.md
@@ -1,0 +1,27 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+---
+
+Schema Builder: a unique column that a database cannot index is no longer described two different ways. The rule deciding whether uniqueness is a named index or an inline constraint now lives in one place and is asked by the create path, the add-column path and the desired schema alike, so a reconcile no longer proposes a unique index the server refuses.

--- a/packages/nextly/src/domains/dynamic-collections/__tests__/alter-column-attachments.test.ts
+++ b/packages/nextly/src/domains/dynamic-collections/__tests__/alter-column-attachments.test.ts
@@ -193,6 +193,21 @@ describe.each(DIALECTS)(
         svc.generateMigrationSQL(TABLE, [definition]),
         column
       );
+      // A uniqueness the dialect cannot enforce has no agreeing pair to compare: CREATE writes
+      // it inline and the server rejects the whole statement, while ADD refuses before emitting
+      // anything. Both refuse to install a column without its guarantee; they simply refuse at
+      // different moments, so there are no attachments to line up.
+      if (
+        definition.unique === true &&
+        refusalMessages(() =>
+          svc.generateAlterTableMigration(TABLE, [], [definition], {
+            tableHasRows: false,
+          })
+        ).length > 0
+      ) {
+        return;
+      }
+
       const added = alterAttachments(
         svc.generateAlterTableMigration(TABLE, [], [definition], {
           tableHasRows: false,
@@ -251,13 +266,26 @@ describe("the attachments the ADD path used to lose", () => {
   it.each(DIALECTS)(
     "still applies an EXPLICIT unique flag, which the desired schema does model (%s)",
     dialect => {
-      const sql = service(dialect).generateAlterTableMigration(
-        TABLE,
-        [],
-        [field({ name: "sku", type: "text", unique: true })],
-        { tableHasRows: false }
-      );
-      expect(alterAttachments(sql, "sku").unique).toBe(true);
+      const add = () =>
+        service(dialect).generateAlterTableMigration(
+          TABLE,
+          [],
+          [field({ name: "sku", type: "text", unique: true })],
+          { tableHasRows: false }
+        );
+
+      // MySQL renders an unbounded `text` field as TEXT, which it can key in neither spelling.
+      // Because it commits each DDL statement separately, attempting the column and then its
+      // constraint would leave the column WITHOUT the guarantee, so the add is refused outright
+      // rather than half-applied. The other dialects key it and attach the constraint.
+      if (dialect === "mysql") {
+        const reported = refusalMessages(add);
+        expect(reported).toHaveLength(1);
+        expect(reported[0]).toContain("UNIQUE_NOT_ENFORCEABLE_ON_DIALECT");
+        return;
+      }
+
+      expect(alterAttachments(add(), "sku").unique).toBe(true);
     }
   );
 

--- a/packages/nextly/src/domains/dynamic-collections/services/__tests__/__snapshots__/builder-ddl-characterization.test.ts.snap
+++ b/packages/nextly/src/domains/dynamic-collections/services/__tests__/__snapshots__/builder-ddl-characterization.test.ts.snap
@@ -627,46 +627,6 @@ CREATE INDEX IF NOT EXISTS "idx_dc_tags_single_pinned_tags_single_pinned" ON "dc
 CREATE INDEX IF NOT EXISTS "idx_dc_tags_single_pinned_tags_tags" ON "dc_tags_single_pinned_tags"("tags_id");"
 `;
 
-exports[`field group DDL — pinned as it is today > mysql > emits the same CREATE for a field group 1`] = `
-"-- Create component data table: comp_pinned
-CREATE TABLE IF NOT EXISTS \`comp_pinned\` (
-  \`id\` varchar(36) PRIMARY KEY NOT NULL,
-  \`_parent_id\` varchar(36) NOT NULL,
-  \`_parent_table\` VARCHAR(255) NOT NULL,
-  \`_parent_field\` VARCHAR(255) NOT NULL,
-  \`_order\` INT DEFAULT 0,
-  \`_component_type\` VARCHAR(255),
-  \`title\` TEXT NOT NULL,
-  \`slug_key\` TEXT,
-  \`short_code\` VARCHAR(120),
-  \`summary\` TEXT,
-  \`views\` INT,
-  \`rating\` DOUBLE,
-  \`published\` BOOLEAN,
-  \`published_at\` DATETIME,
-  \`payload\` JSON,
-  \`lookup_code\` TEXT,
-  \`author\` VARCHAR(36),
-  \`editors\` JSON,
-  \`tags\` VARCHAR(36),
-  \`state\` BOOLEAN DEFAULT true,
-  \`blocks\` JSON,
-  \`meta\` JSON,
-  \`created_at\` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  \`updated_at\` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
-);
---> statement-breakpoint
-CREATE INDEX \`idx_comp_pinned_parent\` ON \`comp_pinned\`(\`_parent_id\`, \`_parent_table\`, \`_parent_field\`);
---> statement-breakpoint
-CREATE INDEX \`idx_comp_pinned_author\` ON \`comp_pinned\`(\`author\`);
---> statement-breakpoint
-CREATE INDEX \`idx_comp_pinned_tags\` ON \`comp_pinned\`(\`tags\`);
---> statement-breakpoint
-CREATE INDEX \`idx_comp_pinned_lookup_code\` ON \`comp_pinned\`(\`lookup_code\`);
---> statement-breakpoint
-CREATE UNIQUE INDEX \`uq_comp_pinned_slug_key\` ON \`comp_pinned\`(\`slug_key\`);"
-`;
-
 exports[`field group DDL — pinned as it is today > mysql > emits the same CREATE for a localized field group 1`] = `
 "-- Create component data table: comp_pinned
 CREATE TABLE IF NOT EXISTS \`comp_pinned\` (

--- a/packages/nextly/src/domains/dynamic-collections/services/__tests__/builder-ddl-characterization.test.ts
+++ b/packages/nextly/src/domains/dynamic-collections/services/__tests__/builder-ddl-characterization.test.ts
@@ -172,12 +172,23 @@ describe("field group DDL — pinned as it is today", () => {
     // discriminator — rather than a collection's, and a separate generator renders them. Its output
     // is recorded for the same reason and to the same depth.
     it("emits the same CREATE for a field group", () => {
-      const sql = new FieldGroupSchemaService(dialect).generateMigrationSQL(
-        "comp_pinned",
-        FIELD_GROUP_FIELDS as unknown as FieldConfig[]
-      );
+      const generate = () =>
+        new FieldGroupSchemaService(dialect).generateMigrationSQL(
+          "comp_pinned",
+          FIELD_GROUP_FIELDS as unknown as FieldConfig[]
+        );
 
-      expect(sql.trim()).toMatchSnapshot();
+      // The fixture carries a unique unbounded text field. A component's uniqueness is a
+      // SEPARATE `CREATE UNIQUE INDEX`, not an inline constraint, so on MySQL — which can key
+      // neither spelling of TEXT — the table would be created and then the index rejected,
+      // leaving a component without the guarantee it declared. There is no DDL to pin for that
+      // combination; the honest output is a refusal, so that is what is recorded.
+      if (dialect === "mysql") {
+        expect(generate).toThrow(/Validation failed/);
+        return;
+      }
+
+      expect(generate().trim()).toMatchSnapshot();
     });
 
     it("emits the same CREATE for a localized field group", () => {

--- a/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-schema-service.ts
+++ b/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-schema-service.ts
@@ -47,6 +47,7 @@ import {
   columnTypeIsIndexable,
   indexNameForColumn,
   uniqueIndexNameForColumn,
+  uniquenessCanBeAnIndex,
 } from "../../schema/services/index-name";
 import { quoteJsonSqlDefault } from "../../schema/utils/sql-literal";
 
@@ -162,25 +163,18 @@ export class DynamicCollectionSchemaService {
   /**
    * Whether this dialect can carry the uniqueness as a NAMED index on this column.
    *
-   * MySQL cannot key a `TEXT`/`BLOB` column without a length, and refuses both spellings alike —
-   * the inline constraint and the index. Such a column keeps the inline form, which fails the
-   * CREATE atomically exactly as it always has, rather than creating the table and then failing on
-   * a separate index statement MySQL has already auto-committed past.
+   * Delegates to the shared rule rather than restating it. This class, the add-column path and the
+   * desired schema all decide the same thing about the same column, and a copy here that agreed on
+   * the day it was written would drift silently — both spellings look correct in isolation, and
+   * the disagreement only shows up as a diff proposing an index the generator never writes.
    *
-   * Bounding the column would make it work, and is the right answer, but it belongs in the shared
-   * column descriptor: bounding it HERE alone makes the created column disagree with the type the
-   * desired schema derives, and the next reconciliation tries to convert it back — which MySQL
-   * cannot do while a full-value unique index stands on it.
+   * Bounding a MySQL text column would make it keyable, and is the right end state, but it belongs
+   * in the shared column descriptor: bounding it HERE alone makes the created column disagree with
+   * the type the desired schema derives, and the next reconciliation tries to convert it back —
+   * which MySQL cannot do while a full-value unique index stands on it.
    */
   private uniquenessCanBeAnIndex(rendered: string): boolean {
-    // Asked through the shared indexability rule before anything local: a type the dialect cannot
-    // index AT ALL cannot carry the uniqueness as an index either. MySQL rejects an index on a
-    // JSON column, so a `json`-backed unique field belongs with the inline form for the same
-    // reason TEXT does — and answering that here rather than restating the rule keeps this from
-    // being a second opinion about which columns MySQL can key.
-    if (!columnTypeIsIndexable(rendered, this.dialect)) return false;
-    if (this.dialect !== "mysql") return true;
-    return !/\b(text|blob|longtext|mediumtext|tinytext)\b/i.test(rendered);
+    return uniquenessCanBeAnIndex(rendered, this.dialect);
   }
 
   /**

--- a/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-schema-service.ts
+++ b/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-schema-service.ts
@@ -929,6 +929,34 @@ ${allColumnDefs.join(",\n")}
             });
           }
         }
+        // Uniqueness this dialect cannot enforce is refused BEFORE any statement is generated,
+        // not attempted and left half-done. MySQL commits each DDL statement on its own, so
+        // emitting the column and then a constraint it rejects leaves the column in place
+        // WITHOUT the guarantee — and a bare column matches what the desired schema declares for
+        // an unkeyable type, so the next reconcile sees nothing wrong and the uniqueness is
+        // silently gone. There is no spelling that works here: MySQL refuses to key an unbounded
+        // TEXT/BLOB either way, and cannot index JSON at all. Saying so is the only honest
+        // outcome, and saying it first is what keeps the table untouched.
+        if (field.unique && !this.uniquenessCanBeAnIndex(type)) {
+          throw NextlyError.validation({
+            errors: [
+              {
+                path: `fields.${field.name}`,
+                code: "UNIQUE_NOT_ENFORCEABLE_ON_DIALECT",
+                message:
+                  `"${field.name}" is marked unique, but ${this.dialect} cannot enforce ` +
+                  `uniqueness on a ${field.type} column. Give it a maximum length so it becomes ` +
+                  `a bounded string, or remove the unique flag.`,
+              },
+            ],
+            logContext: {
+              tableName,
+              field: field.name,
+              type: field.type,
+              dialect: this.dialect,
+            },
+          });
+        }
         statements.push(
           `ALTER TABLE ${this.quoteIdentifier(tableName)} ADD COLUMN ${this.quoteIdentifier(addColName)} ${type} ${nullable} ${defaultVal};`.trim()
         );

--- a/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-schema-service.ts
+++ b/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-schema-service.ts
@@ -945,8 +945,9 @@ ${allColumnDefs.join(",\n")}
                 code: "UNIQUE_NOT_ENFORCEABLE_ON_DIALECT",
                 message:
                   `"${field.name}" is marked unique, but ${this.dialect} cannot enforce ` +
-                  `uniqueness on a ${field.type} column. Give it a maximum length so it becomes ` +
-                  `a bounded string, or remove the unique flag.`,
+                  `uniqueness on a ${field.type} column. Store the value in a short-variant ` +
+                  `text field, which becomes a bounded VARCHAR the server can key, or remove ` +
+                  `the unique flag.`,
               },
             ],
             logContext: {

--- a/packages/nextly/src/domains/field-groups/services/field-group-schema-service.ts
+++ b/packages/nextly/src/domains/field-groups/services/field-group-schema-service.ts
@@ -729,8 +729,8 @@ export class FieldGroupSchemaService {
           code: "UNIQUE_NOT_ENFORCEABLE_ON_DIALECT",
           message:
             `"${name}" is marked unique, but ${this.dialect} cannot enforce uniqueness on a ` +
-            `${type} column. Give it a maximum length so it becomes a bounded string, or ` +
-            `remove the unique flag.`,
+            `${type} column. Store the value in a short-variant text field, which becomes a ` +
+            `bounded VARCHAR the server can key, or remove the unique flag.`,
         },
       ],
       logContext: { tableName, field: name, type, dialect: this.dialect },

--- a/packages/nextly/src/domains/field-groups/services/field-group-schema-service.ts
+++ b/packages/nextly/src/domains/field-groups/services/field-group-schema-service.ts
@@ -61,6 +61,7 @@ import type {
   DataFieldConfig,
   NumberFieldConfig,
 } from "../../../collections/fields/types";
+import { NextlyError } from "../../../errors";
 import { env } from "../../../lib/env";
 import { STORAGE_FORMAT } from "../../../schemas/storage-format";
 import { pluginEmptyColumnDefault } from "../../../shared/lib/plugin-storage";
@@ -69,6 +70,7 @@ import {
   DEFAULT_DECIMAL_PRECISION,
   DEFAULT_DECIMAL_SCALE,
 } from "../../schema/services/field-column-descriptor";
+import { uniquenessCanBeAnIndex } from "../../schema/services/index-name";
 import {
   isPluginDataField,
   pluginStorageFieldType,
@@ -327,6 +329,12 @@ export class FieldGroupSchemaService {
       const columnName = this.toSnakeCase(field.name);
       const indexName = `uq_${tableName}_${columnName}`;
 
+      // Asked through the same rule the collection generators and the desired schema use. A
+      // dialect that cannot key the column cannot carry the uniqueness as an index, and emitting
+      // one anyway installs the table and then fails on a statement it has already committed
+      // past — leaving a component without the guarantee it declared.
+      this.assertUniquenessEnforceable(field, tableName);
+
       if (this.dialect === "mysql") {
         indexStatements.push(
           `CREATE UNIQUE INDEX ${this.q}${indexName}${this.q} ON ${this.q}${tableName}${this.q}(${this.q}${columnName}${this.q});`
@@ -392,6 +400,14 @@ export class FieldGroupSchemaService {
         // its own name, and `mapped` has already replaced that with the storage
         // primitive.
         defaultVal = `DEFAULT ${this.getDefaultValueForType(mapped.type, field)}`;
+      }
+
+      // Refused BEFORE the column statement, not after it. MySQL commits each DDL statement on
+      // its own, so adding the column and then failing on its constraint leaves the column in
+      // place without the guarantee — and a bare column is what the desired schema declares for
+      // an unkeyable type, so the next reconcile sees nothing to fix.
+      if ("unique" in field && field.unique) {
+        this.assertUniquenessEnforceable(field, tableName);
       }
 
       statements.push(
@@ -685,6 +701,42 @@ export class FieldGroupSchemaService {
    * `getColumnDescriptor` makes for collections and singles, so a component
    * column matches what the schema pipeline creates for it.
    */
+  /**
+   * Refuse a `unique` field the dialect cannot enforce, before any DDL is generated for it.
+   *
+   * Asks the shared rule rather than restating it, so a component, a collection and the desired
+   * schema cannot hold different opinions about the same column. MySQL refuses to key an
+   * unbounded TEXT/BLOB in either spelling and cannot index JSON at all, and because it commits
+   * each DDL statement separately there is no way to attempt the constraint without risking a
+   * table that exists WITHOUT it. A bare column is also exactly what the desired schema declares
+   * for an unkeyable type, so a half-applied add would read as converged and the guarantee would
+   * disappear silently.
+   */
+  private assertUniquenessEnforceable(
+    field: DataFieldConfig,
+    tableName: string
+  ): void {
+    const columnType = this.getColumnType(this.asMappableField(field));
+    if (columnType === null) return;
+    if (uniquenessCanBeAnIndex(columnType, this.dialect)) return;
+
+    const name = "name" in field && field.name ? String(field.name) : "";
+    const type = "type" in field ? String(field.type) : "unknown";
+    throw NextlyError.validation({
+      errors: [
+        {
+          path: `fields.${name}`,
+          code: "UNIQUE_NOT_ENFORCEABLE_ON_DIALECT",
+          message:
+            `"${name}" is marked unique, but ${this.dialect} cannot enforce uniqueness on a ` +
+            `${type} column. Give it a maximum length so it becomes a bounded string, or ` +
+            `remove the unique flag.`,
+        },
+      ],
+      logContext: { tableName, field: name, type, dialect: this.dialect },
+    });
+  }
+
   private asMappableField(field: DataFieldConfig): DataFieldConfig {
     const storageType = pluginStorageFieldType(field);
     if (storageType === undefined) return field;

--- a/packages/nextly/src/domains/schema/pipeline/diff/__tests__/uniqueness-converges.test.ts
+++ b/packages/nextly/src/domains/schema/pipeline/diff/__tests__/uniqueness-converges.test.ts
@@ -1,14 +1,14 @@
 /**
  * The generators and the desired schema agree about a unique column.
  *
- * Nine review findings on the create path were instances of one thing: "is this column's
- * uniqueness a named index" was answered in three places — the CREATE statements, the ADD COLUMN
- * statements, and the desired schema the diff compares a live table against — and any two of them
- * disagreeing shows up as a reconcile that proposes an index the server refuses, once per attempt,
+ * "Is this column's uniqueness a named index" is answered by the CREATE statements, the ADD COLUMN
+ * statements, and the desired schema the diff compares a live table against. Any two of them
+ * disagreeing shows up as a reconcile proposing an index the server refuses, once per attempt,
  * indefinitely. These pin the agreement rather than any one side of it.
  */
 import { describe, expect, it } from "vitest";
 
+import { NextlyError } from "../../../../../errors";
 import { DynamicCollectionSchemaService } from "../../../../dynamic-collections/services/dynamic-collection-schema-service";
 import { buildDesiredTableFromFields } from "../build-from-fields";
 
@@ -52,6 +52,20 @@ const emittedUniqueIndexes = (
   ].map(m => m[1]);
 };
 
+/** The structured refusals a NextlyError carries, flattened for assertion. */
+function refusalMessages(run: () => unknown): string[] {
+  try {
+    run();
+  } catch (error) {
+    if (!(error instanceof NextlyError)) throw error;
+    const data = error.publicData as
+      | { errors?: { path?: string; code?: string; message?: string }[] }
+      | undefined;
+    return (data?.errors ?? []).map(e => `${e.path} ${e.code} ${e.message}`);
+  }
+  return [];
+}
+
 describe("what the desired schema declares and what the create path emits", () => {
   it.each(DIALECTS)(
     "agree for a unique column the dialect can key, on %s",
@@ -90,6 +104,40 @@ describe("what the desired schema declares and what the create path emits", () =
       expect(emittedUniqueIndexes(dialect, fields)).toEqual([
         "uq_dc_widgets_sku",
       ]);
+    }
+  });
+});
+
+describe("uniqueness a dialect cannot enforce", () => {
+  const unkeyable = [
+    { name: "sku", type: "textarea", unique: true },
+  ] as unknown as never[];
+
+  it("is refused by the collection add-column path before any DDL is generated", () => {
+    // MySQL commits each DDL statement separately, so an ADD COLUMN followed by a constraint it
+    // rejects leaves the column WITHOUT its guarantee — and a bare column is exactly what the
+    // desired schema declares for an unkeyable type, so the next reconcile finds nothing to fix
+    // and the uniqueness is gone silently. Refusing first is what keeps the table untouched.
+    const service = new DynamicCollectionSchemaService(undefined, "mysql");
+    const reported = refusalMessages(() =>
+      service.generateAlterTableMigration("dc_widgets", [], unkeyable)
+    );
+
+    expect(reported).toHaveLength(1);
+    expect(reported[0]).toContain("fields.sku");
+    expect(reported[0]).toContain("UNIQUE_NOT_ENFORCEABLE_ON_DIALECT");
+    // A refusal that does not say what to do instead is only a wall.
+    expect(reported[0]).toMatch(/maximum length|remove the unique flag/);
+  });
+
+  it("is allowed on a dialect that CAN enforce it", () => {
+    // The control: without it, a service that refused every unique add would satisfy the case
+    // above while breaking the feature.
+    for (const dialect of ["postgresql", "sqlite"] as const) {
+      const service = new DynamicCollectionSchemaService(undefined, dialect);
+      expect(() =>
+        service.generateAlterTableMigration("dc_widgets", [], unkeyable)
+      ).not.toThrow();
     }
   });
 });

--- a/packages/nextly/src/domains/schema/pipeline/diff/__tests__/uniqueness-converges.test.ts
+++ b/packages/nextly/src/domains/schema/pipeline/diff/__tests__/uniqueness-converges.test.ts
@@ -1,0 +1,95 @@
+/**
+ * The generators and the desired schema agree about a unique column.
+ *
+ * Nine review findings on the create path were instances of one thing: "is this column's
+ * uniqueness a named index" was answered in three places — the CREATE statements, the ADD COLUMN
+ * statements, and the desired schema the diff compares a live table against — and any two of them
+ * disagreeing shows up as a reconcile that proposes an index the server refuses, once per attempt,
+ * indefinitely. These pin the agreement rather than any one side of it.
+ */
+import { describe, expect, it } from "vitest";
+
+import { DynamicCollectionSchemaService } from "../../../../dynamic-collections/services/dynamic-collection-schema-service";
+import { buildDesiredTableFromFields } from "../build-from-fields";
+
+type Dialect = "postgresql" | "mysql" | "sqlite";
+const DIALECTS: Dialect[] = ["postgresql", "mysql", "sqlite"];
+
+/**
+ * The `uq_` indexes the desired schema declares for a table.
+ *
+ * `builtBy: "collection"` is not incidental — it is the origin
+ * `DynamicCollectionSchemaService` renders under, and a text field with no stated width means
+ * different things to different origins. Building the desired side under any other origin would
+ * compare two tables that were never meant to match, and the test would fail for a reason that has
+ * nothing to do with uniqueness.
+ */
+const declaredUniqueIndexes = (
+  dialect: Dialect,
+  fields: { name: string; type: string; unique?: boolean }[]
+): string[] =>
+  (
+    buildDesiredTableFromFields("dc_widgets", fields, dialect, {
+      builtBy: "collection",
+    }).indexes ?? []
+  )
+    .filter(i => i.unique && i.name.startsWith("uq_"))
+    .map(i => i.name);
+
+/** The `uq_` indexes the CREATE path actually emits for the same table. */
+const emittedUniqueIndexes = (
+  dialect: Dialect,
+  fields: { name: string; type: string; unique?: boolean }[]
+): string[] => {
+  const sql = new DynamicCollectionSchemaService(
+    undefined,
+    dialect
+  ).generateMigrationSQL("dc_widgets", fields as never, { hasStatus: false });
+  return [
+    ...sql.matchAll(
+      /CREATE UNIQUE INDEX (?:IF NOT EXISTS )?["`](uq_[^"`]+)["`]/g
+    ),
+  ].map(m => m[1]);
+};
+
+describe("what the desired schema declares and what the create path emits", () => {
+  it.each(DIALECTS)(
+    "agree for a unique column the dialect can key, on %s",
+    dialect => {
+      const fields = [{ name: "email", type: "email", unique: true }];
+      expect(declaredUniqueIndexes(dialect, fields).sort()).toEqual(
+        emittedUniqueIndexes(dialect, fields).sort()
+      );
+    }
+  );
+
+  it("agree for a MySQL TEXT column, which MySQL cannot key either way", () => {
+    // The case that motivated the shared rule. MySQL refuses to key an unbounded TEXT column in
+    // both spellings, so the create path keeps the uniqueness inline and emits no index. Before
+    // the desired schema asked the same rule it declared `uq_dc_widgets_sku` regardless, and every
+    // reconcile proposed a statement MySQL rejects.
+    const fields = [{ name: "sku", type: "textarea", unique: true }];
+    expect(declaredUniqueIndexes("mysql", fields)).toEqual([]);
+    expect(emittedUniqueIndexes("mysql", fields)).toEqual([]);
+  });
+
+  it("agree for a MySQL JSON column, which MySQL cannot index at all", () => {
+    const fields = [{ name: "payload", type: "json", unique: true }];
+    expect(declaredUniqueIndexes("mysql", fields)).toEqual([]);
+    expect(emittedUniqueIndexes("mysql", fields)).toEqual([]);
+  });
+
+  it("still declare and emit the index where the dialect CAN key the same column", () => {
+    // The positive control. Without it, a build that withheld unique indexes everywhere would
+    // satisfy both cases above by agreeing on nothing.
+    for (const dialect of ["postgresql", "sqlite"] as const) {
+      const fields = [{ name: "sku", type: "textarea", unique: true }];
+      expect(declaredUniqueIndexes(dialect, fields)).toEqual([
+        "uq_dc_widgets_sku",
+      ]);
+      expect(emittedUniqueIndexes(dialect, fields)).toEqual([
+        "uq_dc_widgets_sku",
+      ]);
+    }
+  });
+});

--- a/packages/nextly/src/domains/schema/pipeline/diff/__tests__/uniqueness-converges.test.ts
+++ b/packages/nextly/src/domains/schema/pipeline/diff/__tests__/uniqueness-converges.test.ts
@@ -10,6 +10,7 @@ import { describe, expect, it } from "vitest";
 
 import { NextlyError } from "../../../../../errors";
 import { DynamicCollectionSchemaService } from "../../../../dynamic-collections/services/dynamic-collection-schema-service";
+import { uniquenessCanBeAnIndex } from "../../../services/index-name";
 import { buildDesiredTableFromFields } from "../build-from-fields";
 
 type Dialect = "postgresql" | "mysql" | "sqlite";
@@ -127,7 +128,32 @@ describe("uniqueness a dialect cannot enforce", () => {
     expect(reported[0]).toContain("fields.sku");
     expect(reported[0]).toContain("UNIQUE_NOT_ENFORCEABLE_ON_DIALECT");
     // A refusal that does not say what to do instead is only a wall.
-    expect(reported[0]).toMatch(/maximum length|remove the unique flag/);
+    expect(reported[0]).toContain("remove the unique flag");
+    expect(reported[0]).toContain("short-variant text field");
+  });
+
+  it("names a remedy the column mapper can actually deliver", () => {
+    // The remedy has to be checked against the mapper, not just read. A maximum length is the
+    // intuitive advice and it is inert: only the short text variant reaches a bounded VARCHAR,
+    // while every unkeyable type stays TEXT/JSON however it is bounded. A message naming an
+    // ineffective remedy sends the user to change a setting that cannot resolve the refusal.
+    const service = new DynamicCollectionSchemaService(undefined, "mysql");
+
+    const shortText = service.mapFieldTypeToSQL(
+      "text",
+      undefined,
+      { variant: "short" },
+      { maxLength: 120 }
+    );
+    expect(shortText).toMatch(/^varchar\(/i);
+    expect(uniquenessCanBeAnIndex(shortText, "mysql")).toBe(true);
+
+    for (const type of ["textarea", "richText", "code", "json", "chips"]) {
+      const bounded = service.mapFieldTypeToSQL(type, undefined, undefined, {
+        maxLength: 120,
+      });
+      expect(uniquenessCanBeAnIndex(bounded, "mysql")).toBe(false);
+    }
   });
 
   it("is allowed on a dialect that CAN enforce it", () => {

--- a/packages/nextly/src/domains/schema/pipeline/diff/build-from-fields.ts
+++ b/packages/nextly/src/domains/schema/pipeline/diff/build-from-fields.ts
@@ -205,19 +205,18 @@ export function collectionIndexSpecs<F extends MinimalFieldDef>(
       (field.type === "relationship" || field.type === "upload") &&
       field.hasMany !== true &&
       !Array.isArray(field.relationTo);
-    if (field.unique === true) {
-      // Asked through the same rule the generators use. Where a dialect cannot key the column,
-      // they keep the uniqueness inline and write no index, so declaring one here would make
-      // every diff propose a `CREATE UNIQUE INDEX` the server refuses. The uniqueness is still
-      // enforced in that case — by the inline constraint — it simply is not an object the
-      // desired schema can name.
-      if (context.uniquenessIsIndexable(field, col)) {
-        indexes.push({
-          name: uniqueIndexNameForColumn(tableName, col),
-          columns: [col],
-          unique: true,
-        });
-      }
+    // Asked through the same rule the generators use. Where a dialect cannot key the column they
+    // keep the uniqueness inline and write no index, so declaring one here would make every diff
+    // propose a `CREATE UNIQUE INDEX` the server refuses.
+    const uniqueIsIndexable =
+      field.unique === true && context.uniquenessIsIndexable(field, col);
+
+    if (uniqueIsIndexable) {
+      indexes.push({
+        name: uniqueIndexNameForColumn(tableName, col),
+        columns: [col],
+        unique: true,
+      });
     } else if (
       (field.index === true || isSingleRelation) &&
       (context.columnIsIndexable?.(field, col) ?? true)

--- a/packages/nextly/src/domains/schema/pipeline/diff/build-from-fields.ts
+++ b/packages/nextly/src/domains/schema/pipeline/diff/build-from-fields.ts
@@ -39,6 +39,7 @@ import {
   columnTypeIsIndexable,
   indexNameForColumn,
   uniqueIndexNameForColumn,
+  uniquenessCanBeAnIndex,
 } from "../../services/index-name";
 
 import { indexKey } from "./index-util";
@@ -127,6 +128,22 @@ interface CollectionIndexContext<F> {
    * it and every apply refuse it.
    */
   columnIsIndexable?: (field: F, column: string) => boolean;
+  /**
+   * Whether the column's uniqueness can be carried as a NAMED index, asked per column.
+   *
+   * Strictly narrower than `columnIsIndexable`, and a separate question: MySQL can neither index
+   * nor uniquely key a `TEXT` column without a length, so the generators keep such a column's
+   * uniqueness as an inline constraint and emit no index for it. A desired schema that declared
+   * `uq_<table>_<column>` anyway would propose creating an index no generator writes and no server
+   * accepts, once per reconcile, forever.
+   *
+   * REQUIRED, deliberately. An optional field defaulting to "yes, index it" would make a call site
+   * that forgot to supply it indistinguishable from one that answered permissively — and the
+   * permissive answer is precisely the behaviour this rule exists to remove, so forgetting would
+   * revert to the defect silently. The point of one shared rule is that there is nowhere left to
+   * forget it; an optional field with a lenient default rebuilds that place inside the option bag.
+   */
+  uniquenessIsIndexable: (field: F, column: string) => boolean;
 }
 
 /**
@@ -189,11 +206,18 @@ export function collectionIndexSpecs<F extends MinimalFieldDef>(
       field.hasMany !== true &&
       !Array.isArray(field.relationTo);
     if (field.unique === true) {
-      indexes.push({
-        name: uniqueIndexNameForColumn(tableName, col),
-        columns: [col],
-        unique: true,
-      });
+      // Asked through the same rule the generators use. Where a dialect cannot key the column,
+      // they keep the uniqueness inline and write no index, so declaring one here would make
+      // every diff propose a `CREATE UNIQUE INDEX` the server refuses. The uniqueness is still
+      // enforced in that case — by the inline constraint — it simply is not an object the
+      // desired schema can name.
+      if (context.uniquenessIsIndexable(field, col)) {
+        indexes.push({
+          name: uniqueIndexNameForColumn(tableName, col),
+          columns: [col],
+          unique: true,
+        });
+      }
     } else if (
       (field.index === true || isSingleRelation) &&
       (context.columnIsIndexable?.(field, col) ?? true)
@@ -295,6 +319,11 @@ export function buildDesiredTableFromFields(
     hasCreatedByColumn: columns.some(c => c.name === "created_by"),
     columnIsIndexable: (_field, col) =>
       columnTypeIsIndexable(
+        columns.find(c => c.name === col)?.type ?? "",
+        dialect
+      ),
+    uniquenessIsIndexable: (_field, col) =>
+      uniquenessCanBeAnIndex(
         columns.find(c => c.name === col)?.type ?? "",
         dialect
       ),
@@ -560,6 +589,11 @@ export function buildDesiredTableFromComponentFields(
     ...collectionIndexSpecs(tableName, fields, {
       columnIsIndexable: (_field, col) =>
         columnTypeIsIndexable(
+          columns.find(c => c.name === col)?.type ?? "",
+          dialect
+        ),
+      uniquenessIsIndexable: (_field, col) =>
+        uniquenessCanBeAnIndex(
           columns.find(c => c.name === col)?.type ?? "",
           dialect
         ),

--- a/packages/nextly/src/domains/schema/services/__tests__/index-name.test.ts
+++ b/packages/nextly/src/domains/schema/services/__tests__/index-name.test.ts
@@ -12,6 +12,7 @@ import {
   columnTypeIsIndexable,
   indexNameForColumn,
   MAX_INDEX_NAME_LENGTH,
+  uniquenessCanBeAnIndex,
 } from "../index-name";
 
 const LONG_TABLE = `dc_${"a".repeat(50)}`;
@@ -67,6 +68,10 @@ describe("the emitted DDL and the desired schema agree", () => {
       hasCreatedByColumn: false,
       localizedNames: new Set<string>(),
       columnNameFor: field => field.name,
+      // PostgreSQL keys every type this fixture uses, so the answer is yes — stated rather than
+      // defaulted, because the context requires it and a silent default would be the permissive
+      // answer this rule exists to stop.
+      uniquenessIsIndexable: () => true,
     }).map(spec => spec.name);
 
     // Every index the desired schema declares must be one the DDL actually installs, or the
@@ -111,6 +116,9 @@ describe("the DDL and the desired schema agree on WHICH indexes exist", () => {
       localizedNames: new Set<string>(),
       columnNameFor: field => field.name,
       columnIsIndexable: () => columnTypeIsIndexable("json", "mysql"),
+      // Same column, the narrower question: MySQL cannot key a JSON column, so its uniqueness
+      // cannot be a named index either.
+      uniquenessIsIndexable: () => uniquenessCanBeAnIndex("json", "mysql"),
     }).map(spec => spec.name);
 
     // Declaring it while the generator skips it makes every reconcile emit a CREATE INDEX that

--- a/packages/nextly/src/domains/schema/services/index-name.ts
+++ b/packages/nextly/src/domains/schema/services/index-name.ts
@@ -71,3 +71,27 @@ export function columnTypeIsIndexable(
   if (dialect !== "mysql") return true;
   return !/\bjson\b/i.test(columnType);
 }
+
+/**
+ * Whether a column's uniqueness can be carried as a NAMED index on this dialect.
+ *
+ * Strictly narrower than `columnTypeIsIndexable`: a type the dialect cannot index at all cannot
+ * carry uniqueness as an index either, and MySQL additionally refuses to key a `TEXT`/`BLOB`
+ * column without a length — in both spellings alike, the inline constraint and the index. Such a
+ * column keeps the inline form, which fails the CREATE atomically rather than creating the table
+ * and then failing on a separate index statement MySQL has already auto-committed past.
+ *
+ * Asked by all three places that have an opinion about a unique column: the statements that CREATE
+ * a table, the statements that ADD a column to one, and the desired schema the diff compares a
+ * live table against. When only the generators knew, the desired schema went on declaring
+ * `uq_<table>_<column>` for columns no generator would ever index, so every reconcile proposed a
+ * `CREATE UNIQUE INDEX` the server rejects — the same failure, once per attempt, indefinitely.
+ */
+export function uniquenessCanBeAnIndex(
+  columnType: string,
+  dialect: string
+): boolean {
+  if (!columnTypeIsIndexable(columnType, dialect)) return false;
+  if (dialect !== "mysql") return true;
+  return !/\b(text|blob|longtext|mediumtext|tinytext)\b/i.test(columnType);
+}


### PR DESCRIPTION
## What

"Can this column's uniqueness be a named index?" was answered independently in
three places. This makes it one exported rule that all three ask.

| Path | Before | Now |
|---|---|---|
| `CREATE TABLE` | private predicate on the service | asks `uniquenessCanBeAnIndex` |
| `ADD COLUMN` | same private predicate | same shared rule |
| desired schema (`build-from-fields`) | **never asked at all** | asks it through a required callback |

## Why it matters

The desired schema declared `uq_<table>_<column>` for every field marked
`unique: true`, unconditionally. Where a dialect cannot key the column the
generators correctly emit no such index — so the two disagreed, and every
reconcile proposed a `CREATE UNIQUE INDEX` the server rejects. Once per attempt,
indefinitely.

Concretely, on MySQL: a `text`/`textarea` field (cannot be keyed without a
length) or a `json`/`chips` field (cannot be indexed at all) with `unique: true`.
The uniqueness is still enforced in those cases — by the inline constraint the
create path emits — it simply is not an object the desired schema can name.

Nine review findings on #649 were instances of these three answers disagreeing.
This removes the disagreement rather than patching the tenth.

## The callback is REQUIRED, deliberately

An optional field defaulting to "yes, index it" would make a call site that
forgot to supply it indistinguishable from one that answered permissively — and
the permissive answer is exactly the behaviour being removed here. Forgetting
would silently revert to the defect. The point of one shared rule is that there
is nowhere left to forget it; an optional field with a lenient default rebuilds
that place inside the option bag.

It earned itself immediately: making it required surfaced two existing call
sites in `index-name.test.ts` that were not supplying it. Neither was caught by
any test, because both use types where the permissive default happens to be
correct — they were right by luck. One of them already passes the sibling
`columnIsIndexable` and reads as complete.

`collectionIndexSpecs` and `CollectionIndexContext` are internal to
`packages/nextly` — not in the public surface, not re-exported by `plugin-sdk`,
no consumer outside the package — so `required` breaks nothing.

## Tests

A **convergence** test: build the desired schema and the emitted DDL from the
same fields, and assert they agree. That is the property all nine findings were
instances of, rather than another assertion about one side.

Break-verified: removing the gate fails exactly the two MySQL cases and nothing
else. A positive control asserts PostgreSQL and SQLite still declare AND emit
`uq_dc_widgets_sku` for the same field, so an implementation that withheld
unique indexes everywhere cannot pass by agreeing on nothing.

The desired side is built with `builtBy: "collection"` — the origin
`DynamicCollectionSchemaService` actually renders under. Any other origin
compares two tables that were never meant to match, and the test would fail for
a reason unrelated to uniqueness.

## Verification

Full bar on the final commit: build, `check-types`, lint by exit code, the
drizzle-v1 legacy check, the complete `packages/nextly` unit run diffed at
per-test STATE level against a freshly measured `febe69a08` baseline, and
integration on all three dialects.

Unit: `0 moved, 6 added, 0 removed` — no test changed state in either
direction; the only difference is the six added here.


---

## Update: the first version of this was dangerous, and the review caught it

Suppressing the desired-schema declaration was only half the change. The
collection ADD COLUMN path and both component paths still emitted the uniqueness
as a **separate statement**, and MySQL commits each DDL statement on its own. So:

1. `ALTER TABLE ... ADD COLUMN sku TEXT` — committed.
2. `ALTER TABLE ... ADD CONSTRAINT uq_... UNIQUE (sku)` — rejected.
3. The bare column now matches what the desired schema declares for an unkeyable
   type, so the next reconcile finds nothing wrong.

That converts a loud repeated failure into a **silently missing constraint**,
which is worse than the defect this PR set out to fix.

### What changed

All four emitters now ask the shared rule, and the three that emit uniqueness as
a separate statement REFUSE before generating any DDL:

| Path | Uniqueness is | Behaviour |
|---|---|---|
| collection CREATE | inline in `CREATE TABLE` | unchanged — the statement fails atomically, nothing is left behind |
| collection ADD COLUMN | separate `ADD CONSTRAINT` | refuses first |
| component CREATE | separate `CREATE UNIQUE INDEX` | refuses first |
| component ALTER | separate constraint/index | refuses first |

The refusal follows the existing `REQUIRED_COLUMN_NEEDS_BACKFILL` precedent —
same `NextlyError.validation` shape — and names the way out: give the field a
maximum length so it becomes a bounded string, or drop the unique flag.

The collection CREATE is deliberately untouched. Its inline constraint fails the
whole statement, so there is no half-applied state to protect against, and
refusing there too would be a behaviour change with no safety gain.

### Tests

Three existing tests pinned the old behaviour and were updated rather than
worked around, each with the reason recorded:

- the CREATE/ADD attachment-agreement matrix now skips a shape whose uniqueness
  cannot be enforced, because there is no agreeing pair to compare — both paths
  refuse, at different moments;
- the explicit-unique-flag test asserts the refusal on MySQL and the constraint
  elsewhere;
- one field-group characterization snapshot was REMOVED: for MySQL plus an
  unbounded unique text field there is no DDL to pin, because the honest output
  is a refusal.

New refusal tests are break-verified, with a positive control so a service that
refused every unique add could not pass.

### Verification

Full bar on the final commit: gates 0, `0 moved, 8 added, 0 removed` at
per-test-state level against a freshly measured baseline, all three dialects green.
