### PR TITLE
test(ui): give the program checks a budget they can meet on CI

### DIFF
--- a/packages/ui/src/__tests__/node-types-stay-out-of-src.test.ts
+++ b/packages/ui/src/__tests__/node-types-stay-out-of-src.test.ts
@@ -51,6 +51,20 @@ const compilerOptions = (config: Record<string, unknown>) =>
  * package folder that has nothing to do with node types — matching `@types` and `node` loosely
  * counts those and reports a leak that is not there.
  */
+/**
+ * How long one program construction gets.
+ *
+ * Building a TypeScript program reads and parses every file it reaches, which takes under a second
+ * on an idle machine and several times that on a CI runner sharing a host with other matrices.
+ * Vitest's default is 5s, and these two cases crossed it there while passing locally -- reddening
+ * unrelated lanes' pull requests, which is the expensive direction for a check to fail in.
+ *
+ * Raised rather than the work reduced, because what makes the second case slow is the thing it
+ * exists to prove: that the reader FINDS node types when they are present. A cheaper control would
+ * be a control of something else.
+ */
+const PROGRAM_TIMEOUT_MS = 60_000;
+
 function nodeTypeFilesIn(configName: string): string[] {
   const configPath = resolve(pkgRoot, configName);
   const { config, error } = ts.readConfigFile(configPath, ts.sys.readFile);
@@ -92,23 +106,31 @@ describe("node types stay out of the shipped surface", () => {
     expect(scripts["check-types"]).toContain("tsconfig.tests.json");
   });
 
-  it("loads no node type file into the shipping program", () => {
-    // The PROPERTY, not the line. Every assertion above reads configuration, and `types` governs
-    // only the AUTOMATIC inclusion of `node_modules/@types/*` — it does nothing about a
-    // `/// <reference types="node" />` inside a `.d.ts` the program already includes. So a
-    // dependency whose types reference node reopens this hole with `types: []` still written down
-    // and all four assertions above still green.
-    //
-    // Not hypothetical: applied to `blocks-react`, whose `/next` subpath imports Next, that same
-    // line is inert — 63 node type files load anyway, because `next/dist/types.d.ts` references
-    // them. The line works here and not there, so what is asserted has to be the outcome.
-    expect(nodeTypeFilesIn("tsconfig.json")).toEqual([]);
-  });
+  it(
+    "loads no node type file into the shipping program",
+    { timeout: PROGRAM_TIMEOUT_MS },
+    () => {
+      // The PROPERTY, not the line. Every assertion above reads configuration, and `types` governs
+      // only the AUTOMATIC inclusion of `node_modules/@types/*` — it does nothing about a
+      // `/// <reference types="node" />` inside a `.d.ts` the program already includes. So a
+      // dependency whose types reference node reopens this hole with `types: []` still written down
+      // and all four assertions above still green.
+      //
+      // Not hypothetical: applied to `blocks-react`, whose `/next` subpath imports Next, that same
+      // line is inert — 63 node type files load anyway, because `next/dist/types.d.ts` references
+      // them. The line works here and not there, so what is asserted has to be the outcome.
+      expect(nodeTypeFilesIn("tsconfig.json")).toEqual([]);
+    }
+  );
 
-  it("loads them into the test program, so the check can tell the two apart", () => {
-    // The positive control. Without it an empty result above cannot be distinguished from a reader
-    // that finds nothing under any circumstances — a bad path, a config that resolved no files, a
-    // filter that matches nothing.
-    expect(nodeTypeFilesIn("tsconfig.tests.json").length).toBeGreaterThan(0);
-  });
+  it(
+    "loads them into the test program, so the check can tell the two apart",
+    { timeout: PROGRAM_TIMEOUT_MS },
+    () => {
+      // The positive control. Without it an empty result above cannot be distinguished from a reader
+      // that finds nothing under any circumstances — a bad path, a config that resolved no files, a
+      // filter that matches nothing.
+      expect(nodeTypeFilesIn("tsconfig.tests.json").length).toBeGreaterThan(0);
+    }
+  );
 });


### PR DESCRIPTION
## Fixes a red `main` that I caused

#701 added two cases that build a TypeScript program. They pass locally in ~800ms and **time out at vitest's 5s default on CI**, failing `@nextlyhq/ui#test` and reddening unrelated lanes' PRs. Reported by the lane it was blocking, with the failing output.

That is the expensive direction for a check to fail in, and it is the failure I have been citing at other people's guards all day. Sorry for the noise.

## The fix

An explicit 60s budget on the two cases that build a program. Raised rather than the work reduced: what makes the control slow is precisely the thing it exists to prove — that the reader FINDS node types when they are present. A cheaper control would be a control of something else.

## Two things worth flagging for the reviewer

**My first attempt was a silent no-op.** I wrote `it(name, TIMEOUT, fn)`, which vitest does not recognise as a timeout — it is not one of the overloads. A probe caught it:

```
it("sleeps 7s with an explicit 60s budget", 60_000, async () => ...)
  × Error: Test timed out in 5000ms.          <- budget ignored
```

Both `it(name, fn, timeout)` and `it(name, { timeout }, fn)` do work; this uses the options form.

**Then only one of the two got fixed.** Prettier had reflowed the first case across lines, so my second edit matched the other one and silently missed it. Caught by asserting the count of replacements rather than trusting them.

Verified by exceeding the old limit inside the case that was previously wrong:

```
const t0 = Date.now(); while (Date.now() - t0 < 7000) {}   // 7s of work
-> 6 passed
```

Before the fix that same insertion produced `Test timed out in 5000ms`.

670 tests pass in `packages/ui`; `lint` and `check-types` green.

No changeset: test-only.