### PR TITLE
test(blocks-engine): type-check the test files, and stop node types reaching src

### DIFF
--- a/.changeset/blocks-engine-typecheck-tests.md
+++ b/.changeset/blocks-engine-typecheck-tests.md
@@ -1,0 +1,33 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+"create-nextly-app": patch
+"nextly": patch
+---
+
+Type-check `blocks-engine`'s test files, and stop Node globals reaching `src`.
+
+Turning the check on surfaced a real defect in the published types:
+`AnyBlockDefinition` widened every prop-consuming member except `seo`, so
+`registerBlocks` rejected every definition built by `defineBlock<P>()` for any
+interface `P` without an index signature — whether or not it contributed SEO.
+`seo` is now widened like its siblings, so typed blocks register.

--- a/packages/blocks-engine/package.json
+++ b/packages/blocks-engine/package.json
@@ -30,7 +30,7 @@
   "scripts": {
     "build": "tsup",
     "dev": "tsup --watch",
-    "check-types": "tsc --noEmit",
+    "check-types": "tsc --noEmit && tsc --noEmit -p tsconfig.tests.json",
     "lint": "eslint . --max-warnings 0",
     "lint:fix": "eslint . --fix",
     "test": "vitest run",

--- a/packages/blocks-engine/src/block.ts
+++ b/packages/blocks-engine/src/block.ts
@@ -394,6 +394,7 @@ export interface AnyBlockDefinition
     | "localized"
     | "render"
     | "rendersNothing"
+    | "seo"
   > {
   example: { props: object; slots?: Record<string, BlockNode[]> };
   defaultProps?: object;
@@ -401,4 +402,18 @@ export interface AnyBlockDefinition
   localized?: string[];
   render(args: BlockRenderArgs<object, unknown>): BlockRenderResult;
   rendersNothing?(this: void, props: object): boolean;
+  /**
+   * Widened for the same reason as the members above, and it was the one member
+   * that was missed.
+   *
+   * Inherited unwidened, `seo` kept `BlockDefinition`'s default prop type, so a
+   * definition built by `defineBlock<CardProps>` carried
+   * `(props: CardProps) => ...` against this type's
+   * `(props: Record<string, unknown>) => ...`. Neither direction is assignable —
+   * an interface without an index signature is not a `Record<string, unknown>`,
+   * and a `Record<string, unknown>` is not a `CardProps` — so bivariance had
+   * nothing to fall back on, and EVERY typed definition was rejected by
+   * `registerBlocks` whether or not it contributed any SEO at all.
+   */
+  seo?(props: object): BlockSeoContribution | undefined;
 }

--- a/packages/blocks-engine/src/derive-seo.test.ts
+++ b/packages/blocks-engine/src/derive-seo.test.ts
@@ -34,10 +34,11 @@ function doc(nodes: BlockNode[]): BlockDocument {
 function definitions(
   extra: Record<string, (props: never) => BlockSeoContribution | undefined> = {}
 ): SeoDefinitionSource {
-  const map: Record<
-    string,
-    { seo?: (props: never) => BlockSeoContribution | undefined }
-  > = {
+  // Derived from the source's own return type rather than restated. The
+  // hand-written version named only `seo`, so the `slots` these fixtures
+  // already carry were invisible to the compiler and the map described a
+  // narrower contract than the function it stands in for.
+  const map: Record<string, NonNullable<ReturnType<SeoDefinitionSource>>> = {
     "core/heading": {
       seo: (p: never) => ({ title: (p as { text?: string }).text }),
     },

--- a/packages/blocks-engine/src/registry.test.ts
+++ b/packages/blocks-engine/src/registry.test.ts
@@ -97,8 +97,12 @@ describe("the define-then-register workflow keeps its prop types", () => {
     const output = def?.render({
       props: node.props,
       node,
-      slots: {},
       className: "nx-pb-x",
+      // Both are required by the render contract. This block draws no slots and
+      // reads no context, so they stand in rather than doing anything — but a
+      // call that omits them is not the call a renderer makes.
+      renderSlot: () => undefined,
+      ctx: undefined,
     });
     expect(output).toBe("hello reader");
   });
@@ -185,7 +189,7 @@ describe("registration rules", () => {
       registerBlocks([
         block({
           name: "core/arr",
-          example: { props: [] as unknown as object },
+          example: { props: [] as never },
         }),
       ])
     ).toThrow(/NEXTLY_BLOCK_INVALID.*plain object/s);

--- a/packages/blocks-engine/src/style/url-host-policy.test.ts
+++ b/packages/blocks-engine/src/style/url-host-policy.test.ts
@@ -12,11 +12,17 @@ import { describe, expect, it } from "vitest";
 import { STYLE_CATALOG } from "./catalog";
 import type { StyleShape } from "./catalog-types";
 import { compilePageCss } from "./compile-page";
-import type { BlockDocument } from "../document";
+import type { BlockDocument, StyleValue } from "../document";
 import { DOCUMENT_FORMAT_VERSION } from "../document";
 
-/** A value the leaf will accept, carrying `url` at the given host. */
-type UrlWriter = (url: string) => unknown;
+/**
+ * A value the leaf will accept, carrying `url` at the given host.
+ *
+ * `StyleValue` rather than `unknown`: every branch below produces one, and
+ * declaring the wider type meant the compiler could not check that the values
+ * these tests build are values a document could actually hold.
+ */
+type UrlWriter = (url: string) => StyleValue;
 
 /**
  * One writer per URL-bearing LEAF in this shape, each placing the URL at that
@@ -69,7 +75,7 @@ const REFUSED = "https://cdn.refused.test/a.png";
 
 function compile(
   property: string,
-  value: unknown,
+  value: StyleValue,
   host?: (url: string) => boolean
 ) {
   const doc: BlockDocument = {
@@ -86,7 +92,11 @@ function compile(
     ],
   };
   return compilePageCss(doc, {
-    breakpoints: { base: {} },
+    // The real shape: two axes, each a list. The previous `{ base: {} }` named
+    // no axis at all, so nothing here described a breakpoint the compiler could
+    // find, and the fixture only worked because these cases live at the base
+    // state where no breakpoint lookup happens.
+    breakpoints: { viewport: [], container: [] },
     ...(host === undefined ? {} : { mayFetchUrl: host }),
   });
 }

--- a/packages/blocks-engine/src/style/validate-style-value.test.ts
+++ b/packages/blocks-engine/src/style/validate-style-value.test.ts
@@ -221,12 +221,12 @@ describe("a budget that predates the site allowance", () => {
     );
     // One warning, and the allowance it came out of now exists on the object.
     expect(issues.map(i => i.code)).toEqual(["unknown-token"]);
-    expect(typeof (legacy as { siteRemaining?: number }).siteRemaining).toBe(
-      "number"
-    );
-    expect((legacy as { siteRemaining: number }).siteRemaining).toBe(
-      MAX_SITE_ISSUES - 1
-    );
+    // Read through ONE optional view. The allowance is absent from the legacy
+    // shape by construction, so a required view of it describes a type the
+    // object could never have had.
+    const filled = legacy as { siteRemaining?: number };
+    expect(typeof filled.siteRemaining).toBe("number");
+    expect(filled.siteRemaining).toBe(MAX_SITE_ISSUES - 1);
   });
 });
 
@@ -482,9 +482,13 @@ describe("composite shapes", () => {
     // complain about and reports it clean. Storage then puts the document
     // through JSON, where a Date becomes a string and a Map becomes `{}`, and
     // the same validator refuses on the next read what it just accepted.
-    expect(codes({ margin: new Date() })).toEqual(["invalid-style-value"]);
-    expect(codes({ background: new Map() })).toEqual(["invalid-style-value"]);
-    expect(codes({ position: /x/ })).toEqual(["invalid-style-value"]);
+    expect(codes({ margin: new Date() as never })).toEqual([
+      "invalid-style-value",
+    ]);
+    expect(codes({ background: new Map() as never })).toEqual([
+      "invalid-style-value",
+    ]);
+    expect(codes({ position: /x/ as never })).toEqual(["invalid-style-value"]);
   });
 
   it("refuses a token reference that is not a plain record", () => {
@@ -500,7 +504,7 @@ describe("composite shapes", () => {
   });
 
   it("accepts a record with no prototype, which JSON leaves alone", () => {
-    const sides = Object.create(null) as Record<string, unknown>;
+    const sides = Object.create(null) as StyleValues;
     sides.inlineStart = "2rem";
     expect(codes({ padding: sides })).toEqual([]);
   });
@@ -517,7 +521,9 @@ describe("union shapes", () => {
   });
 
   it("refuses a value no variant accepts", () => {
-    expect(codes({ borderRadius: true })).toEqual(["invalid-style-value"]);
+    expect(codes({ borderRadius: true as never })).toEqual([
+      "invalid-style-value",
+    ]);
     expect(codes({ fontWeight: "heavy" })).toEqual(["invalid-style-value"]);
   });
 });

--- a/packages/blocks-engine/src/typecheck-config.test.ts
+++ b/packages/blocks-engine/src/typecheck-config.test.ts
@@ -1,0 +1,112 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import ts from "typescript";
+import { describe, expect, it } from "vitest";
+
+/**
+ * The two halves of type-checking this package, held where deleting one is
+ * visible.
+ *
+ * Type-checking the tests and keeping Node globals out of `src` are one change,
+ * not two, and the second half is the one that rots. Test files legitimately
+ * reach `node:fs` and `process`, so `@types/node` has to resolve for them; with
+ * no `types` list it resolves for `src` as well, and a published browser module
+ * can read `process.env` and type-check clean. Measured rather than reasoned:
+ * `export const leak = process.env.SECRET` in `src` compiles with no `types`
+ * field and fails with `TS2591` once the list is empty.
+ *
+ * Nothing else would notice its removal. Deleting `types: []` breaks no build,
+ * fails no test and widens what compiles, so every gate reports green — and it
+ * lives in the SHIPPING config, which nobody reviewing a test change opens.
+ *
+ * The assertions are on config text because that is where the property lives.
+ * A runtime test cannot evaluate "what can `src` see", so the honest thing is
+ * to check the setting that decides it and say plainly that is what this does.
+ */
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const PACKAGE_DIR = join(HERE, "..");
+
+/** Parse a tsconfig, which is JSONC — comments and all. */
+function readConfig(name: string): Record<string, unknown> {
+  const path = join(PACKAGE_DIR, name);
+  const parsed = ts.parseConfigFileTextToJson(path, readFileSync(path, "utf8"));
+  expect(parsed.error, `${name} must be parseable`).toBeUndefined();
+  return parsed.config as Record<string, unknown>;
+}
+
+function compilerOptions(name: string): Record<string, unknown> {
+  const options = readConfig(name).compilerOptions;
+  expect(options, `${name} must set compilerOptions`).toBeDefined();
+  return options as Record<string, unknown>;
+}
+
+function packageJson(): {
+  scripts: Record<string, string>;
+  devDependencies: Record<string, string>;
+} {
+  return JSON.parse(
+    readFileSync(join(PACKAGE_DIR, "package.json"), "utf8")
+  ) as ReturnType<typeof packageJson>;
+}
+
+describe("what the shipping config lets src see", () => {
+  it("admits no ambient type packages", () => {
+    // The line whose deletion is silent. An empty list is not the same as an
+    // absent one: absent means "every @types package installed anywhere in the
+    // tree", which here includes Node.
+    expect(compilerOptions("tsconfig.json").types).toEqual([]);
+  });
+
+  it("still depends on the types the empty list is holding back", () => {
+    // The anti-vacuity control, and it is the assertion that makes the one
+    // above mean something. Remove `@types/node` and `types: []` together and
+    // the first test still passes while the hole it guards no longer exists —
+    // so a later reader would read a guard that had quietly become decoration,
+    // and restoring the dependency would reopen the hole under a green test.
+    expect(packageJson().devDependencies["@types/node"]).toBeDefined();
+  });
+
+  it("keeps test files out of what it builds", () => {
+    const exclude = readConfig("tsconfig.json").exclude;
+    expect(exclude).toContain("**/*.test.ts");
+    // `.tsx` too, though this package has none today. The engine is
+    // runtime-free, so a `.tsx` here would be a mistake — but excluding it from
+    // the SHIPPING config is what makes it a mistake caught at review rather
+    // than a test file compiled into `dist`.
+    expect(exclude).toContain("**/*.test.tsx");
+  });
+});
+
+describe("what the tests config adds back", () => {
+  it("re-widens types for the test files that need Node", () => {
+    // Extending the shipping config inherits `types: []`, which would break
+    // every test importing `node:fs`. The widening has to be deliberate and
+    // confined to this config.
+    expect(compilerOptions("tsconfig.tests.json").types).toContain("node");
+  });
+
+  it("carries no opt-out list", () => {
+    // Every test file in this package compiles. An empty list is a stronger
+    // statement than a short one: the first entry added is a visible
+    // regression rather than one more line in a column that already has many.
+    expect(readConfig("tsconfig.tests.json").exclude).toEqual([
+      "dist",
+      "node_modules",
+    ]);
+  });
+});
+
+describe("both configs actually run", () => {
+  it("checks the tests config as well as the shipping one", () => {
+    // A hand-rolled `tsc -p tsconfig.json` runs only the first and reports a
+    // green that covers no test file at all. That exact false pass has already
+    // cost this repo a defect, which is why the script is asserted rather than
+    // assumed.
+    const script = packageJson().scripts["check-types"];
+    expect(script).toContain("tsc --noEmit");
+    expect(script).toContain("-p tsconfig.tests.json");
+  });
+});

--- a/packages/blocks-engine/src/validation.test.ts
+++ b/packages/blocks-engine/src/validation.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { DOCUMENT_KINDS } from "./document";
-import type { BlockDocument, BreakpointSet } from "./document";
+import type { BlockDocument, BlockNode, BreakpointSet } from "./document";
 import { DEFAULT_LIMITS, documentBytes } from "./limits";
 import {
   MAX_SITE_LOOKUPS,
@@ -363,7 +363,7 @@ describe("validation never throws on adversarial input", () => {
   it("returns a depth issue for a document nested far beyond any stack limit", () => {
     // Build a chain ~20k deep — enough to overflow a recursive walk or
     // JSON.stringify. Validation must return issues, not throw.
-    let node: Record<string, unknown> = {
+    let node: BlockNode = {
       id: "leaf",
       type: "core/text",
       version: 1,
@@ -378,11 +378,11 @@ describe("validation never throws on adversarial input", () => {
         slots: { children: [node] },
       };
     }
-    const doc = {
+    const doc: BlockDocument = {
       formatVersion: 1,
       kind: "page",
       nodes: [node],
-    } as BlockDocument;
+    };
     let issues: ReturnType<typeof validate> = [];
     expect(() => {
       issues = validate(doc, {
@@ -1665,7 +1665,7 @@ describe("what the budget stops, and what it lets through", () => {
 });
 
 describe("a document past the byte cap stops paying to read its values", () => {
-  function styledNodes(count: number, terms: number) {
+  function styledNodes(count: number, terms: number): BlockNode[] {
     return Array.from({ length: count }, (_, index) => ({
       id: `n${index}`,
       type: "core/box",

--- a/packages/blocks-engine/tsconfig.json
+++ b/packages/blocks-engine/tsconfig.json
@@ -1,9 +1,21 @@
+// The SHIPPING config: what `dist` is built from, and the only one whose
+// `types` list decides what ambient globals `src` can see.
+//
+// `types: []` is not tidiness. Without it, `@types/node` — a real devDependency
+// here, needed by the test files — is ambient across `src` as well, and a
+// published browser module can write `process.env.SECRET` and type-check
+// clean. Measured, not reasoned: adding that line to a `src` module compiles
+// with no `types` field and fails with `TS2591` once the list is empty.
+//
+// Test files are type-checked by `tsconfig.tests.json`, which re-widens `types`
+// for itself. Both configs run in `check-types`.
 {
   "extends": "@nextlyhq/tsconfig/base-bundler.json",
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "dist"
+    "outDir": "dist",
+    "types": []
   },
   "include": ["src/**/*"],
-  "exclude": ["dist", "node_modules", "**/*.test.ts"]
+  "exclude": ["dist", "node_modules", "**/*.test.ts", "**/*.test.tsx"]
 }

--- a/packages/blocks-engine/tsconfig.tests.json
+++ b/packages/blocks-engine/tsconfig.tests.json
@@ -1,0 +1,26 @@
+// Type-checks the test files that `tsconfig.json` excludes.
+//
+// The package's own tsconfig excluded `**/*.test.ts`, so no test file was ever
+// type-checked — and vitest does not type-check either, because esbuild strips
+// annotations rather than checking them. Two independent ways for a test to be
+// wrong and look green, with neither gate covering the other.
+//
+// There is no opt-out list, deliberately. Every one of this package's test
+// files compiles, so nothing needs carrying, and an empty list is a stronger
+// statement than a short one: adding the first entry is a visible regression
+// rather than one more line in a column that already has many.
+//
+// `types` is re-widened here because the shipping config sets it to `[]`. Tests
+// legitimately reach `node:fs` and `process`; `src` must not, and that is what
+// the shipping config's empty list enforces. Both halves are needed — the empty
+// list alone would break these files, and node types alone would put `process`
+// in reach of every module this package publishes.
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules"]
+}


### PR DESCRIPTION
Task 208, the `blocks-engine` half. 25 test files in this package were invisible to `tsc`, and vitest does not type-check either — esbuild strips annotations rather than checking them. Two independent ways for a test to be wrong and look green, with neither gate covering the other.

## The defect this surfaced

`AnyBlockDefinition` widens every prop-consuming member to `object` so that typed definitions stay assignable. It missed `seo`, which kept `BlockDefinition`'s default prop type. Neither direction is assignable between `(props: CardProps)` and `(props: Record<string, unknown>)` — an interface without an index signature is not a `Record`, and a `Record` is not a `CardProps` — so bivariance had nothing to fall back on.

**`registerBlocks` therefore rejected every definition built by `defineBlock<P>()`**, for any interface `P`, whether or not it contributed any SEO at all. That is the primary block-author path. `registry.test.ts` already had a test asserting a typed block registers; it passed because nothing type-checked it.

Confirmed with a probe carrying `seo` and one carrying only `editor` — both rejected, both naming `seo` as the cause, which is what showed the failure was in the declared type rather than in what any definition provides.

## The other 14

Fixed by deriving the test's type rather than annotating around the error, wherever that was available:

- `UrlWriter` was declared `(url: string) => unknown` while every branch produces a `StyleValue`, so the compiler could not check that these fixtures build values a document could hold.
- `derive-seo`'s fixture map restated `SeoDefinitionSource` and named only `seo`, so the `slots` those fixtures already carry were invisible. Now `NonNullable<ReturnType<SeoDefinitionSource>>`.
- `styledNodes` had an inferred return type, so the fixture's single style property became the whole shape and a test writing any other property was rejected — the fixture describing the type instead of the type describing it.
- `url-host-policy` named its breakpoints `{ base: {} }`, a shape `BreakpointSet` cannot have. It passed only because those cases sit at the base state where no breakpoint lookup happens.
- `registry.test.ts` called `render` without `renderSlot` or `ctx` — not the call a renderer makes.
- Deliberately-invalid negative-test inputs use `as never`, following the pattern already in `validate-style-value.test.ts`.

Nothing was annotated away with `as any` or `@ts-expect-error`.

## `types: []` is the other half, and it is pre-existing

`@types/node` is a real devDependency here, needed by `runtime-free.test.ts` and `visibility.test.ts`. Without a `types` list it is ambient across `src` as well. Measured on `main`, before any change in this PR:

```ts
// packages/blocks-engine/src/__leak.ts
export const leak = process.env.SECRET;   // compiles clean
```

A published browser module reaching `process.env`, type-checking green. With `types: []` the same file fails `TS2591`.

So the shipping config sets `types: []` and `tsconfig.tests.json` re-widens it for the tests alone — the `packages/nextly` two-config precedent, but with **no opt-out list**, because every test file in this package compiles.

`src/typecheck-config.test.ts` holds both halves visible, including a case pinning that `@types/node` is still a dependency: removing it and `types: []` together would leave a guard that had quietly become decoration, and restoring the dependency later would reopen the hole under a green test.

## Verification

- 26 files / 1119 tests pass; `check-types` clean on both configs; lint clean; `tsup` build unaffected.
- **The check reads test files**: a `const wrong: number = "not a number"` inside `registry.test.ts` now fails `check-types` — while `vitest run` on that same file reports **30 passed**, which is the two-gate gap demonstrated rather than described.
- **The guard fires**: deleting `types: []` fails exactly one test, and the `process.env` probe goes green again in the same state.

## Not in scope

`packages/nextly`'s shipping config has no `types` field either, so the same leak exists there. Not touched here — different package, different lane — and worth its own task.
