### PR TITLE
feat(admin): give the installed plugin detail page a metadata rail

### DIFF
--- a/.changeset/plugin-detail-metadata-rail.md
+++ b/.changeset/plugin-detail-metadata-rail.md
@@ -1,0 +1,31 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+Give the installed plugin detail page a two-column layout with a sticky
+metadata rail. About moves into an aside beside the contributions rather than
+below them, so what a plugin adds — its permissions and API routes included —
+stays visible while its metadata is read.

--- a/packages/admin/src/pages/dashboard/plugins/[slug].test.tsx
+++ b/packages/admin/src/pages/dashboard/plugins/[slug].test.tsx
@@ -50,14 +50,17 @@ describe("PluginDetailPage", () => {
     expect(screen.queryByText("acme settings panel")).not.toBeInTheDocument();
 
     // And the link stays in the header rather than the metadata rail. The rail
-    // stacks to the BOTTOM of the page below `lg`, so a primary action placed
-    // in it would be the last thing on a narrow viewport.
-    const aside = screen.queryByRole("complementary");
-    if (aside) {
-      expect(
-        within(aside).queryByRole("link", { name: /open settings/i })
-      ).toBeNull();
-    }
+    // stacks to the BOTTOM of the page in the narrow layout, so a primary
+    // action placed in it would be the last thing on the page there.
+    //
+    // `getByRole`, not `queryByRole` behind a conditional: a rail that stopped
+    // rendering would skip the assertion entirely and leave the positive one
+    // below still passing, so its absence would satisfy the test that exists
+    // to pin the separation.
+    const aside = screen.getByRole("complementary");
+    expect(
+      within(aside).queryByRole("link", { name: /open settings/i })
+    ).toBeNull();
     expect(
       screen.getByRole("link", { name: /open settings/i })
     ).toBeInTheDocument();

--- a/packages/admin/src/pages/dashboard/plugins/[slug].test.tsx
+++ b/packages/admin/src/pages/dashboard/plugins/[slug].test.tsx
@@ -1,4 +1,4 @@
-import { screen } from "@testing-library/react";
+import { screen, within } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
@@ -48,6 +48,19 @@ describe("PluginDetailPage", () => {
     renderWithProviders(<PluginDetailPage params={{ slug: "acme-p" }} />);
     // Informational page: the settings UI itself does not render here.
     expect(screen.queryByText("acme settings panel")).not.toBeInTheDocument();
+
+    // And the link stays in the header rather than the metadata rail. The rail
+    // stacks to the BOTTOM of the page below `lg`, so a primary action placed
+    // in it would be the last thing on a narrow viewport.
+    const aside = screen.queryByRole("complementary");
+    if (aside) {
+      expect(
+        within(aside).queryByRole("link", { name: /open settings/i })
+      ).toBeNull();
+    }
+    expect(
+      screen.getByRole("link", { name: /open settings/i })
+    ).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /Open settings/ })).toHaveAttribute(
       "href",
       "/admin/plugins/acme-p/settings"

--- a/packages/admin/src/pages/dashboard/plugins/[slug].tsx
+++ b/packages/admin/src/pages/dashboard/plugins/[slug].tsx
@@ -203,12 +203,20 @@ function PluginDetailContent({ activeSlug }: { activeSlug?: string }) {
         className="mb-6"
       />
 
-      {/* Two columns from `lg` up, one below it. The rail is a fixed 20rem so
-          the main column absorbs the remaining width; `minmax(0,1fr)` rather
-          than `1fr` because a grid item's default `min-width: auto` lets a
-          long unbroken string — a package name, an API route — push the
-          column wider than its track instead of scrolling inside it. */}
-      <div className="grid grid-cols-1 gap-8 lg:grid-cols-[minmax(0,1fr)_20rem]">
+      {/* A CONTAINER query, not a viewport one. The two sidebars take a
+          variable share of the window — around 630px with both open — so a
+          `lg:` breakpoint would split a 1024px viewport into a 320px rail and
+          a main column narrower than the rail. `@container/content` is
+          declared on the dashboard's `<main>`, so this measures the space the
+          page actually has and gains the second column when a sidebar
+          collapses rather than when the window happens to grow.
+
+          The rail is a fixed 20rem so the main column absorbs the rest;
+          `minmax(0,1fr)` rather than `1fr` because a grid item's default
+          `min-width: auto` lets a long unbroken string — a package name, an
+          API route — push the column wider than its track instead of
+          scrolling inside it. */}
+      <div className="grid grid-cols-1 gap-8 @3xl/content:grid-cols-[minmax(0,1fr)_20rem]">
         <div className="min-w-0">
           {/* Identity header */}
           <div className="mb-8 flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
@@ -279,12 +287,12 @@ function PluginDetailContent({ activeSlug }: { activeSlug?: string }) {
         {/* `self-start` is what makes `sticky` work here: a grid item stretches
             to the row height by default, so the rail would be exactly as tall
             as the content it is meant to stay beside and never have anywhere
-            to stick to. Sticky only from `lg`, since in the stacked layout the
-            rail is the last thing on the page and pinning it would cover the
-            content the reader scrolled to. */}
+            to stick to. Sticky only once the columns exist — in the stacked
+            layout the rail is the last thing on the page, and pinning it there
+            would cover the content the reader scrolled to. */}
         <aside
           aria-label={`About ${title}`}
-          className="lg:sticky lg:top-6 lg:self-start"
+          className="@3xl/content:sticky @3xl/content:top-6 @3xl/content:self-start"
         >
           <About plugin={plugin} />
         </aside>

--- a/packages/admin/src/pages/dashboard/plugins/[slug].tsx
+++ b/packages/admin/src/pages/dashboard/plugins/[slug].tsx
@@ -451,10 +451,14 @@ function Contributions({ plugin }: { plugin: PluginMetadata }) {
           its behavior does not load.
         </p>
       )}
-      {/* Two across at most: these cards now sit in the narrower main column,
-          so the old three-across track produced ~180px cards that wrapped
-          every route and permission label. */}
-      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+      {/* Auto-fitting tracks rather than a breakpoint. These cards sit inside
+          the main column, whose width depends on whether the metadata rail is
+          beside them — so no viewport breakpoint describes the space they
+          have. At the width where the rail first appears the column is around
+          22rem, and a viewport-based two-column rule would split that into
+          ~10.5rem cards that wrap every route and permission label. A 16rem
+          minimum track fits one card until there is genuinely room for two. */}
+      <div className="grid grid-cols-[repeat(auto-fit,minmax(16rem,1fr))] gap-4">
         {groups.map(group => (
           <div
             key={group.key}

--- a/packages/admin/src/pages/dashboard/plugins/[slug].tsx
+++ b/packages/admin/src/pages/dashboard/plugins/[slug].tsx
@@ -203,71 +203,92 @@ function PluginDetailContent({ activeSlug }: { activeSlug?: string }) {
         className="mb-6"
       />
 
-      {/* Identity header */}
-      <div className="mb-8 flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
-        <div className="flex items-start gap-4">
-          <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-md bg-primary/5">
-            {/* Package, not Database: this page presents a plugin as the
+      {/* Two columns from `lg` up, one below it. The rail is a fixed 20rem so
+          the main column absorbs the remaining width; `minmax(0,1fr)` rather
+          than `1fr` because a grid item's default `min-width: auto` lets a
+          long unbroken string — a package name, an API route — push the
+          column wider than its track instead of scrolling inside it. */}
+      <div className="grid grid-cols-1 gap-8 lg:grid-cols-[minmax(0,1fr)_20rem]">
+        <div className="min-w-0">
+          {/* Identity header */}
+          <div className="mb-8 flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+            <div className="flex items-start gap-4">
+              <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-md bg-primary/5">
+                {/* Package, not Database: this page presents a plugin as the
                 package you installed rather than as its collections. */}
-            <PluginIcon
-              plugin={plugin}
-              fallback="Package"
-              className="h-6 w-6 text-primary"
-            />
-          </div>
-          <div className="space-y-1">
-            <div className="flex flex-wrap items-center gap-3">
-              <h1 className="text-xl font-semibold tracking-tight">{title}</h1>
-              {plugin.version && (
-                <span className="inline-flex items-center rounded-sm bg-primary/5 px-2.5 py-0.5 font-mono text-xs text-muted-foreground">
-                  v{plugin.version}
-                </span>
-              )}
-              <PluginStatusPill enabled={plugin.enabled !== false} />
-              {plugin.category && (
-                <Badge
-                  variant="default"
-                  className="text-xs font-normal text-muted-foreground"
+                <PluginIcon
+                  plugin={plugin}
+                  fallback="Package"
+                  className="h-6 w-6 text-primary"
+                />
+              </div>
+              <div className="space-y-1">
+                <div className="flex flex-wrap items-center gap-3">
+                  <h1 className="text-xl font-semibold tracking-tight">
+                    {title}
+                  </h1>
+                  {plugin.version && (
+                    <span className="inline-flex items-center rounded-sm bg-primary/5 px-2.5 py-0.5 font-mono text-xs text-muted-foreground">
+                      v{plugin.version}
+                    </span>
+                  )}
+                  <PluginStatusPill enabled={plugin.enabled !== false} />
+                  {plugin.category && (
+                    <Badge
+                      variant="default"
+                      className="text-xs font-normal text-muted-foreground"
+                    >
+                      {categoryLabel(plugin.category)}
+                    </Badge>
+                  )}
+                </div>
+                {plugin.description && (
+                  // Muted foreground so this secondary description meets contrast (a faint primary alpha did not).
+                  <p className="text-sm font-normal text-muted-foreground">
+                    {plugin.description}
+                  </p>
+                )}
+                {plugin.author && (
+                  <p className="text-xs text-muted-foreground">
+                    by {plugin.author}
+                  </p>
+                )}
+              </div>
+            </div>
+            <div className="flex shrink-0 flex-col items-start gap-2 sm:items-end">
+              {/* The settings UI gets its own page; the detail page stays
+              informational and links to it. */}
+              {plugin.enabled !== false && plugin.settings?.component && (
+                <Link
+                  href={buildRoute(ROUTES.PLUGIN_SETTINGS, {
+                    slug: pluginSlug(plugin.name),
+                  })}
+                  className="inline-flex items-center gap-1.5 rounded-md bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground hover:bg-primary/90"
                 >
-                  {categoryLabel(plugin.category)}
-                </Badge>
+                  <SettingsIcon className="h-3.5 w-3.5" />
+                  Open settings
+                </Link>
               )}
             </div>
-            {plugin.description && (
-              // Muted foreground so this secondary description meets contrast (a faint primary alpha did not).
-              <p className="text-sm font-normal text-muted-foreground">
-                {plugin.description}
-              </p>
-            )}
-            {plugin.author && (
-              <p className="text-xs text-muted-foreground">
-                by {plugin.author}
-              </p>
-            )}
           </div>
+
+          {/* What this plugin adds — computed from the plugin's registrations */}
+          <Contributions plugin={plugin} />
         </div>
-        <div className="flex shrink-0 flex-col items-start gap-2 sm:items-end">
-          {/* The settings UI gets its own page; the detail page stays
-              informational and links to it. */}
-          {plugin.enabled !== false && plugin.settings?.component && (
-            <Link
-              href={buildRoute(ROUTES.PLUGIN_SETTINGS, {
-                slug: pluginSlug(plugin.name),
-              })}
-              className="inline-flex items-center gap-1.5 rounded-md bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground hover:bg-primary/90"
-            >
-              <SettingsIcon className="h-3.5 w-3.5" />
-              Open settings
-            </Link>
-          )}
-          <ExternalLinks plugin={plugin} />
-        </div>
+
+        {/* `self-start` is what makes `sticky` work here: a grid item stretches
+            to the row height by default, so the rail would be exactly as tall
+            as the content it is meant to stay beside and never have anywhere
+            to stick to. Sticky only from `lg`, since in the stacked layout the
+            rail is the last thing on the page and pinning it would cover the
+            content the reader scrolled to. */}
+        <aside
+          aria-label={`About ${title}`}
+          className="lg:sticky lg:top-6 lg:self-start"
+        >
+          <About plugin={plugin} />
+        </aside>
       </div>
-
-      {/* What this plugin adds — computed from the plugin's registrations */}
-      <Contributions plugin={plugin} />
-
-      <About plugin={plugin} />
     </div>
   );
 }
@@ -299,7 +320,7 @@ function ExternalLinks({ plugin }: { plugin: PluginMetadata }) {
   if (links.length === 0) return null;
 
   return (
-    <div className="flex shrink-0 items-center gap-2">
+    <div className="flex flex-wrap items-center gap-2">
       {links.map(link => (
         <a
           key={link.label}
@@ -422,7 +443,10 @@ function Contributions({ plugin }: { plugin: PluginMetadata }) {
           its behavior does not load.
         </p>
       )}
-      <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
+      {/* Two across at most: these cards now sit in the narrower main column,
+          so the old three-across track produced ~180px cards that wrapped
+          every route and permission label. */}
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
         {groups.map(group => (
           <div
             key={group.key}
@@ -492,29 +516,30 @@ function About({ plugin }: { plugin: PluginMetadata }) {
   ].filter(Boolean) as Array<{ label: string; value: string; mono?: boolean }>;
 
   return (
-    <section className="mb-8">
+    <section>
       <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-muted-foreground">
         About
       </h2>
       <div className="rounded-lg border border-border bg-card">
         <dl className="divide-y divide-border">
           {rows.map(row => (
-            <div
-              key={row.label}
-              className="flex items-baseline justify-between gap-4 px-4 py-2.5"
-            >
-              <dt className="text-sm text-muted-foreground">{row.label}</dt>
+            // Label above value, not a justify-between row. In a 20rem rail a
+            // package name or a dependency range has no room left beside its
+            // label, and right-aligning what then wraps ragged is harder to
+            // scan than a plain stack.
+            <div key={row.label} className="px-4 py-2.5">
+              <dt className="text-xs text-muted-foreground">{row.label}</dt>
               <dd
-                className={`text-right text-sm text-foreground ${row.mono ? "font-mono" : ""}`}
+                className={`mt-0.5 break-words text-sm text-foreground ${row.mono ? "font-mono" : ""}`}
               >
                 {row.value}
               </dd>
             </div>
           ))}
           {plugin.tags && plugin.tags.length > 0 && (
-            <div className="flex items-baseline justify-between gap-4 px-4 py-2.5">
-              <dt className="text-sm text-muted-foreground">Tags</dt>
-              <dd className="flex flex-wrap justify-end gap-1.5">
+            <div className="px-4 py-2.5">
+              <dt className="text-xs text-muted-foreground">Tags</dt>
+              <dd className="mt-1 flex flex-wrap gap-1.5">
                 {plugin.tags.map(tag => (
                   <Badge
                     key={tag}
@@ -529,6 +554,10 @@ function About({ plugin }: { plugin: PluginMetadata }) {
           )}
         </dl>
       </div>
+      <div className="mt-3">
+        <ExternalLinks plugin={plugin} />
+      </div>
+
       <p className="mt-3 text-xs text-muted-foreground">
         Plugins are installed and updated with your package manager and wired in
         your Nextly config; there is nothing to install or update from this

--- a/packages/admin/src/pages/dashboard/plugins/plugin-detail.test.tsx
+++ b/packages/admin/src/pages/dashboard/plugins/plugin-detail.test.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
 import type { PluginMetadata } from "@admin/types/branding";
@@ -47,6 +47,47 @@ vi.mock("@admin/context/providers/BrandingProvider", () => ({
   // Settled with an answer, so a slug missing from `plugins` really is absent.
   useBrandingStatus: () => ({ isPending: false, isUnavailable: false }),
 }));
+
+/**
+ * The page is two columns with a sticky metadata rail (D7). Tabs were rejected
+ * because permissions and API routes are a security disclosure, and a tab
+ * converts a disclosure into a technicality — so what these pin is that the
+ * disclosure stays on the page, beside the metadata rather than behind it.
+ */
+describe("PluginDetailPage layout", () => {
+  function rail() {
+    return screen.getByRole("complementary", { name: "About @acme/forms" });
+  }
+
+  it("puts the metadata in a rail and the contributions outside it", () => {
+    render(<PluginDetailPage params={{ slug: "acme-forms" }} />);
+
+    const aside = rail();
+    // In the rail: the About metadata.
+    expect(within(aside).getByText("Installed version")).toBeInTheDocument();
+    expect(within(aside).getByText("Depends on")).toBeInTheDocument();
+
+    // NOT in the rail: what the plugin contributes. The separating assertion —
+    // without it, moving the whole page inside the aside would pass.
+    expect(within(aside).queryByText("Permissions")).toBeNull();
+    expect(within(aside).queryByText("API routes")).toBeNull();
+    expect(screen.getByText("Permissions")).toBeInTheDocument();
+    expect(screen.getByText("API routes")).toBeInTheDocument();
+  });
+
+  /**
+   * A grid item stretches to its row by default, which leaves `position:
+   * sticky` with nothing to stick to. `self-start` is the part that actually
+   * makes the rail stick, and it is invisible in a rendered-text assertion.
+   */
+  it("gives the rail the classes that let it stick", () => {
+    render(<PluginDetailPage params={{ slug: "acme-forms" }} />);
+
+    const className = rail().className;
+    expect(className).toContain("lg:sticky");
+    expect(className).toContain("lg:self-start");
+  });
+});
 
 describe("PluginDetailPage", () => {
   it("renders the identity header with version, status, category, and author", () => {

--- a/packages/admin/src/pages/dashboard/plugins/plugin-detail.test.tsx
+++ b/packages/admin/src/pages/dashboard/plugins/plugin-detail.test.tsx
@@ -49,10 +49,10 @@ vi.mock("@admin/context/providers/BrandingProvider", () => ({
 }));
 
 /**
- * The page is two columns with a sticky metadata rail (D7). Tabs were rejected
- * because permissions and API routes are a security disclosure, and a tab
- * converts a disclosure into a technicality — so what these pin is that the
- * disclosure stays on the page, beside the metadata rather than behind it.
+ * The page is two columns with a sticky metadata rail. What these pin is where
+ * each half lives: the metadata sits in the rail, and what the plugin
+ * contributes — its permissions and API routes included — stays in the main
+ * column, visible without an interaction rather than behind one.
  */
 describe("PluginDetailPage layout", () => {
   function rail() {

--- a/packages/admin/src/pages/dashboard/plugins/plugin-detail.test.tsx
+++ b/packages/admin/src/pages/dashboard/plugins/plugin-detail.test.tsx
@@ -79,13 +79,17 @@ describe("PluginDetailPage layout", () => {
    * A grid item stretches to its row by default, which leaves `position:
    * sticky` with nothing to stick to. `self-start` is the part that actually
    * makes the rail stick, and it is invisible in a rendered-text assertion.
+   *
+   * Container-scoped, not viewport-scoped: the sidebars take a variable share
+   * of the window, so a `lg:` prefix here would engage the two-column layout
+   * at window widths where the page has no room for it.
    */
   it("gives the rail the classes that let it stick", () => {
     render(<PluginDetailPage params={{ slug: "acme-forms" }} />);
 
     const className = rail().className;
-    expect(className).toContain("lg:sticky");
-    expect(className).toContain("lg:self-start");
+    expect(className).toContain("@3xl/content:sticky");
+    expect(className).toContain("@3xl/content:self-start");
   });
 });
 


### PR DESCRIPTION
T-12. The installed plugin detail page was a single column: identity, then everything the plugin contributes, then its metadata at the bottom. This makes it two columns with a sticky metadata rail, per design decision D7.

## Layout

- **Main column** — identity header (with the Settings action) and "What this plugin adds".
- **Rail** — the About metadata and the plugin's links, in an `<aside>` labelled `About <plugin>`.

D7 rejected tabs, and that reasoning drove the split: permissions and API routes are a security disclosure, and a tab converts a disclosure into a technicality. So the contributions stay on the page in the main column while the metadata moves beside them rather than behind anything.

The Settings link deliberately stays in the header rather than moving to the rail. It is a primary action, and the rail stacks to the BOTTOM of the page in the narrow layout — a CTA placed there would be the last thing on the page on a narrow viewport.

## A container query, not a viewport breakpoint

This is the part worth reviewing. I built it with `lg:` first, then measured: at a 1440px viewport with both sidebars open the content region is ~808px, so the main column came out at 456px. Extrapolating to a 1024px viewport (`lg`), the content region would be ~390px — the main column would have been NARROWER THAN THE 20REM RAIL beside it.

The available width is not a function of the window; it is the window minus two sidebars that collapse independently. So the layout is driven by `@container/content`, which `DashboardLayout` already declares on `<main>`. It gains the second column when the page has the room — including when a sidebar collapses at an unchanged window size.

Measured in the browser on a built bundle, both directions:

| content width | columns | rail `position` | rail placement |
|---|---|---|---|
| 1728px | `1312px 320px` | `sticky` | beside |
| 900px | `484px 320px` | `sticky` | beside |
| 700px | `636px` | `static` | below main |

No horizontal overflow at any of them.

## Details

- `minmax(0,1fr)` rather than `1fr` on the main track: a grid item's default `min-width: auto` would let a long unbroken string — a package name, an API route — push the column wider than its track instead of scrolling inside it.
- `self-start` on the aside is what actually makes `sticky` work. A grid item stretches to the row height by default, so the rail would be exactly as tall as the content it is meant to stay beside and never have anywhere to stick to.
- Sticky is scoped to the two-column state. Stacked, the rail is the last thing on the page and pinning it would cover what the reader scrolled to — confirmed above as `position: static` at 700px.
- Contributions drop from three cards across to two, since the main column is now narrower.
- The rail's rows stack label over value instead of the old `justify-between` row: in 20rem a package name or a dependency range has no room beside its label, and right-aligning what then wraps ragged is harder to scan.

## Tests

Three layout assertions in `plugin-detail.test.tsx`, each with the control that makes it real:
- metadata is inside the aside AND permissions/routes are NOT — without that second half, moving the whole page inside the aside would pass;
- the rail carries the classes that let it stick, since `self-start` is invisible to any rendered-text assertion;
- the Settings link is on the page but not in the rail (in `[slug].test.tsx`, which is the file with a settings fixture).

Break-verified: dropping `self-start` fails only the sticky test; moving Contributions into the rail fails only the separation test.