### PR TITLE
fix(nextly): preview only the renames a resumed run would still do

### DIFF
--- a/.changeset/migration-dry-run-and-backup-gate.md
+++ b/.changeset/migration-dry-run-and-backup-gate.md
@@ -25,4 +25,4 @@
 "@nextlyhq/module-specifiers": patch
 ---
 
-The field-group storage migration can now report what it would do without writing anything, and refuses to run for real unless the caller states that a restorable backup exists.
+The field-group storage migration can now report what it would rename without changing any content or recording that a run happened, and refuses to run for real unless the caller states that a restorable backup exists. A preview still claims the migration lock, so it needs a role that can write to Nextly's own lock table.

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/reconcile.test.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/reconcile.test.ts
@@ -102,6 +102,94 @@ describe("a rollback torn before its pointer update", () => {
   });
 });
 
+// A localized field group moves two physical tables on ONE entry, and MySQL
+// commits each rename as it is issued, so a crash lands between them. The entry
+// is unsatisfied while either remains, which is the right answer for the entry
+// and the wrong one for the question "what is left to do".
+describe("a localized entry torn between its two renames", () => {
+  const localized = row({ hasCompanion: true });
+  const plan = buildMigrationManifest([localized]).entries;
+
+  // The base has moved, its companion has not, and the registry has not: the
+  // first entry's rename committed while the crash took everything after it.
+  const TORN_CATALOG = [
+    "dynamic_components",
+    "fg_hero",
+    `comp_hero${STORAGE_FORMAT.companionSuffix}`,
+  ];
+
+  function reconcileTorn() {
+    return reconcilePlan({
+      entries: plan,
+      rows: [localized],
+      tables: TORN_CATALOG,
+      columns: columnsFor(TORN_CATALOG),
+      // Position 1 is `step + 1`, the commit-before-marker window the runner
+      // supports, which is what makes the moved base explicable rather than an
+      // object no recorded progress accounts for.
+      run: { recorded: true, direction: "up", step: 0 },
+      direction: "up",
+      identifierCase: PRESERVING,
+    });
+  }
+
+  it("reports only the rename that has not happened", () => {
+    const entry = reconcileTorn()[0];
+
+    expect(entry?.pendingTableRenames).toEqual([
+      {
+        from: `comp_hero${STORAGE_FORMAT.companionSuffix}`,
+        to: `fg_hero${STORAGE_FORMAT.companionSuffix}`,
+      },
+    ]);
+  });
+
+  // The separating assertion. `satisfied` is the coarser answer, and it is
+  // CORRECT for what it describes -- work remains on this entry. Anything
+  // deriving the outstanding renames from it reports the moved base as still to
+  // move, so this pins that the two answers are allowed to differ.
+  it("stays unsatisfied while its companion is outstanding", () => {
+    expect(reconcileTorn()[0]?.satisfied).toBeUndefined();
+  });
+
+  it("reports both renames before either has happened", () => {
+    const untouched = reconcilePlan({
+      entries: plan,
+      rows: [localized],
+      tables: [
+        "dynamic_components",
+        "comp_hero",
+        `comp_hero${STORAGE_FORMAT.companionSuffix}`,
+      ],
+      columns: columnsFor([
+        "dynamic_components",
+        "comp_hero",
+        `comp_hero${STORAGE_FORMAT.companionSuffix}`,
+      ]),
+      run: { recorded: false },
+      direction: "up",
+      identifierCase: PRESERVING,
+    });
+
+    expect(untouched[0]?.pendingTableRenames).toEqual([
+      { from: "comp_hero", to: "fg_hero" },
+      {
+        from: `comp_hero${STORAGE_FORMAT.companionSuffix}`,
+        to: `fg_hero${STORAGE_FORMAT.companionSuffix}`,
+      },
+    ]);
+  });
+
+  // A column entry moves no table, so an empty list is its real answer. Asserted
+  // because the alternative -- leaving it absent and falling back where it is
+  // missing -- is how the coarser derivation gets back in.
+  it("gives a column entry an empty list rather than none", () => {
+    const column = reconcileTorn().find(entry => entry.kind === "column");
+
+    expect(column?.pendingTableRenames).toEqual([]);
+  });
+});
+
 describe("field-group migration reconciliation", () => {
   const rows = [row()];
   const plan = buildMigrationManifest(rows).entries;

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/run.test.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/run.test.ts
@@ -785,6 +785,38 @@ describe("a dry run", () => {
     );
   });
 
+  // A localized field group moves its `_locales` companion on the same manifest
+  // entry as its own table, so a preview reading `from` and `to` off the entry
+  // names one rename where two happen -- and omits the one an operator is least
+  // likely to predict.
+  it("names a localized field group's companion table too", async () => {
+    const { adapter } = createRunWorld({
+      tables: [LEGACY_REGISTRY, "comp_hero", "comp_hero_locales"],
+      registryRows: [
+        { id: "1", slug: "hero", table_name: "comp_hero", localized: true },
+      ],
+    });
+
+    const outcome = await runFieldGroupMigration({
+      adapter,
+      logger,
+      direction: "up",
+      dryRun: true,
+    });
+
+    if (outcome.ran !== false || outcome.reason !== "dry-run") {
+      throw new Error("expected a dry-run outcome");
+    }
+    expect(outcome.renames).toContainEqual({
+      from: "comp_hero",
+      to: "fg_hero",
+    });
+    expect(outcome.renames).toContainEqual({
+      from: "comp_hero_locales",
+      to: "fg_hero_locales",
+    });
+  });
+
   it("reads the catalog but records nothing", async () => {
     const { adapter, trace, writes } = unmigrated();
 

--- a/packages/nextly/src/domains/field-groups/migration/manifest.ts
+++ b/packages/nextly/src/domains/field-groups/migration/manifest.ts
@@ -492,6 +492,12 @@ function assertNoTargetConflict(
   }
 }
 
+/** One physical table move: the name it leaves, and the name it takes. */
+export interface TableRename {
+  from: string;
+  to: string;
+}
+
 /**
  * Every physical table an entry moves: its own, and its companion's.
  *
@@ -499,9 +505,7 @@ function assertNoTargetConflict(
  * entry, so name checks have to see it even though it no longer has one of its
  * own. Column entries move no table and contribute nothing.
  */
-export function tableRenamesOf(
-  entry: ManifestEntry
-): { from: string; to: string }[] {
+export function tableRenamesOf(entry: ManifestEntry): TableRename[] {
   if (entry.kind === "column") return [];
   const own = { from: entry.from, to: entry.to };
   return entry.companion === undefined ? [own] : [own, entry.companion];

--- a/packages/nextly/src/domains/field-groups/migration/reconcile.ts
+++ b/packages/nextly/src/domains/field-groups/migration/reconcile.ts
@@ -32,8 +32,27 @@ import {
   tableRenamesOf,
   type ManifestEntry,
   type RegistryRow,
+  type TableRename,
 } from "./manifest";
 import type { MigrationDirection, StorageGeneration } from "./state";
+
+/**
+ * An entry, plus the physical table moves reconciliation found still outstanding.
+ *
+ * 🔴 Carried out of reconciliation rather than recomputed by whoever needs it, and that is the
+ * point of the type. Deciding which renames remain means resolving each source in the catalog, and
+ * reconciliation does exactly that, per physical rename, before collapsing the result into
+ * `satisfied`. Anything that re-derives the question from `satisfied` is asking a COARSER one: an
+ * entry moving a table and its `_locales` companion is unsatisfied while either remains, so a run
+ * torn between the two reports the already-moved table as still to move.
+ *
+ * Required rather than optional, so the answer cannot be reached through a fallback that quietly
+ * reintroduces the coarser derivation. A column entry moves no table and carries an empty list,
+ * which is a real answer rather than a missing one.
+ */
+export type ReconciledEntry = ManifestEntry & {
+  readonly pendingTableRenames: readonly TableRename[];
+};
 
 /** The columns one table carries, as the database reported them. */
 export interface TableColumns {
@@ -80,7 +99,7 @@ export function reconcilePlan(args: {
   run: RunRecord;
   direction: MigrationDirection;
   identifierCase: IdentifierCaseRules;
-}): ManifestEntry[] {
+}): ReconciledEntry[] {
   const { entries, rows, run, direction, identifierCase } = args;
 
   if (run.recorded && run.direction !== direction) {
@@ -126,13 +145,18 @@ export function reconcilePlan(args: {
   return entries.map((entry, index) => {
     const position = index + 1;
     if (entry.kind === "column") {
-      return reconcileColumn(entry, {
-        catalog,
-        columns,
-        otherNames,
-        position,
-        run,
-      });
+      // Attached here rather than threaded through `reconcileColumn`'s four return paths, which
+      // all describe a column and would each have to restate the same empty list.
+      return {
+        ...reconcileColumn(entry, {
+          catalog,
+          columns,
+          otherNames,
+          position,
+          run,
+        }),
+        pendingTableRenames: [],
+      };
     }
     return reconcileRename(entry, catalog, position, run);
   });
@@ -540,7 +564,7 @@ function reconcileRename(
   catalog: CatalogIndex,
   position: number,
   run: RunRecord
-): ManifestEntry {
+): ReconciledEntry {
   // A table entry moves its companion as well as itself, and the two are not
   // always in the same state: MySQL commits each rename separately, so a crash
   // between them leaves the base migrated and the companion still under its old
@@ -548,6 +572,10 @@ function reconcileRename(
   // marking it satisfied on the base alone would let the step skip a companion
   // that is still sitting there.
   let allApplied = true;
+  // Collected from the same resolution that decides `allApplied`, so the two answers come from one
+  // pass over one catalog. The step executes exactly these: it re-resolves each source against a
+  // catalog read at its own turn, and skips the ones already gone.
+  const pendingTableRenames: TableRename[] = [];
 
   for (const rename of tableRenamesOf(entry)) {
     const source = resolveCatalogName(catalog, rename.from);
@@ -573,6 +601,7 @@ function reconcileRename(
           }
         );
       }
+      pendingTableRenames.push(rename);
       allApplied = false;
       continue;
     }
@@ -603,7 +632,9 @@ function reconcileRename(
     });
   }
 
-  return allApplied ? { ...entry, satisfied: true } : entry;
+  return allApplied
+    ? { ...entry, satisfied: true, pendingTableRenames }
+    : { ...entry, pendingTableRenames };
 }
 
 /**

--- a/packages/nextly/src/domains/field-groups/migration/run.ts
+++ b/packages/nextly/src/domains/field-groups/migration/run.ts
@@ -42,7 +42,6 @@ import {
   hashManifest,
   hashRegistryIdentity,
   MIGRATION_TARGET,
-  tableRenamesOf,
   type ManifestEntry,
   type RegistryRow,
 } from "./manifest";
@@ -372,18 +371,17 @@ export async function runFieldGroupMigration(
       // reports a plan the database has already been scored against rather than one the manifest
       // merely proposes.
       if (dryRun) {
-        // Expanded through the same helper the executable steps use. A localized field group
-        // carries its companion `_locales` rename on the SAME manifest entry, so reading `from`
-        // and `to` off the entry reports one rename where two will happen -- and the one it omits
-        // is the one an operator is least likely to predict.
-        // Entries the reconciliation found already applied are dropped. A resumed run starts
-        // after the recorded step and a torn step skips a source that is already absent, so
-        // reporting a satisfied entry tells the operator an object will be renamed that has
-        // already moved — on a resume, which is exactly when they are deciding whether the
-        // remaining work is safe to continue.
-        const renames = reconciled
-          .filter(entry => entry.satisfied !== true)
-          .flatMap(entry => tableRenamesOf(entry));
+        // Read from reconciliation rather than re-derived here, and that is the whole of it. The
+        // question "which renames remain" is one catalog resolution per physical table, and
+        // reconciliation has just done exactly that; asking it a second time in a second place is
+        // how the two came to disagree.
+        //
+        // What they disagreed about: a localized field group carries its `_locales` companion on
+        // the SAME entry, so an entry is unsatisfied while EITHER table remains. Filtering on that
+        // reported both when a run torn between the two had already moved the base — during a
+        // resume, which is precisely when an operator is judging whether the remaining work is
+        // safe to continue.
+        const renames = reconciled.flatMap(entry => entry.pendingTableRenames);
         logger.info?.("field-group migration dry run", {
           phase: FIELD_GROUP_MIGRATION_PHASE,
           direction,

--- a/packages/nextly/src/domains/field-groups/migration/run.ts
+++ b/packages/nextly/src/domains/field-groups/migration/run.ts
@@ -145,7 +145,8 @@ export interface RunMigrationArgs {
    * direction that matters: a staging database restored from production carries the same content
    * as production.
    *
-   * A dry run does not require it, because a dry run writes nothing.
+   * A dry run does not require it, because a dry run writes no content and records no marker.
+   * It is not read-only — see `dryRun` — but nothing it touches is a thing a backup would restore.
    */
   backupConfirmed?: boolean;
 }
@@ -173,7 +174,8 @@ export async function runFieldGroupMigration(
   // resumed run, already read a marker; a caller who forgot the acknowledgement would be told so
   // only after this had interfered with whatever else was trying to change schema.
   //
-  // A dry run is exempt because it writes nothing, and exempting it is what makes the gate usable:
+  // A dry run is exempt because it writes no content and records no marker, and exempting it is
+  // what makes the gate usable:
   // the operator's first action is to see the plan, and demanding they assert a backup before they
   // are allowed to look at what would happen teaches them to assert it without meaning it.
   if (!dryRun && !backupConfirmed) {
@@ -374,7 +376,14 @@ export async function runFieldGroupMigration(
         // carries its companion `_locales` rename on the SAME manifest entry, so reading `from`
         // and `to` off the entry reports one rename where two will happen -- and the one it omits
         // is the one an operator is least likely to predict.
-        const renames = reconciled.flatMap(entry => tableRenamesOf(entry));
+        // Entries the reconciliation found already applied are dropped. A resumed run starts
+        // after the recorded step and a torn step skips a source that is already absent, so
+        // reporting a satisfied entry tells the operator an object will be renamed that has
+        // already moved — on a resume, which is exactly when they are deciding whether the
+        // remaining work is safe to continue.
+        const renames = reconciled
+          .filter(entry => entry.satisfied !== true)
+          .flatMap(entry => tableRenamesOf(entry));
         logger.info?.("field-group migration dry run", {
           phase: FIELD_GROUP_MIGRATION_PHASE,
           direction,


### PR DESCRIPTION
Recovers the review corrections for #725. That PR merged at `c6d643dd2` while `b8c6d1e01` was still in flight — measured, not assumed: merge at `13:28:21Z`, the commit written `13:29:47Z`, 86 seconds later. **Nothing was dropped by the merge**; the commit did not exist when it happened, and I pushed onto an already-closed PR. The content is genuinely not on main either way, verified by markers scoped to the paths the commit changed, with a positive control proving the same search finds them at the branch tip.

## What it carries

**A resumed preview listed renames that had already happened.** Reconciliation keeps entries it found applied, marked `satisfied`, and the real run skips them — a resume starts after the recorded step, and a torn step skips a source already absent. Flattening every entry therefore told an operator that objects which have already moved will move again, at exactly the moment they are deciding whether continuing is safe.

**Three surviving overclaims that a dry run "writes nothing".** Claiming the session lock creates `nextly_field_group_lock` and writes an owner into it, so a dry run issues DDL on first use and fails for a read-only role. The guarantee had been narrowed on `RunMigrationArgs` and left standing in two more `run.ts` sites and — worst, because it is release-facing — the changeset. All now say the same thing: no content is written and no marker recorded, the lock is real.

## What I am NOT claiming

**The satisfied-entry filter has no load-bearing test.** I wrote one; the fixture (registry naming `comp_hero`, only `fg_hero` present) produces a refusal before reconciliation rather than the partly-applied shape, because a genuine resume carries a `migrating` marker with a recorded plan the unit harness does not build. I removed it rather than keep a test failing for an unrelated reason, or reshape it until green without knowing what it exercised.

So this fix is verified by reading `reconcile.ts` (`satisfied: true` at `:473`, `:525`, `:606`) and by the existing 22 tests staying green — not by a test that fails when the filter is removed. That is below the bar the rest of this lane has held and it is stated rather than glossed.

## Verification

`check-types --force`, `lint`, storage gate, drizzle gate, changeset checker: green by exit code. Migration suite 22 passed.