### PR TITLE
test(release): pin the bootstrap placeholder as what holds the dist-tag

### DIFF
--- a/scripts/release/lib.mjs
+++ b/scripts/release/lib.mjs
@@ -191,6 +191,20 @@ export function findMissingPublishFields(pkg) {
  * only-pre and publishes to `alpha`. Approximating this with "no stable version"
  * would expect `latest` for such a package and reject a correct publish on every
  * retry, permanently blocking the consolidated tag.
+ *
+ * A CONSEQUENCE worth stating where it will be read, because it makes the
+ * bootstrap placeholder load-bearing long after it has stopped looking useful.
+ * `firstPrereleaseId("0.0.0")` is `undefined` rather than the active tag, so the
+ * stable `0.0.0` in a package's version list is exactly what makes it NOT
+ * only-pre:
+ *
+ *     ["0.0.0", "0.0.2-alpha.52"] -> alpha      (the placeholder decides this)
+ *     ["0.0.2-alpha.52"]          -> latest     (`latest` onto a prerelease)
+ *
+ * So removing a package's `0.0.0` once it has real versions — which reads as
+ * tidying away a thing that has done its job — reclassifies it as only-pre and
+ * points `latest` at an alpha build on the next publish. The placeholder claims
+ * the name AND holds the dist-tag; only the first of those is obvious.
  */
 export function getExpectedDistTag(registryState, preState) {
   if (!preState) return "latest";

--- a/scripts/release/preflight.test.mjs
+++ b/scripts/release/preflight.test.mjs
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   classifyPreflight,
+  getExpectedDistTag,
   isBootstrapPlaceholderOnly,
   PLACEHOLDER_VERSION,
 } from "./lib.mjs";
@@ -202,5 +203,52 @@ describe("classifyPreflight", () => {
         field.startsWith("publishConfig.access")
       )
     ).toBe(true);
+  });
+});
+
+describe("which dist-tag a package publishes to", () => {
+  const PRE = { mode: "pre", tag: "alpha" };
+
+  it("uses the active prerelease tag for a package with a stable version", () => {
+    expect(
+      getExpectedDistTag({ versions: ["0.0.0", VERSION], distTags: {} }, PRE)
+    ).toBe("alpha");
+  });
+
+  it("moves `latest` when nothing but prereleases of the active tag exist", () => {
+    // Changesets' own `only-pre` rule: a package with no regular release yet
+    // publishes to `latest`. Asserted rather than assumed, because it is the
+    // reason the case below matters.
+    expect(getExpectedDistTag({ versions: [VERSION], distTags: {} }, PRE)).toBe(
+      "latest"
+    );
+  });
+
+  it("treats the bootstrap placeholder as the stable version that holds the tag", () => {
+    // The placeholder does two jobs and only one is obvious. `0.0.0` carries no
+    // prerelease identifier, so its presence is what makes a package NOT
+    // only-pre — and therefore what keeps `latest` off the alpha channel. The
+    // two assertions differ by the placeholder alone.
+    const withPlaceholder = { versions: [PLACEHOLDER_VERSION, VERSION] };
+    const withoutPlaceholder = { versions: [VERSION] };
+
+    expect(getExpectedDistTag(withPlaceholder, PRE)).toBe("alpha");
+    expect(getExpectedDistTag(withoutPlaceholder, PRE)).toBe("latest");
+  });
+
+  it("uses `latest` outside prerelease mode whatever the registry holds", () => {
+    expect(
+      getExpectedDistTag({ versions: [VERSION], distTags: {} }, null)
+    ).toBe("latest");
+  });
+
+  it("does not classify a package whose prereleases are of ANOTHER tag", () => {
+    // `only-pre` is narrower than "has no stable version": every published
+    // version must be a prerelease of the ACTIVE tag. A beta-only package under
+    // an alpha train publishes to alpha, and expecting `latest` here would
+    // reject a correct publish on every retry.
+    expect(
+      getExpectedDistTag({ versions: ["0.0.2-beta.1"], distTags: {} }, PRE)
+    ).toBe("alpha");
   });
 });


### PR DESCRIPTION
`getExpectedDistTag` decides which dist-tag every package in the train publishes
to, and it had **no test coverage at all**. This adds five cases, one of which
pins a property that is invisible from reading the function.

## The property

A package is `only-pre` when every published version is a prerelease of the
active tag, and Changesets sends an `only-pre` package to `latest`.
`firstPrereleaseId("0.0.0")` returns `undefined` rather than the tag — so the
bootstrap placeholder is exactly what makes a package NOT `only-pre`:

```
["0.0.0", "0.0.2-alpha.52"]  ->  alpha
["0.0.2-alpha.52"]           ->  latest      <- `latest` onto a prerelease
```

Verified against the real function rather than reasoned about:

```
alpha   <- WITH 0.0.0 placeholder (blocks-react today)
latest  <- WITHOUT placeholder (alpha versions only)
alpha   <- builder today (placeholder only)
alpha   <- a mature package
```

**So the placeholder claims the name AND holds the dist-tag, and only the first
of those is obvious.** Removing a package's `0.0.0` once it has real versions
reads as tidying away something that has done its job; it would reclassify the
package as `only-pre` and point `latest` at an alpha build on the next publish.

The two assertions in the placeholder test differ by the placeholder alone, so
they state the property rather than describing it.

## Verified in both directions

Making `firstPrereleaseId` report the active tag for stable versions fails
exactly the two assertions that depend on the placeholder and leaves the other 86
passing. 88 tests pass unmodified.

## Also covered

- the active tag is used for a package with a stable version;
- `only-pre` really does go to `latest` — asserted rather than assumed, since it
  is the reason the placeholder case matters;
- `latest` outside prerelease mode whatever the registry holds;
- a beta-only package under an alpha train is NOT `only-pre` (the narrowness the
  docstring already claimed, now checked).

No changeset: test and comment only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release handling to preserve the active prerelease channel when packages include the stable bootstrap version.
  * Prevented prerelease builds from incorrectly redirecting the `latest` channel.
  * Ensured releases use the correct distribution tag across stable, prerelease, bootstrap, and unrelated prerelease scenarios.

* **Tests**
  * Added coverage for distribution-tag selection in multiple release modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->