### PR TITLE
fix(blocks-react): resolve a page tree and its stylesheet together

### DIFF
--- a/.changeset/tidy-moons-repeat.md
+++ b/.changeset/tidy-moons-repeat.md
@@ -1,0 +1,27 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+---
+
+Serving a page through the new `preparePageForRead` no longer publishes stylesheet rules for a block that is missing from the site, so an uninstalled plugin stops leaving its block defaults and named classes behind in the page CSS.

--- a/packages/blocks-react/src/entry-surface.test.ts
+++ b/packages/blocks-react/src/entry-surface.test.ts
@@ -114,10 +114,23 @@ const SOURCE_MODULES: ReadonlyArray<{
     // Deliberately NOT a consumer surface: publishing it would offer a third way
     // to assemble a page by hand, and assembling by hand is precisely the path
     // that gets this wrong. `preparePageForRead` is the consumer's answer.
+    // `gatedEntriesCoverRemovedNodes`, `gatedMapCoversPrunedNodes` and
+    // `hasDuplicateNodeIds` are the artifact-trust vocabulary: what a stored
+    // sheet can still ACCOUNT for once a pass has removed something. They live
+    // beside `isRecordedGatedEntry`, which they read through, so coverage and
+    // delivery cannot disagree about the same map. `page-renderer` and
+    // `read-page` both decide whether to trust a stored artifact and must reach
+    // the same verdict — a type-level rule survives its last node either way,
+    // and a duplicate id suppresses both twins' rules either way. They cross a
+    // module boundary inside this package; a consumer asks the question through
+    // `preparePageForRead` rather than assembling the verdict itself.
     internal: [
       "UNIDENTIFIED_FETCH_POLICY",
       "drawlessTestFor",
       "effectiveCompile",
+      "gatedEntriesCoverRemovedNodes",
+      "gatedMapCoversPrunedNodes",
+      "hasDuplicateNodeIds",
       "isRecordedGatedEntry",
       "isUsableGatedEntry",
       "readableGatedRules",

--- a/packages/blocks-react/src/entry-surface.test.ts
+++ b/packages/blocks-react/src/entry-surface.test.ts
@@ -105,9 +105,19 @@ const SOURCE_MODULES: ReadonlyArray<{
     // reads through it, so a host's override cannot be honoured on one path and
     // ignored on the other. It crosses a module boundary inside this package; a
     // consumer states its answer through `styleContext.drawsNothing` instead.
+    // `effectiveCompile` reconciles a caller's context with what the stored
+    // artifact and the host already knew — the scope that lives on the artifact,
+    // the caps preparation honoured, and the identity a fetch predicate needs
+    // before a stored sheet can be judged against it. `page-renderer` and
+    // `read-page` both resolve a stored page and must not answer any of those
+    // differently, which is why it is one function rather than two.
+    // Deliberately NOT a consumer surface: publishing it would offer a third way
+    // to assemble a page by hand, and assembling by hand is precisely the path
+    // that gets this wrong. `preparePageForRead` is the consumer's answer.
     internal: [
       "UNIDENTIFIED_FETCH_POLICY",
       "drawlessTestFor",
+      "effectiveCompile",
       "isRecordedGatedEntry",
       "isUsableGatedEntry",
       "readableGatedRules",

--- a/packages/blocks-react/src/entry-surface.test.ts
+++ b/packages/blocks-react/src/entry-surface.test.ts
@@ -27,6 +27,7 @@ import * as contextModule from "./context";
 import * as pageRendererModule from "./page-renderer";
 import * as placeholderModule from "./placeholder";
 import * as prepareModule from "./prepare-document";
+import * as readPageModule from "./read-page";
 import * as resolverModule from "./resolver";
 import * as stylesModule from "./styles";
 import * as visibilityModule from "./visibility";
@@ -148,11 +149,25 @@ const SOURCE_MODULES: ReadonlyArray<{
     // prepared document already has `prepareDocumentForRead`; a consumer wanting
     // the intermediates is reasoning about artifact trust, which is this package's
     // job and not something to hand out before anyone has asked for it.
+    //
+    // `readingViewOf` is the all-placeholder rule, which both entry points that
+    // turn stages into something a reader presents must apply identically. It
+    // is exported to delete the second copy, not to be called on its own: it
+    // takes stages, and a consumer holding stages is already past this surface.
     internal: [
       "prepareDocumentReadStages",
       "pruneKnownPlaceholders",
+      "readingViewOf",
       "rendersOwnMarkup",
     ],
+  },
+  {
+    name: "read-page",
+    module: readPageModule,
+    // Nothing withheld: the module exists to offer one entry point, and the
+    // repair test it decides with is module-private because the whole point is
+    // that a caller never has to ask it.
+    internal: [],
   },
   {
     name: "block-boundary",
@@ -177,6 +192,7 @@ describe("the root entry", () => {
       "fetchPolicyLabel",
       "migrationSourceFor",
       "prepareDocumentForRead",
+      "preparePageForRead",
       "pruneHiddenNodes",
       "registeredBlocks",
       "resolvePageStyles",

--- a/packages/blocks-react/src/index.ts
+++ b/packages/blocks-react/src/index.ts
@@ -75,10 +75,20 @@ export type { PageStyles, ResolveStyleOptions } from "./styles";
  * replaces — and is the only thing that produces the tree the page actually presents. Gating alone
  * leaves a tree LARGER than the render's, so styles resolved against it still ship rules for nodes
  * the page drops.
+ *
+ * 🔴 Neither of them is the flow for serving a page's stored STYLESHEET, and preparing a document
+ * then resolving styles against the result is the pairing that looks like it. What the second call
+ * needs to know is whether the first REMOVED anything, and the prepared tree it receives no longer
+ * says: a node the placeholder pass dropped takes its markup off the page while the block-type
+ * defaults and named classes it pulled into the sheet stay, because those tiers are keyed by type
+ * and by class rather than by node. `preparePageForRead` does both halves and answers that question
+ * from the evidence, which is why it exists rather than a documented instruction to pass a flag.
  */
 export { pruneHiddenNodes } from "./visibility";
 export { prepareDocumentForRead } from "./prepare-document";
 export type { PrepareDocumentArgs } from "./prepare-document";
+export { preparePageForRead } from "./read-page";
+export type { PreparedPage, ReadPageArgs } from "./read-page";
 
 /**
  * The engine types this package's own options are written in terms of.

--- a/packages/blocks-react/src/page-renderer.tsx
+++ b/packages/blocks-react/src/page-renderer.tsx
@@ -1,7 +1,6 @@
 import {
   DOCUMENT_FORMAT_VERSION,
   PAGE_ROOT_CLASS,
-  walkNodes,
   type BlockDocument,
   type DocumentLimits,
   type StyleCompileContext,
@@ -23,7 +22,9 @@ import { registeredBlocks, type BlockResolver } from "./resolver";
 import {
   drawlessTestFor,
   effectiveCompile,
-  isRecordedGatedEntry,
+  gatedEntriesCoverRemovedNodes,
+  gatedMapCoversPrunedNodes,
+  hasDuplicateNodeIds,
   readableGatedRules,
   resolvePageStyles,
   styleTextForInjection,
@@ -75,90 +76,6 @@ export interface PageRendererProps {
    * omitting this does not deny remote fetches.
    */
   hostPolicy?: BlockHostPolicy;
-}
-
-/**
- * Whether the artifact holds the OWN rules of every node the prune removed.
- *
- * "A map is present" is not coverage. A stored artifact can be stale relative to the document it
- * is rendered with — compiled when one node was unconditional, so its rules are in `css`, while a
- * different node was already gated and has an entry. The map exists, but it does not cover the
- * node that was actually pruned, and serving the stored sheet publishes that node's rules and
- * asset URLs.
- *
- * The compiler writes an entry for EVERY node it holds back, including one with no styles of its
- * own, so an id missing from the map means the artifact was compiled when that node was still
- * being served. That makes presence-per-removed-id an exact test rather than a heuristic.
- *
- * The ENTRY has to be usable, not merely present. A key whose value the delivery refuses to read
- * certifies coverage that never reaches the sheet, which is the same divergence one value deeper.
- *
- * This is the NODE-LOCAL half on its own, because the two prunes that ask it need different
- * amounts. Written once so neither can drift from the other on the part they share.
- */
-function gatedEntriesCoverRemovedNodes(
-  before: BlockDocument,
-  after: BlockDocument,
-  gated: Readonly<Record<string, unknown>>
-): boolean {
-  const surviving = new Set<string>();
-  walkNodes(after.nodes, node => surviving.add(node.id));
-  let covered = true;
-  walkNodes(before.nodes, node => {
-    if (surviving.has(node.id)) return;
-    if (!isRecordedGatedEntry(gated[node.id])) covered = false;
-  });
-  return covered;
-}
-
-/**
- * Whether the artifact's gated map accounts for every node the visibility prune removed.
- *
- * The node-local rules, plus one thing more. The map holds a node's OWN rules; a block type's
- * defaults are shared, emitted once per type into the main sheet, and stay there — so when pruning
- * removes the last instance of a type, the stored sheet still publishes that type's defaults, and
- * any `url(...)` in them, for a block nobody was served. Only a recompile can drop a type-level
- * rule, so the artifact cannot cover this case and must not claim to.
- *
- * Asked HERE and not of a draws-nothing node, and the difference is what the two prunes are for. A
- * condition withholds content from a reader, so the block a page was built from is itself part of
- * what is being withheld and a rule naming that type says something. A block that draws nothing is
- * an ordinary node the site uses and will draw again as soon as it is filled in; its type's
- * defaults come from the block package rather than from the document, and refusing coverage over
- * them would leave the drop unreachable for the page with one image and no second one.
- */
-function gatedMapCoversPrunedNodes(
-  before: BlockDocument,
-  after: BlockDocument,
-  gated: Readonly<Record<string, unknown>>
-): boolean {
-  const survivingTypes = new Set<string>();
-  walkNodes(after.nodes, node => survivingTypes.add(node.type));
-  const surviving = new Set<string>();
-  walkNodes(after.nodes, node => surviving.add(node.id));
-  let covered = gatedEntriesCoverRemovedNodes(before, after, gated);
-  walkNodes(before.nodes, node => {
-    if (surviving.has(node.id)) return;
-    if (!survivingTypes.has(node.type)) covered = false;
-  });
-  return covered;
-}
-
-/**
- * Whether any id appears on more than one node.
- *
- * The compiler suppresses the node-local rules of every node sharing an id, so a stored sheet
- * compiled from such a document is missing them — and stays missing them after a prune removes the
- * duplicate that made the collision visible.
- */
-function hasDuplicateNodeIds(document: BlockDocument): boolean {
-  const seen = new Set<string>();
-  let duplicate = false;
-  walkNodes(document.nodes, node => {
-    if (seen.has(node.id)) duplicate = true;
-    seen.add(node.id);
-  });
-  return duplicate;
 }
 
 /**

--- a/packages/blocks-react/src/page-renderer.tsx
+++ b/packages/blocks-react/src/page-renderer.tsx
@@ -1,8 +1,6 @@
 import {
-  DEFAULT_LIMITS,
   DOCUMENT_FORMAT_VERSION,
   PAGE_ROOT_CLASS,
-  isFetchableUrl,
   walkNodes,
   type BlockDocument,
   type DocumentLimits,
@@ -23,9 +21,8 @@ import {
 } from "./prepare-document";
 import { registeredBlocks, type BlockResolver } from "./resolver";
 import {
-  UNIDENTIFIED_FETCH_POLICY,
   drawlessTestFor,
-  fetchPolicyLabel,
+  effectiveCompile,
   isRecordedGatedEntry,
   readableGatedRules,
   resolvePageStyles,
@@ -405,57 +402,17 @@ export function PageRenderer({
     (drawlessInput !== visible && !drawlessCoveredByArtifact) ||
     placeholderDropped !== visible;
 
-  // Recompiling after pruning must not lose what the stored artifact and the
-  // renderer knew. `scope` lives on the artifact rather than in the compile
-  // context, and the effective limits come from the prop — so passing the raw
-  // context would rebuild a scoped page unscoped, letting its rules reach
-  // another document rendered beside it, and would repair against default caps
-  // a caller had deliberately raised.
-  const effectiveLimits = limits ?? styleContext?.limits ?? DEFAULT_LIMITS;
-  // A stylesheet fetches too. `background-image: url(...)` is a request the
-  // browser makes on every page the rule applies to, so the host's list has to
-  // reach the compile as well as the blocks — asked of the SAME list, through a
-  // predicate the engine calls, so the two channels cannot drift apart.
-  //
-  // A caller's own `mayFetchUrl` wins. It is the more specific answer, and a
-  // host that passed one deliberately should not have it replaced by one
-  // derived here.
-  const patterns = hostPolicy?.remotePatterns;
-  // The label a compiled sheet is stamped with, and the one a stored sheet is
-  // checked against. Derived from the patterns themselves so it changes exactly
-  // when they do: an editor who adds a host gets every stored sheet recompiled
-  // once, with nothing to remember to invalidate.
-  //
-  // A caller's OWN predicate is authoritative and opaque. It can encode rules no
-  // pattern list describes, and nothing here can tell one such function from
-  // another, so no label can describe it — and reusing a stored sheet across a
-  // change to it would serve CSS whose URLs were admitted by rules that no
-  // longer hold. A caller wanting its sheets cached states which policy its
-  // predicate IS, through `fetchPolicyId` on the style context. One that does
-  // not gets the safe answer rather than the fast one: an identity no artifact
-  // can carry, so every stored sheet reads as compiled under another policy.
-  const fetchPolicyId =
-    styleContext?.mayFetchUrl === undefined
-      ? fetchPolicyLabel(patterns)
-      : (styleContext.fetchPolicyId ?? UNIDENTIFIED_FETCH_POLICY);
-  const compileContext =
-    styleContext === undefined
-      ? undefined
-      : {
-          ...styleContext,
-          limits: effectiveLimits,
-          ...(patterns === undefined || styleContext.mayFetchUrl !== undefined
-            ? {}
-            : { mayFetchUrl: (url: string) => isFetchableUrl(url, patterns) }),
-          // Only a STRING scope is carried over. The artifact is a database
-          // record, so `scope` can be null or a number, and the compiler
-          // dereferences it before any block boundary exists — a malformed one
-          // would fail the whole page rather than render it unstyled.
-          ...(styleContext.scope === undefined &&
-          typeof styles?.scope === "string"
-            ? { scope: styles.scope }
-            : {}),
-        };
+  // Reconciled through the SAME derivation every entry point that resolves a
+  // stored page uses. What a caller supplies is not what a page compiles with:
+  // the scope lives on the artifact, the caps come from this prop, and a
+  // caller's own fetch predicate needs an identity before a stored sheet can be
+  // judged against it.
+  const { context: compileContext, fetchPolicyId } = effectiveCompile({
+    styleContext,
+    styles,
+    limits,
+    remotePatterns: hostPolicy?.remotePatterns,
+  });
 
   const { css, classes, scope } = resolvePageStyles(
     styleInput,

--- a/packages/blocks-react/src/prepare-document.ts
+++ b/packages/blocks-react/src/prepare-document.ts
@@ -291,30 +291,48 @@ export function prepareDocumentReadStages(
 }
 
 /**
+ * The tree a READER should present, or `null` when it should present none.
+ *
+ * The all-placeholder rule belongs to reading, not to the pipeline. A page that
+ * presents nothing but placeholders is unreadable to a visitor who wanted its
+ * content, which is what `null` names here — but the RENDERER must still walk
+ * that document, because the placeholders are the markers it draws. A pipeline
+ * that answered `null` for it would take those markers away and show an
+ * unsupported-format box for a page whose blocks are merely unresolvable.
+ *
+ * Compared against the tree AFTER gating: a page whose blocks are all
+ * condition-gated is legitimately empty, nothing failed, and reporting it as
+ * unreadable would show a fallback for a page working exactly as configured.
+ *
+ * Exported so that every reader applies the SAME rule. More than one entry point
+ * now turns stages into a reading view, and a second copy of this comparison
+ * would decide differently the first time either half moved.
+ */
+export function readingViewOf(
+  stages: DocumentReadStages
+): BlockDocument | null {
+  if (stages.deduped.nodes.length > 0 && stages.prepared.nodes.length === 0) {
+    return null;
+  }
+  return stages.prepared;
+}
+
+/**
  * The prepared document, for readers that need no intermediate state.
  *
  * Derived from `prepareDocumentReadStages` rather than repeating its passes.
  * Two implementations of one pipeline agree the day they are written and drift
  * after, and the drift is silent because both look correct alone.
+ *
+ * 🔴 Enough for a reader that only DESCRIBES the page — metadata, a search
+ * index, a link preview. A reader that also serves the page's stored STYLESHEET
+ * needs `preparePageForRead` instead: the stages hold the fact that decides what
+ * that sheet may still be trusted for, and this return value has dropped it.
  */
 export function prepareDocumentForRead(
   document: BlockDocument,
   args: PrepareDocumentArgs
 ): BlockDocument | null {
   const stages = prepareDocumentReadStages(document, args);
-  if (stages === null) return null;
-  // The all-placeholder rule belongs to READING, not to the pipeline. A page
-  // that presents nothing but placeholders is unreadable to a visitor who wanted
-  // its content, which is what `null` names here — but the RENDERER must still
-  // walk that document, because the placeholders are the markers it draws. A
-  // pipeline that answered `null` for it would take those markers away and show
-  // an unsupported-format box for a page whose blocks are merely unresolvable.
-  //
-  // Compared against the tree AFTER gating: a page whose blocks are all
-  // condition-gated is legitimately empty, nothing failed, and reporting it as
-  // unreadable would show a fallback for a page working exactly as configured.
-  if (stages.deduped.nodes.length > 0 && stages.prepared.nodes.length === 0) {
-    return null;
-  }
-  return stages.prepared;
+  return stages === null ? null : readingViewOf(stages);
 }

--- a/packages/blocks-react/src/read-page.test.tsx
+++ b/packages/blocks-react/src/read-page.test.tsx
@@ -308,16 +308,15 @@ describe("what a page is compiled WITH", () => {
     expect(read.styles.css).toBe("");
   });
 
-  it("never stamps a sheet with the anonymous-policy sentinel", () => {
-    // The sentinel is a comparison value, not a stamp. Stamped, it would answer
-    // "which policy compiled this?" with a stable string, so a later read under
-    // a DIFFERENT anonymous predicate would find its own sentinel on the stored
-    // sheet, compare equal, and reuse CSS that predicate never judged.
+  it("never reuses a sheet compiled under an anonymous predicate", () => {
+    // An anonymous predicate has no identity, so a sheet it compiled is stale
+    // against EVERY later policy. Two transitions break in opposite directions
+    // and neither a stable stamp nor an absent one separates them, so the stamp
+    // records what compiled the sheet and the comparison refuses it outright.
     //
-    // Asserted through a `url(...)` the two predicates disagree about, because
-    // bytes alone cannot separate reuse from a recompile that happens to produce
-    // the same sheet. The URL is the thing a fetch policy exists to decide, and
-    // it is what would actually be published.
+    // Asserted through a `url(...)` the predicates disagree about, because bytes
+    // alone cannot tell reuse from a recompile that happens to match. The URL is
+    // what a fetch policy exists to decide and what would actually be published.
     const fetching: BlockDocument = {
       formatVersion: DOCUMENT_FORMAT_VERSION,
       kind: "page",
@@ -341,17 +340,26 @@ describe("what a page is compiled WITH", () => {
       styleContext: { ...context, mayFetchUrl: () => true },
     });
     expect(permissive.styles.css).toContain("cdn.example.com");
-    // Nothing may carry the sentinel into storage.
-    expect(permissive.styles.fetchPolicyId).toBeUndefined();
+    expect(permissive.styles.fetchPolicyId).toBe(UNIDENTIFIED_FETCH_POLICY);
 
-    // A different anonymous predicate, which refuses that host.
+    // Transition one: another anonymous predicate, which refuses that host. A
+    // stable stamp would compare equal to itself here.
     const strict = preparePageForRead(fetching, {
       resolver: withPlugin,
       styles: permissive.styles,
       styleContext: { ...context, mayFetchUrl: () => false },
     });
-
     expect(strict.styles.css).not.toContain("cdn.example.com");
+
+    // Transition two: the predicate is removed entirely. Absence is also the
+    // honest stamp for an unrestricted compile, so stamping absence would have
+    // reused the restrictive sheet and left the URL missing for good.
+    const unrestricted = preparePageForRead(fetching, {
+      resolver: withPlugin,
+      styles: strict.styles,
+      styleContext: context,
+    });
+    expect(unrestricted.styles.css).toContain("cdn.example.com");
   });
 
   it("CONTROL: reuses the sheet when the caller states its policy identity", () => {

--- a/packages/blocks-react/src/read-page.test.tsx
+++ b/packages/blocks-react/src/read-page.test.tsx
@@ -35,6 +35,18 @@ const drawless = defineBlock<{ draw: boolean }>({
     props.draw ? <p className={className}>drawn</p> : null,
 });
 
+const box = defineBlock<{ label: string }>({
+  name: "test/box",
+  version: 1,
+  description: "A container.",
+  example: { props: { label: "b" } },
+  defaultProps: { label: "" },
+  slots: { children: {} },
+  render: ({ className, renderSlot }) => (
+    <div className={className}>{renderSlot("children")}</div>
+  ),
+});
+
 const text = defineBlock<{ value: string }>({
   name: "test/text",
   version: 1,
@@ -47,6 +59,7 @@ const text = defineBlock<{ value: string }>({
 /** What the site had installed when the page was saved. */
 const withPlugin = createBlockResolver([
   drawless as AnyBlockDefinition,
+  box as AnyBlockDefinition,
   text as AnyBlockDefinition,
 ]);
 /** What the site has installed when the page is read: the plugin is gone. */
@@ -454,12 +467,19 @@ describe("gating is trusted only as far as the artifact accounts for it", () => 
     expect(read.styles.css).not.toContain("crimson");
   });
 
-  it("refuses when gating hid a duplicate id before the address pass saw it", () => {
-    // The compiler writes no node-local rules for either twin. If gating removes
-    // one, the collision never reaches the address pass, the two stages compare
-    // equal, and the survivor is still missing its rules — so the evidence only
-    // exists in the pre-gating tree.
-    const hiddenCollision: BlockDocument = {
+  it("refuses when a duplicate hid inside a subtree gating removed", () => {
+    // The case only the PRE-GATING tree can see, and the reason this is read
+    // from the migrated document rather than inferred by comparing stages.
+    //
+    // The twin sits inside a conditioned container. Gating removes the whole
+    // subtree, so the collision never reaches the address pass and those two
+    // stages compare equal. Coverage still passes: the container has its own
+    // entry, its type survives elsewhere, and the hidden twin is not even looked
+    // for because a node with that id DID survive at the top level. Every other
+    // clause is therefore satisfied — while the compiler, having seen both nodes
+    // carry one id, wrote node-local rules for neither, so the survivor ships
+    // with a class nothing targets.
+    const hidden: BlockDocument = {
       formatVersion: DOCUMENT_FORMAT_VERSION,
       kind: "page",
       nodes: [
@@ -467,30 +487,43 @@ describe("gating is trusted only as far as the artifact accounts for it", () => 
           id: "twin",
           type: "test/text",
           version: 1,
-          props: { value: "conditioned" },
-          styles: { base: { base: { color: "crimson" } } },
-          visibility: {
-            conditions: [[{ field: "tier", op: "eq", value: "vip" }]],
-          },
-        },
-        {
-          id: "twin",
-          type: "test/text",
-          version: 1,
           props: { value: "survivor" },
           styles: { base: { base: { color: "olive" } } },
         },
+        {
+          id: "shell",
+          type: "test/box",
+          version: 1,
+          props: { label: "b" },
+          visibility: {
+            conditions: [[{ field: "tier", op: "eq", value: "vip" }]],
+          },
+          slots: {
+            children: [
+              {
+                id: "twin",
+                type: "test/text",
+                version: 1,
+                props: { value: "hidden" },
+                styles: { base: { base: { color: "crimson" } } },
+              },
+            ],
+          },
+        },
+        {
+          id: "keeps-the-type",
+          type: "test/box",
+          version: 1,
+          props: { label: "c" },
+        },
       ],
     };
-    const stored = resolvePageStyles(
-      hiddenCollision,
-      undefined,
-      context,
-      withPlugin
-    );
+
+    const stored = resolvePageStyles(hidden, undefined, context, withPlugin);
+    // The compiler refused BOTH twins, so the survivor's rule is absent.
     expect(stored.css).not.toContain("olive");
 
-    const read = preparePageForRead(hiddenCollision, {
+    const read = preparePageForRead(hidden, {
       resolver: withPlugin,
       styles: stored,
       styleContext: context,

--- a/packages/blocks-react/src/read-page.test.tsx
+++ b/packages/blocks-react/src/read-page.test.tsx
@@ -232,9 +232,11 @@ describe("what a page is compiled WITH", () => {
   });
 
   it("compiles against the caps preparation actually used", () => {
-    // Preparation honours `limits`; the compiler reads them off the context. A
-    // raw context therefore keeps nodes whose styles were never written, so the
-    // document holds ids the class map does not name.
+    // The two caps must DISAGREE for this to separate anything. Preparation
+    // takes `limits`; compilation reads them off the context, so a context with
+    // a tighter cap of its own writes styles for fewer nodes than preparation
+    // kept — leaving the returned document holding ids the class map never
+    // names, and those nodes rendering unstyled with nothing to say why.
     const wide: BlockDocument = {
       formatVersion: DOCUMENT_FORMAT_VERSION,
       kind: "page",
@@ -253,20 +255,28 @@ describe("what a page is compiled WITH", () => {
           props: { value: "two" },
           styles: { base: { base: { color: "crimson" } } },
         },
+        {
+          id: "n3",
+          type: "test/text",
+          version: 1,
+          props: { value: "three" },
+          styles: { base: { base: { color: "olive" } } },
+        },
       ],
     };
-    const limits = { ...DEFAULT_LIMITS, maxNodes: 2 };
 
     const read = preparePageForRead(wide, {
       resolver: withPlugin,
-      limits,
-      styleContext: context,
+      limits: { ...DEFAULT_LIMITS, maxNodes: 3 },
+      styleContext: { ...context, limits: { ...DEFAULT_LIMITS, maxNodes: 1 } },
     });
 
+    // Every node preparation kept must have been styled by the same run.
+    expect(read.document?.nodes).toHaveLength(3);
     for (const node of read.document?.nodes ?? []) {
       expect(read.styles.classes[node.id]).toBeTypeOf("string");
     }
-    expect(read.styles.css).toContain("crimson");
+    expect(read.styles.css).toContain("olive");
   });
 
   it("refuses a sheet with no policy stamp when a predicate is in force", () => {

--- a/packages/blocks-react/src/read-page.test.tsx
+++ b/packages/blocks-react/src/read-page.test.tsx
@@ -1,0 +1,238 @@
+/**
+ * What a stored stylesheet may still be trusted to describe.
+ *
+ * The pairing these tests exist for is easy to get wrong in BOTH directions, so
+ * almost every case here comes with its opposite. Trusting too much ships rules
+ * for markup that is gone; trusting too little blanks a working page's styling
+ * on the happy path, with no error, which is the worse failure and the one a
+ * test asserting only `css === ""` would happily certify.
+ */
+import { DOCUMENT_FORMAT_VERSION } from "@nextlyhq/blocks-engine";
+import type {
+  AnyBlockDefinition,
+  BlockDocument,
+  StyleCompileContext,
+} from "@nextlyhq/blocks-engine";
+import { describe, expect, it } from "vitest";
+
+import { defineBlock } from "./context";
+import { preparePageForRead } from "./read-page";
+import { createBlockResolver } from "./resolver";
+import { resolvePageStyles } from "./styles";
+
+/** A plugin block that declares it draws nothing for these props. */
+const drawless = defineBlock<{ draw: boolean }>({
+  name: "plugin/drawless",
+  version: 1,
+  description: "Draws only when told to.",
+  example: { props: { draw: true } },
+  defaultProps: { draw: false },
+  rendersNothing: props => props.draw !== true,
+  render: ({ props, className }) =>
+    props.draw ? <p className={className}>drawn</p> : null,
+});
+
+const text = defineBlock<{ value: string }>({
+  name: "test/text",
+  version: 1,
+  description: "Text.",
+  example: { props: { value: "x" } },
+  defaultProps: { value: "" },
+  render: ({ props, className }) => <p className={className}>{props.value}</p>,
+});
+
+/** What the site had installed when the page was saved. */
+const withPlugin = createBlockResolver([
+  drawless as AnyBlockDefinition,
+  text as AnyBlockDefinition,
+]);
+/** What the site has installed when the page is read: the plugin is gone. */
+const withoutPlugin = createBlockResolver([text as AnyBlockDefinition]);
+
+/**
+ * A page whose only `plugin/drawless` node declares it draws nothing.
+ *
+ * That node is what makes the block-type tier and the named class appear in the
+ * sheet, and it is the only thing on the page that justifies either.
+ */
+const document: BlockDocument = {
+  formatVersion: DOCUMENT_FORMAT_VERSION,
+  kind: "page",
+  nodes: [
+    {
+      id: "a",
+      type: "plugin/drawless",
+      version: 1,
+      props: { draw: false },
+      classes: ["only-a"],
+      styles: { base: { base: { color: "rebeccapurple" } } },
+    },
+    {
+      id: "b",
+      type: "test/text",
+      version: 1,
+      props: { value: "y" },
+      styles: { base: { base: { color: "teal" } } },
+    },
+  ],
+};
+
+const context: StyleCompileContext = {
+  blockBases: {
+    "plugin/drawless": { base: { base: { letterSpacing: "3px" } } },
+    "test/text": { base: { base: { fontSize: "16px" } } },
+  },
+  namedClasses: [
+    {
+      id: "only-a",
+      slug: "only-a",
+      orderIndex: 0,
+      styles: { base: { base: { letterSpacing: "7px" } } },
+    },
+  ],
+};
+
+/** The artifact the write path stores for the page above. */
+function storedSheet(): ReturnType<typeof resolvePageStyles> {
+  return resolvePageStyles(document, undefined, context, withPlugin);
+}
+
+describe("a node that is both a placeholder and drawless", () => {
+  it("does not leave the tiers it justified in a trusted sheet", () => {
+    // The node's OWN rules were never the exposure: gating moved them into the
+    // per-node map, and nothing appends them once the node is gone. What stays
+    // is everything keyed by something OTHER than the node — the defaults for
+    // its block type, and the named class only it referenced.
+    const stored = storedSheet();
+    expect(stored.css).toContain("nx-bt-plugin--drawless");
+    expect(stored.css).toContain("nx-c-only-a");
+
+    const read = preparePageForRead(document, {
+      resolver: withoutPlugin,
+      styles: stored,
+    });
+
+    expect(read.styles.css).not.toContain("nx-bt-plugin--drawless");
+    expect(read.styles.css).not.toContain("nx-c-only-a");
+  });
+
+  it("CONTROL: keeps the same sheet while the plugin is installed", () => {
+    // Without this, the case above passes on an implementation that withholds
+    // every stored sheet unconditionally — which is the opposite defect and
+    // costs every page its styling rather than one page some dead bytes.
+    const read = preparePageForRead(document, {
+      resolver: withPlugin,
+      styles: storedSheet(),
+    });
+
+    expect(read.styles.css).toContain("nx-bt-plugin--drawless");
+    expect(read.styles.css).toContain("nx-c-only-a");
+    expect(read.styles.css).toContain("color: teal");
+  });
+
+  it("recompiles rather than withholding when it can", () => {
+    // Withholding is the answer only when there is nothing to compile from. A
+    // caller that supplied the inputs gets a sheet describing the tree that
+    // survived: node b keeps its styling, and the departed node's tiers are gone
+    // because nothing on the page pulls them in any more.
+    const read = preparePageForRead(document, {
+      resolver: withoutPlugin,
+      styles: storedSheet(),
+      styleContext: context,
+    });
+
+    expect(read.styles.css).toContain("color: teal");
+    expect(read.styles.css).not.toContain("nx-bt-plugin--drawless");
+  });
+});
+
+describe("what must NOT count as a repair", () => {
+  it("keeps a stored sheet for a page nothing changed", () => {
+    // Migration allocates a new document on every read, so a repair test that
+    // compared it against the pass before would report every page ever read as
+    // repaired and withhold every stored sheet on the happy path.
+    const read = preparePageForRead(document, {
+      resolver: withPlugin,
+      styles: storedSheet(),
+    });
+
+    expect(read.styles.css).not.toBe("");
+    expect(read.styles.css).toBe(storedSheet().css);
+  });
+
+  it("keeps a stored sheet for a page whose node is condition-gated away", () => {
+    // The per-node map exists for exactly this: a conditioned node's rules
+    // travel separately and are appended for the survivors, so its absence is
+    // described rather than unaccounted. Treating gating as a repair would cost
+    // every page carrying a conditioned block its whole stylesheet.
+    const conditioned: BlockDocument = {
+      ...document,
+      nodes: [
+        {
+          id: "c",
+          type: "test/text",
+          version: 1,
+          props: { value: "hidden" },
+          styles: { base: { base: { color: "crimson" } } },
+          visibility: { conditions: [{ kind: "never" }] },
+        },
+        ...document.nodes,
+      ],
+    };
+    const stored = resolvePageStyles(
+      conditioned,
+      undefined,
+      context,
+      withPlugin
+    );
+    // The fixture has to REACH the gating pass for the rest to mean anything. A
+    // condition the engine does not recognise leaves the node ungated, its rules
+    // in the main sheet, and the assertions below satisfied by a page that never
+    // gated anything.
+    expect(stored.gated?.c).toContain("crimson");
+    expect(stored.css).not.toContain("crimson");
+
+    const read = preparePageForRead(conditioned, {
+      resolver: withPlugin,
+      styles: stored,
+    });
+
+    expect(read.styles.css).toContain("color: teal");
+    expect(read.styles.css).not.toContain("crimson");
+  });
+});
+
+describe("the reading view", () => {
+  it("answers null for an envelope this build cannot speak", () => {
+    const wrongVersion = {
+      formatVersion: 99,
+      kind: "page",
+      nodes: [],
+    } as unknown as BlockDocument;
+
+    const read = preparePageForRead(wrongVersion, { resolver: withPlugin });
+
+    expect(read.document).toBeNull();
+    expect(read.styles.css).toBe("");
+  });
+
+  it("answers null for a page presenting nothing but placeholders", () => {
+    const allPlaceholders: BlockDocument = {
+      formatVersion: DOCUMENT_FORMAT_VERSION,
+      kind: "page",
+      nodes: [{ id: "a", type: "plugin/unregistered", version: 1, props: {} }],
+    };
+
+    const read = preparePageForRead(allPlaceholders, {
+      resolver: withoutPlugin,
+    });
+
+    expect(read.document).toBeNull();
+  });
+
+  it("CONTROL: answers with the tree for a page that survives", () => {
+    const read = preparePageForRead(document, { resolver: withPlugin });
+
+    expect(read.document?.nodes.map(node => node.id)).toEqual(["a", "b"]);
+  });
+});

--- a/packages/blocks-react/src/read-page.test.tsx
+++ b/packages/blocks-react/src/read-page.test.tsx
@@ -7,7 +7,10 @@
  * on the happy path, with no error, which is the worse failure and the one a
  * test asserting only `css === ""` would happily certify.
  */
-import { DOCUMENT_FORMAT_VERSION } from "@nextlyhq/blocks-engine";
+import {
+  DEFAULT_LIMITS,
+  DOCUMENT_FORMAT_VERSION,
+} from "@nextlyhq/blocks-engine";
 import type {
   AnyBlockDefinition,
   BlockDocument,
@@ -18,7 +21,7 @@ import { describe, expect, it } from "vitest";
 import { defineBlock } from "./context";
 import { preparePageForRead } from "./read-page";
 import { createBlockResolver } from "./resolver";
-import { resolvePageStyles } from "./styles";
+import { UNIDENTIFIED_FETCH_POLICY, resolvePageStyles } from "./styles";
 
 /** A plugin block that declares it draws nothing for these props. */
 const drawless = defineBlock<{ draw: boolean }>({
@@ -208,6 +211,155 @@ describe("what must NOT count as a repair", () => {
 
     expect(read.styles.css).toContain("color: teal");
     expect(read.styles.css).not.toContain("crimson");
+  });
+});
+
+describe("what a page is compiled WITH", () => {
+  it("keeps the artifact's scope when a repair forces a recompile", () => {
+    // Scope lives on the artifact, so a caller normally omits it from the
+    // context. Compiling with the raw context rebuilds the page unscoped and
+    // lets its selectors reach another document rendered beside it.
+    const scoped = { ...storedSheet(), scope: "nx-s-abc" };
+
+    const read = preparePageForRead(document, {
+      resolver: withoutPlugin,
+      styles: scoped,
+      styleContext: context,
+    });
+
+    expect(read.styles.scope).toBe("nx-s-abc");
+    expect(read.styles.css).toContain("nx-s-abc");
+  });
+
+  it("compiles against the caps preparation actually used", () => {
+    // Preparation honours `limits`; the compiler reads them off the context. A
+    // raw context therefore keeps nodes whose styles were never written, so the
+    // document holds ids the class map does not name.
+    const wide: BlockDocument = {
+      formatVersion: DOCUMENT_FORMAT_VERSION,
+      kind: "page",
+      nodes: [
+        {
+          id: "n1",
+          type: "test/text",
+          version: 1,
+          props: { value: "one" },
+          styles: { base: { base: { color: "teal" } } },
+        },
+        {
+          id: "n2",
+          type: "test/text",
+          version: 1,
+          props: { value: "two" },
+          styles: { base: { base: { color: "crimson" } } },
+        },
+      ],
+    };
+    const limits = { ...DEFAULT_LIMITS, maxNodes: 2 };
+
+    const read = preparePageForRead(wide, {
+      resolver: withPlugin,
+      limits,
+      styleContext: context,
+    });
+
+    for (const node of read.document?.nodes ?? []) {
+      expect(read.styles.classes[node.id]).toBeTypeOf("string");
+    }
+    expect(read.styles.css).toContain("crimson");
+  });
+
+  it("refuses a sheet with no policy stamp when a predicate is in force", () => {
+    // An unstamped sheet compares equal to "no policy at all", so a caller with
+    // its own `mayFetchUrl` and no stated identity would reuse a sheet that
+    // predicate never judged. The safe answer is an identity no artifact carries.
+    const unstamped = storedSheet();
+    expect(unstamped.fetchPolicyId).toBeUndefined();
+
+    const read = preparePageForRead(document, {
+      resolver: withPlugin,
+      styles: unstamped,
+      styleContext: { ...context, mayFetchUrl: () => true },
+    });
+
+    expect(read.styles.fetchPolicyId).toBe(UNIDENTIFIED_FETCH_POLICY);
+  });
+
+  it("CONTROL: reuses the sheet when the caller states its policy identity", () => {
+    // The other direction. A caller that says which policy its predicate IS gets
+    // its stored sheet back rather than a recompile on every render for ever.
+    const stamped = resolvePageStyles(
+      document,
+      undefined,
+      { ...context, mayFetchUrl: () => true, fetchPolicyId: "policy-1" },
+      withPlugin,
+      false,
+      { fetchPolicyId: "policy-1" }
+    );
+    expect(stamped.fetchPolicyId).toBe("policy-1");
+
+    const read = preparePageForRead(document, {
+      resolver: withPlugin,
+      styles: stamped,
+      styleContext: {
+        ...context,
+        mayFetchUrl: () => true,
+        fetchPolicyId: "policy-1",
+      },
+    });
+
+    expect(read.styles.css).toBe(stamped.css);
+  });
+});
+
+describe("a document carrying duplicate node ids", () => {
+  const duplicated: BlockDocument = {
+    formatVersion: DOCUMENT_FORMAT_VERSION,
+    kind: "page",
+    nodes: [
+      {
+        id: "dup",
+        type: "test/text",
+        version: 1,
+        props: { value: "first" },
+        styles: { base: { base: { color: "teal" } } },
+      },
+      {
+        id: "dup",
+        type: "test/text",
+        version: 1,
+        props: { value: "second" },
+        styles: { base: { base: { color: "crimson" } } },
+      },
+    ],
+  };
+
+  it("styles the node that survived, rather than trusting a sheet that styles neither", () => {
+    // The compiler cannot style two nodes sharing one class, so it styles
+    // neither — while still naming the id in its class map, which is what makes
+    // the artifact read as usable. Deduplication makes the id unique again, so a
+    // recompile is the only thing that can style what is left.
+    const stored = resolvePageStyles(
+      duplicated,
+      undefined,
+      context,
+      withPlugin
+    );
+    // Named in the class map — which is what makes the artifact read as usable —
+    // while carrying no node-local rule for either duplicate. The block-type
+    // tier is still there, so emptiness is not the property to assert.
+    expect(stored.classes.dup).toBeTypeOf("string");
+    expect(stored.css).not.toContain("teal");
+    expect(stored.css).not.toContain("crimson");
+
+    const read = preparePageForRead(duplicated, {
+      resolver: withPlugin,
+      styles: stored,
+      styleContext: context,
+    });
+
+    expect(read.document?.nodes).toHaveLength(1);
+    expect(read.styles.css).toContain("teal");
   });
 });
 

--- a/packages/blocks-react/src/read-page.test.tsx
+++ b/packages/blocks-react/src/read-page.test.tsx
@@ -78,6 +78,10 @@ const document: BlockDocument = {
 };
 
 const context: StyleCompileContext = {
+  // Only the base breakpoint. Every declaration in this file is written at
+  // `base`, so a wider set would emit the same rules again inside media queries
+  // and make the assertions read a sheet whose size says nothing about them.
+  breakpoints: { viewport: [{ id: "base", label: "Desktop" }], container: [] },
   blockBases: {
     "plugin/drawless": { base: { base: { letterSpacing: "3px" } } },
     "test/text": { base: { base: { fontSize: "16px" } } },
@@ -174,7 +178,12 @@ describe("what must NOT count as a repair", () => {
           version: 1,
           props: { value: "hidden" },
           styles: { base: { base: { color: "crimson" } } },
-          visibility: { conditions: [{ kind: "never" }] },
+          // No visitor context reaches the gating pass here, so any condition
+          // at all withholds the node. The field named is immaterial; that it
+          // is a condition is the whole fixture.
+          visibility: {
+            conditions: [[{ field: "tier", op: "eq", value: "vip" }]],
+          },
         },
         ...document.nodes,
       ],

--- a/packages/blocks-react/src/read-page.test.tsx
+++ b/packages/blocks-react/src/read-page.test.tsx
@@ -373,6 +373,133 @@ describe("a document carrying duplicate node ids", () => {
   });
 });
 
+describe("gating is trusted only as far as the artifact accounts for it", () => {
+  /** A conditioned node of a type nothing else on the page uses. */
+  function onlyInstanceOfItsType(): BlockDocument {
+    return {
+      formatVersion: DOCUMENT_FORMAT_VERSION,
+      kind: "page",
+      nodes: [
+        {
+          id: "gone",
+          type: "plugin/drawless",
+          version: 1,
+          props: { draw: true },
+          styles: { base: { base: { color: "crimson" } } },
+          visibility: {
+            conditions: [[{ field: "tier", op: "eq", value: "vip" }]],
+          },
+        },
+        {
+          id: "b",
+          type: "test/text",
+          version: 1,
+          props: { value: "y" },
+          styles: { base: { base: { color: "teal" } } },
+        },
+      ],
+    };
+  }
+
+  it("refuses when gating removes the last node of a block type", () => {
+    // A type's defaults are emitted ONCE into the main sheet and shared, so the
+    // per-node map cannot account for them. When the conditioned node was the
+    // only one of its type, that type's rule stays in `css` — with whatever
+    // `url(...)` it names — for a block nobody was served.
+    const page = onlyInstanceOfItsType();
+    const stored = resolvePageStyles(page, undefined, context, withPlugin);
+    expect(stored.gated?.gone).toContain("crimson");
+    expect(stored.css).toContain("nx-bt-plugin--drawless");
+
+    const read = preparePageForRead(page, {
+      resolver: withPlugin,
+      styles: stored,
+      styleContext: context,
+    });
+
+    expect(read.styles.css).not.toContain("nx-bt-plugin--drawless");
+    expect(read.styles.css).toContain("color: teal");
+  });
+
+  it("CONTROL: trusts it when another node of that type survives", () => {
+    // The separating property. If the type is still on the page its rule is
+    // still earned, the per-node map covers the rest, and the stored sheet must
+    // be reused rather than recompiled on every render.
+    const page = onlyInstanceOfItsType();
+    const withSurvivor: BlockDocument = {
+      ...page,
+      nodes: [
+        ...page.nodes,
+        {
+          id: "stays",
+          type: "plugin/drawless",
+          version: 1,
+          props: { draw: true },
+        },
+      ],
+    };
+    const stored = resolvePageStyles(
+      withSurvivor,
+      undefined,
+      context,
+      withPlugin
+    );
+
+    const read = preparePageForRead(withSurvivor, {
+      resolver: withPlugin,
+      styles: stored,
+    });
+
+    expect(read.styles.css).toContain("nx-bt-plugin--drawless");
+    expect(read.styles.css).not.toContain("crimson");
+  });
+
+  it("refuses when gating hid a duplicate id before the address pass saw it", () => {
+    // The compiler writes no node-local rules for either twin. If gating removes
+    // one, the collision never reaches the address pass, the two stages compare
+    // equal, and the survivor is still missing its rules — so the evidence only
+    // exists in the pre-gating tree.
+    const hiddenCollision: BlockDocument = {
+      formatVersion: DOCUMENT_FORMAT_VERSION,
+      kind: "page",
+      nodes: [
+        {
+          id: "twin",
+          type: "test/text",
+          version: 1,
+          props: { value: "conditioned" },
+          styles: { base: { base: { color: "crimson" } } },
+          visibility: {
+            conditions: [[{ field: "tier", op: "eq", value: "vip" }]],
+          },
+        },
+        {
+          id: "twin",
+          type: "test/text",
+          version: 1,
+          props: { value: "survivor" },
+          styles: { base: { base: { color: "olive" } } },
+        },
+      ],
+    };
+    const stored = resolvePageStyles(
+      hiddenCollision,
+      undefined,
+      context,
+      withPlugin
+    );
+    expect(stored.css).not.toContain("olive");
+
+    const read = preparePageForRead(hiddenCollision, {
+      resolver: withPlugin,
+      styles: stored,
+      styleContext: context,
+    });
+
+    expect(read.styles.css).toContain("olive");
+  });
+});
+
 describe("the reading view", () => {
   it("answers null for an envelope this build cannot speak", () => {
     const wrongVersion = {

--- a/packages/blocks-react/src/read-page.test.tsx
+++ b/packages/blocks-react/src/read-page.test.tsx
@@ -292,20 +292,66 @@ describe("what a page is compiled WITH", () => {
     expect(read.styles.css).toContain("olive");
   });
 
-  it("refuses a sheet with no policy stamp when a predicate is in force", () => {
-    // An unstamped sheet compares equal to "no policy at all", so a caller with
-    // its own `mayFetchUrl` and no stated identity would reuse a sheet that
-    // predicate never judged. The safe answer is an identity no artifact carries.
+  it("refuses a sheet with no policy stamp when a policy is in force", () => {
+    // An unstamped sheet means "compiled under no policy". With one now in
+    // force it cannot be reused, and with nothing to recompile from the CSS is
+    // withheld rather than served under rules that never judged it.
     const unstamped = storedSheet();
     expect(unstamped.fetchPolicyId).toBeUndefined();
 
     const read = preparePageForRead(document, {
       resolver: withPlugin,
       styles: unstamped,
-      styleContext: { ...context, mayFetchUrl: () => true },
+      remotePatterns: [{ protocol: "https", hostname: "cdn.example.com" }],
     });
 
-    expect(read.styles.fetchPolicyId).toBe(UNIDENTIFIED_FETCH_POLICY);
+    expect(read.styles.css).toBe("");
+  });
+
+  it("never stamps a sheet with the anonymous-policy sentinel", () => {
+    // The sentinel is a comparison value, not a stamp. Stamped, it would answer
+    // "which policy compiled this?" with a stable string, so a later read under
+    // a DIFFERENT anonymous predicate would find its own sentinel on the stored
+    // sheet, compare equal, and reuse CSS that predicate never judged.
+    //
+    // Asserted through a `url(...)` the two predicates disagree about, because
+    // bytes alone cannot separate reuse from a recompile that happens to produce
+    // the same sheet. The URL is the thing a fetch policy exists to decide, and
+    // it is what would actually be published.
+    const fetching: BlockDocument = {
+      formatVersion: DOCUMENT_FORMAT_VERSION,
+      kind: "page",
+      nodes: [
+        {
+          id: "img",
+          type: "test/text",
+          version: 1,
+          props: { value: "y" },
+          styles: {
+            base: {
+              base: { background: { url: "https://cdn.example.com/x.png" } },
+            },
+          },
+        },
+      ],
+    };
+
+    const permissive = preparePageForRead(fetching, {
+      resolver: withPlugin,
+      styleContext: { ...context, mayFetchUrl: () => true },
+    });
+    expect(permissive.styles.css).toContain("cdn.example.com");
+    // Nothing may carry the sentinel into storage.
+    expect(permissive.styles.fetchPolicyId).toBeUndefined();
+
+    // A different anonymous predicate, which refuses that host.
+    const strict = preparePageForRead(fetching, {
+      resolver: withPlugin,
+      styles: permissive.styles,
+      styleContext: { ...context, mayFetchUrl: () => false },
+    });
+
+    expect(strict.styles.css).not.toContain("cdn.example.com");
   });
 
   it("CONTROL: reuses the sheet when the caller states its policy identity", () => {

--- a/packages/blocks-react/src/read-page.ts
+++ b/packages/blocks-react/src/read-page.ts
@@ -30,7 +30,13 @@ import type {
 } from "./prepare-document";
 import { prepareDocumentReadStages, readingViewOf } from "./prepare-document";
 import type { PageStyles } from "./styles";
-import { effectiveCompile, resolvePageStyles } from "./styles";
+import {
+  effectiveCompile,
+  gatedMapCoversPrunedNodes,
+  hasDuplicateNodeIds,
+  readableGatedRules,
+  resolvePageStyles,
+} from "./styles";
 
 export interface ReadPageArgs extends PrepareDocumentArgs {
   /** The stylesheet artifact stored with the page, when it has one. */
@@ -74,40 +80,54 @@ export interface PreparedPage {
  * Whether the passes changed the tree in a way a STORED stylesheet cannot
  * describe.
  *
- * Three of the five stage boundaries count, and which three is the whole content
- * of this function:
+ * Four of the five stage boundaries count, and the fifth is excluded for a
+ * reason that would otherwise blank every page:
  *
  * - **The caps pass**, because a document over its limits is truncated, and the
  *   sheet was compiled from the untruncated one.
+ * - **Condition gating**, but only when the artifact cannot ACCOUNT for what it
+ *   removed. The per-node map was built for this case and usually covers it, so
+ *   refusing categorically would cost every page carrying a conditioned block
+ *   its whole stylesheet. Coverage is asked through the same check the renderer
+ *   uses, which is stricter than "every removed node has an entry": a block
+ *   type's defaults are emitted ONCE into the main sheet and shared, so removing
+ *   the LAST node of a type leaves that type's rule — and any `url(...)` in it —
+ *   published for a block nobody was served. Only a recompile can drop a
+ *   type-level rule, so the artifact must not claim to cover that.
  * - **Address repair**, for the reason that first looked like grounds to exclude
  *   it. The compiler refuses to style duplicated ids at all — there is one class
  *   for the id and no way to tell a renderer about a second — so the sheet holds
  *   no node-local rules for EITHER. It still NAMES the id in its class map, so
  *   the artifact reads as usable and is trusted, and the node that survived
- *   deduplication renders carrying a class no rule targets. Recompiling against
- *   the deduplicated tree is what styles it, because by then the id is unique.
+ *   deduplication renders carrying a class no rule targets. Asked of the
+ *   MIGRATED tree rather than by comparing stages, because gating can remove the
+ *   twin first: the collision then never reaches the address pass, the two
+ *   stages compare equal, and the survivor is still missing its rules. The
+ *   pre-gating document is the only place that evidence survives.
  * - **The placeholder pass**, because a node that resolves to a placeholder is
  *   gone for every visitor until the page is republished, while the tiers it
  *   pulled into the sheet stay behind.
  *
- * The remaining two are excluded, and both exclusions are load bearing rather
- * than cosmetic:
- *
- * - **Migration** allocates unconditionally, so comparing it against the caps
- *   pass is true on every document ever read. Included, every page would report
- *   as repaired and every stored sheet would be withheld on the happy path.
- * - **Condition gating** is the case the per-node `gated` map was built for. Its
- *   rules travel per node and are appended for exactly the survivors, so a gated
- *   node's absence is described rather than unaccounted. Included, every page
- *   carrying a conditioned block would lose its whole stylesheet.
+ * **Migration** is the exclusion. It allocates unconditionally, so comparing it
+ * against the caps pass is true on every document ever read; included, every
+ * page would report as repaired and every stored sheet would be withheld on the
+ * happy path.
  */
 function storedSheetCannotDescribe(
   document: BlockDocument,
-  stages: DocumentReadStages
+  stages: DocumentReadStages,
+  styles: PageStyles | undefined
 ): boolean {
+  const gatedRules = readableGatedRules(styles);
+  // An ABSENT map means "compiled before the split existed", not "nothing was
+  // gated", so only a readable one licenses skipping the recompile.
+  const gatingCovered =
+    gatedRules !== undefined &&
+    gatedMapCoversPrunedNodes(stages.migrated, stages.gated, gatedRules);
   return (
     stages.sanitized !== document ||
-    stages.deduped !== stages.gated ||
+    hasDuplicateNodeIds(stages.migrated) ||
+    (stages.gated !== stages.migrated && !gatingCovered) ||
     stages.prepared !== stages.deduped
   );
 }
@@ -156,7 +176,7 @@ export function preparePageForRead(
     args.styles,
     compile.context,
     args.resolver,
-    storedSheetCannotDescribe(document, stages),
+    storedSheetCannotDescribe(document, stages, args.styles),
     { fetchPolicyId: compile.fetchPolicyId }
   );
 

--- a/packages/blocks-react/src/read-page.ts
+++ b/packages/blocks-react/src/read-page.ts
@@ -20,6 +20,7 @@
  */
 import type {
   BlockDocument,
+  RemotePatternInput,
   StyleCompileContext,
 } from "@nextlyhq/blocks-engine";
 
@@ -29,7 +30,7 @@ import type {
 } from "./prepare-document";
 import { prepareDocumentReadStages, readingViewOf } from "./prepare-document";
 import type { PageStyles } from "./styles";
-import { resolvePageStyles } from "./styles";
+import { effectiveCompile, resolvePageStyles } from "./styles";
 
 export interface ReadPageArgs extends PrepareDocumentArgs {
   /** The stylesheet artifact stored with the page, when it has one. */
@@ -42,12 +43,20 @@ export interface ReadPageArgs extends PrepareDocumentArgs {
    */
   styleContext?: StyleCompileContext;
   /**
-   * Which host-fetch policy is in force for this read.
+   * The hosts this site allows a stylesheet to fetch from.
    *
-   * Compared against the stamp the stored artifact carries; a difference means
-   * that artifact admitted `url(...)` values under rules that no longer apply.
+   * A stylesheet fetches too: `background-image: url(...)` is a request the
+   * browser makes on every page the rule applies to, so the host's list has to
+   * reach the compile as well as the blocks.
+   *
+   * The policy IDENTITY is derived from these rather than taken as a field, so
+   * it changes exactly when the policy does and there is nothing to remember to
+   * bump. A caller with its own `mayFetchUrl` states which policy that predicate
+   * is through `styleContext.fetchPolicyId`; one that does not gets an identity
+   * no artifact can carry, so every stored sheet recompiles rather than being
+   * reused under rules that never judged it.
    */
-  fetchPolicyId?: string;
+  remotePatterns?: readonly RemotePatternInput[];
 }
 
 export interface PreparedPage {
@@ -65,34 +74,42 @@ export interface PreparedPage {
  * Whether the passes changed the tree in a way a STORED stylesheet cannot
  * describe.
  *
- * Only two of the five stage boundaries count, and which two is the whole
- * content of this function:
+ * Three of the five stage boundaries count, and which three is the whole content
+ * of this function:
  *
  * - **The caps pass**, because a document over its limits is truncated, and the
  *   sheet was compiled from the untruncated one.
+ * - **Address repair**, for the reason that first looked like grounds to exclude
+ *   it. The compiler refuses to style duplicated ids at all — there is one class
+ *   for the id and no way to tell a renderer about a second — so the sheet holds
+ *   no node-local rules for EITHER. It still NAMES the id in its class map, so
+ *   the artifact reads as usable and is trusted, and the node that survived
+ *   deduplication renders carrying a class no rule targets. Recompiling against
+ *   the deduplicated tree is what styles it, because by then the id is unique.
  * - **The placeholder pass**, because a node that resolves to a placeholder is
  *   gone for every visitor until the page is republished, while the tiers it
  *   pulled into the sheet stay behind.
  *
- * The other three are excluded deliberately, and two of the exclusions are load
- * bearing rather than cosmetic:
+ * The remaining two are excluded, and both exclusions are load bearing rather
+ * than cosmetic:
  *
  * - **Migration** allocates unconditionally, so comparing it against the caps
  *   pass is true on every document ever read. Included, every page would report
  *   as repaired and every stored sheet would be withheld on the happy path.
  * - **Condition gating** is the case the per-node `gated` map was built for. Its
- *   rules travel per node and are appended for exactly the survivors, so a
- *   gated node's absence is described rather than unaccounted. Included, every
- *   page carrying a conditioned block would lose its whole stylesheet.
- * - **Address repair** drops a later duplicate of a repeated id, and the
- *   compiler refuses to style duplicated ids at all, so the sheet holds no rules
- *   for what that pass removes.
+ *   rules travel per node and are appended for exactly the survivors, so a gated
+ *   node's absence is described rather than unaccounted. Included, every page
+ *   carrying a conditioned block would lose its whole stylesheet.
  */
 function storedSheetCannotDescribe(
   document: BlockDocument,
   stages: DocumentReadStages
 ): boolean {
-  return stages.sanitized !== document || stages.prepared !== stages.deduped;
+  return (
+    stages.sanitized !== document ||
+    stages.deduped !== stages.gated ||
+    stages.prepared !== stages.deduped
+  );
 }
 
 /**
@@ -124,13 +141,23 @@ export function preparePageForRead(
     };
   }
 
+  // What a caller supplied is not what this page compiles with. Asked through
+  // the SAME derivation the renderer uses, so a page read here and the same page
+  // rendered cannot disagree about its scope, its caps or which fetch policy
+  // judged its stored sheet.
+  const compile = effectiveCompile({
+    styleContext: args.styleContext,
+    styles: args.styles,
+    limits: args.limits,
+    remotePatterns: args.remotePatterns,
+  });
   const styles = resolvePageStyles(
     stages.prepared,
     args.styles,
-    args.styleContext,
+    compile.context,
     args.resolver,
     storedSheetCannotDescribe(document, stages),
-    { fetchPolicyId: args.fetchPolicyId }
+    { fetchPolicyId: compile.fetchPolicyId }
   );
 
   // Compiled against the PREPARED tree whatever the reading view decides. The

--- a/packages/blocks-react/src/read-page.ts
+++ b/packages/blocks-react/src/read-page.ts
@@ -1,0 +1,142 @@
+/**
+ * The tree to read and the stylesheet that describes it, resolved together.
+ *
+ * Together because neither answer is correct alone. Preparing a document drops
+ * the nodes the page will not present, and whether anything was dropped is the
+ * fact that decides what a STORED stylesheet may still be trusted for — but the
+ * prepared tree no longer contains the evidence, so a caller holding only that
+ * tree cannot supply it and cannot know it is missing.
+ *
+ * `PageRenderer` never had the problem: it runs the passes itself and still
+ * holds each stage when it resolves styles. A consumer assembling the two by
+ * hand holds only the result, and the documented pairing therefore resolved
+ * styles with `repairedDocument` left at its default. That is sound for every
+ * pruned node whose rules the artifact carries per node, and unsound for the
+ * rest of what a pruned node put in the sheet: the block-type tier and the named
+ * classes it referenced are keyed by TYPE and by CLASS, not by node, so they
+ * stay in `css` with nothing left on the page to justify them.
+ *
+ * @module read-page
+ */
+import type {
+  BlockDocument,
+  StyleCompileContext,
+} from "@nextlyhq/blocks-engine";
+
+import type {
+  DocumentReadStages,
+  PrepareDocumentArgs,
+} from "./prepare-document";
+import { prepareDocumentReadStages, readingViewOf } from "./prepare-document";
+import type { PageStyles } from "./styles";
+import { resolvePageStyles } from "./styles";
+
+export interface ReadPageArgs extends PrepareDocumentArgs {
+  /** The stylesheet artifact stored with the page, when it has one. */
+  styles?: PageStyles;
+  /**
+   * The inputs to compile a fresh sheet, when the caller has them.
+   *
+   * Its presence is what lets a repaired document be recompiled instead of
+   * having its stored sheet withheld, so a caller that can supply it should.
+   */
+  styleContext?: StyleCompileContext;
+  /**
+   * Which host-fetch policy is in force for this read.
+   *
+   * Compared against the stamp the stored artifact carries; a difference means
+   * that artifact admitted `url(...)` values under rules that no longer apply.
+   */
+  fetchPolicyId?: string;
+}
+
+export interface PreparedPage {
+  /**
+   * The tree to render or describe, or `null` when the page presents nothing
+   * readable — an envelope this build cannot speak, or a page whose every node
+   * resolved to a placeholder.
+   */
+  document: BlockDocument | null;
+  /** The stylesheet for that tree. */
+  styles: PageStyles;
+}
+
+/**
+ * Whether the passes changed the tree in a way a STORED stylesheet cannot
+ * describe.
+ *
+ * Only two of the five stage boundaries count, and which two is the whole
+ * content of this function:
+ *
+ * - **The caps pass**, because a document over its limits is truncated, and the
+ *   sheet was compiled from the untruncated one.
+ * - **The placeholder pass**, because a node that resolves to a placeholder is
+ *   gone for every visitor until the page is republished, while the tiers it
+ *   pulled into the sheet stay behind.
+ *
+ * The other three are excluded deliberately, and two of the exclusions are load
+ * bearing rather than cosmetic:
+ *
+ * - **Migration** allocates unconditionally, so comparing it against the caps
+ *   pass is true on every document ever read. Included, every page would report
+ *   as repaired and every stored sheet would be withheld on the happy path.
+ * - **Condition gating** is the case the per-node `gated` map was built for. Its
+ *   rules travel per node and are appended for exactly the survivors, so a
+ *   gated node's absence is described rather than unaccounted. Included, every
+ *   page carrying a conditioned block would lose its whole stylesheet.
+ * - **Address repair** drops a later duplicate of a repeated id, and the
+ *   compiler refuses to style duplicated ids at all, so the sheet holds no rules
+ *   for what that pass removes.
+ */
+function storedSheetCannotDescribe(
+  document: BlockDocument,
+  stages: DocumentReadStages
+): boolean {
+  return stages.sanitized !== document || stages.prepared !== stages.deduped;
+}
+
+/**
+ * Read a stored page: its presentable tree and the stylesheet for it.
+ *
+ * This is the whole documented flow for a consumer outside `PageRenderer`.
+ * Preparing the document and resolving its styles as two calls is what leaves
+ * the second one unable to see what the first removed — and the gap is silent,
+ * because the sheet it produces is a valid sheet describing a tree that is one
+ * pass out of date.
+ *
+ * Returns the reading view of the document, so `null` means "do not present
+ * this page" rather than "this page is empty". Styles come back either way: a
+ * caller that decides to show a fallback still has the page's scope and class
+ * names, which the rest of the system expects to exist.
+ */
+export function preparePageForRead(
+  document: BlockDocument,
+  args: ReadPageArgs
+): PreparedPage {
+  const stages = prepareDocumentReadStages(document, args);
+  if (stages === null) {
+    // An unreadable envelope has no tree to compile against and no ids to name,
+    // so there is nothing to resolve. Answered directly rather than by handing
+    // the compiler a document it already refused.
+    return {
+      document: null,
+      styles: { css: "", classes: {} },
+    };
+  }
+
+  const styles = resolvePageStyles(
+    stages.prepared,
+    args.styles,
+    args.styleContext,
+    args.resolver,
+    storedSheetCannotDescribe(document, stages),
+    { fetchPolicyId: args.fetchPolicyId }
+  );
+
+  // Compiled against the PREPARED tree whatever the reading view decides. The
+  // two answer different questions: a page presenting nothing but placeholders
+  // is not worth showing, but its scope and class names are still the ones the
+  // rest of the system expects, and rebuilding them from an empty document would
+  // hand the caller a sheet for a page that does not exist.
+  return { document: readingViewOf(stages), styles };
+}

--- a/packages/blocks-react/src/styles.ts
+++ b/packages/blocks-react/src/styles.ts
@@ -706,8 +706,21 @@ export function resolvePageStyles(
   // to reuse a sheet from, but deciding that needs the rules rather than the
   // label, and a reader that has to reason about the rules is one that can get
   // it wrong quietly.
+  //
+  // A sheet compiled under an ANONYMOUS predicate is stale against every policy
+  // including no policy at all, which is why its own stamp is not enough to
+  // decide by. Two transitions make that concrete and they fail in opposite
+  // directions: to another anonymous predicate, where a stable sentinel would
+  // compare equal to itself and reuse CSS the new predicate never judged; and
+  // away from the predicate entirely, where absence is ALSO the honest stamp for
+  // an unrestricted compile, so a restrictive artifact would be reused and the
+  // URLs it dropped would stay missing for good. Neither a stable stamp nor an
+  // absent one separates those, so the stamp records what compiled the sheet and
+  // this comparison refuses it outright.
   const compiledUnderAnotherPolicy =
-    styles !== undefined && styles.fetchPolicyId !== options.fetchPolicyId;
+    styles !== undefined &&
+    (styles.fetchPolicyId !== options.fetchPolicyId ||
+      styles.fetchPolicyId === UNIDENTIFIED_FETCH_POLICY);
 
   if (
     styles &&
@@ -756,17 +769,7 @@ export function resolvePageStyles(
     return toPageStyles(
       compilePageCss(document, context),
       context.scope,
-      // The sentinel is a COMPARISON value, never a stamp. It says "this policy
-      // has no identity", and an artifact carrying it would answer that question
-      // with a stable string — so a later read under a DIFFERENT anonymous
-      // predicate would find its own sentinel on the stored sheet, compare equal,
-      // and reuse CSS that predicate never judged. Stamped as absent instead,
-      // which reads as "compiled under no policy" and cannot match any policy in
-      // force. That makes a sheet compiled under an anonymous predicate
-      // permanently uncacheable, which is exactly what having no identity means.
-      options.fetchPolicyId === UNIDENTIFIED_FETCH_POLICY
-        ? undefined
-        : options.fetchPolicyId
+      options.fetchPolicyId
     );
   }
   return {

--- a/packages/blocks-react/src/styles.ts
+++ b/packages/blocks-react/src/styles.ts
@@ -756,7 +756,17 @@ export function resolvePageStyles(
     return toPageStyles(
       compilePageCss(document, context),
       context.scope,
-      options.fetchPolicyId
+      // The sentinel is a COMPARISON value, never a stamp. It says "this policy
+      // has no identity", and an artifact carrying it would answer that question
+      // with a stable string — so a later read under a DIFFERENT anonymous
+      // predicate would find its own sentinel on the stored sheet, compare equal,
+      // and reuse CSS that predicate never judged. Stamped as absent instead,
+      // which reads as "compiled under no policy" and cannot match any policy in
+      // force. That makes a sheet compiled under an anonymous predicate
+      // permanently uncacheable, which is exactly what having no identity means.
+      options.fetchPolicyId === UNIDENTIFIED_FETCH_POLICY
+        ? undefined
+        : options.fetchPolicyId
     );
   }
   return {

--- a/packages/blocks-react/src/styles.ts
+++ b/packages/blocks-react/src/styles.ts
@@ -484,6 +484,90 @@ export function fetchPolicyLabel(
  */
 export const UNIDENTIFIED_FETCH_POLICY = "unidentified-fetch-policy";
 
+/**
+ * Whether the artifact holds the OWN rules of every node the prune removed.
+ *
+ * "A map is present" is not coverage. A stored artifact can be stale relative to the document it
+ * is rendered with — compiled when one node was unconditional, so its rules are in `css`, while a
+ * different node was already gated and has an entry. The map exists, but it does not cover the
+ * node that was actually pruned, and serving the stored sheet publishes that node's rules and
+ * asset URLs.
+ *
+ * The compiler writes an entry for EVERY node it holds back, including one with no styles of its
+ * own, so an id missing from the map means the artifact was compiled when that node was still
+ * being served. That makes presence-per-removed-id an exact test rather than a heuristic.
+ *
+ * The ENTRY has to be usable, not merely present. A key whose value the delivery refuses to read
+ * certifies coverage that never reaches the sheet, which is the same divergence one value deeper.
+ *
+ * This is the NODE-LOCAL half on its own, because the two prunes that ask it need different
+ * amounts. Written once so neither can drift from the other on the part they share.
+ */
+export function gatedEntriesCoverRemovedNodes(
+  before: BlockDocument,
+  after: BlockDocument,
+  gated: Readonly<Record<string, unknown>>
+): boolean {
+  const surviving = new Set<string>();
+  walkNodes(after.nodes, node => surviving.add(node.id));
+  let covered = true;
+  walkNodes(before.nodes, node => {
+    if (surviving.has(node.id)) return;
+    if (!isRecordedGatedEntry(gated[node.id])) covered = false;
+  });
+  return covered;
+}
+
+/**
+ * Whether the artifact's gated map accounts for every node the visibility prune removed.
+ *
+ * The node-local rules, plus one thing more. The map holds a node's OWN rules; a block type's
+ * defaults are shared, emitted once per type into the main sheet, and stay there — so when pruning
+ * removes the last instance of a type, the stored sheet still publishes that type's defaults, and
+ * any `url(...)` in them, for a block nobody was served. Only a recompile can drop a type-level
+ * rule, so the artifact cannot cover this case and must not claim to.
+ *
+ * Asked HERE and not of a draws-nothing node, and the difference is what the two prunes are for. A
+ * condition withholds content from a reader, so the block a page was built from is itself part of
+ * what is being withheld and a rule naming that type says something. A block that draws nothing is
+ * an ordinary node the site uses and will draw again as soon as it is filled in; its type's
+ * defaults come from the block package rather than from the document, and refusing coverage over
+ * them would leave the drop unreachable for the page with one image and no second one.
+ */
+export function gatedMapCoversPrunedNodes(
+  before: BlockDocument,
+  after: BlockDocument,
+  gated: Readonly<Record<string, unknown>>
+): boolean {
+  const survivingTypes = new Set<string>();
+  walkNodes(after.nodes, node => survivingTypes.add(node.type));
+  const surviving = new Set<string>();
+  walkNodes(after.nodes, node => surviving.add(node.id));
+  let covered = gatedEntriesCoverRemovedNodes(before, after, gated);
+  walkNodes(before.nodes, node => {
+    if (surviving.has(node.id)) return;
+    if (!survivingTypes.has(node.type)) covered = false;
+  });
+  return covered;
+}
+
+/**
+ * Whether any id appears on more than one node.
+ *
+ * The compiler suppresses the node-local rules of every node sharing an id, so a stored sheet
+ * compiled from such a document is missing them — and stays missing them after a prune removes the
+ * duplicate that made the collision visible.
+ */
+export function hasDuplicateNodeIds(document: BlockDocument): boolean {
+  const seen = new Set<string>();
+  let duplicate = false;
+  walkNodes(document.nodes, node => {
+    if (seen.has(node.id)) duplicate = true;
+    seen.add(node.id);
+  });
+  return duplicate;
+}
+
 /** What a page must be recompiled WITH, and judged BY. */
 export interface EffectiveCompile {
   /** The context to recompile with, or `undefined` when the caller gave none. */

--- a/packages/blocks-react/src/styles.ts
+++ b/packages/blocks-react/src/styles.ts
@@ -1,11 +1,14 @@
 import {
   compilePageCss,
   declaresNoMarkup,
+  isFetchableUrl,
   nodeClassNames,
   walkNodes,
+  DEFAULT_LIMITS,
   type BlockDocument,
   type BlockNode,
   type CompiledPageCss,
+  type DocumentLimits,
   type RemotePatternInput,
   type NodeStyles,
   type StyleCompileContext,
@@ -480,6 +483,76 @@ export function fetchPolicyLabel(
  * impossible-looking sentinel invites.
  */
 export const UNIDENTIFIED_FETCH_POLICY = "unidentified-fetch-policy";
+
+/** What a page must be recompiled WITH, and judged BY. */
+export interface EffectiveCompile {
+  /** The context to recompile with, or `undefined` when the caller gave none. */
+  context: StyleCompileContext | undefined;
+  /** The policy label to compare a stored sheet's stamp against. */
+  fetchPolicyId: string | undefined;
+}
+
+/**
+ * Reconcile what a CALLER supplied with what the stored artifact and the host
+ * already knew.
+ *
+ * A caller's raw context is not the context to compile with, and the three
+ * differences all fail silently:
+ *
+ * - **Scope lives on the ARTIFACT, not the context.** A caller normally omits it
+ *   for exactly that reason, so compiling with the raw context rebuilds a scoped
+ *   page unscoped and lets its selectors reach another document rendered beside
+ *   it. Only a STRING is carried over: the artifact is a database record, so its
+ *   `scope` can be null or a number, and the compiler dereferences it before any
+ *   block boundary exists — a malformed one would fail the whole page rather
+ *   than render it unstyled.
+ * - **Limits come from the caller's own cap**, which preparation already honours.
+ *   Compiling against the context's caps instead retains nodes whose styles were
+ *   never written, so the document holds nodes the class map does not name.
+ * - **A sheet with no policy stamp compares equal to no policy at all.** A caller
+ *   with its own `mayFetchUrl` and no `fetchPolicyId` would therefore reuse an
+ *   unstamped sheet under a predicate that never judged it. A caller's predicate
+ *   is authoritative and opaque — nothing here can tell one such function from
+ *   another — so absent a stated identity it gets one no artifact can carry, and
+ *   every stored sheet reads as compiled under another policy. Safe rather than
+ *   fast, and a caller wanting its sheets cached says which policy its predicate
+ *   IS.
+ *
+ * One derivation for every entry point that resolves a stored page. Two would
+ * agree on the day they were written, and the drift would be a page served with
+ * another page's selectors or with URLs the current policy refuses.
+ */
+export function effectiveCompile(args: {
+  styleContext: StyleCompileContext | undefined;
+  styles: PageStyles | undefined;
+  limits: DocumentLimits | undefined;
+  remotePatterns: readonly RemotePatternInput[] | undefined;
+}): EffectiveCompile {
+  const patterns = args.remotePatterns;
+  // A caller's OWN predicate wins: it is the more specific answer, and a host
+  // that passed one deliberately should not have it replaced by one derived
+  // from the pattern list.
+  const fetchPolicyId =
+    args.styleContext?.mayFetchUrl === undefined
+      ? fetchPolicyLabel(patterns)
+      : (args.styleContext.fetchPolicyId ?? UNIDENTIFIED_FETCH_POLICY);
+  if (args.styleContext === undefined)
+    return { context: undefined, fetchPolicyId };
+  return {
+    context: {
+      ...args.styleContext,
+      limits: args.limits ?? args.styleContext.limits ?? DEFAULT_LIMITS,
+      ...(patterns === undefined || args.styleContext.mayFetchUrl !== undefined
+        ? {}
+        : { mayFetchUrl: (url: string) => isFetchableUrl(url, patterns) }),
+      ...(args.styleContext.scope === undefined &&
+      typeof args.styles?.scope === "string"
+        ? { scope: args.styles.scope }
+        : {}),
+    },
+    fetchPolicyId,
+  };
+}
 
 /** Caller-supplied policy for one style resolution. */
 export interface ResolveStyleOptions {


### PR DESCRIPTION
Closes task 206.

## What was wrong

The documented flow for a consumer outside `PageRenderer` is
`prepareDocumentForRead` then `resolvePageStyles`. The second call needs to know
whether the first REMOVED anything, and the prepared tree it receives no longer
says — so `repairedDocument` was left at its default and the stored sheet was
trusted.

That is sound for every pruned node whose rules the artifact carries per node.
It is unsound for the rest of what a pruned node put in the sheet.

**The task file describes this as the node's own rules leaking. Measured, that
is not the mechanism.** A gated node's own rules move into the per-node `gated`
map (`compile-page.ts`, `if (nodeGated) { gated[node.id] = …; continue; }`) and
`withGatedRules` correctly never appends them once the node is gone. What stays
behind is everything keyed by something OTHER than the node: the **block-type
tier** and the **named classes** it referenced. Per-node accounting cannot see
either.

## Measured, not argued

A page whose only `plugin/drawless` node declares it draws nothing, read after
the plugin is uninstalled:

| | shipped CSS |
|---|---|
| plugin installed (node present) | `.nx-bt-plugin--drawless` + `.nx-c-only-a` + node b |
| plugin uninstalled (node pruned) | **byte-identical** |

Both tiers ship for a page containing neither. The refusal does not fire because
`artifactDescribesUnaccountedNodes` treats a recorded `gated` entry as accounting
for the absence, which is a per-node question.

The neighbouring case behaves correctly and is why the overlap is narrow: a
placeholder that is NOT drawless has no gated entry, the refusal fires, and the
sheet is withheld. The drawless overlap is the only way a pruned node carries one.

## The fix

`preparePageForRead` does both halves and derives the answer from the stages
`prepareDocumentReadStages` already reports. A consumer calls one function and
cannot get it wrong — a documented instruction to pass a flag would be a rule
with nothing enforcing it, and the easy path and the correct path would differ.

Two of the five stage boundaries count. The three exclusions are load bearing:

- **Migration** allocates unconditionally, so including it would report every
  page as repaired and withhold every stored sheet on the happy path.
- **Condition gating** is what the per-node map was built for; including it would
  cost every page carrying a conditioned block its whole stylesheet.
- **Address repair** removes nodes the compiler refuses to style at all.

Design 1 from the task (move the prune out of `prepareDocumentForRead` into
`resolvePageStyles`) was rejected by this lane and the blocks-engine lane: it
moves a pass out of the shared function to serve one caller and re-opens the
drift for the metadata path that is correct today.

`readingViewOf` is extracted so `prepareDocumentForRead` and `preparePageForRead`
apply the same all-placeholder rule rather than each carrying a copy.

## Verification

- **Stub-verified both directions.** With `storedSheetCannotDescribe` forced to
  `false`, exactly the two defect tests fail and all six controls pass.
- Every case has its opposite, because trusting too LITTLE is the worse failure:
  a control asserts the same page keeps its sheet while the plugin is installed,
  so the fix cannot pass by withholding unconditionally.
- The gating fixture carries a positive control (`stored.gated.c` holds the rule,
  `stored.css` does not) so it cannot pass by never reaching the gating pass.
- 479/479 `blocks-react` tests, lint and check-types green.

`check-types` in this package **does** read test files — it caught two real
fixture type errors the runtime was tolerating (a missing breakpoint set, and
`conditions` being `Condition[][]` rather than a flat array).

## Not in scope

The in-repo consumer, `next.ts`, uses `prepareDocumentForRead` for SEO metadata
and never resolves styles, so it is unaffected and unchanged. The exposure is
third-party consumers following the documented pair.
