### PR TITLE
docs(root): state the build check-types actually needs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,7 +85,17 @@ Before editing a package, read its README.md and check for a nested AGENTS.md.
   absent — and `lint` then fails on its self-imports, which is the same missing
   build wearing a different rule's error message.
 
-  **Measure these with `--force`.** Turbo caches both tasks, and a cached task
+  **Two states distort these numbers in OPPOSITE directions, and neither is
+  visible in the summary line.** A warm cache overstates health; a missing
+  `dist` overstates breakage. Measured from both ends: with the cache warm this
+  entry first recorded 19 of 21 passing and `lint` clean, and on a freshly
+  installed tree with nothing built another lane saw `pnpm lint` fail with 361
+  `@nextlyhq/ui` resolution errors and vitest unable to collect at all. Same
+  repository, same commit.
+
+  So state the cache AND the build state when you quote a number.
+
+  **Measure with `--force`.** Turbo caches both tasks, and a cached task
   reports `Tasks: N successful` without running anything — so a warm cache from
   an earlier built state reports a clean tree as passing. That is not a
   hypothetical: the first version of this entry claimed 19 of 21 passing and
@@ -96,7 +106,8 @@ Before editing a package, read its README.md and check for a nested AGENTS.md.
   own: a misspelled specifier, a removed export-map subpath, or a broken
   tsconfig path mapping produces exactly the same error, and no amount of
   rebuilding fixes those. If the error survives a successful build of that
-  package's dependencies, it is a real resolution defect — see
+  package AND its dependencies — the `<pkg>...` form above, not `^...` — it is a
+  real resolution defect — see
   `.claude/rules/verifying-merged-work.md`, which says to check what `main`
   changed before calling any of this environmental.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,8 +57,35 @@ Before editing a package, read its README.md and check for a nested AGENTS.md.
 ## Build and test (read this before running anything)
 
 - `pnpm build` builds all packages (turbo, dependency order).
-- `pnpm check-types` and `pnpm lint` do NOT need a build first. `pnpm test`
-  does (turbo handles it when run from the root).
+- `pnpm lint` does NOT need a build first. `pnpm test` does (turbo handles it
+  when run from the root).
+- `pnpm check-types` needs one for any package that imports a workspace sibling
+  through its package exports, and that is not a corner case: on a clean
+  checkout the root `pnpm check-types` EXITS 1, because `@nextlyhq/admin` cannot
+  resolve `@nextlyhq/ui`, `nextly/config` or `nextly/field-catalog` until their
+  `dist` exists. Nineteen of twenty-one packages pass, so the failure looks
+  local to one package rather than like a missing prerequisite.
+
+  The specifier tells you which case you are in. `TS2307` naming a workspace
+  package (`nextly/...`, `@nextlyhq/...`) is a missing build, not a defect in
+  the code being checked — the same costume described in
+  `.claude/rules/verifying-merged-work.md`. Build just what that package needs:
+
+  ```
+  pnpm --filter <pkg>^... build     # ^... is its dependencies, not the package
+  ```
+
+  A package importing no workspace sibling is genuinely build-free, which is why
+  the guarantee held for so long and why it fails without warning the first time
+  a package takes such a dependency.
+
+  `packages/admin` shows the half-measure that does not close this: it maps
+  `nextly` to `../nextly/src` with tsconfig `paths`, so the bare specifier
+  resolves from source, while its SUBPATHS and `@nextlyhq/ui` still do not.
+  Mapping a sibling's source is also not a general fix — it pulls that sibling's
+  whole program in, and under pnpm isolation its own devDependencies are not
+  visible from the consumer, so the errors change rather than stop.
+
 - CRITICAL: integration tests require built packages. Run them from the ROOT
   (`pnpm test:integration...`) so turbo builds first. Running
   `pnpm --filter nextly test:integration` on an unbuilt tree fails 60+ files

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,34 +57,44 @@ Before editing a package, read its README.md and check for a nested AGENTS.md.
 ## Build and test (read this before running anything)
 
 - `pnpm build` builds all packages (turbo, dependency order).
-- `pnpm lint` does NOT need a build first. `pnpm test` does (turbo handles it
-  when run from the root).
-- `pnpm check-types` needs one for any package that imports a workspace sibling
-  through its package exports, and that is not a corner case: on a clean
-  checkout the root `pnpm check-types` EXITS 1, because `@nextlyhq/admin` cannot
-  resolve `@nextlyhq/ui`, `nextly/config` or `nextly/field-catalog` until their
-  `dist` exists. Nineteen of twenty-one packages pass, so the failure looks
-  local to one package rather than like a missing prerequisite.
+- `pnpm check-types` and `pnpm lint` BOTH need a build first. On a clean
+  checkout, measured with the cache forced off so the numbers are of work that
+  actually ran:
 
-  The specifier tells you which case you are in. `TS2307` naming a workspace
-  package (`nextly/...`, `@nextlyhq/...`) is a missing build, not a defect in
-  the code being checked — the same costume described in
-  `.claude/rules/verifying-merged-work.md`. Build just what that package needs:
+  | command                                         | result on a clean tree                             |
+  | ----------------------------------------------- | -------------------------------------------------- |
+  | `pnpm turbo run check-types --continue --force` | 6 of 21 successful, 18 packages reporting `TS2307` |
+  | `pnpm turbo run lint --continue --force`        | 8 of 22 successful                                 |
 
-  ```
-  pnpm --filter <pkg>^... build     # ^... is its dependencies, not the package
-  ```
+  `check-types` fails because a workspace import resolves through the sibling's
+  package exports to a `dist/index.d.ts` that does not exist yet. `lint` fails
+  for the same underlying reason through a different rule: `import-x/no-unresolved`
+  resolves the same specifiers, so an unbuilt sibling is an unresolved import.
 
-  A package importing no workspace sibling is genuinely build-free, which is why
-  the guarantee held for so long and why it fails without warning the first time
-  a package takes such a dependency.
+  Run `pnpm build` first. A per-package `pnpm --filter <pkg>^... build` builds
+  only that package's dependencies and is enough when you are checking one
+  package, but the failure is workspace-wide rather than local to one package.
 
-  `packages/admin` shows the half-measure that does not close this: it maps
-  `nextly` to `../nextly/src` with tsconfig `paths`, so the bare specifier
-  resolves from source, while its SUBPATHS and `@nextlyhq/ui` still do not.
-  Mapping a sibling's source is also not a general fix — it pulls that sibling's
-  whole program in, and under pnpm isolation its own devDependencies are not
-  visible from the consumer, so the errors change rather than stop.
+  **Measure these with `--force`.** Turbo caches both tasks, and a cached task
+  reports `Tasks: N successful` without running anything — so a warm cache from
+  an earlier built state reports a clean tree as passing. That is not a
+  hypothetical: the first version of this entry claimed 19 of 21 passing and
+  `lint` clean at 22 of 22, and both numbers came from cache hits.
+
+  `TS2307` naming a workspace package (`nextly/...`, `@nextlyhq/...`) is USUALLY
+  a missing build, and the rebuild is what confirms it. It is not proof on its
+  own: a misspelled specifier, a removed export-map subpath, or a broken
+  tsconfig path mapping produces exactly the same error, and no amount of
+  rebuilding fixes those. If the error survives a successful build of that
+  package's dependencies, it is a real resolution defect — see
+  `.claude/rules/verifying-merged-work.md`, which says to check what `main`
+  changed before calling any of this environmental.
+
+  Path mappings cover part of this and are not a general answer.
+  `packages/admin` maps the bare `nextly` specifier to `../nextly/src`, which is
+  why admin resolves it without a build while `packages/plugin-sdk`, which has
+  no such mapping, does not. Subpaths like `nextly/config` and
+  `nextly/field-catalog` are not covered by that mapping and still need `dist`.
 
 - CRITICAL: integration tests require built packages. Run them from the ROOT
   (`pnpm test:integration...`) so turbo builds first. Running

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,19 +61,29 @@ Before editing a package, read its README.md and check for a nested AGENTS.md.
   checkout, measured with the cache forced off so the numbers are of work that
   actually ran:
 
-  | command                                         | result on a clean tree                             |
-  | ----------------------------------------------- | -------------------------------------------------- |
-  | `pnpm turbo run check-types --continue --force` | 6 of 21 successful, 18 packages reporting `TS2307` |
-  | `pnpm turbo run lint --continue --force`        | 8 of 22 successful                                 |
+  | command                                         | result on a clean tree                              |
+  | ----------------------------------------------- | --------------------------------------------------- |
+  | `pnpm turbo run check-types --continue --force` | 6 of 21 successful, 15 packages failing on `TS2307` |
+  | `pnpm turbo run lint --continue --force`        | 8 of 22 successful                                  |
 
   `check-types` fails because a workspace import resolves through the sibling's
   package exports to a `dist/index.d.ts` that does not exist yet. `lint` fails
   for the same underlying reason through a different rule: `import-x/no-unresolved`
   resolves the same specifiers, so an unbuilt sibling is an unresolved import.
 
-  Run `pnpm build` first. A per-package `pnpm --filter <pkg>^... build` builds
-  only that package's dependencies and is enough when you are checking one
-  package, but the failure is workspace-wide rather than local to one package.
+  Run `pnpm build` first. The failure is workspace-wide rather than local to one
+  package, so the whole-repo build is the honest default.
+
+  To check one package, build it WITH its dependencies:
+
+  ```
+  pnpm --filter <pkg>... build      # trailing ... includes <pkg> itself
+  ```
+
+  Not `<pkg>^...`. `pnpm recursive --help` defines that form as the dependencies
+  "without including the matched packages", so the package's own `dist` stays
+  absent — and `lint` then fails on its self-imports, which is the same missing
+  build wearing a different rule's error message.
 
   **Measure these with `--force`.** Turbo caches both tasks, and a cached task
   reports `Tasks: N successful` without running anything — so a warm cache from


### PR DESCRIPTION
`AGENTS.md` told contributors that `check-types` and `lint` both run without a build. **Half of that is true**, and the false half fails in the way that costs the most time: it looks like a broken machine.

## Measured on a clean checkout, not argued

| command | result |
|---|---|
| `pnpm lint` | **22 of 22 successful, exit 0** — genuinely build-free |
| `pnpm check-types` | **exit 1** |

The `check-types` failure is `@nextlyhq/admin`, unable to resolve `@nextlyhq/ui`, `nextly/config`, `nextly/field-catalog` and `nextly/api/versions-diff` until their `dist` exists — **438 unresolved imports**.

**19 of 21 packages pass**, which is what makes this expensive: it reads as one package being broken rather than as a missing prerequisite. CI has never caught it because CI builds first.

## The fix is named and verified, not asserted

```
pnpm --filter <pkg>^... build     # ^... is its dependencies, not the package
```

Verified on the failing package rather than documented from memory:

| | admin `check-types` |
|---|---|
| before | 438 errors, exit 1 |
| after that command | **0 errors, exit 0** |

The entry also says which signal separates the two cases, since that is the part that gets misread: a `TS2307` naming a **workspace** package (`nextly/...`, `@nextlyhq/...`) is a missing build, not a defect in the code being checked. That is the same costume `.claude/rules/verifying-merged-work.md` already warns about; this connects the rule to the command that resolves it.

## Why the obvious repair is not general

Recorded so the next person does not spend the afternoon I did.

`packages/admin` already maps `nextly` to `../nextly/src` with tsconfig `paths`. That resolves the **bare** specifier from source and leaves its **subpaths** and `@nextlyhq/ui` still unresolved — a half-measure that looks like a solved problem.

Extending it does not work either. Mapping a sibling's source pulls that sibling's whole program in, and under pnpm isolation the sibling's own devDependencies are not visible from the consumer. Applied to `builder` → `blocks-engine`, `TS2307` was traded for four unrelated `TS7016`/`TS7006` from the engine's untyped `css-tree` imports. Both are the check failing for a reason that is not about the code being checked, so it was reverted.

## Scope

Documentation only, so no changeset. This is the honest-minimum half of a two-part fix: a follow-up in `blocks-engine` can give `css-tree` a declaration so the source mapping becomes viable, which is the real repair. This one lands now so the guide stops telling contributors the opposite of what will happen.
