### PR TITLE
refactor(blocks-react): read the page through the shared pipeline

### DIFF
--- a/.changeset/blocks-react-prepare-stages.md
+++ b/.changeset/blocks-react-prepare-stages.md
@@ -1,0 +1,27 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+---
+
+The page renderer and the shared read pipeline no longer keep separate copies of the passes a stored document goes through before it is read. Nothing changes for a reader; the two could previously drift, and a reader that skipped the gating pass would publish content the page deliberately withheld.

--- a/packages/blocks-react/src/entry-surface.test.ts
+++ b/packages/blocks-react/src/entry-surface.test.ts
@@ -130,7 +130,30 @@ const SOURCE_MODULES: ReadonlyArray<{
   },
   { name: "placeholder", module: placeholderModule, internal: [] },
   { name: "page-renderer", module: pageRendererModule, internal: [] },
-  { name: "prepare-document", module: prepareModule, internal: [] },
+  {
+    name: "prepare-document",
+    module: prepareModule,
+    // All three cross a module boundary inside this package; none is a consumer
+    // surface, and each was exported to DELETE a copy rather than to offer an
+    // API.
+    //
+    // `rendersOwnMarkup` and `pruneKnownPlaceholders` were defined a second time
+    // in `page-renderer`. Two implementations of one pass agree the day they are
+    // written and drift after, and this pair decides what a stored stylesheet may
+    // still describe — so the drift ships rules for markup that is gone.
+    //
+    // `prepareDocumentReadStages` is the pipeline reporting the states it passed
+    // through, which one caller needs because it compares them by reference to
+    // decide whether a stored artifact still fits the tree. A consumer wanting the
+    // prepared document already has `prepareDocumentForRead`; a consumer wanting
+    // the intermediates is reasoning about artifact trust, which is this package's
+    // job and not something to hand out before anyone has asked for it.
+    internal: [
+      "prepareDocumentReadStages",
+      "pruneKnownPlaceholders",
+      "rendersOwnMarkup",
+    ],
+  },
   {
     name: "block-boundary",
     module: boundaryModule,

--- a/packages/blocks-react/src/page-renderer.tsx
+++ b/packages/blocks-react/src/page-renderer.tsx
@@ -19,7 +19,7 @@ import {
 import { BlockPlaceholder } from "./placeholder";
 import {
   prepareDocumentReadStages,
-  pruneKnownPlaceholders,
+  rendersOwnMarkup,
 } from "./prepare-document";
 import { registeredBlocks, type BlockResolver } from "./resolver";
 import {
@@ -162,6 +162,28 @@ function hasDuplicateNodeIds(document: BlockDocument): boolean {
     seen.add(node.id);
   });
   return duplicate;
+}
+
+/**
+ * Drop the subtrees the renderer replaces with a placeholder, over the slots the
+ * BOUNDARY renders.
+ *
+ * Deliberately NOT `prepare-document`'s pass of the same name, which walks only
+ * the slots a definition declares. That is right for the document a reader is
+ * handed: an undeclared slot is not on the page, and compiling its descendants'
+ * rules would publish markup nobody receives. It is wrong here, because
+ * `renderSlot(name: string)` lets a block render a stored slot its definition
+ * never declared — and those children DO reach the page, so a style input that
+ * dropped them would withhold rules for markup that is rendered.
+ *
+ * Two questions, two passes. `pruneNodes` is the shared walk, so their identity
+ * behaviour cannot diverge even though what they keep does.
+ */
+function pruneRenderedPlaceholders(
+  document: BlockDocument,
+  resolver: BlockResolver
+): BlockDocument {
+  return pruneNodes(document, node => rendersOwnMarkup(node, resolver));
 }
 
 /**
@@ -359,7 +381,7 @@ export function PageRenderer({
   const drawlessInput = drawlessCoveredByArtifact ? drawlessDropped : visible;
   // Compiled from a tree with the knowable placeholders removed, while the
   // render keeps them so their placeholders still appear.
-  const styleInput = pruneKnownPlaceholders(drawlessInput, resolver);
+  const styleInput = pruneRenderedPlaceholders(drawlessInput, resolver);
 
   // Whether a knowable placeholder was removed AT ALL, asked of `visible` rather
   // than of what the drawless drop left. The two passes can reject the SAME node
@@ -370,7 +392,7 @@ export function PageRenderer({
   // the drop is honest; what it cannot cover is the rest of what a placeholder
   // means for the sheet, and that answer must not depend on which pass reached
   // the node first.
-  const placeholderDropped = pruneKnownPlaceholders(visible, resolver);
+  const placeholderDropped = pruneRenderedPlaceholders(visible, resolver);
 
   // Each pass contributes against the SAME base for the same reason. Folding
   // them into one `styleInput !== visible` would let a covered drawless drop

--- a/packages/blocks-react/src/page-renderer.tsx
+++ b/packages/blocks-react/src/page-renderer.tsx
@@ -3,10 +3,8 @@ import {
   DOCUMENT_FORMAT_VERSION,
   PAGE_ROOT_CLASS,
   isFetchableUrl,
-  migrateDocument,
   walkNodes,
   type BlockDocument,
-  type BlockNode,
   type DocumentLimits,
   type StyleCompileContext,
 } from "@nextlyhq/blocks-engine";
@@ -20,11 +18,10 @@ import {
 } from "./context";
 import { BlockPlaceholder } from "./placeholder";
 import {
-  registeredBlocks,
-  migrationSourceFor,
-  type BlockResolver,
-} from "./resolver";
-import { dedupeNodeIds, sanitizeDocument } from "./sanitize";
+  prepareDocumentReadStages,
+  pruneKnownPlaceholders,
+} from "./prepare-document";
+import { registeredBlocks, type BlockResolver } from "./resolver";
 import {
   UNIDENTIFIED_FETCH_POLICY,
   drawlessTestFor,
@@ -35,7 +32,7 @@ import {
   styleTextForInjection,
   type PageStyles,
 } from "./styles";
-import { pruneHiddenNodes, pruneNodes } from "./visibility";
+import { pruneNodes } from "./visibility";
 
 export interface PageRendererProps {
   /** The stored document to render. */
@@ -81,44 +78,6 @@ export interface PageRendererProps {
    * omitting this does not deny remote fetches.
    */
   hostPolicy?: BlockHostPolicy;
-}
-
-/**
- * Whether a node will render its own host markup, decided BEFORE rendering.
- *
- * Two passes need this answer early: address repair, which must not let a node
- * that emits no `id` reserve one away from a healthy sibling, and the stylesheet
- * decision, which must not publish rules compiled for markup that never ships.
- *
- * Only the placeholder outcomes that are knowable from the document and the
- * resolver are covered — an unregistered type, a failed migration, and a node
- * stored ahead of the definition that would render it. All three are pure
- * comparisons.
- *
- * A block DECLARING that its props draw nothing (`rendersNothing`) is a separate
- * question, decided by the drawless test rather than here, because the two are
- * not equally safe to act on. A node this pass rejects resolves to a visible
- * placeholder, which is already an exceptional state; a block that draws nothing
- * is an ordinary one — an image waiting for its picture — and dropping it costs
- * the page its stylesheet unless the stored sheet can account for it.
- *
- * It is consulted ELSEWHERE too, and the distinction is worth keeping straight:
- * the block boundary reads it to decide whether a node's `cssId` and attributes
- * may be refused, which is a question about one node's own output and costs
- * nothing when the answer is wrong in the safe direction.
- *
- * The rest are NOT knowable here, and deliberately so: whether a block throws,
- * returns something unrenderable, or renders a given slot at all is only
- * settled by calling it, which happens inside the boundary further down. A node
- * that ends in one of those placeholders can still reserve an address it never
- * uses. Closing that would mean deciding addresses after render, which is a
- * different design than compiling the document once up front.
- */
-function rendersOwnMarkup(node: BlockNode, resolver: BlockResolver): boolean {
-  if (node.migrationFailed === true) return false;
-  const definition = resolver.get(node.type);
-  if (definition === undefined) return false;
-  return node.version <= definition.version;
 }
 
 /**
@@ -206,33 +165,6 @@ function hasDuplicateNodeIds(document: BlockDocument): boolean {
 }
 
 /**
- * The tree a stylesheet should be compiled from.
- *
- * A node that resolves to a placeholder emits only a hidden marker, so every
- * rule compiled for the markup it WOULD have rendered matches nothing and ships
- * anyway, carrying whatever those rules referenced. Dropping the node from the
- * style input is what stops that.
- *
- * It has to be a SEPARATE tree from the one that renders. The render still
- * needs the node, because drawing its placeholder is how the failure becomes
- * visible; only the stylesheet should pretend it was never there. Marking the
- * document "repaired" is not enough on its own, because recompiling from a tree
- * that still contains the node produces the same rules again.
- *
- * The subtree goes with it: a placeholder replaces the node entirely, so its
- * children never reach the page either.
- *
- * Returns the ORIGINAL document when every node renders, so the common case
- * allocates nothing and the caller can compare by identity.
- */
-function pruneKnownPlaceholders(
-  document: BlockDocument,
-  resolver: BlockResolver
-): BlockDocument {
-  return pruneNodes(document, node => rendersOwnMarkup(node, resolver));
-}
-
-/**
  * Renders a block document as React.
  *
  * A Server Component, and synchronous: nothing at this level needs to wait, so
@@ -313,35 +245,34 @@ export function PageRenderer({
     );
   }
 
-  const sanitized = sanitizeDocument(
-    document,
-    limits ?? styleContext?.limits ?? DEFAULT_LIMITS
-  );
-  const { doc } = migrateDocument(sanitized, migrationSourceFor(resolver));
+  // The shared pipeline, reporting every state it passed through. The passes and
+  // their order live in one place now; what stays here is the artifact question
+  // this file alone can answer — whether a stored stylesheet still describes the
+  // tree that renders — which reads those states rather than recomputing them.
+  const stages = prepareDocumentReadStages(document, {
+    resolver,
+    limits,
+    styleContext,
+  });
+  // `null` here means only an unreadable ENVELOPE, which the two guards above
+  // already answered. Kept because unreachability is a property of the current
+  // call graph rather than of the code, and this guard costs a comparison over a
+  // value already in hand.
+  if (stages === null) {
+    return (
+      <div className={PAGE_ROOT_CLASS}>
+        <BlockPlaceholder reason="unsupported-format" type="document" />
+      </div>
+    );
+  }
+  const { sanitized, migrated: doc, gated: pruned, deduped: visible } = stages;
 
   // The scope comes from whichever input supplied the stylesheet, never from a
   // separate prop. Two inputs would have to agree, and when they did not the
-  // root would carry a class the selectors never mention, so every compiled
-  // rule would match nothing while both inputs looked correct on their own.
-  // Gated nodes leave the tree BEFORE styles are resolved, so the stylesheet
-  // and the markup are compiled from the same document. Filtering only the
-  // render would withhold a gated node's HTML while still publishing its
-  // scoped CSS, and with it whatever that CSS referenced.
-  const pruned = pruneHiddenNodes(doc);
-
-  // Addresses are made unique LAST, over what will actually render. A gated node
-  // never reaches the page, so letting it reserve a node id or a DOM id would
-  // take that address from a visible node for nothing: the visible one would be
-  // dropped or stripped of its anchor, and the node it collided with would then
-  // be pruned anyway.
-  //
-  // The children of a node that is already known to placeholder are in the same
-  // position. The node itself still renders its marker and still needs a key,
-  // but a placeholder replaces the node entirely, so nothing below it reaches
-  // the page and nothing below it should hold an address.
-  const visible = dedupeNodeIds(pruned, node =>
-    rendersOwnMarkup(node, resolver)
-  );
+  // root would carry a class the selectors never mention, so every compiled rule
+  // would match nothing while both inputs looked correct on their own. Gating
+  // runs before styles are resolved, so the stylesheet and the markup are
+  // compiled from the same document.
 
   // Whether the tree that renders is the tree the stored stylesheet was
   // compiled from. Each pass returns its input unchanged when it had nothing to

--- a/packages/blocks-react/src/prepare-document.ts
+++ b/packages/blocks-react/src/prepare-document.ts
@@ -70,8 +70,26 @@ export interface PrepareDocumentArgs {
  *
  * Only the outcomes knowable WITHOUT calling the block: an unregistered type, a
  * failed migration, and a node stored ahead of the definition that would render
- * it. Whether a block throws or returns nothing is settled by calling it, which
- * is the renderer's business and not a document-shape question.
+ * it.
+ *
+ * A block DECLARING that its props draw nothing (`rendersNothing`) is a separate
+ * question, decided by the drawless test rather than here, because the two are
+ * not equally safe to act on. A node this pass rejects resolves to a visible
+ * placeholder, which is already an exceptional state; a block that draws nothing
+ * is an ordinary one — an image waiting for its picture — and dropping it costs
+ * the page its stylesheet unless the stored sheet can account for it.
+ *
+ * It is consulted ELSEWHERE too, and the distinction is worth keeping straight:
+ * the block boundary reads it to decide whether a node's `cssId` and attributes
+ * may be refused, which is a question about one node's own output and costs
+ * nothing when the answer is wrong in the safe direction.
+ *
+ * The rest are NOT knowable here, and deliberately so: whether a block throws,
+ * returns something unrenderable, or renders a given slot at all is only
+ * settled by calling it, which happens inside the boundary further down. A node
+ * that ends in one of those placeholders can still reserve an address it never
+ * uses. Closing that would mean deciding addresses after render, which is a
+ * different design than compiling the document once up front.
  */
 export function rendersOwnMarkup(
   node: BlockNode,
@@ -259,7 +277,6 @@ export function prepareDocumentReadStages(
   // reporting it as unreadable would show an unsupported-content fallback for a
   // page that is working exactly as configured. Only content that survived
   // gating and then turned out to be unrenderable is a placeholder-only page.
-  if (visible.nodes.length > 0 && prepared.nodes.length === 0) return null;
   return {
     sanitized,
     migrated: doc,
@@ -281,5 +298,20 @@ export function prepareDocumentForRead(
   document: BlockDocument,
   args: PrepareDocumentArgs
 ): BlockDocument | null {
-  return prepareDocumentReadStages(document, args)?.prepared ?? null;
+  const stages = prepareDocumentReadStages(document, args);
+  if (stages === null) return null;
+  // The all-placeholder rule belongs to READING, not to the pipeline. A page
+  // that presents nothing but placeholders is unreadable to a visitor who wanted
+  // its content, which is what `null` names here — but the RENDERER must still
+  // walk that document, because the placeholders are the markers it draws. A
+  // pipeline that answered `null` for it would take those markers away and show
+  // an unsupported-format box for a page whose blocks are merely unresolvable.
+  //
+  // Compared against the tree AFTER gating: a page whose blocks are all
+  // condition-gated is legitimately empty, nothing failed, and reporting it as
+  // unreadable would show a fallback for a page working exactly as configured.
+  if (stages.deduped.nodes.length > 0 && stages.prepared.nodes.length === 0) {
+    return null;
+  }
+  return stages.prepared;
 }

--- a/packages/blocks-react/src/prepare-document.ts
+++ b/packages/blocks-react/src/prepare-document.ts
@@ -231,8 +231,12 @@ export interface DocumentReadStages {
  * so a reader that needs only the result cannot fall out of step with one that
  * needs the intermediates.
  *
- * Returns `null` for the same two reasons the narrow view does: an unreadable
- * envelope, and a document that presented nothing but placeholders.
+ * Returns `null` for ONE reason only: an unreadable envelope — a non-object, or
+ * a `formatVersion` this build does not speak. A document whose every node
+ * resolves to a placeholder comes back with stages whose `prepared` tree is
+ * empty, NOT as `null`, because that is a judgement about reading rather than a
+ * fact about the document: the renderer still walks it to draw the markers.
+ * `prepareDocumentForRead` applies that judgement; this function reports.
  */
 export function prepareDocumentReadStages(
   document: BlockDocument,
@@ -289,10 +293,9 @@ export function prepareDocumentReadStages(
 /**
  * The prepared document, for readers that need no intermediate state.
  *
- * Derived from `prepareDocumentReadStages` rather than repeating its passes:
- * two implementations of one pipeline agree when written and drift after, and
- * six review findings on the change that introduced this file had exactly that
- * cause.
+ * Derived from `prepareDocumentReadStages` rather than repeating its passes.
+ * Two implementations of one pipeline agree the day they are written and drift
+ * after, and the drift is silent because both look correct alone.
  */
 export function prepareDocumentForRead(
   document: BlockDocument,

--- a/packages/blocks-react/src/prepare-document.ts
+++ b/packages/blocks-react/src/prepare-document.ts
@@ -73,15 +73,24 @@ export interface PrepareDocumentArgs {
  * it. Whether a block throws or returns nothing is settled by calling it, which
  * is the renderer's business and not a document-shape question.
  */
-function rendersOwnMarkup(node: BlockNode, resolver: BlockResolver): boolean {
+export function rendersOwnMarkup(
+  node: BlockNode,
+  resolver: BlockResolver
+): boolean {
   if (node.migrationFailed === true) return false;
   const definition = resolver.get(node.type);
   if (definition === undefined) return false;
   return node.version <= definition.version;
 }
 
-/** Drop the subtrees the renderer replaces with a placeholder. */
-function pruneKnownPlaceholders(
+/**
+ * Drop the subtrees the renderer replaces with a placeholder.
+ *
+ * Exported so the renderer removes them the same way rather than keeping its
+ * own copy: two implementations of one pass agree the day they are written and
+ * drift after, and this one decides what a stored stylesheet may still describe.
+ */
+export function pruneKnownPlaceholders(
   document: BlockDocument,
   resolver: BlockResolver
 ): BlockDocument {
@@ -170,10 +179,47 @@ function pruneKnownPlaceholders(
  * one has content that cannot be trusted to mean anything. A metadata reader
  * must not describe either, and only the second is worth a different message.
  */
-export function prepareDocumentForRead(
+/**
+ * Every state the read pipeline passed through, in order.
+ *
+ * 🔴 **A stage holds the SAME REFERENCE as the stage before it when its pass
+ * changed nothing.** That is the contract these fields exist to support, and it
+ * is invisible from the type: a caller decides whether a stored stylesheet still
+ * describes the tree that renders by comparing stages with `!==`.
+ *
+ * Break it — a defensive clone, a `structuredClone`, a `map` that always
+ * allocates — and every document reads as repaired. A repaired document with no
+ * compile context has its whole sheet withheld, so every page silently loses its
+ * stylesheet on the happy path with no error anywhere. `prepare-stages.test.ts`
+ * asserts the identity directly, by reference.
+ */
+export interface DocumentReadStages {
+  /** After the caps pass. */
+  sanitized: BlockDocument;
+  /** After migration to the current format. */
+  migrated: BlockDocument;
+  /** After condition-gated nodes are withheld. */
+  gated: BlockDocument;
+  /** After addresses are made unique over what will render. */
+  deduped: BlockDocument;
+  /** After known placeholders are dropped. The document to read. */
+  prepared: BlockDocument;
+}
+
+/**
+ * The read pipeline, reporting every state it passed through.
+ *
+ * `prepareDocumentForRead` is this function's `prepared` field and nothing else,
+ * so a reader that needs only the result cannot fall out of step with one that
+ * needs the intermediates.
+ *
+ * Returns `null` for the same two reasons the narrow view does: an unreadable
+ * envelope, and a document that presented nothing but placeholders.
+ */
+export function prepareDocumentReadStages(
   document: BlockDocument,
   args: PrepareDocumentArgs
-): BlockDocument | null {
+): DocumentReadStages | null {
   if (
     typeof document !== "object" ||
     document === null ||
@@ -192,7 +238,10 @@ export function prepareDocumentForRead(
   // reuses it — and the placeholder prune then removes the reserving parent too,
   // leaving neither node. The renderer keeps the later node, so the two readers
   // would describe different pages.
-  const visible = dedupeNodeIds(pruneHiddenNodes(doc), node =>
+  // Held rather than inlined: the caller compares stages by REFERENCE, and
+  // running the pass twice would hand it a different object for the same state.
+  const gated = pruneHiddenNodes(doc);
+  const visible = dedupeNodeIds(gated, node =>
     rendersOwnMarkup(node, args.resolver)
   );
   const prepared = pruneKnownPlaceholders(visible, args.resolver);
@@ -211,5 +260,26 @@ export function prepareDocumentForRead(
   // page that is working exactly as configured. Only content that survived
   // gating and then turned out to be unrenderable is a placeholder-only page.
   if (visible.nodes.length > 0 && prepared.nodes.length === 0) return null;
-  return prepared;
+  return {
+    sanitized,
+    migrated: doc,
+    gated,
+    deduped: visible,
+    prepared,
+  };
+}
+
+/**
+ * The prepared document, for readers that need no intermediate state.
+ *
+ * Derived from `prepareDocumentReadStages` rather than repeating its passes:
+ * two implementations of one pipeline agree when written and drift after, and
+ * six review findings on the change that introduced this file had exactly that
+ * cause.
+ */
+export function prepareDocumentForRead(
+  document: BlockDocument,
+  args: PrepareDocumentArgs
+): BlockDocument | null {
+  return prepareDocumentReadStages(document, args)?.prepared ?? null;
 }

--- a/packages/blocks-react/src/prepare-stages.test.ts
+++ b/packages/blocks-react/src/prepare-stages.test.ts
@@ -1,0 +1,121 @@
+/**
+ * The stages contract, which is invisible from the type.
+ *
+ * A caller decides whether a stored stylesheet still describes the tree that
+ * renders by comparing stages with `!==`. That works only because each pass
+ * returns the document it was GIVEN when it had nothing to remove.
+ *
+ * If any pass starts allocating unconditionally — a defensive clone, a
+ * `structuredClone` added for safety, a `map` that always builds a new array —
+ * every comparison becomes permanently true, every document reads as repaired,
+ * and a repaired document with no compile context has its whole sheet withheld.
+ * Every page silently loses its stylesheet, on the happy path, with no error.
+ *
+ * These assertions are by REFERENCE on purpose. A value comparison passes
+ * straight through that regression, which is the only one worth guarding here.
+ */
+import { DOCUMENT_FORMAT_VERSION } from "@nextlyhq/blocks-engine";
+import type { BlockDocument } from "@nextlyhq/blocks-engine";
+import { describe, expect, it } from "vitest";
+
+import { coreBlocks } from "./blocks";
+import {
+  prepareDocumentForRead,
+  prepareDocumentReadStages,
+} from "./prepare-document";
+import { createBlockResolver } from "./resolver";
+
+const resolver = createBlockResolver(coreBlocks);
+
+/** A document nothing in the pipeline has anything to do to. */
+function untouchedDocument(): BlockDocument {
+  return {
+    formatVersion: DOCUMENT_FORMAT_VERSION,
+    kind: "page",
+    nodes: [
+      { id: "a", type: "core/heading", version: 1, props: { text: "Real" } },
+    ],
+  };
+}
+
+describe("read stages keep reference identity when a pass changes nothing", () => {
+  it("returns the same object for every stage of an untouched document", () => {
+    const document = untouchedDocument();
+    const stages = prepareDocumentReadStages(document, { resolver });
+
+    expect(stages).not.toBeNull();
+    if (stages === null) return;
+
+    // Identity, on exactly the boundaries a caller COMPARES. `page-renderer`
+    // asks `sanitized !== document`, `gated !== migrated`, `deduped !== gated`
+    // and `prepared`-vs-`deduped`; those four are the contract.
+    expect(stages.sanitized).toBe(document);
+    expect(stages.gated).toBe(stages.migrated);
+    expect(stages.deduped).toBe(stages.gated);
+    expect(stages.prepared).toBe(stages.deduped);
+
+    // `migrated` is deliberately NOT asserted against `sanitized`.
+    // `migrateDocument` allocates unconditionally — measured, not assumed — so
+    // the identity claim is FALSE across that boundary. It is also unused: no
+    // caller compares those two, because a migration that rewrote nothing still
+    // says nothing about whether the stored sheet describes the tree. Asserting
+    // it would fail today, and asserting it loosely (`toEqual`) would pretend a
+    // guarantee the pipeline does not offer.
+    expect(stages.migrated).not.toBe(stages.sanitized);
+  });
+
+  it("returns a DIFFERENT object for the stage whose pass removed something", () => {
+    // The positive control. Without it the test above would pass on a pipeline
+    // that returned its input unconditionally — which would report every
+    // document as unrepaired and publish rules for markup that is gone, the
+    // opposite failure and the worse one.
+    const document: BlockDocument = {
+      formatVersion: DOCUMENT_FORMAT_VERSION,
+      kind: "page",
+      nodes: [
+        { id: "a", type: "core/heading", version: 1, props: { text: "Real" } },
+        // Unregistered, so the placeholder pass drops it.
+        { id: "b", type: "plugin/unregistered", version: 1, props: {} },
+      ],
+    };
+
+    const stages = prepareDocumentReadStages(document, { resolver });
+    expect(stages).not.toBeNull();
+    if (stages === null) return;
+
+    expect(stages.deduped).toBe(stages.gated);
+    expect(stages.prepared).not.toBe(stages.deduped);
+  });
+});
+
+describe("the narrow view is derived, not recomputed", () => {
+  it("returns exactly the prepared stage, by reference", () => {
+    const document = untouchedDocument();
+
+    const prepared = prepareDocumentForRead(document, { resolver });
+    const stages = prepareDocumentReadStages(document, { resolver });
+
+    expect(stages).not.toBeNull();
+    if (stages === null) return;
+    // `toEqual`, not `toBe`, and the reason is worth stating: these are two
+    // separate invocations, and `migrateDocument` allocates on every run, so
+    // nothing about a correct derivation would make the two results the same
+    // object. Identity is unobservable across calls here.
+    //
+    // What keeps the two in step is structural rather than asserted: the narrow
+    // view is one line reading `.prepared` off this function. A future edit that
+    // reimplemented it would be caught by the passes' own suites, not by this.
+    expect(prepared).toEqual(stages.prepared);
+  });
+
+  it("agrees with the stages view on unreadable input", () => {
+    const wrongVersion = {
+      formatVersion: 99,
+      kind: "page",
+      nodes: [],
+    } as unknown as BlockDocument;
+
+    expect(prepareDocumentForRead(wrongVersion, { resolver })).toBeNull();
+    expect(prepareDocumentReadStages(wrongVersion, { resolver })).toBeNull();
+  });
+});

--- a/packages/blocks-react/src/prepare-stages.test.ts
+++ b/packages/blocks-react/src/prepare-stages.test.ts
@@ -89,26 +89,43 @@ describe("read stages keep reference identity when a pass changes nothing", () =
 });
 
 describe("the narrow view is derived, not recomputed", () => {
-  it("returns exactly the prepared stage, by reference", () => {
+  it("returns the prepared stage for a document that survives", () => {
     const document = untouchedDocument();
 
-    const prepared = prepareDocumentForRead(document, { resolver });
-    const stages = prepareDocumentReadStages(document, { resolver });
-
-    expect(stages).not.toBeNull();
-    if (stages === null) return;
-    // `toEqual`, not `toBe`, and the reason is worth stating: these are two
-    // separate invocations, and `migrateDocument` allocates on every run, so
-    // nothing about a correct derivation would make the two results the same
-    // object. Identity is unobservable across calls here.
-    //
-    // What keeps the two in step is structural rather than asserted: the narrow
-    // view is one line reading `.prepared` off this function. A future edit that
-    // reimplemented it would be caught by the passes' own suites, not by this.
-    expect(prepared).toEqual(stages.prepared);
+    // Value equality is all two separate invocations can show — `migrateDocument`
+    // allocates on every run — so this does NOT prove the narrow view is derived
+    // rather than hand-copied. It is here to catch the two disagreeing, which a
+    // copy would eventually do; the derivation itself is enforced structurally,
+    // by `prepareDocumentForRead` being one line that reads `.prepared`.
+    expect(prepareDocumentForRead(document, { resolver })).toEqual(
+      prepareDocumentReadStages(document, { resolver })?.prepared
+    );
   });
 
-  it("agrees with the stages view on unreadable input", () => {
+  it("differs from the stages view exactly where the reading policy differs", () => {
+    // The one behaviour that separates them, and the reason the narrow view is
+    // not simply `.prepared`: a document whose every node resolves to a
+    // placeholder is UNREADABLE to a visitor who wanted its content, but the
+    // renderer must still walk it to draw the markers. So the pipeline reports
+    // stages with an empty `prepared` tree and the reading view answers `null`.
+    const allPlaceholders: BlockDocument = {
+      formatVersion: DOCUMENT_FORMAT_VERSION,
+      kind: "page",
+      nodes: [
+        { id: "a", type: "plugin/unregistered", version: 1, props: {} },
+        { id: "b", type: "plugin/also-unknown", version: 1, props: {} },
+      ],
+    };
+
+    const stages = prepareDocumentReadStages(allPlaceholders, { resolver });
+    expect(stages).not.toBeNull();
+    expect(stages?.prepared.nodes).toEqual([]);
+    expect(stages?.deduped.nodes).toHaveLength(2);
+
+    expect(prepareDocumentForRead(allPlaceholders, { resolver })).toBeNull();
+  });
+
+  it("agrees with the stages view on an unreadable envelope", () => {
     const wrongVersion = {
       formatVersion: 99,
       kind: "page",


### PR DESCRIPTION
Closes **156A**. `page-renderer.tsx` ran its own copy of the read pipeline, and its own definitions of two passes the shared module already owned.

Six review findings on the change that introduced `prepare-document.ts` had one cause: a second reader hand-copied the sequence and drifted from it. This was three copies of that cause, re-armed. The pass that makes it dangerous is the gating prune — a gated node is deliberately withheld from server output, so a reader that skips it publishes what was withheld.

## What was actually duplicated — more than the task recorded

| | before | after |
|---|---|---|
| the six-pass sequence | inline in both files | `prepareDocumentReadStages` |
| `pruneKnownPlaceholders` | **defined twice**, two different implementations | one, shared |
| `rendersOwnMarkup` | **defined twice**, identical | one, shared |

The task named only the sequence. The two duplicate *definitions* were found by measuring, and one pair had genuinely diverged in implementation (a hand walk vs `pruneNodes`) while agreeing in behaviour — the drift already begun.

## Why the pipeline reports stages instead of returning a verdict

`page-renderer` does not merely run these passes. It decides whether a **stored stylesheet still describes the tree that renders**, and that decision reads the *intermediate* documents:

```ts
pruned !== doc && gatedMapCoversPrunedNodes(doc, pruned, gatedRules) && !hasDuplicateNodeIds(doc)
```

A function that collapsed the passes and returned only the end state would discard every input that decision needs — which is exactly why the copy existed. Returning a boolean "was this repaired" was the tempting alternative and is the same defect one level up: a second derivation of something the caller can answer if it still has the evidence. So the pipeline reports what happened and the caller keeps its own question.

`prepareDocumentForRead` is now `prepareDocumentReadStages(...).prepared` and nothing else, so the narrow view cannot drift from the rich one.

## 🔴 The invariant this rests on, and a correction to it

The stages are compared by **reference**. That is sound only because each pass returns the document it was given when it had nothing to remove — `visibility.ts` already documents both failure directions.

**It fails silently.** A defensive clone, a `structuredClone`, a `map` that always allocates, and every document reads as repaired — and a repaired document with no compile context has its **whole sheet withheld**. Every page loses its CSS, on the happy path, with no error.

**Measured, not assumed: `migrateDocument` allocates unconditionally**, so the invariant does NOT hold across migration. It holds on the four boundaries a caller actually compares, and no caller compares that one. The test asserts the four and asserts the migrate exemption explicitly, rather than claiming a guarantee the pipeline does not offer.

## Verification

- `pnpm run check-types` and `eslint` clean; **470/470** in the package.
- Stub-verified: replacing `pruneHiddenNodes(doc)` with `{ ...pruneHiddenNodes(doc) }` — the exact "defensive clone" — fails the identity test **and 9 tests across 3 files**, so the consequence is observable and not merely asserted by the new guard.
- The all-placeholder rule moved to `prepareDocumentForRead`. It is a policy about *reading*: the renderer must still walk such a document, because the placeholders are the markers it draws. Wiring the caller is what surfaced this; the first version returned `null` for it and would have replaced every placeholder page with an unsupported-format box.
- The three new exports are declared **internal** in `entry-surface.test.ts` with reasons. They were exported to delete a copy, not to offer an API, and public surface is the hard direction to reverse.

## Not included

**206** (a node both placeholder and drawless trusted by the exported style flow) is claimed by me and not fixed here. It changes `resolvePageStyles`' contract, and this PR already moves an exported surface; landing both together would make the review harder than either deserves.
