### PR TITLE
test(ui): assert node types stay out of the program, not just the config

### DIFF
--- a/packages/ui/src/__tests__/node-types-stay-out-of-src.test.ts
+++ b/packages/ui/src/__tests__/node-types-stay-out-of-src.test.ts
@@ -22,6 +22,7 @@ import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { describe, expect, it } from "vitest";
+import ts from "typescript";
 
 const here = dirname(fileURLToPath(import.meta.url));
 const pkgRoot = resolve(here, "../..");
@@ -38,6 +39,35 @@ const pkg = readJsonc(resolve(pkgRoot, "package.json"));
 
 const compilerOptions = (config: Record<string, unknown>) =>
   (config.compilerOptions ?? {}) as Record<string, unknown>;
+
+/**
+ * The node type files a config's program actually loads.
+ *
+ * Built through the compiler rather than by spawning `tsc --listFiles`, which answers the same
+ * question a second or two slower and would put a subprocess in a unit suite.
+ *
+ * The directory separator in the pattern is load-bearing. pnpm encodes peer dependencies into its
+ * directory names, so a path like `vitest@4.1.10_@types+node@20.19.17_...` is a perfectly ordinary
+ * package folder that has nothing to do with node types — matching `@types` and `node` loosely
+ * counts those and reports a leak that is not there.
+ */
+function nodeTypeFilesIn(configName: string): string[] {
+  const configPath = resolve(pkgRoot, configName);
+  const { config, error } = ts.readConfigFile(configPath, ts.sys.readFile);
+  // A config that could not be read would otherwise resolve to an empty program, and an empty
+  // program loads no node types — the guard would pass by failing to ask the question.
+  expect(error, `${configName} could not be read`).toBeUndefined();
+  const parsed = ts.parseJsonConfigFileContent(config, ts.sys, pkgRoot);
+  expect(
+    parsed.fileNames.length,
+    `${configName} matched no files`
+  ).toBeGreaterThan(0);
+  const program = ts.createProgram(parsed.fileNames, parsed.options);
+  return program
+    .getSourceFiles()
+    .map(file => file.fileName)
+    .filter(name => name.includes("/@types/node/"));
+}
 
 describe("node types stay out of the shipped surface", () => {
   it("depends on @types/node, so the guard is load-bearing", () => {
@@ -60,5 +90,25 @@ describe("node types stay out of the shipped surface", () => {
     // A test config nothing executes is a file, not a check.
     const scripts = (pkg.scripts ?? {}) as Record<string, string>;
     expect(scripts["check-types"]).toContain("tsconfig.tests.json");
+  });
+
+  it("loads no node type file into the shipping program", () => {
+    // The PROPERTY, not the line. Every assertion above reads configuration, and `types` governs
+    // only the AUTOMATIC inclusion of `node_modules/@types/*` — it does nothing about a
+    // `/// <reference types="node" />` inside a `.d.ts` the program already includes. So a
+    // dependency whose types reference node reopens this hole with `types: []` still written down
+    // and all four assertions above still green.
+    //
+    // Not hypothetical: applied to `blocks-react`, whose `/next` subpath imports Next, that same
+    // line is inert — 63 node type files load anyway, because `next/dist/types.d.ts` references
+    // them. The line works here and not there, so what is asserted has to be the outcome.
+    expect(nodeTypeFilesIn("tsconfig.json")).toEqual([]);
+  });
+
+  it("loads them into the test program, so the check can tell the two apart", () => {
+    // The positive control. Without it an empty result above cannot be distinguished from a reader
+    // that finds nothing under any circumstances — a bad path, a config that resolved no files, a
+    // filter that matches nothing.
+    expect(nodeTypeFilesIn("tsconfig.tests.json").length).toBeGreaterThan(0);
   });
 });


### PR DESCRIPTION
## What

`node-types-stay-out-of-src.test.ts` asserted four things about *configuration*. It now also asserts the *property*: the shipping program loads no `@types/node` file.

## Why

`types` governs only the automatic inclusion of `node_modules/@types/*`. It does nothing about a `/// <reference types="node" />` inside a `.d.ts` the program already includes. So a dependency whose types reference node reopens the hole with `types: []` still written down and all four existing assertions still green — a guard that has quietly become decoration.

**This is not hypothetical.** I applied the same line to `blocks-react` and it was inert: 63 node type files loaded anyway, because its `/next` subpath imports Next and `next/dist/types.d.ts` references node types. `--explainFiles` names it:

```
@types/node/index.d.ts
  Type library referenced via 'node' from file 'next/dist/types.d.ts'
```

The line works in `packages/ui`, works in `blocks-engine`, and is inert in `blocks-react`. That makes it a property of the dependency graph, not something a config assertion can answer — so the outcome is what gets asserted.

## Verification

**Break-verified in the form that matters.** Adding `/// <reference types="node" />` to a `.d.ts` in `src/`, with `types: []` left completely untouched:

```
✓ depends on @types/node, so the guard is load-bearing
✓ keeps ambient types out of the shipping config
✓ scopes node types to the test config
✓ runs both configs, so neither is checked in name only
× loads no node type file into the shipping program      <- only this one
```

All four configuration assertions stay green. Only the new one catches it.

**Controls, because an empty result is otherwise indistinguishable from a reader that finds nothing under any circumstances:**
- the test program is asserted to load node types, so the filter demonstrably works;
- an unreadable config fails rather than resolving to an empty program;
- a config matching no files fails, since an empty program loads no node types and would pass.

**One detail worth flagging for review**, because it produced a wrong answer for another lane before we compared notes: the pattern is `/@types/node/` with separators. pnpm encodes peer dependencies into directory names, so `vitest@4.1.10_@types+node@20.19.17_...` is an ordinary package folder — matching `@types` and `node` loosely counts those and reports a leak that is not there.

Built through the compiler API rather than by spawning `tsc --listFiles`: same answer, no subprocess in a unit suite, ~1s for the file.

667 tests pass in `packages/ui`; `lint` and `check-types` green.

No changeset: test-only.