### PR TITLE
fix(admin): write one part of the provider form without resetting the rest

### DIFF
--- a/.changeset/email-provider-form-reconciliation.md
+++ b/.changeset/email-provider-form-reconciliation.md
@@ -1,0 +1,39 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+---
+
+fix(admin): replace one part of the email provider form without resetting the rest
+
+Changing a provider type, or a plugin returning while the form is open, replaced
+the configuration through a whole-form reset. That makes every current value the
+form's new baseline, so fields it never meant to touch stop differing from it —
+and reconciling a refetch keeps only what still differs. A rename typed before
+either of those happened was silently overwritten by the record's own value.
+
+Each of those now writes only the fields it means to, and a provider type chosen
+in the picker is kept as the operator's until they save. A descriptor that gains
+a configuration field while a form is open now initialises it, so a switch no
+longer draws a position the form does not hold, and a field being edited is left
+alone.

--- a/packages/admin/src/components/features/settings/EmailProviderForm/EmailProviderForm.tsx
+++ b/packages/admin/src/components/features/settings/EmailProviderForm/EmailProviderForm.tsx
@@ -21,13 +21,14 @@ import type {
 import { SettingsRow } from "../SettingsRow";
 import { SettingsSection } from "../SettingsSection";
 
-import { ProviderConfigFields } from "./ProviderConfigFields";
+import { configFieldPath, ProviderConfigFields } from "./ProviderConfigFields";
 import { ProviderTypePicker } from "./ProviderTypePicker";
 import {
   buildProviderSchema,
   defaultFormValues,
   emptyConfiguration,
   formValuesToPayload,
+  missingDeclaredFields,
   providerToFormValues,
   type EmailProviderPayload,
   type ProviderFormValues,
@@ -229,8 +230,6 @@ export function EmailProviderForm({
     hadDescriptor: boolean;
     /** What the record HELD when it filled the form, not when it was written. */
     revision: string;
-    /** Which PROVIDER the configuration on screen was built for. */
-    type: string;
   } | null>(null);
 
   // Repopulate once the record and the catalog have both arrived: both are
@@ -262,29 +261,41 @@ export function EmailProviderForm({
       // which is what the identity guard exists to prevent.
       const revision = recordRevision(provider);
       if (hydrated.revision !== revision) {
-        const typeChanged = hydrated.type !== provider.type;
         hydratedFor.current = {
           id: provider.id,
           hadDescriptor: descriptor !== undefined,
           revision,
-          type: provider.type,
         };
+
+        // Which provider the configuration on screen was built for, read from
+        // the form rather than remembered beside it. The form already holds
+        // the answer, and a remembered copy is a second one that drifts.
+        const typeBefore = form.getValues("type");
+        const held = form.getValues("configuration");
 
         const next = providerToFormValues(provider, descriptor);
         form.reset(next, { keepDirtyValues: true });
 
-        // A revision that also changed the TYPE is not a newer version of the
-        // same form. Configuration typed under the old descriptor describes a
-        // provider this record is no longer, so keeping it submits an SMTP
-        // host to a Resend payload -- stored as an undeclared key by a
-        // permissive parser, or refused outright by a stricter one, on every
-        // save from then on. The identity fields are type-independent and keep
-        // whatever was typed.
-        // `resetField`, not `setValue`: the field has to stop being DIRTY as
-        // well as change value. `shouldDirty: false` leaves an existing dirty
-        // mark standing, and the next refetch's `keepDirtyValues` would then
-        // preserve this now-stale value in place of the server's newer one.
-        if (typeChanged) {
+        // A configuration belongs to the type it was built for, so whichever
+        // side owns the type owns the configuration with it.
+        const typeOnScreen = form.getValues("type");
+        if (typeOnScreen !== provider.type) {
+          // The operator picked a different type and has not saved it, so
+          // their choice survived the reset as a dirty value. The record's
+          // configuration describes a provider the form is no longer showing:
+          // keeping it submits an SMTP host to a Resend payload -- stored as
+          // an undeclared key by a permissive parser, or refused outright by a
+          // stricter one, on every save from then on. The reset above has
+          // already applied it to every field nobody typed into, so the
+          // configuration on screen is put back as it was.
+          form.resetField("configuration", { defaultValue: held });
+        } else if (typeBefore !== provider.type) {
+          // The record moved to another type while the form sat open and
+          // nobody here had chosen one, so the record's configuration is the
+          // right one now. It has to stop being DIRTY as well as change value:
+          // `shouldDirty: false` leaves an existing mark standing, and the next
+          // reconcile's `keepDirtyValues` would then preserve this now-stale
+          // value in place of the server's newer one.
           form.resetField("configuration", {
             defaultValue: next.configuration,
           });
@@ -292,28 +303,49 @@ export function EmailProviderForm({
         return;
       }
 
-      // Already populated, and populated from a descriptor — nothing a later
-      // catalog can add.
-      if (hydrated.hadDescriptor || !descriptor) return;
+      // Nothing a later catalog can offer while it still has no descriptor.
+      if (!descriptor) return;
 
-      // The catalog answered "not registered" when this form opened and
-      // answers otherwise now: the plugin was reinstalled while the tab sat
-      // open. The configuration half was filled from a descriptor that did
-      // not exist, so its fields are empty while the form is editable again —
-      // a required credential reads as missing, and an optional blank submits
-      // as a deliberate removal of what is stored.
-      hydratedFor.current = {
-        id: provider.id,
-        hadDescriptor: true,
-        revision: recordRevision(provider),
-        type: provider.type,
-      };
-      // Only the configuration is replaced. The identity fields were filled
-      // from the record and belong to whoever has the form open.
-      form.reset({
-        ...form.getValues(),
-        configuration: providerToFormValues(provider, descriptor).configuration,
-      });
+      if (!hydrated.hadDescriptor) {
+        // The catalog answered "not registered" when this form opened and
+        // answers otherwise now: the plugin was reinstalled while the tab sat
+        // open. The configuration half was filled from a descriptor that did
+        // not exist, so its fields are empty while the form is editable again —
+        // a required credential reads as missing, and an optional blank submits
+        // as a deliberate removal of what is stored.
+        hydratedFor.current = {
+          id: provider.id,
+          hadDescriptor: true,
+          revision: recordRevision(provider),
+        };
+        // Only the configuration is replaced, and through `resetField` rather
+        // than a whole-form reset. The identity fields were filled from the
+        // record and belong to whoever has the form open.
+        form.resetField("configuration", {
+          defaultValue: providerToFormValues(provider, descriptor)
+            .configuration,
+        });
+        return;
+      }
+
+      // The record is unchanged and this type was registered all along, but a
+      // descriptor can still declare MORE than it did when the form opened. A
+      // field added by a deployment would otherwise hold nothing while its
+      // control renders an empty state, so the control disagrees with what a
+      // save would produce.
+      //
+      // Written one path at a time, and only where the form holds nothing:
+      // replacing the whole configuration would clear the dirty marks on every
+      // other field, and reconciling keeps only what is still marked dirty.
+      for (const missing of missingDeclaredFields(
+        form.getValues("configuration"),
+        provider,
+        descriptor
+      )) {
+        form.resetField(configFieldPath(missing.field), {
+          defaultValue: missing.value,
+        });
+      }
       return;
     }
 
@@ -321,7 +353,6 @@ export function EmailProviderForm({
       id: provider.id,
       hadDescriptor: descriptor !== undefined,
       revision: recordRevision(provider),
-      type: provider.type,
     };
     form.reset(providerToFormValues(provider, descriptor));
   }, [provider, isEdit, descriptors, form]);
@@ -349,12 +380,12 @@ export function EmailProviderForm({
     // unusable; the name, sender address and switches are the operator's own
     // work and have nothing to do with which plugin is installed. Discarding
     // them turns a catalog refresh into lost typing.
+    // Written field by field rather than through a whole-form reset, which
+    // would make every current value the new baseline and clear the dirty
+    // marks on the identity fields this is deliberately keeping.
     const next = defaultFormValues(descriptors[0]);
-    form.reset({
-      ...form.getValues(),
-      type: next.type,
-      configuration: next.configuration,
-    });
+    form.resetField("type", { defaultValue: next.type });
+    form.resetField("configuration", { defaultValue: next.configuration });
   }, [isEdit, descriptors, form]);
 
   // Replace the configuration when the provider type changes. The two
@@ -378,19 +409,32 @@ export function EmailProviderForm({
   const handleTypeChange = useCallback(
     (type: string) => {
       const next = descriptors.find(entry => entry.type === type);
-      form.reset({
-        ...form.getValues(),
-        type,
-        // Coming BACK to the type the record is stored as restores what the
-        // record holds, rather than a blank form. Blanking it would leave the
-        // original type selected with its credential gone: a required one
-        // could not be saved without retyping a secret nobody meant to change,
-        // and an optional one would read as a deliberate removal.
-        configuration:
-          provider && provider.type === type
-            ? providerToFormValues(provider, next).configuration
-            : emptyConfiguration(next),
-      });
+      // Coming BACK to the type the record is stored as restores what the
+      // record holds, rather than a blank form. Blanking it would leave the
+      // original type selected with its credential gone: a required one could
+      // not be saved without retyping a secret nobody meant to change, and an
+      // optional one would read as a deliberate removal.
+      const configuration =
+        provider && provider.type === type
+          ? providerToFormValues(provider, next).configuration
+          : emptyConfiguration(next);
+
+      // The type is the operator's own edit, so it is marked DIRTY: a refetch
+      // reconciles with `keepDirtyValues`, which keeps only what is marked,
+      // and an unmarked selection is silently replaced by the record's. Coming
+      // back to the stored type marks nothing, because there is then nothing
+      // to preserve.
+      form.setValue("type", type, { shouldDirty: true });
+      // The configuration is DERIVED from that choice rather than typed, so it
+      // becomes the new baseline instead: nothing here is work to protect, and
+      // leaving it marked would preserve it over the record's own values on
+      // every later reconcile.
+      //
+      // Both written field by field. A whole-form reset would make every
+      // current value the new baseline, clearing the dirty marks on the
+      // identity fields — and a rename in progress would then be overwritten
+      // by the next refetch with nothing on screen to say so.
+      form.resetField("configuration", { defaultValue: configuration });
     },
     [descriptors, form, provider]
   );

--- a/packages/admin/src/components/features/settings/EmailProviderForm/EmailProviderForm.tsx
+++ b/packages/admin/src/components/features/settings/EmailProviderForm/EmailProviderForm.tsx
@@ -288,7 +288,14 @@ export function EmailProviderForm({
           // stricter one, on every save from then on. The reset above has
           // already applied it to every field nobody typed into, so the
           // configuration on screen is put back as it was.
-          form.resetField("configuration", { defaultValue: held });
+          //
+          // `setValue`, so the baseline keeps holding the record's own
+          // configuration and what is restored keeps DIFFERING from it. A
+          // `resetField` here would make these values the baseline, and the
+          // moment the record moved to the type already on screen the two
+          // would agree, no branch would restore anything, and the next
+          // reconcile would replace an edit still in progress.
+          form.setValue("configuration", held, { shouldDirty: true });
         } else if (typeBefore !== provider.type) {
           // The record moved to another type while the form sat open and
           // nobody here had chosen one, so the record's configuration is the
@@ -328,24 +335,6 @@ export function EmailProviderForm({
         return;
       }
 
-      // The record is unchanged and this type was registered all along, but a
-      // descriptor can still declare MORE than it did when the form opened. A
-      // field added by a deployment would otherwise hold nothing while its
-      // control renders an empty state, so the control disagrees with what a
-      // save would produce.
-      //
-      // Written one path at a time, and only where the form holds nothing:
-      // replacing the whole configuration would clear the dirty marks on every
-      // other field, and reconciling keeps only what is still marked dirty.
-      for (const missing of missingDeclaredFields(
-        form.getValues("configuration"),
-        provider,
-        descriptor
-      )) {
-        form.resetField(configFieldPath(missing.field), {
-          defaultValue: missing.value,
-        });
-      }
       return;
     }
 
@@ -356,6 +345,42 @@ export function EmailProviderForm({
     };
     form.reset(providerToFormValues(provider, descriptor));
   }, [provider, isEdit, descriptors, form]);
+
+  // Give every field the SELECTED provider declares a value, whether or not
+  // the form has been anywhere near a record.
+  //
+  // The catalog refetches on mount and on window focus, so a deployment that
+  // adds a configuration field to a provider type already in use arrives while
+  // forms are open. Nothing about the RECORD changed, so no amount of
+  // reconciling against one reaches this: a create form has no record to
+  // reconcile against, and an edit form carrying an unsaved type change is
+  // showing a provider its record is not. Both would leave the new field
+  // holding nothing while its control renders an empty state — a switch
+  // drawing a position the payload does not carry.
+  //
+  // The record supplies starting values only while it describes the provider
+  // on screen; otherwise the descriptor's own defaults do, exactly as they
+  // would in a form opened now. Field names are shared across providers, so
+  // seeding from a record of another type would carry its setting into a form
+  // where nobody chose it.
+  //
+  // Written one path at a time, and only where the form holds nothing, so a
+  // descriptor that RENAMES a field rather than adding one cannot arrive at an
+  // occupied path and overwrite work in progress.
+  useEffect(() => {
+    if (!selectedDescriptor) return;
+    const source =
+      provider && provider.type === selectedType ? provider : undefined;
+    for (const missing of missingDeclaredFields(
+      form.getValues("configuration"),
+      source,
+      selectedDescriptor
+    )) {
+      form.resetField(configFieldPath(missing.field), {
+        defaultValue: missing.value,
+      });
+    }
+  }, [selectedDescriptor, selectedType, provider, form]);
 
   // Select the first registered provider once the catalog arrives. The form is
   // built before the request finishes, so without this a newly added provider

--- a/packages/admin/src/components/features/settings/EmailProviderForm/rehydrate.test.tsx
+++ b/packages/admin/src/components/features/settings/EmailProviderForm/rehydrate.test.tsx
@@ -241,6 +241,103 @@ describe("the same provider, changed by someone else while the form is open", ()
     ).toBe("Renaming In Progress");
   });
 
+  it("keeps a rename typed before the operator picked another type", async () => {
+    // The operator's OWN type change, not a remote one. Replacing the
+    // configuration has to leave every other field alone: the refetch below
+    // keeps only values that still differ from the form's baseline, so a
+    // rename folded into that baseline is overwritten by whatever the server
+    // holds — an edit lost with nothing on screen to say so.
+    //
+    // Distinct from the remote-type-change case above. That one arrives
+    // through the hydration guard; this one runs in the picker's own handler,
+    // and only this one can move the baseline under a field typed by hand.
+    const user = userEvent.setup();
+    const { rerender } = render(
+      <EmailProviderForm
+        mode="edit"
+        provider={STORED}
+        descriptors={[ACME, OTHER_WITH_FIELD]}
+        isPending={false}
+        onSubmit={() => {}}
+      />
+    );
+
+    const name = document.querySelector<HTMLInputElement>('input[name="name"]');
+    if (!name) throw new Error("expected the name field to render");
+    await user.clear(name);
+    await user.type(name, "Renaming In Progress");
+
+    await user.click(
+      screen.getByRole("button", { name: OTHER_WITH_FIELD.label })
+    );
+
+    // A change made elsewhere arrives on the next focus refetch.
+    rerender(
+      <EmailProviderForm
+        mode="edit"
+        provider={{
+          ...STORED,
+          name: "Renamed By Somebody Else",
+          updatedAt: "2026-02-02T00:00:00.000Z",
+        }}
+        descriptors={[ACME, OTHER_WITH_FIELD]}
+        isPending={false}
+        onSubmit={() => {}}
+      />
+    );
+
+    expect(
+      document.querySelector<HTMLInputElement>('input[name="name"]')?.value
+    ).toBe("Renaming In Progress");
+  });
+
+  it("keeps the type the operator picked when a remote change arrives", async () => {
+    // The same loss on the field the operator actually changed. A selection
+    // folded into the baseline no longer differs from it, so the reconcile
+    // puts the record's type back and the form silently returns to the
+    // provider they had just moved away from.
+    const user = userEvent.setup();
+    const { rerender } = render(
+      <EmailProviderForm
+        mode="edit"
+        provider={STORED}
+        descriptors={[ACME, OTHER_WITH_FIELD]}
+        isPending={false}
+        onSubmit={() => {}}
+      />
+    );
+
+    await user.click(
+      screen.getByRole("button", { name: OTHER_WITH_FIELD.label })
+    );
+
+    // A change to an unrelated field, made elsewhere.
+    rerender(
+      <EmailProviderForm
+        mode="edit"
+        provider={{
+          ...STORED,
+          fromName: "Changed Elsewhere",
+          updatedAt: "2026-02-02T00:00:00.000Z",
+        }}
+        descriptors={[ACME, OTHER_WITH_FIELD]}
+        isPending={false}
+        onSubmit={() => {}}
+      />
+    );
+
+    // Asserted on BOTH cards. A single assertion that the record's type is
+    // deselected passes just as well on a form that lost its selection
+    // entirely.
+    expect(
+      screen.getByRole("button", { name: OTHER_WITH_FIELD.label })
+    ).toHaveAttribute("aria-pressed", "true");
+    expect(screen.getByRole("button", { name: ACME.label })).toHaveAttribute(
+      "aria-pressed",
+      "false"
+    );
+  });
+
   it("reconciles a change that carries the SAME timestamp", async () => {
     // MySQL stores `updated_at` as `datetime` with no fractional seconds, so
     // two writes inside one second come back indistinguishable. Keying on the
@@ -364,6 +461,112 @@ describe("the same provider, changed by someone else while the form is open", ()
     );
 
     expect(regionInput()?.value).toBe("half-typed");
+  });
+});
+
+describe("a descriptor that gains a field while the form is open", () => {
+  /**
+   * The stored type, declaring one field MORE than `ACME`.
+   *
+   * A boolean, because it is the case with no honest empty state: a text input
+   * renders blank whether it holds nothing or an empty string, while a switch
+   * has to draw itself on or off and so states a position the form does not
+   * hold.
+   */
+  const ACME_PLUS: EmailProviderDescriptor = {
+    type: "acme",
+    label: "Acme",
+    capabilities: {},
+    configFields: [
+      { name: "region", label: "Region", kind: "text", required: true },
+      { name: "sandbox", label: "Sandbox", kind: "boolean", default: true },
+    ],
+  };
+
+  async function submittedPayload(
+    payloads: EmailProviderPayload[]
+  ): Promise<EmailProviderPayload | undefined> {
+    const form = document.getElementById(EMAIL_PROVIDER_FORM_ID);
+    if (!form) throw new Error("expected the form to render");
+    fireEvent.submit(form);
+    await waitFor(() => expect(payloads.length).toBeGreaterThan(0));
+    return payloads[0];
+  }
+
+  it("initialises the new field instead of leaving it unset", async () => {
+    // The catalog refetches on mount and on focus, so a deployment that adds a
+    // configuration field to a type already in use arrives while forms are
+    // open. The record has not changed, so nothing else prompts a rehydrate.
+    //
+    // Asserted on the SUBMITTED PAYLOAD rather than the switch. The control
+    // draws its own empty state, so a switch reading "on" cannot distinguish a
+    // form holding `true` from one holding nothing at all — which is the
+    // disagreement being tested.
+    const submitted: EmailProviderPayload[] = [];
+    const { rerender } = render(
+      <EmailProviderForm
+        mode="edit"
+        provider={STORED}
+        descriptors={[ACME]}
+        isPending={false}
+        onSubmit={payload => submitted.push(payload)}
+      />
+    );
+
+    rerender(
+      <EmailProviderForm
+        mode="edit"
+        provider={STORED}
+        descriptors={[ACME_PLUS]}
+        isPending={false}
+        onSubmit={payload => submitted.push(payload)}
+      />
+    );
+
+    expect((await submittedPayload(submitted))?.configuration).toMatchObject({
+      sandbox: true,
+    });
+  });
+
+  it("leaves a field being edited alone while it does so", async () => {
+    // The constraint that makes the rule safe. A descriptor that RENAMES a
+    // field rather than adding one arrives at a path the form already holds,
+    // and initialising it would overwrite work in progress.
+    //
+    // Both halves are asserted together on purpose: the untouched field alone
+    // passes just as well on a rule that never ran at all, which is the
+    // failure this pair exists to separate.
+    const user = userEvent.setup();
+    const submitted: EmailProviderPayload[] = [];
+    const { rerender } = render(
+      <EmailProviderForm
+        mode="edit"
+        provider={STORED}
+        descriptors={[ACME]}
+        isPending={false}
+        onSubmit={payload => submitted.push(payload)}
+      />
+    );
+
+    const input = regionInput();
+    if (!input) throw new Error("expected the region field to render");
+    await user.clear(input);
+    await user.type(input, "typed-by-hand");
+
+    rerender(
+      <EmailProviderForm
+        mode="edit"
+        provider={STORED}
+        descriptors={[ACME_PLUS]}
+        isPending={false}
+        onSubmit={payload => submitted.push(payload)}
+      />
+    );
+
+    expect((await submittedPayload(submitted))?.configuration).toMatchObject({
+      region: "typed-by-hand",
+      sandbox: true,
+    });
   });
 });
 

--- a/packages/admin/src/components/features/settings/EmailProviderForm/rehydrate.test.tsx
+++ b/packages/admin/src/components/features/settings/EmailProviderForm/rehydrate.test.tsx
@@ -338,6 +338,71 @@ describe("the same provider, changed by someone else while the form is open", ()
     );
   });
 
+  it("keeps configuration typed under a picked type across TWO reconciles", async () => {
+    // Two refetches, not one. The first arrives while the record still holds
+    // the old type, so the configuration on screen is restored as not
+    // belonging to the record. The second arrives after the record has moved
+    // to the type the operator had already picked — the types now agree, so
+    // nothing restores anything, and whatever stopped differing from the
+    // form's baseline in between is replaced by the record's values.
+    //
+    // A single-refetch test cannot see this: it passes whether or not the
+    // restore preserved the difference that makes the value survive.
+    const user = userEvent.setup();
+    const { rerender } = render(
+      <EmailProviderForm
+        mode="edit"
+        provider={STORED}
+        descriptors={[ACME, OTHER_WITH_FIELD]}
+        isPending={false}
+        onSubmit={() => {}}
+      />
+    );
+
+    await user.click(
+      screen.getByRole("button", { name: OTHER_WITH_FIELD.label })
+    );
+
+    const input = regionInput();
+    if (!input) throw new Error("expected the region field to render");
+    await user.clear(input);
+    await user.type(input, "typed-for-other");
+
+    // First refetch: an unrelated change, record still the old type.
+    rerender(
+      <EmailProviderForm
+        mode="edit"
+        provider={{
+          ...STORED,
+          fromName: "Changed Elsewhere",
+          updatedAt: "2026-02-02T00:00:00.000Z",
+        }}
+        descriptors={[ACME, OTHER_WITH_FIELD]}
+        isPending={false}
+        onSubmit={() => {}}
+      />
+    );
+
+    // Second refetch: the record has moved to the type already on screen.
+    rerender(
+      <EmailProviderForm
+        mode="edit"
+        provider={{
+          ...STORED,
+          type: "other",
+          fromName: "Changed Elsewhere",
+          configuration: { region: "from-the-server" },
+          updatedAt: "2026-02-03T00:00:00.000Z",
+        }}
+        descriptors={[ACME, OTHER_WITH_FIELD]}
+        isPending={false}
+        onSubmit={() => {}}
+      />
+    );
+
+    expect(regionInput()?.value).toBe("typed-for-other");
+  });
+
   it("reconciles a change that carries the SAME timestamp", async () => {
     // MySQL stores `updated_at` as `datetime` with no fractional seconds, so
     // two writes inside one second come back indistinguishable. Keying on the
@@ -524,6 +589,152 @@ describe("a descriptor that gains a field while the form is open", () => {
     );
 
     expect((await submittedPayload(submitted))?.configuration).toMatchObject({
+      sandbox: true,
+    });
+  });
+
+  /** The OTHER type, declaring one field more than `OTHER_WITH_FIELD`. */
+  const OTHER_PLUS: EmailProviderDescriptor = {
+    type: "other",
+    label: "Other",
+    capabilities: {},
+    configFields: [
+      { name: "region", label: "Region", kind: "text", required: true },
+      { name: "sandbox", label: "Sandbox", kind: "boolean", default: true },
+    ],
+  };
+
+  it("initialises it for the type ON SCREEN, not the stored one", async () => {
+    // The operator has picked a type and not saved it, so the form is showing
+    // a provider the record is not. A field added to THAT type is the one that
+    // needs initialising; reconciling against the record's descriptor instead
+    // leaves it unset, and the switch draws a position the payload does not
+    // carry.
+    const user = userEvent.setup();
+    const submitted: EmailProviderPayload[] = [];
+    const { rerender } = render(
+      <EmailProviderForm
+        mode="edit"
+        provider={STORED}
+        descriptors={[ACME, OTHER_WITH_FIELD]}
+        isPending={false}
+        onSubmit={payload => submitted.push(payload)}
+      />
+    );
+
+    await user.click(
+      screen.getByRole("button", { name: OTHER_WITH_FIELD.label })
+    );
+
+    const input = regionInput();
+    if (!input) throw new Error("expected the region field to render");
+    await user.clear(input);
+    await user.type(input, "typed-for-other");
+
+    rerender(
+      <EmailProviderForm
+        mode="edit"
+        provider={STORED}
+        descriptors={[ACME, OTHER_PLUS]}
+        isPending={false}
+        onSubmit={payload => submitted.push(payload)}
+      />
+    );
+
+    expect((await submittedPayload(submitted))?.configuration).toMatchObject({
+      region: "typed-for-other",
+      sandbox: true,
+    });
+  });
+
+  it("starts it from the DESCRIPTOR when the record is another provider", async () => {
+    // A form showing a type its record is not. The record may still hold a
+    // value at the new field's path — field names are shared across providers,
+    // `apiKey` being declared by both built-in API ones — and seeding from it
+    // would carry one provider's setting into another's form, where nobody
+    // chose it and a save would persist it.
+    //
+    // The stored value has to DISAGREE with the declared default for the two
+    // sources to be distinguishable at all: stored `false` against a
+    // descriptor default of `true`.
+    const user = userEvent.setup();
+    const submitted: EmailProviderPayload[] = [];
+    const storedWithSandbox: EmailProviderRecord = {
+      ...STORED,
+      configuration: { region: "eu-west-1", sandbox: false },
+    };
+
+    const { rerender } = render(
+      <EmailProviderForm
+        mode="edit"
+        provider={storedWithSandbox}
+        descriptors={[ACME, OTHER_WITH_FIELD]}
+        isPending={false}
+        onSubmit={payload => submitted.push(payload)}
+      />
+    );
+
+    await user.click(
+      screen.getByRole("button", { name: OTHER_WITH_FIELD.label })
+    );
+
+    const input = regionInput();
+    if (!input) throw new Error("expected the region field to render");
+    await user.type(input, "typed-for-other");
+
+    rerender(
+      <EmailProviderForm
+        mode="edit"
+        provider={storedWithSandbox}
+        descriptors={[ACME, OTHER_PLUS]}
+        isPending={false}
+        onSubmit={payload => submitted.push(payload)}
+      />
+    );
+
+    // The new provider's declared default, not the old provider's stored value.
+    expect((await submittedPayload(submitted))?.configuration).toMatchObject({
+      sandbox: true,
+    });
+  });
+
+  it("initialises it on a CREATE form too", async () => {
+    // A create form is open across the same deployment and has no record at
+    // all, so a rule that reconciles against one never runs for it.
+    const user = userEvent.setup();
+    const submitted: EmailProviderPayload[] = [];
+    const { rerender } = render(
+      <EmailProviderForm
+        mode="create"
+        descriptors={[ACME]}
+        isPending={false}
+        onSubmit={payload => submitted.push(payload)}
+      />
+    );
+
+    const name = document.querySelector<HTMLInputElement>('input[name="name"]');
+    const fromEmail = document.querySelector<HTMLInputElement>(
+      'input[name="fromEmail"]'
+    );
+    const region = regionInput();
+    if (!name || !fromEmail || !region) {
+      throw new Error("expected the create form's fields to render");
+    }
+    await user.type(name, "New Provider");
+    await user.type(fromEmail, "hello@example.com");
+    await user.type(region, "eu-west-1");
+
+    rerender(
+      <EmailProviderForm
+        mode="create"
+        descriptors={[ACME_PLUS]}
+        isPending={false}
+        onSubmit={payload => submitted.push(payload)}
+      />
+    );
+
+    expect((await submittedPayload(submitted))?.configuration).toMatchObject({
+      region: "eu-west-1",
       sandbox: true,
     });
   });

--- a/packages/admin/src/components/features/settings/EmailProviderForm/schemas/emailProviderSchema.ts
+++ b/packages/admin/src/components/features/settings/EmailProviderForm/schemas/emailProviderSchema.ts
@@ -786,17 +786,24 @@ export function hasStoredSecret(
  * rather than adding one otherwise arrives at an occupied path and overwrites
  * work in progress.
  *
- * Starting values are DERIVED from the same function that fills a form when it
- * opens, so a field added while one is open holds exactly what opening it now
- * would have shown. Deciding that here a second time is how the two come to
- * disagree about a default nobody changed.
+ * Starting values are DERIVED from the same two functions that fill a form when
+ * it opens, so a field added while one is open holds exactly what opening it
+ * now would have shown. Deciding that here a second time is how the two come to
+ * disagree about a default nobody changed — and the two differ on purpose: an
+ * edit shows blank for a field its record has no value for, while a create
+ * pre-fills the declared default.
+ *
+ * `provider` is omitted for a form with no record to draw from: a create form,
+ * or an edit form showing a type its record is not.
  */
 export function missingDeclaredFields(
   held: Record<string, unknown>,
-  provider: EmailProviderRecord,
+  provider: EmailProviderRecord | undefined,
   descriptor?: EmailProviderDescriptor
 ): Array<{ field: EmailProviderConfigField; value: unknown }> {
-  const hydrated = providerToFormValues(provider, descriptor).configuration;
+  const hydrated = provider
+    ? providerToFormValues(provider, descriptor).configuration
+    : emptyConfiguration(descriptor);
   const missing: Array<{ field: EmailProviderConfigField; value: unknown }> =
     [];
 

--- a/packages/admin/src/components/features/settings/EmailProviderForm/schemas/emailProviderSchema.ts
+++ b/packages/admin/src/components/features/settings/EmailProviderForm/schemas/emailProviderSchema.ts
@@ -771,6 +771,54 @@ export function hasStoredSecret(
 }
 
 /**
+ * Declared fields the configuration on screen has no value for, with what each
+ * should start as.
+ *
+ * A catalog refetch can bring a descriptor that declares MORE than the one a
+ * form was built from — a deployment adding a configuration field to a provider
+ * type already in use. The record itself has not changed, so nothing prompts a
+ * rehydrate, and the form holds nothing at the new path while its control
+ * renders an empty state: a switch reads off, a text input reads blank, and a
+ * save produces neither.
+ *
+ * Only paths holding NOTHING are reported. A field being edited, or one already
+ * carrying a stored value, is left out — a descriptor that renames a field
+ * rather than adding one otherwise arrives at an occupied path and overwrites
+ * work in progress.
+ *
+ * Starting values are DERIVED from the same function that fills a form when it
+ * opens, so a field added while one is open holds exactly what opening it now
+ * would have shown. Deciding that here a second time is how the two come to
+ * disagree about a default nobody changed.
+ */
+export function missingDeclaredFields(
+  held: Record<string, unknown>,
+  provider: EmailProviderRecord,
+  descriptor?: EmailProviderDescriptor
+): Array<{ field: EmailProviderConfigField; value: unknown }> {
+  const hydrated = providerToFormValues(provider, descriptor).configuration;
+  const missing: Array<{ field: EmailProviderConfigField; value: unknown }> =
+    [];
+
+  for (const field of descriptor?.configFields ?? []) {
+    const path = splitFieldPath(field.name);
+    if (path === null) continue;
+    if (readAtPath(held, path) !== undefined) continue;
+
+    // A stored value no control can represent is left out of a hydrated form
+    // rather than replaced by a stand-in, so there is nothing to initialise
+    // this field with either. Writing one would offer a value the operator
+    // never chose back as a value to save.
+    const value = readAtPath(hydrated, path);
+    if (value === undefined) continue;
+
+    missing.push({ field, value });
+  }
+
+  return missing;
+}
+
+/**
  * Whether a switch is showing a position its stored value did not choose.
  *
  * A value the control cannot show is left out of the form, so the control


### PR DESCRIPTION
Follow-up to #633. Codex reviewed its final head five minutes after the merge and reported one P2; verifying it turned up the same defect at two more sites, and the fix is the unification that task 209 was deferred waiting for.

## The defect

`handleTypeChange` replaced the configuration with `form.reset({ ...form.getValues(), … })`. A plain `reset` makes whatever it is handed the form's new **baseline**, so every field stops differing from it — including ones the call never meant to touch.

That matters because reconciling a refetch uses `keepDirtyValues`, which keeps only values that still differ from the baseline. So:

1. operator renames a provider,
2. operator picks a different type,
3. a change made elsewhere arrives on the focus refetch,
4. the rename is replaced by the record's own value, with nothing on screen to say so.

Confirmed by execution before any fix: the new test failed with `expected 'Renamed By Somebody Else' to be 'Renaming In Progress'`.

**Three sites shared the shape** — the picker handler, the plugin-returns path, and the chosen-type-left-the-catalog path. The file already held the right primitive in a fourth place (`resetField`, with a comment explaining why `reset` is wrong there). One answer, four places, correct in one.

## What changed

- Every "replace this part" site now writes the fields it means to via `resetField`. The whole-form-reset idiom is gone from the file.
- A type chosen in the picker is written with `setValue`, so it keeps differing from the baseline and survives a reconcile until saved. Previously the operator's own selection was silently reverted too.
- The reconcile asks whether the record's configuration applies to the type **on screen**, read from the form rather than remembered beside it — which removes `hydratedFor.type`, a second copy of an answer the form already holds.
- **Closes task 209.** A descriptor that gains a configuration field while a form is open now initialises it, one path at a time and only where the form holds nothing, so a field being edited is never clobbered. Starting values are derived from `providerToFormValues` rather than decided a second time.

## Verification

- 4 new tests. Each was run against the `origin/main` implementation and **all four fail there**, while the 13 pre-existing tests in the file pass.
- The occupied-path skip was broken on its own: it fails the new test plus 3 pre-existing ones, so it is load-bearing rather than decorative.
- One intermediate claim was wrong and was corrected: flipping `shouldDirty` alone changed nothing. The separating property is whether the **baseline moves**, demonstrated by swapping `setValue` for `resetField` and watching the test flip. The comments name that mechanism, not the flag.
- Admin baseline compared by NAME, not count: **41 failing files on this branch and on `origin/main`, zero unique to the branch.** All in schema-builder / entries / dashboard / role-management, none in email.
- `lint` exit 0, `check-types` exit 0. Both initially failed on unresolved `nextly/config`, which was missing build output rather than code.
- 109 passing in the EmailProviderForm suites.