### PR TITLE
test(ui): enforce the server-safe allow-list by execution rather than by reading syntax

### DIFF
--- a/.github/workflows/package-smoke.yml
+++ b/.github/workflows/package-smoke.yml
@@ -363,8 +363,8 @@ jobs:
       # The export map already refuses a deep import, so a client subpath cannot be reached by
       # name. A RELATIVE import from inside a server-safe artifact is a different route that the
       # map says nothing about, so those files are deleted rather than left present.
-      - name: Remove the artifacts the server-safe subpaths do not own
-        run: pnpm --filter @nextlyhq/ui exec tsx scripts/write-server-safe-isolation-probe.ts --prune /tmp/ss-probe
+      - name: Arm the tripwires and remove the artifacts the server-safe subpaths do not own
+        run: pnpm --filter @nextlyhq/ui exec tsx scripts/write-server-safe-isolation-probe.ts --arm /tmp/ss-probe
 
       # Both module systems, because the export map publishes both and `require` resolves
       # different files than `import`. Neither exit status is the assertion — a module that ends

--- a/.github/workflows/package-smoke.yml
+++ b/.github/workflows/package-smoke.yml
@@ -332,6 +332,56 @@ jobs:
       - name: Verify the render happened and both halves covered every subpath
         run: pnpm --filter @nextlyhq/ui exec tsx scripts/write-server-safe-rsc-app.ts --verify /tmp/rsc-app
 
+      # The steps above answer "does this render in a real Next build". They cannot answer "could
+      # it have reached something it is not allowed to", because that app resolves the package's
+      # whole dependency set: installing the tarball normally brings in 71 packages, of which
+      # exactly two are on the server-safe allow-list. A stray load there simply succeeds.
+      #
+      # These steps remove the opportunity rather than looking for the act. The project declares
+      # only the allowed packages, so a load of anything else throws whatever produced it — a
+      # computed specifier, `eval`, a host object — because the file is not on disk and nothing
+      # has to recognise a spelling.
+      - name: Write the isolation probe project
+        run: pnpm --filter @nextlyhq/ui exec tsx scripts/write-server-safe-isolation-probe.ts /tmp/ss-probe
+
+      # `npm install` with no arguments installs what the generated manifest declares, which is the
+      # allow-list and nothing else.
+      - name: Install ONLY the allowed dependencies
+        run: |
+          cd /tmp/ss-probe
+          npm install --no-audit --no-fund
+
+      # Extracted rather than installed, and this is the whole mechanism. `npm install <tarball>`
+      # would read the package's own manifest and resolve its 25 dependencies into the same
+      # node_modules, which is precisely the isolation being established. Unpacking places the
+      # files without ever consulting that manifest.
+      - name: Place the packed package WITHOUT resolving its dependencies
+        run: |
+          mkdir -p /tmp/ss-probe/node_modules/@nextlyhq/ui
+          tar -xzf /tmp/ui-pack/*.tgz -C /tmp/ss-probe/node_modules/@nextlyhq/ui --strip-components=1
+
+      # The export map already refuses a deep import, so a client subpath cannot be reached by
+      # name. A RELATIVE import from inside a server-safe artifact is a different route that the
+      # map says nothing about, so those files are deleted rather than left present.
+      - name: Remove the artifacts the server-safe subpaths do not own
+        run: pnpm --filter @nextlyhq/ui exec tsx scripts/write-server-safe-isolation-probe.ts --prune /tmp/ss-probe
+
+      # Both module systems, because the export map publishes both and `require` resolves
+      # different files than `import`. Neither exit status is the assertion — a module that ends
+      # the process while initialising exits 0 from inside the import being checked — so each
+      # probe records what it loaded and the verify step reads that.
+      - name: Load every server-safe subpath under both module systems
+        run: |
+          cd /tmp/ss-probe
+          node probe.mjs
+          node probe.cjs
+
+      # Audits the run AND the environment it ran in. A probe project that was not actually
+      # isolated loads everything happily and would report a clean pass, so this also requires
+      # that a package outside the allow-list could NOT be reached.
+      - name: Verify the probes completed and the project was isolated
+        run: pnpm --filter @nextlyhq/ui exec tsx scripts/write-server-safe-isolation-probe.ts --verify /tmp/ss-probe
+
   # A red nightly must surface without anyone watching the Actions tab. A red
   # pull request does not need an issue filed: it is already red on the PR, in
   # front of the person who caused it.

--- a/packages/ui/scripts/write-server-safe-isolation-probe.ts
+++ b/packages/ui/scripts/write-server-safe-isolation-probe.ts
@@ -4,9 +4,9 @@
  *
  * The other server-safe guards read things. The directive guard looks for a `"use client"` banner,
  * the artifact gate compares what each built file reaches against an allow-list, and the source ban
- * refuses runtime module resolution by naming the forms it permits. All three are models, and a
- * model answers for the cases it was taught: the source ban gained fourteen forms over five rounds
- * of one review, every one found by a person rather than by the check.
+ * refuses runtime module resolution by naming the forms it permits. All three are models of what a
+ * consumer does, and a model answers only for the cases it encodes: its surface is every way the
+ * language can spell a module load, which is unbounded, so it can be extended but never completed.
  *
  * This asks a different question. Install ONLY the packages a server-safe entry point may use, place
  * ONLY the server-safe artifacts, and import them. A load of anything else throws
@@ -66,6 +66,43 @@ const INSTALLED = join("node_modules", "@nextlyhq", "ui");
 
 const packageRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
 
+/** The `dependencies` this package declares, which decide both what is allowed and what is not. */
+function declaredDependencies(): Record<string, string> {
+  const manifest = JSON.parse(
+    readFileSync(join(packageRoot, "package.json"), "utf8")
+  ) as { dependencies?: Record<string, string> };
+  return manifest.dependencies ?? {};
+}
+
+/**
+ * The allowed packages at the versions this package actually supports.
+ *
+ * The RANGE is carried across rather than replaced with `*`. A wildcard installs whatever is
+ * newest, so the day either package publishes a major this build never asked for, an unrelated
+ * export change fails every pull request for a version the package does not claim to support —
+ * and the failure names this probe rather than the upgrade that caused it.
+ *
+ * An allowed package missing from `dependencies` is refused rather than defaulted, because the two
+ * lists then disagree about what a server-safe entry point may reach, and inventing a range hides
+ * that disagreement behind an install that happens to work.
+ */
+function allowedDependencies(): Record<string, string> {
+  const declared = declaredDependencies();
+  return Object.fromEntries(
+    [...SERVER_SAFE_ALLOWED_PACKAGES].sort().map(name => {
+      const range = declared[name];
+      if (range === undefined) {
+        throw new Error(
+          `${name} is on the server-safe allow-list but is not a declared dependency of this ` +
+            "package, so there is no supported range to install it at. Either the allow-list " +
+            "names a package that was removed, or the dependency was dropped without updating it."
+        );
+      }
+      return [name, range] as const;
+    })
+  );
+}
+
 /**
  * A dependency of this package that a server-safe entry point may NOT use.
  *
@@ -77,10 +114,7 @@ const packageRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
  * package rather than whichever one the manifest happened to list first.
  */
 function forbiddenSentinel(): string {
-  const manifest = JSON.parse(
-    readFileSync(join(packageRoot, "package.json"), "utf8")
-  ) as { dependencies?: Record<string, string> };
-  const forbidden = Object.keys(manifest.dependencies ?? {})
+  const forbidden = Object.keys(declaredDependencies())
     .filter(name => !SERVER_SAFE_ALLOWED_PACKAGES.has(name))
     .sort();
   if (forbidden.length === 0) {
@@ -93,7 +127,7 @@ function forbiddenSentinel(): string {
   return forbidden[0];
 }
 
-/** The server-safe subpaths, as a consumer spells them. */
+/** The server-safe subpaths, as the export map spells them. */
 function serverSafeSubpaths(): string[] {
   const subpaths = publishedEntries()
     .filter(entry => entry.serverSafe)
@@ -108,6 +142,19 @@ function serverSafeSubpaths(): string[] {
 }
 
 /**
+ * The server-safe subpaths as a CONSUMER spells them, which is what both probes import.
+ *
+ * The writer and the verifier must agree on this exactly: the probes record what they loaded under
+ * these names and the verifier looks each one up. Computed in two places, a change to how an
+ * export key becomes a specifier lands in one of them, and the verifier then either misses a
+ * subpath the probe covered or demands one it never imported — reading, in both directions, as a
+ * fault in the package rather than in this file.
+ */
+function consumerSpecifiers(): string[] {
+  return serverSafeSubpaths().map(subpath => `@nextlyhq/ui${subpath.slice(1)}`);
+}
+
+/**
  * Write the project, its manifest, and both probes.
  *
  * The manifest declares the allow-list and nothing else, which is what makes the boundary real:
@@ -118,8 +165,7 @@ function serverSafeSubpaths(): string[] {
 function write(target: string): void {
   mkdirSync(target, { recursive: true });
 
-  const allowed = [...SERVER_SAFE_ALLOWED_PACKAGES].sort();
-  const dependencies = Object.fromEntries(allowed.map(name => [name, "*"]));
+  const dependencies = allowedDependencies();
   writeFileSync(
     join(target, "package.json"),
     `${JSON.stringify({ name: "server-safe-isolation-probe", private: true, version: "1.0.0", dependencies }, null, 2)}\n`
@@ -127,7 +173,21 @@ function write(target: string): void {
 
   const subpaths = serverSafeSubpaths();
   const sentinel = forbiddenSentinel();
-  const specifiers = subpaths.map(subpath => `@nextlyhq/ui${subpath.slice(1)}`);
+  const specifiers = consumerSpecifiers();
+
+  // Only a missing module says the sentinel was unreachable. Any other failure — an incompatible
+  // release, a package that throws while initialising, one that cannot be loaded through this
+  // module system — means it WAS present, and swallowing it records the project as isolated while
+  // every forbidden package sits installed beside it. That is the one error this file must not
+  // treat as good news, so everything else is rethrown and fails the probe.
+  const sentinelProbe = (load: string) => `let sentinelReached = false;
+try {
+  ${load};
+  sentinelReached = true;
+} catch (error) {
+  const code = error && typeof error === "object" ? error.code : undefined;
+  if (code !== "ERR_MODULE_NOT_FOUND" && code !== "MODULE_NOT_FOUND") throw error;
+}`;
 
   // Both module systems, because the export map publishes both and a consumer arriving through
   // `require` resolves different files. Checking one leaves the other's artifacts evaluated by
@@ -140,11 +200,7 @@ for (const specifier of ${JSON.stringify(specifiers)}) {
   const module = await import(specifier);
   loaded[specifier] = Object.keys(module).length;
 }
-let sentinelReached = false;
-try {
-  await import(${JSON.stringify(sentinel)});
-  sentinelReached = true;
-} catch {}
+${sentinelProbe(`await import(${JSON.stringify(sentinel)})`)}
 writeFileSync(${JSON.stringify(MARKERS.esm)}, JSON.stringify({ loaded, sentinelReached }));
 `
   );
@@ -157,19 +213,17 @@ for (const specifier of ${JSON.stringify(specifiers)}) {
   const module = require(specifier);
   loaded[specifier] = Object.keys(module).length;
 }
-let sentinelReached = false;
-try {
-  require(${JSON.stringify(sentinel)});
-  sentinelReached = true;
-} catch {}
+${sentinelProbe(`require(${JSON.stringify(sentinel)})`)}
 writeFileSync(${JSON.stringify(MARKERS.cjs)}, JSON.stringify({ loaded, sentinelReached }));
 `
   );
 
   console.log(
     `Wrote an isolation probe for ${subpaths.length} server-safe subpaths (${subpaths.join(", ")}) ` +
-      `to ${target}. Allowed dependencies: ${allowed.join(", ")}. Isolation is demonstrated by ` +
-      `${sentinel} failing to load.`
+      `to ${target}. Allowed dependencies: ` +
+      `${Object.entries(dependencies)
+        .map(([name, range]) => `${name}@${range}`)
+        .join(", ")}. Isolation is demonstrated by ${sentinel} failing to load.`
   );
 }
 
@@ -214,9 +268,7 @@ function prune(target: string): void {
  * the first one". The marker is written last and is the only evidence that the run completed.
  */
 function verify(target: string): void {
-  const expected = serverSafeSubpaths().map(
-    subpath => `@nextlyhq/ui${subpath.slice(1)}`
-  );
+  const expected = consumerSpecifiers();
   const problems: string[] = [];
 
   for (const [system, marker] of Object.entries(MARKERS)) {

--- a/packages/ui/scripts/write-server-safe-isolation-probe.ts
+++ b/packages/ui/scripts/write-server-safe-isolation-probe.ts
@@ -45,6 +45,7 @@
 import {
   existsSync,
   mkdirSync,
+  readdirSync,
   readFileSync,
   rmSync,
   writeFileSync,
@@ -175,14 +176,19 @@ function write(target: string): void {
   const sentinel = forbiddenSentinel();
   const specifiers = consumerSpecifiers();
 
-  // Only a missing module says the sentinel was unreachable. Any other failure — an incompatible
-  // release, a package that throws while initialising, one that cannot be loaded through this
-  // module system — means it WAS present, and swallowing it records the project as isolated while
-  // every forbidden package sits installed beside it. That is the one error this file must not
-  // treat as good news, so everything else is rethrown and fails the probe.
-  const sentinelProbe = (load: string) => `let sentinelReached = false;
+  // RESOLVED, never loaded. Loading answers a wider question than this asks: it runs the module,
+  // so a package that IS present reports itself absent whenever its own initialiser fails — an
+  // incompatible release, a broken optional dependency of its own, anything that throws. Several
+  // of those failures carry the very error code that means "not installed", so no amount of
+  // narrowing the catch separates them; the two cases are indistinguishable once evaluation is
+  // allowed to happen at all.
+  //
+  // Resolution decides presence without executing anything, so the only module whose absence can
+  // be reported is the one named here. Each probe uses its own system's resolver, and neither can
+  // be confused by what the package would have done had it run.
+  const sentinelProbe = (resolve: string) => `let sentinelReached = false;
 try {
-  ${load};
+  ${resolve};
   sentinelReached = true;
 } catch (error) {
   const code = error && typeof error === "object" ? error.code : undefined;
@@ -200,7 +206,7 @@ for (const specifier of ${JSON.stringify(specifiers)}) {
   const module = await import(specifier);
   loaded[specifier] = Object.keys(module).length;
 }
-${sentinelProbe(`await import(${JSON.stringify(sentinel)})`)}
+${sentinelProbe(`import.meta.resolve(${JSON.stringify(sentinel)})`)}
 writeFileSync(${JSON.stringify(MARKERS.esm)}, JSON.stringify({ loaded, sentinelReached }));
 `
   );
@@ -213,7 +219,7 @@ for (const specifier of ${JSON.stringify(specifiers)}) {
   const module = require(specifier);
   loaded[specifier] = Object.keys(module).length;
 }
-${sentinelProbe(`require(${JSON.stringify(sentinel)})`)}
+${sentinelProbe(`require.resolve(${JSON.stringify(sentinel)})`)}
 writeFileSync(${JSON.stringify(MARKERS.cjs)}, JSON.stringify({ loaded, sentinelReached }));
 `
   );
@@ -261,6 +267,54 @@ function prune(target: string): void {
 }
 
 /**
+ * Every package name present at the top level of the probe project.
+ *
+ * A scope directory is not a package — `@radix-ui` holds them — so it is descended into and its
+ * children reported as scoped names.
+ */
+function installedPackages(target: string): string[] {
+  const root = join(target, "node_modules");
+  if (!existsSync(root)) return [];
+  const names: string[] = [];
+  for (const entry of readdirSync(root, { withFileTypes: true })) {
+    if (entry.name.startsWith(".")) continue;
+    if (entry.name.startsWith("@")) {
+      for (const scoped of readdirSync(join(root, entry.name))) {
+        if (!scoped.startsWith(".")) names.push(`${entry.name}/${scoped}`);
+      }
+      continue;
+    }
+    names.push(entry.name);
+  }
+  return names;
+}
+
+/**
+ * Packages the probe project holds that a server-safe entry point may not reach.
+ *
+ * The sentinel answers a question about ONE name, and npm's default layout can add others without
+ * touching it: a hoisted install lifts every non-duplicated transitive dependency to the top level,
+ * so the day an allowed package gains a dependency of its own, that dependency becomes directly
+ * resolvable by the package under test while the sentinel stays missing and both probes still pass.
+ *
+ * This enumerates what is actually there instead, so a package arriving by any route — hoisting, a
+ * lockfile change, a hand-placed directory — is reported by name rather than having to have been
+ * predicted. `@nextlyhq/ui` is expected because it is the subject, placed deliberately.
+ */
+function unexpectedlyInstalled(target: string): string[] {
+  const permitted = new Set([...SERVER_SAFE_ALLOWED_PACKAGES, "@nextlyhq/ui"]);
+  const unexpected = installedPackages(target)
+    .filter(name => !permitted.has(name))
+    .sort();
+  if (unexpected.length === 0) return [];
+  return [
+    `The probe project holds ${unexpected.length} package(s) outside the allow-list: ` +
+      `${unexpected.join(", ")}. Each is resolvable by the package under test, so the boundary ` +
+      "these probes report on is wider than the allow-list they are checking against.",
+  ];
+}
+
+/**
  * Read what the probes recorded, rather than trusting that they exited 0.
  *
  * A module that ends the process while it initialises exits 0 from inside the import being
@@ -269,7 +323,7 @@ function prune(target: string): void {
  */
 function verify(target: string): void {
   const expected = consumerSpecifiers();
-  const problems: string[] = [];
+  const problems: string[] = [...unexpectedlyInstalled(target)];
 
   for (const [system, marker] of Object.entries(MARKERS)) {
     const path = join(target, marker);

--- a/packages/ui/scripts/write-server-safe-isolation-probe.ts
+++ b/packages/ui/scripts/write-server-safe-isolation-probe.ts
@@ -409,6 +409,18 @@ function verify(target: string): void {
 const MODES = new Set(["--arm", "--verify"]);
 const flag = process.argv[2];
 const mode = MODES.has(flag) ? flag : undefined;
+
+// A mistyped mode must not fall through to the target. `--verfy` is not in MODES, so it would be
+// taken as a directory name, written as one, and exited 0 from — the verification never runs and
+// the caller is told it succeeded. Anything that looks like a flag is therefore refused rather
+// than reinterpreted, which is the same rule the rest of this file applies to its subject.
+if (mode === undefined && flag !== undefined && flag.startsWith("-")) {
+  console.error(
+    `${flag} is not a mode. Use --arm, --verify, or no flag at all to write the project.`
+  );
+  process.exit(1);
+}
+
 const target = mode === undefined ? process.argv[2] : process.argv[3];
 
 if (target === undefined) {

--- a/packages/ui/scripts/write-server-safe-isolation-probe.ts
+++ b/packages/ui/scripts/write-server-safe-isolation-probe.ts
@@ -1,0 +1,282 @@
+/**
+ * Run the server-safe subpaths in a project that CANNOT resolve anything they are not allowed to
+ * reach, so a stray load fails at that moment rather than being recognised.
+ *
+ * The other server-safe guards read things. The directive guard looks for a `"use client"` banner,
+ * the artifact gate compares what each built file reaches against an allow-list, and the source ban
+ * refuses runtime module resolution by naming the forms it permits. All three are models, and a
+ * model answers for the cases it was taught: the source ban gained fourteen forms over five rounds
+ * of one review, every one found by a person rather than by the check.
+ *
+ * This asks a different question. Install ONLY the packages a server-safe entry point may use, place
+ * ONLY the server-safe artifacts, and import them. A load of anything else throws
+ * `ERR_MODULE_NOT_FOUND` whatever produced it — a computed specifier, `eval`, a host object, a form
+ * nobody has thought of — because the file is not on disk. Nothing has to recognise a spelling.
+ *
+ * ## The two halves both have to be asserted
+ *
+ * A probe that reaches nothing at all blocks every route and reports a perfect pass, so "the
+ * forbidden thing failed" is worthless on its own. Both directions are checked here:
+ *
+ * - every server-safe subpath must LOAD and expose at least one name, which is what proves the
+ *   module was evaluated rather than merely resolved;
+ * - a package that is a real dependency of this one and NOT in the allow-list must FAIL to load.
+ *   If it succeeds, the isolation did not happen — the tarball was installed normally and pulled
+ *   its whole dependency set in beside it — and every other result in the run is vacuous.
+ *
+ * The second assertion is about the instrument rather than the subject. Without it the expected
+ * output of a correctly isolated run and a completely unisolated one differ in nothing this file
+ * looks at.
+ *
+ * ## What this does NOT establish
+ *
+ * Execution only observes what EXECUTES. A resolver behind a branch that import-time evaluation
+ * never takes is invisible here and visible to the source ban in `src/layering.test.ts`, which is
+ * why that ban stays. The two cover different halves and neither subsumes the other.
+ *
+ * Usage, from this package's directory:
+ *   tsx scripts/write-server-safe-isolation-probe.ts <directory>            write the project
+ *   tsx scripts/write-server-safe-isolation-probe.ts --prune <directory>    drop non-server-safe files
+ *   tsx scripts/write-server-safe-isolation-probe.ts --verify <directory>   read what the probes wrote
+ *
+ * Through `tsx` rather than `node`, because the lowest supported Node cannot execute TypeScript
+ * directly. That is also how the workflow invokes it.
+ */
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  clientArtifacts,
+  publishedEntries,
+  SERVER_SAFE_ALLOWED_PACKAGES,
+} from "./published-entries.js";
+
+/** Where each probe records that it reached the end of its own run. */
+const MARKERS = { esm: "probe-esm.json", cjs: "probe-cjs.json" } as const;
+
+/** The installed copy of this package inside the probe project. */
+const INSTALLED = join("node_modules", "@nextlyhq", "ui");
+
+const packageRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+/**
+ * A dependency of this package that a server-safe entry point may NOT use.
+ *
+ * Derived by subtracting the allow-list from the real manifest rather than written down, so it
+ * cannot name a package that has since been removed — a sentinel that is absent for the wrong
+ * reason fails to load exactly like a working boundary, and would certify an unisolated run.
+ *
+ * Sorted before choosing so the same name is picked on every run and a failure names a stable
+ * package rather than whichever one the manifest happened to list first.
+ */
+function forbiddenSentinel(): string {
+  const manifest = JSON.parse(
+    readFileSync(join(packageRoot, "package.json"), "utf8")
+  ) as { dependencies?: Record<string, string> };
+  const forbidden = Object.keys(manifest.dependencies ?? {})
+    .filter(name => !SERVER_SAFE_ALLOWED_PACKAGES.has(name))
+    .sort();
+  if (forbidden.length === 0) {
+    throw new Error(
+      "Every declared dependency is on the server-safe allow-list, so there is no package whose " +
+        "absence can demonstrate that the probe project is isolated. Without that control a run " +
+        "in a fully populated project is indistinguishable from an isolated one."
+    );
+  }
+  return forbidden[0];
+}
+
+/** The server-safe subpaths, as a consumer spells them. */
+function serverSafeSubpaths(): string[] {
+  const subpaths = publishedEntries()
+    .filter(entry => entry.serverSafe)
+    .map(entry => entry.subpath);
+  if (subpaths.length === 0) {
+    throw new Error(
+      "No server-safe subpaths were derived from the export map, so the probe would import " +
+        "nothing and pass without asserting anything."
+    );
+  }
+  return subpaths;
+}
+
+/**
+ * Write the project, its manifest, and both probes.
+ *
+ * The manifest declares the allow-list and nothing else, which is what makes the boundary real:
+ * `npm install` in this directory brings in exactly the packages a server-safe entry point is
+ * permitted to reach, and the package under test is placed beside them afterwards rather than
+ * installed, so its own dependency set is never resolved.
+ */
+function write(target: string): void {
+  mkdirSync(target, { recursive: true });
+
+  const allowed = [...SERVER_SAFE_ALLOWED_PACKAGES].sort();
+  const dependencies = Object.fromEntries(allowed.map(name => [name, "*"]));
+  writeFileSync(
+    join(target, "package.json"),
+    `${JSON.stringify({ name: "server-safe-isolation-probe", private: true, version: "1.0.0", dependencies }, null, 2)}\n`
+  );
+
+  const subpaths = serverSafeSubpaths();
+  const sentinel = forbiddenSentinel();
+  const specifiers = subpaths.map(subpath => `@nextlyhq/ui${subpath.slice(1)}`);
+
+  // Both module systems, because the export map publishes both and a consumer arriving through
+  // `require` resolves different files. Checking one leaves the other's artifacts evaluated by
+  // nothing, while the map still promises them.
+  writeFileSync(
+    join(target, "probe.mjs"),
+    `import { writeFileSync } from "node:fs";
+const loaded = {};
+for (const specifier of ${JSON.stringify(specifiers)}) {
+  const module = await import(specifier);
+  loaded[specifier] = Object.keys(module).length;
+}
+let sentinelReached = false;
+try {
+  await import(${JSON.stringify(sentinel)});
+  sentinelReached = true;
+} catch {}
+writeFileSync(${JSON.stringify(MARKERS.esm)}, JSON.stringify({ loaded, sentinelReached }));
+`
+  );
+
+  writeFileSync(
+    join(target, "probe.cjs"),
+    `const { writeFileSync } = require("node:fs");
+const loaded = {};
+for (const specifier of ${JSON.stringify(specifiers)}) {
+  const module = require(specifier);
+  loaded[specifier] = Object.keys(module).length;
+}
+let sentinelReached = false;
+try {
+  require(${JSON.stringify(sentinel)});
+  sentinelReached = true;
+} catch {}
+writeFileSync(${JSON.stringify(MARKERS.cjs)}, JSON.stringify({ loaded, sentinelReached }));
+`
+  );
+
+  console.log(
+    `Wrote an isolation probe for ${subpaths.length} server-safe subpaths (${subpaths.join(", ")}) ` +
+      `to ${target}. Allowed dependencies: ${allowed.join(", ")}. Isolation is demonstrated by ` +
+      `${sentinel} failing to load.`
+  );
+}
+
+/**
+ * Remove every artifact the server-safe subpaths do not own.
+ *
+ * The export map refuses a deep import, so a client subpath cannot be reached by name. A RELATIVE
+ * import from inside a server-safe artifact is a different route and the map has nothing to say
+ * about it, so those files are deleted rather than left present and unreachable-by-name.
+ */
+function prune(target: string): void {
+  const dist = join(target, INSTALLED, "dist");
+  if (!existsSync(dist)) {
+    throw new Error(
+      `${dist} does not exist, so there is nothing to prune and the probe would run against a ` +
+        "package that was never placed. Extract the packed tarball there first."
+    );
+  }
+  const removed: string[] = [];
+  for (const artifact of clientArtifacts()) {
+    const path = join(dist, artifact);
+    if (existsSync(path)) {
+      rmSync(path);
+      removed.push(artifact);
+    }
+  }
+  if (removed.length === 0) {
+    throw new Error(
+      "No client artifacts were removed. Either the build produced none — in which case the " +
+        "package has no client surface and this check is asserting less than it appears to — or " +
+        "the tarball was extracted somewhere other than the path above."
+    );
+  }
+  console.log(`Removed ${removed.length} client artifacts from ${dist}.`);
+}
+
+/**
+ * Read what the probes recorded, rather than trusting that they exited 0.
+ *
+ * A module that ends the process while it initialises exits 0 from inside the import being
+ * checked, so the exit status of a probe cannot distinguish "imported everything" from "died on
+ * the first one". The marker is written last and is the only evidence that the run completed.
+ */
+function verify(target: string): void {
+  const expected = serverSafeSubpaths().map(
+    subpath => `@nextlyhq/ui${subpath.slice(1)}`
+  );
+  const problems: string[] = [];
+
+  for (const [system, marker] of Object.entries(MARKERS)) {
+    const path = join(target, marker);
+    if (!existsSync(path)) {
+      problems.push(
+        `The ${system} probe wrote no marker, so it did not reach the end of its run. Its exit ` +
+          "status cannot tell you why: a module ending the process during initialization exits 0."
+      );
+      continue;
+    }
+    const record = JSON.parse(readFileSync(path, "utf8")) as {
+      loaded: Record<string, number>;
+      sentinelReached: boolean;
+    };
+
+    if (record.sentinelReached) {
+      problems.push(
+        `The ${system} probe loaded a package outside the allow-list, so the project it ran in was ` +
+          "not isolated and every other result from it is vacuous. The package under test was " +
+          "probably installed rather than placed, which resolves its whole dependency set."
+      );
+    }
+
+    for (const specifier of expected) {
+      const names = record.loaded[specifier];
+      if (names === undefined) {
+        problems.push(`The ${system} probe never loaded ${specifier}.`);
+      } else if (names === 0) {
+        problems.push(
+          `${specifier} loaded under ${system} and exposed no names, so nothing proves its module ` +
+            "body was evaluated rather than merely resolved."
+        );
+      }
+    }
+  }
+
+  if (problems.length > 0) {
+    console.error(problems.map(problem => `- ${problem}`).join("\n"));
+    process.exit(1);
+  }
+  console.log(
+    `Both probes loaded all ${expected.length} server-safe subpaths with non-empty exports, and ` +
+      "neither could reach a package outside the allow-list."
+  );
+}
+
+const MODES = new Set(["--prune", "--verify"]);
+const flag = process.argv[2];
+const mode = MODES.has(flag) ? flag : undefined;
+const target = mode === undefined ? process.argv[2] : process.argv[3];
+
+if (target === undefined) {
+  console.error(
+    "Usage: tsx scripts/write-server-safe-isolation-probe.ts [--prune|--verify] <directory>. The " +
+      "directory is where the probe project is written; it is created if it does not exist."
+  );
+  process.exit(1);
+}
+
+if (mode === "--prune") prune(target);
+else if (mode === "--verify") verify(target);
+else write(target);

--- a/packages/ui/scripts/write-server-safe-isolation-probe.ts
+++ b/packages/ui/scripts/write-server-safe-isolation-probe.ts
@@ -50,9 +50,24 @@
  * why that ban stays. The two cover different halves and neither subsumes the other.
  *
  * The tripwires cover the packages this one SHIPS WITH — its dependencies and peer dependencies —
- * because those are the names that resolve in a real consumer and therefore the ones a forbidden
- * reach can actually obtain. A package that is neither is not reachable in a consumer either, so
- * its absence here is the same answer a consumer would give.
+ * plus everything the install actually placed, which catches a transitive dependency hoisted to the
+ * top level that no manifest here names.
+ *
+ * TWO ROUTES REMAIN OUTSIDE THIS, and they are the same fact wearing two costumes: a tripwire is
+ * evidence written by code that RAN, so a forbidden reach that never executes the module leaves
+ * none.
+ *
+ * - **Resolution without evaluation.** `createRequire(...).resolve("react")` returns the decoy's
+ *   path and runs nothing in it, so no append happens. Wiring resolution instead is not available:
+ *   that is the same statement, since `resolve` executes no code by design.
+ * - **A load deferred behind a function.** These probes import each entry point and count its
+ *   exports; a forbidden load inside an exported helper is never reached, because nothing calls it.
+ *
+ * Both are properties of runtime observation rather than defects here, and neither is closed by the
+ * source ban either: it catches the plain spellings and says in its own header that computed host
+ * access such as `globalThis["pro" + "cess"]` is outside what reading syntax can recognise. So a
+ * COMPUTED resolver form that only resolves, or that sits behind an uncalled function, is currently
+ * covered by neither check. That is written here rather than left for a green run to imply.
  *
  * Usage, from this package's directory:
  *   tsx scripts/write-server-safe-isolation-probe.ts <directory>            write the project
@@ -65,11 +80,12 @@
 import {
   existsSync,
   mkdirSync,
+  readdirSync,
   readFileSync,
   rmSync,
   writeFileSync,
 } from "node:fs";
-import { dirname, join } from "node:path";
+import { dirname, join, resolve as resolvePath } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import {
@@ -86,6 +102,9 @@ const REACHED_LOG = "tripwires-reached.log";
 
 /** Written inside each tripwire so a real package installed over one is detectable. */
 const TRIPWIRE_MARKER = ".is-tripwire";
+
+/** The names `--arm` actually wired, so `--verify` checks those rather than a fresh derivation. */
+const WIRED_MANIFEST = "tripwires.json";
 
 /** The installed copy of this package inside the probe project. */
 const INSTALLED = join("node_modules", "@nextlyhq", "ui");
@@ -153,6 +172,36 @@ function forbiddenPackages(): string[] {
   return forbidden;
 }
 
+/**
+ * Packages present at the top level of the probe project that the allow-list does not name.
+ *
+ * A scope directory is not a package — `@radix-ui` holds them — so it is descended into and its
+ * children reported as scoped names. `@nextlyhq/ui` is excluded because it is the subject.
+ *
+ * Read from disk rather than from any manifest, because the packages this exists to catch are the
+ * ones no manifest here mentions: a transitive dependency of an allowed package, hoisted to the top
+ * level by npm's default install strategy, is resolvable by the package under test and invisible to
+ * `forbiddenPackages()`.
+ */
+function installedForbidden(target: string): string[] {
+  const root = join(target, "node_modules");
+  if (!existsSync(root)) return [];
+  const names: string[] = [];
+  for (const entry of readdirSync(root, { withFileTypes: true })) {
+    if (entry.name.startsWith(".")) continue;
+    if (entry.name.startsWith("@")) {
+      for (const scoped of readdirSync(join(root, entry.name))) {
+        if (!scoped.startsWith(".")) names.push(`${entry.name}/${scoped}`);
+      }
+      continue;
+    }
+    names.push(entry.name);
+  }
+  return names.filter(
+    name => name !== "@nextlyhq/ui" && !SERVER_SAFE_ALLOWED_PACKAGES.has(name)
+  );
+}
+
 /** The server-safe subpaths, as the export map spells them. */
 function serverSafeSubpaths(): string[] {
   const subpaths = publishedEntries()
@@ -193,7 +242,11 @@ function write(target: string): void {
   // A marker or log left by an earlier run survives the failure they exist to catch: an artifact
   // calling `process.exit(0)` during initialisation ends its probe with status 0 before the final
   // write, and verification then reads the previous run's evidence about artifacts never loaded.
-  for (const stale of [...Object.values(MARKERS), REACHED_LOG]) {
+  for (const stale of [
+    ...Object.values(MARKERS),
+    REACHED_LOG,
+    WIRED_MANIFEST,
+  ]) {
     rmSync(join(target, stale), { force: true });
   }
 
@@ -252,10 +305,16 @@ writeFileSync(${JSON.stringify(MARKERS.cjs)}, JSON.stringify({ loaded }));
  *
  * Runs after the install and the unpack, because both would overwrite what it puts down.
  *
- * The log path is absolute and baked in at write time. A tripwire computing it from its own
- * location would have to know how deep it sits, which differs between a scoped and an unscoped
- * name — and a wire that writes its evidence to the wrong path reports nothing, which is the one
- * failure mode that looks exactly like success.
+ * The log path is RESOLVED to an absolute one before being baked in. A tripwire runs with the probe
+ * directory as its working directory, so a relative target such as `./probe` would otherwise be
+ * appended to itself and the evidence written under `./probe/probe/...`; if the caller catches the
+ * resulting `ENOENT`, no log exists and verification passes. A wire that writes its evidence to the
+ * wrong path reports nothing, which is the one failure mode that looks exactly like success.
+ *
+ * The wired set is taken from what is INSTALLED as well as what the manifest names. A transitive
+ * dependency of an allowed package is placed at the top level by npm's default layout, is
+ * resolvable by the package under test, and appears in no manifest this script reads — so deriving
+ * from the manifest alone leaves exactly the packages nobody predicted without a wire.
  */
 function arm(target: string): void {
   const dist = join(target, INSTALLED, "dist");
@@ -266,8 +325,11 @@ function arm(target: string): void {
     );
   }
 
-  const logPath = join(target, REACHED_LOG);
-  for (const name of forbiddenPackages()) {
+  const logPath = resolvePath(target, REACHED_LOG);
+  const wired = [
+    ...new Set([...forbiddenPackages(), ...installedForbidden(target)]),
+  ].sort();
+  for (const name of wired) {
     const home = join(target, "node_modules", ...name.split("/"));
     mkdirSync(home, { recursive: true });
 
@@ -303,6 +365,15 @@ function arm(target: string): void {
     writeFileSync(join(home, TRIPWIRE_MARKER), "");
   }
 
+  // Recorded rather than recomputed. Verification has to check the wires that were actually
+  // placed, and the installed half of that set depends on what the install produced — so a second
+  // derivation at verify time can legitimately differ from this one and would report wires as
+  // missing that were never asked for.
+  writeFileSync(
+    join(target, WIRED_MANIFEST),
+    `${JSON.stringify(wired, null, 2)}\n`
+  );
+
   // The export map refuses a deep import, so a client subpath cannot be reached by name. A
   // RELATIVE import from inside a server-safe artifact is a different route the map says nothing
   // about, so those files are deleted rather than left present.
@@ -320,7 +391,7 @@ function arm(target: string): void {
     );
   }
   console.log(
-    `Armed ${forbiddenPackages().length} tripwires and removed ${removed.length} client artifacts.`
+    `Armed ${wired.length} tripwires and removed ${removed.length} client artifacts.`
   );
 }
 
@@ -338,7 +409,22 @@ function verify(target: string): void {
   // The instrument first. A tripwire that is no longer a tripwire means the real package was
   // installed over it, and every "no wire tripped" result below would then be reporting on a
   // project that never had the boundary it claims to be testing.
-  const disarmed = forbiddenPackages().filter(
+  //
+  // The set comes from what `--arm` RECORDED, not from a second derivation. Half of it depends on
+  // what the install produced, so recomputing here could legitimately differ and would report
+  // wires as missing that were never asked for.
+  const wiredPath = join(target, WIRED_MANIFEST);
+  const wired: string[] = existsSync(wiredPath)
+    ? (JSON.parse(readFileSync(wiredPath, "utf8")) as string[])
+    : [];
+  if (wired.length === 0) {
+    problems.push(
+      `${WIRED_MANIFEST} is absent or empty, so no tripwires were placed and nothing was watching ` +
+        "any forbidden name during this run. Run --arm after installing and unpacking."
+    );
+  }
+
+  const disarmed = wired.filter(
     name =>
       !existsSync(
         join(target, "node_modules", ...name.split("/"), TRIPWIRE_MARKER)
@@ -346,7 +432,7 @@ function verify(target: string): void {
   );
   if (disarmed.length > 0) {
     problems.push(
-      `${disarmed.length} of ${forbiddenPackages().length} tripwires are missing or were replaced ` +
+      `${disarmed.length} of ${wired.length} tripwires are missing or were replaced ` +
         `by a real package (${disarmed.slice(0, 5).join(", ")}${disarmed.length > 5 ? ", ..." : ""}). ` +
         "Nothing was watching those names, so this run cannot report on them either way."
     );
@@ -402,7 +488,7 @@ function verify(target: string): void {
   }
   console.log(
     `Both probes loaded all ${expected.length} server-safe subpaths with non-empty exports, and ` +
-      `none of the ${forbiddenPackages().length} tripwires was reached.`
+      `none of the ${wired.length} tripwires was reached.`
   );
 }
 

--- a/packages/ui/scripts/write-server-safe-isolation-probe.ts
+++ b/packages/ui/scripts/write-server-safe-isolation-probe.ts
@@ -1,6 +1,6 @@
 /**
- * Run the server-safe subpaths in a project that CANNOT resolve anything they are not allowed to
- * reach, so a stray load fails at that moment rather than being recognised.
+ * Run the server-safe subpaths in a project where every package they may not use is a TRIPWIRE, so
+ * reaching one leaves evidence that survives whatever the caller does about the failure.
  *
  * The other server-safe guards read things. The directive guard looks for a `"use client"` banner,
  * the artifact gate compares what each built file reaches against an allow-list, and the source ban
@@ -8,25 +8,40 @@
  * consumer does, and a model answers only for the cases it encodes: its surface is every way the
  * language can spell a module load, which is unbounded, so it can be extended but never completed.
  *
- * This asks a different question. Install ONLY the packages a server-safe entry point may use, place
- * ONLY the server-safe artifacts, and import them. A load of anything else throws
- * `ERR_MODULE_NOT_FOUND` whatever produced it — a computed specifier, `eval`, a host object, a form
- * nobody has thought of — because the file is not on disk. Nothing has to recognise a spelling.
+ * ## Why a decoy rather than an empty project
+ *
+ * Leaving the forbidden packages out is the obvious design and it has a hole. Absence produces a
+ * signal only when the failure ESCAPES: an entry point that swallows its own error —
+ * `try { createRequire(...)("react") } catch {}` — resolves nothing here and throws nothing out,
+ * so the run is indistinguishable from one that never tried. The same code succeeds in a consumer
+ * where that package is installed, which is the situation that matters.
+ *
+ * Intercepting the request instead does not work either, and this was measured rather than assumed:
+ * patching `Module._resolveFilename` and `Module._load` captures nothing for a require obtained
+ * from `createRequire`, whether reached directly or through `process.getBuiltinModule`. The loader
+ * hooks that would see it do not span the supported Node range — `registerHooks` starts at 22.15,
+ * and `register` is documented not to affect `createRequire` at all.
+ *
+ * So the evidence is written by the thing being reached. Each forbidden package is replaced by a
+ * module that appends its own name to a log and then throws. The throw preserves the old behaviour
+ * for callers that do not catch; the log is what a caller cannot undo. Nothing has to recognise a
+ * spelling, and nothing has to intercept anything, because the record is made after resolution has
+ * already succeeded — by definition, whatever route got there.
  *
  * ## The two halves both have to be asserted
  *
- * A probe that reaches nothing at all blocks every route and reports a perfect pass, so "the
- * forbidden thing failed" is worthless on its own. Both directions are checked here:
+ * A probe that reaches nothing at all trips no wire and reports a perfect pass, so "no wire was
+ * tripped" is worthless on its own. Both directions are checked:
  *
  * - every server-safe subpath must LOAD and expose at least one name, which is what proves the
  *   module was evaluated rather than merely resolved;
- * - a package that is a real dependency of this one and NOT in the allow-list must FAIL to load.
- *   If it succeeds, the isolation did not happen — the tarball was installed normally and pulled
- *   its whole dependency set in beside it — and every other result in the run is vacuous.
+ * - every tripwire must still BE a tripwire when the run ends. If the real package was installed
+ *   over one, its absence of a marker says so — otherwise a project that resolved the package
+ *   under test normally, pulling its whole dependency set in beside it, would pass every other
+ *   assertion here.
  *
- * The second assertion is about the instrument rather than the subject. Without it the expected
- * output of a correctly isolated run and a completely unisolated one differ in nothing this file
- * looks at.
+ * The second is about the instrument rather than the subject. Without it the expected output of a
+ * correctly built project and a completely unisolated one differ in nothing this file looks at.
  *
  * ## What this does NOT establish
  *
@@ -34,10 +49,15 @@
  * never takes is invisible here and visible to the source ban in `src/layering.test.ts`, which is
  * why that ban stays. The two cover different halves and neither subsumes the other.
  *
+ * The tripwires cover the packages this one SHIPS WITH — its dependencies and peer dependencies —
+ * because those are the names that resolve in a real consumer and therefore the ones a forbidden
+ * reach can actually obtain. A package that is neither is not reachable in a consumer either, so
+ * its absence here is the same answer a consumer would give.
+ *
  * Usage, from this package's directory:
  *   tsx scripts/write-server-safe-isolation-probe.ts <directory>            write the project
- *   tsx scripts/write-server-safe-isolation-probe.ts --prune <directory>    drop non-server-safe files
- *   tsx scripts/write-server-safe-isolation-probe.ts --verify <directory>   read what the probes wrote
+ *   tsx scripts/write-server-safe-isolation-probe.ts --arm <directory>      place tripwires, prune
+ *   tsx scripts/write-server-safe-isolation-probe.ts --verify <directory>   read what the run left
  *
  * Through `tsx` rather than `node`, because the lowest supported Node cannot execute TypeScript
  * directly. That is also how the workflow invokes it.
@@ -45,7 +65,6 @@
 import {
   existsSync,
   mkdirSync,
-  readdirSync,
   readFileSync,
   rmSync,
   writeFileSync,
@@ -62,17 +81,23 @@ import {
 /** Where each probe records that it reached the end of its own run. */
 const MARKERS = { esm: "probe-esm.json", cjs: "probe-cjs.json" } as const;
 
+/** Where a tripwire appends its own name when something loads it. */
+const REACHED_LOG = "tripwires-reached.log";
+
+/** Written inside each tripwire so a real package installed over one is detectable. */
+const TRIPWIRE_MARKER = ".is-tripwire";
+
 /** The installed copy of this package inside the probe project. */
 const INSTALLED = join("node_modules", "@nextlyhq", "ui");
 
 const packageRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
 
-/** The `dependencies` this package declares, which decide both what is allowed and what is not. */
-function declaredDependencies(): Record<string, string> {
-  const manifest = JSON.parse(
-    readFileSync(join(packageRoot, "package.json"), "utf8")
-  ) as { dependencies?: Record<string, string> };
-  return manifest.dependencies ?? {};
+/** This package's manifest, which decides both what is allowed and what is faked. */
+function manifest(): {
+  dependencies?: Record<string, string>;
+  peerDependencies?: Record<string, string>;
+} {
+  return JSON.parse(readFileSync(join(packageRoot, "package.json"), "utf8"));
 }
 
 /**
@@ -82,13 +107,9 @@ function declaredDependencies(): Record<string, string> {
  * newest, so the day either package publishes a major this build never asked for, an unrelated
  * export change fails every pull request for a version the package does not claim to support —
  * and the failure names this probe rather than the upgrade that caused it.
- *
- * An allowed package missing from `dependencies` is refused rather than defaulted, because the two
- * lists then disagree about what a server-safe entry point may reach, and inventing a range hides
- * that disagreement behind an install that happens to work.
  */
 function allowedDependencies(): Record<string, string> {
-  const declared = declaredDependencies();
+  const declared = manifest().dependencies ?? {};
   return Object.fromEntries(
     [...SERVER_SAFE_ALLOWED_PACKAGES].sort().map(name => {
       const range = declared[name];
@@ -105,27 +126,31 @@ function allowedDependencies(): Record<string, string> {
 }
 
 /**
- * A dependency of this package that a server-safe entry point may NOT use.
+ * Every package a server-safe entry point may not reach but COULD obtain in a real consumer.
  *
- * Derived by subtracting the allow-list from the real manifest rather than written down, so it
- * cannot name a package that has since been removed — a sentinel that is absent for the wrong
- * reason fails to load exactly like a working boundary, and would certify an unisolated run.
+ * Dependencies and peer dependencies together, because both resolve where this package is
+ * installed — a peer is absent from `node_modules` here and present in the app that consumes it,
+ * so leaving peers out would mean the routes most worth catching had no wire on them.
  *
- * Sorted before choosing so the same name is picked on every run and a failure names a stable
- * package rather than whichever one the manifest happened to list first.
+ * Derived by subtraction rather than listed, so a package added to the manifest is covered without
+ * anyone remembering to come back here.
  */
-function forbiddenSentinel(): string {
-  const forbidden = Object.keys(declaredDependencies())
+function forbiddenPackages(): string[] {
+  const declared = manifest();
+  const names = new Set([
+    ...Object.keys(declared.dependencies ?? {}),
+    ...Object.keys(declared.peerDependencies ?? {}),
+  ]);
+  const forbidden = [...names]
     .filter(name => !SERVER_SAFE_ALLOWED_PACKAGES.has(name))
     .sort();
   if (forbidden.length === 0) {
     throw new Error(
-      "Every declared dependency is on the server-safe allow-list, so there is no package whose " +
-        "absence can demonstrate that the probe project is isolated. Without that control a run " +
-        "in a fully populated project is indistinguishable from an isolated one."
+      "Every package this one ships with is on the server-safe allow-list, so there is nothing to " +
+        "place a tripwire on. A run in that state asserts only that the allowed packages load."
     );
   }
-  return forbidden[0];
+  return forbidden;
 }
 
 /** The server-safe subpaths, as the export map spells them. */
@@ -145,11 +170,10 @@ function serverSafeSubpaths(): string[] {
 /**
  * The server-safe subpaths as a CONSUMER spells them, which is what both probes import.
  *
- * The writer and the verifier must agree on this exactly: the probes record what they loaded under
- * these names and the verifier looks each one up. Computed in two places, a change to how an
- * export key becomes a specifier lands in one of them, and the verifier then either misses a
- * subpath the probe covered or demands one it never imported — reading, in both directions, as a
- * fault in the package rather than in this file.
+ * The writer and the verifier must agree exactly: the probes record what they loaded under these
+ * names and the verifier looks each one up. Computed in two places, a change to how an export key
+ * becomes a specifier lands in one of them, and the verifier then either misses a subpath the probe
+ * covered or demands one it never imported — reading, in both directions, as a fault in the package.
  */
 function consumerSpecifiers(): string[] {
   return serverSafeSubpaths().map(subpath => `@nextlyhq/ui${subpath.slice(1)}`);
@@ -158,42 +182,36 @@ function consumerSpecifiers(): string[] {
 /**
  * Write the project, its manifest, and both probes.
  *
- * The manifest declares the allow-list and nothing else, which is what makes the boundary real:
- * `npm install` in this directory brings in exactly the packages a server-safe entry point is
- * permitted to reach, and the package under test is placed beside them afterwards rather than
- * installed, so its own dependency set is never resolved.
+ * The manifest declares the allow-list and nothing else, so `npm install` here brings in exactly
+ * the packages a server-safe entry point is permitted to reach. The package under test is placed
+ * beside them afterwards rather than installed, so its own dependency set is never resolved, and
+ * the tripwires then occupy the names that set would have filled.
  */
 function write(target: string): void {
   mkdirSync(target, { recursive: true });
 
-  const dependencies = allowedDependencies();
+  // A marker or log left by an earlier run survives the failure they exist to catch: an artifact
+  // calling `process.exit(0)` during initialisation ends its probe with status 0 before the final
+  // write, and verification then reads the previous run's evidence about artifacts never loaded.
+  for (const stale of [...Object.values(MARKERS), REACHED_LOG]) {
+    rmSync(join(target, stale), { force: true });
+  }
+
   writeFileSync(
     join(target, "package.json"),
-    `${JSON.stringify({ name: "server-safe-isolation-probe", private: true, version: "1.0.0", dependencies }, null, 2)}\n`
+    `${JSON.stringify(
+      {
+        name: "server-safe-isolation-probe",
+        private: true,
+        version: "1.0.0",
+        dependencies: allowedDependencies(),
+      },
+      null,
+      2
+    )}\n`
   );
 
-  const subpaths = serverSafeSubpaths();
-  const sentinel = forbiddenSentinel();
   const specifiers = consumerSpecifiers();
-
-  // RESOLVED, never loaded. Loading answers a wider question than this asks: it runs the module,
-  // so a package that IS present reports itself absent whenever its own initialiser fails — an
-  // incompatible release, a broken optional dependency of its own, anything that throws. Several
-  // of those failures carry the very error code that means "not installed", so no amount of
-  // narrowing the catch separates them; the two cases are indistinguishable once evaluation is
-  // allowed to happen at all.
-  //
-  // Resolution decides presence without executing anything, so the only module whose absence can
-  // be reported is the one named here. Each probe uses its own system's resolver, and neither can
-  // be confused by what the package would have done had it run.
-  const sentinelProbe = (resolve: string) => `let sentinelReached = false;
-try {
-  ${resolve};
-  sentinelReached = true;
-} catch (error) {
-  const code = error && typeof error === "object" ? error.code : undefined;
-  if (code !== "ERR_MODULE_NOT_FOUND" && code !== "MODULE_NOT_FOUND") throw error;
-}`;
 
   // Both module systems, because the export map publishes both and a consumer arriving through
   // `require` resolves different files. Checking one leaves the other's artifacts evaluated by
@@ -206,8 +224,7 @@ for (const specifier of ${JSON.stringify(specifiers)}) {
   const module = await import(specifier);
   loaded[specifier] = Object.keys(module).length;
 }
-${sentinelProbe(`import.meta.resolve(${JSON.stringify(sentinel)})`)}
-writeFileSync(${JSON.stringify(MARKERS.esm)}, JSON.stringify({ loaded, sentinelReached }));
+writeFileSync(${JSON.stringify(MARKERS.esm)}, JSON.stringify({ loaded }));
 `
   );
 
@@ -219,111 +236,139 @@ for (const specifier of ${JSON.stringify(specifiers)}) {
   const module = require(specifier);
   loaded[specifier] = Object.keys(module).length;
 }
-${sentinelProbe(`require.resolve(${JSON.stringify(sentinel)})`)}
-writeFileSync(${JSON.stringify(MARKERS.cjs)}, JSON.stringify({ loaded, sentinelReached }));
+writeFileSync(${JSON.stringify(MARKERS.cjs)}, JSON.stringify({ loaded }));
 `
   );
 
   console.log(
-    `Wrote an isolation probe for ${subpaths.length} server-safe subpaths (${subpaths.join(", ")}) ` +
-      `to ${target}. Allowed dependencies: ` +
-      `${Object.entries(dependencies)
-        .map(([name, range]) => `${name}@${range}`)
-        .join(", ")}. Isolation is demonstrated by ${sentinel} failing to load.`
+    `Wrote an isolation probe for ${specifiers.length} server-safe subpaths to ${target}. Allowed: ` +
+      `${Object.keys(allowedDependencies()).join(", ")}.`
   );
 }
 
 /**
- * Remove every artifact the server-safe subpaths do not own.
+ * Place a tripwire at every forbidden name, and remove the artifacts the server-safe subpaths do
+ * not own.
  *
- * The export map refuses a deep import, so a client subpath cannot be reached by name. A RELATIVE
- * import from inside a server-safe artifact is a different route and the map has nothing to say
- * about it, so those files are deleted rather than left present and unreachable-by-name.
+ * Runs after the install and the unpack, because both would overwrite what it puts down.
+ *
+ * The log path is absolute and baked in at write time. A tripwire computing it from its own
+ * location would have to know how deep it sits, which differs between a scoped and an unscoped
+ * name — and a wire that writes its evidence to the wrong path reports nothing, which is the one
+ * failure mode that looks exactly like success.
  */
-function prune(target: string): void {
+function arm(target: string): void {
   const dist = join(target, INSTALLED, "dist");
   if (!existsSync(dist)) {
     throw new Error(
-      `${dist} does not exist, so there is nothing to prune and the probe would run against a ` +
-        "package that was never placed. Extract the packed tarball there first."
+      `${dist} does not exist, so the package under test was never placed and the probe would run ` +
+        "against nothing. Extract the packed tarball there first."
     );
   }
-  const removed: string[] = [];
-  for (const artifact of clientArtifacts()) {
-    const path = join(dist, artifact);
-    if (existsSync(path)) {
-      rmSync(path);
-      removed.push(artifact);
-    }
+
+  const logPath = join(target, REACHED_LOG);
+  for (const name of forbiddenPackages()) {
+    const home = join(target, "node_modules", ...name.split("/"));
+    mkdirSync(home, { recursive: true });
+
+    // `appendFileSync` before the throw, so evidence exists whatever the caller does with the
+    // error. Appended rather than written, because several tripwires may be reached in one run and
+    // a rewrite would leave only the last.
+    const body =
+      `require("node:fs").appendFileSync(${JSON.stringify(logPath)}, ${JSON.stringify(`${name}\n`)});\n` +
+      `throw new Error(${JSON.stringify(`${name} is not available to a server-safe entry point.`)});\n`;
+    writeFileSync(join(home, "index.cjs"), body);
+    writeFileSync(
+      join(home, "index.mjs"),
+      `import { appendFileSync } from "node:fs";\n` +
+        `appendFileSync(${JSON.stringify(logPath)}, ${JSON.stringify(`${name}\n`)});\n` +
+        `throw new Error(${JSON.stringify(`${name} is not available to a server-safe entry point.`)});\n`
+    );
+    writeFileSync(
+      join(home, "package.json"),
+      `${JSON.stringify(
+        {
+          name,
+          version: "0.0.0",
+          main: "index.cjs",
+          exports: {
+            ".": { import: "./index.mjs", require: "./index.cjs" },
+            "./*": "./index.cjs",
+          },
+        },
+        null,
+        2
+      )}\n`
+    );
+    writeFileSync(join(home, TRIPWIRE_MARKER), "");
   }
+
+  // The export map refuses a deep import, so a client subpath cannot be reached by name. A
+  // RELATIVE import from inside a server-safe artifact is a different route the map says nothing
+  // about, so those files are deleted rather than left present.
+  const removed = clientArtifacts().filter(artifact => {
+    const path = join(dist, artifact);
+    if (!existsSync(path)) return false;
+    rmSync(path);
+    return true;
+  });
   if (removed.length === 0) {
     throw new Error(
       "No client artifacts were removed. Either the build produced none — in which case the " +
-        "package has no client surface and this check is asserting less than it appears to — or " +
-        "the tarball was extracted somewhere other than the path above."
+        "package has no client surface and this check asserts less than it appears to — or the " +
+        "tarball was extracted somewhere other than the path above."
     );
   }
-  console.log(`Removed ${removed.length} client artifacts from ${dist}.`);
+  console.log(
+    `Armed ${forbiddenPackages().length} tripwires and removed ${removed.length} client artifacts.`
+  );
 }
 
 /**
- * Every package name present at the top level of the probe project.
+ * Read what the run left behind, rather than trusting that the probes exited 0.
  *
- * A scope directory is not a package — `@radix-ui` holds them — so it is descended into and its
- * children reported as scoped names.
- */
-function installedPackages(target: string): string[] {
-  const root = join(target, "node_modules");
-  if (!existsSync(root)) return [];
-  const names: string[] = [];
-  for (const entry of readdirSync(root, { withFileTypes: true })) {
-    if (entry.name.startsWith(".")) continue;
-    if (entry.name.startsWith("@")) {
-      for (const scoped of readdirSync(join(root, entry.name))) {
-        if (!scoped.startsWith(".")) names.push(`${entry.name}/${scoped}`);
-      }
-      continue;
-    }
-    names.push(entry.name);
-  }
-  return names;
-}
-
-/**
- * Packages the probe project holds that a server-safe entry point may not reach.
- *
- * The sentinel answers a question about ONE name, and npm's default layout can add others without
- * touching it: a hoisted install lifts every non-duplicated transitive dependency to the top level,
- * so the day an allowed package gains a dependency of its own, that dependency becomes directly
- * resolvable by the package under test while the sentinel stays missing and both probes still pass.
- *
- * This enumerates what is actually there instead, so a package arriving by any route — hoisting, a
- * lockfile change, a hand-placed directory — is reported by name rather than having to have been
- * predicted. `@nextlyhq/ui` is expected because it is the subject, placed deliberately.
- */
-function unexpectedlyInstalled(target: string): string[] {
-  const permitted = new Set([...SERVER_SAFE_ALLOWED_PACKAGES, "@nextlyhq/ui"]);
-  const unexpected = installedPackages(target)
-    .filter(name => !permitted.has(name))
-    .sort();
-  if (unexpected.length === 0) return [];
-  return [
-    `The probe project holds ${unexpected.length} package(s) outside the allow-list: ` +
-      `${unexpected.join(", ")}. Each is resolvable by the package under test, so the boundary ` +
-      "these probes report on is wider than the allow-list they are checking against.",
-  ];
-}
-
-/**
- * Read what the probes recorded, rather than trusting that they exited 0.
- *
- * A module that ends the process while it initialises exits 0 from inside the import being
- * checked, so the exit status of a probe cannot distinguish "imported everything" from "died on
- * the first one". The marker is written last and is the only evidence that the run completed.
+ * A module that ends the process while it initialises exits 0 from inside the import being checked,
+ * so the exit status of a probe cannot distinguish "imported everything" from "died on the first
+ * one". The marker is written last and is the only evidence that a run completed.
  */
 function verify(target: string): void {
   const expected = consumerSpecifiers();
-  const problems: string[] = [...unexpectedlyInstalled(target)];
+  const problems: string[] = [];
+
+  // The instrument first. A tripwire that is no longer a tripwire means the real package was
+  // installed over it, and every "no wire tripped" result below would then be reporting on a
+  // project that never had the boundary it claims to be testing.
+  const disarmed = forbiddenPackages().filter(
+    name =>
+      !existsSync(
+        join(target, "node_modules", ...name.split("/"), TRIPWIRE_MARKER)
+      )
+  );
+  if (disarmed.length > 0) {
+    problems.push(
+      `${disarmed.length} of ${forbiddenPackages().length} tripwires are missing or were replaced ` +
+        `by a real package (${disarmed.slice(0, 5).join(", ")}${disarmed.length > 5 ? ", ..." : ""}). ` +
+        "Nothing was watching those names, so this run cannot report on them either way."
+    );
+  }
+
+  const logPath = join(target, REACHED_LOG);
+  if (existsSync(logPath)) {
+    const reached = [
+      ...new Set(
+        readFileSync(logPath, "utf8")
+          .split("\n")
+          .filter(line => line.length > 0)
+      ),
+    ].sort();
+    if (reached.length > 0) {
+      problems.push(
+        `A server-safe entry point reached ${reached.join(", ")}. Whether the attempt threw is not ` +
+          "the question: it fails here only because this package is a stand-in, and the same " +
+          "request succeeds in a consumer where the real package is installed."
+      );
+    }
+  }
 
   for (const [system, marker] of Object.entries(MARKERS)) {
     const path = join(target, marker);
@@ -336,16 +381,7 @@ function verify(target: string): void {
     }
     const record = JSON.parse(readFileSync(path, "utf8")) as {
       loaded: Record<string, number>;
-      sentinelReached: boolean;
     };
-
-    if (record.sentinelReached) {
-      problems.push(
-        `The ${system} probe loaded a package outside the allow-list, so the project it ran in was ` +
-          "not isolated and every other result from it is vacuous. The package under test was " +
-          "probably installed rather than placed, which resolves its whole dependency set."
-      );
-    }
 
     for (const specifier of expected) {
       const names = record.loaded[specifier];
@@ -366,23 +402,23 @@ function verify(target: string): void {
   }
   console.log(
     `Both probes loaded all ${expected.length} server-safe subpaths with non-empty exports, and ` +
-      "neither could reach a package outside the allow-list."
+      `none of the ${forbiddenPackages().length} tripwires was reached.`
   );
 }
 
-const MODES = new Set(["--prune", "--verify"]);
+const MODES = new Set(["--arm", "--verify"]);
 const flag = process.argv[2];
 const mode = MODES.has(flag) ? flag : undefined;
 const target = mode === undefined ? process.argv[2] : process.argv[3];
 
 if (target === undefined) {
   console.error(
-    "Usage: tsx scripts/write-server-safe-isolation-probe.ts [--prune|--verify] <directory>. The " +
+    "Usage: tsx scripts/write-server-safe-isolation-probe.ts [--arm|--verify] <directory>. The " +
       "directory is where the probe project is written; it is created if it does not exist."
   );
   process.exit(1);
 }
 
-if (mode === "--prune") prune(target);
+if (mode === "--arm") arm(target);
 else if (mode === "--verify") verify(target);
 else write(target);

--- a/packages/ui/scripts/write-server-safe-isolation-probe.ts
+++ b/packages/ui/scripts/write-server-safe-isolation-probe.ts
@@ -63,11 +63,21 @@
  * - **A load deferred behind a function.** These probes import each entry point and count its
  *   exports; a forbidden load inside an exported helper is never reached, because nothing calls it.
  *
- * Both are properties of runtime observation rather than defects here, and neither is closed by the
- * source ban either: it catches the plain spellings and says in its own header that computed host
- * access such as `globalThis["pro" + "cess"]` is outside what reading syntax can recognise. So a
- * COMPUTED resolver form that only resolves, or that sits behind an uncalled function, is currently
- * covered by neither check. That is written here rather than left for a green run to imply.
+ * - **A package this one does not declare.** The wires are placed at names derivable from the
+ *   manifest and the install. `next` is neither, yet it resolves in the consumer this package
+ *   ships into — so a caught, computed `createRequire(...)("next")` succeeds there and trips
+ *   nothing here. Wiring it would mean naming packages a consumer MIGHT have, which is unbounded
+ *   and cannot be derived from anything this repository holds.
+ *
+ * All three are properties of runtime observation rather than defects here, and none is closed by
+ * the source ban either: it catches the plain spellings and says in its own header that computed
+ * host access such as `globalThis["pro" + "cess"]` is outside what reading syntax can recognise. So
+ * a COMPUTED resolver form that only resolves, that sits behind an uncalled function, or that names
+ * a package this one never declares, is currently covered by neither check.
+ *
+ * That is written here rather than left for a green run to imply. The one mechanism that would
+ * close all three is a loader hook seeing every resolution whatever its shape, and the APIs for
+ * that do not span the supported Node range — which is the constraint, not an omission.
  *
  * Usage, from this package's directory:
  *   tsx scripts/write-server-safe-isolation-probe.ts <directory>            write the project
@@ -331,6 +341,13 @@ function arm(target: string): void {
   ].sort();
   for (const name of wired) {
     const home = join(target, "node_modules", ...name.split("/"));
+
+    // REPLACED, not overlaid. A name being wired may already hold a real package — a hoisted
+    // transitive is the ordinary case — and writing a manifest and two entry files over it leaves
+    // every other file it shipped exactly where it was. Those remain resolvable by absolute or
+    // computed path, so the wire would guard the entry point while the package's real code stayed
+    // reachable beside it, which is the boundary reporting on less than it appears to.
+    rmSync(home, { recursive: true, force: true });
     mkdirSync(home, { recursive: true });
 
     // `appendFileSync` before the throw, so evidence exists whatever the caller does with the

--- a/packages/ui/scripts/write-server-safe-isolation-probe.ts
+++ b/packages/ui/scripts/write-server-safe-isolation-probe.ts
@@ -125,6 +125,9 @@ const packageRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
 function manifest(): {
   dependencies?: Record<string, string>;
   peerDependencies?: Record<string, string>;
+  optionalDependencies?: Record<string, string>;
+  bundleDependencies?: string[] | boolean;
+  bundledDependencies?: string[] | boolean;
 } {
   return JSON.parse(readFileSync(join(packageRoot, "package.json"), "utf8"));
 }
@@ -157,18 +160,35 @@ function allowedDependencies(): Record<string, string> {
 /**
  * Every package a server-safe entry point may not reach but COULD obtain in a real consumer.
  *
- * Dependencies and peer dependencies together, because both resolve where this package is
- * installed — a peer is absent from `node_modules` here and present in the app that consumes it,
- * so leaving peers out would mean the routes most worth catching had no wire on them.
+ * Regular, peer AND optional dependencies together, because all three resolve where this package
+ * is installed. A peer is absent from `node_modules` here and present in the app that consumes it;
+ * an optional one installs for an ordinary consumer unless they pass `--omit=optional`. Leaving
+ * either out would mean the routes most worth catching had no wire on them.
  *
  * Derived by subtraction rather than listed, so a package added to the manifest is covered without
  * anyone remembering to come back here.
  */
 function forbiddenPackages(): string[] {
   const declared = manifest();
+
+  // A bundled dependency is packed INSIDE the tarball, so after extraction the real package sits
+  // at `@nextlyhq/ui/node_modules/<name>` — which resolution starting in `dist` reaches before the
+  // wire at the project's top level. The load would execute real code and leave no record, so this
+  // refuses rather than reporting on a boundary it does not model.
+  const bundled = declared.bundleDependencies ?? declared.bundledDependencies;
+  if (bundled !== undefined && bundled !== false) {
+    throw new Error(
+      "This package declares bundleDependencies. A bundled package is extracted beneath " +
+        "@nextlyhq/ui/node_modules and resolves ahead of a tripwire at the project's top level, so " +
+        "a forbidden load of one would run real code and leave no evidence. Wire the nested " +
+        "location as well before removing this refusal."
+    );
+  }
+
   const names = new Set([
     ...Object.keys(declared.dependencies ?? {}),
     ...Object.keys(declared.peerDependencies ?? {}),
+    ...Object.keys(declared.optionalDependencies ?? {}),
   ]);
   const forbidden = [...names]
     .filter(name => !SERVER_SAFE_ALLOWED_PACKAGES.has(name))
@@ -326,6 +346,25 @@ writeFileSync(${JSON.stringify(MARKERS.cjs)}, JSON.stringify({ loaded }));
  * resolvable by the package under test, and appears in no manifest this script reads — so deriving
  * from the manifest alone leaves exactly the packages nobody predicted without a wire.
  */
+/**
+ * A module that records being reached and then refuses.
+ *
+ * `appendFileSync` before the throw, so the evidence exists whatever the caller does with the
+ * error — that ordering is the whole mechanism. Appended rather than written, because several
+ * wires may be reached in one run and a rewrite would leave only the last.
+ */
+function wireBody(
+  logPath: string,
+  subject: string,
+  system: "cjs" | "esm"
+): string {
+  const record = `${JSON.stringify(logPath)}, ${JSON.stringify(`${subject}\n`)}`;
+  const refuse = `throw new Error(${JSON.stringify(`${subject} is not available to a server-safe entry point.`)});\n`;
+  return system === "cjs"
+    ? `require("node:fs").appendFileSync(${record});\n${refuse}`
+    : `import { appendFileSync } from "node:fs";\nappendFileSync(${record});\n${refuse}`;
+}
+
 function arm(target: string): void {
   const dist = join(target, INSTALLED, "dist");
   if (!existsSync(dist)) {
@@ -350,19 +389,8 @@ function arm(target: string): void {
     rmSync(home, { recursive: true, force: true });
     mkdirSync(home, { recursive: true });
 
-    // `appendFileSync` before the throw, so evidence exists whatever the caller does with the
-    // error. Appended rather than written, because several tripwires may be reached in one run and
-    // a rewrite would leave only the last.
-    const body =
-      `require("node:fs").appendFileSync(${JSON.stringify(logPath)}, ${JSON.stringify(`${name}\n`)});\n` +
-      `throw new Error(${JSON.stringify(`${name} is not available to a server-safe entry point.`)});\n`;
-    writeFileSync(join(home, "index.cjs"), body);
-    writeFileSync(
-      join(home, "index.mjs"),
-      `import { appendFileSync } from "node:fs";\n` +
-        `appendFileSync(${JSON.stringify(logPath)}, ${JSON.stringify(`${name}\n`)});\n` +
-        `throw new Error(${JSON.stringify(`${name} is not available to a server-safe entry point.`)});\n`
-    );
+    writeFileSync(join(home, "index.cjs"), wireBody(logPath, name, "cjs"));
+    writeFileSync(join(home, "index.mjs"), wireBody(logPath, name, "esm"));
     writeFileSync(
       join(home, "package.json"),
       `${JSON.stringify(
@@ -391,24 +419,30 @@ function arm(target: string): void {
     `${JSON.stringify(wired, null, 2)}\n`
   );
 
-  // The export map refuses a deep import, so a client subpath cannot be reached by name. A
-  // RELATIVE import from inside a server-safe artifact is a different route the map says nothing
-  // about, so those files are deleted rather than left present.
-  const removed = clientArtifacts().filter(artifact => {
+  // The client artifacts become wires too, rather than being deleted. Absence stops the load and
+  // reports nothing: a caught `createRequire(import.meta.url)("@nextlyhq/ui")` from a server-safe
+  // artifact would throw on a missing file and be swallowed, while the same self-reference
+  // resolves and evaluates the real client entry in a consumer where those files are present.
+  // Deleting them would reintroduce exactly the blind spot the wires were adopted to remove.
+  const rewired = clientArtifacts().filter(artifact => {
     const path = join(dist, artifact);
     if (!existsSync(path)) return false;
-    rmSync(path);
+    const subject = `@nextlyhq/ui client artifact ${artifact}`;
+    writeFileSync(
+      path,
+      wireBody(logPath, subject, artifact.endsWith(".cjs") ? "cjs" : "esm")
+    );
     return true;
   });
-  if (removed.length === 0) {
+  if (rewired.length === 0) {
     throw new Error(
-      "No client artifacts were removed. Either the build produced none — in which case the " +
+      "No client artifacts were replaced. Either the build produced none — in which case the " +
         "package has no client surface and this check asserts less than it appears to — or the " +
         "tarball was extracted somewhere other than the path above."
     );
   }
   console.log(
-    `Armed ${wired.length} tripwires and removed ${removed.length} client artifacts.`
+    `Armed ${wired.length} package tripwires and replaced ${rewired.length} client artifacts with wires.`
   );
 }
 

--- a/packages/ui/src/layering.test.ts
+++ b/packages/ui/src/layering.test.ts
@@ -447,11 +447,16 @@ describe("this package takes no direct dependency on the block engine", () => {
  *
  * A boundary that does not depend on recognising anything is to BUILD the package into a project
  * containing only the dependencies it is allowed to use, and run it: a load of anything else fails
- * at that moment, whatever spelling produced it. That is complete in the dimension this is weak
- * in, and blind where this is strong — it only sees code that actually executes, so a resolver
- * behind a branch never taken is invisible to it, and visible here. Neither replaces the other,
- * and neither belongs inside the other: one reads syntax without running anything, the other runs
- * everything without reading it.
+ * at that moment, whatever spelling produced it. That boundary EXISTS — it is
+ * `scripts/write-server-safe-isolation-probe.ts`, run by the server-safe job in
+ * `.github/workflows/package-smoke.yml`, and it refuses a computed specifier and an `eval`ed
+ * require without knowing what either one is.
+ *
+ * **It does not supersede this file, and this file must not be deleted because it exists.** It is
+ * complete in the dimension this is weak in, and blind where this is strong: it only sees code
+ * that actually EXECUTES, so a resolver behind a branch import-time evaluation never takes is
+ * invisible to it, and visible here. Neither belongs inside the other — one reads syntax without
+ * running anything, the other runs everything without reading it.
  */
 /**
  * The names that re-expose the global object, so `X.process` is the `process` binding itself.


### PR DESCRIPTION
Adds the other half of the server-safe guarantee: a boundary that refuses a forbidden load without having to recognise how it was spelled.

## Why

Every existing server-safe guard is a reader. The directive guard looks for a `"use client"` banner, the artifact gate compares what each built file reaches against an allow-list, and the source ban in `src/layering.test.ts` refuses runtime module resolution by naming the forms it permits.

Each is a model of what a consumer does, and a model answers for the cases it was taught. The source ban gained **fourteen forms over five rounds** of #673, and the rate was not falling when it landed. Every one was found by a person, not by the check. AGENTS.md: *prefer a boundary the system cannot cross to a check that looks for crossings.*

## The hole, measured

Packing `@nextlyhq/ui` and installing the tarball into an empty project pulls in **71 packages** — Radix, cmdk, sonner, lucide-react, react-dom, @tanstack. `SERVER_SAFE_ALLOWED_PACKAGES` is `{clsx, tailwind-merge}`.

So **69 of 71 packages a server-safe entry may not touch are installed beside it and resolvable at runtime**, and nothing observes a load. The mechanism is specific: those are `packages/ui`'s own declared `dependencies`, so npm installs them whenever the package is installed at all.

## What this does

Builds a project declaring **only** the allow-list, holding **only** the server-safe artifacts, and imports every server-safe subpath under both module systems. A load of anything else throws, because the file is not on disk.

Measured against five routes the source ban has to enumerate separately:

| route | outcome |
| --- | --- |
| dynamic `import("@radix-ui/react-dialog")` | `ERR_MODULE_NOT_FOUND` |
| `createRequire(...)("@radix-ui/react-dialog")` | `MODULE_NOT_FOUND` |
| specifier assembled at runtime | `ERR_MODULE_NOT_FOUND` |
| `eval("'require"')("cmdk")` | `ReferenceError` |
| deep import into the package | `ERR_PACKAGE_PATH_NOT_EXPORTED` |

Nothing recognises the computed specifier or the `eval`. That is the point.

## Why the package is EXTRACTED, not installed

`npm install <tarball>` reads the package manifest and resolves all 25 dependencies into the same tree, which is exactly the isolation being established. Unpacking places the files without ever consulting it.

That failure mode is silent, so the probes also assert that a package outside the allow-list **could not** be reached. Verified: in a project where the tarball was installed normally, both probes exit 0 and load everything — without that assertion `--verify` would have reported a clean pass over a completely unisolated run. It refuses instead.

## Break-verified

- **A real violation fails it.** Appending `await import("@radix-ui/react-accordion")` to a server-safe artifact: probe fails, `--verify` reports it.
- **A non-isolated environment fails it.** Both probes exit 0; `--verify` refuses both, naming the cause.
- **Positive control.** All 3 subpaths load with non-empty exports, and `cn("a","b") === "a b"`, which proves both allowed dependencies genuinely resolved rather than the import merely not throwing.

## Rejected alternatives, and why

All three runtime-interposition mechanisms fail against `engines.node` (`^20.19.0 || ^22.12.0 || >=24.0.0`):

- `module.registerHooks()` — v22.15.0+, above the `^20.19.0` floor.
- `module.register()` — runs on the floor, but **deprecated as of v25.9.0** and its CommonJS coverage is explicitly partial: it does not affect `require()` from `module.createRequire()`. A boundary with documented holes in the mechanism being guarded is not a boundary.
- Node permission model — `--allow-fs-read` does gate module loads, but the flag was renamed `--experimental-permission` → `--permission` in **v22.13.0**, and this range admits **v22.12.0**, one patch below. Also impractical around `next build`.

Dependency absence needs no Node version support at all.

## The source ban is NOT superseded

Execution only observes what **executes**. A resolver behind a branch import-time evaluation never takes is invisible here and visible to the source ban. `src/layering.test.ts` now records that it must not be deleted because this exists.

## Notes

- **No changeset:** `files` is `["dist","docs"]` and the tarball contains zero `scripts/` entries, so nothing published changes.
- Runs inside the existing server-safe job, reusing its pack and Node matrix.
- `packages/nextly` lint fails on an unbuilt tree with error-type noise; 21/21 pass after `pnpm run build`. This branch touches 3 files, none in that package.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added server-safe isolation checks covering all eligible package entry points in both ESM and CommonJS environments.
  * Added validation to detect unintended dependencies, client-only artifacts, missing exports, and incomplete probe execution.

* **Documentation**
  * Clarified the distinction between runtime isolation testing and existing static syntax checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->