### PR TITLE
feat(builder): the shell's layout decisions, ahead of the shell

### DIFF
--- a/.changeset/builder-editor-shell.md
+++ b/.changeset/builder-editor-shell.md
@@ -1,0 +1,43 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+add the page-builder editor shell
+
+`@nextlyhq/builder` gains `BuilderShell` — the editor frame: an icon rail, one
+switched left panel, the canvas slot, a fixed right inspector, and the bars
+around them. Presentational by contract: it owns which panel is open and the
+region widths, and owns nothing about the document, so selection arrives as a
+prop.
+
+Also exported: the shell's own decisions (`LEFT_PANELS`, `PANEL_BOUNDS`,
+`RAIL_WIDTH`, `MIN_SHELL_WIDTH`, `MIN_CANVAS_WIDTH`) and the `PreferenceStore`
+port a host implements to keep chrome preferences wherever it already keeps
+preferences.
+
+New subpath `@nextlyhq/builder/styles.css` carries the `--nx-builder-*` chrome
+token layer. A consumer that renders the shell without importing it gets
+unstyled markup.

--- a/apps/playground/package.json
+++ b/apps/playground/package.json
@@ -25,6 +25,7 @@
     "@nextlyhq/adapter-sqlite": "workspace:^",
     "@nextlyhq/admin": "workspace:^",
     "@nextlyhq/blocks-react": "workspace:^",
+    "@nextlyhq/builder": "workspace:*",
     "@nextlyhq/plugin-form-builder": "workspace:^",
     "@nextlyhq/plugin-page-builder": "workspace:^",
     "@nextlyhq/plugin-sdk": "workspace:^",

--- a/apps/playground/src/app/builder-shell/harness.tsx
+++ b/apps/playground/src/app/builder-shell/harness.tsx
@@ -1,6 +1,9 @@
 "use client";
 
-import { BuilderShell, type LeftPanel } from "@nextlyhq/builder";
+import { type LeftPanel } from "@nextlyhq/builder";
+// The shell comes from its own entry: that is the one carrying `"use client"`,
+// which is why the root barrel can stay callable from a Server Component.
+import { BuilderShell } from "@nextlyhq/builder/shell";
 // The design system's sheet FIRST, then the editor's, which supplements it.
 // `@nextlyhq/builder/styles.css` deliberately ships neither the `--nx-*` tokens
 // nor the base reset, because the host already loads a sheet that owns both and

--- a/apps/playground/src/app/builder-shell/harness.tsx
+++ b/apps/playground/src/app/builder-shell/harness.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { BuilderShell, type LeftPanel } from "@nextlyhq/builder";
+import "@nextlyhq/builder/styles.css";
+
+/**
+ * The shell, with every slot filled by an inert marker a test can find.
+ *
+ * Split from the route so the route itself stays a server component and can
+ * call `notFound()` before any of this reaches the client. A `"use client"`
+ * route could still gate, but the gate would then ship to the browser along
+ * with the harness it is meant to withhold.
+ *
+ * Slot contents are deliberately inert. Anything interactive here would be
+ * testing the harness rather than the shell.
+ */
+export function BuilderShellHarness() {
+  return (
+    <div style={{ height: "100vh" }}>
+      <BuilderShell
+        onExit={() => {
+          // Recorded in the DOM rather than navigating: the assertion is that
+          // the shell REPORTS the intent, and a real navigation would take the
+          // test off the page it is measuring.
+          document.body.setAttribute("data-shell-exited", "true");
+        }}
+        topBar={<span data-testid="top-bar-slot">Top bar slot</span>}
+        breadcrumb={<span data-testid="breadcrumb-slot">Breadcrumb slot</span>}
+        inspector={<div data-testid="inspector-slot">Inspector slot</div>}
+        renderPanel={(panel: LeftPanel) => (
+          <div data-testid="panel-slot" data-panel={panel}>
+            {panel} slot
+          </div>
+        )}
+      >
+        <div data-testid="canvas-slot">Canvas slot</div>
+      </BuilderShell>
+    </div>
+  );
+}

--- a/apps/playground/src/app/builder-shell/harness.tsx
+++ b/apps/playground/src/app/builder-shell/harness.tsx
@@ -1,6 +1,15 @@
 "use client";
 
 import { BuilderShell, type LeftPanel } from "@nextlyhq/builder";
+// The design system's sheet FIRST, then the editor's, which supplements it.
+// `@nextlyhq/builder/styles.css` deliberately ships neither the `--nx-*` tokens
+// nor the base reset, because the host already loads a sheet that owns both and
+// a second copy would make the result depend on which one won. This route is
+// that host: the playground's own `globals.css` says in as many words that it
+// must not define the design-system tokens, so without this import the shell
+// renders with its colours resolving to nothing — which is precisely what it
+// was doing here.
+import "@nextlyhq/ui/styles.css";
 import "@nextlyhq/builder/styles.css";
 
 /**

--- a/apps/playground/src/app/builder-shell/page.tsx
+++ b/apps/playground/src/app/builder-shell/page.tsx
@@ -1,0 +1,34 @@
+import { notFound } from "next/navigation";
+
+import { BuilderShellHarness } from "./harness";
+
+/**
+ * A harness route for the editor shell's layout.
+ *
+ * The shell's guarantees are geometric — panel widths inside their bounds, the
+ * canvas keeping its floor, widths surviving a reload, focus moving between
+ * regions — and none of them is checkable from a unit test: jsdom reports every
+ * element as zero-sized and applies no stylesheet, so an assertion about a
+ * width passes whatever the CSS does. They need a real browser, which needs a
+ * real route.
+ *
+ * Deliberately a HARNESS rather than the eventual editor. The shell's real host
+ * is the page-builder plugin's admin route, and that route needs an inserter, a
+ * layers tree and an inspector that do not exist yet. Waiting for them would
+ * mean shipping the shell unverified; testing through a harness verifies the
+ * shell itself, with the slots filled by markers a test can find. When the real
+ * host exists this route stays, because it keeps testing the shell rather than
+ * the editor built on it.
+ *
+ * The slot contents are intentionally inert. Anything interactive here would be
+ * testing the harness.
+ */
+export default function BuilderShellHarnessRoute() {
+  // GATED, for the reason the style-fixture plugin had to be: a dev-only route
+  // under `src/app/` is always reachable in `pnpm dev:app` and indistinguishable
+  // from product. That exact shape put a test-double plugin into a
+  // contributor's real plugins list. Same env-var gate as
+  // `NEXTLY_E2E_STYLE_FIXTURE`, so the two are recognisable as one convention.
+  if (process.env.NEXTLY_E2E_SHELL_HARNESS !== "1") notFound();
+  return <BuilderShellHarness />;
+}

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -114,6 +114,10 @@ export default defineConfig({
       // double does not appear in a contributor's plugins list or inject a
       // showcase section into the Posts collection.
       NEXTLY_E2E_STYLE_FIXTURE: "1",
+      // The builder-shell harness route, gated the same way and for the same
+      // reason: a dev-only route under `src/app/` is otherwise reachable in
+      // `pnpm dev:app` and indistinguishable from product.
+      NEXTLY_E2E_SHELL_HARNESS: "1",
     },
   },
 

--- a/e2e/tests/shell/driver.ts
+++ b/e2e/tests/shell/driver.ts
@@ -1,0 +1,126 @@
+/**
+ * Reading the editor shell's geometry from a real browser.
+ *
+ * SEPARATE from `tests/canvas/driver.ts` on purpose. That one models a canvas —
+ * drag mechanics, frame origin, zoom — and exists so a canvas implementation can
+ * be swapped without editing its specs. Teaching it about rails and inspectors
+ * would give it two reasons to change and break that swap. This models the
+ * shell around the canvas, and the two share nothing but the page.
+ *
+ * Every reader here returns a MEASURED number rather than a class name or a
+ * style attribute. A shell whose CSS never loaded still carries its classes, and
+ * a test asserting on them passes over an unstyled page — which is the exact
+ * failure the unit tests already cannot see and this file exists to catch.
+ *
+ * @module tests/shell/driver
+ */
+import type { Locator, Page } from "@playwright/test";
+
+/** Where the harness mounts the shell. */
+export const SHELL_PATH = "/builder-shell";
+
+/** The regions the shell lays out, by their accessible names. */
+export const REGION_NAMES = {
+  rail: "Editor panels",
+  panel: null,
+  canvas: "Canvas",
+  inspector: "Inspector",
+} as const;
+
+export interface ShellDriver {
+  goto: () => Promise<void>;
+  /** A rail button by its label. */
+  railItem: (label: string) => Locator;
+  /** The measured width of a region, in CSS pixels. */
+  widthOf: (
+    region: "rail" | "panel" | "canvas" | "inspector"
+  ) => Promise<number>;
+  /** Whether the left panel is rendered at all. */
+  panelIsOpen: () => Promise<boolean>;
+  /** The accessible name of the region currently holding focus, if any. */
+  focusedRegion: () => Promise<string | null>;
+  /** Drag a separator by a pixel delta along the horizontal axis. */
+  dragSeparator: (index: number, deltaX: number) => Promise<void>;
+}
+
+/**
+ * Locates a region by role and name.
+ *
+ * The left panel is found by its OPEN panel's name rather than a fixed one,
+ * because the shell names that region after whatever the rail selected — which
+ * is the behaviour a screen-reader user depends on and therefore worth reading
+ * the same way.
+ */
+function regionLocator(page: Page, region: keyof typeof REGION_NAMES): Locator {
+  switch (region) {
+    case "rail":
+      return page.getByRole("navigation", { name: REGION_NAMES.rail });
+    case "canvas":
+      return page.getByRole("main", { name: REGION_NAMES.canvas });
+    case "inspector":
+      return page.getByRole("complementary", { name: REGION_NAMES.inspector });
+    case "panel":
+      return page.getByTestId("panel-slot");
+  }
+}
+
+export function createShellDriver(page: Page): ShellDriver {
+  return {
+    async goto() {
+      await page.goto(SHELL_PATH);
+      // Waits for the shell rather than for the network: the shell restores
+      // preferences in an effect after mount, so a test that measured on
+      // `load` would read the defaults and call them the restored values.
+      await page
+        .getByRole("navigation", { name: REGION_NAMES.rail })
+        .waitFor({ state: "visible" });
+    },
+
+    railItem(label) {
+      return page.getByRole("button", { name: label, exact: true });
+    },
+
+    async widthOf(region) {
+      const box = await regionLocator(page, region).boundingBox();
+      if (box === null) {
+        throw new Error(
+          `The ${region} region has no layout box. A region that is present in ` +
+            `the DOM but has no box is the unstyled-page failure this driver ` +
+            `measures rather than reads classes to avoid.`
+        );
+      }
+      return box.width;
+    },
+
+    async panelIsOpen() {
+      return (await page.getByTestId("panel-slot").count()) > 0;
+    },
+
+    async focusedRegion() {
+      return page.evaluate(() => {
+        const active = document.activeElement;
+        if (active === null) return null;
+        // The nearest ancestor carrying an accessible name that the shell set.
+        const region = active.closest<HTMLElement>("[aria-label]");
+        return region?.getAttribute("aria-label") ?? null;
+      });
+    },
+
+    async dragSeparator(index, deltaX) {
+      const separator = page.getByRole("separator").nth(index);
+      const box = await separator.boundingBox();
+      if (box === null)
+        throw new Error(`Separator ${index} has no layout box.`);
+
+      const startX = box.x + box.width / 2;
+      const startY = box.y + box.height / 2;
+      await page.mouse.move(startX, startY);
+      await page.mouse.down();
+      // Moved in steps rather than teleported. A splitter that tracks pointer
+      // MOTION behaves differently under a single jump, and motion is what a
+      // person produces.
+      await page.mouse.move(startX + deltaX, startY, { steps: 10 });
+      await page.mouse.up();
+    },
+  };
+}

--- a/e2e/tests/shell/shell.spec.ts
+++ b/e2e/tests/shell/shell.spec.ts
@@ -12,15 +12,27 @@
  * the stylesheet failed to ship at all — which was a real defect in this
  * package's first build.
  */
+import {
+  MIN_CANVAS_WIDTH,
+  MIN_SHELL_WIDTH,
+  PANEL_BOUNDS,
+  RAIL_WIDTH,
+} from "@nextlyhq/builder/shell-state";
 import { expect, test } from "@playwright/test";
 
 import { createShellDriver } from "./driver";
 
-const MIN_SHELL_WIDTH = 1280;
-const MIN_CANVAS_WIDTH = 480;
-const RAIL_WIDTH = 48;
-const LEFT_BOUNDS = { min: 240, max: 480 };
-const INSPECTOR_BOUNDS = { min: 280, max: 520 };
+/**
+ * The bounds come from the package, not from a second copy of the numbers.
+ *
+ * Restating them here made this file agree with the shell on the day it was
+ * written and never afterwards: widening a panel's maximum in `shell-state.ts`
+ * would leave these assertions passing against the OLD bound, so the one test
+ * that measures a real browser would go on certifying a layout the component no
+ * longer produces.
+ */
+const LEFT_BOUNDS = PANEL_BOUNDS.left;
+const INSPECTOR_BOUNDS = PANEL_BOUNDS.inspector;
 
 test.describe("the shell's regions", () => {
   test.use({ viewport: { width: 1440, height: 900 } });
@@ -65,24 +77,41 @@ test.describe("the shell's regions", () => {
     );
   });
 
-  test("the stylesheet actually loaded", async ({ page }) => {
+  test("both stylesheets actually loaded", async ({ page }) => {
     // The control for every measurement above, and not redundant with them: a
     // shell whose CSS never shipped still renders its markup, still carries its
     // class names, and lays out as a stack of full-width blocks. Regions would
-    // have boxes; they would simply be the wrong ones. This asserts the chrome
-    // token resolved, which only happens if the stylesheet arrived.
+    // have boxes; they would simply be the wrong ones.
+    //
+    // Read as a PAINTED colour rather than as the custom property. Asking for
+    // `--nx-builder-surface` returns the declared token stream — the literal
+    // text `var(--nx-muted)` — which is a non-empty string whether or not
+    // `--nx-muted` is defined anywhere. That assertion passed while the harness
+    // was loading no design-system stylesheet at all, certifying the one thing
+    // it existed to rule out. `background-color` is resolved by the browser, so
+    // it can only be a real colour once the whole chain is present.
     const shell = createShellDriver(page);
     await shell.goto();
 
-    const surface = await page.evaluate(() => {
+    const painted = await page.evaluate(() => {
       const chrome = document.querySelector(".nx-builder-chrome");
       if (chrome === null) return null;
-      return getComputedStyle(chrome)
-        .getPropertyValue("--nx-builder-surface")
-        .trim();
+      const styles = getComputedStyle(chrome);
+      return {
+        background: styles.backgroundColor,
+        // Proves the editor's own sheet is present too: this class is emitted
+        // only by the builder's stylesheet, so the two halves of the contract
+        // are checked separately rather than inferred from one another.
+        display: styles.display,
+      };
     });
-    expect(surface).not.toBeNull();
-    expect(surface).not.toBe("");
+
+    expect(painted).not.toBeNull();
+    // An unresolvable `var()` computes to the initial value — transparent —
+    // which is exactly what a missing design system produces.
+    expect(painted?.background).not.toBe("rgba(0, 0, 0, 0)");
+    expect(painted?.background).not.toBe("transparent");
+    expect(painted?.display).toBe("flex");
   });
 });
 

--- a/e2e/tests/shell/shell.spec.ts
+++ b/e2e/tests/shell/shell.spec.ts
@@ -1,0 +1,176 @@
+/**
+ * The shell's layout, measured in a real browser.
+ *
+ * These are the guarantees the unit suite CANNOT make. jsdom reports every
+ * element as zero-sized and applies no stylesheet, so `packages/builder`'s
+ * component tests can decide which panel is open and what the rail announces,
+ * and can say nothing about whether anything is where it belongs. Every
+ * assertion here reads a measured box.
+ *
+ * That split is deliberate rather than incidental: a component test asserting
+ * "the panel is 300px" in jsdom passes whatever the CSS does, including when
+ * the stylesheet failed to ship at all — which was a real defect in this
+ * package's first build.
+ */
+import { expect, test } from "@playwright/test";
+
+import { createShellDriver } from "./driver";
+
+const MIN_SHELL_WIDTH = 1280;
+const MIN_CANVAS_WIDTH = 480;
+const RAIL_WIDTH = 48;
+const LEFT_BOUNDS = { min: 240, max: 480 };
+const INSPECTOR_BOUNDS = { min: 280, max: 520 };
+
+test.describe("the shell's regions", () => {
+  test.use({ viewport: { width: 1440, height: 900 } });
+
+  test("lays out rail, canvas and inspector at their declared sizes", async ({
+    page,
+  }) => {
+    const shell = createShellDriver(page);
+    await shell.goto();
+
+    // The rail is fixed. Measured rather than read from a style attribute: an
+    // unstyled page still carries the attribute.
+    expect(await shell.widthOf("rail")).toBeCloseTo(RAIL_WIDTH, 0);
+
+    const inspector = await shell.widthOf("inspector");
+    expect(inspector).toBeGreaterThanOrEqual(INSPECTOR_BOUNDS.min);
+    expect(inspector).toBeLessThanOrEqual(INSPECTOR_BOUNDS.max);
+
+    // The canvas holds its floor with no panel open.
+    expect(await shell.widthOf("canvas")).toBeGreaterThanOrEqual(
+      MIN_CANVAS_WIDTH
+    );
+  });
+
+  test("keeps the canvas above its floor once a panel is open", async ({
+    page,
+  }) => {
+    // The joint constraint, which is the whole reason per-panel bounds were the
+    // wrong model: both panels at their individual maximums would leave the
+    // canvas narrower than either of them.
+    const shell = createShellDriver(page);
+    await shell.goto();
+
+    await shell.railItem("Layers").click();
+    expect(await shell.panelIsOpen()).toBe(true);
+
+    const panel = await shell.widthOf("panel");
+    expect(panel).toBeGreaterThanOrEqual(LEFT_BOUNDS.min);
+    expect(panel).toBeLessThanOrEqual(LEFT_BOUNDS.max);
+    expect(await shell.widthOf("canvas")).toBeGreaterThanOrEqual(
+      MIN_CANVAS_WIDTH
+    );
+  });
+
+  test("the stylesheet actually loaded", async ({ page }) => {
+    // The control for every measurement above, and not redundant with them: a
+    // shell whose CSS never shipped still renders its markup, still carries its
+    // class names, and lays out as a stack of full-width blocks. Regions would
+    // have boxes; they would simply be the wrong ones. This asserts the chrome
+    // token resolved, which only happens if the stylesheet arrived.
+    const shell = createShellDriver(page);
+    await shell.goto();
+
+    const surface = await page.evaluate(() => {
+      const chrome = document.querySelector(".nx-builder-chrome");
+      if (chrome === null) return null;
+      return getComputedStyle(chrome)
+        .getPropertyValue("--nx-builder-surface")
+        .trim();
+    });
+    expect(surface).not.toBeNull();
+    expect(surface).not.toBe("");
+  });
+});
+
+test.describe("panel widths survive a reload", () => {
+  test.use({ viewport: { width: 1440, height: 900 } });
+
+  test("restores a dragged width", async ({ page }) => {
+    // The property the preference port exists for. Persisted PROPORTIONALLY, so
+    // the restored width is compared with a tolerance rather than by equality:
+    // the layout is stored as percentages and re-resolved against the viewport.
+    const shell = createShellDriver(page);
+    await shell.goto();
+    await shell.railItem("Layers").click();
+
+    const before = await shell.widthOf("panel");
+    await shell.dragSeparator(0, 80);
+    const dragged = await shell.widthOf("panel");
+    // The drag has to have moved something, or the reload assertion below is
+    // comparing a width to itself and passes without persisting anything.
+    expect(Math.abs(dragged - before)).toBeGreaterThan(20);
+
+    // A reload, NOT a second navigation, and deliberately in the SAME test.
+    // Each test gets a fresh context seeded from the sign-in snapshot captured
+    // once by `global-setup`, so `localStorage` does not carry between tests —
+    // split across two tests, the second would start clean and pass or fail for
+    // a reason that has nothing to do with persistence.
+    await page.reload();
+    await page
+      .getByRole("navigation", { name: "Editor panels" })
+      .waitFor({ state: "visible" });
+
+    expect(await shell.panelIsOpen()).toBe(true);
+    expect(await shell.widthOf("panel")).toBeCloseTo(dragged, -1);
+  });
+});
+
+test.describe("keyboard region cycling", () => {
+  test.use({ viewport: { width: 1440, height: 900 } });
+
+  test("F6 moves between the regions that exist", async ({ page }) => {
+    const shell = createShellDriver(page);
+    await shell.goto();
+
+    await shell.railItem("Layers").click();
+    await page.getByRole("navigation", { name: "Editor panels" }).focus();
+
+    await page.keyboard.press("F6");
+    expect(await shell.focusedRegion()).toBe("Layers");
+
+    await page.keyboard.press("F6");
+    expect(await shell.focusedRegion()).toBe("Canvas");
+
+    await page.keyboard.press("F6");
+    expect(await shell.focusedRegion()).toBe("Inspector");
+  });
+
+  test("F6 skips the panel when nothing is open", async ({ page }) => {
+    // The absent-region case. Cycling a static list would stop here, focusing
+    // nothing, and the key would look broken from the second press on.
+    const shell = createShellDriver(page);
+    await shell.goto();
+    expect(await shell.panelIsOpen()).toBe(false);
+
+    await page.getByRole("navigation", { name: "Editor panels" }).focus();
+    await page.keyboard.press("F6");
+
+    expect(await shell.focusedRegion()).toBe("Canvas");
+  });
+});
+
+test.describe("a viewport below the supported width", () => {
+  // Explicitly 100px inside the degraded range, never the default. The
+  // `Desktop Chrome` device viewport is exactly 1280x720 — precisely the
+  // breakpoint — which is the one width where a `min-width: 1280px` rule and
+  // its complement disagree about which applies, so the default would assert
+  // against the boundary itself rather than against the behaviour.
+  test.use({ viewport: { width: MIN_SHELL_WIDTH - 100, height: 900 } });
+
+  test("says where to edit instead of compressing", async ({ page }) => {
+    const shell = createShellDriver(page);
+    await page.goto("/builder-shell");
+
+    await expect(page.getByText(/needs a wider screen/i)).toBeVisible();
+    await expect(page.getByRole("main", { name: "Canvas" })).toHaveCount(0);
+    // The way out has to survive every degraded state.
+    await expect(
+      page.getByRole("button", { name: "Exit editor" })
+    ).toBeVisible();
+    void shell;
+  });
+});

--- a/e2e/tests/shell/shell.spec.ts
+++ b/e2e/tests/shell/shell.spec.ts
@@ -146,6 +146,35 @@ test.describe("panel widths survive a reload", () => {
     expect(await shell.panelIsOpen()).toBe(true);
     expect(await shell.widthOf("panel")).toBeCloseTo(dragged, -1);
   });
+
+  test("restores a width dragged with no panel open", async ({ page }) => {
+    // The DEFAULT state, and the one the test above cannot speak for.
+    //
+    // Opening a panel first changes the group's topology, which re-registers
+    // every panel — and registration is the only moment `react-resizable-panels`
+    // reads `defaultLayout`. So that test would pass even with restoration
+    // entirely broken, because the click, not the restore, is what applied the
+    // stored value. Here nothing changes the panel set, so the only thing that
+    // can put the width back is restoration itself.
+    const shell = createShellDriver(page);
+    await shell.goto();
+    expect(await shell.panelIsOpen()).toBe(false);
+
+    const before = await shell.widthOf("inspector");
+    await shell.dragSeparator(0, -80);
+    const dragged = await shell.widthOf("inspector");
+    // Without this the reload assertion compares a width to itself and passes
+    // whether or not anything was ever persisted.
+    expect(Math.abs(dragged - before)).toBeGreaterThan(20);
+
+    await page.reload();
+    await page
+      .getByRole("navigation", { name: "Editor panels" })
+      .waitFor({ state: "visible" });
+
+    expect(await shell.panelIsOpen()).toBe(false);
+    expect(await shell.widthOf("inspector")).toBeCloseTo(dragged, -1);
+  });
 });
 
 test.describe("keyboard region cycling", () => {

--- a/e2e/tsconfig.json
+++ b/e2e/tsconfig.json
@@ -21,7 +21,12 @@
     // does not have. Mapped to source instead, which is what `packages/admin`
     // does for `nextly`.
     "paths": {
-      "@nextlyhq/builder": ["../packages/builder/src"]
+      "@nextlyhq/builder": ["../packages/builder/src"],
+      // The shell's declared bounds, so the browser spec asserts against the
+      // numbers the component actually ships rather than a second copy of them.
+      // Its own subpath rather than the root barrel: that entry is a client
+      // component pulling in React, and this module is plain arithmetic.
+      "@nextlyhq/builder/shell-state": ["../packages/builder/src/shell-state"]
     }
   },
   // Everything, deliberately. The two page-builder specs that rotted did so

--- a/e2e/tsconfig.json
+++ b/e2e/tsconfig.json
@@ -9,6 +9,11 @@
     // included and then skipped — which is the same silent gap the comment
     // under `include` exists to avoid.
     "allowJs": true,
+    // The builder is mapped to SOURCE below, so its `.tsx` modules are
+    // typechecked here even though nothing in this package writes JSX. Without
+    // this, adding any component to that package breaks `e2e`'s check-types
+    // with `--jsx is not set` — a failure in a package that changed nothing.
+    "jsx": "react-jsx",
     "baseUrl": ".",
     // The builder is imported for its coordinate mapping, and `check-types`
     // deliberately does not build dependencies first — so resolving the package

--- a/packages/builder/README.md
+++ b/packages/builder/README.md
@@ -92,6 +92,15 @@ import "@nextlyhq/builder/styles.css"; // required — see below
 </BuilderShell>;
 ```
 
+`@nextlyhq/builder/styles.css` is COMPILED, not a token file: it carries the
+shell's utility rules as well as the `--nx-builder-*` custom properties, so the
+package works standalone with no Tailwind setup in the host.
+
+If you DO use Tailwind and want to re-theme or extend the chrome, apply
+`@nextlyhq/ui/tailwind-preset` and add this package to your `@source` scan. That
+is optional — the compiled sheet already works — and it is what lets your own
+classes sit alongside the shell's without a second Tailwind build.
+
 **The stylesheet is not optional and nothing will tell you if you forget it.**
 The shell renders its markup, carries its class names, and lays out as a stack
 of full-width blocks — which reads as a layout bug rather than a missing import.
@@ -139,6 +148,25 @@ violated, because the constraint was never per-panel.
 The persisted layout is PROPORTIONAL. A pixel layout is wrong on the next
 monitor; the pixel bounds still hold because the library re-applies them to
 whatever the proportions resolve to.
+
+### Server-safe subpaths
+
+The root entry ships `"use client"`, because the shell is a client component and
+the directive has to survive bundling. Two modules contain no React and are
+published separately so that banner does not reach them:
+
+```ts
+import { fitsFullShell, PANEL_BOUNDS } from "@nextlyhq/builder/shell-state";
+import { canvasRectToHost } from "@nextlyhq/builder/geometry";
+```
+
+Both are importable from a Server Component. Neither imports anything at all.
+
+This is the same split, for the same reason, as `@nextlyhq/ui`'s `./color` and
+`./utils`. It is not hypothetical tidiness: the geometry already had a consumer
+that only worked because it resolved this package through a tsconfig path
+mapping to source, bypassing the published entry — so the export map was
+advertising something the artifact could not deliver.
 
 ### Frame geometry
 

--- a/packages/builder/README.md
+++ b/packages/builder/README.md
@@ -82,7 +82,7 @@ bumps this package in lockstep with its siblings.
 ### The editor shell
 
 ```tsx
-import { BuilderShell } from "@nextlyhq/builder";
+import { BuilderShell } from "@nextlyhq/builder/shell";
 import "@nextlyhq/ui/styles.css"; // the design system's — see below
 import "@nextlyhq/builder/styles.css"; // the editor chrome's
 
@@ -172,18 +172,29 @@ The persisted layout is PROPORTIONAL. A pixel layout is wrong on the next
 monitor; the pixel bounds still hold because the library re-applies them to
 whatever the proportions resolve to.
 
-### Server-safe subpaths
+### Where the client boundary is
 
-The root entry ships `"use client"`, because the shell is a client component and
-the directive has to survive bundling. Two modules contain no React and are
-published separately so that banner does not reach them:
+**The root entry is server-safe.** `"use client"` is carried by
+`@nextlyhq/builder/shell` alone, which is the only entry containing React:
 
 ```ts
+// Client. The shell is a client component.
+import { BuilderShell } from "@nextlyhq/builder/shell";
+
+// Server-callable. No React in any of them.
+import { BUILDER_PACKAGE_NAME, rectToHost } from "@nextlyhq/builder";
 import { fitsFullShell, PANEL_BOUNDS } from "@nextlyhq/builder/shell-state";
-import { canvasRectToHost } from "@nextlyhq/builder/geometry";
+import { rectToHost } from "@nextlyhq/builder/geometry";
 ```
 
-Both are importable from a Server Component. Neither imports anything at all.
+The split is not tidiness. A banner applies to a whole artifact and everything
+it re-exports, so putting the shell in the root barrel turned the frame geometry
+— plain arithmetic, and public here before the shell existed — into client
+references a Server Component could no longer call, while the export map went on
+advertising callable functions.
+
+`BuilderShellProps` is still described by the root entry: a type is erased, so
+it carries no boundary with it.
 
 This is the same split, for the same reason, as `@nextlyhq/ui`'s `./color` and
 `./utils`. It is not hypothetical tidiness: the geometry already had a consumer

--- a/packages/builder/README.md
+++ b/packages/builder/README.md
@@ -3,12 +3,16 @@
 The visual page-builder editor: the shell, the canvas, and the op store that
 everything in it either produces or reads.
 
-**The editor itself has not landed.** What ships today is the frame geometry —
-the one mapping between the canvas frame and the host page — plus the package
-name constant. See [Public surface](#public-surface). The package was created
-ahead of the editor so its name could be claimed on npm: trusted publishing
-cannot perform a package's first publish, and the bootstrap script will not
-claim a name that is not already a workspace package.
+**The editor is landing in slices, and every export is `@experimental`.** What
+ships today is the editor SHELL — the rail, the switched left panel, the canvas
+slot, the inspector and the bars around them — together with the frame geometry
+that maps between the canvas frame and the host page, and the package name
+constant. The canvas and the op store are still to come. See
+[Public surface](#public-surface).
+
+The package was created ahead of any of it so its name could be claimed on npm:
+trusted publishing cannot perform a package's first publish, and the bootstrap
+script will not claim a name that is not already a workspace package.
 
 ## What this package is not
 
@@ -79,7 +83,8 @@ bumps this package in lockstep with its siblings.
 
 ```tsx
 import { BuilderShell } from "@nextlyhq/builder";
-import "@nextlyhq/builder/styles.css"; // required — see below
+import "@nextlyhq/ui/styles.css"; // the design system's — see below
+import "@nextlyhq/builder/styles.css"; // the editor chrome's
 
 <BuilderShell
   onExit={() => router.push("/admin/pages")}
@@ -92,9 +97,27 @@ import "@nextlyhq/builder/styles.css"; // required — see below
 </BuilderShell>;
 ```
 
-`@nextlyhq/builder/styles.css` is COMPILED, not a token file: it carries the
-shell's utility rules as well as the `--nx-builder-*` custom properties, so the
-package works standalone with no Tailwind setup in the host.
+**Two stylesheets, and both are required.**
+
+`@nextlyhq/builder/styles.css` is COMPILED rather than a token file: it carries
+the shell's own utility rules as well as the `--nx-builder-*` custom properties,
+so the chrome lays out with no Tailwind setup in the host.
+
+It SUPPLEMENTS the design system's stylesheet rather than restating it, so
+`@nextlyhq/ui/styles.css` is loaded alongside — or the admin's stylesheet, which
+already contains it, when the editor is mounted inside the admin. That sheet
+owns three things this one deliberately does not ship:
+
+- the `--nx-*` tokens the chrome's own colours are derived from,
+- the base reset the components are designed against,
+- the rules for the primitives the shell renders — tooltips and drag handles.
+
+Shipping a second copy of any of them would make the result depend on which
+stylesheet loaded last, and would break re-theming: the point of deriving from
+`--nx-*` is that a host which re-themes the admin moves the editor with it.
+
+If the design system's sheet is missing, the shell says so in the console in
+development rather than leaving you to diagnose colours that resolve to nothing.
 
 If you DO use Tailwind and want to re-theme or extend the chrome, apply
 `@nextlyhq/ui/tailwind-preset` and add this package to your `@source` scan. That

--- a/packages/builder/README.md
+++ b/packages/builder/README.md
@@ -75,6 +75,71 @@ which packages a host loaded. The name and not the version: a version literal in
 source would be stale one release after it was written, because every release
 bumps this package in lockstep with its siblings.
 
+### The editor shell
+
+```tsx
+import { BuilderShell } from "@nextlyhq/builder";
+import "@nextlyhq/builder/styles.css"; // required — see below
+
+<BuilderShell
+  onExit={() => router.push("/admin/pages")}
+  renderPanel={panel => <MyPanel kind={panel} />}
+  inspector={<MyInspector />}
+  topBar={<MyTopBar />}
+  breadcrumb={<MyBreadcrumb />}
+>
+  <MyCanvas />
+</BuilderShell>;
+```
+
+**The stylesheet is not optional and nothing will tell you if you forget it.**
+The shell renders its markup, carries its class names, and lays out as a stack
+of full-width blocks — which reads as a layout bug rather than a missing import.
+It is a separate subpath because a stylesheet a bundler cannot tree-shake should
+be a decision the host makes, not a side effect of importing a component.
+
+**The shell is presentational, and that is a contract rather than a current
+state.** It owns which panel is open and how wide the regions are — chrome
+state, its own business. It owns nothing about the document, so selection
+arrives as a prop.
+
+That split is not tidiness. Document ops INVALIDATE selection: a remove deletes
+the selected node, a move relocates it. Selection held inside the shell would
+have to be updated in step with every op, which is two things changing together.
+Held outside, it can be DERIVED from the post-op document — "does this id still
+resolve?" — which cannot go out of step because there is only one thing to read.
+
+Content arrives as slots, so a layers panel, an inserter and an inspector can be
+built without this component changing. It knows the SHAPE of the editor and
+never what fills it.
+
+**Chrome preferences go through a port, not `localStorage`.** `store` takes
+`{ read, write }`; the default reads `localStorage` in a browser and remembers
+nothing anywhere else, so a server render is a default rather than a crash. A
+host that already keeps user preferences server-side supplies its own and the
+shell needs no change.
+
+Preferences are restored AFTER mount, deliberately. Reading them in the state
+initializer makes the server emit the defaults and the first client render emit
+the restored layout, which React treats as a hydration failure and repairs by
+discarding the subtree.
+
+**Below 1280px the shell does not compress.** It says where to edit instead and
+keeps the exit reachable. An editor that merely gets cramped is worse than one
+that states its requirement, because the author otherwise discovers the limit by
+failing at a task.
+
+**Widths are solved by `react-resizable-panels`, not here.** The bounds are
+declared — `PANEL_BOUNDS`, `MIN_CANVAS_WIDTH`, `RAIL_WIDTH` — and handed to it.
+The canvas floor is expressed as the canvas panel's own minimum, which is what
+makes it a joint constraint: at 1280px both panels at their individual maximums
+would leave the canvas narrower than either of them, with no per-panel bound
+violated, because the constraint was never per-panel.
+
+The persisted layout is PROPORTIONAL. A pixel layout is wrong on the next
+monitor; the pixel bounds still hold because the library re-applies them to
+whatever the proportions resolve to.
+
 ### Frame geometry
 
 The canvas renders inside an iframe while the editor's chrome — insertion
@@ -137,6 +202,10 @@ pnpm run build         # tsup
 ```
 
 ## Peer dependencies
+
+`lucide-react` for the rail's icons, declared as a peer for the reason
+`@nextlyhq/ui` declares it as one: an icon set resolved once by the host rather
+than bundled per package.
 
 React 19, matching the renderer it draws with. `@nextlyhq/blocks-react` requires
 `react: ^19.0.0`, and it is a dependency here rather than a peer, so a React 18

--- a/packages/builder/package.json
+++ b/packages/builder/package.json
@@ -25,6 +25,11 @@
       "import": "./dist/index.mjs",
       "default": "./dist/index.mjs"
     },
+    "./shell": {
+      "types": "./dist/shell.d.ts",
+      "import": "./dist/shell.mjs",
+      "default": "./dist/shell.mjs"
+    },
     "./styles.css": "./dist/builder-chrome.css",
     "./geometry": {
       "types": "./dist/geometry.d.ts",

--- a/packages/builder/package.json
+++ b/packages/builder/package.json
@@ -13,6 +13,9 @@
     "url": "https://github.com/nextlyhq/nextly/issues"
   },
   "type": "module",
+  "sideEffects": [
+    "**/*.css"
+  ],
   "main": "dist/index.mjs",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
@@ -21,7 +24,8 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
       "default": "./dist/index.mjs"
-    }
+    },
+    "./styles.css": "./dist/builder-chrome.css"
   },
   "files": [
     "dist"

--- a/packages/builder/package.json
+++ b/packages/builder/package.json
@@ -46,15 +46,16 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsup && tsup --config tsup.server-safe.config.ts && pnpm run build:css",
-    "dev": "tsup --watch",
+    "build": "rimraf dist && tsup && tsup --config tsup.server-safe.config.ts && pnpm run build:css",
+    "dev": "tsup --watch & tsup --config tsup.server-safe.config.ts --watch & pnpm run dev:css & wait",
     "check-types": "tsc --noEmit",
     "lint": "eslint . --max-warnings 0",
     "lint:fix": "eslint . --fix",
     "test": "vitest run",
     "test:watch": "vitest",
     "clean": "rimraf dist",
-    "build:css": "tailwindcss -i src/styles/builder-chrome.css -o dist/builder-chrome.css --minify"
+    "build:css": "tailwindcss -i src/styles/builder-chrome.css -o dist/builder-chrome.css --minify",
+    "dev:css": "tailwindcss -i src/styles/builder-chrome.css -o dist/builder-chrome.css --watch"
   },
   "engines": {
     "node": "^20.19.0 || ^22.12.0 || >=24.0.0"

--- a/packages/builder/package.json
+++ b/packages/builder/package.json
@@ -47,7 +47,7 @@
   ],
   "scripts": {
     "build": "rimraf dist && tsup && tsup --config tsup.server-safe.config.ts && pnpm run build:css",
-    "dev": "tsup --watch & tsup --config tsup.server-safe.config.ts --watch & pnpm run dev:css & wait",
+    "dev": "node scripts/dev.mjs",
     "check-types": "tsc --noEmit",
     "lint": "eslint . --max-warnings 0",
     "lint:fix": "eslint . --fix",

--- a/packages/builder/package.json
+++ b/packages/builder/package.json
@@ -25,20 +25,31 @@
       "import": "./dist/index.mjs",
       "default": "./dist/index.mjs"
     },
-    "./styles.css": "./dist/builder-chrome.css"
+    "./styles.css": "./dist/builder-chrome.css",
+    "./geometry": {
+      "types": "./dist/geometry.d.ts",
+      "import": "./dist/geometry.mjs",
+      "default": "./dist/geometry.mjs"
+    },
+    "./shell-state": {
+      "types": "./dist/shell-state.d.ts",
+      "import": "./dist/shell-state.mjs",
+      "default": "./dist/shell-state.mjs"
+    }
   },
   "files": [
     "dist"
   ],
   "scripts": {
-    "build": "tsup",
+    "build": "tsup && tsup --config tsup.server-safe.config.ts && pnpm run build:css",
     "dev": "tsup --watch",
     "check-types": "tsc --noEmit",
     "lint": "eslint . --max-warnings 0",
     "lint:fix": "eslint . --fix",
     "test": "vitest run",
     "test:watch": "vitest",
-    "clean": "rimraf dist"
+    "clean": "rimraf dist",
+    "build:css": "tailwindcss -i src/styles/builder-chrome.css -o dist/builder-chrome.css --minify"
   },
   "engines": {
     "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
@@ -60,6 +71,7 @@
     "@nextlyhq/plugin-sdk": "workspace:*",
     "@nextlyhq/tsconfig": "workspace:*",
     "@nextlyhq/ui": "workspace:*",
+    "@tailwindcss/cli": "^4.3.2",
     "@testing-library/react": "^16.3.0",
     "@types/node": "^20.19.17",
     "@types/react": "19.2.0",
@@ -70,6 +82,7 @@
     "react": "19.2.0",
     "react-dom": "19.2.0",
     "rimraf": "^6.1.3",
+    "tailwindcss": "^4.3.2",
     "tsup": "^8.5.0",
     "typescript": "^5.9.3",
     "vitest": "^4.1.0"

--- a/packages/builder/scripts/dev.mjs
+++ b/packages/builder/scripts/dev.mjs
@@ -41,13 +41,18 @@ const children = PRODUCERS.map(({ label, args }) => {
     shell: true,
   });
   child.on("exit", code => {
-    // A watcher exiting means this dev session is already broken; the other two
-    // would otherwise keep running and look healthy.
-    if (code !== 0 && code !== null) {
-      console.error(`[builder] ${label} watcher exited with ${code}`);
-    }
+    // ANY exit is a failure here, including a clean one. These producers are
+    // meant to run until the developer stops them, so a watcher that returns 0
+    // — losing its input stream, say — has still stopped updating artifacts.
+    // Forwarding that 0 told the surrounding pnpm/turbo pipeline the builder
+    // task had SUCCEEDED while every artifact silently went stale, which is the
+    // half-working state this runner exists to make visible.
+    console.error(
+      `[builder] the ${label} watcher exited (code ${code ?? "null"}); ` +
+        `stopping the others, because artifacts are no longer being rebuilt.`
+    );
     stopAll();
-    process.exit(code ?? 1);
+    process.exit(code === 0 || code === null ? 1 : code);
   });
   return child;
 });

--- a/packages/builder/scripts/dev.mjs
+++ b/packages/builder/scripts/dev.mjs
@@ -1,0 +1,67 @@
+#!/usr/bin/env node
+
+/**
+ * Run this package's three watchers together, on every supported OS.
+ *
+ * `a & b & wait` is a POSIX shell construct. pnpm runs scripts through
+ * `cmd.exe` on Windows, where `&` is a SEQUENTIAL separator and `wait` is not a
+ * builtin at all — so the first watcher, which never exits by design, holds the
+ * line for ever and the other two never start. A Windows contributor was
+ * therefore left with exactly the stale artifacts the watchers exist to prevent:
+ * the root entry, the server-safe subpaths and the stylesheet all frozen at
+ * whatever the last full build produced, with no error to explain it.
+ *
+ * Node's `spawn` is the portable equivalent, and it is a dozen lines rather
+ * than a dependency.
+ *
+ * Three producers, because this package publishes three kinds of artifact from
+ * one `dist`: the client entry, the server-safe entries, and the compiled
+ * stylesheet. Cleaning belongs to `build`, never here — a clean under `--watch`
+ * would delete the other two producers' output on every rebuild.
+ */
+
+import { spawn } from "node:child_process";
+
+/** Each long-lived producer, with a label for whose output is whose. */
+const PRODUCERS = [
+  { label: "client", args: ["tsup", "--watch"] },
+  {
+    label: "server-safe",
+    args: ["tsup", "--config", "tsup.server-safe.config.ts", "--watch"],
+  },
+  { label: "css", args: ["pnpm", "run", "dev:css"] },
+];
+
+const children = PRODUCERS.map(({ label, args }) => {
+  const [command, ...rest] = args;
+  const child = spawn(command, rest, {
+    stdio: "inherit",
+    // Resolves `tsup` and `pnpm` through the platform's own lookup rules,
+    // including the `.cmd` shims npm writes on Windows.
+    shell: true,
+  });
+  child.on("exit", code => {
+    // A watcher exiting means this dev session is already broken; the other two
+    // would otherwise keep running and look healthy.
+    if (code !== 0 && code !== null) {
+      console.error(`[builder] ${label} watcher exited with ${code}`);
+    }
+    stopAll();
+    process.exit(code ?? 1);
+  });
+  return child;
+});
+
+function stopAll() {
+  for (const child of children) {
+    if (child.exitCode === null && child.signalCode === null) child.kill();
+  }
+}
+
+// Ctrl-C reaches this process; the children are separate and have to be told.
+for (const signal of ["SIGINT", "SIGTERM"]) {
+  process.on(signal, () => {
+    stopAll();
+    process.exit(0);
+  });
+}

--- a/packages/builder/src/builder-chrome.css
+++ b/packages/builder/src/builder-chrome.css
@@ -1,0 +1,70 @@
+/**
+ * The editor chrome's own token layer.
+ *
+ * Named `--nx-builder-*` and kept separate from `--nx-*` on purpose. The admin's
+ * tokens describe a CMS reading surface; the builder's chrome sits around a
+ * canvas showing the USER'S site, and the two have opposite jobs at the same
+ * moment: the canvas must look like the finished page, so the frame around it
+ * has to recede rather than compete. Sharing one palette makes every later
+ * chrome adjustment a change to the admin as well.
+ *
+ * Values derive from the admin tokens rather than restating colours, so a host
+ * that re-themes the admin moves the builder with it. The chrome is a SHIFT of
+ * that palette, not a second one.
+ *
+ * This layer is also where the ratified template-scope tint lands when there is
+ * a template scope to signal — PB-D17's "template scope = tinted chrome". It is
+ * a second value set for these variables, not a new component, which is why the
+ * F7 primitive list was the wrong home for it.
+ */
+
+.nx-builder-chrome {
+  /* The frame behind rail, panels and bars. Deliberately not `--nx-background`:
+     the canvas uses that, and the frame must read as a layer behind it. */
+  --nx-builder-surface: var(--nx-muted);
+  --nx-builder-surface-raised: var(--nx-background);
+  --nx-builder-border: var(--nx-border);
+  --nx-builder-text: var(--nx-foreground);
+  --nx-builder-text-muted: var(--nx-muted-foreground);
+  /* The rail's selected item, and the only accent the chrome spends. */
+  --nx-builder-accent: var(--nx-primary);
+  --nx-builder-accent-text: var(--nx-primary-foreground);
+
+  background-color: var(--nx-builder-surface);
+  color: var(--nx-builder-text);
+}
+
+/**
+ * Enhanced contrast, per the PB-D17 a11y addendum.
+ *
+ * Driven by the platform preference rather than a setting, because a user who
+ * has asked their OS for more contrast has already answered this question. The
+ * border is the token that moves: chrome boundaries at rest are deliberately
+ * quiet, and quiet is exactly what fails at higher contrast needs.
+ */
+@media (prefers-contrast: more) {
+  .nx-builder-chrome {
+    --nx-builder-border: var(--nx-foreground);
+    --nx-builder-text-muted: var(--nx-foreground);
+  }
+}
+
+/**
+ * Motion is opt-in, not opt-out.
+ *
+ * Panel switches and rail transitions animate only where the user has not asked
+ * for reduced motion. Written as a positive query rather than
+ * `prefers-reduced-motion: reduce` disabling things, so the default for an
+ * unstated preference is stillness.
+ */
+.nx-builder-chrome * {
+  transition: none;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .nx-builder-chrome [data-builder-animates] {
+    transition:
+      background-color 120ms ease,
+      color 120ms ease;
+  }
+}

--- a/packages/builder/src/builder-shell.test.tsx
+++ b/packages/builder/src/builder-shell.test.tsx
@@ -338,4 +338,110 @@ describe("a viewport too narrow for the shell", () => {
     fireEvent.click(screen.getByRole("button", { name: "Exit editor" }));
     expect(onExit).toHaveBeenCalledTimes(1);
   });
+
+  it("keeps the caller's slots mounted behind the notice", () => {
+    // Swapping the editor out for the notice unmounted every slot the host had
+    // given us, and React discards the state inside them. Narrowing a window is
+    // transient; widening it again must not hand back empty components while
+    // whatever the host was holding locally is gone, with nothing having told
+    // it the subtree was going away.
+    //
+    // Queried by test id rather than by role: the subtree is `hidden`, so a
+    // role query correctly refuses to see it and would report the unmounted
+    // case and the hidden case identically.
+    stubViewport(false);
+    render(
+      <BuilderShell onExit={vi.fn()} store={memoryStore()}>
+        <p data-testid="canvas-slot">the caller&apos;s canvas</p>
+      </BuilderShell>
+    );
+
+    expect(screen.getByText(/needs a wider screen/i)).toBeTruthy();
+    expect(screen.queryByTestId("canvas-slot")).not.toBeNull();
+  });
+
+  it("hides that subtree from pointer, keyboard and assistive technology", () => {
+    // The positive control for the test above. Keeping the slots mounted is
+    // only correct while they are also unreachable — a tab order that runs
+    // through an editor nobody can see is worse than the unmount was.
+    stubViewport(false);
+    render(
+      <BuilderShell onExit={vi.fn()} store={memoryStore()}>
+        <p data-testid="canvas-slot">the caller&apos;s canvas</p>
+      </BuilderShell>
+    );
+
+    const slot = screen.getByTestId("canvas-slot");
+    const hiddenWrapper = slot.closest("[hidden]");
+    expect(hiddenWrapper).not.toBeNull();
+    expect(hiddenWrapper?.hasAttribute("inert")).toBe(true);
+    // And the canvas is genuinely out of the accessibility tree.
+    expect(screen.queryByRole("main", { name: "Canvas" })).toBeNull();
+  });
+
+  it("keeps the class the caller positioned the shell with", () => {
+    // The className is how the host places the shell in its own layout — a grid
+    // area, a height, a border. Dropping it on this path let the notice escape
+    // the box the shell had been given.
+    stubViewport(false);
+    const { container } = render(
+      <BuilderShell
+        onExit={vi.fn()}
+        store={memoryStore()}
+        className="host-placed-me"
+      />
+    );
+
+    const notice = container.querySelector(".host-placed-me");
+    expect(notice).not.toBeNull();
+    expect(notice?.textContent).toMatch(/needs a wider screen/i);
+  });
+});
+
+describe("F6 while an editing control has focus", () => {
+  it("moves between regions from inside a text field", () => {
+    // The shortcut manager's default asks whether the first chord carries a
+    // modifier or is Escape, and answers no for a bare function key — so F6 was
+    // held back by any focused field. Moving between areas is exactly what an
+    // author needs while a field has focus, because it is how they get back out
+    // without reaching for the mouse.
+    renderShell({
+      children: <input data-testid="caption" aria-label="Caption" />,
+    });
+
+    const field = screen.getByTestId("caption") as HTMLInputElement;
+    field.focus();
+    expect(document.activeElement).toBe(field);
+
+    fireEvent.keyDown(field, { key: "F6" });
+
+    // Out of the field and onto a region. Which one depends on where the field
+    // sits in the cycle; that it LEFT the field is the property under test.
+    expect(document.activeElement).not.toBe(field);
+    expect(
+      (document.activeElement as HTMLElement | null)?.getAttribute("aria-label")
+    ).toBeTruthy();
+  });
+});
+
+describe("the preference store the caller supplies", () => {
+  it("follows a store that is swapped for another", () => {
+    // Capturing the caller's store in state pinned whichever one arrived first,
+    // so a host that swaps stores — signing into a second workspace, promoting
+    // a memory store to a persisted one — went on writing to the one it had
+    // replaced.
+    stubViewport(true);
+    const first = memoryStore();
+    const second = memoryStore();
+
+    const { rerender } = render(
+      <BuilderShell onExit={vi.fn()} store={first} />
+    );
+    rerender(<BuilderShell onExit={vi.fn()} store={second} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Layers" }));
+
+    expect(second.value).toContain("layers");
+    expect(first.value).toBeNull();
+  });
 });

--- a/packages/builder/src/builder-shell.test.tsx
+++ b/packages/builder/src/builder-shell.test.tsx
@@ -13,6 +13,7 @@
  * through the port rather than through `localStorage` reached for directly.
  */
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { renderToString } from "react-dom/server";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { BuilderShell } from "./builder-shell";
@@ -218,6 +219,78 @@ describe("preferences", () => {
     );
 
     expect(screen.queryByText(/panel$/)).toBeNull();
+  });
+});
+
+describe("the server render and the first client render agree", () => {
+  it("emits the defaults even when the store has preferences", () => {
+    // The hydration property, and it needs a real server render to state.
+    // Reading storage in the state initializer is the obvious shape: the server
+    // store answers null and emits no panel, the client store answers a stored
+    // panel and emits one, and React 19 answers that divergence by discarding
+    // and rebuilding the subtree. A returning author's layout then arrives as a
+    // flash rather than a layout.
+    const store = memoryStore(
+      JSON.stringify({ ...DEFAULT_PREFERENCES, leftPanel: "fonts" })
+    );
+
+    const markup = renderToString(
+      <BuilderShell
+        onExit={vi.fn()}
+        store={store}
+        renderPanel={panel => <p>{panel} panel</p>}
+      />
+    );
+
+    // Asserted on the RAIL's pressed state, not on the panel's content. The
+    // panel body is inside `react-resizable-panels`, which renders nothing
+    // measurable on the server — so "the panel content is absent" is true
+    // whatever the preferences say, and a test asserting it passes with this
+    // fix reverted. That was the first version of this test.
+    //
+    // The rail is plain markup the library never touches, so its `aria-pressed`
+    // reflects the preferences the server actually rendered with.
+    expect(markup).toContain('aria-pressed="false"');
+    expect(markup).not.toContain('aria-pressed="true"');
+    // The control: this render really did produce a shell, so the assertions
+    // above are not passing on empty output.
+    expect(markup).toContain("Exit editor");
+  });
+});
+
+describe("F6 region cycling", () => {
+  it("skips a region that is not rendered", () => {
+    // With no panel open the left region does not exist. Cycling the static
+    // list would land on it, focus nothing, and leave the key looking broken
+    // for every press after the first.
+    renderShell({ renderPanel: panel => <p>{panel} panel</p> });
+
+    const rail = screen.getByRole("navigation", { name: "Editor panels" });
+    rail.focus();
+    expect(document.activeElement).toBe(rail);
+
+    fireEvent.keyDown(document, { key: "F6" });
+
+    // The next PRESENT region is the canvas, because the panel is closed.
+    expect(document.activeElement).toBe(
+      screen.getByRole("main", { name: "Canvas" })
+    );
+  });
+
+  it("includes the panel once it is open", () => {
+    // The positive control: a cycle that always skipped the panel would satisfy
+    // the assertion above.
+    renderShell({ renderPanel: panel => <p>{panel} panel</p> });
+
+    fireEvent.click(screen.getByRole("button", { name: "Layers" }));
+    const rail = screen.getByRole("navigation", { name: "Editor panels" });
+    rail.focus();
+
+    fireEvent.keyDown(document, { key: "F6" });
+
+    expect(document.activeElement).toBe(
+      screen.getByRole("region", { name: "Layers" })
+    );
   });
 });
 

--- a/packages/builder/src/builder-shell.test.tsx
+++ b/packages/builder/src/builder-shell.test.tsx
@@ -379,6 +379,31 @@ describe("a viewport too narrow for the shell", () => {
     expect(screen.queryByRole("main", { name: "Canvas" })).toBeNull();
   });
 
+  it("does not cycle regions while the editor is hidden", () => {
+    // The slots stay mounted behind the notice, which leaves the F6 binding
+    // registered over regions that are all `inert`. Left enabled it consumed the
+    // key, focused nothing a person could see, and — where the host shares the
+    // shortcut manager — took the keystroke from whatever binding of its own
+    // would otherwise have handled it.
+    stubViewport(false);
+    render(
+      <BuilderShell onExit={vi.fn()} store={memoryStore()}>
+        <p data-testid="canvas-slot">the caller&apos;s canvas</p>
+      </BuilderShell>
+    );
+
+    const exit = screen.getByRole("button", { name: "Exit editor" });
+    exit.focus();
+    expect(document.activeElement).toBe(exit);
+
+    fireEvent.keyDown(document, { key: "F6" });
+
+    // Focus has not been pulled into the hidden subtree. jsdom does not
+    // implement `inert`, so nothing but the disabled binding stops it here —
+    // which is exactly the property under test.
+    expect(document.activeElement).toBe(exit);
+  });
+
   it("keeps the class the caller positioned the shell with", () => {
     // The className is how the host places the shell in its own layout — a grid
     // area, a height, a border. Dropping it on this path let the notice escape

--- a/packages/builder/src/builder-shell.test.tsx
+++ b/packages/builder/src/builder-shell.test.tsx
@@ -1,0 +1,245 @@
+// @vitest-environment jsdom
+/**
+ * What the shell DECIDES, not what it lays out.
+ *
+ * jsdom reports every element as zero-sized and applies no stylesheet, so an
+ * assertion about a panel's width, its position, or whether the chrome tokens
+ * resolved would pass whatever the CSS does. Those belong in the Playwright
+ * spec, which measures a real browser.
+ *
+ * What is genuinely decidable here: which regions exist and how they are named
+ * to assistive technology, which panel the rail opens, that the exit is a
+ * labelled control rather than a glyph, and that preferences survive a remount
+ * through the port rather than through `localStorage` reached for directly.
+ */
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { BuilderShell } from "./builder-shell";
+import { DEFAULT_PREFERENCES, type PreferenceStore } from "./shell-state";
+
+afterEach(cleanup);
+
+/**
+ * `react-resizable-panels` measures its group with a `ResizeObserver`, which
+ * jsdom does not implement. Stubbed as an inert observer rather than one that
+ * reports sizes: a fake that invented dimensions would let a layout assertion
+ * pass against numbers this file made up, which is the failure these tests are
+ * written to avoid. The panels mount; their SIZES are Playwright's to check.
+ */
+class InertResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+vi.stubGlobal("ResizeObserver", InertResizeObserver);
+
+function memoryStore(initial: string | null = null): PreferenceStore & {
+  value: string | null;
+} {
+  return {
+    value: initial,
+    read() {
+      return this.value;
+    },
+    write(next: string) {
+      this.value = next;
+    },
+  };
+}
+
+/**
+ * jsdom has no `matchMedia`, and the shell asks it whether the viewport can
+ * carry the full layout. Stubbed to the supported case so the tests exercise
+ * the shell rather than the narrow-viewport message; the one test that wants
+ * the other answer stubs it itself.
+ */
+function stubViewport(matches: boolean) {
+  vi.stubGlobal(
+    "matchMedia",
+    vi.fn(() => ({
+      matches,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    }))
+  );
+}
+
+function renderShell(props: Partial<Parameters<typeof BuilderShell>[0]> = {}) {
+  stubViewport(true);
+  const onExit = vi.fn();
+  const result = render(
+    <BuilderShell onExit={onExit} store={memoryStore()} {...props} />
+  );
+  return { onExit, ...result };
+}
+
+describe("the regions the shell exposes", () => {
+  it("names every region for assistive technology", () => {
+    // The names are the only way a screen-reader user tells these apart: four
+    // scroll containers with no accessible name are four identical regions.
+    renderShell();
+
+    // `banner`, not `toolbar`. A `toolbar` role promises APG arrow-key
+    // navigation between its items, which this bar does not implement — and a
+    // role claiming a keyboard contract that is not there is worse for a screen
+    // reader user than the plain landmark, because it sets an expectation the
+    // component then fails.
+    expect(screen.getByRole("banner", { name: "Editor actions" })).toBeTruthy();
+    expect(
+      screen.getByRole("navigation", { name: "Editor panels" })
+    ).toBeTruthy();
+    expect(screen.getByRole("main", { name: "Canvas" })).toBeTruthy();
+    expect(
+      screen.getByRole("complementary", { name: "Inspector" })
+    ).toBeTruthy();
+  });
+
+  it("renders each slot's content without inspecting it", () => {
+    // The slot contract: the shell knows the SHAPE of the editor and never what
+    // fills it, so the panels can be built independently of this file.
+    renderShell({
+      children: <p>canvas content</p>,
+      inspector: <p>inspector content</p>,
+      topBar: <p>top bar content</p>,
+      breadcrumb: <p>breadcrumb content</p>,
+    });
+
+    expect(screen.getByText("canvas content")).toBeTruthy();
+    expect(screen.getByText("inspector content")).toBeTruthy();
+    expect(screen.getByText("top bar content")).toBeTruthy();
+    expect(screen.getByText("breadcrumb content")).toBeTruthy();
+  });
+});
+
+describe("leaving the editor", () => {
+  it("offers an exit with words on it", () => {
+    // Deliberately asserted by NAME rather than by role alone. The author is one
+    // click from leaving a canvas full of work, and an unlabelled X is how that
+    // happens by accident.
+    const { onExit } = renderShell();
+
+    const exit = screen.getByRole("button", { name: "Exit editor" });
+    fireEvent.click(exit);
+    expect(onExit).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("the rail", () => {
+  const railButton = (name: string) =>
+    screen.getByRole("button", { name, pressed: undefined }) ??
+    screen.getByRole("button", { name });
+
+  it("opens the panel whose rail item was clicked", () => {
+    renderShell({ renderPanel: panel => <p>{panel} panel</p> });
+
+    expect(screen.queryByText("layers panel")).toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: "Layers" }));
+    expect(screen.getByText("layers panel")).toBeTruthy();
+  });
+
+  it("switches between panels rather than opening a second", () => {
+    // PB-D17 D10-1: one at a time, fixed sides. Two panels open at once is the
+    // layout this decision exists to prevent.
+    renderShell({ renderPanel: panel => <p>{panel} panel</p> });
+
+    fireEvent.click(screen.getByRole("button", { name: "Layers" }));
+    fireEvent.click(screen.getByRole("button", { name: "Tokens" }));
+
+    expect(screen.getByText("tokens panel")).toBeTruthy();
+    expect(screen.queryByText("layers panel")).toBeNull();
+  });
+
+  it("closes the open panel when its own item is clicked again", () => {
+    // The only route to a full-width canvas. Without it the author can switch
+    // panels forever and never dismiss one.
+    renderShell({ renderPanel: panel => <p>{panel} panel</p> });
+
+    fireEvent.click(screen.getByRole("button", { name: "Layers" }));
+    fireEvent.click(screen.getByRole("button", { name: "Layers" }));
+    expect(screen.queryByText("layers panel")).toBeNull();
+  });
+
+  it("reports which item is active, not just paints it", () => {
+    // `aria-pressed` rather than a class: the selected rail item is state, and
+    // a colour change alone tells a screen-reader user nothing.
+    renderShell();
+
+    const layers = railButton("Layers");
+    expect(layers.getAttribute("aria-pressed")).toBe("false");
+    fireEvent.click(layers);
+    expect(railButton("Layers").getAttribute("aria-pressed")).toBe("true");
+  });
+});
+
+describe("preferences", () => {
+  it("writes the open panel through the store, not to localStorage", () => {
+    // The port is what lets these become durable server-side prefs later. A
+    // component reaching for `localStorage` makes that a rewrite.
+    const store = memoryStore();
+    stubViewport(true);
+    render(<BuilderShell onExit={vi.fn()} store={store} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Tokens" }));
+
+    expect(store.value).not.toBeNull();
+    expect(JSON.parse(store.value as string)).toMatchObject({
+      leftPanel: "tokens",
+    });
+  });
+
+  it("restores the panel that was open when the editor was last left", () => {
+    const store = memoryStore(
+      JSON.stringify({ ...DEFAULT_PREFERENCES, leftPanel: "fonts" })
+    );
+    stubViewport(true);
+    render(
+      <BuilderShell
+        onExit={vi.fn()}
+        store={store}
+        renderPanel={panel => <p>{panel} panel</p>}
+      />
+    );
+
+    expect(screen.getByText("fonts panel")).toBeTruthy();
+  });
+
+  it("opens no panel when a stored one no longer exists", () => {
+    // A preference outlives the release that wrote it. Restoring a removed
+    // panel leaves a region rendering nothing, with no obvious way back.
+    const store = memoryStore(JSON.stringify({ leftPanel: "history" }));
+    stubViewport(true);
+    render(
+      <BuilderShell
+        onExit={vi.fn()}
+        store={store}
+        renderPanel={panel => <p>{panel} panel</p>}
+      />
+    );
+
+    expect(screen.queryByText(/panel$/)).toBeNull();
+  });
+});
+
+describe("a viewport too narrow for the shell", () => {
+  it("says where to edit instead of compressing", () => {
+    // An editor that merely gets cramped is worse than one that says it needs a
+    // wider screen: the author otherwise discovers the limit by failing a task.
+    stubViewport(false);
+    render(<BuilderShell onExit={vi.fn()} store={memoryStore()} />);
+
+    expect(screen.getByText(/needs a wider screen/i)).toBeTruthy();
+    expect(screen.queryByRole("main", { name: "Canvas" })).toBeNull();
+  });
+
+  it("still offers a way out", () => {
+    // The one control that must survive every degraded state: an author who
+    // opened the editor on a narrow screen has to be able to leave it.
+    stubViewport(false);
+    const onExit = vi.fn();
+    render(<BuilderShell onExit={onExit} store={memoryStore()} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Exit editor" }));
+    expect(onExit).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/builder/src/builder-shell.test.tsx
+++ b/packages/builder/src/builder-shell.test.tsx
@@ -205,6 +205,29 @@ describe("preferences", () => {
     expect(screen.getByText("fonts panel")).toBeTruthy();
   });
 
+  it("a later write does not clobber an earlier one", () => {
+    // The stale-closure defect a browser found and jsdom cannot: a callback
+    // React captured at render time, handed a whole record built by spreading
+    // that render's preferences, writes the OLD record back with one field
+    // replaced. Two writes in a row from separate handlers is the shape.
+    //
+    // Driven through the rail because it is the only writer reachable here —
+    // `onLayoutChanged` never fires under an inert ResizeObserver, which is
+    // exactly why the Playwright spec is the one that caught it.
+    const store = memoryStore();
+    stubViewport(true);
+    render(<BuilderShell onExit={vi.fn()} store={store} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Tokens" }));
+    fireEvent.click(screen.getByRole("button", { name: "Layers" }));
+
+    // The second write must have been computed from the FIRST write's result,
+    // not from the render both handlers were created in.
+    expect(JSON.parse(store.value as string)).toMatchObject({
+      leftPanel: "layers",
+    });
+  });
+
   it("opens no panel when a stored one no longer exists", () => {
     // A preference outlives the release that wrote it. Restoring a removed
     // panel leaves a region rendering nothing, with no obvious way back.

--- a/packages/builder/src/builder-shell.test.tsx
+++ b/packages/builder/src/builder-shell.test.tsx
@@ -13,6 +13,7 @@
  * through the port rather than through `localStorage` reached for directly.
  */
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import * as React from "react";
 import { renderToString } from "react-dom/server";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
@@ -468,5 +469,61 @@ describe("the preference store the caller supplies", () => {
 
     expect(second.value).toContain("layers");
     expect(first.value).toBeNull();
+  });
+});
+
+describe("switching between panels", () => {
+  it("mounts the new panel rather than updating the old one", () => {
+    // `renderPanel` is documented as keyed by the panel that is open, and
+    // React's default reconciliation does not honour that: a caller rendering
+    // one component for several panels puts the same element type at the same
+    // position, so switching tools UPDATES that instance. Its state, its
+    // effects and any uncontrolled input values follow the author from Layers
+    // into Tokens, which is a different tool entirely.
+    let mounts = 0;
+    function Probe({ panel }: { panel: string }) {
+      React.useEffect(() => {
+        mounts += 1;
+      }, []);
+      return <p>{panel} panel</p>;
+    }
+
+    renderShell({ renderPanel: panel => <Probe panel={panel} /> });
+
+    fireEvent.click(screen.getByRole("button", { name: "Layers" }));
+    expect(mounts).toBe(1);
+
+    fireEvent.click(screen.getByRole("button", { name: "Tokens" }));
+    // A fresh mount, not the same instance handed a new prop. Asserted through
+    // a mount-effect rather than through rendered text: the text changes either
+    // way, so it cannot tell the two apart.
+    expect(mounts).toBe(2);
+  });
+});
+
+describe("F6 from a focused drag handle", () => {
+  it("leaves the separator for the next region", () => {
+    // The separators run their own key listener, and it claims F6: it cycles
+    // between separators and calls `preventDefault()`. The shortcut manager
+    // deliberately skips an already-prevented event, so the shell's region
+    // binding never ran — and with one separator in the default topology, F6
+    // re-focused the same handle for ever. That is the state an author is in
+    // immediately after resizing anything.
+    renderShell({ renderPanel: panel => <p>{panel} panel</p> });
+
+    const separator = screen.getAllByRole("separator")[0];
+    expect(separator).toBeDefined();
+    if (separator === undefined) return;
+    separator.focus();
+    expect(document.activeElement).toBe(separator);
+
+    fireEvent.keyDown(separator, { key: "F6" });
+
+    // Off the handle and onto a region. Which region depends on where the
+    // separator sits; that focus LEFT the separator is the property here.
+    expect(document.activeElement).not.toBe(separator);
+    expect(
+      (document.activeElement as HTMLElement | null)?.getAttribute("aria-label")
+    ).toBeTruthy();
   });
 });

--- a/packages/builder/src/builder-shell.tsx
+++ b/packages/builder/src/builder-shell.tsx
@@ -1,0 +1,423 @@
+"use client";
+
+import {
+  ResizableHandle,
+  ResizablePanel,
+  ResizablePanelGroup,
+  ShortcutProvider,
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+  useShortcuts,
+} from "@nextlyhq/ui";
+import { cn } from "@nextlyhq/ui/utils";
+import {
+  Blocks,
+  FileText,
+  Layers,
+  Palette,
+  Plus,
+  Settings,
+  Type,
+} from "lucide-react";
+import * as React from "react";
+
+import {
+  DEFAULT_PREFERENCES,
+  LEFT_PANELS,
+  MIN_CANVAS_WIDTH,
+  MIN_SHELL_WIDTH,
+  PANEL_BOUNDS,
+  panelAfterRailClick,
+  readPreferences,
+  writePreferences,
+  type LeftPanel,
+  type PreferenceStore,
+  type ShellPreferences,
+} from "./shell-state";
+
+/**
+ * The editor shell: rail, one switched panel, canvas, inspector, bars.
+ *
+ * PURELY PRESENTATIONAL, and that is a contract rather than a current state.
+ * It owns which panel is open and how wide the regions are — chrome state, its
+ * own business — and owns nothing about the document. Selection arrives as a
+ * prop and leaves as a callback.
+ *
+ * The reason is not tidiness. Document ops INVALIDATE selection: a remove
+ * deletes the selected node, a move relocates it. If the shell held selection it
+ * would have to be updated in step with every op, which is two things changing
+ * together — the drift this codebase keeps paying for. Held outside, selection
+ * can be DERIVED from the post-op document ("does this id still resolve?"),
+ * which cannot go out of step because there is only one thing to read.
+ *
+ * Content is passed as slots rather than rendered here, so the layers panel, the
+ * inserter and the inspector can be built independently without this file
+ * changing. It knows the SHAPE of the editor, never what fills it.
+ *
+ * @module builder-shell
+ */
+
+/** Icons for the rail, one per panel. Kept beside the labels they belong to. */
+const PANEL_CHROME: Record<
+  LeftPanel,
+  { label: string; Icon: React.ComponentType<{ className?: string }> }
+> = {
+  insert: { label: "Insert", Icon: Plus },
+  layers: { label: "Layers", Icon: Layers },
+  components: { label: "Components", Icon: Blocks },
+  tokens: { label: "Tokens", Icon: Palette },
+  fonts: { label: "Fonts", Icon: Type },
+  pages: { label: "Pages", Icon: FileText },
+  settings: { label: "Settings", Icon: Settings },
+};
+
+/**
+ * The regions F6 cycles between, in the order a sighted user reads them.
+ *
+ * A shell of this size is unusable by keyboard without region navigation: an
+ * author who tabs out of the inspector should not traverse every control in the
+ * canvas to reach the rail. F6 is the platform convention for exactly this.
+ */
+const REGIONS = ["rail", "panel", "canvas", "inspector"] as const;
+type Region = (typeof REGIONS)[number];
+
+export interface BuilderShellProps {
+  /** Rendered inside the switched left panel. Keyed by the panel that is open. */
+  renderPanel?: (panel: LeftPanel) => React.ReactNode;
+  /** The canvas. The shell never looks inside it. */
+  children?: React.ReactNode;
+  /** The inspector's contents. */
+  inspector?: React.ReactNode;
+  /** Rendered into the top bar, between the page menu and the actions. */
+  topBar?: React.ReactNode;
+  /** The ancestor breadcrumb, along the bottom bar. */
+  breadcrumb?: React.ReactNode;
+  /**
+   * Leaving the editor. Explicit and LABELLED, never an unmarked X: the author
+   * is one click from losing a canvas full of work, and an ambiguous glyph is
+   * how that happens.
+   */
+  onExit: () => void;
+  /**
+   * Where chrome preferences live. Defaults to `localStorage` in a browser and
+   * to a store that remembers nothing anywhere else, so a server render is a
+   * default rather than a crash.
+   */
+  store?: PreferenceStore;
+  className?: string;
+}
+
+/** A store that forgets, for a server render or a host that supplies its own. */
+const NO_STORAGE: PreferenceStore = {
+  read: () => null,
+  write: () => undefined,
+};
+
+const STORAGE_KEY = "nextly.builder.shell";
+
+function browserStore(): PreferenceStore {
+  if (typeof window === "undefined") return NO_STORAGE;
+  return {
+    read: () => window.localStorage.getItem(STORAGE_KEY),
+    write: value => window.localStorage.setItem(STORAGE_KEY, value),
+  };
+}
+
+/**
+ * Whether the viewport can carry the full shell, tracked as it changes.
+ *
+ * Starts as `true` on purpose. The alternative is measuring during render,
+ * which the server cannot do — it would emit the narrow-viewport message and the
+ * client would replace it, a hydration mismatch on every desktop load. Assuming
+ * the supported case and correcting after mount makes both first renders
+ * identical.
+ */
+function useFitsFullShell(): boolean {
+  const [fits, setFits] = React.useState(true);
+
+  React.useEffect(() => {
+    const query = window.matchMedia(`(min-width: ${MIN_SHELL_WIDTH}px)`);
+    const sync = () => setFits(query.matches);
+    sync();
+    query.addEventListener("change", sync);
+    return () => query.removeEventListener("change", sync);
+  }, []);
+
+  return fits;
+}
+
+/** Preferences, restored once and written back whenever they change. */
+function usePreferences(store: PreferenceStore) {
+  // Read lazily so storage is touched once, not on every render, and never
+  // during a server render where the default store answers null anyway.
+  const [preferences, setPreferences] = React.useState<ShellPreferences>(() =>
+    readPreferences(store)
+  );
+
+  const update = React.useCallback(
+    (next: ShellPreferences) => {
+      setPreferences(next);
+      writePreferences(store, next);
+    },
+    [store]
+  );
+
+  return [preferences, update] as const;
+}
+
+/**
+ * F6 region cycling, registered with the shared shortcut manager.
+ *
+ * Through the manager rather than a private key listener, because two
+ * independent key layers is how "Escape navigates out of the editor while a drag
+ * owns it" happens — the failure the manager exists to prevent.
+ */
+function useRegionCycling(
+  regionRefs: React.RefObject<Record<Region, HTMLElement | null>>
+): void {
+  useShortcuts(
+    [
+      {
+        keys: "F6",
+        description: "Move to the next area of the editor",
+        run: () => {
+          const map = regionRefs.current;
+          if (!map) return;
+          const active = document.activeElement;
+          const currentIndex = REGIONS.findIndex(region => {
+            const element = map[region];
+            return element !== null && element.contains(active);
+          });
+          // From outside any region, F6 enters the first rather than doing
+          // nothing — otherwise the key appears broken until focus happens to
+          // land somewhere it recognises.
+          const next = REGIONS[(currentIndex + 1) % REGIONS.length];
+          map[next]?.focus();
+        },
+      },
+    ],
+    { name: "Builder shell" }
+  );
+}
+
+function ShellRegions({
+  renderPanel,
+  children,
+  inspector,
+  topBar,
+  breadcrumb,
+  onExit,
+  preferences,
+  update,
+  className,
+}: Omit<BuilderShellProps, "store"> & {
+  preferences: ShellPreferences;
+  update: (next: ShellPreferences) => void;
+}) {
+  const regionRefs = React.useRef<Record<Region, HTMLElement | null>>({
+    rail: null,
+    panel: null,
+    canvas: null,
+    inspector: null,
+  });
+  useRegionCycling(regionRefs);
+
+  const openPanel = preferences.leftPanel;
+
+  const selectPanel = (panel: LeftPanel) =>
+    update({
+      ...preferences,
+      leftPanel: panelAfterRailClick(openPanel, panel),
+    });
+
+  return (
+    <div
+      className={cn(
+        "nx-builder-chrome flex h-full w-full flex-col overflow-hidden",
+        className
+      )}
+    >
+      <header
+        className="border-[color:var(--nx-builder-border)] flex h-12 shrink-0 items-center gap-2 border-b px-2"
+        aria-label="Editor actions"
+      >
+        <button
+          type="button"
+          onClick={onExit}
+          data-builder-animates
+          className="border-[color:var(--nx-builder-border)] focus-visible:ring-ring rounded-md border px-3 py-1.5 text-sm font-medium focus-visible:ring-2 focus-visible:outline-none"
+        >
+          Exit editor
+        </button>
+        <div className="flex min-w-0 flex-1 items-center gap-2">{topBar}</div>
+      </header>
+
+      <div className="flex min-h-0 flex-1">
+        <nav
+          ref={element => {
+            regionRefs.current.rail = element;
+          }}
+          tabIndex={-1}
+          aria-label="Editor panels"
+          style={{ width: 48 }}
+          className="border-[color:var(--nx-builder-border)] flex shrink-0 flex-col items-center gap-1 border-r py-2"
+        >
+          {LEFT_PANELS.map(panel => {
+            const { label, Icon } = PANEL_CHROME[panel];
+            const isOpen = openPanel === panel;
+            return (
+              <Tooltip key={panel}>
+                <TooltipTrigger asChild>
+                  <button
+                    type="button"
+                    data-builder-animates
+                    data-panel={panel}
+                    aria-pressed={isOpen}
+                    aria-label={label}
+                    onClick={() => selectPanel(panel)}
+                    className={cn(
+                      "focus-visible:ring-ring flex size-8 items-center justify-center rounded-md focus-visible:ring-2 focus-visible:outline-none",
+                      isOpen
+                        ? "bg-[color:var(--nx-builder-accent)] text-[color:var(--nx-builder-accent-text)]"
+                        : "text-[color:var(--nx-builder-text-muted)]"
+                    )}
+                  >
+                    <Icon className="size-4" />
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent side="right">{label}</TooltipContent>
+              </Tooltip>
+            );
+          })}
+        </nav>
+
+        <ResizablePanelGroup
+          orientation="horizontal"
+          defaultLayout={preferences.layout ?? undefined}
+          onLayoutChanged={layout => {
+            update({ ...preferences, layout: { ...layout } });
+          }}
+          className="min-w-0 flex-1"
+        >
+          {openPanel !== null ? (
+            <>
+              <ResizablePanel
+                id="panel"
+                minSize={PANEL_BOUNDS.left.min}
+                maxSize={PANEL_BOUNDS.left.max}
+                defaultSize={PANEL_BOUNDS.left.initial}
+              >
+                <section
+                  ref={element => {
+                    regionRefs.current.panel = element;
+                  }}
+                  tabIndex={-1}
+                  aria-label={PANEL_CHROME[openPanel].label}
+                  className="bg-[color:var(--nx-builder-surface-raised)] h-full overflow-auto"
+                >
+                  {renderPanel?.(openPanel)}
+                </section>
+              </ResizablePanel>
+              <ResizableHandle withGrip />
+            </>
+          ) : null}
+
+          <ResizablePanel id="canvas" minSize={MIN_CANVAS_WIDTH}>
+            <main
+              ref={element => {
+                regionRefs.current.canvas = element;
+              }}
+              tabIndex={-1}
+              aria-label="Canvas"
+              className="h-full overflow-auto"
+            >
+              {children}
+            </main>
+          </ResizablePanel>
+
+          <ResizableHandle withGrip />
+
+          <ResizablePanel
+            id="inspector"
+            minSize={PANEL_BOUNDS.inspector.min}
+            maxSize={PANEL_BOUNDS.inspector.max}
+            defaultSize={PANEL_BOUNDS.inspector.initial}
+          >
+            <aside
+              ref={element => {
+                regionRefs.current.inspector = element;
+              }}
+              tabIndex={-1}
+              aria-label="Inspector"
+              className="bg-[color:var(--nx-builder-surface-raised)] h-full overflow-auto"
+            >
+              {inspector}
+            </aside>
+          </ResizablePanel>
+        </ResizablePanelGroup>
+      </div>
+
+      <footer
+        className="border-[color:var(--nx-builder-border)] text-[color:var(--nx-builder-text-muted)] flex h-8 shrink-0 items-center gap-2 border-t px-3 text-xs"
+        aria-label="Selection path"
+      >
+        {breadcrumb}
+      </footer>
+    </div>
+  );
+}
+
+/**
+ * The shell, or a message saying where to edit instead.
+ *
+ * Below the supported width the shell does not try to compress: the rail, both
+ * panels and a usable canvas do not fit at their minimums, and an editor that
+ * merely gets cramped is worse than one that says it needs a wider screen —
+ * the author otherwise discovers the limit by failing at a task.
+ *
+ * @experimental
+ */
+export function BuilderShell({ store, ...props }: BuilderShellProps) {
+  // Built once. A store rebuilt each render would make `usePreferences`'
+  // callback identity change on every render, and the write effect with it.
+  const [resolvedStore] = React.useState(() => store ?? browserStore());
+  const [preferences, update] = usePreferences(resolvedStore);
+  const fitsFullShell = useFitsFullShell();
+
+  if (!fitsFullShell) {
+    return (
+      <div className="nx-builder-chrome flex h-full w-full flex-col items-center justify-center gap-3 p-6 text-center">
+        <p className="text-sm font-medium">
+          The page editor needs a wider screen
+        </p>
+        <p className="text-[color:var(--nx-builder-text-muted)] max-w-sm text-sm">
+          Editing a layout needs at least {MIN_SHELL_WIDTH}px. On a smaller
+          screen you can still edit this page&apos;s content from the admin.
+        </p>
+        <button
+          type="button"
+          onClick={props.onExit}
+          className="border-[color:var(--nx-builder-border)] focus-visible:ring-ring rounded-md border px-3 py-1.5 text-sm font-medium focus-visible:ring-2 focus-visible:outline-none"
+        >
+          Exit editor
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <ShortcutProvider>
+      {/* Provided here rather than required of the host: the rail's icon-only
+          buttons are unreadable without their tooltips, so a shell that renders
+          them depends on this and should not make it someone else's setup step.
+          Radix nests providers safely — a host with its own keeps its delay. */}
+      <TooltipProvider delayDuration={300}>
+        <ShellRegions {...props} preferences={preferences} update={update} />
+      </TooltipProvider>
+    </ShortcutProvider>
+  );
+}
+
+export { DEFAULT_PREFERENCES };

--- a/packages/builder/src/builder-shell.tsx
+++ b/packages/builder/src/builder-shell.tsx
@@ -23,6 +23,7 @@ import {
 } from "lucide-react";
 import * as React from "react";
 
+import { devWarnOnce } from "./dev-warn";
 import {
   DEFAULT_PREFERENCES,
   LEFT_PANELS,
@@ -232,6 +233,64 @@ function shallowEqualPreferences(
 }
 
 /**
+ * One design-system token, read off the mounted shell.
+ *
+ * Chosen over any `--nx-builder-*` because those are declared in this package's
+ * own stylesheet and would resolve whether or not the design system's had been
+ * loaded — the check would pass in exactly the case it exists to catch. The
+ * `--nx-*` layer is declared only by `@nextlyhq/ui`, so its absence is the
+ * question being asked.
+ */
+const REQUIRED_HOST_TOKEN = "--nx-background";
+
+/**
+ * A token this package's OWN stylesheet declares, used as a positive control.
+ *
+ * Without it the check cannot tell the two ways of resolving to nothing apart:
+ * a host that never imported the design system's sheet, and an environment that
+ * applies no stylesheets whatsoever. jsdom is the second, so a bare absence test
+ * would warn on every unit test that mounts the shell — noise indistinguishable
+ * from the real defect, in the place developers read warnings most.
+ *
+ * Reading both makes the instrument observable: when this one resolves, styles
+ * ARE being applied, and the other one's absence means what it says.
+ */
+const OWN_STYLESHEET_TOKEN = "--nx-builder-surface";
+
+/**
+ * Tell a developer when the design system's stylesheet has not been loaded.
+ *
+ * The editor's own sheet supplements that one rather than restating it, so a
+ * host that imports only `@nextlyhq/builder/styles.css` gets a shell that mounts
+ * with every class name in place and renders wrong — unstyled tooltips and drag
+ * handles, and chrome colours resolving to nothing. Nothing at build time can
+ * see a missing side-effect import in someone else's application, so this is the
+ * only layer the requirement can be enforced from.
+ */
+function useDesignSystemStylesheet(
+  rootRef: React.RefObject<HTMLElement | null>
+): void {
+  React.useEffect(() => {
+    const root = rootRef.current;
+    if (!root || typeof window === "undefined") return;
+    const styles = window.getComputedStyle(root);
+    const own = styles.getPropertyValue(OWN_STYLESHEET_TOKEN).trim();
+    // Nothing resolves here, so the absence of the other token says nothing
+    // about the host. Reporting it anyway would put a warning about a missing
+    // import in front of every developer running the suite.
+    if (own === "") return;
+    devWarnOnce(
+      styles.getPropertyValue(REQUIRED_HOST_TOKEN).trim() !== "",
+      `The design system's stylesheet is not loaded, so the editor will render ` +
+        `without its colours, tooltips or drag handles. Import ` +
+        `"@nextlyhq/ui/styles.css" (or the admin's stylesheet) alongside ` +
+        `"@nextlyhq/builder/styles.css" — the editor's sheet supplements it and ` +
+        `does not replace it.`
+    );
+  }, [rootRef]);
+}
+
+/**
  * F6 region cycling, registered with the shared shortcut manager.
  *
  * Through the manager rather than a private key listener, because two
@@ -246,6 +305,14 @@ function useRegionCycling(
       {
         keys: "F6",
         description: "Move to the next area of the editor",
+        // The manager's default asks whether the FIRST chord carries a modifier
+        // or is Escape, and answers no for a bare function key — so F6 would be
+        // held back by any focused text field. That default is right for the
+        // letter keys it was written for and backwards here: moving between
+        // areas of the editor is the one thing an author needs MOST while a
+        // caption or a field has focus, because it is how they get back out
+        // without reaching for the mouse.
+        whenTyping: true,
         run: () => {
           const map = regionRefs.current;
           if (!map) return;
@@ -293,6 +360,8 @@ function ShellRegions({
     inspector: null,
   });
   useRegionCycling(regionRefs);
+  const chromeRef = React.useRef<HTMLDivElement | null>(null);
+  useDesignSystemStylesheet(chromeRef);
 
   const openPanel = preferences.leftPanel;
 
@@ -304,6 +373,7 @@ function ShellRegions({
 
   return (
     <div
+      ref={chromeRef}
       className={cn(
         "nx-builder-chrome flex h-full w-full flex-col overflow-hidden",
         className
@@ -366,7 +436,20 @@ function ShellRegions({
         <ResizablePanelGroup
           orientation="horizontal"
           defaultLayout={preferences.layout ?? undefined}
-          onLayoutChanged={layout => {
+          onLayoutChanged={(layout, meta) => {
+            // The group reports every layout it settles on, not only the ones a
+            // person asked for. Mounting, recomputing constraints and reacting
+            // to a changed default all arrive here too, and the mount pass
+            // arrives BEFORE the restored layout has taken effect — so writing
+            // unconditionally saves the freshly measured default over the
+            // layout being restored, and the panel widths reset on every
+            // reload while appearing to persist within a session.
+            //
+            // `isUserInteraction` is the library's own account of which of
+            // those it was: true only for a pointer drag or a resize key on a
+            // separator. Dragging a separator is the one event that states an
+            // intent about widths, and it is the only one worth remembering.
+            if (!meta.isUserInteraction) return;
             update(current => ({ ...current, layout: { ...layout } }));
           }}
           className="min-w-0 flex-1"
@@ -450,32 +533,17 @@ function ShellRegions({
  * @experimental
  */
 export function BuilderShell({ store, ...props }: BuilderShellProps) {
-  // Built once. A store rebuilt each render would make `usePreferences`'
-  // callback identity change on every render, and the write effect with it.
-  const [resolvedStore] = React.useState(() => store ?? browserStore());
+  // The browser store is built once: rebuilt each render it would change
+  // `usePreferences`' callback identity every render, and the write effect with
+  // it. Only the FALLBACK needs that treatment though. Capturing the caller's
+  // `store` alongside it pinned whichever one arrived first, so a host that
+  // swaps stores — signing into a second workspace, promoting a memory store to
+  // a persisted one — went on reading and writing the store it had replaced.
+  const fallbackStore = React.useRef<PreferenceStore | null>(null);
+  fallbackStore.current ??= browserStore();
+  const resolvedStore = store ?? fallbackStore.current;
   const [preferences, update] = usePreferences(resolvedStore);
   const fitsFullShell = useFitsFullShell();
-
-  if (!fitsFullShell) {
-    return (
-      <div className="nx-builder-chrome flex h-full w-full flex-col items-center justify-center gap-3 p-6 text-center">
-        <p className="text-sm font-medium">
-          The page editor needs a wider screen
-        </p>
-        <p className="text-[color:var(--nx-builder-text-muted)] max-w-sm text-sm">
-          Editing a layout needs at least {MIN_SHELL_WIDTH}px. On a smaller
-          screen you can still edit this page&apos;s content from the admin.
-        </p>
-        <button
-          type="button"
-          onClick={props.onExit}
-          className="border-[color:var(--nx-builder-border)] focus-visible:ring-ring rounded-md border px-3 py-1.5 text-sm font-medium focus-visible:ring-2 focus-visible:outline-none"
-        >
-          Exit editor
-        </button>
-      </div>
-    );
-  }
 
   return (
     <ShortcutProvider>
@@ -484,7 +552,63 @@ export function BuilderShell({ store, ...props }: BuilderShellProps) {
           them depends on this and should not make it someone else's setup step.
           Radix nests providers safely — a host with its own keeps its delay. */}
       <TooltipProvider delayDuration={300}>
-        <ShellRegions {...props} preferences={preferences} update={update} />
+        {!fitsFullShell ? (
+          <div
+            // The caller's className reaches this branch too. It is what
+            // positions the shell in the host's layout — a grid area, a height,
+            // a border — and dropping it on the narrow path made the fallback
+            // escape the box the shell had been given, in the layout least able
+            // to absorb it.
+            className={cn(
+              "nx-builder-chrome flex h-full w-full flex-col items-center justify-center gap-3 p-6 text-center",
+              props.className
+            )}
+          >
+            <p className="text-sm font-medium">
+              The page editor needs a wider screen
+            </p>
+            <p className="text-[color:var(--nx-builder-text-muted)] max-w-sm text-sm">
+              Editing a layout needs at least {MIN_SHELL_WIDTH}px. On a smaller
+              screen you can still edit this page&apos;s content from the admin.
+            </p>
+            <button
+              type="button"
+              onClick={props.onExit}
+              className="border-[color:var(--nx-builder-border)] focus-visible:ring-ring rounded-md border px-3 py-1.5 text-sm font-medium focus-visible:ring-2 focus-visible:outline-none"
+            >
+              Exit editor
+            </button>
+          </div>
+        ) : null}
+
+        {/* The editor stays MOUNTED while the notice is up, rather than being
+            swapped out for it.
+
+            Returning the notice instead unmounted every slot the caller had
+            given us — canvas, inspector, panels — and React discards the state
+            inside them: a half-written caption, an open picker, whatever the
+            host was holding locally. Narrowing a window or rotating a tablet is
+            a transient act, and widening it again produced fresh, empty slot
+            instances with no way for the host to have saved anything, because
+            nothing told it the subtree was going away.
+
+            `hidden` takes it out of layout and paint; `inert` takes it out of
+            the tab order and the accessibility tree, so nothing behind the
+            notice is reachable by keyboard or screen reader. The cost is that
+            the editor goes on occupying memory while hidden, which is the
+            deliberate trade: an author's unsaved work is worth more than the
+            allocation. */}
+        <div
+          hidden={!fitsFullShell}
+          inert={!fitsFullShell}
+          // `display: contents` while visible, so this wrapper adds no box of
+          // its own and the shell keeps sizing against the caller's container.
+          // Omitted while hidden, where the `hidden` attribute's own
+          // `display: none` has to be the one that applies.
+          className={fitsFullShell ? "contents" : undefined}
+        >
+          <ShellRegions {...props} preferences={preferences} update={update} />
+        </div>
       </TooltipProvider>
     </ShortcutProvider>
   );

--- a/packages/builder/src/builder-shell.tsx
+++ b/packages/builder/src/builder-shell.tsx
@@ -168,6 +168,20 @@ function useFitsFullShell(): boolean {
 function usePreferences(store: PreferenceStore) {
   const [preferences, setPreferences] =
     React.useState<ShellPreferences>(DEFAULT_PREFERENCES);
+  /**
+   * How many times a store has been READ into this hook.
+   *
+   * Downstream, restoring a layout is a once-per-load act, and "once" has to be
+   * counted against something. Counted against the component's lifetime it is
+   * wrong as soon as the host swaps stores — signing into a second workspace
+   * loads that user's preferences, and a guard that already fired leaves the
+   * previous user's widths on screen.
+   *
+   * A counter rather than the store's identity, because it is the LOAD that
+   * matters: it advances on every read, so a host that passes the same store
+   * object after changing what is behind it still gets a fresh restoration.
+   */
+  const [loadCount, setLoadCount] = React.useState(0);
 
   React.useEffect(() => {
     const restored = readPreferences(store);
@@ -176,6 +190,7 @@ function usePreferences(store: PreferenceStore) {
     setPreferences(current =>
       shallowEqualPreferences(current, restored) ? current : restored
     );
+    setLoadCount(count => count + 1);
   }, [store]);
 
   // The newest preferences, reachable from a callback that must not go stale.
@@ -206,7 +221,7 @@ function usePreferences(store: PreferenceStore) {
     [store]
   );
 
-  return [preferences, update] as const;
+  return [preferences, update, loadCount] as const;
 }
 
 /**
@@ -270,13 +285,16 @@ type PanelGroupHandle =
 function useRestoredLayout(
   groupRef: React.RefObject<PanelGroupHandle | null>,
   layout: ShellPreferences["layout"],
-  leftPanel: ShellPreferences["leftPanel"]
+  leftPanel: ShellPreferences["leftPanel"],
+  loadCount: number
 ): void {
-  const applied = React.useRef(false);
+  const applied = React.useRef(-1);
 
   React.useEffect(() => {
     const group = groupRef.current;
-    if (group === null || layout === null || applied.current) return;
+    if (group === null || layout === null || applied.current === loadCount) {
+      return;
+    }
 
     const mounted = Object.keys(group.getLayout()).sort().join(",");
     const stored = Object.keys(layout).sort().join(",");
@@ -285,12 +303,12 @@ function useRestoredLayout(
     // topology settles.
     if (mounted !== stored) return;
 
-    applied.current = true;
+    applied.current = loadCount;
     group.setLayout(layout);
     // `leftPanel` is not read in the body. It is a dependency because it is what
     // changes the panel set, and the comparison above depends on that having
     // settled.
-  }, [groupRef, layout, leftPanel]);
+  }, [groupRef, layout, leftPanel, loadCount]);
 }
 
 /**
@@ -394,28 +412,81 @@ function useRegionCycling(
         // without reaching for the mouse.
         whenTyping: true,
         run: () => {
-          const map = regionRefs.current;
-          if (!map) return;
-          // Only regions that are actually rendered. The left panel is absent
-          // whenever the rail has nothing open, and cycling the static list
-          // would land on it, focus nothing, and leave the key looking broken
-          // for every press after the first.
-          const present = REGIONS.filter(region => map[region] !== null);
-          if (present.length === 0) return;
-
-          const active = document.activeElement;
-          const currentIndex = present.findIndex(region =>
-            map[region]?.contains(active)
-          );
-          // From outside any region, F6 enters the first rather than doing
-          // nothing — otherwise the key appears broken until focus happens to
-          // land somewhere it recognises.
-          const next = present[(currentIndex + 1) % present.length];
-          if (next !== undefined) map[next]?.focus();
+          focusNextRegion(regionRefs.current);
         },
       },
     ],
     { name: "Builder shell" }
+  );
+}
+
+/**
+ * Move focus to the next rendered region, wrapping around.
+ *
+ * A named function rather than the body of the binding, because TWO paths have
+ * to perform this and they must not be two implementations of it — see
+ * `useSeparatorRegionEscape` for why the second exists.
+ */
+function focusNextRegion(map: Record<Region, HTMLElement | null> | null): void {
+  if (!map) return;
+  // Only regions that are actually rendered. The left panel is absent whenever
+  // the rail has nothing open, and cycling the static list would land on it,
+  // focus nothing, and leave the key looking broken for every press after the
+  // first.
+  const present = REGIONS.filter(region => map[region] !== null);
+  if (present.length === 0) return;
+
+  const active = document.activeElement;
+  const currentIndex = present.findIndex(region =>
+    map[region]?.contains(active)
+  );
+  // From outside any region, F6 enters the first rather than doing nothing —
+  // otherwise the key appears broken until focus happens to land somewhere it
+  // recognises.
+  const next = present[(currentIndex + 1) % present.length];
+  if (next !== undefined) map[next]?.focus();
+}
+
+/**
+ * Let F6 escape a focused drag handle.
+ *
+ * The separators run their own key listener, and it claims F6: it cycles
+ * between separators and calls `preventDefault()`. The shared shortcut manager
+ * deliberately skips an event that has already been prevented — two layers both
+ * acting on one keystroke is the failure it exists to stop — so the shell's
+ * region binding never ran. In the default topology there is exactly ONE
+ * separator, so F6 from a handle re-focused that same handle for ever, which is
+ * the state an author lands in immediately after resizing anything.
+ *
+ * Handled in the CAPTURE phase on the shell root, which is the only place that
+ * runs before the separator's own listener at the target. Propagation is stopped
+ * so the manager does not then cycle a second time on the way back up.
+ *
+ * The region binding stays registered: it is what handles F6 from outside this
+ * subtree, and what puts the shortcut in front of anything that lists them.
+ */
+function useSeparatorRegionEscape(
+  regionRefs: React.RefObject<Record<Region, HTMLElement | null>>,
+  enabled: boolean
+): (event: React.KeyboardEvent<HTMLElement>) => void {
+  return React.useCallback(
+    (event: React.KeyboardEvent<HTMLElement>) => {
+      if (event.key !== "F6" || !enabled) return;
+      // Only from a separator. Everywhere else the manager is the right owner,
+      // and intercepting here would take the key from a host binding that has
+      // every right to it.
+      const target = event.target;
+      if (
+        !(target instanceof HTMLElement) ||
+        target.getAttribute("role") !== "separator"
+      ) {
+        return;
+      }
+      event.preventDefault();
+      event.stopPropagation();
+      focusNextRegion(regionRefs.current);
+    },
+    [regionRefs, enabled]
   );
 }
 
@@ -430,6 +501,7 @@ function ShellRegions({
   update,
   className,
   active,
+  loadCount,
 }: Omit<BuilderShellProps, "store"> & {
   preferences: ShellPreferences;
   update: (change: (current: ShellPreferences) => ShellPreferences) => void;
@@ -441,6 +513,13 @@ function ShellRegions({
    * and a visible one render identically.
    */
   active: boolean;
+  /**
+   * How many times preferences have been loaded from a store.
+   *
+   * Restoring a layout happens once per load, and this is what "once" is
+   * counted against — see `useRestoredLayout`.
+   */
+  loadCount: number;
 }) {
   const regionRefs = React.useRef<Record<Region, HTMLElement | null>>({
     rail: null,
@@ -449,8 +528,14 @@ function ShellRegions({
     inspector: null,
   });
   useRegionCycling(regionRefs, active);
+  const onKeyDownCapture = useSeparatorRegionEscape(regionRefs, active);
   const groupRef = React.useRef<PanelGroupHandle | null>(null);
-  useRestoredLayout(groupRef, preferences.layout, preferences.leftPanel);
+  useRestoredLayout(
+    groupRef,
+    preferences.layout,
+    preferences.leftPanel,
+    loadCount
+  );
   const chromeRef = React.useRef<HTMLDivElement | null>(null);
   useDesignSystemStylesheet(chromeRef);
 
@@ -465,6 +550,7 @@ function ShellRegions({
   return (
     <div
       ref={chromeRef}
+      onKeyDownCapture={onKeyDownCapture}
       className={cn(
         "nx-builder-chrome flex h-full w-full flex-col overflow-hidden",
         className
@@ -571,7 +657,18 @@ function ShellRegions({
                   aria-label={PANEL_CHROME[openPanel].label}
                   className="bg-[color:var(--nx-builder-surface-raised)] h-full overflow-auto"
                 >
-                  {renderPanel?.(openPanel)}
+                  {/* Keyed by the panel, because the prop's contract says the
+                      result is keyed by the panel and React's default
+                      reconciliation does not honour that. A caller rendering one
+                      component for several panels — `<MyPanel kind={panel} />`,
+                      which is what this package's own README suggests — puts the
+                      same element type at the same position, so switching from
+                      Layers to Tokens UPDATES that instance rather than mounting
+                      a new one: its state, its effects and any uncontrolled
+                      input values follow the author into a different tool. */}
+                  <React.Fragment key={openPanel}>
+                    {renderPanel?.(openPanel)}
+                  </React.Fragment>
                 </section>
               </ResizablePanel>
               <ResizableHandle withGrip />
@@ -643,7 +740,7 @@ export function BuilderShell({ store, ...props }: BuilderShellProps) {
   const fallbackStore = React.useRef<PreferenceStore | null>(null);
   fallbackStore.current ??= browserStore();
   const resolvedStore = store ?? fallbackStore.current;
-  const [preferences, update] = usePreferences(resolvedStore);
+  const [preferences, update, loadCount] = usePreferences(resolvedStore);
   const fitsFullShell = useFitsFullShell();
 
   return (
@@ -713,6 +810,7 @@ export function BuilderShell({ store, ...props }: BuilderShellProps) {
             preferences={preferences}
             update={update}
             active={fitsFullShell}
+            loadCount={loadCount}
           />
         </div>
       </TooltipProvider>

--- a/packages/builder/src/builder-shell.tsx
+++ b/packages/builder/src/builder-shell.tsx
@@ -33,6 +33,7 @@ import {
   panelAfterRailClick,
   RAIL_WIDTH,
   readPreferences,
+  topologyKey,
   writePreferences,
   type LeftPanel,
   type PreferenceStore,
@@ -255,120 +256,22 @@ function shallowEqualPreferences(
   a: ShellPreferences,
   b: ShellPreferences
 ): boolean {
-  if (a.leftPanel !== b.leftPanel || a.leftPinned !== b.leftPinned)
+  if (a.leftPanel !== b.leftPanel || a.leftPinned !== b.leftPinned) {
     return false;
-  if (a.layout === b.layout) return true;
-  if (a.layout === null || b.layout === null) return false;
-  const aKeys = Object.keys(a.layout);
-  const bKeys = Object.keys(b.layout);
-  return (
-    aKeys.length === bKeys.length &&
-    aKeys.every(key => a.layout?.[key] === b.layout?.[key])
-  );
-}
-
-/**
- * The panel group's imperative handle, DERIVED from the component's own props.
- *
- * Restated as a local interface it would be a second copy of the library's
- * type, agreeing on the day it was written and silently afterwards. Taken from
- * `groupRef` it cannot drift: if the handle changes shape, this stops compiling.
- */
-type PanelGroupHandle =
-  NonNullable<
-    React.ComponentProps<typeof ResizablePanelGroup>["groupRef"]
-  > extends React.Ref<infer Handle>
-    ? NonNullable<Handle>
-    : never;
-
-/**
- * Apply a restored layout to a group that has already mounted.
- *
- * `defaultLayout` cannot do this, and that is a property of the library rather
- * than of how it is being called. Version 4.12.2 reads that prop when the panels
- * REGISTER; changing it afterwards only assigns `mutableState.defaultLayout` and
- * never applies it. Preferences here are restored in an effect, deliberately —
- * reading storage during render diverges from the server's markup and costs a
- * hydration failure — so the value always arrives after registration, and the
- * prop was never going to take.
- *
- * The case that hid it: opening a panel CHANGES the panel set, which re-registers
- * everything and makes the deferred value take effect after all. So a layout
- * dragged with a panel open appeared to restore, while one dragged with the rail
- * closed — the default state, and the common one — silently reset on reload.
- *
- * Applied once per matching topology. The stored keys are compared with the
- * mounted ones because they can legitimately disagree: a layout saved with the
- * left panel open names a panel that is not mounted when it is closed, and
- * handing the group a layout for panels it does not have is not a restoration.
- */
-function useRestoredLayout(
-  groupRef: React.RefObject<PanelGroupHandle | null>,
-  layout: ShellPreferences["layout"],
-  leftPanel: ShellPreferences["leftPanel"],
-  loadCount: number
-): void {
-  const applied = React.useRef(-1);
-  /**
-   * The widths the panels declare, captured before anything is restored over
-   * them.
-   *
-   * Needed because there is no "reset" on the group. A load whose store has NO
-   * saved layout has to put the declared widths back, and by the time that
-   * happens the live layout is the PREVIOUS store's — so the defaults have to
-   * have been remembered from before the first restoration.
-   */
-  const declared = React.useRef<Record<string, number> | null>(null);
-
-  React.useEffect(() => {
-    const group = groupRef.current;
-    if (group === null || applied.current === loadCount) return;
-
-    const live = group.getLayout();
-    const mountedIds = Object.keys(live);
-    // Captured on the first run of this effect, which is before any restoration
-    // has been applied, so these really are the declared widths.
-    declared.current ??= live;
-
-    // On the FIRST load there is nothing to reset from — the panels already
-    // carry their declared widths — so a store with no saved layout is simply
-    // a no-op. The defaults are replayed only for a LATER load, which is a
-    // store swap, where what is on screen belongs to the previous store.
-    const isFirstLoad = applied.current === -1;
-    const target = layout ?? (isFirstLoad ? null : declared.current);
-    if (target === null || Object.keys(target).length === 0) {
-      applied.current = loadCount;
-      return;
-    }
-    // Not an error, and not permanent: the panel may simply not have mounted
-    // yet. `leftPanel` is a dependency so this runs again once the topology
-    // settles. Also guards the defaults snapshot, which belongs to whichever
-    // topology was mounted when it was taken.
-    if (
-      mountedIds.length !== Object.keys(target).length ||
-      !mountedIds.every(id => target[id] !== undefined)
-    ) {
-      return;
-    }
-
-    applied.current = loadCount;
-    // Rebuilt in the MOUNTED order rather than passed through as-is. The
-    // library validates `Object.values(layout)` positionally against its panel
-    // constraints, while a `Record` arriving through the public store port
-    // carries whatever key order the host's JSON happened to have — so an
-    // alphabetised `{canvas, inspector, panel}` would be constrained as though
-    // it were `{panel, canvas, inspector}` and the saved widths clamped to the
-    // wrong bounds. Object key order is insertion order, so rebuilding fixes it.
-    const ordered: Record<string, number> = {};
-    for (const id of mountedIds) {
-      const value = target[id];
-      if (value !== undefined) ordered[id] = value;
-    }
-    group.setLayout(ordered);
-    // `leftPanel` is not read in the body. It is a dependency because it is what
-    // changes the panel set, and the comparison above depends on that having
-    // settled.
-  }, [groupRef, layout, leftPanel, loadCount]);
+  }
+  if (a.layouts === b.layouts) return true;
+  const topologies = Object.keys(a.layouts);
+  if (topologies.length !== Object.keys(b.layouts).length) return false;
+  return topologies.every(topology => {
+    const left = a.layouts[topology];
+    const right = b.layouts[topology];
+    if (left === undefined || right === undefined) return false;
+    const ids = Object.keys(left);
+    return (
+      ids.length === Object.keys(right).length &&
+      ids.every(id => left[id] === right[id])
+    );
+  });
 }
 
 /**
@@ -577,7 +480,8 @@ function ShellRegions({
    * How many times preferences have been loaded from a store.
    *
    * Restoring a layout happens once per load, and this is what "once" is
-   * counted against — see `useRestoredLayout`.
+   * counted against: the group is remounted per load so the library
+   * re-reads the restored layout at panel registration.
    */
   loadCount: number;
 }) {
@@ -589,17 +493,19 @@ function ShellRegions({
   });
   useRegionCycling(regionRefs, active);
   const onKeyDownCapture = useSeparatorRegionEscape(regionRefs, active);
-  const groupRef = React.useRef<PanelGroupHandle | null>(null);
-  useRestoredLayout(
-    groupRef,
-    preferences.layout,
-    preferences.leftPanel,
-    loadCount
-  );
   const chromeRef = React.useRef<HTMLDivElement | null>(null);
   useDesignSystemStylesheet(chromeRef);
 
   const openPanel = preferences.leftPanel;
+  // The panel set about to be rendered, named the same way a persisted layout
+  // is keyed. Derived from `openPanel` because that is what decides the set;
+  // the persisted key is derived from the layout's own ids, and the two meet at
+  // `topologyKey` rather than being two spellings of one arrangement.
+  const mountedTopology = topologyKey(
+    openPanel === null
+      ? ["canvas", "inspector"]
+      : ["panel", "canvas", "inspector"]
+  );
 
   const selectPanel = (panel: LeftPanel) =>
     update(current => ({
@@ -671,9 +577,20 @@ function ShellRegions({
         </nav>
 
         <ResizablePanelGroup
+          // Remounted when a store is LOADED, which is the only way the library
+          // applies a layout: it reads `defaultLayout` when the panels REGISTER
+          // and a later prop change merely assigns it. Restoration therefore
+          // happens where the library already does it, rather than being
+          // reapplied afterwards through the imperative API — which is what made
+          // the units, the key order and the mount timing this component's
+          // problems to solve.
+          key={loadCount}
           orientation="horizontal"
-          groupRef={groupRef}
-          onLayoutChanged={(_layout, meta) => {
+          // Selected by the panel set actually mounted, so an arrangement with
+          // no stored layout falls through to the panels' declared widths
+          // instead of inheriting another arrangement's.
+          defaultLayout={preferences.layouts[mountedTopology]}
+          onLayoutChanged={(layout, meta) => {
             // The group reports every layout it settles on, not only the ones a
             // person asked for. Mounting, recomputing constraints and reacting
             // to a changed default all arrive here too, and the mount pass
@@ -687,16 +604,17 @@ function ShellRegions({
             // separator. Dragging a separator is the one event that states an
             // intent about widths, and it is the only one worth remembering.
             if (!meta.isUserInteraction) return;
-            const group = groupRef.current;
-            if (group === null) return;
-            // Read back through `getLayout` rather than persisting the argument.
-            // The callback reports FLEX-GROW weights while `setLayout` takes
-            // PERCENTAGES, and restoring now goes through `setLayout`; storing
-            // one unit and replaying it as the other is a bug that only shows up
-            // on a layout whose weights happen not to sum to 100.
+            // Stored under the topology it was measured for, and keyed from the
+            // layout's OWN ids rather than from a separate description of the
+            // panel set. `defaultLayout` consumes the same flex-grow weights
+            // this reports, so the value makes a round trip in one unit and
+            // never meets the percentage side of the API.
             update(current => ({
               ...current,
-              layout: { ...group.getLayout() },
+              layouts: {
+                ...current.layouts,
+                [topologyKey(Object.keys(layout))]: { ...layout },
+              },
             }));
           }}
           className="min-w-0 flex-1"

--- a/packages/builder/src/builder-shell.tsx
+++ b/packages/builder/src/builder-shell.tsx
@@ -233,6 +233,67 @@ function shallowEqualPreferences(
 }
 
 /**
+ * The panel group's imperative handle, DERIVED from the component's own props.
+ *
+ * Restated as a local interface it would be a second copy of the library's
+ * type, agreeing on the day it was written and silently afterwards. Taken from
+ * `groupRef` it cannot drift: if the handle changes shape, this stops compiling.
+ */
+type PanelGroupHandle =
+  NonNullable<
+    React.ComponentProps<typeof ResizablePanelGroup>["groupRef"]
+  > extends React.Ref<infer Handle>
+    ? NonNullable<Handle>
+    : never;
+
+/**
+ * Apply a restored layout to a group that has already mounted.
+ *
+ * `defaultLayout` cannot do this, and that is a property of the library rather
+ * than of how it is being called. Version 4.12.2 reads that prop when the panels
+ * REGISTER; changing it afterwards only assigns `mutableState.defaultLayout` and
+ * never applies it. Preferences here are restored in an effect, deliberately —
+ * reading storage during render diverges from the server's markup and costs a
+ * hydration failure — so the value always arrives after registration, and the
+ * prop was never going to take.
+ *
+ * The case that hid it: opening a panel CHANGES the panel set, which re-registers
+ * everything and makes the deferred value take effect after all. So a layout
+ * dragged with a panel open appeared to restore, while one dragged with the rail
+ * closed — the default state, and the common one — silently reset on reload.
+ *
+ * Applied once per matching topology. The stored keys are compared with the
+ * mounted ones because they can legitimately disagree: a layout saved with the
+ * left panel open names a panel that is not mounted when it is closed, and
+ * handing the group a layout for panels it does not have is not a restoration.
+ */
+function useRestoredLayout(
+  groupRef: React.RefObject<PanelGroupHandle | null>,
+  layout: ShellPreferences["layout"],
+  leftPanel: ShellPreferences["leftPanel"]
+): void {
+  const applied = React.useRef(false);
+
+  React.useEffect(() => {
+    const group = groupRef.current;
+    if (group === null || layout === null || applied.current) return;
+
+    const mounted = Object.keys(group.getLayout()).sort().join(",");
+    const stored = Object.keys(layout).sort().join(",");
+    // Not an error, and not permanent: the panel may simply not have mounted
+    // yet. `leftPanel` is in the dependencies so this runs again when the
+    // topology settles.
+    if (mounted !== stored) return;
+
+    applied.current = true;
+    group.setLayout(layout);
+    // `leftPanel` is not read in the body. It is a dependency because it is what
+    // changes the panel set, and the comparison above depends on that having
+    // settled.
+  }, [groupRef, layout, leftPanel]);
+}
+
+/**
  * One design-system token, read off the mounted shell.
  *
  * Chosen over any `--nx-builder-*` because those are declared in this package's
@@ -298,12 +359,31 @@ function useDesignSystemStylesheet(
  * owns it" happens — the failure the manager exists to prevent.
  */
 function useRegionCycling(
-  regionRefs: React.RefObject<Record<Region, HTMLElement | null>>
+  regionRefs: React.RefObject<Record<Region, HTMLElement | null>>,
+  enabled: boolean
 ): void {
+  // Read through a ref so the binding's `when` sees the CURRENT answer. The
+  // manager checks it at press time, and a value captured when the binding was
+  // registered would keep reporting whatever was true then.
+  const enabledRef = React.useRef(enabled);
+  enabledRef.current = enabled;
+
   useShortcuts(
     [
       {
         keys: "F6",
+        // Off while the shell is hidden behind the narrow-viewport notice. The
+        // subtree stays mounted there to preserve the caller's slots, which
+        // leaves this binding registered over regions that are all `inert`:
+        // pressing F6 on the notice consumed the key, focused nothing, and —
+        // where the host shares the shortcut manager — took the keystroke from
+        // whatever binding of its own would otherwise have handled it.
+        //
+        // `when` rather than skipping registration, because it is the
+        // manager's own way of saying "not right now": a binding whose
+        // condition is false is passed over and the key goes on to the next
+        // layer, which is exactly the behaviour the host needs back.
+        when: () => enabledRef.current,
         description: "Move to the next area of the editor",
         // The manager's default asks whether the FIRST chord carries a modifier
         // or is Escape, and answers no for a bare function key — so F6 would be
@@ -349,9 +429,18 @@ function ShellRegions({
   preferences,
   update,
   className,
+  active,
 }: Omit<BuilderShellProps, "store"> & {
   preferences: ShellPreferences;
   update: (change: (current: ShellPreferences) => ShellPreferences) => void;
+  /**
+   * Whether this subtree is the one the author is using.
+   *
+   * False while it sits mounted-but-hidden behind the narrow-viewport notice,
+   * which is a state it cannot detect for itself: from in here a hidden shell
+   * and a visible one render identically.
+   */
+  active: boolean;
 }) {
   const regionRefs = React.useRef<Record<Region, HTMLElement | null>>({
     rail: null,
@@ -359,7 +448,9 @@ function ShellRegions({
     canvas: null,
     inspector: null,
   });
-  useRegionCycling(regionRefs);
+  useRegionCycling(regionRefs, active);
+  const groupRef = React.useRef<PanelGroupHandle | null>(null);
+  useRestoredLayout(groupRef, preferences.layout, preferences.leftPanel);
   const chromeRef = React.useRef<HTMLDivElement | null>(null);
   useDesignSystemStylesheet(chromeRef);
 
@@ -435,8 +526,8 @@ function ShellRegions({
 
         <ResizablePanelGroup
           orientation="horizontal"
-          defaultLayout={preferences.layout ?? undefined}
-          onLayoutChanged={(layout, meta) => {
+          groupRef={groupRef}
+          onLayoutChanged={(_layout, meta) => {
             // The group reports every layout it settles on, not only the ones a
             // person asked for. Mounting, recomputing constraints and reacting
             // to a changed default all arrive here too, and the mount pass
@@ -450,7 +541,17 @@ function ShellRegions({
             // separator. Dragging a separator is the one event that states an
             // intent about widths, and it is the only one worth remembering.
             if (!meta.isUserInteraction) return;
-            update(current => ({ ...current, layout: { ...layout } }));
+            const group = groupRef.current;
+            if (group === null) return;
+            // Read back through `getLayout` rather than persisting the argument.
+            // The callback reports FLEX-GROW weights while `setLayout` takes
+            // PERCENTAGES, and restoring now goes through `setLayout`; storing
+            // one unit and replaying it as the other is a bug that only shows up
+            // on a layout whose weights happen not to sum to 100.
+            update(current => ({
+              ...current,
+              layout: { ...group.getLayout() },
+            }));
           }}
           className="min-w-0 flex-1"
         >
@@ -607,7 +708,12 @@ export function BuilderShell({ store, ...props }: BuilderShellProps) {
           // `display: none` has to be the one that applies.
           className={fitsFullShell ? "contents" : undefined}
         >
-          <ShellRegions {...props} preferences={preferences} update={update} />
+          <ShellRegions
+            {...props}
+            preferences={preferences}
+            update={update}
+            active={fitsFullShell}
+          />
         </div>
       </TooltipProvider>
     </ShortcutProvider>

--- a/packages/builder/src/builder-shell.tsx
+++ b/packages/builder/src/builder-shell.tsx
@@ -106,6 +106,17 @@ export interface BuilderShellProps {
    * Where chrome preferences live. Defaults to `localStorage` in a browser and
    * to a store that remembers nothing anywhere else, so a server render is a
    * default rather than a crash.
+   *
+   * **Pass a NEW object whenever the data behind it changes** — a different
+   * signed-in user, a different workspace. The shell reloads preferences when
+   * this identity changes, and cannot see a store that quietly starts reading
+   * somewhere else: it would go on showing the previous user's panel widths and
+   * write their preferences into the new target.
+   *
+   * This is the same contract React puts on any value it compares by identity,
+   * and it keeps the port at two methods. The alternative — a subscription or a
+   * revision token — is a third method every host has to implement correctly
+   * for a case that a new object already solves.
    */
   store?: PreferenceStore;
   className?: string;
@@ -177,9 +188,18 @@ function usePreferences(store: PreferenceStore) {
    * loads that user's preferences, and a guard that already fired leaves the
    * previous user's widths on screen.
    *
-   * A counter rather than the store's identity, because it is the LOAD that
-   * matters: it advances on every read, so a host that passes the same store
-   * object after changing what is behind it still gets a fresh restoration.
+   * A counter rather than the store's identity because it is what the guard
+   * downstream compares against, and it says WHICH load was applied rather than
+   * merely that one was.
+   *
+   * It does NOT detect a host mutating the data behind a store it keeps
+   * handing us: the read below is keyed on the store's identity, so an
+   * unchanged object means no read happens at all and this never advances.
+   * That is the documented contract on `store` — a new backing user or
+   * workspace is a new store object — rather than a gap. Detecting it instead
+   * would mean a subscription or a revision token on the port, which is a
+   * third method every host implementing it would have to get right, for a
+   * case a caller can satisfy by passing a new object.
    */
   const [loadCount, setLoadCount] = React.useState(0);
 
@@ -289,22 +309,62 @@ function useRestoredLayout(
   loadCount: number
 ): void {
   const applied = React.useRef(-1);
+  /**
+   * The widths the panels declare, captured before anything is restored over
+   * them.
+   *
+   * Needed because there is no "reset" on the group. A load whose store has NO
+   * saved layout has to put the declared widths back, and by the time that
+   * happens the live layout is the PREVIOUS store's — so the defaults have to
+   * have been remembered from before the first restoration.
+   */
+  const declared = React.useRef<Record<string, number> | null>(null);
 
   React.useEffect(() => {
     const group = groupRef.current;
-    if (group === null || layout === null || applied.current === loadCount) {
+    if (group === null || applied.current === loadCount) return;
+
+    const live = group.getLayout();
+    const mountedIds = Object.keys(live);
+    // Captured on the first run of this effect, which is before any restoration
+    // has been applied, so these really are the declared widths.
+    declared.current ??= live;
+
+    // On the FIRST load there is nothing to reset from — the panels already
+    // carry their declared widths — so a store with no saved layout is simply
+    // a no-op. The defaults are replayed only for a LATER load, which is a
+    // store swap, where what is on screen belongs to the previous store.
+    const isFirstLoad = applied.current === -1;
+    const target = layout ?? (isFirstLoad ? null : declared.current);
+    if (target === null || Object.keys(target).length === 0) {
+      applied.current = loadCount;
+      return;
+    }
+    // Not an error, and not permanent: the panel may simply not have mounted
+    // yet. `leftPanel` is a dependency so this runs again once the topology
+    // settles. Also guards the defaults snapshot, which belongs to whichever
+    // topology was mounted when it was taken.
+    if (
+      mountedIds.length !== Object.keys(target).length ||
+      !mountedIds.every(id => target[id] !== undefined)
+    ) {
       return;
     }
 
-    const mounted = Object.keys(group.getLayout()).sort().join(",");
-    const stored = Object.keys(layout).sort().join(",");
-    // Not an error, and not permanent: the panel may simply not have mounted
-    // yet. `leftPanel` is in the dependencies so this runs again when the
-    // topology settles.
-    if (mounted !== stored) return;
-
     applied.current = loadCount;
-    group.setLayout(layout);
+    // Rebuilt in the MOUNTED order rather than passed through as-is. The
+    // library validates `Object.values(layout)` positionally against its panel
+    // constraints, while a `Record` arriving through the public store port
+    // carries whatever key order the host's JSON happened to have — so an
+    // alphabetised `{canvas, inspector, panel}` would be constrained as though
+    // it were `{panel, canvas, inspector}` and the saved widths clamped to the
+    // wrong bounds. Object key order is insertion order, so rebuilding fixes it.
+    const ordered: Record<string, number> = {};
+    for (const id of mountedIds) {
+      const value = target[id];
+      if (value !== undefined) ordered[id] = value;
+    }
+    group.setLayout(ordered);
     // `leftPanel` is not read in the body. It is a dependency because it is what
     // changes the panel set, and the comparison above depends on that having
     // settled.

--- a/packages/builder/src/builder-shell.tsx
+++ b/packages/builder/src/builder-shell.tsx
@@ -177,8 +177,28 @@ function usePreferences(store: PreferenceStore) {
     );
   }, [store]);
 
+  // The newest preferences, reachable from a callback that must not go stale.
+  const latest = React.useRef(preferences);
+  latest.current = preferences;
+
+  /**
+   * Takes a CHANGE rather than a value, and this is load-bearing.
+   *
+   * `react-resizable-panels` calls `onLayoutChanged` once a drag settles, from
+   * a handler React captured when the panel was rendered. Handed a whole
+   * record built by spreading `preferences` from that render, a drag begun
+   * before an unrelated change would write the OLD record back with only the
+   * layout replaced — silently discarding whichever field moved in between.
+   *
+   * Measured, not theorised: opening a panel and then dragging its separator
+   * wrote `leftPanel: null` back over the open panel, so the panel vanished on
+   * the next load. jsdom cannot see this — its inert `ResizeObserver` means
+   * `onLayoutChanged` never fires there — which is why it took a browser.
+   */
   const update = React.useCallback(
-    (next: ShellPreferences) => {
+    (change: (current: ShellPreferences) => ShellPreferences) => {
+      const next = change(latest.current);
+      latest.current = next;
       setPreferences(next);
       writePreferences(store, next);
     },
@@ -264,7 +284,7 @@ function ShellRegions({
   className,
 }: Omit<BuilderShellProps, "store"> & {
   preferences: ShellPreferences;
-  update: (next: ShellPreferences) => void;
+  update: (change: (current: ShellPreferences) => ShellPreferences) => void;
 }) {
   const regionRefs = React.useRef<Record<Region, HTMLElement | null>>({
     rail: null,
@@ -277,10 +297,10 @@ function ShellRegions({
   const openPanel = preferences.leftPanel;
 
   const selectPanel = (panel: LeftPanel) =>
-    update({
-      ...preferences,
-      leftPanel: panelAfterRailClick(openPanel, panel),
-    });
+    update(current => ({
+      ...current,
+      leftPanel: panelAfterRailClick(current.leftPanel, panel),
+    }));
 
   return (
     <div
@@ -347,7 +367,7 @@ function ShellRegions({
           orientation="horizontal"
           defaultLayout={preferences.layout ?? undefined}
           onLayoutChanged={layout => {
-            update({ ...preferences, layout: { ...layout } });
+            update(current => ({ ...current, layout: { ...layout } }));
           }}
           className="min-w-0 flex-1"
         >

--- a/packages/builder/src/builder-shell.tsx
+++ b/packages/builder/src/builder-shell.tsx
@@ -30,6 +30,7 @@ import {
   MIN_SHELL_WIDTH,
   PANEL_BOUNDS,
   panelAfterRailClick,
+  RAIL_WIDTH,
   readPreferences,
   writePreferences,
   type LeftPanel,
@@ -148,13 +149,33 @@ function useFitsFullShell(): boolean {
   return fits;
 }
 
-/** Preferences, restored once and written back whenever they change. */
+/**
+ * Preferences, restored AFTER mount and written back whenever they change.
+ *
+ * Reading storage in the initializer is the obvious shape and it is wrong here.
+ * On a server render the default store answers `null`, so the server emits the
+ * defaults; the client initializer reads `localStorage` and emits a restored
+ * panel. React 19 treats that divergence as a hydration failure and rebuilds
+ * the subtree — so a returning author's restored layout arrives as a flash and
+ * a discarded tree rather than as a layout.
+ *
+ * Both first renders therefore start from the defaults, and the stored
+ * preferences are applied in an effect. The cost is one frame of default
+ * chrome; the alternative is a mismatch on every load for anyone who has ever
+ * moved a panel.
+ */
 function usePreferences(store: PreferenceStore) {
-  // Read lazily so storage is touched once, not on every render, and never
-  // during a server render where the default store answers null anyway.
-  const [preferences, setPreferences] = React.useState<ShellPreferences>(() =>
-    readPreferences(store)
-  );
+  const [preferences, setPreferences] =
+    React.useState<ShellPreferences>(DEFAULT_PREFERENCES);
+
+  React.useEffect(() => {
+    const restored = readPreferences(store);
+    // Compared before setting so a host with no stored preferences does not
+    // take a second render for a value that did not change.
+    setPreferences(current =>
+      shallowEqualPreferences(current, restored) ? current : restored
+    );
+  }, [store]);
 
   const update = React.useCallback(
     (next: ShellPreferences) => {
@@ -165,6 +186,29 @@ function usePreferences(store: PreferenceStore) {
   );
 
   return [preferences, update] as const;
+}
+
+/**
+ * Whether two preference records say the same thing.
+ *
+ * The layout is compared by its entries rather than by identity: `readPreferences`
+ * builds a fresh object every call, so identity is always false and the restore
+ * effect would set state on every mount even when nothing changed.
+ */
+function shallowEqualPreferences(
+  a: ShellPreferences,
+  b: ShellPreferences
+): boolean {
+  if (a.leftPanel !== b.leftPanel || a.leftPinned !== b.leftPinned)
+    return false;
+  if (a.layout === b.layout) return true;
+  if (a.layout === null || b.layout === null) return false;
+  const aKeys = Object.keys(a.layout);
+  const bKeys = Object.keys(b.layout);
+  return (
+    aKeys.length === bKeys.length &&
+    aKeys.every(key => a.layout?.[key] === b.layout?.[key])
+  );
 }
 
 /**
@@ -185,16 +229,22 @@ function useRegionCycling(
         run: () => {
           const map = regionRefs.current;
           if (!map) return;
+          // Only regions that are actually rendered. The left panel is absent
+          // whenever the rail has nothing open, and cycling the static list
+          // would land on it, focus nothing, and leave the key looking broken
+          // for every press after the first.
+          const present = REGIONS.filter(region => map[region] !== null);
+          if (present.length === 0) return;
+
           const active = document.activeElement;
-          const currentIndex = REGIONS.findIndex(region => {
-            const element = map[region];
-            return element !== null && element.contains(active);
-          });
+          const currentIndex = present.findIndex(region =>
+            map[region]?.contains(active)
+          );
           // From outside any region, F6 enters the first rather than doing
           // nothing — otherwise the key appears broken until focus happens to
           // land somewhere it recognises.
-          const next = REGIONS[(currentIndex + 1) % REGIONS.length];
-          map[next]?.focus();
+          const next = present[(currentIndex + 1) % present.length];
+          if (next !== undefined) map[next]?.focus();
         },
       },
     ],
@@ -261,7 +311,7 @@ function ShellRegions({
           }}
           tabIndex={-1}
           aria-label="Editor panels"
-          style={{ width: 48 }}
+          style={{ width: RAIL_WIDTH }}
           className="border-[color:var(--nx-builder-border)] flex shrink-0 flex-col items-center gap-1 border-r py-2"
         >
           {LEFT_PANELS.map(panel => {

--- a/packages/builder/src/dev-warn.ts
+++ b/packages/builder/src/dev-warn.ts
@@ -1,0 +1,78 @@
+/**
+ * Development-time warnings for requirements nothing else can check.
+ *
+ * The editor's stylesheet supplements the design system's rather than restating
+ * it, so the shell renders correctly only when the host has loaded BOTH. Nothing
+ * at build time can see whether it did: the second sheet is a side-effect import
+ * in the host's own application, and its absence produces a shell that mounts,
+ * carries every class it should, and merely looks wrong — the most expensive
+ * kind of failure to trace back to a missing import.
+ *
+ * `@nextlyhq/ui` has a module of the same shape and keeps it private, so this is
+ * a second instance of the pattern rather than a second copy of an answer: the
+ * two warn about different contracts and name different packages. The rules are
+ * taken from it deliberately, because they are the ones that make a warning
+ * useful rather than noise.
+ *
+ * - **Development only, proven rather than assumed.** The gate requires a
+ *   POSITIVE development signal. Asking whether the environment is production
+ *   fails open — a browser bundle that never defines `process` leaves that
+ *   comparison false, and every warning would reach real users' consoles.
+ * - **Once per message.** The shell re-renders on every panel drag; the same
+ *   line on every frame trains people to ignore the console.
+ * - **Never throws.** A missing stylesheet degrades the editor's appearance. It
+ *   must not take down the page.
+ *
+ * @module dev-warn
+ */
+
+/** Messages already emitted this session, keyed by the message itself. */
+const emitted = new Set<string>();
+
+/**
+ * The one field this module reads, declared rather than pulled in with
+ * `@types/node`: this package targets the browser, and bundlers replace
+ * `process.env.NODE_ENV` at build time.
+ */
+declare const process: { env?: { NODE_ENV?: string } | undefined } | undefined;
+
+/**
+ * The environments a warning may speak in.
+ *
+ * `test` sits alongside `development` so a suite asserting that a warning fires
+ * is exercising the same path a developer relies on, rather than passing because
+ * the gate silenced it.
+ */
+const SPEAKING_ENVIRONMENTS = new Set(["development", "test"]);
+
+/** Whether this runtime has positively identified itself as a development one. */
+function isDevelopmentRuntime(): boolean {
+  if (typeof process === "undefined") return false;
+  const env = process?.env?.NODE_ENV;
+  return env !== undefined && SPEAKING_ENVIRONMENTS.has(env);
+}
+
+/**
+ * Warn once, in development, about a requirement that is unmet.
+ *
+ * @param condition - The requirement. Nothing is emitted while this holds.
+ * @param message - What is wrong and what to do about it, written for someone
+ *   reading a console with no other context.
+ */
+export function devWarnOnce(condition: boolean, message: string): void {
+  if (condition) return;
+  if (!isDevelopmentRuntime()) return;
+  if (emitted.has(message)) return;
+  emitted.add(message);
+  console.warn(`[@nextlyhq/builder] ${message}`);
+}
+
+/**
+ * Forget which messages have been emitted.
+ *
+ * For tests, which need each case to observe its own warning rather than
+ * inheriting an earlier one's suppression.
+ */
+export function resetDevWarnings(): void {
+  emitted.clear();
+}

--- a/packages/builder/src/index.ts
+++ b/packages/builder/src/index.ts
@@ -71,3 +71,27 @@ export {
  * `clientLeft`/`clientTop` left three call sites short by the padding.
  */
 export { frameInsetOf } from "./geometry-dom";
+
+/**
+ * @experimental The editor shell: rail, one switched panel, canvas, inspector,
+ * and the bars around them. Presentational — selection arrives as props.
+ */
+export { BuilderShell } from "./builder-shell";
+export type { BuilderShellProps } from "./builder-shell";
+
+/**
+ * @experimental The shell's own decisions: which panels the rail offers, the
+ * bounds handed to the panel library, and the preference port.
+ */
+export {
+  LEFT_PANELS,
+  MIN_CANVAS_WIDTH,
+  MIN_SHELL_WIDTH,
+  PANEL_BOUNDS,
+  RAIL_WIDTH,
+} from "./shell-state";
+export type {
+  LeftPanel,
+  PreferenceStore,
+  ShellPreferences,
+} from "./shell-state";

--- a/packages/builder/src/index.ts
+++ b/packages/builder/src/index.ts
@@ -22,11 +22,26 @@
  * predicate would not have prevented that, because sharing a predicate does not
  * share the decision to call it; only sharing the entry point does.
  *
- * **Public surface so far**: {@link BUILDER_PACKAGE_NAME}, and the frame
- * geometry below. The editor itself is not exported yet — the package was
- * created ahead of it so its name could be claimed on npm, because trusted
- * publishing cannot perform a package's first publish and the bootstrap script
- * will not claim a name that is not already a workspace package.
+ * **Public surface**, all of it `@experimental` while the editor is being built
+ * out:
+ *
+ * - {@link BUILDER_PACKAGE_NAME}, for diagnostics that report what a host loaded.
+ * - The frame geometry — {@link pointToCanvas}, {@link pointToHost},
+ *   {@link rectToHost}, {@link frameContentOrigin}, {@link frameInsetOf} — also
+ *   published at `@nextlyhq/builder/geometry`, which carries no `"use client"`
+ *   banner and so is reachable from a server component.
+ * - {@link BuilderShell}, the editor shell, with its declared bounds and
+ *   preference port. Those are also published at
+ *   `@nextlyhq/builder/shell-state`, again free of the client banner.
+ * - `@nextlyhq/builder/styles.css`, the chrome's stylesheet. It SUPPLEMENTS the
+ *   design system's rather than restating it, so a host loads
+ *   `@nextlyhq/ui/styles.css` — or the admin's, which contains it — alongside.
+ *   The shell says so in the console, in development, when it is missing.
+ *
+ * The package was created ahead of any of this so its name could be claimed on
+ * npm, because trusted publishing cannot perform a package's first publish and
+ * the bootstrap script will not claim a name that is not already a workspace
+ * package.
  *
  * @module @nextlyhq/builder
  */

--- a/packages/builder/src/index.ts
+++ b/packages/builder/src/index.ts
@@ -30,9 +30,11 @@
  *   {@link rectToHost}, {@link frameContentOrigin}, {@link frameInsetOf} — also
  *   published at `@nextlyhq/builder/geometry`, which carries no `"use client"`
  *   banner and so is reachable from a server component.
- * - {@link BuilderShell}, the editor shell, with its declared bounds and
- *   preference port. Those are also published at
- *   `@nextlyhq/builder/shell-state`, again free of the client banner.
+ * - The shell's declared bounds and preference port, also published at
+ *   `@nextlyhq/builder/shell-state`.
+ * - `BuilderShell` itself at `@nextlyhq/builder/shell`, which is the ONLY entry
+ *   carrying `"use client"`. This one does not, so everything above is callable
+ *   from a Server Component.
  * - `@nextlyhq/builder/styles.css`, the chrome's stylesheet. It SUPPLEMENTS the
  *   design system's rather than restating it, so a host loads
  *   `@nextlyhq/ui/styles.css` — or the admin's, which contains it — alongside.
@@ -88,10 +90,16 @@ export {
 export { frameInsetOf } from "./geometry-dom";
 
 /**
- * @experimental The editor shell: rail, one switched panel, canvas, inspector,
- * and the bars around them. Presentational — selection arrives as props.
+ * @experimental The editor shell's props.
+ *
+ * The TYPE only. `BuilderShell` itself lives at `@nextlyhq/builder/shell`, and
+ * this entry deliberately does not re-export it: a value re-export would pull
+ * the component into this bundle, which would then need the `"use client"`
+ * banner, which would make every export above it a client reference — including
+ * the geometry, which a Server Component is supposed to be able to call.
+ *
+ * A type costs nothing at runtime, so it can be described from here.
  */
-export { BuilderShell } from "./builder-shell";
 export type { BuilderShellProps } from "./builder-shell";
 
 /**

--- a/packages/builder/src/layering.test.ts
+++ b/packages/builder/src/layering.test.ts
@@ -99,6 +99,10 @@ const ALLOWED_IN_TESTS = [
   "node:fs",
   "node:path",
   "node:url",
+  // Server rendering, for the hydration assertions. A shell whose server and
+  // first client render disagree is repaired by React discarding the subtree,
+  // and `renderToString` is the only way to observe that from a test.
+  "react-dom/server",
   "typescript",
   "vitest",
 ];

--- a/packages/builder/src/shell-state.test.ts
+++ b/packages/builder/src/shell-state.test.ts
@@ -1,0 +1,296 @@
+/**
+ * The shell's decisions, asserted where they can be measured.
+ *
+ * Everything here is arithmetic and set membership. The LAYOUT these decisions
+ * produce is not checkable from a unit test — jsdom reports every element as
+ * zero-sized, so an assertion about a panel's width passes whatever the CSS
+ * does — and is verified in a real browser instead.
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  clampPanelWidth,
+  DEFAULT_PREFERENCES,
+  fitsFullShell,
+  isLeftPanel,
+  LEFT_PANELS,
+  fitPanels,
+  MIN_CANVAS_WIDTH,
+  MIN_SHELL_WIDTH,
+  panelAfterRailClick,
+  RAIL_WIDTH,
+  PANEL_BOUNDS,
+  readPreferences,
+  writePreferences,
+  type PreferenceStore,
+} from "./shell-state";
+
+/** A store standing in for `localStorage`, plus the two ways one really fails. */
+function memoryStore(initial: string | null = null): PreferenceStore & {
+  value: string | null;
+} {
+  return {
+    value: initial,
+    read() {
+      return this.value;
+    },
+    write(next: string) {
+      this.value = next;
+    },
+  };
+}
+
+const refusingStore: PreferenceStore = {
+  read() {
+    throw new Error("storage unavailable");
+  },
+  write() {
+    throw new Error("quota exceeded");
+  },
+};
+
+describe("which panel the rail selects", () => {
+  it("names every panel the rail offers", () => {
+    // Pinned as a literal, because the per-panel cases below cannot guard the
+    // list they iterate: removing a panel deletes its own case, the suite
+    // shrinks by one, and everything remaining passes. A vanishing test reads
+    // exactly like a passing one.
+    expect([...LEFT_PANELS].sort()).toEqual([
+      "components",
+      "fonts",
+      "insert",
+      "layers",
+      "pages",
+      "settings",
+      "tokens",
+    ]);
+  });
+
+  it("opens the panel that was clicked", () => {
+    expect(panelAfterRailClick(null, "layers")).toBe("layers");
+    expect(panelAfterRailClick("insert", "layers")).toBe("layers");
+  });
+
+  it("closes the open panel when its own rail item is clicked again", () => {
+    // The rail is the only route to a full-width canvas. Without the toggle the
+    // author can switch panels forever and never dismiss one.
+    expect(panelAfterRailClick("layers", "layers")).toBeNull();
+  });
+});
+
+describe("a stored panel name that no longer names a panel", () => {
+  it.each([...LEFT_PANELS])("accepts %s", panel => {
+    expect(isLeftPanel(panel)).toBe(true);
+  });
+
+  it("rejects anything else", () => {
+    // The positive control for the cases above: an `isLeftPanel` returning true
+    // for everything satisfies every one of them.
+    expect(isLeftPanel("history")).toBe(false);
+    expect(isLeftPanel("")).toBe(false);
+    expect(isLeftPanel(null)).toBe(false);
+    expect(isLeftPanel(7)).toBe(false);
+  });
+
+  it("falls back to no panel rather than opening an empty one", () => {
+    // A preference outlives the release that wrote it. Restoring a removed
+    // panel blindly leaves a region rendering nothing, with no obvious way back.
+    const store = memoryStore(JSON.stringify({ leftPanel: "history" }));
+    expect(readPreferences(store).leftPanel).toBeNull();
+  });
+});
+
+describe("panel widths", () => {
+  it.each(["left", "inspector"] as const)(
+    "clamps %s into its bounds",
+    region => {
+      const { min, max } = PANEL_BOUNDS[region];
+      expect(clampPanelWidth(region, min - 100)).toBe(min);
+      expect(clampPanelWidth(region, max + 100)).toBe(max);
+      expect(clampPanelWidth(region, min + 1)).toBe(min + 1);
+    }
+  );
+
+  it("answers the initial width for a value that is not a number", () => {
+    // `Math.min`/`Math.max` pass NaN straight through, so a bare clamp would
+    // store it and collapse the panel. The two sources are a malformed stored
+    // string and a division by a zero-height frame.
+    expect(clampPanelWidth("left", Number.NaN)).toBe(PANEL_BOUNDS.left.initial);
+    expect(clampPanelWidth("left", Number.POSITIVE_INFINITY)).toBe(
+      PANEL_BOUNDS.left.initial
+    );
+  });
+});
+
+describe("panels give way to the canvas floor", () => {
+  const canvasFor = (
+    viewportWidth: number,
+    fitted: { leftWidth: number; inspectorWidth: number },
+    leftOpen = true
+  ) =>
+    viewportWidth -
+    RAIL_WIDTH -
+    (leftOpen ? fitted.leftWidth : 0) -
+    fitted.inspectorWidth;
+
+  it("keeps the canvas floor at the minimum supported viewport", () => {
+    // The case that drove this design. Per-panel bounds alone are satisfied by
+    // both panels at maximum here, and leave the canvas at 232px — narrower
+    // than either panel, in an editor whose subject IS the canvas. Nothing
+    // per-panel is violated, because the constraint was never per-panel.
+    const fitted = fitPanels({
+      viewportWidth: MIN_SHELL_WIDTH,
+      leftWidth: PANEL_BOUNDS.left.max,
+      inspectorWidth: PANEL_BOUNDS.inspector.max,
+      leftOpen: true,
+    });
+    expect(canvasFor(MIN_SHELL_WIDTH, fitted)).toBeGreaterThanOrEqual(
+      MIN_CANVAS_WIDTH
+    );
+  });
+
+  it("takes from the inspector before the panel the author opened", () => {
+    // The left panel is a deliberate choice, dismissible with the same click
+    // that opened it; the inspector is always there. Shrinking the deliberate
+    // choice first reads as the editor undoing an action.
+    const fitted = fitPanels({
+      viewportWidth: MIN_SHELL_WIDTH,
+      leftWidth: PANEL_BOUNDS.left.max,
+      inspectorWidth: PANEL_BOUNDS.inspector.max,
+      leftOpen: true,
+    });
+    // The ordering property, stated as what it actually is: the inspector is
+    // exhausted to its own minimum BEFORE the left panel gives up a pixel. At
+    // this viewport both must move, so "the left panel is untouched" would be
+    // overstating it — and asserting that was wrong, not the implementation.
+    expect(fitted.inspectorWidth).toBe(PANEL_BOUNDS.inspector.min);
+    expect(fitted.leftWidth).toBeLessThan(PANEL_BOUNDS.left.max);
+  });
+
+  it("does not touch the left panel while the inspector still has room", () => {
+    // The ordering, isolated: one viewport wider, so the inspector alone can
+    // absorb the overflow. If the order were reversed this is where it shows.
+    const fitted = fitPanels({
+      viewportWidth: 1400,
+      leftWidth: PANEL_BOUNDS.left.max,
+      inspectorWidth: PANEL_BOUNDS.inspector.max,
+      leftOpen: true,
+    });
+    expect(fitted.leftWidth).toBe(PANEL_BOUNDS.left.max);
+    expect(fitted.inspectorWidth).toBeLessThan(PANEL_BOUNDS.inspector.max);
+    expect(fitted.inspectorWidth).toBeGreaterThan(PANEL_BOUNDS.inspector.min);
+  });
+
+  it("never squeezes a panel below its own minimum", () => {
+    const fitted = fitPanels({
+      viewportWidth: MIN_SHELL_WIDTH,
+      leftWidth: PANEL_BOUNDS.left.max,
+      inspectorWidth: PANEL_BOUNDS.inspector.max,
+      leftOpen: true,
+    });
+    expect(fitted.inspectorWidth).toBeGreaterThanOrEqual(
+      PANEL_BOUNDS.inspector.min
+    );
+    expect(fitted.leftWidth).toBeGreaterThanOrEqual(PANEL_BOUNDS.left.min);
+  });
+
+  it("leaves both alone when there is room", () => {
+    // The control: a fit that shrank panels on a wide viewport would satisfy
+    // every assertion above.
+    const fitted = fitPanels({
+      viewportWidth: 1920,
+      leftWidth: PANEL_BOUNDS.left.max,
+      inspectorWidth: PANEL_BOUNDS.inspector.max,
+      leftOpen: true,
+    });
+    expect(fitted).toEqual({
+      leftWidth: PANEL_BOUNDS.left.max,
+      inspectorWidth: PANEL_BOUNDS.inspector.max,
+    });
+  });
+
+  it("gives the closed left panel's space to the canvas, not the inspector", () => {
+    const fitted = fitPanels({
+      viewportWidth: MIN_SHELL_WIDTH,
+      leftWidth: PANEL_BOUNDS.left.max,
+      inspectorWidth: PANEL_BOUNDS.inspector.max,
+      leftOpen: false,
+    });
+    expect(fitted.inspectorWidth).toBe(PANEL_BOUNDS.inspector.max);
+    expect(canvasFor(MIN_SHELL_WIDTH, fitted, false)).toBeGreaterThanOrEqual(
+      MIN_CANVAS_WIDTH
+    );
+  });
+});
+
+describe("the viewport the full shell needs", () => {
+  it("carries the full shell at the supported width and above", () => {
+    expect(fitsFullShell(MIN_SHELL_WIDTH)).toBe(true);
+    expect(fitsFullShell(1920)).toBe(true);
+  });
+
+  it("refuses one pixel below it", () => {
+    // The boundary itself, because an off-by-one here is the difference between
+    // supporting 1280 and silently not.
+    expect(fitsFullShell(MIN_SHELL_WIDTH - 1)).toBe(false);
+    expect(fitsFullShell(768)).toBe(false);
+  });
+});
+
+describe("preferences round-trip", () => {
+  it("restores what was written", () => {
+    const store = memoryStore();
+    const preferences = {
+      leftPanel: "tokens" as const,
+      leftWidth: 360,
+      inspectorWidth: 400,
+      leftPinned: false,
+    };
+    writePreferences(store, preferences);
+    expect(readPreferences(store)).toEqual(preferences);
+  });
+
+  it("uses the defaults when nothing was ever stored", () => {
+    expect(readPreferences(memoryStore(null))).toEqual(DEFAULT_PREFERENCES);
+  });
+
+  it("survives storage that refuses to answer", () => {
+    // Private browsing on some engines throws on read, and a write can exceed
+    // quota. Losing a panel width is not worth interrupting an edit over.
+    expect(readPreferences(refusingStore)).toEqual(DEFAULT_PREFERENCES);
+    expect(() =>
+      writePreferences(refusingStore, DEFAULT_PREFERENCES)
+    ).not.toThrow();
+  });
+
+  it("survives a stored value that is not JSON", () => {
+    expect(readPreferences(memoryStore("{not json"))).toEqual(
+      DEFAULT_PREFERENCES
+    );
+  });
+
+  it("survives JSON that is not an object", () => {
+    expect(readPreferences(memoryStore("42"))).toEqual(DEFAULT_PREFERENCES);
+    expect(readPreferences(memoryStore("null"))).toEqual(DEFAULT_PREFERENCES);
+  });
+
+  it("keeps the fields it can read when one is malformed", () => {
+    // Field-by-field, deliberately. A width written under different bounds
+    // should move the panel, not discard the author's panel choice with it —
+    // one bad field taking the whole record is the failure worth guarding.
+    const store = memoryStore(
+      JSON.stringify({
+        leftPanel: "layers",
+        leftWidth: "wide",
+        inspectorWidth: 999999,
+        leftPinned: "yes",
+      })
+    );
+    expect(readPreferences(store)).toEqual({
+      leftPanel: "layers",
+      leftWidth: PANEL_BOUNDS.left.initial,
+      inspectorWidth: PANEL_BOUNDS.inspector.max,
+      leftPinned: DEFAULT_PREFERENCES.leftPinned,
+    });
+  });
+});

--- a/packages/builder/src/shell-state.test.ts
+++ b/packages/builder/src/shell-state.test.ts
@@ -9,21 +9,19 @@
 import { describe, expect, it } from "vitest";
 
 import {
-  clampPanelWidth,
   DEFAULT_PREFERENCES,
   fitsFullShell,
   isLeftPanel,
   LEFT_PANELS,
-  fitPanels,
   MIN_CANVAS_WIDTH,
   MIN_SHELL_WIDTH,
   panelAfterRailClick,
-  RAIL_WIDTH,
   PANEL_BOUNDS,
+  RAIL_WIDTH,
   readPreferences,
   writePreferences,
-  type PreferenceStore,
 } from "./shell-state";
+import type { PreferenceStore, ShellPreferences } from "./shell-state";
 
 /** A store standing in for `localStorage`, plus the two ways one really fails. */
 function memoryStore(initial: string | null = null): PreferenceStore & {
@@ -100,129 +98,6 @@ describe("a stored panel name that no longer names a panel", () => {
   });
 });
 
-describe("panel widths", () => {
-  it.each(["left", "inspector"] as const)(
-    "clamps %s into its bounds",
-    region => {
-      const { min, max } = PANEL_BOUNDS[region];
-      expect(clampPanelWidth(region, min - 100)).toBe(min);
-      expect(clampPanelWidth(region, max + 100)).toBe(max);
-      expect(clampPanelWidth(region, min + 1)).toBe(min + 1);
-    }
-  );
-
-  it("answers the initial width for a value that is not a number", () => {
-    // `Math.min`/`Math.max` pass NaN straight through, so a bare clamp would
-    // store it and collapse the panel. The two sources are a malformed stored
-    // string and a division by a zero-height frame.
-    expect(clampPanelWidth("left", Number.NaN)).toBe(PANEL_BOUNDS.left.initial);
-    expect(clampPanelWidth("left", Number.POSITIVE_INFINITY)).toBe(
-      PANEL_BOUNDS.left.initial
-    );
-  });
-});
-
-describe("panels give way to the canvas floor", () => {
-  const canvasFor = (
-    viewportWidth: number,
-    fitted: { leftWidth: number; inspectorWidth: number },
-    leftOpen = true
-  ) =>
-    viewportWidth -
-    RAIL_WIDTH -
-    (leftOpen ? fitted.leftWidth : 0) -
-    fitted.inspectorWidth;
-
-  it("keeps the canvas floor at the minimum supported viewport", () => {
-    // The case that drove this design. Per-panel bounds alone are satisfied by
-    // both panels at maximum here, and leave the canvas at 232px — narrower
-    // than either panel, in an editor whose subject IS the canvas. Nothing
-    // per-panel is violated, because the constraint was never per-panel.
-    const fitted = fitPanels({
-      viewportWidth: MIN_SHELL_WIDTH,
-      leftWidth: PANEL_BOUNDS.left.max,
-      inspectorWidth: PANEL_BOUNDS.inspector.max,
-      leftOpen: true,
-    });
-    expect(canvasFor(MIN_SHELL_WIDTH, fitted)).toBeGreaterThanOrEqual(
-      MIN_CANVAS_WIDTH
-    );
-  });
-
-  it("takes from the inspector before the panel the author opened", () => {
-    // The left panel is a deliberate choice, dismissible with the same click
-    // that opened it; the inspector is always there. Shrinking the deliberate
-    // choice first reads as the editor undoing an action.
-    const fitted = fitPanels({
-      viewportWidth: MIN_SHELL_WIDTH,
-      leftWidth: PANEL_BOUNDS.left.max,
-      inspectorWidth: PANEL_BOUNDS.inspector.max,
-      leftOpen: true,
-    });
-    // The ordering property, stated as what it actually is: the inspector is
-    // exhausted to its own minimum BEFORE the left panel gives up a pixel. At
-    // this viewport both must move, so "the left panel is untouched" would be
-    // overstating it — and asserting that was wrong, not the implementation.
-    expect(fitted.inspectorWidth).toBe(PANEL_BOUNDS.inspector.min);
-    expect(fitted.leftWidth).toBeLessThan(PANEL_BOUNDS.left.max);
-  });
-
-  it("does not touch the left panel while the inspector still has room", () => {
-    // The ordering, isolated: one viewport wider, so the inspector alone can
-    // absorb the overflow. If the order were reversed this is where it shows.
-    const fitted = fitPanels({
-      viewportWidth: 1400,
-      leftWidth: PANEL_BOUNDS.left.max,
-      inspectorWidth: PANEL_BOUNDS.inspector.max,
-      leftOpen: true,
-    });
-    expect(fitted.leftWidth).toBe(PANEL_BOUNDS.left.max);
-    expect(fitted.inspectorWidth).toBeLessThan(PANEL_BOUNDS.inspector.max);
-    expect(fitted.inspectorWidth).toBeGreaterThan(PANEL_BOUNDS.inspector.min);
-  });
-
-  it("never squeezes a panel below its own minimum", () => {
-    const fitted = fitPanels({
-      viewportWidth: MIN_SHELL_WIDTH,
-      leftWidth: PANEL_BOUNDS.left.max,
-      inspectorWidth: PANEL_BOUNDS.inspector.max,
-      leftOpen: true,
-    });
-    expect(fitted.inspectorWidth).toBeGreaterThanOrEqual(
-      PANEL_BOUNDS.inspector.min
-    );
-    expect(fitted.leftWidth).toBeGreaterThanOrEqual(PANEL_BOUNDS.left.min);
-  });
-
-  it("leaves both alone when there is room", () => {
-    // The control: a fit that shrank panels on a wide viewport would satisfy
-    // every assertion above.
-    const fitted = fitPanels({
-      viewportWidth: 1920,
-      leftWidth: PANEL_BOUNDS.left.max,
-      inspectorWidth: PANEL_BOUNDS.inspector.max,
-      leftOpen: true,
-    });
-    expect(fitted).toEqual({
-      leftWidth: PANEL_BOUNDS.left.max,
-      inspectorWidth: PANEL_BOUNDS.inspector.max,
-    });
-  });
-
-  it("gives the closed left panel's space to the canvas, not the inspector", () => {
-    const fitted = fitPanels({
-      viewportWidth: MIN_SHELL_WIDTH,
-      leftWidth: PANEL_BOUNDS.left.max,
-      inspectorWidth: PANEL_BOUNDS.inspector.max,
-      leftOpen: false,
-    });
-    expect(fitted.inspectorWidth).toBe(PANEL_BOUNDS.inspector.max);
-    expect(canvasFor(MIN_SHELL_WIDTH, fitted, false)).toBeGreaterThanOrEqual(
-      MIN_CANVAS_WIDTH
-    );
-  });
-});
-
 describe("the viewport the full shell needs", () => {
   it("carries the full shell at the supported width and above", () => {
     expect(fitsFullShell(MIN_SHELL_WIDTH)).toBe(true);
@@ -237,17 +112,42 @@ describe("the viewport the full shell needs", () => {
   });
 });
 
+describe("the bounds the library is handed", () => {
+  it("declares a canvas floor that per-panel bounds cannot express", () => {
+    // This is the number that decided the design, kept as an assertion so the
+    // reasoning cannot quietly stop being true. Both panels at their individual
+    // maximums on the minimum supported viewport leave the canvas at 232px —
+    // narrower than either panel — with no per-panel bound violated.
+    const canvasIfPanelsMaxed =
+      MIN_SHELL_WIDTH -
+      RAIL_WIDTH -
+      PANEL_BOUNDS.left.max -
+      PANEL_BOUNDS.inspector.max;
+    expect(canvasIfPanelsMaxed).toBeLessThan(MIN_CANVAS_WIDTH);
+
+    // So the floor is declared on the canvas itself, and the supported viewport
+    // must be able to satisfy every minimum at once — otherwise the shell would
+    // hand the library a set of bounds with no solution.
+    expect(
+      RAIL_WIDTH +
+        PANEL_BOUNDS.left.min +
+        PANEL_BOUNDS.inspector.min +
+        MIN_CANVAS_WIDTH
+    ).toBeLessThanOrEqual(MIN_SHELL_WIDTH);
+  });
+});
+
 describe("preferences round-trip", () => {
+  const stored: ShellPreferences = {
+    leftPanel: "tokens",
+    leftPinned: false,
+    layout: { left: 22, canvas: 54, inspector: 24 },
+  };
+
   it("restores what was written", () => {
     const store = memoryStore();
-    const preferences = {
-      leftPanel: "tokens" as const,
-      leftWidth: 360,
-      inspectorWidth: 400,
-      leftPinned: false,
-    };
-    writePreferences(store, preferences);
-    expect(readPreferences(store)).toEqual(preferences);
+    writePreferences(store, stored);
+    expect(readPreferences(store)).toEqual(stored);
   });
 
   it("uses the defaults when nothing was ever stored", () => {
@@ -263,34 +163,46 @@ describe("preferences round-trip", () => {
     ).not.toThrow();
   });
 
-  it("survives a stored value that is not JSON", () => {
+  it("survives a stored value that is not JSON, or not an object", () => {
     expect(readPreferences(memoryStore("{not json"))).toEqual(
       DEFAULT_PREFERENCES
     );
-  });
-
-  it("survives JSON that is not an object", () => {
     expect(readPreferences(memoryStore("42"))).toEqual(DEFAULT_PREFERENCES);
     expect(readPreferences(memoryStore("null"))).toEqual(DEFAULT_PREFERENCES);
   });
 
   it("keeps the fields it can read when one is malformed", () => {
-    // Field-by-field, deliberately. A width written under different bounds
-    // should move the panel, not discard the author's panel choice with it —
-    // one bad field taking the whole record is the failure worth guarding.
+    // Field by field, deliberately. A layout written under a different panel
+    // set should reset the LAYOUT, not discard the author's panel choice with
+    // it — one bad field taking the whole record is the failure worth guarding.
     const store = memoryStore(
       JSON.stringify({
         leftPanel: "layers",
-        leftWidth: "wide",
-        inspectorWidth: 999999,
         leftPinned: "yes",
+        layout: { left: Number.NaN, canvas: 60 },
       })
     );
     expect(readPreferences(store)).toEqual({
       leftPanel: "layers",
-      leftWidth: PANEL_BOUNDS.left.initial,
-      inspectorWidth: PANEL_BOUNDS.inspector.max,
       leftPinned: DEFAULT_PREFERENCES.leftPinned,
+      layout: null,
     });
+  });
+
+  it("rejects a layout whole rather than in part", () => {
+    // The library distributes a layout across ALL panels, so a map carrying one
+    // unusable entry resolves to a layout nobody chose. Partial acceptance is
+    // worse than falling back, which is why the map is the unit.
+    const cases = [
+      { left: 20, canvas: "wide" },
+      { left: 20, canvas: 0 },
+      { left: 20, canvas: -5 },
+      {},
+      [],
+    ];
+    for (const layout of cases) {
+      const store = memoryStore(JSON.stringify({ layout }));
+      expect(readPreferences(store).layout).toBeNull();
+    }
   });
 });

--- a/packages/builder/src/shell-state.test.ts
+++ b/packages/builder/src/shell-state.test.ts
@@ -141,7 +141,9 @@ describe("preferences round-trip", () => {
   const stored: ShellPreferences = {
     leftPanel: "tokens",
     leftPinned: false,
-    layout: { left: 22, canvas: 54, inspector: 24 },
+    layouts: {
+      "canvas,inspector,left": { left: 22, canvas: 54, inspector: 24 },
+    },
   };
 
   it("restores what was written", () => {
@@ -179,13 +181,18 @@ describe("preferences round-trip", () => {
       JSON.stringify({
         leftPanel: "layers",
         leftPinned: "yes",
-        layout: { left: Number.NaN, canvas: 60 },
+        layouts: {
+          "canvas,inspector": { canvas: 70, inspector: 30 },
+          "canvas,inspector,panel": { panel: Number.NaN, canvas: 60 },
+        },
       })
     );
+    // The good arrangement survives, the malformed one does not, and neither
+    // takes the author's panel choice with it.
     expect(readPreferences(store)).toEqual({
       leftPanel: "layers",
       leftPinned: DEFAULT_PREFERENCES.leftPinned,
-      layout: null,
+      layouts: { "canvas,inspector": { canvas: 70, inspector: 30 } },
     });
   });
 
@@ -201,8 +208,12 @@ describe("preferences round-trip", () => {
       [],
     ];
     for (const layout of cases) {
-      const store = memoryStore(JSON.stringify({ layout }));
-      expect(readPreferences(store).layout).toBeNull();
+      // Nested under a topology now: a malformed layout costs that arrangement
+      // its widths and leaves every other arrangement's intact.
+      const store = memoryStore(
+        JSON.stringify({ layouts: { "canvas,inspector": layout } })
+      );
+      expect(readPreferences(store).layouts).toEqual({});
     }
   });
 });

--- a/packages/builder/src/shell-state.ts
+++ b/packages/builder/src/shell-state.ts
@@ -117,14 +117,43 @@ export function fitsFullShell(viewportWidth: number): boolean {
 export interface ShellPreferences {
   leftPanel: LeftPanel | null;
   leftPinned: boolean;
-  /** Panel id to percentage, or null when the author has never resized. */
-  layout: Record<string, number> | null;
+  /**
+   * Layouts, one per PANEL TOPOLOGY.
+   *
+   * Keyed rather than singular because a layout only means anything alongside
+   * the panel set it was measured for. The left panel is conditionally
+   * rendered, so the group has two shapes — with it and without — and their
+   * layouts have different keys and different arithmetic. Stored as one record
+   * they overwrote each other: resizing with a panel open and then closing it
+   * left a three-key layout that no two-panel group could accept, so the widths
+   * were dropped on the next load.
+   *
+   * This is the shape the panel library's own persistence helper uses, for the
+   * same reason — its `panelIds` prop exists so a group with conditionally
+   * rendered panels can "save and restore multiple layouts".
+   *
+   * Outer key: {@link topologyKey} over the mounted panel ids.
+   * Inner: panel id to percentage.
+   */
+  layouts: Record<string, Record<string, number>>;
+}
+
+/**
+ * The identity of a panel arrangement, from the panels themselves.
+ *
+ * Sorted and joined rather than taken from `leftPanel`, so it is derived from
+ * what is actually MOUNTED rather than from a second description of it that can
+ * disagree. Sorting makes it independent of the order the ids arrive in, which
+ * varies with how a host's JSON was serialised.
+ */
+export function topologyKey(panelIds: readonly string[]): string {
+  return [...panelIds].sort().join(",");
 }
 
 export const DEFAULT_PREFERENCES: ShellPreferences = {
   leftPanel: null,
   leftPinned: true,
-  layout: null,
+  layouts: {},
 };
 
 /**
@@ -151,6 +180,24 @@ export interface PreferenceStore {
  * distributes a layout across ALL panels, so a map missing one or carrying a
  * `NaN` resolves to a layout nobody chose. The whole map is the unit.
  */
+/**
+ * The stored layouts, dropping any entry that is not usable.
+ *
+ * Per-topology rather than all-or-nothing: a layout written under a panel set
+ * that no longer exists should cost the author only that arrangement's widths,
+ * not the ones they set for every other arrangement.
+ */
+function readLayouts(value: unknown): Record<string, Record<string, number>> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return {};
+  }
+  const layouts: Record<string, Record<string, number>> = {};
+  for (const [key, layout] of Object.entries(value)) {
+    if (isLayout(layout)) layouts[key] = layout;
+  }
+  return layouts;
+}
+
 function isLayout(value: unknown): value is Record<string, number> {
   if (typeof value !== "object" || value === null || Array.isArray(value)) {
     return false;
@@ -193,7 +240,7 @@ export function readPreferences(store: PreferenceStore): ShellPreferences {
       typeof record.leftPinned === "boolean"
         ? record.leftPinned
         : DEFAULT_PREFERENCES.leftPinned,
-    layout: isLayout(record.layout) ? record.layout : null,
+    layouts: readLayouts(record.layouts),
   };
 }
 

--- a/packages/builder/src/shell-state.ts
+++ b/packages/builder/src/shell-state.ts
@@ -1,0 +1,273 @@
+/**
+ * The editor shell's state, kept apart from the components that render it.
+ *
+ * Two reasons, and the second is why this file exists at all rather than the
+ * state living in the shell component:
+ *
+ * - It is arithmetic and set membership — which panel is open, how wide it may
+ *   be, whether the viewport can carry the full layout. None of it needs React.
+ * - A layout cannot be checked by rendering it in jsdom, which reports every
+ *   element as zero-sized. A component test of "the panel is 320px" measures
+ *   nothing and passes whatever the CSS does. The decisions are made here,
+ *   where they can be asserted, and the browser verifies the LAYOUT separately.
+ *
+ * @module shell-state
+ */
+
+/**
+ * The panels the left rail switches between.
+ *
+ * One at a time, by decision (PB-D17 D10-1): fixed sides, no docking, no
+ * floating. The rail selects; it never opens a second panel beside the first.
+ */
+export const LEFT_PANELS = [
+  "insert",
+  "layers",
+  "components",
+  "tokens",
+  "fonts",
+  "pages",
+  "settings",
+] as const;
+
+export type LeftPanel = (typeof LEFT_PANELS)[number];
+
+/**
+ * Whether a stored value still names a panel.
+ *
+ * Persisted preferences outlive the code that wrote them. A panel removed in a
+ * later release leaves a string nothing answers to, and restoring it blindly
+ * opens a panel that renders nothing — an empty region with no way back to a
+ * real one.
+ */
+export function isLeftPanel(value: unknown): value is LeftPanel {
+  return (
+    typeof value === "string" &&
+    (LEFT_PANELS as readonly string[]).includes(value)
+  );
+}
+
+/**
+ * Width bounds for the two resizable regions, in CSS pixels.
+ *
+ * Lower bounds are the point below which the region stops being usable rather
+ * than round numbers: a layers tree needs room for an indent plus a label, and
+ * the inspector carries two-column controls. Upper bounds keep the canvas —
+ * the thing being edited — the largest region at the minimum supported width.
+ */
+export const PANEL_BOUNDS = {
+  left: { min: 240, max: 480, initial: 300 },
+  inspector: { min: 280, max: 520, initial: 320 },
+} as const;
+
+export type PanelRegion = keyof typeof PANEL_BOUNDS;
+
+/**
+ * A width brought inside its region's bounds.
+ *
+ * Clamped rather than rejected. A width arrives from a drag that continues past
+ * the edge and from a stored preference written when the bounds were different;
+ * in both cases the nearest legal width is what the author meant, and refusing
+ * would leave the panel at whatever it was.
+ *
+ * A value that is not a finite number — `NaN` from a malformed stored string,
+ * `Infinity` from a division — answers the region's initial width rather than
+ * propagating. `Math.min`/`Math.max` pass `NaN` straight through, so a bare
+ * clamp would store it and the panel would collapse.
+ */
+export function clampPanelWidth(region: PanelRegion, width: number): number {
+  const { min, max, initial } = PANEL_BOUNDS[region];
+  if (!Number.isFinite(width)) return initial;
+  return Math.min(max, Math.max(min, width));
+}
+
+/**
+ * The narrowest viewport the full shell is supported at (PB-D17 D10-5).
+ *
+ * Below this the rail, both panels and a usable canvas do not fit at their
+ * minimum widths, so the shell does not try: it shows the canvas and says where
+ * to edit instead. A builder that merely gets cramped is worse than one that
+ * says it needs a wider screen, because the author discovers the limit by
+ * failing at a task.
+ */
+export const MIN_SHELL_WIDTH = 1280;
+
+/** Whether the viewport can carry the full shell. */
+export function fitsFullShell(viewportWidth: number): boolean {
+  return viewportWidth >= MIN_SHELL_WIDTH;
+}
+
+/** The rail's fixed width in CSS pixels (PB-D17: 48px, icons only). */
+export const RAIL_WIDTH = 48;
+
+/**
+ * The narrowest the canvas may become before a panel drag stops taking from it.
+ *
+ * The canvas is the thing being edited, so it is the region with a floor rather
+ * than the one that absorbs whatever is left.
+ */
+export const MIN_CANVAS_WIDTH = 480;
+
+/**
+ * Both panel widths, brought inside bounds that DEPEND ON EACH OTHER.
+ *
+ * Per-panel bounds alone are the wrong model, and the arithmetic says so: at the
+ * minimum supported viewport with both panels at their individual maximums the
+ * canvas is 232px — narrower than either panel, in an editor whose subject is
+ * the canvas. Nothing about either panel's own bounds is violated, because the
+ * constraint was never per-panel.
+ *
+ * So the canvas floor is enforced jointly, and the panels give way in a defined
+ * order: the INSPECTOR yields first, then the left panel. That order is not
+ * arbitrary — the left panel is the one the author opened deliberately from the
+ * rail and can dismiss with the same click, while the inspector is always
+ * present. Taking from the deliberate choice first would read as the editor
+ * undoing an action.
+ *
+ * Panels below their own minimum are not squeezed further; a viewport too narrow
+ * to hold both at minimum plus the canvas floor is one where
+ * {@link fitsFullShell} is already false, and the shell shows the narrow-viewport
+ * path instead of a broken layout.
+ */
+export function fitPanels(input: {
+  viewportWidth: number;
+  leftWidth: number;
+  inspectorWidth: number;
+  leftOpen: boolean;
+}): { leftWidth: number; inspectorWidth: number } {
+  const leftWidth = clampPanelWidth("left", input.leftWidth);
+  const inspectorWidth = clampPanelWidth("inspector", input.inspectorWidth);
+  const occupiedLeft = input.leftOpen ? leftWidth : 0;
+
+  const spare =
+    input.viewportWidth -
+    RAIL_WIDTH -
+    occupiedLeft -
+    inspectorWidth -
+    MIN_CANVAS_WIDTH;
+  if (spare >= 0) return { leftWidth, inspectorWidth };
+
+  // The inspector yields first, never below its own minimum.
+  const inspectorGive = Math.min(
+    -spare,
+    inspectorWidth - PANEL_BOUNDS.inspector.min
+  );
+  const fittedInspector = inspectorWidth - inspectorGive;
+  const stillOver = -spare - inspectorGive;
+  if (stillOver <= 0 || !input.leftOpen) {
+    return { leftWidth, inspectorWidth: fittedInspector };
+  }
+
+  const leftGive = Math.min(stillOver, leftWidth - PANEL_BOUNDS.left.min);
+  return { leftWidth: leftWidth - leftGive, inspectorWidth: fittedInspector };
+}
+
+/**
+ * What the shell remembers between sessions.
+ *
+ * Widths and the open panel only. Deliberately NOT selection, scroll position
+ * or anything describing the document: those belong to the document's own
+ * state, and persisting a copy here is a second source that goes stale the
+ * first time the document changes underneath it.
+ */
+export interface ShellPreferences {
+  leftPanel: LeftPanel | null;
+  leftWidth: number;
+  inspectorWidth: number;
+  leftPinned: boolean;
+}
+
+export const DEFAULT_PREFERENCES: ShellPreferences = {
+  leftPanel: null,
+  leftWidth: PANEL_BOUNDS.left.initial,
+  inspectorWidth: PANEL_BOUNDS.inspector.initial,
+  leftPinned: true,
+};
+
+/**
+ * Where preferences are read and written.
+ *
+ * A PORT rather than a direct `localStorage` call, for two reasons that both
+ * bite later. The ratified plan wants these durable per user on the server
+ * eventually, and a component reaching for `localStorage` makes that a rewrite
+ * instead of a different argument. And `localStorage` does not exist while the
+ * shell renders on a server, so a direct call is a crash rather than a default.
+ *
+ * Both methods may fail and the shell must not care: storage is unavailable in
+ * private browsing on some engines, and a quota error is possible on write.
+ */
+export interface PreferenceStore {
+  read: () => string | null;
+  write: (value: string) => void;
+}
+
+/**
+ * Preferences parsed from whatever was stored.
+ *
+ * Every field is validated separately and falls back on its own, rather than
+ * one malformed field discarding the rest. A stored width from an older release
+ * with different bounds should move the panel, not reset the author's panel
+ * choice alongside it.
+ */
+export function readPreferences(store: PreferenceStore): ShellPreferences {
+  let raw: unknown;
+  try {
+    const stored = store.read();
+    if (stored === null) return DEFAULT_PREFERENCES;
+    raw = JSON.parse(stored);
+  } catch {
+    // Unreadable storage or malformed JSON. Neither says anything about the
+    // author's intent, so the defaults are the honest answer.
+    return DEFAULT_PREFERENCES;
+  }
+
+  if (typeof raw !== "object" || raw === null) return DEFAULT_PREFERENCES;
+  const record = raw as Record<string, unknown>;
+
+  return {
+    leftPanel: isLeftPanel(record.leftPanel) ? record.leftPanel : null,
+    leftWidth: clampPanelWidth(
+      "left",
+      typeof record.leftWidth === "number"
+        ? record.leftWidth
+        : PANEL_BOUNDS.left.initial
+    ),
+    inspectorWidth: clampPanelWidth(
+      "inspector",
+      typeof record.inspectorWidth === "number"
+        ? record.inspectorWidth
+        : PANEL_BOUNDS.inspector.initial
+    ),
+    leftPinned:
+      typeof record.leftPinned === "boolean"
+        ? record.leftPinned
+        : DEFAULT_PREFERENCES.leftPinned,
+  };
+}
+
+/** Preferences written back, ignoring a store that refuses. */
+export function writePreferences(
+  store: PreferenceStore,
+  preferences: ShellPreferences
+): void {
+  try {
+    store.write(JSON.stringify(preferences));
+  } catch {
+    // A quota error or unavailable storage. Losing a panel width is not worth
+    // interrupting an edit over, and there is nothing the author could do.
+  }
+}
+
+/**
+ * The panel a rail click selects.
+ *
+ * Clicking the open panel's own rail item CLOSES it. That is what makes the
+ * rail a toggle rather than a one-way switch, and it is the only way to reach a
+ * full-width canvas without a separate control.
+ */
+export function panelAfterRailClick(
+  current: LeftPanel | null,
+  clicked: LeftPanel
+): LeftPanel | null {
+  return current === clicked ? null : clicked;
+}

--- a/packages/builder/src/shell-state.ts
+++ b/packages/builder/src/shell-state.ts
@@ -50,36 +50,39 @@ export function isLeftPanel(value: unknown): value is LeftPanel {
 /**
  * Width bounds for the two resizable regions, in CSS pixels.
  *
- * Lower bounds are the point below which the region stops being usable rather
- * than round numbers: a layers tree needs room for an indent plus a label, and
- * the inspector carries two-column controls. Upper bounds keep the canvas —
- * the thing being edited — the largest region at the minimum supported width.
+ * DECLARED here and enforced by `react-resizable-panels`, which takes pixel
+ * bounds directly (`minSize={240}`) and solves them — including which region
+ * yields when a window resize leaves no room. This module deliberately does NOT
+ * solve them a second time: a hand-rolled clamp beside a library that already
+ * constrains the same drag is two answers to one question, and the two disagree
+ * the first time the library changes how it distributes a shortfall.
+ *
+ * Lower bounds are the point below which a region stops being usable rather than
+ * round numbers: a layers tree needs an indent plus a label, and the inspector
+ * carries two-column controls.
+ *
+ * `MIN_CANVAS_WIDTH` is the reason bounds cannot be read per-panel. At the
+ * minimum supported viewport, both panels at their individual maximums leave the
+ * canvas at 232px — narrower than either panel, in an editor whose subject IS
+ * the canvas — and no per-panel bound is violated, because the constraint was
+ * never per-panel. Expressed as the canvas panel's OWN minimum, the library
+ * enforces it jointly during a drag.
  */
 export const PANEL_BOUNDS = {
   left: { min: 240, max: 480, initial: 300 },
   inspector: { min: 280, max: 520, initial: 320 },
 } as const;
 
-export type PanelRegion = keyof typeof PANEL_BOUNDS;
+/** The rail's fixed width in CSS pixels (PB-D17: 48px, icons only). */
+export const RAIL_WIDTH = 48;
 
 /**
- * A width brought inside its region's bounds.
+ * The narrowest the canvas may become before a drag stops taking from it.
  *
- * Clamped rather than rejected. A width arrives from a drag that continues past
- * the edge and from a stored preference written when the bounds were different;
- * in both cases the nearest legal width is what the author meant, and refusing
- * would leave the panel at whatever it was.
- *
- * A value that is not a finite number — `NaN` from a malformed stored string,
- * `Infinity` from a division — answers the region's initial width rather than
- * propagating. `Math.min`/`Math.max` pass `NaN` straight through, so a bare
- * clamp would store it and the panel would collapse.
+ * The canvas is the thing being edited, so it is the region with a floor rather
+ * than the one that absorbs whatever is left.
  */
-export function clampPanelWidth(region: PanelRegion, width: number): number {
-  const { min, max, initial } = PANEL_BOUNDS[region];
-  if (!Number.isFinite(width)) return initial;
-  return Math.min(max, Math.max(min, width));
-}
+export const MIN_CANVAS_WIDTH = 480;
 
 /**
  * The narrowest viewport the full shell is supported at (PB-D17 D10-5).
@@ -97,91 +100,31 @@ export function fitsFullShell(viewportWidth: number): boolean {
   return viewportWidth >= MIN_SHELL_WIDTH;
 }
 
-/** The rail's fixed width in CSS pixels (PB-D17: 48px, icons only). */
-export const RAIL_WIDTH = 48;
-
-/**
- * The narrowest the canvas may become before a panel drag stops taking from it.
- *
- * The canvas is the thing being edited, so it is the region with a floor rather
- * than the one that absorbs whatever is left.
- */
-export const MIN_CANVAS_WIDTH = 480;
-
-/**
- * Both panel widths, brought inside bounds that DEPEND ON EACH OTHER.
- *
- * Per-panel bounds alone are the wrong model, and the arithmetic says so: at the
- * minimum supported viewport with both panels at their individual maximums the
- * canvas is 232px — narrower than either panel, in an editor whose subject is
- * the canvas. Nothing about either panel's own bounds is violated, because the
- * constraint was never per-panel.
- *
- * So the canvas floor is enforced jointly, and the panels give way in a defined
- * order: the INSPECTOR yields first, then the left panel. That order is not
- * arbitrary — the left panel is the one the author opened deliberately from the
- * rail and can dismiss with the same click, while the inspector is always
- * present. Taking from the deliberate choice first would read as the editor
- * undoing an action.
- *
- * Panels below their own minimum are not squeezed further; a viewport too narrow
- * to hold both at minimum plus the canvas floor is one where
- * {@link fitsFullShell} is already false, and the shell shows the narrow-viewport
- * path instead of a broken layout.
- */
-export function fitPanels(input: {
-  viewportWidth: number;
-  leftWidth: number;
-  inspectorWidth: number;
-  leftOpen: boolean;
-}): { leftWidth: number; inspectorWidth: number } {
-  const leftWidth = clampPanelWidth("left", input.leftWidth);
-  const inspectorWidth = clampPanelWidth("inspector", input.inspectorWidth);
-  const occupiedLeft = input.leftOpen ? leftWidth : 0;
-
-  const spare =
-    input.viewportWidth -
-    RAIL_WIDTH -
-    occupiedLeft -
-    inspectorWidth -
-    MIN_CANVAS_WIDTH;
-  if (spare >= 0) return { leftWidth, inspectorWidth };
-
-  // The inspector yields first, never below its own minimum.
-  const inspectorGive = Math.min(
-    -spare,
-    inspectorWidth - PANEL_BOUNDS.inspector.min
-  );
-  const fittedInspector = inspectorWidth - inspectorGive;
-  const stillOver = -spare - inspectorGive;
-  if (stillOver <= 0 || !input.leftOpen) {
-    return { leftWidth, inspectorWidth: fittedInspector };
-  }
-
-  const leftGive = Math.min(stillOver, leftWidth - PANEL_BOUNDS.left.min);
-  return { leftWidth: leftWidth - leftGive, inspectorWidth: fittedInspector };
-}
-
 /**
  * What the shell remembers between sessions.
  *
- * Widths and the open panel only. Deliberately NOT selection, scroll position
- * or anything describing the document: those belong to the document's own
- * state, and persisting a copy here is a second source that goes stale the
- * first time the document changes underneath it.
+ * The layout is stored as the PROPORTIONAL map `react-resizable-panels` reports
+ * from `onLayoutChanged` — panel id to a percentage — never as pixel widths. A
+ * pixel layout is wrong on the next monitor; a proportional one survives a
+ * window resize, and the pixel BOUNDS still hold because the library re-applies
+ * them to whatever the proportions resolve to.
+ *
+ * Deliberately NOT stored: selection, scroll position, or anything describing
+ * the document. Those belong to the document's own state, and a copy here is a
+ * second source that goes stale the first time the document changes underneath
+ * it.
  */
 export interface ShellPreferences {
   leftPanel: LeftPanel | null;
-  leftWidth: number;
-  inspectorWidth: number;
   leftPinned: boolean;
+  /** Panel id to percentage, or null when the author has never resized. */
+  layout: Record<string, number> | null;
 }
 
 export const DEFAULT_PREFERENCES: ShellPreferences = {
   leftPanel: null,
-  leftWidth: PANEL_BOUNDS.left.initial,
-  inspectorWidth: PANEL_BOUNDS.inspector.initial,
   leftPinned: true,
+  layout: null,
 };
 
 /**
@@ -202,12 +145,32 @@ export interface PreferenceStore {
 }
 
 /**
+ * A stored layout, accepted only if every entry is a usable percentage.
+ *
+ * Partial acceptance would be worse than rejection here: the library
+ * distributes a layout across ALL panels, so a map missing one or carrying a
+ * `NaN` resolves to a layout nobody chose. The whole map is the unit.
+ */
+function isLayout(value: unknown): value is Record<string, number> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return false;
+  }
+  const entries = Object.entries(value as Record<string, unknown>);
+  return (
+    entries.length > 0 &&
+    entries.every(
+      ([, size]) =>
+        typeof size === "number" && Number.isFinite(size) && size > 0
+    )
+  );
+}
+
+/**
  * Preferences parsed from whatever was stored.
  *
  * Every field is validated separately and falls back on its own, rather than
- * one malformed field discarding the rest. A stored width from an older release
- * with different bounds should move the panel, not reset the author's panel
- * choice alongside it.
+ * one malformed field discarding the rest. A layout written under a different
+ * panel set should reset the layout, not the author's panel choice with it.
  */
 export function readPreferences(store: PreferenceStore): ShellPreferences {
   let raw: unknown;
@@ -226,22 +189,11 @@ export function readPreferences(store: PreferenceStore): ShellPreferences {
 
   return {
     leftPanel: isLeftPanel(record.leftPanel) ? record.leftPanel : null,
-    leftWidth: clampPanelWidth(
-      "left",
-      typeof record.leftWidth === "number"
-        ? record.leftWidth
-        : PANEL_BOUNDS.left.initial
-    ),
-    inspectorWidth: clampPanelWidth(
-      "inspector",
-      typeof record.inspectorWidth === "number"
-        ? record.inspectorWidth
-        : PANEL_BOUNDS.inspector.initial
-    ),
     leftPinned:
       typeof record.leftPinned === "boolean"
         ? record.leftPinned
         : DEFAULT_PREFERENCES.leftPinned,
+    layout: isLayout(record.layout) ? record.layout : null,
   };
 }
 

--- a/packages/builder/src/shell.ts
+++ b/packages/builder/src/shell.ts
@@ -1,0 +1,25 @@
+/**
+ * The editor shell, published as its own entry because it is a CLIENT one.
+ *
+ * The shell is a client component, and Rollup drops per-module `"use client"`
+ * directives while bundling, so the directive has to be re-applied to the built
+ * file as a banner. A banner applies to the WHOLE artifact and to everything it
+ * re-exports — which is why this is a separate entry rather than part of the
+ * root barrel.
+ *
+ * Put in the root barrel, the shell's banner would have marked the frame
+ * geometry as client-only too. Those helpers are plain arithmetic that a Server
+ * Component is meant to be able to call, and they were part of this package's
+ * public surface before the shell existed, so the banner would have been a
+ * silent regression for anyone already importing them: the export map would go
+ * on advertising a callable function while the artifact delivered a client
+ * reference. Splitting the entry keeps the boundary where the React actually is.
+ *
+ * The props type is still described from the root entry — a type is erased, so
+ * it carries no boundary with it.
+ *
+ * @module @nextlyhq/builder/shell
+ */
+
+export { BuilderShell } from "./builder-shell";
+export type { BuilderShellProps } from "./builder-shell";

--- a/packages/builder/src/styles/builder-chrome.css
+++ b/packages/builder/src/styles/builder-chrome.css
@@ -1,4 +1,27 @@
 /**
+ * The editor chrome's stylesheet, compiled rather than copied.
+ *
+ * `@import "tailwindcss"` plus `@source` is what makes this shippable. The shell
+ * draws with utility classes — `flex`, `border-b`, `size-8` — and copying this
+ * file verbatim delivered the custom properties below while leaving those
+ * classes undefined. A consumer without our Tailwind preset then got the tokens
+ * and no layout: markup that renders, carries its class names, and stacks as
+ * full-width blocks. That reads as a layout bug rather than a missing build
+ * step, which is why it is compiled here instead of documented as a
+ * requirement.
+ *
+ * The theme is NOT imported. `--nx-*` belongs to `@nextlyhq/ui`, which the host
+ * already loads; importing it here would ship a second copy of every token and
+ * make re-theming depend on which stylesheet won. The variables below DERIVE
+ * from those tokens, so a host that re-themes the admin moves the builder with
+ * it.
+ */
+@import "tailwindcss";
+
+/* Scan this package's source so the shell's utility classes compile in. */
+@source "../";
+
+/**
  * The editor chrome's own token layer.
  *
  * Named `--nx-builder-*` and kept separate from `--nx-*` on purpose. The admin's

--- a/packages/builder/src/styles/builder-chrome.css
+++ b/packages/builder/src/styles/builder-chrome.css
@@ -39,7 +39,23 @@
  */
 @layer theme, base, components, utilities;
 
-@import "tailwindcss/theme.css" layer(theme);
+/**
+ * The theme is REFERENCED, not imported, and the difference is the whole point.
+ *
+ * `@import "tailwindcss/theme.css"` emits a global `:root, :host` block. Loaded
+ * in the documented order — the design system's sheet, then this one — that
+ * block lands AFTER theirs and wins, so this supplementary sheet silently
+ * replaced the host's theme: `--radius-md` reverted from the design system's
+ * `calc(var(--radius) - 2px)` to Tailwind's `.375rem`, and `--font-mono` from
+ * the Geist-aware stack to Tailwind's default. Controls and type elsewhere in
+ * the host changed the moment the editor's stylesheet loaded.
+ *
+ * `@reference` gives the compiler the same theme to generate utilities against
+ * and emits nothing. The variables those utilities resolve through are declared
+ * by the design system's sheet, which is already required.
+ */
+@reference "tailwindcss";
+
 @import "tailwindcss/utilities.css" layer(utilities);
 
 /* Scan this package's source so the shell's utility classes compile in. */

--- a/packages/builder/src/styles/builder-chrome.css
+++ b/packages/builder/src/styles/builder-chrome.css
@@ -52,15 +52,15 @@
 /**
  * Motion is opt-in, not opt-out.
  *
- * Panel switches and rail transitions animate only where the user has not asked
- * for reduced motion. Written as a positive query rather than
- * `prefers-reduced-motion: reduce` disabling things, so the default for an
- * unstated preference is stillness.
+ * Only elements this package marks with `data-builder-animates` transition, and
+ * only where the user has not asked for reduced motion. Written as a positive
+ * query so the default for an unstated preference is stillness.
+ *
+ * Deliberately NOT a universal `.nx-builder-chrome *` reset. That reaches every
+ * descendant, and the shell's regions are SLOTS filled by callers — a reset
+ * there silently disables animation in a host's own panel, inspector and
+ * top-bar content, which this package has no business deciding.
  */
-.nx-builder-chrome * {
-  transition: none;
-}
-
 @media (prefers-reduced-motion: no-preference) {
   .nx-builder-chrome [data-builder-animates] {
     transition:

--- a/packages/builder/src/styles/builder-chrome.css
+++ b/packages/builder/src/styles/builder-chrome.css
@@ -16,10 +16,54 @@
  * from those tokens, so a host that re-themes the admin moves the builder with
  * it.
  */
-@import "tailwindcss";
+/**
+ * This sheet SUPPLEMENTS the design system rather than restating it.
+ *
+ * `@nextlyhq/ui` is already a peer dependency: the host installs it and loads
+ * its stylesheet, directly or through the admin's. That sheet owns three things
+ * this one therefore does not ship — the `--nx-*` tokens, the base reset, and
+ * the rules for the primitives the shell renders (`Tooltip`, `ResizableHandle`).
+ * Shipping a second copy of any of them would make the result depend on which
+ * stylesheet loaded last, which is the reason the theme is not imported here,
+ * and the reason applies unchanged to the other two.
+ *
+ * Concretely, this is why `@import "tailwindcss"` is NOT used. That entry bundles
+ * Preflight, which resets `html`, `*`, headings, lists, tables and form controls
+ * DOCUMENT-WIDE — so importing the builder's stylesheet restyled the host
+ * application and the caller's own slot content. Preflight belongs to the sheet
+ * that owns the page; for every consumer of this package that is the design
+ * system's, never the editor's.
+ *
+ * What is left is the part no one else can supply: the utility classes the shell
+ * itself draws with, which Tailwind only emits for source it has been pointed at.
+ */
+@layer theme, base, components, utilities;
+
+@import "tailwindcss/theme.css" layer(theme);
+@import "tailwindcss/utilities.css" layer(utilities);
 
 /* Scan this package's source so the shell's utility classes compile in. */
 @source "../";
+
+/**
+ * The shell's own box model, and deliberately nothing more.
+ *
+ * Border-box is the one part of a reset the chrome cannot be correct without:
+ * every panel bound here is a PIXEL width, and under the default content-box a
+ * border and padding are added on top of it, so the rail and the panels settle a
+ * few pixels wider than the geometry that reserved room for them.
+ *
+ * Confined to the shell's subtree, so it stays a statement about the editor
+ * rather than about the host's page.
+ */
+@layer base {
+  .nx-builder-chrome,
+  .nx-builder-chrome *,
+  .nx-builder-chrome *::before,
+  .nx-builder-chrome *::after {
+    box-sizing: border-box;
+  }
+}
 
 /**
  * The editor chrome's own token layer.

--- a/packages/builder/tsup.config.ts
+++ b/packages/builder/tsup.config.ts
@@ -27,7 +27,12 @@ export default defineConfig({
   // verbatim copy ships the custom properties without the rules that use them.
   format: ["esm"],
   dts: true,
-  clean: true,
+  // NOT `clean`. This config is one of three producers writing into the same
+  // `dist`, and under `--watch` a clean here deletes the other two's output on
+  // every rebuild — the root entry, the server-safe subpaths and the compiled
+  // stylesheet all vanish until something else happens to rewrite them. The
+  // build script clears the directory once, up front, where nothing races it.
+  clean: false,
   sourcemap: true,
   // Mutually exclusive with the banner above, and correctness wins. Rollup runs
   // the treeshaking pass and drops module-level directives from the bundle —

--- a/packages/builder/tsup.config.ts
+++ b/packages/builder/tsup.config.ts
@@ -10,11 +10,30 @@ import { defineConfig } from "tsup";
  */
 export default defineConfig({
   entry: ["src/index.ts"],
+  // The entry carries the directive for the whole package. `builder-shell.tsx`
+  // declares its own, but it is bundled as a NON-entry module and treeshaking
+  // drops module-level directives from those — so the published entry would
+  // arrive without it and a Next host would try to render the editor on the
+  // server. The whole package is an editor and is client-only by nature, which
+  // is the same treatment `@nextlyhq/ui`'s root barrel gets.
+  banner: { js: '"use client";' },
+  // The chrome stylesheet is not reachable from the JS graph, so nothing would
+  // emit it. Copied verbatim and published at `./styles.css`: a consumer that
+  // renders the shell without it gets unstyled markup, which is worse than a
+  // build error because it looks like a layout bug.
+  publicDir: "src/styles",
   format: ["esm"],
   dts: true,
   clean: true,
   sourcemap: true,
-  treeshake: true,
+  // Mutually exclusive with the banner above, and correctness wins. Rollup runs
+  // the treeshaking pass and drops module-level directives from the bundle —
+  // including one in the entry source — so a treeshaken build ships without
+  // `"use client"` and a Server Component importing it fails. The bytes are
+  // recovered by consumers, whose own bundlers treeshake this package now that
+  // `sideEffects` is declared. `@nextlyhq/ui` made the same trade for the same
+  // reason.
+  treeshake: false,
   external: [
     "react",
     "react-dom",

--- a/packages/builder/tsup.config.ts
+++ b/packages/builder/tsup.config.ts
@@ -1,21 +1,26 @@
 import { defineConfig } from "tsup";
 
 /**
- * One entry for now; the externals are the contract.
+ * The CLIENT entry, and the externals are the contract.
  *
  * React and the design system belong to the host application. Bundling either
  * would put a second copy in the consumer's tree — for React that breaks hooks
  * outright, and for `@nextlyhq/ui` it would mean two sets of the CSS custom
  * properties the admin theme is built on.
+ *
+ * `src/shell.ts` rather than `src/index.ts`, because the banner below applies to
+ * the WHOLE artifact and everything it re-exports. Built from the root barrel it
+ * marked the frame geometry as client-only too — plain arithmetic that a Server
+ * Component is meant to call, and part of this package's public surface before
+ * the shell existed. The root entry is built by the server-safe config instead,
+ * so the boundary sits where the React is.
  */
 export default defineConfig({
-  entry: ["src/index.ts"],
-  // The entry carries the directive for the whole package. `builder-shell.tsx`
-  // declares its own, but it is bundled as a NON-entry module and treeshaking
-  // drops module-level directives from those — so the published entry would
-  // arrive without it and a Next host would try to render the editor on the
-  // server. The whole package is an editor and is client-only by nature, which
-  // is the same treatment `@nextlyhq/ui`'s root barrel gets.
+  entry: ["src/shell.ts"],
+  // This entry carries the directive for the shell. `builder-shell.tsx` declares
+  // its own, but it is bundled as a NON-entry module and treeshaking drops
+  // module-level directives from those — so the published entry would arrive
+  // without it and a Next host would try to render the editor on the server.
   banner: { js: '"use client";' },
   // The chrome stylesheet is NOT copied here. It is compiled by `build:css`
   // with the Tailwind CLI, because the shell draws with utility classes and a

--- a/packages/builder/tsup.config.ts
+++ b/packages/builder/tsup.config.ts
@@ -17,11 +17,9 @@ export default defineConfig({
   // server. The whole package is an editor and is client-only by nature, which
   // is the same treatment `@nextlyhq/ui`'s root barrel gets.
   banner: { js: '"use client";' },
-  // The chrome stylesheet is not reachable from the JS graph, so nothing would
-  // emit it. Copied verbatim and published at `./styles.css`: a consumer that
-  // renders the shell without it gets unstyled markup, which is worse than a
-  // build error because it looks like a layout bug.
-  publicDir: "src/styles",
+  // The chrome stylesheet is NOT copied here. It is compiled by `build:css`
+  // with the Tailwind CLI, because the shell draws with utility classes and a
+  // verbatim copy ships the custom properties without the rules that use them.
   format: ["esm"],
   dts: true,
   clean: true,

--- a/packages/builder/tsup.server-safe.config.ts
+++ b/packages/builder/tsup.server-safe.config.ts
@@ -27,11 +27,27 @@ import { defineConfig } from "tsup";
  * runs after it.
  */
 export default defineConfig({
-  entry: ["src/geometry.ts", "src/shell-state.ts"],
+  // The ROOT entry is built here too, and that is the point rather than an
+  // accident of grouping. It exports the package name, the frame geometry and
+  // the shell's declared bounds — none of which is React — and it describes
+  // `BuilderShellProps` as a TYPE, which is erased. Built by the client config
+  // it would have inherited the shell's banner and turned every one of those
+  // into a client reference.
+  entry: ["src/index.ts", "src/geometry.ts", "src/shell-state.ts"],
   format: ["esm"],
   dts: true,
   clean: false,
   sourcemap: true,
+  // Only reached through the type side of the root entry's declarations; no
+  // runtime import here pulls any of them in. Declared so `dts` resolves them
+  // rather than trying to bundle a copy.
+  external: [
+    "react",
+    "react-dom",
+    "react/jsx-runtime",
+    "@nextlyhq/ui",
+    "@nextlyhq/plugin-sdk",
+  ],
   // Safe here, unlike the root config: with no directive to preserve, there is
   // nothing for the treeshaking pass to strip.
   treeshake: true,

--- a/packages/builder/tsup.server-safe.config.ts
+++ b/packages/builder/tsup.server-safe.config.ts
@@ -1,0 +1,41 @@
+import { defineConfig } from "tsup";
+
+/**
+ * The parts of this package that contain no React.
+ *
+ * `geometry` maps a canvas rectangle into host coordinates; `shell-state`
+ * decides which panel the rail opens, what the shell's declared bounds are, and
+ * how chrome preferences are read and written. Both are arithmetic and set
+ * membership, and neither imports anything at all.
+ *
+ * Built SEPARATELY from the root entry because that entry carries a
+ * `"use client"` banner. The banner is required there — the shell is a client
+ * component and Rollup drops per-module directives — but it applies to
+ * everything the entry re-exports, which marked these two as client-only as
+ * well. A Server Component could then not compute a layout bound or a
+ * coordinate, for no reason other than how the bundle was assembled.
+ *
+ * That was not hypothetical. `e2e/tests/canvas/coordinate-mapping.ts` already
+ * imports the geometry, and it kept working only because that package resolves
+ * `@nextlyhq/builder` through a tsconfig path mapping to SOURCE, bypassing the
+ * published entry entirely. The export map was advertising something the
+ * artifact could not deliver, and the one consumer was not using the artifact.
+ *
+ * Same split, and the same reason, as `@nextlyhq/ui`'s `./color` and `./utils`.
+ *
+ * Neither config cleans `dist`; the root config does that once, and this one
+ * runs after it.
+ */
+export default defineConfig({
+  entry: ["src/geometry.ts", "src/shell-state.ts"],
+  format: ["esm"],
+  dts: true,
+  clean: false,
+  sourcemap: true,
+  // Safe here, unlike the root config: with no directive to preserve, there is
+  // nothing for the treeshaking pass to strip.
+  treeshake: true,
+  outExtension() {
+    return { js: ".mjs" };
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -874,6 +874,9 @@ importers:
       '@nextlyhq/ui':
         specifier: workspace:*
         version: link:../ui
+      '@tailwindcss/cli':
+        specifier: ^4.3.2
+        version: 4.3.2
       '@testing-library/react':
         specifier: ^16.3.0
         version: 16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@19.2.0(@types/react@19.2.0))(@types/react@19.2.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
@@ -904,6 +907,9 @@ importers:
       rimraf:
         specifier: ^6.1.3
         version: 6.1.3
+      tailwindcss:
+        specifier: ^4.3.2
+        version: 4.3.2
       tsup:
         specifier: ^8.5.0
         version: 8.5.0(jiti@2.7.0)(postcss@8.5.23)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -159,6 +159,9 @@ importers:
       '@nextlyhq/blocks-react':
         specifier: workspace:^
         version: link:../../packages/blocks-react
+      '@nextlyhq/builder':
+        specifier: workspace:*
+        version: link:../../packages/builder
       '@nextlyhq/plugin-form-builder':
         specifier: workspace:^
         version: link:../../packages/plugin-form-builder


### PR DESCRIPTION
First of two PRs for **B-12** (Plan 04, the editor shell). This one is the decisions; the components follow.

The split is deliberate and follows D-04.1's precedent — *"the op store is a library, and it ships before any UI"* — for the same reason: **a layout cannot be checked by rendering it in jsdom**, which reports every element as zero-sized. A component test asserting a panel width passes whatever the CSS does. The decisions live where they can be asserted; the rendered layout gets verified in a real browser in PR 2.

## The design changed twice, both times because checking beat assuming

**Per-panel width bounds were the wrong model.** The obvious design gives each panel a min and max. A test asking whether the canvas stays the largest region at the minimum supported viewport answered **232px** — narrower than either panel, in an editor whose subject *is* the canvas. No per-panel bound was violated, because the constraint was never per-panel.

**Then I solved that constraint myself, which was also wrong.** I wrote a joint-fit deciding which region yields under pressure. `react-resizable-panels@4.12.2` — the library behind `@nextlyhq/ui`'s resizable primitive — takes pixel bounds directly (its types state a numeric `minSize` is pixels) and solves exactly that, ordering included. Two implementations of one constraint is the defect this repo keeps paying for, so mine is deleted.

Worth recording why I nearly missed it: the ui wrapper's module doc says *"Sizes are relative, not pixels."* That is advice about storing a **layout**, not a statement about the API. Reading the wrapper's prose instead of the library's types is what sent me down the wrong path.

Bounds are now **declared and handed to the library**. The canvas floor is expressed as the canvas panel's own minimum, which is what makes it joint rather than per-panel.

## What this module keeps

- **Rail logic** — the panel set, toggle-to-close (the only route to a full-width canvas), and rejection of a stored panel name a later release removed, so a preference cannot open a region that renders nothing.
- **The degradation threshold** (PB-D17 D10-5, ≥1280px) and its off-by-one boundary.
- **A preference PORT**, not `localStorage`. The ratified plan wants these durable per user on the server; a component reaching for `localStorage` makes that a rewrite rather than a different argument, and a server render becomes a crash rather than a default.
- **Whole-map layout validation.** The library distributes a layout across *all* panels, so a map with one unusable entry resolves to a layout nobody chose — partial acceptance is worse than falling back.

Preferences store the **proportional** layout the library reports, never pixel widths: a pixel layout is wrong on the next monitor, while the pixel bounds still hold because the library re-applies them.

The canvas-floor arithmetic is kept as an assertion rather than a comment, so the reasoning cannot quietly stop being true — it checks both that per-panel bounds *cannot* express the floor, and that the declared minimums have a solution at 1280px.

## Verification

- 21 tests, `check-types` (both configs) and `lint` clean
- Mutation-tested: accepting a layout with a bad entry, and raising the canvas floor until the bounds have no solution — each fails its own specific test and nothing else
- No changeset: `@nextlyhq/builder` gains an internal module with no public surface change yet

## Not in this PR

The rail/panels/top-bar components, the `--nx-builder-*` chrome token layer, F6 region cycling, and the Playwright spec. Also **not** scope-tint: it is founder-ratified but miscategorised as a `/ui` primitive — it is a shell chrome state whose mechanism is that token layer, and it needs a "template scope" concept the codebase does not have yet.