### PR TITLE
test(blocks-react): pin visual defaults out of a core block's root

### DIFF
--- a/packages/blocks-react/src/blocks/visual-defaults.test.tsx
+++ b/packages/blocks-react/src/blocks/visual-defaults.test.tsx
@@ -1,3 +1,4 @@
+import { renderToStaticMarkup } from "react-dom/server";
 /**
  * A core block's visual defaults are DATA, never declarations written on its root.
  *
@@ -35,8 +36,7 @@
 import { describe, expect, it } from "vitest";
 
 import type { BlockNode } from "@nextlyhq/blocks-engine";
-import { isValidElement } from "react";
-import type { ReactElement, ReactNode } from "react";
+import type { ReactElement } from "react";
 
 import type { BlockRenderArgs, PageContext } from "../context";
 
@@ -72,44 +72,36 @@ function context(): PageContext {
 }
 
 /**
- * The element a block puts its own `className` on, found in the tree it returns.
+ * The attributes of the element a block puts its own `className` on, as a browser would receive it.
  *
- * The RENDERED element rather than serialized markup, and the element carrying the CLASS rather than
- * the first opening tag. Both matter:
+ * Rendered to markup and read back rather than inspected as a React element tree. The tree is what
+ * the block AUTHORED, and a root delegated to a component — `render: () => <Root className={x} />` —
+ * appears there as an unexecuted `<Root>` whose own props carry no style, while the host element it
+ * eventually returns carries both the class and the declaration. Rendering through is what closes
+ * that, and it is also what a page actually ships.
  *
- * - A block may wrap its content, so the outermost tag is not necessarily the one the compiled rules
- *   land on. Reading the first tag would inspect a wrapper and leave the conflicting declaration on
- *   the classed descendant unexamined.
- * - `style` is read as a PROP, so nothing depends on how React serializes it. Matching text in an
- *   opening tag cannot tell a real `style` attribute from `title="use style=compact"` or from a class
- *   token containing the same characters, and a guard that rejects those costs an unrelated change a
- *   red build.
+ * Found by CLASS rather than by position, so a block that wraps its content is read at the element
+ * the compiled rules land on rather than at the wrapper.
  *
- * Returns every classed element, not the first. A block placing the class twice is malformed in a way
- * worth failing on rather than silently reading one of them.
+ * Attribute NAMES are enumerated rather than the text being searched. React escapes `"` inside a
+ * value as `&quot;`, so quotes delimit values unambiguously in its own output and this parse is
+ * sound for it — which is what lets `title="use style=compact"` be read as a `title`, where matching
+ * the text reports a style attribute that is not there.
  */
-function classedElements(node: ReactNode, className: string): ReactElement[] {
-  const found: ReactElement[] = [];
-  const walk = (current: ReactNode): void => {
-    if (Array.isArray(current)) {
-      for (const child of current) walk(child);
-      return;
-    }
-    if (!isValidElement(current)) return;
-    const props = current.props as {
-      className?: unknown;
-      children?: ReactNode;
-    };
-    if (
-      typeof props.className === "string" &&
-      props.className.split(/\s+/).includes(className)
-    ) {
-      found.push(current);
-    }
-    walk(props.children);
-  };
-  walk(node);
-  return found;
+function classedAttributes(html: string, className: string): string[][] {
+  const tags = [
+    ...html.matchAll(
+      /<([a-zA-Z][a-zA-Z0-9-]*)((?:\s+[a-zA-Z-]+="[^"]*")*)\s*\/?>/g
+    ),
+  ];
+  const matched: string[][] = [];
+  for (const tag of tags) {
+    const attributes = [...tag[2]!.matchAll(/\s([a-zA-Z-]+)="([^"]*)"/g)];
+    const classes = attributes.find(pair => pair[1] === "class")?.[2] ?? "";
+    if (!classes.split(/\s+/).includes(className)) continue;
+    matched.push(attributes.map(pair => pair[1]!));
+  }
+  return matched;
 }
 
 /**
@@ -119,7 +111,7 @@ function classedElements(node: ReactNode, className: string): ReactElement[] {
  * want of a fixture, and the props are the author's own rather than a guess that might miss the
  * branch that styles anything.
  */
-async function drawnBy(block: DrawableBlock): Promise<ReactNode> {
+async function markupOf(block: DrawableBlock): Promise<string> {
   const node: BlockNode = {
     id: "n1",
     type: block.name,
@@ -134,8 +126,8 @@ async function drawnBy(block: DrawableBlock): Promise<ReactNode> {
     renderSlot: () => <span>child</span>,
   } as unknown as BlockRenderArgs<never>;
   // Awaited because several blocks are async server components: calling `render` on one returns a
-  // promise of the element rather than the element itself.
-  return (await block.render(args)) as ReactNode;
+  // promise of the element, and handing that straight to the renderer suspends instead of drawing.
+  return renderToStaticMarkup((await block.render(args)) as ReactElement);
 }
 
 describe("a core block's root element", () => {
@@ -162,32 +154,47 @@ describe("a core block's root element", () => {
   it.each(DRAWABLE.map(block => [block.name, block] as const))(
     "%s writes no inline style",
     async (_name, block) => {
-      const classed = classedElements(await drawnBy(block), BLOCK_CLASS);
+      const classed = classedAttributes(await markupOf(block), BLOCK_CLASS);
       // Asserted BEFORE the absence below, which is otherwise satisfied by absence: a block whose
-      // example renders nothing, or which never applies the class it is handed, would yield an empty
-      // list and pass a "no style" check while never having been examined.
+      // example renders nothing, or which never applies the class it is handed, yields an empty
+      // list and would pass a "no style" check having been examined at all.
       expect(classed).toHaveLength(1);
-      const { style } = classed[0]!.props as { style?: unknown };
-      expect(style).toBeUndefined();
+      expect(classed[0]).not.toContain("style");
     }
   );
 
   it("would catch a block that styled the element carrying the class", async () => {
-    // The positive control, exercising the SAME finder and the SAME property the per-block cases
-    // use. A control asserting something adjacent could stay green while the real check stopped
+    // The positive control, exercising the SAME reader and the SAME property the cases above use.
+    // A control asserting something adjacent could stay green while the real check stopped
     // recognising a style at all.
     const styled: DrawableBlock = {
       ...DRAWABLE[0]!,
       render: () => <div className={BLOCK_CLASS} style={{ padding: 24 }} />,
     };
-    const classed = classedElements(await drawnBy(styled), BLOCK_CLASS);
-    expect(classed).toHaveLength(1);
-    expect((classed[0]!.props as { style?: unknown }).style).toBeDefined();
+    expect(classedAttributes(await markupOf(styled), BLOCK_CLASS)[0]).toContain(
+      "style"
+    );
+  });
+
+  it("sees through a root delegated to a component", async () => {
+    // The case an element-tree walk gets wrong: `<Root className={x} />` appears in the authored
+    // tree as an unexecuted element whose own props carry no style, while the host element it
+    // returns carries both the class and the declaration.
+    const Root = ({ className }: { className: string }) => (
+      <div className={className} style={{ padding: 24 }} />
+    );
+    const delegated: DrawableBlock = {
+      ...DRAWABLE[0]!,
+      render: () => <Root className={BLOCK_CLASS} />,
+    };
+    expect(
+      classedAttributes(await markupOf(delegated), BLOCK_CLASS)[0]
+    ).toContain("style");
   });
 
   it("looks past a wrapper to the element that carries the class", async () => {
-    // The case a first-opening-tag reader gets wrong: the outermost element is not necessarily the
-    // one the compiled rules land on, so a style on the classed DESCENDANT must still be found.
+    // The outermost element is not necessarily the one the compiled rules land on, so a style on
+    // the classed DESCENDANT must still be found.
     const wrapped: DrawableBlock = {
       ...DRAWABLE[0]!,
       render: () => (
@@ -196,20 +203,24 @@ describe("a core block's root element", () => {
         </section>
       ),
     };
-    const classed = classedElements(await drawnBy(wrapped), BLOCK_CLASS);
-    expect(classed).toHaveLength(1);
-    expect((classed[0]!.props as { style?: unknown }).style).toBeDefined();
+    expect(
+      classedAttributes(await markupOf(wrapped), BLOCK_CLASS)[0]
+    ).toContain("style");
   });
 
   it("does not mistake an attribute VALUE for a style attribute", async () => {
-    // Reading the prop rather than the serialized tag is what makes this true. Text matching on an
-    // opening tag reports a style here and rejects markup no style control competes with.
+    // Enumerating attribute NAMES is what makes this true. React escapes `"` inside a value as
+    // `&quot;`, so the decoy serializes as `title="use style=&quot;x&quot;"` and its `style=` is
+    // inside the value. Matching the text reports a style attribute that does not exist, and
+    // rejects markup no style control competes with.
     const decoy: DrawableBlock = {
       ...DRAWABLE[0]!,
-      render: () => <div className={BLOCK_CLASS} title="use style=compact" />,
+      render: () => (
+        <div className={BLOCK_CLASS} title={'use style="compact"'} />
+      ),
     };
-    const classed = classedElements(await drawnBy(decoy), BLOCK_CLASS);
-    expect(classed).toHaveLength(1);
-    expect((classed[0]!.props as { style?: unknown }).style).toBeUndefined();
+    const attributes = classedAttributes(await markupOf(decoy), BLOCK_CLASS)[0];
+    expect(attributes).toContain("title");
+    expect(attributes).not.toContain("style");
   });
 });

--- a/packages/blocks-react/src/blocks/visual-defaults.test.tsx
+++ b/packages/blocks-react/src/blocks/visual-defaults.test.tsx
@@ -1,0 +1,125 @@
+/**
+ * A core block's visual defaults are DATA, never declarations written on its root.
+ *
+ * An inline declaration outranks every class rule regardless of specificity or source order, so a
+ * block that styles the element carrying its own `className` defeats the rules compiled from the
+ * style controls it declares support for. The control still writes a value, the sheet still gains a
+ * rule, and the page does not change — which is the worst shape a defect can take, because nothing
+ * anywhere reports it.
+ *
+ * The library follows this today by convention, stated in prose block by block (`core/spacer`: "The
+ * height is a style rather than a prop"). A convention with nothing enforcing it is not a control,
+ * and the same convention was broken ten times over in the registry this library replaces. This is
+ * the enforcement.
+ *
+ * `baseStyles` is where a default belongs: it compiles to the block-type tier, which the site's
+ * classes, the node's own values and a consumer's stylesheet all override.
+ *
+ * Scoped to the ROOT because that is where the conflict is: the root carries `className`, so it is
+ * the element the block's own compiled rules land on. A nested element is not exempt from the
+ * principle, but it is not the measured defect and a rule reaching further would reject markup no
+ * control competes with.
+ *
+ * ## What this does NOT cover
+ *
+ * Each block is drawn once, from its `example`, so only the branch that instance reaches is read.
+ * A block whose root is conditional has other roots this never renders — `core/quote` returns a
+ * bare `<blockquote>` when nothing is attributed and a `<figure>` otherwise, and the example
+ * attributes, so the `<blockquote>` branch is unchecked here. Found by breaking that branch and
+ * watching the suite stay green, which is the only way this kind of gap announces itself.
+ *
+ * Drawing every branch would mean enumerating prop combinations per block, and the honest state is
+ * that this covers the shipped example rather than the whole render. It is stated so a green is not
+ * read as more than it is.
+ */
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import type { BlockNode } from "@nextlyhq/blocks-engine";
+import type { ReactElement } from "react";
+
+import type { BlockRenderArgs, PageContext } from "../context";
+
+import { coreBlocks } from "./index";
+
+/**
+ * Every core block, seen as the single shape this guard needs.
+ *
+ * `coreBlocks` is a union of definitions whose prop types differ, so calling `render` on the union
+ * demands the INTERSECTION of every block's props, which no instance can satisfy. Each block is
+ * drawn from its OWN example here, so the props always match the block they came from; this names
+ * that narrow contract in one place rather than widening any block's own types.
+ */
+interface DrawableBlock {
+  name: string;
+  version: number;
+  example: { props: unknown };
+  render: (args: BlockRenderArgs<never>) => unknown;
+}
+
+const DRAWABLE: readonly DrawableBlock[] = coreBlocks;
+
+function context(): PageContext {
+  return {
+    entry: null,
+    data: { find: () => Promise.resolve({ items: [], total: 0 }) },
+    resolveMedia: () => Promise.resolve(null),
+    resolveEntryPath: () => Promise.resolve(null),
+  };
+}
+
+/**
+ * Render one block the way a page would, from the worked instance it is required to publish.
+ *
+ * `example` rather than hand-written props: every definition carries one, so no block is skipped for
+ * want of a fixture, and the props are the author's own rather than a guess that might miss the
+ * branch that styles anything.
+ */
+async function rootOf(block: DrawableBlock): Promise<string> {
+  const node: BlockNode = {
+    id: "n1",
+    type: block.name,
+    version: block.version,
+    props: block.example.props as Record<string, unknown>,
+  };
+  const args = {
+    props: block.example.props,
+    node,
+    className: "nx-n1",
+    ctx: context(),
+    renderSlot: () => <span>child</span>,
+  } as unknown as BlockRenderArgs<never>;
+  // Awaited because several blocks are async server components: calling `render` on one returns a
+  // promise of the element, and handing that straight to the renderer suspends instead of drawing.
+  const drawn = await block.render(args);
+  const html = renderToStaticMarkup(drawn as ReactElement);
+  // The opening tag alone. A nested element's own attributes are a different question, and reading
+  // the whole document here would answer it by accident.
+  return html.slice(0, html.indexOf(">") + 1);
+}
+
+describe("a core block's root element", () => {
+  it("covers every block in the library", () => {
+    // The count must not fall silently: a library that stopped being enumerated would leave every
+    // assertion below vacuously true, and a green suite is exactly what that looks like.
+    expect(DRAWABLE.length).toBeGreaterThan(10);
+  });
+
+  it.each(DRAWABLE.map(block => [block.name, block] as const))(
+    "%s writes no inline style",
+    async (_name, block) => {
+      expect(await rootOf(block)).not.toContain("style=");
+    }
+  );
+
+  it("would catch a block that styled its own root", async () => {
+    // The positive control. Without it the assertions above pass for a library whose blocks render
+    // nothing at all, or whose root tag this helper failed to find — neither of which is the
+    // property under test.
+    const styled: DrawableBlock = {
+      ...DRAWABLE[0]!,
+      render: () => <div className="nx-n1" style={{ padding: 24 }} />,
+    };
+    expect(await rootOf(styled)).toContain("style=");
+  });
+});

--- a/packages/blocks-react/src/blocks/visual-defaults.test.tsx
+++ b/packages/blocks-react/src/blocks/visual-defaults.test.tsx
@@ -34,6 +34,11 @@ import { renderToReadableStream } from "react-dom/server";
  * read as more than it is.
  */
 import { describe, expect, it } from "vitest";
+import { readdirSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { createElement } from "react";
 
 import type { BlockNode } from "@nextlyhq/blocks-engine";
 import type { ReactElement } from "react";
@@ -93,7 +98,11 @@ function classedAttributes(html: string, className: string): string[][] {
   // narrow class rejects the whole TAG rather than one attribute, which empties the result and
   // fails a block whose markup carries no style at all. Rejecting valid code is the expensive
   // direction, so this is the character set HTML allows rather than the one this file expects.
-  const NAME = "[a-zA-Z_:][a-zA-Z0-9_:.-]*";
+  // Anything HTML allows in an attribute name: everything except whitespace and the characters
+  // that end a name or a tag. An enumerated character class keeps being too narrow -- it rejected
+  // `data-h2`, then `xml:lang`, then a non-ASCII name, and each time the failure is that the whole
+  // TAG stops matching and a block carrying no style at all is reported as broken.
+  const NAME = "[^\\s\"'>/=]+";
   const tags = [
     ...html.matchAll(
       new RegExp(
@@ -107,9 +116,13 @@ function classedAttributes(html: string, className: string): string[][] {
     const attributes = [
       ...tag[2]!.matchAll(new RegExp(`\\s(${NAME})="([^"]*)"`, "g")),
     ];
-    const classes = attributes.find(pair => pair[1] === "class")?.[2] ?? "";
+    // Lower-cased, because HTML attribute names are case-insensitive: a browser applies `STYLE=`
+    // and `CLASS=` exactly as it applies the lower-case spellings, and React emits whatever it was
+    // given. Comparing exactly would miss a live declaration.
+    const named = attributes.map(pair => [pair[1]!.toLowerCase(), pair[2]!]);
+    const classes = named.find(pair => pair[0] === "class")?.[1] ?? "";
     if (!classes.split(/\s+/).includes(className)) continue;
-    matched.push(attributes.map(pair => pair[1]!));
+    matched.push(named.map(pair => pair[0]!));
   }
   return matched;
 }
@@ -257,6 +270,33 @@ describe("a core block's root element", () => {
     expect(attributes[0]).not.toContain("style");
   });
 
+  it("catches an uppercase STYLE, which a browser applies the same way", async () => {
+    // HTML attribute names are case-insensitive. React warns about the spelling and emits it
+    // unchanged, so the declaration is live on the page while an exact comparison reports nothing.
+    const shouty: DrawableBlock = {
+      ...DRAWABLE[0]!,
+      render: () =>
+        createElement("div", { className: BLOCK_CLASS, STYLE: "padding:24px" }),
+    };
+    expect(classedAttributes(await markupOf(shouty), BLOCK_CLASS)[0]).toContain(
+      "style"
+    );
+  });
+
+  it("reads a tag carrying a non-ASCII attribute name", async () => {
+    // React emits `føø="bar"` unchanged. An ASCII-only grammar rejects the whole tag, which
+    // empties the result and fails a block whose markup carries no style at all.
+    const wide: DrawableBlock = {
+      ...DRAWABLE[0]!,
+      render: () =>
+        createElement("div", { className: BLOCK_CLASS, føø: "bar" }),
+    };
+    const attributes = classedAttributes(await markupOf(wide), BLOCK_CLASS);
+    expect(attributes).toHaveLength(1);
+    expect(attributes[0]).toContain("føø");
+    expect(attributes[0]).not.toContain("style");
+  });
+
   it("does not mistake an attribute VALUE for a style attribute", async () => {
     // Enumerating attribute NAMES is what makes this true. React escapes `"` inside a value as
     // `&quot;`, so the decoy serializes as `title="use style=&quot;x&quot;"` and its `style=` is
@@ -271,5 +311,48 @@ describe("a core block's root element", () => {
     const attributes = classedAttributes(await markupOf(decoy), BLOCK_CLASS)[0];
     expect(attributes).toContain("title");
     expect(attributes).not.toContain("style");
+  });
+});
+
+describe("every branch, not only the one the example renders", () => {
+  // The render check above draws each block ONCE, from its example, so a block whose root is
+  // conditional has roots it never reaches -- `core/quote` returns a bare `<blockquote>` when
+  // nothing is attributed and a `<figure>` otherwise, and only one of those is drawn.
+  //
+  // Enumerating prop combinations per block would be endless. Reading the SOURCES is complete for
+  // the question actually being asked, because the rule is not "no style on the example's root" but
+  // "these blocks do not style themselves at all": every visual default belongs in `baseStyles`,
+  // whichever branch would have carried it.
+  //
+  // The two checks answer different halves and neither subsumes the other. This one cannot tell
+  // which element a declaration lands on, so it cannot distinguish a root from a nested element --
+  // which is why it is a whole-file rule rather than a narrower one. The render check can, and
+  // covers what a component root or a wrapper actually produces, which no source read can predict.
+  const dir = dirname(fileURLToPath(import.meta.url));
+  const files = readdirSync(dir).filter(
+    name => name.endsWith(".tsx") && !name.includes(".test.")
+  );
+
+  it("reads every block file in the library", () => {
+    // Vacuity guard: a glob that matched nothing would leave the rule below asserting over an
+    // empty list, which passes and means nothing.
+    expect(files.length).toBeGreaterThanOrEqual(DRAWABLE.length);
+  });
+
+  it.each(files)("%s declares no inline style anywhere", name => {
+    const source = readFileSync(join(dir, name), "utf8");
+    expect(source).not.toContain("style={");
+  });
+
+  it("would catch a style added to a branch no example renders", () => {
+    // The positive control, on the shape this exists for: a second root, styled, that the example
+    // never selects. The render check above stays green on exactly this input.
+    const unreached = [
+      `export function renderThing({ className, props }) {`,
+      `  if (props.bare) return <div className={className} style={{ padding: 24 }} />;`,
+      `  return <div className={className} />;`,
+      `}`,
+    ].join("\n");
+    expect(unreached).toContain("style={");
   });
 });

--- a/packages/blocks-react/src/blocks/visual-defaults.test.tsx
+++ b/packages/blocks-react/src/blocks/visual-defaults.test.tsx
@@ -99,16 +99,37 @@ async function rootOf(block: DrawableBlock): Promise<string> {
 }
 
 describe("a core block's root element", () => {
-  it("covers every block in the library", () => {
-    // The count must not fall silently: a library that stopped being enumerated would leave every
-    // assertion below vacuously true, and a green suite is exactly what that looks like.
-    expect(DRAWABLE.length).toBeGreaterThan(10);
+  it("covers exactly the blocks the library publishes", () => {
+    // The exact SET, not a floor. A library of 12 that loses one still clears "more than 10", and
+    // the dropped block then stops being checked with nothing to show for it. Naming them also
+    // makes the failure say WHICH block appeared or vanished, which a count cannot.
+    expect([...DRAWABLE.map(block => block.name)].sort()).toEqual([
+      "core/box",
+      "core/button",
+      "core/collection-loop",
+      "core/divider",
+      "core/embed",
+      "core/heading",
+      "core/image",
+      "core/list",
+      "core/quote",
+      "core/section",
+      "core/spacer",
+      "core/text",
+    ]);
   });
 
   it.each(DRAWABLE.map(block => [block.name, block] as const))(
     "%s writes no inline style",
     async (_name, block) => {
-      expect(await rootOf(block)).not.toContain("style=");
+      const root = await rootOf(block);
+      // Asserted BEFORE the absence below, which is otherwise satisfied by absence: a block whose
+      // example renders nothing, or whose opening tag this helper failed to find, yields "" and
+      // passes a `not.toContain` while never having been checked at all.
+      expect(root).toMatch(/^<[a-zA-Z]/);
+      // The attribute, not the substring. `data-style="compact"` contains `style=` and is not an
+      // inline declaration, and a guard that rejects it costs an unrelated change a red build.
+      expect(root).not.toMatch(/\sstyle=/);
     }
   );
 

--- a/packages/blocks-react/src/blocks/visual-defaults.test.tsx
+++ b/packages/blocks-react/src/blocks/visual-defaults.test.tsx
@@ -1,4 +1,4 @@
-import { renderToStaticMarkup } from "react-dom/server";
+import { renderToReadableStream } from "react-dom/server";
 /**
  * A core block's visual defaults are DATA, never declarations written on its root.
  *
@@ -89,14 +89,24 @@ function context(): PageContext {
  * the text reports a style attribute that is not there.
  */
 function classedAttributes(html: string, className: string): string[][] {
+  // The name grammar is deliberately wide. React emits `data-h2` and `xml:lang` unchanged, and a
+  // narrow class rejects the whole TAG rather than one attribute, which empties the result and
+  // fails a block whose markup carries no style at all. Rejecting valid code is the expensive
+  // direction, so this is the character set HTML allows rather than the one this file expects.
+  const NAME = "[a-zA-Z_:][a-zA-Z0-9_:.-]*";
   const tags = [
     ...html.matchAll(
-      /<([a-zA-Z][a-zA-Z0-9-]*)((?:\s+[a-zA-Z-]+="[^"]*")*)\s*\/?>/g
+      new RegExp(
+        `<([a-zA-Z][a-zA-Z0-9-]*)((?:\\s+${NAME}="[^"]*")*)\\s*\\/?>`,
+        "g"
+      )
     ),
   ];
   const matched: string[][] = [];
   for (const tag of tags) {
-    const attributes = [...tag[2]!.matchAll(/\s([a-zA-Z-]+)="([^"]*)"/g)];
+    const attributes = [
+      ...tag[2]!.matchAll(new RegExp(`\\s(${NAME})="([^"]*)"`, "g")),
+    ];
     const classes = attributes.find(pair => pair[1] === "class")?.[2] ?? "";
     if (!classes.split(/\s+/).includes(className)) continue;
     matched.push(attributes.map(pair => pair[1]!));
@@ -127,7 +137,14 @@ async function markupOf(block: DrawableBlock): Promise<string> {
   } as unknown as BlockRenderArgs<never>;
   // Awaited because several blocks are async server components: calling `render` on one returns a
   // promise of the element, and handing that straight to the renderer suspends instead of drawing.
-  return renderToStaticMarkup((await block.render(args)) as ReactElement);
+  // The STREAMING renderer, which resolves async components. `renderToStaticMarkup` is synchronous:
+  // a root delegated to an async server component suspends and throws there, so awaiting
+  // `block.render` alone is not enough -- that only resolves the OUTER element, and any async
+  // component inside it is still unresolved when the markup is produced.
+  const stream = await renderToReadableStream(
+    (await block.render(args)) as ReactElement
+  );
+  return await new Response(stream).text();
 }
 
 describe("a core block's root element", () => {
@@ -192,6 +209,22 @@ describe("a core block's root element", () => {
     ).toContain("style");
   });
 
+  it("resolves a root delegated to an ASYNC component", async () => {
+    // A server component may be async, and the synchronous renderer suspends and throws on one.
+    // Awaiting `block.render` resolves only the outer element, so an async component inside it is
+    // still unresolved when markup is produced -- and the declaration it carries goes unseen.
+    const AsyncRoot = async ({ className }: { className: string }) => (
+      <div className={className} style={{ padding: 24 }} />
+    );
+    const delegated: DrawableBlock = {
+      ...DRAWABLE[0]!,
+      render: () => (<AsyncRoot className={BLOCK_CLASS} />) as ReactElement,
+    };
+    expect(
+      classedAttributes(await markupOf(delegated), BLOCK_CLASS)[0]
+    ).toContain("style");
+  });
+
   it("looks past a wrapper to the element that carries the class", async () => {
     // The outermost element is not necessarily the one the compiled rules land on, so a style on
     // the classed DESCENDANT must still be found.
@@ -206,6 +239,22 @@ describe("a core block's root element", () => {
     expect(
       classedAttributes(await markupOf(wrapped), BLOCK_CLASS)[0]
     ).toContain("style");
+  });
+
+  it("reads a tag carrying attributes with digits and namespaces", async () => {
+    // React emits `data-h2` and `xml:lang` unchanged. A narrow name grammar rejects the whole tag
+    // rather than one attribute, which empties the result and fails a block carrying no style --
+    // rejecting valid markup, which costs an unrelated change a red build.
+    const wide: DrawableBlock = {
+      ...DRAWABLE[0]!,
+      render: () => (
+        <div className={BLOCK_CLASS} data-h2="clean" aria-label="x" />
+      ),
+    };
+    const attributes = classedAttributes(await markupOf(wide), BLOCK_CLASS);
+    expect(attributes).toHaveLength(1);
+    expect(attributes[0]).toContain("data-h2");
+    expect(attributes[0]).not.toContain("style");
   });
 
   it("does not mistake an attribute VALUE for a style attribute", async () => {

--- a/packages/blocks-react/src/blocks/visual-defaults.test.tsx
+++ b/packages/blocks-react/src/blocks/visual-defaults.test.tsx
@@ -32,11 +32,11 @@
  * that this covers the shipped example rather than the whole render. It is stated so a green is not
  * read as more than it is.
  */
-import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
 
 import type { BlockNode } from "@nextlyhq/blocks-engine";
-import type { ReactElement } from "react";
+import { isValidElement } from "react";
+import type { ReactElement, ReactNode } from "react";
 
 import type { BlockRenderArgs, PageContext } from "../context";
 
@@ -59,6 +59,9 @@ interface DrawableBlock {
 
 const DRAWABLE: readonly DrawableBlock[] = coreBlocks;
 
+/** The class a page compiles a node's own rules onto, handed to every render below. */
+const BLOCK_CLASS = "nx-n1";
+
 function context(): PageContext {
   return {
     entry: null,
@@ -69,13 +72,54 @@ function context(): PageContext {
 }
 
 /**
+ * The element a block puts its own `className` on, found in the tree it returns.
+ *
+ * The RENDERED element rather than serialized markup, and the element carrying the CLASS rather than
+ * the first opening tag. Both matter:
+ *
+ * - A block may wrap its content, so the outermost tag is not necessarily the one the compiled rules
+ *   land on. Reading the first tag would inspect a wrapper and leave the conflicting declaration on
+ *   the classed descendant unexamined.
+ * - `style` is read as a PROP, so nothing depends on how React serializes it. Matching text in an
+ *   opening tag cannot tell a real `style` attribute from `title="use style=compact"` or from a class
+ *   token containing the same characters, and a guard that rejects those costs an unrelated change a
+ *   red build.
+ *
+ * Returns every classed element, not the first. A block placing the class twice is malformed in a way
+ * worth failing on rather than silently reading one of them.
+ */
+function classedElements(node: ReactNode, className: string): ReactElement[] {
+  const found: ReactElement[] = [];
+  const walk = (current: ReactNode): void => {
+    if (Array.isArray(current)) {
+      for (const child of current) walk(child);
+      return;
+    }
+    if (!isValidElement(current)) return;
+    const props = current.props as {
+      className?: unknown;
+      children?: ReactNode;
+    };
+    if (
+      typeof props.className === "string" &&
+      props.className.split(/\s+/).includes(className)
+    ) {
+      found.push(current);
+    }
+    walk(props.children);
+  };
+  walk(node);
+  return found;
+}
+
+/**
  * Render one block the way a page would, from the worked instance it is required to publish.
  *
  * `example` rather than hand-written props: every definition carries one, so no block is skipped for
  * want of a fixture, and the props are the author's own rather than a guess that might miss the
  * branch that styles anything.
  */
-async function rootOf(block: DrawableBlock): Promise<string> {
+async function drawnBy(block: DrawableBlock): Promise<ReactNode> {
   const node: BlockNode = {
     id: "n1",
     type: block.name,
@@ -85,17 +129,13 @@ async function rootOf(block: DrawableBlock): Promise<string> {
   const args = {
     props: block.example.props,
     node,
-    className: "nx-n1",
+    className: BLOCK_CLASS,
     ctx: context(),
     renderSlot: () => <span>child</span>,
   } as unknown as BlockRenderArgs<never>;
   // Awaited because several blocks are async server components: calling `render` on one returns a
-  // promise of the element, and handing that straight to the renderer suspends instead of drawing.
-  const drawn = await block.render(args);
-  const html = renderToStaticMarkup(drawn as ReactElement);
-  // The opening tag alone. A nested element's own attributes are a different question, and reading
-  // the whole document here would answer it by accident.
-  return html.slice(0, html.indexOf(">") + 1);
+  // promise of the element rather than the element itself.
+  return (await block.render(args)) as ReactNode;
 }
 
 describe("a core block's root element", () => {
@@ -122,25 +162,54 @@ describe("a core block's root element", () => {
   it.each(DRAWABLE.map(block => [block.name, block] as const))(
     "%s writes no inline style",
     async (_name, block) => {
-      const root = await rootOf(block);
+      const classed = classedElements(await drawnBy(block), BLOCK_CLASS);
       // Asserted BEFORE the absence below, which is otherwise satisfied by absence: a block whose
-      // example renders nothing, or whose opening tag this helper failed to find, yields "" and
-      // passes a `not.toContain` while never having been checked at all.
-      expect(root).toMatch(/^<[a-zA-Z]/);
-      // The attribute, not the substring. `data-style="compact"` contains `style=` and is not an
-      // inline declaration, and a guard that rejects it costs an unrelated change a red build.
-      expect(root).not.toMatch(/\sstyle=/);
+      // example renders nothing, or which never applies the class it is handed, would yield an empty
+      // list and pass a "no style" check while never having been examined.
+      expect(classed).toHaveLength(1);
+      const { style } = classed[0]!.props as { style?: unknown };
+      expect(style).toBeUndefined();
     }
   );
 
-  it("would catch a block that styled its own root", async () => {
-    // The positive control. Without it the assertions above pass for a library whose blocks render
-    // nothing at all, or whose root tag this helper failed to find — neither of which is the
-    // property under test.
+  it("would catch a block that styled the element carrying the class", async () => {
+    // The positive control, exercising the SAME finder and the SAME property the per-block cases
+    // use. A control asserting something adjacent could stay green while the real check stopped
+    // recognising a style at all.
     const styled: DrawableBlock = {
       ...DRAWABLE[0]!,
-      render: () => <div className="nx-n1" style={{ padding: 24 }} />,
+      render: () => <div className={BLOCK_CLASS} style={{ padding: 24 }} />,
     };
-    expect(await rootOf(styled)).toContain("style=");
+    const classed = classedElements(await drawnBy(styled), BLOCK_CLASS);
+    expect(classed).toHaveLength(1);
+    expect((classed[0]!.props as { style?: unknown }).style).toBeDefined();
+  });
+
+  it("looks past a wrapper to the element that carries the class", async () => {
+    // The case a first-opening-tag reader gets wrong: the outermost element is not necessarily the
+    // one the compiled rules land on, so a style on the classed DESCENDANT must still be found.
+    const wrapped: DrawableBlock = {
+      ...DRAWABLE[0]!,
+      render: () => (
+        <section>
+          <div className={BLOCK_CLASS} style={{ padding: 24 }} />
+        </section>
+      ),
+    };
+    const classed = classedElements(await drawnBy(wrapped), BLOCK_CLASS);
+    expect(classed).toHaveLength(1);
+    expect((classed[0]!.props as { style?: unknown }).style).toBeDefined();
+  });
+
+  it("does not mistake an attribute VALUE for a style attribute", async () => {
+    // Reading the prop rather than the serialized tag is what makes this true. Text matching on an
+    // opening tag reports a style here and rejects markup no style control competes with.
+    const decoy: DrawableBlock = {
+      ...DRAWABLE[0]!,
+      render: () => <div className={BLOCK_CLASS} title="use style=compact" />,
+    };
+    const classed = classedElements(await drawnBy(decoy), BLOCK_CLASS);
+    expect(classed).toHaveLength(1);
+    expect((classed[0]!.props as { style?: unknown }).style).toBeUndefined();
   });
 });


### PR DESCRIPTION
## What

Checks that no core block writes an inline `style` on the element carrying its own `className`.

## Why

An inline declaration outranks every class rule regardless of specificity or source order. A block that styles its own root therefore defeats the rules compiled from the style controls it declares support for: the control writes a value, the sheet gains a rule, and the page does not change. Nothing anywhere reports it.

This library already follows the convention, stated block by block in prose — `core/spacer`: *"The height is a style rather than a prop. Spacing is per-breakpoint in this system, and a stored number could only ever be one value."* A convention with nothing enforcing it is not a control, and **the PoC registry this library replaces broke the same convention in ten blocks** (task 166), where it is a live defect today: setting Padding on `core/pricing-table` does nothing.

Those ten are not fixed here, deliberately. `plugin-page-builder/src/render/blocks/*.tsx` is the PoC library scheduled for deletion, and its `BlockDefinition` has no `baseStyles` field — converting it would mean adding a field to a type on its way out. What matters is that the ~22-primitive port does not carry the defect across, which is what this pins.

## The mechanism a default should use

`defineBlock.baseStyles` (PB-D19 Decision C), already shipped and wired: `blockBasesFor` in `styles.ts` reads it off each definition, and `compilePageCss` emits it at the block-type tier, which the site's classes, the node's own values and a consumer's stylesheet all override. Verified against a real compile — the block-type rule and the node's rule share a selector specificity, and the node's is emitted second, so a control's value wins.

## Verification

- Break-verified: an inline style on `core/quote`'s `<figure>` root fails that block's case by assertion.
- **The first break was malformed and is worth recording.** `core/quote` has two `className={className}` branches; I broke the one the example never reaches and the suite stayed green. That is a real coverage limit, not a one-off, so it is stated in the file rather than left implied: each block is drawn once from its `example`, so a conditional root has roots this does not see.
- A positive control asserts a styled root IS caught, so the per-block assertions cannot pass vacuously.
- A count assertion, so a library that stopped being enumerated fails instead of reporting green over nothing.

502 tests pass in `blocks-react`; `lint` and `check-types` green.

No changeset: test-only.