### PR TITLE
fix(blocks-react): withhold a stylesheet a migration made stale

### DIFF
--- a/.changeset/migration-reports-rewritten-nodes.md
+++ b/.changeset/migration-reports-rewritten-nodes.md
@@ -1,0 +1,30 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+---
+
+A stylesheet stored for a page is no longer reused when a block migration has
+since turned one of its nodes into one that renders nothing. The rules compiled
+for that node, and any image the rules fetched, were still being served for
+markup no visitor receives.

--- a/packages/blocks-engine/src/index.ts
+++ b/packages/blocks-engine/src/index.ts
@@ -265,6 +265,7 @@ export {
 export { migrateDocument, migrateProps, findMigrationGaps } from "./migration";
 export type {
   BlockMigrationInfo,
+  MigratedNode,
   MigrateFn,
   MigrateResult,
   MigrationFailure,

--- a/packages/blocks-engine/src/index.ts
+++ b/packages/blocks-engine/src/index.ts
@@ -262,7 +262,12 @@ export {
   styleGroupKeys,
 } from "./style/supports-map";
 
-export { migrateDocument, migrateProps, findMigrationGaps } from "./migration";
+export {
+  migrateDocument,
+  migrateProps,
+  findMigrationGaps,
+  nodeAtPointer,
+} from "./migration";
 export type {
   BlockMigrationInfo,
   MigratedNode,

--- a/packages/blocks-engine/src/migration.test.ts
+++ b/packages/blocks-engine/src/migration.test.ts
@@ -2,7 +2,12 @@ import { describe, expect, it } from "vitest";
 
 import type { BlockDocument } from "./document";
 import type { MigrationSource } from "./migration";
-import { findMigrationGaps, migrateDocument, migrateProps } from "./migration";
+import {
+  findMigrationGaps,
+  migrateDocument,
+  migrateProps,
+  nodeAtPointer,
+} from "./migration";
 
 /** A migration source from a plain record of type → info. */
 function source(
@@ -486,5 +491,72 @@ describe("migrateDocument's report of what it rewrote", () => {
 
     expect(rewritten).toEqual([]);
     expect(propsReplaced(doc, out)).toEqual([]);
+  });
+});
+
+describe("resolving a reported pointer", () => {
+  const src = source({
+    "core/heading": {
+      version: 2,
+      migrate: { 1: (p: Record<string, unknown>) => ({ ...p, level: 2 }) },
+    },
+    "core/box": { version: 1 },
+  });
+
+  it("addresses a node in a slot whose NAME needs escaping", () => {
+    // The separating case. A slot called `hero/main` produces a pointer with the
+    // slash escaped, so a consumer that rebuilds paths by joining raw names
+    // looks up a pointer the producer never wrote — and misses the node
+    // silently, which is indistinguishable from the node not having changed.
+    const doc: BlockDocument = {
+      formatVersion: 1,
+      kind: "page",
+      nodes: [
+        {
+          id: "outer",
+          type: "core/box",
+          version: 1,
+          props: {},
+          slots: {
+            "hero/main": [
+              { id: "deep", type: "core/heading", version: 1, props: {} },
+            ],
+          },
+        },
+      ],
+    } as unknown as BlockDocument;
+
+    const { doc: out, rewritten } = migrateDocument(doc, src);
+
+    expect(rewritten).toHaveLength(1);
+    expect(rewritten[0]?.path).toBe("/nodes/0/slots/hero~1main/0");
+    // Resolves in BOTH documents, which is what lets a caller recover the props
+    // a node was stored with after migration has replaced them.
+    expect(nodeAtPointer(out, rewritten[0]!.path)).toMatchObject({
+      id: "deep",
+      version: 2,
+    });
+    expect(nodeAtPointer(doc, rewritten[0]!.path)).toMatchObject({
+      id: "deep",
+      version: 1,
+    });
+    // The naive join, for contrast: it addresses nothing.
+    expect(nodeAtPointer(out, "/nodes/0/slots/hero/main/0")).toBeUndefined();
+  });
+
+  it("answers undefined rather than a neighbour for a bad index", () => {
+    const doc: BlockDocument = {
+      formatVersion: 1,
+      kind: "page",
+      nodes: [{ id: "a", type: "core/box", version: 1, props: {} }],
+    };
+    expect(nodeAtPointer(doc, "/nodes/0")).toMatchObject({ id: "a" });
+    // `01` and `1.0` both coerce to a valid index numerically; RFC 6901 says a
+    // non-canonical index addresses nothing, and silently returning element 0
+    // would hand a caller the wrong node's props.
+    expect(nodeAtPointer(doc, "/nodes/01")).toBeUndefined();
+    expect(nodeAtPointer(doc, "/nodes/1.0")).toBeUndefined();
+    expect(nodeAtPointer(doc, "/nodes/-1")).toBeUndefined();
+    expect(nodeAtPointer(doc, "")).toBeUndefined();
   });
 });

--- a/packages/blocks-engine/src/migration.test.ts
+++ b/packages/blocks-engine/src/migration.test.ts
@@ -259,3 +259,232 @@ describe("migrateDocument", () => {
     expect(out.nodes[0]).toMatchObject({ version: 9, props: { x: 1 } });
   });
 });
+
+/**
+ * The report of rewritten nodes, guarded at the PRODUCER.
+ *
+ * A reader uses `rewritten` to decide which nodes still need examining, so the
+ * load-bearing property is COMPLETENESS, not brevity: a node missing from the
+ * report is silently exempted from whatever the reader was checking, with no
+ * error and no slow path to notice. Guarding a consumer cannot see that — a
+ * report naming three of four nodes still gets its three read correctly — so
+ * these assert the report against an independent walk of the two documents.
+ */
+describe("migrateDocument's report of what it rewrote", () => {
+  const src = source({
+    "core/heading": {
+      version: 3,
+      migrate: {
+        1: (p: Record<string, unknown>) => ({ ...p, level: p.level ?? 2 }),
+        2: (p: Record<string, unknown>) => ({ ...p, align: "start" }),
+      },
+    },
+    "core/box": { version: 1 },
+    "core/broken": {
+      version: 2,
+      migrate: {
+        1: () => {
+          throw new Error("nope");
+        },
+      },
+    },
+    "core/half-broken": {
+      version: 3,
+      migrate: {
+        1: (p: Record<string, unknown>) => ({ ...p, one: true }),
+        2: () => {
+          throw new Error("nope");
+        },
+      },
+    },
+  });
+
+  /**
+   * Every node whose OWN props object was replaced, found by comparing the two
+   * documents rather than by asking the report.
+   *
+   * Derived independently on purpose: a check that reconstructed the report the
+   * way the producer builds it would agree with a broken producer. Props
+   * identity is the separating signal — a parent rebuilt because a child moved
+   * keeps the very same props object.
+   */
+  function propsReplaced(
+    before: BlockDocument,
+    after: BlockDocument
+  ): string[] {
+    const found: string[] = [];
+    const walk = (a: unknown, b: unknown, path: string): void => {
+      if (
+        typeof a !== "object" ||
+        a === null ||
+        typeof b !== "object" ||
+        b === null
+      ) {
+        return;
+      }
+      const nodeA = a as Record<string, unknown>;
+      const nodeB = b as Record<string, unknown>;
+      if (nodeA.props !== nodeB.props) found.push(path);
+      const slotsA = nodeA.slots;
+      const slotsB = nodeB.slots;
+      if (
+        typeof slotsA === "object" &&
+        slotsA !== null &&
+        typeof slotsB === "object" &&
+        slotsB !== null
+      ) {
+        for (const slot of Object.keys(slotsB as Record<string, unknown>)) {
+          const childrenA = (slotsA as Record<string, unknown>)[slot];
+          const childrenB = (slotsB as Record<string, unknown>)[slot];
+          if (!Array.isArray(childrenA) || !Array.isArray(childrenB)) continue;
+          childrenB.forEach((child, index) => {
+            walk(childrenA[index], child, `${path}/slots/${slot}/${index}`);
+          });
+        }
+      }
+    };
+    const nodesA = before.nodes;
+    const nodesB = after.nodes;
+    if (Array.isArray(nodesA) && Array.isArray(nodesB)) {
+      nodesB.forEach((node, index) => {
+        walk(nodesA[index], node, `/nodes/${index}`);
+      });
+    }
+    return found;
+  }
+
+  it("names a rewritten node NESTED IN A SLOT, which a top-level walk misses", () => {
+    const doc: BlockDocument = {
+      formatVersion: 1,
+      kind: "page",
+      nodes: [
+        {
+          id: "outer",
+          type: "core/box",
+          version: 1,
+          props: {},
+          slots: {
+            children: [
+              { id: "inner", type: "core/heading", version: 1, props: {} },
+            ],
+          },
+        },
+      ],
+    } as unknown as BlockDocument;
+
+    const { doc: out, rewritten } = migrateDocument(doc, src);
+
+    // The separating case. The outer box is at its current version and is
+    // rebuilt ONLY because its child changed, so a report keyed on reference
+    // inequality would name it and a report that never descended would name
+    // nothing at all. Exactly one node was actually rewritten.
+    expect(rewritten).toEqual([
+      {
+        path: "/nodes/0/slots/children/0",
+        id: "inner",
+        type: "core/heading",
+        fromVersion: 1,
+        toVersion: 3,
+      },
+    ]);
+    expect(propsReplaced(doc, out)).toEqual(["/nodes/0/slots/children/0"]);
+  });
+
+  it("names every node whose props were replaced, and no others", () => {
+    const doc: BlockDocument = {
+      formatVersion: 1,
+      kind: "page",
+      nodes: [
+        { id: "current", type: "core/box", version: 1, props: { a: 1 } },
+        { id: "old", type: "core/heading", version: 1, props: {} },
+        {
+          id: "parent",
+          type: "core/box",
+          version: 1,
+          props: {},
+          slots: {
+            children: [
+              { id: "deep", type: "core/heading", version: 2, props: {} },
+              { id: "steady", type: "core/box", version: 1, props: {} },
+            ],
+          },
+        },
+      ],
+    } as unknown as BlockDocument;
+
+    const { doc: out, rewritten } = migrateDocument(doc, src);
+
+    // Compared as SETS against the independent walk. Asserting the report is
+    // non-empty, or that each reported node really changed, would both pass on
+    // a report that dropped one — the direction that matters is the walk's
+    // finding being a subset of the report's.
+    expect(rewritten.map(entry => entry.path).sort()).toEqual(
+      propsReplaced(doc, out).sort()
+    );
+    expect(rewritten.map(entry => entry.path).sort()).toEqual([
+      "/nodes/1",
+      "/nodes/2/slots/children/0",
+    ]);
+  });
+
+  it("names a PARTIALLY migrated node, at the version it reached", () => {
+    const doc: BlockDocument = {
+      formatVersion: 1,
+      kind: "page",
+      nodes: [
+        { id: "h", type: "core/half-broken", version: 1, props: { keep: 1 } },
+      ],
+    };
+
+    const { doc: out, rewritten, failures } = migrateDocument(doc, src);
+
+    // Step 1 ran and step 2 threw, so the props are neither the stored ones nor
+    // the current shape. A reader told this node was untouched would carry a
+    // conclusion drawn from props that no longer exist. `toVersion` is the
+    // level actually REACHED, not the definition's.
+    expect(failures).toHaveLength(1);
+    expect(rewritten).toEqual([
+      {
+        path: "/nodes/0",
+        id: "h",
+        type: "core/half-broken",
+        fromVersion: 1,
+        toVersion: 2,
+      },
+    ]);
+    expect(propsReplaced(doc, out)).toEqual(["/nodes/0"]);
+  });
+
+  it("does NOT name a node whose FIRST step threw, leaving props untouched", () => {
+    const doc: BlockDocument = {
+      formatVersion: 1,
+      kind: "page",
+      nodes: [{ id: "b", type: "core/broken", version: 1, props: { keep: 1 } }],
+    };
+
+    const { doc: out, rewritten, failures } = migrateDocument(doc, src);
+
+    // The node IS flagged and DOES fail, but nothing ran, so its props are the
+    // stored object and anything derived from them still holds. Reporting it
+    // would be reporting the failure rather than the rewrite, and the two come
+    // apart exactly here — which is why the report is keyed on the props object
+    // rather than on the version stamp or on `migrationFailed`.
+    expect(failures).toHaveLength(1);
+    expect(out.nodes[0]).toMatchObject({ migrationFailed: true });
+    expect(rewritten).toEqual([]);
+    expect(propsReplaced(doc, out)).toEqual([]);
+  });
+
+  it("is empty when nothing was rewritten", () => {
+    const doc: BlockDocument = {
+      formatVersion: 1,
+      kind: "page",
+      nodes: [{ id: "t", type: "core/box", version: 1, props: {} }],
+    };
+
+    const { doc: out, rewritten } = migrateDocument(doc, src);
+
+    expect(rewritten).toEqual([]);
+    expect(propsReplaced(doc, out)).toEqual([]);
+  });
+});

--- a/packages/blocks-engine/src/migration.ts
+++ b/packages/blocks-engine/src/migration.ts
@@ -55,9 +55,45 @@ export interface MigrationFailure {
   message: string;
 }
 
+/**
+ * One node whose OWN props migration replaced.
+ *
+ * Reported so a reader can ask what the rewrite changed about a node without
+ * re-deriving which nodes were rewritten. The alternative — comparing node
+ * references across the two documents — answers the same question a second
+ * time, and rests on an invariant that holds today and is asserted only for
+ * top-level nodes.
+ *
+ * Scoped to a node's OWN props, deliberately. `migrateNode` also rebuilds a
+ * parent whose child changed, so reference inequality is wider than this: such
+ * a parent carries the props it always had, and anything derived from its props
+ * answers exactly as before. Reporting it would send readers to re-examine
+ * nodes nothing can have changed about.
+ */
+export interface MigratedNode {
+  /** JSON-Pointer to the node, in BOTH the pre- and post-migration document. */
+  path: string;
+  /** The node's `id`, when it carries a usable one. */
+  id?: string;
+  type: string;
+  fromVersion: number;
+  /** The version reached. Below `toVersion` of the definition when a step failed. */
+  toVersion: number;
+}
+
 export interface MigrateResult {
   doc: BlockDocument;
   failures: MigrationFailure[];
+  /**
+   * Every node whose props were rewritten, in document order.
+   *
+   * COMPLETENESS is the load-bearing property, not brevity. A reader uses this
+   * to decide which nodes still need examining, so a node missing from it is
+   * silently exempted from whatever the reader was checking — no error and no
+   * slow path, just a check that did not run. `migration.test.ts` guards the
+   * producer for that reason rather than guarding any one consumer.
+   */
+  rewritten: MigratedNode[];
 }
 
 /** Result of upgrading a single props object. */
@@ -198,6 +234,35 @@ export function migrateDocument(
   source: MigrationSource
 ): MigrateResult {
   const failures: MigrationFailure[] = [];
+  const rewritten: MigratedNode[] = [];
+
+  // Called from every branch that replaces a node's props, rather than derived
+  // afterwards from what changed. A second pass comparing documents would be a
+  // separate implementation of "was this rewritten", free to disagree with the
+  // rewrite that actually happened.
+  const recordRewrite = (
+    node: BlockNode,
+    path: string,
+    fromVersion: number,
+    toVersion: number,
+    props: Record<string, unknown>
+  ): void => {
+    // The props OBJECT is what decides it, not the version stamp. A step that
+    // returns its input unchanged, and a failure at the very first step, both
+    // leave the stored object in place — so anything a reader derived from
+    // those props still holds, and naming the node would send it to re-examine
+    // something nothing can have changed about.
+    if (props === node.props) return;
+    rewritten.push({
+      path,
+      // Omitted rather than coerced when absent or of the wrong type: a reader
+      // matching on it must not be handed an id the document does not carry.
+      ...(typeof node.id === "string" && node.id !== "" ? { id: node.id } : {}),
+      type: node.type,
+      fromVersion,
+      toVersion,
+    });
+  };
 
   const migrateNode = (node: BlockNode, path: string): BlockNode => {
     if (!isPlainRecord(node)) return node;
@@ -235,9 +300,21 @@ export function migrateDocument(
           version: result.failure.fromVersion,
           migrationFailed: true,
         };
+        // Reported when steps ran before the failing one, because the props are
+        // then no longer the stored ones and a reader's conclusions about them
+        // are stale. A failure at the FIRST step ran nothing, so the props are
+        // the stored object and nothing derived from them can have moved.
+        recordRewrite(
+          node,
+          path,
+          node.version,
+          result.failure.fromVersion,
+          result.props
+        );
       } else {
         next = { ...node, props: result.props, version: info.version };
         if (next.migrationFailed) delete next.migrationFailed;
+        recordRewrite(node, path, node.version, info.version, result.props);
       }
     }
 
@@ -266,5 +343,5 @@ export function migrateDocument(
       )
     : doc.nodes;
 
-  return { doc: { ...doc, nodes }, failures };
+  return { doc: { ...doc, nodes }, failures, rewritten };
 }

--- a/packages/blocks-engine/src/migration.ts
+++ b/packages/blocks-engine/src/migration.ts
@@ -214,6 +214,49 @@ function pointer(parent: string, token: string | number): string {
   return `${parent}/${escapePointer(String(token))}`;
 }
 
+function unescapePointer(token: string): string {
+  // `~1` before `~0`, which is the order RFC 6901 requires: reversing it turns a
+  // literal `~1` in a name into `/`.
+  return token.replace(/~1/g, "/").replace(/~0/g, "~");
+}
+
+/**
+ * The node a reported pointer addresses, in whichever document is passed.
+ *
+ * Exported so the side that READS a pointer and the side that writes one share
+ * an implementation. A consumer rebuilding paths to match against reported ones
+ * is a second encoder: it agrees on every ordinary name and diverges on the
+ * ones the escaping exists for, so a slot called `hero/main` silently addresses
+ * nothing and whatever the pointer was reported for goes unexamined.
+ *
+ * Pointers reported by `migrateDocument` address the PRE- and post-migration
+ * documents alike — migration rewrites nodes in place and adds or removes none —
+ * which is what lets a caller recover the state a node was stored in.
+ */
+export function nodeAtPointer(
+  doc: BlockDocument,
+  path: string
+): BlockNode | undefined {
+  if (path === "") return undefined;
+  let current: unknown = doc;
+  for (const raw of path.split("/").slice(1)) {
+    const token = unescapePointer(raw);
+    if (Array.isArray(current)) {
+      const index = Number(token);
+      // A non-canonical index (`01`, `1.0`, `-1`, a name) addresses nothing in
+      // an array rather than coercing to a neighbouring element.
+      if (!Number.isInteger(index) || String(index) !== token) return undefined;
+      current = current[index];
+      continue;
+    }
+    if (typeof current !== "object" || current === null) return undefined;
+    current = (current as Record<string, unknown>)[token];
+  }
+  return typeof current === "object" && current !== null
+    ? (current as BlockNode)
+    : undefined;
+}
+
 /**
  * Upgrade every node in a document to its block's current schema version.
  *

--- a/packages/blocks-react/src/entry-surface.test.ts
+++ b/packages/blocks-react/src/entry-surface.test.ts
@@ -133,6 +133,11 @@ const SOURCE_MODULES: ReadonlyArray<{
       "hasDuplicateNodeIds",
       "isRecordedGatedEntry",
       "isUsableGatedEntry",
+      // The newest member of that family, and the reason it lives here rather
+      // than beside either caller: a migration that turns a drawing node
+      // drawless leaves stale rules published, and a fix reaching only one
+      // entry point recreates the divergence this list exists to prevent.
+      "migrationChangedWhatDraws",
       "readableGatedRules",
     ],
   },

--- a/packages/blocks-react/src/page-renderer.tsx
+++ b/packages/blocks-react/src/page-renderer.tsx
@@ -25,6 +25,7 @@ import {
   gatedEntriesCoverRemovedNodes,
   gatedMapCoversPrunedNodes,
   hasDuplicateNodeIds,
+  migrationChangedWhatDraws,
   readableGatedRules,
   resolvePageStyles,
   styleTextForInjection,
@@ -317,7 +318,14 @@ export function PageRenderer({
     (pruned !== doc && !gatingCoveredByArtifact) ||
     visible !== pruned ||
     (drawlessInput !== visible && !drawlessCoveredByArtifact) ||
-    placeholderDropped !== visible;
+    placeholderDropped !== visible ||
+    // Asked through the SAME function the exported read path uses. A migration
+    // can turn a node that drew into one that draws nothing, and no comparison
+    // above can see it: every pass returns what it was given, because nothing
+    // was removed. Answering it here as well is the point — the two paths
+    // agreeing is what stops a page rendered through this component keeping
+    // rules the exported reader withholds for the same document.
+    migrationChangedWhatDraws(stages, resolver);
 
   // Reconciled through the SAME derivation every entry point that resolves a
   // stored page uses. What a caller supplies is not what a page compiles with:

--- a/packages/blocks-react/src/prepare-document.ts
+++ b/packages/blocks-react/src/prepare-document.ts
@@ -48,6 +48,7 @@ import type {
   BlockDocument,
   BlockNode,
   DocumentLimits,
+  MigratedNode,
   StyleCompileContext,
 } from "@nextlyhq/blocks-engine";
 
@@ -216,6 +217,16 @@ export interface DocumentReadStages {
   sanitized: BlockDocument;
   /** After migration to the current format. */
   migrated: BlockDocument;
+  /**
+   * Every node migration rewrote the props of, as the engine reported them.
+   *
+   * Carried rather than re-derived. The two documents above make it LOOK
+   * recoverable by comparing node references, but that answers the question a
+   * second time from an invariant asserted only for top-level nodes — and a
+   * parent rebuilt because a child moved compares unequal while its own props
+   * never changed.
+   */
+  rewritten: MigratedNode[];
   /** After condition-gated nodes are withheld. */
   gated: BlockDocument;
   /** After addresses are made unique over what will render. */
@@ -253,7 +264,10 @@ export function prepareDocumentReadStages(
 
   const limits = args.limits ?? args.styleContext?.limits ?? DEFAULT_LIMITS;
   const sanitized = sanitizeDocument(document, limits);
-  const { doc } = migrateDocument(sanitized, migrationSourceFor(args.resolver));
+  const { doc, rewritten } = migrateDocument(
+    sanitized,
+    migrationSourceFor(args.resolver)
+  );
   // The predicate matters as much as the pass: a placeholder replaces its whole
   // subtree, so a child under one holds no address on the page. Deduping without
   // it lets that unreachable child RESERVE an id and drop the later node that
@@ -284,6 +298,7 @@ export function prepareDocumentReadStages(
   return {
     sanitized,
     migrated: doc,
+    rewritten,
     gated,
     deduped: visible,
     prepared,

--- a/packages/blocks-react/src/read-page.test.tsx
+++ b/packages/blocks-react/src/read-page.test.tsx
@@ -621,3 +621,107 @@ describe("the reading view", () => {
     expect(read.document?.nodes.map(node => node.id)).toEqual(["a", "b"]);
   });
 });
+
+/**
+ * A block whose v2 migration turns a drawing node into a drawless one.
+ *
+ * Version 2 with a step from 1, so a node stored at v1 migrates on read. The
+ * step forces `draw: false`, which is exactly what `rendersNothing` keys on —
+ * so the node drew when the sheet was compiled and draws nothing when it is
+ * read back.
+ */
+const flipsToDrawless = defineBlock<{ draw: boolean }>({
+  name: "plugin/drawless",
+  version: 2,
+  description: "Draws only when told to, and v2 stops telling it to.",
+  example: { props: { draw: true } },
+  defaultProps: { draw: false },
+  migrate: { 1: props => ({ ...props, draw: false }) },
+  rendersNothing: props => props.draw !== true,
+  render: ({ props, className }) =>
+    props.draw ? <p className={className}>drawn</p> : null,
+});
+
+/** The same block at v2 whose migration leaves drawing alone. */
+const staysDrawing = defineBlock<{ draw: boolean }>({
+  name: "plugin/drawless",
+  version: 2,
+  description: "Draws only when told to, and v2 keeps telling it to.",
+  example: { props: { draw: true } },
+  defaultProps: { draw: false },
+  migrate: { 1: props => ({ ...props, note: "v2" }) },
+  rendersNothing: props => props.draw !== true,
+  render: ({ props, className }) =>
+    props.draw ? <p className={className}>drawn</p> : null,
+});
+
+describe("a migration that changes whether a node draws", () => {
+  const flipping = createBlockResolver([
+    flipsToDrawless as AnyBlockDefinition,
+    box as AnyBlockDefinition,
+    text as AnyBlockDefinition,
+  ]);
+  const notFlipping = createBlockResolver([
+    staysDrawing as AnyBlockDefinition,
+    box as AnyBlockDefinition,
+    text as AnyBlockDefinition,
+  ]);
+
+  /**
+   * A page whose drawless-capable node IS drawing when the sheet is compiled.
+   *
+   * The shared fixture above stores `draw: false`, so its node never drew and a
+   * migration cannot flip it — the case under test needs the opposite starting
+   * state, and using the shared one would pass for the wrong reason.
+   */
+  const drawingPage: BlockDocument = {
+    formatVersion: DOCUMENT_FORMAT_VERSION,
+    kind: "page",
+    nodes: [
+      {
+        id: "a",
+        type: "plugin/drawless",
+        version: 1,
+        props: { draw: true },
+        classes: ["only-a"],
+        styles: { base: { base: { color: "rebeccapurple" } } },
+      },
+    ],
+  };
+
+  /** Compiled by the WRITE path, against the version the node was stored at. */
+  function sheetForDrawingPage(): ReturnType<typeof resolvePageStyles> {
+    return resolvePageStyles(drawingPage, undefined, context, withPlugin);
+  }
+
+  it("withholds a sheet compiled while the node still drew", () => {
+    // Every stage comparison reads EQUAL here: nothing was truncated, gated,
+    // deduplicated or placeholdered, and the node is registered and present in
+    // the tree the reader gets. The only evidence is that migration rewrote its
+    // props and the answer to "does this draw" moved with them.
+    const stored = sheetForDrawingPage();
+    expect(stored.css).toContain("nx-bt-plugin--drawless");
+
+    const read = preparePageForRead(drawingPage, {
+      resolver: flipping,
+      styles: stored,
+    });
+
+    expect(read.styles.css).not.toContain("nx-bt-plugin--drawless");
+    expect(read.styles.css).not.toContain("nx-c-only-a");
+  });
+
+  it("CONTROL: keeps the sheet when a migration leaves drawing alone", () => {
+    // Without this the case above passes on an implementation that withholds
+    // the sheet for ANY migrated node, which would blank the styling of every
+    // page holding a node behind its definition — a far larger regression than
+    // the one being fixed, and one that also produces a green above.
+    const read = preparePageForRead(drawingPage, {
+      resolver: notFlipping,
+      styles: sheetForDrawingPage(),
+    });
+
+    expect(read.styles.css).toContain("nx-bt-plugin--drawless");
+    expect(read.styles.css).toContain("nx-c-only-a");
+  });
+});

--- a/packages/blocks-react/src/read-page.ts
+++ b/packages/blocks-react/src/read-page.ts
@@ -18,7 +18,6 @@
  *
  * @module read-page
  */
-import { nodeAtPointer } from "@nextlyhq/blocks-engine";
 import type {
   BlockDocument,
   RemotePatternInput,
@@ -33,10 +32,10 @@ import { prepareDocumentReadStages, readingViewOf } from "./prepare-document";
 import type { BlockResolver } from "./resolver";
 import type { PageStyles } from "./styles";
 import {
-  drawlessTestFor,
   effectiveCompile,
   gatedMapCoversPrunedNodes,
   hasDuplicateNodeIds,
+  migrationChangedWhatDraws,
   readableGatedRules,
   resolvePageStyles,
 } from "./styles";
@@ -77,46 +76,6 @@ export interface PreparedPage {
   document: BlockDocument | null;
   /** The stylesheet for that tree. */
   styles: PageStyles;
-}
-
-/**
- * Whether migration turned a node that DREW into one that draws nothing.
- *
- * The stored sheet was compiled while the node still drew, so its rules sit in
- * the main `css` with no gated entry, and every later pass agrees the node is
- * present and registered. Nothing else in this function can see it: the
- * drawless predicate decides which per-node entries to APPEND and cannot
- * withdraw a rule already embedded in the sheet, and the stage comparisons all
- * read equal because no pass REMOVED anything. Only a recompile drops it.
- *
- * Asked ONLY of the nodes the engine reported rewriting. The predicate runs a
- * block's own declaration, so asking it of every node on every read would put
- * plugin code in the path of the ordinary case, where nothing migrated and the
- * answer cannot have changed. That list is empty for any page whose nodes are
- * already current, which is nearly all of them, and this returns before walking
- * anything.
- *
- * The reverse flip needs no handling: a node that starts drawless and begins to
- * draw has no rules in the stored sheet to be stale, and the recompile that
- * gives it some is triggered by the sheet not describing it.
- */
-function migrationChangedWhatDraws(
-  stages: DocumentReadStages,
-  resolver: BlockResolver
-): boolean {
-  if (stages.rewritten.length === 0) return false;
-  const drawsNothing = drawlessTestFor(resolver);
-  // The engine's reported pointers are RESOLVED rather than matched against
-  // paths rebuilt here. Rebuilding them would be a second encoder of the same
-  // format: it agrees on every ordinary slot name and diverges on the ones the
-  // escaping exists for, so the mismatch appears only for the documents this
-  // check most needs to read.
-  return stages.rewritten.some(entry => {
-    const before = nodeAtPointer(stages.sanitized, entry.path);
-    const after = nodeAtPointer(stages.migrated, entry.path);
-    if (before === undefined || after === undefined) return false;
-    return !drawsNothing(before) && drawsNothing(after);
-  });
 }
 
 /**

--- a/packages/blocks-react/src/read-page.ts
+++ b/packages/blocks-react/src/read-page.ts
@@ -20,6 +20,7 @@
  */
 import type {
   BlockDocument,
+  BlockNode,
   RemotePatternInput,
   StyleCompileContext,
 } from "@nextlyhq/blocks-engine";
@@ -29,8 +30,10 @@ import type {
   PrepareDocumentArgs,
 } from "./prepare-document";
 import { prepareDocumentReadStages, readingViewOf } from "./prepare-document";
+import type { BlockResolver } from "./resolver";
 import type { PageStyles } from "./styles";
 import {
+  drawlessTestFor,
   effectiveCompile,
   gatedMapCoversPrunedNodes,
   hasDuplicateNodeIds,
@@ -77,6 +80,89 @@ export interface PreparedPage {
 }
 
 /**
+ * Whether migration turned a node that DREW into one that draws nothing.
+ *
+ * The stored sheet was compiled while the node still drew, so its rules sit in
+ * the main `css` with no gated entry, and every later pass agrees the node is
+ * present and registered. Nothing else in this function can see it: the
+ * drawless predicate decides which per-node entries to APPEND and cannot
+ * withdraw a rule already embedded in the sheet, and the stage comparisons all
+ * read equal because no pass REMOVED anything. Only a recompile drops it.
+ *
+ * Asked ONLY of the nodes the engine reported rewriting. The predicate runs a
+ * block's own declaration, so asking it of every node on every read would put
+ * plugin code in the path of the ordinary case, where nothing migrated and the
+ * answer cannot have changed. That list is empty for any page whose nodes are
+ * already current, which is nearly all of them, and this returns before walking
+ * anything.
+ *
+ * The reverse flip needs no handling: a node that starts drawless and begins to
+ * draw has no rules in the stored sheet to be stale, and the recompile that
+ * gives it some is triggered by the sheet not describing it.
+ */
+function migrationChangedWhatDraws(
+  stages: DocumentReadStages,
+  resolver: BlockResolver
+): boolean {
+  if (stages.rewritten.length === 0) return false;
+  const drawsNothing = drawlessTestFor(resolver);
+  const rewrittenPaths = new Set(stages.rewritten.map(entry => entry.path));
+  let flipped = false;
+
+  // Walked in parallel so each reported node is compared against the props it
+  // was stored with. The paths come from the engine and address both trees,
+  // which is what makes the BEFORE state recoverable at all: after migration
+  // the pre-migration props exist nowhere else.
+  const visit = (before: unknown, after: unknown, path: string): void => {
+    if (flipped) return;
+    if (
+      typeof before !== "object" ||
+      before === null ||
+      typeof after !== "object" ||
+      after === null
+    ) {
+      return;
+    }
+    const priorNode = before as BlockNode;
+    const currentNode = after as BlockNode;
+    if (
+      rewrittenPaths.has(path) &&
+      !drawsNothing(priorNode) &&
+      drawsNothing(currentNode)
+    ) {
+      flipped = true;
+      return;
+    }
+    const priorSlots = priorNode.slots;
+    const currentSlots = currentNode.slots;
+    if (
+      typeof priorSlots !== "object" ||
+      priorSlots === null ||
+      typeof currentSlots !== "object" ||
+      currentSlots === null
+    ) {
+      return;
+    }
+    for (const [slot, children] of Object.entries(currentSlots)) {
+      const priorChildren = (priorSlots as Record<string, unknown>)[slot];
+      if (!Array.isArray(children) || !Array.isArray(priorChildren)) continue;
+      children.forEach((child, index) => {
+        visit(priorChildren[index], child, `${path}/slots/${slot}/${index}`);
+      });
+    }
+  };
+
+  const priorNodes = stages.sanitized.nodes;
+  const currentNodes = stages.migrated.nodes;
+  if (Array.isArray(priorNodes) && Array.isArray(currentNodes)) {
+    currentNodes.forEach((node, index) => {
+      visit(priorNodes[index], node, `/nodes/${index}`);
+    });
+  }
+  return flipped;
+}
+
+/**
  * Whether the passes changed the tree in a way a STORED stylesheet cannot
  * describe.
  *
@@ -108,15 +194,20 @@ export interface PreparedPage {
  *   gone for every visitor until the page is republished, while the tiers it
  *   pulled into the sheet stay behind.
  *
- * **Migration** is the exclusion. It allocates unconditionally, so comparing it
- * against the caps pass is true on every document ever read; included, every
- * page would report as repaired and every stored sheet would be withheld on the
- * happy path.
+ * **Migration** is the exclusion, as a STAGE COMPARISON. It allocates
+ * unconditionally, so comparing it against the caps pass is true on every
+ * document ever read; included that way, every page would report as repaired and
+ * every stored sheet would be withheld on the happy path.
+ *
+ * What migration can still do is change what a node DRAWS, and that is asked
+ * separately below — of the nodes the engine reported rewriting rather than by
+ * comparing the two documents, so the ordinary page pays nothing for it.
  */
 function storedSheetCannotDescribe(
   document: BlockDocument,
   stages: DocumentReadStages,
-  styles: PageStyles | undefined
+  styles: PageStyles | undefined,
+  resolver: BlockResolver
 ): boolean {
   const gatedRules = readableGatedRules(styles);
   // An ABSENT map means "compiled before the split existed", not "nothing was
@@ -128,7 +219,8 @@ function storedSheetCannotDescribe(
     stages.sanitized !== document ||
     hasDuplicateNodeIds(stages.migrated) ||
     (stages.gated !== stages.migrated && !gatingCovered) ||
-    stages.prepared !== stages.deduped
+    stages.prepared !== stages.deduped ||
+    migrationChangedWhatDraws(stages, resolver)
   );
 }
 
@@ -176,7 +268,7 @@ export function preparePageForRead(
     args.styles,
     compile.context,
     args.resolver,
-    storedSheetCannotDescribe(document, stages, args.styles),
+    storedSheetCannotDescribe(document, stages, args.styles, args.resolver),
     { fetchPolicyId: compile.fetchPolicyId }
   );
 

--- a/packages/blocks-react/src/read-page.ts
+++ b/packages/blocks-react/src/read-page.ts
@@ -18,9 +18,9 @@
  *
  * @module read-page
  */
+import { nodeAtPointer } from "@nextlyhq/blocks-engine";
 import type {
   BlockDocument,
-  BlockNode,
   RemotePatternInput,
   StyleCompileContext,
 } from "@nextlyhq/blocks-engine";
@@ -106,60 +106,17 @@ function migrationChangedWhatDraws(
 ): boolean {
   if (stages.rewritten.length === 0) return false;
   const drawsNothing = drawlessTestFor(resolver);
-  const rewrittenPaths = new Set(stages.rewritten.map(entry => entry.path));
-  let flipped = false;
-
-  // Walked in parallel so each reported node is compared against the props it
-  // was stored with. The paths come from the engine and address both trees,
-  // which is what makes the BEFORE state recoverable at all: after migration
-  // the pre-migration props exist nowhere else.
-  const visit = (before: unknown, after: unknown, path: string): void => {
-    if (flipped) return;
-    if (
-      typeof before !== "object" ||
-      before === null ||
-      typeof after !== "object" ||
-      after === null
-    ) {
-      return;
-    }
-    const priorNode = before as BlockNode;
-    const currentNode = after as BlockNode;
-    if (
-      rewrittenPaths.has(path) &&
-      !drawsNothing(priorNode) &&
-      drawsNothing(currentNode)
-    ) {
-      flipped = true;
-      return;
-    }
-    const priorSlots = priorNode.slots;
-    const currentSlots = currentNode.slots;
-    if (
-      typeof priorSlots !== "object" ||
-      priorSlots === null ||
-      typeof currentSlots !== "object" ||
-      currentSlots === null
-    ) {
-      return;
-    }
-    for (const [slot, children] of Object.entries(currentSlots)) {
-      const priorChildren = (priorSlots as Record<string, unknown>)[slot];
-      if (!Array.isArray(children) || !Array.isArray(priorChildren)) continue;
-      children.forEach((child, index) => {
-        visit(priorChildren[index], child, `${path}/slots/${slot}/${index}`);
-      });
-    }
-  };
-
-  const priorNodes = stages.sanitized.nodes;
-  const currentNodes = stages.migrated.nodes;
-  if (Array.isArray(priorNodes) && Array.isArray(currentNodes)) {
-    currentNodes.forEach((node, index) => {
-      visit(priorNodes[index], node, `/nodes/${index}`);
-    });
-  }
-  return flipped;
+  // The engine's reported pointers are RESOLVED rather than matched against
+  // paths rebuilt here. Rebuilding them would be a second encoder of the same
+  // format: it agrees on every ordinary slot name and diverges on the ones the
+  // escaping exists for, so the mismatch appears only for the documents this
+  // check most needs to read.
+  return stages.rewritten.some(entry => {
+    const before = nodeAtPointer(stages.sanitized, entry.path);
+    const after = nodeAtPointer(stages.migrated, entry.path);
+    if (before === undefined || after === undefined) return false;
+    return !drawsNothing(before) && drawsNothing(after);
+  });
 }
 
 /**

--- a/packages/blocks-react/src/styles.ts
+++ b/packages/blocks-react/src/styles.ts
@@ -2,6 +2,7 @@ import {
   compilePageCss,
   declaresNoMarkup,
   isFetchableUrl,
+  nodeAtPointer,
   nodeClassNames,
   walkNodes,
   DEFAULT_LIMITS,
@@ -14,6 +15,7 @@ import {
   type StyleCompileContext,
 } from "@nextlyhq/blocks-engine";
 
+import type { DocumentReadStages } from "./prepare-document";
 import type { BlockResolver } from "./resolver";
 import { pruneNodes } from "./visibility";
 
@@ -347,6 +349,46 @@ export function drawlessTestFor(
   blocks: BlockResolver
 ): (node: BlockNode) => boolean {
   return node => declaresNoMarkup(node, type => blocks.get(type));
+}
+
+/**
+ * Whether migration turned a node that DREW into one that draws nothing.
+ *
+ * The stored sheet was compiled while the node still drew, so its rules sit in
+ * the main `css` with no gated entry, and every later pass agrees the node is
+ * present and registered. Nothing else in this function can see it: the
+ * drawless predicate decides which per-node entries to APPEND and cannot
+ * withdraw a rule already embedded in the sheet, and the stage comparisons all
+ * read equal because no pass REMOVED anything. Only a recompile drops it.
+ *
+ * Asked ONLY of the nodes the engine reported rewriting. The predicate runs a
+ * block's own declaration, so asking it of every node on every read would put
+ * plugin code in the path of the ordinary case, where nothing migrated and the
+ * answer cannot have changed. That list is empty for any page whose nodes are
+ * already current, which is nearly all of them, and this returns before walking
+ * anything.
+ *
+ * The reverse flip needs no handling: a node that starts drawless and begins to
+ * draw has no rules in the stored sheet to be stale, and the recompile that
+ * gives it some is triggered by the sheet not describing it.
+ */
+export function migrationChangedWhatDraws(
+  stages: DocumentReadStages,
+  resolver: BlockResolver
+): boolean {
+  if (stages.rewritten.length === 0) return false;
+  const drawsNothing = drawlessTestFor(resolver);
+  // The engine's reported pointers are RESOLVED rather than matched against
+  // paths rebuilt here. Rebuilding them would be a second encoder of the same
+  // format: it agrees on every ordinary slot name and diverges on the ones the
+  // escaping exists for, so the mismatch appears only for the documents this
+  // check most needs to read.
+  return stages.rewritten.some(entry => {
+    const before = nodeAtPointer(stages.sanitized, entry.path);
+    const after = nodeAtPointer(stages.migrated, entry.path);
+    if (before === undefined || after === undefined) return false;
+    return !drawsNothing(before) && drawsNothing(after);
+  });
 }
 
 function withGatedRules(


### PR DESCRIPTION
Task 219 (renumbered from 215; three files carried that prefix). Codex P1 on #693.

## The defect

A block migration can change props so that `rendersNothing` becomes true for a node that previously drew. The stored stylesheet was compiled while the node still drew, so its rules — and any `url(...)` inside them — sit in the main `css` with no gated entry, and every existing check agrees the page is fine: nothing was truncated, gated, deduplicated or placeholdered, and the node is registered and present in the tree the reader gets. The stale rules stay published until the page is republished.

Measured on both entry points before writing anything. `preparePageForRead` and `PageRenderer` shipped the stale rule identically, so this is a property of the shared design rather than a regression from #693 — which is why #693 deliberately did not fix it.

## The approach, and the one rejected

`migrateDocument` now reports which nodes it rewrote, and the read path asks the drawless question only of those.

The cheaper alternative was to recover the same answer by comparing node references across the two documents, with no engine change. Rejected on a measurement: the engine does preserve node identity when nothing changed, and it is a tested contract — but only for TOP-LEVEL nodes (`migration.test.ts:240`). There is no equivalent assertion for nested slot children, and `migrateNode` rebuilds a parent whenever any child changed. That would have made correctness rest on an invariant nobody asserts, which is worse than a new field: the day someone optimises the traversal, nothing points at the change.

The report is keyed on the **props object**, not the version stamp and not `migrationFailed`. A step returning its input unchanged, and a failure at the very first step, both leave the stored object in place, so nothing derived from those props can have moved.

## Cost

`rewritten` is empty for any page whose nodes are already current, which is nearly all of them, and the check returns before walking anything. A block's own `rendersNothing` runs only for nodes the engine reported rewriting, so plugin code stays off the ordinary read path.

## Verification

The producer is guarded on COMPLETENESS rather than on any consumer reading it. A node missing from the report is silently exempted from whatever the reader checks — no error, no slow path — and a consumer-side test cannot see that, because a report naming three of four nodes still gets its three read correctly. `migration.test.ts` compares the report against an independent walk of both documents.

That guard immediately caught a defect in the first implementation: a migration throwing at its FIRST step runs nothing, so props are the same object and the node was not rewritten — but it was being reported. Both cases are now tested separately.

The consumer test is differential:

| | reproduction | control |
|---|---|---|
| with the fix | pass | pass |
| clause removed | **fail** | pass |

The control is doing real work. Without it, an implementation that withheld the sheet for ANY migrated node also goes green — and that would blank the styling of every page holding a node behind its definition, a far larger regression than the one being fixed.

Gates: 1126 blocks-engine tests, 490 blocks-react, lint clean by exit code.
