### PR TITLE
ci(ui): build the server-safe subpaths in a real Server Component

### DIFF
--- a/.github/workflows/package-smoke.yml
+++ b/.github/workflows/package-smoke.yml
@@ -9,24 +9,43 @@ name: Package smoke
 # compatibility, and native-module (better-sqlite3) prebuilds across the Node
 # lines the packages claim to support.
 #
-# Scheduled instead of per-PR: full installs take minutes, and this class of
-# drift moves slowly. A red night shows up as an issue, not a slower PR.
+# Mostly scheduled: full installs take minutes, and packaging drift moves
+# slowly. A red night shows up as an issue, not a slower PR.
+#
+# The RSC build is the exception and runs per PR as well, because it is the ONLY
+# control on the server-safe claim — the checks beside it read code and model
+# what Next.js would do, and a property with one control should not wait until
+# night to be checked. Path-filtered to the package that can change the answer.
 
 on:
   schedule:
     - cron: "0 3 * * *"
   workflow_dispatch:
+  pull_request:
+    paths:
+      - "packages/ui/**"
+      - ".github/workflows/package-smoke.yml"
 
+# Least privilege at the top. The one job that files an issue asks for more, so
+# a `pull_request` run — which is the event a fork can trigger — carries a token
+# that can only read.
 permissions:
   contents: read
-  # The failure reporter files an issue via `gh`.
-  issues: write
+
+# Keyed by ref for pull requests, so a new push supersedes the run under review,
+# and by SHA otherwise, so two nightly runs never cancel each other.
+concurrency:
+  group: package-smoke-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
+  cancel-in-progress: true
 
 jobs:
   pack-and-consume:
     name: Install packed tarballs in a clean project
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    # Nightly only: this installs every tarball in the repo, and nothing about a
+    # single package's PR changes whether the SET of them resolves together.
+    if: github.event_name != 'pull_request'
 
     steps:
       - name: Checkout
@@ -93,6 +112,9 @@ jobs:
     name: Scaffold and build (Node ${{ matrix.node }})
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    # Nightly only: this scaffolds and builds a whole app from the CLI, and the
+    # per-PR scaffold smoke already covers the scaffolder itself.
+    if: github.event_name != 'pull_request'
     strategy:
       fail-fast: false
       # Current LTS lines only; the interesting failure here is a
@@ -154,13 +176,19 @@ jobs:
     timeout-minutes: 20
     strategy:
       fail-fast: false
-      # Every line the package's `engines` range admits, LOW END INCLUDED. The
-      # web globals Node adds over time are exactly what makes a server-safe
-      # claim version-dependent: a module reading `navigator` at module scope
-      # builds cleanly on 22 and 24 and throws for a consumer on the floor, so a
-      # matrix without the floor answers for the machines we happen to run on.
+      # Nightly runs every line the package's `engines` range admits, LOW END
+      # INCLUDED. The web globals Node adds over time are what make a
+      # server-safe claim version-dependent: a module reading `navigator` at
+      # module scope builds cleanly on 22 and 24 and throws for a consumer on
+      # the floor, so a matrix without the floor answers only for the machines
+      # we happen to run on.
+      #
+      # A pull request runs the FLOOR alone. It is the leg that catches the most
+      # for this property — everything the newer lines reject, 20 rejects too,
+      # plus the post-floor globals they accept — so one leg per PR buys nearly
+      # all of the signal at a third of the minutes.
       matrix:
-        node: [20, 22, 24]
+        node: ${{ fromJSON(github.event_name == 'pull_request' && '[20]' || '[20, 22, 24]') }}
 
     steps:
       - name: Checkout
@@ -211,13 +239,20 @@ jobs:
           cd /tmp/rsc-app
           npx next build
 
-  # A red nightly must surface without anyone watching the Actions tab.
+  # A red nightly must surface without anyone watching the Actions tab. A red
+  # pull request does not need an issue filed: it is already red on the PR, in
+  # front of the person who caused it.
   report-failure:
     name: File an issue on failure
     needs: [pack-and-consume, scaffold-and-build, server-safe-rsc-build]
-    if: failure()
+    if: failure() && github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    # The only job that writes anything, so it is the only one holding the
+    # permission to.
+    permissions:
+      contents: read
+      issues: write
     steps:
       - name: Create or update the tracking issue
         env:

--- a/.github/workflows/package-smoke.yml
+++ b/.github/workflows/package-smoke.yml
@@ -261,6 +261,14 @@ jobs:
       - name: Verify the route was prerendered, naming every subpath
         run: node packages/ui/scripts/write-server-safe-rsc-app.mjs --verify /tmp/rsc-app
 
+      # The page above reaches only the `import` condition, so the `.cjs` targets are published and
+      # never evaluated even though the export map promises them. This loads them the way a
+      # CommonJS consumer does: same install, same export map, same Node.
+      - name: Evaluate the CommonJS targets the export map also publishes
+        run: |
+          cd /tmp/rsc-app
+          node require-check.cjs
+
   # A red nightly must surface without anyone watching the Actions tab. A red
   # pull request does not need an issue filed: it is already red on the PR, in
   # front of the person who caused it.

--- a/.github/workflows/package-smoke.yml
+++ b/.github/workflows/package-smoke.yml
@@ -38,10 +38,16 @@ on:
 permissions:
   contents: read
 
-# Keyed by ref for pull requests, so a new push supersedes the run under review,
-# and by SHA otherwise, so two nightly runs never cancel each other.
+# Keyed by ref for pull requests, so a new push supersedes the run under review.
+#
+# Keyed by RUN for everything else, which makes the group unique and the
+# cancellation flag inert. Keying those by SHA reads as safe and is not: a manual
+# dispatch during a nightly, or two dispatches, evaluate to the same commit and
+# the second would kill the first. There is no case where one scheduled or
+# dispatched run should cancel another, so the group is per-run rather than
+# per-commit.
 concurrency:
-  group: package-smoke-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
+  group: package-smoke-${{ github.event_name == 'pull_request' && github.ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/package-smoke.yml
+++ b/.github/workflows/package-smoke.yml
@@ -270,16 +270,22 @@ jobs:
       # prerendered HTML the build wrote and requires every server-safe subpath
       # to appear in it with a non-empty export count, which only a render that
       # actually ran can produce.
-      - name: Verify the route was prerendered, naming every subpath
-        run: node packages/ui/scripts/write-server-safe-rsc-app.mjs --verify /tmp/rsc-app
-
       # The page above reaches only the `import` condition, so the `.cjs` targets are published and
       # never evaluated even though the export map promises them. This loads them the way a
       # CommonJS consumer does: same install, same export map, same Node.
+      #
+      # Its exit status is deliberately NOT the assertion — a module ending the process during
+      # initialization exits 0 from inside the import being checked. The verify step below reads
+      # the marker it writes on completion instead.
       - name: Evaluate the CommonJS targets the export map also publishes
         run: |
           cd /tmp/rsc-app
           node require-check.cjs
+
+      # Runs LAST, because it audits both halves: that the route was rendered at build time rather
+      # than merely compiled, and that the CommonJS probe reached the end of its own run.
+      - name: Verify the render happened and both halves covered every subpath
+        run: node packages/ui/scripts/write-server-safe-rsc-app.mjs --verify /tmp/rsc-app
 
   # A red nightly must surface without anyone watching the Actions tab. A red
   # pull request does not need an issue filed: it is already red on the PR, in

--- a/.github/workflows/package-smoke.yml
+++ b/.github/workflows/package-smoke.yml
@@ -24,6 +24,12 @@ on:
   pull_request:
     paths:
       - "packages/ui/**"
+      # The lockfile decides what the build INLINES and which versions of the
+      # allow-listed packages the artifacts reach, so a lockfile-only change —
+      # a dependency bump, which arrives without touching a single source file —
+      # can alter the packed artifacts and introduce exactly the module-scope
+      # browser access this job exists to catch.
+      - "pnpm-lock.yaml"
       - ".github/workflows/package-smoke.yml"
 
 # Least privilege at the top. The one job that files an issue asks for more, so
@@ -183,15 +189,21 @@ jobs:
       # 22.12.0, so a floating leg reports a pass the floor never earned.
       #
       # The three floors come from the root `engines`
-      # (`^20.19.0 || ^22.12.0 || >=24.0.0`). The bare `24` leg is the other
-      # direction — the open-ended line's newest release, where the risk is Node
-      # removing or changing something rather than not having it yet.
+      # (`^20.19.0 || ^22.12.0 || >=24.0.0`).
+      #
+      # `latest` is the other direction, and it is deliberately not a pinned
+      # major. The third clause is OPEN-ENDED, so every release Node has made
+      # since 24 is a version these packages claim to support; pinning `24` there
+      # would test the newest 24.x and leave every later major unexercised while
+      # the manifest promised it worked. Resolving to whatever Node has shipped
+      # keeps the leg matched to the claim with no edit here when a major lands.
+      # A new major breaking this job is not noise — it is the `>=` being wrong.
       #
       # A pull request runs the LOWEST floor alone. Everything the newer lines
       # reject, 20.19.0 rejects too, plus the post-floor globals they accept, so
-      # one leg buys nearly all the signal at a quarter of the minutes.
+      # one leg buys nearly all the signal at a fraction of the minutes.
       matrix:
-        node: ${{ fromJSON(github.event_name == 'pull_request' && '["20.19.0"]' || '["20.19.0", "22.12.0", "24.0.0", "24"]') }}
+        node: ${{ fromJSON(github.event_name == 'pull_request' && '["20.19.0"]' || '["20.19.0", "22.12.0", "24.0.0", "latest"]') }}
 
     steps:
       - name: Checkout

--- a/.github/workflows/package-smoke.yml
+++ b/.github/workflows/package-smoke.yml
@@ -30,6 +30,10 @@ on:
       # can alter the packed artifacts and introduce exactly the module-scope
       # browser access this job exists to catch.
       - "pnpm-lock.yaml"
+      # The root manifest carries `engines.node`, which decides the version legs
+      # below. A change there needs this job to run under the NEW range rather
+      # than only be told by a unit test that the two disagree.
+      - "package.json"
       - ".github/workflows/package-smoke.yml"
 
 # Least privilege at the top. The one job that files an issue asks for more, so

--- a/.github/workflows/package-smoke.yml
+++ b/.github/workflows/package-smoke.yml
@@ -350,7 +350,7 @@ jobs:
           else
             # printf keeps the multi-line body inside this YAML block scalar;
             # a raw multi-line string here would dedent and break the file.
-            body=$(printf 'The nightly package-smoke workflow failed. Run: %s\n\nOne of three things: the packed tarballs no longer install/import in a clean project, `create-nextly-app` no longer scaffolds an app that builds, a subpath declared server-safe no longer survives a real Next.js Server Component build, or the Node legs could not be derived from the engines range. The last one names a Node version in the job title, and a failure on the floor leg alone means the subpath uses something newer than the oldest supported Node. See the run logs for the failing job.' "$RUN_URL")
+            body=$(printf 'The nightly package-smoke workflow failed. Run: %s\n\nOne of four things: the packed tarballs no longer install/import in a clean project, `create-nextly-app` no longer scaffolds an app that builds, a subpath declared server-safe no longer survives a real Next.js Server Component build, or the Node legs could not be derived from the engines range. The server-safe build names its Node version in the job title, and a failure on the floor leg alone means the subpath uses something newer than the oldest supported Node. See the run logs for the failing job.' "$RUN_URL")
             gh issue create --repo "${{ github.repository }}" \
               --title "Nightly package smoke is failing" \
               --label ci-nightly-failure \

--- a/.github/workflows/package-smoke.yml
+++ b/.github/workflows/package-smoke.yml
@@ -207,9 +207,14 @@ jobs:
       # No install: the script reads the manifest and fetches the release index using built-ins
       # only. It FAILS rather than falling back to a shorter list, since a narrower matrix passes
       # while covering less, which is the failure this job exists to prevent one level up.
+      # A pull request runs one leg, and that leg comes from the manifest alone — so it does not
+      # fetch. Otherwise an outage at nodejs.org would fail a UI pull request that never needed the
+      # released majors, letting an outside service decide whether unrelated work can merge.
       - name: Derive
         id: derive
-        run: node packages/ui/scripts/node-matrix.mjs --github
+        run: |
+          node packages/ui/scripts/node-matrix.mjs --github \
+            ${{ github.event_name == 'pull_request' && '--floor-only' || '' }}
 
   server-safe-rsc-build:
     name: Server-safe subpaths in an RSC build (Node ${{ matrix.node }})

--- a/.github/workflows/package-smoke.yml
+++ b/.github/workflows/package-smoke.yml
@@ -176,19 +176,22 @@ jobs:
     timeout-minutes: 20
     strategy:
       fail-fast: false
-      # Nightly runs every line the package's `engines` range admits, LOW END
-      # INCLUDED. The web globals Node adds over time are what make a
-      # server-safe claim version-dependent: a module reading `navigator` at
-      # module scope builds cleanly on 22 and 24 and throws for a consumer on
-      # the floor, so a matrix without the floor answers only for the machines
-      # we happen to run on.
+      # EXACT floors, not major selectors. `20` resolves to the newest 20.x,
+      # which is not the version the `engines` range promises to support, and
+      # the gap is precisely where this job's signal lives: a global added in
+      # 22.13 is present on the newest 22.x and absent for a consumer pinned to
+      # 22.12.0, so a floating leg reports a pass the floor never earned.
       #
-      # A pull request runs the FLOOR alone. It is the leg that catches the most
-      # for this property — everything the newer lines reject, 20 rejects too,
-      # plus the post-floor globals they accept — so one leg per PR buys nearly
-      # all of the signal at a third of the minutes.
+      # The three floors come from the root `engines`
+      # (`^20.19.0 || ^22.12.0 || >=24.0.0`). The bare `24` leg is the other
+      # direction — the open-ended line's newest release, where the risk is Node
+      # removing or changing something rather than not having it yet.
+      #
+      # A pull request runs the LOWEST floor alone. Everything the newer lines
+      # reject, 20.19.0 rejects too, plus the post-floor globals they accept, so
+      # one leg buys nearly all the signal at a quarter of the minutes.
       matrix:
-        node: ${{ fromJSON(github.event_name == 'pull_request' && '[20]' || '[20, 22, 24]') }}
+        node: ${{ fromJSON(github.event_name == 'pull_request' && '["20.19.0"]' || '["20.19.0", "22.12.0", "24.0.0", "24"]') }}
 
     steps:
       - name: Checkout
@@ -225,10 +228,20 @@ jobs:
       - name: Write the Server Component app
         run: node packages/ui/scripts/write-server-safe-rsc-app.mjs /tmp/rsc-app
 
+      # Majors are pinned so a Next or React release cannot turn this nightly red
+      # for a reason that has nothing to do with the package under test; moving
+      # to the next major is then a deliberate edit here. Patches and minors
+      # still flow, which is where a genuine RSC behaviour change would arrive.
+      #
+      # One React major rather than the `^18 || ^19` the package accepts as a
+      # peer, because React's version cannot decide this question: a server-safe
+      # subpath may not reach React at all, and the artifact gate enforces that
+      # against an allow-list of two string utilities. The PAGE uses React; the
+      # subpaths under test do not.
       - name: Install Next.js and the packed UI tarball
         run: |
           cd /tmp/rsc-app
-          npm install next react react-dom /tmp/ui-pack/*.tgz --no-audit --no-fund
+          npm install next@16 react@19 react-dom@19 /tmp/ui-pack/*.tgz --no-audit --no-fund
 
       # An App Router page is prerendered during the build, so every module the
       # Server Component imports is evaluated in a real server render. A module
@@ -238,6 +251,15 @@ jobs:
         run: |
           cd /tmp/rsc-app
           npx next build
+
+      # The build exiting 0 is not the whole assertion. Next also exits 0 for a
+      # route it classifies as DYNAMIC, where the render is deferred to the first
+      # request and the module bodies have only been compiled. This reads the
+      # prerendered HTML the build wrote and requires every server-safe subpath
+      # to appear in it with a non-empty export count, which only a render that
+      # actually ran can produce.
+      - name: Verify the route was prerendered, naming every subpath
+        run: node packages/ui/scripts/write-server-safe-rsc-app.mjs --verify /tmp/rsc-app
 
   # A red nightly must surface without anyone watching the Actions tab. A red
   # pull request does not need an issue filed: it is already red on the PR, in
@@ -267,7 +289,7 @@ jobs:
           else
             # printf keeps the multi-line body inside this YAML block scalar;
             # a raw multi-line string here would dedent and break the file.
-            body=$(printf 'The nightly package-smoke workflow failed. Run: %s\n\nEither the packed tarballs no longer install/import in a clean project, or `create-nextly-app` no longer scaffolds an app that builds. See the run logs for the failing job.' "$RUN_URL")
+            body=$(printf 'The nightly package-smoke workflow failed. Run: %s\n\nOne of three things: the packed tarballs no longer install/import in a clean project, `create-nextly-app` no longer scaffolds an app that builds, or a subpath declared server-safe no longer survives a real Next.js Server Component build. The last one names a Node version in the job title, and a failure on the floor leg alone means the subpath uses something newer than the oldest supported Node. See the run logs for the failing job.' "$RUN_URL")
             gh issue create --repo "${{ github.repository }}" \
               --title "Nightly package smoke is failing" \
               --label ci-nightly-failure \

--- a/.github/workflows/package-smoke.yml
+++ b/.github/workflows/package-smoke.yml
@@ -182,8 +182,38 @@ jobs:
   # model only answers for what it was taught, and the artifact gate spent 29
   # review rounds learning ways a simulated environment differs from a real one.
   # This asks the real toolchain instead, and the assertion is the build passing.
+  # The version legs are COMPUTED from `engines.node` rather than written beside it, because the
+  # range's last clause is open-ended: `>=24.0.0` promises every major Node has released since, and
+  # a list naming the floor and the newest leaves the ones between them untested. Node's own release
+  # index says which exist, so nothing here needs an edit when a major ships.
+  node-matrix:
+    name: Derive the Node legs from the engines range
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      versions: ${{ steps.derive.outputs.versions }}
+      lowest: ${{ steps.derive.outputs.lowest }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version-file: .nvmrc
+
+      # No install: the script reads the manifest and fetches the release index using built-ins
+      # only. It FAILS rather than falling back to a shorter list, since a narrower matrix passes
+      # while covering less, which is the failure this job exists to prevent one level up.
+      - name: Derive
+        id: derive
+        run: node packages/ui/scripts/node-matrix.mjs --github
+
   server-safe-rsc-build:
     name: Server-safe subpaths in an RSC build (Node ${{ matrix.node }})
+    needs: node-matrix
     runs-on: ubuntu-latest
     # A module that calls `process.exit` while it initializes leaves the build
     # with no verdict to report rather than a failure, so the deadline is what
@@ -192,28 +222,17 @@ jobs:
     timeout-minutes: 20
     strategy:
       fail-fast: false
-      # EXACT floors, not major selectors. `20` resolves to the newest 20.x,
-      # which is not the version the `engines` range promises to support, and
-      # the gap is precisely where this job's signal lives: a global added in
-      # 22.13 is present on the newest 22.x and absent for a consumer pinned to
-      # 22.12.0, so a floating leg reports a pass the floor never earned.
-      #
-      # The three floors come from the root `engines`
-      # (`^20.19.0 || ^22.12.0 || >=24.0.0`).
-      #
-      # `latest` is the other direction, and it is deliberately not a pinned
-      # major. The third clause is OPEN-ENDED, so every release Node has made
-      # since 24 is a version these packages claim to support; pinning `24` there
-      # would test the newest 24.x and leave every later major unexercised while
-      # the manifest promised it worked. Resolving to whatever Node has shipped
-      # keeps the leg matched to the claim with no edit here when a major lands.
-      # A new major breaking this job is not noise — it is the `>=` being wrong.
+      # Nightly runs every version the range asks for: the EXACT floor of each
+      # closed clause, where a global Node added later is absent — which is the
+      # failure this job exists to find, and one a floating `20` would miss by
+      # installing the newest 20.x — plus every released major above the open
+      # clause's floor.
       #
       # A pull request runs the LOWEST floor alone. Everything the newer lines
-      # reject, 20.19.0 rejects too, plus the post-floor globals they accept, so
-      # one leg buys nearly all the signal at a fraction of the minutes.
+      # reject, it rejects too, plus the post-floor globals they accept, so one
+      # leg buys nearly all the signal at a fraction of the minutes.
       matrix:
-        node: ${{ fromJSON(github.event_name == 'pull_request' && '["20.19.0"]' || '["20.19.0", "22.12.0", "24.0.0", "latest"]') }}
+        node: ${{ fromJSON(github.event_name == 'pull_request' && needs.node-matrix.outputs.lowest || needs.node-matrix.outputs.versions) }}
 
     steps:
       - name: Checkout
@@ -302,7 +321,13 @@ jobs:
   # front of the person who caused it.
   report-failure:
     name: File an issue on failure
-    needs: [pack-and-consume, scaffold-and-build, server-safe-rsc-build]
+    needs:
+      [
+        pack-and-consume,
+        scaffold-and-build,
+        node-matrix,
+        server-safe-rsc-build,
+      ]
     if: failure() && github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -325,7 +350,7 @@ jobs:
           else
             # printf keeps the multi-line body inside this YAML block scalar;
             # a raw multi-line string here would dedent and break the file.
-            body=$(printf 'The nightly package-smoke workflow failed. Run: %s\n\nOne of three things: the packed tarballs no longer install/import in a clean project, `create-nextly-app` no longer scaffolds an app that builds, or a subpath declared server-safe no longer survives a real Next.js Server Component build. The last one names a Node version in the job title, and a failure on the floor leg alone means the subpath uses something newer than the oldest supported Node. See the run logs for the failing job.' "$RUN_URL")
+            body=$(printf 'The nightly package-smoke workflow failed. Run: %s\n\nOne of three things: the packed tarballs no longer install/import in a clean project, `create-nextly-app` no longer scaffolds an app that builds, a subpath declared server-safe no longer survives a real Next.js Server Component build, or the Node legs could not be derived from the engines range. The last one names a Node version in the job title, and a failure on the floor leg alone means the subpath uses something newer than the oldest supported Node. See the run logs for the failing job.' "$RUN_URL")
             gh issue create --repo "${{ github.repository }}" \
               --title "Nightly package smoke is failing" \
               --label ci-nightly-failure \

--- a/.github/workflows/package-smoke.yml
+++ b/.github/workflows/package-smoke.yml
@@ -1,11 +1,13 @@
 name: Package smoke
 
 # Nightly proof that the published artifacts actually work: the tarballs
-# install into a clean project and import, and the scaffolder produces an app
-# that really installs and builds. publint and attw validate manifests and
+# install into a clean project and import, the scaffolder produces an app that
+# really installs and builds, and the subpaths declared server-safe survive a
+# real Next.js Server Component build. publint and attw validate manifests and
 # types statically on every PR; this covers the runtime layer they cannot —
-# missing `files` entries, broken bins, template dependency drift, and
-# native-module (better-sqlite3) prebuilds across current Node LTS lines.
+# missing `files` entries, broken bins, template dependency drift, RSC
+# compatibility, and native-module (better-sqlite3) prebuilds across the Node
+# lines the packages claim to support.
 #
 # Scheduled instead of per-PR: full installs take minutes, and this class of
 # drift moves slowly. A red night shows up as an issue, not a slower PR.
@@ -136,10 +138,83 @@ jobs:
           cd smoke-app
           npm run build
 
+  # The three static server-safe checks in packages/ui are all MODELS of what
+  # Next.js does with those subpaths: one looks for a `"use client"` banner, one
+  # walks the sources, one reads the built artifacts against an allow-list. A
+  # model only answers for what it was taught, and the artifact gate spent 29
+  # review rounds learning ways a simulated environment differs from a real one.
+  # This asks the real toolchain instead, and the assertion is the build passing.
+  server-safe-rsc-build:
+    name: Server-safe subpaths in an RSC build (Node ${{ matrix.node }})
+    runs-on: ubuntu-latest
+    # A module that calls `process.exit` while it initializes leaves the build
+    # with no verdict to report rather than a failure, so the deadline is what
+    # turns that into a red job. Generous relative to the work: install plus a
+    # build of one page takes about a minute.
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      # Every line the package's `engines` range admits, LOW END INCLUDED. The
+      # web globals Node adds over time are exactly what makes a server-safe
+      # claim version-dependent: a module reading `navigator` at module scope
+      # builds cleanly on 22 and 24 and throws for a consumer on the floor, so a
+      # matrix without the floor answers for the machines we happen to run on.
+      matrix:
+        node: [20, 22, 24]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: ${{ matrix.node }}
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build the UI package
+        run: pnpm turbo build --filter=@nextlyhq/ui
+
+      # Packed and installed as a tarball rather than linked from the workspace,
+      # so the app resolves the subpaths through the published export map — the
+      # thing being claimed — instead of through pnpm's workspace links.
+      - name: Pack the UI package
+        run: |
+          mkdir -p /tmp/ui-pack
+          (cd packages/ui && pnpm pack --pack-destination /tmp/ui-pack)
+
+      # The app is GENERATED from the export map, so a new server-safe subpath is
+      # covered without editing this workflow. A hand-written import list would
+      # keep passing on the entries someone remembered.
+      - name: Write the Server Component app
+        run: node packages/ui/scripts/write-server-safe-rsc-app.mjs /tmp/rsc-app
+
+      - name: Install Next.js and the packed UI tarball
+        run: |
+          cd /tmp/rsc-app
+          npm install next react react-dom /tmp/ui-pack/*.tgz --no-audit --no-fund
+
+      # An App Router page is prerendered during the build, so every module the
+      # Server Component imports is evaluated in a real server render. A module
+      # body that reads `document` fails here naming the file, with nothing
+      # having to recognise the spelling of that read.
+      - name: Build the app
+        run: |
+          cd /tmp/rsc-app
+          npx next build
+
   # A red nightly must surface without anyone watching the Actions tab.
   report-failure:
     name: File an issue on failure
-    needs: [pack-and-consume, scaffold-and-build]
+    needs: [pack-and-consume, scaffold-and-build, server-safe-rsc-build]
     if: failure()
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/packages/ui/scripts/node-matrix.d.mts
+++ b/packages/ui/scripts/node-matrix.d.mts
@@ -1,0 +1,19 @@
+/**
+ * Types for the Node-leg derivation, which is plain ESM so a workflow step and a Vitest suite can
+ * both read it without a build step.
+ */
+
+/**
+ * The exact versions a supported range asks to be tested, given the majors Node has released.
+ *
+ * A closed clause contributes its FLOOR; an open clause contributes its floor plus every released
+ * major above it. Throws on a clause form it does not recognise, rather than returning a shorter
+ * list that would pass while covering less.
+ */
+export function matrixFor(
+  range: string,
+  releasedMajors: readonly number[]
+): string[];
+
+/** The single lowest floor of a range, which is the one leg a pull request runs. */
+export function lowestFloor(range: string): string;

--- a/packages/ui/scripts/node-matrix.mjs
+++ b/packages/ui/scripts/node-matrix.mjs
@@ -55,22 +55,38 @@ export function matrixFor(range, releasedMajors) {
     }
     const floor = Number(open[1]);
     versions.push(`${open[1]}.${open[2]}.${open[3]}`);
-    // Every major ABOVE the open floor that exists. The floor's own major is already covered by the
-    // exact floor version pushed above.
+    // Every major ABOVE the open floor that exists, named by its own FLOOR rather than by the bare
+    // major. `setup-node` resolves `25` to the newest 25.x, which is not the version the range
+    // promises — the same defect the closed clauses avoid by naming exact floors, and the gap is
+    // exactly where an API added after 25.0.0 lives.
     for (const major of [...new Set(releasedMajors)].sort((a, b) => a - b)) {
-      if (major > floor) versions.push(String(major));
+      if (major > floor) versions.push(`${major}.0.0`);
     }
   }
   return versions;
 }
 
-/** The single lowest floor, which is the one leg a pull request runs. */
+/**
+ * The single lowest floor, which is the one leg a pull request runs.
+ *
+ * Compared NUMERICALLY rather than taken from the front of the list. A semver union has no required
+ * order, so `>=24.0.0 || ^20.19.0` states the same contract as `^20.19.0 || >=24.0.0` — and reading
+ * the first clause would run Node 24 on every pull request while the real floor went unexercised,
+ * with every synchronisation check still green.
+ */
 export function lowestFloor(range) {
-  const first = matrixFor(range, [])[0];
-  if (first === undefined) {
+  const floors = matrixFor(range, []);
+  if (floors.length === 0) {
     throw new Error("engines.node named no versions, so no leg could be selected.");
   }
-  return first;
+  const parts = version => version.split(".").map(Number);
+  return floors.reduce((lowest, candidate) => {
+    const [major, minor, patch] = parts(candidate);
+    const [lowMajor, lowMinor, lowPatch] = parts(lowest);
+    if (major !== lowMajor) return major < lowMajor ? candidate : lowest;
+    if (minor !== lowMinor) return minor < lowMinor ? candidate : lowest;
+    return patch < lowPatch ? candidate : lowest;
+  });
 }
 
 /** Every major with at least one release, read from Node's own index. */

--- a/packages/ui/scripts/node-matrix.mjs
+++ b/packages/ui/scripts/node-matrix.mjs
@@ -1,0 +1,110 @@
+/**
+ * The Node versions the server-safe RSC job runs against, derived from the supported range.
+ *
+ * The range and the matrix answer one question and cannot be one value — a matrix needs exact
+ * versions and `engines.node` is a semver expression — so the matrix is COMPUTED from the range
+ * rather than written beside it. A list written by hand drifts the first time the range moves, and
+ * the drift is silent: every leg passes, on the versions someone remembered.
+ *
+ * Two kinds of clause, and they need opposite treatment:
+ *
+ * - A CLOSED clause (`^20.19.0`) admits one line, and the version worth testing is its FLOOR. That
+ *   is where a global Node added later is absent, which is the failure this job exists to find.
+ * - An OPEN clause (`>=24.0.0`) admits every line from its floor upward, including ones that do not
+ *   exist yet. Testing the floor and the newest release leaves the majors BETWEEN them unexercised
+ *   — with 24, 25 and 26 released, a floor of 24 plus `latest` never runs 25.
+ *
+ * So the open clause contributes its floor plus every released major above it. That list comes from
+ * Node's own release index rather than from a constant here, because a constant is the hand-written
+ * list one level down: it would need an edit every six months, and nothing would fail until the
+ * major it was missing broke a consumer.
+ *
+ * Usage:
+ *   node scripts/node-matrix.mjs            print the matrix as JSON
+ *   node scripts/node-matrix.mjs --github   append `versions=<json>` to $GITHUB_OUTPUT
+ */
+import { appendFileSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const RELEASE_INDEX = "https://nodejs.org/dist/index.json";
+
+/**
+ * The exact versions a range asks to be tested, given the majors Node has actually released.
+ *
+ * @param {string} range a semver range of `^x.y.z` and `>=x.y.z` clauses joined by `||`
+ * @param {readonly number[]} releasedMajors every major with at least one release
+ * @returns {string[]}
+ */
+export function matrixFor(range, releasedMajors) {
+  const versions = [];
+  for (const clause of range.split("||").map(part => part.trim())) {
+    const caret = /^\^(\d+)\.(\d+)\.(\d+)$/.exec(clause);
+    const open = /^>=(\d+)\.(\d+)\.(\d+)$/.exec(clause);
+    if (caret !== null) {
+      versions.push(`${caret[1]}.${caret[2]}.${caret[3]}`);
+      continue;
+    }
+    if (open === null) {
+      // Refused rather than skipped. Skipping produces a SHORTER matrix, which is a quieter
+      // failure than none at all: the job keeps passing on the clauses that were understood.
+      throw new Error(
+        `engines.node clause ${JSON.stringify(clause)} is neither a caret nor a >= range, so the ` +
+          `versions it admits could not be derived. Teach this function the new form.`
+      );
+    }
+    const floor = Number(open[1]);
+    versions.push(`${open[1]}.${open[2]}.${open[3]}`);
+    // Every major ABOVE the open floor that exists. The floor's own major is already covered by the
+    // exact floor version pushed above.
+    for (const major of [...new Set(releasedMajors)].sort((a, b) => a - b)) {
+      if (major > floor) versions.push(String(major));
+    }
+  }
+  return versions;
+}
+
+/** The single lowest floor, which is the one leg a pull request runs. */
+export function lowestFloor(range) {
+  const first = matrixFor(range, [])[0];
+  if (first === undefined) {
+    throw new Error("engines.node named no versions, so no leg could be selected.");
+  }
+  return first;
+}
+
+/** Every major with at least one release, read from Node's own index. */
+async function releasedMajors() {
+  const response = await fetch(RELEASE_INDEX);
+  if (!response.ok) {
+    throw new Error(
+      `${RELEASE_INDEX} answered ${response.status}, so the released majors are unknown. Failing ` +
+        `rather than running a narrower matrix, which would pass while covering less.`
+    );
+  }
+  const releases = await response.json();
+  return releases.map(release => Number(release.version.slice(1).split(".")[0]));
+}
+
+const invokedDirectly =
+  process.argv[1] !== undefined &&
+  process.argv[1].endsWith("node-matrix.mjs");
+
+if (invokedDirectly) {
+  const root = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
+  const range = JSON.parse(readFileSync(join(root, "package.json"), "utf8"))
+    .engines.node;
+  const versions = matrixFor(range, await releasedMajors());
+  const payload = JSON.stringify(versions);
+
+  if (process.argv[2] === "--github") {
+    const out = process.env.GITHUB_OUTPUT;
+    if (out === undefined) {
+      console.error("GITHUB_OUTPUT is not set, so the matrix could not be published.");
+      process.exit(1);
+    }
+    appendFileSync(out, `versions=${payload}\n`);
+    appendFileSync(out, `lowest=${JSON.stringify([lowestFloor(range)])}\n`);
+  }
+  console.log(payload);
+}

--- a/packages/ui/scripts/node-matrix.mjs
+++ b/packages/ui/scripts/node-matrix.mjs
@@ -20,8 +20,14 @@
  * major it was missing broke a consumer.
  *
  * Usage:
- *   node scripts/node-matrix.mjs            print the matrix as JSON
- *   node scripts/node-matrix.mjs --github   append `versions=<json>` to $GITHUB_OUTPUT
+ *   node scripts/node-matrix.mjs                 print the matrix as JSON
+ *   node scripts/node-matrix.mjs --github        write the outputs to $GITHUB_OUTPUT
+ *   node scripts/node-matrix.mjs --floor-only    the lowest floor alone, WITHOUT the network
+ *
+ * `--floor-only` exists because a pull request runs one leg, and that leg is derivable from the
+ * manifest alone. Fetching anyway would let an outage at nodejs.org fail a UI pull request that
+ * never needed the released majors — an outside dependency deciding whether unrelated work can
+ * merge. Scheduled runs, which consume the full matrix, still fetch.
  */
 import { appendFileSync, readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
@@ -107,20 +113,29 @@ const invokedDirectly =
   process.argv[1].endsWith("node-matrix.mjs");
 
 if (invokedDirectly) {
+  const flags = new Set(process.argv.slice(2));
   const root = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
   const range = JSON.parse(readFileSync(join(root, "package.json"), "utf8"))
     .engines.node;
-  const versions = matrixFor(range, await releasedMajors());
+  const floor = lowestFloor(range);
+
+  // Both outputs carry the floor in floor-only mode, rather than one of them being empty. The
+  // workflow picks between them with an expression, and an empty list there would expand to a
+  // matrix of NO legs — a job that passes having run nothing, which is worse than the outage this
+  // mode exists to survive.
+  const versions = flags.has("--floor-only")
+    ? [floor]
+    : matrixFor(range, await releasedMajors());
   const payload = JSON.stringify(versions);
 
-  if (process.argv[2] === "--github") {
+  if (flags.has("--github")) {
     const out = process.env.GITHUB_OUTPUT;
     if (out === undefined) {
       console.error("GITHUB_OUTPUT is not set, so the matrix could not be published.");
       process.exit(1);
     }
     appendFileSync(out, `versions=${payload}\n`);
-    appendFileSync(out, `lowest=${JSON.stringify([lowestFloor(range)])}\n`);
+    appendFileSync(out, `lowest=${JSON.stringify([floor])}\n`);
   }
   console.log(payload);
 }

--- a/packages/ui/scripts/write-server-safe-rsc-app.mjs
+++ b/packages/ui/scripts/write-server-safe-rsc-app.mjs
@@ -69,6 +69,16 @@ if (serverSafe.length === 0) {
  */
 const PRERENDERED = join(target, ".next", "server", "app", "index.html");
 
+/**
+ * The file the CommonJS probe writes as its LAST act, and nothing else does.
+ *
+ * A module calling `process.exit(0)` while it initializes ends that probe with a success status
+ * before its assertions, its remaining subpaths, or its final log ever run — so the exit code
+ * alone reports a pass for the one defect that stops the check happening at all. Reaching the end
+ * is the only thing that produces this.
+ */
+const SENTINEL = "require-check.done";
+
 if (verifying) {
   if (!existsSync(PRERENDERED)) {
     console.error(
@@ -111,9 +121,28 @@ if (verifying) {
     process.exit(1);
   }
 
+  // The CommonJS probe ran to completion. Checked here rather than by its own exit status, which
+  // an artifact can set to 0 from inside the very import being checked.
+  const sentinel = join(target, SENTINEL);
+  if (!existsSync(sentinel)) {
+    console.error(
+      `${sentinel} does not exist, so the CommonJS probe did not reach the end of its run. An ` +
+        `artifact that ends the process while it initializes would end a consumer's the same way.`
+    );
+    process.exit(1);
+  }
+  const reached = Number(readFileSync(sentinel, "utf8").trim());
+  if (reached !== serverSafe.length) {
+    console.error(
+      `The CommonJS probe recorded ${reached} subpaths where ${serverSafe.length} are declared ` +
+        `server-safe, so the two halves of this check are reading different sets.`
+    );
+    process.exit(1);
+  }
+
   console.log(
     `Prerendered at build time, reporting all ${serverSafe.length} server-safe subpaths ` +
-      `(${serverSafe.map(entry => entry.subpath).join(", ")}).`
+      `(${serverSafe.map(entry => entry.subpath).join(", ")}), and the CommonJS probe completed.`
   );
   process.exit(0);
 }
@@ -196,6 +225,8 @@ const manifest = {
 // installed package, through the same export map's `require` condition, on the same Node. A `.cjs`
 // file inside a `"type": "module"` package is CommonJS regardless of the manifest.
 const requireCheck = `const assert = require("node:assert");
+const { writeFileSync } = require("node:fs");
+const { join } = require("node:path");
 
 const subpaths = ${JSON.stringify(serverSafe.map(entry => specifier(entry.subpath)), null, 2)};
 
@@ -207,6 +238,12 @@ for (const subpath of subpaths) {
     \`\${subpath} resolved through the require condition but exported nothing\`
   );
 }
+
+// Written LAST, and the workflow requires it. A module calling \`process.exit(0)\` while it
+// initializes ends this process with a success status before the assertion above, the remaining
+// subpaths, or this line ever run — so the exit code alone reports a pass for the one defect that
+// stops the check from happening at all. Only reaching the end can produce this file.
+writeFileSync(join(__dirname, "${SENTINEL}"), \`\${subpaths.length}\\n\`);
 
 console.log(\`Required \${subpaths.length} server-safe subpaths through the CommonJS condition.\`);
 `;

--- a/packages/ui/scripts/write-server-safe-rsc-app.mjs
+++ b/packages/ui/scripts/write-server-safe-rsc-app.mjs
@@ -188,10 +188,34 @@ const manifest = {
   type: "module",
 };
 
+// The export map publishes BOTH module systems, and only one of them is reachable from the page
+// above: a static `import` resolves each subpath's `import` condition, so the `.cjs` targets are
+// built, published, and never evaluated. Their wrappers are generated separately and can differ.
+//
+// Requiring them is not a simulation of a consumer, it is what a CommonJS consumer does — the same
+// installed package, through the same export map's `require` condition, on the same Node. A `.cjs`
+// file inside a `"type": "module"` package is CommonJS regardless of the manifest.
+const requireCheck = `const assert = require("node:assert");
+
+const subpaths = ${JSON.stringify(serverSafe.map(entry => specifier(entry.subpath)), null, 2)};
+
+for (const subpath of subpaths) {
+  const loaded = require(subpath);
+  // A namespace with no bindings loads exactly like a real module and would otherwise pass.
+  assert.ok(
+    loaded && typeof loaded === "object" && Object.keys(loaded).length > 0,
+    \`\${subpath} resolved through the require condition but exported nothing\`
+  );
+}
+
+console.log(\`Required \${subpaths.length} server-safe subpaths through the CommonJS condition.\`);
+`;
+
 mkdirSync(join(target, "app"), { recursive: true });
 writeFileSync(join(target, "package.json"), `${JSON.stringify(manifest, null, 2)}\n`);
 writeFileSync(join(target, "app", "page.jsx"), page);
 writeFileSync(join(target, "app", "layout.jsx"), layout);
+writeFileSync(join(target, "require-check.cjs"), requireCheck);
 
 console.log(
   `Wrote a Server Component importing ${serverSafe.length} server-safe subpaths ` +

--- a/packages/ui/scripts/write-server-safe-rsc-app.mjs
+++ b/packages/ui/scripts/write-server-safe-rsc-app.mjs
@@ -1,0 +1,120 @@
+/**
+ * Write a minimal Next.js app that imports every server-safe subpath from a Server Component.
+ *
+ * The other server-safe checks in this package read code: the directive guard looks for a
+ * `"use client"` banner, and the artifact gate compares what each built file reaches against an
+ * allow-list. Both are models of what Next.js does with these packages, and a model only answers
+ * for the cases it was taught. This asks the real toolchain instead — the app it writes is built by
+ * the Next.js and React versions a consumer installs, on the Node the job runs.
+ *
+ * The assertion is the BUILD SUCCEEDING. An App Router page is prerendered at build time, so every
+ * module it imports is evaluated in a real server render. A module whose body reads `document`, or
+ * that leaves the render unable to complete, fails the build naming the file. Nothing here has to
+ * recognise the spelling of that read for it to happen, which is the whole reason this exists
+ * rather than a longer list of globals to probe for.
+ *
+ * The subpaths are DERIVED from the export map rather than written down. A hand-written list makes
+ * a new server-safe subpath silently uncovered, which is the failure this check would be least
+ * likely to notice — it would keep passing, on the entries someone remembered.
+ *
+ * Usage: node scripts/write-server-safe-rsc-app.mjs <directory>
+ */
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { publishedEntries } from "./published-entries.mjs";
+
+const target = process.argv[2];
+if (target === undefined) {
+  console.error(
+    "Usage: node scripts/write-server-safe-rsc-app.mjs <directory>. The directory is where the " +
+      "app is written; it is created if it does not exist."
+  );
+  process.exit(1);
+}
+
+const serverSafe = publishedEntries().filter(entry => entry.serverSafe);
+
+// An empty list would write an app that imports nothing and builds cleanly, reporting a pass for
+// having checked no entry point at all.
+if (serverSafe.length === 0) {
+  console.error(
+    "No server-safe subpaths were derived from the export map, so the generated app would assert " +
+      "nothing."
+  );
+  process.exit(1);
+}
+
+/** The bare specifier a consumer writes for a subpath: `./color` is imported as `<pkg>/color`. */
+const specifier = subpath =>
+  subpath === "." ? "@nextlyhq/ui" : `@nextlyhq/ui/${subpath.slice(2)}`;
+
+// A NAMESPACE import, so this holds whatever each subpath exports without naming any binding. The
+// alternative is a list of names per subpath, which is the hand-written list this file exists to
+// avoid, one level down.
+const imports = serverSafe
+  .map((entry, index) => `import * as entry${index} from "${specifier(entry.subpath)}";`)
+  .join("\n");
+
+// Every namespace is READ, and the result is rendered. An import whose binding is never used is
+// removable, and a bundler that removes it leaves the module unevaluated — the page would build
+// green having imported nothing. Counting the exports forces the namespace object to exist, and
+// rendering the count keeps the expression from being dropped as dead.
+const reads = serverSafe
+  .map(
+    (entry, index) =>
+      `  { subpath: ${JSON.stringify(entry.subpath)}, exports: Object.keys(entry${index}).length },`
+  )
+  .join("\n");
+
+const page = `${imports}
+
+// No "use client" banner: this file is a Server Component, which is the environment the subpaths
+// above claim to support.
+const imported = [
+${reads}
+];
+
+export default function Page() {
+  return (
+    <main>
+      {imported.map(entry => (
+        <p key={entry.subpath}>
+          {entry.subpath}: {entry.exports} exports
+        </p>
+      ))}
+    </main>
+  );
+}
+`;
+
+const layout = `export const metadata = { title: "server-safe subpaths" };
+
+export default function RootLayout({ children }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}
+`;
+
+// Written here rather than in the workflow, so the whole app is one generated artifact and the CI
+// step is an install and a build. A manifest split across a YAML heredoc is a second place for the
+// app's shape to live, and it drifts from this file the first time either changes.
+const manifest = {
+  name: "server-safe-rsc-smoke",
+  private: true,
+  version: "0.0.0",
+  type: "module",
+};
+
+mkdirSync(join(target, "app"), { recursive: true });
+writeFileSync(join(target, "package.json"), `${JSON.stringify(manifest, null, 2)}\n`);
+writeFileSync(join(target, "app", "page.jsx"), page);
+writeFileSync(join(target, "app", "layout.jsx"), layout);
+
+console.log(
+  `Wrote a Server Component importing ${serverSafe.length} server-safe subpaths ` +
+    `(${serverSafe.map(entry => entry.subpath).join(", ")}) to ${target}.`
+);

--- a/packages/ui/scripts/write-server-safe-rsc-app.mjs
+++ b/packages/ui/scripts/write-server-safe-rsc-app.mjs
@@ -95,15 +95,24 @@ if (verifying) {
   const missing = [];
   const empty = [];
   for (const entry of serverSafe) {
-    const match = html.match(
-      new RegExp(
-        `data-subpath="${entry.subpath.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}" data-exports="(\\d+)"`
-      )
+    const quoted = entry.subpath.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    // The ELEMENT is located first, then its attributes are read independently. Requiring the two
+    // attributes to be adjacent and in order made this depend on how React happens to serialize a
+    // tag, which is not part of any contract it publishes — a reordering or an inserted attribute
+    // would fail a build whose page is correct, and a required check that reds on a correct build
+    // costs more than the case it was guarding.
+    const element = html.match(
+      new RegExp(`<[a-zA-Z][a-zA-Z0-9-]*\\s[^>]*data-subpath="${quoted}"[^>]*>`)
     );
-    if (match === null) missing.push(entry.subpath);
+    if (element === null) {
+      missing.push(entry.subpath);
+      continue;
+    }
+    const exported = element[0].match(/data-exports="(\d+)"/);
     // A namespace with no bindings means the import resolved to something empty, which renders the
-    // same as a real module and would otherwise read as a pass.
-    else if (Number(match[1]) === 0) empty.push(entry.subpath);
+    // same as a real module and would otherwise read as a pass. An element carrying the subpath but
+    // no count is the same absence of evidence.
+    if (exported === null || Number(exported[1]) === 0) empty.push(entry.subpath);
   }
 
   if (missing.length > 0 || empty.length > 0) {

--- a/packages/ui/scripts/write-server-safe-rsc-app.mjs
+++ b/packages/ui/scripts/write-server-safe-rsc-app.mjs
@@ -17,6 +17,13 @@
  * a new server-safe subpath silently uncovered, which is the failure this check would be least
  * likely to notice — it would keep passing, on the entries someone remembered.
  *
+ * Deriving covers one direction only, and the other one matters just as much: a subpath RECLASSIFIED
+ * as client code leaves this list, and a shrinking derived list agrees with itself and reports a
+ * pass over less than it did yesterday. What stops that is `src/ui-surface.test.ts`, which compares
+ * the same derived set against the subpaths STABILITY.md names in prose, in both directions. The
+ * enumerated side lives there, where a deletion is loud, and the derived side lives here, where an
+ * addition is free.
+ *
  * Usage: node scripts/write-server-safe-rsc-app.mjs <directory>
  */
 import { mkdirSync, writeFileSync } from "node:fs";

--- a/packages/ui/scripts/write-server-safe-rsc-app.mjs
+++ b/packages/ui/scripts/write-server-safe-rsc-app.mjs
@@ -24,18 +24,25 @@
  * enumerated side lives there, where a deletion is loud, and the derived side lives here, where an
  * addition is free.
  *
- * Usage: node scripts/write-server-safe-rsc-app.mjs <directory>
+ * Usage:
+ *   node scripts/write-server-safe-rsc-app.mjs <directory>            write the app
+ *   node scripts/write-server-safe-rsc-app.mjs --verify <directory>   check what the build produced
+ *
+ * The two modes share this file, and therefore share ONE derivation of the subpath list. Split
+ * across a generator and a separate verifier, the verifier is free to check a different set to the
+ * one that was written, and it would report a pass over whichever set it had.
  */
-import { mkdirSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
 import { publishedEntries } from "./published-entries.mjs";
 
-const target = process.argv[2];
+const verifying = process.argv[2] === "--verify";
+const target = verifying ? process.argv[3] : process.argv[2];
 if (target === undefined) {
   console.error(
-    "Usage: node scripts/write-server-safe-rsc-app.mjs <directory>. The directory is where the " +
-      "app is written; it is created if it does not exist."
+    "Usage: node scripts/write-server-safe-rsc-app.mjs [--verify] <directory>. The directory is " +
+      "where the app is written; it is created if it does not exist."
   );
   process.exit(1);
 }
@@ -50,6 +57,65 @@ if (serverSafe.length === 0) {
       "nothing."
   );
   process.exit(1);
+}
+
+/**
+ * The file a BUILD-TIME render writes, and nothing else does.
+ *
+ * `next build` exits 0 for a route it classifies as dynamic too, where the render is deferred to
+ * the first request. Reading the exit code alone would then report that the module bodies ran when
+ * they had only been compiled, and a future release changing how a route is classified would
+ * weaken this check without touching it.
+ */
+const PRERENDERED = join(target, ".next", "server", "app", "index.html");
+
+if (verifying) {
+  if (!existsSync(PRERENDERED)) {
+    console.error(
+      `${PRERENDERED} does not exist, so the route was compiled but never rendered at build time. ` +
+        `A server-safe entry point is only proven by a render that actually ran.`
+    );
+    process.exit(1);
+  }
+  const html = readFileSync(PRERENDERED, "utf8");
+
+  // Matched on ATTRIBUTES rather than on the visible text. React separates adjacent expressions in
+  // a text node with `<!-- -->` comments, so the rendered prose reads `./utils<!-- -->: <!-- -->1`
+  // and a literal search for what the page appears to say finds nothing.
+  const missing = [];
+  const empty = [];
+  for (const entry of serverSafe) {
+    const match = html.match(
+      new RegExp(
+        `data-subpath="${entry.subpath.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}" data-exports="(\\d+)"`
+      )
+    );
+    if (match === null) missing.push(entry.subpath);
+    // A namespace with no bindings means the import resolved to something empty, which renders the
+    // same as a real module and would otherwise read as a pass.
+    else if (Number(match[1]) === 0) empty.push(entry.subpath);
+  }
+
+  if (missing.length > 0 || empty.length > 0) {
+    if (missing.length > 0) {
+      console.error(
+        `The prerendered page does not report ${missing.join(", ")}, so ${missing.length === 1 ? "that subpath was" : "those subpaths were"} ` +
+          `not imported by the Server Component that was built.`
+      );
+    }
+    if (empty.length > 0) {
+      console.error(
+        `${empty.join(", ")} rendered with no exports, so the import resolved to an empty module.`
+      );
+    }
+    process.exit(1);
+  }
+
+  console.log(
+    `Prerendered at build time, reporting all ${serverSafe.length} server-safe subpaths ` +
+      `(${serverSafe.map(entry => entry.subpath).join(", ")}).`
+  );
+  process.exit(0);
 }
 
 /** The bare specifier a consumer writes for a subpath: `./color` is imported as `<pkg>/color`. */
@@ -86,7 +152,13 @@ export default function Page() {
   return (
     <main>
       {imported.map(entry => (
-        <p key={entry.subpath}>
+        // The attributes are what the verifier reads. Rendered text is separated by React comment
+        // markers between adjacent expressions, so an attribute is the stable form.
+        <p
+          key={entry.subpath}
+          data-subpath={entry.subpath}
+          data-exports={entry.exports}
+        >
           {entry.subpath}: {entry.exports} exports
         </p>
       ))}

--- a/packages/ui/src/__tests__/rsc-matrix-matches-engines.test.ts
+++ b/packages/ui/src/__tests__/rsc-matrix-matches-engines.test.ts
@@ -46,16 +46,20 @@ describe("deriving the Node legs from a supported range", () => {
   it("tests every released major above an open clause, not just its endpoints", () => {
     // `>=24.0.0` promises 24, 25 and 26 alike. The floor plus the newest release leaves 25
     // unexercised, and a regression confined to it reaches consumers with every leg green.
+    //
+    // Each is named by its own FLOOR. A bare `25` is a selector `setup-node` resolves to the
+    // newest 25.x, which is not the version the range promises — the same mistake the closed
+    // clauses avoid, and the gap is where an API added after 25.0.0 lives.
     expect(matrixFor(">=24.0.0", [22, 24, 25, 26])).toEqual([
       "24.0.0",
-      "25",
-      "26",
+      "25.0.0",
+      "26.0.0",
     ]);
   });
 
   it("picks up a new major without an edit here", () => {
     // The property that makes this worth deriving at all.
-    expect(matrixFor(">=24.0.0", [24, 25, 26, 27])).toContain("27");
+    expect(matrixFor(">=24.0.0", [24, 25, 26, 27])).toContain("27.0.0");
   });
 
   it("names no major that has not been released", () => {
@@ -73,6 +77,18 @@ describe("deriving the Node legs from a supported range", () => {
 
   it("selects the lowest floor for a pull request", () => {
     expect(lowestFloor("^20.19.0 || ^22.12.0 || >=24.0.0")).toBe("20.19.0");
+  });
+
+  it("selects the lowest floor however the clauses are ordered", () => {
+    // A semver union has no required order, so this states the same contract as the ascending
+    // spelling above. Reading the first clause would run Node 24 on every pull request while the
+    // real floor went unexercised — and every synchronisation check here would still be green,
+    // because they compare the matrix to the range rather than to what the range MEANS.
+    expect(lowestFloor(">=24.0.0 || ^20.19.0")).toBe("20.19.0");
+    expect(lowestFloor("^22.12.0 || ^20.19.0")).toBe("20.19.0");
+    // Ordering is numeric, not lexicographic: "9.0.0" must not beat "10.0.0" by string compare.
+    expect(lowestFloor("^10.0.0 || ^9.0.0")).toBe("9.0.0");
+    expect(lowestFloor("^20.9.0 || ^20.19.0")).toBe("20.9.0");
   });
 
   it("reads this repository's own range without throwing", () => {

--- a/packages/ui/src/__tests__/rsc-matrix-matches-engines.test.ts
+++ b/packages/ui/src/__tests__/rsc-matrix-matches-engines.test.ts
@@ -1,0 +1,116 @@
+/**
+ * The Node versions the RSC smoke job runs against, checked against the range the repo supports.
+ *
+ * The job's matrix is a list of exact versions and the `engines.node` range is a semver expression,
+ * so the two cannot be one value — but they answer one question, and a copy drifts. Widening the
+ * range without touching the workflow leaves a newly supported floor untested while every leg stays
+ * green, which is the shape a version matrix is least likely to be suspected of.
+ *
+ * Checked here rather than derived inside the workflow. A setup job computing the matrix would
+ * remove the copy entirely, at the cost of an extra job on every run and a second place for the
+ * parsing to live; this suite already runs on every pull request, including the ones that change the
+ * root manifest, so the drift is caught at the same moment for less.
+ */
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+const repoRoot = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "..",
+  "..",
+  ".."
+);
+
+const engines: string = JSON.parse(
+  readFileSync(path.join(repoRoot, "package.json"), "utf8")
+).engines.node;
+
+const workflow = readFileSync(
+  path.join(repoRoot, ".github", "workflows", "package-smoke.yml"),
+  "utf8"
+);
+
+/**
+ * The exact versions a semver range's clauses START at, plus whether any clause is open-ended.
+ *
+ * Only the two forms the range actually uses are recognised, and anything else THROWS rather than
+ * being skipped. A parser that ignores what it cannot read would return a shorter list, and a
+ * shorter list compares unequal and fails — but it would fail naming the wrong cause, sending the
+ * next reader to the workflow when the range is what changed shape.
+ */
+function floorsOf(range: string): { floors: string[]; openEnded: boolean } {
+  const floors: string[] = [];
+  let openEnded = false;
+  for (const clause of range.split("||").map(part => part.trim())) {
+    const caret = /^\^(\d+\.\d+\.\d+)$/.exec(clause);
+    const atLeast = /^>=(\d+\.\d+\.\d+)$/.exec(clause);
+    if (caret !== null) {
+      floors.push(caret[1]);
+    } else if (atLeast !== null) {
+      floors.push(atLeast[1]);
+      openEnded = true;
+    } else {
+      throw new Error(
+        `engines.node clause ${JSON.stringify(clause)} is neither a caret nor a >= range, so the ` +
+          `versions it admits could not be derived. Teach this parser the new form.`
+      );
+    }
+  }
+  return { floors, openEnded };
+}
+
+/** The two version lists the matrix expression chooses between, pull-request first. */
+function matrixLists(): { onPullRequest: string[]; nightly: string[] } {
+  const line = workflow
+    .split("\n")
+    .find(text => text.includes("fromJSON(github.event_name =="));
+  expect(
+    line,
+    "the RSC job's matrix expression was not found, so this test would assert nothing"
+  ).toBeDefined();
+  const arrays = [...(line as string).matchAll(/'(\[[^\]]*\])'/g)].map(match =>
+    JSON.parse(match[1])
+  );
+  expect(
+    arrays.length,
+    `expected two version lists in the matrix expression, found ${arrays.length}`
+  ).toBe(2);
+  return { onPullRequest: arrays[0], nightly: arrays[1] };
+}
+
+describe("the RSC smoke matrix and the engines range", () => {
+  it("runs every floor the supported range declares", () => {
+    const { floors, openEnded } = floorsOf(engines);
+    expect(floors.length, "engines.node named no versions").toBeGreaterThan(0);
+
+    // `latest` stands for the open-ended clause. Every release since that floor is a version the
+    // manifest promises, and there is no highest one to enumerate.
+    const expected = openEnded ? [...floors, "latest"] : floors;
+    expect(matrixLists().nightly).toEqual(expected);
+  });
+
+  it("runs the lowest floor on a pull request", () => {
+    // One leg per PR, and it has to be the LOWEST: everything the newer lines reject it rejects
+    // too, plus the globals they have and it does not.
+    const { floors } = floorsOf(engines);
+    expect(matrixLists().onPullRequest).toEqual([floors[0]]);
+  });
+
+  it("derives the floors from the range rather than restating them", () => {
+    // The control on the parser itself. Without it, a `floorsOf` that returned a hard-coded list
+    // would satisfy both assertions above for as long as the range happened to match.
+    expect(floorsOf("^20.19.0 || ^22.12.0 || >=24.0.0")).toEqual({
+      floors: ["20.19.0", "22.12.0", "24.0.0"],
+      openEnded: true,
+    });
+    expect(floorsOf("^18.0.0 || ^20.1.2")).toEqual({
+      floors: ["18.0.0", "20.1.2"],
+      openEnded: false,
+    });
+    expect(() => floorsOf("20.x")).toThrow(/neither a caret nor a >= range/);
+  });
+});

--- a/packages/ui/src/__tests__/rsc-matrix-matches-engines.test.ts
+++ b/packages/ui/src/__tests__/rsc-matrix-matches-engines.test.ts
@@ -1,21 +1,20 @@
 /**
- * The Node versions the RSC smoke job runs against, checked against the range the repo supports.
+ * The derivation behind the RSC job's Node legs, and the workflow's use of it.
  *
- * The job's matrix is a list of exact versions and the `engines.node` range is a semver expression,
- * so the two cannot be one value — but they answer one question, and a copy drifts. Widening the
- * range without touching the workflow leaves a newly supported floor untested while every leg stays
- * green, which is the shape a version matrix is least likely to be suspected of.
+ * Two separate claims, and only the first is about behaviour. `matrixFor` decides which versions a
+ * supported range asks to be tested; the workflow has to actually CONSUME that rather than carry a
+ * list beside it. A correct derivation nothing reads is the same as no derivation.
  *
- * Checked here rather than derived inside the workflow. A setup job computing the matrix would
- * remove the copy entirely, at the cost of an extra job on every run and a second place for the
- * parsing to live; this suite already runs on every pull request, including the ones that change the
- * root manifest, so the drift is caught at the same moment for less.
+ * The released majors are passed IN here rather than fetched. A unit suite that reaches the network
+ * fails when the network does, and reports it as a defect in this package.
  */
 import { readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { describe, expect, it } from "vitest";
+
+import { lowestFloor, matrixFor } from "../../scripts/node-matrix.mjs";
 
 const repoRoot = path.join(
   path.dirname(fileURLToPath(import.meta.url)),
@@ -34,83 +33,77 @@ const workflow = readFileSync(
   "utf8"
 );
 
-/**
- * The exact versions a semver range's clauses START at, plus whether any clause is open-ended.
- *
- * Only the two forms the range actually uses are recognised, and anything else THROWS rather than
- * being skipped. A parser that ignores what it cannot read would return a shorter list, and a
- * shorter list compares unequal and fails — but it would fail naming the wrong cause, sending the
- * next reader to the workflow when the range is what changed shape.
- */
-function floorsOf(range: string): { floors: string[]; openEnded: boolean } {
-  const floors: string[] = [];
-  let openEnded = false;
-  for (const clause of range.split("||").map(part => part.trim())) {
-    const caret = /^\^(\d+\.\d+\.\d+)$/.exec(clause);
-    const atLeast = /^>=(\d+\.\d+\.\d+)$/.exec(clause);
-    if (caret !== null) {
-      floors.push(caret[1]);
-    } else if (atLeast !== null) {
-      floors.push(atLeast[1]);
-      openEnded = true;
-    } else {
-      throw new Error(
-        `engines.node clause ${JSON.stringify(clause)} is neither a caret nor a >= range, so the ` +
-          `versions it admits could not be derived. Teach this parser the new form.`
-      );
-    }
-  }
-  return { floors, openEnded };
-}
-
-/** The two version lists the matrix expression chooses between, pull-request first. */
-function matrixLists(): { onPullRequest: string[]; nightly: string[] } {
-  const line = workflow
-    .split("\n")
-    .find(text => text.includes("fromJSON(github.event_name =="));
-  expect(
-    line,
-    "the RSC job's matrix expression was not found, so this test would assert nothing"
-  ).toBeDefined();
-  const arrays = [...(line as string).matchAll(/'(\[[^\]]*\])'/g)].map(match =>
-    JSON.parse(match[1])
-  );
-  expect(
-    arrays.length,
-    `expected two version lists in the matrix expression, found ${arrays.length}`
-  ).toBe(2);
-  return { onPullRequest: arrays[0], nightly: arrays[1] };
-}
-
-describe("the RSC smoke matrix and the engines range", () => {
-  it("runs every floor the supported range declares", () => {
-    const { floors, openEnded } = floorsOf(engines);
-    expect(floors.length, "engines.node named no versions").toBeGreaterThan(0);
-
-    // `latest` stands for the open-ended clause. Every release since that floor is a version the
-    // manifest promises, and there is no highest one to enumerate.
-    const expected = openEnded ? [...floors, "latest"] : floors;
-    expect(matrixLists().nightly).toEqual(expected);
+describe("deriving the Node legs from a supported range", () => {
+  it("tests the exact floor of a closed clause", () => {
+    // The floor is where a global Node added later is ABSENT, which is the whole signal. A major
+    // selector would install the newest of that line and never reach it.
+    expect(matrixFor("^20.19.0 || ^22.12.0", [20, 22])).toEqual([
+      "20.19.0",
+      "22.12.0",
+    ]);
   });
 
-  it("runs the lowest floor on a pull request", () => {
-    // One leg per PR, and it has to be the LOWEST: everything the newer lines reject it rejects
-    // too, plus the globals they have and it does not.
-    const { floors } = floorsOf(engines);
-    expect(matrixLists().onPullRequest).toEqual([floors[0]]);
+  it("tests every released major above an open clause, not just its endpoints", () => {
+    // `>=24.0.0` promises 24, 25 and 26 alike. The floor plus the newest release leaves 25
+    // unexercised, and a regression confined to it reaches consumers with every leg green.
+    expect(matrixFor(">=24.0.0", [22, 24, 25, 26])).toEqual([
+      "24.0.0",
+      "25",
+      "26",
+    ]);
   });
 
-  it("derives the floors from the range rather than restating them", () => {
-    // The control on the parser itself. Without it, a `floorsOf` that returned a hard-coded list
-    // would satisfy both assertions above for as long as the range happened to match.
-    expect(floorsOf("^20.19.0 || ^22.12.0 || >=24.0.0")).toEqual({
-      floors: ["20.19.0", "22.12.0", "24.0.0"],
-      openEnded: true,
-    });
-    expect(floorsOf("^18.0.0 || ^20.1.2")).toEqual({
-      floors: ["18.0.0", "20.1.2"],
-      openEnded: false,
-    });
-    expect(() => floorsOf("20.x")).toThrow(/neither a caret nor a >= range/);
+  it("picks up a new major without an edit here", () => {
+    // The property that makes this worth deriving at all.
+    expect(matrixFor(">=24.0.0", [24, 25, 26, 27])).toContain("27");
+  });
+
+  it("names no major that has not been released", () => {
+    // The mirror: a range admits versions that do not exist, and asking CI to install one fails the
+    // job for a reason that is not about this package.
+    expect(matrixFor(">=24.0.0", [24])).toEqual(["24.0.0"]);
+  });
+
+  it("refuses a clause it cannot read rather than returning a shorter list", () => {
+    // Skipping is the quieter failure: the job keeps passing on the clauses that were understood.
+    expect(() => matrixFor("20.x", [20])).toThrow(
+      /neither a caret nor a >= range/
+    );
+  });
+
+  it("selects the lowest floor for a pull request", () => {
+    expect(lowestFloor("^20.19.0 || ^22.12.0 || >=24.0.0")).toBe("20.19.0");
+  });
+
+  it("reads this repository's own range without throwing", () => {
+    // The control that keeps the cases above from being a private grammar: the range this repo
+    // actually declares has to be one the parser accepts.
+    expect(matrixFor(engines, [20, 22, 24]).length).toBeGreaterThan(0);
+  });
+});
+
+describe("the workflow's use of that derivation", () => {
+  it("takes its matrix from the derivation job, not from a list", () => {
+    const line = workflow
+      .split("\n")
+      .find(text => text.trimStart().startsWith("node: ${{"));
+    expect(
+      line,
+      "the RSC job's matrix expression was not found, so this test would assert nothing"
+    ).toBeDefined();
+    // A literal array here is the drift this whole module exists to remove, so it is named as the
+    // failure rather than left to a mismatch further down.
+    expect(
+      line,
+      "the matrix names versions inline; it must read them from the node-matrix job"
+    ).not.toMatch(/\[\s*"\d/);
+    expect(line).toContain("needs.node-matrix.outputs.versions");
+    expect(line).toContain("needs.node-matrix.outputs.lowest");
+  });
+
+  it("declares the dependency that makes those outputs available", () => {
+    // `needs` is what populates `needs.node-matrix.outputs`; without it the expression resolves to
+    // empty and the matrix silently produces no legs at all.
+    expect(workflow).toMatch(/\n {4}needs: node-matrix\n/);
   });
 });

--- a/packages/ui/turbo.json
+++ b/packages/ui/turbo.json
@@ -1,22 +1,65 @@
 {
-  "$schema": "https://turborepo.com/schema.json",
+  "$schema": "https://turbo.build/schema.json",
   "extends": ["//"],
   "tasks": {
-    // Only this package's suite reads files OUTSIDE its own directory: it checks the RSC job's
-    // Node legs against the root `engines.node`, so a change to either the workflow or the root
-    // manifest must move this task's hash — otherwise CI replays the previous pass in exactly the
-    // commit that changed the wiring the suite exists to compare.
-    //
-    // Declared HERE rather than on the root `test` task. There, the two entries become inputs to
-    // every package's tests, so a workflow edit invalidates the whole monorepo's unit-test cache
-    // and reruns suites that cannot read either file.
-    //
-    // `$TURBO_DEFAULT$` keeps the package's own files as inputs, since a task definition in a
-    // package configuration REPLACES the root's `inputs` rather than adding to it. Restating the
-    // root's curated globs here would be a second copy of that list, and the copy is what drifts.
     "test": {
+      // The release-tag guard reads this package's OWN `dist/index.d.ts`: the
+      // tags it checks are written by the declaration bundler, so there is
+      // nothing to assert against until the package is built, and the root task
+      // depends on `^build`, which builds dependencies and not this package.
+      //
+      // This makes turbo do that one build, in order, and cache it. The runs
+      // turbo never sees — `pnpm --filter @nextlyhq/ui test`, and the watch,
+      // UI and coverage entry points, none of which read this file — are
+      // covered instead by `ensureDeclarations()` in the surface suite's
+      // `beforeAll`, which rebuilds the declarations itself. It rebuilds every
+      // time rather than testing for staleness, so the two do build twice on
+      // a cache miss; that is the deliberate trade, because deciding whether
+      // `dist` was current meant re-implementing turbo's input tracking and
+      // every error in it passed stale declarations.
+      "dependsOn": ["$TURBO_EXTENDS$", "build"],
+      // The contrast alpha-utilities guard scans admin and plugin source, so
+      // those trees are real inputs to this package's tests. $TURBO_EXTENDS$
+      // inherits the root test inputs (so they stay in sync and nothing is
+      // dropped) and appends the scanned call-site trees, so a faint alpha
+      // utility added in a call-site package invalidates the cached pass
+      // instead of hiding behind it. The root task supplies dependsOn / cache.
       "inputs": [
-        "$TURBO_DEFAULT$",
+        "$TURBO_EXTENDS$",
+        "vitest.config.ts",
+        "$TURBO_ROOT$/packages/admin/src/**",
+        "$TURBO_ROOT$/packages/plugin-form-builder/src/**",
+        "$TURBO_ROOT$/packages/plugin-page-builder/src/**",
+        // The RSC-matrix suite reads the root manifest and the package-smoke
+        // workflow, comparing the job's Node legs against `engines.node`. Listed
+        // here rather than on the root task: there they become inputs to every
+        // package's tests, so a workflow edit invalidates the whole monorepo's
+        // unit-test cache and reruns suites that cannot read either file.
+        "$TURBO_ROOT$/package.json",
+        "$TURBO_ROOT$/.github/workflows/package-smoke.yml"
+      ]
+    },
+    "test:coverage": {
+      // The same ordering as `test`, for the same reason. Inheriting only
+      // `^build` from the root left this task with no edge to this package's
+      // own `build`, so turbo was free to schedule them together: the surface
+      // suite's `beforeAll` runs `tsup` while `build:js` is removing `dist`
+      // underneath it, and a coverage task starting mid-build reads
+      // half-written artifacts. Coverage asserts on the same declarations
+      // `test` does, so it needs the same guarantee that they exist and are
+      // not being rewritten.
+      "dependsOn": ["$TURBO_EXTENDS$", "build"],
+      "inputs": [
+        "$TURBO_EXTENDS$",
+        "vitest.config.ts",
+        "$TURBO_ROOT$/packages/admin/src/**",
+        "$TURBO_ROOT$/packages/plugin-form-builder/src/**",
+        "$TURBO_ROOT$/packages/plugin-page-builder/src/**",
+        // The RSC-matrix suite reads the root manifest and the package-smoke
+        // workflow, comparing the job's Node legs against `engines.node`. Listed
+        // here rather than on the root task: there they become inputs to every
+        // package's tests, so a workflow edit invalidates the whole monorepo's
+        // unit-test cache and reruns suites that cannot read either file.
         "$TURBO_ROOT$/package.json",
         "$TURBO_ROOT$/.github/workflows/package-smoke.yml"
       ]

--- a/packages/ui/turbo.json
+++ b/packages/ui/turbo.json
@@ -1,53 +1,24 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "extends": ["//"],
   "tasks": {
+    // Only this package's suite reads files OUTSIDE its own directory: it checks the RSC job's
+    // Node legs against the root `engines.node`, so a change to either the workflow or the root
+    // manifest must move this task's hash — otherwise CI replays the previous pass in exactly the
+    // commit that changed the wiring the suite exists to compare.
+    //
+    // Declared HERE rather than on the root `test` task. There, the two entries become inputs to
+    // every package's tests, so a workflow edit invalidates the whole monorepo's unit-test cache
+    // and reruns suites that cannot read either file.
+    //
+    // `$TURBO_DEFAULT$` keeps the package's own files as inputs, since a task definition in a
+    // package configuration REPLACES the root's `inputs` rather than adding to it. Restating the
+    // root's curated globs here would be a second copy of that list, and the copy is what drifts.
     "test": {
-      // The release-tag guard reads this package's OWN `dist/index.d.ts`: the
-      // tags it checks are written by the declaration bundler, so there is
-      // nothing to assert against until the package is built, and the root task
-      // depends on `^build`, which builds dependencies and not this package.
-      //
-      // This makes turbo do that one build, in order, and cache it. The runs
-      // turbo never sees — `pnpm --filter @nextlyhq/ui test`, and the watch,
-      // UI and coverage entry points, none of which read this file — are
-      // covered instead by `ensureDeclarations()` in the surface suite's
-      // `beforeAll`, which rebuilds the declarations itself. It rebuilds every
-      // time rather than testing for staleness, so the two do build twice on
-      // a cache miss; that is the deliberate trade, because deciding whether
-      // `dist` was current meant re-implementing turbo's input tracking and
-      // every error in it passed stale declarations.
-      "dependsOn": ["$TURBO_EXTENDS$", "build"],
-      // The contrast alpha-utilities guard scans admin and plugin source, so
-      // those trees are real inputs to this package's tests. $TURBO_EXTENDS$
-      // inherits the root test inputs (so they stay in sync and nothing is
-      // dropped) and appends the scanned call-site trees, so a faint alpha
-      // utility added in a call-site package invalidates the cached pass
-      // instead of hiding behind it. The root task supplies dependsOn / cache.
       "inputs": [
-        "$TURBO_EXTENDS$",
-        "vitest.config.ts",
-        "$TURBO_ROOT$/packages/admin/src/**",
-        "$TURBO_ROOT$/packages/plugin-form-builder/src/**",
-        "$TURBO_ROOT$/packages/plugin-page-builder/src/**"
-      ]
-    },
-    "test:coverage": {
-      // The same ordering as `test`, for the same reason. Inheriting only
-      // `^build` from the root left this task with no edge to this package's
-      // own `build`, so turbo was free to schedule them together: the surface
-      // suite's `beforeAll` runs `tsup` while `build:js` is removing `dist`
-      // underneath it, and a coverage task starting mid-build reads
-      // half-written artifacts. Coverage asserts on the same declarations
-      // `test` does, so it needs the same guarantee that they exist and are
-      // not being rewritten.
-      "dependsOn": ["$TURBO_EXTENDS$", "build"],
-      "inputs": [
-        "$TURBO_EXTENDS$",
-        "vitest.config.ts",
-        "$TURBO_ROOT$/packages/admin/src/**",
-        "$TURBO_ROOT$/packages/plugin-form-builder/src/**",
-        "$TURBO_ROOT$/packages/plugin-page-builder/src/**"
+        "$TURBO_DEFAULT$",
+        "$TURBO_ROOT$/package.json",
+        "$TURBO_ROOT$/.github/workflows/package-smoke.yml"
       ]
     }
   }

--- a/turbo.jsonc
+++ b/turbo.jsonc
@@ -324,14 +324,7 @@
         // client/server classification leaves the cache key untouched, so CI replays the previous
         // pass precisely when the source of truth those guards read has changed.
         "scripts/**",
-        "tsup*.config.ts",
-        // Files OUTSIDE the package that tests read. The ui suite checks the RSC job's Node legs
-        // against the root `engines.node`, so a change to either the workflow or the root manifest
-        // must move the hash — otherwise CI replays the previous pass in exactly the commit that
-        // changed the wiring the suite exists to compare. `$TURBO_ROOT$` rather than `../`, which
-        // turbo does not resolve for inputs.
-        "$TURBO_ROOT$/package.json",
-        "$TURBO_ROOT$/.github/workflows/package-smoke.yml"
+        "tsup*.config.ts"
       ],
       "outputs": ["coverage/**"], // Coverage reports
       "cache": true // Cache test results (only re-run if inputs change)

--- a/turbo.jsonc
+++ b/turbo.jsonc
@@ -324,7 +324,14 @@
         // client/server classification leaves the cache key untouched, so CI replays the previous
         // pass precisely when the source of truth those guards read has changed.
         "scripts/**",
-        "tsup*.config.ts"
+        "tsup*.config.ts",
+        // Files OUTSIDE the package that tests read. The ui suite checks the RSC job's Node legs
+        // against the root `engines.node`, so a change to either the workflow or the root manifest
+        // must move the hash — otherwise CI replays the previous pass in exactly the commit that
+        // changed the wiring the suite exists to compare. `$TURBO_ROOT$` rather than `../`, which
+        // turbo does not resolve for inputs.
+        "$TURBO_ROOT$/package.json",
+        "$TURBO_ROOT$/.github/workflows/package-smoke.yml"
       ],
       "outputs": ["coverage/**"], // Coverage reports
       "cache": true // Cache test results (only re-run if inputs change)


### PR DESCRIPTION
Closes the "prove it with a real build" half of the server-safe story. Pairs with #673, which cuts
the simulated half of the artifact gate; this is what replaces it.

## Why

`packages/ui` publishes four subpaths declared server-safe (`./utils`, `./color`,
`./tailwind-preset`, `./breakpoints`). Three checks defend that claim today, and **all three are
models of what Next.js does**: one looks for a `"use client"` banner, one walks the sources, one
reads the built artifacts against an allow-list. Nothing in CI ever asked the compiler and runtime a
consumer actually uses.

A model answers for what it was taught. The artifact gate spent 29 review rounds learning ways a
simulated environment differs from a real one, and 49 of its ~70 findings were exactly that. This
asks the real toolchain instead.

## What it does

A nightly job packs `@nextlyhq/ui`, installs it into a throwaway app beside Next.js and React, and
builds a Server Component importing every server-safe subpath. **The assertion is the build
succeeding.** An App Router page is prerendered during the build, so every imported module is
evaluated in a real server render — a module body reading `document` fails naming the file, with
nothing having to recognise the spelling of that read.

Two design points:

- **Installed as a packed tarball, not linked from the workspace**, so the app resolves through the
  published export map — the thing being claimed — rather than through pnpm's links.
- **The imports are generated from the export map**, not written down. That already paid: deriving
  the list found `./breakpoints`, a fourth server-safe subpath. A list written when there were three
  would have kept passing on the three someone remembered.

## Coverage, measured rather than assumed

I spliced each break into the packed `dist/utils.mjs` a consumer resolves and ran a real build.
**This is not a strict superset of the evaluation it replaces**, and it would be easy to claim
otherwise:

| module-scope break | the evaluator #673 deletes | this |
|---|---|---|
| `document.title` | caught | **caught** — `ReferenceError`, exit 1 |
| `navigator.userAgent` | caught, by emulating the floor | **passes on 22/24** — Node has it since v21 |
| `globalThis.location = {...}` | not caught | not caught |
| `process.exit(0)` | caught, by intercepting the call | **hangs** — no verdict, killed at >150s |

Both gaps are handled rather than noted:

- **Row 2 is why the matrix is `[20, 22, 24]`** and not the `[22, 24]` its neighbouring job uses.
  The floor leg is the whole point: a module reading a post-floor global builds cleanly on a modern
  runner and throws for a consumer on 20.19. Next 16 requires Node >=20.9 and our floor is 20.19, so
  the leg is viable.
- **Row 4 is a real regression in signal quality**, stated plainly. The old check named the artifact
  and the call; a build that never returns a verdict is turned into a red job by
  `timeout-minutes: 20` and nothing better. Catching it precisely was what the entire simulation
  cost, so this is an accepted trade rather than a wash.

## Verification

Run end to end locally on Node 22 against Next.js 16.3.0 / React 19.2.8:

- clean generate → install → `next build` → **exit 0**, page reported as `○ (Static) prerendered`,
  which is what proves the modules were evaluated rather than merely resolved
- `document.title` spliced into the packed artifact → **exit 1**, `ReferenceError: document is not
  defined`; restored → exit 0
- the workflow YAML parses, and `report-failure` gains the new job in `needs` so a red leg still
  files an issue

## Runs per PR, not only nightly

Originally filed as nightly. It is now **both**: nightly on the full matrix, and per pull request
filtered to `packages/ui/**` plus this workflow. A property with exactly one control should not wait
until night to be checked, and after #673 this is that one control.

- The **floor leg alone** runs on a PR. Everything the newer lines reject, Node 20 rejects too, plus
  the post-floor globals they accept, so one leg buys nearly all the signal at a third of the
  minutes. Nightly still runs all three.
- The other two jobs are **skipped on PRs** — they install every tarball in the repo and build a
  whole scaffolded app, and neither question is about the package under review.
- Opening a workflow to `pull_request` meant two hardening changes: the `issues: write` permission
  moves from the top of the file onto the single job that files an issue, so a fork-triggered run
  carries a read-only token; and the issue reporter is gated to non-PR events, since a red PR is
  already red in front of whoever caused it.

**This PR touches the workflow, which is in its own path filter, so the new job runs on this pull
request.** The change is exercised by the change.

## Why deriving the list is safe in both directions

Deriving covers a subpath being ADDED. It does not, on its own, cover one being RECLASSIFIED as
client code — a shrinking derived list agrees with itself and passes over less than it did
yesterday, which is the failure a derived check is worst at seeing.

That direction is already covered, in `src/ui-surface.test.ts`: it compares the same derived
server-safe set against the subpaths **STABILITY.md names in prose**, in both directions, with a
vacuity guard. So the enumerated side lives where a deletion is loud, and the derived side lives
here where an addition is free.

Verified rather than assumed — flipping `./color` to `client: true` fails the ledger test naming the
missing subpath. The generator's header points at that file so the pairing is not re-litigated.

No changeset: CI and build-tooling only, no published code changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automated compatibility checks across supported Node.js versions.
  - Added a Server Component build validation that verifies package exports, rendered output, and CommonJS compatibility.
  - Pull requests now receive targeted smoke-test coverage for relevant UI and package changes.

- **Bug Fixes**
  - Improved failure reporting for build and compatibility-check errors.
  - Prevented scheduled and manually triggered checks from canceling one another.

- **Tests**
  - Added coverage for Node.js version selection and workflow integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->