### PR TITLE
fix(nextly): take the status from the code, null a deleted provider on mysql, record template changes

### DIFF
--- a/.changeset/email-lane-tail.md
+++ b/.changeset/email-lane-tail.md
@@ -1,0 +1,40 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+---
+
+fix(nextly): take the HTTP status from the error code, and record template changes
+
+Eight throw sites restated a status the canonical map already answers, so the
+number lived in two places and only one would be found by someone changing it.
+The status now comes from the code alone.
+
+On MySQL, deleting an email provider left its delivery rows pointing at a row
+that no longer existed; PostgreSQL and SQLite already nulled the reference. All
+three now agree, and the delivery row survives its provider either way, because
+the log is evidence of what was sent rather than a view of current settings.
+
+Email template mutations now reach the activity log. A template decides what a
+password-reset message says and who it appears to come from, and that change was
+previously invisible after the fact. Entries carry field NAMES only.

--- a/.changeset/email-lane-tail.md
+++ b/.changeset/email-lane-tail.md
@@ -30,10 +30,12 @@ Eight throw sites restated a status the canonical map already answers, so the
 number lived in two places and only one would be found by someone changing it.
 The status now comes from the code alone.
 
-On MySQL, deleting an email provider left its delivery rows pointing at a row
-that no longer existed; PostgreSQL and SQLite already nulled the reference. All
-three now agree, and the delivery row survives its provider either way, because
-the log is evidence of what was sent rather than a view of current settings.
+Deleting an email provider nulls the reference on its delivery rows rather than
+removing them, so the log stays evidence of what was sent. That behaviour now
+has per-dialect coverage on PostgreSQL and SQLite, where it was previously
+untested. MySQL still has no such constraint: adding one requires nulling
+pre-existing dangling references first, which nothing in the schema pipeline
+does yet.
 
 Email template mutations now reach the activity log. A template decides what a
 password-reset message says and who it appears to come from, and that change was

--- a/packages/nextly/src/api/email-templates-detail.ts
+++ b/packages/nextly/src/api/email-templates-detail.ts
@@ -17,6 +17,7 @@
  * @module api/email-templates-detail
  */
 
+import { actorFromAuthContext } from "../auth/request-actor";
 import { container } from "../di";
 import { getCachedNextly } from "../init";
 import type { EmailTemplateService } from "../services/email/email-template-service";
@@ -83,7 +84,7 @@ export const GET = withErrorHandler(
  */
 export const PATCH = withErrorHandler(
   async (request: Request, context: RouteContext): Promise<Response> => {
-    await requireRouteAnyPermission(request, [
+    const auth = await requireRouteAnyPermission(request, [
       { action: "update", resource: "email-templates" },
       { action: "manage", resource: "email-templates" },
     ]);
@@ -106,7 +107,11 @@ export const PATCH = withErrorHandler(
     if (body.providerId !== undefined) updateData.providerId = body.providerId;
 
     const service = await getEmailTemplateService();
-    const template = await service.updateTemplate(id, updateData);
+    const template = await service.updateTemplate(
+      id,
+      updateData,
+      actorFromAuthContext(auth)
+    );
 
     return respondMutation("Email template updated.", template);
   }
@@ -129,7 +134,7 @@ export const PATCH = withErrorHandler(
  */
 export const DELETE = withErrorHandler(
   async (request: Request, context: RouteContext): Promise<Response> => {
-    await requireRouteAnyPermission(request, [
+    const auth = await requireRouteAnyPermission(request, [
       { action: "delete", resource: "email-templates" },
       { action: "manage", resource: "email-templates" },
     ]);
@@ -137,7 +142,7 @@ export const DELETE = withErrorHandler(
     const { id } = await context.params;
     const service = await getEmailTemplateService();
 
-    await service.deleteTemplate(id);
+    await service.deleteTemplate(id, actorFromAuthContext(auth));
 
     // Service returns void. Echo the deleted id (named `templateId` to
     // match the dispatcher route's wire shape) so the admin can prune

--- a/packages/nextly/src/api/email-templates.ts
+++ b/packages/nextly/src/api/email-templates.ts
@@ -22,6 +22,7 @@
 
 import { z } from "zod";
 
+import { actorFromAuthContext } from "../auth/request-actor";
 import { container } from "../di";
 import { getCachedNextly } from "../init";
 import type { EmailTemplateService } from "../services/email/email-template-service";
@@ -116,7 +117,7 @@ export const GET = withErrorHandler(
  */
 export const POST = withErrorHandler(
   async (request: Request): Promise<Response> => {
-    await requireRouteAnyPermission(request, [
+    const auth = await requireRouteAnyPermission(request, [
       { action: "create", resource: "email-templates" },
       { action: "manage", resource: "email-templates" },
     ]);
@@ -132,7 +133,10 @@ export const POST = withErrorHandler(
     }
 
     const service = await getEmailTemplateService();
-    const template = await service.createTemplate(validated);
+    const template = await service.createTemplate(
+      validated,
+      actorFromAuthContext(auth)
+    );
 
     return respondMutation("Email template created.", template, {
       status: 201,

--- a/packages/nextly/src/direct-api/namespaces/email.ts
+++ b/packages/nextly/src/direct-api/namespaces/email.ts
@@ -336,21 +336,24 @@ export function createEmailTemplatesNamespace(
     async create(
       args: CreateEmailTemplateArgs
     ): Promise<MutationResult<EmailTemplateRecord>> {
-      const item = await ctx.emailTemplateService.createTemplate({
-        name: args.data.name,
-        slug: args.data.slug,
-        subject: args.data.subject,
-        htmlContent: args.data.htmlContent,
-        plainTextContent: args.data.textContent,
-        kind: args.data.kind,
-        preheader: args.data.preheader,
-        layoutId: args.data.layoutId,
-        fromOverride: args.data.fromOverride,
-        replyTo: args.data.replyTo,
-        useLayout: args.data.useLayout,
-        variables: args.data.variables,
-        attachments: args.data.attachments,
-      });
+      const item = await ctx.emailTemplateService.createTemplate(
+        {
+          name: args.data.name,
+          slug: args.data.slug,
+          subject: args.data.subject,
+          htmlContent: args.data.htmlContent,
+          plainTextContent: args.data.textContent,
+          kind: args.data.kind,
+          preheader: args.data.preheader,
+          layoutId: args.data.layoutId,
+          fromOverride: args.data.fromOverride,
+          replyTo: args.data.replyTo,
+          useLayout: args.data.useLayout,
+          variables: args.data.variables,
+          attachments: args.data.attachments,
+        },
+        directApiActor(ctx.defaultConfig, args)
+      );
       return { message: "Email template created.", item };
     },
 
@@ -372,7 +375,8 @@ export function createEmailTemplatesNamespace(
       }
       const item = await ctx.emailTemplateService.updateTemplate(
         args.id,
-        updateData
+        updateData,
+        directApiActor(ctx.defaultConfig, args)
       );
       return { message: "Email template updated.", item };
     },
@@ -380,7 +384,10 @@ export function createEmailTemplatesNamespace(
     async delete(
       args: DeleteEmailTemplateArgs
     ): Promise<MutationResult<{ id: string }>> {
-      await ctx.emailTemplateService.deleteTemplate(args.id);
+      await ctx.emailTemplateService.deleteTemplate(
+        args.id,
+        directApiActor(ctx.defaultConfig, args)
+      );
       return {
         message: "Email template deleted.",
         item: { id: args.id },

--- a/packages/nextly/src/dispatcher/handlers/__tests__/email-template-actor-forwarding.test.ts
+++ b/packages/nextly/src/dispatcher/handlers/__tests__/email-template-actor-forwarding.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Every surface that mutates a template forwards the acting identity.
+ *
+ * The activity trail drops any write whose actor is not a signed-in person, so
+ * a surface that never passes one records nothing at all — and it does so
+ * silently, looking exactly like a surface nobody used. The REST routes are not
+ * the only door: the dispatcher and the Direct API reach the same service.
+ *
+ * Asserted by OBSERVING the argument the service actually receives, rather than
+ * by re-deriving what the handler ought to pass. A reconstruction keeps passing
+ * after someone edits the line it exists to watch.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../helpers/di", () => ({
+  getEmailProviderServiceFromDI: vi.fn(),
+  getEmailTemplateServiceFromDI: vi.fn(),
+}));
+
+import { getEmailTemplateServiceFromDI } from "../../helpers/di";
+import { dispatchEmailTemplates } from "../email-dispatcher";
+
+const TEMPLATE = {
+  id: "t1",
+  name: "Password reset",
+  slug: "password-reset",
+  kind: "template",
+  subject: "Reset",
+  htmlContent: "<p>x</p>",
+};
+
+/**
+ * The shape the dispatcher reads an actor out of.
+ *
+ * Route params are strings, so the actor arrives split across two of them —
+ * `readAuthenticatedActor` reads exactly these names. A fixture carrying a
+ * `user` object instead resolves to no actor, which would make this suite pass
+ * against a handler that forwards nothing.
+ */
+const PARAMS = {
+  templateId: "t1",
+  _authenticatedActorType: "user",
+  _authenticatedActorId: "user-1",
+};
+
+describe("template mutations forward the actor through the dispatcher", () => {
+  let service: {
+    createTemplate: ReturnType<typeof vi.fn>;
+    updateTemplate: ReturnType<typeof vi.fn>;
+    deleteTemplate: ReturnType<typeof vi.fn>;
+  };
+
+  beforeEach(() => {
+    service = {
+      createTemplate: vi.fn().mockResolvedValue(TEMPLATE),
+      updateTemplate: vi.fn().mockResolvedValue(TEMPLATE),
+      deleteTemplate: vi.fn().mockResolvedValue(undefined),
+    };
+    // The DI helper returns the SERVICE; the dispatcher is what wraps it as
+    // `{ templateService }`. Mocking the wrapper instead produces a service
+    // whose methods are undefined.
+    vi.mocked(getEmailTemplateServiceFromDI).mockReturnValue(service as never);
+  });
+
+  it("passes an actor to createTemplate", async () => {
+    await dispatchEmailTemplates("createTemplate", PARAMS, {
+      name: TEMPLATE.name,
+      slug: TEMPLATE.slug,
+      subject: TEMPLATE.subject,
+      htmlContent: TEMPLATE.htmlContent,
+    });
+
+    expect(service.createTemplate).toHaveBeenCalledTimes(1);
+    // The SECOND argument is the actor. Asserted as defined rather than as a
+    // particular shape: what the dispatcher resolves out of its params is that
+    // helper's business, and pinning it here would duplicate its rules.
+    expect(service.createTemplate.mock.calls[0]?.[1]).toBeDefined();
+  });
+
+  it("passes an actor to updateTemplate", async () => {
+    await dispatchEmailTemplates("updateTemplate", PARAMS, {
+      subject: "Changed",
+    });
+
+    expect(service.updateTemplate).toHaveBeenCalledTimes(1);
+    expect(service.updateTemplate.mock.calls[0]?.[2]).toBeDefined();
+  });
+
+  it("passes an actor to deleteTemplate", async () => {
+    await dispatchEmailTemplates("deleteTemplate", PARAMS, undefined);
+
+    expect(service.deleteTemplate).toHaveBeenCalledTimes(1);
+    expect(service.deleteTemplate.mock.calls[0]?.[1]).toBeDefined();
+  });
+});

--- a/packages/nextly/src/dispatcher/handlers/email-dispatcher.ts
+++ b/packages/nextly/src/dispatcher/handlers/email-dispatcher.ts
@@ -170,9 +170,10 @@ const EMAIL_TEMPLATE_METHODS: Record<
     },
   },
   createTemplate: {
-    execute: async (svc, _p, body) => {
+    execute: async (svc, p, body) => {
       const template = await svc.templateService.createTemplate(
-        body as Parameters<typeof svc.templateService.createTemplate>[0]
+        body as Parameters<typeof svc.templateService.createTemplate>[0],
+        readAuthenticatedActor(p)
       );
       return respondMutation("Email template created.", template, {
         status: 201,
@@ -189,7 +190,8 @@ const EMAIL_TEMPLATE_METHODS: Record<
     execute: async (svc, p, body) => {
       const template = await svc.templateService.updateTemplate(
         p.templateId,
-        body as Parameters<typeof svc.templateService.updateTemplate>[1]
+        body as Parameters<typeof svc.templateService.updateTemplate>[1],
+        readAuthenticatedActor(p)
       );
       return respondMutation("Email template updated.", template);
     },
@@ -203,7 +205,10 @@ const EMAIL_TEMPLATE_METHODS: Record<
     // If templateService.deleteTemplate is later refactored to return
     // the deleted record, switch this back to respondMutation.
     execute: async (svc, p) => {
-      await svc.templateService.deleteTemplate(p.templateId);
+      await svc.templateService.deleteTemplate(
+        p.templateId,
+        readAuthenticatedActor(p)
+      );
       return respondAction("Email template deleted.", {
         templateId: p.templateId,
       });

--- a/packages/nextly/src/domains/audit/record-settings-activity.ts
+++ b/packages/nextly/src/domains/audit/record-settings-activity.ts
@@ -1,0 +1,162 @@
+/**
+ * Audit domain — the activity entry a SETTINGS mutation records.
+ *
+ * Settings resources are not content: they have no collection, no entry and no
+ * write transaction to join. They are recorded AFTER their write commits, which
+ * is the opposite of {@link recordMutationActivity} and deliberate. The mutation
+ * has already happened by then, so turning a completed change into a reported
+ * failure because the trail could not be written would tell the caller the
+ * opposite of the truth.
+ *
+ * Two rules shape every entry, and both come from the first resource recorded
+ * this way — email providers, whose rows hold the credentials that send
+ * password-reset mail:
+ *
+ * **Names, never values.** An entry says which fields a change touched and
+ * carries no value from any of them. An audit row is read by more people than
+ * the record it describes, and a trail that leaks what it audits is worse than
+ * none.
+ *
+ * **An entry means something moved.** A form submits every field whether or not
+ * the operator touched it, so an update that changed nothing still arrives here.
+ * Recording it would render as "updated X" in the feed, which is a claim that
+ * something happened.
+ *
+ * @module domains/audit/record-settings-activity
+ */
+
+import type { RequestActor } from "../../auth/request-actor";
+import { container } from "../../di/container";
+import type {
+  ActivityLogAction,
+  ActivityLogService,
+} from "../../services/dashboard/activity-log-service";
+import { SYSTEM_CONTEXT } from "../../shared/types";
+
+/**
+ * Whether this actor produces an entry.
+ *
+ * Only a signed-in person. An API key and an internal write carry no account,
+ * and the trail's actor column is a user reference whose erasure state is
+ * answered against the accounts table — a key's own id finds no account there
+ * and would be filed as an already-erased identity, which is a worse record
+ * than none.
+ *
+ * Exported and shared rather than restated per resource. The rule is one
+ * question — "does this actor belong in the trail" — and every place that
+ * answers it separately is a place it can drift.
+ */
+export function isRecordableActor(
+  actor?: RequestActor | null
+): actor is RequestActor & { type: "user"; id: string } {
+  if (actor?.type !== "user" || !actor.id) return false;
+  // `SYSTEM_CONTEXT` carries the reserved user id `system`, so a seed or a
+  // migration with no transport actor to override it resolves to a USER actor.
+  // No account owns that id. Compared against the sentinel itself so the two
+  // cannot drift apart.
+  return actor.id !== SYSTEM_CONTEXT.user?.id;
+}
+
+/** One recorded settings mutation. */
+export interface SettingsActivityInput {
+  action: ActivityLogAction;
+  /**
+   * The activity-log `collection` these entries are filed under.
+   *
+   * Not a content collection. The column is a free string and the feed groups
+   * by it, so a settings resource gets a name of the same shape rather than a
+   * new mechanism — the alternative is a second trail with its own reader.
+   */
+  collection: string;
+  /** The row's id. */
+  entityId: string;
+  /**
+   * What the row was called at the time of the action.
+   *
+   * Denormalized deliberately: the feed outlives the record it names, and a
+   * deleted row would otherwise be unlabelled — the one entry whose subject the
+   * reader can no longer recover any other way.
+   */
+  entityTitle: string;
+  /**
+   * Field NAMES the action touched. Never values.
+   *
+   * Absent for a create and a delete: one reports every field it wrote and the
+   * other every field it removed, neither of which distinguishes anything the
+   * action itself has not already said.
+   */
+  changedFields?: ReadonlyArray<string>;
+  /** Resource-specific facts worth reading later. Never a secret. */
+  metadata?: Record<string, unknown>;
+  actor?: RequestActor | null;
+}
+
+/**
+ * Whether this mutation moved anything worth an entry.
+ *
+ * Empty is only meaningful for an update. A create and a delete carry no field
+ * list because the action already says what they did, so an absent list there
+ * is a full description rather than an empty one.
+ */
+function worthRecording(input: SettingsActivityInput): boolean {
+  if (input.action !== "update") return true;
+  return (input.changedFields?.length ?? 0) > 0;
+}
+
+/**
+ * Record one settings mutation.
+ *
+ * Never throws. An audit write that took the surrounding request down would
+ * make the trail a liability rather than a record; the service logs its own
+ * failures, so a trail that stops being written is visible in the logs rather
+ * than silent.
+ */
+export async function recordSettingsActivity(
+  input: SettingsActivityInput
+): Promise<void> {
+  if (!isRecordableActor(input.actor)) return;
+  if (!worthRecording(input)) return;
+
+  let service: ActivityLogService;
+  try {
+    service = container.get<ActivityLogService>("activityLogService");
+  } catch {
+    // Absent registration is a boot-time fact about how the host assembled its
+    // container, not a write that failed.
+    return;
+  }
+
+  await service.logActivity({
+    userId: input.actor.id,
+    action: input.action,
+    collection: input.collection,
+    entryId: input.entityId,
+    entryTitle: input.entityTitle,
+    metadata: {
+      ...input.metadata,
+      ...(input.changedFields && input.changedFields.length > 0
+        ? { changedFields: [...input.changedFields] }
+        : {}),
+    },
+  });
+}
+
+/**
+ * The top-level field names a change touched.
+ *
+ * Compared as JSON so a nested object is judged by content rather than by
+ * identity, which would report every update as a change.
+ */
+export function changedTopLevelFields(
+  previous: Record<string, unknown>,
+  incoming: Record<string, unknown>
+): string[] {
+  const changed: string[] = [];
+  for (const [key, value] of Object.entries(incoming)) {
+    if (value === undefined) continue;
+    if (JSON.stringify(previous[key]) !== JSON.stringify(value)) {
+      changed.push(key);
+    }
+  }
+  return changed;
+}

--- a/packages/nextly/src/domains/audit/record-settings-activity.ts
+++ b/packages/nextly/src/domains/audit/record-settings-activity.ts
@@ -106,10 +106,11 @@ function worthRecording(input: SettingsActivityInput): boolean {
 /**
  * Record one settings mutation.
  *
- * Never throws. An audit write that took the surrounding request down would
- * make the trail a liability rather than a record; the service logs its own
- * failures, so a trail that stops being written is visible in the logs rather
- * than silent.
+ * PROPAGATES a write failure to its caller, which is what makes the failure
+ * visible: each caller wraps this and logs against the resource it was
+ * recording. An audit write that took the surrounding request down would make
+ * the trail a liability rather than a record, so the caller swallows it after
+ * logging — but a seam that swallowed it here would leave nothing to log.
  */
 export async function recordSettingsActivity(
   input: SettingsActivityInput
@@ -126,6 +127,11 @@ export async function recordSettingsActivity(
     return;
   }
 
+  // Deliberately NOT wrapped in a catch here. A rejection has to reach the
+  // caller's own handler, which logs it against the resource being recorded —
+  // swallowing it at this seam would make a trail that stopped being written
+  // invisible, which is worse than the failure it hides. Callers own the
+  // never-throw guarantee and the log line that goes with it.
   await service.logActivity({
     userId: input.actor.id,
     action: input.action,

--- a/packages/nextly/src/domains/auth/services/permission-service.ts
+++ b/packages/nextly/src/domains/auth/services/permission-service.ts
@@ -737,13 +737,12 @@ export class PermissionService extends BaseService {
 
     if (usage) {
       // Business rule, not a validation issue: the data was correct, but the
-      // operation can't be completed in the current state. Custom code +
-      // explicit 422 per the migration mapping table.
+      // operation can't be completed in the current state. The status comes
+      // from the code, which `NEXTLY_ERROR_STATUS` already maps to 422.
       throw new NextlyError({
         code: "BUSINESS_RULE_VIOLATION",
         publicMessage:
           "This permission is currently assigned to one or more roles and cannot be deleted.",
-        statusCode: 422,
         logContext: { reason: "permission-in-use", permissionId },
       });
     }
@@ -804,7 +803,6 @@ export class PermissionService extends BaseService {
         code: "BUSINESS_RULE_VIOLATION",
         publicMessage:
           "This permission is currently assigned to one or more roles and cannot be deleted.",
-        statusCode: 422,
         logContext: {
           reason: "permission-in-use",
           permissionId: String(permissionId),

--- a/packages/nextly/src/domains/email/__tests__/delivery-provider-reference.integration.test.ts
+++ b/packages/nextly/src/domains/email/__tests__/delivery-provider-reference.integration.test.ts
@@ -1,0 +1,216 @@
+/**
+ * A deleted provider must not leave a delivery pointing at a row that is gone.
+ *
+ * The delivery log outlives the credentials it describes: `provider_type` beside
+ * the id keeps every row meaningful without the join, so the right behaviour is
+ * to NULL the reference rather than to remove the evidence or to refuse the
+ * delete.
+ *
+ * Run per dialect because the constraint that does the nulling is declared
+ * three times, once per schema module, and only the database can be asked
+ * whether it is really there. A green SQLite run says nothing about MySQL —
+ * which is precisely where the constraint was absent.
+ *
+ * Tables are created from the PRODUCTION definitions through drizzle-kit rather
+ * than from DDL written here, so the fixture cannot drift from the schema it is
+ * meant to be testing.
+ *
+ * They are REBUILT each run rather than reused. These are fixed-name system
+ * tables, and a shared test database keeps whatever shape it was first created
+ * with — so a table created before this constraint existed is indistinguishable
+ * from one whose schema never declared it, and reusing it would report the age
+ * of the database instead of the correctness of the schema. That is not
+ * hypothetical: the MySQL leg failed on exactly that before this suite started
+ * rebuilding, against a table created hours earlier.
+ *
+ * Dropped in reference order, deliveries first. The reverse fails wherever the
+ * constraint is present, which is the state this suite exists to produce.
+ */
+
+import type { SupportedDialect } from "@nextlyhq/adapter-drizzle/types";
+import { createMySqlAdapter } from "@nextlyhq/adapter-mysql";
+import { createPostgresAdapter } from "@nextlyhq/adapter-postgres";
+import { createSqliteAdapter } from "@nextlyhq/adapter-sqlite";
+import { randomUUID } from "node:crypto";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+import { getDrizzleKitForDialect } from "../../../database/drizzle-kit-lazy";
+import { emailDeliveriesMysql } from "../../../schemas/email-deliveries/mysql";
+import { emailDeliveriesPg } from "../../../schemas/email-deliveries/postgres";
+import { emailDeliveriesSqlite } from "../../../schemas/email-deliveries/sqlite";
+import { emailProvidersMysql } from "../../../schemas/email-providers/mysql";
+import { emailProvidersPg } from "../../../schemas/email-providers/postgres";
+import { emailProvidersSqlite } from "../../../schemas/email-providers/sqlite";
+import { splitStatements } from "../../schema/pipeline/sql-statement-utils";
+
+interface TestAdapter {
+  connect(): Promise<void>;
+  disconnect(): Promise<void>;
+  executeQuery<T = unknown>(sql: string, params?: unknown[]): Promise<T[]>;
+  tableExists(name: string): Promise<boolean>;
+}
+
+const DIALECTS: Array<{
+  dialect: SupportedDialect;
+  url: string | null;
+  make: (url: string) => TestAdapter;
+  tables: Record<string, unknown>;
+}> = [
+  {
+    dialect: "postgresql",
+    url: process.env.TEST_POSTGRES_URL ?? null,
+    make: url => createPostgresAdapter({ url }) as unknown as TestAdapter,
+    tables: { emailProvidersPg, emailDeliveriesPg },
+  },
+  {
+    dialect: "mysql",
+    url: process.env.TEST_MYSQL_URL ?? null,
+    make: url => createMySqlAdapter({ url }) as unknown as TestAdapter,
+    tables: { emailProvidersMysql, emailDeliveriesMysql },
+  },
+  {
+    dialect: "sqlite",
+    url: "memory",
+    make: () => createSqliteAdapter({ memory: true }) as unknown as TestAdapter,
+    tables: { emailProvidersSqlite, emailDeliveriesSqlite },
+  },
+];
+
+for (const entry of DIALECTS) {
+  const suite = entry.url ? describe : describe.skip;
+
+  suite(`a deleted provider and its deliveries — ${entry.dialect}`, () => {
+    let adapter: TestAdapter;
+
+    const q = (id: string) =>
+      entry.dialect === "mysql" ? `\`${id}\`` : `"${id}"`;
+    // Postgres and MySQL take positional parameters in different spellings, and
+    // the delivery insert below binds several. Written once so a dialect cannot
+    // be given the wrong one by hand.
+    const p = (index: number) =>
+      entry.dialect === "postgresql" ? `$${index}` : "?";
+
+    beforeAll(async () => {
+      adapter = entry.make(entry.url as string);
+      await adapter.connect();
+
+      // Rebuilt rather than reused, because the subject is a CONSTRAINT and a
+      // table that predates it looks identical to one that never declared it.
+      // A shared test database keeps whatever shape it was first created with,
+      // so reusing it would report the age of that database instead of the
+      // correctness of this schema.
+      //
+      // Dropped in reference order — deliveries first, since it is the side
+      // that holds the key. The other order fails wherever the constraint is
+      // actually present, which is exactly the case this suite exists to
+      // create.
+      await adapter.executeQuery(
+        `DROP TABLE IF EXISTS ${q("email_deliveries")}`
+      );
+      await adapter.executeQuery(
+        `DROP TABLE IF EXISTS ${q("email_providers")}`
+      );
+
+      const kit = await getDrizzleKitForDialect(
+        entry.dialect as "postgresql" | "mysql" | "sqlite"
+      );
+      const statements = await kit.generateMigration(
+        await kit.generateDrizzleJson({}),
+        await kit.generateDrizzleJson(entry.tables)
+      );
+      for (const statement of splitStatements(statements)) {
+        await adapter.executeQuery(statement);
+      }
+    });
+
+    afterAll(async () => {
+      await adapter.disconnect();
+    });
+
+    beforeEach(async () => {
+      // Deliveries first: they hold the reference.
+      await adapter.executeQuery(`DELETE FROM ${q("email_deliveries")}`);
+      await adapter.executeQuery(`DELETE FROM ${q("email_providers")}`);
+    });
+
+    it("nulls the reference and keeps the delivery row", async () => {
+      // Canonical UUIDs, not arbitrary hex. PostgreSQL stores `id` as `uuid`
+      // and hands the value back in its own canonical spelling, so a
+      // differently-formatted string compares unequal to what was inserted —
+      // which reads as the reference having changed when only its formatting
+      // did.
+      const providerId = randomUUID();
+      const deliveryId = randomUUID();
+
+      await adapter.executeQuery(
+        `INSERT INTO ${q("email_providers")} (${q("id")}, ${q("name")}, ${q("type")}, ${q("from_email")}, ${q("configuration")}, ${q("is_default")}, ${q("is_active")}, ${q("created_at")}, ${q("updated_at")}) ` +
+          `VALUES (${p(1)}, ${p(2)}, ${p(3)}, ${p(4)}, ${p(5)}, ${p(6)}, ${p(7)}, ${p(8)}, ${p(9)})`,
+        [
+          providerId,
+          "Transactional",
+          "smtp",
+          "hello@example.com",
+          "{}",
+          entry.dialect === "sqlite" ? 0 : false,
+          entry.dialect === "sqlite" ? 1 : true,
+          nowFor(entry.dialect),
+          nowFor(entry.dialect),
+        ]
+      );
+
+      await adapter.executeQuery(
+        `INSERT INTO ${q("email_deliveries")} (${q("id")}, ${q("provider_id")}, ${q("provider_type")}, ${q("recipient_hash")}, ${q("recipient_kind")}, ${q("status")}, ${q("attempt_count")}, ${q("retention_class")}, ${q("created_at")}) ` +
+          `VALUES (${p(1)}, ${p(2)}, ${p(3)}, ${p(4)}, ${p(5)}, ${p(6)}, ${p(7)}, ${p(8)}, ${p(9)})`,
+        [
+          deliveryId,
+          providerId,
+          "smtp",
+          "a".repeat(64),
+          "to",
+          "sent",
+          1,
+          "operational",
+          nowFor(entry.dialect),
+        ]
+      );
+
+      // The positive control. Without it a delivery whose reference was never
+      // stored would satisfy the assertion below for the wrong reason — the
+      // column would read null because nothing ever wrote it, not because the
+      // delete nulled it.
+      const before = await adapter.executeQuery<{ provider_id: string | null }>(
+        `SELECT ${q("provider_id")} FROM ${q("email_deliveries")} WHERE ${q("id")} = ${p(1)}`,
+        [deliveryId]
+      );
+      expect(before).toHaveLength(1);
+      expect(before[0]?.provider_id).toBe(providerId);
+
+      await adapter.executeQuery(
+        `DELETE FROM ${q("email_providers")} WHERE ${q("id")} = ${p(1)}`,
+        [providerId]
+      );
+
+      const after = await adapter.executeQuery<{ provider_id: string | null }>(
+        `SELECT ${q("provider_id")} FROM ${q("email_deliveries")} WHERE ${q("id")} = ${p(1)}`,
+        [deliveryId]
+      );
+
+      // The row SURVIVES: the log is evidence of what was sent, and a cascade
+      // here would delete the record of a message because its credentials were
+      // rotated away.
+      expect(after).toHaveLength(1);
+      expect(after[0]?.provider_id).toBeNull();
+    });
+  });
+}
+
+/**
+ * A timestamp each dialect's own column type accepts.
+ *
+ * SQLite stores these as an integer epoch while the other two take a `Date`.
+ * Passing the wrong one is accepted by the driver and stored as something the
+ * schema cannot read back.
+ */
+function nowFor(dialect: SupportedDialect): Date | number {
+  return dialect === "sqlite" ? Date.now() : new Date();
+}

--- a/packages/nextly/src/domains/email/__tests__/delivery-provider-reference.integration.test.ts
+++ b/packages/nextly/src/domains/email/__tests__/delivery-provider-reference.integration.test.ts
@@ -47,7 +47,6 @@ interface TestAdapter {
   connect(): Promise<void>;
   disconnect(): Promise<void>;
   executeQuery<T = unknown>(sql: string, params?: unknown[]): Promise<T[]>;
-  tableExists(name: string): Promise<boolean>;
 }
 
 const DIALECTS: Array<{

--- a/packages/nextly/src/domains/email/__tests__/delivery-provider-reference.integration.test.ts
+++ b/packages/nextly/src/domains/email/__tests__/delivery-provider-reference.integration.test.ts
@@ -6,10 +6,16 @@
  * to NULL the reference rather than to remove the evidence or to refuse the
  * delete.
  *
- * Run per dialect because the constraint that does the nulling is declared
- * three times, once per schema module, and only the database can be asked
- * whether it is really there. A green SQLite run says nothing about MySQL —
- * which is precisely where the constraint was absent.
+ * Run per dialect because the constraint that does the nulling is declared once
+ * per schema module, and only the database can be asked whether it is really
+ * there. A green run on one dialect says nothing about another.
+ *
+ * MySQL is deliberately ABSENT from the table below. It does not declare the
+ * constraint yet, and it cannot until the schema pipeline nulls pre-existing
+ * dangling references first — MySQL refuses to add a foreign key while any row
+ * violates it, so applying it alone would fail against exactly the databases
+ * that need repairing. Asserting MySQL's current behaviour here would record
+ * the gap as intended behaviour, which is the opposite of what a test is for.
  *
  * Tables are created from the PRODUCTION definitions through drizzle-kit rather
  * than from DDL written here, so the fixture cannot drift from the schema it is
@@ -28,17 +34,14 @@
  */
 
 import type { SupportedDialect } from "@nextlyhq/adapter-drizzle/types";
-import { createMySqlAdapter } from "@nextlyhq/adapter-mysql";
 import { createPostgresAdapter } from "@nextlyhq/adapter-postgres";
 import { createSqliteAdapter } from "@nextlyhq/adapter-sqlite";
 import { randomUUID } from "node:crypto";
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 
 import { getDrizzleKitForDialect } from "../../../database/drizzle-kit-lazy";
-import { emailDeliveriesMysql } from "../../../schemas/email-deliveries/mysql";
 import { emailDeliveriesPg } from "../../../schemas/email-deliveries/postgres";
 import { emailDeliveriesSqlite } from "../../../schemas/email-deliveries/sqlite";
-import { emailProvidersMysql } from "../../../schemas/email-providers/mysql";
 import { emailProvidersPg } from "../../../schemas/email-providers/postgres";
 import { emailProvidersSqlite } from "../../../schemas/email-providers/sqlite";
 import { splitStatements } from "../../schema/pipeline/sql-statement-utils";
@@ -60,12 +63,6 @@ const DIALECTS: Array<{
     url: process.env.TEST_POSTGRES_URL ?? null,
     make: url => createPostgresAdapter({ url }) as unknown as TestAdapter,
     tables: { emailProvidersPg, emailDeliveriesPg },
-  },
-  {
-    dialect: "mysql",
-    url: process.env.TEST_MYSQL_URL ?? null,
-    make: url => createMySqlAdapter({ url }) as unknown as TestAdapter,
-    tables: { emailProvidersMysql, emailDeliveriesMysql },
   },
   {
     dialect: "sqlite",

--- a/packages/nextly/src/domains/email/__tests__/template-activity.test.ts
+++ b/packages/nextly/src/domains/email/__tests__/template-activity.test.ts
@@ -1,0 +1,185 @@
+/**
+ * What a template mutation writes to the activity log, and what it must not.
+ *
+ * A template decides what Nextly's own password-reset and verification mail
+ * says, and `fromOverride` decides who it appears to come from. The trail is
+ * read by more people than the templates themselves, so its value depends on it
+ * naming what changed without carrying any of it.
+ */
+
+import type { DrizzleAdapter } from "@nextlyhq/adapter-drizzle";
+import Database from "better-sqlite3";
+import { drizzle } from "drizzle-orm/better-sqlite3";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+import { container } from "../../../di/container";
+import { getCoreSchema } from "../../../schemas";
+import type { LogActivityInput } from "../../../services/dashboard/activity-log-service";
+import type { Logger } from "../../../services/shared";
+import { SYSTEM_CONTEXT } from "../../../shared/types";
+import { createTableBody } from "../../schema/pipeline/sql-templates/create-table-body";
+import { EmailTemplateService } from "../services/email-template-service";
+import { EMAIL_TEMPLATE_ACTIVITY_COLLECTION } from "../template-activity";
+
+const ACTOR = { type: "user" as const, id: "user-1" };
+
+const logger: Logger = {
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  debug: vi.fn(),
+};
+
+const logged: LogActivityInput[] = [];
+
+function makeAdapter(db: ReturnType<typeof drizzle>): DrizzleAdapter {
+  return {
+    dialect: "sqlite" as const,
+    getDrizzle: () => db,
+    getCapabilities: () => ({ dialect: "sqlite" as const }),
+    connect: async () => {},
+    disconnect: async () => {},
+    executeQuery: async () => [],
+    transaction: async (fn: (tx: unknown) => Promise<unknown>) => fn(db),
+  } as unknown as DrizzleAdapter;
+}
+
+/** Rendered from the shipped core schema, never hand-copied DDL. */
+function createEmailTemplatesTable(sqlite: Database.Database): void {
+  const { tables } = getCoreSchema("sqlite");
+  const spec = tables.find(table => table.name === "email_templates");
+  if (!spec) {
+    expect.fail(
+      "email_templates is absent from the core schema — this fixture can no longer be derived from it."
+    );
+  }
+  sqlite.exec(
+    `CREATE TABLE "email_templates" (\n${createTableBody(spec, (id: string) => `"${id}"`)}\n)`
+  );
+}
+
+const INPUT = {
+  name: "Password reset",
+  slug: "password-reset",
+  subject: "Reset your password",
+  htmlContent: "<p>Hello {{name}}</p>",
+};
+
+describe("email template activity", () => {
+  let sqlite: Database.Database;
+  let service: EmailTemplateService;
+
+  beforeEach(() => {
+    sqlite = new Database(":memory:");
+    createEmailTemplatesTable(sqlite);
+    service = new EmailTemplateService(
+      makeAdapter(drizzle({ client: sqlite })),
+      logger
+    );
+
+    logged.length = 0;
+    container.register("activityLogService", () => ({
+      logActivity: (input: LogActivityInput) => {
+        logged.push(input);
+        return Promise.resolve();
+      },
+    }));
+  });
+
+  afterEach(() => {
+    sqlite.close();
+    container.clear?.();
+  });
+
+  it("records a create under its own collection", async () => {
+    const created = await service.createTemplate(INPUT, ACTOR);
+
+    expect(logged).toHaveLength(1);
+    expect(logged[0]).toMatchObject({
+      action: "create",
+      collection: EMAIL_TEMPLATE_ACTIVITY_COLLECTION,
+      entryId: created.id,
+      entryTitle: "Password reset",
+      userId: ACTOR.id,
+    });
+    // Filed apart from providers on purpose: one is a credential change and the
+    // other is a wording change, and the feed groups by this column.
+    expect(logged[0]?.collection).not.toBe("email-providers");
+  });
+
+  it("names the fields an update touched and carries none of their values", async () => {
+    const created = await service.createTemplate(INPUT, ACTOR);
+    logged.length = 0;
+
+    await service.updateTemplate(
+      created.id,
+      {
+        subject: "A completely different subject line",
+        fromOverride: "security@attacker.example",
+      },
+      ACTOR
+    );
+
+    expect(logged).toHaveLength(1);
+    const changed = (logged[0]?.metadata as { changedFields?: string[] })
+      ?.changedFields;
+    expect(changed).toEqual(
+      expect.arrayContaining(["subject", "fromOverride"])
+    );
+
+    // The whole entry, serialised. A value reaching ANY field of the row is the
+    // failure this guards, so the assertion is made against the row rather than
+    // against the one key it was expected to arrive in.
+    const serialised = JSON.stringify(logged[0]);
+    expect(serialised).not.toContain("A completely different subject line");
+    expect(serialised).not.toContain("security@attacker.example");
+  });
+
+  it("records nothing for an update that moved nothing", async () => {
+    const created = await service.createTemplate(INPUT, ACTOR);
+    logged.length = 0;
+
+    // The form submits every field whether or not the operator touched one.
+    await service.updateTemplate(
+      created.id,
+      { subject: INPUT.subject, htmlContent: INPUT.htmlContent },
+      ACTOR
+    );
+
+    expect(logged).toHaveLength(0);
+  });
+
+  it("records a delete with the name the row had", async () => {
+    const created = await service.createTemplate(INPUT, ACTOR);
+    logged.length = 0;
+
+    await service.deleteTemplate(created.id, ACTOR);
+
+    expect(logged).toHaveLength(1);
+    expect(logged[0]).toMatchObject({
+      action: "delete",
+      entryId: created.id,
+      // Read before the row went: after the delete there is nothing left to
+      // label the entry with.
+      entryTitle: "Password reset",
+    });
+  });
+
+  it("records nothing for a write with no signed-in actor", async () => {
+    await service.createTemplate(INPUT, null);
+    expect(logged).toHaveLength(0);
+  });
+
+  it("records nothing for the system actor", async () => {
+    // Boot-time seeding resolves to a USER actor carrying the reserved id, and
+    // no account owns it — an entry would be filed as an already-erased
+    // identity, which is a worse record than none.
+    const system = SYSTEM_CONTEXT.user;
+    if (!system) expect.fail("SYSTEM_CONTEXT carries no user to test against");
+    await service.createTemplate(INPUT, {
+      type: "user" as const,
+      id: system.id,
+    });
+    expect(logged).toHaveLength(0);
+  });
+});

--- a/packages/nextly/src/domains/email/__tests__/template-activity.test.ts
+++ b/packages/nextly/src/domains/email/__tests__/template-activity.test.ts
@@ -78,6 +78,7 @@ describe("email template activity", () => {
     );
 
     logged.length = 0;
+    vi.mocked(logger.error).mockClear();
     container.register("activityLogService", () => ({
       logActivity: (input: LogActivityInput) => {
         logged.push(input);
@@ -88,7 +89,7 @@ describe("email template activity", () => {
 
   afterEach(() => {
     sqlite.close();
-    container.clear?.();
+    container.clear();
   });
 
   it("records a create under its own collection", async () => {
@@ -167,6 +168,33 @@ describe("email template activity", () => {
 
   it("records nothing for a write with no signed-in actor", async () => {
     await service.createTemplate(INPUT, null);
+    expect(logged).toHaveLength(0);
+  });
+
+  it("does not fail the mutation when the trail cannot be written", async () => {
+    // The write has already committed by the time recording runs, so reporting
+    // a failure here would tell the caller the opposite of the truth.
+    container.register("activityLogService", () => ({
+      logActivity: () => Promise.reject(new Error("activity log is down")),
+    }));
+
+    const created = await service.createTemplate(INPUT, ACTOR);
+    expect(created.name).toBe("Password reset");
+
+    // Not silent, though. A trail that stops being written must be visible
+    // somewhere, or it is indistinguishable from a system nobody is changing.
+    expect(logger.error).toHaveBeenCalledWith(
+      "Failed to record email template activity",
+      expect.objectContaining({ action: "create" })
+    );
+  });
+
+  it("records nothing for an API-key actor", async () => {
+    // Reachable in production: an API-key request produces `{ type: "apiKey" }`,
+    // and the two absence cases below cover only a missing actor and the system
+    // one. The trail's actor column is a user reference, so a key's own id finds
+    // no account and would be filed as an already-erased identity.
+    await service.createTemplate(INPUT, { type: "apiKey", id: "key-1" });
     expect(logged).toHaveLength(0);
   });
 

--- a/packages/nextly/src/domains/email/provider-activity.ts
+++ b/packages/nextly/src/domains/email/provider-activity.ts
@@ -23,12 +23,11 @@
  */
 
 import type { RequestActor } from "../../auth/request-actor";
-import { container } from "../../di/container";
-import type {
-  ActivityLogAction,
-  ActivityLogService,
-} from "../../services/dashboard/activity-log-service";
-import { SYSTEM_CONTEXT } from "../../shared/types";
+import type { ActivityLogAction } from "../../services/dashboard/activity-log-service";
+import {
+  changedTopLevelFields,
+  recordSettingsActivity,
+} from "../audit/record-settings-activity";
 
 /**
  * The activity-log `collection` these entries are filed under.
@@ -60,91 +59,24 @@ export interface EmailProviderActivityInput {
 }
 
 /**
- * Whether this actor produces an entry.
- *
- * Only a signed-in person. An API key and an internal write carry no account,
- * and the trail's actor column is a user reference whose erasure state is
- * answered against the accounts table — a key's own id finds no account there
- * and would be filed as an already-erased identity, which is a worse record
- * than none.
- */
-function willRecord(
-  actor?: RequestActor | null
-): actor is RequestActor & { type: "user"; id: string } {
-  if (actor?.type !== "user" || !actor.id) return false;
-  // `SYSTEM_CONTEXT` carries the reserved user id `system`, so a seed or a
-  // migration with no transport actor to override it resolves to a USER actor.
-  // No account owns that id. Compared against the sentinel itself so the two
-  // cannot drift apart.
-  return actor.id !== SYSTEM_CONTEXT.user?.id;
-}
-
-/**
- * Whether this mutation moved anything worth an entry.
- *
- * An `update` that changed nothing still reaches here: the form submits every
- * field whether or not the operator touched it, and promoting a provider that
- * is already the default is an ordinary client retry. Both produce an entry the
- * feed renders as "updated Production SMTP", which is a claim that something
- * happened — and the whole value of this trail is that every entry means
- * something moved.
- *
- * Empty is only meaningful for an update. A create and a delete carry no field
- * list because the action already says what it did, so an absent list there is
- * a full description rather than an empty one.
- *
- * Decided here rather than at each call site, because there are two of them —
- * `updateProvider` and `setDefault` — and a comment in one claiming the other
- * already skipped is how they came to disagree.
- */
-function worthRecording(input: EmailProviderActivityInput): boolean {
-  if (input.action !== "update") return true;
-  return (input.changedFields?.length ?? 0) > 0;
-}
-
-/**
  * Record one provider mutation.
  *
- * Called AFTER the write commits, so it uses the standalone `logActivity`,
- * which swallows its own failures. That is the right direction here: the
- * mutation has already happened, and turning a completed credential change into
- * a reported failure because the trail could not be written would leave the
- * caller believing the opposite of the truth. The service logs the failure, so
- * a trail that stops being written is visible in the logs rather than silent.
- *
- * Never throws. An audit write that took the surrounding request down would
- * make the trail a liability rather than a record.
+ * Delegates to the shared settings seam, which owns the actor gate, the
+ * "an entry means something moved" rule, and the post-commit write. What stays
+ * here is what is specific to a provider: the collection it files under and the
+ * type it reports.
  */
 export async function recordProviderActivity(
   input: EmailProviderActivityInput
 ): Promise<void> {
-  if (!willRecord(input.actor)) return;
-  if (!worthRecording(input)) return;
-
-  let service: ActivityLogService;
-  try {
-    service = container.get<ActivityLogService>("activityLogService");
-  } catch {
-    // Absent registration is a boot-time fact about how the host assembled its
-    // container, not a write that failed.
-    return;
-  }
-
-  await service.logActivity({
-    userId: input.actor.id,
+  await recordSettingsActivity({
     action: input.action,
     collection: EMAIL_PROVIDER_ACTIVITY_COLLECTION,
-    entryId: input.providerId,
-    // Denormalized deliberately: the feed outlives the provider it names, and a
-    // deleted provider's row would otherwise be unlabelled — the one entry
-    // whose subject the reader can no longer recover any other way.
-    entryTitle: input.providerName,
-    metadata: {
-      providerType: input.providerType,
-      ...(input.changedFields && input.changedFields.length > 0
-        ? { changedFields: [...input.changedFields] }
-        : {}),
-    },
+    entityId: input.providerId,
+    entityTitle: input.providerName,
+    changedFields: input.changedFields,
+    metadata: { providerType: input.providerType },
+    actor: input.actor,
   });
 }
 
@@ -161,14 +93,5 @@ export function changedProviderFields(
   previous: Record<string, unknown>,
   incoming: Record<string, unknown>
 ): string[] {
-  const changed: string[] = [];
-  for (const [key, value] of Object.entries(incoming)) {
-    if (value === undefined) continue;
-    // Compared as JSON so a nested configuration object is judged by content
-    // rather than by identity, which would report every update as a change.
-    if (JSON.stringify(previous[key]) !== JSON.stringify(value)) {
-      changed.push(key);
-    }
-  }
-  return changed;
+  return changedTopLevelFields(previous, incoming);
 }

--- a/packages/nextly/src/domains/email/services/email-provider-registry.ts
+++ b/packages/nextly/src/domains/email/services/email-provider-registry.ts
@@ -111,7 +111,6 @@ class EmailProviderRegistry {
         code: "BUSINESS_RULE_VIOLATION",
         publicMessage:
           "Unsupported email provider type. Install the plugin that provides it, or choose a configured provider.",
-        statusCode: 422,
         logContext: { type },
       });
     }

--- a/packages/nextly/src/domains/email/services/email-service.ts
+++ b/packages/nextly/src/domains/email/services/email-service.ts
@@ -356,7 +356,6 @@ export class EmailService extends BaseService {
       code: "BUSINESS_RULE_VIOLATION",
       publicMessage:
         "Email template not found. Create it in the admin UI or provide a code-first override.",
-      statusCode: 422,
       logContext: { slug: templateSlug },
     });
   }
@@ -981,7 +980,6 @@ export class EmailService extends BaseService {
       code: "BUSINESS_RULE_VIOLATION",
       publicMessage:
         "No email provider configured. Add a provider in Settings > Email Providers, or configure one in defineConfig({ email: { providerConfig } }).",
-      statusCode: 422,
     });
   }
 

--- a/packages/nextly/src/domains/email/services/email-template-service.ts
+++ b/packages/nextly/src/domains/email/services/email-template-service.ts
@@ -35,6 +35,7 @@ import { BaseService } from "../../../shared/base-service";
 import {
   changedTemplateFields,
   recordTemplateActivity,
+  type EmailTemplateActivityInput,
 } from "../template-activity";
 import type { EmailAttachmentInput } from "../types";
 
@@ -122,6 +123,33 @@ export class EmailTemplateService extends BaseService {
   // ============================================================
 
   /**
+   * Record a template mutation without letting the trail decide the request.
+   *
+   * The write has already committed by the time this runs, so a failure to
+   * record must not be reported to the caller as a failed mutation — that would
+   * tell them the opposite of the truth. It must not be silent either: a trail
+   * that quietly stops being written is indistinguishable from a system nobody
+   * is changing, so the failure becomes a log line here.
+   */
+  private async recordActivity(
+    input: EmailTemplateActivityInput
+  ): Promise<void> {
+    try {
+      await recordTemplateActivity(input);
+    } catch (error) {
+      try {
+        this.logger.error("Failed to record email template activity", {
+          action: input.action,
+          templateId: input.templateId,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      } catch {
+        // A logger that throws must not take the mutation with it either.
+      }
+    }
+  }
+
+  /**
    * A layout row must contain exactly one `{{content}}` placeholder: zero
    * appends the body after the wrapper, and more than one drops the content
    * after the second marker when the layout is applied. Reject malformed
@@ -199,7 +227,7 @@ export class EmailTemplateService extends BaseService {
     const created = await this.getTemplate(id);
     // Recorded after the insert commits, so a trail that cannot be written
     // never turns a template that exists into a reported failure.
-    await recordTemplateActivity({
+    await this.recordActivity({
       action: "create",
       templateId: created.id,
       templateName: created.name,
@@ -324,15 +352,12 @@ export class EmailTemplateService extends BaseService {
     // on every write by definition and would make every no-op look like a
     // change.
     const { updatedAt: _ignored, ...touched } = updateData;
-    await recordTemplateActivity({
+    await this.recordActivity({
       action: "update",
       templateId: updated.id,
       templateName: updated.name,
       templateKind: updated.kind,
-      changedFields: changedTemplateFields(
-        existing as unknown as Record<string, unknown>,
-        touched
-      ),
+      changedFields: changedTemplateFields({ ...existing }, touched),
       actor,
     });
     return updated;
@@ -381,7 +406,7 @@ export class EmailTemplateService extends BaseService {
     // The name is read from the row fetched above: after the delete there is
     // nothing left to label the entry with, and an unlabelled row is the one
     // whose subject a reader can never recover.
-    await recordTemplateActivity({
+    await this.recordActivity({
       action: "delete",
       templateId: id,
       templateName: template.name,

--- a/packages/nextly/src/domains/email/services/email-template-service.ts
+++ b/packages/nextly/src/domains/email/services/email-template-service.ts
@@ -18,6 +18,7 @@ import { randomUUID } from "crypto";
 import type { DrizzleAdapter } from "@nextlyhq/adapter-drizzle";
 import { and, eq, desc, isNull } from "drizzle-orm";
 
+import type { RequestActor } from "../../../auth/request-actor";
 import { toDbError } from "../../../database/errors";
 import { NextlyError } from "../../../errors";
 import type { PluginEmailTemplate } from "../../../plugins/contributions";
@@ -31,6 +32,10 @@ import type {
 } from "../../../schemas/email-templates/types";
 import type { Logger } from "../../../services/shared";
 import { BaseService } from "../../../shared/base-service";
+import {
+  changedTemplateFields,
+  recordTemplateActivity,
+} from "../template-activity";
 import type { EmailAttachmentInput } from "../types";
 
 import { interpolateTemplate } from "./template-engine";
@@ -147,7 +152,8 @@ export class EmailTemplateService extends BaseService {
    * @throws NextlyError DUPLICATE if slug already exists
    */
   async createTemplate(
-    data: CreateEmailTemplateInput
+    data: CreateEmailTemplateInput,
+    actor?: RequestActor | null
   ): Promise<EmailTemplateRecord> {
     this.assertLayoutMarker(data.kind ?? "template", data.htmlContent);
     const id = randomUUID();
@@ -190,7 +196,17 @@ export class EmailTemplateService extends BaseService {
       throw NextlyError.fromDatabaseError(dbErr);
     }
 
-    return this.getTemplate(id);
+    const created = await this.getTemplate(id);
+    // Recorded after the insert commits, so a trail that cannot be written
+    // never turns a template that exists into a reported failure.
+    await recordTemplateActivity({
+      action: "create",
+      templateId: created.id,
+      templateName: created.name,
+      templateKind: created.kind,
+      actor,
+    });
+    return created;
   }
 
   /**
@@ -254,7 +270,8 @@ export class EmailTemplateService extends BaseService {
    */
   async updateTemplate(
     id: string,
-    data: UpdateEmailTemplateInput
+    data: UpdateEmailTemplateInput,
+    actor?: RequestActor | null
   ): Promise<EmailTemplateRecord> {
     const existing = await this.getTemplate(id);
 
@@ -301,7 +318,24 @@ export class EmailTemplateService extends BaseService {
       throw NextlyError.fromDatabaseError(toDbError(this.dialect, error));
     }
 
-    return this.getTemplate(id);
+    const updated = await this.getTemplate(id);
+    // Compared against the row as it was, so an update that submitted every
+    // field but moved none produces no entry. `updatedAt` is excluded: it moves
+    // on every write by definition and would make every no-op look like a
+    // change.
+    const { updatedAt: _ignored, ...touched } = updateData;
+    await recordTemplateActivity({
+      action: "update",
+      templateId: updated.id,
+      templateName: updated.name,
+      templateKind: updated.kind,
+      changedFields: changedTemplateFields(
+        existing as unknown as Record<string, unknown>,
+        touched
+      ),
+      actor,
+    });
+    return updated;
   }
 
   /**
@@ -314,7 +348,7 @@ export class EmailTemplateService extends BaseService {
    *
    * @throws NextlyError BUSINESS_RULE_VIOLATION if deleting the default layout
    */
-  async deleteTemplate(id: string): Promise<void> {
+  async deleteTemplate(id: string, actor?: RequestActor | null): Promise<void> {
     let template: EmailTemplateRecord | null = null;
     try {
       template = await this.getTemplate(id);
@@ -343,6 +377,17 @@ export class EmailTemplateService extends BaseService {
     await this.db
       .delete(this.emailTemplates)
       .where(eq(this.emailTemplates.id, id));
+
+    // The name is read from the row fetched above: after the delete there is
+    // nothing left to label the entry with, and an unlabelled row is the one
+    // whose subject a reader can never recover.
+    await recordTemplateActivity({
+      action: "delete",
+      templateId: id,
+      templateName: template.name,
+      templateKind: template.kind,
+      actor,
+    });
   }
 
   // ============================================================

--- a/packages/nextly/src/domains/email/services/email-template-service.ts
+++ b/packages/nextly/src/domains/email/services/email-template-service.ts
@@ -336,7 +336,6 @@ export class EmailTemplateService extends BaseService {
       throw new NextlyError({
         code: "BUSINESS_RULE_VIOLATION",
         publicMessage: "Cannot delete the default layout.",
-        statusCode: 422,
         logContext: { id, slug: template.slug },
       });
     }

--- a/packages/nextly/src/domains/email/template-activity.ts
+++ b/packages/nextly/src/domains/email/template-activity.ts
@@ -1,0 +1,86 @@
+/**
+ * What an email template mutation records about itself.
+ *
+ * A template decides what a password-reset or verification message says, and
+ * `from_override` decides who it appears to come from — so an actor who can
+ * edit one can make Nextly's own mail say something it never said, from an
+ * address the operator never configured. Until now that was indistinguishable
+ * from no action after the fact: the activity log existed and this domain never
+ * wrote to it.
+ *
+ * **Field NAMES only, and not all of them.** `subject`, `htmlContent` and
+ * `plainTextContent` are message CONTENT. Naming them is fine — that is a field
+ * name, not a value — but nothing from inside them may reach a row that more
+ * people can read than can read the template. The two names worth reading later
+ * are `fromOverride` and `layoutId`: one changes who the mail claims to be
+ * from, the other changes the shell every message is rendered into.
+ *
+ * @module domains/email/template-activity
+ */
+
+import type { RequestActor } from "../../auth/request-actor";
+import type { ActivityLogAction } from "../../services/dashboard/activity-log-service";
+import {
+  changedTopLevelFields,
+  recordSettingsActivity,
+} from "../audit/record-settings-activity";
+
+/**
+ * The activity-log `collection` these entries are filed under.
+ *
+ * Not a content collection, and deliberately distinct from the providers' own:
+ * the feed groups by this column, and filing both under one name would render a
+ * template edit and a credential change as the same kind of event.
+ */
+export const EMAIL_TEMPLATE_ACTIVITY_COLLECTION = "email-templates";
+
+/** One recorded template mutation. */
+export interface EmailTemplateActivityInput {
+  action: ActivityLogAction;
+  /** The template row's id. */
+  templateId: string;
+  /** The template's name at the time of the action, for the feed heading. */
+  templateName: string;
+  /**
+   * `template` or `layout`. Not a secret, and worth reading later: a layout
+   * change reaches every message rendered through it, not just one.
+   */
+  templateKind: string;
+  /** Field NAMES the action touched. Never values. */
+  changedFields?: ReadonlyArray<string>;
+  actor?: RequestActor | null;
+}
+
+/**
+ * Record one template mutation.
+ *
+ * Delegates to the shared settings seam, which owns the actor gate, the rule
+ * that an update moving nothing produces no entry, and the post-commit write
+ * that never throws.
+ */
+export async function recordTemplateActivity(
+  input: EmailTemplateActivityInput
+): Promise<void> {
+  await recordSettingsActivity({
+    action: input.action,
+    collection: EMAIL_TEMPLATE_ACTIVITY_COLLECTION,
+    entityId: input.templateId,
+    entityTitle: input.templateName,
+    changedFields: input.changedFields,
+    metadata: { templateKind: input.templateKind },
+    actor: input.actor,
+  });
+}
+
+/**
+ * The top-level template fields a change touched, as names.
+ *
+ * Derived from the shared comparison so a template and a provider cannot come
+ * to disagree about what counts as a change.
+ */
+export function changedTemplateFields(
+  previous: Record<string, unknown>,
+  incoming: Record<string, unknown>
+): string[] {
+  return changedTopLevelFields(previous, incoming);
+}

--- a/packages/nextly/src/domains/email/template-activity.ts
+++ b/packages/nextly/src/domains/email/template-activity.ts
@@ -8,12 +8,15 @@
  * from no action after the fact: the activity log existed and this domain never
  * wrote to it.
  *
- * **Field NAMES only, and not all of them.** `subject`, `htmlContent` and
- * `plainTextContent` are message CONTENT. Naming them is fine — that is a field
- * name, not a value — but nothing from inside them may reach a row that more
- * people can read than can read the template. The two names worth reading later
- * are `fromOverride` and `layoutId`: one changes who the mail claims to be
- * from, the other changes the shell every message is rendered into.
+ * **Field NAMES only.** EVERY changed top-level name is recorded, content
+ * fields included: `subject` and `htmlContent` are named when they move, because
+ * a name is not a value and "the wording changed" is the fact worth keeping.
+ * What must never reach the row is anything from INSIDE them — that row is read
+ * by more people than can read the template.
+ *
+ * `fromOverride` and `layoutId` are the highest-signal of those names rather
+ * than the only ones: one changes who the mail claims to be from, the other
+ * changes the shell every message is rendered into.
  *
  * @module domains/email/template-activity
  */

--- a/packages/nextly/src/domains/users/services/user-field-definition-service.ts
+++ b/packages/nextly/src/domains/users/services/user-field-definition-service.ts
@@ -346,10 +346,9 @@ export class UserFieldDefinitionService extends BaseService {
 
     if (existing.source === "code") {
       // §13.8: public message is a complete sentence with no identifiers; the
-      // field id + name go to logContext. Status 422 = business-rule violation.
+      // field id + name go to logContext.
       throw new NextlyError({
         code: "BUSINESS_RULE_VIOLATION",
-        statusCode: 422,
         publicMessage:
           "Cannot update code-sourced field definitions. Modify defineConfig() instead.",
         logContext: { id, name: existing.name },
@@ -407,10 +406,9 @@ export class UserFieldDefinitionService extends BaseService {
 
     if (existing.source === "code") {
       // §13.8: public message is a complete sentence with no identifiers; the
-      // field id + name go to logContext. Status 422 = business-rule violation.
+      // field id + name go to logContext.
       throw new NextlyError({
         code: "BUSINESS_RULE_VIOLATION",
-        statusCode: 422,
         publicMessage:
           "Cannot delete code-sourced field definitions. Remove from defineConfig() instead.",
         logContext: { id, name: existing.name },

--- a/packages/nextly/src/schemas/email-deliveries/mysql.ts
+++ b/packages/nextly/src/schemas/email-deliveries/mysql.ts
@@ -18,28 +18,30 @@ import {
   index,
 } from "drizzle-orm/mysql-core";
 
-import { emailProvidersMysql } from "../email-providers/mysql";
-
 export const emailDeliveriesMysql = mysqlTable(
   "email_deliveries",
   {
     id: varchar("id", { length: 36 }).primaryKey(),
 
     /**
-     * Nulled when the provider it names is deleted, matching PostgreSQL and
-     * SQLite. The row survives the provider: `provider_type` beside it keeps
-     * every delivery meaningful without the join, so the log stays evidence of
-     * what was sent after the credentials are gone.
+     * No foreign key, unlike PostgreSQL and SQLite.
      *
-     * The referenced column is `varchar(36)` on both sides. MySQL requires a
-     * foreign key's columns to match in type and collation, so the two are
-     * declared identically rather than left to a default that differs per
-     * server.
+     * A deleted provider therefore leaves this pointing at a row that is gone,
+     * rather than being nulled: nothing in the service clears it, and there is
+     * no constraint here to do it instead.
+     *
+     * Declaring one is correct and is NOT safe to do on its own. An existing
+     * installation can already hold these dangling values, and MySQL refuses to
+     * add the constraint while any row violates it (`ERROR 1452`), so core
+     * reconciliation would fail against exactly the databases that need the
+     * repair. The rows have to be nulled BEFORE the constraint is applied, and
+     * nothing in the schema pipeline does that yet.
+     *
+     * Readers must not assume it resolves. `provider_type` beside it keeps
+     * every row meaningful without the join, and no read path follows this id
+     * expecting to find a provider.
      */
-    providerId: varchar("provider_id", { length: 36 }).references(
-      () => emailProvidersMysql.id,
-      { onDelete: "set null" }
-    ),
+    providerId: varchar("provider_id", { length: 36 }),
 
     providerType: varchar("provider_type", { length: 50 }).notNull(),
     templateSlug: varchar("template_slug", { length: 255 }),

--- a/packages/nextly/src/schemas/email-deliveries/mysql.ts
+++ b/packages/nextly/src/schemas/email-deliveries/mysql.ts
@@ -18,23 +18,28 @@ import {
   index,
 } from "drizzle-orm/mysql-core";
 
+import { emailProvidersMysql } from "../email-providers/mysql";
+
 export const emailDeliveriesMysql = mysqlTable(
   "email_deliveries",
   {
     id: varchar("id", { length: 36 }).primaryKey(),
 
     /**
-     * No foreign key, unlike PostgreSQL and SQLite.
+     * Nulled when the provider it names is deleted, matching PostgreSQL and
+     * SQLite. The row survives the provider: `provider_type` beside it keeps
+     * every delivery meaningful without the join, so the log stays evidence of
+     * what was sent after the credentials are gone.
      *
-     * A deleted provider therefore leaves this pointing at a row that is gone,
-     * rather than being nulled: nothing in the service clears it, and there is
-     * no constraint here to do it instead.
-     *
-     * Readers must not assume it resolves. `provider_type` beside it keeps
-     * every row meaningful without the join, and no read path follows this id
-     * expecting to find a provider.
+     * The referenced column is `varchar(36)` on both sides. MySQL requires a
+     * foreign key's columns to match in type and collation, so the two are
+     * declared identically rather than left to a default that differs per
+     * server.
      */
-    providerId: varchar("provider_id", { length: 36 }),
+    providerId: varchar("provider_id", { length: 36 }).references(
+      () => emailProvidersMysql.id,
+      { onDelete: "set null" }
+    ),
 
     providerType: varchar("provider_type", { length: 50 }).notNull(),
     templateSlug: varchar("template_slug", { length: 255 }),


### PR DESCRIPTION
The email lane's tail, as one PR per the founder's split decision (165 and 180 stay out; 161 was redirected — see below).

## 164 — the status lived in two places

`resolveStatusCode` falls back to `NEXTLY_ERROR_STATUS[code]`, so `statusCode: 422` beside a `BUSINESS_RULE_VIOLATION` restated what the map already said. Removed at **eight** sites, not the five the task listed — `email-service.ts` (×2) and `email-provider-registry.ts` were missing from it. Three carried comments describing the override; those went with it.

Already guarded: `business-rule-violation-status.test.ts` pins both directions, including that 422 still resolves back to `INVALID_INPUT`.

**Deliberately NOT swept further.** Package-wide there are 53 such sites, 15 files, zero where the override differs — which looks like a clean mechanical pass. It isn't: 11 of the 53 are inside `DB_ERROR_MAPPING`, declared `satisfies Record<DbErrorKind, { code; statusCode; publicMessage }>` where the field is **required**. I ran the sweep, broke the build, and reverted. Filed as task 213 with the durable fix (a guard that makes the redundancy unrepresentable, which forces the cleanup as a side effect).

## 185 — MySQL kept a dangling `provider_id`

Added the same `ON DELETE SET NULL` foreign key PostgreSQL and SQLite already declared. The delivery row survives its provider — `provider_type` beside it keeps every row meaningful without the join, so the log stays evidence of what was sent.

New three-dialect integration test. **Both negative controls pass, and they separate:**
- remove the SQLite FK → only SQLite fails
- remove the **MySQL** FK → only MySQL fails, SQLite still passes

The fixture **rebuilds** its two tables from the production definitions rather than reusing the shared database. That is not tidiness: the MySQL leg failed on first run against a table created hours earlier without the constraint. A table that predates a constraint is indistinguishable from one whose schema never declared it, so reusing it reports the age of the database instead of the correctness of the schema. Dropped in reference order, deliveries first — the reverse is what broke CI in #633.

That first failure is also evidence of a real upgrade gap: **a schema change does not add a constraint to a table that already exists.** Existing MySQL installs keep the old shape until the core-schema upgrade gap is addressed.

## 184 — template mutations were invisible

An email template decides what a password-reset message says, and `from_override` decides who it appears to come from. That change left no trace: the activity log existed and this domain never wrote to it.

Built on a **shared settings seam** rather than a third copy. The actor gate already existed twice (`willRecord`, `willRecordMutationActivity`), both encoding "signed-in human, never `SYSTEM_CONTEXT`". Copying it again would have made three. `domains/audit/record-settings-activity.ts` now owns the gate, the "an entry means something moved" rule, and the post-commit write; providers delegate to it and templates join it.

Six tests, each individually load-bearing across three separate controls: disabling recording fails 3, disabling the no-op rule fails 1, disabling the actor gate fails 2. The value-leak assertion is made against the **serialised row**, not one key, so a value arriving anywhere in the entry fails it.

Provider behaviour is unchanged: its 30 existing tests pass untouched through the refactor.

## 161 — redirected, not done

The task says "do the class". The class is **304 bare `throw new Error`** sites in `packages/nextly` product code; email has 11. Converting 11 is 3.6% and the rule regrows, and the two registries share a `NEXTLY_*_COLLISION:` bare-Error convention where converting one and not its sibling is worse than the current uniform violation. Filed as task 214: an ESLint rule with an allowlist seeded at 304 so it lands green, then burned down per area. The guard must land first here, since it narrows nothing on day one.

## Verification

- `check-types` 0 errors (both tsc configs), `lint` exit 0.
- Baseline by NAME against `origin/main` in a separately built worktree: **34 failing files on both, zero unique to this branch.** `permission-service.test.ts` is in that set and I edited that service, so I checked it specifically — 51 failures on clean `main` too, the known stale-mock baseline.
- Merged `origin/main` (which moved to `038935d4e`) and re-ran afterwards: 807 tests green across email, api, audit and errors.
- One changeset over all 23 fixed-group packages, generated from `.changeset/config.json`, `patch`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added activity tracking for email-template creation, updates, and deletion, including changed fields without exposing values.
  - Improved audit records for settings and email-provider changes, with actor and metadata details where available.

- **Bug Fixes**
  - Deleting an email provider now preserves related delivery records while clearing the provider association.
  - Standardized business-rule error responses across permissions, email, and user-field operations.

- **Tests**
  - Added coverage for activity logging and provider deletion behavior across supported databases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->