### PR TITLE
docs: note what a derived check cannot see

### DIFF
--- a/.claude/rules/derived-checks.md
+++ b/.claude/rules/derived-checks.md
@@ -104,6 +104,20 @@ The same shape applies to a derived check over routes, over registered field
 types, over dialects in a matrix: derive so nothing new escapes, then name the
 one or two whose disappearance is the thing you are actually afraid of.
 
+The general case of that pin is older than this rule and already in the same
+file, which is the best argument for it. A prohibition — "no entry point exposes
+these 22 names" — is satisfied PERFECTLY by an empty module, so it is paired
+with an assertion that the replacement API is present:
+
+```ts
+// The counterpart to the list above: absence alone would also be satisfied
+// by deleting the API, so the replacements are asserted present.
+expect(typeof cfg.defineFieldGroup).toBe("function");
+```
+
+Every prohibition needs that counterpart, and it is the half that gets skipped,
+because a prohibition passing feels like the check working.
+
 ## A pattern matching a common word is a narrowing check in reverse
 
 The separating-property test has a mirror image. A check can also fail by
@@ -134,6 +148,27 @@ granularity the language distinguishes — a word boundary, a parsed binding —
 read every hit before reporting a number. **A count is not a finding until
 something has looked at what it counted**, and "I filtered it" is not the same
 as having looked.
+
+The generalisation is worth more than the instance: **when you refine a check,
+ask what the refinement EXCLUDES, not only what it admits.** Two people refined
+this same scan on the same day and both narrowed the question instead of
+sharpening the answer — one restricted the path set on the reasoning that only
+one package publishes entry points, the other restricted the line set to those
+containing `export`. Each refinement felt like rigour and each silently dropped
+cases the unrefined version would have surfaced.
+
+A refinement that cannot be stated as "this excludes X, and X cannot matter
+because Y" is a guess wearing the costume of precision.
+
+Worth separating the SCAN from the GUARD here, because conflating them nearly
+put a false limitation into this file. A diff-text scan cannot see
+`export * from "./legacy-module"` — the forbidden name never appears in the
+diff. The suite is unaffected: it imports each entry point and asks
+`name in mod` against the live namespace object, and export-star bindings are
+present on that namespace (measured, not assumed). So the blind spot belonged to
+the pre-warning heuristic, not to the check that actually protects the package.
+When something looks like a hole, establish WHICH layer it is in before
+describing it as one.
 
 ## A derived check must match on three axes, not one
 

--- a/.claude/rules/derived-checks.md
+++ b/.claude/rules/derived-checks.md
@@ -99,10 +99,16 @@ existing", which neither of the others can see.
 Worked example, from this repo. `packages/nextly/src/__tests__/export-contract.test.ts`
 hand-listed 6 entry points while `package.json` published 42, and pinned the
 expected count beside the list it counted — so both sides moved together and a
-new subpath was never checked. It now derives the matrix from
-`Object.keys(manifest.exports)`, which closes the addition case completely.
+new subpath was never checked.
 
-It still carries one hardcoded assertion:
+It now does all three. The matrix comes from `Object.keys(manifest.exports)`,
+which is TOTAL — the whole manifest, with no predicate or glob between, which is
+what makes the addition case genuinely closed rather than merely relocated. Its
+length is then asserted against `declaredSubpaths.length` and against zero, so a
+mapping that silently selected a subset, or none, fails instead of deleting its
+own cases.
+
+And it still carries one hardcoded assertion:
 
 ```ts
 expect(declaredSubpaths).toContain("./field-group-type");

--- a/.claude/rules/derived-checks.md
+++ b/.claude/rules/derived-checks.md
@@ -89,14 +89,22 @@ So a derived check needs three things, and is usually written with one:
 
    ```ts
    const population = Object.keys(raw);
-   expect(derived).toHaveLength(population.length); // no narrowing transform
-   expect(population.length).toBeGreaterThan(0); // the source was really read
+   expect(new Set(derived.map(id))).toEqual(new Set(population)); // same members
+   expect(derived).toHaveLength(population.length); // and no duplicates
+   expect(population).toContain(KNOWN_MEMBER); // the INTENDED source was read
    ```
 
-   The first catches a glob or predicate quietly selecting a subset. The second
-   catches the collapse where the read returns nothing and every remaining case
-   passes over an empty matrix — without it, `toHaveLength(0)` against an empty
-   source is a green that asserts nothing.
+   Compare MEMBERS, not just how many. Equal lengths are satisfied by a
+   derivation that substitutes one member for another, or emits a duplicate
+   while dropping a real one — the count agrees and a raw member has no case.
+   The length assertion still earns its place beside the set comparison, because
+   a set silently absorbs duplicates.
+
+   The third line is the one usually left out, and non-emptiness cannot replace
+   it: a loader that reads the WRONG manifest, or returns a non-empty fallback,
+   passes every count check, and the derived length agrees with it because both
+   sides came from the same wrong input. Pin something only the intended source
+   contains.
 
 3. **Pin by name the members whose absence would itself be the regression.**
 

--- a/.claude/rules/derived-checks.md
+++ b/.claude/rules/derived-checks.md
@@ -84,10 +84,20 @@ So a derived check needs three things, and is usually written with one:
 1. **Derive the population** from the richest source available — the manifest,
    the registry, the config — not a hand-kept copy of it.
 2. **Assert the derivation is complete**, against that raw source and against
-   zero. `expect(derived).toHaveLength(Object.keys(raw).length)` catches a
-   narrowing transform that quietly selects a subset, and
-   `expect(raw.length).toBeGreaterThan(0)` catches the collapse where the source
-   read returns nothing and every remaining case passes over an empty matrix.
+   zero. With `raw` the source as read — usually an object, so count the same
+   key population on both sides rather than reaching for `.length` on one:
+
+   ```ts
+   const population = Object.keys(raw);
+   expect(derived).toHaveLength(population.length); // no narrowing transform
+   expect(population.length).toBeGreaterThan(0); // the source was really read
+   ```
+
+   The first catches a glob or predicate quietly selecting a subset. The second
+   catches the collapse where the read returns nothing and every remaining case
+   passes over an empty matrix — without it, `toHaveLength(0)` against an empty
+   source is a green that asserts nothing.
+
 3. **Pin by name the members whose absence would itself be the regression.**
 
 Each answers a different question. Deriving answers "did we forget to check
@@ -136,8 +146,14 @@ with an assertion that the replacement API is present:
 expect(typeof cfg.defineFieldGroup).toBe("function");
 ```
 
-Every prohibition needs that counterpart, and it is the half that gets skipped,
-because a prohibition passing feels like the check working.
+That counterpart is the half that gets skipped, because a prohibition passing
+feels like the check working. It is not unconditional though, and demanding it
+everywhere would contradict the pin rule above: a subject that may legitimately
+be empty — a feature-gated plugin registering no routes — has no required
+replacement to assert, and inventing one manufactures a contract the system does
+not have. Pair the prohibition with a presence assertion exactly when emptying
+the subject would itself break the contract, which is the same test as deciding
+what to pin by name.
 
 ## A pattern matching a common word is a narrowing check in reverse
 
@@ -316,15 +332,22 @@ believed**, because it looks like provenance rather than like a string somebody
 chose. It is a login, and in this repo many agents commit under one. Measured
 over the last 400 commits: 343 carry a single identity.
 
-So the field answers a narrower question than it appears to. It DOES separate
-one contributor from another — three distinct humans appear in that same range.
-It does NOT separate the many concurrent sessions sharing one credential, and no
-amount of reading it will, because the distinction was never recorded.
+And it is not a credential in any checkable sense either: the name comes from
+environment or configuration, so it is chosen rather than authenticated, two
+contributors can pick the same one, and one contributor can change theirs. So it
+does not reliably separate contributors, and it certainly does not separate the
+concurrent sessions sharing a single configured identity — that distinction was
+never recorded anywhere.
 
 Two different questions, and only one of them has a sound instrument:
 
-- **"did this line predate that change?"** — a fact about the tree.
-  `git show <ref>^:<path>` answers it exactly.
+- **"did this line predate that change?"** — a fact about the tree, and
+  `git show <ref>^:<path>` answers it for the ordinary case: a single-parent
+  commit where the path did not move. `^` selects the FIRST parent only, so
+  across a merge it cannot see a line that arrived on another branch, and it
+  looks the path up verbatim, so a rename reads as absence. Where either
+  applies, check each parent and follow the rename (`git log --follow`) before
+  claiming precedence.
 - **"who wrote this line?"** — `git log --format=%an` answers a question about a
   credential. Under a shared one it is a guess with a citation attached, which
   is worse than an obvious guess.

--- a/.claude/rules/derived-checks.md
+++ b/.claude/rules/derived-checks.md
@@ -339,35 +339,30 @@ that. It is usually available and it usually costs the same.
 
 **A commit's author field is one of these, and it is the one most likely to be
 believed**, because it looks like provenance rather than like a string somebody
-chose. It is a login, and in this repo many agents commit under one. Measured
-over the last 400 commits: 343 carry a single identity.
+chose. It is configured, not authenticated: two contributors can set the same
+name and one can change theirs, so it identifies nobody in particular. In this
+repo many agents also commit under one identity — 343 of the last 400 commits
+carry a single name — so it does not separate sessions either. That distinction
+was never recorded anywhere, and no query recovers it.
 
-And it is not a credential in any checkable sense either: the name comes from
-environment or configuration, so it is chosen rather than authenticated, two
-contributors can pick the same one, and one contributor can change theirs. So it
-does not reliably separate contributors, and it certainly does not separate the
-concurrent sessions sharing a single configured identity — that distinction was
-never recorded anywhere.
+Which splits into two questions, and only one of them has an answer:
 
-Two different questions, and only one of them has a sound instrument:
+- **"did this line predate that change?"** is a fact about the TREE, and the
+  tree can be read. Compare the file at the two revisions.
+- **"who wrote this line?"** has no sound instrument here. Line-scoped history
+  finds the COMMIT, which is real; the name attached to it is the configured
+  string above.
 
-- **"did this line predate that change?"** — a fact about the tree, and
-  `git show <ref>^:<path>` answers it for the ordinary case: a single-parent
-  commit where the path did not move. `^` selects the FIRST parent only, so
-  across a merge it cannot see a line that arrived on another branch, and it
-  looks the path up verbatim, so a rename reads as absence. Where either
-  applies, check each parent and follow the rename (`git log --follow`) before
-  claiming precedence.
-- **"who wrote this line?"** — two separate failures, and the first is
-  mechanical. `git log --format=%an` has no line selector at all: it prints an
-  author for every commit the revision range selected, so it associates the line
-  with whoever touched the file. The line-scoped forms are `git blame -L
-<range> <file>` and `git log -L <range>:<file>`.
+So: use history to reach the commit, then stop. The commit is a fact; the name
+on it is a claim.
 
-  Reach for those and the second failure remains: what they return is configured
-  author metadata, so under a shared identity it is a guess with a citation
-  attached, which is worse than an obvious guess. Use them to find the commit,
-  then stop — the commit is a fact, the name on it is a claim.
+🔴 Deliberately no command recipes. Four review rounds on this paragraph each
+corrected a different one — a missing pathspec, an unanchored revision, a
+first-parent-only lookup, a command with no line selector at all — and each
+correction attracted the next. The exact invocation depends on merges, renames
+and which revision you anchor to, and a rule file that specifies it will be
+wrong in a way readers trust. Naming the question and its limits is the part
+that keeps.
 
 This surfaced while attributing a comment in `export-contract.test.ts`. The
 precedence claim was settled from the tree and held; the authorship claim around

--- a/.claude/rules/derived-checks.md
+++ b/.claude/rules/derived-checks.md
@@ -96,7 +96,7 @@ So a derived check needs three things, and is usually written with one:
    const id = (entry: Derived): string => entry.key;
    expect(new Set(derived.map(id))).toEqual(new Set(population)); // same members
    expect(derived).toHaveLength(population.length); // and no duplicates
-   expect(population).toContain(KNOWN_MEMBER); // the INTENDED source was read
+   expect(population).toContain(KNOWN_MEMBER); // ONLY if empty is invalid here
    ```
 
    Compare MEMBERS, not just how many. Equal lengths are satisfied by a
@@ -105,8 +105,14 @@ So a derived check needs three things, and is usually written with one:
    The length assertion still earns its place beside the set comparison, because
    a set silently absorbs duplicates.
 
-   The third line is the one usually left out, and non-emptiness cannot replace
-   it: a loader that reads the WRONG manifest, or returns a non-empty fallback,
+   🔴 The third line is CONDITIONAL, and applies exactly when emptiness would
+   violate the subject's contract — the same test as deciding what to pin by
+   name. A subject that may legitimately be empty (a feature-gated registry with
+   no routes) is proved complete by the set and length comparisons alone, and
+   demanding a known member there rejects a valid configuration and invents the
+   presence contract this rule warns against further down.
+
+   Where it does apply, non-emptiness cannot replace it: a loader that reads the WRONG manifest, or returns a non-empty fallback,
    passes every count check, and the derived length agrees with it because both
    sides came from the same wrong input. Pin something only the intended source
    contains.
@@ -126,12 +132,17 @@ new subpath was never checked. `696281d12` then published a 42nd subpath and
 replaced the hand-written matrix in the same commit, which is why no single
 revision shows the gap at its widest.
 
-It now does all three. The matrix comes from `Object.keys(manifest.exports)`,
-which is TOTAL — the whole manifest, with no predicate or glob between, which is
-what makes the addition case genuinely closed rather than merely relocated. Its
-length is then asserted against `declaredSubpaths.length` and against zero, so a
-mapping that silently selected a subset, or none, fails instead of deleting its
-own cases.
+It now derives from `Object.keys(manifest.exports)`, which is TOTAL — the whole
+manifest, with no predicate or glob between, which is what makes the addition
+case genuinely closed rather than merely relocated. Its length is asserted
+against `declaredSubpaths.length` and against zero, so a mapping that silently
+selected a subset, or none, fails instead of deleting its own cases.
+
+🔴 It does NOT yet compare member identities, so the guidance above is ahead of
+this example: a mapping that substituted or duplicated one entry while omitting
+another keeps the count equal, and the generated cases inspect the duplicate
+twice. Counts catch a mapping that returns FEWER things; only the set comparison
+catches one that returns the WRONG things.
 
 And it still carries one hardcoded assertion:
 

--- a/.claude/rules/derived-checks.md
+++ b/.claude/rules/derived-checks.md
@@ -115,9 +115,11 @@ list into a pattern nobody rereads. A by-name pin answers "did something stop
 existing", which neither of the others can see.
 
 Worked example, from this repo. `packages/nextly/src/__tests__/export-contract.test.ts`
-hand-listed 6 entry points while `package.json` published 42, and pinned the
+hand-listed 5 entry points while `package.json` published 41, and pinned the
 expected count beside the list it counted — so both sides moved together and a
-new subpath was never checked.
+new subpath was never checked. `696281d12` then published a 42nd subpath and
+replaced the hand-written matrix in the same commit, which is why no single
+revision shows the gap at its widest.
 
 It now does all three. The matrix comes from `Object.keys(manifest.exports)`,
 which is TOTAL — the whole manifest, with no predicate or glob between, which is

--- a/.claude/rules/derived-checks.md
+++ b/.claude/rules/derived-checks.md
@@ -275,6 +275,29 @@ The tell is a check whose correctness depends on how some other system chose to
 spell something. Ask instead what property makes the answer true, and query
 that. It is usually available and it usually costs the same.
 
+**A commit's author field is one of these, and it is the one most likely to be
+believed**, because it looks like provenance rather than like a string somebody
+chose. It is a login, and in this repo many agents commit under one. Measured
+over the last 400 commits: 343 carry a single identity.
+
+So the field answers a narrower question than it appears to. It DOES separate
+one contributor from another — three distinct humans appear in that same range.
+It does NOT separate the many concurrent sessions sharing one credential, and no
+amount of reading it will, because the distinction was never recorded.
+
+Two different questions, and only one of them has a sound instrument:
+
+- **"did this line predate that change?"** — a fact about the tree.
+  `git show <ref>^:<path>` answers it exactly.
+- **"who wrote this line?"** — `git log --format=%an` answers a question about a
+  credential. Under a shared one it is a guess with a citation attached, which
+  is worse than an obvious guess.
+
+This surfaced while attributing a comment in `export-contract.test.ts`. The
+precedence claim was settled from the tree and held; the authorship claim around
+it could not have been settled at all, in either direction. `gh pr list --author
+@me` has the same shape — it filters by credential and reads as ownership.
+
 **"Structural" is not automatically "coarse", and the first two above are where
 that bites.** Replacing a name with a broader property is only correct when the
 broader property still separates the cases you must tell apart:

--- a/.claude/rules/derived-checks.md
+++ b/.claude/rules/derived-checks.md
@@ -62,6 +62,79 @@ Two rules follow, and the second is the one that gets missed:
   reconstructing the same call in the test. A hand-copied argument list keeps
   passing after someone edits the line the test exists to watch.
 
+## Derivation cannot see DELETION, and the green looks identical
+
+Deriving fixes drift. It does not fix removal, and those are different failures:
+
+- **The subject gains a member the check forgot** → deriving makes this
+  impossible. The case exists the moment the member does.
+- **The subject LOSES a member** → still silent. The derived population shrinks
+  with it, every remaining case passes, and the suite reports green over a
+  subject that stopped doing something.
+
+A derived check inherits its subject's blind spots: it can only assert about
+what the subject currently says. Removing the subject removes the assertion —
+and removes its test alongside, so the count drops without a failure.
+
+So: **derive the population, pin by name the members whose absence would itself
+be the regression.** Deriving answers "did we forget to check something that
+exists". A by-name pin answers "did something stop existing". Most checks need
+both and are written with only the first.
+
+Worked example, from this repo. `packages/nextly/src/__tests__/export-contract.test.ts`
+hand-listed 6 entry points while `package.json` published 42, and pinned the
+expected count beside the list it counted — so both sides moved together and a
+new subpath was never checked. It now derives the matrix from
+`Object.keys(manifest.exports)`, which closes the addition case completely.
+
+It still carries one hardcoded assertion:
+
+```ts
+expect(declaredSubpaths).toContain("./field-group-type");
+```
+
+because the derived matrix would pass just as happily if that subpath were
+dropped from `package.json` — the published surface would simply be described as
+smaller. That entry point is the supported way to read a field group's type, and
+its absence sends callers back to reading the raw storage key by hand, which is
+the defect the whole rename exists to remove. Deriving cannot express that; only
+naming it can.
+
+The same shape applies to a derived check over routes, over registered field
+types, over dialects in a matrix: derive so nothing new escapes, then name the
+one or two whose disappearance is the thing you are actually afraid of.
+
+## A pattern matching a common word is a narrowing check in reverse
+
+The separating-property test has a mirror image. A check can also fail by
+matching too MUCH, and it fails more convincingly, because a hit reads as
+evidence while a miss reads as nothing.
+
+Measured here, scanning every open PR for the 22 forbidden identifiers in
+`export-contract.test.ts`. The count fell to nothing under each refinement:
+
+| pass                                            | result                              |
+| ----------------------------------------------- | ----------------------------------- |
+| substring match on added lines                  | **10 PRs flagged**                  |
+| ...restricted to lines containing `export`      | 4 lines, one PR, all prose comments |
+| word-boundary match on the 21 DISTINCTIVE names | **0**                               |
+
+Every hit came from `component`, the one entry in the list that is also an
+ordinary English word: "renders the same detail-page component type". Acting on
+the first number would have meant warning ten lanes about nothing.
+
+Note the middle pass, because it is the more instructive failure. Filtering to
+lines containing `export` looks like the rigorous move and is itself unsound: a
+re-export inside a block puts the binding on its own line, so `  ComponentConfig,`
+carries no `export` and the filter drops the exact case it was written to catch.
+One narrowing check laid over one widening one, each hiding the other's defect.
+
+An identifier list containing an ordinary word is the tell. Match at a
+granularity the language distinguishes — a word boundary, a parsed binding — or
+read every hit before reporting a number. **A count is not a finding until
+something has looked at what it counted**, and "I filtered it" is not the same
+as having looked.
+
 ## A derived check must match on three axes, not one
 
 Asking "does it compute the same thing" is not enough:

--- a/.claude/rules/derived-checks.md
+++ b/.claude/rules/derived-checks.md
@@ -346,8 +346,8 @@ that. It is usually available and it usually costs the same.
 believed**, because it looks like provenance rather than like a string somebody
 chose. It is configured, not authenticated: two contributors can set the same
 name and one can change theirs, so it identifies nobody in particular. In this
-repo many agents also commit under one identity — 343 of the last 400 commits
-carry a single name — so it does not separate sessions either. That distinction
+repo many agents also commit under one identity, so it does not separate
+sessions either. That distinction
 was never recorded anywhere, and no query recovers it.
 
 Which splits into two questions, and only one of them has an answer:

--- a/.claude/rules/derived-checks.md
+++ b/.claude/rules/derived-checks.md
@@ -180,12 +180,18 @@ Measured here, scanning every open PR for the 22 forbidden identifiers in
 `export-contract.test.ts`. **Three successive refinements, each of which felt
 like rigour, and all three were unsound in the same direction:**
 
-| pass                                            | result                              | sound? |
-| ----------------------------------------------- | ----------------------------------- | ------ |
-| substring match on added lines                  | 10 PRs flagged                      | noisy  |
-| ...restricted to lines containing `export`      | 4 lines, one PR, all prose comments | NO     |
-| ...word boundary, dropping `component`          | 0                                   | NO     |
-| all 22 names, word boundary, **every hit read** | 43 hits, all prose, **0 real**      | yes    |
+| pass                                            | result                              |
+| ----------------------------------------------- | ----------------------------------- |
+| substring match on added lines                  | 10 PRs flagged                      |
+| ...restricted to lines containing `export`      | 4 lines, one PR, all prose comments |
+| ...word boundary, dropping `component`          | 0                                   |
+| all 22 names, word boundary, **every hit read** | 43 hits, all prose, **0 real**      |
+
+🔴 **No regex pass was sound, including the last one.** A pattern cannot tell a
+binding from prose, so every row above is a pattern that would have missed a
+real re-export written slightly differently. What settled the question was
+READING all 43 hits. Crediting the fourth pattern would repeat the error this
+section is about — the refinement was not what made the answer trustworthy.
 
 Each middle pass is worth naming, because they are the same mistake escalating.
 

--- a/.claude/rules/derived-checks.md
+++ b/.claude/rules/derived-checks.md
@@ -222,9 +222,20 @@ So the clean zero was produced by a scan that had been narrowed until it could
 not fail. That it agreed with the honest answer is luck, and the agreement is
 what would have stopped anyone looking.
 
-The sound method was the unglamorous one: keep all 22, accept 43 hits, and read
-them. **A count is not a finding until something has looked at what it counted**,
-and "I filtered it" is not the same as having looked.
+Keeping all 22 and reading the 43 hits is what made the COUNT trustworthy, and
+no more than that. **The scan is still not sound and cannot be made sound**: a
+PR adding only `export * from "./legacy-module"` produces no hit at all, since
+the forbidden name appears nowhere in the diff, and no amount of reading finds a
+line that was never printed.
+
+So the diff scan is a pre-warning heuristic. The sound instrument is the one
+that resolves the real thing — the suite that imports each entry point and asks
+`name in mod` of the live namespace, where export-star bindings ARE present. A
+parsed-binding check would also qualify; a regex over a diff never will.
+
+Within what it can see, though: **a count is not a finding until something has
+looked at what it counted**, and "I filtered it" is not the same as having
+looked.
 
 An identifier list containing an ordinary word is the tell. Match at a
 granularity the language distinguishes — a parsed binding, not a regex — or read

--- a/.claude/rules/derived-checks.md
+++ b/.claude/rules/derived-checks.md
@@ -66,20 +66,35 @@ Two rules follow, and the second is the one that gets missed:
 
 Deriving fixes drift. It does not fix removal, and those are different failures:
 
-- **The subject gains a member the check forgot** → deriving makes this
-  impossible. The case exists the moment the member does.
-- **The subject LOSES a member** → still silent. The derived population shrinks
-  with it, every remaining case passes, and the suite reports green over a
-  subject that stopped doing something.
+- **The subject gains a member the check forgot** → deriving fixes this, but
+  only when the derivation is TOTAL. Read the whole manifest and every new member
+  gets a case the moment it exists. Reach it through a glob, a predicate or a
+  filter and a member landing outside that selection still generates nothing —
+  the derivation has merely moved the hand-kept list into a pattern.
+- **The subject LOSES a member** → still silent, always. The derived population
+  shrinks with it, every remaining case passes, and the suite reports green over
+  a subject that stopped doing something.
 
 A derived check inherits its subject's blind spots: it can only assert about
 what the subject currently says. Removing the subject removes the assertion —
 and removes its test alongside, so the count drops without a failure.
 
-So: **derive the population, pin by name the members whose absence would itself
-be the regression.** Deriving answers "did we forget to check something that
-exists". A by-name pin answers "did something stop existing". Most checks need
-both and are written with only the first.
+So a derived check needs three things, and is usually written with one:
+
+1. **Derive the population** from the richest source available — the manifest,
+   the registry, the config — not a hand-kept copy of it.
+2. **Assert the derivation is complete**, against that raw source and against
+   zero. `expect(derived).toHaveLength(Object.keys(raw).length)` catches a
+   narrowing transform that quietly selects a subset, and
+   `expect(raw.length).toBeGreaterThan(0)` catches the collapse where the source
+   read returns nothing and every remaining case passes over an empty matrix.
+3. **Pin by name the members whose absence would itself be the regression.**
+
+Each answers a different question. Deriving answers "did we forget to check
+something that exists". The completeness assertion answers "is the derivation
+still seeing everything" — without it, step 1 has only relocated the hand-kept
+list into a pattern nobody rereads. A by-name pin answers "did something stop
+existing", which neither of the others can see.
 
 Worked example, from this repo. `packages/nextly/src/__tests__/export-contract.test.ts`
 hand-listed 6 entry points while `package.json` published 42, and pinned the
@@ -125,40 +140,55 @@ matching too MUCH, and it fails more convincingly, because a hit reads as
 evidence while a miss reads as nothing.
 
 Measured here, scanning every open PR for the 22 forbidden identifiers in
-`export-contract.test.ts`. The count fell to nothing under each refinement:
+`export-contract.test.ts`. **Three successive refinements, each of which felt
+like rigour, and all three were unsound in the same direction:**
 
-| pass                                            | result                              |
-| ----------------------------------------------- | ----------------------------------- |
-| substring match on added lines                  | **10 PRs flagged**                  |
-| ...restricted to lines containing `export`      | 4 lines, one PR, all prose comments |
-| word-boundary match on the 21 DISTINCTIVE names | **0**                               |
+| pass                                            | result                              | sound? |
+| ----------------------------------------------- | ----------------------------------- | ------ |
+| substring match on added lines                  | 10 PRs flagged                      | noisy  |
+| ...restricted to lines containing `export`      | 4 lines, one PR, all prose comments | NO     |
+| ...word boundary, dropping `component`          | 0                                   | NO     |
+| all 22 names, word boundary, **every hit read** | 43 hits, all prose, **0 real**      | yes    |
 
-Every hit came from `component`, the one entry in the list that is also an
-ordinary English word: "renders the same detail-page component type". Acting on
-the first number would have meant warning ten lanes about nothing.
+Each middle pass is worth naming, because they are the same mistake escalating.
 
-Note the middle pass, because it is the more instructive failure. Filtering to
-lines containing `export` looks like the rigorous move and is itself unsound: a
+**Filtering to lines containing `export`** drops the case it exists to catch: a
 re-export inside a block puts the binding on its own line, so `  ComponentConfig,`
-carries no `export` and the filter drops the exact case it was written to catch.
-One narrowing check laid over one widening one, each hiding the other's defect.
+carries no `export` at all.
+
+**Dropping `component` from the list** was worse, and it was mine. The
+justification was that it is an ordinary English word producing only prose hits —
+true of the hits, and irrelevant to the question. `component` is itself one of
+the 22 forbidden exports, so the refined scan could no longer see a PR
+re-exporting it. **The refinement excluded exactly one name, and it was the one
+most likely to be re-exported by accident**, being the shortest and most natural
+to reach for.
+
+So the clean zero was produced by a scan that had been narrowed until it could
+not fail. That it agreed with the honest answer is luck, and the agreement is
+what would have stopped anyone looking.
+
+The sound method was the unglamorous one: keep all 22, accept 43 hits, and read
+them. **A count is not a finding until something has looked at what it counted**,
+and "I filtered it" is not the same as having looked.
 
 An identifier list containing an ordinary word is the tell. Match at a
-granularity the language distinguishes — a word boundary, a parsed binding — or
-read every hit before reporting a number. **A count is not a finding until
-something has looked at what it counted**, and "I filtered it" is not the same
-as having looked.
+granularity the language distinguishes — a parsed binding, not a regex — or read
+every hit. Do not drop the awkward name; the awkward name is why the check
+exists.
 
 The generalisation is worth more than the instance: **when you refine a check,
-ask what the refinement EXCLUDES, not only what it admits.** Two people refined
-this same scan on the same day and both narrowed the question instead of
-sharpening the answer — one restricted the path set on the reasoning that only
-one package publishes entry points, the other restricted the line set to those
-containing `export`. Each refinement felt like rigour and each silently dropped
-cases the unrefined version would have surfaced.
+ask what the refinement EXCLUDES, not only what it admits.** Three refinements of
+one scan in one day, by two people, all narrowing the question rather than
+sharpening the answer — one restricted the path set, one the line set, one the
+name set.
 
 A refinement that cannot be stated as "this excludes X, and X cannot matter
-because Y" is a guess wearing the costume of precision.
+because Y" is a guess wearing the costume of precision. Note that the third
+refinement CAN be given that sentence — "this excludes `component`, and
+`component` cannot matter because its hits are prose" — and the sentence is
+false. Writing it down is what exposes it; the excluded thing has to be checked,
+not merely named.
 
 Worth separating the SCAN from the GUARD here, because conflating them nearly
 put a false limitation into this file. A diff-text scan cannot see

--- a/.claude/rules/derived-checks.md
+++ b/.claude/rules/derived-checks.md
@@ -356,9 +356,16 @@ Two different questions, and only one of them has a sound instrument:
   looks the path up verbatim, so a rename reads as absence. Where either
   applies, check each parent and follow the rename (`git log --follow`) before
   claiming precedence.
-- **"who wrote this line?"** — `git log --format=%an` answers a question about a
-  credential. Under a shared one it is a guess with a citation attached, which
-  is worse than an obvious guess.
+- **"who wrote this line?"** — two separate failures, and the first is
+  mechanical. `git log --format=%an` has no line selector at all: it prints an
+  author for every commit the revision range selected, so it associates the line
+  with whoever touched the file. The line-scoped forms are `git blame -L
+<range> <file>` and `git log -L <range>:<file>`.
+
+  Reach for those and the second failure remains: what they return is configured
+  author metadata, so under a shared identity it is a guess with a citation
+  attached, which is worse than an obvious guess. Use them to find the commit,
+  then stop — the commit is a fact, the name on it is a claim.
 
 This surfaced while attributing a comment in `export-contract.test.ts`. The
 precedence claim was settled from the tree and held; the authorship claim around

--- a/.claude/rules/derived-checks.md
+++ b/.claude/rules/derived-checks.md
@@ -89,6 +89,11 @@ So a derived check needs three things, and is usually written with one:
 
    ```ts
    const population = Object.keys(raw);
+   // `id` projects a derived case back onto the raw key it came from — the
+   // subpath, the route name, the field type. Name it explicitly: if you cannot
+   // write it, the derivation is not traceable to its source and the comparison
+   // below is not the one you think it is.
+   const id = (entry: Derived): string => entry.key;
    expect(new Set(derived.map(id))).toEqual(new Set(population)); // same members
    expect(derived).toHaveLength(population.length); // and no duplicates
    expect(population).toContain(KNOWN_MEMBER); // the INTENDED source was read


### PR DESCRIPTION
Three additions to `.claude/rules/derived-checks.md`. All are patterns two lanes hit independently today, and none is currently in the rule.

**Every one of them has live prior art in this repo**, which is the strongest thing about them — none is a proposed practice.

## 1. Derivation cannot see deletion

The rule argues the derive-don't-recompute side hard and says nothing about derivation's blind spot. Deriving fixes **drift**; it does not fix **removal**:

- subject gains a member the check forgot → deriving makes this impossible
- subject **loses** a member → still silent. The derived population shrinks with it, every remaining case passes, and the test that would have caught it disappears alongside the member, so the count drops without a failure.

The pairing that fixes it: **derive the population, pin by name the members whose absence would itself be the regression.**

Prior art is `packages/nextly/src/__tests__/export-contract.test.ts`, which states the asymmetry in its own comment:

> Guards the derivation, not the package. [...] a mapping that silently produced fewer entries — or none — would delete its own cases and leave a suite whose every remaining case passes. A vanished test reads exactly like a passing one.

## 2. A prohibition needs a presence assertion

A forbidden-names check passes **perfectly on an empty module**. Deleting the API satisfies it completely.

🔴 To be clear about attribution, since a peer credited this to me: this one is **not mine and predates #722**. It is at line 57 of the pre-merge file, and it is the sharpest thing in the suite:

```ts
// The counterpart to the list above: absence alone would also be satisfied
// by deleting the API, so the replacements are asserted present.
expect(typeof cfg.defineFieldGroup).toBe("function");
```

Generalised into the rule because it is the half people skip — a passing prohibition feels like the check working.

## 3. A pattern matching a common word is a narrowing check in reverse

The mirror of the separating-property test. A check can fail by matching too much, and it fails more convincingly, because a hit reads as evidence while a miss reads as nothing.

Measured across every open PR for the 22 forbidden identifiers:

| pass | result |
| --- | --- |
| substring match on added lines | **10 PRs flagged** |
| ...restricted to lines containing `export` | 4 lines, one PR, all prose comments |
| word-boundary match on the 21 distinctive names | **0** |

Every hit was `component`, the one entry that is also an ordinary English word.

**The middle pass is the more instructive failure and is called out as such.** Filtering to lines containing `export` looks like the rigorous move and is unsound: a re-export inside a block puts the binding on its own line — `  ComponentConfig,` carries no `export` — so the filter drops the exact case it exists to catch. A narrowing check laid over a widening one, each concealing the other's defect.

Generalised: **when you refine a check, ask what the refinement EXCLUDES, not only what it admits.** Two people refined this same scan on the same day; one restricted the path set, one the line set, and both narrowed the question rather than sharpening the answer.

## A correction I made to myself, now in the rule

I initially described `export * from "./legacy-module"` as a hole in the guard. It is not. The suite imports each entry point and asks `name in mod` against the live namespace object, and export-star bindings are present on that namespace — **measured, not assumed**:

```
namespace keys: [ 'ComponentConfig', 'defineComponent', 'somethingElse' ]
leaked via name in mod: [ 'ComponentConfig', 'defineComponent' ]
```

The blind spot belonged to my pre-warning diff scan, not to the check that protects the package. The rule now says to establish which layer a hole is in before describing it as one — conflating the two nearly put a false limitation into this file.

## Notes

- Docs-only, so no changeset.
- Every claim about the export-contract suite was verified against `origin/main`: the by-name pin at line 106, the derivation at line 44, the export count 42, and the presence assertion at line 57 of the **pre-merge** file.
- The measurement in §3 is my own re-run, not a peer's reported figure — my naive count was 10 where theirs was 3, because they scoped to `packages/nextly/src` and I scanned every path. Same answer: zero.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for ensuring derived checks detect both additions and deletions.
  * Documented best practices for comparing complete populations, validating pattern-based checks, and distinguishing scans from live guards.
  * Clarified how to assess commit authorship, tree precedence, and commit identity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->