### PR TITLE
test(ui): keep the generic UI layer block-agnostic

### DIFF
--- a/packages/ui/src/layering.test.ts
+++ b/packages/ui/src/layering.test.ts
@@ -41,6 +41,14 @@ import { describe, expect, it } from "vitest";
 
 const SRC = join(__dirname);
 
+/** Every manifest field that can make a package resolvable from here. */
+const DEPENDENCY_FIELDS = [
+  "dependencies",
+  "devDependencies",
+  "peerDependencies",
+  "optionalDependencies",
+] as const;
+
 /** Every source file in this package, tests excluded. */
 function sourceFiles(dir: string): string[] {
   return readdirSync(dir).flatMap(entry => {
@@ -59,13 +67,40 @@ describe("the generic UI layer stays block-agnostic", () => {
     expect(sourceFiles(SRC).length).toBeGreaterThan(20);
   });
 
-  it("declares no dependency on the block engine", () => {
-    const manifest: { dependencies?: Record<string, string> } = JSON.parse(
+  it("declares no dependency on the block engine, in ANY field", () => {
+    // All four fields, because each makes the engine reachable in its own way:
+    // `peerDependencies` and `optionalDependencies` push it onto consumers,
+    // and `devDependencies` makes it resolvable while the package is being
+    // written, which is exactly when a component would reach for it.
+    const manifest: Record<string, unknown> = JSON.parse(
       readFileSync(join(SRC, "..", "package.json"), "utf8")
+    ) as Record<string, unknown>;
+
+    const declared = DEPENDENCY_FIELDS.flatMap(field =>
+      Object.keys((manifest[field] as Record<string, string>) ?? {}).map(
+        name => `${field}.${name}`
+      )
     );
-    expect(Object.keys(manifest.dependencies ?? {})).not.toContain(
-      "@nextlyhq/blocks-engine"
+
+    expect(
+      declared.filter(entry => entry.endsWith(".@nextlyhq/blocks-engine")),
+      "packages/ui is the block-agnostic layer. A component needing the block " +
+        "model belongs in packages/builder, which already depends on the engine."
+    ).toEqual([]);
+  });
+
+  it("is exercised — the manifest scan reads fields that exist", () => {
+    // An empty result is only evidence once the fields being read are shown to
+    // hold something. A renamed field returns the same clean answer as
+    // compliance does.
+    const manifest: Record<string, unknown> = JSON.parse(
+      readFileSync(join(SRC, "..", "package.json"), "utf8")
+    ) as Record<string, unknown>;
+
+    const populated = DEPENDENCY_FIELDS.filter(
+      field => Object.keys((manifest[field] as object) ?? {}).length > 0
     );
+    expect(populated.length).toBeGreaterThanOrEqual(2);
   });
 
   it("is exercised — the import scan can find the specifier it hunts", () => {

--- a/packages/ui/src/layering.test.ts
+++ b/packages/ui/src/layering.test.ts
@@ -1,0 +1,98 @@
+/**
+ * `@nextlyhq/ui` is the block-agnostic layer.
+ *
+ * The page builder splits three ways, and the split is what keeps one rule in
+ * one place:
+ *
+ * - `blocks-engine` owns the block model, its validation and its style
+ *   compiler. No UI.
+ * - `packages/builder` is UI that UNDERSTANDS blocks. It depends on the engine
+ *   and reads rules from it directly.
+ * - this package is generic primitives — button, dialog, input, colour
+ *   arithmetic — and knows nothing about blocks.
+ *
+ * The third clause is the load-bearing one. A block-aware component placed HERE
+ * cannot reach the engine cheaply, so it restates the engine's rules instead,
+ * and the copy drifts silently: the editor accepts a definition compilation
+ * discards, or refuses one it would have kept. That has already happened three
+ * times, in the breakpoint rules, a token predicate and an access context.
+ *
+ * This is not a new rule. `.claude/rules/derived-checks.md` already states it —
+ * a narrower view must be DERIVED from the richer one, because two
+ * implementations agree the day they are written and drift silently after —
+ * and records defects from five unrelated packages behind it.
+ *
+ * What this file can enforce is the PLACEMENT, not the duplication. A second
+ * implementation of a rule is not detectable by any import scan; it looks like
+ * ordinary code. Keeping block-aware modules out of this package is what
+ * removes the REASON to write one, so that is the boundary drawn here.
+ *
+ * Placement is worth enforcing precisely because availability is not enough.
+ * `baseStyles` on the block definition is the supported way to declare a
+ * block's visual defaults, is derived by the renderer, and is used by no block
+ * in this repository — while blocks restate the same defaults inline. A
+ * supported export that is merely available loses to the easy path, so the
+ * boundary has to be one something FAILS at.
+ */
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const SRC = join(__dirname);
+
+/** Every source file in this package, tests excluded. */
+function sourceFiles(dir: string): string[] {
+  return readdirSync(dir).flatMap(entry => {
+    const path = join(dir, entry);
+    if (statSync(path).isDirectory()) return sourceFiles(path);
+    if (!/\.tsx?$/.test(entry)) return [];
+    if (/\.test\.tsx?$/.test(entry)) return [];
+    return [path];
+  });
+}
+
+describe("the generic UI layer stays block-agnostic", () => {
+  it("is exercised — there are source files to scan", () => {
+    // Without this the assertions below pass against an empty list, which is
+    // the shape of a guard that reports success because it found nothing.
+    expect(sourceFiles(SRC).length).toBeGreaterThan(20);
+  });
+
+  it("declares no dependency on the block engine", () => {
+    const manifest: { dependencies?: Record<string, string> } = JSON.parse(
+      readFileSync(join(SRC, "..", "package.json"), "utf8")
+    );
+    expect(Object.keys(manifest.dependencies ?? {})).not.toContain(
+      "@nextlyhq/blocks-engine"
+    );
+  });
+
+  it("is exercised — the import scan can find the specifier it hunts", () => {
+    // An empty offender list is only evidence once the search is shown to
+    // work. A renamed package or a typo in the pattern returns exactly the
+    // same clean result as compliance does.
+    const pattern = /from\s+["']@nextlyhq\/blocks-engine/;
+    expect(pattern.test('import { x } from "@nextlyhq/blocks-engine";')).toBe(
+      true
+    );
+    expect(pattern.test('import { x } from "@nextlyhq/ui";')).toBe(false);
+  });
+
+  it("imports nothing from the block engine", () => {
+    // The manifest alone is not a boundary: under pnpm a package hoisted for
+    // another workspace member stays importable from one whose own manifest
+    // never declares it. The import is the thing that would actually resolve,
+    // so the import is what is checked.
+    const offenders = sourceFiles(SRC).filter(file =>
+      /from\s+["']@nextlyhq\/blocks-engine/.test(readFileSync(file, "utf8"))
+    );
+
+    expect(
+      offenders,
+      "A component that needs the block model belongs in packages/builder, " +
+        "which already depends on the engine. Importing it here makes this " +
+        "package block-aware; restating its rules here makes them drift."
+    ).toEqual([]);
+  });
+});

--- a/packages/ui/src/layering.test.ts
+++ b/packages/ui/src/layering.test.ts
@@ -61,6 +61,27 @@ const DEPENDENCY_FIELDS = [
   "optionalDependencies",
 ] as const;
 
+/** The package this layer may not reach. */
+const FORBIDDEN = "@nextlyhq/blocks-engine";
+
+/**
+ * The one matcher. Its positive control below reads THIS value rather than a
+ * copy: a control with its own regex proves the copy works, and stays green
+ * while the matcher it stands for drifts.
+ */
+const IMPORTS_FORBIDDEN = new RegExp(
+  `from\\s+["']${FORBIDDEN.replace("/", "\\/")}`
+);
+
+/** Every `field.package` a manifest declares, across all four fields. */
+function declarationsIn(manifest: Record<string, unknown>): string[] {
+  return DEPENDENCY_FIELDS.flatMap(field =>
+    Object.keys((manifest[field] as Record<string, string>) ?? {}).map(
+      name => `${field}.${name}`
+    )
+  );
+}
+
 /**
  * Every SHIPPED source file in this package.
  *
@@ -98,42 +119,50 @@ describe("this package takes no direct dependency on the block engine", () => {
       readFileSync(join(SRC, "..", "package.json"), "utf8")
     ) as Record<string, unknown>;
 
-    const declared = DEPENDENCY_FIELDS.flatMap(field =>
-      Object.keys((manifest[field] as Record<string, string>) ?? {}).map(
-        name => `${field}.${name}`
-      )
-    );
-
     expect(
-      declared.filter(entry => entry.endsWith(".@nextlyhq/blocks-engine")),
+      declarationsIn(manifest).filter(entry => entry.endsWith(`.${FORBIDDEN}`)),
       "packages/ui is the block-agnostic layer. A component needing the block " +
         "model belongs in packages/builder, which already depends on the engine."
     ).toEqual([]);
   });
 
-  it("is exercised — the manifest scan reads fields that exist", () => {
-    // An empty result is only evidence once the fields being read are shown to
-    // hold something. A renamed field returns the same clean answer as
-    // compliance does.
-    const manifest: Record<string, unknown> = JSON.parse(
-      readFileSync(join(SRC, "..", "package.json"), "utf8")
-    ) as Record<string, unknown>;
-
-    const populated = DEPENDENCY_FIELDS.filter(
-      field => Object.keys((manifest[field] as object) ?? {}).length > 0
-    );
-    expect(populated.length).toBeGreaterThanOrEqual(2);
+  it("names every npm dependency field, so no route can go missing", () => {
+    // Pinned as a literal set, because the per-field control below cannot
+    // guard the list it iterates: removing a field deletes that field's own
+    // case, the suite shrinks by one and every remaining case passes. A
+    // vanishing test reads exactly like a passing one.
+    expect([...DEPENDENCY_FIELDS].sort()).toEqual([
+      "dependencies",
+      "devDependencies",
+      "optionalDependencies",
+      "peerDependencies",
+    ]);
   });
+
+  it.each(DEPENDENCY_FIELDS)(
+    "is exercised — the collector reads the %s field",
+    field => {
+      // Per field, not in aggregate. A count-based control is satisfied by the
+      // fields that happen to be populated, so dropping `dependencies` from the
+      // list would leave it green while the real assertion stopped inspecting
+      // runtime dependencies entirely. A sentinel in ONE field at a time is the
+      // only shape that fails when that field's route is missing.
+      expect(
+        declarationsIn({ [field]: { [FORBIDDEN]: "workspace:*" } })
+      ).toEqual([`${field}.${FORBIDDEN}`]);
+    }
+  );
 
   it("is exercised — the import scan can find the specifier it hunts", () => {
     // An empty offender list is only evidence once the search is shown to
     // work. A renamed package or a typo in the pattern returns exactly the
     // same clean result as compliance does.
-    const pattern = /from\s+["']@nextlyhq\/blocks-engine/;
-    expect(pattern.test('import { x } from "@nextlyhq/blocks-engine";')).toBe(
-      true
+    expect(
+      IMPORTS_FORBIDDEN.test('import { x } from "@nextlyhq/blocks-engine";')
+    ).toBe(true);
+    expect(IMPORTS_FORBIDDEN.test('import { x } from "@nextlyhq/ui";')).toBe(
+      false
     );
-    expect(pattern.test('import { x } from "@nextlyhq/ui";')).toBe(false);
   });
 
   it("imports it in no shipped source file", () => {
@@ -142,7 +171,7 @@ describe("this package takes no direct dependency on the block engine", () => {
     // never declares it. The import is the thing that would actually resolve,
     // so the import is what is checked.
     const offenders = sourceFiles(SRC).filter(file =>
-      /from\s+["']@nextlyhq\/blocks-engine/.test(readFileSync(file, "utf8"))
+      IMPORTS_FORBIDDEN.test(readFileSync(file, "utf8"))
     );
 
     expect(

--- a/packages/ui/src/layering.test.ts
+++ b/packages/ui/src/layering.test.ts
@@ -68,6 +68,21 @@ const FORBIDDEN = "@nextlyhq/blocks-engine";
  * The one matcher. Its positive control below reads THIS value rather than a
  * copy: a control with its own regex proves the copy works, and stays green
  * while the matcher it stands for drifts.
+ *
+ * WHAT A PASS DOES NOT MEAN. This matches the `from` spelling only. A bare
+ * side-effect `import "@nextlyhq/blocks-engine"`, a dynamic `import(...)`, a
+ * `require(...)`, an `import x = require(...)` and a `typeof import(...)` in
+ * type position all reach the package and all pass this check. Reading
+ * specifiers from the TypeScript AST is what covers them, and
+ * `packages/builder/src/layering.test.ts` already does exactly that, with each
+ * form and its reason written out.
+ *
+ * A second AST walker is not the answer here — that is the duplication this
+ * file exists to argue against. The answer is one shared reader all three
+ * layering tests call, which is a decision about where test infrastructure
+ * crossing three packages lives. Until then this catches the common spelling
+ * and every manifest declaration, and the limit is written down rather than
+ * left to be inferred from a green run.
  */
 const IMPORTS_FORBIDDEN = new RegExp(
   `from\\s+["']${FORBIDDEN.replace("/", "\\/")}`

--- a/packages/ui/src/layering.test.ts
+++ b/packages/ui/src/layering.test.ts
@@ -22,10 +22,22 @@
  * implementations agree the day they are written and drift silently after —
  * and records defects from five unrelated packages behind it.
  *
- * What this file can enforce is the PLACEMENT, not the duplication. A second
- * implementation of a rule is not detectable by any import scan; it looks like
- * ordinary code. Keeping block-aware modules out of this package is what
- * removes the REASON to write one, so that is the boundary drawn here.
+ * WHAT THIS FILE DOES NOT ESTABLISH, stated first because a green suite here
+ * would otherwise read as the whole claim: this package is NOT block-agnostic
+ * today. `lib/breakpoints.ts` reimplements the compiler's breakpoint drop
+ * rules and `breakpoint-dialog.tsx` consumes them. Both are green under every
+ * assertion below, because a second implementation of a rule is not an import
+ * — it is ordinary code, and no import scan can see it.
+ *
+ * So the invariant asserted is the narrow one the checks actually decide: this
+ * package takes no DIRECT dependency on the engine, by manifest or by import.
+ * That is worth holding on its own — it is what keeps a block-aware component
+ * from being casually added here — but it is a precondition for the layer being
+ * block-agnostic, not evidence that it is.
+ *
+ * The remaining half is a MOVE: `lib/breakpoints.ts` and `breakpoint-dialog.tsx`
+ * belong in `packages/builder`, which already depends on the engine and can
+ * derive those rules instead of restating them.
  *
  * Placement is worth enforcing precisely because availability is not enough.
  * `baseStyles` on the block definition is the supported way to declare a
@@ -49,25 +61,35 @@ const DEPENDENCY_FIELDS = [
   "optionalDependencies",
 ] as const;
 
-/** Every source file in this package, tests excluded. */
+/**
+ * Every SHIPPED source file in this package.
+ *
+ * Test material is excluded by three separate spellings, because it uses all
+ * three: a `.test.ts` filename, a `__tests__` directory holding helpers that
+ * carry no test suffix, and a `.fixture.ts` file. Excluding only the filename
+ * suffix reports a helper importing the engine FOR a test as a production
+ * layering violation, which is a false alarm about code that never ships.
+ */
 function sourceFiles(dir: string): string[] {
   return readdirSync(dir).flatMap(entry => {
     const path = join(dir, entry);
-    if (statSync(path).isDirectory()) return sourceFiles(path);
+    if (statSync(path).isDirectory()) {
+      return entry === "__tests__" ? [] : sourceFiles(path);
+    }
     if (!/\.tsx?$/.test(entry)) return [];
-    if (/\.test\.tsx?$/.test(entry)) return [];
+    if (/\.(test|fixture)\.tsx?$/.test(entry)) return [];
     return [path];
   });
 }
 
-describe("the generic UI layer stays block-agnostic", () => {
+describe("this package takes no direct dependency on the block engine", () => {
   it("is exercised — there are source files to scan", () => {
     // Without this the assertions below pass against an empty list, which is
     // the shape of a guard that reports success because it found nothing.
     expect(sourceFiles(SRC).length).toBeGreaterThan(20);
   });
 
-  it("declares no dependency on the block engine, in ANY field", () => {
+  it("declares it in no manifest field", () => {
     // All four fields, because each makes the engine reachable in its own way:
     // `peerDependencies` and `optionalDependencies` push it onto consumers,
     // and `devDependencies` makes it resolvable while the package is being
@@ -114,7 +136,7 @@ describe("the generic UI layer stays block-agnostic", () => {
     expect(pattern.test('import { x } from "@nextlyhq/ui";')).toBe(false);
   });
 
-  it("imports nothing from the block engine", () => {
+  it("imports it in no shipped source file", () => {
     // The manifest alone is not a boundary: under pnpm a package hoisted for
     // another workspace member stays importable from one whose own manifest
     // never declares it. The import is the thing that would actually resolve,


### PR DESCRIPTION
Enforces a rule this repo **already made** — I am citing it, not proposing it.

`.claude/rules/derived-checks.md`, first section:

> A narrower view must be derived FROM the richer one. Two implementations of the same question agree on the day they are written and drift afterwards, and the drift is silent because both look correct in isolation. This has caused defects in five unrelated packages that share no code.

## Why this file exists

Codex raised the same P1 three times in two days — the breakpoint rules (#699), a token predicate (#706, now closed), and an access context (#697). I treated them as three findings. They are one: **I put block-aware code in the generic UI package**, which then could not reach the engine cheaply and had to restate its rules.

The industry answer is settled and Nextly already has the layers. WordPress splits it three ways — [`@wordpress/blocks`](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-blocks/) (model + validation, no UI), [`@wordpress/block-editor`](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-block-editor/) (UI that understands blocks, imports the model freely), and [`@wordpress/components`](https://woracious.com/understanding-the-difference-between-wordpress-components-and-wordpress-block-editor/) (generic primitives that know nothing about blocks). That maps onto `blocks-engine` / `packages/builder` / `packages/ui`, and `packages/builder` **already** depends on the engine at `workspace:*`.

## Two things I had wrong, corrected by measurement

- **"`packages/ui` cannot import `blocks-engine`" is false.** Nothing forbids it; the engine has two runtime deps and `css-tree` never reaches the document model. It is expensive (single root export, no subpath), not illegal. I had built an architecture around a constraint that was not real.
- **A supported export is not enough on its own.** `baseStyles` already exists on the block definition, is already derived by the renderer, and is used by **no block in this repository** — while blocks restate the same defaults inline. Availability loses to the easy path, which is why the boundary has to be one something FAILS at.

## What it enforces, and what it cannot

**Can:** placement. No dependency on the engine, and no import of it, in `packages/ui`.

**Cannot:** duplication itself. A second implementation of a rule looks like ordinary code and no import scan sees it. Keeping block-aware modules out is what removes the *reason* to write one — that is the honest scope, and it is stated in the file.

## Tests

Four, and two are instruments rather than assertions:

- the file list is non-empty, so the scan cannot pass by finding nothing
- the import pattern is proven to MATCH the specifier it hunts and not match a sibling, so a rename or typo cannot certify compliance by failing to search

Proven by mutation: adding `import { x } from "@nextlyhq/blocks-engine"` to `src/lib/utils.ts` fails the guard with a message naming `packages/builder` as where such a component belongs.

## Verification

`pnpm run check-types` (both configs) and `pnpm run lint` clean; `packages/ui` at its pre-existing baseline of 1 failure (`comments-describe-code`, whose hits are all in gitignored `.next-e2e` artifacts).

## Not in this PR

Moving `breakpoint-dialog.tsx` + `lib/breakpoints.ts` into `packages/builder` is the follow-through, and it needs the builder/blocks-engine lane — asked, awaiting an answer. This guard passes today because those files do not IMPORT the engine; they restate it, which is exactly the case the scan cannot see.