### PR TITLE
feat(plugin-page-builder): name the plugin in the admin

### DIFF
--- a/.changeset/page-builder-admin-identity.md
+++ b/.changeset/page-builder-admin-identity.md
@@ -1,0 +1,27 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+---
+
+The page builder now names itself in the admin. Its entry in the plugins list and on the dashboard showed the raw package specifier where other plugins show a readable name.

--- a/packages/plugin-page-builder/src/plugin-admin-identity.test.ts
+++ b/packages/plugin-page-builder/src/plugin-admin-identity.test.ts
@@ -1,0 +1,45 @@
+/**
+ * How this plugin names itself in the admin.
+ *
+ * `admin-meta.ts` resolves a plugin's displayed name as
+ * `appearance?.label ?? meta.name`, and `meta.name` is the raw package
+ * specifier. Without an `appearance` the plugins list and the dashboard show
+ * `@nextlyhq/plugin-page-builder` in the place where the form builder shows
+ * "Forms" — a difference nothing type-checks and no other test observes,
+ * because both branches produce a perfectly valid string.
+ */
+import { describe, expect, it } from "vitest";
+
+import { pageBuilder } from "./plugin";
+
+describe("page-builder admin identity", () => {
+  it("names itself rather than falling back to the package specifier", () => {
+    const plugin = pageBuilder();
+
+    expect(plugin.admin).toMatchObject({
+      appearance: { icon: "Layout", label: "Page Builder" },
+      description:
+        "Build pages visually from blocks with drag-and-drop editing",
+    });
+
+    // The fallback this exists to avoid. Asserting the label is present would
+    // also pass if it were set to the package name, which is the one value that
+    // makes the whole field pointless.
+    expect(plugin.admin?.appearance?.label).not.toBe(plugin.name);
+  });
+
+  it("stays in the plugins section, so its menu entry is the only main-rail item", () => {
+    const plugin = pageBuilder();
+
+    // The neighbouring case, and the reason the form builder carries a similar
+    // assertion: it takes `placement: "standalone"` and contributes NO menu
+    // item, so "Forms" appears exactly once. This plugin does the opposite — it
+    // contributes a "Pages" menu entry — so taking standalone placement too
+    // would put "Page Builder" and "Pages" in the main rail as two entries for
+    // one feature.
+    expect(plugin.admin?.placement).toBeUndefined();
+    expect(plugin.contributes?.admin?.menu ?? []).toEqual([
+      { label: "Pages", to: "/admin/collections/pages", icon: "Layout" },
+    ]);
+  });
+});

--- a/packages/plugin-page-builder/src/plugin.ts
+++ b/packages/plugin-page-builder/src/plugin.ts
@@ -124,6 +124,13 @@ export const pageBuilder = (opts: PageBuilderOptions = {}) =>
     tags: ["page-builder", "blocks", "visual-editor"],
     enabled: opts.enabled,
     admin: {
+      // How the plugin names itself wherever the admin lists it. Without this
+      // the dashboard section and the plugins list fall back to `meta.name`,
+      // which is the raw package specifier — `@nextlyhq/plugin-page-builder`
+      // shown where the form builder shows "Forms". The icon matches the Pages
+      // menu entry this plugin contributes, so one feature is not drawn two
+      // different ways in the same sidebar.
+      appearance: { icon: "Layout", label: "Page Builder" },
       description:
         "Build pages visually from blocks with drag-and-drop editing",
     },


### PR DESCRIPTION
The page builder showed the raw package specifier where every other plugin shows a readable name.

`plugins/admin-meta.ts` resolves a plugin's displayed name as `appearance?.label ?? meta.name`, and `meta.name` is `@nextlyhq/plugin-page-builder`. The form builder declares `appearance: { icon: "FileText", label: "Forms" }`; the page builder declared no `appearance` at all, so the dashboard and the plugins list rendered the specifier beside Forms' plain "Forms".

## One correction to how this was filed

It was recorded as "plugin-page-builder has no `label`/`description`". **The description was already there** — "Build pages visually from blocks with drag-and-drop editing", in the top-level `admin` block. Only `appearance` was missing, so that is all this adds.

Worth stating because the two live in the same object at the same nesting, and a first pass looking for "the metadata block" finds one that already looks populated. There is also a SECOND `admin` key on this plugin, nested under `contributes`, holding menu entries and slots — different type (`PluginAdminContributions`), no `appearance` field. Adding it there type-errors, which is how the distinction surfaced rather than shipping quietly in the wrong place.

## What it does not change

Placement stays unset, so the plugin remains in the Plugins section. The form builder takes `placement: "standalone"` and contributes **no** menu item, so "Forms" appears exactly once in the main rail. This plugin does the opposite — it contributes a `Pages` menu entry — so giving it standalone placement too would put "Page Builder" and "Pages" in the rail as two entries for one feature. That is a product decision rather than a metadata gap, and it is not made here.

The icon matches the `Pages` menu entry the plugin already contributes, so one feature is not drawn two different ways in the same sidebar.

## Verification

- `pnpm run check-types` and `eslint` clean.
- New `plugin-admin-identity.test.ts`, stub-verified **both** ways:
  - removing `appearance` fails the identity test (1 of 2), and
  - setting `label` to the package name **also** fails it.

  The second stub is the one that matters. Asserting only that a label exists would pass on the single value that makes the field pointless, so the test asserts `label !== plugin.name` — the property that separates a working implementation from a plausible broken one.
- The second test pins the no-duplicate-rail-entry reasoning above, so a later change to `placement` has to confront it rather than discover it in the sidebar.
