### PR TITLE
fix(plugin-sdk): type-check the test files nothing was compiling

### DIFF
--- a/packages/plugin-sdk/package.json
+++ b/packages/plugin-sdk/package.json
@@ -49,7 +49,7 @@
   "scripts": {
     "build": "tsup",
     "dev": "tsup --watch",
-    "check-types": "tsc --noEmit",
+    "check-types": "tsc --noEmit && tsc --noEmit -p tsconfig.tests.json",
     "lint": "eslint . --max-warnings 0",
     "clean": "rimraf dist",
     "test": "vitest run"
@@ -81,6 +81,7 @@
     "@nextlyhq/admin": "workspace:*",
     "@nextlyhq/eslint-config": "workspace:*",
     "@nextlyhq/tsconfig": "workspace:*",
+    "@types/node": "^20.19.17",
     "@types/react": "19.2.0",
     "nextly": "workspace:*",
     "react": "19.2.0",

--- a/packages/plugin-sdk/tsconfig.json
+++ b/packages/plugin-sdk/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "@nextlyhq/tsconfig/base-bundler.json",
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "dist"
+    "outDir": "dist",
+    "types": []
   },
   "include": ["src/**/*"],
   "exclude": ["dist", "node_modules", "**/*.test.ts"]

--- a/packages/plugin-sdk/tsconfig.tests.json
+++ b/packages/plugin-sdk/tsconfig.tests.json
@@ -1,0 +1,30 @@
+// Type-checks the test files that `tsconfig.json` excludes.
+//
+// The package's own tsconfig excludes `**/*.test.ts`, so no test file here was
+// ever type-checked — and vitest does not type-check either, because esbuild
+// strips annotations rather than checking them. Two independent ways for a test
+// to be wrong and look green, with neither gate covering the other. This
+// package is the ONLY stable import surface plugin authors have, so a test
+// asserting the shape of that surface is exactly the kind that must compile.
+//
+// `types` is re-widened here because the shipping config sets it to `[]`. Test
+// files legitimately reach `node:fs`, `node:path`, `node:url` and `node:util`
+// to read the built package off disk; `src` must not, and the shipping config's
+// empty list is what enforces that. Both halves are needed — the empty list
+// alone breaks these files, and node types alone would put `process` and the
+// filesystem in ambient reach of every module this package publishes, which is
+// the one surface plugin authors are told is stable.
+//
+// There is no opt-out list, deliberately. Every one of this package's test
+// files compiles, so nothing needs carrying, and an empty list is a stronger
+// statement than a short one: adding the first entry is a visible regression
+// rather than one more line in a column that already has several.
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1357,6 +1357,9 @@ importers:
       '@nextlyhq/tsconfig':
         specifier: workspace:*
         version: link:../tsconfig
+      '@types/node':
+        specifier: ^20.19.17
+        version: 20.19.17
       '@types/react':
         specifier: 19.2.0
         version: 19.2.0
@@ -1377,7 +1380,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.10(@types/node@24.10.0)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.9.0)(jsdom@27.1.0)(vite@7.3.6(@types/node@24.10.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.10(@types/node@20.19.17)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.9.0)(jsdom@27.1.0)(vite@7.3.6(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/plugin-seo:
     devDependencies:

--- a/turbo.jsonc
+++ b/turbo.jsonc
@@ -169,10 +169,17 @@
       // missing here leaves the hash unmoved, so CI replays a cached green
       // without ever checking the changed module. Kept in step with
       // `MODULE_EXTENSIONS` in `packages/builder/src/source-modules.ts`.
+      //
+      // `tsconfig.tests.json` is listed for the same reason as the extensions
+      // above. Several packages run a SECOND `tsc` over that config to cover the
+      // test files their shipping config excludes, and a config outside this
+      // list does not move the hash — so narrowing what that pass checks would
+      // replay a cached green rather than re-running it.
       "inputs": [
         "src/**/*.{ts,tsx,mts,cts}",
         "*.{ts,tsx,mts,cts}",
-        "tsconfig.json"
+        "tsconfig.json",
+        "tsconfig.tests.json"
       ],
       "outputs": ["**/*.tsbuildinfo"] // TypeScript incremental cache
     },


### PR DESCRIPTION
Task 167, scoped to `packages/plugin-sdk` after re-measuring. No changeset: this changes what CI checks, not what a user installs.

## What was actually wrong

`packages/plugin-sdk/tsconfig.json` excludes `**/*.test.ts`, and `check-types` ran that config alone. Vitest strips annotations rather than checking them. So a type error in any of this package's four test files was reported by **nothing** — including `plugin-surface.test.ts`, which asserts the shape of the published surface.

## The task file was stale in both directions, so this is narrower than it says

Re-measured on `main`, by execution rather than by reading `exclude`:

| package | test files | in the tsc program |
|---|---|---|
| `admin` | 197 | **197 — already covered, no work needed** |
| `plugin-sdk` | 4 | **0 — this PR** |

`admin` and `builder` never excluded test files, so their single `tsc --noEmit` already compiles them. `blocks-engine` and `ui` both gained a second pass since 167 was filed. The task file now carries this measurement; the note claiming `@types/node` is absent from `ui` was also wrong (it has it).

## Why this touches the shipping config too

The four test files legitimately reach `node:fs`, `node:path`, `node:url` and `node:util`, so the tests config needs node types. But `packages/tsconfig/base-bundler.json` sets no `types` key and `plugin-sdk` did not either — so simply adding `@types/node` as a devDependency would have made `process` and the filesystem **ambient across `src`**, in the one package plugin authors are told is stable.

Measured, not assumed. With `types: []` removed from the shipping config, `import { readFileSync } from "node:fs"` in `src/index.ts` compiles clean. With it, `TS2307`. `blocks-engine` already states the empty list for exactly this reason; `plugin-sdk` never did.

`src` reaches zero node builtins today, so the empty list costs nothing and closes the door before the dependency opens it.

## Verification

Both halves proven by breaking them, separately:

- a real type error planted in `src/secret.test.ts` (`const x: number = "s"`) is now reported as `TS2322` — it was invisible before;
- a `node:fs` import planted in `src/index.ts` is refused with `TS2307` under `types: []`, and **accepted** with that line removed, which is what makes the line load-bearing rather than decorative.

Gates: `check-types` clean (both passes), 16 tests pass, lint clean by exit code once `dist` exists.

⚠️ `pnpm lint` fails in a fresh worktree with `import-x/no-unresolved` on the package's self-referencing `.test-d.ts` imports until `dist` is built. Confirmed identical on unmodified `main`, so it is pre-existing and environmental, not from this change.
