### PR TITLE
fix(admin): label both ends of a date range

### DIFF
--- a/.changeset/labelled-date-ranges.md
+++ b/.changeset/labelled-date-ranges.md
@@ -1,0 +1,32 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+Label both ends of a date range, instead of relying on a placeholder that never renders.
+
+A date input paints its own `dd/mm/yyyy` format hint and ignores `placeholder` outright, so a range written that way drew two identical empty boxes with nothing saying which end was which. The same spelling renders correctly on text and number inputs, which is why it survived: the defect is specific to one input type and invisible in the source.
+
+Both date ranges in the admin -- the condition row and the entries filter menu -- now use one `RangeField` with real `<label>` elements bound to their inputs, and the pair is exposed as a named group. The filter menu had no accessible name on either input at all.

--- a/packages/admin/src/components/features/entries/EntryList/EntryTable.tsx
+++ b/packages/admin/src/components/features/entries/EntryList/EntryTable.tsx
@@ -16,7 +16,6 @@ import {
   DropdownMenuCheckboxItem,
   DropdownMenuLabel,
   DropdownMenuSeparator,
-  Input,
 } from "@nextlyhq/ui";
 import {
   useState,
@@ -28,6 +27,7 @@ import {
 
 import { Pencil, Trash2 } from "@admin/components/icons";
 import { Pagination } from "@admin/components/shared/pagination";
+import { RangeField } from "@admin/components/shared/range-field";
 import { DataTableView } from "@admin/components/ui/table/data-table";
 import type {
   DataTableSelection,
@@ -463,38 +463,28 @@ export const EntryTable = forwardRef<EntryTableRef, EntryTableProps>(
                       <p className="text-xs font-medium text-muted-foreground">
                         Created Date
                       </p>
-                      <div className="grid grid-cols-1 gap-2">
-                        <Input
-                          type="date"
-                          value={createdFrom}
-                          onChange={e => onCreatedFromChange?.(e.target.value)}
-                          placeholder="From"
-                        />
-                        <Input
-                          type="date"
-                          value={createdTo}
-                          onChange={e => onCreatedToChange?.(e.target.value)}
-                          placeholder="To"
-                        />
-                      </div>
+                      <RangeField
+                        label="Created date"
+                        type="date"
+                        orientation="column"
+                        from={createdFrom}
+                        to={createdTo}
+                        onFromChange={value => onCreatedFromChange?.(value)}
+                        onToChange={value => onCreatedToChange?.(value)}
+                      />
 
                       <p className="pt-1 text-xs font-medium text-muted-foreground">
                         Updated Date
                       </p>
-                      <div className="grid grid-cols-1 gap-2">
-                        <Input
-                          type="date"
-                          value={updatedFrom}
-                          onChange={e => onUpdatedFromChange?.(e.target.value)}
-                          placeholder="From"
-                        />
-                        <Input
-                          type="date"
-                          value={updatedTo}
-                          onChange={e => onUpdatedToChange?.(e.target.value)}
-                          placeholder="To"
-                        />
-                      </div>
+                      <RangeField
+                        label="Updated date"
+                        type="date"
+                        orientation="column"
+                        from={updatedFrom}
+                        to={updatedTo}
+                        onFromChange={value => onUpdatedFromChange?.(value)}
+                        onToChange={value => onUpdatedToChange?.(value)}
+                      />
 
                       <button
                         type="button"

--- a/packages/admin/src/components/features/schema-builder/field-editor-sheet/__tests__/ConditionBuilder.test.tsx
+++ b/packages/admin/src/components/features/schema-builder/field-editor-sheet/__tests__/ConditionBuilder.test.tsx
@@ -197,10 +197,10 @@ describe("ConditionBuilder -- value editor", () => {
         onChange={onChange}
       />
     );
-    await user.type(
-      screen.getByRole("spinbutton", { name: /condition value from/i }),
-      "5"
-    );
+    // Named "From" by its visible label now, inside a group named for the
+    // range. The old accessible name came from an `aria-label` that rendered
+    // nothing, which is why a date range showed two identical empty boxes.
+    await user.type(screen.getByRole("spinbutton", { name: "From" }), "5");
     expect(onChange).toHaveBeenCalledWith(
       expect.objectContaining({ value: { min: "5", max: "" } })
     );

--- a/packages/admin/src/components/field-ui/ConditionRow.test.tsx
+++ b/packages/admin/src/components/field-ui/ConditionRow.test.tsx
@@ -101,7 +101,7 @@ describe("editing one condition", () => {
     expect(screen.queryByLabelText("Condition value")).toBeNull();
   });
 
-  it("shows two inputs for a range", () => {
+  it("shows two labelled inputs for a range", () => {
     render(
       <ConditionRow
         condition={{ field: "count", operator: "between", value: { min: 1 } }}
@@ -109,8 +109,50 @@ describe("editing one condition", () => {
         onChange={vi.fn()}
       />
     );
-    expect(screen.getByLabelText("Condition value from")).toHaveValue(1);
-    expect(screen.getByLabelText("Condition value to")).toHaveValue(null);
+
+    const from = screen.getByLabelText("From");
+    const to = screen.getByLabelText("To");
+    expect(from).toHaveValue(1);
+    expect(to).toHaveValue(null);
+
+    // Bound by a real label rather than named by an `aria-label`. The pair used
+    // to be distinguished only by an accessible name and a placeholder, and a
+    // date input renders neither -- so both ends drew as the same empty
+    // `dd/mm/yyyy` box with nothing saying which was which.
+    const document = from.ownerDocument;
+    expect(document.querySelector(`label[for="${from.id}"]`)?.textContent).toBe(
+      "From"
+    );
+    expect(document.querySelector(`label[for="${to.id}"]`)?.textContent).toBe(
+      "To"
+    );
+
+    // The short labels are disambiguated by the group they sit in, which is
+    // what a screen reader announces on entry.
+    expect(
+      screen.getByRole("group", { name: "Condition value range" })
+    ).toBeTruthy();
+  });
+
+  it("labels a date range the same way, where a placeholder would not render", () => {
+    // The regression this guards is type-specific and therefore invisible in
+    // the markup: `placeholder="From"` renders on text and number inputs and is
+    // ignored outright on a date input. Asserting the number case alone would
+    // have stayed green through the whole defect.
+    render(
+      <ConditionRow
+        condition={{ field: "due", operator: "between", value: {} }}
+        sources={SOURCES}
+        onChange={vi.fn()}
+      />
+    );
+
+    const from = screen.getByLabelText("From");
+    expect(from.getAttribute("type")).toBe("date");
+    expect(from.getAttribute("placeholder")).toBeNull();
+    expect(
+      from.ownerDocument.querySelector(`label[for="${from.id}"]`)?.textContent
+    ).toBe("From");
   });
 
   it("falls back when the source no longer offers the stored operator", () => {

--- a/packages/admin/src/components/field-ui/ConditionRow.tsx
+++ b/packages/admin/src/components/field-ui/ConditionRow.tsx
@@ -28,6 +28,8 @@ import {
   SelectValue,
 } from "@nextlyhq/ui";
 
+import { RangeField } from "@admin/components/shared/range-field";
+
 /** Every operator a condition can use. */
 export type ConditionOperatorName =
   | "equals"
@@ -325,43 +327,34 @@ export function ConditionRow({
       </Select>
 
       {takesValue && operator === "between" ? (
-        <div className="grid grid-cols-2 gap-1">
-          <Input
-            type={numeric ? "number" : dated ? "date" : "text"}
-            aria-label="Condition value from"
-            // A visible placeholder, not only an aria-label. These fields start
-            // empty and carry no visible label, so without it the border is
-            // the only thing marking where the control is -- and the field
-            // border is deliberately below 1.4.11's 3:1 for controls that have
-            // other cues. This is the other cue.
-            placeholder="From"
-            disabled={readOnly}
-            value={rangeEnd(condition?.value, "min")}
-            onChange={event =>
-              emit({
-                value: {
-                  ...(isRange(condition?.value) ? condition.value : {}),
-                  min: event.target.value,
-                },
-              })
-            }
-          />
-          <Input
-            type={numeric ? "number" : dated ? "date" : "text"}
-            aria-label="Condition value to"
-            placeholder="To"
-            disabled={readOnly}
-            value={rangeEnd(condition?.value, "max")}
-            onChange={event =>
-              emit({
-                value: {
-                  ...(isRange(condition?.value) ? condition.value : {}),
-                  max: event.target.value,
-                },
-              })
-            }
-          />
-        </div>
+        // Labelled rather than placeholder-hinted. These fields start empty and
+        // the field border is deliberately below 1.4.11's 3:1 for controls that
+        // carry other cues, so the label IS the other cue -- and a placeholder
+        // cannot be it when the field is a date, because the control paints its
+        // own format hint and never renders the attribute.
+        <RangeField
+          label="Condition value range"
+          type={numeric ? "number" : dated ? "date" : "text"}
+          disabled={readOnly}
+          from={rangeEnd(condition?.value, "min")}
+          to={rangeEnd(condition?.value, "max")}
+          onFromChange={min =>
+            emit({
+              value: {
+                ...(isRange(condition?.value) ? condition.value : {}),
+                min,
+              },
+            })
+          }
+          onToChange={max =>
+            emit({
+              value: {
+                ...(isRange(condition?.value) ? condition.value : {}),
+                max,
+              },
+            })
+          }
+        />
       ) : takesValue && choices !== undefined ? (
         <Select
           value={scalar(condition?.value)}

--- a/packages/admin/src/components/shared/range-field/RangeField.test.tsx
+++ b/packages/admin/src/components/shared/range-field/RangeField.test.tsx
@@ -1,0 +1,126 @@
+/**
+ * The property under test is that each end of the range is labelled by
+ * something a user can SEE, and that the label is bound to its own input.
+ *
+ * An `aria-label` satisfies `getByLabelText` while rendering nothing a sighted
+ * user can see, and that is exactly what the markup this replaced carried:
+ * `aria-label="Condition value from"` plus a `placeholder` that a date input
+ * ignores. A query on the accessible name therefore passes on both the fixed
+ * and the broken version, so it is not the separating property.
+ *
+ * What separates them is a `<label>` ELEMENT whose `for` resolves to the input:
+ * rendered text, bound to a control. Hence `labelFor` below rather than a
+ * name-based assertion alone.
+ */
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { RangeField } from "./index";
+
+function labelFor(input: HTMLElement): HTMLLabelElement | null {
+  return input.ownerDocument.querySelector<HTMLLabelElement>(
+    `label[for="${input.id}"]`
+  );
+}
+
+describe("RangeField", () => {
+  it("labels each end with visible text bound to that input", () => {
+    render(
+      <RangeField
+        label="Created date"
+        type="date"
+        from=""
+        to=""
+        onFromChange={() => {}}
+        onToChange={() => {}}
+      />
+    );
+
+    const from = screen.getByLabelText("From");
+    const to = screen.getByLabelText("To");
+
+    // The name has to come from a real label element, not a placeholder: a date
+    // input ignores `placeholder` entirely, so a placeholder-named field is
+    // invisible in exactly the case this component exists for.
+    expect(labelFor(from)?.textContent).toBe("From");
+    expect(labelFor(to)?.textContent).toBe("To");
+    expect(from.getAttribute("placeholder")).toBeNull();
+    expect(to.getAttribute("placeholder")).toBeNull();
+
+    // Distinct ids, so each label points at its own control rather than both
+    // resolving to the first.
+    expect(from.id).not.toBe(to.id);
+  });
+
+  it("gives two instances different ids", () => {
+    // Two ranges on one page is the normal case (created and updated), and
+    // hand-built ids collide there, which silently points one range's labels at
+    // the other's inputs.
+    render(
+      <>
+        <RangeField
+          label="Created date"
+          from=""
+          to=""
+          onFromChange={() => {}}
+          onToChange={() => {}}
+          fromLabel="Created after"
+          toLabel="Created before"
+        />
+        <RangeField
+          label="Updated date"
+          from=""
+          to=""
+          onFromChange={() => {}}
+          onToChange={() => {}}
+          fromLabel="Updated after"
+          toLabel="Updated before"
+        />
+      </>
+    );
+
+    const ids = [
+      screen.getByLabelText("Created after").id,
+      screen.getByLabelText("Created before").id,
+      screen.getByLabelText("Updated after").id,
+      screen.getByLabelText("Updated before").id,
+    ];
+    expect(new Set(ids).size).toBe(4);
+  });
+
+  it("names the pair as a group", () => {
+    render(
+      <RangeField
+        label="Created date"
+        from=""
+        to=""
+        onFromChange={() => {}}
+        onToChange={() => {}}
+      />
+    );
+    expect(screen.getByRole("group", { name: "Created date" })).toBeTruthy();
+  });
+
+  it("reports each end separately", () => {
+    const onFromChange = vi.fn();
+    const onToChange = vi.fn();
+    render(
+      <RangeField
+        label="Created date"
+        from="2026-01-01"
+        to="2026-02-01"
+        onFromChange={onFromChange}
+        onToChange={onToChange}
+      />
+    );
+
+    // Values land on the right control. Swapping them is the kind of mistake a
+    // labelled-but-unasserted component makes look correct.
+    expect((screen.getByLabelText("From") as HTMLInputElement).value).toBe(
+      "2026-01-01"
+    );
+    expect((screen.getByLabelText("To") as HTMLInputElement).value).toBe(
+      "2026-02-01"
+    );
+  });
+});

--- a/packages/admin/src/components/shared/range-field/RangeField.test.tsx
+++ b/packages/admin/src/components/shared/range-field/RangeField.test.tsx
@@ -13,6 +13,7 @@
  * name-based assertion alone.
  */
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 
 import { RangeField } from "./index";
@@ -101,26 +102,51 @@ describe("RangeField", () => {
     expect(screen.getByRole("group", { name: "Created date" })).toBeTruthy();
   });
 
-  it("reports each end separately", () => {
-    const onFromChange = vi.fn();
-    const onToChange = vi.fn();
+  it("shows each end's value on its own control", () => {
     render(
       <RangeField
         label="Created date"
         from="2026-01-01"
         to="2026-02-01"
-        onFromChange={onFromChange}
-        onToChange={onToChange}
+        onFromChange={() => {}}
+        onToChange={() => {}}
       />
     );
 
-    // Values land on the right control. Swapping them is the kind of mistake a
-    // labelled-but-unasserted component makes look correct.
     expect((screen.getByLabelText("From") as HTMLInputElement).value).toBe(
       "2026-01-01"
     );
     expect((screen.getByLabelText("To") as HTMLInputElement).value).toBe(
       "2026-02-01"
     );
+  });
+
+  it("reports each end through its own callback", async () => {
+    // The controls are TYPED INTO rather than merely rendered. Passing two
+    // spies and then asserting only the values `from` and `to` supplied would
+    // leave both spies uncalled, so dropping a handler or wiring both ends to
+    // the same one would pass -- the props go in, nothing checks they come out.
+    const user = userEvent.setup();
+    const onFromChange = vi.fn();
+    const onToChange = vi.fn();
+    render(
+      <RangeField
+        label="Created date"
+        from=""
+        to=""
+        onFromChange={onFromChange}
+        onToChange={onToChange}
+      />
+    );
+
+    await user.type(screen.getByLabelText("From"), "a");
+    expect(onFromChange).toHaveBeenCalledWith("a");
+    // The other end stays silent, which is what separates correct wiring from
+    // both inputs reporting through one handler.
+    expect(onToChange).not.toHaveBeenCalled();
+
+    await user.type(screen.getByLabelText("To"), "b");
+    expect(onToChange).toHaveBeenCalledWith("b");
+    expect(onFromChange).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/admin/src/components/shared/range-field/index.tsx
+++ b/packages/admin/src/components/shared/range-field/index.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import { Input } from "@nextlyhq/ui";
+import { useId } from "react";
+
+import { cn } from "@admin/lib/utils";
+
+/**
+ * A pair of inputs bounding a range, each with a REAL label rather than a
+ * placeholder.
+ *
+ * The distinction is not stylistic. A `placeholder` on `<input type="date">` is
+ * never rendered — the control paints its own format hint (`dd/mm/yyyy`) and
+ * ignores the attribute entirely — so a date range written that way shows two
+ * identical boxes with nothing saying which end is which. Measured in a browser:
+ * `placeholder="From"` and `placeholder="To"` on adjacent date inputs render
+ * indistinguishably, while the same placeholders on `text` and `number` inputs
+ * render fine. That is why the bug hid: it is invisible in the spelling and only
+ * appears for one input type.
+ *
+ * Labels are used for every type rather than only for dates. Two reasons, and
+ * the second is the one that matters:
+ *
+ * - a placeholder disappears the moment a value is typed, so it labels an empty
+ *   field and nothing else;
+ * - the input type here is chosen by the field the user picked, so labelling
+ *   only dates would make the row change height when they switch fields.
+ */
+export interface RangeFieldProps {
+  /** Names the pair for assistive technology, e.g. "Created date". */
+  label: string;
+  type?: "date" | "number" | "text";
+  from: string;
+  to: string;
+  onFromChange: (value: string) => void;
+  onToChange: (value: string) => void;
+  /** Wording for the two ends, where "From"/"To" does not read naturally. */
+  fromLabel?: string;
+  toLabel?: string;
+  disabled?: boolean;
+  /**
+   * `row` places the two inputs side by side, `column` stacks them. A narrow
+   * container — a filter menu — has no room for two date inputs in a row.
+   */
+  orientation?: "row" | "column";
+  className?: string;
+}
+
+export function RangeField({
+  label,
+  type = "text",
+  from,
+  to,
+  onFromChange,
+  onToChange,
+  fromLabel = "From",
+  toLabel = "To",
+  disabled = false,
+  orientation = "row",
+  className,
+}: RangeFieldProps) {
+  // Generated rather than derived from `label`, because two ranges can share a
+  // label in different parts of a page and duplicate ids would point every
+  // label at the first input.
+  const id = useId();
+  const fromId = `${id}-from`;
+  const toId = `${id}-to`;
+
+  return (
+    <div
+      role="group"
+      aria-label={label}
+      className={cn(
+        "grid gap-2",
+        orientation === "row" ? "grid-cols-2" : "grid-cols-1",
+        className
+      )}
+    >
+      <div className="space-y-1">
+        <label
+          htmlFor={fromId}
+          className="block text-xs font-medium text-muted-foreground"
+        >
+          {fromLabel}
+        </label>
+        <Input
+          id={fromId}
+          type={type}
+          value={from}
+          disabled={disabled}
+          onChange={event => onFromChange(event.target.value)}
+        />
+      </div>
+      <div className="space-y-1">
+        <label
+          htmlFor={toId}
+          className="block text-xs font-medium text-muted-foreground"
+        >
+          {toLabel}
+        </label>
+        <Input
+          id={toId}
+          type={type}
+          value={to}
+          disabled={disabled}
+          onChange={event => onToChange(event.target.value)}
+        />
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Follow-up to #720, which weakened the field border and added `placeholder="From"` / `placeholder="To"` as the compensating cue. On a date input that cue never appears.

## What actually renders

Measured in a browser rather than inferred:

| markup | what the user sees |
| --- | --- |
| `<input type="date" placeholder="From">` | `dd/mm/yyyy` and a calendar icon — the placeholder is **ignored** |
| the two range inputs together | **identical**; nothing says which end is which |
| `<input type="text" placeholder="From">` | renders "From" correctly |

So the defect belongs to one input type and is invisible in the source: the same spelling is correct on text and number inputs and silently wrong on dates. That is why it survived.

The single date input is fine on its own and is left alone — a date field is self-evidently a date field. The reported problem is real for the **range**, where the two ends are indistinguishable.

## Scope

It was in two places, not one. `ConditionRow` had `aria-label`s that named the fields for assistive technology while showing a sighted user nothing. `EntryTable`'s filter menu — two ranges, Created and Updated — had **no accessible name on any of the four inputs at all**, so it was worse.

Both now use one `RangeField`:

- real `<label>` elements bound by `htmlFor`, so the text renders **and** is announced;
- ids from `useId`, because two ranges on one page is the normal case and hand-built ids would point one range's labels at the other's inputs;
- `role="group"` with a name, so "From" is disambiguated by what a screen reader announces on entry;
- `orientation` for the stacked filter-menu layout versus the side-by-side condition row.

Labels are used for **every** range type rather than only dates. A placeholder stops labelling a field the moment a value is typed, and the input type here follows whichever field the user picked — so labelling only dates would change the row's height when they switch fields.

## On the test

`getByLabelText` matches an `aria-label`, so it passes on both the fixed and the broken version — it is not the separating property. Verified: with the label swapped back to an `aria-label`, three of the four assertions still pass and only the one checking for a bound `<label>` element fails. That assertion is the test.

There is also a case pinned specifically on the **date** branch, because asserting the number case alone would have stayed green through the entire defect.

## Verification

- admin suite 27 failed / 6 files, unchanged from `main`'s baseline; the 4 new tests pass
- `check-types` and `lint` clean
- rendering confirmed in a browser, before and after
