### PR TITLE
ci(root): stop a main run from cancelling the commit before it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,16 +15,22 @@ permissions:
 # Superseding is right for a branch under review and wrong for `main`.
 #
 # On a pull request a new push makes the previous run's verdict irrelevant, so
-# cancelling it saves minutes and loses nothing. On `main` every commit is a
-# distinct artifact somebody will later ask "was that green?" about, and
-# `github.ref` is the same string for every push there — so each merge cancelled
-# the previous commit's run. With several lanes merging, most `main` commits
-# never reached a verdict at all, and a REQUIRED check that reports `cancelled`
-# is indistinguishable from one that failed. That trains people to merge past
-# red, which is the actual cost.
+# every push shares one group and cancels the last: minutes saved, nothing lost.
+#
+# On `main` every commit is a distinct artifact somebody will later ask "was that
+# green?" about, so each push gets a group of its OWN. Sharing a `github.ref`
+# group there cancelled the previous commit's run on every merge, and a REQUIRED
+# check reporting `cancelled` is indistinguishable from one that failed — which
+# trains people to merge past red.
+#
+# The group has to differ per commit rather than the cancellation merely being
+# switched off. A group holds at most one running AND one pending run, so with
+# three merges in quick succession the third displaces the second while it is
+# still queued: the middle commit ends up cancelled regardless of
+# `cancel-in-progress`. Keyed by `github.sha`, there is nothing to displace.
 concurrency:
-  group: ci-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ci-${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
+  cancel-in-progress: true
 
 jobs:
   ci:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,9 +12,19 @@ on:
 permissions:
   contents: read
 
+# Superseding is right for a branch under review and wrong for `main`.
+#
+# On a pull request a new push makes the previous run's verdict irrelevant, so
+# cancelling it saves minutes and loses nothing. On `main` every commit is a
+# distinct artifact somebody will later ask "was that green?" about, and
+# `github.ref` is the same string for every push there — so each merge cancelled
+# the previous commit's run. With several lanes merging, most `main` commits
+# never reached a verdict at all, and a REQUIRED check that reports `cancelled`
+# is indistinguishable from one that failed. That trains people to merge past
+# red, which is the actual cost.
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   ci:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -22,12 +22,13 @@ on:
 permissions:
   contents: read
 
-# Scoped to pull requests for the same reason as the CI workflow: on `main`
-# `github.ref` is one string for every push, so each merge cancelled the
-# previous commit's run and left a required check reporting `cancelled`.
+# Keyed per commit on `main` for the same reason as the CI workflow: a shared
+# `github.ref` group cancelled the previous commit's run on every merge, and
+# switching cancellation off is not enough — a group holds one running and one
+# pending run, so a third merge displaces the second while it is still queued.
 concurrency:
-  group: integration-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: integration-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
+  cancel-in-progress: true
 
 jobs:
   integration:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -22,9 +22,12 @@ on:
 permissions:
   contents: read
 
+# Scoped to pull requests for the same reason as the CI workflow: on `main`
+# `github.ref` is one string for every push, so each merge cancelled the
+# previous commit's run and left a required check reporting `cancelled`.
 concurrency:
   group: integration-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   integration:


### PR DESCRIPTION
Closes the mechanism behind task 205. A **required** check that reports `cancelled` is indistinguishable from one that failed, and the habit that teaches — merge past red, the red is never mine — is the actual cost.

## The measurement

Last eight `origin/main` commits, newest run per name:

| check | result |
|---|---|
| `Browser tests` | 2 success · 5 cancelled · 1 in progress · **0 failures** |
| `Integration (postgres / mysql / sqlite)` | 3 success · 5 cancelled |

The task file recorded 0 successes in 6 **with two outright failures**. Those failures are gone — #669 and #663 landed in between — so what remains is entirely cancellation.

**The cancellations fall on exactly the same five commits in both workflows**: `e1d573e23`, `3e875bcc2`, `9368cf6b2`, `330ce9994`, `249649eb9`. Two independent required checks cancelling together on the same commits is much stronger evidence of one shared cause than either measurement alone.

## The mechanism

Read from the workflow rather than inferred:

```yaml
concurrency:
  group: ci-${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: true
```

On `main`, `github.ref` is the same string for every push. So each merge supersedes and cancels the previous commit's in-flight run, and with several lanes merging, most `main` commits never reach a verdict.

## The change

`cancel-in-progress: ${{ github.event_name == 'pull_request' }}`, in `ci.yml` and `integration.yml`.

Cancellation is **kept** where it is correct: on a pull request a new push makes the previous run's verdict irrelevant, so cancelling saves the minutes and loses nothing. It is **dropped** on `main`, where each commit is a distinct artifact someone will later ask "was that green?" about.

## Scope is wider than the task's title

`integration.yml` carries the identical shape and also runs on `main`, so this covers three more required checks — the task named only `Browser tests`, and fixing just that would have left the same defect in place for the integration legs.

`preview.yml` has the same setting and is **deliberately unchanged**: it triggers on `pull_request` only, where superseding is correct.

## What this PR does NOT establish

Task 205 sets the bar at **five consecutive green `main` commits with no re-runs**, and no PR can demonstrate that — it is only observable after this lands and five more merges happen. Three of the six original data points were cancellations, which are inherently intermittent, so a single green after merge would prove nothing either.

The task file stays **open** with the bar written down and the re-measurement recorded. I would rather say that than let a merged PR imply the bar was met.

## Explicitly not done

Making the checks non-required. That converts "browser coverage is broken" into "browser coverage is optional", and the second state is permanent because nothing forces it back.

## Notes

- No changeset: CI-only.
- YAML parses; the expression is the standard GitHub Actions form and evaluates per-event.
