### PR TITLE
fix(nextly): stop an infinite retention window from deleting

### DIFF
--- a/.changeset/one-retention-window-resolver.md
+++ b/.changeset/one-retention-window-resolver.md
@@ -47,6 +47,14 @@ window, and any window longer than a date can express, now mean keep forever.
 Values that ask for less than the default, or for nothing coherent, still fall
 back to the default, because that direction cannot lose data.
 
+How long a window a trail can express is stated by the trail rather than shared,
+because it is set by the column the cutoff is compared against and those differ.
+Content activity is compared against a column counting from 1970 and so tops out
+around fifty years; the audit, event and delivery trails count from a calendar
+year and accept far longer windows. Sharing one ceiling would have meant a
+window a column can hold being answered with "never prune", which is unbounded
+growth on a setting that asked for the opposite.
+
 Two positions each trail holds on its own are unchanged: `false` still means
 keep forever everywhere, and a delivery ledger set to zero still keeps nothing,
 which is a real choice for a table whose only purpose is making a retry

--- a/.changeset/one-retention-window-resolver.md
+++ b/.changeset/one-retention-window-resolver.md
@@ -1,0 +1,54 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+Retention now keeps what you asked it to keep.
+
+Setting a retention window to `Infinity` — the strongest way the type allows you
+to say "keep these forever" — was deleting instead. Audit trails were removed
+after 90 days and webhook events after 30, on the schedule the default sets,
+while the setting itself read as accepted. Nothing surfaced it: the pass ran,
+reported success, and pruned rows the configuration had asked to retain.
+
+The cause was three separate answers to one question. Audit, webhook and email
+retention each resolved a configured window in their own file, and the three had
+drifted: a 2000-year window kept everything, an infinite one deleted, and the
+same input produced different outcomes depending on which trail it was written
+for. Webhook retention also had no upper bound at all, so a very large window
+produced a cutoff date no database column can store, which made the pass fail
+silently on every run and leave the ledger unpruned.
+
+There is now one resolver behind all of them, built on the rule the copies
+disagreed about: refusing a value must never delete more than accepting it
+would. An infinite window, and any window longer than a date can express, now
+mean keep forever. Values that ask for less than the default, or for nothing
+coherent, still fall back to the default, because that direction cannot lose
+data.
+
+Two positions each trail holds on its own are unchanged: `false` still means
+keep forever everywhere, and a delivery ledger set to zero still keeps nothing,
+which is a real choice for a table whose only purpose is making a retry
+possible.

--- a/.changeset/one-retention-window-resolver.md
+++ b/.changeset/one-retention-window-resolver.md
@@ -33,20 +33,19 @@ after 90 days and webhook events after 30, on the schedule the default sets,
 while the setting itself read as accepted. Nothing surfaced it: the pass ran,
 reported success, and pruned rows the configuration had asked to retain.
 
-The cause was three separate answers to one question. Audit, webhook and email
-retention each resolved a configured window in their own file, and the three had
-drifted: a 2000-year window kept everything, an infinite one deleted, and the
-same input produced different outcomes depending on which trail it was written
-for. Webhook retention also had no upper bound at all, so a very large window
-produced a cutoff date no database column can store, which made the pass fail
-silently on every run and leave the ledger unpruned.
+The cause was two separate answers to one question. Audit and webhook retention
+each resolved a configured window in their own file, and the two had drifted: a
+2000-year window kept everything, an infinite one deleted, and the same input
+produced different outcomes depending on which trail it was written for. Webhook
+retention also had no upper bound at all, so a very large window produced a
+cutoff date no database column can store, which made the pass fail silently on
+every run and leave the ledger unpruned.
 
-There is now one resolver behind all of them, built on the rule the copies
-disagreed about: refusing a value must never delete more than accepting it
-would. An infinite window, and any window longer than a date can express, now
-mean keep forever. Values that ask for less than the default, or for nothing
-coherent, still fall back to the default, because that direction cannot lose
-data.
+There is now one resolver behind both, built on the rule they disagreed about:
+refusing a value must never delete more than accepting it would. An infinite
+window, and any window longer than a date can express, now mean keep forever.
+Values that ask for less than the default, or for nothing coherent, still fall
+back to the default, because that direction cannot lose data.
 
 Two positions each trail holds on its own are unchanged: `false` still means
 keep forever everywhere, and a delivery ledger set to zero still keeps nothing,

--- a/packages/nextly/src/domains/audit/__tests__/retention-config.test.ts
+++ b/packages/nextly/src/domains/audit/__tests__/retention-config.test.ts
@@ -33,12 +33,26 @@ describe("resolveAuditRetentionConfig", () => {
     expect(resolved.authMaxAgeMs).toBe(false);
   });
 
+  it("reads an infinite window as keeping everything", () => {
+    // `Infinity` and the 2000-year window in the test above are the SAME
+    // request — keep rows longer than a cutoff can express — and this file used
+    // to answer them differently: the finite one kept everything while the
+    // infinite one fell back to a default that DELETES after 90 days. The
+    // stronger spelling of "keep forever" was the destructive one.
+    const resolved = resolveAuditRetentionConfig({
+      activityMaxAgeMs: Infinity,
+      authMaxAgeMs: Infinity,
+    });
+    expect(resolved.activityMaxAgeMs).toBe(false);
+    expect(resolved.authMaxAgeMs).toBe(false);
+  });
+
   it("falls back when a window is not a finite positive number", () => {
-    // MAX_SAFE_INTEGER is the one that survives a finiteness check: subtracted
-    // from now it leaves the Date range, so the cutoff is an Invalid Date the
-    // driver rejects — a pass that fails every run and is swallowed, leaving
-    // the trail unpruned while the configuration reads as accepted.
-    for (const bad of [Infinity, -Infinity, NaN, 0, -1]) {
+    // Every value here asks for LESS retention than the default, or asks for
+    // nothing coherent — so falling back cannot delete more than honouring it
+    // would. `Infinity` is deliberately not in this list; it is the one input
+    // that asks for MORE, and it is covered above.
+    for (const bad of [-Infinity, NaN, 0, -1]) {
       const resolved = resolveAuditRetentionConfig({
         activityMaxAgeMs: bad,
         authMaxAgeMs: bad,

--- a/packages/nextly/src/domains/audit/retention-config.ts
+++ b/packages/nextly/src/domains/audit/retention-config.ts
@@ -11,6 +11,11 @@
  * @since 1.0.0
  */
 
+import {
+  MAX_STORABLE_OFFSET_MS,
+  resolveRetentionWindow,
+} from "../retention/window";
+
 /** `false` means keep forever and accept the growth. */
 type MaxAge = number | false;
 
@@ -69,38 +74,16 @@ export interface ResolvedAuditRetentionConfig {
 }
 
 /**
- * The largest offset whose resulting date every supported column can store.
+ * A window, resolved by the rule every trail shares.
  *
- * A window is subtracted from now to form a cutoff, and an interval likewise,
- * so both are bounded by the narrowest column that receives one. That is not
- * `Date` (±8.64e15 ms) and not MySQL `DATETIME` (from year 1000): it is MySQL
- * `TIMESTAMP`, which `activity_log.created_at` uses and which **starts at
- * 1970**. A cutoff before then is rejected under strict mode, so the pass fails
- * on every run and is swallowed — the trail unpruned while its configuration
- * reads as accepted.
- *
- * Fifty years is the conservative form: any clock later than 2020 minus this
- * offset lands after 1970, so it holds without consulting the current time. It
- * is also past the point of meaning — a window longer than the epoch itself can
- * select nothing, because no row can be older than the time it measures from.
+ * The bound and the direction of each rejection live in
+ * `domains/retention/window`, so this trail cannot drift from the others on a
+ * question none of them owns alone. Zero is `malformed` here rather than
+ * "keep nothing": an audit trail set to zero is far more likely to be a typo
+ * than a decision, and erasing the record of who did what is not recoverable.
  */
-const MAX_STORABLE_OFFSET_MS = 50 * 365 * DAY_MS;
-
 function maxAge(value: MaxAge | undefined, fallback: number): MaxAge {
-  if (value === false) return false;
-  // A non-positive window would delete rows the moment they are written, and a
-  // non-finite one is worse than either: `Infinity` is a positive number, so it
-  // passes a naive check and then produces an Invalid Date cutoff, which the
-  // pass swallows as a failure — retention that looks configured and silently
-  // never runs. `false` is how "keep forever" is expressed.
-  const window = value as number;
-  if (!Number.isFinite(window) || window <= 0) return fallback;
-  // Beyond what a cutoff can express, the request is to keep essentially
-  // everything — so it is honoured as `false` rather than replaced by the
-  // default. The default is SHORTER, and substituting it would delete what the
-  // configuration asked to retain: rejecting a value must never be more
-  // destructive than honouring it.
-  return window <= MAX_STORABLE_OFFSET_MS ? window : false;
+  return resolveRetentionWindow(value, { fallback, zero: "malformed" });
 }
 
 function positive(value: number | undefined, fallback: number): number {

--- a/packages/nextly/src/domains/audit/retention-config.ts
+++ b/packages/nextly/src/domains/audit/retention-config.ts
@@ -12,7 +12,8 @@
  */
 
 import {
-  MAX_STORABLE_OFFSET_MS,
+  CALENDAR_COLUMN_MAX_OFFSET_MS,
+  EPOCH_COLUMN_MAX_OFFSET_MS,
   resolveRetentionWindow,
 } from "../retention/window";
 
@@ -76,24 +77,39 @@ export interface ResolvedAuditRetentionConfig {
 /**
  * A window, resolved by the rule every trail shares.
  *
- * The bound and the direction of each rejection live in
- * `domains/retention/window`, so this trail cannot drift from the others on a
- * question none of them owns alone. Zero is `malformed` here rather than
- * "keep nothing": an audit trail set to zero is far more likely to be a typo
- * than a decision, and erasing the record of who did what is not recoverable.
+ * The direction of each rejection lives in `domains/retention/window`, so this
+ * trail cannot drift from the others on a question none of them owns alone.
+ * Zero is `malformed` here rather than "keep nothing": an audit trail set to
+ * zero is far more likely to be a typo than a decision, and erasing the record
+ * of who did what is not recoverable.
+ *
+ * The bound is the caller's, because the two trails write to different column
+ * types: `maxOffsetMs` names which one governs at each call site below.
  */
-function maxAge(value: MaxAge | undefined, fallback: number): MaxAge {
-  return resolveRetentionWindow(value, { fallback, zero: "malformed" });
+function maxAge(
+  value: MaxAge | undefined,
+  fallback: number,
+  maxOffsetMs: number
+): MaxAge {
+  return resolveRetentionWindow(value, {
+    fallback,
+    zero: "malformed",
+    maxOffsetMs,
+  });
 }
 
+/**
+ * An interval is subtracted from now to decide whether a pass is due, so it has
+ * to stay a real date; a value outside the `Date` range makes that comparison
+ * unanswerable and no pass ever runs again. Unlike a window it is never stored
+ * or compared against a column, so no column sets this ceiling — any finite
+ * bound past the point where an interval means anything will do.
+ */
+const MAX_INTERVAL_MS = 50 * 365 * DAY_MS;
+
 function positive(value: number | undefined, fallback: number): number {
-  // Bounded for the same reason a window is: the gate subtracts the interval
-  // from now to decide whether a pass is due, so a value that leaves the Date
-  // range makes that comparison unanswerable and no pass ever runs again.
   const ms = value as number;
-  return Number.isFinite(ms) && ms > 0 && ms <= MAX_STORABLE_OFFSET_MS
-    ? ms
-    : fallback;
+  return Number.isFinite(ms) && ms > 0 && ms <= MAX_INTERVAL_MS ? ms : fallback;
 }
 
 /** A batch count, which must be a whole number of batches. */
@@ -124,11 +140,21 @@ export function resolveAuditRetentionConfig(
   }
 
   return {
+    // `activity_log.created_at` is a MySQL TIMESTAMP, so its cutoff cannot
+    // predate 1970 — the narrowest column in the schema, and the only one on
+    // this bound.
     activityMaxAgeMs: maxAge(
       input?.activityMaxAgeMs,
-      DEFAULT_ACTIVITY_MAX_AGE_MS
+      DEFAULT_ACTIVITY_MAX_AGE_MS,
+      EPOCH_COLUMN_MAX_OFFSET_MS
     ),
-    authMaxAgeMs: maxAge(input?.authMaxAgeMs, DEFAULT_AUTH_MAX_AGE_MS),
+    // `audit_log.created_at` is a MySQL DATETIME, which reaches back to year
+    // 1000, so this trail accepts windows the one above cannot express.
+    authMaxAgeMs: maxAge(
+      input?.authMaxAgeMs,
+      DEFAULT_AUTH_MAX_AGE_MS,
+      CALENDAR_COLUMN_MAX_OFFSET_MS
+    ),
     intervalMs: positive(
       input?.intervalMs,
       DEFAULT_AUDIT_RETENTION_INTERVAL_MS

--- a/packages/nextly/src/domains/retention/__tests__/window.test.ts
+++ b/packages/nextly/src/domains/retention/__tests__/window.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Resolving a retention window never deletes more than the configuration asked
+ * for.
+ *
+ * The asymmetry is the entire subject, so every case below asserts a DIRECTION
+ * rather than merely that a value was clamped. A resolver that answers a value
+ * it cannot use by substituting the default is not "safe": every default here
+ * is a finite window that deletes, so substituting one for a value that asked
+ * to keep MORE is data loss on a schedule, and it is invisible because the
+ * configuration reads as accepted.
+ *
+ * `Infinity` is the case that makes it concrete. It is the strongest available
+ * spelling of "keep forever", and both shipped resolvers answered it with a
+ * default that deleted — audit after 90 days, webhook events after 30.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { MAX_STORABLE_OFFSET_MS, resolveRetentionWindow } from "../window";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const FALLBACK = 90 * DAY_MS;
+
+const keeping = { fallback: FALLBACK, zero: "malformed" } as const;
+const ledger = { fallback: FALLBACK, zero: "keep-nothing" } as const;
+
+describe("resolving a retention window", () => {
+  it("honours a window it can use", () => {
+    // The instrument control. Every assertion below compares against a resolved
+    // value, and a resolver that returned the fallback for everything would
+    // satisfy several of them by accident.
+    expect(resolveRetentionWindow(30 * DAY_MS, keeping)).toBe(30 * DAY_MS);
+    expect(resolveRetentionWindow(2 * FALLBACK, keeping)).toBe(2 * FALLBACK);
+  });
+
+  it("keeps everything when retention is turned off", () => {
+    // `false` is a deliberate operator position, not a missing value.
+    expect(resolveRetentionWindow(false, keeping)).toBe(false);
+  });
+
+  it.each([
+    ["infinite", Number.POSITIVE_INFINITY],
+    ["past the storable range", MAX_STORABLE_OFFSET_MS + 1],
+    ["the largest safe integer", Number.MAX_SAFE_INTEGER],
+  ])(
+    "degrades %s to keeping everything, not to the default",
+    (_label, value) => {
+      // The direction assertion, and the reason this module exists. These are all
+      // the same request — keep rows longer than a cutoff can express — and
+      // answering any of them with the default deletes what was asked to be kept.
+      const resolved = resolveRetentionWindow(value, keeping);
+      expect(resolved).toBe(false);
+      expect(resolved).not.toBe(FALLBACK);
+    }
+  );
+
+  it.each([
+    ["negative", -1],
+    ["NaN", Number.NaN],
+    ["negative infinity", Number.NEGATIVE_INFINITY],
+    ["a string", "90d"],
+    ["null", null],
+    ["undefined", undefined],
+  ])("falls back for a %s window", (_label, value) => {
+    // The opposite direction, and it is safe here precisely because none of
+    // these asked for MORE retention than the default gives.
+    expect(resolveRetentionWindow(value, keeping)).toBe(FALLBACK);
+  });
+
+  it("reads zero the way the trail asks it to", () => {
+    // The two shipped resolvers disagreed on this and both readings are
+    // defensible, so it is the caller's decision. Asserting both spellings
+    // keeps that a decision rather than an accident of which one was written
+    // second.
+    expect(resolveRetentionWindow(0, ledger)).toBe(0);
+    expect(resolveRetentionWindow(0, keeping)).toBe(FALLBACK);
+  });
+
+  it("floors a fractional window", () => {
+    expect(resolveRetentionWindow(1000.9, keeping)).toBe(1000);
+  });
+
+  it("passes a fallback of false through unchanged", () => {
+    // A trail whose default is already "keep forever" must not acquire a
+    // deleting window by being handed a malformed value.
+    const forever = { fallback: false, zero: "malformed" } as const;
+    expect(resolveRetentionWindow(Number.NaN, forever)).toBe(false);
+    expect(resolveRetentionWindow(-1, forever)).toBe(false);
+  });
+
+  it("never answers a keep-longer request with a shorter window", () => {
+    // The invariant itself, asserted over the whole boundary rather than at
+    // the points chosen above. A resolver that clamps the top of the range to
+    // the fallback satisfies every individual case that names a specific value
+    // and fails here.
+    const asksForMore = [
+      Number.POSITIVE_INFINITY,
+      Number.MAX_VALUE,
+      Number.MAX_SAFE_INTEGER,
+      MAX_STORABLE_OFFSET_MS + 1,
+      MAX_STORABLE_OFFSET_MS * 2,
+    ];
+    for (const value of asksForMore) {
+      const resolved = resolveRetentionWindow(value, keeping);
+      expect(
+        resolved,
+        `${value} asked to keep more than the range allows, and must not be answered with a window that deletes`
+      ).toBe(false);
+    }
+  });
+
+  it("keeps the boundary itself usable", () => {
+    // The largest value that is still a window rather than "forever". Off by
+    // one here would silently convert the longest supported retention into
+    // unbounded growth.
+    expect(resolveRetentionWindow(MAX_STORABLE_OFFSET_MS, keeping)).toBe(
+      MAX_STORABLE_OFFSET_MS
+    );
+  });
+});

--- a/packages/nextly/src/domains/retention/__tests__/window.test.ts
+++ b/packages/nextly/src/domains/retention/__tests__/window.test.ts
@@ -16,13 +16,26 @@
 
 import { describe, expect, it } from "vitest";
 
-import { MAX_STORABLE_OFFSET_MS, resolveRetentionWindow } from "../window";
+import {
+  CALENDAR_COLUMN_MAX_OFFSET_MS,
+  EPOCH_COLUMN_MAX_OFFSET_MS,
+  resolveRetentionWindow,
+} from "../window";
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 const FALLBACK = 90 * DAY_MS;
+const MAX = EPOCH_COLUMN_MAX_OFFSET_MS;
 
-const keeping = { fallback: FALLBACK, zero: "malformed" } as const;
-const ledger = { fallback: FALLBACK, zero: "keep-nothing" } as const;
+const keeping = {
+  fallback: FALLBACK,
+  zero: "malformed",
+  maxOffsetMs: MAX,
+} as const;
+const ledger = {
+  fallback: FALLBACK,
+  zero: "keep-nothing",
+  maxOffsetMs: MAX,
+} as const;
 
 describe("resolving a retention window", () => {
   it("honours a window it can use", () => {
@@ -40,7 +53,7 @@ describe("resolving a retention window", () => {
 
   it.each([
     ["infinite", Number.POSITIVE_INFINITY],
-    ["past the storable range", MAX_STORABLE_OFFSET_MS + 1],
+    ["past the storable range", MAX + 1],
     ["the largest safe integer", Number.MAX_SAFE_INTEGER],
   ])(
     "degrades %s to keeping everything, not to the default",
@@ -83,7 +96,11 @@ describe("resolving a retention window", () => {
   it("passes a fallback of false through unchanged", () => {
     // A trail whose default is already "keep forever" must not acquire a
     // deleting window by being handed a malformed value.
-    const forever = { fallback: false, zero: "malformed" } as const;
+    const forever = {
+      fallback: false,
+      zero: "malformed",
+      maxOffsetMs: MAX,
+    } as const;
     expect(resolveRetentionWindow(Number.NaN, forever)).toBe(false);
     expect(resolveRetentionWindow(-1, forever)).toBe(false);
   });
@@ -97,8 +114,8 @@ describe("resolving a retention window", () => {
       Number.POSITIVE_INFINITY,
       Number.MAX_VALUE,
       Number.MAX_SAFE_INTEGER,
-      MAX_STORABLE_OFFSET_MS + 1,
-      MAX_STORABLE_OFFSET_MS * 2,
+      MAX + 1,
+      MAX * 2,
     ];
     for (const value of asksForMore) {
       const resolved = resolveRetentionWindow(value, keeping);
@@ -113,8 +130,51 @@ describe("resolving a retention window", () => {
     // The largest value that is still a window rather than "forever". Off by
     // one here would silently convert the longest supported retention into
     // unbounded growth.
-    expect(resolveRetentionWindow(MAX_STORABLE_OFFSET_MS, keeping)).toBe(
-      MAX_STORABLE_OFFSET_MS
+    expect(resolveRetentionWindow(MAX, keeping)).toBe(MAX);
+  });
+
+  it("bounds each trail by the column its cutoff is compared against", () => {
+    // The bound belongs to the destination, not to retention. A window of 51
+    // years yields a cutoff in 1975: outside MySQL TIMESTAMP, which counts from
+    // 1970, and comfortably inside DATETIME, which counts from year 1000.
+    // Applying one trail's ceiling to every trail turns a window the column can
+    // express into "never prune", which is unbounded growth on a setting that
+    // asked for pruning.
+    const window = 51 * 365 * DAY_MS;
+    const epoch = { ...keeping, maxOffsetMs: EPOCH_COLUMN_MAX_OFFSET_MS };
+    const calendar = { ...keeping, maxOffsetMs: CALENDAR_COLUMN_MAX_OFFSET_MS };
+
+    expect(resolveRetentionWindow(window, epoch)).toBe(false);
+    expect(resolveRetentionWindow(window, calendar)).toBe(window);
+
+    // Both bounds still answer a request past their own range the safe way, so
+    // widening one did not reintroduce the defect this module exists for.
+    expect(resolveRetentionWindow(Number.POSITIVE_INFINITY, calendar)).toBe(
+      false
+    );
+    expect(
+      resolveRetentionWindow(CALENDAR_COLUMN_MAX_OFFSET_MS + 1, calendar)
+    ).toBe(false);
+  });
+
+  it("keeps every bound inside what a Date can express", () => {
+    // A bound exists to stop a cutoff leaving the representable range, so a
+    // bound that itself leaves it would defeat the check it belongs to. Read
+    // from a fixed clock rather than `now` so this asserts the constants rather
+    // than the day it runs on.
+    const clock = new Date("2026-01-01T00:00:00.000Z").getTime();
+    for (const bound of [
+      EPOCH_COLUMN_MAX_OFFSET_MS,
+      CALENDAR_COLUMN_MAX_OFFSET_MS,
+    ]) {
+      expect(Number.isNaN(new Date(clock - bound).getTime())).toBe(false);
+    }
+    // The epoch bound has the stricter promise: its cutoff must also land after
+    // 1970, which is what MySQL TIMESTAMP can store.
+    expect(clock - EPOCH_COLUMN_MAX_OFFSET_MS).toBeGreaterThan(0);
+    // And the calendar bound's must land after year 1000.
+    expect(clock - CALENDAR_COLUMN_MAX_OFFSET_MS).toBeGreaterThan(
+      new Date("1000-01-01T00:00:00.000Z").getTime()
     );
   });
 });

--- a/packages/nextly/src/domains/retention/window.ts
+++ b/packages/nextly/src/domains/retention/window.ts
@@ -1,0 +1,97 @@
+/**
+ * How a configured retention window is read, for every trail that has one.
+ *
+ * One question with one implementation. Three domains resolved this separately
+ * — audit, webhooks and email deliveries — and the three had drifted into three
+ * different answers for the same input, which is the failure mode a shared
+ * question always has when it is answered in more than one place.
+ *
+ * The invariant every caller depends on, and the one the copies disagreed on:
+ *
+ *   **Rejecting a value must never delete more than honouring it would.**
+ *
+ * A window that cannot be used is replaced by a fallback, and every fallback
+ * here is a finite window that DELETES. So the direction of each rejection has
+ * to be chosen, not defaulted: substituting the default for a value that asked
+ * to keep MORE turns a malformed setting into data loss, silently, on a
+ * schedule. `Infinity` is exactly that value, and both shipped copies rejected
+ * it into a default that deleted after 90 and 30 days respectively.
+ *
+ * @module domains/retention/window
+ */
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/** A window in milliseconds, or `false` to keep rows indefinitely. */
+export type RetentionWindow = number | false;
+
+/**
+ * The largest offset whose resulting date every supported column can store.
+ *
+ * A window is subtracted from now to form a cutoff, so the bound is set by the
+ * narrowest column that receives one. That is not `Date` (±8.64e15 ms) and not
+ * MySQL `DATETIME` (from year 1000): it is MySQL `TIMESTAMP`, which
+ * `activity_log.created_at` uses and which **starts at 1970**. A cutoff before
+ * then is rejected under strict mode, so the pass fails on every run and is
+ * swallowed — the trail unpruned while its configuration reads as accepted.
+ *
+ * Fifty years is the conservative form: any clock later than 2020 minus this
+ * offset lands after 1970, so it holds without consulting the current time. It
+ * is also past the point of meaning — a window longer than the epoch itself can
+ * select nothing, because no row can be older than the time it measures from.
+ */
+export const MAX_STORABLE_OFFSET_MS = 50 * 365 * DAY_MS;
+
+/**
+ * What a window of exactly zero means to a trail.
+ *
+ * The two shipped resolvers disagreed, and both readings are defensible, so it
+ * stays the caller's decision rather than being unified into whichever one was
+ * written second. A delivery ledger may reasonably be configured to keep
+ * nothing — the row's purpose is a retry window, and an operator who does not
+ * want the addresses stored at all is expressing a real position. An audit
+ * trail configured to zero is far more likely to be a mistake, and erasing the
+ * record of who did what on a typo is not a recoverable outcome.
+ */
+export type ZeroWindow = "keep-nothing" | "malformed";
+
+export interface RetentionWindowPolicy {
+  /** Used when the value is absent or unusable. */
+  fallback: RetentionWindow;
+  /** How to read a window of exactly zero. */
+  zero: ZeroWindow;
+}
+
+/**
+ * Resolve one configured window. Pure, total, and never throws.
+ *
+ * Each branch is a decision about DIRECTION rather than about validity:
+ *
+ * - `false` is a position an operator holds deliberately, so it is honoured.
+ * - A window past what a cutoff can express — `Infinity` included — is a request
+ *   to keep more than the range allows, so it degrades to `false`. Falling back
+ *   would delete rows the configuration asked to retain, and `Infinity` is the
+ *   case where that reads worst: the operator wrote the strongest available
+ *   spelling of "keep forever" and got a 90-day delete.
+ * - `NaN`, a non-number and a negative window say nothing coherent about how
+ *   long to keep rows, so the fallback applies. That direction is safe here
+ *   because none of them asked for MORE retention than the default gives.
+ *
+ * Floored because a window is a whole number of milliseconds; a fractional
+ * value is not wrong, only unrepresentable in what it is compared against.
+ */
+export function resolveRetentionWindow(
+  value: unknown,
+  policy: RetentionWindowPolicy
+): RetentionWindow {
+  if (value === false) return false;
+  if (typeof value !== "number" || Number.isNaN(value)) return policy.fallback;
+  // Ordered before the range check on purpose: `Infinity > MAX` is true, so
+  // both land here together and are answered the same way. Separating them is
+  // how the shipped copies came to treat the more extreme request as the less
+  // valid one.
+  if (value > MAX_STORABLE_OFFSET_MS) return false;
+  if (value === 0) return policy.zero === "keep-nothing" ? 0 : policy.fallback;
+  if (value < 0) return policy.fallback;
+  return Math.floor(value);
+}

--- a/packages/nextly/src/domains/retention/window.ts
+++ b/packages/nextly/src/domains/retention/window.ts
@@ -31,21 +31,39 @@ const DAY_MS = 24 * 60 * 60 * 1000;
 export type RetentionWindow = number | false;
 
 /**
- * The largest offset whose resulting date every supported column can store.
+ * The largest offset whose cutoff a column counting from the UNIX epoch holds.
  *
- * A window is subtracted from now to form a cutoff, so the bound is set by the
- * narrowest column that receives one. That is not `Date` (±8.64e15 ms) and not
- * MySQL `DATETIME` (from year 1000): it is MySQL `TIMESTAMP`, which
- * `activity_log.created_at` uses and which **starts at 1970**. A cutoff before
- * then is rejected under strict mode, so the pass fails on every run and is
- * swallowed — the trail unpruned while its configuration reads as accepted.
+ * A window is subtracted from now to form a cutoff, so the bound belongs to the
+ * narrowest column that receives one — and the narrowest in this schema is
+ * MySQL `TIMESTAMP`, which **starts at 1970**. A cutoff before then is rejected
+ * under strict mode, so the pass fails on every run and is swallowed: the trail
+ * goes unpruned while its configuration reads as accepted.
  *
  * Fifty years is the conservative form: any clock later than 2020 minus this
  * offset lands after 1970, so it holds without consulting the current time. It
  * is also past the point of meaning — a window longer than the epoch itself can
  * select nothing, because no row can be older than the time it measures from.
+ *
+ * `activity_log.created_at` is the only column in this family.
  */
-export const MAX_STORABLE_OFFSET_MS = 50 * 365 * DAY_MS;
+export const EPOCH_COLUMN_MAX_OFFSET_MS = 50 * 365 * DAY_MS;
+
+/**
+ * The same bound for a column counting from a calendar year rather than 1970.
+ *
+ * MySQL `DATETIME` starts at year 1000, and both Postgres and SQLite reach
+ * further back still, so the narrowest of those is what this expresses. A
+ * thousand years keeps the cutoff at year 1020 or later for any clock after
+ * 2020, which is inside `DATETIME` without consulting the current time.
+ *
+ * A bound is still needed here rather than none at all: `Number.MAX_SAFE_INTEGER`
+ * milliseconds is roughly 285,000 years, past what `Date` itself represents, so
+ * subtracting it yields `Invalid Date` and every comparison built from it is
+ * meaningless.
+ *
+ * `audit_log`, `nextly_events` and `nextly_webhook_deliveries` are this family.
+ */
+export const CALENDAR_COLUMN_MAX_OFFSET_MS = 1000 * 365 * DAY_MS;
 
 /**
  * What a window of exactly zero means to a trail.
@@ -65,6 +83,19 @@ export interface RetentionWindowPolicy {
   fallback: RetentionWindow;
   /** How to read a window of exactly zero. */
   zero: ZeroWindow;
+  /**
+   * The longest window this trail can still express as a cutoff.
+   *
+   * Stated per caller because it is a property of the COLUMN the cutoff is
+   * compared against, not of retention. Applying one trail's bound everywhere
+   * silently disables pruning on trails whose columns reach further back: a
+   * window of 51 years produces a cutoff of 1975, which `DATETIME` stores
+   * without complaint, and refusing it there converts a configured window into
+   * unbounded growth. Pass {@link EPOCH_COLUMN_MAX_OFFSET_MS} or
+   * {@link CALENDAR_COLUMN_MAX_OFFSET_MS} according to the narrowest column the
+   * window reaches.
+   */
+  maxOffsetMs: number;
 }
 
 /**
@@ -91,11 +122,11 @@ export function resolveRetentionWindow(
 ): RetentionWindow {
   if (value === false) return false;
   if (typeof value !== "number" || Number.isNaN(value)) return policy.fallback;
-  // Ordered before the range check on purpose: `Infinity > MAX` is true, so
-  // both land here together and are answered the same way. Separating them is
-  // how the shipped copies came to treat the more extreme request as the less
-  // valid one.
-  if (value > MAX_STORABLE_OFFSET_MS) return false;
+  // `Infinity` is not special-cased: it is greater than every finite bound, so
+  // it lands here alongside any other over-long window and is answered the same
+  // way. Separating the two is how the shipped copies came to treat the more
+  // extreme request as the less valid one.
+  if (value > policy.maxOffsetMs) return false;
   if (value === 0) return policy.zero === "keep-nothing" ? 0 : policy.fallback;
   if (value < 0) return policy.fallback;
   return Math.floor(value);

--- a/packages/nextly/src/domains/retention/window.ts
+++ b/packages/nextly/src/domains/retention/window.ts
@@ -1,10 +1,10 @@
 /**
  * How a configured retention window is read, for every trail that has one.
  *
- * One question with one implementation. Three domains resolved this separately
- * — audit, webhooks and email deliveries — and the three had drifted into three
- * different answers for the same input, which is the failure mode a shared
- * question always has when it is answered in more than one place.
+ * One question with one implementation. The two trails that resolve a window —
+ * audit and webhooks — did it separately and had drifted into different answers
+ * for the same input, which is the failure mode a shared question always has
+ * when it is answered in more than one place.
  *
  * The invariant every caller depends on, and the one the copies disagreed on:
  *
@@ -14,8 +14,13 @@
  * here is a finite window that DELETES. So the direction of each rejection has
  * to be chosen, not defaulted: substituting the default for a value that asked
  * to keep MORE turns a malformed setting into data loss, silently, on a
- * schedule. `Infinity` is exactly that value, and both shipped copies rejected
- * it into a default that deleted after 90 and 30 days respectively.
+ * schedule. `Infinity` is exactly that value, and both copies rejected it into
+ * a default that deleted after 90 and 30 days respectively.
+ *
+ * A third trail is expected to ask this question — the delivery log records one
+ * row per recipient and has no window of its own yet — and the reason it is
+ * named here is the policy parameters below, which exist so a caller can differ
+ * where the difference is real without forking the invariant.
  *
  * @module domains/retention/window
  */

--- a/packages/nextly/src/domains/webhooks/__tests__/retention-config.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/retention-config.test.ts
@@ -93,6 +93,40 @@ describe("resolveWebhookRetentionConfig", () => {
     expect(policy?.intervalMs).toBeGreaterThan(0);
   });
 
+  it("reads an infinite window as keeping everything", () => {
+    // An operator writing `Infinity` has spelled "keep forever" the strongest
+    // way the type allows, and this used to fall back to a default that DELETES
+    // after 30 days. Nothing in this file covered it, which is how it shipped.
+    const policy = resolveWebhookRetentionConfig({
+      eventsMaxAgeMs: Number.POSITIVE_INFINITY,
+      auditEventsMaxAgeMs: Number.POSITIVE_INFINITY,
+      deliveriesMaxAgeMs: Number.POSITIVE_INFINITY,
+    });
+    expect(policy?.eventsMaxAgeMs).toBe(false);
+    expect(policy?.auditEventsMaxAgeMs).toBe(false);
+    expect(policy?.deliveriesMaxAgeMs).toBe(false);
+  });
+
+  it("clamps a window past the storable range instead of producing a bad cutoff", () => {
+    // This resolver had no upper bound at all, so `MAX_SAFE_INTEGER` resolved
+    // to roughly 285,000 years and the cutoff derived from it was a date no
+    // column can hold — a pass that fails every run and is swallowed, leaving
+    // the ledger unpruned while the configuration reads as accepted.
+    const policy = resolveWebhookRetentionConfig({
+      eventsMaxAgeMs: Number.MAX_SAFE_INTEGER,
+    });
+    expect(policy?.eventsMaxAgeMs).toBe(false);
+  });
+
+  it("still lets an operator ask to keep nothing", () => {
+    // Zero is a real position for a delivery ledger, and it must survive the
+    // move to the shared resolver: the row exists to make a redelivery
+    // possible, so an operator who does not want addresses stored at all is
+    // deciding rather than mistyping.
+    const policy = resolveWebhookRetentionConfig({ deliveriesMaxAgeMs: 0 });
+    expect(policy?.deliveriesMaxAgeMs).toBe(0);
+  });
+
   it("clamps an oversized batch to the portable bind-parameter limit", () => {
     // Above this a pass exceeds SQLite's parameter cap and fails every time,
     // and the safe runner swallows it, so retention would stop making progress

--- a/packages/nextly/src/domains/webhooks/retention-config.ts
+++ b/packages/nextly/src/domains/webhooks/retention-config.ts
@@ -13,7 +13,10 @@
  * @module domains/webhooks/retention-config
  */
 
-import { resolveRetentionWindow } from "../retention/window";
+import {
+  CALENDAR_COLUMN_MAX_OFFSET_MS,
+  resolveRetentionWindow,
+} from "../retention/window";
 
 /**
  * Which retention window governs an event row.
@@ -165,9 +168,17 @@ function positiveInt(value: unknown, fallback: number, max?: number): number {
  * past what a cutoff can express is clamped to `false` instead of producing a
  * date no column can hold — previously a window of `MAX_SAFE_INTEGER` resolved
  * to roughly 285,000 years and the resulting cutoff was unusable.
+ *
+ * Both event and delivery cutoffs are compared against MySQL `DATETIME`
+ * columns, which reach back to year 1000, so that is the bound this trail
+ * carries.
  */
 function maxAge(value: unknown, fallback: number | false): number | false {
-  return resolveRetentionWindow(value, { fallback, zero: "keep-nothing" });
+  return resolveRetentionWindow(value, {
+    fallback,
+    zero: "keep-nothing",
+    maxOffsetMs: CALENDAR_COLUMN_MAX_OFFSET_MS,
+  });
 }
 
 /** The longest window any event class may be kept for. */

--- a/packages/nextly/src/domains/webhooks/retention-config.ts
+++ b/packages/nextly/src/domains/webhooks/retention-config.ts
@@ -13,6 +13,8 @@
  * @module domains/webhooks/retention-config
  */
 
+import { resolveRetentionWindow } from "../retention/window";
+
 /**
  * Which retention window governs an event row.
  *
@@ -150,13 +152,22 @@ function positiveInt(value: unknown, fallback: number, max?: number): number {
   return max === undefined ? resolved : Math.min(resolved, max);
 }
 
-/** A non-negative duration, `false` for "keep forever", or the fallback. */
+/**
+ * A window, resolved by the rule every trail shares.
+ *
+ * Zero is `keep-nothing` here rather than malformed, preserving what this
+ * ledger already accepted: the row exists to make a redelivery possible, and an
+ * operator who does not want recipient addresses stored at all is expressing a
+ * position rather than making a mistake.
+ *
+ * Two behaviours change, both toward keeping more. `Infinity` now means keep
+ * forever instead of falling back to a window that deletes, and a finite value
+ * past what a cutoff can express is clamped to `false` instead of producing a
+ * date no column can hold — previously a window of `MAX_SAFE_INTEGER` resolved
+ * to roughly 285,000 years and the resulting cutoff was unusable.
+ */
 function maxAge(value: unknown, fallback: number | false): number | false {
-  if (value === false) return false;
-  if (typeof value === "number" && Number.isFinite(value) && value >= 0) {
-    return Math.floor(value);
-  }
-  return fallback;
+  return resolveRetentionWindow(value, { fallback, zero: "keep-nothing" });
 }
 
 /** The longest window any event class may be kept for. */


### PR DESCRIPTION
`Infinity` is the strongest way the type lets an operator say "keep these forever". Both shipped resolvers answered it with a default that **deletes**.

```
AUDIT LOG (default 90d)              WEBHOOK EVENTS (default 30d)
  false      -> KEEP FOREVER           false      -> KEEP FOREVER
  Infinity   -> deletes after 90d      Infinity   -> deletes after 30d
  MAX_SAFE   -> KEEP FOREVER           MAX_SAFE   -> deletes after 104,249,991d
```

The pass ran, reported success, and pruned rows the configuration had asked to retain — while the setting itself read as accepted. Audit trails are compliance evidence, and the deletion is not recoverable.

## Why it happened

Three answers to one question. Audit, webhooks and email deliveries each resolved a configured window in their own file, and the three had drifted:

- **Audit contradicted itself two tests apart.** One test asserts a 2000-year window resolves to `false` (keep forever). The next asserted `Infinity` — the *same request* — resolves to a 90-day delete, with `Infinity` sitting in a list beside `NaN` and `-1` as though it were malformed.
- **Webhooks had no upper bound at all.** `MAX_SAFE_INTEGER` resolved to roughly 285,000 years, and the cutoff derived from it is a date no column can store, so the pass fails on every run and is swallowed — the ledger unpruned while the configuration reads as accepted.
- **Email** (on a separate branch) had already been written with the correct handling, which is how the divergence became visible.

## The fix

`domains/retention/window` holds the rule all of them now ask, stated as the invariant the copies disagreed on:

> **Refusing a value must never delete more than accepting it would.**

Every fallback here is a finite window that DELETES, so the direction of each rejection is a decision rather than a default. `Infinity` and anything past the storable range are the same request and get the same answer: keep forever. `NaN`, negatives and non-numbers still fall back, because none of them asked for *more* retention than the default gives.

The bound is audit's — 50 years, set by MySQL `TIMESTAMP` starting at 1970 rather than by the `Date` range. That reasoning was the most careful of the three and now applies everywhere.

## What deliberately stays per-trail

Two positions differ legitimately, so they are parameters rather than being unified into whichever was written second:

- **`false`** means keep forever everywhere.
- **Zero** means *keep nothing* for a delivery ledger, whose row exists only to make a retry possible — an operator who does not want addresses stored at all is deciding, not mistyping. For an audit trail it is *malformed*, because erasing the record of who did what on a typo is not recoverable.

## The tests asserted the defect

The audit suite had `Infinity` in its malformed list. That test is split, and the two now agree with each other. **The webhook suite covered neither `Infinity` nor an oversized window at all**, which is how that half shipped.

## Verification

Every new assertion was negative-controlled — the shipped logic reinstated inside the shared resolver, confirming red for the intended reason, then restored:

```
with the shipped Infinity handling:
  × reads an infinite window as keeping everything        (audit, public surface)
  × reads an infinite window as keeping everything        (webhooks, public surface)
  × degrades infinite to keeping everything, not to the default
  × never answers a keep-longer request with a shorter window
  4 failed | 276 passed
restored: 280 passed
```

The last of those asserts the invariant over the whole boundary rather than at chosen points, so a resolver that clamps the top of the range to the fallback fails it while satisfying every case that names a specific value.

Full `nextly` unit suite: 361 failures, all pre-existing baseline, **none in a file this change touches**. `lint` and `check-types` clean (built with `pnpm --filter nextly... build` first).

## Follow-up

The email delivery-log resolver on `feat/email-retention-sweep` will derive from this module too, rather than keeping its own correct-but-separate copy. That is the third caller and it lands with the retention sweep.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved retention setting validation across audit and webhook data.
  - Infinite retention windows now correctly preserve data indefinitely.
  - Excessively large or unsupported values resolve safely instead of producing invalid cleanup dates.
  - Zero-day retention settings retain their intended behavior.
  - Fractional and malformed values are handled consistently.

- **Tests**
  - Added comprehensive coverage for valid, invalid, zero, negative, oversized, infinite, and date-safe retention windows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->