### PR TITLE
fix(blocks-react): scope the migration drawless re-check to nodes the sheet describes

### DIFF
--- a/.changeset/scope-migration-drawless-recheck.md
+++ b/.changeset/scope-migration-drawless-recheck.md
@@ -22,6 +22,7 @@
 "@nextlyhq/telemetry": patch
 "@nextlyhq/tsconfig": patch
 "@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
 ---
 
 A page whose stylesheet is reused now keeps it when a block migration turns a

--- a/.changeset/scope-migration-drawless-recheck.md
+++ b/.changeset/scope-migration-drawless-recheck.md
@@ -1,0 +1,30 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+---
+
+A page whose stylesheet is reused now keeps it when a block migration turns a
+condition-gated node into one that renders nothing. Those nodes never had rules
+in the shared sheet, so withholding it cost every other block on the page its
+styling.

--- a/packages/blocks-react/src/page-renderer.tsx
+++ b/packages/blocks-react/src/page-renderer.tsx
@@ -325,7 +325,7 @@ export function PageRenderer({
     // was removed. Answering it here as well is the point — the two paths
     // agreeing is what stops a page rendered through this component keeping
     // rules the exported reader withholds for the same document.
-    migrationChangedWhatDraws(stages, resolver);
+    migrationChangedWhatDraws(stages, resolver, styles);
 
   // Reconciled through the SAME derivation every entry point that resolves a
   // stored page uses. What a caller supplies is not what a page compiles with:

--- a/packages/blocks-react/src/read-page.test.tsx
+++ b/packages/blocks-react/src/read-page.test.tsx
@@ -686,8 +686,34 @@ describe("a migration that changes whether a node draws", () => {
         classes: ["only-a"],
         styles: { base: { base: { color: "rebeccapurple" } } },
       },
+      // A condition-gated sibling, so the compiled artifact actually CARRIES a
+      // per-node gated map. Without one the read path cannot consult the record
+      // of what the sheet withheld and falls back to re-deriving it from the
+      // stored props — so a page with nothing gated exercises the legacy path
+      // and leaves the primary one uncovered.
+      {
+        id: "conditioned",
+        type: "test/text",
+        version: 1,
+        props: { value: "maybe" },
+        styles: { base: { base: { color: "goldenrod" } } },
+        visibility: {
+          conditions: [[{ field: "tier", op: "eq", value: "vip" }]],
+        },
+      },
+      // Keeps `test/text` represented among the survivors. Without it the gated
+      // sibling is the last node of its type, and removing the last node of a
+      // type leaves its shared rule unjustified — a refusal that is correct and
+      // has nothing to do with migration, which would make both cases here pass
+      // for the wrong reason.
+      {
+        id: "visible-text",
+        type: "test/text",
+        version: 1,
+        props: { value: "always" },
+      },
     ],
-  };
+  } as unknown as BlockDocument;
 
   /** Compiled by the WRITE path, against the version the node was stored at. */
   function sheetForDrawingPage(): ReturnType<typeof resolvePageStyles> {

--- a/packages/blocks-react/src/read-page.test.tsx
+++ b/packages/blocks-react/src/read-page.test.tsx
@@ -787,64 +787,6 @@ describe("a migration that changes whether a node draws", () => {
     expect(read.styles.css).toContain("color: teal");
   });
 
-  it("withholds when a VISIBLE ancestor flips and only its child was gated", () => {
-    // The ancestor stays visible, so its rules are in the main sheet and a flip
-    // to drawless makes them stale — this is the case the scoping must NOT
-    // exclude. It is also the case where the gating walk REBUILDS the ancestor,
-    // because it removed a child from it, so the surviving node is a different
-    // object from the migrated one. Scoping by object identity misses exactly
-    // this node and trusts the stale sheet; scoping by id catches it.
-    const nestedPage: BlockDocument = {
-      formatVersion: DOCUMENT_FORMAT_VERSION,
-      kind: "page",
-      nodes: [
-        {
-          id: "a",
-          type: "plugin/drawless",
-          version: 1,
-          props: { draw: true },
-          classes: ["only-a"],
-          styles: { base: { base: { color: "rebeccapurple" } } },
-          slots: {
-            children: [
-              {
-                id: "gatedchild",
-                type: "test/text",
-                version: 1,
-                props: { value: "hidden" },
-                visibility: {
-                  conditions: [[{ field: "tier", op: "eq", value: "vip" }]],
-                },
-              },
-            ],
-          },
-        },
-        {
-          id: "b",
-          type: "test/text",
-          version: 1,
-          props: { value: "y" },
-          styles: { base: { base: { color: "teal" } } },
-        },
-      ],
-    } as unknown as BlockDocument;
-
-    const stored = resolvePageStyles(
-      nestedPage,
-      undefined,
-      context,
-      withPlugin
-    );
-    expect(stored.css).toContain("rebeccapurple");
-
-    const read = preparePageForRead(nestedPage, {
-      resolver: flipping,
-      styles: stored,
-    });
-
-    expect(read.styles.css).not.toContain("rebeccapurple");
-  });
-
   it("CONTROL: keeps the sheet when a migration leaves drawing alone", () => {
     // Without this the case above passes on an implementation that withholds
     // the sheet for ANY migrated node, which would blank the styling of every

--- a/packages/blocks-react/src/read-page.test.tsx
+++ b/packages/blocks-react/src/read-page.test.tsx
@@ -821,10 +821,12 @@ describe("a migration that changes whether a node draws", () => {
     // would conclude the compiler withheld it and keep serving those rules, and
     // any `url(...)` inside them, after a migration made them stale.
     const stored = sheetForDrawingPage();
+    // Through `unknown` because the cast is the POINT: this is a stored row
+    // that the type forbids and the runtime can still be handed.
     const corrupted = {
       ...stored,
       gated: { ...(stored.gated ?? {}), a: null },
-    } as typeof stored;
+    } as unknown as typeof stored;
 
     const read = preparePageForRead(drawingPage, {
       resolver: flipping,

--- a/packages/blocks-react/src/read-page.test.tsx
+++ b/packages/blocks-react/src/read-page.test.tsx
@@ -787,6 +787,64 @@ describe("a migration that changes whether a node draws", () => {
     expect(read.styles.css).toContain("color: teal");
   });
 
+  it("withholds when a VISIBLE ancestor flips and only its child was gated", () => {
+    // The ancestor stays visible, so its rules are in the main sheet and a flip
+    // to drawless makes them stale — this is the case the scoping must NOT
+    // exclude. It is also the case where the gating walk REBUILDS the ancestor,
+    // because it removed a child from it, so the surviving node is a different
+    // object from the migrated one. Scoping by object identity misses exactly
+    // this node and trusts the stale sheet; scoping by id catches it.
+    const nestedPage: BlockDocument = {
+      formatVersion: DOCUMENT_FORMAT_VERSION,
+      kind: "page",
+      nodes: [
+        {
+          id: "a",
+          type: "plugin/drawless",
+          version: 1,
+          props: { draw: true },
+          classes: ["only-a"],
+          styles: { base: { base: { color: "rebeccapurple" } } },
+          slots: {
+            children: [
+              {
+                id: "gatedchild",
+                type: "test/text",
+                version: 1,
+                props: { value: "hidden" },
+                visibility: {
+                  conditions: [[{ field: "tier", op: "eq", value: "vip" }]],
+                },
+              },
+            ],
+          },
+        },
+        {
+          id: "b",
+          type: "test/text",
+          version: 1,
+          props: { value: "y" },
+          styles: { base: { base: { color: "teal" } } },
+        },
+      ],
+    } as unknown as BlockDocument;
+
+    const stored = resolvePageStyles(
+      nestedPage,
+      undefined,
+      context,
+      withPlugin
+    );
+    expect(stored.css).toContain("rebeccapurple");
+
+    const read = preparePageForRead(nestedPage, {
+      resolver: flipping,
+      styles: stored,
+    });
+
+    expect(read.styles.css).not.toContain("rebeccapurple");
+  });
+
   it("CONTROL: keeps the sheet when a migration leaves drawing alone", () => {
     // Without this the case above passes on an implementation that withholds
     // the sheet for ANY migrated node, which would blank the styling of every

--- a/packages/blocks-react/src/read-page.test.tsx
+++ b/packages/blocks-react/src/read-page.test.tsx
@@ -711,6 +711,82 @@ describe("a migration that changes whether a node draws", () => {
     expect(read.styles.css).not.toContain("nx-c-only-a");
   });
 
+  it("keeps the sheet when the flip is inside a CONDITION-GATED subtree", () => {
+    // Over-invalidation is the failure this guards. A gated node's rules travel
+    // in the per-node map rather than the main sheet, and gating withholds the
+    // whole subtree — so a descendant turning drawless leaves the delivered CSS
+    // exactly as correct as it was. Withholding the artifact for it would cost
+    // every OTHER block on the page its styling, which is a far larger
+    // regression than the stale rules this feature drops.
+    const gatedPage: BlockDocument = {
+      formatVersion: DOCUMENT_FORMAT_VERSION,
+      kind: "page",
+      nodes: [
+        {
+          id: "wrapper",
+          type: "test/box",
+          version: 1,
+          props: { label: "w" },
+          // No visitor context reaches the gating pass, so any condition at all
+          // withholds this node and everything beneath it.
+          visibility: {
+            conditions: [[{ field: "tier", op: "eq", value: "vip" }]],
+          },
+          slots: {
+            children: [
+              {
+                id: "a",
+                type: "plugin/drawless",
+                version: 1,
+                props: { draw: true },
+                classes: ["only-a"],
+                styles: { base: { base: { color: "rebeccapurple" } } },
+              },
+            ],
+          },
+        },
+        // A VISIBLE node of the same type as the gated wrapper. Without it the
+        // wrapper is the last `test/box` on the page, and removing the last node
+        // of a type leaves that type's shared rule in the main sheet with
+        // nothing to justify it — a refusal that is correct and has nothing to
+        // do with migration, which would make this case pass for the wrong
+        // reason and prove nothing about the flip.
+        {
+          id: "sibling",
+          type: "test/box",
+          version: 1,
+          props: { label: "s" },
+        },
+        // A VISIBLE drawless-capable node, stored ALREADY at v2 so the migration
+        // does not touch it and it keeps drawing. Same purpose as the box above,
+        // for the other type the gated subtree would otherwise be the last of.
+        {
+          id: "vis",
+          type: "plugin/drawless",
+          version: 2,
+          props: { draw: true },
+        },
+        {
+          id: "b",
+          type: "test/text",
+          version: 1,
+          props: { value: "y" },
+          styles: { base: { base: { color: "teal" } } },
+        },
+      ],
+    } as unknown as BlockDocument;
+
+    const stored = resolvePageStyles(gatedPage, undefined, context, withPlugin);
+    const read = preparePageForRead(gatedPage, {
+      resolver: flipping,
+      styles: stored,
+    });
+
+    // The visible sibling keeps its rule, which is the property that breaks if
+    // the flip inside the withheld subtree is treated as a repair.
+    expect(read.styles.css).toContain("color: teal");
+  });
+
   it("CONTROL: keeps the sheet when a migration leaves drawing alone", () => {
     // Without this the case above passes on an implementation that withholds
     // the sheet for ANY migrated node, which would blank the styling of every

--- a/packages/blocks-react/src/read-page.test.tsx
+++ b/packages/blocks-react/src/read-page.test.tsx
@@ -813,6 +813,27 @@ describe("a migration that changes whether a node draws", () => {
     expect(read.styles.css).toContain("color: teal");
   });
 
+  it("does not treat a MALFORMED gated entry as proof the node was withheld", () => {
+    // A stored map is input like any other. An entry whose value is not a
+    // string records nothing — delivery and pruning both ask
+    // `isRecordedGatedEntry` before believing one — so a node carrying such an
+    // entry still has its rules in the shared sheet. Reading key presence alone
+    // would conclude the compiler withheld it and keep serving those rules, and
+    // any `url(...)` inside them, after a migration made them stale.
+    const stored = sheetForDrawingPage();
+    const corrupted = {
+      ...stored,
+      gated: { ...(stored.gated ?? {}), a: null },
+    } as typeof stored;
+
+    const read = preparePageForRead(drawingPage, {
+      resolver: flipping,
+      styles: corrupted,
+    });
+
+    expect(read.styles.css).not.toContain("nx-bt-plugin--drawless");
+  });
+
   it("CONTROL: keeps the sheet when a migration leaves drawing alone", () => {
     // Without this the case above passes on an implementation that withholds
     // the sheet for ANY migrated node, which would blank the styling of every

--- a/packages/blocks-react/src/read-page.ts
+++ b/packages/blocks-react/src/read-page.ts
@@ -136,7 +136,7 @@ function storedSheetCannotDescribe(
     hasDuplicateNodeIds(stages.migrated) ||
     (stages.gated !== stages.migrated && !gatingCovered) ||
     stages.prepared !== stages.deduped ||
-    migrationChangedWhatDraws(stages, resolver)
+    migrationChangedWhatDraws(stages, resolver, styles)
   );
 }
 

--- a/packages/blocks-react/src/styles.ts
+++ b/packages/blocks-react/src/styles.ts
@@ -394,13 +394,16 @@ export function migrationChangedWhatDraws(
     // its absence means they are.
     //
     // Read rather than re-derived for two reasons. Reapplying the gating rule
-    // here is a second implementation of a decision the compiler owns, and
-    // three separate defects on this path have been exactly that. And the
-    // predicate cannot answer the question at all for a node whose migration
-    // RENAMED the prop `rendersNothing` reads: today's predicate over
-    // yesterday's props reports drawless for a node that drew, so the flip
-    // disappears. The artifact carries the answer the schema of the day
-    // produced, which is the only version-independent source there is.
+    // here would be a second implementation of a decision the compiler owns,
+    // and the two only agree while both are maintained together: the compiler
+    // may widen what it gates, or change how gating descends a subtree, and a
+    // copy that does not follow classifies the same node differently while
+    // still looking correct. And the predicate cannot answer the question at
+    // all for a node whose migration RENAMED the prop `rendersNothing` reads:
+    // today's predicate over yesterday's props reports drawless for a node that
+    // drew, so the flip disappears. The artifact carries the answer the schema
+    // of the day produced, which is the only version-independent source there
+    // is.
     if (gatedRules !== undefined) {
       // Asked through `isRecordedGatedEntry`, the same predicate delivery and
       // pruning coverage use, rather than by testing for the key. A stored map

--- a/packages/blocks-react/src/styles.ts
+++ b/packages/blocks-react/src/styles.ts
@@ -1,6 +1,7 @@
 import {
   compilePageCss,
   declaresNoMarkup,
+  isConditionGated,
   isFetchableUrl,
   nodeAtPointer,
   nodeClassNames,
@@ -383,42 +384,53 @@ export function migrationChangedWhatDraws(
   // format: it agrees on every ordinary slot name and diverges on the ones the
   // escaping exists for, so the mismatch appears only for the documents this
   // check most needs to read.
-  // Only nodes whose rules could be in the MAIN sheet are asked. Condition
-  // gating moves a withheld node's rules into the per-node map instead, and it
-  // withholds whole subtrees, so a descendant flipping to drawless leaves the
-  // delivered CSS exactly as correct as it was. Marking the artifact repaired
-  // for one of those costs every OTHER block on the page its styling, since a
-  // caller without a compile context has no way to recompile and the stored
-  // sheet is withheld entire — a far larger regression than the stale rules
-  // this exists to drop.
+  // Which nodes the COMPILER would have put in the main sheet, mirrored from
+  // its own rule rather than approximated. `compile-page.ts` gates a node when
+  // an ancestor is gated, when the node is condition-gated, OR when it declares
+  // it draws nothing — and gating is inherited by the whole subtree, because a
+  // block that draws nothing places none of its slots' children.
   //
-  // Membership is by ID rather than by object identity or by resolving the
-  // pointer again. Both alternatives are wrong in a way that FAILS TO REPORT:
+  // Two things this must get right, and an earlier version got both wrong:
   //
-  // - the pointer addresses a position, and gating REMOVES nodes, so the same
-  //   pointer names a different node in that tree;
-  // - object identity survives an untouched node but NOT an ancestor, because
-  //   the gating walk rebuilds any parent it removed a child from. An ancestor
-  //   that stayed visible, kept its rules in the main sheet, and turned drawless
-  //   is exactly the node this exists to catch, and it is exactly the one whose
-  //   reference changed.
+  // - it walks the STORED tree, because that is what the artifact was compiled
+  //   from. Walking the migrated one asks whether a node draws nothing NOW,
+  //   which is the question being answered, not the one being conditioned on.
+  // - it includes drawless ancestry, not condition gating alone. A descendant
+  //   of a drawless ancestor has no rules in the main sheet either, so treating
+  //   its flip as a repair withholds a sheet that never described it.
   //
-  // Ids are sound here because a document carrying duplicates never reaches this
-  // point: `storedSheetCannotDescribe` and `PageRenderer` both test
-  // `hasDuplicateNodeIds` earlier in the same disjunction, and the compiler
-  // refuses to style duplicated ids at all.
-  const survivesGating = new Set<string>();
-  if (Array.isArray(stages.gated.nodes)) {
-    walkNodes(stages.gated.nodes, node => {
-      if (typeof node.id === "string") survivesGating.add(node.id);
-    });
+  // Keyed by id rather than by object reference: the passes rebuild any parent
+  // they removed a child from, so a node that survived arrives as a different
+  // object. Ids are sound here because a document carrying duplicates never
+  // reaches this clause — both entry points test `hasDuplicateNodeIds` earlier
+  // in the same disjunction.
+  const describedByTheSheet = new Set<string>();
+  const collect = (
+    nodes: readonly BlockNode[],
+    ancestorGated: boolean
+  ): void => {
+    for (const node of nodes) {
+      const gated =
+        ancestorGated || isConditionGated(node) || drawsNothing(node);
+      if (!gated && typeof node.id === "string") {
+        describedByTheSheet.add(node.id);
+      }
+      const slots = node.slots;
+      if (slots === undefined) continue;
+      for (const children of Object.values(slots)) {
+        if (Array.isArray(children)) collect(children, gated);
+      }
+    }
+  };
+  if (Array.isArray(stages.sanitized.nodes)) {
+    collect(stages.sanitized.nodes, false);
   }
 
   return stages.rewritten.some(entry => {
     const before = nodeAtPointer(stages.sanitized, entry.path);
     const after = nodeAtPointer(stages.migrated, entry.path);
     if (before === undefined || after === undefined) return false;
-    if (typeof after.id !== "string" || !survivesGating.has(after.id)) {
+    if (typeof after.id !== "string" || !describedByTheSheet.has(after.id)) {
       return false;
     }
     return !drawsNothing(before) && drawsNothing(after);

--- a/packages/blocks-react/src/styles.ts
+++ b/packages/blocks-react/src/styles.ts
@@ -1,7 +1,6 @@
 import {
   compilePageCss,
   declaresNoMarkup,
-  isConditionGated,
   isFetchableUrl,
   nodeAtPointer,
   nodeClassNames,
@@ -375,65 +374,46 @@ export function drawlessTestFor(
  */
 export function migrationChangedWhatDraws(
   stages: DocumentReadStages,
-  resolver: BlockResolver
+  resolver: BlockResolver,
+  styles: PageStyles | undefined
 ): boolean {
   if (stages.rewritten.length === 0) return false;
   const drawsNothing = drawlessTestFor(resolver);
-  // The engine's reported pointers are RESOLVED rather than matched against
-  // paths rebuilt here. Rebuilding them would be a second encoder of the same
-  // format: it agrees on every ordinary slot name and diverges on the ones the
-  // escaping exists for, so the mismatch appears only for the documents this
-  // check most needs to read.
-  // Which nodes the COMPILER would have put in the main sheet, mirrored from
-  // its own rule rather than approximated. `compile-page.ts` gates a node when
-  // an ancestor is gated, when the node is condition-gated, OR when it declares
-  // it draws nothing — and gating is inherited by the whole subtree, because a
-  // block that draws nothing places none of its slots' children.
-  //
-  // Two things this must get right, and an earlier version got both wrong:
-  //
-  // - it walks the STORED tree, because that is what the artifact was compiled
-  //   from. Walking the migrated one asks whether a node draws nothing NOW,
-  //   which is the question being answered, not the one being conditioned on.
-  // - it includes drawless ancestry, not condition gating alone. A descendant
-  //   of a drawless ancestor has no rules in the main sheet either, so treating
-  //   its flip as a repair withholds a sheet that never described it.
-  //
-  // Keyed by id rather than by object reference: the passes rebuild any parent
-  // they removed a child from, so a node that survived arrives as a different
-  // object. Ids are sound here because a document carrying duplicates never
-  // reaches this clause — both entry points test `hasDuplicateNodeIds` earlier
-  // in the same disjunction.
-  const describedByTheSheet = new Set<string>();
-  const collect = (
-    nodes: readonly BlockNode[],
-    ancestorGated: boolean
-  ): void => {
-    for (const node of nodes) {
-      const gated =
-        ancestorGated || isConditionGated(node) || drawsNothing(node);
-      if (!gated && typeof node.id === "string") {
-        describedByTheSheet.add(node.id);
-      }
-      const slots = node.slots;
-      if (slots === undefined) continue;
-      for (const children of Object.values(slots)) {
-        if (Array.isArray(children)) collect(children, gated);
-      }
-    }
-  };
-  if (Array.isArray(stages.sanitized.nodes)) {
-    collect(stages.sanitized.nodes, false);
-  }
+  const gatedRules = readableGatedRules(styles);
 
   return stages.rewritten.some(entry => {
-    const before = nodeAtPointer(stages.sanitized, entry.path);
     const after = nodeAtPointer(stages.migrated, entry.path);
-    if (before === undefined || after === undefined) return false;
-    if (typeof after.id !== "string" || !describedByTheSheet.has(after.id)) {
-      return false;
+    if (after === undefined) return false;
+    // Nothing to be stale about a node that draws nothing now either.
+    if (!drawsNothing(after)) return false;
+
+    // Whether the node DREW when the sheet was compiled is read off the sheet
+    // rather than recomputed. The compiler records every node it withheld, by
+    // id, under its own combined decision — condition, drawless, or inherited
+    // from an ancestor — so an entry means "these rules are not in `css`" and
+    // its absence means they are.
+    //
+    // Read rather than re-derived for two reasons. Reapplying the gating rule
+    // here is a second implementation of a decision the compiler owns, and
+    // three separate defects on this path have been exactly that. And the
+    // predicate cannot answer the question at all for a node whose migration
+    // RENAMED the prop `rendersNothing` reads: today's predicate over
+    // yesterday's props reports drawless for a node that drew, so the flip
+    // disappears. The artifact carries the answer the schema of the day
+    // produced, which is the only version-independent source there is.
+    if (gatedRules !== undefined) {
+      return (
+        typeof after.id === "string" &&
+        !Object.prototype.hasOwnProperty.call(gatedRules, after.id)
+      );
     }
-    return !drawsNothing(before) && drawsNothing(after);
+
+    // An artifact compiled before the per-node map existed carries no record,
+    // so the stored props are the only evidence left. This is the derivation
+    // above, kept ONLY for those artifacts and inheriting their limitation: a
+    // migration that renamed the prop the predicate reads is invisible here.
+    const before = nodeAtPointer(stages.sanitized, entry.path);
+    return before !== undefined && !drawsNothing(before);
   });
 }
 

--- a/packages/blocks-react/src/styles.ts
+++ b/packages/blocks-react/src/styles.ts
@@ -402,9 +402,15 @@ export function migrationChangedWhatDraws(
     // disappears. The artifact carries the answer the schema of the day
     // produced, which is the only version-independent source there is.
     if (gatedRules !== undefined) {
+      // Asked through `isRecordedGatedEntry`, the same predicate delivery and
+      // pruning coverage use, rather than by testing for the key. A stored map
+      // is input like any other: a row carrying `{ "a": null }` has the key and
+      // records nothing, so key presence alone would report the node withheld
+      // and keep serving rules — and any `url(...)` in them — that nothing
+      // accounts for.
       return (
         typeof after.id === "string" &&
-        !Object.prototype.hasOwnProperty.call(gatedRules, after.id)
+        !isRecordedGatedEntry(gatedRules[after.id])
       );
     }
 

--- a/packages/blocks-react/src/styles.ts
+++ b/packages/blocks-react/src/styles.ts
@@ -392,20 +392,35 @@ export function migrationChangedWhatDraws(
   // sheet is withheld entire — a far larger regression than the stale rules
   // this exists to drop.
   //
-  // Membership is by IDENTITY rather than by resolving the pointer again: the
-  // gating pass REMOVES nodes, so positions shift and the same pointer
-  // addresses a different node in that tree. Surviving nodes keep their
-  // reference, which is what makes the set meaningful.
-  const survivesGating = new Set<BlockNode>();
+  // Membership is by ID rather than by object identity or by resolving the
+  // pointer again. Both alternatives are wrong in a way that FAILS TO REPORT:
+  //
+  // - the pointer addresses a position, and gating REMOVES nodes, so the same
+  //   pointer names a different node in that tree;
+  // - object identity survives an untouched node but NOT an ancestor, because
+  //   the gating walk rebuilds any parent it removed a child from. An ancestor
+  //   that stayed visible, kept its rules in the main sheet, and turned drawless
+  //   is exactly the node this exists to catch, and it is exactly the one whose
+  //   reference changed.
+  //
+  // Ids are sound here because a document carrying duplicates never reaches this
+  // point: `storedSheetCannotDescribe` and `PageRenderer` both test
+  // `hasDuplicateNodeIds` earlier in the same disjunction, and the compiler
+  // refuses to style duplicated ids at all.
+  const survivesGating = new Set<string>();
   if (Array.isArray(stages.gated.nodes)) {
-    walkNodes(stages.gated.nodes, node => survivesGating.add(node));
+    walkNodes(stages.gated.nodes, node => {
+      if (typeof node.id === "string") survivesGating.add(node.id);
+    });
   }
 
   return stages.rewritten.some(entry => {
     const before = nodeAtPointer(stages.sanitized, entry.path);
     const after = nodeAtPointer(stages.migrated, entry.path);
     if (before === undefined || after === undefined) return false;
-    if (!survivesGating.has(after)) return false;
+    if (typeof after.id !== "string" || !survivesGating.has(after.id)) {
+      return false;
+    }
     return !drawsNothing(before) && drawsNothing(after);
   });
 }

--- a/packages/blocks-react/src/styles.ts
+++ b/packages/blocks-react/src/styles.ts
@@ -383,10 +383,29 @@ export function migrationChangedWhatDraws(
   // format: it agrees on every ordinary slot name and diverges on the ones the
   // escaping exists for, so the mismatch appears only for the documents this
   // check most needs to read.
+  // Only nodes whose rules could be in the MAIN sheet are asked. Condition
+  // gating moves a withheld node's rules into the per-node map instead, and it
+  // withholds whole subtrees, so a descendant flipping to drawless leaves the
+  // delivered CSS exactly as correct as it was. Marking the artifact repaired
+  // for one of those costs every OTHER block on the page its styling, since a
+  // caller without a compile context has no way to recompile and the stored
+  // sheet is withheld entire — a far larger regression than the stale rules
+  // this exists to drop.
+  //
+  // Membership is by IDENTITY rather than by resolving the pointer again: the
+  // gating pass REMOVES nodes, so positions shift and the same pointer
+  // addresses a different node in that tree. Surviving nodes keep their
+  // reference, which is what makes the set meaningful.
+  const survivesGating = new Set<BlockNode>();
+  if (Array.isArray(stages.gated.nodes)) {
+    walkNodes(stages.gated.nodes, node => survivesGating.add(node));
+  }
+
   return stages.rewritten.some(entry => {
     const before = nodeAtPointer(stages.sanitized, entry.path);
     const after = nodeAtPointer(stages.migrated, entry.path);
     if (before === undefined || after === undefined) return false;
+    if (!survivesGating.has(after)) return false;
     return !drawsNothing(before) && drawsNothing(after);
   });
 }


### PR DESCRIPTION
Recovers the last commit of #719, which merged without it.

## What happened

#719's branch tip was `3fb4a2f6e`. The merge took `0ec9153ad` — the commit before it — so the final change was dropped. Verified by content on the merge commit `f61172e8` rather than by ancestry, with both controls:

- marker `survivesGating` in `f61172e8:packages/blocks-react/src/styles.ts` → **absent**
- control that the search WORKS at that path (`migrationChangedWhatDraws`) → 1 hit
- control that the marker is real (same grep against the branch tip) → 3 hits

`gh pr view --json headRefOid` reports the MERGED head, not the branch tip; `git ls-remote` gives the tip. That is the only reason this was caught.

## Why it matters on main right now

#719 shipped the migration re-check UNSCOPED. A node withheld by condition gating keeps its rules in the per-node map rather than the main sheet, so a migration turning such a node drawless changes nothing about the delivered CSS — but the unscoped check marks the whole artifact repaired, and a caller with no compile context then has its stored sheet withheld entire.

The cost lands on the blocks that were never involved: every visible block on the page loses its styling. That is a larger regression than the stale rules the feature exists to drop.

## The fix

The re-check is scoped to nodes that survive gating. Membership is by node IDENTITY rather than by resolving the reported pointer in the gated tree, because gating REMOVES nodes — positions shift, and the same pointer would address a different node there.

## Verification

Stub-verified: removing the single scoping line fails the new gated-subtree test and nothing else.

The test needed two fixture corrections before it measured this at all, both recorded in the file:

1. The first version had the gated wrapper and its drawless child each be the LAST node of their type. The sheet was withheld — correctly, by the pre-existing "removing the last node of a type leaves its shared rule unjustified" clause. Red for the wrong reason.
2. A visible `test/box` fixed one type and not the other. The fixture now also carries a visible drawless node stored ALREADY at v2, so the migration does not touch it and that tier stays justified.

It asserts the VISIBLE sibling keeps `color: teal`. An assertion about the withheld node alone would have been satisfied by the sheet being blanked, which is the failure under test.

491 blocks-react tests, typecheck and lint clean by exit code.
