### PR TITLE
fix(nextly): round a retention window before reading it as zero

### DIFF
--- a/.changeset/floor-before-reading-zero.md
+++ b/.changeset/floor-before-reading-zero.md
@@ -1,0 +1,43 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+Retention no longer reads a sub-millisecond window as a request to delete everything.
+
+A retention window is a whole number of milliseconds, so a fractional value is
+rounded down. That rounding ran AFTER the check for zero, which meant any window
+under one millisecond arrived as a window rather than as the zero it becomes:
+\`0.5\` was not zero when the check ran, and was zero by the time it was used.
+
+On the audit trails a window of zero is treated as a mistake and replaced by the
+default, because erasing the record of who did what on a typo is not
+recoverable. That protection was reachable only by writing exactly zero. A value
+that rounded to zero skipped it and produced a cutoff of the current moment,
+which removes the entire trail on the next pass.
+
+The rounding now happens before the reading, so a window is judged as the value
+it actually resolves to. A delivery ledger set to a fraction still keeps
+nothing, which is that trail's own position on zero and unchanged.

--- a/packages/nextly/src/domains/retention/__tests__/window.test.ts
+++ b/packages/nextly/src/domains/retention/__tests__/window.test.ts
@@ -93,6 +93,33 @@ describe("resolving a retention window", () => {
     expect(resolveRetentionWindow(1000.9, keeping)).toBe(1000);
   });
 
+  it("reads a window that FLOORS to zero the way the trail reads zero", () => {
+    // Rounding is what produces the zero here, so the order of the two steps
+    // decides the outcome. Read before flooring, `0.5` is not `=== 0` and skips
+    // the policy entirely, then floors to a window of zero — a cutoff of now,
+    // which removes the whole trail. It is the one input where the direction
+    // inverts: every other rejection keeps more than honouring it would.
+    expect(resolveRetentionWindow(0.5, keeping)).toBe(FALLBACK);
+    expect(resolveRetentionWindow(0.999, keeping)).toBe(FALLBACK);
+
+    // A ledger that reads zero as "keep nothing" still gets that answer, because
+    // the question asked is the same one — only asked of the whole milliseconds
+    // the window actually resolves to.
+    expect(resolveRetentionWindow(0.5, ledger)).toBe(0);
+
+    // The positive control for the boundary: one whole millisecond is a window,
+    // not a zero, and must survive.
+    expect(resolveRetentionWindow(1, keeping)).toBe(1);
+    expect(resolveRetentionWindow(1.5, keeping)).toBe(1);
+  });
+
+  it("does not let a negative fraction round into a window", () => {
+    // `Math.floor(-0.5)` is `-1`, so flooring before the sign check would turn
+    // an incoherent value into a negative window rather than the fallback.
+    expect(resolveRetentionWindow(-0.5, keeping)).toBe(FALLBACK);
+    expect(resolveRetentionWindow(-0.5, ledger)).toBe(FALLBACK);
+  });
+
   it("passes a fallback of false through unchanged", () => {
     // A trail whose default is already "keep forever" must not acquire a
     // deleting window by being handed a malformed value.

--- a/packages/nextly/src/domains/retention/window.ts
+++ b/packages/nextly/src/domains/retention/window.ts
@@ -115,6 +115,12 @@ export interface RetentionWindowPolicy {
  *
  * Floored because a window is a whole number of milliseconds; a fractional
  * value is not wrong, only unrepresentable in what it is compared against.
+ * Flooring happens BEFORE the zero reading rather than after, because rounding
+ * is what can PRODUCE a zero: every window under a millisecond floors to one,
+ * and read afterwards it arrives as a window rather than as the zero the policy
+ * exists to judge. On a trail whose policy calls zero malformed, that is the
+ * difference between the default and a cutoff of now — the whole record
+ * removed, from a value that never asked for it.
  */
 export function resolveRetentionWindow(
   value: unknown,
@@ -127,7 +133,11 @@ export function resolveRetentionWindow(
   // way. Separating the two is how the shipped copies came to treat the more
   // extreme request as the less valid one.
   if (value > policy.maxOffsetMs) return false;
-  if (value === 0) return policy.zero === "keep-nothing" ? 0 : policy.fallback;
+  // Ahead of the flooring, because `Math.floor` moves a negative value AWAY
+  // from zero and a fraction like -0.5 would arrive as -1 rather than as the
+  // incoherent value it is.
   if (value < 0) return policy.fallback;
-  return Math.floor(value);
+  const whole = Math.floor(value);
+  if (whole === 0) return policy.zero === "keep-nothing" ? 0 : policy.fallback;
+  return whole;
 }

--- a/packages/nextly/src/domains/retention/window.ts
+++ b/packages/nextly/src/domains/retention/window.ts
@@ -115,12 +115,14 @@ export interface RetentionWindowPolicy {
  *
  * Floored because a window is a whole number of milliseconds; a fractional
  * value is not wrong, only unrepresentable in what it is compared against.
- * Flooring happens BEFORE the zero reading rather than after, because rounding
- * is what can PRODUCE a zero: every window under a millisecond floors to one,
- * and read afterwards it arrives as a window rather than as the zero the policy
- * exists to judge. On a trail whose policy calls zero malformed, that is the
- * difference between the default and a cutoff of now — the whole record
- * removed, from a value that never asked for it.
+ *
+ * The zero reading happens AFTER the flooring, because rounding is what can
+ * PRODUCE a zero: every window under one millisecond floors to zero, and a
+ * value read BEFORE that — `0.5` is not `=== 0` — passes the zero branch as
+ * though it were an ordinary window, then becomes one anyway. On a trail whose
+ * policy calls zero malformed, that is the difference between the default and a
+ * cutoff of now, which is the whole record removed from a value that never
+ * asked for it.
  */
 export function resolveRetentionWindow(
   value: unknown,

--- a/packages/nextly/src/domains/retention/window.ts
+++ b/packages/nextly/src/domains/retention/window.ts
@@ -116,13 +116,18 @@ export interface RetentionWindowPolicy {
  * Floored because a window is a whole number of milliseconds; a fractional
  * value is not wrong, only unrepresentable in what it is compared against.
  *
- * The zero reading happens AFTER the flooring, because rounding is what can
- * PRODUCE a zero: every window under one millisecond floors to zero, and a
+ * The zero reading happens AFTER the flooring, because flooring is what can
+ * PRODUCE a zero: a POSITIVE window under one millisecond floors to zero, and a
  * value read BEFORE that — `0.5` is not `=== 0` — passes the zero branch as
  * though it were an ordinary window, then becomes one anyway. On a trail whose
  * policy calls zero malformed, that is the difference between the default and a
  * cutoff of now, which is the whole record removed from a value that never
  * asked for it.
+ *
+ * A negative fraction never reaches the flooring, because the sign check is
+ * ordered ahead of it. That ordering matters in the other direction: `Math.floor`
+ * moves a negative value AWAY from zero, so `-0.5` would arrive as `-1` and be
+ * read as a window rather than as the incoherent value it is.
  */
 export function resolveRetentionWindow(
   value: unknown,


### PR DESCRIPTION
## What

A retention window under one millisecond was resolving to a window of zero and,
on the audit trails, removing the whole record.

Follow-up to #743, from CodeRabbit's review of that PR. The finding arrived after
it merged, so this is separate rather than a fix in place.

## The defect

A window is a whole number of milliseconds, so a fractional value is floored.
That flooring ran *after* the check for zero:

```ts
if (value === 0) return policy.zero === "keep-nothing" ? 0 : policy.fallback;
if (value < 0) return policy.fallback;
return Math.floor(value);
```

`0.5` is not `=== 0` when the check runs, and is zero by the time it is used. So
every window in `(0, 1)` bypasses the zero policy entirely.

The audit trails set `zero: "malformed"` precisely because erasing the record of
who did what on a typo is not recoverable. That protection was reachable only by
writing exactly `0`.

Measured against the merged resolver, audit policy, 90-day default:

```
      0 -> 7776000000   (fallback, safe)
    0.5 -> 0   <-- cutoff of now: prunes the ENTIRE audit trail
  0.999 -> 0   <-- same
    1.5 -> 1
   -0.5 -> 7776000000   (fallback, safe)
```

It is the one input where the module's invariant inverts. Every other rejection
keeps *more* than honouring the value would; this one keeps nothing.

## The fix

Floor first, then read the result as a window or a zero. The sign check stays
ahead of the flooring, because `Math.floor(-0.5)` is `-1` and would turn an
incoherent value into a negative window rather than the fallback.

A delivery ledger set to a fraction still keeps nothing. That is its own stated
position on zero, and it is unchanged.

## Tests

Two cases added to `domains/retention/__tests__/window.test.ts`: one for a window
that floors to zero on both policies, one for a negative fraction. Both carry the
boundary control that a whole `1` ms is still a window.

**Negative control.** Restored the merged ordering and re-ran: exactly the new
floors-to-zero test fails, with `expected +0 to be 7776000000` — the resolver
answering "delete everything" where the default is correct. Restored, 33 pass.

`check-types` and `lint` both exit 0 (after `pnpm --filter nextly... build`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved retention-window handling for fractional values.
  * Sub-millisecond positive windows now follow the configured zero-value policy.
  * Negative fractional values correctly fall back instead of producing negative windows.
  * Whole-millisecond values remain usable as configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->