### PR TITLE
fix(nextly): canonicalise the field-group type key on write

### DIFF
--- a/.changeset/storage-key-write-canonicalises.md
+++ b/.changeset/storage-key-write-canonicalises.md
@@ -1,0 +1,27 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+---
+
+A field group instance saved through the shared accessor now carries only the current spelling of its type key. Previously an instance loaded from storage before the rename kept its old key alongside the new one, so saving it produced a document carrying both.

--- a/.changeset/storage-key-write-canonicalises.md
+++ b/.changeset/storage-key-write-canonicalises.md
@@ -24,4 +24,4 @@
 "@nextlyhq/builder": patch
 ---
 
-A field group instance saved through the shared accessor now carries only the current spelling of its type key. Previously an instance loaded from storage before the rename kept its old key alongside the new one, so saving it produced a document carrying both.
+A version snapshot now records each field group instance under one spelling of its type key. An entry captured before the storage rename, restored, and captured again previously kept its old key alongside the new one, so the snapshot announced the same instance's type twice.

--- a/packages/nextly/src/domains/field-groups/storage/__tests__/field-group-type-key.post-flip.test.ts
+++ b/packages/nextly/src/domains/field-groups/storage/__tests__/field-group-type-key.post-flip.test.ts
@@ -70,6 +70,27 @@ describe("after the catalog has been flipped to the new spelling", () => {
     expect(Object.keys(instance)).toEqual(["_fieldGroupType"]);
   });
 
+  it("REPLACES a legacy spelling rather than writing alongside it", () => {
+    // 🔴 The case starting from `{}` cannot reach this. An instance read back from storage before
+    // the rewrite pass reached it arrives carrying the old key, and that is the population the
+    // whole dual-read exists for — so an empty fixture tests the one shape the mechanism never
+    // meets in production.
+    //
+    // Assigning without clearing leaves BOTH keys. Reads still resolve, so nothing surfaces; what
+    // breaks is the invariant that makes the migration finish — the legacy set stops shrinking as
+    // documents are saved, and every save mints a document a later reader has to disambiguate.
+    const instance: Record<string, unknown> = {
+      _componentType: "hero",
+      label: "kept",
+    };
+
+    writeFieldGroupType(instance, "cta");
+
+    expect(instance._componentType).toBeUndefined();
+    expect(instance._fieldGroupType).toBe("cta");
+    expect(instance.label).toBe("kept");
+  });
+
   it("prefers the current spelling when a document carries both", () => {
     expect(
       readFieldGroupType({ _fieldGroupType: "new", _componentType: "old" })

--- a/packages/nextly/src/domains/field-groups/storage/field-group-type-key.ts
+++ b/packages/nextly/src/domains/field-groups/storage/field-group-type-key.ts
@@ -132,5 +132,12 @@ export function writeFieldGroupType(
   instance: Record<string, unknown>,
   type: string
 ): void {
+  // Every other spelling goes first, so an instance that arrived carrying the old key leaves
+  // carrying only the new one. Assigning without clearing emits BOTH on any instance read back
+  // from storage before the rewrite reached it — the read still resolves, but the document is now
+  // one a later reader must disambiguate, and the legacy set stops shrinking as writes happen.
+  // Canonicalising on write is what makes the migration finish by ordinary use rather than only by
+  // the rewrite pass.
+  clearFieldGroupType(instance);
   instance[currentFieldGroupTypeKey] = type;
 }

--- a/packages/nextly/src/domains/versions/__tests__/tag-component-types.post-flip.test.ts
+++ b/packages/nextly/src/domains/versions/__tests__/tag-component-types.post-flip.test.ts
@@ -97,6 +97,27 @@ describe("tagging a snapshot after the catalog has been renamed", () => {
     expect(tagged.zone[0]._componentType).toBe("hero");
   });
 
+  it("tags a single component with ONE spelling when it already carried the old one", () => {
+    // The production path for the accessor's canonicalisation. A single-component value that was
+    // captured before the rename, restored, and captured again arrives already carrying the old
+    // key; spreading it and adding the current one leaves the snapshot announcing its type twice.
+    //
+    // A double-tagged value still reads — `readFieldGroupType` prefers the current spelling — so
+    // nothing surfaces at capture. It matters because the set of legacy-spelled documents stops
+    // shrinking as snapshots are taken, which is the invariant that lets the rename finish.
+    const entry = { hero: { _componentType: "hero", title: "Old" } };
+
+    const tagged = tagComponentTypes(
+      entry,
+      [{ name: "hero", type: "component", component: "hero" }] as FieldConfig[],
+      () => undefined
+    ) as { hero: Record<string, unknown> };
+
+    expect(tagged.hero._fieldGroupType).toBe("hero");
+    expect(tagged.hero._componentType).toBeUndefined();
+    expect(tagged.hero.title).toBe("Old");
+  });
+
   it("still leaves a row alone when its type names a component the field forbids", () => {
     // The dual read widens which spellings are understood, not which components are allowed.
     const entry = {

--- a/packages/nextly/src/domains/versions/tag-component-types.ts
+++ b/packages/nextly/src/domains/versions/tag-component-types.ts
@@ -20,8 +20,8 @@ import type { FieldConfig } from "../../collections/fields/types";
 import { storageTypeToken } from "../../shared/lib/plugin-storage";
 import {
   clearFieldGroupType,
-  currentFieldGroupTypeKey,
   readFieldGroupType,
+  writeFieldGroupType,
 } from "../field-groups/storage/field-group-type-key";
 
 import type { ComponentSchemas } from "./restore-snapshot";
@@ -160,13 +160,34 @@ function tagValue(
   // stopping at the repeated slug would tag the first two levels and leave
   // every level below them bare.
   const ownFields = resolve?.(slug);
-  if (!ownFields) return { ...source, [currentFieldGroupTypeKey]: slug };
+  if (!ownFields) return taggedCopy(source, slug);
 
   seen.add(source);
   const inner = tagFieldsIn(source, ownFields, resolve, seen);
   seen.delete(source);
 
-  return { ...inner, [currentFieldGroupTypeKey]: slug };
+  return taggedCopy(inner, slug);
+}
+
+/**
+ * A copy of one value carrying exactly one spelling of its type.
+ *
+ * Spreading and then assigning the current spelling is not the same thing: a value that already
+ * carries an older spelling keeps it, and the copy ends up announcing its type twice. That happens
+ * whenever the value came from data an earlier release wrote — a snapshot captured before the
+ * storage rename, restored and captured again — so the shape reaching a new snapshot depends on
+ * how old the entry is.
+ *
+ * Writing through the accessor removes every spelling before adding the current one, so the
+ * guarantee holds without reasoning about where the value came from.
+ */
+function taggedCopy(
+  value: Record<string, unknown>,
+  slug: string
+): Record<string, unknown> {
+  const tagged = { ...value };
+  writeFieldGroupType(tagged, slug);
+  return tagged;
 }
 
 /**

--- a/scripts/check-storage-format-literals.cjs
+++ b/scripts/check-storage-format-literals.cjs
@@ -146,7 +146,22 @@ function splitGrepLine(line) {
 
 function grep(label, pattern, opts = {}) {
   const {
-    include = ["*.ts", "*.tsx"],
+    // 🔴 Every source extension the repository ships, not only TypeScript. A reader or writer of
+    // the storage key added to an existing `.js` or `.mjs` file — a CLI bin, a build script, a
+    // template's runtime — is product code by every meaning that matters here, and a TS-only
+    // include list skips it while still reporting PASS. That is the narrowing failure this gate
+    // exists to prevent, committed by the gate itself: a check that cannot read part of its
+    // subject answers a smaller question and answers it in the affirmative.
+    include = [
+      "*.ts",
+      "*.tsx",
+      "*.js",
+      "*.jsx",
+      "*.mjs",
+      "*.cjs",
+      "*.mts",
+      "*.cts",
+    ],
     paths = ["packages", "apps", "templates"],
     allowMatches = [],
   } = opts;


### PR DESCRIPTION
Restores two fixes that were reviewed and verified on #705 but **did not reach main**: that PR merged at `8cb3cf00f`, one commit behind its branch, so `22f7c46c5` was dropped. Verified by content against the merge commit with markers scoped to the paths the commit changed, plus a positive control proving the search finds them at the branch tip.

## 1. A write that grew the legacy set instead of shrinking it

`writeFieldGroupType` assigned the current spelling without clearing the others, so an instance read back from storage before the rewrite pass reached it — the entire population the dual read exists for — left carrying **both** keys.

Reads still resolve, so nothing surfaces. What breaks is the invariant that lets the rename finish through ordinary use rather than only through the rewrite pass: every save minted a document a later reader has to disambiguate, and the legacy set stopped shrinking.

This contradicted the function's own documented contract.

### The existing test could not have caught it

It wrote into `{}` — a shape the mechanism never meets in production — so the assertion was satisfied by absence. Proven rather than asserted: with the fix reverted, the new case fails and **the old `{}` case still passes**.

The regression test starts from `{ _componentType: "hero", label: "kept" }` and asserts the legacy key is gone, the new one holds the new value, and unrelated fields survive — the last because `clearFieldGroupType` iterates keys, and a regression there would delete more than the discriminator.

## 2. The gate scanned only TypeScript

A storage reader added to any of the 40 JS/ESM sources under the scanned roots was skipped while the gate reported PASS. Now covers `ts, tsx, js, jsx, mjs, cjs, mts, cts`.

This is the failure the gate exists to prevent, committed by the gate itself — a check that cannot read part of its subject answers a smaller question, in the affirmative. Second instance in this lane: the column checks previously required quotes, so ordinary property syntax was invisible to them.

Widening caught **no** existing sites, so this carries no conversions.

## Verification

- break-verified with an anchor asserted to match exactly once: `1 failed | 38 passed`, and the failure is the new case
- gate controls, each planted then removed, exit code observed: `.js` → 1, `.mjs` → 1, `.cjs` → 1, clean → 0
- `check-types --force`, `lint`, `check-drizzle-v1-legacy`, `check:storage-format-literals` all green by exit code
- accessor suites 39 passed