### PR TITLE
fix(admin): make the plugins sidebar item navigate to its page

### DIFF
--- a/.changeset/plugins-sidebar-item-navigates.md
+++ b/.changeset/plugins-sidebar-item-navigates.md
@@ -28,3 +28,5 @@
 The Plugins item in the admin sidebar now opens the plugins page when you click it, instead of only expanding the sub-sidebar and leaving you to find the page yourself. It also stays visible when no plugins are installed, so a new project can reach the plugins page at all.
 
 Users who can read a plugin's collections but cannot manage settings keep the sub-sidebar, since the plugins page itself is settings-guarded.
+
+The secondary sidebar now closes when the category it is showing stops being one of the sidebar's destinations, so a slow or failing permissions load no longer leaves an empty panel open beside the page.

--- a/.changeset/plugins-sidebar-item-navigates.md
+++ b/.changeset/plugins-sidebar-item-navigates.md
@@ -22,6 +22,9 @@
 "@nextlyhq/telemetry": patch
 "@nextlyhq/tsconfig": patch
 "@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
 ---
 
 The Plugins item in the admin sidebar now opens the plugins page when you click it, instead of only expanding the sub-sidebar and leaving you to find the page yourself. It also stays visible when no plugins are installed, so a new project can reach the plugins page at all.
+
+Users who can read a plugin's collections but cannot manage settings keep the sub-sidebar, since the plugins page itself is settings-guarded.

--- a/.changeset/plugins-sidebar-item-navigates.md
+++ b/.changeset/plugins-sidebar-item-navigates.md
@@ -25,7 +25,7 @@
 "@nextlyhq/module-specifiers": patch
 ---
 
-The Plugins item in the admin sidebar now opens the plugins page when you click it, instead of only expanding the sub-sidebar and leaving you to find the page yourself. It also stays visible when no plugins are installed, so a new project can reach the plugins page at all.
+On desktop, the Plugins item in the admin sidebar now opens the plugins page when you click it, instead of only expanding the sub-sidebar and leaving you to find the page yourself. On mobile it still opens the panel, as every sidebar section with a panel does, and Installed Plugins is the first entry inside it. The item also stays visible when no plugins are installed, so a new project can reach the plugins page at all.
 
 Users who can read a plugin's collections but cannot manage settings keep the sub-sidebar, since the plugins page itself is settings-guarded.
 

--- a/.changeset/plugins-sidebar-item-navigates.md
+++ b/.changeset/plugins-sidebar-item-navigates.md
@@ -1,0 +1,27 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+---
+
+The Plugins item in the admin sidebar now opens the plugins page when you click it, instead of only expanding the sub-sidebar and leaving you to find the page yourself. It also stays visible when no plugins are installed, so a new project can reach the plugins page at all.

--- a/packages/admin/src/components/features/dashboard/DynamicPluginNav.test.tsx
+++ b/packages/admin/src/components/features/dashboard/DynamicPluginNav.test.tsx
@@ -192,6 +192,58 @@ describe("DynamicPluginNav", () => {
   });
 });
 
+describe("DynamicPluginNav expanded", () => {
+  /**
+   * A group is expandable when it retains a collection, and only then.
+   *
+   * Two plugins can share a display group — every collection without an
+   * `admin.group` heading lands under "Other" — and they need not agree about
+   * placement. A group-level placement answer has to be one value for both, so
+   * it hides the group that still holds a reachable collection: the rail shows
+   * a Plugins item whose panel has nothing in it.
+   */
+  it("expands a shared group that still retains a reachable collection", () => {
+    mockCanManageSettings = false;
+    mockBranding = {
+      plugins: [
+        {
+          name: "@acme/moves",
+          collections: ["gadgets"],
+          placement: "settings",
+        },
+        { name: "@acme/stays", collections: ["widgets"] },
+      ],
+    } as unknown as AdminBranding;
+    mockCollectionCaps = {
+      widgets: { canRead: true },
+      gadgets: { canRead: true },
+    };
+    mockCollections = {
+      items: [
+        // `gadgets` first, so the placed plugin is the one a group-level
+        // lookup would find and apply to the whole group.
+        {
+          id: "c2",
+          name: "gadgets",
+          labels: { plural: "Gadgets" },
+          admin: { isPlugin: true },
+        },
+        {
+          id: "c1",
+          name: "widgets",
+          labels: { plural: "Widgets" },
+          admin: { isPlugin: true },
+        },
+      ],
+    };
+
+    renderNav();
+
+    // The group renders, because `widgets` is still under Plugins.
+    expect(screen.getByRole("button", { name: /other/i })).toBeInTheDocument();
+  });
+});
+
 describe("DynamicPluginNav collapsed", () => {
   it("offers the guarded destinations to a user who can open them", async () => {
     givePluginWithReadableCollection();
@@ -254,10 +306,9 @@ describe("DynamicPluginNav collapsed", () => {
    * The same omission, for a placed collection that declares no `admin.group`.
    *
    * `admin.group` is an optional heading, so these collections are grouped
-   * under "Other" and cannot be found by group at all. A group-keyed placement
-   * lookup answers "no placement" for them, which reads as "belongs under
-   * Plugins" — so the collection appears here AND under Settings, which is the
-   * duplicate the placement rule exists to prevent.
+   * under "Other" and are identifiable only by the plugin that owns them.
+   * Placement is read from that owner, which is what keeps the collection out
+   * of this menu while it is rendered under Settings.
    */
   it("omits a placed collection that declares no display group", async () => {
     mockCanManageSettings = false;
@@ -287,7 +338,7 @@ describe("DynamicPluginNav collapsed", () => {
           id: "c2",
           name: "gadgets",
           labels: { plural: "Gadgets" },
-          // No `group`. This is what the group-keyed lookup could not see.
+          // No `group`: owned by a plugin, but carrying no heading.
           admin: { isPlugin: true },
         },
       ],

--- a/packages/admin/src/components/features/dashboard/DynamicPluginNav.test.tsx
+++ b/packages/admin/src/components/features/dashboard/DynamicPluginNav.test.tsx
@@ -20,9 +20,19 @@ let mockIsError = false;
 vi.mock("@admin/context/providers/BrandingProvider", () => ({
   useBranding: () => mockBranding,
 }));
+let mockCanManageSettings = true;
+let mockCollectionCaps: Record<string, { canRead: boolean }> = {};
 vi.mock("@admin/hooks/useCurrentUserPermissions", () => ({
   useCurrentUserPermissions: () => ({
-    capabilities: { canViewCollections: true, canManageSettings: true },
+    capabilities: {
+      canViewCollections: true,
+      canManageSettings: mockCanManageSettings,
+      isSuperAdmin: false,
+      // Real `filterCollectionItems` runs here rather than a stub: a
+      // pass-through mock would certify that a collection reaches the panel
+      // without the permission that actually admits it.
+      collections: mockCollectionCaps,
+    },
   }),
 }));
 vi.mock("@admin/hooks/queries", () => ({
@@ -54,6 +64,8 @@ afterEach(() => {
   mockCollections = { items: [] };
   mockIsLoading = false;
   mockIsError = false;
+  mockCanManageSettings = true;
+  mockCollectionCaps = {};
   vi.restoreAllMocks();
 });
 
@@ -68,19 +80,61 @@ describe("DynamicPluginNav", () => {
   });
 
   /**
-   * The separating case. Without it, a component that rendered the link
-   * unconditionally under every circumstance would satisfy the assertion
-   * above, including when the panel should be suppressed entirely.
+   * The separating case, corrected. An earlier version asserted that a
+   * collections error suppressed the link, which encoded a bug as the control:
+   * `/admin/plugins` reads `admin-meta`, not collections, so it stays reachable
+   * during that failure and only the collection-derived entries are lost.
+   *
+   * What actually separates "renders the link always" from "renders it for the
+   * right users" is the capability, so that is the control.
    */
-  it("renders nothing when the collections query errored", () => {
+  it("withholds the link from a collection reader who cannot open the page", () => {
+    // The panel must still RENDER for this user — they opened it to reach
+    // their plugin's collections — so a plugin collection is present. Without
+    // it the component returns early and the assertion below passes on the
+    // early return rather than on the link being gated, which is what an
+    // earlier version of this test did.
+    mockCanManageSettings = false;
+    mockBranding = {
+      plugins: [{ name: "@acme/p", collections: ["widgets"] }],
+    } as unknown as AdminBranding;
+    mockCollectionCaps = { widgets: { canRead: true } };
+    mockCollections = {
+      items: [
+        {
+          id: "c1",
+          name: "widgets",
+          label: "Widgets",
+          labels: { plural: "Widgets" },
+          admin: { isPlugin: true },
+        },
+      ],
+    };
+
+    const { container } = renderNav();
+
+    // Positive control on the component, not on any particular row: the panel
+    // rendered something, so the missing link is a fact about the gate rather
+    // than about a component that returned null. An earlier version asserted
+    // only the absence, and passed on the early return instead of the gate.
+    expect(container).not.toBeEmptyDOMElement();
+    expect(
+      screen.queryByRole("link", { name: /installed plugins/i })
+    ).toBeNull();
+  });
+
+  it("keeps the link when the collections query errors", () => {
     mockBranding = { plugins: [] } as unknown as AdminBranding;
     mockIsError = true;
 
     renderNav();
 
+    // The overview reads admin-meta, so a collections failure must not remove
+    // the only sidebar route to it — on mobile the primary icon is a button
+    // that opens this panel rather than navigating.
     expect(
-      screen.queryByRole("link", { name: /installed plugins/i })
-    ).toBeNull();
+      screen.getByRole("link", { name: /installed plugins/i })
+    ).toHaveAttribute("href", "/admin/plugins");
   });
 
   it("still offers exactly one overview link when plugins are installed", () => {

--- a/packages/admin/src/components/features/dashboard/DynamicPluginNav.test.tsx
+++ b/packages/admin/src/components/features/dashboard/DynamicPluginNav.test.tsx
@@ -178,6 +178,52 @@ describe("DynamicPluginNav collapsed", () => {
     ).toBeInTheDocument();
   });
 
+  it("omits a placed plugin's collections from the collection reader's menu", async () => {
+    // A placed plugin's collections live under Collections, Settings or its own
+    // standalone section. Repeating them here would show one collection twice.
+    mockCanManageSettings = false;
+    mockBranding = {
+      plugins: [
+        { name: "@acme/here", collections: ["widgets"], placement: "plugins" },
+        {
+          name: "@acme/elsewhere",
+          collections: ["gadgets"],
+          placement: "settings",
+        },
+      ],
+    } as unknown as AdminBranding;
+    mockCollectionCaps = {
+      widgets: { canRead: true },
+      gadgets: { canRead: true },
+    };
+    mockCollections = {
+      items: [
+        {
+          id: "c1",
+          name: "widgets",
+          labels: { plural: "Widgets" },
+          admin: { isPlugin: true, group: "Here" },
+        },
+        {
+          id: "c2",
+          name: "gadgets",
+          labels: { plural: "Gadgets" },
+          admin: { isPlugin: true, group: "Elsewhere" },
+        },
+      ],
+    };
+
+    const { container } = renderNav({ collapsed: true });
+    fireEvent.mouseEnter(container.querySelector("li")!);
+
+    // Positive control: the unplaced one IS offered, so the absence below is
+    // about placement rather than about a menu that rendered nothing.
+    expect(
+      await screen.findByRole("menuitem", { name: "Widgets" })
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("menuitem", { name: "Gadgets" })).toBeNull();
+  });
+
   /**
    * Every destination the collapsed dropdown offers by default is
    * manage-settings guarded, so a collection reader would get a menu whose

--- a/packages/admin/src/components/features/dashboard/DynamicPluginNav.test.tsx
+++ b/packages/admin/src/components/features/dashboard/DynamicPluginNav.test.tsx
@@ -80,20 +80,16 @@ describe("DynamicPluginNav", () => {
   });
 
   /**
-   * The separating case, corrected. An earlier version asserted that a
-   * collections error suppressed the link, which encoded a bug as the control:
-   * `/admin/plugins` reads `admin-meta`, not collections, so it stays reachable
-   * during that failure and only the collection-derived entries are lost.
-   *
-   * What actually separates "renders the link always" from "renders it for the
-   * right users" is the capability, so that is the control.
+   * The separating case: what distinguishes "renders the link always" from
+   * "renders it for users who can open the page" is the capability, not the
+   * presence of data. A collections error is not that separator, because
+   * `/admin/plugins` reads `admin-meta` and stays reachable through one.
    */
   it("withholds the link from a collection reader who cannot open the page", () => {
-    // The panel must still RENDER for this user — they opened it to reach
-    // their plugin's collections — so a plugin collection is present. Without
-    // it the component returns early and the assertion below passes on the
-    // early return rather than on the link being gated, which is what an
-    // earlier version of this test did.
+    // The panel must still RENDER for this user, since they opened it to reach
+    // their plugin's collections, so a plugin collection is present. Without
+    // one the component returns early and the assertion below is satisfied by
+    // that return rather than by the gate under test.
     mockCanManageSettings = false;
     mockBranding = {
       plugins: [{ name: "@acme/p", collections: ["widgets"] }],
@@ -115,8 +111,7 @@ describe("DynamicPluginNav", () => {
 
     // Positive control on the component, not on any particular row: the panel
     // rendered something, so the missing link is a fact about the gate rather
-    // than about a component that returned null. An earlier version asserted
-    // only the absence, and passed on the early return instead of the gate.
+    // than about a component that returned null.
     expect(container).not.toBeEmptyDOMElement();
     expect(
       screen.queryByRole("link", { name: /installed plugins/i })

--- a/packages/admin/src/components/features/dashboard/DynamicPluginNav.test.tsx
+++ b/packages/admin/src/components/features/dashboard/DynamicPluginNav.test.tsx
@@ -136,6 +136,32 @@ describe("DynamicPluginNav", () => {
     ).toBeNull();
   });
 
+  it("keeps the link while the collections query is still loading", () => {
+    // The skeleton stands in for the collection entries. The overview reads
+    // admin-meta, which has resolved, so replacing the whole panel would make
+    // /admin/plugins unreachable for the duration of a slow request.
+    mockBranding = { plugins: [] } as unknown as AdminBranding;
+    mockIsLoading = true;
+
+    renderNav();
+
+    expect(
+      screen.getByRole("link", { name: /installed plugins/i })
+    ).toHaveAttribute("href", "/admin/plugins");
+  });
+
+  it("withholds it while loading from a user who cannot open it", () => {
+    mockBranding = { plugins: [] } as unknown as AdminBranding;
+    mockIsLoading = true;
+    mockCanManageSettings = false;
+
+    renderNav();
+
+    expect(
+      screen.queryByRole("link", { name: /installed plugins/i })
+    ).toBeNull();
+  });
+
   it("keeps the link when the collections query errors", () => {
     mockBranding = { plugins: [] } as unknown as AdminBranding;
     mockIsError = true;

--- a/packages/admin/src/components/features/dashboard/DynamicPluginNav.test.tsx
+++ b/packages/admin/src/components/features/dashboard/DynamicPluginNav.test.tsx
@@ -2,10 +2,9 @@
  * The plugins panel must offer a route to the overview on every install,
  * including one with nothing installed.
  *
- * This is the case the component previously returned `null` for. It matters
- * most on mobile, where the primary plugins icon only opens this panel rather
- * than navigating, so an empty panel left `/admin/plugins` unreachable from
- * anywhere in the UI.
+ * The empty-install case matters most on mobile, where the primary plugins
+ * icon only opens this panel rather than navigating, so a panel with no link
+ * leaves `/admin/plugins` unreachable from anywhere in the UI.
  */
 import { render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -139,9 +138,9 @@ describe("DynamicPluginNav", () => {
 
     renderNav();
 
-    // Exactly one: the panel previously grew a second, parallel copy of this
-    // link so that the empty case had one, which produced two adjacent links
-    // to the same page on every non-empty install.
+    // Exactly one. This component owns the overview link; a second copy
+    // rendered by the panel around it would put two adjacent links to the same
+    // page in front of every non-empty install.
     expect(
       screen.getAllByRole("link", { name: /installed plugins/i })
     ).toHaveLength(1);

--- a/packages/admin/src/components/features/dashboard/DynamicPluginNav.test.tsx
+++ b/packages/admin/src/components/features/dashboard/DynamicPluginNav.test.tsx
@@ -6,7 +6,7 @@
  * icon only opens this panel rather than navigating, so a panel with no link
  * leaves `/admin/plugins` unreachable from anywhere in the UI.
  */
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import type { AdminBranding } from "@admin/types/branding";
@@ -50,12 +50,31 @@ const noop = () => false;
 // The real provider rather than a mocked `useSidebar`: the component reads
 // collapsed state from it, so a stub would let a change to that contract pass
 // unnoticed here.
-function renderNav() {
+function renderNav({ collapsed = false }: { collapsed?: boolean } = {}) {
   return render(
-    <SidebarProvider>
+    <SidebarProvider defaultOpen={!collapsed}>
       <DynamicPluginNav isActive={noop} />
     </SidebarProvider>
   );
+}
+
+/** A plugin owning one collection this user is permitted to read. */
+function givePluginWithReadableCollection() {
+  mockBranding = {
+    plugins: [{ name: "@acme/p", collections: ["widgets"] }],
+  } as unknown as AdminBranding;
+  mockCollectionCaps = { widgets: { canRead: true } };
+  mockCollections = {
+    items: [
+      {
+        id: "c1",
+        name: "widgets",
+        label: "Widgets",
+        labels: { plural: "Widgets" },
+        admin: { isPlugin: true, group: "Acme" },
+      },
+    ],
+  };
 }
 
 afterEach(() => {
@@ -144,5 +163,38 @@ describe("DynamicPluginNav", () => {
     expect(
       screen.getAllByRole("link", { name: /installed plugins/i })
     ).toHaveLength(1);
+  });
+});
+
+describe("DynamicPluginNav collapsed", () => {
+  it("offers the guarded destinations to a user who can open them", async () => {
+    givePluginWithReadableCollection();
+
+    const { container } = renderNav({ collapsed: true });
+    fireEvent.mouseEnter(container.querySelector("li")!);
+
+    expect(
+      await screen.findByRole("menuitem", { name: /installed plugins/i })
+    ).toBeInTheDocument();
+  });
+
+  /**
+   * Every destination the collapsed dropdown offers by default is
+   * manage-settings guarded, so a collection reader would get a menu whose
+   * every item redirects. They are offered their collections instead.
+   */
+  it("offers a collection reader their collections, not guarded pages", async () => {
+    givePluginWithReadableCollection();
+    mockCanManageSettings = false;
+
+    const { container } = renderNav({ collapsed: true });
+    fireEvent.mouseEnter(container.querySelector("li")!);
+
+    expect(
+      await screen.findByRole("menuitem", { name: "Widgets" })
+    ).toHaveAttribute("href", "/admin/collections/widgets");
+    expect(
+      screen.queryByRole("menuitem", { name: /installed plugins/i })
+    ).toBeNull();
   });
 });

--- a/packages/admin/src/components/features/dashboard/DynamicPluginNav.test.tsx
+++ b/packages/admin/src/components/features/dashboard/DynamicPluginNav.test.tsx
@@ -1,0 +1,100 @@
+/**
+ * The plugins panel must offer a route to the overview on every install,
+ * including one with nothing installed.
+ *
+ * This is the case the component previously returned `null` for. It matters
+ * most on mobile, where the primary plugins icon only opens this panel rather
+ * than navigating, so an empty panel left `/admin/plugins` unreachable from
+ * anywhere in the UI.
+ */
+import { render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { AdminBranding } from "@admin/types/branding";
+
+let mockBranding: AdminBranding | undefined;
+let mockCollections: { items: unknown[] } | undefined = { items: [] };
+let mockIsLoading = false;
+let mockIsError = false;
+
+vi.mock("@admin/context/providers/BrandingProvider", () => ({
+  useBranding: () => mockBranding,
+}));
+vi.mock("@admin/hooks/useCurrentUserPermissions", () => ({
+  useCurrentUserPermissions: () => ({
+    capabilities: { canViewCollections: true, canManageSettings: true },
+  }),
+}));
+vi.mock("@admin/hooks/queries", () => ({
+  useCollections: () => ({
+    data: mockCollections,
+    isLoading: mockIsLoading,
+    isError: mockIsError,
+    error: mockIsError ? new Error("boom") : undefined,
+  }),
+}));
+import { DynamicPluginNav } from "@admin/components/features/dashboard/DynamicPluginNav";
+import { SidebarProvider } from "@admin/components/layout/sidebar";
+
+const noop = () => false;
+
+// The real provider rather than a mocked `useSidebar`: the component reads
+// collapsed state from it, so a stub would let a change to that contract pass
+// unnoticed here.
+function renderNav() {
+  return render(
+    <SidebarProvider>
+      <DynamicPluginNav isActive={noop} />
+    </SidebarProvider>
+  );
+}
+
+afterEach(() => {
+  mockBranding = undefined;
+  mockCollections = { items: [] };
+  mockIsLoading = false;
+  mockIsError = false;
+  vi.restoreAllMocks();
+});
+
+describe("DynamicPluginNav", () => {
+  it("offers the overview link when nothing is installed", () => {
+    mockBranding = { plugins: [] } as unknown as AdminBranding;
+
+    renderNav();
+
+    const link = screen.getByRole("link", { name: /installed plugins/i });
+    expect(link).toHaveAttribute("href", "/admin/plugins");
+  });
+
+  /**
+   * The separating case. Without it, a component that rendered the link
+   * unconditionally under every circumstance would satisfy the assertion
+   * above, including when the panel should be suppressed entirely.
+   */
+  it("renders nothing when the collections query errored", () => {
+    mockBranding = { plugins: [] } as unknown as AdminBranding;
+    mockIsError = true;
+
+    renderNav();
+
+    expect(
+      screen.queryByRole("link", { name: /installed plugins/i })
+    ).toBeNull();
+  });
+
+  it("still offers exactly one overview link when plugins are installed", () => {
+    mockBranding = {
+      plugins: [{ name: "@acme/p", collections: [] }],
+    } as unknown as AdminBranding;
+
+    renderNav();
+
+    // Exactly one: the panel previously grew a second, parallel copy of this
+    // link so that the empty case had one, which produced two adjacent links
+    // to the same page on every non-empty install.
+    expect(
+      screen.getAllByRole("link", { name: /installed plugins/i })
+    ).toHaveLength(1);
+  });
+});

--- a/packages/admin/src/components/features/dashboard/DynamicPluginNav.test.tsx
+++ b/packages/admin/src/components/features/dashboard/DynamicPluginNav.test.tsx
@@ -251,6 +251,111 @@ describe("DynamicPluginNav collapsed", () => {
   });
 
   /**
+   * The same omission, for a placed collection that declares no `admin.group`.
+   *
+   * `admin.group` is an optional heading, so these collections are grouped
+   * under "Other" and cannot be found by group at all. A group-keyed placement
+   * lookup answers "no placement" for them, which reads as "belongs under
+   * Plugins" — so the collection appears here AND under Settings, which is the
+   * duplicate the placement rule exists to prevent.
+   */
+  it("omits a placed collection that declares no display group", async () => {
+    mockCanManageSettings = false;
+    mockBranding = {
+      plugins: [
+        { name: "@acme/here", collections: ["widgets"], placement: "plugins" },
+        {
+          name: "@acme/elsewhere",
+          collections: ["gadgets"],
+          placement: "settings",
+        },
+      ],
+    } as unknown as AdminBranding;
+    mockCollectionCaps = {
+      widgets: { canRead: true },
+      gadgets: { canRead: true },
+    };
+    mockCollections = {
+      items: [
+        {
+          id: "c1",
+          name: "widgets",
+          labels: { plural: "Widgets" },
+          admin: { isPlugin: true, group: "Here" },
+        },
+        {
+          id: "c2",
+          name: "gadgets",
+          labels: { plural: "Gadgets" },
+          // No `group`. This is what the group-keyed lookup could not see.
+          admin: { isPlugin: true },
+        },
+      ],
+    };
+
+    const { container } = renderNav({ collapsed: true });
+    fireEvent.mouseEnter(container.querySelector("li")!);
+
+    // Positive control: the unplaced collection IS offered, so the absence
+    // below is about placement rather than about an empty menu.
+    expect(
+      await screen.findByRole("menuitem", { name: "Widgets" })
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("menuitem", { name: "Gadgets" })).toBeNull();
+  });
+
+  /**
+   * Two plugins, both with group-less collections, disagreeing about placement.
+   *
+   * This is the case a group-level answer cannot get right at all, rather than
+   * one it happens to miss. Both collections are grouped under "Other", so a
+   * single flag on that group has to be true or false for both — and one of
+   * them is placed while the other is not. Only a per-collection rule can list
+   * one and omit the other.
+   */
+  it("separates two group-less collections that disagree about placement", async () => {
+    mockCanManageSettings = false;
+    mockBranding = {
+      plugins: [
+        { name: "@acme/stays", collections: ["widgets"] },
+        {
+          name: "@acme/moves",
+          collections: ["gadgets"],
+          placement: "settings",
+        },
+      ],
+    } as unknown as AdminBranding;
+    mockCollectionCaps = {
+      widgets: { canRead: true },
+      gadgets: { canRead: true },
+    };
+    mockCollections = {
+      items: [
+        {
+          id: "c1",
+          name: "widgets",
+          labels: { plural: "Widgets" },
+          admin: { isPlugin: true },
+        },
+        {
+          id: "c2",
+          name: "gadgets",
+          labels: { plural: "Gadgets" },
+          admin: { isPlugin: true },
+        },
+      ],
+    };
+
+    const { container } = renderNav({ collapsed: true });
+    fireEvent.mouseEnter(container.querySelector("li")!);
+
+    expect(
+      await screen.findByRole("menuitem", { name: "Widgets" })
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("menuitem", { name: "Gadgets" })).toBeNull();
+  });
+
+  /**
    * Every destination the collapsed dropdown offers by default is
    * manage-settings guarded, so a collection reader would get a menu whose
    * every item redirects. They are offered their collections instead.

--- a/packages/admin/src/components/features/dashboard/DynamicPluginNav.tsx
+++ b/packages/admin/src/components/features/dashboard/DynamicPluginNav.tsx
@@ -197,12 +197,13 @@ export function DynamicPluginNav({
     return <PluginSkeleton />;
   }
 
-  // `plugins` is derived from plugin-owned collections, but a plugin that
-  // only contributes pages/settings/slots owns none — the overview must stay
-  // reachable whenever anything is installed, or those plugins are invisible.
-  const hasInstalledPlugins = (pluginMetadata?.length ?? 0) > 0;
-
-  if (error || (plugins.length === 0 && !hasInstalledPlugins)) {
+  // Only an error suppresses this panel. An empty install used to return null
+  // here, which left the panel with a search box and no link at all — and on
+  // mobile the primary icon only opens this panel rather than navigating, so
+  // there was no route to the overview from anywhere. The overview link below
+  // is the one implementation of that destination, so it has to render even
+  // when there is nothing to list underneath it.
+  if (error) {
     return null;
   }
 

--- a/packages/admin/src/components/features/dashboard/DynamicPluginNav.tsx
+++ b/packages/admin/src/components/features/dashboard/DynamicPluginNav.tsx
@@ -452,6 +452,12 @@ function CollapsedPluginDropdown({
                 </DropdownMenuItem>,
               ];
             }
+            // Only UNPLACED plugins contribute collections here. A placed
+            // plugin's collections already appear under Collections, Settings
+            // or its own standalone section, which is why the expanded view
+            // filters on the same flag; listing them again under Plugins would
+            // show one collection in two places.
+            if (plugin.isPlaced) return [];
             return plugin.collections.map(collection => {
               const href = getCollectionUrl(collection);
               const active = isActive(href);

--- a/packages/admin/src/components/features/dashboard/DynamicPluginNav.tsx
+++ b/packages/admin/src/components/features/dashboard/DynamicPluginNav.tsx
@@ -82,7 +82,13 @@ export function DynamicPluginNav({
   const { capabilities } = useCurrentUserPermissions();
   const branding = useBranding();
 
-  const { data, isLoading, error } = useCollections(
+  // `error` is deliberately not read. A collections failure leaves `data`
+  // undefined, so the collection-derived entries below are empty on their own,
+  // and the overview link must survive that failure because it reads
+  // admin-meta rather than collections. Branching on the error here is what
+  // used to remove the only sidebar route to /admin/plugins during an
+  // unrelated API outage.
+  const { data, isLoading } = useCollections(
     {
       pagination: { page: 0, pageSize: 100 },
       sorting: [{ field: "name", direction: "asc" }],
@@ -197,13 +203,21 @@ export function DynamicPluginNav({
     return <PluginSkeleton />;
   }
 
-  // Only an error suppresses this panel. An empty install used to return null
-  // here, which left the panel with a search box and no link at all — and on
-  // mobile the primary icon only opens this panel rather than navigating, so
-  // there was no route to the overview from anywhere. The overview link below
-  // is the one implementation of that destination, so it has to render even
-  // when there is nothing to list underneath it.
-  if (error) {
+  // The overview link is shown only to users who can open the page it points
+  // at: /admin/plugins is manage-settings guarded, and a collection reader
+  // opens this panel to reach their plugin's collections. Linking them to a
+  // route that redirects would replace working navigation with a bounce.
+  const canOpenOverview = capabilities.canManageSettings;
+
+  // A collections failure does NOT suppress the overview link. That
+  // destination reads admin-meta, not collections, so it is still reachable;
+  // only the collection-derived entries below are lost. On mobile the primary
+  // plugins icon is a button that opens this panel rather than navigating, so
+  // suppressing the link here would leave a settings manager with no route to
+  // the page during an unrelated API failure.
+  //
+  // Nothing to offer at all is the one case that renders nothing.
+  if (!canOpenOverview && plugins.length === 0) {
     return null;
   }
 
@@ -248,20 +262,22 @@ export function DynamicPluginNav({
 
   return (
     <>
-      {/* Installed Plugins overview link */}
-      <SidebarMenuItem>
-        <SidebarMenuButton asChild isActive={isOverviewActive}>
-          <Link href={overviewHref}>
-            <Package
-              className={cn(
-                "shrink-0",
-                !isOverviewActive && "text-muted-foreground"
-              )}
-            />
-            <span>Installed Plugins</span>
-          </Link>
-        </SidebarMenuButton>
-      </SidebarMenuItem>
+      {/* Installed Plugins overview link, for users who can open that page */}
+      {canOpenOverview && (
+        <SidebarMenuItem>
+          <SidebarMenuButton asChild isActive={isOverviewActive}>
+            <Link href={overviewHref}>
+              <Package
+                className={cn(
+                  "shrink-0",
+                  !isOverviewActive && "text-muted-foreground"
+                )}
+              />
+              <span>Installed Plugins</span>
+            </Link>
+          </SidebarMenuButton>
+        </SidebarMenuItem>
+      )}
 
       {/* Plugin collections (only for plugins not placed elsewhere) */}
       {pluginsWithCollections.map(plugin => {

--- a/packages/admin/src/components/features/dashboard/DynamicPluginNav.tsx
+++ b/packages/admin/src/components/features/dashboard/DynamicPluginNav.tsx
@@ -44,6 +44,33 @@ interface DynamicPluginNavProps {
 }
 
 /**
+ * The Installed Plugins entry.
+ *
+ * One implementation, used while collections load and after they settle. The
+ * link reads admin-meta only, so it is available in both states, and rendering
+ * it twice from two places is how the two would drift.
+ */
+function PluginOverviewLink({
+  isActive,
+}: {
+  isActive: (href?: string) => boolean;
+}) {
+  const active = isActive("/admin/plugins");
+  return (
+    <SidebarMenuItem>
+      <SidebarMenuButton asChild isActive={active}>
+        <Link href={ROUTES.PLUGINS}>
+          <Package
+            className={cn("shrink-0", !active && "text-muted-foreground")}
+          />
+          <span>Installed Plugins</span>
+        </Link>
+      </SidebarMenuButton>
+    </SidebarMenuItem>
+  );
+}
+
+/**
  * Loading skeleton for plugin items
  */
 function PluginSkeleton() {
@@ -198,16 +225,26 @@ export function DynamicPluginNav({
     );
   }, [allPluginCollections, visibleCollectionIds, isPluginPlaced, search]);
 
-  if (isLoading) {
-    if (isCollapsed) return null;
-    return <PluginSkeleton />;
-  }
-
   // The overview link is shown only to users who can open the page it points
   // at: /admin/plugins is manage-settings guarded, and a collection reader
   // opens this panel to reach their plugin's collections. Linking them to a
   // route that redirects would replace working navigation with a bounce.
   const canOpenOverview = capabilities.canManageSettings;
+
+  if (isLoading) {
+    if (isCollapsed) return null;
+    // The skeleton stands in for the collection entries only. The overview
+    // link reads admin-meta, which has already resolved, so replacing the whole
+    // panel would make /admin/plugins unreachable for as long as a slow or
+    // hung collections request lasts — and on mobile the rail item is a button
+    // that opens this panel rather than navigating, so there is no other way in.
+    return (
+      <>
+        {canOpenOverview && <PluginOverviewLink isActive={isActive} />}
+        <PluginSkeleton />
+      </>
+    );
+  }
 
   // A collections failure does NOT suppress the overview link. That
   // destination reads admin-meta, not collections, so it is still reachable;
@@ -251,12 +288,6 @@ export function DynamicPluginNav({
     );
   }
 
-  // Expanded mode — the overview link goes to the plugins list; each plugin
-  // has its own detail page now, so linking a plugin's slug here would land
-  // on one plugin instead of the overview.
-  const overviewHref = ROUTES.PLUGINS;
-  const isOverviewActive = isActive("/admin/plugins");
-
   // Plugins with unplaced collections (shown as expandable with collection sub-items)
   const pluginsWithCollections = plugins.filter(
     p => !p.isPlaced && p.collections.length > 0
@@ -265,21 +296,7 @@ export function DynamicPluginNav({
   return (
     <>
       {/* Installed Plugins overview link, for users who can open that page */}
-      {canOpenOverview && (
-        <SidebarMenuItem>
-          <SidebarMenuButton asChild isActive={isOverviewActive}>
-            <Link href={overviewHref}>
-              <Package
-                className={cn(
-                  "shrink-0",
-                  !isOverviewActive && "text-muted-foreground"
-                )}
-              />
-              <span>Installed Plugins</span>
-            </Link>
-          </SidebarMenuButton>
-        </SidebarMenuItem>
-      )}
+      {canOpenOverview && <PluginOverviewLink isActive={isActive} />}
 
       {/* Plugin collections (only for plugins not placed elsewhere) */}
       {pluginsWithCollections.map(plugin => {

--- a/packages/admin/src/components/features/dashboard/DynamicPluginNav.tsx
+++ b/packages/admin/src/components/features/dashboard/DynamicPluginNav.tsx
@@ -29,6 +29,7 @@ import { useBranding } from "@admin/context/providers/BrandingProvider";
 import { useCollections } from "@admin/hooks/queries";
 import { useCurrentUserPermissions } from "@admin/hooks/useCurrentUserPermissions";
 import { filterCollectionItems } from "@admin/lib/permissions/authorization";
+import { isCollectionPlacedElsewhere } from "@admin/lib/plugins/collection-placement";
 import { pluginSlug } from "@admin/lib/plugins/plugin-slug";
 import { cn } from "@admin/lib/utils";
 import type { ApiCollection } from "@admin/types/entities";
@@ -111,10 +112,15 @@ export function DynamicPluginNav({
 
   // `error` is deliberately not read. The two things this panel renders have
   // different data sources: collection entries come from this query, and the
-  // overview link comes from admin-meta. A failure here empties `data`, which
-  // suppresses the collection entries on its own, and must not reach the
-  // overview link, which is still backed and still the only sidebar route to
-  // /admin/plugins on mobile.
+  // overview link comes from admin-meta, so a collections failure must not
+  // remove the overview link — on mobile it is the only sidebar route to
+  // /admin/plugins.
+  //
+  // Whether the collection entries survive is `data`'s business, not this
+  // flag's. A failed background refetch keeps the last successful result, so
+  // the entries stay; only a first load that never succeeded leaves `data`
+  // empty. Reading `error` here would blank the entries in the first case too,
+  // replacing a still-accurate list with nothing.
   const { data, isLoading } = useCollections(
     {
       pagination: { page: 0, pageSize: 100 },
@@ -155,9 +161,14 @@ export function DynamicPluginNav({
       const collectionSlugs = new Set(meta.collections ?? []);
       for (const collection of allPluginCollections) {
         if (collectionSlugs.has(collection.name)) {
-          const groupSlug = pluginSlug(collection.admin?.group || "");
-          if (groupSlug && !map.has(groupSlug)) {
-            map.set(groupSlug, meta);
+          // Keyed by the group NAME the entries below are keyed by, not by a
+          // slug of it. `admin.group` is optional and those collections are
+          // grouped under "Other"; deriving the key from the absent heading
+          // produced an empty string, which was skipped, so the plugin was
+          // never found and its placement read as unset.
+          const groupName = collection.admin?.group || "Other";
+          if (!map.has(groupName)) {
+            map.set(groupName, meta);
           }
         }
       }
@@ -165,11 +176,16 @@ export function DynamicPluginNav({
     return map;
   }, [pluginMetadata, allPluginCollections]);
 
-  // Helper: determine if a plugin group is placed in another sidebar section
-  // Uses config-only placement (no user overrides)
+  // Whether a plugin group is rendered in another sidebar section, from the
+  // config's placement only — user overrides do not apply here.
+  //
+  // Group-level, so it decides how the WHOLE entry renders: placed groups show
+  // a settings link, unplaced ones expand into their collections. Which
+  // individual collections may be listed is a per-collection question, and
+  // `isCollectionPlacedElsewhere` answers that one.
   const isPluginPlaced = React.useCallback(
-    (slug: string): boolean => {
-      const meta = groupToPluginMeta.get(slug);
+    (groupName: string): boolean => {
+      const meta = groupToPluginMeta.get(groupName);
       const placement = meta?.placement ?? meta?.group;
       if (!placement || placement === "plugins") return false;
       // "standalone" plugins get their own top-level sidebar icon, so treat as placed
@@ -197,13 +213,20 @@ export function DynamicPluginNav({
         pluginMap.set(groupName, {
           name: groupName,
           slug,
-          isPlaced: isPluginPlaced(slug),
+          isPlaced: isPluginPlaced(groupName),
           collections: [],
         });
       }
 
-      // Only add to sub-items if the collection is visible and permitted
-      if (visibleCollectionIds.has(collection.id)) {
+      // A sub-item must be visible, permitted, and not already rendered in
+      // another section. Placement is declared per collection, so it is decided
+      // per collection: `admin.group` is an optional heading, and a group-level
+      // answer cannot see a collection that declares none, which lists it here
+      // as well as wherever its plugin placed it.
+      if (
+        visibleCollectionIds.has(collection.id) &&
+        !isCollectionPlacedElsewhere(collection.name, pluginMetadata)
+      ) {
         pluginMap.get(groupName)!.collections.push(collection);
       }
     }
@@ -223,7 +246,13 @@ export function DynamicPluginNav({
     return Array.from(pluginMap.values()).sort((a, b) =>
       a.name.localeCompare(b.name)
     );
-  }, [allPluginCollections, visibleCollectionIds, isPluginPlaced, search]);
+  }, [
+    allPluginCollections,
+    visibleCollectionIds,
+    isPluginPlaced,
+    pluginMetadata,
+    search,
+  ]);
 
   // The overview link is shown only to users who can open the page it points
   // at: /admin/plugins is manage-settings guarded, and a collection reader
@@ -469,12 +498,9 @@ function CollapsedPluginDropdown({
                 </DropdownMenuItem>,
               ];
             }
-            // Only UNPLACED plugins contribute collections here. A placed
-            // plugin's collections already appear under Collections, Settings
-            // or its own standalone section, which is why the expanded view
-            // filters on the same flag; listing them again under Plugins would
-            // show one collection in two places.
-            if (plugin.isPlaced) return [];
+            // No placement check here: `plugin.collections` already excludes
+            // anything rendered in another section, so both this menu and the
+            // expanded view list the same set.
             return plugin.collections.map(collection => {
               const href = getCollectionUrl(collection);
               const active = isActive(href);

--- a/packages/admin/src/components/features/dashboard/DynamicPluginNav.tsx
+++ b/packages/admin/src/components/features/dashboard/DynamicPluginNav.tsx
@@ -245,6 +245,8 @@ export function DynamicPluginNav({
         isActive={isActive}
         isAnyActive={isAnyPluginActive}
         getPluginUrl={getPluginUrl}
+        getCollectionUrl={getCollectionUrl}
+        canOpenPluginPages={canOpenOverview}
       />
     );
   }
@@ -347,11 +349,21 @@ function CollapsedPluginDropdown({
   isActive,
   isAnyActive,
   getPluginUrl,
+  getCollectionUrl,
+  canOpenPluginPages,
 }: {
   plugins: PluginEntry[];
   isActive: (href?: string) => boolean;
   isAnyActive: boolean;
   getPluginUrl: (slug: string) => string;
+  getCollectionUrl: (collection: ApiCollection) => string;
+  /**
+   * Whether this user can open `/admin/plugins` and the per-plugin detail
+   * pages, both guarded by `manage-settings`. When false the dropdown offers
+   * the plugin's collections instead, which are what such a user came here to
+   * reach; listing the guarded pages would make every item a redirect.
+   */
+  canOpenPluginPages: boolean;
 }) {
   const [isOpen, setIsOpen] = React.useState(false);
   const timeoutRef = React.useRef<NodeJS.Timeout | null>(null);
@@ -401,38 +413,68 @@ function CollapsedPluginDropdown({
           <DropdownMenuLabel>Plugins</DropdownMenuLabel>
           <DropdownMenuSeparator />
           {/* The overview stays reachable even when no plugin owns a
-              collection — metadata-only plugins are listed there. */}
-          <DropdownMenuItem asChild>
-            <Link
-              href={ROUTES.PLUGINS}
-              data-active={isActive(ROUTES.PLUGINS) ? "true" : undefined}
-              className={cn(
-                "flex w-full cursor-pointer items-center gap-2 transition-none admin-dropdown-item",
-                isActive(ROUTES.PLUGINS) && "font-bold!"
-              )}
-            >
-              <Package className="h-4 w-4" />
-              <span>Installed Plugins</span>
-            </Link>
-          </DropdownMenuItem>
-          {plugins.map(plugin => {
-            const href = getPluginUrl(plugin.slug);
-            const active = isActive(href);
-            return (
-              <DropdownMenuItem key={plugin.slug} asChild>
-                <Link
-                  href={href}
-                  data-active={active ? "true" : undefined}
-                  className={cn(
-                    "flex w-full cursor-pointer items-center gap-2 transition-none admin-dropdown-item",
-                    active && "font-bold!"
-                  )}
-                >
-                  <Package className="h-4 w-4" />
-                  <span>{plugin.name}</span>
-                </Link>
-              </DropdownMenuItem>
-            );
+              collection: metadata-only plugins are listed there. */}
+          {canOpenPluginPages && (
+            <DropdownMenuItem asChild>
+              <Link
+                href={ROUTES.PLUGINS}
+                data-active={isActive(ROUTES.PLUGINS) ? "true" : undefined}
+                className={cn(
+                  "flex w-full cursor-pointer items-center gap-2 transition-none admin-dropdown-item",
+                  isActive(ROUTES.PLUGINS) && "font-bold!"
+                )}
+              >
+                <Package className="h-4 w-4" />
+                <span>Installed Plugins</span>
+              </Link>
+            </DropdownMenuItem>
+          )}
+          {plugins.flatMap(plugin => {
+            // A user who can open plugin pages navigates by plugin. One who
+            // cannot navigates to the collections themselves, which are the
+            // only destinations here they are permitted to reach.
+            if (canOpenPluginPages) {
+              const href = getPluginUrl(plugin.slug);
+              const active = isActive(href);
+              return [
+                <DropdownMenuItem key={plugin.slug} asChild>
+                  <Link
+                    href={href}
+                    data-active={active ? "true" : undefined}
+                    className={cn(
+                      "flex w-full cursor-pointer items-center gap-2 transition-none admin-dropdown-item",
+                      active && "font-bold!"
+                    )}
+                  >
+                    <Package className="h-4 w-4" />
+                    <span>{plugin.name}</span>
+                  </Link>
+                </DropdownMenuItem>,
+              ];
+            }
+            return plugin.collections.map(collection => {
+              const href = getCollectionUrl(collection);
+              const active = isActive(href);
+              const label =
+                collection.labels?.plural ||
+                collection.label ||
+                collection.name;
+              return (
+                <DropdownMenuItem key={collection.id} asChild>
+                  <Link
+                    href={href}
+                    data-active={active ? "true" : undefined}
+                    className={cn(
+                      "flex w-full cursor-pointer items-center gap-2 transition-none admin-dropdown-item",
+                      active && "font-bold!"
+                    )}
+                  >
+                    <Package className="h-4 w-4" />
+                    <span>{label}</span>
+                  </Link>
+                </DropdownMenuItem>
+              );
+            });
           })}
         </DropdownMenuContent>
       </DropdownMenu>

--- a/packages/admin/src/components/features/dashboard/DynamicPluginNav.tsx
+++ b/packages/admin/src/components/features/dashboard/DynamicPluginNav.tsx
@@ -88,9 +88,11 @@ function PluginSkeleton() {
 interface PluginEntry {
   name: string;
   slug: string;
-  /** Whether this plugin's items have been placed in another section */
-  isPlaced: boolean;
-  /** The plugin's collections (only shown when not placed) */
+  /**
+   * The plugin's collections that belong under Plugins. Empty when every one
+   * of them is rendered in another section, which is what makes a group
+   * unrenderable here — there is no separate placement flag to disagree with.
+   */
   collections: ApiCollection[];
 }
 
@@ -152,48 +154,6 @@ export function DynamicPluginNav({
   // Plugin-level metadata with declared placement
   const pluginMetadata = branding?.plugins;
 
-  // Build a lookup: collection group slug → plugin metadata
-  // Matches by checking if any collection in the group belongs to a plugin's collections list
-  const groupToPluginMeta = React.useMemo(() => {
-    const map = new Map<string, NonNullable<typeof pluginMetadata>[number]>();
-    if (!pluginMetadata) return map;
-    for (const meta of pluginMetadata) {
-      const collectionSlugs = new Set(meta.collections ?? []);
-      for (const collection of allPluginCollections) {
-        if (collectionSlugs.has(collection.name)) {
-          // Keyed by the group NAME the entries below are keyed by, not by a
-          // slug of it. `admin.group` is optional and those collections are
-          // grouped under "Other"; deriving the key from the absent heading
-          // produced an empty string, which was skipped, so the plugin was
-          // never found and its placement read as unset.
-          const groupName = collection.admin?.group || "Other";
-          if (!map.has(groupName)) {
-            map.set(groupName, meta);
-          }
-        }
-      }
-    }
-    return map;
-  }, [pluginMetadata, allPluginCollections]);
-
-  // Whether a plugin group is rendered in another sidebar section, from the
-  // config's placement only — user overrides do not apply here.
-  //
-  // Group-level, so it decides how the WHOLE entry renders: placed groups show
-  // a settings link, unplaced ones expand into their collections. Which
-  // individual collections may be listed is a per-collection question, and
-  // `isCollectionPlacedElsewhere` answers that one.
-  const isPluginPlaced = React.useCallback(
-    (groupName: string): boolean => {
-      const meta = groupToPluginMeta.get(groupName);
-      const placement = meta?.placement ?? meta?.group;
-      if (!placement || placement === "plugins") return false;
-      // "standalone" plugins get their own top-level sidebar icon, so treat as placed
-      return true;
-    },
-    [groupToPluginMeta]
-  );
-
   // Build plugin entries from ALL plugin collections (so the plugin always appears
   // with its Settings link), but only include visible collections as sub-items
   const plugins = React.useMemo(() => {
@@ -213,16 +173,15 @@ export function DynamicPluginNav({
         pluginMap.set(groupName, {
           name: groupName,
           slug,
-          isPlaced: isPluginPlaced(groupName),
           collections: [],
         });
       }
 
       // A sub-item must be visible, permitted, and not already rendered in
-      // another section. Placement is declared per collection, so it is decided
-      // per collection: `admin.group` is an optional heading, and a group-level
-      // answer cannot see a collection that declares none, which lists it here
-      // as well as wherever its plugin placed it.
+      // another section. Placement is declared per collection and read from the
+      // plugin that owns it, so a collection carrying no `admin.group` heading
+      // is still placed: the heading groups collections for display and says
+      // nothing about which section owns them.
       if (
         visibleCollectionIds.has(collection.id) &&
         !isCollectionPlacedElsewhere(collection.name, pluginMetadata)
@@ -246,13 +205,7 @@ export function DynamicPluginNav({
     return Array.from(pluginMap.values()).sort((a, b) =>
       a.name.localeCompare(b.name)
     );
-  }, [
-    allPluginCollections,
-    visibleCollectionIds,
-    isPluginPlaced,
-    pluginMetadata,
-    search,
-  ]);
+  }, [allPluginCollections, visibleCollectionIds, pluginMetadata, search]);
 
   // The overview link is shown only to users who can open the page it points
   // at: /admin/plugins is manage-settings guarded, and a collection reader
@@ -297,10 +250,7 @@ export function DynamicPluginNav({
     isActive("/admin/plugins") ||
     plugins.some(p => {
       if (isActive(getPluginUrl(p.slug))) return true;
-      if (!p.isPlaced) {
-        return p.collections.some(c => isActive(getCollectionUrl(c)));
-      }
-      return false;
+      return p.collections.some(c => isActive(getCollectionUrl(c)));
     });
 
   // Collapsed mode: single icon with dropdown listing the overview + plugin names
@@ -317,10 +267,12 @@ export function DynamicPluginNav({
     );
   }
 
-  // Plugins with unplaced collections (shown as expandable with collection sub-items)
-  const pluginsWithCollections = plugins.filter(
-    p => !p.isPlaced && p.collections.length > 0
-  );
+  // A group is expandable exactly when it retains a collection to expand into.
+  // Two plugins can share a display group — every group-less collection lands
+  // under "Other" — so one of them being placed elsewhere says nothing about
+  // the group, and a group-level answer would hide the other plugin's
+  // reachable collection behind a rail item that opens an empty panel.
+  const pluginsWithCollections = plugins.filter(p => p.collections.length > 0);
 
   return (
     <>

--- a/packages/admin/src/components/features/dashboard/DynamicPluginNav.tsx
+++ b/packages/admin/src/components/features/dashboard/DynamicPluginNav.tsx
@@ -82,12 +82,12 @@ export function DynamicPluginNav({
   const { capabilities } = useCurrentUserPermissions();
   const branding = useBranding();
 
-  // `error` is deliberately not read. A collections failure leaves `data`
-  // undefined, so the collection-derived entries below are empty on their own,
-  // and the overview link must survive that failure because it reads
-  // admin-meta rather than collections. Branching on the error here is what
-  // used to remove the only sidebar route to /admin/plugins during an
-  // unrelated API outage.
+  // `error` is deliberately not read. The two things this panel renders have
+  // different data sources: collection entries come from this query, and the
+  // overview link comes from admin-meta. A failure here empties `data`, which
+  // suppresses the collection entries on its own, and must not reach the
+  // overview link, which is still backed and still the only sidebar route to
+  // /admin/plugins on mobile.
   const { data, isLoading } = useCollections(
     {
       pagination: { page: 0, pageSize: 100 },

--- a/packages/admin/src/components/layout/sidebar/DualSidebar.tsx
+++ b/packages/admin/src/components/layout/sidebar/DualSidebar.tsx
@@ -26,6 +26,7 @@ import { cn } from "@admin/lib/utils";
 import type { ApiCollection } from "@admin/types/entities";
 
 import { hasPluginsSection } from "./lib/has-plugins-section";
+import { isSubSidebarCategory, isSubSidebarOpen } from "./lib/has-sub-sidebar";
 import { resolveItemHref as resolveItemHrefHelper } from "./lib/resolve-item-href";
 import type { MainMenuCategory, MainMenuItem } from "./sidebar-types";
 import { getFilteredMenuItems } from "./sidebar-types";
@@ -413,35 +414,14 @@ export function DualSidebar({ isMobile }: DualSidebarProps = {}) {
     return filterCollectionItems(visible, capabilities);
   }, [collectionsData, capabilities]);
 
-  // Determine if we should show the second sidebar. For media the sub-sidebar
-  // holds the folder tree, so it follows the tree's visibility toggle.
-  const hasSubSidebar =
-    [
-      "collections",
-      "singles",
-      "plugins",
-      "settings",
-      ...(showBuilder ? ["builders" as const] : []),
-    ].includes(selectedMain) ||
-    selectedMain.startsWith("standalone-") ||
-    (selectedMain === "media" && isFolderTreeVisible);
-
-  const CATEGORIES_WITH_SUB_SIDEBAR = [
-    "collections",
-    "singles",
-    "media",
-    "plugins",
-    "settings",
-    "builders",
-  ];
-
-  // Media only has a sub-sidebar while the folder tree is visible; treating
-  // it as a sub-sidebar category with the tree hidden would turn the mobile
-  // Media icon into a button that opens nothing instead of a link.
   const hasSubSidebarCategory = (id: string) =>
-    (CATEGORIES_WITH_SUB_SIDEBAR.includes(id) &&
-      (id !== "media" || isFolderTreeVisible)) ||
-    id.startsWith("standalone-");
+    isSubSidebarCategory(id, isFolderTreeVisible);
+
+  const hasSubSidebar = isSubSidebarOpen(
+    selectedMain,
+    visibleMenuItems.map(item => item.id),
+    isFolderTreeVisible
+  );
 
   // The Settings icon lands on the first subpage the user can actually OPEN —
   // gated on each route's own guard, not the broader "can see the link" flag, so

--- a/packages/admin/src/components/layout/sidebar/DualSidebar.tsx
+++ b/packages/admin/src/components/layout/sidebar/DualSidebar.tsx
@@ -231,7 +231,6 @@ export function DualSidebar({ isMobile }: DualSidebarProps = {}) {
       const placement = getCollectionPlacement(collection);
       return !placement || placement === "plugins";
     }),
-    installedPluginCount: branding?.plugins?.length ?? 0,
   });
 
   const hasMediaSection = hasPermissionDataPending

--- a/packages/admin/src/components/layout/sidebar/DualSidebar.tsx
+++ b/packages/admin/src/components/layout/sidebar/DualSidebar.tsx
@@ -25,6 +25,7 @@ import { resolvePluginIcon } from "@admin/lib/plugins/resolve-plugin-icon";
 import { cn } from "@admin/lib/utils";
 import type { ApiCollection } from "@admin/types/entities";
 
+import { hasPluginsSection } from "./lib/has-plugins-section";
 import { resolveItemHref as resolveItemHrefHelper } from "./lib/resolve-item-href";
 import type { MainMenuCategory, MainMenuItem } from "./sidebar-types";
 import { getFilteredMenuItems } from "./sidebar-types";
@@ -222,18 +223,16 @@ export function DualSidebar({ isMobile }: DualSidebarProps = {}) {
       isSinglesError ||
       permittedSingles.some(single => !single.admin?.hidden));
 
-  const hasPluginsSection =
-    capabilities.canViewCollections &&
-    (hasPermissionDataPending ||
-      isCollectionsLoading ||
-      isCollectionsError ||
-      permittedCollections.some(collection => {
-        if (!collection.admin?.isPlugin || collection.admin?.hidden)
-          return false;
-        const placement = getCollectionPlacement(collection);
-        return !placement || placement === "plugins";
-      }) ||
-      (branding?.plugins?.length ?? 0) > 0);
+  const pluginsSectionVisible = hasPluginsSection(capabilities, {
+    isPending:
+      hasPermissionDataPending || isCollectionsLoading || isCollectionsError,
+    hasVisiblePluginCollection: permittedCollections.some(collection => {
+      if (!collection.admin?.isPlugin || collection.admin?.hidden) return false;
+      const placement = getCollectionPlacement(collection);
+      return !placement || placement === "plugins";
+    }),
+    installedPluginCount: branding?.plugins?.length ?? 0,
+  });
 
   const hasMediaSection = hasPermissionDataPending
     ? true
@@ -270,7 +269,7 @@ export function DualSidebar({ isMobile }: DualSidebarProps = {}) {
           case "singles":
             return hasSinglesSection;
           case "plugins":
-            return hasPluginsSection;
+            return pluginsSectionVisible;
           case "media":
             return hasMediaSection;
           case "settings":
@@ -285,7 +284,7 @@ export function DualSidebar({ isMobile }: DualSidebarProps = {}) {
       filteredMenuItems,
       hasCollectionsSection,
       hasSinglesSection,
-      hasPluginsSection,
+      pluginsSectionVisible,
       hasMediaSection,
       hasSettingsSection,
       hasBuildersSection,
@@ -466,7 +465,12 @@ export function DualSidebar({ isMobile }: DualSidebarProps = {}) {
                 : ROUTES.SETTINGS;
 
   const resolveItemHref = (item: MainMenuItem): string =>
-    resolveItemHrefHelper(item, visibleStandalonePlugins, settingsHref);
+    resolveItemHrefHelper(
+      item,
+      visibleStandalonePlugins,
+      settingsHref,
+      capabilities.canManageSettings
+    );
 
   // Resolve collections for the active standalone plugin section
   const pluginCollectionsForSection = useMemo(() => {

--- a/packages/admin/src/components/layout/sidebar/DualSidebar.tsx
+++ b/packages/admin/src/components/layout/sidebar/DualSidebar.tsx
@@ -48,10 +48,9 @@ export function DualSidebar({ isMobile }: DualSidebarProps = {}) {
   const showBuilder = branding?.showBuilder ?? true;
 
   // Runtime-controlled builder visibility from /api/admin-meta
-  const hasInstalledPlugins = (branding?.plugins?.length ?? 0) > 0;
   const baseMenuItems = useMemo(
-    () => getFilteredMenuItems(showBuilder, hasInstalledPlugins),
-    [showBuilder, hasInstalledPlugins]
+    () => getFilteredMenuItems(showBuilder),
+    [showBuilder]
   );
 
   // Compute standalone plugins from branding metadata

--- a/packages/admin/src/components/layout/sidebar/DualSidebar.tsx
+++ b/packages/admin/src/components/layout/sidebar/DualSidebar.tsx
@@ -20,6 +20,7 @@ import {
   filterCollectionItems,
   filterSingleItems,
 } from "@admin/lib/permissions/authorization";
+import { resolveCollectionPlacement } from "@admin/lib/plugins/collection-placement";
 import { pluginSlug } from "@admin/lib/plugins/plugin-slug";
 import { resolvePluginIcon } from "@admin/lib/plugins/resolve-plugin-icon";
 import { cn } from "@admin/lib/utils";
@@ -188,14 +189,13 @@ export function DualSidebar({ isMobile }: DualSidebarProps = {}) {
     return filterSingleItems(allSingles, capabilities);
   }, [singlesData?.items, capabilities]);
 
+  // Bound to this render's metadata rather than reimplemented: the rail's
+  // visibility and the panel's contents must agree about where a collection
+  // belongs, and two implementations of that would let the rail offer a
+  // section whose destinations have all moved elsewhere.
   const getCollectionPlacement = useMemo(() => {
-    return (collection: ApiCollection): string | undefined => {
-      if (!pluginMetadata) return undefined;
-      const meta = pluginMetadata.find(p =>
-        (p.collections ?? []).includes(collection.name)
-      );
-      return meta?.placement ?? meta?.group ?? undefined;
-    };
+    return (collection: ApiCollection): string | undefined =>
+      resolveCollectionPlacement(collection.name, pluginMetadata);
   }, [pluginMetadata]);
 
   const hasPermissionDataPending =

--- a/packages/admin/src/components/layout/sidebar/DualSidebar.tsx
+++ b/packages/admin/src/components/layout/sidebar/DualSidebar.tsx
@@ -224,8 +224,11 @@ export function DualSidebar({ isMobile }: DualSidebarProps = {}) {
       permittedSingles.some(single => !single.admin?.hidden));
 
   const pluginsSectionVisible = hasPluginsSection(capabilities, {
-    isPending:
-      hasPermissionDataPending || isCollectionsLoading || isCollectionsError,
+    // Loading only. A FAILED collections query is not pending: it will never
+    // resolve into visible collections, and for a user without
+    // `canManageSettings` the panel then has no destination at all, so keeping
+    // the rail item would open an empty panel rather than defer a decision.
+    isPending: hasPermissionDataPending || isCollectionsLoading,
     hasVisiblePluginCollection: permittedCollections.some(collection => {
       if (!collection.admin?.isPlugin || collection.admin?.hidden) return false;
       const placement = getCollectionPlacement(collection);

--- a/packages/admin/src/components/layout/sidebar/SubSidebarContent.tsx
+++ b/packages/admin/src/components/layout/sidebar/SubSidebarContent.tsx
@@ -123,24 +123,6 @@ export function SubSidebarContent({
             Plugins
           </p>
           <SidebarMenu>
-            {/* Rendered here rather than left to DynamicPluginNav, which
-                returns null when no plugin metadata and no plugin collections
-                exist. On mobile the primary icon is a button that only opens
-                this panel, so without a static entry a project with nothing
-                installed has a panel containing a search box and no link at
-                all, and /admin/plugins is unreachable. */}
-            <SidebarMenuItem>
-              <SidebarMenuButton
-                asChild
-                isActive={isActive(ROUTES.PLUGINS)}
-                className="justify-start px-3"
-              >
-                <Link href={ROUTES.PLUGINS}>
-                  <Puzzle className="h-4 w-4" />
-                  <span>Installed Plugins</span>
-                </Link>
-              </SidebarMenuButton>
-            </SidebarMenuItem>
             <DynamicPluginNav isActive={isActive} search={pluginSearch} />
           </SidebarMenu>
         </div>

--- a/packages/admin/src/components/layout/sidebar/SubSidebarContent.tsx
+++ b/packages/admin/src/components/layout/sidebar/SubSidebarContent.tsx
@@ -119,6 +119,9 @@ export function SubSidebarContent({
           onChange={onPluginSearchChange}
         />
         <div className="space-y-1">
+          {/* Names what the panel contains: the installed-plugins overview and
+              navigation into each plugin's collections. Nothing here installs
+              a plugin, which happens through the Nextly config. */}
           <p className="text-xs font-bold uppercase tracking-wider text-sidebar-foreground px-3 mb-2">
             Plugins
           </p>

--- a/packages/admin/src/components/layout/sidebar/SubSidebarContent.tsx
+++ b/packages/admin/src/components/layout/sidebar/SubSidebarContent.tsx
@@ -120,9 +120,27 @@ export function SubSidebarContent({
         />
         <div className="space-y-1">
           <p className="text-xs font-bold uppercase tracking-wider text-sidebar-foreground px-3 mb-2">
-            Install Plugins
+            Plugins
           </p>
           <SidebarMenu>
+            {/* Rendered here rather than left to DynamicPluginNav, which
+                returns null when no plugin metadata and no plugin collections
+                exist. On mobile the primary icon is a button that only opens
+                this panel, so without a static entry a project with nothing
+                installed has a panel containing a search box and no link at
+                all, and /admin/plugins is unreachable. */}
+            <SidebarMenuItem>
+              <SidebarMenuButton
+                asChild
+                isActive={isActive(ROUTES.PLUGINS)}
+                className="justify-start px-3"
+              >
+                <Link href={ROUTES.PLUGINS}>
+                  <Puzzle className="h-4 w-4" />
+                  <span>Installed Plugins</span>
+                </Link>
+              </SidebarMenuButton>
+            </SidebarMenuItem>
             <DynamicPluginNav isActive={isActive} search={pluginSearch} />
           </SidebarMenu>
         </div>

--- a/packages/admin/src/components/layout/sidebar/__tests__/has-plugins-section.test.ts
+++ b/packages/admin/src/components/layout/sidebar/__tests__/has-plugins-section.test.ts
@@ -5,7 +5,6 @@ import { hasPluginsSection } from "../lib/has-plugins-section";
 const SETTLED = {
   isPending: false,
   hasVisiblePluginCollection: false,
-  installedPluginCount: 0,
 };
 
 describe("hasPluginsSection", () => {
@@ -39,7 +38,7 @@ describe("hasPluginsSection", () => {
     expect(
       hasPluginsSection(
         { canManageSettings: false, canViewCollections: false },
-        { ...SETTLED, installedPluginCount: 3 }
+        SETTLED
       )
     ).toBe(false);
   });
@@ -67,13 +66,18 @@ describe("hasPluginsSection", () => {
     ).toBe(true);
   });
 
-  it("shows it for a collection reader when plugins are installed", () => {
+  /**
+   * A collection reader whose plugins own no collection they may see has no
+   * reachable destination in the panel: the overview and the per-plugin pages
+   * are both manage-settings guarded. The rail item would open an empty panel.
+   */
+  it("hides it from a collection reader whose plugins expose nothing to them", () => {
     expect(
       hasPluginsSection(
         { canManageSettings: false, canViewCollections: true },
-        { ...SETTLED, installedPluginCount: 1 }
+        SETTLED
       )
-    ).toBe(true);
+    ).toBe(false);
   });
 
   /**

--- a/packages/admin/src/components/layout/sidebar/__tests__/has-plugins-section.test.ts
+++ b/packages/admin/src/components/layout/sidebar/__tests__/has-plugins-section.test.ts
@@ -12,10 +12,10 @@ describe("hasPluginsSection", () => {
   /**
    * The case this predicate was extracted for. A fresh project has no plugins
    * and no plugin-owned collections, so every arm below `canManageSettings` is
-   * false. Before this rule the entry disappeared once loading settled, which
-   * left no route to `/admin/plugins` at all. That page lists installed
-   * plugins; its empty state explains that plugins are added through the
-   * Nextly config, and it performs no installation itself.
+   * false, so only the `canManageSettings` arm keeps the entry. It has to:
+   * `/admin/plugins` lists installed plugins and explains in its empty state
+   * that plugins are added through the Nextly config, and the sidebar entry is
+   * the only route to it.
    */
   it("shows the entry on a fresh project once loading has settled", () => {
     expect(

--- a/packages/admin/src/components/layout/sidebar/__tests__/has-plugins-section.test.ts
+++ b/packages/admin/src/components/layout/sidebar/__tests__/has-plugins-section.test.ts
@@ -9,12 +9,11 @@ const SETTLED = {
 
 describe("hasPluginsSection", () => {
   /**
-   * The case this predicate was extracted for. A fresh project has no plugins
-   * and no plugin-owned collections, so every arm below `canManageSettings` is
-   * false, so only the `canManageSettings` arm keeps the entry. It has to:
-   * `/admin/plugins` lists installed plugins and explains in its empty state
-   * that plugins are added through the Nextly config, and the sidebar entry is
-   * the only route to it.
+   * A fresh project has no plugins and no plugin-owned collections, so every
+   * arm below `canManageSettings` is false and only that arm keeps the entry.
+   * It has to: `/admin/plugins` lists installed plugins and explains in its
+   * empty state that plugins are added through the Nextly config, and the
+   * sidebar entry is the only route to it.
    */
   it("shows the entry on a fresh project once loading has settled", () => {
     expect(

--- a/packages/admin/src/components/layout/sidebar/__tests__/has-plugins-section.test.ts
+++ b/packages/admin/src/components/layout/sidebar/__tests__/has-plugins-section.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+
+import { hasPluginsSection } from "../lib/has-plugins-section";
+
+const SETTLED = {
+  isPending: false,
+  hasVisiblePluginCollection: false,
+  installedPluginCount: 0,
+};
+
+describe("hasPluginsSection", () => {
+  /**
+   * The case this predicate was extracted for. A fresh project has no plugins
+   * and no plugin-owned collections, so every arm below `canManageSettings` is
+   * false. Before this rule the entry disappeared once loading settled, which
+   * left no route to the page that installs a plugin.
+   */
+  it("shows the entry on a fresh project once loading has settled", () => {
+    expect(
+      hasPluginsSection(
+        { canManageSettings: true, canViewCollections: true },
+        SETTLED
+      )
+    ).toBe(true);
+  });
+
+  it("shows it for a settings manager who cannot view collections", () => {
+    expect(
+      hasPluginsSection(
+        { canManageSettings: true, canViewCollections: false },
+        SETTLED
+      )
+    ).toBe(true);
+  });
+
+  it("hides it from a user with neither capability", () => {
+    expect(
+      hasPluginsSection(
+        { canManageSettings: false, canViewCollections: false },
+        { ...SETTLED, installedPluginCount: 3 }
+      )
+    ).toBe(false);
+  });
+
+  /**
+   * The collections arm. This user cannot open /admin/plugins, and
+   * resolve-item-href keeps their icon a sub-sidebar opener, but the entry has
+   * to exist for them to reach the plugin-owned collection underneath it.
+   */
+  it("shows it for a collection reader with a visible plugin collection", () => {
+    expect(
+      hasPluginsSection(
+        { canManageSettings: false, canViewCollections: true },
+        { ...SETTLED, hasVisiblePluginCollection: true }
+      )
+    ).toBe(true);
+  });
+
+  it("shows it for a collection reader while data is still pending", () => {
+    expect(
+      hasPluginsSection(
+        { canManageSettings: false, canViewCollections: true },
+        { ...SETTLED, isPending: true }
+      )
+    ).toBe(true);
+  });
+
+  it("shows it for a collection reader when plugins are installed", () => {
+    expect(
+      hasPluginsSection(
+        { canManageSettings: false, canViewCollections: true },
+        { ...SETTLED, installedPluginCount: 1 }
+      )
+    ).toBe(true);
+  });
+
+  /**
+   * The separating case. Without this, a predicate that simply returned `true`
+   * would satisfy every assertion above, and the fresh-project test would read
+   * as coverage while proving nothing.
+   */
+  it("hides it from a collection reader with no plugins and nothing pending", () => {
+    expect(
+      hasPluginsSection(
+        { canManageSettings: false, canViewCollections: true },
+        SETTLED
+      )
+    ).toBe(false);
+  });
+});

--- a/packages/admin/src/components/layout/sidebar/__tests__/has-plugins-section.test.ts
+++ b/packages/admin/src/components/layout/sidebar/__tests__/has-plugins-section.test.ts
@@ -57,6 +57,20 @@ describe("hasPluginsSection", () => {
     ).toBe(true);
   });
 
+  /**
+   * A failed collections query is not pending. It will never resolve into
+   * visible collections, so for this user the panel has no destination and the
+   * rail item would open an empty one. The caller passes loading only.
+   */
+  it("hides it from a collection reader once loading has settled with nothing visible", () => {
+    expect(
+      hasPluginsSection(
+        { canManageSettings: false, canViewCollections: true },
+        { isPending: false, hasVisiblePluginCollection: false }
+      )
+    ).toBe(false);
+  });
+
   it("shows it for a collection reader while data is still pending", () => {
     expect(
       hasPluginsSection(

--- a/packages/admin/src/components/layout/sidebar/__tests__/has-plugins-section.test.ts
+++ b/packages/admin/src/components/layout/sidebar/__tests__/has-plugins-section.test.ts
@@ -13,7 +13,9 @@ describe("hasPluginsSection", () => {
    * The case this predicate was extracted for. A fresh project has no plugins
    * and no plugin-owned collections, so every arm below `canManageSettings` is
    * false. Before this rule the entry disappeared once loading settled, which
-   * left no route to the page that installs a plugin.
+   * left no route to `/admin/plugins` at all. That page lists installed
+   * plugins; its empty state explains that plugins are added through the
+   * Nextly config, and it performs no installation itself.
    */
   it("shows the entry on a fresh project once loading has settled", () => {
     expect(

--- a/packages/admin/src/components/layout/sidebar/__tests__/has-sub-sidebar.test.ts
+++ b/packages/admin/src/components/layout/sidebar/__tests__/has-sub-sidebar.test.ts
@@ -1,0 +1,76 @@
+/**
+ * The secondary panel and the rail answer to the same list of destinations.
+ * These cover the window where they could disagree: a selection that names a
+ * category the rail no longer shows.
+ */
+import { describe, expect, it } from "vitest";
+
+import { isSubSidebarCategory, isSubSidebarOpen } from "../lib/has-sub-sidebar";
+
+const ALL = ["collections", "singles", "media", "plugins", "settings"];
+
+describe("isSubSidebarOpen", () => {
+  it("opens the panel for a category the rail is showing", () => {
+    expect(isSubSidebarOpen("plugins", ALL, false)).toBe(true);
+  });
+
+  /**
+   * A collection reader clicks Plugins while the collections query is pending,
+   * which is what put the entry on the rail; the query then settles with no
+   * permitted plugin collection and the entry goes. Nothing resets the
+   * selection, so this is the only thing standing between them and a panel
+   * with no destinations in it.
+   */
+  it("closes it once the selected category leaves the rail", () => {
+    expect(isSubSidebarOpen("plugins", ["collections", "singles"], false)).toBe(
+      false
+    );
+  });
+
+  /**
+   * The same shape, on a category that has nothing to do with plugins. The
+   * defect belongs to the selection outliving its rail item, so a fix that
+   * only knows about plugins leaves it in place everywhere else.
+   */
+  it("closes it for any category the rail drops, not only plugins", () => {
+    expect(isSubSidebarOpen("collections", ["settings"], false)).toBe(false);
+    expect(isSubSidebarOpen("settings", ["collections"], false)).toBe(false);
+  });
+
+  it("keeps a standalone plugin's panel only while its rail item is shown", () => {
+    // Positive control first: the prefix IS recognised, so the `false` below
+    // is about the destination being gone rather than about an id shape this
+    // function never accepts.
+    expect(
+      isSubSidebarOpen("standalone-acme", ["standalone-acme"], false)
+    ).toBe(true);
+    expect(isSubSidebarOpen("standalone-acme", ALL, false)).toBe(false);
+  });
+
+  it("opens Media only while the folder tree is visible", () => {
+    expect(isSubSidebarOpen("media", ALL, true)).toBe(true);
+    expect(isSubSidebarOpen("media", ALL, false)).toBe(false);
+  });
+
+  it("never opens one for a category that owns no panel", () => {
+    expect(isSubSidebarOpen("dashboard", [...ALL, "dashboard"], true)).toBe(
+      false
+    );
+  });
+});
+
+describe("isSubSidebarCategory", () => {
+  /**
+   * This one decides whether the MOBILE rail icon is a button or a link, so it
+   * asks only whether the category owns a panel at all. Visibility is the
+   * caller's question: an icon the rail is not rendering has no behaviour to
+   * pick.
+   */
+  it("answers for the category alone, ignoring what the rail shows", () => {
+    expect(isSubSidebarCategory("plugins", false)).toBe(true);
+    expect(isSubSidebarCategory("standalone-acme", false)).toBe(true);
+    expect(isSubSidebarCategory("dashboard", true)).toBe(false);
+    expect(isSubSidebarCategory("media", false)).toBe(false);
+    expect(isSubSidebarCategory("media", true)).toBe(true);
+  });
+});

--- a/packages/admin/src/components/layout/sidebar/__tests__/resolve-item-href.test.ts
+++ b/packages/admin/src/components/layout/sidebar/__tests__/resolve-item-href.test.ts
@@ -37,13 +37,13 @@ describe("resolveItemHref", () => {
     ).toBe(ROUTES.SINGLES);
   });
 
-  it("keeps the plugins icon as a sub-sidebar opener (no landing page)", () => {
+  it("routes the plugins icon to the section landing page", () => {
     expect(
       resolveItemHref(
         makeItem({ id: "plugins", label: "Plugins", href: "#" }),
         []
       )
-    ).toBe("#");
+    ).toBe(ROUTES.PLUGINS);
   });
 
   it("routes the settings icon to the first reachable subpage when given one", () => {

--- a/packages/admin/src/components/layout/sidebar/__tests__/resolve-item-href.test.ts
+++ b/packages/admin/src/components/layout/sidebar/__tests__/resolve-item-href.test.ts
@@ -37,13 +37,39 @@ describe("resolveItemHref", () => {
     ).toBe(ROUTES.SINGLES);
   });
 
-  it("routes the plugins icon to the section landing page", () => {
+  it("routes the plugins icon to the section landing page when the user can open it", () => {
+    expect(
+      resolveItemHref(
+        makeItem({ id: "plugins", label: "Plugins", href: "#" }),
+        [],
+        undefined,
+        true
+      )
+    ).toBe(ROUTES.PLUGINS);
+  });
+
+  it("keeps the plugins icon a sub-sidebar opener without manage-settings", () => {
+    // The icon is shown to users who can read a plugin-owned collection, which
+    // is a wider set than the page's own guard admits. Navigating them would
+    // bounce them to the dashboard and remove their only route to that
+    // collection, so they keep the sub-sidebar.
+    expect(
+      resolveItemHref(
+        makeItem({ id: "plugins", label: "Plugins", href: "#" }),
+        [],
+        undefined,
+        false
+      )
+    ).toBe("#");
+  });
+
+  it("defaults to the sub-sidebar when the caller states no capability", () => {
     expect(
       resolveItemHref(
         makeItem({ id: "plugins", label: "Plugins", href: "#" }),
         []
       )
-    ).toBe(ROUTES.PLUGINS);
+    ).toBe("#");
   });
 
   it("routes the settings icon to the first reachable subpage when given one", () => {

--- a/packages/admin/src/components/layout/sidebar/__tests__/sidebar-types.test.ts
+++ b/packages/admin/src/components/layout/sidebar/__tests__/sidebar-types.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+
+import { getFilteredMenuItems } from "../sidebar-types";
+
+describe("getFilteredMenuItems", () => {
+  it("lists plugins whether or not the builder is shown", () => {
+    expect(getFilteredMenuItems(false).map(i => i.id)).toContain("plugins");
+    expect(getFilteredMenuItems(true).map(i => i.id)).toContain("plugins");
+  });
+
+  // Positive controls for the case above: the helper still filters something,
+  // so a version that stopped filtering entirely cannot pass this file by
+  // returning every item unconditionally.
+  it("hides the builders item when the builder is off", () => {
+    expect(getFilteredMenuItems(false).map(i => i.id)).not.toContain(
+      "builders"
+    );
+  });
+
+  it("shows the builders item when the builder is on", () => {
+    expect(getFilteredMenuItems(true).map(i => i.id)).toContain("builders");
+  });
+});

--- a/packages/admin/src/components/layout/sidebar/lib/has-plugins-section.ts
+++ b/packages/admin/src/components/layout/sidebar/lib/has-plugins-section.ts
@@ -3,35 +3,29 @@ import type { AdminCapabilities } from "@admin/types/permissions";
 interface PluginsSectionInputs {
   /** True while permissions or the collections query are still resolving. */
   isPending: boolean;
-  /** True when at least one plugin-owned collection is visible in this section. */
+  /** True when at least one plugin-owned collection is visible to this user. */
   hasVisiblePluginCollection: boolean;
-  /** How many plugins `/api/admin-meta` reports as registered. */
-  installedPluginCount: number;
 }
 
 /**
  * Whether the Plugins entry appears in the primary rail.
  *
- * Extracted for the same reason `resolveItemHref` was: the decision is a pure
- * function of a few inputs, and reaching it through a rendered `DualSidebar`
- * needs the branding, media, permission and collection providers all stood up.
- * A test that cannot reach the real predicate proves nothing about what the
- * rail renders, which is the failure this file exists to prevent. Only the
- * plugins predicate is extracted, because it is the one whose rule changed;
- * the sibling sections keep their inline form until they need the same.
+ * The rail item exists to open the plugins panel, so it is shown exactly when
+ * that panel has a destination this user can reach. The two arms below are the
+ * two kinds of destination, and they admit different users:
  *
- * Two arms, and they admit different users on purpose:
+ * - `canManageSettings` reaches `/admin/plugins`, which is guarded by that
+ *   permission. It needs nothing installed: the page lists installed plugins
+ *   and its empty state explains that plugins are added through the Nextly
+ *   config, so a project with none still has somewhere to go.
+ * - `canViewCollections` plus a visible plugin-owned collection reaches that
+ *   collection through the panel. Such a user does not get the overview link,
+ *   which is why the collection itself has to be the reachable thing.
  *
- * - `canManageSettings` shows the entry unconditionally, including on a fresh
- *   project with nothing installed. `/admin/plugins` is the installed-plugins
- *   list; today its empty state explains that plugins are added to the Nextly
- *   config, and it offers no directory or install action. Hiding the entry
- *   until a plugin exists means a new project cannot reach even that
- *   explanation.
- * - The collections arm keeps the entry for a user who can read a plugin-owned
- *   collection but cannot manage settings. They reach that collection through
- *   the sub-sidebar; `resolveItemHref` deliberately does not navigate them to
- *   the guarded page.
+ * A global installed count is deliberately not an input. It answers "does the
+ * project have plugins", not "can this user reach any of them", and for a
+ * collection reader whose plugin is metadata-only or whose collections are all
+ * denied those differ: the rail item would open a panel with nothing in it.
  *
  * @module components/layout/sidebar/lib/has-plugins-section
  */
@@ -46,9 +40,7 @@ export function hasPluginsSection(
 
   if (!capabilities.canViewCollections) return false;
 
-  return (
-    inputs.isPending ||
-    inputs.hasVisiblePluginCollection ||
-    inputs.installedPluginCount > 0
-  );
+  // Pending counts as reachable so the entry does not flicker out and back in
+  // while the collections query resolves.
+  return inputs.isPending || inputs.hasVisiblePluginCollection;
 }

--- a/packages/admin/src/components/layout/sidebar/lib/has-plugins-section.ts
+++ b/packages/admin/src/components/layout/sidebar/lib/has-plugins-section.ts
@@ -1,0 +1,52 @@
+import type { AdminCapabilities } from "@admin/types/permissions";
+
+interface PluginsSectionInputs {
+  /** True while permissions or the collections query are still resolving. */
+  isPending: boolean;
+  /** True when at least one plugin-owned collection is visible in this section. */
+  hasVisiblePluginCollection: boolean;
+  /** How many plugins `/api/admin-meta` reports as registered. */
+  installedPluginCount: number;
+}
+
+/**
+ * Whether the Plugins entry appears in the primary rail.
+ *
+ * Extracted for the same reason `resolveItemHref` was: the decision is a pure
+ * function of a few inputs, and reaching it through a rendered `DualSidebar`
+ * needs the branding, media, permission and collection providers all stood up.
+ * A test that cannot reach the real predicate proves nothing about what the
+ * rail renders, which is the failure this file exists to prevent. Only the
+ * plugins predicate is extracted, because it is the one whose rule changed;
+ * the sibling sections keep their inline form until they need the same.
+ *
+ * Two arms, and they admit different users on purpose:
+ *
+ * - `canManageSettings` shows the entry unconditionally, including on a fresh
+ *   project with nothing installed. The plugins page is how a plugin gets
+ *   installed, so gating it on already having one leaves a new project with no
+ *   route to it.
+ * - The collections arm keeps the entry for a user who can read a plugin-owned
+ *   collection but cannot manage settings. They reach that collection through
+ *   the sub-sidebar; `resolveItemHref` deliberately does not navigate them to
+ *   the guarded page.
+ *
+ * @module components/layout/sidebar/lib/has-plugins-section
+ */
+export function hasPluginsSection(
+  capabilities: Pick<
+    AdminCapabilities,
+    "canManageSettings" | "canViewCollections"
+  >,
+  inputs: PluginsSectionInputs
+): boolean {
+  if (capabilities.canManageSettings) return true;
+
+  if (!capabilities.canViewCollections) return false;
+
+  return (
+    inputs.isPending ||
+    inputs.hasVisiblePluginCollection ||
+    inputs.installedPluginCount > 0
+  );
+}

--- a/packages/admin/src/components/layout/sidebar/lib/has-plugins-section.ts
+++ b/packages/admin/src/components/layout/sidebar/lib/has-plugins-section.ts
@@ -23,9 +23,11 @@ interface PluginsSectionInputs {
  * Two arms, and they admit different users on purpose:
  *
  * - `canManageSettings` shows the entry unconditionally, including on a fresh
- *   project with nothing installed. The plugins page is how a plugin gets
- *   installed, so gating it on already having one leaves a new project with no
- *   route to it.
+ *   project with nothing installed. `/admin/plugins` is the installed-plugins
+ *   list; today its empty state explains that plugins are added to the Nextly
+ *   config, and it offers no directory or install action. Hiding the entry
+ *   until a plugin exists means a new project cannot reach even that
+ *   explanation.
  * - The collections arm keeps the entry for a user who can read a plugin-owned
  *   collection but cannot manage settings. They reach that collection through
  *   the sub-sidebar; `resolveItemHref` deliberately does not navigate them to

--- a/packages/admin/src/components/layout/sidebar/lib/has-sub-sidebar.ts
+++ b/packages/admin/src/components/layout/sidebar/lib/has-sub-sidebar.ts
@@ -1,0 +1,53 @@
+/**
+ * Which rail categories own a secondary panel.
+ *
+ * Standalone plugins are not listed: their ids are generated per install, so
+ * they are recognised by prefix rather than enumerated.
+ */
+const CATEGORIES_WITH_SUB_SIDEBAR: readonly string[] = [
+  "collections",
+  "singles",
+  "media",
+  "plugins",
+  "settings",
+  "builders",
+];
+
+/**
+ * Whether a rail id is one that owns a secondary panel at all.
+ *
+ * Media only owns one while the folder tree is visible; treating it as a
+ * sub-sidebar category with the tree hidden turns the mobile Media icon into a
+ * button that opens nothing instead of a link.
+ */
+export function isSubSidebarCategory(
+  id: string,
+  isFolderTreeVisible: boolean
+): boolean {
+  return (
+    (CATEGORIES_WITH_SUB_SIDEBAR.includes(id) &&
+      (id !== "media" || isFolderTreeVisible)) ||
+    id.startsWith("standalone-")
+  );
+}
+
+/**
+ * Whether the secondary panel is open for the current selection.
+ *
+ * The panel follows the rail rather than a list of its own. A selection
+ * outlives the item it names: it is synced from the pathname and from clicks,
+ * and nothing revisits it when a pending query settles into nothing or fails.
+ * A second list of panel-owning categories answers the same question as the
+ * rail and disagrees in exactly that window, leaving a panel open with nothing
+ * to put in it, so the visible destinations decide both.
+ */
+export function isSubSidebarOpen(
+  selectedMain: string,
+  visibleMenuItemIds: readonly string[],
+  isFolderTreeVisible: boolean
+): boolean {
+  return (
+    isSubSidebarCategory(selectedMain, isFolderTreeVisible) &&
+    visibleMenuItemIds.includes(selectedMain)
+  );
+}

--- a/packages/admin/src/components/layout/sidebar/lib/resolve-item-href.ts
+++ b/packages/admin/src/components/layout/sidebar/lib/resolve-item-href.ts
@@ -6,10 +6,12 @@ import type { MainMenuItem } from "../sidebar-types";
 
 // Why: collections / singles primary-icon clicks navigate to the section
 // landing page smart-redirect routes pick the most-recently-
-// created record server-side). Plugins remain pure sub-sidebar openers
-// (no landing-page convention yet). Standalone plugins jump to their
-// first registered collection. Extracted to a pure helper so the routing
-// logic is unit-testable without mounting the full DualSidebar tree.
+// created record server-side). Plugins follows the same convention and lands
+// on the installed list; that list's empty state is what routes onward to the
+// directory, so an install with nothing installed still has somewhere to go.
+// Standalone plugins jump to their first registered collection. Extracted to a
+// pure helper so the routing logic is unit-testable without mounting the full
+// DualSidebar tree.
 export function resolveItemHref(
   item: MainMenuItem,
   visibleStandalonePlugins: PluginMetadata[],
@@ -21,7 +23,7 @@ export function resolveItemHref(
 ): string {
   if (item.id === "collections") return ROUTES.COLLECTIONS;
   if (item.id === "singles") return ROUTES.SINGLES;
-  if (item.id === "plugins") return "#";
+  if (item.id === "plugins") return ROUTES.PLUGINS;
   if (item.id === "settings" && settingsHref) return settingsHref;
   if (item.id.startsWith("standalone-")) {
     const slug = item.id.replace("standalone-", "");

--- a/packages/admin/src/components/layout/sidebar/lib/resolve-item-href.ts
+++ b/packages/admin/src/components/layout/sidebar/lib/resolve-item-href.ts
@@ -7,11 +7,10 @@ import type { MainMenuItem } from "../sidebar-types";
 // Why: collections / singles primary-icon clicks navigate to the section
 // landing page smart-redirect routes pick the most-recently-
 // created record server-side). Plugins follows the same convention and lands
-// on the installed list; that list's empty state is what routes onward to the
-// directory, so an install with nothing installed still has somewhere to go.
-// Standalone plugins jump to their first registered collection. Extracted to a
-// pure helper so the routing logic is unit-testable without mounting the full
-// DualSidebar tree.
+// on the installed list, which today renders an empty table when nothing is
+// installed. Standalone plugins jump to their first registered collection.
+// Extracted to a pure helper so the routing logic is unit-testable without
+// mounting the full DualSidebar tree.
 export function resolveItemHref(
   item: MainMenuItem,
   visibleStandalonePlugins: PluginMetadata[],
@@ -19,11 +18,19 @@ export function resolveItemHref(
   // href (/admin/settings) is guarded by `manage-settings`, so a user whose only
   // settings access is API Keys or Webhooks would be redirected away; the caller
   // resolves this to a reachable subpage for them.
-  settingsHref?: string
+  settingsHref?: string,
+  // Whether this user can open /admin/plugins, which is `manage-settings`
+  // guarded in pages/registry.ts. The plugins ICON is shown more widely than
+  // that: a user who can read a plugin-owned collection sees it in order to
+  // reach that collection through the sub-sidebar. Navigating them to the
+  // guarded page would bounce them to the dashboard and remove their only route
+  // to content they are allowed to see, so for them the icon stays a
+  // sub-sidebar opener.
+  canOpenPluginsPage = false
 ): string {
   if (item.id === "collections") return ROUTES.COLLECTIONS;
   if (item.id === "singles") return ROUTES.SINGLES;
-  if (item.id === "plugins") return ROUTES.PLUGINS;
+  if (item.id === "plugins") return canOpenPluginsPage ? ROUTES.PLUGINS : "#";
   if (item.id === "settings" && settingsHref) return settingsHref;
   if (item.id.startsWith("standalone-")) {
     const slug = item.id.replace("standalone-", "");

--- a/packages/admin/src/components/layout/sidebar/lib/resolve-item-href.ts
+++ b/packages/admin/src/components/layout/sidebar/lib/resolve-item-href.ts
@@ -4,13 +4,17 @@ import type { PluginMetadata } from "@admin/types/branding";
 
 import type { MainMenuItem } from "../sidebar-types";
 
-// Why: collections / singles primary-icon clicks navigate to the section
-// landing page smart-redirect routes pick the most-recently-
-// created record server-side). Plugins follows the same convention and lands
-// on the installed list, which today renders an empty table when nothing is
-// installed. Standalone plugins jump to their first registered collection.
-// Extracted to a pure helper so the routing logic is unit-testable without
-// mounting the full DualSidebar tree.
+// Where a primary sidebar icon points.
+//
+// Collections and singles land on their section page, whose smart-redirect
+// routes pick the most-recently-created record server-side. Plugins follows the
+// same convention and lands on the installed list, which renders an empty table
+// when nothing is installed. Standalone plugins have no section page, so they
+// jump to their first registered collection instead.
+//
+// A pure function of the item and the caller's capabilities: every destination
+// here is decided by those two, and nothing about the answer depends on the
+// sidebar being mounted.
 export function resolveItemHref(
   item: MainMenuItem,
   visibleStandalonePlugins: PluginMetadata[],

--- a/packages/admin/src/components/layout/sidebar/sidebar-types.ts
+++ b/packages/admin/src/components/layout/sidebar/sidebar-types.ts
@@ -48,9 +48,10 @@ export const MAIN_MENU_ITEMS: MainMenuItem[] = [
   },
 ];
 
-// Plugins is always listed, including on an install with none registered: the
-// entry is the only route to the plugin directory, so hiding it until a plugin
-// exists leaves a new install unable to find the page that installs one.
+// Plugins is always listed, including on an install with none registered. The
+// entry is the only route to `/admin/plugins`, which is the installed-plugins
+// list; hiding it until a plugin exists leaves a new install unable to reach
+// that page at all.
 export const getFilteredMenuItems = (showBuilder: boolean) =>
   MAIN_MENU_ITEMS.filter(item => {
     if (item.id === "builders" && !showBuilder) return false;

--- a/packages/admin/src/components/layout/sidebar/sidebar-types.ts
+++ b/packages/admin/src/components/layout/sidebar/sidebar-types.ts
@@ -48,14 +48,11 @@ export const MAIN_MENU_ITEMS: MainMenuItem[] = [
   },
 ];
 
-export const getFilteredMenuItems = (
-  showBuilder: boolean,
-  hasInstalledPlugins: boolean = false
-) =>
+// Plugins is always listed, including on an install with none registered: the
+// entry is the only route to the plugin directory, so hiding it until a plugin
+// exists leaves a new install unable to find the page that installs one.
+export const getFilteredMenuItems = (showBuilder: boolean) =>
   MAIN_MENU_ITEMS.filter(item => {
     if (item.id === "builders" && !showBuilder) return false;
-    // Plugins functionality is in development; hide the menu entry until at
-    // least one plugin is registered so empty installs don't see a stub page.
-    if (item.id === "plugins" && !hasInstalledPlugins) return false;
     return true;
   });

--- a/packages/admin/src/lib/plugins/__tests__/collection-placement.test.ts
+++ b/packages/admin/src/lib/plugins/__tests__/collection-placement.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Placement decides which sidebar section may list a plugin collection. These
+ * cover the case that made a group-keyed lookup wrong: a collection whose
+ * plugin placed it elsewhere but which declares no display group.
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  isCollectionPlacedElsewhere,
+  resolveCollectionPlacement,
+} from "../collection-placement";
+
+import type { PluginMetadata } from "@admin/types/branding";
+
+const META = [
+  {
+    name: "@acme/settings-plugin",
+    placement: "settings",
+    collections: ["gadgets"],
+  },
+  { name: "@acme/plain", collections: ["widgets"] },
+  { name: "@acme/grouped", group: "settings", collections: ["cogs"] },
+] as unknown as PluginMetadata[];
+
+describe("resolveCollectionPlacement", () => {
+  it("reads the placement from the plugin that owns the collection", () => {
+    expect(resolveCollectionPlacement("gadgets", META)).toBe("settings");
+  });
+
+  it("falls back to the plugin's group when no placement is declared", () => {
+    expect(resolveCollectionPlacement("cogs", META)).toBe("settings");
+  });
+
+  it("is undefined for a plugin declaring neither", () => {
+    expect(resolveCollectionPlacement("widgets", META)).toBeUndefined();
+  });
+
+  it("is undefined for a collection no plugin claims", () => {
+    expect(resolveCollectionPlacement("posts", META)).toBeUndefined();
+  });
+
+  it("is undefined when metadata has not loaded", () => {
+    expect(resolveCollectionPlacement("gadgets", undefined)).toBeUndefined();
+  });
+});
+
+describe("isCollectionPlacedElsewhere", () => {
+  /**
+   * The separating case. `gadgets` carries no `admin.group`, so a lookup keyed
+   * on the display group cannot find its plugin and reports no placement —
+   * which reads as "belongs under Plugins" and lists it there as well as under
+   * Settings. Nothing about this answer involves the group.
+   */
+  it("finds a placement for a collection that declares no display group", () => {
+    expect(isCollectionPlacedElsewhere("gadgets", META)).toBe(true);
+  });
+
+  /**
+   * An undeclared placement means Plugins, not "unknown, so hide it". Treating
+   * it as elsewhere would remove the collection from every section.
+   */
+  it("keeps a collection whose plugin declares no placement", () => {
+    expect(isCollectionPlacedElsewhere("widgets", META)).toBe(false);
+  });
+
+  it("keeps one placed in Plugins explicitly", () => {
+    const explicit = [
+      { name: "@acme/here", placement: "plugins", collections: ["here"] },
+    ] as unknown as PluginMetadata[];
+
+    expect(isCollectionPlacedElsewhere("here", explicit)).toBe(false);
+  });
+
+  it("keeps a collection no plugin claims", () => {
+    expect(isCollectionPlacedElsewhere("posts", META)).toBe(false);
+  });
+});

--- a/packages/admin/src/lib/plugins/__tests__/collection-placement.test.ts
+++ b/packages/admin/src/lib/plugins/__tests__/collection-placement.test.ts
@@ -1,7 +1,8 @@
 /**
- * Placement decides which sidebar section may list a plugin collection. These
- * cover the case that made a group-keyed lookup wrong: a collection whose
- * plugin placed it elsewhere but which declares no display group.
+ * Placement decides which sidebar section may list a plugin collection, and it
+ * is a property of the plugin that OWNS the collection. These cover the inputs
+ * where ownership and display grouping come apart: a collection with no
+ * `admin.group` heading is still owned, so its placement is still knowable.
  */
 import { describe, expect, it } from "vitest";
 

--- a/packages/admin/src/lib/plugins/collection-placement.ts
+++ b/packages/admin/src/lib/plugins/collection-placement.ts
@@ -1,0 +1,43 @@
+import type { PluginMetadata } from "@admin/types/branding";
+
+/**
+ * Where a plugin-owned collection belongs in the sidebar.
+ *
+ * Resolved from the metadata of the plugin that OWNS the collection, found by
+ * matching the collection's name against that plugin's declared `collections`.
+ *
+ * Not from the display group the collection happens to sit under. `admin.group`
+ * is an optional heading, so a collection declaring none cannot be found by
+ * group at all — and a lookup keyed on it reports "no placement", which reads
+ * as "belongs under Plugins". The collection is then listed under Plugins and
+ * under wherever its plugin actually placed it.
+ *
+ * @module lib/plugins/collection-placement
+ */
+export function resolveCollectionPlacement(
+  collectionName: string,
+  pluginMetadata: readonly PluginMetadata[] | undefined
+): string | undefined {
+  if (!pluginMetadata) return undefined;
+  const meta = pluginMetadata.find(plugin =>
+    (plugin.collections ?? []).includes(collectionName)
+  );
+  return meta?.placement ?? meta?.group ?? undefined;
+}
+
+/**
+ * Whether a plugin collection is rendered somewhere other than the Plugins
+ * panel, and so must not also be listed inside it.
+ *
+ * An undeclared placement means Plugins, which is why this is not simply
+ * `placement !== "plugins"` applied to an optional value: a collection whose
+ * plugin declares nothing belongs here, and treating "unknown" as "elsewhere"
+ * would hide it from every section.
+ */
+export function isCollectionPlacedElsewhere(
+  collectionName: string,
+  pluginMetadata: readonly PluginMetadata[] | undefined
+): boolean {
+  const placement = resolveCollectionPlacement(collectionName, pluginMetadata);
+  return placement !== undefined && placement !== "plugins";
+}


### PR DESCRIPTION
## Summary

Clicking **Plugins** in the primary sidebar did nothing except expand the sub-sidebar. The only route to `/admin/plugins` was the "Installed Plugins" item inside that sub-sidebar.

The cause was deliberate rather than a bug. `resolve-item-href.ts` returned a literal `"#"` for the plugins item, with a comment saying *"Plugins remain pure sub-sidebar openers (no landing-page convention yet)"*. Collections and singles both resolve to their section landing route in the same function; plugins was the only section that did not. It now does.

A second, sharper problem sat next to it. `getFilteredMenuItems` hid the Plugins entry entirely until at least one plugin was registered, so on a fresh project the plugins page was **unreachable through the UI at all**. That filter is removed, and `hasInstalledPlugins` goes with it since feeding that filter was its only purpose.

## What changed

- `lib/resolve-item-href.ts` returns `ROUTES.PLUGINS` for the plugins item, and the block comment no longer claims the convention is absent.
- `sidebar-types.ts` always lists the plugins item. `getFilteredMenuItems` loses its second parameter.
- `DualSidebar.tsx` drops the now-unused `hasInstalledPlugins` computation and memo dependency.
- `href: "#"` stays in `MAIN_MENU_ITEMS` for the plugins entry, matching collections and singles. `item.href` is only ever read through `resolveItemHref`, so putting a real route in the array would create a second source of truth for the same destination.

## Test plan

- [x] `pnpm lint` — 22/22, exit 0
- [x] `pnpm check-types` — 21/21, exit 0
- [x] `pnpm build` — 19/19
- [x] `pnpm --filter @nextlyhq/admin test -- sidebar` — 4 files, 25 tests, all passing
- [x] Verified in a browser via Playwright against a running playground

**Tests.** The existing case `__tests__/resolve-item-href.test.ts` asserted the old behaviour (`toBe("#")`). It is changed, deliberately, to assert the new one; that file's collections, singles, settings, builders and standalone-plugin cases are untouched and act as positive controls that the helper still resolves section items at all.

A new `__tests__/sidebar-types.test.ts` covers the visibility change. Its builders on/off cases are positive controls: without them, a `getFilteredMenuItems` that stopped filtering entirely would pass the plugins assertions for the wrong reason.

Both were run red before the fix and green after. The red was the intended assertion failing (`expected '#' to be '/admin/plugins'`), not a compile error.

**Browser verification.** Clicked the sidebar item on a running playground: the anchor now carries `/url: /admin/plugins` and the click lands on `http://localhost:3005/admin/plugins`. One console error is present, `/admin/api/seed` returning 400, which is a dev-seed endpoint unrelated to this change and reproduces without it.

## Pre-existing failures, not caused by this PR

`pnpm --filter @nextlyhq/admin test` reports **27 failures across 6 files**: `StatsCard`, `RoleBasicInfo`, `BasicsTab`, `SlugInput`, `DefaultValueField`, `SearchBar`. These are the known failing baseline `AGENTS.md` warns about. Another lane measured the identical count and the identical six files today, independently.

None of the six is a sidebar file and this diff touches only sidebar files, so they are unreachable from it. Sidebar tests specifically: 4 files, 25 tests, all green.

Separately, a **fresh worktree fails `pnpm lint` with 361 `Unable to resolve path to module '@nextlyhq/ui'` errors until `pnpm build` has run**, because `pnpm install` does not produce `dist`. That is the documented missing-build-output state, not a regression. Lint is green at 22/22 after a build.

## Changeset

Changeset added: yes (patch), covering all 23 packages in the fixed group. The list was generated from `.changeset/config.json` rather than typed by hand.

## Notes for reviewers

This is the first of seven small PRs building the admin plugins surface. The others add a shared slug/category/icon resolver, a curated plugin catalogue, a browse page, a two-column detail page, and disclosure of what a disabled plugin would add if enabled. Each lands separately.

One thing this PR deliberately does **not** do: `/admin/plugins` still has no empty state pointing at a directory, because the directory does not exist yet. A project with zero plugins now reaches the page and sees an empty table. The "Browse plugins" call to action lands with the browse page.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated **Plugins** sidebar section with an **Installed Plugins** entry.
  * Users with settings-management access can open the Plugins page directly.
  * Plugin navigation adapts to permissions, available plugin data, and loading states.
* **Bug Fixes**
  * Plugin navigation remains available independently of Builder visibility.
  * Refined navigation for users without settings-management access, including permitted collection links.
* **Tests**
  * Added coverage for plugin visibility, navigation, permissions, loading states, and menu filtering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->