### PR TITLE
fix(plugin-page-builder): sync the inspector tab on block type change

### DIFF
--- a/.changeset/tidy-pugs-shave.md
+++ b/.changeset/tidy-pugs-shave.md
@@ -1,0 +1,28 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+Page builder inspector: keep the open panel tab in sync when the selected block changes type, so the inspector no longer shows a tab the block does not have.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -15,6 +15,7 @@ const REACT_FILES = [
   "packages/ui/**/*.{ts,tsx,js,jsx}",
   "packages/blocks-react/**/*.{ts,tsx,js,jsx}",
   "packages/builder/**/*.{ts,tsx,js,jsx}",
+  "packages/plugin-page-builder/**/*.{ts,tsx,js,jsx}",
   "apps/playground/**/*.{ts,tsx,js,jsx}",
 ];
 

--- a/packages/plugin-page-builder/src/admin/panels/Inspector.tsx
+++ b/packages/plugin-page-builder/src/admin/panels/Inspector.tsx
@@ -717,7 +717,12 @@ export function Inspector() {
       node?.type === QUERY_LOOP_TYPE ? "content" : firstPopulatedTab(def);
     setTab(initial);
     setStyleState("normal");
-  }, [state.selectedId]);
+    // The block's TYPE is a dependency, not just the selection: a node whose type
+    // changes under a stable id — an undo, or a migration applied in place —
+    // populates a different set of panels, and recomputing only on selection
+    // would leave the inspector open on a tab this block does not have. `def` is
+    // the registry entry for that type and moves with it.
+  }, [state.selectedId, def, node?.type]);
 
   if (!node) {
     return (


### PR DESCRIPTION
Task 189, first half. No changeset: this changes what CI checks, not what a user installs.

## The gap

`packages/plugin-page-builder` has eight React components under `src/admin/`, and the root `eslint.config.mjs` never applied the React rule set to them. `lint-staged` invokes ESLint from the repository root, so on a pre-commit only the base rules reached those files.

Measured with `--print-config` rather than by looking for reported problems, because an empty report also means "the file is clean":

```
plugin-page-builder/src/admin/panels/Inspector.tsx   rules-of-hooks: UNDEFINED   exhaustive-deps: UNDEFINED
blocks-react/src/page-renderer.tsx                   rules-of-hooks: [2]         exhaustive-deps: [1]
```

The second line is the control: the same probe on a package already in scope returns the rules, so `UNDEFINED` is a real absence rather than a bad probe.

## Why this is worth doing on a package scheduled for deletion

`src/admin` is Phase 3 of `tasks/2026-08-02-poc-retirement-strategy.md`, and Phase 3 has not started. §6 is explicit that the PoC "is what ships today", and that the guardrail worth having is a lint guard. This adds no capability and no blocks — it is coverage over code users run now.

## It carries what it newly catches

Widening surfaces exactly one finding, and the package lints with `--max-warnings 0`, so leaving it would turn the next unrelated PR red:

`Inspector.tsx:720` — an effect that resets the inspector's tab on selection change, with `def` and `node?.type` missing from its dependency array.

Fixed at the cause rather than silenced, per the repo's no-eslint-disable rule. The fix is also a real correction: a node whose type changes under a stable id — an undo, or a migration applied in place — populates a different set of panels, and recomputing only on selection change left the inspector open on a tab the block does not have.

## Verification

Differential on the resolved config, since a lint pass that reports nothing looks identical either way:

- widening removed → `exhaustive-deps: UNDEFINED`
- widening present → `exhaustive-deps: [1]`

Gates: root ESLint over the package clean, package `lint` clean by exit code, `check-types` clean, 655 tests pass.

⚠️ Before the workspace dependencies are built, the same root lint run reports 38 `import-x/no-unresolved` errors. Those are the unbuilt-`dist` environment state, not this change: after `turbo run build`, the count is 1 problem — the warning above.

## The second half of 189 is NOT here, and the reason is measured

The task also asks for a `tsconfig.tests.json` so the package's test files are type-checked. That half is deliberately left out.

`packages/plugin-page-builder` has **73 test files and 0 of them in the tsc program**. Adding the second pass surfaces **33 type errors** — measured, not estimated. Fixing those is a substantial change confined to test files in a package Phase 3 deletes, and the alternative (an opt-out list) is a documented rule with nothing enforcing it.

That is a scope decision worth making deliberately rather than absorbing into a lint PR, so the numbers are recorded on the task for whoever takes it.
