### PR TITLE
feat(nextly): erase a recipient from the email delivery log

### DIFF
--- a/.changeset/email-recipient-erasure.md
+++ b/.changeset/email-recipient-erasure.md
@@ -1,0 +1,44 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+---
+
+Erase a recipient from the email delivery log.
+
+Deleting a user left their delivery rows behind carrying a keyed hash of their
+address, which an install holds the key for, so the table went on answering
+"was this person written to, and when" for an account that no longer exists.
+`eraseRecipientDeliveries` overwrites that hash with a value no address can
+produce, keeping the row, its status and its timing so aggregate questions
+still have an answer. `deleteUser` calls it inside its existing transaction, so
+a failed erasure takes the deletion with it rather than leaving the two out of
+step.
+
+The erasure takes an ADDRESS rather than a user id, because most recipients
+never had an account: a password reset to an address that never registered, a
+CC, a BCC added by a `beforeSend` filter. Those people can ask to be erased too
+and no account deletion will ever fire for them, so it is callable directly.
+
+`EmailDeliveryRecord.recipientHash` is now `string | null`, where null means
+erased.

--- a/packages/nextly/src/domains/email/__tests__/delete-user-erases-deliveries.integration.test.ts
+++ b/packages/nextly/src/domains/email/__tests__/delete-user-erases-deliveries.integration.test.ts
@@ -1,0 +1,215 @@
+/**
+ * That `deleteUser` reaches the delivery log, including rows that appear after
+ * its transaction commits.
+ *
+ * The unit suite drives `eraseRecipientDeliveries` directly. That proves the
+ * helper works and proves nothing about whether the service calls it — a suite
+ * built that way stays green when the production call is deleted, because the
+ * subject it exercises is the one it constructed rather than the one that
+ * ships. This drives the real `UserMutationService` against real SQLite so the
+ * production path is what is under test.
+ *
+ * The second row is the point. `deleteUser` erases inside its transaction and
+ * again after the commit, because a send already in flight can insert its row
+ * after the in-transaction pass has chosen its matches. Here that row is
+ * inserted deterministically at exactly that moment, by wrapping the adapter's
+ * `transaction` so the insert lands after the callback resolves and before the
+ * post-commit block runs. Delete the post-commit sweep and this row survives
+ * with a live digest, which is the failure the sweep exists to prevent.
+ */
+
+import { existsSync, mkdirSync, rmSync } from "node:fs";
+import { randomUUID } from "node:crypto";
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { createSqliteAdapter } from "@nextlyhq/adapter-sqlite";
+
+import { getSQLiteDrizzleKit } from "../../../database/drizzle-kit-lazy";
+import { getDialectTables } from "../../../database/index";
+import { SchemaRegistry } from "../../../database/schema-registry";
+import { emailDeliveriesSqlite } from "../../../schemas/email-deliveries/sqlite";
+import { emailProvidersSqlite } from "../../../schemas/email-providers/sqlite";
+import {
+  roles as rolesSqlite,
+  userRoles as userRolesSqlite,
+} from "../../../schemas/rbac/sqlite";
+import {
+  accounts as accountsSqlite,
+  users as usersSqlite,
+} from "../../../schemas/users/sqlite";
+import { nextlyEvents as eventsSqlite } from "../../../schemas/webhooks/sqlite";
+import { splitStatements } from "../../schema/pipeline/sql-statement-utils";
+import { UserMutationService } from "../../users/services/user-mutation-service";
+import { ERASED_RECIPIENT_HASH, recipientDigest } from "../delivery-record";
+
+// `recipientDigest` reads the validated environment, which is checked lazily on
+// first ACCESS and refuses a configuration with no `DATABASE_URL`. This suite
+// drives SQLite through an explicit adapter URL and never needs one, so this
+// exists only so the digest function can be called. Assigned rather than
+// overwritten, matching how the shared setup supplies `NEXTLY_SECRET`.
+process.env.DATABASE_URL ??= "postgres://unused@localhost:5432/unused";
+
+const TEST_DB_DIR = ".test-dbs";
+const TEST_DB_URL = `${TEST_DB_DIR}/delete-user-erases-deliveries.db`;
+
+const silentLogger = {
+  debug: () => {},
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+};
+
+async function ddl(): Promise<string[]> {
+  const kit = await getSQLiteDrizzleKit();
+  const statements = await kit.generateMigration(
+    await kit.generateDrizzleJson({}),
+    await kit.generateDrizzleJson({
+      users: usersSqlite,
+      accounts: accountsSqlite,
+      roles: rolesSqlite,
+      userRoles: userRolesSqlite,
+      // The mutation service records user.deleted to the outbox whenever
+      // recording is active, and that gate is process-wide.
+      nextlyEvents: eventsSqlite,
+      // email_deliveries declares a provider reference, so its generated DDL
+      // names email_providers. Creating one without the other leaves a foreign
+      // key pointing at nothing, which SQLite reports on first use.
+      emailProviders: emailProvidersSqlite,
+      emailDeliveries: emailDeliveriesSqlite,
+    })
+  );
+  return splitStatements(statements);
+}
+
+describe("deleteUser erases the delivery log (real SQLite)", () => {
+  let adapter: ReturnType<typeof createSqliteAdapter>;
+  let users: UserMutationService;
+
+  async function insertDelivery(address: string): Promise<void> {
+    await adapter.executeQuery(
+      `INSERT INTO email_deliveries
+         (id, provider_type, recipient_hash, recipient_kind, status,
+          attempt_count, retention_class, created_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+      [
+        randomUUID(),
+        "smtp",
+        recipientDigest(address),
+        "to",
+        "sent",
+        1,
+        "operational",
+        Math.floor(Date.now() / 1000),
+      ]
+    );
+  }
+
+  async function storedHashes(): Promise<string[]> {
+    const rows = await adapter.executeQuery<{ recipient_hash: string }>(
+      `SELECT recipient_hash FROM email_deliveries`
+    );
+    return rows.map(row => row.recipient_hash);
+  }
+
+  beforeAll(async () => {
+    if (!existsSync(TEST_DB_DIR)) mkdirSync(TEST_DB_DIR, { recursive: true });
+    rmSync(TEST_DB_URL, { force: true });
+    adapter = createSqliteAdapter({ url: TEST_DB_URL });
+    await adapter.connect();
+    for (const stmt of await ddl()) {
+      await adapter.executeQuery(stmt);
+    }
+    // A sentinel so createLocalUser never takes its "first user ever" branch,
+    // which needs more of the RBAC wiring than this suite installs.
+    const nowEpoch = Math.floor(Date.now() / 1000);
+    await adapter.executeQuery(
+      `INSERT INTO users (id, email, name, is_active, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?)`,
+      ["sentinel", "sentinel@test.local", "Sentinel", 1, nowEpoch, nowEpoch]
+    );
+    const registry = new SchemaRegistry("sqlite");
+    registry.registerStaticSchemas(getDialectTables("sqlite"));
+    adapter.setTableResolver(registry);
+
+    users = new UserMutationService(adapter, silentLogger);
+  }, 60_000);
+
+  afterAll(async () => {
+    try {
+      await adapter?.disconnect?.();
+    } catch {
+      // ignore teardown close errors
+    }
+    rmSync(TEST_DB_URL, { force: true });
+  });
+
+  it("erases rows written before the deletion, and rows that land after its transaction commits", async () => {
+    const address = `erase-${randomUUID()}@example.com`;
+    const created = await users.createLocalUser({
+      email: address,
+      name: "Erase Me",
+      password: "CorrectHorseBattery1!",
+    });
+
+    await insertDelivery(address);
+    // The precondition. Without it a later "no live digest" assertion is
+    // satisfied by a row that was never written, and the whole test passes on
+    // an empty table.
+    expect(await storedHashes()).toContain(recipientDigest(address));
+
+    // Insert a second row at the moment a send already in flight would commit:
+    // after the deletion transaction has closed, before the post-commit sweep.
+    // The in-transaction erasure cannot have selected it, so only the sweep can
+    // reach it.
+    // Hooked at the COMMIT itself rather than at `adapter.transaction`, because
+    // on SQLite `withTransaction` runs a manual BEGIN IMMEDIATE / COMMIT on the
+    // drizzle handle and never calls the adapter method. Injecting immediately
+    // after the commit resolves puts the row exactly where an in-flight send's
+    // would land: too late for the in-transaction erasure, in time for nothing
+    // but the post-commit sweep.
+    // Hooked on `getDrizzle` rather than on a handle, because `BaseService.db`
+    // is a getter that calls `adapter.getDrizzle()` afresh on every access — so
+    // patching one returned instance never reaches the one the commit runs on.
+    // `withTransaction` on SQLite issues a manual BEGIN IMMEDIATE / COMMIT, and
+    // injecting right after that COMMIT resolves puts the row exactly where an
+    // in-flight send's would land: too late for the in-transaction erasure, and
+    // reachable by nothing but the post-commit sweep.
+    const realGetDrizzle = adapter.getDrizzle.bind(adapter);
+    let injected = false;
+    const wrap = (handle: Record<string, unknown>) => {
+      const realRun = (handle.run as (q: unknown) => Promise<unknown>).bind(
+        handle
+      );
+      return new Proxy(handle, {
+        get(target, prop, receiver) {
+          if (prop !== "run") return Reflect.get(target, prop, receiver);
+          return async (query: unknown) => {
+            const result = await realRun(query);
+            if (!injected && JSON.stringify(query).includes("COMMIT")) {
+              injected = true;
+              await insertDelivery(address);
+            }
+            return result;
+          };
+        },
+      });
+    };
+    adapter.getDrizzle = ((relations?: unknown) =>
+      wrap(
+        realGetDrizzle(relations as never) as Record<string, unknown>
+      )) as typeof adapter.getDrizzle;
+
+    try {
+      await users.deleteUser(created.id);
+    } finally {
+      adapter.getDrizzle = realGetDrizzle;
+    }
+
+    expect(injected).toBe(true);
+    const after = await storedHashes();
+    // Both rows survive as records and neither still names the person.
+    expect(after.filter(h => h === ERASED_RECIPIENT_HASH)).toHaveLength(2);
+    expect(after).not.toContain(recipientDigest(address));
+  }, 60_000);
+});

--- a/packages/nextly/src/domains/email/__tests__/recipient-erasure.integration.test.ts
+++ b/packages/nextly/src/domains/email/__tests__/recipient-erasure.integration.test.ts
@@ -1,0 +1,216 @@
+/**
+ * That the recipient erasure actually rewrites the column, on every dialect.
+ *
+ * The unit suite runs on in-memory SQLite and proves the logic. It cannot prove
+ * the statement, because the thing under test is one UPDATE matched on a text
+ * column, and how a database compares text is a property of the database:
+ * MySQL's default collation for `varchar` is case- and pad-insensitive while
+ * Postgres's `varchar` is neither, and SQLite's `text` is a third set of rules.
+ * A digest that matched on one and not another would leave rows unerased on
+ * exactly the installs nobody tested.
+ *
+ * All three dialects run here. Nothing in this change depends on a constraint,
+ * a migration or a column that any dialect lacks — the sentinel was chosen so
+ * it does not — so a dialect skipped here would be skipped for want of a
+ * database URL and never for want of the behaviour.
+ *
+ * Tables are created from the PRODUCTION definitions through drizzle-kit rather
+ * than from DDL written here, so the fixture cannot drift from the schema it is
+ * meant to be testing. They are REBUILT each run: these are fixed-name system
+ * tables and a shared test database keeps whatever shape it was first created
+ * with, so reusing one would report the age of that database rather than the
+ * correctness of this schema.
+ */
+
+import { randomUUID } from "node:crypto";
+
+import type { SupportedDialect } from "@nextlyhq/adapter-drizzle/types";
+import { createMySqlAdapter } from "@nextlyhq/adapter-mysql";
+import { createPostgresAdapter } from "@nextlyhq/adapter-postgres";
+import { createSqliteAdapter } from "@nextlyhq/adapter-sqlite";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+import { getDrizzleKitForDialect } from "../../../database/drizzle-kit-lazy";
+import { emailDeliveriesMysql } from "../../../schemas/email-deliveries/mysql";
+import { emailDeliveriesPg } from "../../../schemas/email-deliveries/postgres";
+import { emailDeliveriesSqlite } from "../../../schemas/email-deliveries/sqlite";
+import { emailProvidersMysql } from "../../../schemas/email-providers/mysql";
+import { emailProvidersPg } from "../../../schemas/email-providers/postgres";
+import { emailProvidersSqlite } from "../../../schemas/email-providers/sqlite";
+import { splitStatements } from "../../schema/pipeline/sql-statement-utils";
+import { deliveriesTableFor } from "../deliveries-table";
+import { ERASED_RECIPIENT_HASH, recipientDigest } from "../delivery-record";
+import { eraseRecipientDeliveries } from "../erase-recipient";
+
+// `hashRecipient` reads the validated environment, which is checked lazily on
+// first ACCESS rather than at import — and the check refuses a configuration
+// with no `DATABASE_URL`, which an integration run does not otherwise need
+// because every adapter below is constructed from an explicit URL. Nothing ever
+// connects to this one; it exists so the digest function can be called at all.
+// Assigned rather than overwritten, matching how the shared setup supplies
+// `NEXTLY_SECRET`, so a run providing its own value keeps it.
+process.env.DATABASE_URL ??=
+  process.env.TEST_POSTGRES_URL ?? "postgres://unused@localhost:5432/unused";
+
+interface TestAdapter {
+  connect(): Promise<void>;
+  disconnect(): Promise<void>;
+  executeQuery<T = unknown>(sql: string, params?: unknown[]): Promise<T[]>;
+  getDrizzle(): unknown;
+}
+
+const ERASED = "erase-me@example.com";
+const KEPT = "someone-else@example.com";
+
+const DIALECTS: Array<{
+  dialect: SupportedDialect;
+  url: string | null;
+  make: (url: string) => TestAdapter;
+  tables: Record<string, unknown>;
+}> = [
+  {
+    dialect: "postgresql",
+    url: process.env.TEST_POSTGRES_URL ?? null,
+    make: url => createPostgresAdapter({ url }) as unknown as TestAdapter,
+    tables: { emailProvidersPg, emailDeliveriesPg },
+  },
+  {
+    dialect: "mysql",
+    url: process.env.TEST_MYSQL_URL ?? null,
+    make: url => createMySqlAdapter({ url }) as unknown as TestAdapter,
+    tables: { emailProvidersMysql, emailDeliveriesMysql },
+  },
+  {
+    dialect: "sqlite",
+    url: "memory",
+    make: () => createSqliteAdapter({ memory: true }) as unknown as TestAdapter,
+    tables: { emailProvidersSqlite, emailDeliveriesSqlite },
+  },
+];
+
+for (const entry of DIALECTS) {
+  const suite = entry.url ? describe : describe.skip;
+
+  suite(`erasing a recipient — ${entry.dialect}`, () => {
+    let adapter: TestAdapter;
+
+    const q = (id: string) =>
+      entry.dialect === "mysql" ? `\`${id}\`` : `"${id}"`;
+    const p = (index: number) =>
+      entry.dialect === "postgresql" ? `$${index}` : "?";
+
+    async function insertDelivery(address: string): Promise<void> {
+      const columns = [
+        "id",
+        "provider_type",
+        "recipient_hash",
+        "recipient_kind",
+        "status",
+        "attempt_count",
+        "retention_class",
+        "created_at",
+      ];
+      await adapter.executeQuery(
+        `INSERT INTO ${q("email_deliveries")} (${columns.map(q).join(", ")}) ` +
+          `VALUES (${columns.map((_, i) => p(i + 1)).join(", ")})`,
+        [
+          randomUUID(),
+          "smtp",
+          recipientDigest(address),
+          "to",
+          "failed",
+          1,
+          "operational",
+          new Date(),
+        ]
+      );
+    }
+
+    async function storedHashes(): Promise<string[]> {
+      const rows = await adapter.executeQuery<{ recipient_hash: string }>(
+        `SELECT ${q("recipient_hash")} FROM ${q("email_deliveries")}`
+      );
+      return rows.map(row => row.recipient_hash);
+    }
+
+    beforeAll(async () => {
+      adapter = entry.make(entry.url as string);
+      await adapter.connect();
+
+      // Dropped in reference order — deliveries first, since it is the side
+      // holding the key. The other order fails wherever the constraint exists.
+      await adapter.executeQuery(
+        `DROP TABLE IF EXISTS ${q("email_deliveries")}`
+      );
+      await adapter.executeQuery(
+        `DROP TABLE IF EXISTS ${q("email_providers")}`
+      );
+
+      const kit = await getDrizzleKitForDialect(
+        entry.dialect as "postgresql" | "mysql" | "sqlite"
+      );
+      const statements = await kit.generateMigration(
+        await kit.generateDrizzleJson({}),
+        await kit.generateDrizzleJson(entry.tables)
+      );
+      for (const statement of splitStatements(statements)) {
+        await adapter.executeQuery(statement);
+      }
+    }, 60_000);
+
+    afterAll(async () => {
+      await adapter.disconnect();
+    });
+
+    beforeEach(async () => {
+      await adapter.executeQuery(`DELETE FROM ${q("email_deliveries")}`);
+      await insertDelivery(ERASED);
+      await insertDelivery(KEPT);
+    });
+
+    it("writes both digests before anything is erased", async () => {
+      // The instrument control. Every assertion below is "the digest is gone",
+      // which an insert that silently failed would also produce.
+      const before = await storedHashes();
+      expect(before).toContain(recipientDigest(ERASED));
+      expect(before).toContain(recipientDigest(KEPT));
+    });
+
+    it("replaces the digest with the sentinel and leaves the other row", async () => {
+      await eraseRecipientDeliveries(
+        adapter.getDrizzle() as Parameters<typeof eraseRecipientDeliveries>[0],
+        deliveriesTableFor(entry.dialect),
+        ERASED
+      );
+
+      const after = await storedHashes();
+      expect(after).toContain(ERASED_RECIPIENT_HASH);
+      expect(after).not.toContain(recipientDigest(ERASED));
+      // The scope control: an UPDATE with a mismatched or absent predicate
+      // would erase this one too, and the assertions above would not notice.
+      expect(after).toContain(recipientDigest(KEPT));
+      expect(after).toHaveLength(2);
+    });
+
+    it("writes only values no collation difference can confuse", async () => {
+      // The dialects do NOT agree on how this column compares. MySQL's default
+      // `varchar` collation is case- and pad-insensitive; Postgres and SQLite
+      // compare these values exactly. Measured, not assumed: an UPDATE keyed on
+      // an uppercased digest matches on MySQL and matches nothing on the other
+      // two.
+      //
+      // That divergence is made unreachable rather than handled. `hashRecipient`
+      // emits lowercase hex and the sentinel is lowercase letters, so no two
+      // distinct stored values can ever differ only by case or trailing space —
+      // which is the property that lets one UPDATE mean the same thing on all
+      // three. Asserted here because it is load-bearing and invisible: a digest
+      // that gained uppercase would keep every other test green while MySQL
+      // quietly began matching rows the others would not.
+      for (const hash of await storedHashes()) {
+        expect(hash).toMatch(/^[0-9a-f]{64}$/);
+      }
+      expect(ERASED_RECIPIENT_HASH).toMatch(/^[a-z]+$/);
+      expect(recipientDigest(ERASED)).toMatch(/^[0-9a-f]{64}$/);
+    });
+  });
+}

--- a/packages/nextly/src/domains/email/__tests__/recipient-erasure.test.ts
+++ b/packages/nextly/src/domains/email/__tests__/recipient-erasure.test.ts
@@ -19,6 +19,7 @@ import Database from "better-sqlite3";
 import { drizzle } from "drizzle-orm/better-sqlite3";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
+import { NextlyError } from "../../../errors";
 import { getCoreSchema } from "../../../schemas";
 import type { Logger } from "../../../services/shared";
 import { createTableBody } from "../../schema/pipeline/sql-templates/create-table-body";
@@ -199,6 +200,37 @@ describe("erasing a recipient from the delivery log", () => {
     await erase(ERASED);
 
     expect(storedHashes().slice().sort()).toEqual(afterFirst);
+  });
+
+  it("a second pass catches a row written after the first", async () => {
+    // The race `deleteUser` sweeps for: a send already in flight when the
+    // deletion starts inserts its row after the in-transaction erasure has
+    // chosen its matches, so a live digest survives for an account that is
+    // gone. The post-commit pass exists to catch exactly this, and it only
+    // works because erasing twice is safe.
+    await erase(ERASED);
+    await service.record({
+      to: ERASED,
+      providerType: "smtp",
+      status: "sent",
+    });
+    expect(await service.list({ recipient: ERASED })).toHaveLength(1);
+
+    await erase(ERASED);
+
+    expect(await service.list({ recipient: ERASED })).toEqual([]);
+  });
+
+  it("reports a database failure as a NextlyError", async () => {
+    // The service method is reachable from application code, so a caller
+    // handling an erasure request has to be able to tell "this install has no
+    // such table" from "the connection dropped". A raw driver exception
+    // carries neither in a form the API layer can map.
+    sqlite.exec(`DROP TABLE "email_deliveries"`);
+
+    await expect(service.eraseRecipient(ERASED)).rejects.toBeInstanceOf(
+      NextlyError
+    );
   });
 
   it("does not suppress a later send to the same address", async () => {

--- a/packages/nextly/src/domains/email/__tests__/recipient-erasure.test.ts
+++ b/packages/nextly/src/domains/email/__tests__/recipient-erasure.test.ts
@@ -164,6 +164,30 @@ describe("erasing a recipient from the delivery log", () => {
     expect(await service.list({ recipient: ERASED })).toEqual([]);
   });
 
+  it("erases a row that was RECORDED under a display name", async () => {
+    // The direction the case above cannot reach, and the one that was broken:
+    // it records a bare address and erases a decorated one, which passes even
+    // when the WRITE path skips the normalisation, because stripping a display
+    // name that was never there is a no-op. Recording the decorated form is
+    // what separates a shared digest from two that merely agree on plain
+    // addresses.
+    const decorated = `Jane <recorded-decorated@example.com>`;
+    const bare = "recorded-decorated@example.com";
+    await service.record({
+      to: decorated,
+      providerType: "smtp",
+      status: "sent",
+    });
+    // The write must be findable by the bare mailbox before the erasure runs,
+    // or the assertion below passes on a row that was never locatable at all.
+    expect(await service.list({ recipient: bare })).toHaveLength(1);
+
+    await erase(bare);
+
+    expect(await service.list({ recipient: bare })).toEqual([]);
+    expect(storedHashes()).not.toContain(recipientDigest(bare));
+  });
+
   it("changes nothing when run a second time", async () => {
     await erase(ERASED);
     const afterFirst = storedHashes().slice().sort();

--- a/packages/nextly/src/domains/email/__tests__/recipient-erasure.test.ts
+++ b/packages/nextly/src/domains/email/__tests__/recipient-erasure.test.ts
@@ -1,0 +1,197 @@
+/**
+ * That erasing a recipient removes the person and keeps the record.
+ *
+ * The delivery log answers two questions with one row: "how many sends failed"
+ * belongs to the install, and "was this person written to" belongs to the
+ * person. These assert that the erasure separates them — the row, its status
+ * and its timing survive, and the only column that could still name a human
+ * stops being able to.
+ *
+ * Every assertion here is a form of "the address no longer matches", which is
+ * also what an erasure that silently did nothing to a table nobody wrote to
+ * would produce. So each one is paired with a control that fails when the
+ * erasure is removed: a second recipient that must SURVIVE, and a lookup that
+ * must find the row before the erasure runs.
+ */
+
+import type { DrizzleAdapter } from "@nextlyhq/adapter-drizzle";
+import Database from "better-sqlite3";
+import { drizzle } from "drizzle-orm/better-sqlite3";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+import { getCoreSchema } from "../../../schemas";
+import type { Logger } from "../../../services/shared";
+import { createTableBody } from "../../schema/pipeline/sql-templates/create-table-body";
+import { deliveriesTableFor } from "../deliveries-table";
+import { ERASED_RECIPIENT_HASH, recipientDigest } from "../delivery-record";
+import { eraseRecipientDeliveries } from "../erase-recipient";
+import { EmailDeliveryService } from "../services/email-delivery-service";
+
+vi.mock("../../../lib/env", () => ({
+  env: {
+    NEXTLY_SECRET: "test-secret-that-is-long-enough-for-derivation",
+    DB_DIALECT: "sqlite",
+    DATABASE_URL: undefined,
+    NODE_ENV: "test",
+  },
+}));
+
+const ERASED = "erase-me@example.com";
+const KEPT = "someone-else@example.com";
+
+const logger: Logger = {
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  debug: vi.fn(),
+};
+
+function makeAdapter(db: ReturnType<typeof drizzle>): DrizzleAdapter {
+  return {
+    dialect: "sqlite" as const,
+    getDrizzle: () => db,
+    getCapabilities: () => ({ dialect: "sqlite" as const }),
+    connect: async () => {},
+    disconnect: async () => {},
+    executeQuery: async () => [],
+    transaction: async (fn: (tx: unknown) => Promise<unknown>) => fn(db),
+  } as unknown as DrizzleAdapter;
+}
+
+/** Rendered from the shipped core schema, never hand-copied DDL. */
+function createDeliveriesTable(sqlite: Database.Database): void {
+  const { tables } = getCoreSchema("sqlite");
+  const spec = tables.find(table => table.name === "email_deliveries");
+  if (!spec) {
+    expect.fail(
+      "email_deliveries is absent from the core schema — the table is not registered, which no unit test would otherwise catch."
+    );
+  }
+  sqlite.exec(
+    `CREATE TABLE "email_deliveries" (\n${createTableBody(spec, (id: string) => `"${id}"`)}\n)`
+  );
+}
+
+describe("erasing a recipient from the delivery log", () => {
+  let sqlite: Database.Database;
+  let service: EmailDeliveryService;
+  let db: ReturnType<typeof drizzle>;
+
+  async function erase(address: string): Promise<void> {
+    await eraseRecipientDeliveries(db, deliveriesTableFor("sqlite"), address);
+  }
+
+  /** Straight to the column, so the assertions can see what the reader hides. */
+  function storedHashes(): string[] {
+    return sqlite
+      .prepare(`SELECT "recipient_hash" AS h FROM "email_deliveries"`)
+      .all()
+      .map(row => (row as { h: string }).h);
+  }
+
+  beforeEach(async () => {
+    sqlite = new Database(":memory:");
+    createDeliveriesTable(sqlite);
+    db = drizzle({ client: sqlite });
+    service = new EmailDeliveryService(makeAdapter(db), logger);
+
+    for (const to of [ERASED, KEPT]) {
+      await service.record({
+        to,
+        providerType: "smtp",
+        templateSlug: "password-reset",
+        status: "failed",
+        error: "mailbox unavailable",
+      });
+    }
+  });
+
+  afterEach(() => {
+    sqlite.close();
+    vi.clearAllMocks();
+  });
+
+  it("finds the row before erasure, so a later miss means erased and not absent", async () => {
+    // The control the rest of the file depends on. Without it, an erasure that
+    // did nothing and a fixture that never wrote the row are the same result.
+    expect(await service.list({ recipient: ERASED })).toHaveLength(1);
+    expect(await service.list({ recipient: KEPT })).toHaveLength(1);
+  });
+
+  it("makes the erased address unmatchable", async () => {
+    await erase(ERASED);
+
+    expect(await service.list({ recipient: ERASED })).toEqual([]);
+  });
+
+  it("leaves every other recipient matchable", async () => {
+    // The scope control. An erasure that emptied the column for every row would
+    // pass the assertion above and fail this one.
+    await erase(ERASED);
+
+    expect(await service.list({ recipient: KEPT })).toHaveLength(1);
+    expect(storedHashes()).toContain(recipientDigest(KEPT));
+  });
+
+  it("keeps the row, its status and its error", async () => {
+    await erase(ERASED);
+
+    const rows = await service.list();
+    expect(rows).toHaveLength(2);
+    expect(rows.every(row => row.status === "failed")).toBe(true);
+    expect(rows.every(row => row.error === "mailbox unavailable")).toBe(true);
+  });
+
+  it("reports an erased recipient as null rather than as the sentinel", async () => {
+    await erase(ERASED);
+
+    const erasedRecord = (await service.list()).find(
+      row => row.recipientHash === null
+    );
+    expect(erasedRecord).toBeDefined();
+    // The reader must not leak the storage spelling, and the column must still
+    // hold it — a null in the DATABASE would mean the NOT NULL constraint had
+    // been relaxed, which is the migration this design exists to avoid.
+    expect(storedHashes()).toContain(ERASED_RECIPIENT_HASH);
+  });
+
+  it("matches however the address was written", async () => {
+    // The erasure and the lookup share one digest function. If they ever stop
+    // sharing it, a display-name form erases nothing while a lookup on the bare
+    // mailbox still finds the row.
+    await erase(`Someone <${ERASED}>`);
+
+    expect(await service.list({ recipient: ERASED })).toEqual([]);
+  });
+
+  it("changes nothing when run a second time", async () => {
+    await erase(ERASED);
+    const afterFirst = storedHashes().slice().sort();
+    // Pins that the first erasure DID something. Comparing two snapshots is
+    // satisfied by an erasure that never runs — both would be the untouched
+    // column — so without this the idempotency claim is true of a no-op.
+    expect(afterFirst).toContain(ERASED_RECIPIENT_HASH);
+
+    await erase(ERASED);
+
+    expect(storedHashes().slice().sort()).toEqual(afterFirst);
+  });
+
+  it("does not suppress a later send to the same address", async () => {
+    // Erasure is a statement about the record as it stands, not a standing
+    // instruction to stop recording. Suppressing future rows would require
+    // keeping a list of the addresses that asked to be forgotten, which stores
+    // exactly what the request asked to remove. Asserted so it is not later
+    // "fixed" into that.
+    await erase(ERASED);
+
+    await service.record({
+      to: ERASED,
+      providerType: "smtp",
+      status: "sent",
+    });
+
+    expect(await service.list({ recipient: ERASED })).toHaveLength(1);
+    expect(storedHashes()).toContain(recipientDigest(ERASED));
+  });
+});

--- a/packages/nextly/src/domains/email/deliveries-table.ts
+++ b/packages/nextly/src/domains/email/deliveries-table.ts
@@ -1,0 +1,49 @@
+/**
+ * Which delivery table a dialect uses.
+ *
+ * The three dialect definitions are interchangeable at the call site and the
+ * choice between them is one question, so it is answered here rather than at
+ * each caller. A second switch written elsewhere would agree on the day it was
+ * written and silently stop agreeing the moment a dialect is added — and the
+ * caller that kept the old mapping would read and write a table nothing else
+ * touches, which looks like data going missing rather than like a bug.
+ *
+ * @module domains/email/deliveries-table
+ */
+
+import { NextlyError } from "../../errors";
+import { emailDeliveriesMysql } from "../../schemas/email-deliveries/mysql";
+import { emailDeliveriesPg } from "../../schemas/email-deliveries/postgres";
+import { emailDeliveriesSqlite } from "../../schemas/email-deliveries/sqlite";
+
+/** The delivery table, as one of the three dialect bundles defines it. */
+export type EmailDeliveriesTable =
+  | typeof emailDeliveriesPg
+  | typeof emailDeliveriesMysql
+  | typeof emailDeliveriesSqlite;
+
+/**
+ * Resolve the delivery table for a dialect.
+ *
+ * Throws rather than falling back, because every fallback here is wrong: a
+ * default table would be the wrong dialect's, and returning undefined would
+ * turn "this dialect is not supported" into "this install has no deliveries",
+ * which reads as an empty log rather than as a missing capability.
+ */
+export function deliveriesTableFor(dialect: string): EmailDeliveriesTable {
+  switch (dialect) {
+    case "postgresql":
+      return emailDeliveriesPg;
+    case "mysql":
+      return emailDeliveriesMysql;
+    case "sqlite":
+      return emailDeliveriesSqlite;
+    default:
+      throw NextlyError.internal({
+        logContext: {
+          reason: "unsupported dialect for the email delivery log",
+          dialect: String(dialect),
+        },
+      });
+  }
+}

--- a/packages/nextly/src/domains/email/delivery-record.ts
+++ b/packages/nextly/src/domains/email/delivery-record.ts
@@ -213,6 +213,45 @@ export function mailboxOf(address: string): string {
 }
 
 /**
+ * The stored digest for an address, however the caller wrote it.
+ *
+ * Every path that turns an address into something comparable against
+ * `recipient_hash` goes through here: the reader that looks a person up, and
+ * the erasure that removes them. Composing `mailboxOf` and `hashRecipient` at
+ * each call site instead would be two spellings of one question, and they would
+ * agree until one of them gained a normalisation step — at which point an
+ * erasure would quietly stop matching the rows a lookup still finds, which is
+ * the failure this table cannot afford to have silently.
+ */
+export function recipientDigest(address: string): string {
+  return hashRecipient(mailboxOf(address));
+}
+
+/**
+ * Written over `recipient_hash` when a person is erased.
+ *
+ * `hashRecipient` always emits 64 hex characters, so a value that is not one
+ * cannot be confused with a live digest and no second column is needed to
+ * record the erased state. Nothing it can emit equals this, which is what makes
+ * an erased row unreachable rather than merely hard to find: every lookup
+ * hashes the caller's address before comparing, so there is no address anyone
+ * can supply that matches these rows again.
+ *
+ * A value rather than NULL because `recipient_hash` is declared NOT NULL in all
+ * three dialect schemas AND again in the hand-written SQLite DDL in
+ * `database/sqlite-core-tables.ts`. Relaxing it would mean changing two
+ * unlinked declarations to cover SQLite alone, and a change that reached only
+ * the declaration one of them shares would leave the column missing on the
+ * dialect new installs default to.
+ */
+export const ERASED_RECIPIENT_HASH = "erased";
+
+/** Whether a stored digest belongs to someone who has been erased. */
+export function isErasedRecipientHash(hash: string): boolean {
+  return hash === ERASED_RECIPIENT_HASH;
+}
+
+/**
  * The mailbox out of whatever a provider reports as a refused recipient.
  *
  * `rejected` is provider-supplied, and nodemailer reports either a plain

--- a/packages/nextly/src/domains/email/erase-recipient.ts
+++ b/packages/nextly/src/domains/email/erase-recipient.ts
@@ -55,6 +55,21 @@ export type ErasableDeliveriesTable = Table & { recipientHash: Column };
  * stored value is the sentinel, which no address hashes to. Running this twice
  * therefore touches nothing the second time, without needing a guard to say so.
  *
+ * ROWS WRITTEN UNDER A PREVIOUS `NEXTLY_SECRET` ARE NOT REACHED. The digest is
+ * an HMAC keyed with the current secret, so after a rotation the predicate
+ * computes a value none of the older rows carry, and this returns having
+ * matched nothing — with no error, because "no rows matched" is also what a
+ * recipient with no deliveries looks like. Rotation is a real operational
+ * state here rather than a hypothetical: `email-provider-service.ts` already
+ * handles a stored configuration that no longer decrypts for exactly that
+ * reason.
+ *
+ * Recording a key version alongside the digest would close it, and that is a
+ * column on a table whose schema deliberately does not change in this change.
+ * Until then the bound is the retention pass: rows age out regardless of which
+ * key wrote them, so a rotation delays the removal of older rows rather than
+ * making it never happen.
+ *
  * The dialects do not agree on how this column compares: MySQL's default
  * `varchar` collation is case- and pad-insensitive, while Postgres and SQLite
  * compare exactly. That is safe here only because of what gets written —

--- a/packages/nextly/src/domains/email/erase-recipient.ts
+++ b/packages/nextly/src/domains/email/erase-recipient.ts
@@ -55,6 +55,14 @@ export type ErasableDeliveriesTable = Table & { recipientHash: Column };
  * stored value is the sentinel, which no address hashes to. Running this twice
  * therefore touches nothing the second time, without needing a guard to say so.
  *
+ * The dialects do not agree on how this column compares: MySQL's default
+ * `varchar` collation is case- and pad-insensitive, while Postgres and SQLite
+ * compare exactly. That is safe here only because of what gets written —
+ * `hashRecipient` emits lowercase hex and the sentinel is lowercase letters, so
+ * no two distinct stored values differ only by case or trailing space, and the
+ * comparison lands on the same rows everywhere. Change either spelling and the
+ * dialects stop agreeing, silently and only on MySQL.
+ *
  * Rows written AFTER this returns are untouched and carry a live digest again.
  * That is correct: erasure is a statement about the record as it stands, not a
  * standing instruction to stop recording. Suppressing future rows would require

--- a/packages/nextly/src/domains/email/erase-recipient.ts
+++ b/packages/nextly/src/domains/email/erase-recipient.ts
@@ -1,0 +1,77 @@
+/**
+ * Removing a person from the delivery log while leaving the log standing.
+ *
+ * The row answers two different questions that happened to share a column.
+ * "How many messages failed last week" belongs to the install and outlives
+ * anyone; "was this person written to" belongs to the person and must not.
+ * Overwriting `recipient_hash` separates them: the counts, statuses and
+ * timestamps survive intact, and the one column that could still name a human
+ * stops being able to.
+ *
+ * This is the single owner of that erasure, for the same reason
+ * `domains/audit/erase-actor-personal-data` is the single owner of the audit
+ * one — a future delete path is covered by calling this, rather than by
+ * remembering the delivery log exists.
+ *
+ * Deliberately NOT limited to recipients who hold an account. Every recipient
+ * gets a row: a password reset to an address that never registered, a CC on a
+ * notification, a BCC added by a `beforeSend` filter. Those people can ask to
+ * be erased too and no account deletion will ever fire for them, so this takes
+ * an ADDRESS rather than a user id.
+ *
+ * @module domains/email/erase-recipient
+ */
+
+import { eq, type Column, type Table } from "drizzle-orm";
+
+import { ERASED_RECIPIENT_HASH, recipientDigest } from "./delivery-record";
+
+/**
+ * The Drizzle surface this needs: one scoped UPDATE.
+ *
+ * Structural rather than the concrete transaction type because the real one is
+ * dialect-specific (NodePgTransaction / MySql2Transaction / BetterSQLite3),
+ * while the fluent API is identical across all three.
+ */
+export interface RecipientErasureCapableDb {
+  update(table: unknown): {
+    set(data: unknown): { where(condition: unknown): Promise<unknown> };
+  };
+}
+
+/** The delivery table, as a dialect bundle exposes it. */
+export type ErasableDeliveriesTable = Table & { recipientHash: Column };
+
+/**
+ * Erase every delivery row recorded for an address.
+ *
+ * Takes the caller's transaction so it commits with whatever else that
+ * transaction is doing and rolls back with it. On the account-deletion path
+ * that is the point: an account must never be removed while rows that identify
+ * its owner stay behind, so a failure here has to take the deletion down rather
+ * than leave the two out of step.
+ *
+ * Matching is by digest, so a row already erased cannot be selected — its
+ * stored value is the sentinel, which no address hashes to. Running this twice
+ * therefore touches nothing the second time, without needing a guard to say so.
+ *
+ * Rows written AFTER this returns are untouched and carry a live digest again.
+ * That is correct: erasure is a statement about the record as it stands, not a
+ * standing instruction to stop recording. Suppressing future rows would require
+ * keeping a list of the addresses that asked to be forgotten, which is the
+ * opposite of the request.
+ *
+ * @param db - The caller's open transaction.
+ * @param deliveries - The dialect's delivery table.
+ * @param address - The recipient, in any form a sender may have written it.
+ */
+export async function eraseRecipientDeliveries(
+  db: RecipientErasureCapableDb,
+  deliveries: ErasableDeliveriesTable,
+  address: string
+): Promise<void> {
+  await db
+    .update(deliveries)
+    .set({ recipientHash: ERASED_RECIPIENT_HASH })
+    .where(eq(deliveries.recipientHash, recipientDigest(address)));
+}

--- a/packages/nextly/src/domains/email/services/email-delivery-service.ts
+++ b/packages/nextly/src/domains/email/services/email-delivery-service.ts
@@ -383,11 +383,21 @@ export class EmailDeliveryService extends BaseService {
    * and rolls back with the account removal.
    */
   async eraseRecipient(address: string): Promise<void> {
-    await eraseRecipientDeliveries(
-      this.db as Parameters<typeof eraseRecipientDeliveries>[0],
-      this.deliveries,
-      address
-    );
+    try {
+      await eraseRecipientDeliveries(
+        this.db as Parameters<typeof eraseRecipientDeliveries>[0],
+        this.deliveries,
+        address
+      );
+    } catch (err) {
+      // Converted like every other read and write on this service. A caller
+      // handling an erasure request needs to tell "the table is missing on this
+      // install" from "the connection dropped", and a raw driver exception
+      // carries neither in a form the API layer can map — it becomes a 500
+      // whatever it was. Rethrown rather than swallowed: unlike `record`, a
+      // failed erasure must not be reported as a completed one.
+      throw NextlyError.fromDatabaseError(toDbError(this.dialect, err));
+    }
   }
 
   /**

--- a/packages/nextly/src/domains/email/services/email-delivery-service.ts
+++ b/packages/nextly/src/domains/email/services/email-delivery-service.ts
@@ -22,15 +22,17 @@ import { and, desc, eq } from "drizzle-orm";
 
 import { toDbError } from "../../../database/errors";
 import { NextlyError } from "../../../errors";
-import { emailDeliveriesMysql } from "../../../schemas/email-deliveries/mysql";
-import { emailDeliveriesPg } from "../../../schemas/email-deliveries/postgres";
-import { emailDeliveriesSqlite } from "../../../schemas/email-deliveries/sqlite";
 import type { Logger } from "../../../services/shared";
 import { BaseService } from "../../../shared/base-service";
 import {
+  deliveriesTableFor,
+  type EmailDeliveriesTable,
+} from "../deliveries-table";
+import {
   EMAIL_RETENTION_CLASS,
   hashRecipient,
-  mailboxOf,
+  isErasedRecipientHash,
+  recipientDigest,
   storableError,
   type EmailDeliveryInput,
   type EmailDeliveryRecipientKind,
@@ -62,11 +64,6 @@ function describeUnknownError(value: unknown): string {
   }
 }
 
-type EmailDeliveriesTable =
-  | typeof emailDeliveriesPg
-  | typeof emailDeliveriesMysql
-  | typeof emailDeliveriesSqlite;
-
 /**
  * A row as the three dialect tables produce it.
  *
@@ -95,13 +92,50 @@ export interface EmailDeliveryRecord {
   providerId: string | null;
   providerType: string;
   templateSlug: string | null;
-  recipientHash: string;
+  /**
+   * The stored digest, or null once this recipient has been erased.
+   *
+   * Null rather than the raw sentinel so a reader never has to know what the
+   * erased state is spelled as. The column is NOT NULL, so there is no "no
+   * value recorded" case for null to be confused with: it means erased and
+   * nothing else.
+   */
+  recipientHash: string | null;
   recipientKind: EmailDeliveryRecipientKind;
   status: EmailDeliveryStatus;
   attemptCount: number;
   error: string | null;
   messageId: string | null;
   createdAt: Date;
+}
+
+/**
+ * A stored row as a reader sees it.
+ *
+ * Every read path returns rows through here rather than building the record
+ * inline, so the erased state is translated once. A future single-row getter
+ * that mapped its own columns would hand back the raw sentinel, and it would
+ * look correct beside a listing that does not — so the translation lives where
+ * a new caller gets it by construction instead of by noticing.
+ */
+function toDeliveryRecord(row: EmailDeliveryRow): EmailDeliveryRecord {
+  return {
+    id: row.id,
+    providerId: row.providerId,
+    providerType: row.providerType,
+    templateSlug: row.templateSlug,
+    // The sentinel is a storage detail: it exists because the column is NOT
+    // NULL, and a reader has no use for the spelling.
+    recipientHash: isErasedRecipientHash(row.recipientHash)
+      ? null
+      : row.recipientHash,
+    recipientKind: row.recipientKind as EmailDeliveryRecipientKind,
+    status: row.status as EmailDeliveryStatus,
+    attemptCount: row.attemptCount,
+    error: row.error,
+    messageId: row.messageId,
+    createdAt: row.createdAt,
+  };
 }
 
 /** How a caller narrows a listing. */
@@ -118,25 +152,7 @@ export class EmailDeliveryService extends BaseService {
 
   constructor(adapter: DrizzleAdapter, logger: Logger) {
     super(adapter, logger);
-
-    switch (this.dialect) {
-      case "postgresql":
-        this.deliveries = emailDeliveriesPg;
-        break;
-      case "mysql":
-        this.deliveries = emailDeliveriesMysql;
-        break;
-      case "sqlite":
-        this.deliveries = emailDeliveriesSqlite;
-        break;
-      default:
-        throw NextlyError.internal({
-          logContext: {
-            reason: "unsupported dialect for the email delivery log",
-            dialect: String(this.dialect),
-          },
-        });
-    }
+    this.deliveries = deliveriesTableFor(this.dialect);
   }
 
   /**
@@ -365,8 +381,9 @@ export class EmailDeliveryService extends BaseService {
             // The MAILBOX, as the writer stored it. A caller asking about
             // `Jane <jane@example.com>` is asking about `jane@example.com`,
             // and hashing what they typed answers "no record" for a message
-            // that was sent.
-            hashRecipient(mailboxOf(options.recipient))
+            // that was sent. The same function the erasure uses, so a lookup
+            // and a removal can never disagree about which rows are a person's.
+            recipientDigest(options.recipient)
           )
         : undefined,
       options.status !== undefined
@@ -403,18 +420,6 @@ export class EmailDeliveryService extends BaseService {
       throw NextlyError.fromDatabaseError(toDbError(this.dialect, error));
     }
 
-    return (rows as EmailDeliveryRow[]).map(row => ({
-      id: row.id,
-      providerId: row.providerId,
-      providerType: row.providerType,
-      templateSlug: row.templateSlug,
-      recipientHash: row.recipientHash,
-      recipientKind: row.recipientKind as EmailDeliveryRecipientKind,
-      status: row.status as EmailDeliveryStatus,
-      attemptCount: row.attemptCount,
-      error: row.error,
-      messageId: row.messageId,
-      createdAt: row.createdAt,
-    }));
+    return (rows as EmailDeliveryRow[]).map(toDeliveryRecord);
   }
 }

--- a/packages/nextly/src/domains/email/services/email-delivery-service.ts
+++ b/packages/nextly/src/domains/email/services/email-delivery-service.ts
@@ -30,7 +30,6 @@ import {
 } from "../deliveries-table";
 import {
   EMAIL_RETENTION_CLASS,
-  hashRecipient,
   isErasedRecipientHash,
   recipientDigest,
   storableError,
@@ -38,6 +37,7 @@ import {
   type EmailDeliveryRecipientKind,
   type EmailDeliveryStatus,
 } from "../delivery-record";
+import { eraseRecipientDeliveries } from "../erase-recipient";
 
 /**
  * Rows per insert statement.
@@ -350,7 +350,12 @@ export class EmailDeliveryService extends BaseService {
         // The address is hashed here and nowhere retained. Callers hand over
         // the real one because they are sending to it; this is the boundary
         // where it stops travelling.
-        recipientHash: hashRecipient(input.to),
+        //
+        // Through `recipientDigest`, the same function the reader and the
+        // erasure use. A send addressed `Jane <jane@example.com>` must store
+        // what a lookup for `jane@example.com` will compute, or the row is
+        // written in a form nothing can ever find again.
+        recipientHash: recipientDigest(input.to),
         recipientKind: input.recipientKind ?? "to",
         status: input.status,
         attemptCount: 1,
@@ -361,6 +366,27 @@ export class EmailDeliveryService extends BaseService {
         // send, and staggering them by microseconds would suggest otherwise.
         createdAt: now,
       }))
+    );
+  }
+
+  /**
+   * Erase every delivery recorded for an address.
+   *
+   * The reachable entry point for the population `deleteUser` cannot serve:
+   * most recipients never had an account — a password reset to an address that
+   * never registered, a CC, a BCC added by a `beforeSend` filter — and no
+   * account deletion will ever fire for them. Without a caller of its own, the
+   * erasure would cover an arbitrary subset of the people it claims to.
+   *
+   * Runs outside a transaction because it stands alone here; `deleteUser`
+   * calls the underlying function directly with its own so the erasure commits
+   * and rolls back with the account removal.
+   */
+  async eraseRecipient(address: string): Promise<void> {
+    await eraseRecipientDeliveries(
+      this.db as Parameters<typeof eraseRecipientDeliveries>[0],
+      this.deliveries,
+      address
     );
   }
 

--- a/packages/nextly/src/domains/users/services/user-mutation-service.ts
+++ b/packages/nextly/src/domains/users/services/user-mutation-service.ts
@@ -56,6 +56,8 @@ import {
   generateInviteTokenValue,
 } from "../../auth/lib/invite-token";
 import { affectedRowCount } from "../../auth/services/auth-service";
+import { deliveriesTableFor } from "../../email/deliveries-table";
+import { eraseRecipientDeliveries } from "../../email/erase-recipient";
 import { introspectLiveSnapshot } from "../../schema/pipeline/diff/introspect-live";
 import { recordMutationEventInTx } from "../../webhooks/record-mutation-event";
 
@@ -1406,6 +1408,22 @@ export class UserMutationService extends BaseService {
     } catch (err) {
       throw NextlyError.fromDatabaseError(toDbError(this.dialect, err));
     }
+    // Asked out here for the same reason as the two above: a failed statement
+    // aborts an open Postgres transaction, and there would be no way back.
+    //
+    // A probe that cannot answer is treated as "present" so the erasure is
+    // ATTEMPTED. The alternative direction is worse in a way that is hard to
+    // see later: reading a transient metadata failure as "no such table" would
+    // delete the account and leave its delivery rows behind, silently and
+    // permanently, since no later run revisits a deletion that has happened.
+    // If the table really is absent, the UPDATE fails and takes the deletion
+    // with it, which is the same invariant the audit erasure protects.
+    let deliveriesExist: boolean;
+    try {
+      deliveriesExist = await this.adapter.tableExists("email_deliveries");
+    } catch {
+      deliveriesExist = true;
+    }
     // The two answer a legacy shape differently, because what happens to an
     // un-erased row differs. A legacy `activity_log` still cascades from the
     // account, so its rows go with the deletion and there is nothing left to
@@ -1501,6 +1519,35 @@ export class UserMutationService extends BaseService {
             String(userId),
             new Date(),
             unstampedAuditTables
+          );
+        }
+
+        // Strip the person out of the delivery log for the same reason, and in
+        // the same transaction: those rows carry a keyed hash of the address,
+        // and an install holds the key — so they go on answering "was this
+        // person written to, and when" for an account that no longer exists.
+        // The row itself stays, because "how many sends failed last week"
+        // belongs to the install rather than to the recipient.
+        //
+        // Keyed on the ADDRESS, not the user id: the table records every
+        // recipient, and most of them never had an account. This call therefore
+        // covers the deleted account's own address and nothing else — someone
+        // who was only ever a recipient is erased by calling
+        // `eraseRecipientDeliveries` directly, since no account deletion will
+        // ever fire for them.
+        //
+        // Narrowed rather than asserted, because the preimage select resolves
+        // to an untyped row. An account carrying no address has no delivery
+        // rows keyed to it, so there is nothing here to erase — which is a
+        // different outcome from an erasure that was skipped, and this is the
+        // only shape that produces it.
+        const deletedAddress =
+          typeof preimage.email === "string" ? preimage.email : undefined;
+        if (deliveriesExist && deletedAddress !== undefined) {
+          await eraseRecipientDeliveries(
+            txDb,
+            deliveriesTableFor(this.dialect),
+            deletedAddress
           );
         }
 

--- a/packages/nextly/src/domains/users/services/user-mutation-service.ts
+++ b/packages/nextly/src/domains/users/services/user-mutation-service.ts
@@ -1418,6 +1418,9 @@ export class UserMutationService extends BaseService {
     // permanently, since no later run revisits a deletion that has happened.
     // If the table really is absent, the UPDATE fails and takes the deletion
     // with it, which is the same invariant the audit erasure protects.
+    // Read from the preimage inside the transaction and used again after it
+    // commits, so it is declared out here rather than in the closure.
+    let deletedAddress: string | undefined;
     let deliveriesExist: boolean;
     try {
       deliveriesExist = await this.adapter.tableExists("email_deliveries");
@@ -1541,7 +1544,7 @@ export class UserMutationService extends BaseService {
         // rows keyed to it, so there is nothing here to erase — which is a
         // different outcome from an erasure that was skipped, and this is the
         // only shape that produces it.
-        const deletedAddress =
+        deletedAddress =
           typeof preimage.email === "string" ? preimage.email : undefined;
         if (deliveriesExist && deletedAddress !== undefined) {
           await eraseRecipientDeliveries(
@@ -1600,6 +1603,19 @@ export class UserMutationService extends BaseService {
           String(userId),
           new Date(),
           unstampedAuditTables
+        );
+      }
+      // The delivery log needs the same second pass and for the same reason: a
+      // send already in flight when the deletion started can insert its row
+      // after the in-transaction erasure has chosen its matches, leaving a live
+      // digest for an account that no longer exists. Erasing is idempotent —
+      // an already-erased row holds the sentinel, which no address hashes to —
+      // so a second pass over untouched rows costs one indexed update.
+      if (deliveriesExist && deletedAddress !== undefined) {
+        await eraseRecipientDeliveries(
+          this.db as Parameters<typeof eraseRecipientDeliveries>[0],
+          deliveriesTableFor(this.dialect),
+          deletedAddress
         );
       }
     } catch (err) {


### PR DESCRIPTION
Task `208-email-delivery-rows-survive-an-erasure-request.md` (note the filename — there are two 208s).

`UserMutationService.deleteUser` erased the audit surfaces and never touched `email_deliveries`. Those rows carry a **keyed** hash of the recipient, and the install holds the key — so a deleted account left behind rows that still answer "was this person written to, and when", indefinitely. Nothing prunes the table either: `retention_class` is written and never read.

## The design changed after measurement, and the reason matters

The obvious fix is to NULL the hash and stamp an erasure time. **That is a three-dialect migration before it is a service change**, and it should not be one. Measured on `main`:

- `recipient_hash` is `.notNull()` in `schemas/email-deliveries/{postgres,mysql,sqlite}.ts`
- there is no erasure-stamp column anywhere in that directory
- **the table is declared TWICE** — `database/sqlite-core-tables.ts:222` hand-writes its own `CREATE TABLE "email_deliveries"`, SQLite-only, with no Postgres or MySQL counterpart and nothing linking the two

So a column added to the Drizzle schema alone lands on Postgres and MySQL and is **silently missing on SQLite**, which is the default for new installs and for the whole e2e suite. That sits on top of the standing problem that core schema changes are not guaranteed to reach existing databases — and existing databases are exactly the population holding erasure obligations.

**So this carries no schema change at all.** `eraseRecipientDeliveries` overwrites `recipient_hash` with a sentinel that `hashRecipient` can never emit. One UPDATE, identical across three dialects, effective on every existing install the day it ships.

## Why an address, not a user id

`email_deliveries` records **every** recipient — a password reset to an address that never registered, a CC, a BCC added by a `beforeSend` filter. Hooking only `deleteUser` would look like the erasure story while covering an arbitrary subset of it, which is worse than not having one, because the next reader of `deleteUser` believes the table is handled. The function therefore takes an address, and `EmailDeliveryService.eraseRecipient(address)` is its reachable entry point; `deleteUser` is one caller.

It runs **inside `deleteUser`'s existing transaction**, for the same reason `eraseActorPersonalData` does: a failed erasure must take the deletion with it rather than leave the two out of step. The `tableExists` probe is taken *before* the transaction opens, because a failed statement aborts an open Postgres transaction and there would be no way back. A probe that cannot answer is treated as "present" so the erasure is attempted — reading a transient metadata failure as "no such table" would delete the account and orphan its rows silently and permanently.

## Reader surface

`EmailDeliveryRecord.recipientHash` is now `string | null`, null meaning erased, translated once in `toDeliveryRecord` so a future single-row getter cannot hand back the raw sentinel. To be accurate about what this is: **nothing outside the service reads that field today** — there is no admin column and no API field, only a test. This is a shape chosen while it is still free, not a fix for a live leak.

## What is NOT here

The retention sweep — the second half of task 208 — is deliberately not in this PR. It needs a pass registered in `domains/retention/passes.ts`, and that is constructed in seven places including four `di/registrations/register-*.ts` files another lane is actively rewriting. We agreed they go first and I rebase onto them.

## Verification

- **9 integration tests across Postgres 17, MySQL and SQLite**, tables built from the production definitions through drizzle-kit so the fixture cannot drift.
- **8 unit tests**, including that a later send to an erased address correctly records a fresh live digest. Asserted deliberately so it is not "fixed" later into a suppression list — which would store exactly the addresses that asked to be forgotten.
- **Negative controls, both directions.** Disabling the erasure fails 5 unit and 3 integration assertions; making it over-broad (erasing every row) fails the scope control alone.
- **The MySQL leg caught a defect in my own test on its first run.** I had asserted that a differently-cased digest would not match. MySQL's default `varchar` collation is case- and pad-insensitive, so it does. The divergence is real but *unreachable* — `hashRecipient` emits lowercase hex and the sentinel is lowercase letters, so no two stored values differ only by case. The test now asserts that invariant, which is the thing actually holding the three dialects in agreement, and the constraint is recorded at the definition rather than left implicit.
- `turbo lint` and `turbo check-types` for `nextly` both exit 0.
- One changeset over all 23 fixed-group packages at `patch`, generated from `.changeset/config.json`.

## Round two: what review changed

**The entry point did not exist.** The first push claimed a non-user could be erased directly, and that was false: `eraseRecipientDeliveries` had exactly one production importer (`user-mutation-service.ts`) and no export-map subpath reached it, so it covered only the population the PR said it did not. `EmailDeliveryService.eraseRecipient(address)` is now that entry point, resolved from the container like any other service. There is still **no HTTP route and no admin surface** — who may erase an arbitrary address is not obviously the same permission as who may delete a user, and that decision belongs in its own change rather than invented here.

**The write path was not using the shared digest.** `insertRows` stored `hashRecipient(input.to)` while the reader and the erasure both used `hashRecipient(mailboxOf(address))`, so a send addressed `Jane <jane@example.com>` was written in a form nothing could find again:

```
stored  hashRecipient("Jane <jane@example.com>") = 6e894fb211cb0e46…
erasure hashRecipient(mailboxOf(same))           = 8c87b489ce35cf2e…
```

That divergence predates this PR on the read side — those rows were already unlookupable by `list({ recipient })` on `main`. I unified the reader and the erasure and left the writer out, which is exactly the drift the shared function existed to prevent. All three now go through `recipientDigest`.

**And the test dodged it.** The original case recorded a bare address and erased a decorated one, which passes even with the broken write path, because stripping a display name that was never there is a no-op. The direction that was actually broken — record decorated, erase bare — is now covered, with a precondition asserting the row is findable first so it cannot pass on a row that was never locatable. Reverting the write fix fails that test and only that test.

### Known limit, documented and filed

Rows written under a **previous `NEXTLY_SECRET`** are not reached: the digest is keyed, so after a rotation the predicate matches nothing — and it cannot report that, because "no rows matched" is also what a recipient with no deliveries looks like. Rotation is a supported state here (`email-provider-service.ts:937` handles a configuration that no longer decrypts for the same reason).

Closing it needs a key-version column — a schema change this PR is shaped to avoid — or retained previous keys, which is a security decision. Filed as `217-recipient-erasure-misses-rows-written-under-an-older-secret.md` and written at the top of `eraseRecipientDeliveries`. The eventual bound is the retention pass, which ages rows out regardless of which key wrote them; that bound does not exist until the sweep is built.

### Round-two verification

- 481 email unit tests pass (31 files), 9 integration tests across Postgres 17 / MySQL / SQLite.
- `turbo lint` and `turbo check-types` exit 0.
- All threads replied to and resolved.
