### PR TITLE
feat(ui): add the colour value union to the server-safe colour entry

### DIFF
--- a/.changeset/color-value-union.md
+++ b/.changeset/color-value-union.md
@@ -1,0 +1,27 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+---
+
+Add the colour value union to @nextlyhq/ui/color: a literal, or a reference to a colour the site defines. Resolving a token to its colour before storing it severs the link that made it a token, so the reference is kept as the value.

--- a/packages/ui/src/__snapshots__/ui-surface.test.ts.snap
+++ b/packages/ui/src/__snapshots__/ui-surface.test.ts.snap
@@ -303,14 +303,19 @@ exports[`ui public export surface > ./breakpoints surface is unchanged 1`] = `
 
 exports[`ui public export surface > ./color surface is unchanged 1`] = `
 [
+  "ColorTokenValue (type)",
+  "ColorValue (type)",
   "Hsv (type)",
   "Oklch (type)",
   "Rgb (type)",
   "Rgba (type)",
+  "colorTokenName (value)",
   "hsvToRgb (value)",
+  "isColorTokenValue (value)",
   "normalizeHue (value)",
   "oklchToRgb (value)",
   "parseHex (value)",
+  "resolveColorValue (value)",
   "rgbToHsv (value)",
   "rgbToOklch (value)",
   "toHex (value)",

--- a/packages/ui/src/lib/color/index.ts
+++ b/packages/ui/src/lib/color/index.ts
@@ -42,3 +42,14 @@ export {
  * opaque, so a value reads back the way it was entered.
  */
 export { parseHex, toHex } from "./hex";
+
+/**
+ * @experimental The value a colour control hands back: a literal, or a
+ * reference to a colour the site defines.
+ *
+ * Kept as a union rather than resolved at pick time, because resolving a token
+ * to its colour before storing it is what severs the link that made it a token.
+ */
+export { colorTokenName, isColorTokenValue, resolveColorValue } from "./value";
+/** @experimental */
+export type { ColorTokenValue, ColorValue } from "./value";

--- a/packages/ui/src/lib/color/value.test.ts
+++ b/packages/ui/src/lib/color/value.test.ts
@@ -73,6 +73,25 @@ describe("resolving a value to a colour", () => {
     expect(resolveColorValue({ $token: "color.ghost" }, tokens)).toBeNull();
   });
 
+  it.each(["constructor", "toString", "valueOf"])(
+    "answers null for the inherited name %s",
+    name => {
+      // A token name is a dot path with no reserved words, so these are legal
+      // names a site can define. Read off an ordinary object they resolve to
+      // functions from the prototype — not a colour, and not the null the
+      // signature promises.
+      expect(resolveColorValue({ $token: name }, tokens)).toBeNull();
+    }
+  );
+
+  it("still resolves a token the site DOES define", () => {
+    // The positive control for the three above: refusing every inherited name
+    // by refusing everything would satisfy them.
+    expect(resolveColorValue({ $token: "color.primary" }, tokens)).toBe(
+      "#3b82f6"
+    );
+  });
+
   it("answers null for a token when no lookup is supplied", () => {
     expect(resolveColorValue({ $token: "color.primary" })).toBeNull();
   });

--- a/packages/ui/src/lib/color/value.test.ts
+++ b/packages/ui/src/lib/color/value.test.ts
@@ -1,0 +1,79 @@
+/**
+ * The union exists so a token survives being stored. Every case below is a
+ * value that would otherwise be mistaken for the other member of it — and the
+ * consequence of each mistake is not symmetric: treating a literal as a token
+ * loses a colour, while treating a token as a literal loses the LINK, so the
+ * page stops following the site's theme and nothing reports it.
+ */
+import { describe, expect, it } from "vitest";
+
+import { colorTokenName, isColorTokenValue, resolveColorValue } from "./value";
+
+describe("telling a token from a colour", () => {
+  it("recognises a token reference", () => {
+    expect(isColorTokenValue({ $token: "color.primary" })).toBe(true);
+    expect(colorTokenName({ $token: "color.primary" })).toBe("color.primary");
+  });
+
+  it("treats a literal colour as a literal", () => {
+    expect(isColorTokenValue("#3b82f6")).toBe(false);
+    expect(colorTokenName("#3b82f6")).toBeNull();
+  });
+
+  it.each([
+    ["an array", []],
+    ["null", null],
+    ["a number", 7],
+    ["an object with no $token", { token: "color.primary" }],
+    ["a $token that is not a string", { $token: 7 }],
+  ])("rejects %s", (_label, value) => {
+    expect(isColorTokenValue(value)).toBe(false);
+  });
+
+  it.each([
+    [
+      "an array carrying $token",
+      Object.assign([], { $token: "color.primary" }),
+    ],
+    [
+      "a class instance carrying $token",
+      new (class {
+        $token = "color.primary";
+      })(),
+    ],
+  ])("rejects %s, which is not a plain object", (_label, value) => {
+    // The separating cases. Every rejection above is already satisfied by the
+    // `$token` test alone, so they pass whether or not the shape is checked at
+    // all — these are the only ones that require it. The array matters because
+    // it reaches storage looking like a token and serializes to `[]`, losing
+    // the reference with nothing to report it.
+    expect(isColorTokenValue(value)).toBe(false);
+  });
+});
+
+describe("resolving a value to a colour", () => {
+  const tokens = { "color.primary": "#3b82f6" };
+
+  it("looks a token up in the site's tokens", () => {
+    expect(resolveColorValue({ $token: "color.primary" }, tokens)).toBe(
+      "#3b82f6"
+    );
+  });
+
+  it("returns a literal unchanged", () => {
+    // The positive control: a resolver that answered null for everything would
+    // satisfy the absent-token case below.
+    expect(resolveColorValue("#ff0000", tokens)).toBe("#ff0000");
+  });
+
+  it("answers null for a token the site does not define", () => {
+    // Not a fallback colour. A swatch that confidently renders the wrong colour
+    // is worse than one that renders nothing, because only one of them is
+    // visible as a problem.
+    expect(resolveColorValue({ $token: "color.ghost" }, tokens)).toBeNull();
+  });
+
+  it("answers null for a token when no lookup is supplied", () => {
+    expect(resolveColorValue({ $token: "color.primary" })).toBeNull();
+  });
+});

--- a/packages/ui/src/lib/color/value.test.ts
+++ b/packages/ui/src/lib/color/value.test.ts
@@ -30,6 +30,21 @@ describe("telling a token from a colour", () => {
     expect(isColorTokenValue(value)).toBe(false);
   });
 
+  it("rejects a $token inherited from a polluted Object.prototype", () => {
+    // Object.prototype ITSELF, not an intermediate object. An intermediate one
+    // fails the plain-object check long before the marker is read, so it never
+    // reaches the own-property test this exists for. A plain `{}` under
+    // pollution passes every other check, and serializing it drops the
+    // inherited property — a value stored on that basis becomes `{}`.
+    const proto = Object.prototype as unknown as Record<string, unknown>;
+    proto.$token = "color.primary";
+    try {
+      expect(isColorTokenValue({})).toBe(false);
+    } finally {
+      delete proto.$token;
+    }
+  });
+
   it.each([
     [
       "an array carrying $token",
@@ -90,6 +105,17 @@ describe("resolving a value to a colour", () => {
     expect(resolveColorValue({ $token: "color.primary" }, tokens)).toBe(
       "#3b82f6"
     );
+  });
+
+  it("never hands back an object the predicate rejected", () => {
+    // The type admits shapes the predicate does not: this instance satisfies
+    // `ColorTokenValue` structurally, so it reaches the literal branch. Passing
+    // it through would break `string | null` for every rendering caller.
+    const instance = new (class {
+      $token = "color.primary";
+    })();
+
+    expect(resolveColorValue(instance, tokens)).toBeNull();
   });
 
   it("answers null for a token when no lookup is supplied", () => {

--- a/packages/ui/src/lib/color/value.ts
+++ b/packages/ui/src/lib/color/value.ts
@@ -82,5 +82,11 @@ export function resolveColorValue(
   tokens: Readonly<Record<string, string>> = {}
 ): string | null {
   if (!isColorTokenValue(value)) return value;
-  return tokens[value.$token] ?? null;
+  // Own keys only. A token name is a dot path with no reserved words, so
+  // `constructor` and `toString` are legal names — and reading them off an
+  // ordinary object walks the prototype and answers with a FUNCTION, which is
+  // neither a colour nor the null this promises.
+  if (!Object.hasOwn(tokens, value.$token)) return null;
+  const resolved: unknown = tokens[value.$token];
+  return typeof resolved === "string" ? resolved : null;
 }

--- a/packages/ui/src/lib/color/value.ts
+++ b/packages/ui/src/lib/color/value.ts
@@ -54,6 +54,11 @@ export function isColorTokenValue(value: unknown): value is ColorTokenValue {
   }
   const proto: unknown = Object.getPrototypeOf(value);
   if (proto !== Object.prototype && proto !== null) return false;
+  // The marker must be the object's OWN. An inherited `$token` — from a
+  // polluted `Object.prototype` — is not something this value carries, and
+  // serializing it drops the property, so a caller that stored it would find
+  // `{}` where a token had been.
+  if (!Object.hasOwn(value, "$token")) return false;
   return typeof (value as { $token: unknown }).$token === "string";
 }
 
@@ -81,7 +86,13 @@ export function resolveColorValue(
   value: ColorValue,
   tokens: Readonly<Record<string, string>> = {}
 ): string | null {
-  if (!isColorTokenValue(value)) return value;
+  // Narrowed rather than returned as-is. The TYPE admits shapes the predicate
+  // rejects — a class instance carrying `$token` satisfies `ColorTokenValue`
+  // structurally — so this branch can hold an object, and handing one back
+  // would break the `string | null` this promises for every rendering caller.
+  if (!isColorTokenValue(value)) {
+    return typeof value === "string" ? value : null;
+  }
   // Own keys only. A token name is a dot path with no reserved words, so
   // `constructor` and `toString` are legal names — and reading them off an
   // ordinary object walks the prototype and answers with a FUNCTION, which is

--- a/packages/ui/src/lib/color/value.ts
+++ b/packages/ui/src/lib/color/value.ts
@@ -1,0 +1,86 @@
+/**
+ * The value a colour control hands back.
+ *
+ * A styling surface has two different things to say about a colour, and they
+ * are not interchangeable. A LITERAL is the colour itself and never changes. A
+ * TOKEN REFERENCE names something the site defines, so re-theming moves every
+ * value that points at it — which is the whole reason a token exists, and is
+ * lost the moment a control resolves one to its colour before storing it.
+ *
+ * So the value is the union, and it is structurally the same shape the block
+ * engine already stores (`{ $token }` beside a literal). Declared here rather
+ * than imported: this package publishes browser components and takes no
+ * dependency on the engine.
+ *
+ * What is deliberately NOT here is the mapping from a token name to the CSS
+ * custom property it compiles to. The engine owns that, applies a site-chosen
+ * prefix to it, and validates the name; restating it here would be a second
+ * implementation of a decision that already has one. A caller that needs the
+ * colour of a token resolves it through a lookup the host supplies.
+ *
+ * @module lib/color/value
+ */
+
+/**
+ * A reference to a colour the site defines, by dot path (`color.primary`).
+ *
+ * @experimental
+ */
+export interface ColorTokenValue {
+  $token: string;
+}
+
+/**
+ * A colour control's value: a literal in any CSS notation, or a token
+ * reference.
+ *
+ * @experimental
+ */
+export type ColorValue = string | ColorTokenValue;
+
+/**
+ * Whether a value names a token rather than being a colour.
+ *
+ * Accepts only a PLAIN object. The prototype check is what does that work, and
+ * it excludes arrays and class instances alike — an array is the case worth
+ * naming, because it passes a bare `typeof === "object"` test, and a value that
+ * reached storage through one serializes to `[]` and loses the token.
+ *
+ * @experimental
+ */
+export function isColorTokenValue(value: unknown): value is ColorTokenValue {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+  const proto: unknown = Object.getPrototypeOf(value);
+  if (proto !== Object.prototype && proto !== null) return false;
+  return typeof (value as { $token: unknown }).$token === "string";
+}
+
+/**
+ * The token a value names, or null when it is a literal colour.
+ *
+ * @experimental
+ */
+export function colorTokenName(value: ColorValue): string | null {
+  return isColorTokenValue(value) ? value.$token : null;
+}
+
+/**
+ * The colour a value stands for, given the site's tokens.
+ *
+ * `tokens` is supplied by the host because it is the host that knows them: they
+ * are site settings, they carry a value per light/dark mode, and which mode is
+ * showing is the host's decision. A token absent from the lookup answers null
+ * rather than falling back to some other colour — a swatch that renders the
+ * wrong colour confidently is worse than one that renders nothing.
+ *
+ * @experimental
+ */
+export function resolveColorValue(
+  value: ColorValue,
+  tokens: Readonly<Record<string, string>> = {}
+): string | null {
+  if (!isColorTokenValue(value)) return value;
+  return tokens[value.$token] ?? null;
+}


### PR DESCRIPTION
Foundation for the colour picker (the remaining Phase 4 blocker). Ships the value contract on its own so the contract can be reviewed before a component is built on it.

## The decision this encodes

A styling surface has two different things to say about a colour, and they are not interchangeable. A LITERAL is the colour itself. A TOKEN REFERENCE names something the site defines, so re-theming moves every value pointing at it — and that is lost the instant a control resolves a token to its colour before storing it.

So the value is the union: `string | { $token: string }`. That is **structurally what `blocks-engine` already stores** (`StyleValue`/`TokenRef`), so a picker speaking this union feeds the engine directly. It also means one component serves both audiences: the three admin rich-text call sites using `<input type="color">` get a plain string, and a tokens surface gets the reference — no fork.

Declared structurally rather than imported: `packages/ui` publishes browser components and takes no dependency on the engine.

## What is deliberately NOT here

The mapping from a token name to its CSS custom property. The engine owns it, applies a site-chosen prefix and validates the name. Restating it here would be a second implementation of a decision that already has one — which is the concern raised on #699 and still open. Resolution instead goes through a lookup the host supplies, which is also where light/dark mode is decided.

## Tests

13, including the ones that separate rather than merely pass. Worth calling out how two of them came about: mutation testing showed my first `isColorTokenValue` had **two redundant guards**, and my "rejects an array" case passed with BOTH removed — it was satisfied by the missing `$token`, not by any shape check. The separating cases are an array and a class instance that CARRY `$token`; those fail without the prototype check and pass with it.

A missing token resolves to `null`, never a fallback colour: a swatch that confidently renders the wrong colour is worse than one that renders nothing, because only one of them is visible as a problem.

## Verification

- `pnpm run check-types` (both configs) and `pnpm run lint` clean
- full `packages/ui` colour suite green (123)
- `ui-surface` snapshot updated; exports carry `@experimental` on the declaration
- server-safe: pure functions, no DOM, no React — it belongs to the existing `@nextlyhq/ui/color` entry