### PR TITLE
fix(ui): start both dev watchers on every platform, and prove it on the one that broke

### DIFF
--- a/.changeset/ui-dev-watchers-cross-platform.md
+++ b/.changeset/ui-dev-watchers-cross-platform.md
@@ -1,0 +1,30 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+Start both build watchers of `@nextlyhq/ui` on every platform. The `dev` script used a POSIX
+background-and-wait, which `cmd.exe` runs sequentially, so on Windows the first watcher held the
+line and the server-safe artifacts were never rebuilt — with no error, no exit code and no output.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -550,24 +550,30 @@ jobs:
             sleep 1
           done
 
-          # Checked BEFORE the kill. Producing both artifacts is not the whole claim: a pair of
-          # one-shot builds — `--watch` dropped by a later edit — writes exactly these files and
-          # then exits, and the loop above would break on the files and report success for a dev
-          # script that no longer watches anything. Still running is what makes them watchers.
-          alive=yes
-          kill -0 "$dev_pid" 2>/dev/null || alive=no
-
-          kill "$dev_pid" 2>/dev/null || true
-
           missing=""
           [ -f dist/index.mjs ] || missing="$missing client(dist/index.mjs)"
           [ -f dist/color.mjs ] || missing="$missing server-safe(dist/color.mjs)"
+          # Still running when the artifacts appear, checked BEFORE the kill.
+          #
+          # Stated plainly, because it is weaker than it looks: this does NOT separate a watcher
+          # from a one-shot build. tsup writes these files before its declaration phase, so a pair
+          # of one-shot builds is still alive at this moment too.
+          #
+          # The check that WOULD separate them is editing a source and requiring a rebuild. It is
+          # not here because `tsup --watch` in this package does not currently rebuild at all — it
+          # logs `Change detected` and emits nothing, measured on one watcher and on two, and on
+          # the shell script this replaced. That is a real defect and it is filed separately; a
+          # control that fails for a reason this pull request does not cause would only teach
+          # people to ignore it.
+          alive=yes
+          kill -0 "$dev_pid" 2>/dev/null || alive=no
+          kill "$dev_pid" 2>/dev/null || true
 
           if [ -n "$missing" ] || [ "$alive" = "no" ]; then
             [ -n "$missing" ] && echo "The dev script did not produce output for:$missing"
-            [ "$alive" = "no" ] && echo "The dev script exited instead of continuing to watch."
+            [ "$alive" = "no" ] && echo "The dev script exited before its outputs were complete."
             echo "--- dev script output ---"
             cat /tmp/dev.log
             exit 1
           fi
-          echo "Both watchers produced output and the script was still watching."
+          echo "Both commands produced their output and the script was still running."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -476,3 +476,89 @@ jobs:
           # avoids the multi-minute pnpm install during the smoke check.
           npm exec --yes --package="$tarball" -- create-nextly-app smoke-app --template blank --skip-install --yes
           test -f smoke-app/package.json && echo "scaffold ok"
+  # The `dev` script of `packages/ui` starts TWO watchers, and the shape it used
+  # before — `a --watch & b --watch & wait` — is POSIX. `cmd.exe` treats `&` as a
+  # SEQUENTIAL separator and has no `wait`, so on Windows the first watcher held
+  # the line and the second never ran. Nothing errored: a contributor saw a
+  # running dev server, a healthy client bundle, and stale server-safe artifacts
+  # beside it.
+  #
+  # A unit test now refuses that construct in any workspace script, which stops
+  # it being reintroduced. It cannot show that the REPLACEMENT works, and the
+  # replacement is where the risk moved: a runner that spawns one watcher
+  # correctly and drops the other fails exactly as silently as the shell did.
+  #
+  # So this runs the real script on the platform that had the bug and requires
+  # BOTH watchers to produce output. Windows is the subject; ubuntu is the
+  # control, because a check that fails on every platform says nothing about
+  # Windows in particular.
+  dev-script-smoke:
+    name: Dev script starts every watcher (${{ matrix.os }})
+    needs: [ci]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # The watchers compile this package's own sources, but its workspace
+      # dependencies still have to exist for the client entry to resolve them.
+      - name: Build the dependencies of the UI package
+        run: pnpm --filter @nextlyhq/ui^... build
+
+      # `shell: bash` on every leg, so one script covers all of them — Git Bash
+      # ships on the Windows runners. The dev script is still launched through
+      # pnpm, which is what puts `node_modules/.bin` on PATH; running the runner
+      # directly would fail to find `tsup` for reasons that have nothing to do
+      # with the property under test.
+      #
+      # `dist` is removed first so a file found afterwards was produced by THIS
+      # run. Without that, a previous build satisfies the assertion and the job
+      # passes with no watcher having started at all.
+      - name: Start the dev script and require every watcher to build
+        shell: bash
+        run: |
+          cd packages/ui
+          rm -rf dist
+          pnpm dev > /tmp/dev.log 2>&1 &
+          dev_pid=$!
+
+          # One artifact per watcher: `index.mjs` is the client config's, and
+          # `color.mjs` belongs to the server-safe config — the one the broken
+          # script never reached.
+          for _ in $(seq 1 120); do
+            if [ -f dist/index.mjs ] && [ -f dist/color.mjs ]; then break; fi
+            sleep 1
+          done
+
+          kill "$dev_pid" 2>/dev/null || true
+
+          missing=""
+          [ -f dist/index.mjs ] || missing="$missing client(dist/index.mjs)"
+          [ -f dist/color.mjs ] || missing="$missing server-safe(dist/color.mjs)"
+          if [ -n "$missing" ]; then
+            echo "The dev script did not produce output for:$missing"
+            echo "--- dev script output ---"
+            cat /tmp/dev.log
+            exit 1
+          fi
+          echo "Both watchers produced output."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -550,15 +550,24 @@ jobs:
             sleep 1
           done
 
+          # Checked BEFORE the kill. Producing both artifacts is not the whole claim: a pair of
+          # one-shot builds — `--watch` dropped by a later edit — writes exactly these files and
+          # then exits, and the loop above would break on the files and report success for a dev
+          # script that no longer watches anything. Still running is what makes them watchers.
+          alive=yes
+          kill -0 "$dev_pid" 2>/dev/null || alive=no
+
           kill "$dev_pid" 2>/dev/null || true
 
           missing=""
           [ -f dist/index.mjs ] || missing="$missing client(dist/index.mjs)"
           [ -f dist/color.mjs ] || missing="$missing server-safe(dist/color.mjs)"
-          if [ -n "$missing" ]; then
-            echo "The dev script did not produce output for:$missing"
+
+          if [ -n "$missing" ] || [ "$alive" = "no" ]; then
+            [ -n "$missing" ] && echo "The dev script did not produce output for:$missing"
+            [ "$alive" = "no" ] && echo "The dev script exited instead of continuing to watch."
             echo "--- dev script output ---"
             cat /tmp/dev.log
             exit 1
           fi
-          echo "Both watchers produced output."
+          echo "Both watchers produced output and the script was still watching."

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -72,7 +72,7 @@
     "build": "pnpm build:js && node scripts/build-css.mjs",
     "build:js": "rimraf dist && tsup && tsup --config tsup.server-safe.config.ts && tsx scripts/check-client-directive.ts && tsx scripts/check-server-safe-artifacts.ts",
     "build:css": "node scripts/build-css.mjs",
-    "dev": "tsup --watch & tsup --config tsup.server-safe.config.ts --watch & wait",
+    "dev": "node scripts/dev.mjs",
     "check-types": "tsc --noEmit && tsc --noEmit -p tsconfig.tests.json",
     "lint": "eslint . --max-warnings 0",
     "lint:fix": "eslint . --fix",

--- a/packages/ui/scripts/dev.mjs
+++ b/packages/ui/scripts/dev.mjs
@@ -11,25 +11,54 @@
  * server-safe artifacts beside it. The thing they would check — is the dev script running? —
  * answered yes. Nothing observable at the point of use distinguished it from working.
  *
+ * ## No shell, so the child IS the watcher
+ *
+ * `spawn("tsup", …, { shell: true })` is the obvious way to find the binary, and it makes the
+ * spawned process the SHELL rather than tsup. Killing it then kills `/bin/sh` or `cmd.exe` and can
+ * leave the watcher underneath running — so a failure in one watcher would tear down its sibling's
+ * shell while the sibling kept writing into `dist`, and Ctrl-C would leave processes behind.
+ *
+ * Resolving tsup's own entry and running it under this same Node removes the intermediary: the
+ * process this file holds a handle to is the one doing the work, `kill()` reaches it directly, and
+ * nothing depends on how a platform's shell resolves a name or forwards a signal.
+ *
  * ## Any exit is a failure, including a clean one
  *
  * These are watchers. They are meant to run until the developer stops them, so a watcher that
  * returns 0 has still stopped rebuilding artifacts, and forwarding that 0 would report SUCCESS to
  * the surrounding pnpm and turbo pipeline while every output silently went stale. That is the same
- * half-working state this file exists to expose, reintroduced one layer up. A child exiting is
- * therefore always reported and always non-zero, whatever code it used.
+ * half-working state this file exists to expose, reintroduced one layer up.
  *
  * The logging is unconditional for the same reason. Logging only on a non-zero code leaves the
  * clean exit — the case hardest to notice and easiest to misread as intentional — silent.
- *
- * ## Why this is a runtime invariant rather than a startup check
- *
- * Both children are spawned explicitly, so "the second one never started" cannot recur in the
- * original form. What the exit handler adds is broader: at no point during the session may either
- * watcher be absent. A future edit that breaks one of them fails loudly at the moment it happens
- * rather than producing artifacts nobody rebuilt.
  */
 import { spawn } from "node:child_process";
+import { createRequire } from "node:module";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const packageRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+const require = createRequire(join(packageRoot, "package.json"));
+
+/**
+ * The file tsup's `tsup` command actually runs.
+ *
+ * Read from the package's own manifest rather than assumed, because the path is tsup's to change
+ * between versions and a hard-coded one would break on an upgrade with a `MODULE_NOT_FOUND` that
+ * names this file instead of the cause.
+ */
+function tsupEntry() {
+  const manifestPath = require.resolve("tsup/package.json");
+  const { bin } = require(manifestPath);
+  const relative = typeof bin === "string" ? bin : bin?.tsup;
+  if (typeof relative !== "string") {
+    throw new Error(
+      "tsup's manifest declares no `tsup` binary, so there is nothing to run. Its `bin` field is " +
+        `${JSON.stringify(bin)}.`
+    );
+  }
+  return join(dirname(manifestPath), relative);
+}
 
 /**
  * The watchers, and what each one produces.
@@ -45,6 +74,7 @@ const WATCHERS = [
   },
 ];
 
+const entry = tsupEntry();
 const children = [];
 let stopping = false;
 
@@ -63,9 +93,10 @@ function stopAll() {
 }
 
 for (const { label, args } of WATCHERS) {
-  // `shell: true` so `tsup` resolves through the platform's own lookup, which on Windows means the
-  // `.cmd` shim npm installs rather than an extensionless file that `spawn` alone cannot execute.
-  const child = spawn("tsup", args, { stdio: "inherit", shell: true });
+  const child = spawn(process.execPath, [entry, ...args], {
+    cwd: packageRoot,
+    stdio: "inherit",
+  });
   children.push(child);
 
   child.on("error", error => {

--- a/packages/ui/scripts/dev.mjs
+++ b/packages/ui/scripts/dev.mjs
@@ -1,0 +1,97 @@
+/**
+ * Run this package's two build watchers together, on every platform.
+ *
+ * The script this replaces was `tsup --watch & tsup --config ... --watch & wait`, which is POSIX.
+ * pnpm runs scripts through `cmd.exe` on Windows, where `&` separates commands SEQUENTIALLY and
+ * `wait` is not a builtin — so the first watcher, which never exits by design, held the line and
+ * the second never started.
+ *
+ * The reason that survived is the shape of its failure rather than its subtlety. Nothing errored:
+ * a Windows contributor saw a dev server running, a healthy `dist/index.*`, and stale or absent
+ * server-safe artifacts beside it. The thing they would check — is the dev script running? —
+ * answered yes. Nothing observable at the point of use distinguished it from working.
+ *
+ * ## Any exit is a failure, including a clean one
+ *
+ * These are watchers. They are meant to run until the developer stops them, so a watcher that
+ * returns 0 has still stopped rebuilding artifacts, and forwarding that 0 would report SUCCESS to
+ * the surrounding pnpm and turbo pipeline while every output silently went stale. That is the same
+ * half-working state this file exists to expose, reintroduced one layer up. A child exiting is
+ * therefore always reported and always non-zero, whatever code it used.
+ *
+ * The logging is unconditional for the same reason. Logging only on a non-zero code leaves the
+ * clean exit — the case hardest to notice and easiest to misread as intentional — silent.
+ *
+ * ## Why this is a runtime invariant rather than a startup check
+ *
+ * Both children are spawned explicitly, so "the second one never started" cannot recur in the
+ * original form. What the exit handler adds is broader: at no point during the session may either
+ * watcher be absent. A future edit that breaks one of them fails loudly at the moment it happens
+ * rather than producing artifacts nobody rebuilt.
+ */
+import { spawn } from "node:child_process";
+
+/**
+ * The watchers, and what each one produces.
+ *
+ * Named so a failure says which output stopped being rebuilt. "the server-safe watcher exited" is
+ * actionable in a way that a bare exit code is not.
+ */
+const WATCHERS = [
+  { label: "client", args: ["--watch"] },
+  {
+    label: "server-safe",
+    args: ["--config", "tsup.server-safe.config.ts", "--watch"],
+  },
+];
+
+const children = [];
+let stopping = false;
+
+/**
+ * Stop every watcher that is still running.
+ *
+ * Guarded by `stopping` because this runs from both the exit handler and the signal handlers, and
+ * killing a child triggers the exit handler of its siblings — without the guard the first failure
+ * cascades into a loop of teardowns reporting each other.
+ */
+function stopAll() {
+  stopping = true;
+  for (const child of children) {
+    if (child.exitCode === null && child.signalCode === null) child.kill();
+  }
+}
+
+for (const { label, args } of WATCHERS) {
+  // `shell: true` so `tsup` resolves through the platform's own lookup, which on Windows means the
+  // `.cmd` shim npm installs rather than an extensionless file that `spawn` alone cannot execute.
+  const child = spawn("tsup", args, { stdio: "inherit", shell: true });
+  children.push(child);
+
+  child.on("error", error => {
+    console.error(`[ui] the ${label} watcher could not start: ${error.message}`);
+    stopAll();
+    process.exit(1);
+  });
+
+  child.on("exit", (code, signal) => {
+    if (stopping) return;
+    console.error(
+      `[ui] the ${label} watcher exited (code ${code ?? "null"}, signal ${signal ?? "none"}); ` +
+        "stopping the others, because its artifacts are no longer being rebuilt."
+    );
+    stopAll();
+    // Never the child's own code: 0 would tell the pipeline this task succeeded while the outputs
+    // it exists to produce have stopped changing.
+    process.exit(code === 0 || code === null ? 1 : code);
+  });
+}
+
+// Ctrl-C reaches this process, not the children, so they are told separately. Without this they
+// outlive the terminal that started them and keep writing into `dist`.
+for (const signal of ["SIGINT", "SIGTERM"]) {
+  process.on(signal, () => {
+    stopAll();
+    process.exit(0);
+  });
+}

--- a/packages/ui/src/__tests__/package-scripts-are-cross-platform.test.ts
+++ b/packages/ui/src/__tests__/package-scripts-are-cross-platform.test.ts
@@ -1,0 +1,106 @@
+/**
+ * No package script may background a process with `&` and then `wait` for it.
+ *
+ * That construct is POSIX. pnpm runs scripts through `cmd.exe` on Windows, where `&` separates
+ * commands SEQUENTIALLY and `wait` is not a builtin, so the first command holds the line and
+ * everything after it never runs. When the first command is a watcher — which never exits by
+ * design — the rest of the script is unreachable for the whole session.
+ *
+ * It is checked rather than merely fixed because of how it fails: nothing errors, nothing exits
+ * non-zero, and the developer sees a running process. `packages/ui` carried it while producing a
+ * healthy client bundle and stale server-safe artifacts beside it, and the fix — a `spawn` runner —
+ * is ordinary JavaScript that a later edit could plausibly collapse back into a one-line script.
+ *
+ * Scanned across the whole workspace rather than this package alone. The construct is not specific
+ * to anything here, `packages/builder` carried it too, and a guard that watches one package would
+ * pass while the next copy of it landed somewhere else.
+ */
+import { readdirSync, readFileSync, existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+const repoRoot = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "..",
+  "..",
+  ".."
+);
+
+/**
+ * Backgrounding followed by a wait, in the forms a shell actually accepts.
+ *
+ * `&` between commands, or trailing, paired with a `wait` that stands alone as a command rather
+ * than appearing inside a longer word. Matching `wait` loosely would reject `pnpm run wait-for-db`,
+ * which is a perfectly portable script name.
+ */
+const BACKGROUND_THEN_WAIT = /&\s*(?:\S[\s\S]*)?(?:^|\s|;|&)wait(?:\s|;|$)/;
+
+/** Every workspace manifest, found by walking the directories pnpm-workspace covers. */
+function workspaceManifests(): {
+  path: string;
+  scripts: Record<string, string>;
+}[] {
+  const found: { path: string; scripts: Record<string, string> }[] = [];
+  for (const group of ["packages", "apps", "templates"]) {
+    const groupDir = join(repoRoot, group);
+    if (!existsSync(groupDir)) continue;
+    for (const entry of readdirSync(groupDir, { withFileTypes: true })) {
+      if (!entry.isDirectory()) continue;
+      const manifest = join(groupDir, entry.name, "package.json");
+      if (!existsSync(manifest)) continue;
+      const parsed = JSON.parse(readFileSync(manifest, "utf8")) as {
+        scripts?: Record<string, string>;
+      };
+      found.push({
+        path: `${group}/${entry.name}`,
+        scripts: parsed.scripts ?? {},
+      });
+    }
+  }
+  return found;
+}
+
+describe("package scripts run on every supported platform", () => {
+  // A scan that reads nothing reports no violations, which is the same output as a clean
+  // workspace. This is the control that separates them.
+  it("finds manifests to scan", () => {
+    const manifests = workspaceManifests();
+    expect(manifests.length).toBeGreaterThan(5);
+    expect(manifests.some(({ path }) => path === "packages/ui")).toBe(true);
+  });
+
+  it("recognises the construct it exists to reject", () => {
+    expect(
+      BACKGROUND_THEN_WAIT.test(
+        "tsup --watch & tsup --config other.ts --watch & wait"
+      )
+    ).toBe(true);
+    expect(BACKGROUND_THEN_WAIT.test("node a.mjs & node b.mjs & wait")).toBe(
+      true
+    );
+  });
+
+  it("does not reject portable scripts that merely contain the word", () => {
+    expect(BACKGROUND_THEN_WAIT.test("node scripts/dev.mjs")).toBe(false);
+    expect(BACKGROUND_THEN_WAIT.test("pnpm run wait-for-db && vitest")).toBe(
+      false
+    );
+    expect(
+      BACKGROUND_THEN_WAIT.test(
+        "tsup && tsup --config tsup.server-safe.config.ts"
+      )
+    ).toBe(false);
+  });
+
+  it("no workspace script backgrounds a process and waits for it", () => {
+    const offenders = workspaceManifests().flatMap(({ path, scripts }) =>
+      Object.entries(scripts)
+        .filter(([, command]) => BACKGROUND_THEN_WAIT.test(command))
+        .map(([name, command]) => `${path} → ${name}: ${command}`)
+    );
+    expect(offenders).toEqual([]);
+  });
+});

--- a/packages/ui/src/__tests__/package-scripts-are-cross-platform.test.ts
+++ b/packages/ui/src/__tests__/package-scripts-are-cross-platform.test.ts
@@ -19,6 +19,7 @@ import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
+import ts from "typescript";
 import { describe, expect, it } from "vitest";
 
 const repoRoot = join(
@@ -85,22 +86,19 @@ function workspaceDirectories(): string[] {
 /**
  * Every manifest whose scripts a contributor runs.
  *
- * The workspace packages, plus the repository root — its scripts run through the same pnpm and
- * break the same way — plus `templates`, which pnpm does not manage but which becomes a user's
- * project verbatim, so a construct there ships the bug rather than merely hosting it.
+ * The workspace packages plus the repository root, whose scripts go through the same pnpm and
+ * break the same way.
+ *
+ * `templates/` is deliberately NOT here: none of those directories contains a `package.json` at
+ * all. A scaffolded project's manifest is GENERATED, which is what `generatedScriptCommands()`
+ * below covers — filtering this list by file existence would silently drop every template while
+ * this suite claimed to scan them.
  */
 function scannedManifests(): {
   path: string;
   scripts: Record<string, string>;
 }[] {
-  const templates = join(repoRoot, "templates");
-  const templateDirs = existsSync(templates)
-    ? readdirSync(templates, { withFileTypes: true })
-        .filter(entry => entry.isDirectory())
-        .map(entry => join(templates, entry.name))
-    : [];
-
-  return [repoRoot, ...workspaceDirectories(), ...templateDirs]
+  return [repoRoot, ...workspaceDirectories()]
     .map(directory => ({
       directory,
       manifest: join(directory, "package.json"),
@@ -118,10 +116,80 @@ function scannedManifests(): {
     });
 }
 
+/** Where a scaffolded project's `scripts` block is actually written. */
+const GENERATOR = join(
+  repoRoot,
+  "packages",
+  "create-nextly-app",
+  "src",
+  "utils",
+  "template.ts"
+);
+
+/**
+ * Every command a scaffolded project's `package.json` will contain.
+ *
+ * A user's project is not in this repository — it is produced by `generatePackageJson` and its
+ * plugin counterpart — so scanning directories cannot see those scripts at all. A forbidden
+ * construct there is worse than one here: it ships to people who never chose it, and their first
+ * build is where it surfaces.
+ *
+ * Read from the generator's own syntax rather than by calling it, because calling it would make
+ * this package depend on `create-nextly-app` at test time; this repository already guards across
+ * package boundaries by reading source, as the contrast utilities do for admin.
+ */
+function generatedScriptCommands(): {
+  path: string;
+  scripts: Record<string, string>;
+}[] {
+  const source = ts.createSourceFile(
+    GENERATOR,
+    readFileSync(GENERATOR, "utf8"),
+    ts.ScriptTarget.Latest,
+    true
+  );
+
+  const blocks: Record<string, string>[] = [];
+  const visit = (node: ts.Node): void => {
+    if (
+      ts.isPropertyAssignment(node) &&
+      ts.isIdentifier(node.name) &&
+      node.name.text === "scripts" &&
+      ts.isObjectLiteralExpression(node.initializer)
+    ) {
+      const block: Record<string, string> = {};
+      for (const property of node.initializer.properties) {
+        if (!ts.isPropertyAssignment(property)) continue;
+        const key = ts.isIdentifier(property.name)
+          ? property.name.text
+          : ts.isStringLiteral(property.name)
+            ? property.name.text
+            : undefined;
+        // Only literal commands can be judged. A computed one is reported rather than skipped, so
+        // a script assembled at runtime cannot pass by being unreadable.
+        if (key === undefined) continue;
+        block[key] = ts.isStringLiteral(property.initializer)
+          ? property.initializer.text
+          : ts.isNoSubstitutionTemplateLiteral(property.initializer)
+            ? property.initializer.text
+            : `<non-literal: ${property.initializer.getText(source)}>`;
+      }
+      blocks.push(block);
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(source);
+
+  return blocks.map((scripts, index) => ({
+    path: `create-nextly-app scripts block #${index + 1}`,
+    scripts,
+  }));
+}
+
 describe("package scripts run on every supported platform", () => {
   // A scan that reads nothing reports no violations, which is the same output as a clean
   // workspace. These separate the two.
-  it("scans the root, every pnpm workspace, and the templates", () => {
+  it("scans the root and every pnpm workspace", () => {
     const paths = scannedManifests().map(({ path }) => path);
     expect(paths).toContain("<root>");
     expect(paths).toContain("packages/ui");
@@ -129,6 +197,21 @@ describe("package scripts run on every supported platform", () => {
     // hand-written directory list would miss.
     expect(paths).toContain("e2e");
     expect(paths.length).toBeGreaterThan(10);
+  });
+
+  // The generator is the only place a scaffolded project's scripts exist, and a scan of it that
+  // silently found nothing would report no violations — the same output as a clean generator.
+  it("reads the scripts a scaffolded project will actually receive", () => {
+    const blocks = generatedScriptCommands();
+    expect(blocks.length).toBeGreaterThanOrEqual(2);
+
+    const commands = blocks.flatMap(({ scripts }) => Object.entries(scripts));
+    expect(commands.length).toBeGreaterThan(5);
+    // Pinned because they are what a user runs first. If the generator stops emitting these, the
+    // scan is reading the wrong thing and should say so rather than pass over an empty set.
+    expect(commands.map(([name]) => name)).toEqual(
+      expect.arrayContaining(["dev", "build"])
+    );
   });
 
   it("recognises the construct it exists to reject, spaced or not", () => {
@@ -154,8 +237,11 @@ describe("package scripts run on every supported platform", () => {
     }
   });
 
-  it("no scanned script backgrounds a process and waits for it", () => {
-    const offenders = scannedManifests().flatMap(({ path, scripts }) =>
+  it("no scanned or generated script backgrounds a process and waits for it", () => {
+    const offenders = [
+      ...scannedManifests(),
+      ...generatedScriptCommands(),
+    ].flatMap(({ path, scripts }) =>
       Object.entries(scripts)
         .filter(([, command]) => BACKGROUND_THEN_WAIT.test(command))
         .map(([name, command]) => `${path} → ${name}: ${command}`)

--- a/packages/ui/src/__tests__/package-scripts-are-cross-platform.test.ts
+++ b/packages/ui/src/__tests__/package-scripts-are-cross-platform.test.ts
@@ -11,11 +11,11 @@
  * healthy client bundle and stale server-safe artifacts beside it, and the fix — a `spawn` runner —
  * is ordinary JavaScript that a later edit could plausibly collapse back into a one-line script.
  *
- * Scanned across the whole workspace rather than this package alone. The construct is not specific
- * to anything here, `packages/builder` carried it too, and a guard that watches one package would
- * pass while the next copy of it landed somewhere else.
+ * The set of manifests is DERIVED from `pnpm-workspace.yaml` rather than listed here. A hand-written
+ * list is a second definition of what the workspace contains: it agreed with pnpm the day it was
+ * written, and the first package added outside its assumptions is silently unscanned.
  */
-import { readdirSync, readFileSync, existsSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -32,71 +32,130 @@ const repoRoot = join(
 /**
  * Backgrounding followed by a wait, in the forms a shell actually accepts.
  *
- * `&` between commands, or trailing, paired with a `wait` that stands alone as a command rather
- * than appearing inside a longer word. Matching `wait` loosely would reject `pnpm run wait-for-db`,
- * which is a perfectly portable script name.
+ * `&` is a control operator, so a shell needs no whitespace around it: `a & wait`, `a &wait` and
+ * `a&wait` are the same command and all three carry the Windows failure. The separator before
+ * `wait` is therefore optional whitespace rather than required whitespace.
+ *
+ * `wait` still has to stand alone as a command rather than open a longer word, so `wait-for-db`
+ * is not matched — that is a perfectly portable script name.
  */
-const BACKGROUND_THEN_WAIT = /&\s*(?:\S[\s\S]*)?(?:^|\s|;|&)wait(?:\s|;|$)/;
+const BACKGROUND_THEN_WAIT = /&[\s\S]*?(?:^|[\s;&])?\bwait(?![\w-])/;
 
-/** Every workspace manifest, found by walking the directories pnpm-workspace covers. */
-function workspaceManifests(): {
+/**
+ * Directory globs pnpm treats as workspaces, read from its own configuration.
+ *
+ * Only the shapes this repository uses are interpreted — a trailing `/*` meaning "every child of
+ * this directory", and a bare path meaning one package. An unrecognised pattern throws rather than
+ * being skipped, because silently ignoring a workspace glob is how this scan would come to cover
+ * less than it claims while still reporting a pass.
+ */
+function workspaceDirectories(): string[] {
+  const yaml = readFileSync(join(repoRoot, "pnpm-workspace.yaml"), "utf8");
+  const patterns = [
+    ...yaml.matchAll(/^\s*-\s*["']?([^"'\n#]+?)["']?\s*$/gm),
+  ].map(match => match[1]);
+  if (patterns.length === 0) {
+    throw new Error(
+      "No workspace patterns were parsed from pnpm-workspace.yaml, so this scan would read " +
+        "nothing and report no violations — which is what a clean workspace also looks like."
+    );
+  }
+
+  const directories: string[] = [];
+  for (const pattern of patterns) {
+    if (pattern.endsWith("/*")) {
+      const parent = join(repoRoot, pattern.slice(0, -2));
+      if (!existsSync(parent)) continue;
+      for (const entry of readdirSync(parent, { withFileTypes: true })) {
+        if (entry.isDirectory()) directories.push(join(parent, entry.name));
+      }
+      continue;
+    }
+    if (pattern.includes("*")) {
+      throw new Error(
+        `pnpm-workspace.yaml contains the pattern "${pattern}", which this scan does not know how ` +
+          "to expand. Teach it the shape rather than letting those packages go unscanned."
+      );
+    }
+    directories.push(join(repoRoot, pattern));
+  }
+  return directories;
+}
+
+/**
+ * Every manifest whose scripts a contributor runs.
+ *
+ * The workspace packages, plus the repository root — its scripts run through the same pnpm and
+ * break the same way — plus `templates`, which pnpm does not manage but which becomes a user's
+ * project verbatim, so a construct there ships the bug rather than merely hosting it.
+ */
+function scannedManifests(): {
   path: string;
   scripts: Record<string, string>;
 }[] {
-  const found: { path: string; scripts: Record<string, string> }[] = [];
-  for (const group of ["packages", "apps", "templates"]) {
-    const groupDir = join(repoRoot, group);
-    if (!existsSync(groupDir)) continue;
-    for (const entry of readdirSync(groupDir, { withFileTypes: true })) {
-      if (!entry.isDirectory()) continue;
-      const manifest = join(groupDir, entry.name, "package.json");
-      if (!existsSync(manifest)) continue;
+  const templates = join(repoRoot, "templates");
+  const templateDirs = existsSync(templates)
+    ? readdirSync(templates, { withFileTypes: true })
+        .filter(entry => entry.isDirectory())
+        .map(entry => join(templates, entry.name))
+    : [];
+
+  return [repoRoot, ...workspaceDirectories(), ...templateDirs]
+    .map(directory => ({
+      directory,
+      manifest: join(directory, "package.json"),
+    }))
+    .filter(({ manifest }) => existsSync(manifest))
+    .map(({ directory, manifest }) => {
       const parsed = JSON.parse(readFileSync(manifest, "utf8")) as {
         scripts?: Record<string, string>;
       };
-      found.push({
-        path: `${group}/${entry.name}`,
-        scripts: parsed.scripts ?? {},
-      });
-    }
-  }
-  return found;
+      const relative =
+        directory === repoRoot
+          ? "<root>"
+          : directory.slice(repoRoot.length + 1);
+      return { path: relative, scripts: parsed.scripts ?? {} };
+    });
 }
 
 describe("package scripts run on every supported platform", () => {
   // A scan that reads nothing reports no violations, which is the same output as a clean
-  // workspace. This is the control that separates them.
-  it("finds manifests to scan", () => {
-    const manifests = workspaceManifests();
-    expect(manifests.length).toBeGreaterThan(5);
-    expect(manifests.some(({ path }) => path === "packages/ui")).toBe(true);
+  // workspace. These separate the two.
+  it("scans the root, every pnpm workspace, and the templates", () => {
+    const paths = scannedManifests().map(({ path }) => path);
+    expect(paths).toContain("<root>");
+    expect(paths).toContain("packages/ui");
+    // `e2e` is a workspace that is neither under `packages/` nor `apps/`, so it is the one a
+    // hand-written directory list would miss.
+    expect(paths).toContain("e2e");
+    expect(paths.length).toBeGreaterThan(10);
   });
 
-  it("recognises the construct it exists to reject", () => {
-    expect(
-      BACKGROUND_THEN_WAIT.test(
-        "tsup --watch & tsup --config other.ts --watch & wait"
-      )
-    ).toBe(true);
-    expect(BACKGROUND_THEN_WAIT.test("node a.mjs & node b.mjs & wait")).toBe(
-      true
-    );
+  it("recognises the construct it exists to reject, spaced or not", () => {
+    for (const command of [
+      "tsup --watch & tsup --config other.ts --watch & wait",
+      "node a.mjs & node b.mjs & wait",
+      "node a.mjs &wait",
+      "node a.mjs&wait",
+      "node a.mjs & wait;",
+    ]) {
+      expect(BACKGROUND_THEN_WAIT.test(command), command).toBe(true);
+    }
   });
 
   it("does not reject portable scripts that merely contain the word", () => {
-    expect(BACKGROUND_THEN_WAIT.test("node scripts/dev.mjs")).toBe(false);
-    expect(BACKGROUND_THEN_WAIT.test("pnpm run wait-for-db && vitest")).toBe(
-      false
-    );
-    expect(
-      BACKGROUND_THEN_WAIT.test(
-        "tsup && tsup --config tsup.server-safe.config.ts"
-      )
-    ).toBe(false);
+    for (const command of [
+      "node scripts/dev.mjs",
+      "pnpm run wait-for-db && vitest",
+      "tsup && tsup --config tsup.server-safe.config.ts",
+      "echo waiting && next build",
+    ]) {
+      expect(BACKGROUND_THEN_WAIT.test(command), command).toBe(false);
+    }
   });
 
-  it("no workspace script backgrounds a process and waits for it", () => {
-    const offenders = workspaceManifests().flatMap(({ path, scripts }) =>
+  it("no scanned script backgrounds a process and waits for it", () => {
+    const offenders = scannedManifests().flatMap(({ path, scripts }) =>
       Object.entries(scripts)
         .filter(([, command]) => BACKGROUND_THEN_WAIT.test(command))
         .map(([name, command]) => `${path} → ${name}: ${command}`)


### PR DESCRIPTION
The `dev` script of `packages/ui` started ONE of its two watchers on Windows, silently.

## The bug

```
"dev": "tsup --watch & tsup --config tsup.server-safe.config.ts --watch & wait"
```

That is POSIX. pnpm runs scripts through `cmd.exe` on Windows, where `&` is a **sequential** separator and `wait` is not a builtin. The first watcher never exits by design, so it holds the line and the second never runs.

**The failure has no error, no exit code and no output.** A Windows contributor sees a running dev server, a healthy client bundle, and stale or absent server-safe artifacts beside it. The thing they would check — is the dev script running? — answers yes. Reported by the builder-shell lane; `packages/ui` was the last package carrying the construct.

## The fix

`packages/ui/scripts/dev.mjs`, ~90 lines, no new dependency.

- **Any child exit is a failure, including a clean one.** These are watchers; a `0` means it stopped rebuilding artifacts, and forwarding that `0` would tell the surrounding pnpm/turbo pipeline the task succeeded while every output silently went stale — the same half-working state this file exists to expose, one layer up. Logged unconditionally, because the clean exit is the case hardest to notice.
- `shell: true` so `tsup` resolves through the platform's own lookup, which on Windows means npm's `.cmd` shim.
- `SIGINT`/`SIGTERM` handlers, because Ctrl-C reaches the parent and the children have to be told separately.

Credit to the builder-shell lane for the exit-code correction — their first version forwarded the child code and Codex caught it there, so this one never shipped with it.

## Two controls, because the risks are different

**1. Reintroduction** — a unit test refuses the construct in every workspace manifest (`packages`, `apps`, `templates`).

Break-verified: restoring the old script fails the test naming the offender exactly, and restoring the fix passes it.

```
+   "packages/ui → dev: tsup --watch & tsup --config tsup.server-safe.config.ts --watch & wait"
      Tests  1 failed | 3 passed (4)
```

It carries its own positive controls: one asserting the scan finds manifests at all (a scan that reads nothing reports no violations, which looks identical to a clean workspace), one asserting it recognises the construct, and one asserting it does NOT reject portable scripts like `pnpm run wait-for-db && vitest`.

**2. The replacement being wrong** — the unit test cannot show the runner works, and that is where the risk moved: a runner that spawns one watcher and drops the other fails exactly as silently as the shell did.

So a CI job runs the real `pnpm dev` on **ubuntu and windows-latest**, removes `dist` first so a file found afterwards was produced by that run, and requires an artifact from EACH watcher — `dist/index.mjs` from the client config, `dist/color.mjs` from the server-safe one, which is the output the broken script never produced. Windows is the subject; ubuntu is the control, since a check that fails everywhere says nothing about Windows in particular.

Verified locally on macOS: both watchers start and all four server-safe artifacts appear within 2s, with zero orphan processes after SIGINT.

## Notes

- **No changeset.** `files` is `["dist","docs"]` so `scripts/` does not ship, and `scripts.dev` is dev tooling no consumer executes. Nothing published changes behaviour. Happy to add one if you read that differently.
- `engines.node` in `packages/ui/package.json` verified byte-identical to the root: `^20.19.0 || ^22.12.0 || >=24.0.0`. The manifest diff is one line.
- Job placed in `ci.yml` rather than `package-smoke.yml` on purpose — my #746 is editing the latter, and one workflow touched by two of my PRs is a conflict resolved twice.