### PR TITLE
docs(root): add a repo rule for whole-file writes over config

### DIFF
--- a/.claude/rules/verifying-merged-work.md
+++ b/.claude/rules/verifying-merged-work.md
@@ -1,7 +1,10 @@
----
-paths:
-  - "**/*"
----
+<!--
+No `paths` frontmatter: Claude Code loads such a rule at launch,
+unconditionally, while a rule WITH the field — including `paths: ["**/*"]` — is
+conditional and triggers only when a matching file is read. Verifying a merge is
+an act rather than a file type, and the checks below are needed before any file
+of the merged work has been opened.
+-->
 
 ## A squash merge makes every ancestry check unsound
 

--- a/.claude/rules/whole-file-writes.md
+++ b/.claude/rules/whole-file-writes.md
@@ -38,19 +38,41 @@ bypassed, and it is the bypass rather than the command that does the damage.
 plus three call-site input trees, and the result parsed, ran, and passed
 everything.
 
+## First, name the BASELINE — everything below compares against it
+
+Every check in this rule asks one question: what was at this path before the
+write. So the baseline is chosen once, and each command follows from it. Getting
+this wrong is not a smaller version of the same answer — it silently swaps which
+content is being judged.
+
+- The last commit held the pre-write state → the baseline is `HEAD`, and
+  comparisons take the form `git diff HEAD -- <path>`.
+- The path carried deliberate STAGED edits when it was written → the index holds
+  the pre-write state, `HEAD` never did, and comparisons are the bare
+  `git diff -- <path>`, which is working tree against index. Inspect the staged
+  copy with `git diff --cached HEAD -- <path>` or `git show :<path>`; note that
+  `git status` shows only `MM` and reveals none of it.
+
+Both failure directions are live, which is why this is not a detail. Comparing
+against `HEAD` when the index is the baseline reports the staged additions as
+though they were your edit — and, worse, a clobber that preserved everything in
+`HEAD` while destroying the staged lines shows additions ONLY, clearing the
+overwrite that just happened. Comparing against the index when `HEAD` is the
+baseline misses anything already staged.
+
 ## Three tells that this has happened, in the order they appear
 
 They are worth knowing individually, because each looks like good news:
 
 1. **The diffstat shows deletions on a file you believe you are creating**, read
-   against the right baseline. A created file has no deleted lines, so one `-`
-   in its `++---` bar settles it — but only when the comparison starts from
-   before the file existed. A bare `git diff --stat` compares the working tree
-   with the INDEX, so a genuinely new path that was staged and then shortened
-   reports deletions too, and the tell fires on a file that really is new. Use
-   `git diff HEAD --stat`. This is the cheapest tell and the one most easily
-   read past, because by then the write has already succeeded and attention has
-   moved on.
+   against the baseline named above. A created file has no deleted lines, so one
+   `-` in its `++---` bar settles it — but only when the comparison starts from
+   before the file existed. A bare `git diff --stat` against the wrong baseline
+   answers a different question: with `HEAD` as the baseline it reports
+   deletions for a genuinely new path that was staged and then shortened, firing
+   on a file that really is new. This is the cheapest tell and the one most
+   easily read past, because by then the write has already succeeded and
+   attention has moved on.
 
 2. **A metric improves far more than the change should explain.** "1264 inputs
    became 119" was recorded as evidence that the new scoping was tight. It was
@@ -70,8 +92,8 @@ They are worth knowing individually, because each looks like good news:
    A tell that fires there sends a correct additive edit into a destructive
    recovery procedure, which is worse than the miss it was guarding.
 
-   So confirm it against the baseline — `git diff HEAD --stat -- <path>`, then
-   the hunks — and require content that predates your edit to have vanished.
+   So confirm it against the baseline named above — the `--stat`, then the hunks
+   — and require content that predates your edit to have vanished.
 
 ## Configuration coverage is UNEVEN, so find out before trusting green
 
@@ -145,13 +167,11 @@ command is right by default:
 
 Then prove it, and prove it **before submitting**:
 
-- Compare the repaired path against **the same baseline you restored from**, and
-  expect to see only the edit you meant. Which command that is follows from that
-  choice, not from habit: `git diff <pre-write-rev> -- <path>` when the baseline
-  was a commit, and the bare `git diff -- <path>` — working tree against index —
-  when the index held the only surviving pre-write state. Reaching for `HEAD` in
-  that second case mixes the deliberate staged edits into the delta being
-  checked, so the proof reports a difference the recovery did not cause.
+- Compare the repaired path against the baseline — the same one the tells used
+  and the one you restored from — and expect to see only the edit you meant. The
+  command follows from that choice, as above; reaching for `HEAD` when the index
+  is the baseline mixes the deliberate staged edits into the delta, so the proof
+  reports a difference the recovery did not cause.
 - The reason this step is not optional: the clobber and the restore both live
   inside one PR, so the branch diffstat nets out and reads as though nothing
   happened. The summary is exactly the artifact that hides this.

--- a/.claude/rules/whole-file-writes.md
+++ b/.claude/rules/whole-file-writes.md
@@ -35,7 +35,7 @@ generated output, a concurrent tool, another session — is truncated by a check
 that passed a moment earlier. An exclusive create refuses at write time instead,
 which is a boundary rather than a look:
 
-```
+```sh
 set -o noclobber        # `>` now fails on an existing file; `>|` opts out
 ```
 
@@ -51,39 +51,30 @@ bypassed, and it is the bypass rather than the command that does the damage.
 **A symlink anywhere in the path defeats every check below.** A shell redirect
 follows links and truncates the RESOLVED target; the named path is untouched, so
 `git diff -- <path>` reports nothing and each tell and proof clears a write that
-destroyed a different file.
+destroyed a different file. Any component can be the link, and testing the leaf
+does not find it: with `linkdir -> real`, `test -L linkdir/file.txt` is FALSE
+because the file itself is regular, while the write still lands in
+`real/file.txt`.
 
-Testing the leaf is not enough, and this is the trap: with `linkdir -> real`,
-`test -L linkdir/file.txt` is FALSE — the file itself is regular — while the
-write still lands in `real/file.txt`. Any component can be the link. So resolve
-the whole path unconditionally and treat the RESULT as the path being written,
-rather than inspecting components for links. Then every check in this rule runs
-against the file that actually changed.
+**The exclusive create above already answers this, which is why no path
+canonicalisation is prescribed here.** Measured: with `link.txt -> real.txt`
+holding content, both `set -o noclobber` and Node's `wx` flag refuse the write
+and leave `real.txt` untouched; with a DANGLING `link.txt -> ghost.txt`, both
+refuse as well and no `ghost.txt` is created. The refusal follows the link
+without needing to be told about it, which a resolver written here cannot claim
+— a leaf that exists, a leaf that is a link, a leaf that is a dangling link and
+a leaf that is absent are four behaviours, and a routine short by one hands back
+the wrong path silently.
 
-Resolve it with something that exists everywhere this repo runs — CI covers
-Ubuntu, macOS and Windows:
+That conservatism has one cost worth stating: a deliberate write through a
+dangling symlink is refused too, because the link entry exists. Take that with
+`>|`, or by writing the target directly, having decided it.
 
-```
-node -e 'const {realpathSync,existsSync}=require("fs"), {join,dirname,basename}=require("path");
-const p=process.argv[1];
-console.log(existsSync(p) ? realpathSync(p)
-                          : join(realpathSync(dirname(p)), basename(p)))' -- <path>
-```
-
-Resolve the whole path when the leaf EXISTS, and fall back to resolving the
-parent and re-attaching the leaf only when it does not. Both halves are
-load-bearing and each is wrong alone: `realpathSync` throws `ENOENT` on a path
-that does not exist, so resolving the leaf unconditionally rejects every
-genuinely new file — the case a blind write is legitimately for — while
-resolving only the parent returns the LINK when the leaf is itself a symlink,
-which is the case that started all this. Measured: for `link.txt -> real.txt`,
-parent-only yields `link.txt` and full resolution yields `real.txt`.
-
-`readlink -f` is a GNU extension, absent from POSIX and from Windows shells, so
-it is not the portable instruction even where it happens to work. If resolving
-the PARENT fails, stop rather than falling back to the unresolved path: not
-knowing which directory you are about to write into is the condition this whole
-rule is about.
+Resolution still matters for DIAGNOSIS — after a write, the file that changed is
+the resolved target rather than the path you named, so that is what the tells
+and the proof must inspect. Determine it with the platform's own tooling
+(`realpath`, `fs.realpathSync`, `lstat` for the link entry itself) at the moment
+you need it, rather than from a recipe transcribed here.
 
 `turbo.json` in `packages/ui` was replaced this way. It lost
 `dependsOn: ["$TURBO_EXTENDS$", "build"]` on both `test` and `test:coverage`,
@@ -101,8 +92,9 @@ The question is not "which of these two is it". Any of the last commit, the
 index, a retained stash, or nothing in git at all can hold that content — an
 untracked or ignored file was never in either, a stash holds edits that were
 reapplied and then clobbered, and edits that were only ever in the working tree
-are in none of them. Enumerating the cases is how this section kept being wrong;
-what settles it is naming the revision and CHECKING it holds what you expect:
+are in none of them. Enumerating the cases cannot be complete, because which
+revision holds the content depends on how the work reached the tree; what
+settles it is naming the revision and CHECKING it holds what you expect:
 
 - `git show <rev>:<path>` prints a candidate's copy — `HEAD`, a stash, any
   commit — and `git show :<path>` prints the index copy. Read the one you intend

--- a/.claude/rules/whole-file-writes.md
+++ b/.claude/rules/whole-file-writes.md
@@ -18,11 +18,20 @@ distinguishes "there was nothing here" from "I removed everything that was".
 
 The belief that a file is new is the whole risk. Nobody overwrites a file they
 know exists; they overwrite one they are sure does not. So the precaution is not
-"be careful with destructive commands" — it is to READ the path first, and treat
-a successful read as a refusal to write blind. Under an editing tool that
-requires a prior read, use it; reaching for the shell to write a file the tool
-would have made you read is how the requirement gets bypassed, and it is the
-bypass rather than the command that does the damage.
+"be careful with destructive commands" — it is to establish that the path is
+absent, and to treat anything short of that as a refusal to write blind.
+
+**A failed read is not an absent file, and this is where the precaution leaks.**
+"I tried to read it and got nothing back" covers a path that does not exist AND
+a path that exists but could not be read — too large, binary, wrong permissions,
+a tool that declines it. Both produce the same silence, and only one of them
+makes a redirect safe. So the condition to require is an explicit NOT FOUND;
+every other read failure aborts, because a file the reader could not open is
+still a file the shell will happily truncate.
+
+Under an editing tool that requires a prior read, use it; reaching for the shell
+to write a file the tool would have made you read is how the requirement gets
+bypassed, and it is the bypass rather than the command that does the damage.
 
 `turbo.json` in `packages/ui` was replaced this way. It lost
 `dependsOn: ["$TURBO_EXTENDS$", "build"]` on both `test` and `test:coverage`,
@@ -49,11 +58,20 @@ They are worth knowing individually, because each looks like good news:
    magnitude in the direction you were hoping for is the moment to ask which
    change produced it, not to write it down as a result.
 
-3. **The overwritten content contradicts the reason you gave for writing it.**
-   The replaced file already used `$TURBO_EXTENDS$` — the very mechanism the new
-   comment introduced as if it were absent. Whenever a file turns out to have
-   been doing the thing you are adding, you did not add it; you replaced
-   something that already worked.
+3. **Content you did not write, and did not mean to remove, is gone.** This is
+   the only one of the three that is conclusive on its own, and it has to be
+   stated as the disappearance rather than as the suspicion that led there.
+
+   What led there in the real case was noticing that the replaced file already
+   used `$TURBO_EXTENDS$` — the mechanism the new comment introduced as if it
+   were absent. That is a good prompt to go and look, and it is NOT evidence:
+   adding `$TURBO_EXTENDS$` to `test:coverage` when `test` already uses it means
+   the file was also "already doing the thing", with nothing overwritten at all.
+   A tell that fires there sends a correct additive edit into a destructive
+   recovery procedure, which is worse than the miss it was guarding.
+
+   So confirm it against the baseline — `git diff HEAD --stat -- <path>`, then
+   the hunks — and require content that predates your edit to have vanished.
 
 ## Configuration coverage is UNEVEN, so find out before trusting green
 
@@ -105,9 +123,14 @@ command is right by default:
   state**, which is common and not a given. Where the path carried deliberate
   staged or unstaged edits when it was clobbered, `HEAD` never held them, and
   this overwrites the index and the working-tree copy alike from that commit —
-  destroying the edits being recovered. Read `git status` and
-  `git diff HEAD -- <path>` first; with uncommitted work in flight, the index
-  copy or a stash may be the only surviving pre-write state.
+  destroying the edits being recovered. Inspect the INDEX before choosing, and
+  note which command actually shows it: `git status` reports only `MM`, and
+  `git diff HEAD -- <path>` renders the post-clobber working tree, so neither
+  displays the staged content at risk. `git diff --cached HEAD -- <path>` — or
+  `git show :<path>` for the copy verbatim — is what puts it on screen. With
+  uncommitted work in flight, that index copy or a stash may be the only
+  surviving pre-write state, and it is the one a `checkout` from a commit
+  destroys without ever having shown it to you.
 - **`git checkout origin/main -- <path>` restores from `origin/main`, which is a
   different question**, and two independent things break it: the branch may have
   committed its own edits to that path, and `main` may have changed the path

--- a/.claude/rules/whole-file-writes.md
+++ b/.claude/rules/whole-file-writes.md
@@ -3,7 +3,9 @@
 # things follow. Any path can be clobbered, so no glob over filenames selects
 # the population; and the failure is a shell redirect, which reads nothing, so a
 # rule keyed to reading a matching path would be absent at exactly the moment it
-# applies.
+# applies. `derived-checks.md` matches by extension across the repo for the same
+# reason its own header gives: enumerating directories is how it kept missing the
+# code it is about.
 paths:
   - "**/*"
 ---
@@ -120,11 +122,16 @@ command is right by default:
 
 Then prove it, and prove it **before submitting**:
 
-- Compare the repaired path against its pre-write version —
-  `git diff <pre-write-rev> -- <path>` — and expect to see only the edit you
-  meant. The clobber and the restore both live inside one PR, so the branch
-  diffstat nets out and reads as though nothing happened; the summary is exactly
-  the artifact that hides this.
+- Compare the repaired path against **the same baseline you restored from**, and
+  expect to see only the edit you meant. Which command that is follows from that
+  choice, not from habit: `git diff <pre-write-rev> -- <path>` when the baseline
+  was a commit, and the bare `git diff -- <path>` — working tree against index —
+  when the index held the only surviving pre-write state. Reaching for `HEAD` in
+  that second case mixes the deliberate staged edits into the delta being
+  checked, so the proof reports a difference the recovery did not cause.
+- The reason this step is not optional: the clobber and the restore both live
+  inside one PR, so the branch diffstat nets out and reads as though nothing
+  happened. The summary is exactly the artifact that hides this.
 - The merge-commit content check in `verifying-merged-work.md` is a SEPARATE,
   post-merge confirmation. It cannot run while the PR is open, so it is not a
   substitute for the check above — by the time it is available, a broken config

--- a/.claude/rules/whole-file-writes.md
+++ b/.claude/rules/whole-file-writes.md
@@ -1,14 +1,9 @@
 ---
-# Scoped to everything, and the first draft's path list is why. It named
-# `tsup.config.ts` and `vitest.config.ts` and therefore missed
-# `packages/nextly/tsup.config.js`, `packages/ui/tsup.server-safe.config.ts`,
-# `packages/*/vitest.integration.config.ts` and `apps/playground/next.config.ts`
-# — an enumeration of spellings, in a rule about not enumerating.
-#
-# The deeper reason is that a path-scoped rule loads when a matching path is
-# READ or EDITED, and the failure here is a shell redirect that reads nothing.
-# The rule would have been absent at exactly the moment it applies. This is a
-# property of the ACT, not of the file type.
+# Unconditional, because the subject is an ACT rather than a kind of file. Two
+# things follow. Any path can be clobbered, so no glob over filenames selects
+# the population; and the failure is a shell redirect, which reads nothing, so a
+# rule keyed to reading a matching path would be absent at exactly the moment it
+# applies.
 paths:
   - "**/*"
 ---
@@ -36,11 +31,15 @@ everything.
 
 They are worth knowing individually, because each looks like good news:
 
-1. **The diffstat shows deletions on a file you believe you are creating.** A
-   created file has no deleted lines, so a single `-` in its `++---` bar is
-   conclusive, whatever the counts. This is the cheapest tell and the one most
-   easily read past, because by then the write has already succeeded and
-   attention has moved on.
+1. **The diffstat shows deletions on a file you believe you are creating**, read
+   against the right baseline. A created file has no deleted lines, so one `-`
+   in its `++---` bar settles it — but only when the comparison starts from
+   before the file existed. A bare `git diff --stat` compares the working tree
+   with the INDEX, so a genuinely new path that was staged and then shortened
+   reports deletions too, and the tell fires on a file that really is new. Use
+   `git diff HEAD --stat`. This is the cheapest tell and the one most easily
+   read past, because by then the write has already succeeded and attention has
+   moved on.
 
 2. **A metric improves far more than the change should explain.** "1264 inputs
    became 119" was recorded as evidence that the new scoping was tight. It was
@@ -93,15 +92,20 @@ drop whatever the root supplies.
 
 ## Restoring, and proving the restore
 
-The target is the **pre-write** content of that path, which is not a fixed
-command — name it before running anything:
+The target is the **pre-write** content of that path. Which revision holds it is
+a question about this working tree, so answer it before running anything — no
+command is right by default:
 
 - **`git checkout -- <path>` restores from the INDEX, not from a commit.** If
   the clobbered content was staged it repairs nothing, and if deliberate earlier
-  edits were staged it reinstates those. `git checkout HEAD -- <path>` is the
-  form that goes to the last commit.
-- **`git checkout HEAD -- <path>` is the default answer**, because the branch's
-  own last commit is where the pre-write content is.
+  edits were staged it reinstates those.
+- **`git checkout HEAD -- <path>` is right when the last commit IS the pre-write
+  state**, which is common and not a given. Where the path carried deliberate
+  staged or unstaged edits when it was clobbered, `HEAD` never held them, and
+  this overwrites the index and the working-tree copy alike from that commit —
+  destroying the edits being recovered. Read `git status` and
+  `git diff HEAD -- <path>` first; with uncommitted work in flight, the index
+  copy or a stash may be the only surviving pre-write state.
 - **`git checkout origin/main -- <path>` restores from `origin/main`, which is a
   different question**, and two independent things break it: the branch may have
   committed its own edits to that path, and `main` may have changed the path
@@ -109,8 +113,10 @@ command — name it before running anything:
   content while looking like a clean repair, and no check on the branch's own
   history detects it. Reach for it only when you specifically want `main`'s
   version — not as the way to undo a clobber.
-- Whichever source you take, the deliberate edit is then re-applied on top as an
-  APPEND. The restore does not carry it.
+- Whichever source you take, the restore does not carry the deliberate edit —
+  re-apply that on top as the delta it actually was. An append is right for the
+  additive case only; for a removal or a replacement it duplicates a setting, or
+  reinstates content that was meant to go.
 
 Then prove it, and prove it **before submitting**:
 

--- a/.claude/rules/whole-file-writes.md
+++ b/.claude/rules/whole-file-writes.md
@@ -1,14 +1,12 @@
----
-# Unconditional, because the subject is an ACT rather than a kind of file. Two
-# things follow. Any path can be clobbered, so no glob over filenames selects
-# the population; and the failure is a shell redirect, which reads nothing, so a
-# rule keyed to reading a matching path would be absent at exactly the moment it
-# applies. `derived-checks.md` matches by extension across the repo for the same
-# reason its own header gives: enumerating directories is how it kept missing the
-# code it is about.
-paths:
-  - "**/*"
----
+<!--
+Deliberately has NO `paths` frontmatter. Claude Code loads a rule without that
+field at launch, unconditionally; a rule WITH it — including `paths: ["**/*"]` —
+is conditional and triggers when a matching file is read. The failure this rule
+is about is a shell redirect, which reads nothing, so the conditional form is
+absent at exactly the moment it applies. A path-scoped rule is also not
+re-injected after /compact until it next matches, which the unconditional form
+avoids.
+-->
 
 ## A whole-file write is a delete plus a create
 
@@ -36,13 +34,22 @@ that passed a moment earlier. An exclusive create refuses at write time instead,
 which is a boundary rather than a look:
 
 ```sh
-set -o noclobber        # `>` now fails on an existing file; `>|` opts out
+set -o noclobber; printf '%s' "$content" > path    # ONE command, both parts
 ```
 
-Node's equivalent is the `wx` flag, which throws `EEXIST` rather than
-truncating: `writeFileSync(path, data, { flag: "wx" })`. Use one of these when
-the intent is genuinely "create", and keep the NOT FOUND probe for deciding
-whether that is the intent at all.
+**The option and the redirect must run in the same shell**, which for an agent
+means the same tool call. Each invocation starts a fresh shell with the option
+back at its default, so setting it in one call and redirecting in the next
+protects nothing — measured: separate invocations truncate the file, the
+compound command above fails with `cannot overwrite existing file`. `>|` opts
+out where overwriting is the intent.
+
+Node's equivalent has no such scoping problem, because the flag is an argument
+to the write itself: `writeFileSync(path, data, { flag: "wx" })` throws `EEXIST`
+rather than truncating. Prefer it when the choice is available.
+
+Use one of these when the intent is genuinely "create", and keep the NOT FOUND
+probe for deciding whether that is the intent at all.
 
 Under an editing tool that requires a prior read, use it; reaching for the shell
 to write a file the tool would have made you read is how the requirement gets
@@ -113,6 +120,15 @@ settles it is naming the revision and CHECKING it holds what you expect:
   `git diff <rev> -- <path>`; against the index, the bare `git diff -- <path>`,
   which is working tree versus index. Note that `git status` shows only `MM` and
   reveals neither.
+- **Those forms only compare TRACKED content.** If the recovered path is
+  untracked — the `stash@{n}^3` case above is the common one — `git diff <rev>`
+  reports the baseline as deleted and says nothing about what the file now
+  holds, whatever that is. Measured: with the original in the stash and
+  replacement text on disk, it prints `-ORIGINAL` and no `+` line at all, so a
+  clobber reads as a plain deletion. Materialise the candidate
+  (`git show <rev>:<path> > /tmp/base`) and compare with
+  `git diff --no-index /tmp/base <path>`, which reads both sides from the
+  filesystem and shows `-ORIGINAL +CLOBBERED`.
 
 **If no revision holds it — and you have established that rather than inferred
 it from an empty result — stop.** Say so and look outside git — editor local

--- a/.claude/rules/whole-file-writes.md
+++ b/.claude/rules/whole-file-writes.md
@@ -1,16 +1,16 @@
 ---
-# Build configuration is where this costs the most, because no suite reads it —
-# but the failure is the write, not the format, so the paths cover every config
-# a whole-file write plausibly lands on.
+# Scoped to everything, and the first draft's path list is why. It named
+# `tsup.config.ts` and `vitest.config.ts` and therefore missed
+# `packages/nextly/tsup.config.js`, `packages/ui/tsup.server-safe.config.ts`,
+# `packages/*/vitest.integration.config.ts` and `apps/playground/next.config.ts`
+# — an enumeration of spellings, in a rule about not enumerating.
+#
+# The deeper reason is that a path-scoped rule loads when a matching path is
+# READ or EDITED, and the failure here is a shell redirect that reads nothing.
+# The rule would have been absent at exactly the moment it applies. This is a
+# property of the ACT, not of the file type.
 paths:
-  - "**/turbo.json"
-  - "**/turbo.jsonc"
-  - "**/tsconfig*.json"
-  - "**/package.json"
-  - "**/tsup.config.ts"
-  - "**/vitest.config.ts"
-  - "**/*.yml"
-  - "**/*.yaml"
+  - "**/*"
 ---
 
 ## A whole-file write is a delete plus a create
@@ -24,7 +24,8 @@ know exists; they overwrite one they are sure does not. So the precaution is not
 "be careful with destructive commands" — it is to READ the path first, and treat
 a successful read as a refusal to write blind. Under an editing tool that
 requires a prior read, use it; reaching for the shell to write a file the tool
-would have made you read is how the requirement gets bypassed.
+would have made you read is how the requirement gets bypassed, and it is the
+bypass rather than the command that does the damage.
 
 `turbo.json` in `packages/ui` was replaced this way. It lost
 `dependsOn: ["$TURBO_EXTENDS$", "build"]` on both `test` and `test:coverage`,
@@ -35,10 +36,11 @@ everything.
 
 They are worth knowing individually, because each looks like good news:
 
-1. **The diffstat shows deletions on a file you believe you are creating.**
-   `61 ++---` on a new file is not a formatting artifact. A created file has no
-   deleted lines. This is the cheapest tell and the one most easily read past,
-   because by then the write has already succeeded and attention has moved on.
+1. **The diffstat shows deletions on a file you believe you are creating.** A
+   created file has no deleted lines, so a single `-` in its `++---` bar is
+   conclusive, whatever the counts. This is the cheapest tell and the one most
+   easily read past, because by then the write has already succeeded and
+   attention has moved on.
 
 2. **A metric improves far more than the change should explain.** "1264 inputs
    became 119" was recorded as evidence that the new scoping was tight. It was
@@ -52,13 +54,15 @@ They are worth knowing individually, because each looks like good news:
    been doing the thing you are adding, you did not add it; you replaced
    something that already worked.
 
-## Why configuration specifically
+## Why build configuration is the worst place for it
 
 The clobber survived `lint`, `check-types` and the full unit suite, because no
 test asserts on build configuration. Product code has a suite standing behind
-it; a `turbo.json`, a `tsconfig`, a workflow file and a `package.json` have only
-the diff. Green after touching one of these is not corroboration — it is the
-absence of any instrument.
+it; a `turbo.json`, a `tsconfig`, a `tsup.config.*`, a `vitest.*.config.*`, a
+`next.config.*`, a workflow file and a `package.json` have only the diff. Green
+after touching one of these is not corroboration — it is the absence of any
+instrument. That list is examples rather than a boundary: the property is "no
+suite reads it", not the filename.
 
 The consequence is delayed and looks unrelated. Dropping this package's own
 `build` from `dependsOn` leaves the root task's `^build`, which builds
@@ -84,13 +88,29 @@ drop whatever the root supplies.
 
 ## Restoring, and proving the restore
 
-`git checkout origin/main -- <path>` puts the file back, and re-applies the
-edit as an append. Two follow-ups make the difference between believing it and
-knowing it:
+The target is the **pre-write** content of that path, which is not a fixed
+command — name it before running anything:
 
-- `git checkout -- <path>` restores to the last COMMIT, not to the state before
-  your write. Commit or stash deliberate work first, or the restore takes that
-  with it.
-- Verify by CONTENT in the merge commit, not by "I restored it" —
-  see `verifying-merged-work.md`. The clobber and the restore both live inside
-  one PR, so the diffstat nets out and reads as though nothing happened.
+- **`git checkout -- <path>` restores from the INDEX, not from a commit.** If
+  the clobbered content was staged it repairs nothing, and if deliberate earlier
+  edits were staged it reinstates those. `git checkout HEAD -- <path>` is the
+  form that goes to the last commit.
+- **`git checkout origin/main -- <path>` is right only when the branch has made
+  no committed change to that path.** Otherwise it discards this PR's own
+  earlier edits along with the clobber, while looking like a clean repair. Check
+  that condition — `git log <base>..HEAD -- <path>` — rather than reaching for
+  the command because it worked somewhere else.
+- Whichever source you take, the deliberate edit is then re-applied on top as an
+  APPEND. The restore does not carry it.
+
+Then prove it, and prove it **before submitting**:
+
+- Compare the repaired path against its pre-write version —
+  `git diff <pre-write-rev> -- <path>` — and expect to see only the edit you
+  meant. The clobber and the restore both live inside one PR, so the branch
+  diffstat nets out and reads as though nothing happened; the summary is exactly
+  the artifact that hides this.
+- The merge-commit content check in `verifying-merged-work.md` is a SEPARATE,
+  post-merge confirmation. It cannot run while the PR is open, so it is not a
+  substitute for the check above — by the time it is available, a broken config
+  has already merged.

--- a/.claude/rules/whole-file-writes.md
+++ b/.claude/rules/whole-file-writes.md
@@ -54,23 +54,28 @@ They are worth knowing individually, because each looks like good news:
    been doing the thing you are adding, you did not add it; you replaced
    something that already worked.
 
-## Why build configuration is the worst place for it
+## Configuration coverage is UNEVEN, so find out before trusting green
 
-The clobber survived `lint`, `check-types` and the full unit suite, because no
-test asserts on build configuration. Product code has a suite standing behind
-it; a `turbo.json`, a `tsconfig`, a `tsup.config.*`, a `vitest.*.config.*`, a
-`next.config.*`, a workflow file and a `package.json` have only the diff. Green
-after touching one of these is not corroboration — it is the absence of any
-instrument. That list is examples rather than a boundary: the property is "no
-suite reads it", not the filename.
+The clobber survived `lint`, `check-types` and the full unit suite. The reason
+is narrower than "configuration is untested", and the narrow version is the
+useful one, because the broad version is false: nine suites in this repo read
+build configuration and assert on it. `packages/blocks-engine/src/typecheck-config.test.ts`
+parses `tsconfig.json`, `tsconfig.tests.json` and `package.json` and pins exact
+settings; `packages/builder/src/layering.test.ts` parses `vitest.config.ts` and
+asserts its `include`. For a property one of those covers, a green run IS
+corroboration.
 
-The consequence is delayed and looks unrelated. Dropping this package's own
-`build` from `dependsOn` leaves the root task's `^build`, which builds
-DEPENDENCIES and not this package, so turbo becomes free to schedule `build` and
-`test:coverage` together: the surface suite's `beforeAll` runs `tsup` while
-`build:js` is removing `dist` underneath it, and coverage reads half-written
-artifacts. That surfaces later, as flake, in a package whose diff no longer
-mentions any of this.
+`turbo.json` has no such suite, which is why this one went through. So the
+question to answer before reading green as evidence is not "is this a config
+file" but "does anything read the property I just changed" — and the answer
+varies by file, by package, and by which field inside it.
+
+The consequence of getting that wrong is delayed and looks unrelated to the
+diff. A dropped `inputs` entry means the hash no longer moves when that input
+changes, so turbo replays a cached pass over code nothing ran against. A dropped
+`dependsOn` edge means two tasks that were ordered may now be scheduled
+together. Neither fails at the moment of the edit, and by the time either
+surfaces the diff that caused it mentions none of the symptoms.
 
 ## `$TURBO_EXTENDS$` means the package config ADDS
 
@@ -95,11 +100,15 @@ command — name it before running anything:
   the clobbered content was staged it repairs nothing, and if deliberate earlier
   edits were staged it reinstates those. `git checkout HEAD -- <path>` is the
   form that goes to the last commit.
-- **`git checkout origin/main -- <path>` is right only when the branch has made
-  no committed change to that path.** Otherwise it discards this PR's own
-  earlier edits along with the clobber, while looking like a clean repair. Check
-  that condition — `git log <base>..HEAD -- <path>` — rather than reaching for
-  the command because it worked somewhere else.
+- **`git checkout HEAD -- <path>` is the default answer**, because the branch's
+  own last commit is where the pre-write content is.
+- **`git checkout origin/main -- <path>` restores from `origin/main`, which is a
+  different question**, and two independent things break it: the branch may have
+  committed its own edits to that path, and `main` may have changed the path
+  since the branch point. In the second case the checkout imports newer upstream
+  content while looking like a clean repair, and no check on the branch's own
+  history detects it. Reach for it only when you specifically want `main`'s
+  version — not as the way to undo a clobber.
 - Whichever source you take, the deliberate edit is then re-applied on top as an
   APPEND. The restore does not carry it.
 

--- a/.claude/rules/whole-file-writes.md
+++ b/.claude/rules/whole-file-writes.md
@@ -33,13 +33,17 @@ Under an editing tool that requires a prior read, use it; reaching for the shell
 to write a file the tool would have made you read is how the requirement gets
 bypassed, and it is the bypass rather than the command that does the damage.
 
-**A symlink defeats every check below, so refuse to write through one.** A shell
-redirect follows the link and truncates its TARGET; the link entry itself is
-untouched, so `git diff -- <path>` reports nothing and each tell and proof
-clears a write that destroyed a different file. Test the path with `test -L`
-first. If a link genuinely has to be written through, resolve it — `readlink -f`
-— and run every check in this rule against the resolved target instead, because
-that is the file that changed.
+**A symlink anywhere in the path defeats every check below.** A shell redirect
+follows links and truncates the RESOLVED target; the named path is untouched, so
+`git diff -- <path>` reports nothing and each tell and proof clears a write that
+destroyed a different file.
+
+Testing the leaf is not enough, and this is the trap: with `linkdir -> real`,
+`test -L linkdir/file.txt` is FALSE — the file itself is regular — while the
+write still lands in `real/file.txt`. Any component can be the link. So resolve
+the whole path unconditionally with `readlink -f` and treat the RESULT as the
+path being written, rather than inspecting components for links. Then every
+check in this rule runs against the file that actually changed.
 
 `turbo.json` in `packages/ui` was replaced this way. It lost
 `dependsOn: ["$TURBO_EXTENDS$", "build"]` on both `test` and `test:coverage`,
@@ -53,21 +57,23 @@ write. So the baseline is chosen once, and each command follows from it. Getting
 this wrong is not a smaller version of the same answer — it silently swaps which
 content is being judged.
 
-- The last commit held the pre-write state → the baseline is `HEAD`, and
-  comparisons take the form `git diff HEAD -- <path>`.
-- The path carried deliberate STAGED edits when it was written → the index holds
-  the pre-write state, `HEAD` never did, and comparisons are the bare
-  `git diff -- <path>`, which is working tree against index. Inspect the staged
-  copy with `git diff --cached HEAD -- <path>` or `git show :<path>`; note that
-  `git status` shows only `MM` and reveals none of it.
-- The path carried deliberate UNSTAGED edits that were never committed or
-  stashed → **git holds no copy of the pre-write state, and this is where the
-  procedure stops.** Neither source above contains those lines, so choosing
-  either produces a repair that looks clean and silently omits them. Say so and
-  go outside git — the editor's local history, a backup, an open buffer — rather
-  than picking the nearest baseline. A recovery that cannot recover is worth
-  naming as one; running the steps anyway converts a known loss into an
-  unnoticed one.
+Ask them in this order, because the first question that answers YES settles it:
+
+1. **Did the path carry deliberate UNSTAGED edits that were never committed or
+   stashed?** Then **git holds no copy of the pre-write state, and the procedure
+   stops here.** This takes precedence even when staged edits ALSO existed — the
+   index preserves only the staged subset, so restoring from it produces a
+   convincing delta that silently drops the unstaged lines. Say so and go
+   outside git: the editor's local history, a backup, an open buffer. A recovery
+   that cannot recover is worth naming as one; running the steps anyway converts
+   a known loss into an unnoticed one.
+2. **Were there deliberate STAGED edits (and no unstaged ones)?** The index holds
+   the pre-write state, `HEAD` never did, and comparisons are the bare
+   `git diff -- <path>`, which is working tree against index. Inspect the staged
+   copy with `git diff --cached HEAD -- <path>` or `git show :<path>`; note that
+   `git status` shows only `MM` and reveals none of it.
+3. **Otherwise** the last commit held it: the baseline is `HEAD`, and comparisons
+   take the form `git diff HEAD -- <path>`.
 
 Both failure directions are live, which is why this is not a detail. Comparing
 against `HEAD` when the index is the baseline reports the staged additions as

--- a/.claude/rules/whole-file-writes.md
+++ b/.claude/rules/whole-file-writes.md
@@ -1,0 +1,96 @@
+---
+# Build configuration is where this costs the most, because no suite reads it —
+# but the failure is the write, not the format, so the paths cover every config
+# a whole-file write plausibly lands on.
+paths:
+  - "**/turbo.json"
+  - "**/turbo.jsonc"
+  - "**/tsconfig*.json"
+  - "**/package.json"
+  - "**/tsup.config.ts"
+  - "**/vitest.config.ts"
+  - "**/*.yml"
+  - "**/*.yaml"
+---
+
+## A whole-file write is a delete plus a create
+
+`cat > f`, `>` and a full-file editor write all replace the file. When the file
+already existed, its previous contents are gone, and nothing in the command
+distinguishes "there was nothing here" from "I removed everything that was".
+
+The belief that a file is new is the whole risk. Nobody overwrites a file they
+know exists; they overwrite one they are sure does not. So the precaution is not
+"be careful with destructive commands" — it is to READ the path first, and treat
+a successful read as a refusal to write blind. Under an editing tool that
+requires a prior read, use it; reaching for the shell to write a file the tool
+would have made you read is how the requirement gets bypassed.
+
+`turbo.json` in `packages/ui` was replaced this way. It lost
+`dependsOn: ["$TURBO_EXTENDS$", "build"]` on both `test` and `test:coverage`,
+plus three call-site input trees, and the result parsed, ran, and passed
+everything.
+
+## Three tells that this has happened, in the order they appear
+
+They are worth knowing individually, because each looks like good news:
+
+1. **The diffstat shows deletions on a file you believe you are creating.**
+   `61 ++---` on a new file is not a formatting artifact. A created file has no
+   deleted lines. This is the cheapest tell and the one most easily read past,
+   because by then the write has already succeeded and attention has moved on.
+
+2. **A metric improves far more than the change should explain.** "1264 inputs
+   became 119" was recorded as evidence that the new scoping was tight. It was
+   evidence that inputs had been REMOVED. A number that moves an order of
+   magnitude in the direction you were hoping for is the moment to ask which
+   change produced it, not to write it down as a result.
+
+3. **The overwritten content contradicts the reason you gave for writing it.**
+   The replaced file already used `$TURBO_EXTENDS$` — the very mechanism the new
+   comment introduced as if it were absent. Whenever a file turns out to have
+   been doing the thing you are adding, you did not add it; you replaced
+   something that already worked.
+
+## Why configuration specifically
+
+The clobber survived `lint`, `check-types` and the full unit suite, because no
+test asserts on build configuration. Product code has a suite standing behind
+it; a `turbo.json`, a `tsconfig`, a workflow file and a `package.json` have only
+the diff. Green after touching one of these is not corroboration — it is the
+absence of any instrument.
+
+The consequence is delayed and looks unrelated. Dropping this package's own
+`build` from `dependsOn` leaves the root task's `^build`, which builds
+DEPENDENCIES and not this package, so turbo becomes free to schedule `build` and
+`test:coverage` together: the surface suite's `beforeAll` runs `tsup` while
+`build:js` is removing `dist` underneath it, and coverage reads half-written
+artifacts. That surfaces later, as flake, in a package whose diff no longer
+mentions any of this.
+
+## `$TURBO_EXTENDS$` means the package config ADDS
+
+Two package configs use it — `packages/ui/turbo.json` and
+`packages/blocks-react/turbo.json` — and both rely on the property:
+`$TURBO_EXTENDS$` inside `dependsOn` or `inputs` interpolates the ROOT task's
+list at that position. `["$TURBO_EXTENDS$", "build"]` is "everything the root
+task depends on, plus this package's own build".
+
+So a package task list is an APPENDIX, never a replacement, and writing one from
+scratch is a silent subtraction: the file still parses, turbo still runs, and
+the inherited entries are simply not there. To add an input, append to the
+existing array. If you find yourself composing the whole array, you are about to
+drop whatever the root supplies.
+
+## Restoring, and proving the restore
+
+`git checkout origin/main -- <path>` puts the file back, and re-applies the
+edit as an append. Two follow-ups make the difference between believing it and
+knowing it:
+
+- `git checkout -- <path>` restores to the last COMMIT, not to the state before
+  your write. Commit or stash deliberate work first, or the restore takes that
+  with it.
+- Verify by CONTENT in the merge commit, not by "I restored it" —
+  see `verifying-merged-work.md`. The clobber and the restore both live inside
+  one PR, so the diffstat nets out and reads as though nothing happened.

--- a/.claude/rules/whole-file-writes.md
+++ b/.claude/rules/whole-file-writes.md
@@ -162,48 +162,37 @@ drop whatever the root supplies.
 
 ## Restoring, and proving the restore
 
-The target is the **pre-write** content of that path. Which revision holds it is
-a question about this working tree, so answer it before running anything — no
-command is right by default:
+Recovery is where this rule stops being a procedure, deliberately. The full
+matter of which git revision holds a given pre-write state is a large surface —
+seven successive corrections to this section all found real defects in it — and
+a manual that is right about six cases and silent about the seventh reads as
+complete. Three things are worth stating; the rest is the situation in front of
+you.
 
-- **`git checkout -- <path>` restores from the INDEX, not from a commit.** If
-  the clobbered content was staged it repairs nothing, and if deliberate earlier
-  edits were staged it reinstates those.
-- **`git checkout HEAD -- <path>` is right when the last commit IS the pre-write
-  state**, which is common and not a given. Where the path carried deliberate
-  staged or unstaged edits when it was clobbered, `HEAD` never held them, and
-  this overwrites the index and the working-tree copy alike from that commit —
-  destroying the edits being recovered. Inspect the INDEX before choosing, and
-  note which command actually shows it: `git status` reports only `MM`, and
-  `git diff HEAD -- <path>` renders the post-clobber working tree, so neither
-  displays the staged content at risk. `git diff --cached HEAD -- <path>` — or
-  `git show :<path>` for the copy verbatim — is what puts it on screen. With
-  uncommitted work in flight, that index copy or a stash may be the only
-  surviving pre-write state, and it is the one a `checkout` from a commit
-  destroys without ever having shown it to you.
-- **`git checkout origin/main -- <path>` restores from `origin/main`, which is a
-  different question**, and two independent things break it: the branch may have
-  committed its own edits to that path, and `main` may have changed the path
-  since the branch point. In the second case the checkout imports newer upstream
-  content while looking like a clean repair, and no check on the branch's own
-  history detects it. Reach for it only when you specifically want `main`'s
-  version — not as the way to undo a clobber.
-- Whichever source you take, the restore does not carry the deliberate edit —
-  re-apply that on top as the delta it actually was. An append is right for the
-  additive case only; for a removal or a replacement it duplicates a setting, or
-  reinstates content that was meant to go.
+**1. Identify which revision actually holds the pre-write content, before
+running anything.** No command is right by default. Ask in this order, first YES
+settles it:
 
-Then prove it, and prove it **before submitting**:
+- Deliberate edits that were never committed or stashed, staged or not? Then
+  **git does not hold it, and this is where the procedure stops.** Say so and
+  look outside git — editor local history, a backup, an open buffer. Running the
+  steps anyway converts a known loss into an unnoticed one.
+- Otherwise it is a commit or the index, and the reading commands follow from
+  the baseline section above.
 
-- Compare the repaired path against the baseline — the same one the tells used
-  and the one you restored from — and expect to see only the edit you meant. The
-  command follows from that choice, as above; reaching for `HEAD` when the index
-  is the baseline mixes the deliberate staged edits into the delta, so the proof
-  reports a difference the recovery did not cause.
-- The reason this step is not optional: the clobber and the restore both live
-  inside one PR, so the branch diffstat nets out and reads as though nothing
-  happened. The summary is exactly the artifact that hides this.
-- The merge-commit content check in `verifying-merged-work.md` is a SEPARATE,
-  post-merge confirmation. It cannot run while the PR is open, so it is not a
-  substitute for the check above — by the time it is available, a broken config
-  has already merged.
+**2. The restore does not carry your edit.** Re-apply it on top as the delta it
+actually was — an append only where the edit was additive; for a removal or a
+replacement, appending duplicates a setting or reinstates content meant to go.
+
+**3. Prove it BEFORE submitting, against the same baseline.** Expect only the
+edit you meant. This step is not optional, because the clobber and the restore
+both live inside one PR: the branch diffstat nets out and reads as though
+nothing happened, and that summary is exactly what hides the loss. The
+merge-commit check in `verifying-merged-work.md` is a separate, post-merge
+confirmation — by the time it can run, a broken config has already merged.
+
+Two commands are worth knowing because their names mislead: `git checkout --
+<path>` restores from the INDEX rather than a commit, and
+`git checkout origin/main -- <path>` answers "what does main have", which is a
+different question from "what was here before my write" and quietly imports
+upstream changes when `main` has moved.

--- a/.claude/rules/whole-file-writes.md
+++ b/.claude/rules/whole-file-writes.md
@@ -125,13 +125,29 @@ settles it is naming the revision and CHECKING it holds what you expect:
   reports the baseline as deleted and says nothing about what the file now
   holds, whatever that is. Measured: with the original in the stash and
   replacement text on disk, it prints `-ORIGINAL` and no `+` line at all, so a
-  clobber reads as a plain deletion. Materialise the candidate
-  (`git show <rev>:<path> > /tmp/base`) and compare with
-  `git diff --no-index /tmp/base <path>`, which reads both sides from the
-  filesystem and shows `-ORIGINAL +CLOBBERED`.
+  clobber reads as a plain deletion. Materialise the candidate into a file
+  created for the purpose, and compare with `git diff --no-index`, which reads
+  both sides from the filesystem and shows `-ORIGINAL +CLOBBERED`:
 
-**If no revision holds it — and you have established that rather than inferred
-it from an empty result — stop.** Say so and look outside git — editor local
+  ```sh
+  base="$(mktemp)" && git show <rev>:<path> > "$base" && git diff --no-index "$base" <path>
+  ```
+
+  `mktemp` rather than a fixed name, and one `&&` chain rather than separate
+  steps, for the reason this whole rule exists: `> /tmp/base` truncates whatever
+  is already at that path — through a symlink included — and two recoveries at
+  once overwrite each other's baseline. Chaining also stops a failed `git show`
+  leaving an empty file that the comparison then reads as recovered content.
+
+**Before concluding git holds nothing, look at the objects no ref points at.**
+Content staged and then reset out of the index is unreachable rather than gone:
+`git fsck --unreachable` lists the blob and `git cat-file -p <sha>` prints it.
+Measured — a file staged with deliberate content, unstaged, then clobbered is
+absent from `git show :<path>` and recovered verbatim from its unreachable blob.
+That is the last place to look, and no `<rev>:<path>` form above reaches it.
+
+**If no revision and no unreachable object holds it — and you have established
+that rather than inferred it from an empty result — stop.** Say so and look outside git — editor local
 history, a backup, an open buffer. A recovery that cannot recover is worth
 naming as one; running the steps anyway converts a known loss into an unnoticed
 one, because the resulting diff looks entirely clean.

--- a/.claude/rules/whole-file-writes.md
+++ b/.claude/rules/whole-file-writes.md
@@ -49,13 +49,22 @@ Resolve it with something that exists everywhere this repo runs — CI covers
 Ubuntu, macOS and Windows:
 
 ```
-node -e 'console.log(require("fs").realpathSync(process.argv[1]))' -- <path>
+node -e 'const {realpathSync}=require("fs"), {join,dirname,basename}=require("path");
+const p=process.argv[1];
+console.log(join(realpathSync(dirname(p)), basename(p)))' -- <path>
 ```
 
+Resolve the PARENT and re-attach the leaf, rather than resolving the whole path.
+`realpathSync` throws `ENOENT` on a path that does not exist, and the file not
+existing is the case a blind write is legitimately for — resolving the leaf
+would reject every genuinely new file, which is the outcome this rule is meant
+to permit. The parent is what carries the symlink risk, and it exists.
+
 `readlink -f` is a GNU extension, absent from POSIX and from Windows shells, so
-it is not the portable instruction even where it happens to work. If resolution
-FAILS, stop rather than falling back to the unresolved path: not knowing which
-file you are about to replace is the condition this whole rule is about.
+it is not the portable instruction even where it happens to work. If resolving
+the PARENT fails, stop rather than falling back to the unresolved path: not
+knowing which directory you are about to write into is the condition this whole
+rule is about.
 
 `turbo.json` in `packages/ui` was replaced this way. It lost
 `dependsOn: ["$TURBO_EXTENDS$", "build"]` on both `test` and `test:coverage`,
@@ -76,16 +85,26 @@ reapplied and then clobbered, and edits that were only ever in the working tree
 are in none of them. Enumerating the cases is how this section kept being wrong;
 what settles it is naming the revision and CHECKING it holds what you expect:
 
-- `git show <rev>:<path>` prints a candidate's copy — `HEAD`, a stash
-  (`stash@{0}`), any commit — and `git show :<path>` prints the index copy.
-  Read the one you intend to restore from BEFORE restoring, and confirm it
-  contains the pre-write content rather than assuming it does.
+- `git show <rev>:<path>` prints a candidate's copy — `HEAD`, a stash, any
+  commit — and `git show :<path>` prints the index copy. Read the one you intend
+  to restore from BEFORE restoring, and confirm it contains the pre-write
+  content rather than assuming it does.
+- **A command that prints nothing has not shown you the file is absent.** It is
+  equally the shape of asking the wrong question, and two ways of doing that are
+  easy to hit here. `<rev>:<path>` names a path inside the revision's TREE, so
+  the absolute path a symlink resolver just produced is not a valid argument and
+  every candidate reads as missing; convert to repository-relative first. And a
+  path that was untracked when it was stashed is not in the stash commit at all
+  — `git stash -u` puts it in the stash's THIRD parent, reachable as
+  `stash@{n}^3:<path>` — so the obvious query says absent while git holds an
+  exact copy.
 - The reading commands follow from that choice. Against a commit,
   `git diff <rev> -- <path>`; against the index, the bare `git diff -- <path>`,
   which is working tree versus index. Note that `git status` shows only `MM` and
   reveals neither.
 
-**If no revision holds it, stop.** Say so and look outside git — editor local
+**If no revision holds it — and you have established that rather than inferred
+it from an empty result — stop.** Say so and look outside git — editor local
 history, a backup, an open buffer. A recovery that cannot recover is worth
 naming as one; running the steps anyway converts a known loss into an unnoticed
 one, because the resulting diff looks entirely clean.

--- a/.claude/rules/whole-file-writes.md
+++ b/.claude/rules/whole-file-writes.md
@@ -41,9 +41,21 @@ destroyed a different file.
 Testing the leaf is not enough, and this is the trap: with `linkdir -> real`,
 `test -L linkdir/file.txt` is FALSE — the file itself is regular — while the
 write still lands in `real/file.txt`. Any component can be the link. So resolve
-the whole path unconditionally with `readlink -f` and treat the RESULT as the
-path being written, rather than inspecting components for links. Then every
-check in this rule runs against the file that actually changed.
+the whole path unconditionally and treat the RESULT as the path being written,
+rather than inspecting components for links. Then every check in this rule runs
+against the file that actually changed.
+
+Resolve it with something that exists everywhere this repo runs — CI covers
+Ubuntu, macOS and Windows:
+
+```
+node -e 'console.log(require("fs").realpathSync(process.argv[1]))' -- <path>
+```
+
+`readlink -f` is a GNU extension, absent from POSIX and from Windows shells, so
+it is not the portable instruction even where it happens to work. If resolution
+FAILS, stop rather than falling back to the unresolved path: not knowing which
+file you are about to replace is the condition this whole rule is about.
 
 `turbo.json` in `packages/ui` was replaced this way. It lost
 `dependsOn: ["$TURBO_EXTENDS$", "build"]` on both `test` and `test:coverage`,
@@ -57,23 +69,26 @@ write. So the baseline is chosen once, and each command follows from it. Getting
 this wrong is not a smaller version of the same answer — it silently swaps which
 content is being judged.
 
-Ask them in this order, because the first question that answers YES settles it:
+The question is not "which of these two is it". Any of the last commit, the
+index, a retained stash, or nothing in git at all can hold that content — an
+untracked or ignored file was never in either, a stash holds edits that were
+reapplied and then clobbered, and edits that were only ever in the working tree
+are in none of them. Enumerating the cases is how this section kept being wrong;
+what settles it is naming the revision and CHECKING it holds what you expect:
 
-1. **Did the path carry deliberate UNSTAGED edits that were never committed or
-   stashed?** Then **git holds no copy of the pre-write state, and the procedure
-   stops here.** This takes precedence even when staged edits ALSO existed — the
-   index preserves only the staged subset, so restoring from it produces a
-   convincing delta that silently drops the unstaged lines. Say so and go
-   outside git: the editor's local history, a backup, an open buffer. A recovery
-   that cannot recover is worth naming as one; running the steps anyway converts
-   a known loss into an unnoticed one.
-2. **Were there deliberate STAGED edits (and no unstaged ones)?** The index holds
-   the pre-write state, `HEAD` never did, and comparisons are the bare
-   `git diff -- <path>`, which is working tree against index. Inspect the staged
-   copy with `git diff --cached HEAD -- <path>` or `git show :<path>`; note that
-   `git status` shows only `MM` and reveals none of it.
-3. **Otherwise** the last commit held it: the baseline is `HEAD`, and comparisons
-   take the form `git diff HEAD -- <path>`.
+- `git show <rev>:<path>` prints a candidate's copy — `HEAD`, a stash
+  (`stash@{0}`), any commit — and `git show :<path>` prints the index copy.
+  Read the one you intend to restore from BEFORE restoring, and confirm it
+  contains the pre-write content rather than assuming it does.
+- The reading commands follow from that choice. Against a commit,
+  `git diff <rev> -- <path>`; against the index, the bare `git diff -- <path>`,
+  which is working tree versus index. Note that `git status` shows only `MM` and
+  reveals neither.
+
+**If no revision holds it, stop.** Say so and look outside git — editor local
+history, a backup, an open buffer. A recovery that cannot recover is worth
+naming as one; running the steps anyway converts a known loss into an unnoticed
+one, because the resulting diff looks entirely clean.
 
 Both failure directions are live, which is why this is not a detail. Comparing
 against `HEAD` when the index is the baseline reports the staged additions as
@@ -89,12 +104,17 @@ They are worth knowing individually, because each looks like good news:
 1. **The diffstat shows deletions on a file you believe you are creating**, read
    against the baseline named above. A created file has no deleted lines, so one
    `-` in its `++---` bar settles it — but only when the comparison starts from
-   before the file existed. A bare `git diff --stat` against the wrong baseline
-   answers a different question: with `HEAD` as the baseline it reports
-   deletions for a genuinely new path that was staged and then shortened, firing
-   on a file that really is new. This is the cheapest tell and the one most
-   easily read past, because by then the write has already succeeded and
-   attention has moved on.
+   before the file existed.
+
+   Read against the wrong baseline it answers a different question. A genuinely
+   new path that was STAGED and then shortened shows deletions under the bare
+   `git diff --stat`, which compares the working tree with the index where the
+   longer version now sits; against `HEAD`, where the path does not exist at
+   all, the same file shows additions only. So the bare form is the one that
+   fires on a file that really is new, and it fires exactly when the baseline
+   section says the index is NOT the baseline. This is the cheapest tell and the
+   one most easily read past, because by then the write has already succeeded
+   and attention has moved on.
 
 2. **A metric improves far more than the change should explain.** "1264 inputs
    became 119" was recorded as evidence that the new scoping was tight. It was
@@ -162,23 +182,15 @@ drop whatever the root supplies.
 
 ## Restoring, and proving the restore
 
-Recovery is where this rule stops being a procedure, deliberately. The full
-matter of which git revision holds a given pre-write state is a large surface —
-seven successive corrections to this section all found real defects in it — and
-a manual that is right about six cases and silent about the seventh reads as
-complete. Three things are worth stating; the rest is the situation in front of
-you.
+Recovery is deliberately not a procedure here. Which revision holds a given
+pre-write state depends on how the work reached the tree — committed, staged,
+stashed, or never recorded — and a manual that covers most of those and is
+silent about the rest reads as complete, which is worse than being brief. Three
+things are worth stating; the rest is the situation in front of you.
 
-**1. Identify which revision actually holds the pre-write content, before
-running anything.** No command is right by default. Ask in this order, first YES
-settles it:
-
-- Deliberate edits that were never committed or stashed, staged or not? Then
-  **git does not hold it, and this is where the procedure stops.** Say so and
-  look outside git — editor local history, a backup, an open buffer. Running the
-  steps anyway converts a known loss into an unnoticed one.
-- Otherwise it is a commit or the index, and the reading commands follow from
-  the baseline section above.
+**1. Identify which revision actually holds the pre-write content, and read it,
+before running anything.** That is the baseline question above, including its
+stop condition. No command is right by default.
 
 **2. The restore does not carry your edit.** Re-apply it on top as the delta it
 actually was — an append only where the edit was additive; for a removal or a

--- a/.claude/rules/whole-file-writes.md
+++ b/.claude/rules/whole-file-writes.md
@@ -33,6 +33,14 @@ Under an editing tool that requires a prior read, use it; reaching for the shell
 to write a file the tool would have made you read is how the requirement gets
 bypassed, and it is the bypass rather than the command that does the damage.
 
+**A symlink defeats every check below, so refuse to write through one.** A shell
+redirect follows the link and truncates its TARGET; the link entry itself is
+untouched, so `git diff -- <path>` reports nothing and each tell and proof
+clears a write that destroyed a different file. Test the path with `test -L`
+first. If a link genuinely has to be written through, resolve it — `readlink -f`
+— and run every check in this rule against the resolved target instead, because
+that is the file that changed.
+
 `turbo.json` in `packages/ui` was replaced this way. It lost
 `dependsOn: ["$TURBO_EXTENDS$", "build"]` on both `test` and `test:coverage`,
 plus three call-site input trees, and the result parsed, ran, and passed
@@ -52,6 +60,14 @@ content is being judged.
   `git diff -- <path>`, which is working tree against index. Inspect the staged
   copy with `git diff --cached HEAD -- <path>` or `git show :<path>`; note that
   `git status` shows only `MM` and reveals none of it.
+- The path carried deliberate UNSTAGED edits that were never committed or
+  stashed → **git holds no copy of the pre-write state, and this is where the
+  procedure stops.** Neither source above contains those lines, so choosing
+  either produces a repair that looks clean and silently omits them. Say so and
+  go outside git — the editor's local history, a backup, an open buffer — rather
+  than picking the nearest baseline. A recovery that cannot recover is worth
+  naming as one; running the steps anyway converts a known loss into an
+  unnoticed one.
 
 Both failure directions are live, which is why this is not a detail. Comparing
 against `HEAD` when the index is the baseline reports the staged additions as
@@ -80,9 +96,15 @@ They are worth knowing individually, because each looks like good news:
    magnitude in the direction you were hoping for is the moment to ask which
    change produced it, not to write it down as a result.
 
-3. **Content you did not write, and did not mean to remove, is gone.** This is
-   the only one of the three that is conclusive on its own, and it has to be
-   stated as the disappearance rather than as the suspicion that led there.
+3. **Content you did not write, and did not mean to remove, is gone.**
+   Conclusive, and it has to be stated as the disappearance rather than as the
+   suspicion that led there.
+
+   Two of these three settle it and one does not, so the split is worth stating
+   plainly rather than by rank: a deletion against the correctly chosen baseline
+   (1) and vanished content (3) are each conclusive on their own; the metric (2)
+   is only ever a prompt to go and look, because a number can move for reasons
+   that have nothing to do with a write.
 
    What led there in the real case was noticing that the replaced file already
    used `$TURBO_EXTENDS$` — the mechanism the new comment introduced as if it

--- a/.claude/rules/whole-file-writes.md
+++ b/.claude/rules/whole-file-writes.md
@@ -29,6 +29,21 @@ makes a redirect safe. So the condition to require is an explicit NOT FOUND;
 every other read failure aborts, because a file the reader could not open is
 still a file the shell will happily truncate.
 
+**Better still, do not separate the check from the write.** A probe followed by
+a redirect is two operations, and anything that creates the path in between —
+generated output, a concurrent tool, another session — is truncated by a check
+that passed a moment earlier. An exclusive create refuses at write time instead,
+which is a boundary rather than a look:
+
+```
+set -o noclobber        # `>` now fails on an existing file; `>|` opts out
+```
+
+Node's equivalent is the `wx` flag, which throws `EEXIST` rather than
+truncating: `writeFileSync(path, data, { flag: "wx" })`. Use one of these when
+the intent is genuinely "create", and keep the NOT FOUND probe for deciding
+whether that is the intent at all.
+
 Under an editing tool that requires a prior read, use it; reaching for the shell
 to write a file the tool would have made you read is how the requirement gets
 bypassed, and it is the bypass rather than the command that does the damage.
@@ -49,16 +64,20 @@ Resolve it with something that exists everywhere this repo runs — CI covers
 Ubuntu, macOS and Windows:
 
 ```
-node -e 'const {realpathSync}=require("fs"), {join,dirname,basename}=require("path");
+node -e 'const {realpathSync,existsSync}=require("fs"), {join,dirname,basename}=require("path");
 const p=process.argv[1];
-console.log(join(realpathSync(dirname(p)), basename(p)))' -- <path>
+console.log(existsSync(p) ? realpathSync(p)
+                          : join(realpathSync(dirname(p)), basename(p)))' -- <path>
 ```
 
-Resolve the PARENT and re-attach the leaf, rather than resolving the whole path.
-`realpathSync` throws `ENOENT` on a path that does not exist, and the file not
-existing is the case a blind write is legitimately for — resolving the leaf
-would reject every genuinely new file, which is the outcome this rule is meant
-to permit. The parent is what carries the symlink risk, and it exists.
+Resolve the whole path when the leaf EXISTS, and fall back to resolving the
+parent and re-attaching the leaf only when it does not. Both halves are
+load-bearing and each is wrong alone: `realpathSync` throws `ENOENT` on a path
+that does not exist, so resolving the leaf unconditionally rejects every
+genuinely new file — the case a blind write is legitimately for — while
+resolving only the parent returns the LINK when the leaf is itself a symlink,
+which is the case that started all this. Measured: for `link.txt -> real.txt`,
+parent-only yields `link.txt` and full resolution yields `real.txt`.
 
 `readlink -f` is a GNU extension, absent from POSIX and from Windows shells, so
 it is not the portable instruction even where it happens to work. If resolving
@@ -125,13 +144,14 @@ They are worth knowing individually, because each looks like good news:
    `-` in its `++---` bar settles it — but only when the comparison starts from
    before the file existed.
 
-   Read against the wrong baseline it answers a different question. A genuinely
-   new path that was STAGED and then shortened shows deletions under the bare
-   `git diff --stat`, which compares the working tree with the index where the
-   longer version now sits; against `HEAD`, where the path does not exist at
-   all, the same file shows additions only. So the bare form is the one that
-   fires on a file that really is new, and it fires exactly when the baseline
-   section says the index is NOT the baseline. This is the cheapest tell and the
+   Read against the wrong baseline it answers a different question, and a new
+   path that was STAGED is the case that makes this concrete. The index holds
+   its pre-write content and `HEAD` does not, so the index IS the baseline —
+   the bare `git diff --stat` is the right command, and it correctly shows
+   deletions when that staged content was clobbered. Reaching for `HEAD` there
+   compares against a revision where the path does not exist at all, which
+   reports additions only and clears the overwrite. The baseline section decides
+   this; the tell just uses what it decided. This is the cheapest tell and the
    one most easily read past, because by then the write has already succeeded
    and attention has moved on.
 


### PR DESCRIPTION
## What

Adds `.claude/rules/whole-file-writes.md`, path-scoped to build configuration
(`turbo.json*`, `tsconfig*.json`, `package.json`, `tsup.config.ts`,
`vitest.config.ts`, `*.yml`/`*.yaml`).

## Why

`packages/ui/turbo.json` was replaced with `cat >` in the belief it was a new
file. It lost `dependsOn: ["$TURBO_EXTENDS$", "build"]` on both `test` and
`test:coverage`, plus three call-site input trees — and the result parsed, ran,
and passed `lint`, `check-types` and the full unit suite. It was caught and
restored inside the same PR, so the diffstat netted out.

The rule covers four things:

- **A whole-file write is a delete plus a create.** The belief that a file is
  new is the entire risk, so the precaution is to read the path first rather
  than to be careful with the command.
- **Three tells**, each of which was present and each of which read as good
  news: a diffstat showing deletions on a file believed to be new; a metric
  improving an order of magnitude in the hoped-for direction ("1264 inputs
  became 119" was recorded as evidence of tight scoping, and was evidence of
  removal); and overwritten content that already used the mechanism the new
  comment introduced as if absent.
- **Why configuration specifically** — no suite asserts on it, so green is the
  absence of an instrument. The delayed consequence is named: dropping this
  package's own `build` leaves only the root's `^build`, which builds
  dependencies and not this package, freeing turbo to run `build` and
  `test:coverage` concurrently so coverage reads half-written `dist`.
- **`$TURBO_EXTENDS$` means the package config ADDS.** Both configs that use it
  (`packages/ui`, `packages/blocks-react`) rely on the root list being
  interpolated at that position, so writing the array from scratch subtracts
  silently.

## Verification

Every factual claim checked against `origin/main` rather than recalled:

- root `test` task is `"dependsOn": ["^build"]`
- `packages/blocks-react/turbo.json` uses `$TURBO_EXTENDS$` in both `dependsOn`
  and `inputs`; `packages/ui` and `blocks-react` are the only two package
  configs that use it at all
- `.claude/rules/verifying-merged-work.md` exists for the cross-reference

Prettier clean. No changeset: docs-only, no published code changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added repository-wide guidance for safely writing or replacing complete files.
  * Documented handling for missing files, symlinks, Git history, overwrite detection, and configuration inheritance.
  * Added procedures and portable examples for cautiously restoring files and verifying changes.
  * Included guidance for preventing configuration loss scenarios and addressing gaps in configuration test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->