### PR TITLE
refactor(nextly): update a single's schema and row in one place

### DIFF
--- a/.changeset/single-schema-into-service.md
+++ b/.changeset/single-schema-into-service.md
@@ -24,4 +24,4 @@
 "@nextlyhq/builder": patch
 ---
 
-A Single schema change now applies its table change and writes its registry row in one place, so a failure before any statement runs is reported as a refusal instead of being recorded as a failed migration that saved a field list the table never received.
+A Single's schema change now applies its table change and writes its registry row in one place, and the row records the outcome the apply actually reached. Saving a Single that only toggles Internationalization or Draft/Published now records that its companion table was provisioned, and re-saving a Single whose table failed to create can rebuild it and report success instead of staying stuck on "failed" however many times it is retried.

--- a/.changeset/single-schema-into-service.md
+++ b/.changeset/single-schema-into-service.md
@@ -1,0 +1,27 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+---
+
+A Single schema change now applies its table change and writes its registry row in one place, so a failure before any statement runs is reported as a refusal instead of being recorded as a failed migration that saved a field list the table never received.

--- a/packages/nextly/src/database/__tests__/schema-registry.test.ts
+++ b/packages/nextly/src/database/__tests__/schema-registry.test.ts
@@ -123,6 +123,39 @@ describe("SchemaRegistry", () => {
     });
   });
 
+  describe("retractDynamicSchema", () => {
+    it("forgets one table and leaves the others", () => {
+      // The counterpart registration lacked. A caller whose schema change failed part way cannot
+      // say what shape a table now has, and `ensureSingleRuntimeTable` adopts a foreign
+      // registration rather than rebuilding — so before this there was no way to express
+      // "unknown", only a guess that survived to the next restart.
+      registry.registerDynamicSchema("dc_products", { _name: "dc_products" });
+      registry.registerDynamicSchema("dc_orders", { _name: "dc_orders" });
+
+      registry.retractDynamicSchema("dc_products");
+
+      expect(registry.getTable("dc_products")).toBeNull();
+      expect(registry.getTable("dc_orders")).not.toBeNull();
+    });
+
+    it("leaves a static table of the same name reachable", () => {
+      // Retracting removes the dynamic OVERRIDE, not the name. Deleting the static fallback too
+      // would make an unrelated table disappear, which is the failure a blanket clear() causes and
+      // the reason this exists as a separate operation.
+      registry.registerStaticSchemas({ users: { _name: "users" } });
+      registry.registerDynamicSchema("users", { _name: "dynamic-users" });
+
+      registry.retractDynamicSchema("users");
+
+      expect(registry.getTable("users")).toEqual({ _name: "users" });
+    });
+
+    it("is a no-op for a table that was never registered", () => {
+      expect(() => registry.retractDynamicSchema("never-there")).not.toThrow();
+      expect(registry.getTable("never-there")).toBeNull();
+    });
+  });
+
   describe("clear", () => {
     it("removes all dynamic schemas", () => {
       registry.registerDynamicSchema("dc_products", {});

--- a/packages/nextly/src/database/schema-registry.ts
+++ b/packages/nextly/src/database/schema-registry.ts
@@ -130,6 +130,27 @@ export class SchemaRegistry {
     this.relationsCache = null;
   }
 
+  /**
+   * Forget one dynamic table, so the next lookup rebuilds it instead of adopting it.
+   *
+   * The counterpart `registerDynamicSchema` was missing. A caller that has changed a table's
+   * storage and then FAILED part way cannot say what shape the table now has — the change may have
+   * landed on one half and not the other — and there was previously no way to express that. Every
+   * such caller had to bind SOME shape, because `ensureSingleRuntimeTable` adopts a registration it
+   * did not make rather than rebuilding, so a wrong guess survived to the next restart.
+   *
+   * Retracting says the one thing such a caller always knows correctly: this is no longer
+   * describable from here. The rebuild that follows asks the database where the columns physically
+   * are, which is the answer a guess was standing in for.
+   */
+  retractDynamicSchema(tableName: string): void {
+    this.dynamicSchemas.delete(tableName);
+    this.dynamicEdges.delete(tableName);
+    // Same reason the registration path invalidates it: relations close over table objects, so a
+    // stale assembled config keeps traversing an object no longer registered.
+    this.relationsCache = null;
+  }
+
   // Look up a table object by SQL table name (for queries).
   // Checks dynamic schemas first since they may override static in edge cases.
   getTable(tableName: string): unknown {

--- a/packages/nextly/src/dispatcher/handlers/__tests__/single-dispatcher-update-ddl.test.ts
+++ b/packages/nextly/src/dispatcher/handlers/__tests__/single-dispatcher-update-ddl.test.ts
@@ -124,6 +124,14 @@ vi.mock("../../../domains/schema/pipeline/live-table-facts", () => ({
  * Both are needed because they leave the table in OPPOSITE states, and a double that can only
  * produce one of them cannot show that the recovery treats them alike.
  */
+/**
+ * How many times the REAL reconcile actually ran.
+ *
+ * Without this the two parameterized rows are indistinguishable from outside: both end in the same
+ * recovery, so both stay green even if one of them never reaches the state it names. This is the
+ * assertion that makes "before" mean before.
+ */
+const realReconcileCalls = { count: 0 };
 const companionFailure: { error: unknown; when: "before" | "after" } = {
   error: undefined,
   when: "after",
@@ -138,6 +146,16 @@ vi.mock(
       ...actual,
       reconcileSingleCompanion: vi.fn(
         async (args: Parameters<typeof actual.reconcileSingleCompanion>[0]) => {
+          // BEFORE the real call: the reconcile is rejected at its first statement, so nothing it
+          // owns has moved. AFTER: it completed its DDL and failed on the tail. The two leave the
+          // table in opposite states, which is the whole reason both are driven.
+          if (
+            companionFailure.error !== undefined &&
+            companionFailure.when === "before"
+          ) {
+            throw companionFailure.error;
+          }
+          realReconcileCalls.count += 1;
           const result = await actual.reconcileSingleCompanion(args);
           if (companionFailure.error !== undefined)
             throw companionFailure.error;
@@ -250,6 +268,7 @@ async function runUpdate(
   liveTableHasRows.value = tableHasRows;
   companionFailure.error = options.companionFailure;
   companionFailure.when = options.companionFailureWhen ?? "after";
+  realReconcileCalls.count = 0;
   adapter = makeAdapter(dialect, { mainTableExists, onStatement });
   const registry = wireRegistry(options.existing ?? existingSingle());
   const result = await dispatchSingles(
@@ -423,6 +442,9 @@ describe("updateSingleSchema — where a failure is allowed to surface", () => {
       );
 
       expect(written?.migrationStatus).toBe("failed");
+      // The rows must reach DIFFERENT states, or the parameterization is decoration: "before" must
+      // not have run the reconcile at all, "after" must have run it to completion.
+      expect(realReconcileCalls.count).toBe(when === "before" ? 0 : 1);
       expect(retractedTables).toHaveBeenCalledWith("single_page");
       // Binding anything here would be adopted by the next reader instead of rebuilt.
       expect(registeredShapes).not.toHaveBeenCalled();

--- a/packages/nextly/src/dispatcher/handlers/__tests__/single-dispatcher-update-ddl.test.ts
+++ b/packages/nextly/src/dispatcher/handlers/__tests__/single-dispatcher-update-ddl.test.ts
@@ -45,17 +45,33 @@ function makeAdapter(
   } = {}
 ) {
   const { mainTableExists = true, onStatement } = options;
+  // Whether the main table has been CREATED during this run. The apply confirms the table exists
+  // before recording "applied", so a double answering a flat `false` would report every rebuild as
+  // failed — the test would then pass for the wrong reason, describing a create that did not work.
+  let created = false;
   return {
     dialect,
     getCapabilities: () => ({ dialect }),
     tableExists: vi.fn(async (name: string) =>
-      name.includes("_locales") ? false : mainTableExists
+      name.includes("_locales") ? false : mainTableExists || created
     ),
     selectOne: vi.fn(async (): Promise<{ id: string } | null> => null),
-    getDrizzle: vi.fn(() => ({})),
+    // The companion reconcile reaches the database through Drizzle rather than `executeQuery`, so
+    // its own statements are NOT visible in `executed`. That is why the flag-only assertion below
+    // is phrased as "no statement naming the MAIN table" rather than "no statements at all": the
+    // claim under test is that the plan rendered no migration SQL, not that the companion did
+    // nothing — the companion doing something is the reason that plan exists at all.
+    //
+    // Shaped the way node-postgres answers through Drizzle — a result object carrying `rows` —
+    // rather than a bare array, which satisfies the call and then fails inside the copy with
+    // "rows is not iterable", a failure that reads as a defect in the code under test.
+    getDrizzle: vi.fn(() => ({
+      execute: async () => ({ rows: [] }),
+    })),
     executeQuery: vi.fn(async (sql: string) => {
       executed.push(sql);
       onStatement?.(sql);
+      if (/CREATE TABLE/i.test(sql)) created = true;
       return [];
     }),
   };
@@ -78,8 +94,9 @@ vi.mock("../../../di/container", () => ({
 // The live-table facts the ALTER generator reads. Doubled because the real readers issue dialect
 // specific catalog queries against a database that is not there, and what this file is recording is
 // the statements the update EMITS, not how those facts are gathered.
+const liveTableHasRows = { value: false };
 vi.mock("../../../domains/schema/pipeline/live-table-facts", () => ({
-  tableHasRows: vi.fn(async () => false),
+  tableHasRows: vi.fn(async () => liveTableHasRows.value),
   readForeignKeyColumns: vi.fn(async () => new Map<string, string[]>()),
   readIndexNames: vi.fn(async () => new Set<string>()),
 }));
@@ -99,8 +116,8 @@ import { dispatchSingles } from "../single-dispatcher";
 const logger: Logger = {
   debug: vi.fn(),
   info: vi.fn(),
-  warn: vi.fn((...a: unknown[]) => console.log("LOGWARN", ...a)),
-  error: vi.fn((...a: unknown[]) => console.log("LOGERR", ...a)),
+  warn: vi.fn(),
+  error: vi.fn(),
 };
 
 /** The registry row an update starts from: a single that already exists and is not locked. */
@@ -168,15 +185,18 @@ async function runUpdate(
     dialect?: "postgresql" | "mysql" | "sqlite";
     existing?: Record<string, unknown>;
     mainTableExists?: boolean;
+    tableHasRows?: boolean;
     onStatement?: (sql: string) => void;
   } = {}
 ) {
   const {
     dialect = "postgresql",
     mainTableExists = true,
+    tableHasRows = false,
     onStatement,
   } = options;
   executed.length = 0;
+  liveTableHasRows.value = tableHasRows;
   adapter = makeAdapter(dialect, { mainTableExists, onStatement });
   const registry = wireRegistry(options.existing ?? existingSingle());
   const result = await dispatchSingles(
@@ -224,57 +244,79 @@ describe("updateSingleSchema — what the request forwards into the DDL", () => 
     expect(written?.migrationStatus).toBe("applied");
   });
 
-  it("emits no table statements for a save that only flips a flag", async () => {
+  it("emits no main-table statements for a save that only flips a flag", async () => {
     // The flag-only save is a plan that renders no SQL, not a second execution path. It still has
-    // companion work to do, which is why it is a plan at all rather than an early return.
-    const { sql, written } = await runUpdate({ localized: true });
+    // companion work — saving Draft/Published on a localized single ADDs or DROPs the companion's
+    // own `_status` — which is why it is a plan at all rather than an early return.
+    //
+    // 🔴 Driven by SAVING the toggle at a value it already holds. That is the case `statusRequested`
+    // exists for and the one a derived `hasStatus !== wasStatus` would collapse: provisioning is
+    // idempotent, so this save is what repairs a localized single whose companion `_status` was
+    // never created. Were it treated as a no-op the repair would silently stop happening.
+    const { sql, written } = await runUpdate(
+      { status: false },
+      { existing: existingSingle({ localized: true, status: false }) }
+    );
 
-    expect(sql).not.toMatch(/ALTER TABLE single_page\b/i);
+    expect(sql).not.toMatch(/ALTER TABLE\s+"?single_page"?\s/i);
+    expect(sql).not.toMatch(/CREATE TABLE\s+"?single_page"?\s/i);
     expect(written?.migrationStatus).toBe("applied");
   });
 
-  it("does not plan a second title column for a field that already owns one", async () => {
-    // The system columns are matched by the COLUMN each field becomes, not by its name. A field
-    // named `Title` already owns `title`, so prepending the system declaration beside it would hand
-    // the diff two fields for one column and plan an ADD COLUMN against a column that exists.
-    const { sql } = await runUpdate({
+  it("emits nothing destructive when a field group is named after a system column", async () => {
+    // A field group stores its values in its own table and declares NO column, so one named `title`
+    // must not be mistaken for the table's own `title`. The normaliser keys the system declarations
+    // on the COLUMN each field becomes rather than on its name, which is what keeps them apart.
+    //
+    // 🔴 This asserts the OUTCOME, not that mechanism, and the distinction is worth stating: keying
+    // on the name instead was measured against this same input and produced byte-identical SQL,
+    // because the generator does not DROP a system column that goes missing from the desired list.
+    // So the two keyings are indistinguishable at this seam and no assertion here can separate
+    // them — `columnsDeclaredBy` is where that choice is decidable and tested. What this does hold
+    // is the outcome a future generator could break: adding a field group beside a system column
+    // must never emit DDL against that column.
+    const { sql, written } = await runUpdate({
       fields: [
-        { name: "Title", type: "text" },
         { name: "heading", type: "text" },
+        { name: "title", type: "component", component: "seo" },
       ],
     });
 
-    expect(sql).not.toMatch(/ADD COLUMN "?title"?\s/i);
+    expect(sql).not.toMatch(/DROP COLUMN\s+"?title"?/i);
+    expect(sql).not.toMatch(/ADD COLUMN\s+"?title"?/i);
+    expect(written?.migrationStatus).toBe("applied");
   });
 });
 
 describe("updateSingleSchema — where a failure is allowed to surface", () => {
   it("raises a refusal instead of saving the fields it refused", async () => {
-    // The generator is a validator as well as a renderer: it refuses an edit it can never apply
-    // before any statement runs, and at that point the table is untouched and the caller's field
-    // list is unsaved. Recording that as `failed` would persist a schema the table does not have
-    // and report the single as having it.
-    const existing = existingSingle({
-      fields: [{ name: "heading", type: "textarea", unique: true }],
-    });
+    // The generator is a validator as well as a renderer: a REQUIRED column has no value for the
+    // rows already there, so it refuses before any statement runs. At that point the table is
+    // untouched and the caller's field list is unsaved — recording that as `failed` would persist a
+    // schema the table does not have and report the single as having it.
     let threw: unknown;
-    let registry;
+    let out;
     try {
-      ({ registry } = await runUpdate(
+      out = await runUpdate(
         {
           fields: [
-            { name: "heading", type: "textarea", unique: true },
-            { name: "body", type: "textarea", unique: true },
+            { name: "heading", type: "text" },
+            {
+              name: "author",
+              type: "relationship",
+              required: true,
+              relationTo: "users",
+            },
           ],
         },
-        { dialect: "mysql", existing }
-      ));
+        { tableHasRows: true }
+      );
     } catch (error) {
       threw = error;
     }
 
     expect(threw).toBeInstanceOf(NextlyError);
-    expect(registry).toBeUndefined();
+    expect(out, "the update did not reach its registry write").toBeUndefined();
     expect(executed, "nothing ran against the database").toEqual([]);
   });
 

--- a/packages/nextly/src/dispatcher/handlers/__tests__/single-dispatcher-update-ddl.test.ts
+++ b/packages/nextly/src/dispatcher/handlers/__tests__/single-dispatcher-update-ddl.test.ts
@@ -418,11 +418,10 @@ describe("updateSingleSchema — where a failure is allowed to surface", () => {
     expect(registeredShapes).toHaveBeenCalledTimes(1);
   });
 
-  it("leaves a failed single failed when the save ran no statements against it", async () => {
+  it("leaves a failed single failed when the save only describes a change to it", async () => {
     // A create that got its `CREATE TABLE` through and then failed on an index leaves the table
-    // PRESENT but incomplete. Re-saving unchanged fields takes the alter branch, emits nothing, and
-    // finds the table there — so confirming existence would report a schema this save never
-    // inspected, and would overwrite the one durable record that something is wrong.
+    // PRESENT but incomplete. Every later save takes the alter branch, and an ALTER re-establishes
+    // nothing it does not mention, so the missing artifact stays missing.
     const { sql, written } = await runUpdate(
       { fields: [{ name: "heading", type: "text" }] },
       { existing: existingSingle({ migrationStatus: "failed" }) }
@@ -430,6 +429,42 @@ describe("updateSingleSchema — where a failure is allowed to surface", () => {
 
     expect(sql).not.toMatch(/ALTER TABLE/i);
     expect(written?.migrationStatus).toBe("failed");
+  });
+
+  it("leaves a failed single failed even when its alter runs statements", async () => {
+    // 🔴 The case "did anything run?" gets wrong, and the reason the rule asks what the plan
+    // DESCRIBES instead. An unrelated field edit against the same incomplete table emits a real
+    // ALTER and runs it — plenty of statements, none of them anywhere near the index that never
+    // got created. Counting statements would clear the one durable record that something is wrong.
+    const { sql, written } = await runUpdate(
+      {
+        fields: [
+          { name: "heading", type: "text" },
+          { name: "subtitle", type: "text" },
+        ],
+      },
+      { existing: existingSingle({ migrationStatus: "failed" }) }
+    );
+
+    expect(sql, "the alter really did run").toMatch(/ALTER TABLE/i);
+    expect(written?.migrationStatus).toBe("failed");
+  });
+
+  it("clears a failed single when the save rebuilds the whole table", async () => {
+    // The control, and the case the rule must NOT block: the table is absent, so the plan renders
+    // it from the desired spec in full — every column, index and junction table. Reaching the end
+    // of that does mean the schema is whole, which is what makes the repair recordable at all.
+    // Without this, a rule that simply never cleared `failed` would satisfy both cases above.
+    const { sql, written } = await runUpdate(
+      { fields: [{ name: "heading", type: "text" }] },
+      {
+        existing: existingSingle({ migrationStatus: "failed" }),
+        mainTableExists: false,
+      }
+    );
+
+    expect(sql).toMatch(/CREATE TABLE/i);
+    expect(written?.migrationStatus).toBe("applied");
   });
 
   it("records a database failure rather than raising it, once a statement has run", async () => {

--- a/packages/nextly/src/dispatcher/handlers/__tests__/single-dispatcher-update-ddl.test.ts
+++ b/packages/nextly/src/dispatcher/handlers/__tests__/single-dispatcher-update-ddl.test.ts
@@ -385,13 +385,15 @@ describe("updateSingleSchema — where a failure is allowed to surface", () => {
     expect(written?.migrationStatus).toBe("failed");
   });
 
-  it("does not bind the runtime shape when the companion reconcile fails", async () => {
-    // 🔴 The shape bound on a localization ENABLE omits the translatable columns, which are still
-    // physically on the main table until the companion has taken them. Binding it before the
-    // companion succeeds leaves the resolver describing a table that does not exist in that shape —
-    // and `ensure-runtime-table.ts` treats a registration it did not make as owned by whoever made
-    // it, so it ADOPTS this one rather than rebuilding. Reads would drop those fields until a
-    // restart.
+  it("binds the shape the main table actually has when the companion fails mid-enable", async () => {
+    // 🔴 A failed companion leaves the two halves in DIFFERENT states, and the runtime shape is
+    // composed from both: the main table holds the new field set, while the translatable columns
+    // have not moved off it. Binding the shape the save ASKED for would omit columns that are
+    // still physically there.
+    //
+    // Something must be bound rather than nothing: `ensure-runtime-table.ts` adopts a registration
+    // it did not make instead of rebuilding, and the registry cannot invalidate one table, so a
+    // stale entry survives to the next restart either way.
     const { written } = await runUpdate(
       { localized: true },
       {
@@ -401,7 +403,37 @@ describe("updateSingleSchema — where a failure is allowed to surface", () => {
     );
 
     expect(written?.migrationStatus).toBe("failed");
-    expect(registeredShapes).not.toHaveBeenCalled();
+    expect(registeredShapes).toHaveBeenCalledTimes(1);
+    const table = registeredShapes.mock.calls[0][1] as Record<string, unknown>;
+    // `heading` is a text field, so it translates by default. It is still on main because the
+    // enable never completed, and the bound shape has to say so.
+    expect(Object.keys(table)).toContain("heading");
+  });
+
+  it("binds the new columns when a localized single's own ALTER succeeded", async () => {
+    // The other half of the same rule, and the case that ordering alone cannot fix. An
+    // already-localized single edits a NON-translatable field: the main ALTER adds the column, then
+    // the companion fails. Binding nothing leaves the resolver on a shape without the column the
+    // ALTER just added, and reads drop it until a restart.
+    const { written } = await runUpdate(
+      {
+        fields: [
+          { name: "heading", type: "text" },
+          { name: "count", type: "number" },
+        ],
+      },
+      {
+        existing: existingSingle({
+          localized: true,
+          fields: [{ name: "heading", type: "text" }],
+        }),
+        companionFailure: new Error("companion ALTER rejected"),
+      }
+    );
+
+    expect(written?.migrationStatus).toBe("failed");
+    const table = registeredShapes.mock.calls[0][1] as Record<string, unknown>;
+    expect(Object.keys(table)).toContain("count");
   });
 
   it("binds the runtime shape once the companion has taken", async () => {

--- a/packages/nextly/src/dispatcher/handlers/__tests__/single-dispatcher-update-ddl.test.ts
+++ b/packages/nextly/src/dispatcher/handlers/__tests__/single-dispatcher-update-ddl.test.ts
@@ -30,6 +30,9 @@ vi.mock("../../helpers/di", () => ({
 
 const executed: string[] = [];
 
+/** Every main-table shape the apply bound, in order, so registration timing is observable. */
+const registeredShapes = vi.fn();
+
 /**
  * The adapter surface an update touches.
  *
@@ -56,6 +59,10 @@ function makeAdapter(
       name.includes("_locales") ? false : mainTableExists || created
     ),
     selectOne: vi.fn(async (): Promise<{ id: string } | null> => null),
+    // Present so runtime registration is OBSERVABLE. The create-side sibling omits it deliberately
+    // to skip re-registration; here the order of that call against the companion reconcile is the
+    // property under test, so it has to be visible.
+    tableResolver: { registerDynamicSchema: registeredShapes },
     // The companion reconcile reaches the database through Drizzle rather than `executeQuery`, so
     // its own statements are NOT visible in `executed`. That is why the flag-only assertion below
     // is phrased as "no statement naming the MAIN table" rather than "no statements at all": the
@@ -228,6 +235,7 @@ async function runUpdate(
     onStatement,
   } = options;
   executed.length = 0;
+  registeredShapes.mockClear();
   liveTableHasRows.value = tableHasRows;
   companionFailure.error = options.companionFailure;
   adapter = makeAdapter(dialect, { mainTableExists, onStatement });
@@ -374,6 +382,53 @@ describe("updateSingleSchema — where a failure is allowed to surface", () => {
       }
     );
 
+    expect(written?.migrationStatus).toBe("failed");
+  });
+
+  it("does not bind the runtime shape when the companion reconcile fails", async () => {
+    // 🔴 The shape bound on a localization ENABLE omits the translatable columns, which are still
+    // physically on the main table until the companion has taken them. Binding it before the
+    // companion succeeds leaves the resolver describing a table that does not exist in that shape —
+    // and `ensure-runtime-table.ts` treats a registration it did not make as owned by whoever made
+    // it, so it ADOPTS this one rather than rebuilding. Reads would drop those fields until a
+    // restart.
+    const { written } = await runUpdate(
+      { localized: true },
+      {
+        existing: existingSingle({ localized: false }),
+        companionFailure: new Error("companion CREATE TABLE rejected"),
+      }
+    );
+
+    expect(written?.migrationStatus).toBe("failed");
+    expect(registeredShapes).not.toHaveBeenCalled();
+  });
+
+  it("binds the runtime shape once the companion has taken", async () => {
+    // The control. Without it, an apply that never registered at all would satisfy the case above
+    // while silently dropping the rebinding a successful save depends on.
+    const { written } = await runUpdate({
+      fields: [
+        { name: "heading", type: "text" },
+        { name: "subtitle", type: "text" },
+      ],
+    });
+
+    expect(written?.migrationStatus).toBe("applied");
+    expect(registeredShapes).toHaveBeenCalledTimes(1);
+  });
+
+  it("leaves a failed single failed when the save ran no statements against it", async () => {
+    // A create that got its `CREATE TABLE` through and then failed on an index leaves the table
+    // PRESENT but incomplete. Re-saving unchanged fields takes the alter branch, emits nothing, and
+    // finds the table there — so confirming existence would report a schema this save never
+    // inspected, and would overwrite the one durable record that something is wrong.
+    const { sql, written } = await runUpdate(
+      { fields: [{ name: "heading", type: "text" }] },
+      { existing: existingSingle({ migrationStatus: "failed" }) }
+    );
+
+    expect(sql).not.toMatch(/ALTER TABLE/i);
     expect(written?.migrationStatus).toBe("failed");
   });
 

--- a/packages/nextly/src/dispatcher/handlers/__tests__/single-dispatcher-update-ddl.test.ts
+++ b/packages/nextly/src/dispatcher/handlers/__tests__/single-dispatcher-update-ddl.test.ts
@@ -32,6 +32,8 @@ const executed: string[] = [];
 
 /** Every main-table shape the apply bound, in order, so registration timing is observable. */
 const registeredShapes = vi.fn();
+/** Every table the apply retracted, so the recovery path is observable rather than inferred. */
+const retractedTables = vi.fn();
 
 /**
  * The adapter surface an update touches.
@@ -62,7 +64,10 @@ function makeAdapter(
     // Present so runtime registration is OBSERVABLE. The create-side sibling omits it deliberately
     // to skip re-registration; here the order of that call against the companion reconcile is the
     // property under test, so it has to be visible.
-    tableResolver: { registerDynamicSchema: registeredShapes },
+    tableResolver: {
+      registerDynamicSchema: registeredShapes,
+      retractDynamicSchema: retractedTables,
+    },
     // The companion reconcile reaches the database through Drizzle rather than `executeQuery`, so
     // its own statements are NOT visible in `executed`. That is why the flag-only assertion below
     // is phrased as "no statement naming the MAIN table" rather than "no statements at all": the
@@ -109,16 +114,20 @@ vi.mock("../../../domains/schema/pipeline/live-table-facts", () => ({
 }));
 
 /**
- * A failure raised by the companion reconcile, injected per test.
+ * A failure raised by the companion reconcile, injected per test, on either side of the real call.
  *
- * The real module runs unless a test sets this, so every other case still exercises it. What this
- * stands in for is the tail of a localization DISABLE: the reconcile restores the translations,
- * archives them and DROPS the companion table, and only then clears the transition marker — which
- * refuses a slug containing a dot and raises a `NextlyError`. By that point the schema has already
- * changed, which is the property under test; reproducing the dotted slug end to end would pin the
- * one path that reaches it rather than the rule that governs all of them.
+ * `when: "before"` stands for a reconcile that stopped at its first statement — an enable whose
+ * companion CREATE was rejected, so nothing moved. `when: "after"` stands for one that completed
+ * its DDL and failed on the tail: a disable restores the columns, archives them, DROPS the
+ * companion, and only then clears the transition marker, which refuses a dotted slug.
+ *
+ * Both are needed because they leave the table in OPPOSITE states, and a double that can only
+ * produce one of them cannot show that the recovery treats them alike.
  */
-const companionFailure: { error: unknown } = { error: undefined };
+const companionFailure: { error: unknown; when: "before" | "after" } = {
+  error: undefined,
+  when: "after",
+};
 vi.mock(
   "../../../domains/singles/services/reconcile-single-companion",
   async () => {
@@ -225,6 +234,7 @@ async function runUpdate(
     mainTableExists?: boolean;
     tableHasRows?: boolean;
     companionFailure?: unknown;
+    companionFailureWhen?: "before" | "after";
     onStatement?: (sql: string) => void;
   } = {}
 ) {
@@ -236,8 +246,10 @@ async function runUpdate(
   } = options;
   executed.length = 0;
   registeredShapes.mockClear();
+  retractedTables.mockClear();
   liveTableHasRows.value = tableHasRows;
   companionFailure.error = options.companionFailure;
+  companionFailure.when = options.companionFailureWhen ?? "after";
   adapter = makeAdapter(dialect, { mainTableExists, onStatement });
   const registry = wireRegistry(options.existing ?? existingSingle());
   const result = await dispatchSingles(
@@ -385,56 +397,37 @@ describe("updateSingleSchema — where a failure is allowed to surface", () => {
     expect(written?.migrationStatus).toBe("failed");
   });
 
-  it("binds the shape the main table actually has when the companion fails mid-enable", async () => {
-    // 🔴 A failed companion leaves the two halves in DIFFERENT states, and the runtime shape is
-    // composed from both: the main table holds the new field set, while the translatable columns
-    // have not moved off it. Binding the shape the save ASKED for would omit columns that are
-    // still physically there.
-    //
-    // Something must be bound rather than nothing: `ensure-runtime-table.ts` adopts a registration
-    // it did not make instead of rebuilding, and the registry cannot invalidate one table, so a
-    // stale entry survives to the next restart either way.
-    const { written } = await runUpdate(
-      { localized: true },
-      {
-        existing: existingSingle({ localized: false }),
-        companionFailure: new Error("companion CREATE TABLE rejected"),
-      }
-    );
+  it.each([
+    ["before its DDL ran", "before" as const],
+    ["after its DDL completed", "after" as const],
+  ])(
+    "retracts the runtime shape when the companion fails %s",
+    async (_label, when) => {
+      // 🔴 The recovery RETRACTS rather than rebinding, and these two cases are why. A reconcile
+      // that stops at its first statement leaves the translatable columns on main; one that stops
+      // on its tail — a disable that restored the columns, dropped the companion and then failed
+      // clearing its transition marker — leaves them somewhere else entirely. Every fixed shape is
+      // correct for one of these and wrong for the other, and which one happened is not observable
+      // from outside the reconcile.
+      //
+      // Retracting is the claim that holds for both: no longer describable from here. The rebuild
+      // in `ensure-runtime-table.ts` then PROBES the database for where the columns physically
+      // live, which is the fact any bound shape would have been guessing.
+      const { written } = await runUpdate(
+        { localized: true },
+        {
+          existing: existingSingle({ localized: false }),
+          companionFailure: new Error("companion reconcile rejected"),
+          companionFailureWhen: when,
+        }
+      );
 
-    expect(written?.migrationStatus).toBe("failed");
-    expect(registeredShapes).toHaveBeenCalledTimes(1);
-    const table = registeredShapes.mock.calls[0][1] as Record<string, unknown>;
-    // `heading` is a text field, so it translates by default. It is still on main because the
-    // enable never completed, and the bound shape has to say so.
-    expect(Object.keys(table)).toContain("heading");
-  });
-
-  it("binds the new columns when a localized single's own ALTER succeeded", async () => {
-    // The other half of the same rule, and the case that ordering alone cannot fix. An
-    // already-localized single edits a NON-translatable field: the main ALTER adds the column, then
-    // the companion fails. Binding nothing leaves the resolver on a shape without the column the
-    // ALTER just added, and reads drop it until a restart.
-    const { written } = await runUpdate(
-      {
-        fields: [
-          { name: "heading", type: "text" },
-          { name: "count", type: "number" },
-        ],
-      },
-      {
-        existing: existingSingle({
-          localized: true,
-          fields: [{ name: "heading", type: "text" }],
-        }),
-        companionFailure: new Error("companion ALTER rejected"),
-      }
-    );
-
-    expect(written?.migrationStatus).toBe("failed");
-    const table = registeredShapes.mock.calls[0][1] as Record<string, unknown>;
-    expect(Object.keys(table)).toContain("count");
-  });
+      expect(written?.migrationStatus).toBe("failed");
+      expect(retractedTables).toHaveBeenCalledWith("single_page");
+      // Binding anything here would be adopted by the next reader instead of rebuilt.
+      expect(registeredShapes).not.toHaveBeenCalled();
+    }
+  );
 
   it("binds the runtime shape once the companion has taken", async () => {
     // The control. Without it, an apply that never registered at all would satisfy the case above
@@ -448,6 +441,9 @@ describe("updateSingleSchema — where a failure is allowed to surface", () => {
 
     expect(written?.migrationStatus).toBe("applied");
     expect(registeredShapes).toHaveBeenCalledTimes(1);
+    // The control's other half: a service that retracted unconditionally would satisfy both cases
+    // above while throwing away the rebinding every successful save depends on.
+    expect(retractedTables).not.toHaveBeenCalled();
   });
 
   it("leaves a failed single failed when the save only describes a change to it", async () => {

--- a/packages/nextly/src/dispatcher/handlers/__tests__/single-dispatcher-update-ddl.test.ts
+++ b/packages/nextly/src/dispatcher/handlers/__tests__/single-dispatcher-update-ddl.test.ts
@@ -101,6 +101,37 @@ vi.mock("../../../domains/schema/pipeline/live-table-facts", () => ({
   readIndexNames: vi.fn(async () => new Set<string>()),
 }));
 
+/**
+ * A failure raised by the companion reconcile, injected per test.
+ *
+ * The real module runs unless a test sets this, so every other case still exercises it. What this
+ * stands in for is the tail of a localization DISABLE: the reconcile restores the translations,
+ * archives them and DROPS the companion table, and only then clears the transition marker — which
+ * refuses a slug containing a dot and raises a `NextlyError`. By that point the schema has already
+ * changed, which is the property under test; reproducing the dotted slug end to end would pin the
+ * one path that reaches it rather than the rule that governs all of them.
+ */
+const companionFailure: { error: unknown } = { error: undefined };
+vi.mock(
+  "../../../domains/singles/services/reconcile-single-companion",
+  async () => {
+    const actual = await vi.importActual<
+      typeof import("../../../domains/singles/services/reconcile-single-companion")
+    >("../../../domains/singles/services/reconcile-single-companion");
+    return {
+      ...actual,
+      reconcileSingleCompanion: vi.fn(
+        async (args: Parameters<typeof actual.reconcileSingleCompanion>[0]) => {
+          const result = await actual.reconcileSingleCompanion(args);
+          if (companionFailure.error !== undefined)
+            throw companionFailure.error;
+          return result;
+        }
+      ),
+    };
+  }
+);
+
 import { NextlyError } from "../../../errors";
 import { SingleMetadataService } from "../../../domains/singles/services/single-metadata-service";
 import type { SingleRegistryService } from "../../../domains/singles/services/single-registry-service";
@@ -186,6 +217,7 @@ async function runUpdate(
     existing?: Record<string, unknown>;
     mainTableExists?: boolean;
     tableHasRows?: boolean;
+    companionFailure?: unknown;
     onStatement?: (sql: string) => void;
   } = {}
 ) {
@@ -197,6 +229,7 @@ async function runUpdate(
   } = options;
   executed.length = 0;
   liveTableHasRows.value = tableHasRows;
+  companionFailure.error = options.companionFailure;
   adapter = makeAdapter(dialect, { mainTableExists, onStatement });
   const registry = wireRegistry(options.existing ?? existingSingle());
   const result = await dispatchSingles(
@@ -320,47 +353,28 @@ describe("updateSingleSchema — where a failure is allowed to surface", () => {
     expect(executed, "nothing ran against the database").toEqual([]);
   });
 
-  it("raises a refusal that reaches it from the apply phase too", async () => {
-    // 🔴 A separate rule from the phase split, not a consequence of it. The split decides that a
-    // DATABASE failure after the first statement is RECORDED rather than raised, because a
-    // statement may already have run. A refusal is not that: it is a guard rejecting the edit, and
-    // it propagates whatever phase it arrives from. Without this, a future apply-phase refusal is
-    // silently recorded as `failed` and the field list is saved against a table that never took it.
+  it("records a refusal raised after the schema has already changed, rather than raising it", async () => {
+    // 🔴 The phase decides this, NOT the error type, and the distinction is the whole point of the
+    // split. Before anything runs, a refusal means the request was rejected and nothing was
+    // touched, so it is raised. Once a statement has run, raising SKIPS the registry write — and a
+    // row that never learns what happened leaves the registry describing storage that no longer
+    // matches it.
     //
-    // Injected at the statement seam because no adapter raises one today — they raise
-    // `DatabaseError`, which extends `Error` and not `NextlyError`. That is what makes the rule
-    // cheap rather than unnecessary: the call graph is what makes it unreachable, and call graphs
-    // change.
-    let threw: unknown;
-    let out;
-    try {
-      out = await runUpdate(
-        {
-          fields: [
-            { name: "heading", type: "text" },
-            { name: "subtitle", type: "text" },
-          ],
-        },
-        {
-          onStatement: () => {
-            throw NextlyError.validation({
-              errors: [
-                {
-                  path: "fields.subtitle",
-                  code: "REFUSED_DURING_APPLY",
-                  message: "refused while applying",
-                },
-              ],
-            });
-          },
-        }
-      );
-    } catch (error) {
-      threw = error;
-    }
+    // The reachable case is a localization disable: the companion is restored, archived and
+    // DROPPED, and only then does clearing the transition marker refuse a dotted slug. Raise there
+    // and the companion is gone while the row still says the single is localized, so every later
+    // read targets a table that is not there — with nothing recording the state.
+    const { written } = await runUpdate(
+      { localized: false },
+      {
+        existing: existingSingle({ localized: true }),
+        companionFailure: NextlyError.internal({
+          logContext: { reason: "raised after the companion was dropped" },
+        }),
+      }
+    );
 
-    expect(threw).toBeInstanceOf(NextlyError);
-    expect(out, "the update did not reach its registry write").toBeUndefined();
+    expect(written?.migrationStatus).toBe("failed");
   });
 
   it("records a database failure rather than raising it, once a statement has run", async () => {

--- a/packages/nextly/src/dispatcher/handlers/__tests__/single-dispatcher-update-ddl.test.ts
+++ b/packages/nextly/src/dispatcher/handlers/__tests__/single-dispatcher-update-ddl.test.ts
@@ -1,0 +1,344 @@
+/**
+ * What an UPDATE request turns into on the way to the database, recorded from the request in.
+ *
+ * The sibling `single-dispatcher-ddl.test.ts` does this for creates and says why: a generator
+ * snapshot records what a generator RENDERS and cannot record what a caller PASSES, so a handler
+ * that stops forwarding `localized`, `hasStatus` or the adapter's dialect still reaches every one
+ * of those assertions and they all still pass. The update path had no equivalent — its only unit
+ * coverage replaces the schema service with a stub returning `""` because it is testing response
+ * envelopes — so nothing observed the statements an update actually emits.
+ *
+ * These drive the dispatcher with a request-shaped payload and assert on what the adapter is
+ * handed, plus where a failure is allowed to surface. The second half is the part with teeth: an
+ * update decides, from the phase it fails in, whether to raise the error or record it against a
+ * row, and both outcomes look like "the save did not work" from outside.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../helpers/di", () => ({
+  getSingleRegistryFromDI: vi.fn(),
+  getSingleEntryServiceFromDI: vi.fn(),
+  getSingleMetadataServiceFromDI: vi.fn(),
+  getComponentRegistryFromDI: vi.fn().mockReturnValue(undefined),
+  getAdapterFromDI: vi.fn(),
+  // Reached by the companion reconciliation a localized update runs. Omitted, calling it throws
+  // and the update records a companion-provisioning failure — so the assertions below would
+  // describe a FAILED migration while passing.
+  getConfigFromDI: vi.fn(() => undefined),
+  getSchemaRegistryFromDI: vi.fn(() => undefined),
+}));
+
+const executed: string[] = [];
+
+/**
+ * The adapter surface an update touches.
+ *
+ * `tableExists` is what the plan asks to decide between altering the table and rebuilding it, so
+ * it is a per-test input rather than a constant: answering `false` for the main table is how a
+ * single whose earlier create failed reaches the rebuild path.
+ */
+function makeAdapter(
+  dialect: "postgresql" | "mysql" | "sqlite",
+  options: {
+    mainTableExists?: boolean;
+    onStatement?: (sql: string) => void;
+  } = {}
+) {
+  const { mainTableExists = true, onStatement } = options;
+  return {
+    dialect,
+    getCapabilities: () => ({ dialect }),
+    tableExists: vi.fn(async (name: string) =>
+      name.includes("_locales") ? false : mainTableExists
+    ),
+    selectOne: vi.fn(async (): Promise<{ id: string } | null> => null),
+    getDrizzle: vi.fn(() => ({})),
+    executeQuery: vi.fn(async (sql: string) => {
+      executed.push(sql);
+      onStatement?.(sql);
+      return [];
+    }),
+  };
+}
+
+let adapter: ReturnType<typeof makeAdapter>;
+
+vi.mock("../../../di/container", () => ({
+  container: {
+    has: vi.fn((key: string) => key === "adapter" || key === "config"),
+    get: vi.fn((key: string) => {
+      if (key === "adapter") return adapter;
+      if (key === "config")
+        return { localization: { locales: ["en"], defaultLocale: "en" } };
+      return undefined;
+    }),
+  },
+}));
+
+// The live-table facts the ALTER generator reads. Doubled because the real readers issue dialect
+// specific catalog queries against a database that is not there, and what this file is recording is
+// the statements the update EMITS, not how those facts are gathered.
+vi.mock("../../../domains/schema/pipeline/live-table-facts", () => ({
+  tableHasRows: vi.fn(async () => false),
+  readForeignKeyColumns: vi.fn(async () => new Map<string, string[]>()),
+  readIndexNames: vi.fn(async () => new Set<string>()),
+}));
+
+import { NextlyError } from "../../../errors";
+import { SingleMetadataService } from "../../../domains/singles/services/single-metadata-service";
+import type { SingleRegistryService } from "../../../domains/singles/services/single-registry-service";
+import type { Logger } from "../../../shared/types";
+import {
+  getSingleEntryServiceFromDI,
+  getSingleMetadataServiceFromDI,
+  getSingleRegistryFromDI,
+} from "../../helpers/di";
+import { dispatchSingles } from "../single-dispatcher";
+
+/** Silent: these tests read the statements, not the log. */
+const logger: Logger = {
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn((...a: unknown[]) => console.log("LOGWARN", ...a)),
+  error: vi.fn((...a: unknown[]) => console.log("LOGERR", ...a)),
+};
+
+/** The registry row an update starts from: a single that already exists and is not locked. */
+function existingSingle(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "single-1",
+    slug: "page",
+    label: "Page",
+    tableName: "single_page",
+    fields: [{ name: "heading", type: "text" }],
+    locked: false,
+    status: false,
+    localized: false,
+    migrationStatus: "applied",
+    ...overrides,
+  };
+}
+
+function wireRegistry(existing: Record<string, unknown>) {
+  const registry = {
+    listSingles: vi.fn(),
+    getAllSingles: vi.fn().mockResolvedValue([]),
+    getSingleBySlug: vi.fn(async () => existing),
+    registerSingle: vi.fn(async (row: unknown) => row),
+    updateMigrationStatus: vi.fn(),
+    updateSingle: vi.fn(
+      async (slug: string, data: Record<string, unknown>) => ({
+        ...existing,
+        ...data,
+      })
+    ),
+    deleteSingle: vi.fn(),
+  };
+  vi.mocked(getSingleRegistryFromDI).mockReturnValue(
+    registry as unknown as ReturnType<typeof getSingleRegistryFromDI>
+  );
+  vi.mocked(getSingleEntryServiceFromDI).mockReturnValue({
+    get: vi.fn(),
+    update: vi.fn(),
+  } as unknown as ReturnType<typeof getSingleEntryServiceFromDI>);
+  // The REAL service over the same doubles: what an update forwards into the DDL is decided inside
+  // it, so a stub standing in for it would leave these assertions describing the stub.
+  vi.mocked(getSingleMetadataServiceFromDI).mockReturnValue(
+    new SingleMetadataService(
+      registry as unknown as SingleRegistryService,
+      logger,
+      adapter as unknown as ConstructorParameters<
+        typeof SingleMetadataService
+      >[2]
+    )
+  );
+  return registry;
+}
+
+/**
+ * Drive one update and hand back both halves of what it did.
+ *
+ * The recorded status is returned rather than asserted here, because unlike the create file these
+ * tests deliberately cover the failing outcomes too — a shared precondition demanding "applied"
+ * would make half of them unwritable.
+ */
+async function runUpdate(
+  payload: Record<string, unknown>,
+  options: {
+    dialect?: "postgresql" | "mysql" | "sqlite";
+    existing?: Record<string, unknown>;
+    mainTableExists?: boolean;
+    onStatement?: (sql: string) => void;
+  } = {}
+) {
+  const {
+    dialect = "postgresql",
+    mainTableExists = true,
+    onStatement,
+  } = options;
+  executed.length = 0;
+  adapter = makeAdapter(dialect, { mainTableExists, onStatement });
+  const registry = wireRegistry(options.existing ?? existingSingle());
+  const result = await dispatchSingles(
+    "updateSingleSchema",
+    { slug: "page" },
+    payload
+  );
+  const written = registry.updateSingle.mock.calls[0]?.[1] as
+    | { migrationStatus?: string }
+    | undefined;
+  return { registry, result, sql: executed.join("\n"), written };
+}
+
+beforeEach(() => {
+  vi.mocked(getSingleRegistryFromDI).mockReset();
+  vi.mocked(getSingleEntryServiceFromDI).mockReset();
+  vi.mocked(getSingleMetadataServiceFromDI).mockReset();
+});
+
+describe("updateSingleSchema — what the request forwards into the DDL", () => {
+  it("alters the existing table for a field the single did not have", async () => {
+    const { sql, written } = await runUpdate({
+      fields: [
+        { name: "heading", type: "text" },
+        { name: "subtitle", type: "text" },
+      ],
+    });
+
+    expect(sql).toMatch(/ALTER TABLE/i);
+    expect(sql).toMatch(/subtitle/);
+    expect(written?.migrationStatus).toBe("applied");
+  });
+
+  it("rebuilds a table an earlier create never left behind, rather than altering nothing", async () => {
+    // The create-or-alter decision belongs to the plan, where the database's state is still safe to
+    // ask about. A single whose create failed has a registry row and no table; altering it would
+    // emit ADD COLUMN against something that is not there.
+    const { sql, written } = await runUpdate(
+      { fields: [{ name: "heading", type: "text" }] },
+      { mainTableExists: false }
+    );
+
+    expect(sql).toMatch(/CREATE TABLE/i);
+    expect(sql).not.toMatch(/ALTER TABLE/i);
+    expect(written?.migrationStatus).toBe("applied");
+  });
+
+  it("emits no table statements for a save that only flips a flag", async () => {
+    // The flag-only save is a plan that renders no SQL, not a second execution path. It still has
+    // companion work to do, which is why it is a plan at all rather than an early return.
+    const { sql, written } = await runUpdate({ localized: true });
+
+    expect(sql).not.toMatch(/ALTER TABLE single_page\b/i);
+    expect(written?.migrationStatus).toBe("applied");
+  });
+
+  it("does not plan a second title column for a field that already owns one", async () => {
+    // The system columns are matched by the COLUMN each field becomes, not by its name. A field
+    // named `Title` already owns `title`, so prepending the system declaration beside it would hand
+    // the diff two fields for one column and plan an ADD COLUMN against a column that exists.
+    const { sql } = await runUpdate({
+      fields: [
+        { name: "Title", type: "text" },
+        { name: "heading", type: "text" },
+      ],
+    });
+
+    expect(sql).not.toMatch(/ADD COLUMN "?title"?\s/i);
+  });
+});
+
+describe("updateSingleSchema — where a failure is allowed to surface", () => {
+  it("raises a refusal instead of saving the fields it refused", async () => {
+    // The generator is a validator as well as a renderer: it refuses an edit it can never apply
+    // before any statement runs, and at that point the table is untouched and the caller's field
+    // list is unsaved. Recording that as `failed` would persist a schema the table does not have
+    // and report the single as having it.
+    const existing = existingSingle({
+      fields: [{ name: "heading", type: "textarea", unique: true }],
+    });
+    let threw: unknown;
+    let registry;
+    try {
+      ({ registry } = await runUpdate(
+        {
+          fields: [
+            { name: "heading", type: "textarea", unique: true },
+            { name: "body", type: "textarea", unique: true },
+          ],
+        },
+        { dialect: "mysql", existing }
+      ));
+    } catch (error) {
+      threw = error;
+    }
+
+    expect(threw).toBeInstanceOf(NextlyError);
+    expect(registry).toBeUndefined();
+    expect(executed, "nothing ran against the database").toEqual([]);
+  });
+
+  it("raises a refusal that reaches it from the apply phase too", async () => {
+    // 🔴 A separate rule from the phase split, not a consequence of it. The split decides that a
+    // DATABASE failure after the first statement is RECORDED rather than raised, because a
+    // statement may already have run. A refusal is not that: it is a guard rejecting the edit, and
+    // it propagates whatever phase it arrives from. Without this, a future apply-phase refusal is
+    // silently recorded as `failed` and the field list is saved against a table that never took it.
+    //
+    // Injected at the statement seam because no adapter raises one today — they raise
+    // `DatabaseError`, which extends `Error` and not `NextlyError`. That is what makes the rule
+    // cheap rather than unnecessary: the call graph is what makes it unreachable, and call graphs
+    // change.
+    let threw: unknown;
+    let out;
+    try {
+      out = await runUpdate(
+        {
+          fields: [
+            { name: "heading", type: "text" },
+            { name: "subtitle", type: "text" },
+          ],
+        },
+        {
+          onStatement: () => {
+            throw NextlyError.validation({
+              errors: [
+                {
+                  path: "fields.subtitle",
+                  code: "REFUSED_DURING_APPLY",
+                  message: "refused while applying",
+                },
+              ],
+            });
+          },
+        }
+      );
+    } catch (error) {
+      threw = error;
+    }
+
+    expect(threw).toBeInstanceOf(NextlyError);
+    expect(out, "the update did not reach its registry write").toBeUndefined();
+  });
+
+  it("records a database failure rather than raising it, once a statement has run", async () => {
+    // The other side of the same boundary, and the control for the test above: without it, a
+    // service that raised EVERYTHING would satisfy the refusal cases while breaking every ordinary
+    // failure. A migration that got part way leaves the table changed, so the row has to say so.
+    const { written } = await runUpdate(
+      {
+        fields: [
+          { name: "heading", type: "text" },
+          { name: "subtitle", type: "text" },
+        ],
+      },
+      {
+        onStatement: () => {
+          throw new Error("connection reset mid-migration");
+        },
+      }
+    );
+
+    expect(written?.migrationStatus).toBe("failed");
+  });
+});

--- a/packages/nextly/src/dispatcher/handlers/single-dispatcher.ts
+++ b/packages/nextly/src/dispatcher/handlers/single-dispatcher.ts
@@ -36,18 +36,11 @@ import {
 } from "../../api/versions-access";
 import type { FieldConfig } from "../../collections/fields/types";
 import { container } from "../../di/container";
-import { DynamicCollectionSchemaService } from "../../domains/dynamic-collections/services/dynamic-collection-schema-service";
-import { resolveLocalizedFieldNames } from "../../domains/i18n/classify-fields";
 import { assertLocalizationConfigured } from "../../domains/i18n/config/require-app-config";
 import { buildCompanionRuntimeTable } from "../../domains/i18n/runtime/companion-registration";
 import { translatePipelinePreviewToLegacy } from "../../domains/schema/legacy-preview/translate";
 import { RealClassifier } from "../../domains/schema/pipeline/classifier/classifier";
 import { extractDatabaseNameFromUrl } from "../../domains/schema/pipeline/database-url";
-import {
-  readForeignKeyColumns,
-  readIndexNames,
-  tableHasRows,
-} from "../../domains/schema/pipeline/live-table-facts";
 import { RealPreCleanupExecutor } from "../../domains/schema/pipeline/pre-cleanup/executor";
 import { previewDesiredSchema } from "../../domains/schema/pipeline/preview";
 import {
@@ -62,9 +55,7 @@ import {
 import { RegexRenameDetector } from "../../domains/schema/pipeline/rename-detector";
 import type { Resolution } from "../../domains/schema/pipeline/resolution/types";
 import type { DesiredSingle } from "../../domains/schema/pipeline/types";
-import { applyMigrationStatements } from "../../domains/schema/services/apply-migration-statements";
 import { DrizzleStatementExecutor } from "../../domains/schema/services/drizzle-statement-executor";
-import { columnsDeclaredBy } from "../../domains/schema/services/field-column-descriptor";
 import { generateRuntimeSchema } from "../../domains/schema/services/runtime-schema-generator";
 import type { FieldResolution } from "../../domains/schema/services/schema-change-types";
 import { calculateSchemaHash } from "../../domains/schema/services/schema-hash";
@@ -876,7 +867,6 @@ const SINGLES_METHODS: Record<string, MethodHandler<SinglesServices>> = {
       const wasLocalized = existing.localized === true;
       const isLocalized =
         b.localized !== undefined ? b.localized === true : wasLocalized;
-      const alterOmitLocalized = isLocalized || wasLocalized;
       // i18n: gate the Internationalization enable on the app-level
       // `localization` config (false→true only — an already-localized
       // single keeps saving, and disabling is always allowed).
@@ -884,330 +874,39 @@ const SINGLES_METHODS: Record<string, MethodHandler<SinglesServices>> = {
         assertLocalizationConfigured("single", slug);
       }
 
-      let migrationStatus = existing.migrationStatus;
+      // What the single is being saved AS, and what it currently IS. Both halves are needed: the
+      // ALTER adds or drops the `status` column between them, and the companion's disable restore
+      // needs to know whether main carried it before this save.
+      const wasStatus = (existing as { status?: boolean }).status === true;
+      const hasStatus = b.status !== undefined ? b.status === true : wasStatus;
 
+      let schemaFields: FieldDefinition[] | undefined;
       if (b.fields !== undefined) {
         // Same rules as the ui-schema.json mirror (see api/fields-payload).
         assertValidFieldsPayload(b.fields);
         updateData.fields = b.fields;
         updateData.schemaHash = calculateSchemaHash(b.fields);
-
-        // Generate and execute ALTER TABLE migration. The dialect comes from
-        // the adapter that will run it, for the same reason as the create
-        // path above: the service's own default is "postgresql". Read
-        // optionally, matching how the execution below reads it.
-        const updateDialect = container.has("adapter")
-          ? container.get<DrizzleAdapter>("adapter").getCapabilities().dialect
-          : undefined;
-        const schemaService = new DynamicCollectionSchemaService(
-          undefined,
-          updateDialect
-        );
-        const tableName = existing.tableName;
-
-        // Normalize field lists for ALTER TABLE comparison. The physical
-        // table always has system columns (title, slug, updatedAt) added
-        // by generateMigrationSQL, but stored field definitions may not
-        // include them. We ensure both old and new lists include these
-        // so the diff doesn't try to ADD COLUMN for columns that already
-        // exist in the physical table.
-        const systemFields: FieldDefinition[] = [
-          // `localized: false` for the same reason the synthetic declarations
-          // carry it: these are main-table system columns, and text-like
-          // fields localize by default. Without it `omitLocalized` below
-          // strips them from a localized single's ALTER input, so the
-          // main-table diff stops seeing the `title`/`slug` it already has
-          // and plans them as additions against columns that exist.
-          { name: "title", type: "text", required: true, localized: false },
-          { name: "slug", type: "text", required: true, localized: false },
-        ];
-
-        const existingFields = (existing.fields ??
-          []) as unknown as FieldDefinition[];
-        // i18n: when the single is localized (in either state), translatable columns live on the
-        // companion, never the main table — drop them from the ALTER input so the main-table diff
-        // never tries to ADD/DROP them. `reconcileSingleCompanion` owns the companion side.
-        const omitLocalized = (
-          fields: FieldDefinition[]
-        ): FieldDefinition[] => {
-          if (!alterOmitLocalized) return fields;
-          const localizedNames = new Set(
-            resolveLocalizedFieldNames(fields, true)
-          );
-          return fields.filter(f => !localizedNames.has(f.name));
-        };
-        // Keyed by the COLUMN each field becomes, matching `defineSingle` and the generators. A
-        // field named `Title` already owns the `title` column, so prepending the system one beside
-        // it hands the alter two fields for a single column.
-        const declaredColumns = (fields: FieldDefinition[]): Set<string> =>
-          columnsDeclaredBy(fields);
-        const existingFieldsForAlter = omitLocalized(existingFields);
-        const existingFieldColumns = declaredColumns(existingFieldsForAlter);
-        const normalizedOldFields: FieldDefinition[] = [
-          ...systemFields.filter(sf => !existingFieldColumns.has(sf.name)),
-          ...existingFieldsForAlter,
-          {
-            name: "updatedAt",
-            type: "date",
-            required: false,
-          },
-        ];
-
-        const newFieldsRaw = b.fields as unknown as FieldDefinition[];
-        const newFieldsForAlter = omitLocalized(newFieldsRaw);
-        const newFieldColumns = declaredColumns(newFieldsForAlter);
-        const normalizedNewFields: FieldDefinition[] = [
-          ...systemFields.filter(sf => !newFieldColumns.has(sf.name)),
-          ...newFieldsForAlter,
-          {
-            name: "updatedAt",
-            type: "date",
-            required: false,
-          },
-        ];
-
-        // Forward status flags so the alter migration can ADD/DROP the
-        // `status` column when the user toggles Draft/Published. `existing`
-        // holds the previous value; `b.status` holds what the user is
-        // saving (undefined = leave alone).
-        const wasStatus = (existing as { status?: boolean }).status === true;
-        const hasStatus =
-          b.status !== undefined ? b.status === true : wasStatus;
-        // Generated where the table is known to exist, below. Whether a required column can be
-        // added without a value for the rows already there, and which columns are referenced by
-        // a foreign key, are read from the live table, and neither question has an answer for a
-        // table that was never created.
-        let migrationSQL = "";
-        // Whether any statement of this migration reached the database. Everything before that
-        // point — reading the live table, generating the SQL — either succeeds or leaves the
-        // schema exactly as it was, and a failure there must not be recorded as a migration
-        // that ran and save a field list the table never received.
-        let migrationBegan = false;
-
-        migrationStatus = "pending";
-
-        try {
-          if (container.has("adapter")) {
-            const adapter = container.get<DrizzleAdapter>("adapter");
-
-            // If the table doesn't exist (e.g. earlier creation failed),
-            // create it fresh instead of altering nothing.
-            const tableExistsBefore = await adapter.tableExists(tableName);
-
-            if (!tableExistsBefore) {
-              const createSQL = schemaService.generateMigrationSQL(
-                tableName,
-                normalizedNewFields,
-                // i18n: fresh (re)create omits translatable columns when localized.
-                { isSingle: true, hasStatus, localized: isLocalized }
-              );
-              // Same boundary as the ALTER branch below: once a statement is sent, a failure
-              // has left the table partly built rather than untouched.
-              migrationBegan = true;
-              await applyMigrationStatements(adapter, createSQL);
-            } else {
-              const db = adapter.getDrizzle();
-              const liveDialect = adapter.getCapabilities().dialect;
-              const [rows, foreignKeys, indexNames] = await Promise.all([
-                tableHasRows(db, liveDialect, tableName),
-                readForeignKeyColumns(db, liveDialect, tableName),
-                readIndexNames(db, liveDialect, tableName),
-              ]);
-              migrationSQL = schemaService.generateAlterTableMigration(
-                tableName,
-                normalizedOldFields,
-                normalizedNewFields,
-                {
-                  wasStatus,
-                  hasStatus,
-                  tableHasRows: rows,
-                  foreignKeysByColumn: foreignKeys,
-                  indexNames,
-                }
-              );
-              // Past this point a statement may have run, so a failure is a partly-applied
-              // migration rather than an edit that never started.
-              migrationBegan = true;
-              await applyMigrationStatements(adapter, migrationSQL);
-            }
-
-            const tableExistsAfter = await adapter.tableExists(tableName);
-            if (tableExistsAfter) {
-              migrationStatus = "applied";
-
-              // Re-register runtime schema with updated fields.
-              try {
-                const { generateRuntimeSchema } = await import(
-                  "../../domains/schema/services/runtime-schema-generator"
-                );
-                const dialect = adapter.getCapabilities().dialect;
-                const { table: runtimeTable } = generateRuntimeSchema(
-                  tableName,
-                  (b.fields ?? existing.fields) as FieldDefinition[],
-                  dialect,
-                  // i18n: main runtime table omits translatable columns when localized.
-                  { status: hasStatus, localized: isLocalized }
-                );
-                const resolver = (
-                  adapter as unknown as {
-                    tableResolver?: {
-                      registerDynamicSchema?: (
-                        name: string,
-                        table: unknown
-                      ) => void;
-                    };
-                  }
-                ).tableResolver;
-                if (
-                  resolver &&
-                  typeof resolver.registerDynamicSchema === "function"
-                ) {
-                  resolver.registerDynamicSchema(tableName, runtimeTable);
-                }
-              } catch {
-                // Non-fatal.
-              }
-
-              // i18n: provision/alter the companion single_<slug>_locales table for the new
-              // localized field set: CREATE + seed the default locale from main and drop those
-              // columns when newly localized (enable), restore + archive + drop on disable, or
-              // ADD/DROP columns as translatable fields change. `wasLocalized` drives the
-              // enable/disable detection.
-              try {
-                await reconcileSingleCompanion({
-                  slug,
-                  tableName,
-                  oldFields: existing.fields as unknown as FieldDefinition[],
-                  newFields: (b.fields ??
-                    existing.fields) as unknown as FieldDefinition[],
-                  localized: isLocalized,
-                  wasLocalized,
-                  status: hasStatus,
-                  // Already computed above from the persisted record, for the shared ALTER. The
-                  // disable restore needs the same fact.
-                  wasStatus,
-                  adapter,
-                });
-              } catch (companionErr) {
-                migrationStatus = "failed";
-                const m =
-                  companionErr instanceof Error
-                    ? companionErr.message
-                    : String(companionErr);
-                console.error(
-                  `[Singles] Companion reconcile failed for "${tableName}": ${m}`
-                );
-              }
-            } else {
-              migrationStatus = "failed";
-              console.error(
-                `[Singles] Table "${tableName}" not found after migration update`
-              );
-            }
-          } else {
-            console.warn(
-              "[Singles] No adapter found in container, migration not executed"
-            );
-          }
-        } catch (migrationError) {
-          // A refusal is not a failed migration. The generator rejects an edit it can never
-          // apply — a required column with no value for the rows already there, a referenced
-          // column SQLite cannot detach — before any statement runs, and the field list is
-          // still exactly what the caller sent. Recording "failed" and saving that list anyway
-          // would persist a schema the table does not have and report success for it, so the
-          // refusal is raised to the caller with the field it names.
-          //
-          // The same holds for anything else thrown before the first statement: a probe that
-          // cannot reach the database, or a catalog read the connection is not permitted, ends
-          // the save rather than reporting a migration that never began as one that failed.
-          if (migrationError instanceof NextlyError || !migrationBegan) {
-            throw migrationError;
-          }
-          migrationStatus = "failed";
-          const message =
-            migrationError instanceof Error
-              ? migrationError.message
-              : String(migrationError);
-          console.error("[Singles] Migration execution failed:", message);
-          console.error("[Singles] Migration SQL was:", migrationSQL);
-        }
-
-        updateData.migrationStatus = migrationStatus;
-      } else if (
-        isLocalized !== wasLocalized ||
-        (b.status !== undefined && (isLocalized || wasLocalized))
-      ) {
-        // Flag-only save (no field changes) that still needs companion work: an i18n
-        // enable/disable transition, or a Draft/Published toggle on a localized single (which
-        // ADDs/DROPs the companion `_status`). Without this, a settings-only toggle persisted the
-        // flag while leaving the physical schema untouched — data would strand in the wrong table.
-        try {
-          if (container.has("adapter")) {
-            const adapter = container.get<DrizzleAdapter>("adapter");
-            const tableName = existing.tableName;
-            const existingFields =
-              existing.fields as unknown as FieldDefinition[];
-            // What the single is being saved AS, and what it currently IS. The disable restore
-            // needs the second: whether main carried `status` and the companion `_status` before
-            // this apply.
-            const wasStatus =
-              (existing as { status?: boolean }).status === true;
-            const hasStatus =
-              b.status !== undefined ? b.status === true : wasStatus;
-            await reconcileSingleCompanion({
-              slug,
-              tableName,
-              oldFields: existingFields,
-              newFields: existingFields,
-              localized: isLocalized,
-              wasLocalized,
-              status: hasStatus,
-              wasStatus,
-              adapter,
-            });
-            // Re-register the main runtime table so it reflects the new column shape: a disable
-            // restores the translatable columns onto main, an enable omits them.
-            try {
-              const dialect = adapter.getCapabilities().dialect;
-              const { table: runtimeTable } = generateRuntimeSchema(
-                tableName,
-                existingFields,
-                dialect,
-                { status: hasStatus, localized: isLocalized }
-              );
-              const resolver = (
-                adapter as unknown as {
-                  tableResolver?: {
-                    registerDynamicSchema?: (
-                      name: string,
-                      table: unknown
-                    ) => void;
-                  };
-                }
-              ).tableResolver;
-              if (typeof resolver?.registerDynamicSchema === "function") {
-                resolver.registerDynamicSchema(tableName, runtimeTable);
-              }
-            } catch {
-              // Non-fatal: next boot re-registers the runtime table.
-            }
-            updateData.migrationStatus = "applied";
-          }
-        } catch (companionErr) {
-          const m =
-            companionErr instanceof Error
-              ? companionErr.message
-              : String(companionErr);
-          console.error(
-            `[Singles] Companion transition failed for "${existing.tableName}": ${m}`
-          );
-          updateData.migrationStatus = "failed";
-        }
+        schemaFields = b.fields as unknown as FieldDefinition[];
       }
 
-      const updated = await svc.registry.updateSingle(slug, updateData, {
-        source: "ui",
-      });
+      // The schema change and the registry row are written by one service call, because a lock has
+      // to cover both and cannot do that from here: the DDL would already have run by the time a
+      // lock taken inside the registry service was acquired.
+      const { record: updated, migrationStatus } =
+        await svc.metadata.updateSingleSchema({
+          slug,
+          existing,
+          updateData,
+          fields: schemaFields,
+          isLocalized,
+          wasLocalized,
+          hasStatus,
+          wasStatus,
+          // Whether the request SET the toggle, which is not the same as changing it: saving it at
+          // its current value still reaches the companion, and that is what repairs a localized
+          // single whose companion `_status` was never provisioned.
+          statusRequested: b.status !== undefined,
+        });
 
       // Migration status drives the toast copy so admins see "applied"
       // vs "pending" immediately.

--- a/packages/nextly/src/domains/schema/services/__tests__/apply-migration-statements.test.ts
+++ b/packages/nextly/src/domains/schema/services/__tests__/apply-migration-statements.test.ts
@@ -58,15 +58,12 @@ describe("applyMigrationStatements", () => {
       [index]: new Error("Duplicate key name 'idx_single_page_created_at'"),
     });
 
-    // The count includes the tolerated statement: it was dispatched, and a caller asking "did
-    // anything reach the database" is owed a yes. Asserting the number rather than merely that it
-    // resolves is what makes "keeps going" observable from the return value as well as the log.
     await expect(
       applyMigrationStatements(
         adapter,
         `${index}\n--> statement-breakpoint\nSELECT 1`
       )
-    ).resolves.toBe(2);
+    ).resolves.toBeUndefined();
 
     // The statement AFTER the tolerated one still ran: tolerating must not abandon the migration.
     expect(adapter.executed).toContain("SELECT 1");
@@ -78,14 +75,16 @@ describe("applyMigrationStatements", () => {
       [create]: new Error("Table 'single_page' already exists"),
     });
 
-    await expect(applyMigrationStatements(adapter, create)).resolves.toBe(1);
+    await expect(
+      applyMigrationStatements(adapter, create)
+    ).resolves.toBeUndefined();
   });
 
-  it("counts no statements for a diff that rendered only a comment", async () => {
-    // 🔴 What the count exists for. A diff with no operations still renders a header comment, so
-    // the SQL string is non-empty while nothing runs — and a caller that inferred "something
-    // happened" from the string would claim a schema it never touched. `SingleMetadataService`
-    // asks this before deciding it may clear a durable `failed` verdict.
+  it("runs nothing for a diff that rendered only a comment", async () => {
+    // A diff with no operations still renders a header comment, so a non-empty SQL string is not
+    // a non-empty migration. Worth pinning because that asymmetry is what makes "the SQL is not
+    // empty" the wrong way to ask whether anything reached the database — a guard written that way
+    // never fires, and reads as though it does.
     const adapter = runner({});
 
     await expect(
@@ -93,7 +92,7 @@ describe("applyMigrationStatements", () => {
         adapter,
         "-- Update dynamic collection: single_page"
       )
-    ).resolves.toBe(0);
+    ).resolves.toBeUndefined();
     expect(adapter.executed).toEqual([]);
   });
 

--- a/packages/nextly/src/domains/schema/services/__tests__/apply-migration-statements.test.ts
+++ b/packages/nextly/src/domains/schema/services/__tests__/apply-migration-statements.test.ts
@@ -58,12 +58,15 @@ describe("applyMigrationStatements", () => {
       [index]: new Error("Duplicate key name 'idx_single_page_created_at'"),
     });
 
+    // The count includes the tolerated statement: it was dispatched, and a caller asking "did
+    // anything reach the database" is owed a yes. Asserting the number rather than merely that it
+    // resolves is what makes "keeps going" observable from the return value as well as the log.
     await expect(
       applyMigrationStatements(
         adapter,
         `${index}\n--> statement-breakpoint\nSELECT 1`
       )
-    ).resolves.toBeUndefined();
+    ).resolves.toBe(2);
 
     // The statement AFTER the tolerated one still ran: tolerating must not abandon the migration.
     expect(adapter.executed).toContain("SELECT 1");
@@ -75,9 +78,23 @@ describe("applyMigrationStatements", () => {
       [create]: new Error("Table 'single_page' already exists"),
     });
 
+    await expect(applyMigrationStatements(adapter, create)).resolves.toBe(1);
+  });
+
+  it("counts no statements for a diff that rendered only a comment", async () => {
+    // 🔴 What the count exists for. A diff with no operations still renders a header comment, so
+    // the SQL string is non-empty while nothing runs — and a caller that inferred "something
+    // happened" from the string would claim a schema it never touched. `SingleMetadataService`
+    // asks this before deciding it may clear a durable `failed` verdict.
+    const adapter = runner({});
+
     await expect(
-      applyMigrationStatements(adapter, create)
-    ).resolves.toBeUndefined();
+      applyMigrationStatements(
+        adapter,
+        "-- Update dynamic collection: single_page"
+      )
+    ).resolves.toBe(0);
+    expect(adapter.executed).toEqual([]);
   });
 
   /**

--- a/packages/nextly/src/domains/schema/services/apply-migration-statements.ts
+++ b/packages/nextly/src/domains/schema/services/apply-migration-statements.ts
@@ -50,16 +50,25 @@ export interface MigrationStatementRunner {
  * Apply a generated migration, tolerating statements the schema already satisfies.
  *
  * Throws on anything else, so a caller can still record the change as failed.
+ *
+ * @returns how many statements were dispatched. A caller deciding what it may claim about the
+ * schema afterwards needs to know whether anything actually ran, and the SQL string cannot answer
+ * that: a diff with no operations still renders a header comment, so a non-empty string is not a
+ * non-empty migration. Counted here because this is where the splitting rule lives, and any caller
+ * re-deriving it from the text would be a second implementation of that rule.
  */
 export async function applyMigrationStatements(
   adapter: MigrationStatementRunner,
   migrationSQL: string
-): Promise<void> {
+): Promise<number> {
+  let dispatched = 0;
   for (const statement of splitStatements([migrationSQL])) {
+    dispatched += 1;
     try {
       await adapter.executeQuery(statement);
     } catch (error) {
       if (!isIdempotencyError(error)) throw error;
     }
   }
+  return dispatched;
 }

--- a/packages/nextly/src/domains/schema/services/apply-migration-statements.ts
+++ b/packages/nextly/src/domains/schema/services/apply-migration-statements.ts
@@ -50,25 +50,16 @@ export interface MigrationStatementRunner {
  * Apply a generated migration, tolerating statements the schema already satisfies.
  *
  * Throws on anything else, so a caller can still record the change as failed.
- *
- * @returns how many statements were dispatched. A caller deciding what it may claim about the
- * schema afterwards needs to know whether anything actually ran, and the SQL string cannot answer
- * that: a diff with no operations still renders a header comment, so a non-empty string is not a
- * non-empty migration. Counted here because this is where the splitting rule lives, and any caller
- * re-deriving it from the text would be a second implementation of that rule.
  */
 export async function applyMigrationStatements(
   adapter: MigrationStatementRunner,
   migrationSQL: string
-): Promise<number> {
-  let dispatched = 0;
+): Promise<void> {
   for (const statement of splitStatements([migrationSQL])) {
-    dispatched += 1;
     try {
       await adapter.executeQuery(statement);
     } catch (error) {
       if (!isIdempotencyError(error)) throw error;
     }
   }
-  return dispatched;
 }

--- a/packages/nextly/src/domains/singles/__tests__/single-registry-service.status-persist.test.ts
+++ b/packages/nextly/src/domains/singles/__tests__/single-registry-service.status-persist.test.ts
@@ -16,10 +16,7 @@ import { describe, it, expect, beforeEach } from "vitest";
 
 import { SingleRegistryService } from "../services/single-registry-service";
 
-import {
-  createMockAdapter,
-  createSilentLogger,
-} from "./single-test-helpers";
+import { createMockAdapter, createSilentLogger } from "./single-test-helpers";
 
 function createCtx() {
   const adapter = createMockAdapter();
@@ -160,6 +157,74 @@ describe("SingleRegistryService.updateSingle — status persistence", () => {
       unknown
     >;
     expect(updateData.status).toBe(0);
+  });
+
+  /**
+   * An outcome the caller OBSERVED is a different thing from the `"pending"` the row falls back to.
+   *
+   * `migration_status` used to be written only inside the `data.fields` branch, and only when the
+   * field hash or the status flag had changed. That gate exists to stop a metadata-only sync
+   * flagging a migration nobody asked for — a rule about the DEFAULT — but it also discarded a
+   * status the caller passed explicitly, which is not a guess: `SingleMetadataService` has run the
+   * statements and confirmed the table by the time it hands one over.
+   *
+   * These assert the row the adapter is actually handed, not an argument a double merged, because
+   * the gate lives here and a service-level test cannot see it.
+   */
+  it("records an explicitly supplied migration status when the fields did not change", async () => {
+    // 🔴 The rebuild path, and the reason this matters. A single whose create failed carries
+    // `migration_status: 'failed'`; re-saving it sends the SAME fields, so the hash matches and the
+    // gate is closed. The one save able to repair it could never record that it had.
+    mockSelectOne(dbRow({ locked: 0, schema_hash: "hash-1" }));
+    ctx.adapter.update.mockResolvedValue([dbRow()]);
+
+    await ctx.service.updateSingle("site-settings", {
+      fields: [{ name: "heading", type: "text" }],
+      schemaHash: "hash-1",
+      migrationStatus: "applied",
+    } as unknown as Parameters<typeof ctx.service.updateSingle>[1]);
+
+    const updateData = ctx.adapter.update.mock.calls[0][1] as Record<
+      string,
+      unknown
+    >;
+    expect(updateData.migration_status).toBe("applied");
+    // The gate still owns `schema_version`: nothing physical changed, so it must not bump.
+    expect("schema_version" in updateData).toBe(false);
+  });
+
+  it("records an explicitly supplied migration status when the save carries no fields", async () => {
+    // A flag-only save never reached the gate at all, so its companion provisioning went
+    // unrecorded however it turned out.
+    mockSelectOne(dbRow({ locked: 0 }));
+    ctx.adapter.update.mockResolvedValue([dbRow()]);
+
+    await ctx.service.updateSingle("site-settings", {
+      localized: true,
+      migrationStatus: "applied",
+    } as unknown as Parameters<typeof ctx.service.updateSingle>[1]);
+
+    const updateData = ctx.adapter.update.mock.calls[0][1] as Record<
+      string,
+      unknown
+    >;
+    expect(updateData.migration_status).toBe("applied");
+  });
+
+  it("still leaves migration status alone when the caller states none", async () => {
+    // The control. Without it, a registry that wrote `migration_status` unconditionally would
+    // satisfy both cases above while reintroducing the spurious pending cycle the gate exists to
+    // prevent.
+    mockSelectOne(dbRow({ locked: 0 }));
+    ctx.adapter.update.mockResolvedValue([dbRow()]);
+
+    await ctx.service.updateSingle("site-settings", { label: "New Label" });
+
+    const updateData = ctx.adapter.update.mock.calls[0][1] as Record<
+      string,
+      unknown
+    >;
+    expect("migration_status" in updateData).toBe(false);
   });
 
   it("does not include status in the update when caller omits it", async () => {

--- a/packages/nextly/src/domains/singles/services/single-metadata-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-metadata-service.ts
@@ -679,6 +679,15 @@ export class SingleMetadataService {
       //
       // The rebuild branch is the exception because it renders the table from the desired spec in
       // full, so reaching the end of it does mean every artifact was asked for.
+      //
+      // ⚠️ Known cost, accepted: a create that built the main table and failed only its COMPANION
+      // can never clear this, because every retry finds the table present and so takes the alter
+      // branch, even when the retry's reconcile succeeds and the schema is now complete. Clearing
+      // it correctly needs both halves established, and `migration_status` is one bit — it records
+      // that a migration failed, not which half. Verifying the live table against the desired spec
+      // is the answer, and until something does, holding a stale `failed` is the safer error: it is
+      // visible and blocks nothing, where a wrong `applied` hides an unenforced constraint until a
+      // write fails.
       if (
         input.existing.migrationStatus === "failed" &&
         !plan.describesWholeTable

--- a/packages/nextly/src/domains/singles/services/single-metadata-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-metadata-service.ts
@@ -542,12 +542,10 @@ export class SingleMetadataService {
    * asked nothing of the main table's schema, so overwriting the previous verdict with one about a
    * migration that was never requested would be a claim this apply cannot make.
    *
-   * 🔴 A refusal propagates, whatever phase it reaches this catch from. That is a separate rule
-   * from the phase split, not a consequence of it: the split decides that a DATABASE failure after
-   * the first statement is recorded rather than raised, while a `NextlyError` is the generator or
-   * a guard refusing the edit outright. Recording a refusal as `failed` would save the field list
-   * anyway and report the single as having a schema its table does not have. No adapter raises one
-   * today, so this costs nothing and holds the moment one does.
+   * 🔴 Never throws once it has begun. The PHASE decides that, not the error type: from here on a
+   * statement may already have run, and raising would skip the row write and leave the registry
+   * describing storage that no longer matches it. Refusals are the plan's job, which is where
+   * raising is free because nothing has been touched yet.
    */
   private async applyUpdateDdl(
     input: UpdateSingleSchemaInput,
@@ -602,7 +600,23 @@ export class SingleMetadataService {
 
       return "applied";
     } catch (error) {
-      if (error instanceof NextlyError) throw error;
+      // 🔴 Everything inside this block is recorded, including a `NextlyError`, and the error TYPE
+      // is deliberately not consulted.
+      //
+      // The tempting rule is "a refusal propagates whatever phase it arrives from", on the grounds
+      // that recording one as `failed` would save a field list the table never took. It is the
+      // wrong rule here, because by this point the schema may already have changed and raising
+      // skips the row write entirely — which leaves the registry describing storage that no longer
+      // matches it. Disabling localization is the reachable case: `reconcileSingleCompanion`
+      // restores the translations, archives them and DROPS the companion, and only then clears the
+      // transition marker, which refuses a slug containing a dot. Raise there and the companion is
+      // gone while the row still says the single is localized, so every later read targets a table
+      // that no longer exists — silently, and with nothing left to describe the state.
+      //
+      // Recording is strictly better once a statement has run: `failed` is visible, accurate and
+      // retryable, where a raise leaves an inconsistency nothing reports. Refusals belong in the
+      // PLAN, which runs before any of this and raises exactly as before; that is what the phase
+      // split is for, and it is the only place where raising costs nothing.
       this.logger.error(
         `[Singles] Migration execution failed for "${tableName}": ${
           error instanceof Error ? error.message : String(error)

--- a/packages/nextly/src/domains/singles/services/single-metadata-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-metadata-service.ts
@@ -108,6 +108,13 @@ interface CreateDdlPlan {
  */
 interface DynamicSchemaResolver {
   registerDynamicSchema?: (name: string, table: unknown) => void;
+  /**
+   * Forget the table, so the next lookup rebuilds it.
+   *
+   * Optional because a caller may hold a resolver older than the method. Where it is absent the
+   * failure path leaves the previous registration alone, which is what this code did before.
+   */
+  retractDynamicSchema?: (name: string) => void;
 }
 
 /**
@@ -616,20 +623,22 @@ export class SingleMetadataService {
           adapter,
         });
       } catch (companionError) {
-        // The main table changed and the companion did not, so the shape that is TRUE right now is
-        // the new field set under the PREVIOUS localization. Binding either end whole would be
-        // wrong in one direction: `isLocalized` omits translatable columns an enable has not moved
-        // yet, and leaving the old registration in place omits the column the ALTER just added.
+        // 🔴 The shape is RETRACTED here, never rebound, because nothing at this level knows what
+        // the table now looks like.
         //
-        // Something has to be bound rather than nothing, because `ensure-runtime-table.ts` adopts a
-        // registration it did not make instead of rebuilding, and the registry has no way to
-        // invalidate one table — so a stale entry survives until a restart either way.
-        await this.registerUpdatedRuntimeSchema(
-          input,
-          plan,
-          adapter,
-          input.wasLocalized
-        );
+        // A reconcile that fails has stopped somewhere inside a sequence that moves columns between
+        // the main table and its companion, and where it stopped decides the answer. Binding the
+        // DESIRED shape is wrong when an enable never moved the columns; binding the PREVIOUS one
+        // is wrong when a disable had already restored them and failed afterwards, clearing its
+        // transition marker; binding nothing is wrong when the main ALTER added a column. Each of
+        // those is correct for one stopping point and wrong for another, and the stopping point is
+        // not observable from out here.
+        //
+        // Retracting is the one claim that is always correct: this is no longer describable from
+        // here. `ensureSingleRuntimeTable` then rebuilds on the next touch, and its rebuild branch
+        // PROBES the database for where the translatable columns physically live — which is the
+        // fact every one of those guesses was standing in for.
+        this.retractRuntimeSchema(adapter, tableName);
         this.logger.error(
           `[Singles] Companion reconcile failed for "${tableName}": ${
             companionError instanceof Error
@@ -709,6 +718,24 @@ export class SingleMetadataService {
         this.logger.error(`[Singles] Migration SQL was: ${plan.migrationSQL}`);
       }
       return "failed";
+    }
+  }
+
+  /**
+   * Forget the main table's registered shape, so the next read rebuilds it from the database.
+   *
+   * Best-effort in the same way the registration is: a resolver that cannot retract leaves the
+   * previous entry in place, which is where this path was before the method existed.
+   */
+  private retractRuntimeSchema(
+    adapter: DrizzleAdapter,
+    tableName: string
+  ): void {
+    const resolver = (
+      adapter as unknown as { tableResolver?: DynamicSchemaResolver }
+    ).tableResolver;
+    if (resolver && typeof resolver.retractDynamicSchema === "function") {
+      resolver.retractDynamicSchema(tableName);
     }
   }
 

--- a/packages/nextly/src/domains/singles/services/single-metadata-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-metadata-service.ts
@@ -561,11 +561,20 @@ export class SingleMetadataService {
       return plan.ownsMigrationStatus ? "pending" : undefined;
     }
 
+    // How many statements actually reached the database, which is NOT the same question as
+    // whether `migrationSQL` is a non-empty string: a diff with no operations still renders a
+    // header comment. What this apply may claim about the main table afterwards depends on the
+    // former.
+    let statementsRun = 0;
+
     try {
       if (plan.migrationSQL) {
         // The shared runner, not a private copy: it owns both the splitting rule and the tolerance
         // that makes re-running over half-applied schema the repair case rather than a dead end.
-        await applyMigrationStatements(adapter, plan.migrationSQL);
+        statementsRun = await applyMigrationStatements(
+          adapter,
+          plan.migrationSQL
+        );
       }
 
       // Observed, not assumed, and it covers the rebuild case as well as the alter: a plan that
@@ -615,7 +624,7 @@ export class SingleMetadataService {
       // a junction table leaves the table PRESENT but incomplete; re-saving unchanged fields takes
       // the alter branch, emits nothing, and finds the table there. Confirming existence is not
       // confirming the schema, so the durable verdict stands until something actually repairs it.
-      if (!plan.migrationSQL && input.existing.migrationStatus === "failed") {
+      if (statementsRun === 0 && input.existing.migrationStatus === "failed") {
         this.logger.warn(
           `[Singles] "${tableName}" is recorded as a failed migration and this save ran no ` +
             `statements against it, so its status is left as failed`

--- a/packages/nextly/src/domains/singles/services/single-metadata-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-metadata-service.ts
@@ -592,6 +592,10 @@ export class SingleMetadataService {
         return "failed";
       }
 
+      // 🔴 Past this point the MAIN table holds `plan.fields`. The companion may or may not follow,
+      // and the two halves are what the runtime shape is composed from — so from here the position
+      // in this method is the evidence for which state is true, and no flag is needed to track it.
+      //
       // i18n: provision or alter the companion for the field set being saved — CREATE and seed the
       // default locale from main on enable, restore and archive on disable, ADD/DROP columns as
       // translatable fields change. Reported as a failed migration rather than thrown: the main
@@ -599,17 +603,42 @@ export class SingleMetadataService {
       const { reconcileSingleCompanion } = await import(
         "./reconcile-single-companion"
       );
-      await reconcileSingleCompanion({
-        slug: input.slug,
-        tableName,
-        oldFields: plan.previousFields,
-        newFields: plan.fields,
-        localized: input.isLocalized,
-        wasLocalized: input.wasLocalized,
-        status: input.hasStatus,
-        wasStatus: input.wasStatus,
-        adapter,
-      });
+      try {
+        await reconcileSingleCompanion({
+          slug: input.slug,
+          tableName,
+          oldFields: plan.previousFields,
+          newFields: plan.fields,
+          localized: input.isLocalized,
+          wasLocalized: input.wasLocalized,
+          status: input.hasStatus,
+          wasStatus: input.wasStatus,
+          adapter,
+        });
+      } catch (companionError) {
+        // The main table changed and the companion did not, so the shape that is TRUE right now is
+        // the new field set under the PREVIOUS localization. Binding either end whole would be
+        // wrong in one direction: `isLocalized` omits translatable columns an enable has not moved
+        // yet, and leaving the old registration in place omits the column the ALTER just added.
+        //
+        // Something has to be bound rather than nothing, because `ensure-runtime-table.ts` adopts a
+        // registration it did not make instead of rebuilding, and the registry has no way to
+        // invalidate one table — so a stale entry survives until a restart either way.
+        await this.registerUpdatedRuntimeSchema(
+          input,
+          plan,
+          adapter,
+          input.wasLocalized
+        );
+        this.logger.error(
+          `[Singles] Companion reconcile failed for "${tableName}": ${
+            companionError instanceof Error
+              ? companionError.message
+              : String(companionError)
+          }`
+        );
+        return "failed";
+      }
 
       // 🔴 Registered only once the companion has been reconciled, never before it.
       //
@@ -623,7 +652,12 @@ export class SingleMetadataService {
       //
       // Leaving the previous shape in place on failure is the safe direction: it is at worst stale
       // in the same way it was before the save, and the lazy rebuild can still correct it.
-      await this.registerUpdatedRuntimeSchema(input, plan, adapter);
+      await this.registerUpdatedRuntimeSchema(
+        input,
+        plan,
+        adapter,
+        input.isLocalized
+      );
 
       // 🔴 Only a plan that describes the WHOLE table may clear a durable `failed`.
       //
@@ -687,7 +721,14 @@ export class SingleMetadataService {
   private async registerUpdatedRuntimeSchema(
     input: UpdateSingleSchemaInput,
     plan: UpdateDdlPlan,
-    adapter: DrizzleAdapter
+    adapter: DrizzleAdapter,
+    /**
+     * Where the translatable columns physically live RIGHT NOW, which is not always what the save
+     * asked for: an enable that failed its companion leaves them on the main table. Passed rather
+     * than read from `input.isLocalized` so the caller states what it observed instead of what it
+     * intended.
+     */
+    localized: boolean
   ): Promise<void> {
     try {
       const { generateRuntimeSchema } = await import(
@@ -698,8 +739,8 @@ export class SingleMetadataService {
         plan.fields,
         adapter.getCapabilities().dialect,
         // i18n: the main runtime table omits translatable columns for a localized single, matching
-        // the DDL above.
-        { status: input.hasStatus, localized: input.isLocalized }
+        // where those columns physically are.
+        { status: input.hasStatus, localized }
       );
       const resolver = (
         adapter as unknown as { tableResolver?: DynamicSchemaResolver }

--- a/packages/nextly/src/domains/singles/services/single-metadata-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-metadata-service.ts
@@ -172,6 +172,15 @@ interface UpdateDdlPlan {
   /** The field list the table holds now. The companion reconcile diffs against it. */
   previousFields: FieldDefinition[];
   /**
+   * Whether the statements describe the WHOLE table rather than a change to it.
+   *
+   * Only a plan that rebuilds the table from the desired spec re-establishes every artifact it
+   * needs — the columns, the indexes, the junction tables. An ALTER describes a delta and says
+   * nothing about anything it does not mention, which is why it cannot vouch for a table whose
+   * create failed part way.
+   */
+  describesWholeTable: boolean;
+  /**
    * Whether this plan owns `migration_status`.
    *
    * A field change does: the column records how far the schema change got, and an app with no
@@ -380,6 +389,7 @@ export class SingleMetadataService {
         migrationSQL: "",
         fields: previousFields,
         previousFields,
+        describesWholeTable: false,
         ownsMigrationStatus: false,
       };
     }
@@ -401,6 +411,7 @@ export class SingleMetadataService {
         migrationSQL: "",
         fields,
         previousFields,
+        describesWholeTable: false,
         ownsMigrationStatus: true,
       };
     }
@@ -420,6 +431,9 @@ export class SingleMetadataService {
         }),
         fields,
         previousFields,
+        // The table is absent, so this renders it in full: every column, index and junction table
+        // the desired spec asks for.
+        describesWholeTable: true,
         ownsMigrationStatus: true,
       };
     }
@@ -453,6 +467,7 @@ export class SingleMetadataService {
       ),
       fields,
       previousFields,
+      describesWholeTable: false,
       ownsMigrationStatus: true,
     };
   }
@@ -561,20 +576,11 @@ export class SingleMetadataService {
       return plan.ownsMigrationStatus ? "pending" : undefined;
     }
 
-    // How many statements actually reached the database, which is NOT the same question as
-    // whether `migrationSQL` is a non-empty string: a diff with no operations still renders a
-    // header comment. What this apply may claim about the main table afterwards depends on the
-    // former.
-    let statementsRun = 0;
-
     try {
       if (plan.migrationSQL) {
         // The shared runner, not a private copy: it owns both the splitting rule and the tolerance
         // that makes re-running over half-applied schema the repair case rather than a dead end.
-        statementsRun = await applyMigrationStatements(
-          adapter,
-          plan.migrationSQL
-        );
+        await applyMigrationStatements(adapter, plan.migrationSQL);
       }
 
       // Observed, not assumed, and it covers the rebuild case as well as the alter: a plan that
@@ -619,15 +625,24 @@ export class SingleMetadataService {
       // in the same way it was before the save, and the lazy rebuild can still correct it.
       await this.registerUpdatedRuntimeSchema(input, plan, adapter);
 
-      // A plan that rendered no main-table statements never touched the main table, so it cannot
-      // vouch for one. A create that got its `CREATE TABLE` through and then failed on an index or
-      // a junction table leaves the table PRESENT but incomplete; re-saving unchanged fields takes
-      // the alter branch, emits nothing, and finds the table there. Confirming existence is not
-      // confirming the schema, so the durable verdict stands until something actually repairs it.
-      if (statementsRun === 0 && input.existing.migrationStatus === "failed") {
+      // 🔴 Only a plan that describes the WHOLE table may clear a durable `failed`.
+      //
+      // A create that got its `CREATE TABLE` through and then failed on an index or a junction
+      // table leaves the table PRESENT but incomplete. Every later save takes the alter branch,
+      // and an ALTER describes a delta: it re-establishes nothing it does not mention, so an
+      // unrelated field edit can run plenty of statements without going anywhere near the missing
+      // artifact. Neither "the table exists" nor "something ran" is evidence the schema is whole,
+      // and the durable verdict is the only record that it is not.
+      //
+      // The rebuild branch is the exception because it renders the table from the desired spec in
+      // full, so reaching the end of it does mean every artifact was asked for.
+      if (
+        input.existing.migrationStatus === "failed" &&
+        !plan.describesWholeTable
+      ) {
         this.logger.warn(
-          `[Singles] "${tableName}" is recorded as a failed migration and this save ran no ` +
-            `statements against it, so its status is left as failed`
+          `[Singles] "${tableName}" is recorded as a failed migration and this save only ` +
+            `describes a change to it, so its status is left as failed`
         );
         return "failed";
       }

--- a/packages/nextly/src/domains/singles/services/single-metadata-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-metadata-service.ts
@@ -110,6 +110,79 @@ interface DynamicSchemaResolver {
   registerDynamicSchema?: (name: string, table: unknown) => void;
 }
 
+/**
+ * A schema change to an existing Single, with everything the caller has already decided.
+ *
+ * The caller owns every rejection: the locked-single check, the field-payload validation, the
+ * retention-without-toggle rejection and the localization-config gate all run before this is
+ * built. What arrives here is a change that is allowed to proceed.
+ *
+ * The two flag pairs are passed rather than derived because only the caller can tell them apart.
+ * `hasStatus`/`isLocalized` are what the single is being saved AS, `wasStatus`/`wasLocalized` what
+ * it currently IS, and an undefined toggle in the request body means "leave alone" — which reads
+ * as the previous value, not as `false`.
+ */
+export interface UpdateSingleSchemaInput {
+  slug: string;
+  existing: DynamicSingleRecord;
+  /**
+   * The registry columns to write, minus `migrationStatus`, which this service owns.
+   *
+   * Passed through rather than rebuilt: the caller has already normalised the version-retention,
+   * revalidation and webhook toggles into the resolved configs the runtime readers test, and
+   * re-deriving them here would be a second implementation of that normalisation.
+   */
+  updateData: Record<string, unknown>;
+  /** The new field list, or undefined when the save changes only flags. */
+  fields?: FieldDefinition[];
+  isLocalized: boolean;
+  wasLocalized: boolean;
+  hasStatus: boolean;
+  wasStatus: boolean;
+  /**
+   * Whether the request SET the Draft/Published toggle, as opposed to leaving it alone.
+   *
+   * Not derivable from `hasStatus !== wasStatus`: saving the toggle at the value it already holds
+   * is a request that reaches the companion, because provisioning is idempotent and a single whose
+   * companion `_status` never got created is repaired by exactly that save. Collapsing the two
+   * would turn the repair into a no-op.
+   */
+  statusRequested: boolean;
+}
+
+/** The updated row, and the status the caller reports back to the user. */
+export interface UpdateSingleSchemaResult {
+  record: DynamicSingleRecord;
+  migrationStatus: SingleMigrationStatus;
+}
+
+/**
+ * The schema work an update has to do, decided before any statement runs.
+ *
+ * One plan covers both shapes of update. A field change renders statements; a save that only flips
+ * Internationalization or Draft/Published renders none but still has companion work, and modelling
+ * that as an empty statement list rather than as a second execution path is what keeps the two
+ * from drifting: they share one apply, one status vocabulary and one failure contract.
+ */
+interface UpdateDdlPlan {
+  /** Statements to run. Empty for a save that changes only flags. */
+  migrationSQL: string;
+  /** The field list the table holds once this plan has run. */
+  fields: FieldDefinition[];
+  /** The field list the table holds now. The companion reconcile diffs against it. */
+  previousFields: FieldDefinition[];
+  /**
+   * Whether this plan owns `migration_status`.
+   *
+   * A field change does: the column records how far the schema change got, and an app with no
+   * adapter registered leaves it `pending` for the migration runner to pick up later. A flag-only
+   * save does not — with no adapter there is nothing to provision and nothing was asked of the
+   * main table's schema, so the previous status is left exactly as it was rather than being
+   * overwritten with a verdict about a migration that was never requested.
+   */
+  ownsMigrationStatus: boolean;
+}
+
 export class SingleMetadataService {
   constructor(
     private readonly registry: SingleRegistryService,
@@ -223,6 +296,360 @@ export class SingleMetadataService {
       await this.registry.deleteSingle(slug, { force: true });
     } catch (error) {
       if (!NextlyError.isNotFound(error)) throw error;
+    }
+  }
+
+  /**
+   * Apply a schema change to an existing Single and write the registry row that describes it.
+   *
+   * The same three phases as `createSingle`, and for the same reason: a lock has to cover the
+   * table change and the row write together, and it can only do that where both halves live.
+   *
+   * 🔴 The phase boundary is what decides whether a failure is raised or recorded, and it replaces
+   * a `migrationBegan` flag the request handler carried. Everything that can reject — reading the
+   * live table, asking the generator for statements — happens in the PLAN, where the schema is
+   * still exactly as it was and the caller's field list has not been saved. Once APPLY starts, a
+   * statement may already have run, so a failure is a partly-applied migration that must be
+   * recorded rather than a request that never began.
+   */
+  async updateSingleSchema(
+    input: UpdateSingleSchemaInput
+  ): Promise<UpdateSingleSchemaResult> {
+    // 1. PLAN. May reject; nothing is persisted and no statement has run.
+    const plan = await this.planUpdate(input);
+
+    // The status the response reports. A save with no schema work at all keeps whatever the last
+    // migration reached, because this request neither confirmed nor changed it.
+    let migrationStatus = input.existing.migrationStatus;
+    const updateData = { ...input.updateData };
+
+    if (plan) {
+      // 2. APPLY. Returns a status rather than throwing, except for a refusal (see below).
+      const applied = await this.applyUpdateDdl(input, plan);
+      if (applied !== undefined) {
+        updateData.migrationStatus = applied;
+        migrationStatus = applied;
+      }
+    }
+
+    // 3. RECORD, with the outcome already known.
+    const record = await this.registry.updateSingle(input.slug, updateData, {
+      source: "ui",
+    });
+
+    return { record, migrationStatus };
+  }
+
+  /**
+   * Work out what the schema change has to do, reading the live table but changing nothing.
+   *
+   * Returns null when the save asks nothing of the schema: no field change, no Internationalization
+   * transition, and no Draft/Published save on a single that has a companion to keep in step.
+   *
+   * Allowed to throw, and that is the point. The generator is a validator as well as a renderer —
+   * it refuses a required column with no value for the rows already there, or a referenced column
+   * SQLite cannot detach — and refusing here, before the apply, is what leaves the table untouched
+   * and the caller's field list unsaved.
+   */
+  private async planUpdate(
+    input: UpdateSingleSchemaInput
+  ): Promise<UpdateDdlPlan | null> {
+    const {
+      existing,
+      fields,
+      isLocalized,
+      wasLocalized,
+      hasStatus,
+      wasStatus,
+      statusRequested,
+    } = input;
+    const previousFields = (existing.fields ??
+      []) as unknown as FieldDefinition[];
+
+    if (fields === undefined) {
+      // A save with no field change still has companion work when the single is crossing the
+      // Internationalization boundary, or when Draft/Published is saved on a single that is
+      // localized in either state — that toggle ADDs or DROPs the companion's own `_status`.
+      // Without this the flag persisted while the physical schema stayed as it was, stranding
+      // data in the table the new flag says it does not live in.
+      const needsCompanionWork =
+        isLocalized !== wasLocalized ||
+        (statusRequested && (isLocalized || wasLocalized));
+      if (!needsCompanionWork) return null;
+      return {
+        migrationSQL: "",
+        fields: previousFields,
+        previousFields,
+        ownsMigrationStatus: false,
+      };
+    }
+
+    const adapter = this.adapter;
+    const tableName = existing.tableName;
+    const { DynamicCollectionSchemaService } = await import(
+      "../../dynamic-collections/services/dynamic-collection-schema-service"
+    );
+    const schemaService = new DynamicCollectionSchemaService(
+      undefined,
+      this.dialect
+    );
+
+    // With no adapter there is no live table to read and no statement to run. The row still
+    // records `pending`, which is what the migration runner looks for.
+    if (!adapter) {
+      return {
+        migrationSQL: "",
+        fields,
+        previousFields,
+        ownsMigrationStatus: true,
+      };
+    }
+
+    // Create or alter is decided HERE, not in the apply, because it is a question about the
+    // database's current state and the apply is past the point where questions are safe to ask.
+    // A table missing because an earlier create failed is rebuilt rather than altered into
+    // nothing.
+    if (!(await adapter.tableExists(tableName))) {
+      return {
+        // i18n: a fresh (re)create omits translatable columns when localized; they belong to the
+        // companion.
+        migrationSQL: schemaService.generateMigrationSQL(tableName, fields, {
+          isSingle: true,
+          hasStatus,
+          localized: isLocalized,
+        }),
+        fields,
+        previousFields,
+        ownsMigrationStatus: true,
+      };
+    }
+
+    const alterInput = await this.normalizeFieldsForAlter(
+      previousFields,
+      fields,
+      isLocalized || wasLocalized
+    );
+
+    // Whether a required column can be added without a value for the rows already there, and
+    // which columns a foreign key or an index references, are facts about the live table. The
+    // generator refuses an edit these rule out, which is why they are read before the apply.
+    const db = adapter.getDrizzle();
+    const liveDialect = adapter.getCapabilities().dialect;
+    const [tableHasAnyRows, foreignKeysByColumn, indexNames] =
+      await this.readLiveTableFacts(db, liveDialect, tableName);
+
+    return {
+      migrationSQL: schemaService.generateAlterTableMigration(
+        tableName,
+        alterInput.oldFields,
+        alterInput.newFields,
+        {
+          wasStatus,
+          hasStatus,
+          tableHasRows: tableHasAnyRows,
+          foreignKeysByColumn,
+          indexNames,
+        }
+      ),
+      fields,
+      previousFields,
+      ownsMigrationStatus: true,
+    };
+  }
+
+  /**
+   * The two field lists the ALTER diff compares, normalised to describe the same table.
+   *
+   * Two adjustments, and both exist because the stored field list and the physical table are not
+   * the same thing:
+   *
+   * - The physical table always carries `title`, `slug` and `updated_at`, which the generators add
+   *   and the stored definitions may not mention. Without them the diff plans an ADD COLUMN for
+   *   columns that already exist. They are matched by the COLUMN a field becomes rather than by
+   *   its name: a field named `Title` already owns the `title` column, and prepending the system
+   *   one beside it would hand the diff two fields for one column.
+   * - i18n: translatable columns live on the companion whenever the single is localized in either
+   *   state, so they are dropped from both sides — the main-table diff must never ADD or DROP
+   *   them. `reconcileSingleCompanion` owns that side.
+   */
+  private async normalizeFieldsForAlter(
+    previousFields: FieldDefinition[],
+    newFields: FieldDefinition[],
+    omitLocalizedColumns: boolean
+  ): Promise<{ oldFields: FieldDefinition[]; newFields: FieldDefinition[] }> {
+    const { resolveLocalizedFieldNames } = await import(
+      "../../i18n/classify-fields"
+    );
+    const { columnsDeclaredBy } = await import(
+      "../../schema/services/field-column-descriptor"
+    );
+
+    // `localized: false` for the same reason the synthetic declarations carry it: these are
+    // main-table system columns, and text-like fields localize by default. Without it the filter
+    // below strips them from a localized single's ALTER input, so the diff stops seeing the
+    // `title`/`slug` the table already has and plans them as additions.
+    const systemFields: FieldDefinition[] = [
+      { name: "title", type: "text", required: true, localized: false },
+      { name: "slug", type: "text", required: true, localized: false },
+    ];
+    const updatedAt: FieldDefinition = {
+      name: "updatedAt",
+      type: "date",
+      required: false,
+    };
+
+    const omitLocalized = (fields: FieldDefinition[]): FieldDefinition[] => {
+      if (!omitLocalizedColumns) return fields;
+      const localizedNames = new Set(resolveLocalizedFieldNames(fields, true));
+      return fields.filter(f => !localizedNames.has(f.name));
+    };
+
+    const normalize = (fields: FieldDefinition[]): FieldDefinition[] => {
+      const forAlter = omitLocalized(fields);
+      const declared = columnsDeclaredBy(forAlter);
+      return [
+        ...systemFields.filter(sf => !declared.has(sf.name)),
+        ...forAlter,
+        updatedAt,
+      ];
+    };
+
+    return {
+      oldFields: normalize(previousFields),
+      newFields: normalize(newFields),
+    };
+  }
+
+  /** The live-table facts the ALTER generator needs, read in one round trip. */
+  private async readLiveTableFacts(
+    db: unknown,
+    dialect: "postgresql" | "mysql" | "sqlite",
+    tableName: string
+  ): Promise<[boolean, Map<string, string[]>, Set<string>]> {
+    const { readForeignKeyColumns, readIndexNames, tableHasRows } =
+      await import("../../schema/pipeline/live-table-facts");
+    return Promise.all([
+      tableHasRows(db, dialect, tableName),
+      readForeignKeyColumns(db, dialect, tableName),
+      readIndexNames(db, dialect, tableName),
+    ]);
+  }
+
+  /**
+   * Run the plan, reporting how far it got.
+   *
+   * Returns undefined when the plan owns no status — a flag-only save with no adapter registered
+   * asked nothing of the main table's schema, so overwriting the previous verdict with one about a
+   * migration that was never requested would be a claim this apply cannot make.
+   *
+   * 🔴 A refusal propagates, whatever phase it reaches this catch from. That is a separate rule
+   * from the phase split, not a consequence of it: the split decides that a DATABASE failure after
+   * the first statement is recorded rather than raised, while a `NextlyError` is the generator or
+   * a guard refusing the edit outright. Recording a refusal as `failed` would save the field list
+   * anyway and report the single as having a schema its table does not have. No adapter raises one
+   * today, so this costs nothing and holds the moment one does.
+   */
+  private async applyUpdateDdl(
+    input: UpdateSingleSchemaInput,
+    plan: UpdateDdlPlan
+  ): Promise<SingleMigrationStatus | undefined> {
+    const adapter = this.adapter;
+    const tableName = input.existing.tableName;
+
+    if (!adapter) {
+      this.logger.warn(
+        "[Singles] No adapter registered, migration not executed"
+      );
+      return plan.ownsMigrationStatus ? "pending" : undefined;
+    }
+
+    try {
+      if (plan.migrationSQL) {
+        // The shared runner, not a private copy: it owns both the splitting rule and the tolerance
+        // that makes re-running over half-applied schema the repair case rather than a dead end.
+        await applyMigrationStatements(adapter, plan.migrationSQL);
+      }
+
+      // Observed, not assumed, and it covers the rebuild case as well as the alter: a plan that
+      // created the table has to find it afterwards for "applied" to mean anything.
+      if (!(await adapter.tableExists(tableName))) {
+        this.logger.error(
+          `[Singles] Table "${tableName}" not found after migration update`
+        );
+        return "failed";
+      }
+
+      await this.registerUpdatedRuntimeSchema(input, plan, adapter);
+
+      // i18n: provision or alter the companion for the field set being saved — CREATE and seed the
+      // default locale from main on enable, restore and archive on disable, ADD/DROP columns as
+      // translatable fields change. Reported as a failed migration rather than thrown: the main
+      // table is already in its new shape, and the row describing it is what makes a retry possible.
+      const { reconcileSingleCompanion } = await import(
+        "./reconcile-single-companion"
+      );
+      await reconcileSingleCompanion({
+        slug: input.slug,
+        tableName,
+        oldFields: plan.previousFields,
+        newFields: plan.fields,
+        localized: input.isLocalized,
+        wasLocalized: input.wasLocalized,
+        status: input.hasStatus,
+        wasStatus: input.wasStatus,
+        adapter,
+      });
+
+      return "applied";
+    } catch (error) {
+      if (error instanceof NextlyError) throw error;
+      this.logger.error(
+        `[Singles] Migration execution failed for "${tableName}": ${
+          error instanceof Error ? error.message : String(error)
+        }`
+      );
+      if (plan.migrationSQL) {
+        this.logger.error(`[Singles] Migration SQL was: ${plan.migrationSQL}`);
+      }
+      return "failed";
+    }
+  }
+
+  /**
+   * Rebind the main table to the running server so the next read sees its new column shape.
+   *
+   * Best-effort, like the create path's: the registry is rebuilt from the database on the next
+   * boot, so a failure costs a restart rather than the migration.
+   */
+  private async registerUpdatedRuntimeSchema(
+    input: UpdateSingleSchemaInput,
+    plan: UpdateDdlPlan,
+    adapter: DrizzleAdapter
+  ): Promise<void> {
+    try {
+      const { generateRuntimeSchema } = await import(
+        "../../schema/services/runtime-schema-generator"
+      );
+      const { table } = generateRuntimeSchema(
+        input.existing.tableName,
+        plan.fields,
+        adapter.getCapabilities().dialect,
+        // i18n: the main runtime table omits translatable columns for a localized single, matching
+        // the DDL above.
+        { status: input.hasStatus, localized: input.isLocalized }
+      );
+      const resolver = (
+        adapter as unknown as { tableResolver?: DynamicSchemaResolver }
+      ).tableResolver;
+      if (resolver && typeof resolver.registerDynamicSchema === "function") {
+        resolver.registerDynamicSchema(input.existing.tableName, table);
+      }
+    } catch (error) {
+      this.logger.warn(
+        `[Singles] Runtime schema registration failed for "${input.existing.tableName}": ${
+          error instanceof Error ? error.message : String(error)
+        }`
+      );
     }
   }
 

--- a/packages/nextly/src/domains/singles/services/single-metadata-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-metadata-service.ts
@@ -577,8 +577,6 @@ export class SingleMetadataService {
         return "failed";
       }
 
-      await this.registerUpdatedRuntimeSchema(input, plan, adapter);
-
       // i18n: provision or alter the companion for the field set being saved — CREATE and seed the
       // default locale from main on enable, restore and archive on disable, ADD/DROP columns as
       // translatable fields change. Reported as a failed migration rather than thrown: the main
@@ -597,6 +595,33 @@ export class SingleMetadataService {
         wasStatus: input.wasStatus,
         adapter,
       });
+
+      // 🔴 Registered only once the companion has been reconciled, never before it.
+      //
+      // The shape this binds is derived from what the single is being saved AS, so on a
+      // localization ENABLE it omits the translatable columns — which are still physically on the
+      // main table until the companion has taken them. Bind it first and a companion CREATE that
+      // then fails leaves the resolver describing a main table that does not exist in that shape,
+      // and `ensureSingleRuntimeTable` treats a registration it did not make as owned by whoever
+      // made it, so it adopts this one instead of rebuilding. Reads and writes would drop those
+      // fields until a restart.
+      //
+      // Leaving the previous shape in place on failure is the safe direction: it is at worst stale
+      // in the same way it was before the save, and the lazy rebuild can still correct it.
+      await this.registerUpdatedRuntimeSchema(input, plan, adapter);
+
+      // A plan that rendered no main-table statements never touched the main table, so it cannot
+      // vouch for one. A create that got its `CREATE TABLE` through and then failed on an index or
+      // a junction table leaves the table PRESENT but incomplete; re-saving unchanged fields takes
+      // the alter branch, emits nothing, and finds the table there. Confirming existence is not
+      // confirming the schema, so the durable verdict stands until something actually repairs it.
+      if (!plan.migrationSQL && input.existing.migrationStatus === "failed") {
+        this.logger.warn(
+          `[Singles] "${tableName}" is recorded as a failed migration and this save ran no ` +
+            `statements against it, so its status is left as failed`
+        );
+        return "failed";
+      }
 
       return "applied";
     } catch (error) {

--- a/packages/nextly/src/domains/singles/services/single-registry-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-registry-service.ts
@@ -493,6 +493,23 @@ export class SingleRegistryService extends BaseRegistryService<
       }
     }
 
+    // An outcome the caller OBSERVED is recorded whatever else the save changed, and that is a
+    // different question from the gate above.
+    //
+    // That gate exists to stop a metadata-only sync flagging a migration nobody asked for, so what
+    // it is really guarding is the DEFAULT — `"pending"` is a guess about work still to do. A
+    // status the caller passes explicitly is not a guess: `SingleMetadataService` has just run the
+    // statements and confirmed the table, and this is the only place that answer can be kept.
+    //
+    // Suppressing it left two saves unable to record what they had already done. A flag-only save
+    // carries no `fields`, so it never reached the gate at all and its companion provisioning went
+    // unrecorded. And a re-save of UNCHANGED fields against a single whose create failed is exactly
+    // the rebuild path — same schema hash, so `fieldsActuallyChanged` is false — which meant the
+    // one save able to repair a `failed` single could never record that it had.
+    if (data.migrationStatus !== undefined) {
+      updateData.migration_status = data.migrationStatus;
+    }
+
     if (data.admin !== undefined) {
       updateData.admin = data.admin ? JSON.stringify(data.admin) : null;
     }


### PR DESCRIPTION
## What

Moves `updateSingleSchema`'s DDL body out of the request handler and into
`SingleMetadataService`, which already owns `createSingle` and `deleteSingle`.
The handler drops from 1579 to 1288 lines.

This is the last piece of task 116. It matters because a migration lock cannot be
placed where the schema change and the registry row live in different objects: a lock
taken inside the registry service is acquired *after* the tables have already changed,
so it samples rather than holds.

## How

Re-expressed in the service's existing three-phase contract rather than copied:

| Phase | Contract |
|---|---|
| **PLAN** (`planUpdate`) | Reads the live table, decides create-vs-alter, renders SQL. **May reject** — nothing is persisted and no statement has run. |
| **APPLY** (`applyUpdateDdl`) | Runs statements, confirms the table, registers the runtime schema, reconciles the companion. Returns a status. |
| **RECORD** | `registry.updateSingle`, with the outcome already known. |

The phase boundary replaces the `migrationBegan` flag the handler carried.

### One plan, not two branches

A save that only flips Internationalization or Draft/Published is a plan whose
`migrationSQL` is `""` — not a parallel execution path. Both shapes now share one
apply, one status vocabulary and one failure contract, so they cannot drift.

### 🔴 `instanceof NextlyError` is NOT replaced by the phase split

The handler's catch was two rules:

```js
if (migrationError instanceof NextlyError || !migrationBegan) throw
```

The split replaces `!migrationBegan`. It does **not** replace the first clause, which
is a separate defensive rule: a refusal propagates whatever phase it arrives from.
Without it a future apply-phase refusal would be recorded as `"failed"` and the field
list saved against a table that never took it.

That clause is unreachable today — adapters raise `DatabaseError`, which extends
`Error`, not `NextlyError` — which is what makes carrying it cheap rather than
unnecessary. Unreachability is a property of the current call graph.

### `statusRequested` is passed, not derived

The old condition was `b.status !== undefined`, meaning "the request SET the toggle".
That is not the same as `hasStatus !== wasStatus`: saving Draft/Published at its
current value still reaches the companion, and because provisioning is idempotent,
that save is what repairs a localized single whose companion `_status` was never
created. Deriving it would collapse the repair into a no-op.

## Tests

New file `single-dispatcher-update-ddl.test.ts`. **The update path had no unit
coverage of its DDL at all** — its only unit tests replace the schema service with a
stub returning `""` because they test response envelopes.

Three hazard tests were proven by breaking the code they guard:

| Break | Result |
|---|---|
| Remove the `instanceof NextlyError` rethrow | 1 failed / 6 passed — the apply-phase refusal test, alone |
| Remove the create-vs-alter split | 1 failed / 6 passed — the rebuild test, alone |
| Key the normaliser on NAME instead of COLUMN | **7 passed — did not break** |

That third one is stated honestly in the file rather than shipped as coverage.
Measured directly: both keyings emit byte-identical SQL, because the generator does
not DROP a system column that goes missing from the desired list. The test was
relabelled to say it asserts the outcome and cannot separate the mechanism, and names
`columnsDeclaredBy` as where that choice is decidable.

## Verification

- `check-types --force`, `lint` (by exit code), `check-drizzle-v1-legacy`: all `0`
- Full `packages/nextly` unit run, per-test STATE diff against a freshly measured
  baseline at `9a1525260` (`passed=7416 failed=361 skipped=42 pending=6`):
  **0 moved, 0 removed, 7 added**
- Integration, all three dialects, on the pre-rebase tree: sqlite 1186 passed /
  postgres17 1395 passed / mysql 1311 passed, **0 failed**. Counts confirmed non-zero
  so a self-skipped leg could not read as a pass. CI covers the rebased combination.
