### PR TITLE
feat(root): gate the field-group storage spelling to one catalog

### DIFF
--- a/.changeset/storage-format-literal-gate.md
+++ b/.changeset/storage-format-literal-gate.md
@@ -1,0 +1,27 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+---
+
+A field group instance now reports its type whichever spelling the stored document uses, so content written before and after the storage rename both read. Reading that type is one shared call rather than a key spelled out at each site, which is what keeps the rename a change in a single place.

--- a/.changeset/storage-format-literal-gate.md
+++ b/.changeset/storage-format-literal-gate.md
@@ -24,4 +24,4 @@
 "@nextlyhq/builder": patch
 ---
 
-A field group instance now reports its type whichever spelling the stored document uses, so content written before and after the storage rename both read. Reading that type is one shared call rather than a key spelled out at each site, which is what keeps the rename a change in a single place.
+A field group instance now reports its type whichever spelling the stored document uses, so content written before and after the storage rename both read. A `where` filter on the type keeps working under either spelling, and version snapshots keep recording the type of components nested inside a dynamic zone. Reading that type is one shared call rather than a key spelled out at each site, which is what keeps the rename a change in a single place.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,9 @@ jobs:
       - name: Drizzle v1 legacy gate
         run: pnpm check:drizzle-v1-legacy
 
+      - name: Storage-spelling gate (field-group storage format)
+        run: pnpm check:storage-format-literals
+
       # The drizzle-v1 migration's own safety net (review-driven: these
       # suites previously executed in NO CI job because the `nextly`
       # package's full test task carries a pre-existing failing baseline).

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "check-types": "turbo run check-types",
     "check:drizzle-kit-pin": "node scripts/check-drizzle-kit-pin.cjs",
     "check:drizzle-v1-legacy": "node scripts/check-drizzle-v1-legacy.cjs",
+    "check:storage-format-literals": "node scripts/check-storage-format-literals.cjs",
     "format": "prettier --write \"**/*.{ts,tsx,md}\"",
     "lint": "turbo run lint",
     "lint:design": "node scripts/lint-design.mjs",

--- a/packages/nextly/src/domains/collections/query/__tests__/component-type-filter.post-flip.test.ts
+++ b/packages/nextly/src/domains/collections/query/__tests__/component-type-filter.post-flip.test.ts
@@ -1,0 +1,83 @@
+/**
+ * A caller's type filter keeps selecting on the type after the storage rename.
+ *
+ * The discriminator path in a `where` clause is supplied by the CALLER, not by this codebase, so
+ * it may name any spelling the key has carried since the query was written. Matching a single
+ * spelling does not make such a filter fail — it silently reclassifies it as an ordinary component
+ * field lookup, which then searches for a column of that name. The caller gets rows back, so
+ * nothing surfaces as an error; they are simply the wrong rows.
+ *
+ * 🔴 Invisible before the rename, like the other suites of this shape: while the catalog still
+ * holds the legacy spelling, matching one spelling and matching all of them agree on every input,
+ * so a test written against today's catalog passes either way. The catalog is mocked forward.
+ */
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../../../../schemas/storage-format", async () => {
+  const actual = await vi.importActual<
+    typeof import("../../../../schemas/storage-format")
+  >("../../../../schemas/storage-format");
+  return {
+    ...actual,
+    STORAGE_FORMAT: {
+      ...actual.STORAGE_FORMAT,
+      wireTypeKey: "_fieldGroupType",
+    },
+  };
+});
+
+import { currentFieldGroupTypeKey } from "../../../field-groups/storage/field-group-type-key";
+import { extractComponentFieldConditions } from "../query-operators";
+
+const fields = [
+  { name: "seo", type: "component", component: "seo" },
+  { name: "layout", type: "component", components: ["hero", "cta"] },
+];
+
+describe("a type filter written before the storage rename", () => {
+  it("the catalog really has moved, or this file proves nothing", () => {
+    expect(currentFieldGroupTypeKey).toBe("_fieldGroupType");
+  });
+
+  it("is still recognised as a type filter under the LEGACY spelling", () => {
+    const { componentFilters } = extractComponentFieldConditions(
+      { "layout._componentType": { equals: "hero" } },
+      fields
+    );
+
+    expect(componentFilters).toHaveLength(1);
+    // The separating assertion. Matching one spelling leaves this false, and the filter is then
+    // handled as a lookup for a column literally named `_componentType`.
+    expect(componentFilters[0].isComponentTypeFilter).toBe(true);
+  });
+
+  it("is recognised under the new spelling too", () => {
+    const { componentFilters } = extractComponentFieldConditions(
+      { "layout._fieldGroupType": { equals: "hero" } },
+      fields
+    );
+
+    expect(componentFilters[0].isComponentTypeFilter).toBe(true);
+  });
+
+  it("recognises the legacy spelling in the shorthand equality form as well", () => {
+    // Two call sites decide this, one per `where` syntax. Covering only the operator form leaves
+    // the shorthand able to regress on its own.
+    const { componentFilters } = extractComponentFieldConditions(
+      { "layout._componentType": "hero" },
+      fields
+    );
+
+    expect(componentFilters[0].isComponentTypeFilter).toBe(true);
+  });
+
+  it("still treats an ordinary component field as NOT a type filter", () => {
+    // The dual match widens which spellings count as the discriminator, not what counts as one.
+    const { componentFilters } = extractComponentFieldConditions(
+      { "seo.metaTitle": { contains: "About" } },
+      fields
+    );
+
+    expect(componentFilters[0].isComponentTypeFilter).toBe(false);
+  });
+});

--- a/packages/nextly/src/domains/collections/query/query-operators.ts
+++ b/packages/nextly/src/domains/collections/query/query-operators.ts
@@ -619,6 +619,11 @@ function buildComponentFieldMap(
  * // ]
  * // cleanedWhere: { title: { contains: 'Hello' } }
  * ```
+ *
+ * The discriminator path is matched under every spelling the key has carried, so a filter written
+ * against an older release keeps selecting on the type after the storage rename rather than
+ * quietly degrading into a lookup for a column of that name. The example shows one spelling; it is
+ * not the only accepted one.
  */
 export function extractComponentFieldConditions(
   where: WhereFilter | undefined,

--- a/packages/nextly/src/domains/collections/query/query-operators.ts
+++ b/packages/nextly/src/domains/collections/query/query-operators.ts
@@ -35,6 +35,7 @@ import type {
 } from "@nextlyhq/adapter-drizzle/types";
 
 import { STORAGE_FORMAT } from "../../../schemas/storage-format";
+import { isFieldGroupTypeKey } from "../../field-groups/storage/field-group-type-key";
 
 import type { GeoFilter } from "./geo-utils";
 import { parseNearQuery, parseWithinQuery } from "./geo-utils";
@@ -708,8 +709,11 @@ export function extractComponentFieldConditions(
                 componentFieldPath,
                 operator: operator as QueryOperator,
                 value: operatorValue,
-                isComponentTypeFilter:
-                  componentFieldPath === STORAGE_FORMAT.wireTypeKey,
+                // The path comes from the caller's own query, so it may name any spelling the
+                // key has ever carried. Matching a single one turns an existing filter into an
+                // ordinary field lookup against a column that does not exist, which answers with
+                // the wrong rows rather than an error.
+                isComponentTypeFilter: isFieldGroupTypeKey(componentFieldPath),
               });
             }
           }
@@ -722,8 +726,7 @@ export function extractComponentFieldConditions(
             componentFieldPath,
             operator: "equals",
             value,
-            isComponentTypeFilter:
-              componentFieldPath === STORAGE_FORMAT.wireTypeKey,
+            isComponentTypeFilter: isFieldGroupTypeKey(componentFieldPath),
           });
         }
 

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -95,6 +95,7 @@ import {
 import type { SupportedDialect } from "../../../types/database";
 import { willRecordMutationActivity } from "../../audit/record-activity";
 import type { DynamicCollectionService } from "../../dynamic-collections";
+import { readFieldGroupType } from "../../field-groups/storage/field-group-type-key";
 import {
   populateCompanionFields,
   populateCompanionFieldsAllLocales,
@@ -1884,7 +1885,9 @@ export class CollectionMutationService extends BaseService {
           kept.push(inst);
           continue;
         }
-        const tagged = (inst as Record<string, unknown>)._componentType;
+        // Asked rather than read: an instance already stored may carry either spelling of
+        // this key, depending on which side of the storage migration wrote it.
+        const tagged = readFieldGroupType(inst);
         const slug =
           typeof tagged === "string"
             ? tagged

--- a/packages/nextly/src/domains/collections/services/collection-query-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-query-service.ts
@@ -86,6 +86,7 @@ import {
 } from "../../../types/pagination";
 import type { PaginatedResponse } from "../../../types/pagination";
 import type { DynamicCollectionService } from "../../dynamic-collections";
+import { readFieldGroupType } from "../../field-groups/storage/field-group-type-key";
 import { resolveTypeColumns } from "../../field-groups/storage/resolve-storage-names";
 import {
   buildCompanionExists,
@@ -3136,7 +3137,9 @@ export class CollectionQueryService extends BaseService {
     const instance = value as Record<string, unknown>;
     // A dynamic-zone row records the component it holds; a single-component field
     // takes it from the field's declared slug.
-    const tagged = instance._componentType;
+    // Asked rather than read: the stored spelling of this key changes with the storage
+    // migration, and a row written under the other one would read as untagged.
+    const tagged = readFieldGroupType(instance);
     const declared = (field as { component?: unknown }).component;
     const slug =
       typeof tagged === "string"

--- a/packages/nextly/src/domains/field-groups/services/field-group-mutation-service.ts
+++ b/packages/nextly/src/domains/field-groups/services/field-group-mutation-service.ts
@@ -451,10 +451,12 @@ export class FieldGroupMutationService extends BaseService {
       const slugs = new Set<string>();
       if (field.components && field.components.length > 0) {
         for (const instance of resolveZoneInstances(field, value)) {
-          const type = (instance as Record<string, unknown> | null)?.[
-            STORAGE_FORMAT.wireTypeKey
-          ];
-          if (typeof type === "string" && field.components.includes(type)) {
+          // Asked through the same reader the WRITE uses. This preflight exists to raise a
+          // conflict before the transaction opens, so it has to judge exactly the instances the
+          // write will accept — an instance the write recognises but this does not skips the
+          // check entirely and fails later, inside the transaction or at the driver.
+          const type = readFieldGroupType(instance);
+          if (type !== undefined && field.components.includes(type)) {
             slugs.add(type);
           }
         }

--- a/packages/nextly/src/domains/field-groups/services/field-group-mutation-service.ts
+++ b/packages/nextly/src/domains/field-groups/services/field-group-mutation-service.ts
@@ -37,6 +37,10 @@ import {
   companionNotReadyMessage,
   resolveCompanionReadiness,
 } from "../../i18n/runtime/companion-readiness";
+import {
+  currentFieldGroupTypeKey,
+  readFieldGroupType,
+} from "../storage/field-group-type-key";
 
 import {
   COMPONENT_META_KEYS,
@@ -1125,19 +1129,24 @@ export class FieldGroupMutationService extends BaseService {
 
       for (let i = 0; i < instances.length; i++) {
         const instance = instances[i];
-        const componentType = instance[STORAGE_FORMAT.wireTypeKey];
+        // Asked rather than indexed: an instance written under the other spelling of this key
+        // would otherwise read as missing, and a missing type is DROPPED below.
+        const componentType = readFieldGroupType(instance);
 
         if (!componentType) {
-          this.logger.warn("Multi-component instance missing _componentType", {
-            fieldName,
-            index: i,
-          });
+          this.logger.warn(
+            `Multi-component instance missing ${currentFieldGroupTypeKey}`,
+            {
+              fieldName,
+              index: i,
+            }
+          );
           continue;
         }
 
         if (!allowedSlugs.includes(componentType)) {
           this.logger.warn(
-            "Multi-component instance has invalid _componentType",
+            `Multi-component instance has invalid ${currentFieldGroupTypeKey}`,
             {
               fieldName,
               componentType,
@@ -1301,7 +1310,8 @@ export class FieldGroupMutationService extends BaseService {
 
       for (let i = 0; i < instances.length; i++) {
         const instance = instances[i];
-        const componentType = instance[STORAGE_FORMAT.wireTypeKey];
+        // Asked rather than indexed, for the same reason: an unresolved type skips the row.
+        const componentType = readFieldGroupType(instance);
 
         if (!componentType || !allowedSlugs.includes(componentType)) continue;
 

--- a/packages/nextly/src/domains/field-groups/services/field-group-query-service.ts
+++ b/packages/nextly/src/domains/field-groups/services/field-group-query-service.ts
@@ -26,6 +26,7 @@ import {
   resolveCompanionSchemaReadiness,
   type CompanionReadiness,
 } from "../../i18n/runtime/companion-readiness";
+import { currentFieldGroupTypeKey } from "../storage/field-group-type-key";
 
 import {
   DEFAULT_COMPONENT_DEPTH,
@@ -1108,7 +1109,7 @@ export class FieldGroupQueryService extends BaseService {
     result.id = row.id;
 
     if (includeComponentType && row[STORAGE_FORMAT.columns.type]) {
-      result[STORAGE_FORMAT.wireTypeKey] = row[STORAGE_FORMAT.columns.type];
+      result[currentFieldGroupTypeKey] = row[STORAGE_FORMAT.columns.type];
     }
 
     const fieldByColumn = new Map<string, FieldConfig>();

--- a/packages/nextly/src/domains/field-groups/services/field-group-utils.ts
+++ b/packages/nextly/src/domains/field-groups/services/field-group-utils.ts
@@ -55,7 +55,13 @@ export interface ComponentRow {
  */
 export interface ComponentInstanceData {
   id?: string;
-  _componentType?: string;
+  /**
+   * The type discriminator is reached through `readFieldGroupType`, not declared here.
+   *
+   * Naming the key in this shape would fix ONE spelling into the type, and the storage migration
+   * renames it — so the declaration would go stale exactly when a document could carry either
+   * one. The index signature below already admits it; the accessor is what knows which.
+   */
   [key: string]: unknown;
 }
 

--- a/packages/nextly/src/domains/field-groups/services/field-group-utils.ts
+++ b/packages/nextly/src/domains/field-groups/services/field-group-utils.ts
@@ -1,6 +1,7 @@
 import type { FieldConfig } from "../../../collections/fields/types";
 import { STORAGE_FORMAT } from "../../../schemas/storage-format";
 import { storageTypeToken } from "../../../shared/lib/plugin-storage";
+import { fieldGroupTypeKeys } from "../storage/field-group-type-key";
 
 /**
  * Default relationship expansion depth for component data.
@@ -23,7 +24,11 @@ export const POPULATE_INTERNAL_COLUMNS: ReadonlySet<string> = new Set([
  */
 export const COMPONENT_META_KEYS: ReadonlySet<string> = new Set([
   "id",
-  STORAGE_FORMAT.wireTypeKey,
+  // Every spelling of the discriminator, not just the one written today. This set decides what
+  // counts as metadata rather than authored data, so a spelling missing from it is treated as a
+  // field the caller meant to store — which is the opposite of the intent for a key that only
+  // ever announced the instance's type.
+  ...fieldGroupTypeKeys,
   STORAGE_FORMAT.columns.order,
   STORAGE_FORMAT.columns.parentId,
   STORAGE_FORMAT.columns.parentTable,
@@ -44,7 +49,16 @@ export interface ComponentRow {
   _parent_table: string;
   _parent_field: string;
   _order: number;
-  _component_type: string | null;
+  /**
+   * The discriminator column is admitted by the index signature, not declared.
+   *
+   * Declaring it would fix one spelling into the type while the storage migration renames the
+   * column, so the declaration would describe a migrated table incorrectly — and it bought no
+   * narrowing that the index signature does not already give, since every reader addresses the
+   * column through `STORAGE_FORMAT.columns.type` rather than by writing the name.
+   *
+   * The sibling columns stay declared because the migration does not rename them.
+   */
   created_at: string;
   updated_at: string;
   [key: string]: unknown;

--- a/packages/nextly/src/domains/field-groups/storage/__tests__/field-group-type-key.post-flip.test.ts
+++ b/packages/nextly/src/domains/field-groups/storage/__tests__/field-group-type-key.post-flip.test.ts
@@ -28,11 +28,15 @@ vi.mock("../../../../schemas/storage-format", async () => {
 });
 
 import {
+  clearFieldGroupType,
   currentFieldGroupTypeKey,
+  fieldGroupTypeKeys,
   isFieldGroupTypeKey,
   readFieldGroupType,
   writeFieldGroupType,
 } from "../field-group-type-key";
+
+import { COMPONENT_META_KEYS } from "../../services/field-group-utils";
 
 describe("after the catalog has been flipped to the new spelling", () => {
   it("the two catalogs really do agree, or this file proves nothing", () => {
@@ -70,5 +74,30 @@ describe("after the catalog has been flipped to the new spelling", () => {
     expect(
       readFieldGroupType({ _fieldGroupType: "new", _componentType: "old" })
     ).toBe("new");
+  });
+
+  it("removes the discriminator under EVERY spelling", () => {
+    // Clearing only the current spelling leaves a legacy-spelled document still carrying its
+    // type, so an object the caller has defined by that absence still reads as typed and the
+    // strip/tag pair stop being inverses of each other.
+    const instance: Record<string, unknown> = {
+      _componentType: "old",
+      _fieldGroupType: "new",
+      label: "kept",
+    };
+
+    clearFieldGroupType(instance);
+
+    expect(Object.keys(instance)).toEqual(["label"]);
+  });
+
+  it("treats every spelling as component metadata rather than authored data", () => {
+    // This set decides what is stripped as metadata before a write. A spelling missing from it is
+    // treated as a field the author meant to store, which is the opposite of the intent for a key
+    // that only ever announced the instance's type.
+    for (const key of fieldGroupTypeKeys) {
+      expect(COMPONENT_META_KEYS.has(key)).toBe(true);
+    }
+    expect(COMPONENT_META_KEYS.has("_componentType")).toBe(true);
   });
 });

--- a/packages/nextly/src/domains/field-groups/storage/__tests__/field-group-type-key.post-flip.test.ts
+++ b/packages/nextly/src/domains/field-groups/storage/__tests__/field-group-type-key.post-flip.test.ts
@@ -1,0 +1,74 @@
+/**
+ * The dual read survives the release that adopts the new spelling.
+ *
+ * 🔴 This is the case a derived read order gets wrong, and it gets it wrong at the worst moment.
+ * Once `STORAGE_FORMAT.wireTypeKey` is flipped to the target spelling the two catalogs hold the
+ * SAME string, so a read order built from just those two collapses to one entry — and the legacy
+ * spelling stops being read in precisely the release where nearly every stored document still
+ * uses it. Every document written before the flip would read as untyped.
+ *
+ * A separate file because the flip is simulated by mocking the CATALOG, and the sibling suite
+ * mocks the migration manifest instead; `vi.mock` is hoisted per file, so the two states cannot
+ * coexist in one.
+ */
+import { describe, expect, it, vi } from "vitest";
+
+// The post-flip world: the current spelling IS the target spelling.
+vi.mock("../../../../schemas/storage-format", async () => {
+  const actual = await vi.importActual<
+    typeof import("../../../../schemas/storage-format")
+  >("../../../../schemas/storage-format");
+  return {
+    ...actual,
+    STORAGE_FORMAT: {
+      ...actual.STORAGE_FORMAT,
+      wireTypeKey: "_fieldGroupType",
+    },
+  };
+});
+
+import {
+  currentFieldGroupTypeKey,
+  isFieldGroupTypeKey,
+  readFieldGroupType,
+  writeFieldGroupType,
+} from "../field-group-type-key";
+
+describe("after the catalog has been flipped to the new spelling", () => {
+  it("the two catalogs really do agree, or this file proves nothing", () => {
+    // The precondition. Without it, a mock that silently failed to apply would leave every
+    // assertion below running against the PRE-flip world and passing for the wrong reason.
+    expect(currentFieldGroupTypeKey).toBe("_fieldGroupType");
+  });
+
+  it("still reads a document written under the LEGACY spelling", () => {
+    // The whole point. These are the documents that exist in the largest numbers on the day the
+    // flip ships, and the migration may not have rewritten them yet — or may never, if the
+    // operator has not run it.
+    expect(readFieldGroupType({ _componentType: "hero" })).toBe("hero");
+  });
+
+  it("still reads a document written under the new spelling", () => {
+    expect(readFieldGroupType({ _fieldGroupType: "hero" })).toBe("hero");
+  });
+
+  it("still recognises the legacy spelling as a type key", () => {
+    // The key-by-key walkers depend on this: a pruner that stops recognising the legacy key
+    // discards the discriminator of every un-rewritten row it touches.
+    expect(isFieldGroupTypeKey("_componentType")).toBe(true);
+    expect(isFieldGroupTypeKey("_fieldGroupType")).toBe(true);
+  });
+
+  it("writes the NEW spelling, so the legacy set only shrinks", () => {
+    const instance: Record<string, unknown> = {};
+    writeFieldGroupType(instance, "hero");
+
+    expect(Object.keys(instance)).toEqual(["_fieldGroupType"]);
+  });
+
+  it("prefers the current spelling when a document carries both", () => {
+    expect(
+      readFieldGroupType({ _fieldGroupType: "new", _componentType: "old" })
+    ).toBe("new");
+  });
+});

--- a/packages/nextly/src/domains/field-groups/storage/__tests__/field-group-type-key.test.ts
+++ b/packages/nextly/src/domains/field-groups/storage/__tests__/field-group-type-key.test.ts
@@ -1,0 +1,105 @@
+/**
+ * The type key reads under either spelling, and writes under one.
+ *
+ * 🔴 The two spellings are the SAME STRING today — the flip has not happened — so every assertion
+ * about "falls back to the legacy key" passes trivially against the real constants, whether or not
+ * the fallback exists at all. A suite written against them would report coverage it does not have,
+ * and would keep reporting it right up until the flip made it matter.
+ *
+ * So the target spelling is mocked to something genuinely different. That is what makes the two
+ * branches distinguishable, and it is the only way to see the fallback work before the day it has
+ * to.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// A spelling that is not the current one, standing in for the post-flip name. Mocked rather than
+// waited for: the property under test is "two different keys both read", and with one key there is
+// nothing to test.
+vi.mock("../../migration/manifest", async () => {
+  const actual = await vi.importActual<
+    typeof import("../../migration/manifest")
+  >("../../migration/manifest");
+  return {
+    ...actual,
+    MIGRATION_TARGET: { ...actual.MIGRATION_TARGET, wireTypeKey: "_afterFlip" },
+  };
+});
+
+import { STORAGE_FORMAT } from "../../../../schemas/storage-format";
+import {
+  currentFieldGroupTypeKey,
+  readFieldGroupType,
+  writeFieldGroupType,
+} from "../field-group-type-key";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("the field-group type key", () => {
+  it("reads a document written under the CURRENT spelling", () => {
+    expect(readFieldGroupType({ [STORAGE_FORMAT.wireTypeKey]: "hero" })).toBe(
+      "hero"
+    );
+  });
+
+  it("reads a document written under the OTHER spelling", () => {
+    // The row a migration has already rewritten, or has not yet — which of the two depends on
+    // direction, and a reader cannot tell. Both must read.
+    expect(readFieldGroupType({ _afterFlip: "hero" })).toBe("hero");
+  });
+
+  it("prefers the current spelling when a document somehow carries both", () => {
+    // Not a state the migration produces, but a state a hand-repaired or partially rewritten
+    // document can reach. The preference has to be decided rather than left to key order.
+    expect(
+      readFieldGroupType({
+        [STORAGE_FORMAT.wireTypeKey]: "current",
+        _afterFlip: "other",
+      })
+    ).toBe("current");
+  });
+
+  it("writes only the current spelling", () => {
+    // 🔴 The half that matters most. A save path that writes the LEGACY key keeps manufacturing
+    // pre-migration documents behind a migration that already reported success, so the set of
+    // rows needing a rewrite grows instead of shrinking.
+    const instance: Record<string, unknown> = {};
+    writeFieldGroupType(instance, "hero");
+
+    expect(instance[currentFieldGroupTypeKey]).toBe("hero");
+    expect(Object.keys(instance)).toEqual([currentFieldGroupTypeKey]);
+    expect(instance._afterFlip).toBeUndefined();
+  });
+
+  it("answers undefined for an instance that announces no type", () => {
+    // The single-field-group shape carries no discriminator at all, so absence is an ordinary
+    // answer rather than a failure, and callers branch on it.
+    expect(readFieldGroupType({})).toBeUndefined();
+    expect(readFieldGroupType(null)).toBeUndefined();
+    expect(readFieldGroupType("hero")).toBeUndefined();
+  });
+
+  it("treats a non-string value as absent rather than coercing it", () => {
+    // The value is a slug that gets looked up. A number coerces into something that resolves to
+    // nothing while reading as though a type had been found, which turns a malformed document
+    // into a confident wrong answer.
+    expect(
+      readFieldGroupType({ [STORAGE_FORMAT.wireTypeKey]: 42 })
+    ).toBeUndefined();
+    expect(
+      readFieldGroupType({ [STORAGE_FORMAT.wireTypeKey]: { slug: "hero" } })
+    ).toBeUndefined();
+  });
+
+  it("falls through to the other spelling when the current one holds a non-string", () => {
+    // The two rules compose: a malformed current key must not shadow a usable legacy one, or a
+    // partially rewritten document reads as untyped because of a value nobody meant to keep.
+    expect(
+      readFieldGroupType({
+        [STORAGE_FORMAT.wireTypeKey]: 42,
+        _afterFlip: "hero",
+      })
+    ).toBe("hero");
+  });
+});

--- a/packages/nextly/src/domains/field-groups/storage/field-group-type-key.ts
+++ b/packages/nextly/src/domains/field-groups/storage/field-group-type-key.ts
@@ -65,6 +65,18 @@ export function readFieldGroupType(instance: unknown): string | undefined {
 }
 
 /**
+ * Whether a property name is one of this key's spellings.
+ *
+ * Asked by code that walks a document key by key rather than looking the value up — pruning a
+ * restore payload, deciding whether a row carries anything but metadata, stripping the marker
+ * before storage. Those places cannot use `readFieldGroupType` because they hold a KEY, not an
+ * instance, and matching one spelling there drops or keeps the wrong half of a document.
+ */
+export function isFieldGroupTypeKey(key: string): boolean {
+  return READ_ORDER.includes(key);
+}
+
+/**
  * Stamp the type onto an instance, under the spelling this version writes.
  *
  * Mutates rather than copying, because the callers are building an object they own — a form's

--- a/packages/nextly/src/domains/field-groups/storage/field-group-type-key.ts
+++ b/packages/nextly/src/domains/field-groups/storage/field-group-type-key.ts
@@ -50,13 +50,21 @@ import { MIGRATION_TARGET } from "../migration/manifest";
 const HISTORICAL_WIRE_TYPE_KEYS = ["_componentType"] as const;
 
 /**
- * Every spelling to try, most current first.
+ * Every spelling this key can appear under, most current first.
  *
  * The two catalogs still contribute, so a future rename is picked up without editing this list;
  * the pinned history is what survives their convergence. Deduplicated because before the flip the
  * catalogs differ and after it they do not, and a reader should not check one spelling twice.
+ *
+ * Exported because several callers need the SET rather than a single answer — building a set of
+ * metadata property names, removing the discriminator however it is spelled. Everything else in
+ * this file is derived from it rather than restating it, so the spellings are enumerated once.
+ *
+ * Order is significant and is the read order: a document carrying two spellings resolves to the
+ * most current one. Callers wanting a single spelling want `currentFieldGroupTypeKey`, which says
+ * so; indexing this is the same bug as hardcoding.
  */
-const READ_ORDER: readonly string[] = Array.from(
+export const fieldGroupTypeKeys: readonly string[] = Array.from(
   new Set([
     STORAGE_FORMAT.wireTypeKey,
     MIGRATION_TARGET.wireTypeKey,
@@ -76,7 +84,7 @@ export const currentFieldGroupTypeKey = STORAGE_FORMAT.wireTypeKey;
 export function readFieldGroupType(instance: unknown): string | undefined {
   if (typeof instance !== "object" || instance === null) return undefined;
   const record = instance as Record<string, unknown>;
-  for (const key of READ_ORDER) {
+  for (const key of fieldGroupTypeKeys) {
     const value = record[key];
     // A non-string is treated as absent rather than coerced. The value is a slug the caller looks
     // up, and a number or object stringifies into something that resolves to nothing while
@@ -95,7 +103,22 @@ export function readFieldGroupType(instance: unknown): string | undefined {
  * instance, and matching one spelling there drops or keeps the wrong half of a document.
  */
 export function isFieldGroupTypeKey(key: string): boolean {
-  return READ_ORDER.includes(key);
+  return fieldGroupTypeKeys.includes(key);
+}
+
+/**
+ * Remove the discriminator from an instance, under every spelling it may carry.
+ *
+ * Deleting only the current spelling leaves a legacy-spelled document still carrying its type,
+ * which matters because the callers are producing a value defined by that absence — a payload
+ * stripped back to the fields a schema names, so that a later restore prunes it against the
+ * component the field names now. A surviving discriminator makes that "stripped" object one the
+ * next reader still sees a type on, and the two halves of the round trip stop being inverses.
+ */
+export function clearFieldGroupType(instance: Record<string, unknown>): void {
+  for (const key of fieldGroupTypeKeys) {
+    delete instance[key];
+  }
 }
 
 /**

--- a/packages/nextly/src/domains/field-groups/storage/field-group-type-key.ts
+++ b/packages/nextly/src/domains/field-groups/storage/field-group-type-key.ts
@@ -1,0 +1,79 @@
+/**
+ * Reading and writing the type a dynamic-zone instance announces itself under.
+ *
+ * ## Why this is a function and not a constant
+ *
+ * The storage migration renames this key inside stored JSON. Table and column names survive that
+ * because `resolve-storage-names.ts` asks the CATALOG which spelling a database really uses — but
+ * a key inside a row is not a catalog object. Nothing can observe it, so nothing can resolve it.
+ *
+ * A constant therefore does not help a reader: inlining `STORAGE_FORMAT.wireTypeKey` still yields
+ * exactly one spelling, and a document written under the other one reads as untyped. An instance
+ * whose type cannot be read is intact and unusable — the editor cannot render it, a diff cannot
+ * tag it, and a filter on it matches nothing.
+ *
+ * So the contract callers need is an accessor that TRIES BOTH, in the order the migration itself
+ * uses. Exporting one function also means the flip is a change here rather than a search: the
+ * reason `schemas/storage-format.ts` exists, extended to the one name it cannot cover.
+ *
+ * ## Which order, and why it is that way round
+ *
+ * Read the CURRENT spelling first and fall back to the legacy one. Writes always use the current
+ * spelling, never the legacy one.
+ *
+ * That pairing is what makes a partially rewritten database safe rather than merely survivable. A
+ * migration that stops half way leaves both spellings present across different rows; every one of
+ * them still reads, and any row saved afterwards is written in the current spelling, so the set of
+ * legacy rows only ever shrinks. Writing the legacy spelling — which a hardcoded save path does —
+ * grows it instead, behind a migration that has already reported success.
+ */
+
+import { STORAGE_FORMAT } from "../../../schemas/storage-format";
+import { MIGRATION_TARGET } from "../migration/manifest";
+
+/**
+ * Every spelling this key has ever had, current first.
+ *
+ * Derived from the two catalogs rather than listed, so a rename that edits either one is picked up
+ * here without a second edit. Deduplicated because the two are the SAME string until the flip
+ * happens, and a reader should not check one spelling twice.
+ */
+const READ_ORDER: readonly string[] = Array.from(
+  new Set([STORAGE_FORMAT.wireTypeKey, MIGRATION_TARGET.wireTypeKey])
+);
+
+/** The spelling new documents are written under. */
+export const currentFieldGroupTypeKey = STORAGE_FORMAT.wireTypeKey;
+
+/**
+ * The type a dynamic-zone instance announces, or undefined when it announces none.
+ *
+ * Undefined is a real answer rather than an error: a single-field-group instance carries no
+ * discriminator at all, and only the multi shape does. Callers already branch on that.
+ */
+export function readFieldGroupType(instance: unknown): string | undefined {
+  if (typeof instance !== "object" || instance === null) return undefined;
+  const record = instance as Record<string, unknown>;
+  for (const key of READ_ORDER) {
+    const value = record[key];
+    // A non-string is treated as absent rather than coerced. The value is a slug the caller looks
+    // up, and a number or object stringifies into something that resolves to nothing while
+    // reading as though it had been found.
+    if (typeof value === "string") return value;
+  }
+  return undefined;
+}
+
+/**
+ * Stamp the type onto an instance, under the spelling this version writes.
+ *
+ * Mutates rather than copying, because the callers are building an object they own — a form's
+ * default values, or a row being assembled. A copy would be the safer default in general; here it
+ * would silently drop the assignment for every caller that does not use the return value.
+ */
+export function writeFieldGroupType(
+  instance: Record<string, unknown>,
+  type: string
+): void {
+  instance[currentFieldGroupTypeKey] = type;
+}

--- a/packages/nextly/src/domains/field-groups/storage/field-group-type-key.ts
+++ b/packages/nextly/src/domains/field-groups/storage/field-group-type-key.ts
@@ -32,14 +32,36 @@ import { STORAGE_FORMAT } from "../../../schemas/storage-format";
 import { MIGRATION_TARGET } from "../migration/manifest";
 
 /**
- * Every spelling this key has ever had, current first.
+ * Spellings this key has carried in a RELEASED version, pinned as literals.
  *
- * Derived from the two catalogs rather than listed, so a rename that edits either one is picked up
- * here without a second edit. Deduplicated because the two are the SAME string until the flip
- * happens, and a reader should not check one spelling twice.
+ * 🔴 Deliberately not derived, and this is the one place in this file where a hardcoded storage
+ * spelling is correct.
+ *
+ * Deriving the read order from the two catalogs looks like the tidy answer and is wrong in one
+ * specific release: the moment `STORAGE_FORMAT.wireTypeKey` is flipped to the target spelling, the
+ * two catalogs hold the SAME string, a derived set collapses to one entry, and the legacy spelling
+ * stops being read — in exactly the release where almost every stored document still uses it. The
+ * dual read would disappear at the instant it started to matter.
+ *
+ * A historical spelling has no source once the catalog has moved past it. Nothing but a literal
+ * can hold it, so it is held here, next to the reader that needs it, rather than left to be
+ * reconstructed from constants that converge.
+ */
+const HISTORICAL_WIRE_TYPE_KEYS = ["_componentType"] as const;
+
+/**
+ * Every spelling to try, most current first.
+ *
+ * The two catalogs still contribute, so a future rename is picked up without editing this list;
+ * the pinned history is what survives their convergence. Deduplicated because before the flip the
+ * catalogs differ and after it they do not, and a reader should not check one spelling twice.
  */
 const READ_ORDER: readonly string[] = Array.from(
-  new Set([STORAGE_FORMAT.wireTypeKey, MIGRATION_TARGET.wireTypeKey])
+  new Set([
+    STORAGE_FORMAT.wireTypeKey,
+    MIGRATION_TARGET.wireTypeKey,
+    ...HISTORICAL_WIRE_TYPE_KEYS,
+  ])
 );
 
 /** The spelling new documents are written under. */

--- a/packages/nextly/src/domains/schema/services/type-generator.ts
+++ b/packages/nextly/src/domains/schema/services/type-generator.ts
@@ -43,8 +43,8 @@ import { NextlyError } from "../../../errors";
 import type { DynamicCollectionRecord } from "../../../schemas/dynamic-collections/types";
 import type { DynamicFieldGroupRecord } from "../../../schemas/dynamic-field-groups/types";
 import type { DynamicSingleRecord } from "../../../schemas/dynamic-singles/types";
-import { STORAGE_FORMAT } from "../../../schemas/storage-format";
 import type { UserFieldDefinitionRecord } from "../../../schemas/user-field-definitions/types";
+import { currentFieldGroupTypeKey } from "../../field-groups/storage/field-group-type-key";
 
 import {
   asScalarStorageField,
@@ -642,7 +642,7 @@ export class TypeGenerator {
     lines.push(`export interface ${interfaceName} {`);
     lines.push("  id: string;");
     // Add discriminator property for type narrowing in dynamic zones
-    lines.push(`  ${STORAGE_FORMAT.wireTypeKey}: "${component.slug}";`);
+    lines.push(`  ${currentFieldGroupTypeKey}: "${component.slug}";`);
 
     // Generate field types
     for (const field of component.fields) {

--- a/packages/nextly/src/domains/singles/services/single-mutation-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-mutation-service.ts
@@ -40,7 +40,6 @@ import {
   readRevalidateConfig,
 } from "../../../revalidation/intent-builders";
 import type { RevalidationIntent } from "../../../revalidation/types";
-import { STORAGE_FORMAT } from "../../../schemas/storage-format";
 import {
   AccessControlService,
   type CollectionAccessRules,
@@ -68,6 +67,7 @@ import {
   stripSystemOwnerField,
 } from "../../../shared/lib/password-fields";
 import type { Logger } from "../../../shared/types";
+import { readFieldGroupType } from "../../field-groups/storage/field-group-type-key";
 import { resolveLocalizedFieldNames } from "../../i18n/classify-fields";
 import {
   isBlank,
@@ -149,18 +149,12 @@ function writtenComponentInstances(
   const instances = Array.isArray(value) ? value : value != null ? [value] : [];
   const out: Array<{ slug: string; data: Record<string, unknown> }> = [];
   for (const instance of instances) {
-    if (
-      instance &&
-      typeof instance === "object" &&
-      STORAGE_FORMAT.wireTypeKey in instance &&
-      typeof (instance as { _componentType?: unknown })[
-        STORAGE_FORMAT.wireTypeKey
-      ] === "string"
-    ) {
+    // Asked rather than indexed. Indexing the catalog reads exactly one spelling, so an
+    // instance written under the other one is skipped silently — and skipping is what loses it.
+    const slug = readFieldGroupType(instance);
+    if (slug !== undefined) {
       out.push({
-        slug: (instance as { _componentType: string })[
-          STORAGE_FORMAT.wireTypeKey
-        ],
+        slug,
         data: instance as Record<string, unknown>,
       });
     }

--- a/packages/nextly/src/domains/versions/__tests__/restore-snapshot.test.ts
+++ b/packages/nextly/src/domains/versions/__tests__/restore-snapshot.test.ts
@@ -329,6 +329,40 @@ describe("buildRestorePayload — layered schemas", () => {
     expect(droppedFields).toEqual(["auth"]);
   });
 
+  it("emits the RESOLVED type, not whichever discriminator the loop saw last", () => {
+    // 🔴 A document can carry both spellings — hand-repaired, or partially rewritten. The reader
+    // already applies precedence and rejects a non-string, and that verdict is what selected the
+    // schema this row was pruned against. Copying each raw entry onto the write key as the loop
+    // encounters it lets INSERTION ORDER override both, so a junk value under one spelling can
+    // overwrite a good value under the other — and the save path then reads the row as untyped,
+    // skips it, and deletes the live instance.
+    const zone = [
+      { name: "blocks", type: "component", components: ["banner"] },
+    ] as FieldConfig[];
+    const schemas = componentSchemasOf({
+      banner: [{ name: "heading", type: "text" }] as FieldConfig[],
+    });
+
+    const { payload } = buildRestorePayload(
+      {
+        blocks: [
+          {
+            id: "row-1",
+            _fieldGroupType: "banner",
+            _componentType: 42,
+            heading: "Hi",
+          },
+        ],
+      },
+      zone,
+      { ...ctx, componentSchemas: schemas }
+    );
+
+    expect(payload).toEqual({
+      blocks: [{ id: "row-1", _componentType: "banner", heading: "Hi" }],
+    });
+  });
+
   it("normalises a discriminator captured under the other spelling onto the write key", () => {
     // 🔴 A snapshot taken after the storage rename records the type under the OTHER spelling.
     // Recognising it is not enough — the pruning below keeps only what it recognises as row

--- a/packages/nextly/src/domains/versions/__tests__/restore-snapshot.test.ts
+++ b/packages/nextly/src/domains/versions/__tests__/restore-snapshot.test.ts
@@ -329,6 +329,35 @@ describe("buildRestorePayload — layered schemas", () => {
     expect(droppedFields).toEqual(["auth"]);
   });
 
+  it("normalises a discriminator captured under the other spelling onto the write key", () => {
+    // 🔴 A snapshot taken after the storage rename records the type under the OTHER spelling.
+    // Recognising it is not enough — the pruning below keeps only what it recognises as row
+    // metadata, so an unrecognised discriminator is DROPPED and the row arrives untyped. The
+    // save path skips an untyped dynamic-zone row and then deletes the live instance that was
+    // not in the incoming set, which turns a restore into a deletion.
+    //
+    // Emitting it under the CURRENT spelling rather than copying the key verbatim is what makes
+    // the payload writable: the save path consumes exactly one spelling.
+    const zone = [
+      { name: "blocks", type: "component", components: ["banner"] },
+    ] as FieldConfig[];
+    const schemas = componentSchemasOf({
+      banner: [{ name: "heading", type: "text" }] as FieldConfig[],
+    });
+
+    const { payload, droppedFields } = buildRestorePayload(
+      { blocks: [{ id: "row-1", _fieldGroupType: "banner", heading: "Hi" }] },
+      zone,
+      { ...ctx, componentSchemas: schemas }
+    );
+
+    expect(payload).toEqual({
+      blocks: [{ id: "row-1", _componentType: "banner", heading: "Hi" }],
+    });
+    // The discriminator was carried, not quietly discarded as an unknown key.
+    expect(droppedFields).toEqual([]);
+  });
+
   it("keeps a component instance id so the row is updated, not replaced", () => {
     // The save path uses the id to update the existing row; without it a
     // restore deletes and reinserts instances, taking their per-locale

--- a/packages/nextly/src/domains/versions/__tests__/tag-component-types.post-flip.test.ts
+++ b/packages/nextly/src/domains/versions/__tests__/tag-component-types.post-flip.test.ts
@@ -1,0 +1,112 @@
+/**
+ * A snapshot walk still recognises a zone row written under the legacy spelling.
+ *
+ * 🔴 This property is invisible before the rename. While the catalog still says `_componentType`,
+ * a reader that consults only the catalog and one that tries every spelling behave identically, so
+ * a test written against today's catalog passes whether or not the walk is dual and certifies
+ * nothing. The catalog is mocked to the post-rename state to separate them.
+ *
+ * What the single-spelling version does here is not a cosmetic loss. `tagZoneRows` returns the row
+ * untouched when it cannot read a type, so the components nested inside it are never tagged; the
+ * snapshot records no type for them, and a later restore prunes those values against whichever
+ * component the field names at restore time. The row survives and its contents do not.
+ *
+ * A separate file because the flip is simulated by mocking the catalog module, and `vi.mock` is
+ * hoisted per file.
+ */
+import { describe, expect, it, vi } from "vitest";
+
+// The post-rename world: the catalog has moved on, stored documents have not.
+vi.mock("../../../schemas/storage-format", async () => {
+  const actual = await vi.importActual<
+    typeof import("../../../schemas/storage-format")
+  >("../../../schemas/storage-format");
+  return {
+    ...actual,
+    STORAGE_FORMAT: {
+      ...actual.STORAGE_FORMAT,
+      wireTypeKey: "_fieldGroupType",
+    },
+  };
+});
+
+import { currentFieldGroupTypeKey } from "../../field-groups/storage/field-group-type-key";
+import { tagComponentTypes } from "../tag-component-types";
+
+import type { FieldConfig } from "../../../collections/fields/types";
+
+const zoneField = {
+  name: "zone",
+  type: "component",
+  components: ["hero"],
+} as unknown as FieldConfig;
+
+/** `hero` holds a single `cta`, so a correct walk reaches one level below the zone row. */
+const heroFields = [
+  { name: "cta", type: "component", component: "cta" },
+] as unknown as FieldConfig[];
+
+const resolve = (slug: string): FieldConfig[] | undefined =>
+  slug === "hero" ? heroFields : undefined;
+
+describe("tagging a snapshot after the catalog has been renamed", () => {
+  it("the catalog really has moved, or this file proves nothing", () => {
+    // Without this precondition a mock that failed to apply would leave every assertion below
+    // running against the pre-rename world, where both implementations agree.
+    expect(currentFieldGroupTypeKey).toBe("_fieldGroupType");
+  });
+
+  it("tags a component nested inside a LEGACY-spelled zone row", () => {
+    const entry = {
+      zone: [{ _componentType: "hero", cta: { label: "Buy" } }],
+    };
+
+    const tagged = tagComponentTypes(entry, [zoneField], resolve) as {
+      zone: { cta: Record<string, unknown> }[];
+    };
+
+    // The separating assertion: a single-spelling reader cannot resolve this row's type, returns
+    // it untouched, and leaves `cta` with no record of the component it came from.
+    expect(tagged.zone[0].cta._fieldGroupType).toBe("cta");
+  });
+
+  it("still tags one nested inside a row using the new spelling", () => {
+    const entry = {
+      zone: [{ _fieldGroupType: "hero", cta: { label: "Buy" } }],
+    };
+
+    const tagged = tagComponentTypes(entry, [zoneField], resolve) as {
+      zone: { cta: Record<string, unknown> }[];
+    };
+
+    expect(tagged.zone[0].cta._fieldGroupType).toBe("cta");
+  });
+
+  it("leaves the row's own legacy discriminator in place", () => {
+    // The walk reads the row's type; it does not restamp it. Rewriting the spelling here would
+    // migrate content as a side effect of taking a snapshot, which is the migration's job and
+    // subject to its own resumability and verification.
+    const entry = {
+      zone: [{ _componentType: "hero", cta: { label: "Buy" } }],
+    };
+
+    const tagged = tagComponentTypes(entry, [zoneField], resolve) as {
+      zone: Record<string, unknown>[];
+    };
+
+    expect(tagged.zone[0]._componentType).toBe("hero");
+  });
+
+  it("still leaves a row alone when its type names a component the field forbids", () => {
+    // The dual read widens which spellings are understood, not which components are allowed.
+    const entry = {
+      zone: [{ _componentType: "banner", cta: { label: "Buy" } }],
+    };
+
+    const tagged = tagComponentTypes(entry, [zoneField], resolve) as {
+      zone: { cta: Record<string, unknown> }[];
+    };
+
+    expect(tagged.zone[0].cta._fieldGroupType).toBeUndefined();
+  });
+});

--- a/packages/nextly/src/domains/versions/diff/compute-diff.ts
+++ b/packages/nextly/src/domains/versions/diff/compute-diff.ts
@@ -24,6 +24,7 @@ import { dequal } from "dequal";
 import type { FieldConfig } from "../../../collections/fields/types";
 import { normalizeStoredValue } from "../../../shared/lib/normalize-stored-value";
 import { defineOwnProperty } from "../../../shared/lib/own-property";
+import { readFieldGroupType } from "../../field-groups/storage/field-group-type-key";
 
 import { reconcileById, type ItemMatch } from "./reconcile-list";
 import { diffText } from "./text-diff";
@@ -182,8 +183,9 @@ function enrichedComponentSchemas(
   ).componentSchemas;
 }
 function componentTypeOf(item: Record<string, unknown>): string | undefined {
-  const tag = item._componentType;
-  return typeof tag === "string" ? tag : undefined;
+  // Asked rather than read: the stored spelling of this key changes with the storage migration,
+  // and a document written under the other one would otherwise diff as untyped.
+  return readFieldGroupType(item);
 }
 
 function asObject(value: unknown): Record<string, unknown> {

--- a/packages/nextly/src/domains/versions/restore-snapshot.ts
+++ b/packages/nextly/src/domains/versions/restore-snapshot.ts
@@ -413,13 +413,11 @@ function pruneContainerValue(
       // repeater is written as part of that container's JSON, and a marker left
       // inside would be stored verbatim and then served by ordinary reads.
       if (isFieldGroupTypeKey(key)) {
-        if (!storesType) continue;
-        // 🔴 Normalised onto the spelling this version WRITES, not copied under the one the
-        // snapshot happened to use. A snapshot captured after the storage rename carries the
-        // other spelling, and the save path consumes exactly one — so copying the key verbatim
-        // leaves the row untyped downstream, and an untyped dynamic-zone row is SKIPPED, which
-        // deletes the instance it was meant to restore.
-        out[currentFieldGroupTypeKey] = child;
+        // 🔴 Every raw discriminator entry is SKIPPED here; the resolved one is stamped once,
+        // after the loop. Writing each raw value onto the current key as it is encountered lets
+        // object insertion order decide the winner, which overrides both the precedence and the
+        // non-string rejection the reader already applied — a document carrying a good value
+        // under one spelling and a junk value under another would emit the junk.
         continue;
       }
       out[key] = child;
@@ -486,6 +484,18 @@ function pruneContainerValue(
       allowedHere !== null && !fieldNamesMultipleComponents(field)
         ? withoutTypeMarker(kept)
         : kept;
+  }
+
+  // 🔴 The discriminator is stamped ONCE, from the value the reader already resolved, under the
+  // spelling this version writes. Doing it here rather than inside the loop is what makes the
+  // emitted type the one the schema was chosen by: the loop sees raw entries in insertion order
+  // and cannot honour the reader's precedence or its rejection of a non-string.
+  //
+  // `storesType` gates it because only a dynamic zone consumes the marker. A single component
+  // nested in a group or repeater is written as part of that container's JSON, and a marker left
+  // inside would be stored verbatim and then served by ordinary reads.
+  if (isComponentValue && storesType && rowType !== undefined) {
+    out[currentFieldGroupTypeKey] = rowType;
   }
 
   return out;

--- a/packages/nextly/src/domains/versions/restore-snapshot.ts
+++ b/packages/nextly/src/domains/versions/restore-snapshot.ts
@@ -19,6 +19,7 @@
 import type { FieldConfig } from "../../collections/fields/types";
 import { IMMUTABLE_SYSTEM_FIELDS_ANY_ENTITY } from "../../lib/immutable-system-fields";
 import { STORAGE_FORMAT } from "../../schemas/storage-format";
+import { readFieldGroupType } from "../field-groups/storage/field-group-type-key";
 import { isFieldLocalized } from "../i18n/classify-fields";
 
 /**
@@ -379,9 +380,9 @@ function pruneContainerValue(
   // keeps a key that this row's component has since lost merely because a
   // sibling component still declares it — and the save path, which serializes
   // against the row's own schema, then drops it without saying so.
-  const rowType = (value as { _componentType?: unknown })[
-    STORAGE_FORMAT.wireTypeKey
-  ];
+  // Asked rather than indexed: a snapshot being restored was written under the schema of its
+  // day, so its type key may carry either spelling.
+  const rowType = readFieldGroupType(value);
   const rowSchema =
     isComponentValue && typeof rowType === "string"
       ? componentSchemas?.get(rowType)
@@ -550,10 +551,9 @@ function partitionAllowedInstances(
 ): { kept: unknown; rejected: string[] } {
   if (allowed === null) return { kept: value, rejected: [] };
 
-  const typeOf = (row: unknown): string | undefined =>
-    typeof row === "object" && row !== null
-      ? (row as { _componentType?: string })[STORAGE_FORMAT.wireTypeKey]
-      : undefined;
+  // Asked rather than indexed. A row whose type does not resolve is treated as untyped, and
+  // an untyped row is dropped here — so reading only one spelling would discard live instances.
+  const typeOf = (row: unknown): string | undefined => readFieldGroupType(row);
 
   // A row keeps its place when its type is allowed, or when this field stores
   // no type at all. Where a type IS required, a row without one cannot be

--- a/packages/nextly/src/domains/versions/restore-snapshot.ts
+++ b/packages/nextly/src/domains/versions/restore-snapshot.ts
@@ -18,8 +18,11 @@
 
 import type { FieldConfig } from "../../collections/fields/types";
 import { IMMUTABLE_SYSTEM_FIELDS_ANY_ENTITY } from "../../lib/immutable-system-fields";
-import { STORAGE_FORMAT } from "../../schemas/storage-format";
-import { readFieldGroupType } from "../field-groups/storage/field-group-type-key";
+import {
+  currentFieldGroupTypeKey,
+  isFieldGroupTypeKey,
+  readFieldGroupType,
+} from "../field-groups/storage/field-group-type-key";
 import { isFieldLocalized } from "../i18n/classify-fields";
 
 /**
@@ -402,17 +405,23 @@ function pruneContainerValue(
     // Only for component instances. A group or repeater is ordinary JSON, where
     // a stale key that happens to be called `id` is exactly the kind of unknown
     // key this function exists to remove.
-    if (
-      isComponentValue &&
-      (key === STORAGE_FORMAT.wireTypeKey || key === "id")
-    ) {
+    if (isComponentValue && (isFieldGroupTypeKey(key) || key === "id")) {
       // The type marker exists to record what the snapshot captured, and it has
       // already done its work above by selecting this row's schema. Carrying it
       // into the payload is only safe where the write path consumes it, which
       // is the dynamic zone alone. A single component nested in a group or
       // repeater is written as part of that container's JSON, and a marker left
       // inside would be stored verbatim and then served by ordinary reads.
-      if (key === STORAGE_FORMAT.wireTypeKey && !storesType) continue;
+      if (isFieldGroupTypeKey(key)) {
+        if (!storesType) continue;
+        // 🔴 Normalised onto the spelling this version WRITES, not copied under the one the
+        // snapshot happened to use. A snapshot captured after the storage rename carries the
+        // other spelling, and the save path consumes exactly one — so copying the key verbatim
+        // leaves the row untyped downstream, and an untyped dynamic-zone row is SKIPPED, which
+        // deletes the instance it was meant to restore.
+        out[currentFieldGroupTypeKey] = child;
+        continue;
+      }
       out[key] = child;
       continue;
     }
@@ -495,7 +504,7 @@ function retainsNothing(pruned: unknown): boolean {
     if (typeof row !== "object" || row === null) return false;
     const keys = Object.keys(row);
     if (keys.length === 0) return false;
-    return keys.every(k => k === "id" || k === STORAGE_FORMAT.wireTypeKey);
+    return keys.every(k => k === "id" || isFieldGroupTypeKey(k));
   };
 
   if (Array.isArray(pruned)) {
@@ -530,7 +539,7 @@ function withoutTypeMarker(value: unknown): unknown {
 
   const out: Record<string, unknown> = {};
   for (const [key, child] of Object.entries(value as Record<string, unknown>)) {
-    if (key !== STORAGE_FORMAT.wireTypeKey) out[key] = child;
+    if (!isFieldGroupTypeKey(key)) out[key] = child;
   }
   return out;
 }

--- a/packages/nextly/src/domains/versions/snapshot-references.ts
+++ b/packages/nextly/src/domains/versions/snapshot-references.ts
@@ -16,6 +16,7 @@
 
 import type { AuthenticatedScope } from "../../auth/authenticated-scope";
 import type { FieldConfig } from "../../collections/fields/types";
+import { readFieldGroupType } from "../field-groups/storage/field-group-type-key";
 import type { UserContext } from "../singles/types";
 
 import {
@@ -78,8 +79,10 @@ function componentChildFieldsFor(
     componentFields?: FieldConfig[];
     componentSchemas?: Record<string, { fields?: FieldConfig[] }>;
   };
+  // Asked rather than read: a snapshot was written under the schema of its day, which may be
+  // either side of the storage migration's rename of this key.
   const type = isPlainObject(instance)
-    ? (instance as { _componentType?: string })._componentType
+    ? readFieldGroupType(instance)
     : undefined;
   if (type && enriched.componentSchemas?.[type]?.fields) {
     return enriched.componentSchemas[type].fields ?? [];

--- a/packages/nextly/src/domains/versions/tag-component-types.ts
+++ b/packages/nextly/src/domains/versions/tag-component-types.ts
@@ -17,8 +17,12 @@
  */
 
 import type { FieldConfig } from "../../collections/fields/types";
-import { STORAGE_FORMAT } from "../../schemas/storage-format";
 import { storageTypeToken } from "../../shared/lib/plugin-storage";
+import {
+  clearFieldGroupType,
+  currentFieldGroupTypeKey,
+  readFieldGroupType,
+} from "../field-groups/storage/field-group-type-key";
 
 import type { ComponentSchemas } from "./restore-snapshot";
 
@@ -156,13 +160,13 @@ function tagValue(
   // stopping at the repeated slug would tag the first two levels and leave
   // every level below them bare.
   const ownFields = resolve?.(slug);
-  if (!ownFields) return { ...source, [STORAGE_FORMAT.wireTypeKey]: slug };
+  if (!ownFields) return { ...source, [currentFieldGroupTypeKey]: slug };
 
   seen.add(source);
   const inner = tagFieldsIn(source, ownFields, resolve, seen);
   seen.delete(source);
 
-  return { ...inner, [STORAGE_FORMAT.wireTypeKey]: slug };
+  return { ...inner, [currentFieldGroupTypeKey]: slug };
 }
 
 /**
@@ -191,8 +195,8 @@ function tagZoneRows(
   // The row's own type decides which schema its values belong to. A row whose
   // type is missing, or names a component the field does not allow, is left
   // alone rather than walked against a schema that may not describe it.
-  const rowType = source[STORAGE_FORMAT.wireTypeKey];
-  if (typeof rowType !== "string" || !allowed.includes(rowType)) return source;
+  const rowType = readFieldGroupType(source);
+  if (rowType === undefined || !allowed.includes(rowType)) return source;
 
   const ownFields = resolve?.(rowType);
   if (!ownFields) return source;
@@ -331,7 +335,7 @@ function stripSingleValue(
   const ownFields = resolve?.(slug);
   if (!ownFields) {
     const bare = { ...source };
-    delete bare[STORAGE_FORMAT.wireTypeKey];
+    clearFieldGroupType(bare);
     return bare;
   }
 
@@ -340,7 +344,7 @@ function stripSingleValue(
   seen.delete(source);
 
   const out = { ...inner };
-  delete out[STORAGE_FORMAT.wireTypeKey];
+  clearFieldGroupType(out);
   return out;
 }
 
@@ -359,8 +363,8 @@ function stripZoneRows(
   const source = value as Record<string, unknown>;
   if (seen.has(source)) return source;
 
-  const rowType = source[STORAGE_FORMAT.wireTypeKey];
-  if (typeof rowType !== "string" || !allowed.includes(rowType)) return source;
+  const rowType = readFieldGroupType(source);
+  if (rowType === undefined || !allowed.includes(rowType)) return source;
 
   const ownFields = resolve?.(rowType);
   if (!ownFields) return source;
@@ -491,13 +495,8 @@ export function rehydrateSnapshotDates(
     for (const instance of instances) {
       if (instance === null || typeof instance !== "object") continue;
       const rec = instance as Record<string, unknown>;
-      const tagged = rec[STORAGE_FORMAT.wireTypeKey];
-      const slug =
-        typeof tagged === "string"
-          ? tagged
-          : typeof single === "string"
-            ? single
-            : undefined;
+      const tagged = readFieldGroupType(rec);
+      const slug = tagged ?? (typeof single === "string" ? single : undefined);
       const compFields = slug ? componentSchemas?.get(slug)?.fields : undefined;
       if (compFields) {
         rehydrateSnapshotDates(rec, compFields, componentSchemas);

--- a/packages/nextly/src/domains/webhooks/envelope.ts
+++ b/packages/nextly/src/domains/webhooks/envelope.ts
@@ -10,8 +10,8 @@
  * @module domains/webhooks/envelope
  */
 
-import { STORAGE_FORMAT } from "../../schemas/storage-format";
 import { defineOwnProperty } from "../../shared/lib/own-property";
+import { readFieldGroupType } from "../field-groups/storage/field-group-type-key";
 
 import { componentTypeSegment } from "./expand-component-fields";
 import type {
@@ -83,9 +83,9 @@ function stripValue(
     // Two member types can share a field name with only one marking it
     // sensitive, so those denials are recorded under a type-tagged path and
     // only apply to instances of that type.
-    const componentType = (value as { _componentType?: unknown })[
-      STORAGE_FORMAT.wireTypeKey
-    ];
+    // Asked rather than indexed, so an instance stored under either spelling still resolves to
+    // the type its denial paths are recorded under.
+    const componentType = readFieldGroupType(value);
     const prefixes =
       typeof componentType === "string"
         ? [

--- a/scripts/check-storage-format-literals.cjs
+++ b/scripts/check-storage-format-literals.cjs
@@ -1,0 +1,140 @@
+#!/usr/bin/env node
+/**
+ * Storage-spelling gate: the field-group storage format is named in ONE place.
+ *
+ * `schemas/storage-format.ts` exists so that renaming the stored spelling is a change to a
+ * catalog rather than a search across the codebase. That only holds while everything asks the
+ * catalog, and nothing enforced it — 43 mentions of the raw spellings had accumulated in product
+ * code by the time this gate was written.
+ *
+ * ## Why this is a gate and not a convention
+ *
+ * The storage migration renames tables, columns and a JSON key on a live database. Table and
+ * column names survive a literal, badly but visibly, because `storage/resolve-storage-names.ts`
+ * reads the CATALOG and addresses whichever name is really there.
+ *
+ * 🔴 **A JSON key inside a row has no catalog.** Nothing can observe it, so nothing can resolve
+ * it, so a literal is the whole exposure: after the flip a hardcoded reader looks for a key the
+ * migrated document no longer has and finds nothing. The instance is intact and untyped — which
+ * the editor cannot render and a diff cannot tag. The write side is worse: a literal in a SAVE
+ * path keeps stamping the legacy spelling onto new documents behind a completed migration, so the
+ * divergence grows for as long as the app runs.
+ *
+ * ## Why a source scan, given a scan is the weaker kind of control
+ *
+ * A boundary the system cannot cross would be better, and there isn't one available: the key is a
+ * property name on an author's own JSON, so no type, module graph or manifest can prevent an
+ * access. Between an unenforced convention and a scan, the scan is what exists — and it is the
+ * same shape as `check-drizzle-v1-legacy.cjs`, which guards a comparable "compiles fine, wrong at
+ * runtime" class.
+ *
+ * Its limit is worth stating rather than discovering: a spelling assembled at runtime
+ * (`"_component" + "Type"`) passes. That is not the failure mode this exists for — the 43 sites it
+ * was written against are all plain literals — but it is why the catalog remains the rule and this
+ * is only what makes the rule hold.
+ */
+
+const { execFileSync } = require("node:child_process");
+const path = require("node:path");
+
+const ROOT = path.resolve(__dirname, "..");
+
+let failures = 0;
+
+/**
+ * Paths that legitimately name both spellings.
+ *
+ * - the catalog itself, which is where the strings are DEFINED;
+ * - the migration engine, whose entire job is to rename one to the other, so it must name both;
+ * - the storage-name resolver, which decides from the catalog which of the two a database uses;
+ * - tests, which assert concrete stored bytes and would otherwise have to describe them
+ *   indirectly — a test that cannot say `_componentType` cannot pin the storage format.
+ */
+const ALLOWED = [
+  /packages\/nextly\/src\/schemas\/storage-format\.ts:/,
+  /packages\/nextly\/src\/domains\/field-groups\/migration\//,
+  /packages\/nextly\/src\/domains\/field-groups\/storage\//,
+  /__tests__\//,
+  /\.test\.tsx?:/,
+  /\.test-d\.ts:/,
+];
+
+function grep(label, pattern, opts = {}) {
+  const {
+    include = ["*.ts", "*.tsx"],
+    paths = ["packages", "apps", "templates"],
+    allowMatches = [],
+  } = opts;
+  const args = [
+    "-rEn",
+    pattern,
+    ...paths,
+    ...include.map(i => `--include=${i}`),
+    // Excluded at the grep level rather than filtered afterwards: scanning node_modules can
+    // overflow execFileSync's buffer and crash the gate with ENOBUFS, which is not a verdict.
+    "--exclude-dir=node_modules",
+    "--exclude-dir=dist",
+    "--exclude-dir=.next",
+    "--exclude-dir=.turbo",
+    "--exclude-dir=build",
+  ];
+  let out = "";
+  try {
+    out = execFileSync("grep", args, {
+      cwd: ROOT,
+      encoding: "utf8",
+      maxBuffer: 64 * 1024 * 1024,
+    });
+  } catch (e) {
+    // grep exits 1 for "no matches", which is the pass case.
+    if (e.status !== 1) throw e;
+  }
+  const lines = out
+    .split("\n")
+    .filter(Boolean)
+    .filter(l => !l.includes("node_modules"))
+    .filter(l => !/\/(dist|\.next|\.turbo)\//.test(l))
+    .filter(l => !ALLOWED.some(a => a.test(l)))
+    .filter(l => !allowMatches.some(a => a.test(l)))
+    // Comments and doc blocks describe the format; they do not read it.
+    .filter(l => !/:\s*(\/\/|\*|\/\*)/.test(l.replace(/^[^:]*:\d+:/, ":")));
+
+  if (lines.length > 0) {
+    failures++;
+    console.error(`✗ ${label} (${lines.length} hit(s)):`);
+    for (const l of lines.slice(0, 20)) console.error(`    ${l}`);
+    if (lines.length > 20) console.error(`    … ${lines.length - 20} more`);
+  } else {
+    console.log(`✓ ${label}`);
+  }
+}
+
+// 1. 🔴 The content key. No catalog can describe a key inside a row, so a literal here is the
+// one spelling a database cannot be asked about — read it wrong and the instance loses its type.
+grep(
+  "content type key goes through STORAGE_FORMAT.wireTypeKey",
+  "_componentType"
+);
+
+// 2. The discriminator column. Catalog-resolvable, so a literal degrades rather than breaks —
+// but it degrades on exactly the databases that have migrated.
+grep(
+  "type column goes through STORAGE_FORMAT.columns.type",
+  "[\"'`]_component_type[\"'`]"
+);
+
+// 3. The registry table. Same shape as the column.
+grep(
+  "registry table goes through STORAGE_FORMAT.registryTable",
+  "[\"'`]dynamic_components[\"'`]"
+);
+
+if (failures > 0) {
+  console.error(
+    `\n${failures} storage-spelling gate failure(s).\n` +
+      `Read the spelling from schemas/storage-format.ts instead of writing it out. ` +
+      `The catalog is what makes the storage migration a rename rather than a search.`
+  );
+  process.exit(1);
+}
+console.log("\nStorage-spelling gate passed.");

--- a/scripts/check-storage-format-literals.cjs
+++ b/scripts/check-storage-format-literals.cjs
@@ -59,6 +59,21 @@ const ALLOWED = [
   /\.test-d\.ts:/,
 ];
 
+/**
+ * Known-outstanding sites: reported every run, but not yet failing.
+ *
+ * `packages/admin` cannot reach the catalog — `STORAGE_FORMAT` is not exported from any surface
+ * admin imports — so fixing these needs a public accessor export, which is an API decision rather
+ * than a mechanical edit. They are listed here instead of allowlisted so every run states that
+ * they exist and how many remain: an allowlist would make them disappear, and a gate whose output
+ * shrinks silently is how the original 43 accumulated.
+ *
+ * This list must reach empty. It is not a place to move an inconvenient hit to.
+ */
+const PENDING = [/^packages\/admin\//];
+const PENDING_TRACKED_IN =
+  "tasks/left-tasks/2026-08-12-0800-storage-key-read-by-literal-blocks-b2.md";
+
 function grep(label, pattern, opts = {}) {
   const {
     include = ["*.ts", "*.tsx"],
@@ -99,13 +114,24 @@ function grep(label, pattern, opts = {}) {
     // Comments and doc blocks describe the format; they do not read it.
     .filter(l => !/:\s*(\/\/|\*|\/\*)/.test(l.replace(/^[^:]*:\d+:/, ":")));
 
-  if (lines.length > 0) {
+  const pending = lines.filter(l => PENDING.some(p => p.test(l)));
+  const failing = lines.filter(l => !PENDING.some(p => p.test(l)));
+
+  if (failing.length > 0) {
     failures++;
-    console.error(`✗ ${label} (${lines.length} hit(s)):`);
-    for (const l of lines.slice(0, 20)) console.error(`    ${l}`);
-    if (lines.length > 20) console.error(`    … ${lines.length - 20} more`);
+    console.error(`✗ ${label} (${failing.length} hit(s)):`);
+    for (const l of failing.slice(0, 20)) console.error(`    ${l}`);
+    if (failing.length > 20)
+      console.error(`    … ${failing.length - 20} more`);
   } else {
     console.log(`✓ ${label}`);
+  }
+
+  if (pending.length > 0) {
+    console.log(
+      `  ⧗ ${pending.length} known-outstanding site(s) not yet failing — ${PENDING_TRACKED_IN}`
+    );
+    for (const l of pending) console.log(`      ${l}`);
   }
 }
 

--- a/scripts/check-storage-format-literals.cjs
+++ b/scripts/check-storage-format-literals.cjs
@@ -45,6 +45,14 @@
  * - **Comment and doc-block lines**, filtered on purpose: prose describing the format does not read
  *   it, and requiring the docs to avoid naming the thing they document makes them worse.
  *
+ *   🔴 That justification covers PROSE; the filter's effect covers ALL comments, and the two are
+ *   the same set only until someone parks code or writes an example. A commented-out assignment is
+ *   an executable site the moment it is uncommented, and a doc-block code EXAMPLE is worse than an
+ *   executable occurrence — it teaches the spelling to everyone who copies it, in the documents
+ *   most likely to be describing the rename. Neither announces itself later, because the gate
+ *   stays green while the gap widens. Distinguishing them mechanically means parsing comment
+ *   bodies, which is more machinery than this is worth; the limit is stated instead.
+ *
  * What a pass DOES mean is narrower and still worth having: no product source line outside the
  * catalog, the accessor and the migration engine names either spelling of the table, the column or
  * the content key, and none reads that key from the catalog instead of through the accessor.

--- a/scripts/check-storage-format-literals.cjs
+++ b/scripts/check-storage-format-literals.cjs
@@ -28,10 +28,30 @@
  * same shape as `check-drizzle-v1-legacy.cjs`, which guards a comparable "compiles fine, wrong at
  * runtime" class.
  *
- * Its limit is worth stating rather than discovering: a spelling assembled at runtime
- * (`"_component" + "Type"`) passes. That is not the failure mode this exists for — the 43 sites it
- * was written against are all plain literals — but it is why the catalog remains the rule and this
- * is only what makes the rule hold.
+ * ## 🔴 What a PASS here does NOT mean
+ *
+ * Stated rather than left to be inferred, because the next reader's honest reading of a green run
+ * decides whether they look further. A scan reports on the forms it can see, and these are the
+ * forms it cannot:
+ *
+ * - **A spelling assembled at runtime** — `"_component" + "Type"`, a template literal, or the key
+ *   reached through a variable or a constant defined elsewhere. Nothing textual can follow that.
+ * - **TEST files and `__tests__/`**, exempted wholesale. A test that asserts concrete stored bytes
+ *   cannot describe them indirectly without asserting nothing, so the exemption is deliberate —
+ *   but it is broad, and a stored-row FIXTURE written with the raw key is one of the ways a
+ *   completed rename gets quietly reverted later. There is currently no automatic way to tell a
+ *   fixture from an assertion about the format, so this stays a review-time concern.
+ * - **The pinned `packages/admin` sites** below, which are reported on every run and do not fail.
+ * - **Comment and doc-block lines**, filtered on purpose: prose describing the format does not read
+ *   it, and requiring the docs to avoid naming the thing they document makes them worse.
+ *
+ * What a pass DOES mean is narrower and still worth having: no product source line outside the
+ * catalog, the accessor and the migration engine names either spelling of the table, the column or
+ * the content key, and none reads that key from the catalog instead of through the accessor.
+ *
+ * The gate is also only as current as the run: a file that gains its first occurrence after a
+ * sweep is not exempt, so this is worth running against the merge target immediately before
+ * merging rather than trusting the state at branch time.
  */
 
 const { execFileSync } = require("node:child_process");

--- a/scripts/check-storage-format-literals.cjs
+++ b/scripts/check-storage-format-literals.cjs
@@ -70,7 +70,7 @@ const ALLOWED = [
 ];
 
 /**
- * Known-outstanding sites: reported every run, but not yet failing.
+ * Known-outstanding sites: reported every run, not failing, and PINNED individually.
  *
  * `packages/admin` cannot reach the catalog — `STORAGE_FORMAT` is not exported from any surface
  * admin imports — so fixing these needs a public accessor export, which is an API decision rather
@@ -78,11 +78,43 @@ const ALLOWED = [
  * they exist and how many remain: an allowlist would make them disappear, and a gate whose output
  * shrinks silently is how the original 43 accumulated.
  *
- * This list must reach empty. It is not a place to move an inconvenient hit to.
+ * 🔴 Pinned as exact source text rather than as a path pattern, and that distinction is the whole
+ * point. A pattern like `^packages/admin/` exempts every file the directory will ever contain, so
+ * a NEW hardcoded reader lands reported-but-passing and CI stays green — which is the regression
+ * this gate exists to catch, reintroduced by the mechanism that was supposed to track its own
+ * debt. Matching the text means a known site is tolerated and anything else is not.
+ *
+ * Counted, not just matched: duplicating a pinned line is a new site, and a set would accept it.
+ *
+ * Line numbers are deliberately absent — they move under edits elsewhere in the file, and a pin
+ * that breaks on unrelated churn gets re-pinned reflexively, which is how a control stops being
+ * read. Text is stable while the site is unfixed, which is exactly as long as it needs to be.
+ *
+ * This list must reach empty, and the gate says so on every run. It is not a place to move an
+ * inconvenient hit to: the correct response to a new hit is the accessor, never a new line here.
  */
-const PENDING = [/^packages\/admin\//];
+const PENDING_OCCURRENCES = {
+  "packages/admin/src/components/features/entries/fields/structured/ComponentInput.tsx":
+    [
+      "defaultValues._componentType = componentType;",
+      "const currentType = currentData?._componentType as string | undefined;",
+      "const itemComponentType = itemData._componentType as",
+    ],
+  "packages/admin/src/components/features/versions/value-display/FieldValueDisplay.tsx":
+    [
+      "? (instance as { _componentType?: string })._componentType",
+      "? ((instance as { _componentType?: string })._componentType ?? null)",
+    ],
+};
 const PENDING_TRACKED_IN =
   "tasks/left-tasks/2026-08-12-0800-storage-key-read-by-literal-blocks-b2.md";
+
+/** Split a grep line into the path and the source text, dropping the line number. */
+function splitGrepLine(line) {
+  const m = /^([^:]+):(\d+):(.*)$/.exec(line);
+  if (!m) return null;
+  return { path: m[1], lineNo: m[2], text: m[3].trim() };
+}
 
 function grep(label, pattern, opts = {}) {
   const {
@@ -124,8 +156,30 @@ function grep(label, pattern, opts = {}) {
     // Comments and doc blocks describe the format; they do not read it.
     .filter(l => !/:\s*(\/\/|\*|\/\*)/.test(l.replace(/^[^:]*:\d+:/, ":")));
 
-  const pending = lines.filter(l => PENDING.some(p => p.test(l)));
-  const failing = lines.filter(l => !PENDING.some(p => p.test(l)));
+  // Classify each hit against the pinned occurrences. A hit is tolerated only when its file AND
+  // its source text are pinned, and only as many times as they were pinned; everything else fails,
+  // including a second copy of a pinned line.
+  const remainingBudget = new Map();
+  for (const [path, texts] of Object.entries(PENDING_OCCURRENCES)) {
+    for (const text of texts) {
+      const key = `${path}::${text}`;
+      remainingBudget.set(key, (remainingBudget.get(key) ?? 0) + 1);
+    }
+  }
+
+  const pending = [];
+  const failing = [];
+  for (const l of lines) {
+    const parsed = splitGrepLine(l);
+    const key = parsed ? `${parsed.path}::${parsed.text}` : null;
+    const budget = key ? (remainingBudget.get(key) ?? 0) : 0;
+    if (budget > 0) {
+      remainingBudget.set(key, budget - 1);
+      pending.push(l);
+    } else {
+      failing.push(l);
+    }
+  }
 
   if (failing.length > 0) {
     failures++;
@@ -139,9 +193,12 @@ function grep(label, pattern, opts = {}) {
 
   if (pending.length > 0) {
     console.log(
-      `  ⧗ ${pending.length} known-outstanding site(s) not yet failing — ${PENDING_TRACKED_IN}`
+      `  ⧗ ${pending.length} pinned known-outstanding site(s) not yet failing — ${PENDING_TRACKED_IN}`
     );
     for (const l of pending) console.log(`      ${l}`);
+    console.log(
+      `  ⧗ this list must reach empty; a NEW hit is a failure, never a new pin`
+    );
   }
 }
 
@@ -167,24 +224,34 @@ grep(
 
 // 2. The discriminator column. Catalog-resolvable, so a literal degrades rather than breaks —
 // but it degrades on exactly the databases that have migrated.
-grep(
-  "type column goes through the catalog (legacy spelling)",
-  "[\"'`]_component_type[\"'`]"
-);
-grep(
-  "type column goes through the catalog (target spelling)",
-  "[\"'`]_field_group_type[\"'`]"
-);
+//
+// 🔴 Matched WITHOUT requiring quotes. A quoted-only pattern reads as though it covers the name,
+// and misses `row._component_type` and `{ _field_group_type: value }` — ordinary TypeScript
+// property syntax, and the form a reader is most likely to write. The check that motivated the
+// rule was the one the pattern could not see. `\b` is sound here because the character before the
+// leading underscore is always a non-word one (`.`, a quote, a brace, whitespace).
+grep("type column goes through the catalog (legacy spelling)", "\\b_component_type\\b");
+grep("type column goes through the catalog (target spelling)", "\\b_field_group_type\\b");
 
 // 3. The registry table. Same shape as the column.
-grep(
-  "registry table goes through the catalog (legacy spelling)",
-  "[\"'`]dynamic_components[\"'`]"
-);
-grep(
-  "registry table goes through the catalog (target spelling)",
-  "[\"'`]dynamic_field_groups[\"'`]"
-);
+grep("registry table goes through the catalog (legacy spelling)", "\\bdynamic_components\\b");
+grep("registry table goes through the catalog (target spelling)", "\\bdynamic_field_groups\\b");
+
+// 4. 🔴 Reading the CATALOG for the content key, outside the accessor.
+//
+// The checks above ban writing the spelling out. They do not ban asking the catalog for it, and
+// that is not the same rule: `instance[STORAGE_FORMAT.wireTypeKey]` contains no literal, resolves
+// correctly, passes every check above — and still consults exactly ONE spelling, so after the flip
+// it reads a legacy-spelled document as untyped precisely as a hardcoded reader would.
+//
+// The property that actually matters is therefore not "no literals" but "the wire key is reached
+// only through the accessor", which is what this enforces. `field-group-type-key.ts` is where the
+// two catalogs are legitimately combined into a read order; the migration engine names both
+// because renaming one to the other is its job.
+//
+// Note this bans the catalog READ, not the catalog. Sibling `STORAGE_FORMAT` members — column
+// names, table prefixes — stay resolvable everywhere, because those a database can be asked about.
+grep("content type key is reached through the accessor", "\\bwireTypeKey\\b");
 
 if (failures > 0) {
   console.error(

--- a/scripts/check-storage-format-literals.cjs
+++ b/scripts/check-storage-format-literals.cjs
@@ -51,9 +51,19 @@ let failures = 0;
  *   indirectly — a test that cannot say `_componentType` cannot pin the storage format.
  */
 const ALLOWED = [
+  // The catalogs themselves, where the strings are DEFINED.
   /packages\/nextly\/src\/schemas\/storage-format\.ts:/,
+  // 🔴 Named FILE by file, not by directory. A directory exemption covers whatever is added to it
+  // later, so a new reader dropped beside these would inherit their licence to hardcode and the
+  // gate would report success — the exact regression it exists to catch. Adding a file here should
+  // require justifying it, which a folder pattern silently skips.
+  /packages\/nextly\/src\/domains\/field-groups\/storage\/field-group-type-key\.ts:/,
+  /packages\/nextly\/src\/domains\/field-groups\/storage\/resolve-storage-names\.ts:/,
+  // The migration engine is exempt as a DIRECTORY, and that one is deliberate: renaming one
+  // spelling to the other is the whole of its job, so every file in it names both by construction.
+  // Narrowing it to a file list would be a list that has to be edited for each new step, which is
+  // the same failure in slower form.
   /packages\/nextly\/src\/domains\/field-groups\/migration\//,
-  /packages\/nextly\/src\/domains\/field-groups\/storage\//,
   /__tests__\//,
   /\.test\.tsx?:/,
   /\.test-d\.ts:/,

--- a/scripts/check-storage-format-literals.cjs
+++ b/scripts/check-storage-format-literals.cjs
@@ -135,24 +135,45 @@ function grep(label, pattern, opts = {}) {
   }
 }
 
-// 1. 🔴 The content key. No catalog can describe a key inside a row, so a literal here is the
-// one spelling a database cannot be asked about — read it wrong and the instance loses its type.
+// 🔴 BOTH generations are banned, not only the legacy one.
+//
+// The target spellings are what a migrated database actually uses, so a literal reading
+// `_fieldGroupType` is wrong on precisely the installs the migration has already reached — and it
+// is the spelling someone writing new code AFTER the flip would naturally reach for. Guarding only
+// the legacy names would enforce the single-catalog rule on the generation that is on its way out
+// while leaving the incoming one unguarded, which is the wrong half.
+//
+// 1. The content key, in both generations. No catalog can describe a key inside a row, so a
+// literal here is the one spelling a database cannot be asked about — read it wrong and the
+// instance loses its type.
 grep(
-  "content type key goes through STORAGE_FORMAT.wireTypeKey",
+  "content type key goes through the catalog (legacy spelling)",
   "_componentType"
+);
+grep(
+  "content type key goes through the catalog (target spelling)",
+  "_fieldGroupType"
 );
 
 // 2. The discriminator column. Catalog-resolvable, so a literal degrades rather than breaks —
 // but it degrades on exactly the databases that have migrated.
 grep(
-  "type column goes through STORAGE_FORMAT.columns.type",
+  "type column goes through the catalog (legacy spelling)",
   "[\"'`]_component_type[\"'`]"
+);
+grep(
+  "type column goes through the catalog (target spelling)",
+  "[\"'`]_field_group_type[\"'`]"
 );
 
 // 3. The registry table. Same shape as the column.
 grep(
-  "registry table goes through STORAGE_FORMAT.registryTable",
+  "registry table goes through the catalog (legacy spelling)",
   "[\"'`]dynamic_components[\"'`]"
+);
+grep(
+  "registry table goes through the catalog (target spelling)",
+  "[\"'`]dynamic_field_groups[\"'`]"
 );
 
 if (failures > 0) {


### PR DESCRIPTION
## Why

The components → field-groups storage migration renames a JSON key inside stored content. Table and column names survive that because `storage/resolve-storage-names.ts` reads the **catalog** and addresses whichever name is really there.

🔴 **A JSON key inside a row has no catalog.** Nothing can observe it, so nothing can resolve it — and `schemas/storage-format.ts` was being bypassed by 43 mentions of the raw spelling in product code, with nothing enforcing it.

The consequence is not deletion. After a flip, a hardcoded reader looks for a key the migrated document no longer has and finds nothing: the instance is intact and **untyped**, which the editor cannot render, a diff cannot tag, and a `_componentType` filter cannot match. To a live site that is indistinguishable from data loss.

The write side is worse. `ComponentInput.tsx:202` does `defaultValues._componentType = ...`, so a flip would leave the admin stamping the **legacy** spelling onto new documents behind a completed migration — divergence that grows for as long as the app runs.

## What this does

**1. A dual-reading accessor** (`domains/field-groups/storage/field-group-type-key.ts`).

A constant does not help a reader: inlining it still yields exactly one spelling. So the accessor tries both, in the order the migration itself uses, and writes only the current one. That pairing is what makes a partially rewritten database safe rather than merely survivable — every row still reads, and anything saved afterwards is written in the current spelling, so the legacy set only ever shrinks.

**2. A gate** (`scripts/check-storage-format-literals.cjs`), wired into `package.json` and CI beside `check-drizzle-v1-legacy`.

Installed **first**, before the fixes. Installed afterwards it would only record the current state; installed first it proves the binding is real.

**3. Twelve `nextly` sites routed through the accessor** — including four that indexed the catalog correctly but still named the literal in a cast, which would go stale at the flip.

## Scope, stated rather than hidden

The five `packages/admin` sites are **not** fixed here. Admin cannot reach the catalog — `STORAGE_FORMAT` is exported from no surface it imports — so fixing them needs a public accessor export, which is an API decision rather than a mechanical edit.

They are **reported by every run as known-outstanding**, not allowlisted:

```
✓ content type key goes through STORAGE_FORMAT.wireTypeKey
  ⧗ 5 known-outstanding site(s) not yet failing — tasks/…-blocks-b2.md
```

An allowlist would make them disappear, and a gate whose output shrinks silently is how the original 43 accumulated.

## Verification

**The tests could not have worked by accident.** The two spellings are the *same string* today, so every "falls back to the legacy key" assertion passes trivially against the real constants — a suite written against them would report coverage it does not have, right up until the flip made it matter. The target spelling is therefore mocked to something genuinely different, which is the only way to see the fallback work before the day it has to.

Proven by breaking, both halves:

| Break | Result |
|---|---|
| read only the current spelling | 2 failed / 5 passed — the fallback cases, alone |
| write the legacy spelling | 1 failed / 6 passed — the write case, alone |

**The gate was checked as an instrument**, not just used as one: with a literal planted it exits `1`; clean it exits `0`. A gate that reports a failure and exits `0` blocks nothing.

- `build`, `check-types`, `lint` (by exit code), `check-drizzle-v1-legacy`, and the new gate: all `0`
- Full `packages/nextly` unit run vs a freshly measured baseline at `4e4309aec`: **0 moved, 0 removed, 7 added**

⚠️ One measurement note: two tests in `trust-bound` embed an **absolute path in their test name**, so any baseline diff taken across two worktrees reports them as moved. They are the same passing test under a different directory. Normalising the path out gives the 0/0/7 above. Worth fixing separately — it makes cross-worktree baselines noisy for everyone.

## What this does not do

It does not arm anything. The storage migration engine remains dark. This closes the largest of the blockers in front of it; `nextly migrate` holding no exclusion, and field-group update still running DDL from its dispatcher, remain open and filed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility when reading and processing component data stored with legacy or current field-group type keys.
  * Ensured snapshot restores, queries, mutations, webhooks, and versioning consistently resolve component types.
  * Standardized new writes and restores to use the current field-group type key while preserving legacy data.

* **Tests**
  * Added regression coverage for key migration, precedence, cleanup, tagging, and snapshot restoration.

* **Chores**
  * Added automated checks to prevent unsupported storage-format literals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->