### PR TITLE
fix(ui): ignore a dispatched event that is not a keystroke

### DIFF
--- a/.changeset/shortcuts-ignore-non-keyboard-events.md
+++ b/.changeset/shortcuts-ignore-non-keyboard-events.md
@@ -1,0 +1,34 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+---
+
+fix(ui): ignore a dispatched event that is not a keystroke
+
+The shortcut manager listens on `document`, so every event dispatched anywhere on
+the page reaches it — including synthetic ones from code outside the application.
+A password manager typing into a credential field dispatches a `keydown` carrying
+no `key`, and the manager spread it as a string, crashing the page with
+`TypeError: key is not iterable`. It now ignores an event it cannot read as a
+keystroke, and leaves it propagating to whichever listener does understand it.

--- a/packages/ui/src/lib/shortcuts/manager.test.ts
+++ b/packages/ui/src/lib/shortcuts/manager.test.ts
@@ -2703,3 +2703,45 @@ describe("a step that names modifiers and no key", () => {
     ).toThrow();
   });
 });
+
+describe("an event the manager cannot read as a keystroke", () => {
+  /**
+   * `attach` listens on `document`, so everything dispatched on the page arrives here — not
+   * only events this library or the application created. Password managers, autofill shims and
+   * any code doing `new CustomEvent("keydown")` produce an object with no `key`, and the match
+   * path spreads it and calls `startsWith` on it.
+   */
+  it("ignores a synthetic keydown carrying no key", () => {
+    const manager = managerFor();
+    const run = vi.fn();
+    manager.register([binding("mod+k", run)], { name: "a", depth: 0 });
+
+    const synthetic = new CustomEvent("keydown", { bubbles: true });
+    expect(() =>
+      manager.handle(synthetic as unknown as KeyboardEvent)
+    ).not.toThrow();
+    expect(run).not.toHaveBeenCalled();
+  });
+
+  it("leaves that event propagating rather than claiming it", () => {
+    // Reported as NOT consumed on purpose. An event this manager cannot interpret has to reach
+    // whichever listener does understand it; swallowing it would trade a crash for a key that
+    // silently stops working.
+    const manager = managerFor();
+    manager.register([binding("mod+k", vi.fn())], { name: "a", depth: 0 });
+
+    const synthetic = new CustomEvent("keydown", { bubbles: true });
+    expect(manager.handle(synthetic as unknown as KeyboardEvent)).toBe(false);
+  });
+
+  it("still handles a real keystroke that merely lacks modifiers", () => {
+    // The control. The guard admits on `key` being a STRING, not on the event being complete —
+    // a plain letter press carries no modifier flags worth speaking of and must still match.
+    const manager = managerFor();
+    const run = vi.fn();
+    manager.register([binding("g", run)], { name: "a", depth: 0 });
+
+    manager.handle(press("g"));
+    expect(run).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/ui/src/lib/shortcuts/manager.ts
+++ b/packages/ui/src/lib/shortcuts/manager.ts
@@ -753,7 +753,22 @@ export function createShortcutManager(
   }
 
   function handle(event: KeyboardEvent): boolean {
-    // Checked FIRST: an owner closer to the keystroke has already answered it, and that stays
+    // An event this manager cannot read as a keystroke at all.
+    //
+    // `attach` listens on `document`, so EVERYTHING dispatched on the page arrives here,
+    // including synthetic events from code that is not ours -- `new CustomEvent("keydown")`,
+    // password managers, autofill shims. Those carry no `key`, and the match path spreads it
+    // (`[...key]`) and calls `startsWith` on it, both of which throw on `undefined`.
+    //
+    // Admitted ONCE, here, rather than defended at each read: `handle` is the only way in, and
+    // `key` is the only property whose absence throws. The modifier flags degrade to "no match"
+    // when undefined, and `getModifierState` is already optional-chained at both call sites.
+    //
+    // Reported as NOT consumed, so `attach` leaves it propagating: an event this manager cannot
+    // interpret must reach whatever listener does understand it.
+    if (typeof event.key !== "string") return false;
+
+    // Checked FIRST among real keystrokes: an owner closer to the keystroke has already answered it, and that stays
     // true even while an IME is composing. Reported as consumed so `attach` stops it
     // propagating — the manager runs no binding, but it is the one place that can keep a
     // window-level owner from acting on a key someone else already answered.


### PR DESCRIPTION
Founder-reported runtime crash on **Settings → Email Providers → Create**:

```
TypeError: key is not iterable
  at normalizeKey (packages/ui/src/lib/shortcuts/key-spec.ts:52)
  at chordMatches (key-spec.ts:198)
  at matchDepth (manager.ts:487)
  at handle (manager.ts:872)
  at HTMLDocument.listener (manager.ts:961)
```

## What is actually wrong

`attach` installs a listener on `document` and casts what arrives to `KeyboardEvent`. That cast is an assumption about **other people's code**: everything dispatched anywhere on the page reaches a document listener, including synthetic events the application never created. Those carry no `key`, and the match path does `[...key]`.

**Reproduced before fixing**, with `new CustomEvent("keydown")` dispatched into `handle` — fails with the founder's exact message, `TypeError: key is not iterable`. No password manager needed to trigger it.

## Why that page

The create-provider form renders `type="password"` inputs (`SecretField`, and `ProviderConfigFields` for any `kind: "password"` descriptor field — SMTP password, API keys). Password managers hook password fields and dispatch synthetic events on them, which bubble to `document`. Nothing in `packages/{admin,ui,builder}` dispatches synthetic keyboard events — verified by grep — so the source is outside the app, which is exactly why the fix belongs at the boundary rather than at a caller.

That also explains the repeat count in the founder's log: the extension fires per field, not once.

## The fix, and why it is placed where it is

One guard, as the first statement of `handle`:

```ts
if (typeof event.key !== "string") return false;
```

- **`handle` is the only way in.** `attach`'s listener calls it, and it is also part of the public manager surface, so guarding here covers both. Guarding inside `normalizeKey` would run once per binding per keystroke and still leave direct callers exposed.
- **`key` is the only property whose absence throws — established by enumeration, not from the stack trace.** The handler reads 14 properties off the event. The modifier flags degrade to "no match" when `undefined`; `getModifierState` is already optional-chained at both call sites (`manager.ts:523`, `key-spec.ts:215`); `code`, `repeat`, `isComposing` and `defaultPrevented` are only read for truthiness. Only `key` is spread and `startsWith`-ed.
- **Returns `false` (not consumed)**, so `attach` leaves the event propagating. An event this manager cannot interpret must reach whichever listener does understand it — swallowing it would trade a crash for a key that silently stops working.

## Verification

- 3 new tests. **Negative-controlled**: removing the guard fails exactly the two that assert it, while the third — a real keystroke carrying no modifiers — still passes, so the control is not merely breaking everything.
- That third test is the positive control for the guard's shape: it admits on `key` being a *string*, not on the event being *complete*.
- `packages/ui`: **668 tests across 28 files, all passing**; `check-types` 0 errors; `lint` exit 0. This package has no pre-existing failing baseline, so there is nothing to net out.
- One changeset over all 23 fixed-group packages, generated from `.changeset/config.json`, `patch`.