### PR TITLE
test(nextly): assert the refused preview-link gate answers 403, not merely 4xx

### DIFF
--- a/packages/nextly/src/api/preview-links.test.ts
+++ b/packages/nextly/src/api/preview-links.test.ts
@@ -210,15 +210,20 @@ describe("mintPreviewLink", () => {
   });
 
   it("does not mint when the gate refuses", async () => {
+    // The error the real gate throws, not a stand-in. `throwAuthError` raises
+    // `NextlyError.forbidden`, which the handler renders as 403; a bare `Error`
+    // is an unrecognised failure and renders as 500. Both are >= 400, so a
+    // range assertion over a stand-in passes whether the refusal is reported
+    // as a refusal or as a crash.
     (
       requireRouteCollectionAccess as ReturnType<typeof vi.fn>
-    ).mockRejectedValueOnce(new Error("forbidden"));
+    ).mockRejectedValueOnce(NextlyError.forbidden());
 
     const response = await mintPreviewLink(
       post({ collection: "pages", entryId: "7" })
     );
 
-    expect(response.status).toBeGreaterThanOrEqual(400);
+    expect(response.status).toBe(403);
     // The gate has to run BEFORE the token exists, not merely before it is
     // returned: a token that was signed and then discarded is still a token.
     expect(getGeneration).not.toHaveBeenCalled();
@@ -322,14 +327,14 @@ describe("revokePreviewLinks", () => {
 
   it("does not revoke when the gate refuses", async () => {
     (requireRoutePermission as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
-      new Error("forbidden")
+      NextlyError.forbidden()
     );
 
     const response = await revokePreviewLinks(
       post({}, "http://x/api/nextly/preview-links/revoke")
     );
 
-    expect(response.status).toBeGreaterThanOrEqual(400);
+    expect(response.status).toBe(403);
     expect(revokeAll).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
D6 from the #601 review. A preview link is a bearer credential, so "the gate
refused" and "the handler crashed" are not the same outcome — and these two tests
scored them the same.

## The gap

Both refusal tests rejected with a bare `Error("forbidden")`. The real gate
throws what `throwAuthError` raises:

```
route-auth.ts:57
  throw NextlyError.forbidden({ logContext: { … } });   ->  403
```

A bare `Error` is an unrecognised failure, so `withErrorHandler` renders
`INTERNAL_ERROR` **500**. Both are `>= 400`, which is what the tests asserted, so
the assertion passed whether the endpoint refused the caller or fell over.

## Measured before changing it

Asserting `403` against the previous mock, on both endpoints:

```
× does not mint when the gate refuses     AssertionError: expected 500 to be 403
× does not revoke when the gate refuses   AssertionError: expected 500 to be 403
```

The mocks now reject with `NextlyError.forbidden()` — the error production
actually throws — and the assertions name `403`. 16 tests pass.

## One sibling found and deliberately not changed

`src/api/schema-journal.test.ts:74` has the same shape: `>= 400` for what its own
comment expects to be a 401-class response, so a 500 would pass there too. It is a
different subsystem and a different review, so it is named here rather than swept
in. The other three `>= 400` assertions in the package are NOT this defect and
were left alone:

- `handler-shapes.test.ts:355` is parameterised over a typed AND an untyped
  failure on purpose — the range is the assertion.
- `role-service` / `permission-service` cover a closed-database path with no one
  determinate code.
- `versions-label.test.ts` asserts propagation by message at the service layer,
  not a status mapping.

No changeset: test-only.
