### PR TITLE
refactor(admin): resolve plugin slugs, categories and icons in one place

### DIFF
--- a/.changeset/plugin-foundation-helpers-and-catalogue.md
+++ b/.changeset/plugin-foundation-helpers-and-catalogue.md
@@ -1,0 +1,32 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+Plugin icons now resolve through one shared rule, so the same plugin shows the same icon everywhere in the admin, and a plugin can ship its own logo image instead of naming a built-in glyph.
+
+The SEO plugin now describes itself in the plugins list instead of showing a bare package name.
+
+A styling fixture used only by the end-to-end suite no longer appears as an installed plugin, and no longer injects a showcase section into the Posts collection list, in a normal development server.

--- a/apps/playground/nextly.config.ts
+++ b/apps/playground/nextly.config.ts
@@ -81,9 +81,22 @@ export default defineConfig({
   collections: [Posts, Categories, Tags, BlockPages],
   singles: [Homepage, LandingPage, SiteSettings],
   fieldGroups: [Seo],
-  // Dev-harness plugins: page builder, form builder, and the styling fixture
-  // (exercises the plugin admin-styling layers for e2e).
-  plugins: [pageBuilder(), formBuilderPlugin, styleFixturePlugin],
+  // Dev-harness plugins: page builder and form builder are what a contributor
+  // works against.
+  //
+  // The styling fixture is registered only for the e2e run. It exists so
+  // plugin-admin-styling.spec.ts can prove a plugin's admin UI is styled in the
+  // real admin, and plugin-page-routing.spec.ts can resolve a deep link to a
+  // plugin page. In a normal `pnpm dev:app` it is neither of those things: it
+  // is a test double listed among real plugins, and it injects a showcase
+  // section into the Posts collection list, both of which read as product.
+  plugins: [
+    pageBuilder(),
+    formBuilderPlugin,
+    ...(process.env.NEXTLY_E2E_STYLE_FIXTURE === "1"
+      ? [styleFixturePlugin]
+      : []),
+  ],
   typescript: {
     outputFile: "./src/types/nextly-types.ts",
   },

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -109,6 +109,11 @@ export default defineConfig({
       // asserts against. They are off by default so a contributor's admin
       // keeps the monochrome identity a default install has.
       NEXTLY_E2E_BRANDING: "1",
+      // Registers the style fixture, which plugin-admin-styling.spec.ts and
+      // plugin-page-routing.spec.ts both depend on. Off by default so a test
+      // double does not appear in a contributor's plugins list or inject a
+      // showcase section into the Posts collection.
+      NEXTLY_E2E_STYLE_FIXTURE: "1",
     },
   },
 

--- a/packages/admin/src/components/features/dashboard/DynamicPluginNav.tsx
+++ b/packages/admin/src/components/features/dashboard/DynamicPluginNav.tsx
@@ -29,6 +29,7 @@ import { useBranding } from "@admin/context/providers/BrandingProvider";
 import { useCollections } from "@admin/hooks/queries";
 import { useCurrentUserPermissions } from "@admin/hooks/useCurrentUserPermissions";
 import { filterCollectionItems } from "@admin/lib/permissions/authorization";
+import { pluginSlug } from "@admin/lib/plugins/plugin-slug";
 import { cn } from "@admin/lib/utils";
 import type { ApiCollection } from "@admin/types/entities";
 
@@ -54,17 +55,6 @@ function PluginSkeleton() {
       </SidebarMenuButton>
     </SidebarMenuItem>
   );
-}
-
-/**
- * Derive a URL-friendly slug from a plugin group name.
- * e.g. "Form Builder" -> "form-builder"
- */
-function toSlug(name: string): string {
-  return name
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-+|-+$/g, "");
 }
 
 interface PluginEntry {
@@ -132,7 +122,7 @@ export function DynamicPluginNav({
       const collectionSlugs = new Set(meta.collections ?? []);
       for (const collection of allPluginCollections) {
         if (collectionSlugs.has(collection.name)) {
-          const groupSlug = toSlug(collection.admin?.group || "");
+          const groupSlug = pluginSlug(collection.admin?.group || "");
           if (groupSlug && !map.has(groupSlug)) {
             map.set(groupSlug, meta);
           }
@@ -170,7 +160,7 @@ export function DynamicPluginNav({
       }
 
       if (!pluginMap.has(groupName)) {
-        const slug = toSlug(groupName);
+        const slug = pluginSlug(groupName);
         pluginMap.set(groupName, {
           name: groupName,
           slug,

--- a/packages/admin/src/components/features/dashboard/DynamicPluginSectionItems.tsx
+++ b/packages/admin/src/components/features/dashboard/DynamicPluginSectionItems.tsx
@@ -164,15 +164,14 @@ export function DynamicPluginSectionItems({
                   // declares none. Below that the shared chain decides, so
                   // asset-over-lucide precedence lives in one place.
                   //
-                  // Lucide branch only, for the same reason as the sidebar
-                  // rail: this renders an ElementType looked up by name, so a
-                  // shipped image has nowhere to go here.
+                  // Cannot render an image, for the same reason as the
+                  // sidebar rail, so it declares that and keeps whatever lucide
+                  // name the plugin supplied beside its asset.
                   const resolved = resolvePluginIcon(group.meta, {
                     fallback: "Database",
+                    allowAsset: false,
                   });
-                  const iconName =
-                    collection.admin?.icon ||
-                    (resolved.kind === "lucide" ? resolved.name : "Database");
+                  const iconName = collection.admin?.icon || resolved.name;
                   const IconComponent =
                     (Icons as Record<string, React.ElementType>)[iconName] ||
                     Database;

--- a/packages/admin/src/components/features/dashboard/DynamicPluginSectionItems.tsx
+++ b/packages/admin/src/components/features/dashboard/DynamicPluginSectionItems.tsx
@@ -16,20 +16,10 @@ import { useBranding } from "@admin/context/providers/BrandingProvider";
 import { useCollections } from "@admin/hooks/queries";
 import { useCurrentUserPermissions } from "@admin/hooks/useCurrentUserPermissions";
 import { filterCollectionItems } from "@admin/lib/permissions/authorization";
+import { pluginSlug } from "@admin/lib/plugins/plugin-slug";
 import { resolvePluginIcon } from "@admin/lib/plugins/resolve-plugin-icon";
 import type { PluginMetadata } from "@admin/types/branding";
 import type { ApiCollection } from "@admin/types/entities";
-
-/**
- * Derive a URL-friendly slug from a name.
- * e.g. "Form Builder" -> "form-builder"
- */
-function toSlug(name: string): string {
-  return name
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-+|-+$/g, "");
-}
 
 interface PluginGroup {
   meta: PluginMetadata;
@@ -91,7 +81,7 @@ export function DynamicPluginSectionItems({
     // Group collections by their plugin (match by collections list)
     const groups: PluginGroup[] = [];
     for (const meta of matchingPlugins) {
-      const slug = toSlug(meta.name);
+      const slug = pluginSlug(meta.name);
       const pluginCollectionSlugs = new Set(meta.collections ?? []);
       const collections = permittedCollections
         .filter(c => pluginCollectionSlugs.has(c.name))

--- a/packages/admin/src/components/features/dashboard/DynamicPluginSectionItems.tsx
+++ b/packages/admin/src/components/features/dashboard/DynamicPluginSectionItems.tsx
@@ -16,6 +16,7 @@ import { useBranding } from "@admin/context/providers/BrandingProvider";
 import { useCollections } from "@admin/hooks/queries";
 import { useCurrentUserPermissions } from "@admin/hooks/useCurrentUserPermissions";
 import { filterCollectionItems } from "@admin/lib/permissions/authorization";
+import { resolvePluginIcon } from "@admin/lib/plugins/resolve-plugin-icon";
 import type { PluginMetadata } from "@admin/types/branding";
 import type { ApiCollection } from "@admin/types/entities";
 
@@ -168,11 +169,20 @@ export function DynamicPluginSectionItems({
                     collection.label ||
                     collection.name;
 
-                  // Resolve icon: collection icon > plugin appearance icon > Database default
+                  // A collection's own icon wins: this row IS the collection,
+                  // and the plugin's icon is only a stand-in for one that
+                  // declares none. Below that the shared chain decides, so
+                  // asset-over-lucide precedence lives in one place.
+                  //
+                  // Lucide branch only, for the same reason as the sidebar
+                  // rail: this renders an ElementType looked up by name, so a
+                  // shipped image has nowhere to go here.
+                  const resolved = resolvePluginIcon(group.meta, {
+                    fallback: "Database",
+                  });
                   const iconName =
                     collection.admin?.icon ||
-                    group.meta.appearance?.icon ||
-                    "Database";
+                    (resolved.kind === "lucide" ? resolved.name : "Database");
                   const IconComponent =
                     (Icons as Record<string, React.ElementType>)[iconName] ||
                     Database;

--- a/packages/admin/src/components/layout/sidebar/DualSidebar.tsx
+++ b/packages/admin/src/components/layout/sidebar/DualSidebar.tsx
@@ -100,14 +100,15 @@ export function DualSidebar({ isMobile }: DualSidebarProps = {}) {
     >();
     for (const sp of visibleStandalonePlugins) {
       const slug = pluginSlug(sp.name);
-      // Resolved through the shared chain so asset precedence is decided in one
-      // place. This surface renders the lucide branch only: a menu item stores
-      // an ElementType and is rendered as `<Icon className=... />`, so a shipped
-      // image has nowhere to go without changing that data model. A plugin that
-      // ships only an asset therefore shows the fallback here while showing its
-      // logo in the plugins table and on its detail page.
-      const resolved = resolvePluginIcon(sp, { fallback: "Database" });
-      const iconName = resolved.kind === "lucide" ? resolved.name : "Database";
+      // A menu item stores an ElementType rendered as `<Icon className=… />`,
+      // so this surface cannot show an image. It says so rather than resolving
+      // an asset and discarding it, which would also discard the lucide name a
+      // plugin declared alongside the asset for precisely this surface.
+      const resolved = resolvePluginIcon(sp, {
+        fallback: "Database",
+        allowAsset: false,
+      });
+      const iconName = resolved.name;
       const IconComponent = iconMap[iconName] || Database;
       // The former top-level Users icon is gone; User Management now lives
       // under Settings, so a plugin still declaring `after: "users"` is anchored
@@ -295,10 +296,7 @@ export function DualSidebar({ isMobile }: DualSidebarProps = {}) {
   const activeCategory = useMemo(() => {
     // 0. Check standalone plugin collection routes first
     for (const sp of visibleStandalonePlugins) {
-      const slug = sp.name
-        .toLowerCase()
-        .replace(/[^a-z0-9]+/g, "-")
-        .replace(/^-+|-+$/g, "");
+      const slug = pluginSlug(sp.name);
       const standaloneId = `standalone-${slug}` as MainMenuCategory;
       const collectionSlugs = sp.collections ?? [];
       if (
@@ -475,13 +473,7 @@ export function DualSidebar({ isMobile }: DualSidebarProps = {}) {
   const pluginCollectionsForSection = useMemo(() => {
     if (!selectedMain.startsWith("standalone-")) return [];
     const slug = selectedMain.replace("standalone-", "");
-    const sp = visibleStandalonePlugins.find(
-      p =>
-        p.name
-          .toLowerCase()
-          .replace(/[^a-z0-9]+/g, "-")
-          .replace(/^-+|-+$/g, "") === slug
-    );
+    const sp = visibleStandalonePlugins.find(p => pluginSlug(p.name) === slug);
     if (!sp) return [];
     const collectionSlugs = new Set(sp.collections ?? []);
     return authorizedPlugins
@@ -500,13 +492,7 @@ export function DualSidebar({ isMobile }: DualSidebarProps = {}) {
   const standaloneLabel = useMemo(() => {
     if (!selectedMain.startsWith("standalone-")) return "";
     const slug = selectedMain.replace("standalone-", "");
-    const sp = visibleStandalonePlugins.find(
-      p =>
-        p.name
-          .toLowerCase()
-          .replace(/[^a-z0-9]+/g, "-")
-          .replace(/^-+|-+$/g, "") === slug
-    );
+    const sp = visibleStandalonePlugins.find(p => pluginSlug(p.name) === slug);
     return sp?.appearance?.label || sp?.name || slug;
   }, [selectedMain, visibleStandalonePlugins]);
 

--- a/packages/admin/src/components/layout/sidebar/DualSidebar.tsx
+++ b/packages/admin/src/components/layout/sidebar/DualSidebar.tsx
@@ -20,6 +20,8 @@ import {
   filterCollectionItems,
   filterSingleItems,
 } from "@admin/lib/permissions/authorization";
+import { pluginSlug } from "@admin/lib/plugins/plugin-slug";
+import { resolvePluginIcon } from "@admin/lib/plugins/resolve-plugin-icon";
 import { cn } from "@admin/lib/utils";
 import type { ApiCollection } from "@admin/types/entities";
 
@@ -97,11 +99,15 @@ export function DualSidebar({ isMobile }: DualSidebarProps = {}) {
       Array<{ item: MainMenuItem; order: number }>
     >();
     for (const sp of visibleStandalonePlugins) {
-      const slug = sp.name
-        .toLowerCase()
-        .replace(/[^a-z0-9]+/g, "-")
-        .replace(/^-+|-+$/g, "");
-      const iconName = sp.appearance?.icon || "Database";
+      const slug = pluginSlug(sp.name);
+      // Resolved through the shared chain so asset precedence is decided in one
+      // place. This surface renders the lucide branch only: a menu item stores
+      // an ElementType and is rendered as `<Icon className=... />`, so a shipped
+      // image has nowhere to go without changing that data model. A plugin that
+      // ships only an asset therefore shows the fallback here while showing its
+      // logo in the plugins table and on its detail page.
+      const resolved = resolvePluginIcon(sp, { fallback: "Database" });
+      const iconName = resolved.kind === "lucide" ? resolved.name : "Database";
       const IconComponent = iconMap[iconName] || Database;
       // The former top-level Users icon is gone; User Management now lives
       // under Settings, so a plugin still declaring `after: "users"` is anchored

--- a/packages/admin/src/components/layout/sidebar/lib/resolve-item-href.ts
+++ b/packages/admin/src/components/layout/sidebar/lib/resolve-item-href.ts
@@ -1,4 +1,5 @@
 import { ROUTES, buildRoute } from "@admin/constants/routes";
+import { pluginSlug } from "@admin/lib/plugins/plugin-slug";
 import type { PluginMetadata } from "@admin/types/branding";
 
 import type { MainMenuItem } from "../sidebar-types";
@@ -24,13 +25,7 @@ export function resolveItemHref(
   if (item.id === "settings" && settingsHref) return settingsHref;
   if (item.id.startsWith("standalone-")) {
     const slug = item.id.replace("standalone-", "");
-    const sp = visibleStandalonePlugins.find(
-      p =>
-        p.name
-          .toLowerCase()
-          .replace(/[^a-z0-9]+/g, "-")
-          .replace(/^-+|-+$/g, "") === slug
-    );
+    const sp = visibleStandalonePlugins.find(p => pluginSlug(p.name) === slug);
     const firstCol = sp?.collections?.[0];
     return firstCol
       ? buildRoute(ROUTES.COLLECTION_ENTRIES, { slug: firstCol })

--- a/packages/admin/src/components/shared/plugin-icon/index.test.tsx
+++ b/packages/admin/src/components/shared/plugin-icon/index.test.tsx
@@ -34,10 +34,13 @@ describe("PluginIcon", () => {
     expect(img).not.toBeNull();
     fireEvent.error(img!);
 
-    // The image is gone and something replaced it, rather than a broken glyph
-    // being left in place.
+    // The identity of the replacement is the point. Asserting only that the
+    // image went and something took its place passes equally when the caller
+    // fallback renders, which is the plausible broken version: the declared
+    // glyph is what the plugin asked for on this surface.
     expect(container.querySelector("img")).toBeNull();
-    expect(container).not.toBeEmptyDOMElement();
+    expect(container.querySelector(".lucide-puzzle")).not.toBeNull();
+    expect(container.querySelector(".lucide-package")).toBeNull();
   });
 
   /**

--- a/packages/admin/src/components/shared/plugin-icon/index.test.tsx
+++ b/packages/admin/src/components/shared/plugin-icon/index.test.tsx
@@ -1,0 +1,76 @@
+/**
+ * A plugin's logo may fail to load. What must not happen is one plugin's
+ * broken logo suppressing the next plugin's working one: the admin router
+ * renders the same detail-page component type for every `/admin/plugins/[slug]`
+ * without a key, so component state survives navigation between plugins.
+ */
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { PluginIcon } from "@admin/components/shared/plugin-icon";
+import type { PluginMetadata } from "@admin/types/branding";
+
+const withAsset = (src: string, icon?: string) =>
+  ({ appearance: { iconAsset: src, ...(icon ? { icon } : {}) } }) as Pick<
+    PluginMetadata,
+    "appearance"
+  >;
+
+describe("PluginIcon", () => {
+  it("renders a declared asset", () => {
+    render(<PluginIcon plugin={withAsset("/a.svg")} fallback="Package" />);
+    expect(screen.getByRole("presentation", { hidden: true })).toBeTruthy();
+  });
+
+  it("falls back to the declared glyph when the asset fails", () => {
+    const { container } = render(
+      <PluginIcon
+        plugin={withAsset("/broken.svg", "Puzzle")}
+        fallback="Package"
+      />
+    );
+
+    const img = container.querySelector("img");
+    expect(img).not.toBeNull();
+    fireEvent.error(img!);
+
+    // The image is gone and something replaced it, rather than a broken glyph
+    // being left in place.
+    expect(container.querySelector("img")).toBeNull();
+    expect(container).not.toBeEmptyDOMElement();
+  });
+
+  /**
+   * The regression this keys on. With failure tracked as a boolean, the second
+   * render below would skip a perfectly good asset because the first one broke.
+   */
+  it("retries a different asset after an earlier one failed", () => {
+    const { container, rerender } = render(
+      <PluginIcon plugin={withAsset("/broken.svg")} fallback="Package" />
+    );
+
+    fireEvent.error(container.querySelector("img")!);
+    expect(container.querySelector("img")).toBeNull();
+
+    // Same component instance, different plugin — exactly what client-side
+    // navigation between two plugin detail pages produces.
+    rerender(<PluginIcon plugin={withAsset("/good.svg")} fallback="Package" />);
+
+    const img = container.querySelector("img");
+    expect(img).not.toBeNull();
+    expect(img).toHaveAttribute("src", "/good.svg");
+  });
+
+  it("does not retry the same asset that just failed", () => {
+    const { container, rerender } = render(
+      <PluginIcon plugin={withAsset("/broken.svg")} fallback="Package" />
+    );
+
+    fireEvent.error(container.querySelector("img")!);
+    rerender(
+      <PluginIcon plugin={withAsset("/broken.svg")} fallback="Package" />
+    );
+
+    expect(container.querySelector("img")).toBeNull();
+  });
+});

--- a/packages/admin/src/components/shared/plugin-icon/index.tsx
+++ b/packages/admin/src/components/shared/plugin-icon/index.tsx
@@ -1,0 +1,56 @@
+import type React from "react";
+
+import * as Icons from "@admin/components/icons";
+import { resolvePluginIcon } from "@admin/lib/plugins/resolve-plugin-icon";
+import type { PluginMetadata } from "@admin/types/branding";
+
+interface PluginIconProps {
+  /** The plugin whose icon to render. Only `appearance` is read. */
+  plugin: Pick<PluginMetadata, "appearance">;
+  /**
+   * The lucide icon to use when the plugin declares none.
+   *
+   * Required rather than defaulted, because the right answer depends on the
+   * surface: the sidebar shows a standalone plugin as the collections it
+   * registers (`Database`), while the plugins table and detail page show it as
+   * a package (`Package`). A default here would silently pick one.
+   */
+  fallback: string;
+  className?: string;
+  /** Alt text for the asset case. Decorative by default. */
+  alt?: string;
+}
+
+/**
+ * Render a plugin's icon, whether it ships an image or names a lucide glyph.
+ *
+ * This exists so the discriminated union `resolvePluginIcon` returns is handled
+ * in ONE place. Four call sites render a plugin icon; branching on the union at
+ * each of them would rebuild, in a new shape, exactly the duplication the
+ * shared resolver was introduced to remove.
+ *
+ * @module components/shared/plugin-icon
+ */
+export function PluginIcon({
+  plugin,
+  fallback,
+  className,
+  alt = "",
+}: PluginIconProps): React.ReactElement {
+  const source = resolvePluginIcon(plugin, { fallback });
+
+  if (source.kind === "asset") {
+    // Decorative by default: the plugin's name is always rendered beside this,
+    // so announcing the logo as well repeats it for a screen reader.
+    return <img src={source.src} alt={alt} className={className} />;
+  }
+
+  const registry = Icons as unknown as Record<string, React.ElementType>;
+  // An unknown lucide name resolves to nothing, so fall through to the
+  // caller's fallback rather than rendering a hole. A plugin can name any
+  // string here and the icon barrel only carries the icons this admin uses.
+  const Named = registry[source.name] ?? registry[fallback];
+  if (!Named) return <span className={className} aria-hidden="true" />;
+
+  return <Named className={className} />;
+}

--- a/packages/admin/src/components/shared/plugin-icon/index.tsx
+++ b/packages/admin/src/components/shared/plugin-icon/index.tsx
@@ -45,10 +45,16 @@ export function PluginIcon({
   // icon it replaced. On failure the component re-resolves with assets
   // disallowed, so it lands on whatever lucide name the plugin declared beside
   // the asset before reaching the caller's fallback.
-  const [assetFailed, setAssetFailed] = useState(false);
+  // The failed URL rather than a boolean. A boolean survives client-side
+  // navigation between two plugin detail pages, because the router renders the
+  // same component type without a key, so React keeps the state: one plugin's
+  // broken logo would suppress the next plugin's working one. Keying on the
+  // source means a different asset is always attempted.
+  const [failedSrc, setFailedSrc] = useState<string | null>(null);
+  const declaredAsset = plugin.appearance?.iconAsset;
   const source = resolvePluginIcon(plugin, {
     fallback,
-    allowAsset: !assetFailed,
+    allowAsset: declaredAsset !== undefined && declaredAsset !== failedSrc,
   });
 
   if (source.kind === "asset") {
@@ -61,7 +67,7 @@ export function PluginIcon({
       <img
         src={source.src}
         alt={alt}
-        onError={() => setAssetFailed(true)}
+        onError={() => setFailedSrc(source.src)}
         className={cn("object-contain", className)}
       />
     );

--- a/packages/admin/src/components/shared/plugin-icon/index.tsx
+++ b/packages/admin/src/components/shared/plugin-icon/index.tsx
@@ -2,6 +2,7 @@ import type React from "react";
 
 import * as Icons from "@admin/components/icons";
 import { resolvePluginIcon } from "@admin/lib/plugins/resolve-plugin-icon";
+import { cn } from "@admin/lib/utils";
 import type { PluginMetadata } from "@admin/types/branding";
 
 interface PluginIconProps {
@@ -42,7 +43,16 @@ export function PluginIcon({
   if (source.kind === "asset") {
     // Decorative by default: the plugin's name is always rendered beside this,
     // so announcing the logo as well repeats it for a screen reader.
-    return <img src={source.src} alt={alt} className={className} />;
+    // object-contain, because every caller sizes this with equal h-* and w-*
+    // and the default object-fit of `fill` would squash a rectangular logo
+    // into that square.
+    return (
+      <img
+        src={source.src}
+        alt={alt}
+        className={cn("object-contain", className)}
+      />
+    );
   }
 
   const registry = Icons as unknown as Record<string, React.ElementType>;

--- a/packages/admin/src/components/shared/plugin-icon/index.tsx
+++ b/packages/admin/src/components/shared/plugin-icon/index.tsx
@@ -1,4 +1,5 @@
 import type React from "react";
+import { useState } from "react";
 
 import * as Icons from "@admin/components/icons";
 import { resolvePluginIcon } from "@admin/lib/plugins/resolve-plugin-icon";
@@ -38,7 +39,17 @@ export function PluginIcon({
   className,
   alt = "",
 }: PluginIconProps): React.ReactElement {
-  const source = resolvePluginIcon(plugin, { fallback });
+  // A declared asset can still fail to arrive: a mistyped path, a deleted
+  // file, or a Content-Security-Policy that blocks the origin. Without this the
+  // surface keeps a broken-image glyph forever, which is worse than the plain
+  // icon it replaced. On failure the component re-resolves with assets
+  // disallowed, so it lands on whatever lucide name the plugin declared beside
+  // the asset before reaching the caller's fallback.
+  const [assetFailed, setAssetFailed] = useState(false);
+  const source = resolvePluginIcon(plugin, {
+    fallback,
+    allowAsset: !assetFailed,
+  });
 
   if (source.kind === "asset") {
     // Decorative by default: the plugin's name is always rendered beside this,
@@ -50,6 +61,7 @@ export function PluginIcon({
       <img
         src={source.src}
         alt={alt}
+        onError={() => setAssetFailed(true)}
         className={cn("object-contain", className)}
       />
     );

--- a/packages/admin/src/hooks/usePluginPageRegistration.ts
+++ b/packages/admin/src/hooks/usePluginPageRegistration.ts
@@ -6,19 +6,12 @@ import {
   clearPluginPages,
   pluginPagePath,
 } from "@admin/lib/plugins/plugin-route-registry";
+import { pluginSlug } from "@admin/lib/plugins/plugin-slug";
 import type { PluginMetadata } from "@admin/types/branding";
 
 /** Order-independent signature of a set of registered plugin routes. */
 function routeSignature(routes: string[]): string {
   return JSON.stringify([...routes].sort());
-}
-
-/** Derive a plugin's admin slug from its name (matches the server's derivation). */
-function toSlug(name: string): string {
-  return name
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-+|-+$/g, "");
 }
 
 /**
@@ -48,7 +41,7 @@ export function usePluginPageRegistration(
     // pages if a plugin is disabled; both must still reach the change check
     // below so a removed route stops resolving.
     for (const plugin of plugins ?? []) {
-      const slug = toSlug(plugin.name);
+      const slug = pluginSlug(plugin.name);
       if (plugin.pages && plugin.pages.length > 0) {
         registerPluginPages(
           slug,

--- a/packages/admin/src/lib/plugins/__tests__/plugin-slug.test.ts
+++ b/packages/admin/src/lib/plugins/__tests__/plugin-slug.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+
+import { pluginSlug } from "../plugin-slug";
+
+/**
+ * The contract shared with `pluginAdminSlug` in core, which derives the same
+ * slug server-side. The two cannot import one another, so this table is the
+ * only thing that fails when either side drifts. Changing a row here without
+ * changing core is the mistake it exists to catch.
+ */
+const CASES: Array<[string, string]> = [
+  ["@acme/p", "acme-p"],
+  ["@nextlyhq/plugin-page-builder", "nextlyhq-plugin-page-builder"],
+  ["style-fixture", "style-fixture"],
+  ["Weird__Name!!", "weird-name"],
+  ["--leading-and-trailing--", "leading-and-trailing"],
+  ["Form Builder", "form-builder"],
+];
+
+describe("pluginSlug", () => {
+  it.each(CASES)("derives %s to %s", (input, expected) => {
+    expect(pluginSlug(input)).toBe(expected);
+  });
+
+  it("is idempotent, so a slug fed back in is unchanged", () => {
+    for (const [, expected] of CASES) {
+      expect(pluginSlug(expected)).toBe(expected);
+    }
+  });
+});

--- a/packages/admin/src/lib/plugins/__tests__/resolve-plugin-icon.test.ts
+++ b/packages/admin/src/lib/plugins/__tests__/resolve-plugin-icon.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+
+import { resolvePluginIcon } from "../resolve-plugin-icon";
+
+describe("resolvePluginIcon", () => {
+  it("prefers a shipped asset over a declared lucide name", () => {
+    expect(
+      resolvePluginIcon(
+        { appearance: { icon: "Puzzle", iconAsset: "/x/logo.svg" } },
+        { fallback: "Package" }
+      )
+    ).toEqual({ kind: "asset", src: "/x/logo.svg" });
+  });
+
+  it("uses the declared lucide name when no asset is shipped", () => {
+    expect(
+      resolvePluginIcon(
+        { appearance: { icon: "Puzzle" } },
+        { fallback: "Package" }
+      )
+    ).toEqual({ kind: "lucide", name: "Puzzle" });
+  });
+
+  it("falls back to the caller's icon when the plugin declares neither", () => {
+    expect(
+      resolvePluginIcon({ appearance: undefined }, { fallback: "Database" })
+    ).toEqual({ kind: "lucide", name: "Database" });
+  });
+
+  it("falls back when appearance is absent entirely", () => {
+    expect(resolvePluginIcon({}, { fallback: "Package" })).toEqual({
+      kind: "lucide",
+      name: "Package",
+    });
+  });
+
+  /**
+   * The two sidebar call sites pass `Database` and the two package-shaped call
+   * sites pass `Package`. That difference is intended, so this asserts the
+   * fallback is honoured rather than that all callers agree: a resolver that
+   * hardcoded one default would pass every case above and fail here.
+   */
+  it("honours a different fallback for a different context", () => {
+    const meta = { appearance: {} };
+    expect(resolvePluginIcon(meta, { fallback: "Database" })).toEqual({
+      kind: "lucide",
+      name: "Database",
+    });
+    expect(resolvePluginIcon(meta, { fallback: "Package" })).toEqual({
+      kind: "lucide",
+      name: "Package",
+    });
+  });
+});

--- a/packages/admin/src/lib/plugins/__tests__/resolve-plugin-icon.test.ts
+++ b/packages/admin/src/lib/plugins/__tests__/resolve-plugin-icon.test.ts
@@ -52,3 +52,37 @@ describe("resolvePluginIcon", () => {
     });
   });
 });
+
+describe("resolvePluginIcon on a surface that cannot render images", () => {
+  it("keeps the declared lucide name instead of the asset", () => {
+    // The case the option exists for: a plugin declaring both is saying "logo
+    // where you can, this glyph where you cannot". Resolving the asset and
+    // substituting a default afterwards would discard that glyph.
+    expect(
+      resolvePluginIcon(
+        { appearance: { icon: "Puzzle", iconAsset: "/x/logo.svg" } },
+        { fallback: "Database", allowAsset: false }
+      )
+    ).toEqual({ kind: "lucide", name: "Puzzle" });
+  });
+
+  it("falls back only when the plugin declared no lucide name", () => {
+    expect(
+      resolvePluginIcon(
+        { appearance: { iconAsset: "/x/logo.svg" } },
+        { fallback: "Database", allowAsset: false }
+      )
+    ).toEqual({ kind: "lucide", name: "Database" });
+  });
+
+  // Control: with assets allowed the same input still resolves to the asset,
+  // so the option is what changes the answer rather than the input.
+  it("still resolves the asset when the surface allows one", () => {
+    expect(
+      resolvePluginIcon(
+        { appearance: { icon: "Puzzle", iconAsset: "/x/logo.svg" } },
+        { fallback: "Database" }
+      )
+    ).toEqual({ kind: "asset", src: "/x/logo.svg" });
+  });
+});

--- a/packages/admin/src/lib/plugins/plugin-categories.ts
+++ b/packages/admin/src/lib/plugins/plugin-categories.ts
@@ -1,0 +1,61 @@
+/**
+ * The controlled vocabulary a plugin declares in `category`.
+ *
+ * This lived inside the plugin detail page component until a second page
+ * needed it. A page component is the wrong home for a vocabulary two pages
+ * share: the second consumer copies it, and the copies drift.
+ *
+ * The vocabulary is deliberately narrow. `marketing` and `storage` are NOT
+ * members and are the two most commonly reached for: an SEO plugin is `seo`,
+ * and a storage adapter is `integration` or `media` depending on whether it is
+ * the transport or the asset handling that matters to the reader.
+ *
+ * @module lib/plugins/plugin-categories
+ */
+
+export const PLUGIN_CATEGORIES = [
+  "content",
+  "forms",
+  "seo",
+  "media",
+  "commerce",
+  "integration",
+  "dev-tools",
+  "other",
+] as const;
+
+export type PluginCategory = (typeof PLUGIN_CATEGORIES)[number];
+
+/** Human labels for the vocabulary. */
+export const CATEGORY_LABELS: Record<PluginCategory, string> = {
+  content: "Content",
+  forms: "Forms",
+  seo: "SEO",
+  media: "Media",
+  commerce: "Commerce",
+  integration: "Integration",
+  "dev-tools": "Dev Tools",
+  other: "Other",
+};
+
+/**
+ * Narrow a plugin's free-form `category` to the vocabulary.
+ *
+ * A third-party plugin can declare anything, so callers rendering
+ * `PluginMetadata` must keep tolerating an unknown value rather than throwing.
+ * This exists so our OWN catalogue can be checked at build time instead.
+ */
+export function isPluginCategory(
+  value: string | undefined
+): value is PluginCategory {
+  return (
+    value !== undefined &&
+    (PLUGIN_CATEGORIES as readonly string[]).includes(value)
+  );
+}
+
+/** The label for a category, or the raw value when a plugin declares its own. */
+export function categoryLabel(value: string | undefined): string | undefined {
+  if (value === undefined) return undefined;
+  return isPluginCategory(value) ? CATEGORY_LABELS[value] : value;
+}

--- a/packages/admin/src/lib/plugins/plugin-slug.ts
+++ b/packages/admin/src/lib/plugins/plugin-slug.ts
@@ -1,0 +1,24 @@
+/**
+ * Derive a plugin's admin slug from its package name.
+ *
+ * `"@acme/p"` becomes `"acme-p"`. One implementation for the whole admin:
+ * before this existed, `PluginsTable` carried a private copy, so a table row
+ * and the router could in principle disagree about where a plugin lives.
+ *
+ * The algorithm mirrors `pluginAdminSlug` in core, which derives the same slug
+ * server-side for a different consumer (host `pluginOverrides` lookups and
+ * plugin admin route namespacing). The two cannot share a module without the
+ * admin importing a core internal, so the case table in `plugin-slug.test.ts`
+ * is what keeps them honest: it is the contract, and it fails on either side
+ * drifting.
+ *
+ * @module lib/plugins/plugin-slug
+ */
+
+/** Lower-case, collapse every non-alphanumeric run to a dash, trim dashes. */
+export function pluginSlug(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}

--- a/packages/admin/src/lib/plugins/plugin-slug.ts
+++ b/packages/admin/src/lib/plugins/plugin-slug.ts
@@ -1,9 +1,8 @@
 /**
  * Derive a plugin's admin slug from its package name.
  *
- * `"@acme/p"` becomes `"acme-p"`. One implementation for the whole admin:
- * before this existed, `PluginsTable` carried a private copy, so a table row
- * and the router could in principle disagree about where a plugin lives.
+ * `"@acme/p"` becomes `"acme-p"`. One implementation for the whole admin, so
+ * a table row and the router cannot disagree about where a plugin lives.
  *
  * The algorithm mirrors `pluginAdminSlug` in core, which derives the same slug
  * server-side for a different consumer (host `pluginOverrides` lookups and

--- a/packages/admin/src/lib/plugins/registry/__tests__/registry.test.ts
+++ b/packages/admin/src/lib/plugins/registry/__tests__/registry.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+
+import { isPluginCategory } from "../../plugin-categories";
+import { pluginSlug } from "../../plugin-slug";
+import {
+  MAX_FEATURED,
+  shouldShowFeatured,
+  staticRegistrySource,
+} from "../static-source";
+
+describe("the plugin registry", () => {
+  it("is not empty, so the checks below are not vacuous", async () => {
+    expect((await staticRegistrySource.list()).length).toBeGreaterThan(0);
+  });
+
+  it("gives every entry a non-empty description", async () => {
+    for (const e of await staticRegistrySource.list()) {
+      expect(e.description.trim(), `${e.id} has no description`).not.toBe("");
+    }
+  });
+
+  it("uses only categories from the vocabulary", async () => {
+    for (const e of await staticRegistrySource.list()) {
+      expect(
+        isPluginCategory(e.category),
+        `${e.id} declares category ${e.category}`
+      ).toBe(true);
+    }
+  });
+
+  it("gives every entry an id that survives slug derivation", async () => {
+    for (const e of await staticRegistrySource.list()) {
+      const slug = pluginSlug(e.id);
+      expect(slug, `${e.id} produced an empty slug`).not.toBe("");
+      expect(pluginSlug(slug), `${e.id} slug is not idempotent`).toBe(slug);
+    }
+  });
+
+  it("resolves every featured id to an entry", async () => {
+    const ids = new Set((await staticRegistrySource.list()).map(e => e.id));
+    for (const id of await staticRegistrySource.featured()) {
+      expect(ids.has(id), `featured id ${id} matches no entry`).toBe(true);
+    }
+  });
+
+  it("caps the featured list", async () => {
+    expect((await staticRegistrySource.featured()).length).toBeLessThanOrEqual(
+      MAX_FEATURED
+    );
+  });
+
+  /**
+   * Positive control for the featured checks. They pass trivially on an empty
+   * featured list, so this proves the lookup can distinguish a real id from a
+   * fabricated one.
+   */
+  it("does not contain a fabricated id", async () => {
+    const ids = new Set((await staticRegistrySource.list()).map(e => e.id));
+    expect(ids.has("@nope/does-not-exist")).toBe(false);
+  });
+
+  it("keeps at least one entry out of the featured strip", async () => {
+    const entries = await staticRegistrySource.list();
+    const featured = await staticRegistrySource.featured();
+    expect(
+      shouldShowFeatured(entries, featured),
+      "featuring every entry makes the strip a duplicate of the grid"
+    ).toBe(true);
+  });
+});
+
+describe("shouldShowFeatured", () => {
+  const entry = (id: string) => ({ id }) as never;
+
+  it("hides the strip when it would contain every entry", () => {
+    expect(shouldShowFeatured([entry("a"), entry("b")], ["a", "b"])).toBe(
+      false
+    );
+  });
+
+  it("hides the strip when nothing is featured", () => {
+    expect(shouldShowFeatured([entry("a"), entry("b")], [])).toBe(false);
+  });
+
+  it("shows the strip when the grid still has something else", () => {
+    expect(shouldShowFeatured([entry("a"), entry("b")], ["a"])).toBe(true);
+  });
+});

--- a/packages/admin/src/lib/plugins/registry/entries.ts
+++ b/packages/admin/src/lib/plugins/registry/entries.ts
@@ -25,10 +25,7 @@ export const REGISTRY_ENTRIES: RegistryPlugin[] = [
     category: "content",
     tags: ["blocks", "editor", "pages"],
     icon: { lucide: "LayoutTemplate" },
-    install: {
-      package: "@nextlyhq/plugin-page-builder",
-      configSnippet: "plugins: [pageBuilder()]",
-    },
+    configSnippet: "plugins: [pageBuilder()]",
     links: {
       homepage: "https://nextlyhq.com",
       repository: "https://github.com/nextlyhq/nextly",
@@ -42,10 +39,10 @@ export const REGISTRY_ENTRIES: RegistryPlugin[] = [
     category: "forms",
     tags: ["forms", "submissions"],
     icon: { lucide: "ClipboardList" },
-    install: {
-      package: "@nextlyhq/plugin-form-builder",
-      configSnippet: "plugins: [formBuilder()]",
-    },
+    // `formBuilderPlugin`, not `formBuilder()`: the factory returns a
+    // FormBuilderPluginResult whose definition is at `.plugin`, and the package
+    // exports the unwrapped value for exactly this use.
+    configSnippet: "plugins: [formBuilderPlugin]",
     links: {
       homepage: "https://nextlyhq.com",
       repository: "https://github.com/nextlyhq/nextly",
@@ -60,10 +57,9 @@ export const REGISTRY_ENTRIES: RegistryPlugin[] = [
     category: "seo",
     tags: ["seo", "meta"],
     icon: { lucide: "Search" },
-    install: {
-      package: "@nextlyhq/plugin-seo",
-      configSnippet: "plugins: [seo()]",
-    },
+    // `seoPlugin`, and `collections` is required: the plugin adds the SEO group
+    // only to the collections it is given, so a bare call does not type-check.
+    configSnippet: 'plugins: [seoPlugin({ collections: ["posts"] })]',
     links: {
       homepage: "https://nextlyhq.com",
       repository: "https://github.com/nextlyhq/nextly",

--- a/packages/admin/src/lib/plugins/registry/entries.ts
+++ b/packages/admin/src/lib/plugins/registry/entries.ts
@@ -1,0 +1,72 @@
+import type { RegistryPlugin } from "./types";
+
+/**
+ * The curated catalogue. Array order is the grid's default order.
+ *
+ * Scope: packages that call `definePlugin` and therefore appear in
+ * `plugins: [...]`. The `storage-*` packages are deliberately absent. They are
+ * storage adapters configured through `storage:` rather than plugins, they
+ * never appear in `branding.plugins`, and listing them in a plugin directory
+ * would tell a user to install them the wrong way.
+ *
+ * Descriptions are copied from each plugin's own `definePlugin` declaration so
+ * the catalogue and the installed detail page say the same thing. Where a
+ * plugin declares none, the text here is the one being added to the plugin in
+ * the same change rather than a second, drifting copy.
+ *
+ * @module lib/plugins/registry/entries
+ */
+export const REGISTRY_ENTRIES: RegistryPlugin[] = [
+  {
+    id: "@nextlyhq/plugin-page-builder",
+    name: "Page Builder",
+    description: "Build pages visually from blocks with drag-and-drop editing",
+    author: "Nextly",
+    category: "content",
+    tags: ["blocks", "editor", "pages"],
+    icon: { lucide: "LayoutTemplate" },
+    install: {
+      package: "@nextlyhq/plugin-page-builder",
+      configSnippet: "plugins: [pageBuilder()]",
+    },
+    links: {
+      homepage: "https://nextlyhq.com",
+      repository: "https://github.com/nextlyhq/nextly",
+    },
+  },
+  {
+    id: "@nextlyhq/plugin-form-builder",
+    name: "Form Builder",
+    description: "Create and manage forms with submission tracking",
+    author: "Nextly",
+    category: "forms",
+    tags: ["forms", "submissions"],
+    icon: { lucide: "ClipboardList" },
+    install: {
+      package: "@nextlyhq/plugin-form-builder",
+      configSnippet: "plugins: [formBuilder()]",
+    },
+    links: {
+      homepage: "https://nextlyhq.com",
+      repository: "https://github.com/nextlyhq/nextly",
+    },
+  },
+  {
+    id: "@nextlyhq/plugin-seo",
+    name: "SEO",
+    description:
+      "Add an SEO meta field group to your collections, with title, description and social preview fields",
+    author: "Nextly",
+    category: "seo",
+    tags: ["seo", "meta"],
+    icon: { lucide: "Search" },
+    install: {
+      package: "@nextlyhq/plugin-seo",
+      configSnippet: "plugins: [seo()]",
+    },
+    links: {
+      homepage: "https://nextlyhq.com",
+      repository: "https://github.com/nextlyhq/nextly",
+    },
+  },
+];

--- a/packages/admin/src/lib/plugins/registry/featured.ts
+++ b/packages/admin/src/lib/plugins/registry/featured.ts
@@ -1,0 +1,16 @@
+/**
+ * The curated first screen, in order.
+ *
+ * A list rather than a flag per entry, so the whole editorial decision reads
+ * top to bottom in one place instead of being spread across every entry.
+ *
+ * The cap is asserted in the test rather than stated in a comment, because a
+ * comment does not fail a build and a strip that grows to eight has stopped
+ * being a recommendation.
+ *
+ * @module lib/plugins/registry/featured
+ */
+export const FEATURED_IDS: string[] = [
+  "@nextlyhq/plugin-page-builder",
+  "@nextlyhq/plugin-form-builder",
+];

--- a/packages/admin/src/lib/plugins/registry/static-source.ts
+++ b/packages/admin/src/lib/plugins/registry/static-source.ts
@@ -1,0 +1,40 @@
+import { REGISTRY_ENTRIES } from "./entries";
+import { FEATURED_IDS } from "./featured";
+import type { PluginRegistrySource, RegistryPlugin } from "./types";
+
+/** Cap on the curated strip. Enforced by the registry test, not by a comment. */
+export const MAX_FEATURED = 3;
+
+/**
+ * Whether a curated strip is worth rendering at all.
+ *
+ * A "featured" section that contains every entry is not a recommendation, it
+ * is the list with a second heading. With three plugins in the catalogue that
+ * is a live concern rather than a hypothetical, so the strip earns its place
+ * only while it is a strict subset with something left over in the grid.
+ *
+ * Exported so the page and the test ask the same question, rather than the
+ * page embedding a threshold the test restates.
+ */
+export function shouldShowFeatured(
+  entries: readonly RegistryPlugin[],
+  featuredIds: readonly string[]
+): boolean {
+  return featuredIds.length > 0 && entries.length > featuredIds.length;
+}
+
+/**
+ * The in-repo catalogue.
+ *
+ * Resolves instantly; the interface is async by design so a remote source can
+ * replace this without touching a consumer.
+ *
+ * @module lib/plugins/registry/static-source
+ */
+export const staticRegistrySource: PluginRegistrySource = {
+  // `Promise.resolve` rather than an `async` body: the interface is async so a
+  // remote source can replace this, but there is nothing here to await and an
+  // async function that never awaits is a lint error rather than a signal.
+  list: () => Promise.resolve(REGISTRY_ENTRIES),
+  featured: () => Promise.resolve(FEATURED_IDS),
+};

--- a/packages/admin/src/lib/plugins/registry/types.ts
+++ b/packages/admin/src/lib/plugins/registry/types.ts
@@ -1,0 +1,48 @@
+import type { PluginCategory } from "../plugin-categories";
+
+/**
+ * A plugin in the curated catalogue. Not necessarily installed.
+ *
+ * Distinct from `PluginMetadata`, which describes a plugin the server has
+ * actually loaded. Everything here is a curated claim; nothing here has been
+ * observed running. Callers must not render catalogue data inside a surface
+ * that reports what an installed plugin contributes.
+ *
+ * @module lib/plugins/registry/types
+ */
+export interface RegistryPlugin {
+  /**
+   * npm package name, and the identity this joins to `PluginMetadata.name` on.
+   * Also the source of the detail-page slug, via `pluginSlug`.
+   */
+  id: string;
+  name: string;
+  /** Required, unlike `PluginMetadata.description`: this catalogue is ours. */
+  description: string;
+  author: string;
+  category: PluginCategory;
+  tags?: string[];
+  icon: { lucide: string; asset?: string };
+  install: {
+    /** What to pass to the package manager. */
+    package: string;
+    /** The line to add inside `plugins: [...]` in nextly.config.ts. */
+    configSnippet: string;
+  };
+  links?: { homepage?: string; repository?: string; docs?: string };
+}
+
+/**
+ * Where catalogue data comes from.
+ *
+ * Async although the only implementation resolves instantly. A synchronous
+ * source teaches every consumer that the data is always present and never
+ * fails, so the day it becomes remote (an npm keyword search, a hosted
+ * registry) every consumer and every test is rewritten. Two states now cost
+ * one await.
+ */
+export interface PluginRegistrySource {
+  list(): Promise<RegistryPlugin[]>;
+  /** Ordered ids for the curated strip, at most `MAX_FEATURED`. */
+  featured(): Promise<string[]>;
+}

--- a/packages/admin/src/lib/plugins/registry/types.ts
+++ b/packages/admin/src/lib/plugins/registry/types.ts
@@ -23,12 +23,15 @@ export interface RegistryPlugin {
   category: PluginCategory;
   tags?: string[];
   icon: { lucide: string; asset?: string };
-  install: {
-    /** What to pass to the package manager. */
-    package: string;
-    /** The line to add inside `plugins: [...]` in nextly.config.ts. */
-    configSnippet: string;
-  };
+  /**
+   * The line to add inside `plugins: [...]` in nextly.config.ts.
+   *
+   * No package name beside it: that is `id`, and storing it twice means a
+   * rename can update one and leave the other, so the detail page would join
+   * on the new name while the install command still fetched the old one.
+   * Derive the command with `installCommand()`.
+   */
+  configSnippet: string;
   links?: { homepage?: string; repository?: string; docs?: string };
 }
 

--- a/packages/admin/src/lib/plugins/resolve-plugin-icon.ts
+++ b/packages/admin/src/lib/plugins/resolve-plugin-icon.ts
@@ -1,0 +1,38 @@
+import type { PluginMetadata } from "@admin/types/branding";
+
+/**
+ * What a caller should render for a plugin: an image the plugin ships, or a
+ * lucide icon named by its string.
+ */
+export type PluginIconSource =
+  | { kind: "asset"; src: string }
+  | { kind: "lucide"; name: string };
+
+/**
+ * Resolve which icon represents a plugin.
+ *
+ * The CHAIN is shared; the final fallback is not, and that split is
+ * deliberate. Four call sites resolved this independently and two of them
+ * disagreed on the default, which is the drift this fixes. But the
+ * disagreement was partly legitimate: the sidebar represents a standalone
+ * plugin by the collections it registers, where `Database` reads correctly,
+ * while the plugins table and detail page represent it as a package, where
+ * `Package` does. Unifying the default would silently change the sidebar.
+ *
+ * So the ordering lives here and the context-appropriate default stays with
+ * the caller that knows its own context.
+ *
+ * @module lib/plugins/resolve-plugin-icon
+ */
+export function resolvePluginIcon(
+  meta: Pick<PluginMetadata, "appearance">,
+  opts: { fallback: string }
+): PluginIconSource {
+  const asset = meta.appearance?.iconAsset;
+  if (asset) return { kind: "asset", src: asset };
+
+  const name = meta.appearance?.icon;
+  if (name) return { kind: "lucide", name };
+
+  return { kind: "lucide", name: opts.fallback };
+}

--- a/packages/admin/src/lib/plugins/resolve-plugin-icon.ts
+++ b/packages/admin/src/lib/plugins/resolve-plugin-icon.ts
@@ -24,12 +24,36 @@ export type PluginIconSource =
  *
  * @module lib/plugins/resolve-plugin-icon
  */
+/** A surface that cannot render an image always gets the lucide variant. */
 export function resolvePluginIcon(
   meta: Pick<PluginMetadata, "appearance">,
-  opts: { fallback: string }
+  opts: { fallback: string; allowAsset: false }
+): Extract<PluginIconSource, { kind: "lucide" }>;
+export function resolvePluginIcon(
+  meta: Pick<PluginMetadata, "appearance">,
+  opts: { fallback: string; allowAsset?: boolean }
+): PluginIconSource;
+export function resolvePluginIcon(
+  meta: Pick<PluginMetadata, "appearance">,
+  opts: {
+    fallback: string;
+    /**
+     * Whether this surface can render an image. The sidebar rail and the
+     * plugin section items cannot: they look an icon up by name and render an
+     * ElementType, so there is nowhere to put an `<img>`.
+     *
+     * Passing `false` skips the asset rather than making the caller undo the
+     * choice afterwards. That distinction matters: a plugin declaring BOTH an
+     * asset and a lucide name is saying "use my logo where you can, this glyph
+     * where you cannot", and a caller that resolved the asset and then
+     * substituted its own default would throw away the glyph the plugin
+     * declared for exactly this case.
+     */
+    allowAsset?: boolean;
+  }
 ): PluginIconSource {
   const asset = meta.appearance?.iconAsset;
-  if (asset) return { kind: "asset", src: asset };
+  if (asset && opts.allowAsset !== false) return { kind: "asset", src: asset };
 
   const name = meta.appearance?.icon;
   if (name) return { kind: "lucide", name };

--- a/packages/admin/src/pages/dashboard/plugins/[slug].tsx
+++ b/packages/admin/src/pages/dashboard/plugins/[slug].tsx
@@ -25,6 +25,7 @@ import { Link } from "@admin/components/ui/link";
 import { ROUTES, buildRoute } from "@admin/constants/routes";
 import { useBranding } from "@admin/context/providers/BrandingProvider";
 import { categoryLabel } from "@admin/lib/plugins/plugin-categories";
+import { pluginSlug } from "@admin/lib/plugins/plugin-slug";
 import type { PluginMetadata } from "@admin/types/branding";
 
 import { PluginStatusPill } from "./components/PluginsTable";
@@ -37,13 +38,6 @@ const PLACEMENT_LABELS: Record<string, string> = {
   plugins: "Plugins",
   standalone: "Standalone",
 };
-
-function toSlug(name: string): string {
-  return name
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-+|-+$/g, "");
-}
 
 interface PluginDetailPageProps {
   params?: { slug?: string };
@@ -76,7 +70,7 @@ function PluginDetailContent({ activeSlug }: { activeSlug?: string }) {
   const branding = useBranding();
   const plugins = branding?.plugins ?? [];
   const plugin = activeSlug
-    ? plugins.find(p => toSlug(p.name) === activeSlug)
+    ? plugins.find(p => pluginSlug(p.name) === activeSlug)
     : undefined;
 
   if (!plugin) {
@@ -166,7 +160,7 @@ function PluginDetailContent({ activeSlug }: { activeSlug?: string }) {
           {plugin.enabled !== false && plugin.settings?.component && (
             <Link
               href={buildRoute(ROUTES.PLUGIN_SETTINGS, {
-                slug: toSlug(plugin.name),
+                slug: pluginSlug(plugin.name),
               })}
               className="inline-flex items-center gap-1.5 rounded-md bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground hover:bg-primary/90"
             >
@@ -318,7 +312,7 @@ function Contributions({ plugin }: { plugin: PluginMetadata }) {
       label: "API routes",
       icon: Route,
       items: (plugin.routes ?? []).map(r => ({
-        primary: `${r.method} /api/plugins/${toSlug(plugin.name)}${r.path}`,
+        primary: `${r.method} /api/plugins/${pluginSlug(plugin.name)}${r.path}`,
       })),
     },
   ].filter(group => group.items.length > 0);

--- a/packages/admin/src/pages/dashboard/plugins/[slug].tsx
+++ b/packages/admin/src/pages/dashboard/plugins/[slug].tsx
@@ -1,9 +1,7 @@
 "use client";
 
 import { Badge } from "@nextlyhq/ui";
-import type React from "react";
 
-import * as Icons from "@admin/components/icons";
 import {
   BookOpen,
   ExternalLink,
@@ -21,25 +19,15 @@ import {
 import { PageContainer } from "@admin/components/layout/page-container";
 import { Breadcrumbs } from "@admin/components/shared";
 import { PageErrorFallback } from "@admin/components/shared/error-fallbacks";
+import { PluginIcon } from "@admin/components/shared/plugin-icon";
 import { QueryErrorBoundary } from "@admin/components/shared/query-error-boundary";
 import { Link } from "@admin/components/ui/link";
 import { ROUTES, buildRoute } from "@admin/constants/routes";
 import { useBranding } from "@admin/context/providers/BrandingProvider";
+import { categoryLabel } from "@admin/lib/plugins/plugin-categories";
 import type { PluginMetadata } from "@admin/types/branding";
 
 import { PluginStatusPill } from "./components/PluginsTable";
-
-/** Human labels for the category vocabulary plugins declare. */
-const CATEGORY_LABELS: Record<string, string> = {
-  content: "Content",
-  forms: "Forms",
-  seo: "SEO",
-  media: "Media",
-  commerce: "Commerce",
-  integration: "Integration",
-  "dev-tools": "Dev Tools",
-  other: "Other",
-};
 
 const PLACEMENT_LABELS: Record<string, string> = {
   collections: "Collections",
@@ -117,9 +105,6 @@ function PluginDetailContent({ activeSlug }: { activeSlug?: string }) {
   }
 
   const title = plugin.appearance?.label ?? plugin.name;
-  const iconName = plugin.appearance?.icon || "Package";
-  const IconComponent =
-    (Icons as Record<string, React.ElementType>)[iconName] || Package;
 
   return (
     <div>
@@ -136,7 +121,13 @@ function PluginDetailContent({ activeSlug }: { activeSlug?: string }) {
       <div className="mb-8 flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
         <div className="flex items-start gap-4">
           <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-md bg-primary/5">
-            <IconComponent className="h-6 w-6 text-primary" />
+            {/* Package, not Database: this page presents a plugin as the
+                package you installed rather than as its collections. */}
+            <PluginIcon
+              plugin={plugin}
+              fallback="Package"
+              className="h-6 w-6 text-primary"
+            />
           </div>
           <div className="space-y-1">
             <div className="flex flex-wrap items-center gap-3">
@@ -152,7 +143,7 @@ function PluginDetailContent({ activeSlug }: { activeSlug?: string }) {
                   variant="default"
                   className="text-xs font-normal text-muted-foreground"
                 >
-                  {CATEGORY_LABELS[plugin.category] ?? plugin.category}
+                  {categoryLabel(plugin.category)}
                 </Badge>
               )}
             </div>

--- a/packages/admin/src/pages/dashboard/plugins/[slug]/settings.tsx
+++ b/packages/admin/src/pages/dashboard/plugins/[slug]/settings.tsx
@@ -10,13 +10,7 @@ import { PluginSlot } from "@admin/components/shared/plugin-slot";
 import { QueryErrorBoundary } from "@admin/components/shared/query-error-boundary";
 import { ROUTES, buildRoute } from "@admin/constants/routes";
 import { useBranding } from "@admin/context/providers/BrandingProvider";
-
-function toSlug(name: string): string {
-  return name
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-+|-+$/g, "");
-}
+import { pluginSlug } from "@admin/lib/plugins/plugin-slug";
 
 interface PluginSettingsPageProps {
   params?: { slug?: string };
@@ -47,7 +41,7 @@ function PluginSettingsContent({ activeSlug }: { activeSlug?: string }) {
   const branding = useBranding();
   const plugins = branding?.plugins ?? [];
   const plugin = activeSlug
-    ? plugins.find(p => toSlug(p.name) === activeSlug)
+    ? plugins.find(p => pluginSlug(p.name) === activeSlug)
     : undefined;
 
   const title = plugin?.appearance?.label ?? plugin?.name;

--- a/packages/admin/src/pages/dashboard/plugins/components/PluginsTable.tsx
+++ b/packages/admin/src/pages/dashboard/plugins/components/PluginsTable.tsx
@@ -11,12 +11,11 @@ import {
   DropdownMenuTrigger,
 } from "@nextlyhq/ui";
 import { useSuspenseQuery } from "@tanstack/react-query";
-import type React from "react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 
-import * as Icons from "@admin/components/icons";
-import { Columns, Package } from "@admin/components/icons";
+import { Columns } from "@admin/components/icons";
 import { Pagination } from "@admin/components/shared/pagination";
+import { PluginIcon } from "@admin/components/shared/plugin-icon";
 import { SearchBar } from "@admin/components/shared/search-bar";
 import { DataTableView } from "@admin/components/ui/table/data-table";
 import type { NextlyColumn } from "@admin/components/ui/table/data-table";
@@ -25,30 +24,13 @@ import { ROUTES, buildRoute } from "@admin/constants/routes";
 import { UI } from "@admin/constants/ui";
 import { useDebouncedValue } from "@admin/hooks/useDebouncedValue";
 import { publicApi } from "@admin/lib/api/publicApi";
+import { categoryLabel } from "@admin/lib/plugins/plugin-categories";
+import { pluginSlug } from "@admin/lib/plugins/plugin-slug";
 import type { PluginMetadata, AdminBranding } from "@admin/types/branding";
-
-/** Human labels for the category vocabulary plugins declare. */
-const CATEGORY_LABELS: Record<string, string> = {
-  content: "Content",
-  forms: "Forms",
-  seo: "SEO",
-  media: "Media",
-  commerce: "Commerce",
-  integration: "Integration",
-  "dev-tools": "Dev Tools",
-  other: "Other",
-};
 
 type PluginWithId = PluginMetadata & { id: string };
 
 type StatusFilter = "all" | "enabled" | "disabled";
-
-function toSlug(name: string): string {
-  return name
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-+|-+$/g, "");
-}
 
 /** Columns pinned as always-visible in the column toggle. */
 const ALWAYS_VISIBLE = new Set(["name"]);
@@ -118,7 +100,7 @@ export default function PluginsTable() {
   const pluginsWithId = useMemo(() => {
     return (branding?.plugins ?? []).map(plugin => ({
       ...plugin,
-      id: toSlug(plugin.name),
+      id: pluginSlug(plugin.name),
     }));
   }, [branding?.plugins]);
 
@@ -165,9 +147,6 @@ export default function PluginsTable() {
         name: "name",
         header: "PLUGIN",
         cell: ({ row }) => {
-          const iconName = row.appearance?.icon || "Package";
-          const IconComponent =
-            (Icons as Record<string, React.ElementType>)[iconName] || Package;
           // Secondary metadata (description, author) packs under the name so
           // the table stays two-scan-columns wide like an installed-list should.
           const secondary = [row.description, row.author && `by ${row.author}`]
@@ -176,7 +155,13 @@ export default function PluginsTable() {
           return (
             <div className="flex items-center gap-3">
               <div className="table-row-icon-cover">
-                <IconComponent className="h-4 w-4" />
+                {/* Package, not Database: this surface presents a plugin as the
+                    package you installed rather than as its collections. */}
+                <PluginIcon
+                  plugin={row}
+                  fallback="Package"
+                  className="h-4 w-4"
+                />
               </div>
               <div className="flex min-w-0 flex-1 flex-col">
                 <span className="truncate text-sm font-medium text-foreground">
@@ -210,7 +195,9 @@ export default function PluginsTable() {
               variant="default"
               className="text-xs font-normal text-muted-foreground"
             >
-              {CATEGORY_LABELS[value] ?? value}
+              {/* Falls back to the raw value for a third-party plugin that
+                  declares a category outside the vocabulary. */}
+              {categoryLabel(value)}
             </Badge>
           ) : (
             <span className="text-sm text-muted-foreground">—</span>

--- a/packages/admin/src/types/branding.ts
+++ b/packages/admin/src/types/branding.ts
@@ -95,7 +95,15 @@ export interface PluginMetadata {
   routes?: Array<{ method: string; path: string }>;
   /** Sidebar appearance customization from plugin config. */
   appearance?: {
+    /** A lucide icon name. The common case; always theme-aware. */
     icon?: string;
+    /**
+     * A URL to an image the plugin ships, for a plugin that wants its own
+     * branding rather than a generic glyph. Takes precedence over `icon` when
+     * both are present. Resolve through `resolvePluginIcon` rather than
+     * reading either field directly.
+     */
+    iconAsset?: string;
     label?: string;
     badge?: string;
     badgeVariant?: "default" | "secondary" | "destructive" | "outline";

--- a/packages/nextly/src/plugins/plugin-context.ts
+++ b/packages/nextly/src/plugins/plugin-context.ts
@@ -363,6 +363,17 @@ export interface PluginContext {
 export interface PluginAdminAppearance {
   /** Lucide icon name for the plugin's sidebar entry */
   icon?: string;
+  /**
+   * URL of an image the plugin ships, for a plugin that wants its own branding
+   * rather than a built-in glyph. Takes precedence over `icon` where both are
+   * declared, and the admin scales it rather than cropping, so a rectangular
+   * logo keeps its proportions.
+   *
+   * `icon` remains the common case: a lucide name is theme-aware by
+   * construction, while an image has to work on both the light and the dark
+   * surface on its own.
+   */
+  iconAsset?: string;
   /** Custom label override (defaults to plugin name) */
   label?: string;
   /** Badge text shown next to the plugin name (e.g., "Beta", "New") */

--- a/packages/plugin-seo/src/plugin.ts
+++ b/packages/plugin-seo/src/plugin.ts
@@ -183,6 +183,14 @@ export function seoPlugin(options: SeoPluginOptions): PluginDefinition {
     homepage: "https://nextlyhq.com",
     repository: "https://github.com/nextlyhq/nextly",
     license: "MIT",
+    // How the plugin presents itself wherever the admin lists it. Without a
+    // description the plugins list shows a bare name, which says nothing about
+    // what installing this does. The other first-party plugins declare theirs
+    // in the same place.
+    admin: {
+      description:
+        "Add an SEO meta field group to your collections, with title, description and social preview fields",
+    },
     category: "seo",
     tags: ["seo", "meta"],
     contributes,


### PR DESCRIPTION
## Summary

Three questions about a plugin were each answered in more than one place, and one pair had already drifted.

| Question | Implementations before | Drifted? |
|---|---|---|
| What is this plugin's admin slug? | 3 — `PluginsTable.toSlug`, an inline copy in `DualSidebar`, `pluginAdminSlug` in core | Not yet |
| What is this category called? | 2 — both inside page components | Not yet |
| Which icon represents this plugin? | 4 call sites | **Yes.** Two fall back to `Database`, two to `Package` |

Each now has one implementation. This also adds the curated plugin catalogue the browse page will consume, scopes a test fixture out of the product surface, and gives the SEO plugin the description it never had.

## The icon fallback stays a caller argument, deliberately

Unifying all four sites onto a single default would have silently changed the sidebar. The disagreement is partly legitimate: `DualSidebar` and `DynamicPluginSectionItems` present a standalone plugin as **the collections it registers**, where `Database` reads correctly, while `PluginsTable` and the detail page present it as **a package**, where `Package` does.

So `resolvePluginIcon(meta, { fallback })` owns the ordering — asset, then declared lucide name, then the caller's default — and each surface keeps the default that suits it. The test asserts the chain per branch rather than asserting the four callers agree, because they intentionally do not.

Two of the four render the lucide branch only. `MainMenuItem.icon` stores a `React.ElementType` rendered as `<Icon className=… />`, so a shipped image has nowhere to go without changing that data model. A plugin shipping only an asset therefore shows its fallback in the sidebar and its logo in the table and detail page. Noted in the code at both sites rather than left to be discovered.

## What else is here

- **`appearance.iconAsset`** added to `PluginMetadata`, so a plugin can ship a logo. Defined now so lighting it up on more surfaces later is not a breaking change.
- **`PluginIcon`** component, so the asset-or-lucide union is handled once. Branching on it at four call sites would have rebuilt the duplication this PR removes, in a new shape.
- **The curated catalogue** (`lib/plugins/registry/**`) behind an async `PluginRegistrySource`. Async although nothing awaits: a synchronous source teaches every consumer the data is always present and never fails, so the day it becomes remote every consumer and its tests get rewritten.
- **`plugin-seo` gains a description.** It declared author, homepage, repository, license, category and tags, but no description, so the plugins list showed a bare package name.
- **The style fixture registers only under the e2e run.**

## Two corrections worth stating, because both were wrong in earlier planning

**Which plugins lack a description.** I claimed `plugin-page-builder` did, from reading the opening of its `definePlugin` call and not finding `description` near `author`. Then I claimed `style-fixture` was the only one, from a screenshot of a plugins list that does not include `seo`. Measured per package, the answer is **`plugin-seo` and `style-fixture`**. A claim about which packages lack something is a claim about a population and has to be measured across it.

**Where a description lives.** It is `definePlugin({ admin: { description } })` — a top-level `admin` block, sibling to `tags` and `enabled`. Not top-level `description`, and not `contributes.admin.description`. `check-types` rejected both of my first two attempts, which is the type system doing its job.

**The catalogue has three entries, not a dozen.** Only `plugin-page-builder`, `plugin-form-builder` and `plugin-seo` call `definePlugin`. The `storage-*` packages are adapters configured through `storage:`, never appear in `branding.plugins`, and listing them in a plugin directory would tell users to install them the wrong way.

That has a design consequence: with three entries and a featured cap of three, a "featured" strip could contain everything, which makes it the grid with a second heading. `shouldShowFeatured()` renders it only while it is a strict subset, and a test asserts the catalogue keeps at least one entry out of it.

## Test plan

- [x] `pnpm check-types` — exit 0
- [x] `pnpm lint` — exit 0
- [x] `pnpm build` — 19/19
- [x] `pnpm --filter @nextlyhq/admin test` — **27 failures across the same 6 files as `origin/main`**, and 1661 passing versus 1641 before. No new failures; this branch adds 20 passing tests in 2 new files.
- [x] **e2e, both directions.**

The fixture change is the only part of this PR that can break something, so it was verified in both directions rather than one:

- **Present under e2e:** `plugin-admin-styling.spec.ts` and `plugin-page-routing.spec.ts`, 3 passed. The server log shows `GET /admin/plugins/style-fixture/showcase 200`, so the fixture really is registered rather than the specs passing vacuously.
- **Absent in normal dev:** booted the playground with no e2e env and read `/admin/api/admin-meta`. Registered plugins are `["@nextlyhq/plugin-page-builder", "@nextlyhq/plugin-form-builder"]`. `style-fixture` is gone, and both remaining plugins now carry descriptions.

One process note: my first e2e attempt printed `No projects matched the filters` and **exited 0**. A filter that matches nothing reports success, so the exit code alone would have certified a run that never happened.

## Pre-existing failures, not from this PR

The 27 admin failures above (`StatsCard`, `RoleBasicInfo`, `BasicsTab`, `SlugInput`, `DefaultValueField`, `SearchBar`) are the known baseline `AGENTS.md` warns about. Another lane measured the identical six files and count independently today.

Separately: a fresh worktree fails both `pnpm lint` and vitest with `@nextlyhq/ui` resolution errors until `pnpm build` runs, because `pnpm install` does not produce `dist`. Documented environment state, not a regression.

## Changeset

Changeset added: yes (patch), all 24 packages in the fixed group, generated from `.changeset/config.json` rather than typed by hand.

## Notes for reviewers

Nothing user-visible changes on any page. The catalogue is unreferenced until the browse page lands in the next PR; the icon and slug work is a refactor with one visible consequence, which is that a plugin declaring an unknown lucide name now falls back to its surface's default instead of rendering nothing.

Stacked after #727 (plugins sidebar navigation), which touches a different hunk of `DualSidebar.tsx`. Both branch from `origin/main` and should merge in either order.
