### PR TITLE
fix(admin): stop SidebarInset from emitting a second main landmark

### DIFF
--- a/.changeset/sidebar-inset-landmark.md
+++ b/.changeset/sidebar-inset-landmark.md
@@ -1,0 +1,27 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+"create-nextly-app": patch
+"nextly": patch
+---
+
+stop the sidebar content panel from emitting a second main landmark

--- a/packages/admin/src/components/layout/sidebar/__tests__/sidebar-landmarks.test.tsx
+++ b/packages/admin/src/components/layout/sidebar/__tests__/sidebar-landmarks.test.tsx
@@ -1,0 +1,50 @@
+/**
+ * The sidebar module contributes no document landmark.
+ *
+ * The admin shell renders the page's one primary landmark in `DashboardLayout`.
+ * Anything nested inside it that also renders a `main` gives the document two,
+ * which costs assistive technology an unambiguous "skip to the main content"
+ * and forces any query for the main region to disambiguate between them.
+ *
+ * `SidebarInset` is the only component here that ever emitted one, so it is
+ * the only one whose element is pinned. It is currently rendered nowhere, and
+ * that is exactly why this is worth a test rather than a code reading: an
+ * unrendered component has nothing else holding its markup still, and the
+ * moment someone reaches for it the defect ships with them. Upstream ships it
+ * as a `main` because it assumes the panel IS the page, so a future sync is a
+ * live way for the element to come back.
+ *
+ * The assertion is on the ROLE rather than on the tag, because the defect is
+ * "a second main landmark exists", not "the string `main` appears". Setting
+ * `role="main"` on a `div` would reintroduce it while a tag check stayed green.
+ */
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { SidebarInset } from "../index";
+
+describe("sidebar landmarks", () => {
+  it("renders SidebarInset without a main landmark", () => {
+    render(<SidebarInset>panel</SidebarInset>);
+
+    // A positive control on the query itself: the component rendered, so an
+    // empty landmark result is a fact about the markup and not about a render
+    // that never happened.
+    expect(screen.getByText("panel")).toBeInTheDocument();
+    expect(screen.queryAllByRole("main")).toHaveLength(0);
+  });
+
+  it("still renders its children and forwards props", () => {
+    // The element changed; the component did not stop being one. Without this,
+    // deleting the body entirely would satisfy the landmark assertion above.
+    render(
+      <SidebarInset className="custom" data-testid="inset">
+        <span>content</span>
+      </SidebarInset>
+    );
+
+    const inset = screen.getByTestId("inset");
+    expect(inset).toHaveClass("custom");
+    expect(inset).toHaveTextContent("content");
+  });
+});

--- a/packages/admin/src/components/layout/sidebar/index.tsx
+++ b/packages/admin/src/components/layout/sidebar/index.tsx
@@ -286,12 +286,26 @@ const SidebarRail = React.forwardRef<
 });
 SidebarRail.displayName = "SidebarRail";
 
+/**
+ * The content panel beside the sidebar.
+ *
+ * A plain `div`, not a `main`. The admin shell already renders the page's one
+ * primary landmark in `DashboardLayout`, so a second `main` inside it would
+ * give the document two -- assistive technology loses "skip to the main
+ * content" as an unambiguous move, and any query for the main region has to
+ * choose between them.
+ *
+ * This is the only component in this module that would emit a landmark, which
+ * is why it is the only one whose element is pinned by a test. Upstream ships
+ * it as a `main` because it assumes the panel IS the page; here it is a region
+ * inside one.
+ */
 const SidebarInset = React.forwardRef<
   HTMLDivElement,
-  React.ComponentProps<"main">
+  React.ComponentProps<"div">
 >(({ className, ...props }, ref) => {
   return (
-    <main
+    <div
       ref={ref}
       className={cn(
         "relative flex w-full flex-1 flex-col bg-background",


### PR DESCRIPTION
`SidebarInset` rendered a `<main>`. The admin shell already renders the page's one primary landmark in `DashboardLayout.tsx:105`, so anything nested inside it that also renders a `main` gives the document two: assistive technology loses "skip to the main content" as an unambiguous move, and any query for the main region has to choose between them.

It is now a `div`. That also settles a disagreement the file already carried — the component declared `React.forwardRef<HTMLDivElement, React.ComponentProps<"main">>`, so the types said div while the markup said main.

## Why this component and not the other twelve

`SidebarInset` is currently rendered nowhere, and "it's dead code" is not the reason to touch it — **13 of the 23 exports in that module are unrendered**, so acting on this one for being unused would have been arbitrary:

```
DEAD Sidebar, SidebarContent, SidebarFooter, SidebarGroupAction, SidebarHeader,
     SidebarInput, SidebarInset, SidebarMenuAction, SidebarMenuBadge,
     SidebarMenuSkeleton, SidebarRail, SidebarSeparator, SidebarTrigger
LIVE SidebarGroup(7) SidebarGroupContent(6) SidebarGroupLabel(5) SidebarMenu(16)
     SidebarMenuButton(6) SidebarMenuItem(29) SidebarMenuSub(5)
     SidebarMenuSubButton(2) SidebarMenuSubItem(5) SidebarProvider(2)
```

What makes this one different is that it is **the only component in the module that emits a document landmark** — `grep -n "<main\|<nav\|<header\|<footer\|<aside\|<section"` over the file returns exactly one hit. The others are divs, buttons and inputs, so they cannot carry this defect.

That is also why the fix is to change the element rather than delete the component. Deleting it would remove a piece of vendored shadcn surface on a basis that applies equally to twelve of its neighbours; changing the element removes the actual hazard and leaves that larger question alone.

## The test, and why an unrendered component gets one

Being unrendered is the argument *for* pinning it, not against. Nothing else holds the markup of an unused component still, and upstream ships this as a `main` because it assumes the panel **is** the page — so a future sync is a live route for the element to come back, and it would come back attached to whoever first reaches for the component.

The assertion is on the **role**, not the tag, because the defect is "a second main landmark exists" rather than "the string `main` appears".

Stub-verified both ways:

| stub | result |
| --- | --- |
| element restored to `<main>` | fails — `expected [ <main …></main> ] to have a length of +0` |
| kept as `<div>`, added `role="main"` | fails — `expected [ <div role="main" …></div> ] to have a length of +0` |

The second is the one that matters: a tag-based check would have passed it. A second case pins children and prop forwarding, so emptying the component body cannot satisfy the landmark assertion on its own.

## Checks

`packages/admin` typecheck, lint, and 27 layout tests green. Changeset generated in node from `.changeset/config.json` (23 packages, all `patch`) and verified with `scripts/release/check-changesets.mjs` — including a positive control confirming it exits 1 on a partial list, so the pass means something.
