### PR TITLE
fix(builder): watch src, because tsup at the default root never rebuilds

### DIFF
--- a/.changeset/builder-dev-watch-root.md
+++ b/.changeset/builder-dev-watch-root.md
@@ -1,0 +1,38 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+point the builder dev watchers at `src`, so `pnpm dev` rebuilds again
+
+`tsup --watch` defaults to watching `.`, and at that root it never notices an
+edit: no `Change detected`, no rebuild, and an artifact byte-identical
+afterwards. Measured back to back on tsup 8.5.0 — `--watch .` saw nothing,
+`--watch src` detected the same edit and rebuilt it.
+
+Nothing errored while it was broken, which is why it survived: the watcher logs
+a successful initial build and then `Watching for changes`, and the only symptom
+is the ABSENCE of a later build line in output that scrolls. Anyone debugging a
+stale `dist` was debugging code that had never been rebuilt.

--- a/packages/builder/scripts/dev.mjs
+++ b/packages/builder/scripts/dev.mjs
@@ -14,6 +14,14 @@
  * Node's `spawn` is the portable equivalent, and it is a dozen lines rather
  * than a dependency.
  *
+ * **Each watcher is pointed at `src` rather than left to default.** Bare
+ * `tsup --watch` watches `.`, and at that root it never notices an edit at all:
+ * no `Change detected`, no rebuild, and an artifact that is byte-identical
+ * afterwards. Measured back to back in one session on tsup 8.5.0 — `--watch .`
+ * saw nothing, `--watch src` detected the same edit and rebuilt it. Anyone who
+ * then debugs a stale artifact is debugging code that was never rebuilt, and
+ * the failure is the ABSENCE of a build line among output that scrolls.
+ *
  * Three producers, because this package publishes three kinds of artifact from
  * one `dist`: the client entry, the server-safe entries, and the compiled
  * stylesheet. Cleaning belongs to `build`, never here — a clean under `--watch`
@@ -24,10 +32,10 @@ import { spawn } from "node:child_process";
 
 /** Each long-lived producer, with a label for whose output is whose. */
 const PRODUCERS = [
-  { label: "client", args: ["tsup", "--watch"] },
+  { label: "client", args: ["tsup", "--watch", "src"] },
   {
     label: "server-safe",
-    args: ["tsup", "--config", "tsup.server-safe.config.ts", "--watch"],
+    args: ["tsup", "--config", "tsup.server-safe.config.ts", "--watch", "src"],
   },
   { label: "css", args: ["pnpm", "run", "dev:css"] },
 ];


### PR DESCRIPTION
`tsup --watch` defaults to watching `.`, and at that root it does not notice an edit at all — no `Change detected`, no rebuild, and an artifact byte-identical afterwards.

## Measured, back to back in one session

tsup 8.5.0, `packages/builder`, probe = an **added export** (not a comment: tsup strips comments, so a comment-only probe is byte-identical either way and cannot distinguish the cases in either direction).

| watch root | new log lines | `Change detected` | dist md5 | marker in dist |
|---|---|---|---|---|
| `.` (default) | 0 | 0 | unchanged | 0 |
| `src` | 15 | 1 | **changed** | 1 |

Controls: the edit was confirmed present in the source, and a manual build was confirmed to pick it up and change the artifact — so the probe could detect a rebuild if one had happened.

## Why this is worth a PR of its own

Nothing errors. The watcher logs a successful initial build, then `Watching for changes`, which reads as healthy. **The only symptom is the absence of a later build line, in output that scrolls.** So `pnpm dev` looks like it is working while every artifact freezes at the last full build, and whoever then debugs a stale `dist` is debugging code that was never rebuilt.

## A dead end, recorded so nobody re-walks it

The unfinished `DTS Build start` line looked like the cause. It is not: with `dts: false` the watcher still never detects. It is a symptom sitting beside the failure.

## Scope

Dev-script only — no published behaviour changes, so no changeset. `packages/ui` has the same default-root watchers and the same bug; that is the UI lane's file and they have been told rather than had it edited underneath them.

Found by the UI server-safe lane, who measured the *detects-but-never-rebuilds* half on `packages/ui`; this package never detects at all.