### PR TITLE
test(builder): read module specifiers through one shared reader

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -31,7 +31,8 @@
       "@nextlyhq/prettier-config",
       "@nextlyhq/telemetry",
       "@nextlyhq/tsconfig",
-      "@nextlyhq/builder"
+      "@nextlyhq/builder",
+      "@nextlyhq/module-specifiers"
     ]
   ],
   "linked": [],

--- a/packages/builder/package.json
+++ b/packages/builder/package.json
@@ -51,6 +51,7 @@
   },
   "devDependencies": {
     "@nextlyhq/eslint-config": "workspace:*",
+    "@nextlyhq/module-specifiers": "workspace:*",
     "@nextlyhq/plugin-sdk": "workspace:*",
     "@nextlyhq/tsconfig": "workspace:*",
     "@nextlyhq/ui": "workspace:*",

--- a/packages/builder/src/layering.test.ts
+++ b/packages/builder/src/layering.test.ts
@@ -2,6 +2,10 @@ import { readFileSync, readdirSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
+import {
+  importedSpecifiers,
+  UNRESOLVABLE_SPECIFIER,
+} from "@nextlyhq/module-specifiers";
 import ts from "typescript";
 import { describe, expect, it } from "vitest";
 import {
@@ -84,23 +88,13 @@ const ALLOWED_RUNTIME_IMPORTS = [
 
 /** Node built-ins and test-only tooling, which never reach a consumer's bundle. */
 const ALLOWED_IN_TESTS = [
+  "@nextlyhq/module-specifiers",
   "node:fs",
   "node:path",
   "node:url",
   "typescript",
   "vitest",
 ];
-
-/**
- * Stands in for a module call whose target is not a literal, such as
- * `import(base + name)` or `require(name)`.
- *
- * Such a target cannot be resolved by reading the file, so the honest report is
- * "unknown", and unknown has to be a violation: the alternative is a guard that
- * approves whatever it could not read. It is deliberately not a legal package
- * specifier, so it can never be satisfied by an allowlist entry.
- */
-const UNRESOLVABLE_SPECIFIER = "<unresolvable-specifier>";
 
 /**
  * Extensions the bundler will follow, and therefore the ones this guard must read.
@@ -119,115 +113,9 @@ function sourceFiles(dir: string): string[] {
   );
 }
 
-/**
- * Every module specifier a source text imports, read from the AST rather than by
- * regex.
- *
- * Several shapes reach a module, not one, and a visitor that reads only
- * declarations walks straight past most of them — approving a file that pulls
- * the forbidden package in anyway:
- *
- * - `import ... from` and `export ... from`, which carry a module specifier.
- * - `import("pkg")` and `require("pkg")`, which are call expressions. A bare
- *   `require` identifier only: `loader.require("x")` is a method on some object,
- *   not a module resolve.
- * - `import x = require("pkg")`, the documented CommonJS-interop spelling, which
- *   is neither of the above.
- * - `typeof import("pkg")` in type position, which the parser gives as an
- *   `ImportTypeNode` rather than a call. It erases at build, so a purely runtime
- *   guard would skip it — this one does not, for the reason below.
- *
- * Template literals with no substitutions are as statically known as quoted
- * strings, so they count as literals here.
- *
- * Type-only imports are collected too, which is stricter than a purely runtime
- * guard would be. The admin prohibition is not only about what reaches a bundle:
- * importing admin's types is the same dependency on internals nobody promised to
- * keep, and it is one rename away from becoming a value import.
- *
- * Separated from the file reading so the shapes above can be asserted against
- * source text directly: the contract tests below scan real files, and a file
- * that happens to contain none of a shape cannot demonstrate the shape is seen.
- */
-function importsOfSource(text: string, fileName = "module.ts"): string[] {
-  const source = ts.createSourceFile(
-    fileName,
-    text,
-    ts.ScriptTarget.ESNext,
-    true
-  );
-  const found: string[] = [];
-  const seen = new Set<ts.Node>();
-  const visit = (node: ts.Node): void => {
-    if (seen.has(node)) return;
-    seen.add(node);
-    if (
-      (ts.isImportDeclaration(node) || ts.isExportDeclaration(node)) &&
-      node.moduleSpecifier &&
-      ts.isStringLiteralLike(node.moduleSpecifier)
-    ) {
-      found.push(node.moduleSpecifier.text);
-    } else if (ts.isJSDocImportTag(node)) {
-      // `/** @import { X } from "pkg" */`. A tag with its own module specifier, not the
-      // `ImportTypeNode` a `@typedef` produces, so entering the JSDoc tree is not enough.
-      const target = node.moduleSpecifier;
-      found.push(
-        target && ts.isStringLiteralLike(target)
-          ? target.text
-          : UNRESOLVABLE_SPECIFIER
-      );
-    } else if (ts.isImportTypeNode(node)) {
-      // `type A = typeof import("pkg")`. A type query, so it never reaches a bundle — but it is
-      // still a dependency on that package's internals, which is what the admin rule forbids.
-      const target = node.argument;
-      found.push(
-        ts.isLiteralTypeNode(target) && ts.isStringLiteralLike(target.literal)
-          ? target.literal.text
-          : UNRESOLVABLE_SPECIFIER
-      );
-    } else if (
-      ts.isImportEqualsDeclaration(node) &&
-      ts.isExternalModuleReference(node.moduleReference)
-    ) {
-      const target = node.moduleReference.expression;
-      found.push(
-        ts.isStringLiteralLike(target) ? target.text : UNRESOLVABLE_SPECIFIER
-      );
-    } else if (ts.isCallExpression(node)) {
-      const callee = node.expression;
-      const resolvesAModule =
-        callee.kind === ts.SyntaxKind.ImportKeyword ||
-        (ts.isIdentifier(callee) && callee.text === "require");
-      if (resolvesAModule) {
-        const target = node.arguments[0];
-        found.push(
-          target && ts.isStringLiteralLike(target)
-            ? target.text
-            : UNRESOLVABLE_SPECIFIER
-        );
-      }
-    }
-    ts.forEachChild(node, visit);
-    // JSDoc hangs off a node rather than sitting under it, so `forEachChild` never enters it.
-    // In a JavaScript file that is where the types live: `@typedef {import("pkg").T}` puts an
-    // ImportTypeNode inside the comment, invisible to every branch above.
-    for (const doc of ts.getJSDocCommentsAndTags(node)) visit(doc);
-  };
-  visit(source);
-
-  // `/// <reference types="pkg" />` is not part of the node tree, so `forEachChild` never
-  // reaches it. The parser puts it here instead, and it is a dependency on that package's
-  // types exactly as an `import type` is.
-  for (const directive of source.typeReferenceDirectives) {
-    found.push(directive.fileName);
-  }
-
-  return found;
-}
-
 /** Every module specifier a file imports. */
 function importsOf(file: string): string[] {
-  return importsOfSource(readFileSync(file, "utf8"), file);
+  return importedSpecifiers(readFileSync(file, "utf8"), file);
 }
 
 /**
@@ -250,112 +138,36 @@ function isBare(specifier: string): boolean {
 }
 
 describe("reading a module's imports", () => {
-  it("sees static imports and re-exports", () => {
-    expect(importsOfSource(`import { a } from "react";`)).toEqual(["react"]);
-    expect(importsOfSource(`export { b } from "@nextlyhq/ui";`)).toEqual([
-      "@nextlyhq/ui",
-    ]);
-    expect(importsOfSource(`export * from "@nextlyhq/blocks-react";`)).toEqual([
-      "@nextlyhq/blocks-react",
-    ]);
-  });
+  // One case per import form the reader claims — static, side-effect, dynamic,
+  // require, import-equals, typeof-import, JSDoc, triple-slash, template
+  // literal — and the comment and string cases it must not claim, now live
+  // beside the reader in `packages/module-specifiers/src/index.test.ts`. They
+  // moved with it: a reader that quietly stops recognising a form returns a
+  // clean result to every consumer at once, so the corpus that catches it
+  // belongs where the reader is, not copied into each guard that calls it.
+  //
+  // What remains here is this package's own wiring, which the shared corpus
+  // cannot establish.
 
-  it("sees type-only imports, which a rename could turn into a value import", () => {
+  it("is exercised — the reader this guard calls finds a specifier", () => {
+    // An empty offender list is only evidence once the search is shown to work.
+    // A misrouted import or a renamed export returns exactly the same clean
+    // result as compliance does.
     expect(
-      importsOfSource(`import type { P } from "@nextlyhq/admin";`)
+      importedSpecifiers(`import type { P } from "@nextlyhq/admin";`, "m.ts")
     ).toEqual(["@nextlyhq/admin"]);
-  });
-
-  it("sees dynamic imports, which carry a dependency no declaration records", () => {
     expect(
-      importsOfSource(`const m = await import("@nextlyhq/admin/lexical");`)
-    ).toEqual(["@nextlyhq/admin/lexical"]);
-    expect(
-      importsOfSource("const m = await import(`@nextlyhq/admin`);")
-    ).toEqual(["@nextlyhq/admin"]);
-  });
-
-  it("sees a bare require, which reaches a module exactly as an import does", () => {
-    expect(importsOfSource(`const a = require("@nextlyhq/admin");`)).toEqual([
-      "@nextlyhq/admin",
-    ]);
-  });
-
-  it("sees a triple-slash type reference, which is not in the node tree at all", () => {
-    // The parser stores these on `typeReferenceDirectives`, so a visitor built on
-    // `forEachChild` cannot reach one however carefully it is written.
-    expect(
-      importsOfSource(`/// <reference types="@nextlyhq/admin" />\nexport {};`)
-    ).toEqual(["@nextlyhq/admin"]);
-  });
-
-  it("sees a JSDoc @import tag, which carries its own module specifier", () => {
-    // Distinct from the `@typedef` form: `@import` parses to a JSDocImportTag, so walking into
-    // JSDoc reaches it but no ImportTypeNode branch records it. Asserted against a subpath the
-    // guard genuinely must catch, since admin is unresolvable here anyway.
-    expect(
-      importsOfSource(
-        `/** @import { N } from "@nextlyhq/blocks-react/next" */\nexport const x = 1;`,
-        "probe.js"
+      importedSpecifiers(
+        `export const C = () => <div>{require("@nextlyhq/admin")}</div>;`,
+        "m.tsx"
       )
-    ).toContain("@nextlyhq/blocks-react/next");
-  });
-
-  it("sees an import type inside a JSDoc typedef, which JavaScript files use", () => {
-    // JSDoc is attached to a node, not nested under it, so `forEachChild` walks past the whole
-    // comment. This only became reachable once the enumerator started scanning `.js` files.
-    expect(
-      importsOfSource(
-        `/** @typedef {import("@nextlyhq/admin").Node} Node */\nexport const x = 1;`,
-        "probe.js"
-      )
-    ).toContain("@nextlyhq/admin");
-  });
-
-  it("sees a typeof-import type query, which no call expression covers", () => {
-    // The parser gives this as an ImportTypeNode, so a visitor watching for calls and declarations
-    // walks past it. It erases at build, which is exactly why it is an easy way to take a
-    // dependency on admin internals without appearing to import anything.
-    expect(
-      importsOfSource(`type A = typeof import("@nextlyhq/admin");`)
     ).toEqual(["@nextlyhq/admin"]);
-    expect(
-      importsOfSource(`let x: import("@nextlyhq/admin/lexical").Node;`)
-    ).toEqual(["@nextlyhq/admin/lexical"]);
-  });
-
-  it("sees the CommonJS-interop import-equals spelling", () => {
-    expect(
-      importsOfSource(`import admin = require("@nextlyhq/admin");`)
-    ).toEqual(["@nextlyhq/admin"]);
-  });
-
-  it("does not count a method that merely happens to be named require", () => {
-    // `loader.require("x")` resolves nothing; treating it as an import would make the guard
-    // fail CLOSED on innocent code, which gets guards deleted rather than obeyed.
-    expect(importsOfSource(`loader.require("@nextlyhq/admin");`)).toEqual([]);
-  });
-
-  it("reports a require it cannot resolve rather than dropping it", () => {
-    expect(importsOfSource(`const a = require(name);`)).toEqual([
-      UNRESOLVABLE_SPECIFIER,
-    ]);
-  });
-
-  it("reports a dynamic import it cannot resolve rather than dropping it", () => {
-    // The failure this replaces is silent: an unreadable target that produced no
-    // entry left the allowlist with nothing to reject.
-    expect(importsOfSource(`const m = await import(name);`)).toEqual([
-      UNRESOLVABLE_SPECIFIER,
-    ]);
-    expect(
-      importsOfSource("const m = await import(`@nextlyhq/${pkg}`);")
-    ).toEqual([UNRESOLVABLE_SPECIFIER]);
   });
 
   it("rejects an unresolved dynamic import through the same allowlist as a named one", () => {
     // The sentinel is only useful if it survives the two filters between the
-    // reader and the verdict: it must look bare, and must match no entry.
+    // reader and the verdict: it must look bare, and must match no entry. That
+    // is a property of THIS package's allowlists, so it stays here.
     expect(isBare(UNRESOLVABLE_SPECIFIER)).toBe(true);
     expect(ALLOWED_RUNTIME_IMPORTS).not.toContain(UNRESOLVABLE_SPECIFIER);
     expect(ALLOWED_IN_TESTS).not.toContain(UNRESOLVABLE_SPECIFIER);
@@ -363,7 +175,7 @@ describe("reading a module's imports", () => {
 
   it("ignores relative imports of the package's own code", () => {
     expect(
-      importsOfSource(`import { x } from "./canvas";`).filter(isBare)
+      importedSpecifiers(`import { x } from "./canvas";`, "m.ts").filter(isBare)
     ).toEqual([]);
   });
 });

--- a/packages/module-specifiers/README.md
+++ b/packages/module-specifiers/README.md
@@ -1,0 +1,69 @@
+# @nextlyhq/module-specifiers
+
+One AST reader for the module specifiers a source file loads. Private, consumed
+only by layering guards inside this repository, never published and never
+bundled into anything shipped.
+
+```ts
+import {
+  importedSpecifiers,
+  UNRESOLVABLE_SPECIFIER,
+} from "@nextlyhq/module-specifiers";
+
+importedSpecifiers(readFileSync(file, "utf8"), file);
+```
+
+## Why this exists
+
+Several packages each need the same answer — which packages does this file reach
+— and each had grown its own reader. They agreed the day they were written and
+had already drifted. `.claude/rules/derived-checks.md` states the rule: a
+narrower view must be DERIVED from the richer one, never computed alongside it.
+
+## Scope: the IMPORT boundary, not reachability
+
+This answers **which specifiers a SOURCE file loads**. That is the right level
+for a layering rule, which is a statement about what an author may write.
+
+It is **not** the answer to "what does this entry point actually reach". A
+bundler can inline a dependency, and the specifier then exists nowhere in the
+output — no source reader can see an import that no longer exists. That question
+is answered by reading the built artifact and the bundler's metafile, which
+`packages/ui/scripts/check-server-safe-artifacts.mjs` does deliberately
+separately. Do not merge the two: they take different inputs and answer
+different questions, and neither subsumes the other.
+
+## Two things callers get wrong
+
+**`fileName` is required, and is not diagnostic.** TypeScript picks its parser
+from the extension. Reading a `.tsx` file under a `.ts` name parses `<div>` as a
+type assertion; the recovered tree contains no import nodes, so the file reports
+as importing nothing. That is a clean green over a file that was never read, and
+it was a live defect in two of the readers this replaces.
+
+**`UNRESOLVABLE_SPECIFIER` is a finding, not an absence.** A target that is not a
+literal — `import(base + name)` — cannot be resolved by reading the file, so the
+honest report is "unknown", and unknown has to be a violation. A caller that
+filters it out has built a guard that approves whatever it could not read. It is
+deliberately not a legal package specifier, so no allowlist entry can satisfy it.
+
+## Why it exports TypeScript source
+
+`exports` points at `./src/index.ts` rather than a build output, which is
+Turborepo's just-in-time shape for an internal package. It is load-bearing for
+the one control that proves the consumers are wired to it: **break this reader
+and every consuming suite must go red.** Were this to emit a `dist`, consumers
+would resolve the built output, breaking the source would leave them green
+against stale artifacts, and that green reads as "this consumer is not wired up"
+— the exact opposite of the truth.
+
+## The corpus lives here on purpose
+
+`src/index.test.ts` holds one case per import form the reader claims, and the
+forms it must not claim. A reader that quietly stops recognising a form returns a
+clean result to every consumer at once, while each consumer's own suite reports
+the green it always did. The corpus that catches that belongs beside the reader.
+
+Note this is a different control from "the input set is non-empty". A guard can
+read every file it was given and still be unable to fail on any input. Only a
+known offender it must REJECT catches that.

--- a/packages/module-specifiers/package.json
+++ b/packages/module-specifiers/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@nextlyhq/module-specifiers",
+  "version": "0.0.2-alpha.56",
+  "description": "One AST reader for the module specifiers a source file loads. Consumed only by layering guards inside this repository; exports TypeScript source and is never published or bundled.",
+  "license": "MIT",
+  "type": "module",
+  "private": true,
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "check-types": "tsc --noEmit",
+    "lint": "eslint . --max-warnings 0",
+    "lint:fix": "eslint . --fix",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "devDependencies": {
+    "@nextlyhq/eslint-config": "workspace:*",
+    "@nextlyhq/tsconfig": "workspace:*",
+    "@types/node": "^20.19.17",
+    "eslint": "^9.39.1",
+    "typescript": "^5.9.3",
+    "vitest": "^4.1.0"
+  },
+  "peerDependencies": {
+    "typescript": "^5.9.3"
+  },
+  "engines": {
+    "node": ">=20.0.0"
+  }
+}

--- a/packages/module-specifiers/src/index.test.ts
+++ b/packages/module-specifiers/src/index.test.ts
@@ -1,0 +1,148 @@
+/**
+ * One case per form the reader CLAIMS to see, plus the forms it must not
+ * report.
+ *
+ * These live here rather than in each consuming guard on purpose. A reader that
+ * quietly stops recognising a form returns a clean result to every consumer at
+ * once, and each consumer's own suite reports the same green it always did. The
+ * corpus that would catch it belongs beside the reader.
+ *
+ * This is a different control from "the input set is non-empty". A guard can
+ * read every file it was given and still be unable to fail on any input — one
+ * in this repository hunted a `node:` prefix its bundler never emits, read the
+ * whole built graph, and passed a deliberately-dependent entry. An input check
+ * passes that cleanly. Only a known offender it must REJECT catches it.
+ */
+import { describe, expect, it } from "vitest";
+
+import { UNRESOLVABLE_SPECIFIER, importedSpecifiers } from "./index";
+
+const read = (text: string, fileName = "module.ts"): string[] =>
+  importedSpecifiers(text, fileName);
+
+describe("the forms this reader claims to see", () => {
+  it("sees static imports and re-exports", () => {
+    expect(read('import x from "pkg";')).toContain("pkg");
+    expect(read('export { x } from "pkg";')).toContain("pkg");
+  });
+
+  it("sees a bare side-effect import, which carries no bindings to notice", () => {
+    expect(read('import "pkg";')).toContain("pkg");
+  });
+
+  it("sees type-only imports, which a rename could turn into a value import", () => {
+    expect(read('import type { T } from "pkg";')).toContain("pkg");
+  });
+
+  it("sees dynamic imports, which carry a dependency no declaration records", () => {
+    expect(read('await import("pkg");')).toContain("pkg");
+  });
+
+  it("sees a bare require, which reaches a module exactly as an import does", () => {
+    expect(read('require("pkg");')).toContain("pkg");
+  });
+
+  it("does not see a require METHOD, which resolves nothing", () => {
+    // `loader.require("x")` is a call on some object. Reporting it is a false
+    // positive, and a guard that cries wolf about code the compiler never loads
+    // stops being read — taking its true findings with it.
+    expect(read('loader.require("pkg");')).toEqual([]);
+  });
+
+  it("sees the CommonJS-interop import-equals spelling", () => {
+    expect(read('import x = require("pkg");')).toContain("pkg");
+  });
+
+  it("sees a typeof-import type query, which no call expression covers", () => {
+    expect(read('type A = typeof import("pkg");')).toContain("pkg");
+  });
+
+  it("sees a JSDoc @import tag, which carries its own module specifier", () => {
+    expect(read('/** @import { T } from "pkg" */', "module.js")).toContain(
+      "pkg"
+    );
+  });
+
+  it("sees an import type inside a JSDoc typedef, which JavaScript files use", () => {
+    expect(read('/** @typedef {import("pkg").T} T */', "module.js")).toContain(
+      "pkg"
+    );
+  });
+
+  it("sees a triple-slash type reference, which is not in the node tree at all", () => {
+    expect(read('/// <reference types="pkg" />')).toContain("pkg");
+  });
+
+  it("sees a specifier written as a substitution-free template literal", () => {
+    // As statically known as a quoted string, and a reader that accepts only
+    // `StringLiteral` walks past it.
+    expect(read("await import(`pkg`);")).toContain("pkg");
+  });
+});
+
+describe("the forms this reader must NOT report", () => {
+  it("ignores a specifier that appears only in a comment", () => {
+    expect(read('// never import from "pkg" here')).toEqual([]);
+  });
+
+  it("ignores a specifier that appears only inside a string", () => {
+    expect(read(`const s = 'from "pkg"';`)).toEqual([]);
+  });
+});
+
+describe("a target it cannot resolve is a finding, not an absence", () => {
+  it("reports a computed dynamic import as unresolvable", () => {
+    // The alternative is a guard that approves whatever it could not read.
+    expect(read("await import(base + name);")).toEqual([
+      UNRESOLVABLE_SPECIFIER,
+    ]);
+  });
+
+  it("reports a computed require as unresolvable", () => {
+    expect(read("require(name);")).toEqual([UNRESOLVABLE_SPECIFIER]);
+  });
+
+  it("uses a marker no allowlist entry can satisfy", () => {
+    // It has to be un-spellable as a package: an allowlist that happened to
+    // contain it would turn every unreadable call into a pass.
+    expect(UNRESOLVABLE_SPECIFIER).toContain("<");
+  });
+});
+
+describe("the parser follows the filename, not a default", () => {
+  it("reads a load inside JSX when the file is .tsx", () => {
+    // The load is INSIDE a JSX expression on purpose. Read as `.ts`, `<div>`
+    // parses as a type assertion and the recovered tree contains no import
+    // nodes at all, so the file reports as importing nothing — a clean green
+    // over a file that was never really read.
+    const jsx = 'export const C = () => <div>{require("pkg")}</div>;';
+    expect(importedSpecifiers(jsx, "component.tsx")).toContain("pkg");
+  });
+
+  it("reads a plain .ts angle-bracket assertion, which .tsx cannot parse", () => {
+    // The other direction, so the fix cannot be "always parse as TSX": this is
+    // valid TypeScript and a syntax error in a `.tsx` file.
+    const assertion = 'const el = <HTMLElement>document.body;\nimport "pkg";';
+    expect(importedSpecifiers(assertion, "module.ts")).toContain("pkg");
+  });
+});
+
+describe("the JSDoc descent terminates", () => {
+  it("reads a typedef attached to a declaration without recursing forever", () => {
+    // The two descents reach each other. A `@typedef` on a declaration is
+    // reachable from that declaration, and `forEachChild` on the tag walks back
+    // to it, so an unguarded walk overflows the stack rather than returning a
+    // wrong answer.
+    //
+    // The ATTACHED form is what makes this fixture reach the mechanism: a
+    // free-floating `/** @typedef ... */` with no declaration under it has
+    // nothing to cycle through, terminates either way, and passes with the
+    // guard removed. That was the first version of this test.
+    expect(
+      read(
+        '/** @typedef {import("pkg").T} T */\nexport const x = 1;',
+        "module.js"
+      )
+    ).toEqual(["pkg"]);
+  });
+});

--- a/packages/module-specifiers/src/index.ts
+++ b/packages/module-specifiers/src/index.ts
@@ -1,0 +1,162 @@
+/**
+ * One reader for the module specifiers a source file loads.
+ *
+ * Layering guards in several packages each need the same answer — which
+ * packages does this file reach — and each had grown its own reader. They
+ * agreed the day they were written and had already drifted: the copy in
+ * `packages/ui` omitted import-equals declarations, import types and JSDoc
+ * imports, parsed every `.tsx` file with the TypeScript parser, and treated a
+ * dynamic import it could not resolve as importing nothing. Three of those are
+ * silent, and all three answer "clean".
+ *
+ * `.claude/rules/derived-checks.md` states the rule this file exists to satisfy:
+ * a narrower view must be DERIVED from the richer one, never computed alongside
+ * it.
+ *
+ * SCOPE, stated because the wrong consumer is the likely failure. This answers
+ * "which specifiers does this SOURCE load", which is the import-boundary
+ * question. It is NOT the answer to "what does this entry point actually
+ * reach": a bundler can INLINE a dependency, and the specifier then exists
+ * nowhere in the output, so no source reader can see it. That question is
+ * answered by reading the built artifact and the bundler's metafile, which
+ * `packages/ui/scripts/check-server-safe-artifacts.mjs` does deliberately
+ * separately.
+ *
+ * @module @nextlyhq/module-specifiers
+ */
+import ts from "typescript";
+
+/**
+ * Stands in for a module call whose target is not a literal, such as
+ * `import(base + name)` or `require(name)`.
+ *
+ * Such a target cannot be resolved by reading the file, so the honest report is
+ * "unknown", and unknown has to be a violation: the alternative is a guard that
+ * approves whatever it could not read. It is deliberately not a legal package
+ * specifier, so it can never be satisfied by an allowlist entry.
+ */
+export const UNRESOLVABLE_SPECIFIER = "<unresolvable-specifier>";
+
+/**
+ * Every module specifier a source text loads, read from the AST rather than by
+ * regex.
+ *
+ * A raw-text search cannot do this. It reports the specifier appearing in a
+ * COMMENT or a string as an import — a false positive, and the worse direction
+ * for a guard, because one that cries wolf about code the compiler never loads
+ * stops being read.
+ *
+ * Several shapes reach a module, not one, and a visitor that reads only
+ * declarations walks straight past most of them:
+ *
+ * - `import ... from` and `export ... from`, which carry a module specifier.
+ * - `import "pkg"`, a bare side-effect import, which carries no bindings.
+ * - `import("pkg")` and `require("pkg")`, which are call expressions. A bare
+ *   `require` identifier only: `loader.require("x")` is a method on some object,
+ *   not a module resolve.
+ * - `import x = require("pkg")`, the documented CommonJS-interop spelling, which
+ *   is neither of the above.
+ * - `typeof import("pkg")` in type position, which the parser gives as an
+ *   `ImportTypeNode` rather than a call. It erases at build, so a purely runtime
+ *   guard would skip it.
+ * - `/** @import ... *␍/` and `@typedef {import("pkg").T}` in JSDoc, which is
+ *   where a JavaScript file keeps its types.
+ * - `/// <reference types="pkg" />`, which is not in the node tree at all.
+ *
+ * Template literals with no substitutions are as statically known as quoted
+ * strings, so they count as literals here.
+ *
+ * Type-only imports are collected too, which is stricter than a purely runtime
+ * guard would be: depending on a package's types is the same dependency on
+ * internals nobody promised to keep, and it is one rename away from becoming a
+ * value import. A caller wanting runtime-only reachability filters afterwards.
+ *
+ * `fileName` is REQUIRED, and is not merely diagnostic. TypeScript picks its
+ * parser from the extension, so reading a `.tsx` file under a `.ts` name parses
+ * `<div>` as a type assertion; the malformed tree that follows contains no
+ * import nodes, and the file reports as importing nothing. That is a clean green
+ * over a file that was never read, and it was a live defect in two of the
+ * readers this replaces. A default would let any caller reintroduce it silently.
+ */
+export function importedSpecifiers(text: string, fileName: string): string[] {
+  const source = ts.createSourceFile(
+    fileName,
+    text,
+    ts.ScriptTarget.ESNext,
+    true
+  );
+  const found: string[] = [];
+  const seen = new Set<ts.Node>();
+
+  const visit = (node: ts.Node): void => {
+    // A CYCLE guard, not a de-duplicator. The explicit JSDoc descent below and
+    // `forEachChild` reach each other: a `@typedef` attached to a declaration
+    // is reachable from that declaration, and `forEachChild` on the tag walks
+    // back to it, so the walk recurses until the stack overflows. Measured —
+    // removing this throws `RangeError` on
+    // `/** @typedef {import("pkg").T} T */ export const x = 1;` rather than
+    // reporting the specifier twice.
+    if (seen.has(node)) return;
+    seen.add(node);
+
+    if (
+      (ts.isImportDeclaration(node) || ts.isExportDeclaration(node)) &&
+      node.moduleSpecifier &&
+      ts.isStringLiteralLike(node.moduleSpecifier)
+    ) {
+      found.push(node.moduleSpecifier.text);
+    } else if (ts.isJSDocImportTag(node)) {
+      const target = node.moduleSpecifier;
+      found.push(
+        target && ts.isStringLiteralLike(target)
+          ? target.text
+          : UNRESOLVABLE_SPECIFIER
+      );
+    } else if (ts.isImportTypeNode(node)) {
+      const target = node.argument;
+      found.push(
+        ts.isLiteralTypeNode(target) && ts.isStringLiteralLike(target.literal)
+          ? target.literal.text
+          : UNRESOLVABLE_SPECIFIER
+      );
+    } else if (
+      ts.isImportEqualsDeclaration(node) &&
+      ts.isExternalModuleReference(node.moduleReference)
+    ) {
+      const target = node.moduleReference.expression;
+      found.push(
+        ts.isStringLiteralLike(target) ? target.text : UNRESOLVABLE_SPECIFIER
+      );
+    } else if (ts.isCallExpression(node)) {
+      const callee = node.expression;
+      const resolvesAModule =
+        callee.kind === ts.SyntaxKind.ImportKeyword ||
+        (ts.isIdentifier(callee) && callee.text === "require");
+      if (resolvesAModule) {
+        const target = node.arguments[0];
+        found.push(
+          target && ts.isStringLiteralLike(target)
+            ? target.text
+            : UNRESOLVABLE_SPECIFIER
+        );
+      }
+    }
+
+    ts.forEachChild(node, visit);
+    // JSDoc hangs off a node rather than sitting under it, so `forEachChild`
+    // never enters it. In a JavaScript file that is where the types live:
+    // `@typedef {import("pkg").T}` puts an ImportTypeNode inside the comment,
+    // invisible to every branch above.
+    for (const doc of ts.getJSDocCommentsAndTags(node)) visit(doc);
+  };
+  visit(source);
+
+  // `/// <reference types="pkg" />` is not part of the node tree, so
+  // `forEachChild` never reaches it. The parser puts it here instead, and it is
+  // a dependency on that package's types exactly as an `import type` is.
+  for (const directive of source.typeReferenceDirectives) {
+    found.push(directive.fileName);
+  }
+
+  return found;
+}

--- a/packages/module-specifiers/tsconfig.json
+++ b/packages/module-specifiers/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "@nextlyhq/tsconfig/base-bundler.json",
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/packages/module-specifiers/vitest.config.ts
+++ b/packages/module-specifiers/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+  },
+});

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -102,6 +102,7 @@
   "devDependencies": {
     "@nextlyhq/admin-css": "workspace:*",
     "@nextlyhq/eslint-config": "workspace:*",
+    "@nextlyhq/module-specifiers": "workspace:*",
     "@nextlyhq/tsconfig": "workspace:*",
     "@tailwindcss/cli": "^4.3.2",
     "@types/culori": "^4.0.1",

--- a/packages/ui/src/layering.test.ts
+++ b/packages/ui/src/layering.test.ts
@@ -49,7 +49,7 @@
 import { readFileSync, readdirSync, statSync } from "node:fs";
 import { join } from "node:path";
 
-import ts from "typescript";
+import { importedSpecifiers } from "@nextlyhq/module-specifiers";
 import { describe, expect, it } from "vitest";
 
 const SRC = join(__dirname);
@@ -95,59 +95,6 @@ const MODULE_EXTENSIONS = [
 function isShippedModule(entry: string): boolean {
   if (/\.(test|fixture)\./.test(entry)) return false;
   return MODULE_EXTENSIONS.some(extension => entry.endsWith(extension));
-}
-
-/**
- * Every module specifier a source text loads, read from the AST.
- *
- * A raw-text search cannot do this. It reports the specifier appearing in a
- * COMMENT or a string as an import — a false positive, and the worse direction
- * for a guard, because one that cries wolf about code the compiler never loads
- * stops being read. It also misses a bare side-effect `import "pkg"`, a dynamic
- * `import("pkg")` and a `require("pkg")`, none of which carry `from`.
- *
- * DELIBERATE DUPLICATION, and it is the thing this file otherwise argues
- * against. `packages/builder/src/layering.test.ts` already has a fuller reader
- * covering `import x = require(...)`, `typeof import(...)` in type position and
- * JSDoc `@import`. One shared reader that all the layering tests call is what
- * removes this copy. It exists meanwhile because a guard with FALSE POSITIVES
- * is worse than a temporary second implementation: one that reports code the
- * compiler never loads stops being read, and takes the true findings with it.
- */
-function importedSpecifiers(text: string, fileName: string): string[] {
-  // The real filename, because TypeScript picks its parser from the extension.
-  // Reading a `.tsx` file as `.ts` parses `<div>` as a type assertion, and the
-  // malformed tree that follows hides every load inside JSX — which in this
-  // package is most of them. Required rather than defaulted: a caller that
-  // forgets restores exactly that blindness, and silently.
-  const source = ts.createSourceFile(
-    fileName,
-    text,
-    ts.ScriptTarget.ESNext,
-    true
-  );
-  const found: string[] = [];
-  const visit = (node: ts.Node): void => {
-    if (
-      (ts.isImportDeclaration(node) || ts.isExportDeclaration(node)) &&
-      node.moduleSpecifier &&
-      ts.isStringLiteralLike(node.moduleSpecifier)
-    ) {
-      found.push(node.moduleSpecifier.text);
-    } else if (ts.isCallExpression(node)) {
-      const callee = node.expression;
-      const loads =
-        callee.kind === ts.SyntaxKind.ImportKeyword ||
-        (ts.isIdentifier(callee) && callee.text === "require");
-      const target = node.arguments[0];
-      if (loads && target && ts.isStringLiteralLike(target)) {
-        found.push(target.text);
-      }
-    }
-    ts.forEachChild(node, visit);
-  };
-  visit(source);
-  return found;
 }
 
 /**
@@ -313,37 +260,27 @@ describe("this package takes no direct dependency on the block engine", () => {
 
   it("is exercised — the import scan can find the specifier it hunts", () => {
     // An empty offender list is only evidence once the search is shown to
-    // work. A renamed package or a typo in the pattern returns exactly the
-    // same clean result as compliance does.
-    // Every form the reader claims, and the two it must NOT claim. The
-    // comment and string cases are the false positives a text search produces,
-    // and they are asserted here because that is where the reader's value is.
-    const read = (text: string): string[] =>
-      importedSpecifiers(text, "module.ts");
-
-    expect(read(`import { x } from "${FORBIDDEN}";`)).toContain(FORBIDDEN);
-    expect(read(`import "${FORBIDDEN}";`)).toContain(FORBIDDEN);
-    expect(read(`export { x } from "${FORBIDDEN}";`)).toContain(FORBIDDEN);
-    expect(read(`await import("${FORBIDDEN}");`)).toContain(FORBIDDEN);
-    expect(read(`require("${FORBIDDEN}");`)).toContain(FORBIDDEN);
-
-    expect(read(`// never import from "${FORBIDDEN}" here`)).toEqual([]);
-    expect(read(`const s = 'from "${FORBIDDEN}"';`)).toEqual([]);
-    expect(read('import { x } from "@nextlyhq/ui";')).toEqual(["@nextlyhq/ui"]);
-  });
-
-  it("reads a JSX module with the parser that extension needs", () => {
-    // The load is placed INSIDE a JSX expression on purpose. A `.tsx` file read
-    // as `.ts` parses `<div>` as a type assertion and recovers into a tree this
-    // visitor walks without finding anything, so the guard returns clean over a
-    // file it never really read. Most of this package is `.tsx`, which is what
-    // makes the blind spot worth a case of its own.
+    // work. A renamed package or a typo in the pattern returns exactly the same
+    // clean result as compliance does.
+    //
+    // This asserts the WIRING, in the two shapes this package's own files take:
+    // a `.ts` module and the `.tsx` most of it is written in. One case per
+    // import form the reader claims — and the comment and string cases it must
+    // NOT claim — lives beside the reader in
+    // `packages/module-specifiers/src/index.test.ts`, so a reader that stops
+    // recognising a form fails there rather than silently in every consumer.
+    expect(
+      importedSpecifiers(`import { x } from "${FORBIDDEN}";`, "module.ts")
+    ).toContain(FORBIDDEN);
     expect(
       importedSpecifiers(
         `export const C = () => <div>{require("${FORBIDDEN}")}</div>;`,
         "component.tsx"
       )
     ).toContain(FORBIDDEN);
+    expect(
+      importedSpecifiers('import { x } from "@nextlyhq/ui";', "module.ts")
+    ).toEqual(["@nextlyhq/ui"]);
   });
 
   it("counts a subpath of the forbidden package, and only that package", () => {

--- a/packages/ui/src/layering.test.ts
+++ b/packages/ui/src/layering.test.ts
@@ -49,7 +49,10 @@
 import { readFileSync, readdirSync, statSync } from "node:fs";
 import { join } from "node:path";
 
-import { importedSpecifiers } from "@nextlyhq/module-specifiers";
+import {
+  importedSpecifiers,
+  UNRESOLVABLE_SPECIFIER,
+} from "@nextlyhq/module-specifiers";
 import { describe, expect, it } from "vitest";
 
 const SRC = join(__dirname);
@@ -109,6 +112,26 @@ function isShippedModule(entry: string): boolean {
  */
 function resolvesToForbidden(specifier: string): boolean {
   return specifier === FORBIDDEN || specifier.startsWith(`${FORBIDDEN}/`);
+}
+
+/**
+ * Whether a specifier stops this file being cleared.
+ *
+ * Two different reasons, and the second is easy to lose. A specifier that
+ * RESOLVES to the engine is the obvious one. A specifier the reader could not
+ * read — `import(name)`, `require(base + id)` — is the other: it is reported as
+ * {@link UNRESOLVABLE_SPECIFIER}, and passing that through a "does this name the
+ * engine" test answers `false`, which certifies a load nobody has read.
+ *
+ * This guard is allow-by-default: it names ONE forbidden package rather than
+ * listing what is permitted, so an unreadable specifier falls straight through
+ * unless it is rejected on purpose. `packages/builder` is deny-by-default and
+ * gets this for free, because a marker that matches no allowlist entry is
+ * already a violation there. The marker was designed for that shape; this
+ * consumer has to opt in.
+ */
+function blocksClearance(specifier: string): boolean {
+  return resolvesToForbidden(specifier) || specifier === UNRESOLVABLE_SPECIFIER;
 }
 
 /**
@@ -315,15 +338,43 @@ describe("this package takes no direct dependency on the block engine", () => {
     ).toBe(true);
   });
 
+  it("refuses to clear a file whose load it could not read", () => {
+    // A computed target cannot be resolved by reading the file, so the reader
+    // reports a marker rather than a name. Asked only "does this name the
+    // engine", the marker answers no — and the file is certified on the
+    // strength of a load nobody read.
+    //
+    // Driven through the reader rather than by handing the marker straight to
+    // the predicate: the two have to agree about what an unreadable load
+    // produces, and a test that supplies the marker itself would pass even if
+    // the reader stopped emitting it.
+    const computed = importedSpecifiers(
+      `const m = await import(name);`,
+      "module.ts"
+    );
+    expect(computed).toEqual([UNRESOLVABLE_SPECIFIER]);
+    expect(computed.some(blocksClearance)).toBe(true);
+
+    // And the reason it needs saying here at all: the narrower predicate this
+    // one wraps says no, because the marker is not the engine's name.
+    expect(computed.some(resolvesToForbidden)).toBe(false);
+
+    // An ordinary import is still cleared, so the guard has not become one that
+    // rejects everything.
+    expect(
+      importedSpecifiers('import { x } from "react";', "module.ts").some(
+        blocksClearance
+      )
+    ).toBe(false);
+  });
+
   it("imports it in no shipped source file", () => {
     // The manifest alone is not a boundary: under pnpm a package hoisted for
     // another workspace member stays importable from one whose own manifest
     // never declares it. The import is the thing that would actually resolve,
     // so the import is what is checked.
     const offenders = sourceFiles(SRC).filter(file =>
-      importedSpecifiers(readFileSync(file, "utf8"), file).some(
-        resolvesToForbidden
-      )
+      importedSpecifiers(readFileSync(file, "utf8"), file).some(blocksClearance)
     );
 
     expect(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -859,6 +859,9 @@ importers:
       '@nextlyhq/eslint-config':
         specifier: workspace:*
         version: link:../eslint-config
+      '@nextlyhq/module-specifiers':
+        specifier: workspace:*
+        version: link:../module-specifiers
       '@nextlyhq/plugin-sdk':
         specifier: workspace:*
         version: link:../plugin-sdk
@@ -1001,6 +1004,27 @@ importers:
       typescript-eslint:
         specifier: ^8.59.0
         version: 8.59.0(eslint@9.39.1(jiti@2.7.0))(typescript@5.9.3)
+
+  packages/module-specifiers:
+    devDependencies:
+      '@nextlyhq/eslint-config':
+        specifier: workspace:*
+        version: link:../eslint-config
+      '@nextlyhq/tsconfig':
+        specifier: workspace:*
+        version: link:../tsconfig
+      '@types/node':
+        specifier: ^20.19.17
+        version: 20.19.17
+      eslint:
+        specifier: ^9.39.1
+        version: 9.39.1(jiti@2.7.0)
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^4.1.0
+        version: 4.1.10(@types/node@20.19.17)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.9.0)(jsdom@27.1.0)(vite@7.3.6(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/nextly:
     dependencies:
@@ -1664,6 +1688,9 @@ importers:
       '@nextlyhq/eslint-config':
         specifier: workspace:*
         version: link:../eslint-config
+      '@nextlyhq/module-specifiers':
+        specifier: workspace:*
+        version: link:../module-specifiers
       '@nextlyhq/tsconfig':
         specifier: workspace:*
         version: link:../tsconfig
@@ -13395,7 +13422,7 @@ snapshots:
       '@humanfs/node': 0.16.6
       '@humanwhocodes/module-importer': 1.0.1
       '@humanwhocodes/retry': 0.4.3
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
       ajv: 6.15.0
       chalk: 4.1.2
       cross-spawn: 7.0.6


### PR DESCRIPTION
Three layering guards each carried their own AST reader for the same question — which packages does this file reach. They agreed the day they were written and had already drifted.

The copy in `packages/ui` omitted import-equals declarations, import types and JSDoc imports, parsed every `.tsx` file with the TypeScript parser, and treated a dynamic import it could not resolve as importing nothing. Three of those are silent, and all three answer "clean".

`.claude/rules/derived-checks.md` states the rule this satisfies: a narrower view must be DERIVED from the richer one, never computed alongside it.

## What moved

`packages/builder`'s reader is the base — it already threaded the real filename through and reports a distinguished `UNRESOLVABLE_SPECIFIER`. It gains ui's **required** `fileName` parameter, because builder's was optional with a `"module.ts"` default, which is the latent form of a P1 fixed in #717: reading a `.tsx` file under a `.ts` name parses `<div>` as a type assertion, the recovered tree contains no import nodes, and the file reports as importing nothing. A clean green over a file that was never read.

`packages/ui` and `packages/builder` now import it. **`packages/blocks-react`'s fourth copy is deliberately untouched** — its owner has two PRs open in that package and asked to review any change to its guard separately.

## Why it exports TypeScript source

`exports` points at `./src/index.ts`, not a build output. This is load-bearing for the control that proves the consumers are wired: **break the reader and every consuming suite must go red.** Verified — breaking it fails 2 tests in ui and 1 in builder.

Were this to emit a `dist`, consumers would resolve the built output, breaking the source would leave them green against stale artifacts, and that green reads as "this consumer is not wired up" — the exact opposite of the truth. Neither consumer's vitest config aliases workspace packages to source, so this was not hypothetical.

## Why the corpus lives in the new package

One case per import form the reader claims, and the forms it must not claim, moved with it. A reader that quietly stops recognising a form returns a clean result to every consumer at once while each consumer's suite reports its usual green.

This is a different control from "the input set is non-empty" — a guard can read every file it was given and still be unable to fail on any input. Only a known offender it must reject catches that.

## Two things found while writing it

**The `seen` set is a cycle guard, not a de-duplicator.** My first test asserted it prevented double-counting and **passed with the guard removed**. Measuring it showed the real behaviour: a `@typedef` attached to a declaration is reachable from that declaration and `forEachChild` on the tag walks back, so an unguarded walk throws `RangeError: Maximum call stack size exceeded`. The free-floating fixture I first used has nothing to cycle through and terminates either way. Both the comment and the test now state the real property.

**`typescript` stays in `ALLOWED_IN_TESTS`.** I trimmed it and the guard correctly failed: `geometry-ownership.test.ts` imports it, and this file still parses the vitest config with it.

## Landing shape

The package and both consumers are one commit on purpose. The hygiene baseline is keyed by file path, so a move plus a new package is rename-shaped on both halves; and a package that exists before anything imports it trips the workspace glob check separately.

`@nextlyhq/module-specifiers` **is** in the changeset `fixed` group — `scripts/release/check-changesets.mjs` requires every package under `packages/` to be a member and explicitly accommodates private ones. No changeset: test-only, no published runtime code changes.

## Verification

- `check-types` (both configs) and `lint` clean on all three packages
- `packages/ui` at its baseline of 1 (`comments-describe-code`, hits only in gitignored `.next-e2e` artifacts); `builder` 49 passing; new package 20 passing
- Every fix mutation-tested: forced `.tsx` parsing, dropped cycle guard, dropped `typeReferenceDirectives` — each failed its own specific test and nothing else