### PR TITLE
refactor(ui): one colour type across the harness and the engine

### DIFF
--- a/apps/playground/src/theme-lab/audit-evidence/tokens.json
+++ b/apps/playground/src/theme-lab/audit-evidence/tokens.json
@@ -1,6 +1,6 @@
 {
   "generatedBy": "scripts/audit-themes.mjs",
-  "contrastSourceRev": "27b7e36e51a4",
+  "contrastSourceRev": "00482d925c3b",
   "note": "Ratios are only comparable with others taken against the same contrastSourceRev.",
   "themes": [
     {

--- a/apps/playground/src/theme-lab/contrast-report.generated.ts
+++ b/apps/playground/src/theme-lab/contrast-report.generated.ts
@@ -7,7 +7,7 @@
  * that miss WCAG AA on purpose, this measures all of them, so a tweakcn
  * preset shows its real score instead of defaulting to "pass".
  *
- * Measured against contrast source `27b7e36e51a4`
+ * Measured against contrast source `00482d925c3b`
  * (packages/ui/src/styles/contrast). These counts are only comparable with
  * others taken against the SAME revision -- the harness deciding them is as
  * much an input as the theme is.

--- a/packages/ui/src/styles/contrast/__tests__/rgba-is-one-type.test.ts
+++ b/packages/ui/src/styles/contrast/__tests__/rgba-is-one-type.test.ts
@@ -1,0 +1,118 @@
+/**
+ * The contrast harness and the published colour engine share one colour type,
+ * and agree on what its numbers mean.
+ *
+ * `contrast/color.ts` used to declare its own structurally identical `Rgb`.
+ * Two definitions of one concept in one package drift, and this drift would be
+ * silent in the worst way: both put channels in [0, 1] today, so moving either
+ * to 0-255 would typecheck, produce wrong ratios in every pairing, and leave
+ * the contrast suite green -- because both sides of every comparison shift
+ * together. A shape match is not a semantics match.
+ *
+ * `contrast/Rgb` is now an alias of `lib/color`'s `Rgba`, which removes the
+ * second definition. What an alias cannot state is that the two modules read
+ * the numbers the same way, so that is what this pins.
+ */
+import { describe, expect, it } from "vitest";
+
+import { toHex as publishedToHex, type Rgba } from "../../../lib/color/hex";
+import { compositeOver, toHex, toClampedRgb, type Rgb } from "../color";
+
+/** A value both modules must agree about, opaque and translucent. */
+const SAMPLES: ReadonlyArray<{ label: string; value: Rgba }> = [
+  { label: "black", value: { r: 0, g: 0, b: 0, alpha: 1 } },
+  { label: "white", value: { r: 1, g: 1, b: 1, alpha: 1 } },
+  { label: "mid grey", value: { r: 0.5, g: 0.5, b: 0.5, alpha: 1 } },
+  {
+    label: "a channel that rounds",
+    value: { r: 0.2, g: 0.4, b: 0.6, alpha: 1 },
+  },
+  // Alpha differs between the two signatures: the harness ignores the
+  // object's, the published one reads its own parameter. This is the sample
+  // that would expose the difference if either changed.
+  { label: "half transparent", value: { r: 0.2, g: 0.4, b: 0.6, alpha: 0.5 } },
+];
+
+describe("one colour type across the harness and the engine", () => {
+  it("carries an alpha on every value the harness produces", () => {
+    // What a RUNTIME test can prove about the type, which is not identity.
+    //
+    // Type identity is compile-time only, and this package typechecks zero
+    // test files -- `tsconfig.json` excludes every test glob -- so a
+    // type-level assertion here would be transpiled away and pass no matter
+    // what. That was tried: widening `Rgb` to `alpha?: number` left an
+    // assignment assertion green, because nothing ever typechecked it.
+    //
+    // So the property is asserted where it bites instead. `compositeOver`
+    // reads `.alpha` unconditionally; if the type ever went optional and a
+    // producer stopped setting it, the arithmetic yields NaN rather than a
+    // compile error. Every entry point is checked for a real number.
+    const produced = [
+      toClampedRgb("#ff0000"),
+      toClampedRgb("oklch(0.5 0 0 / 0.25)"),
+      compositeOver(
+        { r: 1, g: 0, b: 0, alpha: 0.5 },
+        { r: 0, g: 0, b: 1, alpha: 1 }
+      ),
+    ];
+
+    const missing = produced.filter(
+      value => typeof value.alpha !== "number" || Number.isNaN(value.alpha)
+    );
+
+    expect(
+      missing,
+      `A colour left the harness without a usable alpha. compositeOver ` +
+        `multiplies by it, so an undefined one produces NaN channels and ` +
+        `every ratio computed from them silently becomes NaN.`
+    ).toEqual([]);
+  });
+
+  it("propagates a missing alpha as NaN, which is why the type must require it", () => {
+    // The positive control for the test above: proof that the failure it
+    // guards against is real rather than theoretical. A value with no alpha
+    // does not throw and does not default -- it poisons the arithmetic.
+    const noAlpha = { r: 1, g: 0, b: 0 } as unknown as Rgb;
+    const composited = compositeOver(noAlpha, { r: 0, g: 0, b: 1, alpha: 1 });
+
+    expect(Number.isNaN(composited.r)).toBe(true);
+  });
+
+  it("reads channels in the same units", () => {
+    // The check that a shape match cannot make. If one module moved to 0-255,
+    // 1.0 would render as #010101 there and #ffffff here, and nothing else in
+    // either suite would notice.
+    expect(toHex({ r: 1, g: 1, b: 1, alpha: 1 })).toBe("#ffffff");
+    expect(publishedToHex({ r: 1, g: 1, b: 1 })).toBe("#ffffff");
+    expect(toHex({ r: 0, g: 0, b: 0, alpha: 1 })).toBe("#000000");
+    expect(publishedToHex({ r: 0, g: 0, b: 0 })).toBe("#000000");
+  });
+
+  it("formats the same colour identically, ignoring alpha on both sides", () => {
+    // The harness's `toHex` takes alpha from nowhere; the published one takes
+    // it from a parameter defaulting to 1. They agree only because the
+    // harness never passes one -- compatible by accident, which is a fine
+    // thing to rely on and a bad thing to assume.
+    const disagreeing = SAMPLES.filter(
+      ({ value }) => toHex(value) !== publishedToHex(value)
+    ).map(({ label }) => label);
+
+    expect(
+      disagreeing,
+      `The two hex formatters disagree about a colour. They are relied on ` +
+        `interchangeably in failure messages, so a divergence would make two ` +
+        `reports of the same pairing name different colours.`
+    ).toEqual([]);
+  });
+
+  it("parses to the shared type with alpha carried, not defaulted", () => {
+    // `toClampedRgb` is the harness's entry point and the reason the type
+    // needs alpha at all: a translucent token composited over its surface is
+    // the whole point of the contrast maths.
+    const opaque = toClampedRgb("#ff0000");
+    expect(opaque.alpha).toBe(1);
+
+    const translucent = toClampedRgb("oklch(0.5 0 0 / 0.5)");
+    expect(translucent.alpha).toBeCloseTo(0.5, 5);
+  });
+});

--- a/packages/ui/src/styles/contrast/color.ts
+++ b/packages/ui/src/styles/contrast/color.ts
@@ -10,15 +10,27 @@
  */
 import { converter, parse } from "culori";
 
+import type { Rgba } from "../../lib/color/hex";
+
 const toRgb = converter("rgb");
 
-/** An sRGB color with gamma-encoded channels in [0, 1] and an alpha in [0, 1]. */
-export interface Rgb {
-  r: number;
-  g: number;
-  b: number;
-  alpha: number;
-}
+/**
+ * An sRGB color with gamma-encoded channels in [0, 1] and an alpha in [0, 1].
+ *
+ * Re-exported from `lib/color` rather than declared again. Two structurally
+ * identical definitions of one concept in one package is a drift waiting to
+ * happen, and the drift that matters would be silent: the two agree on
+ * channels in [0, 1] today, so a future edit moving either to 0-255 would
+ * typecheck, produce wrong ratios in every pairing, and leave this suite green
+ * because both sides of each comparison shift together.
+ *
+ * The direction is deliberate. `lib/color` is the published surface and this
+ * module is not, so importing from there consumes existing public API rather
+ * than creating any. The reverse -- moving the WCAG maths out to `lib/color`
+ * -- would publish which formula, which compositing rule and which gamut-edge
+ * behaviour this harness uses, freezing decisions it may need to revise.
+ */
+export type Rgb = Rgba;
 
 const clamp01 = (n: number): number => Math.min(1, Math.max(0, n));
 


### PR DESCRIPTION
`packages/ui` carried two structurally identical definitions of one colour type: `styles/contrast/color.ts` declared its own `Rgb`, and `lib/color` exports `Rgba`. The harness now imports the published one.

## Why this was worth doing

Two definitions of one concept drift, and the drift that matters here would be **silent**. Both put channels in `[0, 1]` today. Moving either to `0-255` would typecheck, produce wrong ratios in every asserted pairing, and leave the contrast suite green — because both sides of every comparison shift together. There is no symptom to notice.

That was the check worth running before agreeing the swap was safe, and it is not one a type system can make: a shape match tells you nothing about what the numbers mean.

Also verified: `Rgba extends Rgb { alpha: number }` — **required**, not optional. Had it been optional, `compositeOver` would read `undefined` and every composite would be wrong while compiling cleanly.

## Direction, and what stays private

The import goes **from** the published `lib/color` **into** the unpublished harness. That consumes existing public API rather than creating any, so there is no changeset. `styles/contrast/` is reachable from no published subpath and no barrel, and `"files": ["dist", "docs"]` means the source does not ship either.

The reverse move — relocating `relativeLuminance` / `contrastRatio` / `compositeOver` into `lib/color` — is deliberately **not** made. It would publish which WCAG formula, which compositing rule, and which gamut-edge behaviour this harness uses, freezing decisions it may still need to revise. The trigger for that move is an external consumer who needs WCAG maths, not a tidier tree.

## The test, and why it is not a type assertion

I wrote a type-level assertion first. It was worthless, and finding out why is the useful part of this PR: **`packages/ui` typechecks zero test files** — `tsconfig.json` excludes every test glob — so the assertion was transpiled away and passed regardless. Widening `Rgb` back to `alpha?: number` left it green.

So the properties are pinned where they bite at runtime:

- **Units** — both formatters render `1.0` as `#ffffff`. Stub-verified: shifting one module to `0-255` fails two assertions.
- **Hex equivalence** — the two `toHex` implementations agree across opaque and translucent samples. They are compatible *by accident* (the published one reads alpha from a parameter the harness never passes), which is fine to rely on and bad to assume.
- **Alpha survival** — every harness entry point yields a real number, with a **positive control** proving the failure is real: a value with no alpha does not throw and does not default, it poisons the arithmetic into `NaN`.

## Verification

`packages/ui`: **263 tests**, typecheck clean, lint clean. `apps/playground`: **132 tests**, typecheck clean.

The generated contrast report is regenerated because its stamp hashes the harness contents — the counts are unchanged, only the provenance stamp moved.
