### PR TITLE
test(ui): read jsx call sites, and stop reporting an erased inline style

### DIFF
--- a/packages/ui/src/components/__tests__/tabs-contract.test.ts
+++ b/packages/ui/src/components/__tests__/tabs-contract.test.ts
@@ -1032,12 +1032,23 @@ function ownsStyleProperty(slot: string, property: string): boolean {
 /**
  * Whether a file can hold a JSX call site.
  *
- * Both extensions, and neither `.ts` nor `.js`: an element cannot appear in
- * those, so reading them would cost time and find nothing. Named rather than
- * inlined so the traversal and the Turbo input globs can be checked against one
- * list instead of two that agree until someone edits one.
+ * `.js` is on the list and that is not an oversight corrected — it is the case
+ * an earlier version of this test actively certified as SAFE. A JavaScript
+ * Next.js app puts JSX in `.js` routinely, so a first-party `page.js` importing
+ * `TabsTrigger` was invisible to the scan while a control asserted that
+ * invisibility was correct. A test that ratifies a gap is worse than no test,
+ * because it answers the question and closes it.
+ *
+ * `.ts` stays off: an element cannot appear there, so reading those files would
+ * cost time and find nothing.
+ *
+ * Named once because the Turbo input globs must cover exactly these — an
+ * extension the scan reads but the hash does not cover is a file that can
+ * change behind a cached green, which is the same silent gap wearing different
+ * clothes. `turbo.json` is static JSON and cannot import this, so the two are
+ * tied together by a contract test below rather than by a claim in a comment.
  */
-const CALL_SITE_EXTENSIONS = [".tsx", ".jsx"] as const;
+const CALL_SITE_EXTENSIONS = [".tsx", ".jsx", ".js"] as const;
 
 function isCallSite(name: string): boolean {
   return CALL_SITE_EXTENSIONS.some(extension => name.endsWith(extension));
@@ -2207,6 +2218,26 @@ describe("the tab indicator contract", () => {
       "the same assertion around a parenthesised nothing",
       "<TabsTrigger style={{ borderBottomColor: (undefined) as string | undefined }} />",
     ],
+    // The non-null branch. `!` asserts to the COMPILER that a value is present
+    // and erases entirely at runtime, so `undefined!` still reaches React as
+    // `undefined` and still emits nothing. Without this case, deleting
+    // `ts.isNonNullExpression` from the unwrapper leaves the suite green.
+    [
+      "an inline property with a non-null assertion on nothing",
+      "<TabsTrigger style={{ borderBottomColor: undefined! }} />",
+    ],
+    // The unwrapping in front of the BINDING lookup, which is a second path
+    // through the same helper. A wrapper around an identifier has to be peeled
+    // before the resolver is asked, or the lookup never happens and the value
+    // is reported on the strength of its wrapper alone.
+    [
+      "a bound nothing behind an assertion",
+      "const empty = undefined;\n<TabsTrigger style={{ borderBottomColor: empty as string | undefined }} />",
+    ],
+    [
+      "a bound nothing behind a non-null assertion",
+      "const empty = undefined;\n<TabsTrigger style={{ borderBottomColor: empty! }} />",
+    ],
     // Tailwind's own child variants. `*` compiles to `:is(& > *)` and `**` to
     // `:is(& *)`, so both land on children and neither can repaint the tab.
     [
@@ -2348,9 +2379,43 @@ describe("which files the call-site scan reads", () => {
 
       const found = sourceFiles(dir).map(path => path.slice(dir.length + 1));
 
-      expect(found.sort()).toEqual(["a.tsx", "b.jsx"].sort());
+      expect(found.sort()).toEqual(["a.tsx", "b.jsx", "d.js"].sort());
     } finally {
       rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("has a Turbo input glob for every extension it reads", () => {
+    // The claim this replaces was a comment saying the list was "named once and
+    // read by both". It was not: the extensions were repeated by hand in two
+    // task input lists, and `turbo.json` is static JSON that cannot import a
+    // constant. So the tie is asserted here instead of asserted in prose.
+    //
+    // What it protects is the same silent gap this PR closes from the other
+    // side: an extension the scan reads but the hash does not cover is a file
+    // that can change behind a cached green, and the cached pass looks exactly
+    // like a real one.
+    const config = JSON.parse(
+      readFileSync(resolve(HERE, "../../../turbo.json"), "utf8").replace(
+        // The file carries `//` comments, which `JSON.parse` rejects.
+        /^\s*\/\/.*$/gm,
+        ""
+      )
+    ) as { tasks: Record<string, { inputs?: string[] }> };
+
+    // BOTH tasks, because a coverage gap in either replays a stale green.
+    for (const task of ["test", "test:coverage"]) {
+      const inputs = config.tasks[task]?.inputs ?? [];
+      for (const extension of CALL_SITE_EXTENSIONS) {
+        const covered = inputs.filter(glob => glob.endsWith(`*${extension}`));
+        // Named in the failure, so a reader is told WHICH extension and WHICH
+        // task rather than being handed a false.
+        expect(
+          covered.length > 0
+            ? `${task} covers ${extension}`
+            : { task, extension }
+        ).toBe(`${task} covers ${extension}`);
+      }
     }
   });
 

--- a/packages/ui/src/components/__tests__/tabs-contract.test.ts
+++ b/packages/ui/src/components/__tests__/tabs-contract.test.ts
@@ -941,6 +941,42 @@ function dependenciesOfUncached(cls: string): string[] {
 
 const dependenciesOf = perClass(dependenciesOfUncached);
 
+/**
+ * The attributes a JSX spread carries, when they can be read here.
+ *
+ * Only an object literal is read, for the same reason a style prop is: knowing
+ * what a name holds means tracing it. `readable` false means the spread may
+ * carry anything, which includes the two props this contract owns.
+ */
+function spreadAttributes(
+  attribute: ts.JsxSpreadAttribute,
+  checker: ts.TypeChecker
+): {
+  attributes: Array<{ name: string; value: ts.Expression }>;
+  readable: boolean;
+} {
+  const { objects, readable } = styleResolver(checker).objectsFrom(
+    attribute.expression
+  );
+  if (!readable) return { attributes: [], readable: false };
+  const attributes: Array<{ name: string; value: ts.Expression }> = [];
+  for (const object of objects) {
+    for (const property of object.properties) {
+      if (!ts.isPropertyAssignment(property)) {
+        // A shorthand or a spread inside the spread is a value this does not
+        // read, and the props it carries are unknown rather than absent.
+        return { attributes: [], readable: false };
+      }
+      const name = property.name;
+      if (!ts.isIdentifier(name) && !ts.isStringLiteral(name)) {
+        return { attributes: [], readable: false };
+      }
+      attributes.push({ name: name.text, value: property.initializer });
+    }
+  }
+  return { attributes, readable: true };
+}
+
 /** Which of a component's owned classes a caller's `className` takes over. */
 function displacedBy(exported: string, classes: string): string[] {
   const owned = OWNED_BY_SLOT[exported] ?? [];
@@ -2357,6 +2393,59 @@ function violationsIn(file: string, source: string): Violation[] {
       );
       if (exported) {
         for (const attribute of node.attributes.properties) {
+          // `<TabsTrigger {...props} />` carries whatever `props` holds, which
+          // includes `style` and `className`. Skipping spreads left the whole
+          // contract bypassable by one idiom, on both halves at once.
+          if (ts.isJsxSpreadAttribute(attribute)) {
+            const spread = spreadAttributes(attribute, checker);
+            if (!spread.readable) {
+              found.push({
+                file,
+                line: at(attribute),
+                why: "spreads props this scan cannot read, which may carry `style` or `className` — spread an object literal, or pass the props this primitive owns explicitly",
+              });
+              continue;
+            }
+            for (const carried of spread.attributes) {
+              const carriedName = carried.name;
+              if (carriedName === "className") {
+                const classes = literalStrings(carried.value).join(" ");
+                const displaced = displacedBy(exported, classes);
+                if (displaced.length > 0) {
+                  found.push({
+                    file,
+                    line: at(attribute),
+                    why: `spreads ${displaced.join(", ")} — the primitive owns that appearance, and every surface should change with it`,
+                  });
+                }
+              }
+              if (carriedName === "style") {
+                const resolver = styleResolver(checker);
+                const { objects, readable } = resolver.objectsFrom(
+                  carried.value
+                );
+                if (!readable) {
+                  found.push({
+                    file,
+                    line: at(attribute),
+                    why: "spreads an inline style this scan cannot read — write it as a literal object, or move it to `className` so the primitive keeps its appearance",
+                  });
+                  continue;
+                }
+                const owned = objects
+                  .map(object => ownedStyleProperty(exported, object, resolver))
+                  .find(Boolean);
+                if (owned) {
+                  found.push({
+                    file,
+                    line: at(attribute),
+                    why: `spreads \`${owned}\` inline, which beats every class the primitive applies`,
+                  });
+                }
+              }
+            }
+            continue;
+          }
           if (!ts.isJsxAttribute(attribute)) continue;
           const name = attribute.name.getText(sourceFile);
           if (name === "style") {
@@ -2913,6 +3002,23 @@ describe("the tab indicator contract", () => {
     [
       "an inline style read from a member access",
       "<TabsTrigger style={theme.tab} />",
+    ],
+    // A JSX spread carries whatever the object holds, including the two props
+    // this contract owns. Skipping spreads left both halves bypassable by one
+    // idiom.
+    [
+      "an owned property spread in as a literal style prop",
+      'const props = { style: { borderBottomColor: "red" } };\n<TabsTrigger {...{ style: { borderBottomColor: "red" } }} />',
+    ],
+    [
+      "a displacing class spread in as a literal className",
+      '<TabsTrigger {...{ className: "border-b-0" }} />',
+    ],
+    // And a spread whose contents cannot be read at all, which may carry
+    // either of them.
+    [
+      "a spread of props the scan cannot read",
+      'const props = { className: "border-b-0" };\n<TabsTrigger {...props} />',
     ],
   ])("catches %s", (_label, body) => {
     // The positive controls. Each is a shape an earlier version returned clean

--- a/packages/ui/src/components/__tests__/tabs-contract.test.ts
+++ b/packages/ui/src/components/__tests__/tabs-contract.test.ts
@@ -438,7 +438,10 @@ function wins(owned: Utility, caller: Utility): boolean {
     .every(variant => callerVariants.has(variant));
   // Carrying every variant the owned class carries is SUFFICIENT, not
   // necessary, which is why the cascade is asked as well rather than instead.
-  return asQualified || outranks(owned, caller);
+  // Restating the appearance is a third route: it wins nothing today and holds
+  // the same appearance anyway, so it survives a change to the primitive that
+  // the call site never hears about.
+  return asQualified || outranks(owned, caller) || restates(owned, caller);
 }
 
 /**
@@ -564,21 +567,93 @@ const declarationsOf = perClass(declarationsOfUncached);
  * outright and needs no such test.
  */
 function disagree(owned: string, caller: string): boolean {
-  // Expanded on both sides, for the same reason the intersection is: a caller's
-  // `outline` shorthand and the primitive's `outline-style` are the same
-  // declaration seen at two granularities, and compared as raw names they never
-  // met — so a rule that replaces the owned outline read as agreeing with it.
-  const expand = (declarations: Map<string, string>): Map<string, string> => {
-    const flat = new Map<string, string>();
-    for (const [property, value] of declarations) {
-      for (const longhand of expandsTo(property)) flat.set(longhand, value);
-    }
-    return flat;
-  };
-  const ownedDeclarations = expand(declarationsOf(owned));
-  for (const [property, value] of expand(declarationsOf(caller))) {
+  const ownedDeclarations = expandDeclarations(declarationsOf(owned));
+  for (const [property, value] of expandDeclarations(declarationsOf(caller))) {
     const existing = ownedDeclarations.get(property);
     if (existing !== undefined && existing !== value) return true;
+  }
+  return false;
+}
+
+/**
+ * Declarations restated at every granularity they can be compared at.
+ *
+ * A caller's `outline` shorthand and the primitive's `outline-style` are the
+ * same declaration seen at two granularities, and compared as raw names they
+ * never met — so a rule that replaces the owned outline read as agreeing with
+ * it.
+ */
+function expandDeclarations(
+  declarations: Map<string, string>
+): Map<string, string> {
+  const flat = new Map<string, string>();
+  for (const [property, value] of declarations) {
+    for (const longhand of expandsTo(property)) flat.set(longhand, value);
+  }
+  return flat;
+}
+
+/**
+ * Whether a value is a composition whose other slots belong to someone else.
+ *
+ * Tailwind uses one property as a shared canvas: `box-shadow` is a list of
+ * `var()` slots, and a ring utility fills `--tw-ring-shadow` while leaving
+ * `--tw-shadow` for whoever else is on the element. A value containing a slot
+ * the utility fills ITSELF is such a canvas, so what it holds is a composition
+ * rather than an appearance of its own.
+ */
+function fillsSharedCanvas(value: string, own: Set<string>): boolean {
+  return [...value.matchAll(/var\(\s*(--[a-zA-Z0-9-]+)/g)].some(match =>
+    own.has(match[1] ?? "")
+  );
+}
+
+/**
+ * The declarations a utility makes exclusively its own.
+ *
+ * The shared canvas is excluded, and that exclusion is what makes an equality
+ * comparison meaningful at all: `shadow-sm` and `focus-visible:ring-2` both
+ * write `box-shadow` with byte-identical text while contributing through
+ * different variables, so on the raw declarations every ring and every shadow
+ * in the repository would read as restating each other.
+ */
+function exclusiveDeclarationsUncached(cls: string): Map<string, string> {
+  const declarations = declarationsOf(cls);
+  const own = new Set(declarations.keys());
+  const exclusive = new Map<string, string>();
+  for (const [property, value] of declarations) {
+    if (fillsSharedCanvas(value, own)) continue;
+    exclusive.set(property, value);
+  }
+  return exclusive;
+}
+
+const exclusiveDeclarationsOf = perClass(exclusiveDeclarationsUncached);
+
+/**
+ * Whether a caller declares an owned appearance AGAIN, with the same value.
+ *
+ * Nothing is displaced and nothing conflicts, so neither the merge nor the
+ * cascade comparison can see it: `aria-[controls]:outline-none` beside the
+ * primitive's `focus-visible:outline-none` shares no variant, and the values
+ * are equal so `disagree` correctly reports no override. It is still a second
+ * copy of one appearance, and the copy is what survives when the primitive
+ * changes — the day the outline becomes a visible ring, this rule goes on
+ * suppressing it from a call site that never mentioned the change.
+ *
+ * Asked as an ADDITIONAL way to hold owned appearance, never by weakening
+ * `disagree`: that function's rejection branch is load-bearing, and stubbing it
+ * to always return true reports a state-qualified utility that touches nothing
+ * the primitive draws.
+ */
+function restates(owned: Utility, caller: Utility): boolean {
+  const ownedDeclarations = expandDeclarations(
+    exclusiveDeclarationsOf(owned.full)
+  );
+  for (const [property, value] of expandDeclarations(
+    exclusiveDeclarationsOf(caller.full)
+  )) {
+    if (ownedDeclarations.get(property) === value) return true;
   }
   return false;
 }
@@ -716,12 +791,12 @@ function dependenciesOfUncached(cls: string): string[] {
   const own = new Set(declarations.keys());
   const found = new Set<string>();
   for (const value of declarations.values()) {
-    const referenced = [...value.matchAll(/var\(\s*(--[a-zA-Z0-9-]+)/g)].map(
-      match => match[1] ?? ""
-    );
-    // A value carrying one of this utility's own slots is a shared canvas.
-    if (referenced.some(property => own.has(property))) continue;
-    for (const property of referenced) found.add(property);
+    // A value carrying one of this utility's own slots is a shared canvas, and
+    // the same test decides which declarations are exclusively its own.
+    if (fillsSharedCanvas(value, own)) continue;
+    for (const match of value.matchAll(/var\(\s*(--[a-zA-Z0-9-]+)/g)) {
+      found.add(match[1] ?? "");
+    }
   }
   return [...found];
 }
@@ -2399,6 +2474,14 @@ describe("the tab indicator contract", () => {
     [
       "an owned property set to a locally shadowed undefined",
       'function Row() {\n  const undefined = "red";\n  return <TabsTrigger style={{ borderBottomColor: undefined }} />;\n}',
+    ],
+    // A second copy of an owned appearance, declared with the same value under
+    // a different variant. Nothing is displaced and nothing conflicts today,
+    // which is exactly why no comparison saw it — and the day the primitive
+    // changes its outline, this rule keeps suppressing it.
+    [
+      "an owned declaration restated under a different variant",
+      '<TabsTrigger className="aria-[controls]:outline-none" />',
     ],
   ])("catches %s", (_label, body) => {
     // The positive controls. Each is a shape an earlier version returned clean

--- a/packages/ui/src/components/__tests__/tabs-contract.test.ts
+++ b/packages/ui/src/components/__tests__/tabs-contract.test.ts
@@ -1612,9 +1612,16 @@ function styleResolver(
         (list.flags & ts.NodeFlags.Const) === 0;
       return { initializer: declaration.initializer, mutable };
     }
-    // A parameter's default is what it holds only when the caller passes
-    // nothing, and an import, a function or a catch binding has no initializer
-    // to read at all. Each is a binding whose value is undecidable here.
+    // A parameter's default IS one of the values it holds — rendering the
+    // component without an argument passes exactly that object — so it counts
+    // as a value the element can receive. It is `mutable` because it is only
+    // ONE of them: a caller supplying an argument replaces it, which is why the
+    // key question, needing a single answer, still treats it as undecidable.
+    //
+    // An import, a function or a catch binding has no initializer to read.
+    if (ts.isParameter(declaration)) {
+      return { initializer: declaration.initializer, mutable: true };
+    }
     return { initializer: undefined, mutable: true };
   };
 
@@ -1678,19 +1685,36 @@ function styleResolver(
    * Across different units the order is not decidable and the write is kept,
    * which is the reporting side and therefore the safe one.
    */
-  const writesTo = (
-    declaration: ts.Declaration
-  ): Array<{ value: ts.Expression; straightLine: boolean; at: number }> => {
+  interface Write {
+    value: ts.Expression;
+    /** Shares the element's execution unit, so it runs in source order. */
+    sameUnit: boolean;
+    /** Runs before the element every time, so it replaces what came before. */
+    straightLine: boolean;
+    at: number;
+  }
+
+  /**
+   * The operators that give a binding a new value.
+   *
+   * A logical assignment writes only when the current value passes its test, so
+   * it ADDS a value the binding might hold. `=` is the only one that can be
+   * said to have replaced what was there.
+   */
+  const ASSIGNMENT_OPERATORS = new Map<ts.SyntaxKind, boolean>([
+    [ts.SyntaxKind.EqualsToken, true],
+    [ts.SyntaxKind.QuestionQuestionEqualsToken, false],
+    [ts.SyntaxKind.BarBarEqualsToken, false],
+    [ts.SyntaxKind.AmpersandAmpersandEqualsToken, false],
+  ]);
+
+  const writesTo = (declaration: ts.Declaration): Write[] => {
     const elementUnit = executionUnitOf(element);
-    const found: Array<{
-      value: ts.Expression;
-      straightLine: boolean;
-      at: number;
-    }> = [];
+    const found: Write[] = [];
     const visit = (node: ts.Node): void => {
       if (
         ts.isBinaryExpression(node) &&
-        node.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
+        ASSIGNMENT_OPERATORS.has(node.operatorToken.kind) &&
         ts.isIdentifier(node.left) &&
         declarationOf(node.left, checker) === declaration
       ) {
@@ -1699,11 +1723,16 @@ function styleResolver(
         if (!sameUnit || before) {
           found.push({
             value: node.right,
+            sameUnit,
             // Definite only when it shares the element's execution unit, runs
-            // before it, and no branch stands between: those three together are
-            // what let a write be said to have HAPPENED.
+            // before it, no branch stands between, and the operator always
+            // writes: those together are what let a write be said to have
+            // HAPPENED, which is what killing an earlier value requires.
             straightLine:
-              sameUnit && before && alwaysRuns(node, elementUnit ?? undefined),
+              sameUnit &&
+              before &&
+              (ASSIGNMENT_OPERATORS.get(node.operatorToken.kind) ?? false) &&
+              alwaysRuns(node, elementUnit ?? undefined),
             at: node.getStart(),
           });
         }
@@ -1731,25 +1760,42 @@ function styleResolver(
    * a write that definitely runs can kill, so a reset inside an `if` narrows
    * nothing and every earlier value stays in play.
    *
+   * Killing reaches only the element's OWN execution unit. A write inside a
+   * function runs when that function is called, which the source order does not
+   * tell you: `function paint() { style = { ...owned } }` written above a
+   * `style = {}` still paints when `paint()` is called after it. Those writes
+   * survive whatever their position.
+   *
    * An empty list means the name resolved to a declaration that carries no
-   * readable value — a parameter, an import — which the callers treat as
-   * undecidable in whichever direction is conservative for them.
+   * readable value — an import, a parameter with no default — which the callers
+   * treat as undecidable in whichever direction is conservative for them.
    */
   const reachingValues = (identifier: ts.Identifier): ts.Expression[] => {
     const declaration = declarationOf(identifier, checker);
     if (!declaration) return [];
     const writes = writesTo(declaration);
-    const lastDefinite = writes.map(w => w.straightLine).lastIndexOf(true);
+    const here = writes.filter(write => write.sameUnit);
+    // Order across units is not decidable, so nothing here can rule them out.
+    const elsewhere = writes
+      .filter(write => !write.sameUnit)
+      .map(write => write.value);
+    const lastDefinite = here
+      .map(write => write.straightLine)
+      .lastIndexOf(true);
     if (lastDefinite === -1) {
       const initializer = bindingOf(identifier)?.initializer;
       return [
         ...(initializer ? [initializer] : []),
-        ...writes.map(w => w.value),
+        ...here.map(write => write.value),
+        ...elsewhere,
       ];
     }
     // The initializer and everything before that write are values the binding
     // has already stopped holding.
-    return writes.slice(lastDefinite).map(w => w.value);
+    return [
+      ...here.slice(lastDefinite).map(write => write.value),
+      ...elsewhere,
+    ];
   };
 
   /**
@@ -1776,11 +1822,13 @@ function styleResolver(
         objects.push(node);
         return;
       }
-      if (ts.isParenthesizedExpression(node)) return walk(node.expression);
-      // `as CSSProperties` and `satisfies` wrap the value without changing it.
-      if (ts.isAsExpression(node) || ts.isSatisfiesExpression(node)) {
-        return walk(node.expression);
-      }
+      // Parentheses, `as`, `satisfies` and `!` all wrap the value without
+      // changing it. Peeled by the SAME helper the property-value side uses, so
+      // the two cannot come to disagree about which syntax is erased — listing
+      // them here independently left `style={style!}` unread while the value
+      // side understood it.
+      const unwrapped = withoutTypeWrappers(node);
+      if (unwrapped !== node) return walk(unwrapped);
       // A literal condition decides the branch, and the branch it excludes is
       // one React never receives. Asked through the same helper the class half
       // uses, so one spelling of "this cannot be taken" cannot be resolved on
@@ -1896,11 +1944,12 @@ function propertyNameOf(
  * `[key as string]` resolves like a bare `key`.
  *
  * `seen` stops a self-referential binding from recursing. It holds DECLARATIONS
- * rather than names: keyed on text, an alias chain crossing a shadowed name
- * stopped at the second spelling of it and returned clean on a call site that
- * paints. Two bindings sharing a name are two entries here. Anything else — a
- * template with substitutions, a call, a member access — stays undecidable and
- * returns undefined, which leaves the property unnamed rather than guessed.
+ * rather than names, because a name is not what a binding IS: two bindings can
+ * share a spelling, and an alias chain may legitimately pass through both. The
+ * declaration is what makes them one binding or two, so it is what a cycle has
+ * to be measured in. Anything else — a template with substitutions, a call, a
+ * member access — stays undecidable and returns undefined, which leaves the
+ * property unnamed rather than guessed.
  *
  * KNOWN LIMIT, and it is a hole rather than a decision to be comfortable with:
  * a reassignable key escapes. `let k = "x"; k = "borderBottomColor";
@@ -2654,6 +2703,33 @@ describe("the tab indicator contract", () => {
     [
       "an owned property assigned to a style binding after it is declared",
       'let style = {};\nstyle = { borderBottomColor: "red" };\n<TabsTrigger style={style} />',
+    ],
+    // A write inside a function runs when that function is CALLED, which the
+    // source order does not tell you. Written above a reset and called below
+    // it, it is still the value the element renders — so a straight-line reset
+    // cannot rule it out.
+    [
+      "an owned property written by a closure called after a reset",
+      'let style: Record<string, string> = {};\nfunction paint() {\n  style = { borderBottomColor: "red" };\n}\nstyle = {};\npaint();\n<TabsTrigger style={style} />',
+    ],
+    // A logical assignment writes when its test passes, so it is one of the
+    // values the binding can hold. Accepting only `=` left the binding
+    // resolving to no object at all.
+    [
+      "an owned property supplied by a logical assignment",
+      'let style;\nstyle ??= { borderBottomColor: "red" };\n<TabsTrigger style={style} />',
+    ],
+    // Rendering the component without an argument passes exactly the default,
+    // so the default is a value the element receives.
+    [
+      "an owned property in a parameter's default object",
+      'function Row(style = { borderBottomColor: "red" }) {\n  return <TabsTrigger style={style} />;\n}',
+    ],
+    // `!` is erased before the code runs, so the element receives the object
+    // itself. The property-value side already read through it.
+    [
+      "an owned property behind a non-null assertion on the style object",
+      'const style = { borderBottomColor: "red" };\n<TabsTrigger style={style!} />',
     ],
     // A reset that MIGHT not happen clears nothing. Only a write that
     // definitely runs replaces what came before it, so the owned value is still

--- a/packages/ui/src/components/__tests__/tabs-contract.test.ts
+++ b/packages/ui/src/components/__tests__/tabs-contract.test.ts
@@ -996,11 +996,30 @@ const REACHES_BOTTOM = new Set([
 ]);
 
 const BORDER_ASPECTS = ["width", "style", "color"];
+
+/**
+ * The border-image shorthand and its longhands.
+ *
+ * Every one of them changes what the border renders rather than an aspect of
+ * it, so none names an edge or an aspect and none is reachable through the
+ * shorthand split above. `border-image-source` alone replaces the drawn border
+ * wherever the image covers it, which on a tab is the underline the primitive
+ * owns.
+ */
+const BORDER_IMAGE = /^border-image(?:-(source|slice|width|outset|repeat))?$/;
 const ANY_CORNER = /^border(-[a-z]+)*-radius$/;
 const BOTTOM_OFFSET = /^margin(-(bottom|block-end|block|y))?$/;
 
 function expandsTo(property: string): string[] {
   const kebab = property.replace(/([A-Z])/g, "-$1").toLowerCase();
+  // A border IMAGE replaces what the border draws, on every edge it covers.
+  // Checked before the shorthand split because it is not one: `border-image`
+  // names no edge and no aspect, so the pattern below does not match it and it
+  // stood for itself — a name that intersects nothing the primitive owns, while
+  // a gradient painted straight over the underline on every tab.
+  if (BORDER_IMAGE.test(kebab)) {
+    return BORDER_ASPECTS.map(aspect => `border-bottom-${aspect}`);
+  }
   const border = BORDER_PROPERTY.exec(kebab);
   if (border) {
     const [, edge, aspect] = border;
@@ -2232,6 +2251,21 @@ describe("the tab indicator contract", () => {
     [
       "a shorthand that replaces an owned longhand",
       '<TabsTrigger className="aria-[controls]:[outline:2px_solid_red]" />',
+    ],
+    // A border image paints over the border the primitive draws, on every tab
+    // including the inactive ones whose colour it owns. It names no edge and no
+    // aspect, so it reaches the underline without mentioning it.
+    [
+      "a border image painted over the underline",
+      '<TabsTrigger className="[border-image:linear-gradient(red,red)_1]" />',
+    ],
+    [
+      "the same border image set inline",
+      '<TabsTrigger style={{ borderImage: "linear-gradient(red,red) 1" }} />',
+    ],
+    [
+      "a border-image longhand on its own",
+      '<TabsTrigger style={{ borderImageSource: "linear-gradient(red,red)" }} />',
     ],
     [
       "a destructured namespace member",

--- a/packages/ui/src/components/__tests__/tabs-contract.test.ts
+++ b/packages/ui/src/components/__tests__/tabs-contract.test.ts
@@ -1,5 +1,37 @@
 /**
- * No call site may repaint the tab indicator.
+ * A BEST-EFFORT LINT over call sites that repaint the tab indicator.
+ *
+ * Read this first, because the name of the file oversells it. A pass means
+ * "no violation this scanner could see", NOT "no violation". The scan reads
+ * source syntax, and syntax has an unbounded surface: 24 review rounds
+ * produced 94 findings and not one round came back empty, with the last three
+ * finding gaps in the previous round's fixes. Treat a green here as evidence,
+ * never as a guarantee, and never as a reason to skip looking.
+ *
+ * KNOWN GAPS, left open deliberately rather than patched:
+ *
+ *   - a namespace member destructured off a shadowed namespace import
+ *     (`const { TabsTrigger: T } = UI` where a local `UI` shadows the import)
+ *   - a `className` bound through a `const` reaching the class walk without a
+ *     resolver, so a constant-bound owned class is not read
+ *   - an equal-value restatement under a DIFFERENT caller variant, where the
+ *     owned rule still wins the cascade by emission order
+ *   - `require` resolved by text rather than by binding, so a local function
+ *     named `require` is read as CommonJS
+ *
+ * WHY THEY ARE NOT FIXED. Measured across the repository: 124 files consume
+ * these primitives and NONE overrides the underline or the corners. Every real
+ * override is layout or size — `mx-3 mt-2.5`, `w-full justify-start`,
+ * `h-8 bg-transparent p-0`, `text-xs` — which the design intends to allow, and
+ * which `cn()` composition exists to serve. So this guards a violation that has
+ * not occurred, and closing four obscure spellings of it does not change that.
+ *
+ * The repeated overrides above are the real signal: `h-8/h-7 bg-transparent
+ * p-0` and `text-xs` want a named variant on the primitive, which is how the
+ * other 11 `cva` components in this package express the same thing. That is the
+ * follow-up, and it addresses the actual pressure rather than policing it.
+ *
+ * The original rationale follows, and still holds for what the scan DOES read:
  *
  * `Tabs` is an underline control: the active state is a 2px bottom border on the
  * trigger, and the trigger is square so that border runs flush to its edges. The
@@ -2771,7 +2803,7 @@ function violations(): Violation[] {
   return found;
 }
 
-describe("the tab indicator contract", () => {
+describe("the tab indicator lint", () => {
   beforeAll(async () => {
     designSystem = await loadDesignSystem();
   });

--- a/packages/ui/src/components/__tests__/tabs-contract.test.ts
+++ b/packages/ui/src/components/__tests__/tabs-contract.test.ts
@@ -1057,15 +1057,20 @@ const CALL_SITE_EXTENSIONS = [".tsx", ".jsx", ".js"] as const;
  * of them. That is slow, and worse, it makes the result depend on whether
  * somebody happened to build locally — a suite that reads generated output is
  * reading a different repository on each machine.
+ *
+ * Every name here is one that ONLY ever denotes generated output, and the list
+ * is short for that reason rather than by oversight. `build`, `out` and
+ * `coverage` are deliberately absent: they are output conventions at particular
+ * project locations, but they are also ordinary Next.js route segments, so
+ * `app/build/page.js` is a real call site. Pruning by BASENAME anywhere in the
+ * tree would drop it before the extension check ran — a false green produced by
+ * the very list meant to keep the scan honest.
  */
 const GENERATED_DIRECTORIES = new Set([
   "node_modules",
   "dist",
   ".turbo",
   ".next",
-  "coverage",
-  "out",
-  "build",
 ]);
 
 function isCallSite(name: string): boolean {
@@ -2398,9 +2403,18 @@ describe("which files the call-site scan reads", () => {
       mkdirSync(join(dir, ".next"));
       writeFileSync(join(dir, ".next", "chunk.js"), "");
 
+      // And a route that happens to be NAMED like an output directory. Pruning
+      // by basename would drop this, which is a call site going silently
+      // unread — the failure the pruning list is supposed to prevent, caused by
+      // the pruning list.
+      mkdirSync(join(dir, "build"));
+      writeFileSync(join(dir, "build", "page.js"), "");
+
       const found = sourceFiles(dir).map(path => path.slice(dir.length + 1));
 
-      expect(found.sort()).toEqual(["a.tsx", "b.jsx", "d.js"].sort());
+      expect(found.sort()).toEqual(
+        ["a.tsx", "b.jsx", "d.js", join("build", "page.js")].sort()
+      );
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
@@ -2449,6 +2463,31 @@ describe("which files the call-site scan reads", () => {
       // task list exists — and a bare `false` tells them nothing.
       expect({ task, missing }).toEqual({ task, missing: [] });
     }
+  });
+
+  it("reruns in watch mode for every extension it reads", () => {
+    // The scan reaches call sites with `readFileSync`, so Vitest has no module
+    // dependency on them: without an explicit trigger a watch session keeps
+    // displaying the previous green after a real violation is added to a `.js`
+    // or `.jsx` file. `forceRerunTriggers` is what supplies that dependency,
+    // and it is a second list of extensions — so it is checked against the
+    // first rather than trusted to stay in step.
+    const config = readFileSync(
+      resolve(HERE, "../../../vitest.config.ts"),
+      "utf8"
+    );
+    const trigger = /"\*\*\/src\/\*\*\/\*\.\{([^}]+)\}"/.exec(config)?.[1];
+
+    // Proves the pattern found something before anything is concluded from it:
+    // a renamed option or a reformatted config would otherwise read as a pass.
+    expect(trigger).toBeDefined();
+
+    const covered = (trigger ?? "").split(",").map(part => part.trim());
+    const missing = CALL_SITE_EXTENSIONS.map(e => e.slice(1)).filter(
+      extension => !covered.includes(extension)
+    );
+
+    expect(missing).toEqual([]);
   });
 
   it("finds a violation in a .jsx call site", () => {

--- a/packages/ui/src/components/__tests__/tabs-contract.test.ts
+++ b/packages/ui/src/components/__tests__/tabs-contract.test.ts
@@ -672,7 +672,59 @@ function restates(owned: Utility, caller: Utility): boolean {
  * does not see, and the consequence of missing one is a report rather than a
  * silence, which is the safer direction for a check whose findings are read.
  */
-function excludeEachOther(a: string, b: string): boolean {
+/**
+ * A selector with the parts that qualify an ANCESTOR removed.
+ *
+ * A qualifier only contradicts another when both constrain the same element.
+ * Tailwind's `group-*` variants compile to a functional group holding a
+ * descendant combinator — `group-not-disabled:` becomes
+ * `&:is(:where(.group):not(*:disabled) *)` — where the negation describes the
+ * GROUP and the subject is the trailing `*`. Read whole, that negation looks
+ * like a contradiction of the tab's own `:disabled`, and a caller that really
+ * can apply to a disabled tab inside an enabled group was excluded from every
+ * comparison.
+ *
+ * Distinct from `subjectOf`, which picks the last compound after a TOP-LEVEL
+ * combinator: the combinator here sits inside the parentheses, where that scan
+ * cannot see it. This runs first so the two compose rather than overlap.
+ *
+ * Dropping the whole group rather than parsing out its subject is deliberate:
+ * what remains is a selector with FEWER requirements, so it excludes less and
+ * compares more, and comparing is the reporting side.
+ */
+function withoutAncestorQualifiers(selector: string): string {
+  let out = "";
+  let at = 0;
+  while (at < selector.length) {
+    const functional = /^:(is|where|has|not)\(/.exec(selector.slice(at));
+    if (!functional) {
+      out += selector[at];
+      at += 1;
+      continue;
+    }
+    const open = at + functional[0].length;
+    let depth = 1;
+    let end = open;
+    while (end < selector.length && depth > 0) {
+      if (selector[end] === "(") depth += 1;
+      else if (selector[end] === ")") depth -= 1;
+      end += 1;
+    }
+    const inner = selector.slice(open, end - 1);
+    // A combinator at the group's own level means it relates two elements, so
+    // what it requires is not a requirement on the subject.
+    const describesAncestor =
+      splitTopLevel(inner, " ").length > 1 ||
+      splitTopLevel(inner, ">").length > 1;
+    if (!describesAncestor) out += selector.slice(at, end);
+    at = end;
+  }
+  return out;
+}
+
+function excludeEachOther(whole: string, other: string): boolean {
+  const a = withoutAncestorQualifiers(whole);
+  const b = withoutAncestorQualifiers(other);
   const negatedIn = (selector: string): string[] =>
     [...selector.matchAll(/:not\(([^)]*)\)/g)].map(match =>
       // A leading `*` is the universal selector Tailwind writes inside the
@@ -1577,7 +1629,10 @@ function styleResolver(
     seen?: Set<ts.Node>
   ): ts.ObjectLiteralExpression[];
   valueOf(identifier: ts.Identifier): ts.Expression | undefined;
-  reachingValues(identifier: ts.Identifier): ts.Expression[];
+  reachingValues(identifier: ts.Identifier): {
+    values: ts.Expression[];
+    exhaustive: boolean;
+  };
   declarationOf(identifier: ts.Identifier): ts.Declaration | undefined;
 } {
   /**
@@ -1653,6 +1708,16 @@ function styleResolver(
    */
   const alwaysRuns = (node: ts.Node, unit: ts.Node | undefined): boolean => {
     for (let at = node.parent; at && at !== unit; at = at.parent) {
+      // A `for` INITIALIZER runs once before the condition is ever asked, so it
+      // is unconditional even though the body beside it is not.
+      if (
+        ts.isForStatement(at) &&
+        at.initializer &&
+        node.getStart() >= at.initializer.getStart() &&
+        node.getEnd() <= at.initializer.getEnd()
+      ) {
+        continue;
+      }
       if (
         ts.isIfStatement(at) ||
         ts.isIterationStatement(at, /* lookInLabeledStatements */ true) ||
@@ -1687,6 +1752,7 @@ function styleResolver(
    */
   interface Write {
     value: ts.Expression;
+    operator: ts.SyntaxKind;
     /** Shares the element's execution unit, so it runs in source order. */
     sameUnit: boolean;
     /** Runs before the element every time, so it replaces what came before. */
@@ -1708,8 +1774,8 @@ function styleResolver(
     [ts.SyntaxKind.AmpersandAmpersandEqualsToken, false],
   ]);
 
-  const writesTo = (declaration: ts.Declaration): Write[] => {
-    const elementUnit = executionUnitOf(element);
+  const writesTo = (declaration: ts.Declaration, at: ts.Node): Write[] => {
+    const elementUnit = executionUnitOf(at);
     const found: Write[] = [];
     const visit = (node: ts.Node): void => {
       if (
@@ -1719,10 +1785,11 @@ function styleResolver(
         declarationOf(node.left, checker) === declaration
       ) {
         const sameUnit = executionUnitOf(node) === elementUnit;
-        const before = node.getStart() < element.getStart();
+        const before = node.getStart() < at.getStart();
         if (!sameUnit || before) {
           found.push({
             value: node.right,
+            operator: node.operatorToken.kind,
             sameUnit,
             // Definite only when it shares the element's execution unit, runs
             // before it, no branch stands between, and the operator always
@@ -1766,36 +1833,59 @@ function styleResolver(
    * `style = {}` still paints when `paint()` is called after it. Those writes
    * survive whatever their position.
    *
-   * An empty list means the name resolved to a declaration that carries no
-   * readable value — an import, a parameter with no default — which the callers
-   * treat as undecidable in whichever direction is conservative for them.
+   * Resolved AT THE IDENTIFIER, not at the element. An identifier is evaluated
+   * where it is written, so `const saved = style; style = {}` holds whatever
+   * `style` was on the line the alias was written — reading it beside the
+   * element instead applied a later reset to a value already captured.
+   *
+   * `exhaustive` says whether the list is the whole story. A variable's writes
+   * are all visible in the file, so its list is complete and a property emits
+   * only if one of them emits. A parameter or an import receives values from
+   * outside, so its list is a sample: the default a parameter declares is one
+   * value the element can receive, never the only one.
    */
-  const reachingValues = (identifier: ts.Identifier): ts.Expression[] => {
+  interface Reaching {
+    values: ts.Expression[];
+    /** No value can arrive from outside the ones listed. */
+    exhaustive: boolean;
+  }
+
+  const reachingValues = (identifier: ts.Identifier): Reaching => {
     const declaration = declarationOf(identifier, checker);
-    if (!declaration) return [];
-    const writes = writesTo(declaration);
-    const here = writes.filter(write => write.sameUnit);
+    if (!declaration) return { values: [], exhaustive: false };
+    if (!ts.isVariableDeclaration(declaration)) {
+      const binding = bindingOf(identifier);
+      return {
+        values: binding?.initializer ? [binding.initializer] : [],
+        exhaustive: false,
+      };
+    }
+    const writes = writesTo(declaration, identifier);
     // Order across units is not decidable, so nothing here can rule them out.
     const elsewhere = writes
       .filter(write => !write.sameUnit)
       .map(write => write.value);
-    const lastDefinite = here
-      .map(write => write.straightLine)
-      .lastIndexOf(true);
-    if (lastDefinite === -1) {
-      const initializer = bindingOf(identifier)?.initializer;
-      return [
-        ...(initializer ? [initializer] : []),
-        ...here.map(write => write.value),
-        ...elsewhere,
-      ];
+    const initializer = bindingOf(identifier)?.initializer;
+    let held: ts.Expression[] = initializer ? [initializer] : [];
+    for (const write of writes.filter(write => write.sameUnit)) {
+      if (write.straightLine) {
+        // Everything before is a value the binding has stopped holding.
+        held = [write.value];
+        continue;
+      }
+      // A `??=` whose current value is already there cannot fire, so its right
+      // side is not a value the binding can hold — the ordinary way to fill a
+      // style object only when nothing filled it yet.
+      if (
+        write.operator === ts.SyntaxKind.QuestionQuestionEqualsToken &&
+        held.length > 0 &&
+        held.every(isDefinitelyPresent)
+      ) {
+        continue;
+      }
+      held = [...held, write.value];
     }
-    // The initializer and everything before that write are values the binding
-    // has already stopped holding.
-    return [
-      ...here.slice(lastDefinite).map(write => write.value),
-      ...elsewhere,
-    ];
+    return { values: [...held, ...elsewhere], exhaustive: true };
   };
 
   /**
@@ -1858,7 +1948,7 @@ function styleResolver(
       // `let style = { ... }` is a false negative, the opposite polarity to an
       // unresolved property value.
       if (ts.isIdentifier(node)) {
-        for (const value of reachingValues(node)) walk(value);
+        for (const value of reachingValues(node).values) walk(value);
       }
     };
     walk(root);
@@ -1983,6 +2073,26 @@ function staticKeyOf(
     if (bound) return staticKeyOf(bound, resolver, seen);
   }
   return undefined;
+}
+
+/**
+ * Whether a value is certainly neither `null` nor `undefined`.
+ *
+ * Narrow on purpose: it decides whether a `??=` can fire, and answering "yes"
+ * removes a value from consideration. Only forms that cannot be nullish however
+ * they are read qualify, so anything unfamiliar keeps the write in play.
+ */
+function isDefinitelyPresent(value: ts.Expression): boolean {
+  const inner = withoutTypeWrappers(value);
+  return (
+    ts.isObjectLiteralExpression(inner) ||
+    ts.isArrayLiteralExpression(inner) ||
+    ts.isStringLiteral(inner) ||
+    ts.isNoSubstitutionTemplateLiteral(inner) ||
+    ts.isNumericLiteral(inner) ||
+    inner.kind === ts.SyntaxKind.TrueKeyword ||
+    inner.kind === ts.SyntaxKind.FalseKeyword
+  );
 }
 
 /**
@@ -2159,9 +2269,12 @@ function emitsValue(
     // branch carries its own trail, or one branch's visits would cut another's
     // short and report it as emitting.
     const reaching = resolver.reachingValues(inner);
-    if (reaching.length > 0) {
-      return reaching.some(value => emitsValue(value, resolver, new Set(seen)));
-    }
+    // A name fed from outside — a parameter, an import — can hold a value this
+    // file never shows, so the list is a sample and cannot clear the property.
+    if (!reaching.exhaustive) return true;
+    return reaching.values.some(value =>
+      emitsValue(value, resolver, new Set(seen))
+    );
   }
   return true;
 }
@@ -2752,6 +2865,18 @@ describe("the tab indicator contract", () => {
       "an owned declaration restated under a different variant",
       '<TabsTrigger className="aria-[controls]:outline-none" />',
     ],
+    // A parameter default is one value among many. A caller supplying a real
+    // colour is a value this file cannot see, so the default cannot clear it.
+    [
+      "an owned property whose parameter default a caller can replace",
+      'function Row(colour = undefined) {\n  return <TabsTrigger style={{ borderBottomColor: colour }} />;\n}\n<Row colour="red" />',
+    ],
+    // An alias captures the value at the line it is WRITTEN. A later reset of
+    // the source does not reach into what was already snapshotted.
+    [
+      "an owned property captured by an alias before the source is reset",
+      'let style = { borderBottomColor: "red" };\nconst saved = style;\nstyle = {};\n<TabsTrigger style={saved} />',
+    ],
   ])("catches %s", (_label, body) => {
     // The positive controls. Each is a shape an earlier version returned clean
     // on, or a category it never read. Without these, a check that can never
@@ -3042,6 +3167,18 @@ describe("the tab indicator contract", () => {
       "an equal declaration under a negated form of the owned qualifier",
       '<TabsTrigger className="not-disabled:opacity-50" />',
     ],
+    // A `??=` whose binding already holds a value cannot fire, so its right
+    // side is never what the element receives.
+    [
+      "an owned property behind a logical assignment that cannot fire",
+      'let style = {};\nstyle ??= { borderBottomColor: "red" };\n<TabsTrigger style={style} />',
+    ],
+    // A `for` initializer runs once before the condition is ever asked, so it
+    // is unconditional even though the body beside it is not.
+    [
+      "an owned property reset in a loop initializer",
+      'let style: Record<string, string> = { borderBottomColor: "red" };\nfor (style = {}; false; ) {\n  break;\n}\n<TabsTrigger style={style} />',
+    ],
   ])("does not report %s", (_label, body) => {
     // The complement, and the reason this is a contract rather than a ban. A
     // check that flags a documented example or a legitimate layout class gets
@@ -3287,6 +3424,14 @@ describe("which files the call-site scan reads", () => {
     expect(
       excludeEachOther('&[data-state="active"]', '&[data-state="inactive"]')
     ).toBe(true);
+
+    // An ancestor's qualifier is not the subject's. A disabled tab inside a
+    // group that is NOT disabled matches both rules, so they coexist and the
+    // comparison has to run — `group-not-disabled:` compiles the negation into
+    // a descendant group, where it describes the group and not the tab.
+    expect(
+      excludeEachOther("&:is(:where(.group):not(*:disabled) *)", "&:disabled")
+    ).toBe(false);
 
     // The positive control. Without it a test that answered `true` to
     // everything would pass both cases above, and every comparison in the

--- a/packages/ui/src/components/__tests__/tabs-contract.test.ts
+++ b/packages/ui/src/components/__tests__/tabs-contract.test.ts
@@ -18,6 +18,15 @@
  *     owned rule still wins the cascade by emission order
  *   - `require` resolved by text rather than by binding, so a local function
  *     named `require` is read as CommonJS
+ *   - an object spread inside a class map (`cn({ ...{ "border-b-0": true } })`)
+ *     is not traversed, so a class clsx applies is not read
+ *   - a METHOD in a JSX spread (`{...{ onClick() {} }}`) makes the whole spread
+ *     unreadable, even though its key is statically known to be unrelated
+ *   - a REASSIGNED component alias freezes ownership at its declaration, so
+ *     `let T = Other; T = TabsTrigger` is missed and the reverse is reported
+ *     falsely. Deliberate: following it needs reaching-definitions dataflow,
+ *     roughly 700 lines of which this change already removed after measuring
+ *     that it guarded zero real call sites
  *
  * WHY THEY ARE NOT FIXED. Measured across the repository: 124 files consume
  * these primitives and NONE overrides the underline or the corners. Every real

--- a/packages/ui/src/components/__tests__/tabs-contract.test.ts
+++ b/packages/ui/src/components/__tests__/tabs-contract.test.ts
@@ -90,29 +90,6 @@ const REPO = resolve(HERE, "../../../../..");
  */
 const SCAN_ROOT_NAMES = ["packages", "apps", "templates"] as const;
 
-/**
- * The watch-trigger glob that subscribes to each scanned root.
- *
- * DERIVED from `SCAN_ROOT_NAMES` rather than listed beside it, so a root added
- * to the traversal appears here without anyone remembering to add it. An
- * independently maintained copy would stay green while the newly scanned tree
- * went unwatched, which is the failure this mapping exists to prevent wearing
- * the mapping's own clothes.
- *
- * Vitest resolves `forceRerunTriggers` relative to the package, so each root is
- * reached by relative path here rather than by the `$TURBO_ROOT$` the Turbo
- * inputs use — `packages` is this package's parent, the rest are siblings of it.
- *
- * The recursive wildcard follows the root immediately, with no directory
- * segment in between. A file placed DIRECTLY under a root is one the traversal
- * reads, and a glob requiring a package or app directory first does not match
- * it — measured against the installed matcher, not assumed from the shape.
- */
-const CALL_SITE_ROOT_GLOBS = SCAN_ROOT_NAMES.map(root => ({
-  root,
-  prefix: root === "packages" ? "../**/*." : `../../${root}/**/*.`,
-}));
-
 const SCAN_ROOTS = SCAN_ROOT_NAMES.map(r => resolve(REPO, r));
 
 /** The primitive itself declares the contract; it is not a call site. */
@@ -998,15 +975,16 @@ const REACHES_BOTTOM = new Set([
 const BORDER_ASPECTS = ["width", "style", "color"];
 
 /**
- * The border-image shorthand and its longhands.
+ * The border-image properties that can put an image over the border.
  *
- * Every one of them changes what the border renders rather than an aspect of
- * it, so none names an edge or an aspect and none is reachable through the
- * shorthand split above. `border-image-source` alone replaces the drawn border
- * wherever the image covers it, which on a tab is the underline the primitive
- * owns.
+ * Only the shorthand and `-source`, because only they can supply one. While
+ * `border-image-source` is its initial `none` there is no image to draw, so
+ * `-slice`, `-width`, `-outset` and `-repeat` change nothing on screen and the
+ * primitive's own bottom border renders exactly as it did. Owning all five
+ * reported those four as repainting an underline they cannot reach; they fall
+ * through to standing for themselves, and intersect nothing the primitive owns.
  */
-const BORDER_IMAGE = /^border-image(?:-(source|slice|width|outset|repeat))?$/;
+const BORDER_IMAGE = /^border-image(?:-source)?$/;
 const ANY_CORNER = /^border(-[a-z]+)*-radius$/;
 const BOTTOM_OFFSET = /^margin(-(bottom|block-end|block|y))?$/;
 
@@ -1151,14 +1129,92 @@ function sourceFiles(dir: string, found: string[] = []): string[] {
  * from the delimiters of a JSX element being grammatical, so no character-class
  * approximation of them holds.
  */
-function parse(file: string, source: string): ts.SourceFile {
-  return ts.createSourceFile(
+/**
+ * The compiler options the binder runs under.
+ *
+ * `noLib` is load-bearing rather than a saving. It is what makes an unshadowed
+ * `undefined` resolve to NO symbol, which is how a local `const undefined` is
+ * told apart from the global one; with a lib loaded both would resolve to a
+ * declaration and the two cases would read alike. `noResolve` keeps the program
+ * to the single file: nothing here reads a type or follows an import, so
+ * resolving the module graph would buy nothing and cost the whole workspace.
+ */
+const BINDER_OPTIONS: ts.CompilerOptions = {
+  noResolve: true,
+  noLib: true,
+  allowJs: true,
+  jsx: ts.JsxEmit.Preserve,
+  types: [],
+};
+
+/**
+ * Parse as TSX, and BIND, so names resolve the way the language resolves them.
+ *
+ * The binder rather than a scope walk written here, because every lexical form
+ * that declares a name is a form the walk has to know about: a parameter, a
+ * catch binding, an import, a function declaration, a loop variable. A hand
+ * written resolver is a list of the ones remembered, and the ones forgotten
+ * fail SILENTLY — the search continues outward and finds a different binding of
+ * the same name, which reads as a confident answer about the wrong declaration.
+ * `getSymbolAtLocation` answers from the same tables the compiler itself uses,
+ * so shadowing, parameters and alias identity are correct by construction
+ * rather than by enumeration.
+ *
+ * One program per file keeps `violationsIn` a pure function of its source,
+ * which is what lets every case below state a whole file and read the result.
+ */
+function parse(
+  file: string,
+  source: string
+): { sourceFile: ts.SourceFile; checker: ts.TypeChecker } {
+  const sourceFile = ts.createSourceFile(
     file,
     source,
     ts.ScriptTarget.Latest,
     /* setParentNodes */ true,
     ts.ScriptKind.TSX
   );
+  const host: ts.CompilerHost = {
+    getSourceFile: name => (name === file ? sourceFile : undefined),
+    getDefaultLibFileName: () => "lib.d.ts",
+    writeFile: () => {},
+    getCurrentDirectory: () => REPO,
+    getCanonicalFileName: name => name,
+    useCaseSensitiveFileNames: () => true,
+    getNewLine: () => "\n",
+    fileExists: name => name === file,
+    readFile: name => (name === file ? source : undefined),
+  };
+  const checker = ts
+    .createProgram([file], BINDER_OPTIONS, host)
+    .getTypeChecker();
+  return { sourceFile, checker };
+}
+
+/**
+ * The declaration a name refers to HERE, or undefined when it refers to none.
+ *
+ * Undefined has two meanings that callers must keep apart: a global (there is
+ * no declaration in this file) and a name the binder could not resolve. Both
+ * say "not a local binding", which is all any caller here asks.
+ *
+ * A shorthand needs its own question. In `{ borderBottomColor }` the identifier
+ * is both the property name and the value, and `getSymbolAtLocation` answers
+ * with the PROPERTY — a member of the object literal, whose declaration is the
+ * shorthand itself. Following that resolves the value to the entry that holds
+ * it, so a shorthand bound to `undefined` looked like a colour and was
+ * reported. The value binding is a separate lookup.
+ */
+function declarationOf(
+  identifier: ts.Identifier,
+  checker: ts.TypeChecker
+): ts.Declaration | undefined {
+  const parent = identifier.parent;
+  const symbol =
+    ts.isShorthandPropertyAssignment(parent) && parent.name === identifier
+      ? checker.getShorthandAssignmentValueSymbol(parent)
+      : checker.getSymbolAtLocation(identifier);
+  return symbol?.valueDeclaration;
 }
 
 /**
@@ -1383,82 +1439,76 @@ function literalStrings(node: ts.Node, found: string[] = []): string[] {
  * in the other order, invents one. Which declaration a name refers to is a
  * lexical question, and the answer is the nearest enclosing one.
  */
-function styleResolver(attribute: ts.JsxAttribute): {
+function styleResolver(checker: ts.TypeChecker): {
   objectsFrom(
     expression: ts.Expression | undefined,
     seen?: Set<ts.Node>
   ): ts.ObjectLiteralExpression[];
-  valueOf(
-    name: string,
-    from?: ts.Node
-  ): { value: ts.Expression; scope: ts.Node } | undefined;
+  valueOf(identifier: ts.Identifier): ts.Expression | undefined;
+  declarationOf(identifier: ts.Identifier): ts.Declaration | undefined;
 } {
   /**
-   * The nearest declaration of a name, and whether it can be trusted.
+   * What a name holds, for a name the binder resolved to a declaration here.
    *
-   * Two things this deliberately does NOT do, each of which was a false
-   * negative:
+   * Mutability is REPORTED rather than filtered on, because the right answer
+   * depends on the CALLER. For a property value, unresolved means "assume it
+   * emits" and reporting is the safe side. For the style object itself,
+   * unresolved means an empty object list and therefore silence — so the same
+   * filter that protects one caller blinds the other.
    *
-   * - It stops at the FIRST scope declaring the name, even when that
-   *   declaration is mutable. Skipping a mutable shadow and continuing outward
-   *   resolves the use to a completely different binding: an inner
-   *   `let colour = "red"` under an outer `const colour = undefined` rendered
-   *   red while the scan read the outer `undefined` and stayed silent. A shadow
-   *   makes the name undecidable; it does not make it the outer one.
-   * - It reports mutability rather than filtering on it, because the right
-   *   answer depends on the CALLER. For a property value, unresolved means
-   *   "assume it emits" and reporting is the safe side. For the style object
-   *   itself, unresolved means an empty object list and therefore silence — so
-   *   the same filter that protects one caller blinds the other.
-   *
-   * The declaration's own scope comes back with it, so an alias is followed
-   * from where it was WRITTEN. `const key = sourceKey` must resolve `sourceKey`
-   * against the alias's scope; resolving it against the element's picks up an
-   * inner `sourceKey` that the alias never saw.
+   * A declaration with no initializer is still a binding. It stops the question
+   * at the right place: a parameter shadowing an outer constant means the name
+   * is the parameter, whose value the caller supplies, so the property is
+   * undecidable rather than the outer constant's.
    */
   interface Binding {
-    initializer: ts.Expression;
-    /** The declaration is `let` or `var`, so its initializer is not final. */
+    /** The declaration's own initializer, where it has one. */
+    initializer: ts.Expression | undefined;
+    /** The initializer is not necessarily what the name holds at the element. */
     mutable: boolean;
-    /** Where the declaration lives, for following aliases from there. */
-    scope: ts.Node;
   }
 
-  const declaredIn = (scope: ts.Node, name: string): Binding | undefined => {
-    let found: Binding | undefined;
-    // Only the scope's OWN statements, so a declaration nested inside a
-    // sibling function is not mistaken for one in this scope.
-    ts.forEachChild(scope, statement => {
-      if (!ts.isVariableStatement(statement)) return;
+  const bindingOf = (identifier: ts.Identifier): Binding | undefined => {
+    const declaration = declarationOf(identifier, checker);
+    if (!declaration) return undefined;
+    if (ts.isVariableDeclaration(declaration)) {
+      const list = declaration.parent;
+      // `const` is the only form whose initializer is still the value later on.
       const mutable =
-        (statement.declarationList.flags & ts.NodeFlags.Const) === 0;
-      for (const declaration of statement.declarationList.declarations) {
-        if (
-          ts.isIdentifier(declaration.name) &&
-          declaration.name.text === name &&
-          declaration.initializer
-        ) {
-          found = { initializer: declaration.initializer, mutable, scope };
-        }
-      }
-    });
-    return found;
+        !ts.isVariableDeclarationList(list) ||
+        (list.flags & ts.NodeFlags.Const) === 0;
+      return { initializer: declaration.initializer, mutable };
+    }
+    // A parameter's default is what it holds only when the caller passes
+    // nothing, and an import, a function or a catch binding has no initializer
+    // to read at all. Each is a binding whose value is undecidable here.
+    return { initializer: undefined, mutable: true };
   };
 
-  const bindingOf = (name: string, from: ts.Node): Binding | undefined => {
-    for (let scope: ts.Node | undefined = from; scope; scope = scope.parent) {
+  /**
+   * Every value assigned to a binding anywhere in the file.
+   *
+   * A declaration initializer is only the FIRST value a mutable binding holds:
+   * `let style = {}; style = { borderBottomColor: "red" }` renders the second
+   * one, and reading the declaration alone reported nothing at all. Matched by
+   * DECLARATION identity rather than by name, so a same-named binding in
+   * another scope contributes nothing and the whole file can be searched.
+   */
+  const assignedValues = (declaration: ts.Declaration): ts.Expression[] => {
+    const values: ts.Expression[] = [];
+    const visit = (node: ts.Node): void => {
       if (
-        ts.isBlock(scope) ||
-        ts.isSourceFile(scope) ||
-        ts.isCaseClause(scope)
+        ts.isBinaryExpression(node) &&
+        node.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
+        ts.isIdentifier(node.left) &&
+        declarationOf(node.left, checker) === declaration
       ) {
-        // The FIRST scope that declares it wins, mutable or not. Continuing
-        // past a shadow is what reads the wrong binding.
-        const found = declaredIn(scope, name);
-        if (found) return found;
+        values.push(node.right);
       }
-    }
-    return undefined;
+      ts.forEachChild(node, visit);
+    };
+    visit(declaration.getSourceFile());
+    return values;
   };
 
   /**
@@ -1507,12 +1557,16 @@ function styleResolver(attribute: ts.JsxAttribute): {
         walk(node.right);
         return;
       }
-      // Followed whether or not the binding is mutable. An unresolved object
-      // yields an EMPTY list here, and an empty list reports nothing — so
-      // dropping a `let style = { ... }` is a false negative, the opposite
-      // polarity to an unresolved property value.
+      // Followed whether or not the binding is mutable, and through every
+      // ASSIGNMENT as well as the declaration. An unresolved object yields an
+      // EMPTY list here, and an empty list reports nothing — so dropping a
+      // `let style = { ... }` is a false negative, the opposite polarity to an
+      // unresolved property value.
       if (ts.isIdentifier(node)) {
-        walk(bindingOf(node.text, node)?.initializer);
+        const declaration = declarationOf(node, checker);
+        if (!declaration) return;
+        walk(bindingOf(node)?.initializer);
+        for (const assigned of assignedValues(declaration)) walk(assigned);
       }
     };
     walk(root);
@@ -1527,27 +1581,32 @@ function styleResolver(attribute: ts.JsxAttribute): {
    * treat an unresolved value as emitting, so undecidable errs towards
    * reporting.
    *
-   * `from` is where the name was written, so an alias resolves against its own
-   * scope rather than the element's.
+   * The identifier itself is the input, never its text: the binder resolves it
+   * at its own position, so an alias is followed from where it was WRITTEN
+   * without the caller having to carry a scope along with it.
    */
-  const valueOf = (
-    name: string,
-    from: ts.Node = attribute
-  ): { value: ts.Expression; scope: ts.Node } | undefined => {
-    const binding = bindingOf(name, from);
+  const valueOf = (identifier: ts.Identifier): ts.Expression | undefined => {
+    const binding = bindingOf(identifier);
     if (!binding || binding.mutable) return undefined;
-    return { value: binding.initializer, scope: binding.scope };
+    return binding.initializer;
   };
 
-  return { objectsFrom, valueOf };
+  return {
+    objectsFrom,
+    valueOf,
+    declarationOf: identifier => declarationOf(identifier, checker),
+  };
 }
 
 /** The objects an element's `style` prop can resolve to here. */
-function styleObjectsFor(attribute: ts.JsxAttribute): {
+function styleObjectsFor(
+  attribute: ts.JsxAttribute,
+  checker: ts.TypeChecker
+): {
   objects: ts.ObjectLiteralExpression[];
   resolver: ReturnType<typeof styleResolver>;
 } {
-  const resolver = styleResolver(attribute);
+  const resolver = styleResolver(checker);
   const initializer = attribute.initializer;
   if (!initializer || !ts.isJsxExpression(initializer)) {
     return { objects: [], resolver };
@@ -1591,7 +1650,10 @@ function propertyNameOf(
  * declared side by side are read the same way, and wrappers are peeled first so
  * `[key as string]` resolves like a bare `key`.
  *
- * `seen` stops a self-referential binding from recursing. Anything else — a
+ * `seen` stops a self-referential binding from recursing. It holds DECLARATIONS
+ * rather than names: keyed on text, an alias chain crossing a shadowed name
+ * stopped at the second spelling of it and returned clean on a call site that
+ * paints. Two bindings sharing a name are two entries here. Anything else — a
  * template with substitutions, a call, a member access — stays undecidable and
  * returns undefined, which leaves the property unnamed rather than guessed.
  *
@@ -1605,27 +1667,26 @@ function propertyNameOf(
  * reported — the conservative side. For a KEY, undecidable means the property
  * is not known at all, and defaulting to "owned" would report every computed
  * key in the repository, including the overwhelming majority that name nothing
- * this primitive draws. Closing this needs the assignments in scope to be read,
- * not a change of default.
+ * this primitive draws.
  */
 function staticKeyOf(
   expression: ts.Expression,
   resolver: ReturnType<typeof styleResolver>,
-  seen = new Set<string>(),
-  from?: ts.Node
+  seen = new Set<ts.Declaration>()
 ): string | undefined {
   const value = withoutTypeWrappers(expression);
   if (ts.isStringLiteral(value) || ts.isNoSubstitutionTemplateLiteral(value)) {
     return value.text;
   }
-  if (ts.isIdentifier(value) && !seen.has(value.text)) {
-    seen.add(value.text);
-    const bound = resolver.valueOf(value.text, from);
-    // Followed from the DECLARATION's scope, not the element's. An alias like
-    // `const key = sourceKey` refers to whatever `sourceKey` meant where the
-    // alias was written, and resolving it beside the element instead picks up
-    // an inner `sourceKey` the alias never saw.
-    if (bound) return staticKeyOf(bound.value, resolver, seen, bound.scope);
+  if (ts.isIdentifier(value)) {
+    const declaration = resolver.declarationOf(value);
+    if (!declaration || seen.has(declaration)) return undefined;
+    seen.add(declaration);
+    // The binder resolved this identifier at its own position, so an alias
+    // like `const key = sourceKey` already refers to whatever `sourceKey`
+    // meant where the alias was written.
+    const bound = resolver.valueOf(value);
+    if (bound) return staticKeyOf(bound, resolver, seen);
   }
   return undefined;
 }
@@ -1638,10 +1699,19 @@ function staticKeyOf(
  * decidable here and must keep being reported, because the same variable holds a
  * colour on the next render — which is exactly how the violation that motivated
  * the inline half was written.
+ *
+ * `undefined` is a NAME, not a keyword, so a local declaration of it is a
+ * colour like any other. It counts as nothing only when it resolves to no
+ * declaration in this file, which is what the global one does.
  */
-function isDefinitelyNothing(initializer: ts.Expression): boolean {
+function isDefinitelyNothing(
+  initializer: ts.Expression,
+  resolver: ReturnType<typeof styleResolver>
+): boolean {
   const value = withoutTypeWrappers(initializer);
-  if (ts.isIdentifier(value)) return value.text === "undefined";
+  if (ts.isIdentifier(value)) {
+    return value.text === "undefined" && !resolver.declarationOf(value);
+  }
   if (value.kind === ts.SyntaxKind.NullKeyword) return true;
   // `void 0` is the other spelling of the same intent.
   return ts.isVoidExpression(value);
@@ -1768,19 +1838,20 @@ function declaredProperties(
 function emitsValue(
   value: ts.Expression,
   resolver: ReturnType<typeof styleResolver>,
-  seen = new Set<string>(),
-  from?: ts.Node
+  seen = new Set<ts.Declaration>()
 ): boolean {
   const inner = withoutTypeWrappers(value);
-  if (isDefinitelyNothing(inner)) return false;
+  if (isDefinitelyNothing(inner, resolver)) return false;
   // Unwrapped before the binding lookup too, so `(colour as string)` resolves
   // through the same identifier path a bare `colour` does.
-  if (ts.isIdentifier(inner) && !seen.has(inner.text)) {
-    seen.add(inner.text);
-    const bound = resolver.valueOf(inner.text, from);
-    // Same lexical rule as a computed key: an alias is resolved from where it
-    // was declared.
-    if (bound) return emitsValue(bound.value, resolver, seen, bound.scope);
+  if (ts.isIdentifier(inner)) {
+    const declaration = resolver.declarationOf(inner);
+    // Keyed on the declaration, so two bindings that share a name are two
+    // entries and a chain crossing a shadow is not mistaken for a cycle.
+    if (!declaration || seen.has(declaration)) return true;
+    seen.add(declaration);
+    const bound = resolver.valueOf(inner);
+    if (bound) return emitsValue(bound, resolver, seen);
   }
   return true;
 }
@@ -1806,7 +1877,7 @@ interface Violation {
 }
 
 function violationsIn(file: string, source: string): Violation[] {
-  const sourceFile = parse(file, source);
+  const { sourceFile, checker } = parse(file, source);
   const { ownership, exportedNameOf } = ownershipIn(sourceFile);
   const found: Violation[] = [];
   const at = (node: ts.Node): number =>
@@ -1821,7 +1892,7 @@ function violationsIn(file: string, source: string): Violation[] {
           if (!ts.isJsxAttribute(attribute)) continue;
           const name = attribute.name.getText(sourceFile);
           if (name === "style") {
-            const { objects, resolver } = styleObjectsFor(attribute);
+            const { objects, resolver } = styleObjectsFor(attribute, checker);
             const property = objects
               .map(object => ownedStyleProperty(exported, object, resolver))
               .find(Boolean);
@@ -2263,8 +2334,12 @@ describe("the tab indicator contract", () => {
       "the same border image set inline",
       '<TabsTrigger style={{ borderImage: "linear-gradient(red,red) 1" }} />',
     ],
+    // The one longhand that can put an image there. It is what keeps the
+    // narrowing below honest: the other four are reported by nothing, so
+    // without a case on `-source` a mapping that owned no border image at all
+    // would pass.
     [
-      "a border-image longhand on its own",
+      "a border image supplied by the source longhand",
       '<TabsTrigger style={{ borderImageSource: "linear-gradient(red,red)" }} />',
     ],
     [
@@ -2304,6 +2379,26 @@ describe("the tab indicator contract", () => {
     [
       "a computed key aliasing a constant shadowed near the element",
       'const sourceKey = "borderBottomColor";\nconst key = sourceKey;\nfunction Row() {\n  const sourceKey = "width";\n  return <TabsTrigger style={{ [key]: "red" }} />;\n}',
+    ],
+    // An alias chain CROSSING a shadowed name. Two distinct bindings spelled
+    // `key`, so a cycle guard keyed on the spelling stops at the second one and
+    // never reaches the owned property the chain names.
+    [
+      "a computed key aliased through a second binding of the same name",
+      'const key = "borderBottomColor";\nfunction Row() {\n  const alias = key;\n  {\n    const key = alias;\n    return <TabsTrigger style={{ [key]: "red" }} />;\n  }\n}',
+    ],
+    // The value a mutable binding holds at the element is the last one ASSIGNED
+    // to it, not the one it was declared with. Reading only the declaration saw
+    // an empty object and reported nothing.
+    [
+      "an owned property assigned to a style binding after it is declared",
+      'let style = {};\nstyle = { borderBottomColor: "red" };\n<TabsTrigger style={style} />',
+    ],
+    // `undefined` is a NAME. Shadowed by a local declaration it is an ordinary
+    // colour, and reading the spelling alone cleared a call site that paints.
+    [
+      "an owned property set to a locally shadowed undefined",
+      'function Row() {\n  const undefined = "red";\n  return <TabsTrigger style={{ borderBottomColor: undefined }} />;\n}',
     ],
   ])("catches %s", (_label, body) => {
     // The positive controls. Each is a shape an earlier version returned clean
@@ -2534,6 +2629,21 @@ describe("the tab indicator contract", () => {
       "a spread whose owned property the object then clears",
       'const inherited = { borderBottomColor: "red" };\n<TabsTrigger style={{ ...inherited, borderBottomColor: undefined }} />',
     ],
+    // A PARAMETER shadowing an outer constant. The name is the parameter, whose
+    // value the caller supplies, so the property is undecidable — not the outer
+    // constant's. Walking past the parameter named an owned property for an
+    // element that renders whatever it is passed.
+    [
+      "a computed key bound to a parameter shadowing an outer constant",
+      'const key = "borderBottomColor";\nfunction Row(key = "width") {\n  return <TabsTrigger style={{ [key]: "red" }} />;\n}',
+    ],
+    // The border-image longhands that cannot draw. With `border-image-source`
+    // at its initial `none` there is no image, so these change nothing on
+    // screen and the primitive's own bottom border renders as it did.
+    [
+      "border-image longhands with no source to draw",
+      '<TabsTrigger style={{ borderImageRepeat: "round", borderImageSlice: "30", borderImageWidth: "4px", borderImageOutset: "2px" }} />',
+    ],
   ])("does not report %s", (_label, body) => {
     // The complement, and the reason this is a contract rather than a ban. A
     // check that flags a documented example or a legitimate layout class gets
@@ -2687,7 +2797,7 @@ describe("which files the call-site scan reads", () => {
     }
   });
 
-  it("reruns in watch mode for every root and extension it reads", () => {
+  it("reruns in watch mode for every root and extension it reads", async () => {
     // The scan reaches call sites with `readFileSync`, so Vitest has no module
     // dependency on them: without an explicit trigger a watch session keeps
     // displaying the previous green after a real violation is added.
@@ -2697,57 +2807,42 @@ describe("which files the call-site scan reads", () => {
     // `**/src` subscribes to `packages/ui` alone — a call site in
     // `packages/admin`, an app or a template could gain a violation and the
     // suite reporting on it would never rerun.
-    const config = readFileSync(
-      resolve(HERE, "../../../vitest.config.ts"),
-      "utf8"
-    );
-
-    const triggers = [...config.matchAll(/"([^"]*)\{([^}]+)\}"/g)].map(
-      match => ({
-        prefix: match[1],
-        extensions: match[2].split(",").map(part => part.trim()),
+    // The REAL triggers and the REAL matcher, on the REAL paths.
+    //
+    // Every earlier version of this case compared the config's strings against
+    // strings assembled here, and a comparison between two things written in
+    // the same change proves nothing about either: the triggers were relative,
+    // matched none of the absolute paths Vitest hands the matcher, and this
+    // contract stayed green throughout because it never ran one.
+    //
+    // So the config is IMPORTED rather than parsed, picomatch is resolved
+    // through Vitest so it is the same version and cannot drift, and the paths
+    // are the ones the traversal actually returns.
+    const { default: config } = (await import("../../../vitest.config")) as {
+      default: { test?: { forceRerunTriggers?: string[] } };
+    };
+    const triggers = config.test?.forceRerunTriggers ?? [];
+    const fromHere = createRequire(import.meta.url);
+    const isMatch = fromHere(
+      fromHere.resolve("picomatch", {
+        paths: [dirname(fromHere.resolve("vitest/package.json"))],
       })
+    ).isMatch as (path: string, globs: string[]) => boolean;
+
+    // A negative control first, so a matcher that says yes to everything — the
+    // one way every assertion below could pass while covering nothing — is
+    // caught before its answers are trusted. A Markdown file is read by no
+    // scan and must not trigger a rerun.
+    expect(isMatch(resolve(REPO, "packages/ui/README.md"), triggers)).toBe(
+      false
     );
 
-    // Proves the pattern matched something before anything is concluded from
-    // it: a renamed option or a reformatted config would otherwise read as a
-    // pass, which is the failure this whole case exists to prevent.
-    expect(triggers.length).toBeGreaterThan(0);
-
-    // The watched roots ARE the scanned roots. Deriving the list is what keeps
-    // them in step today; asserting it is what notices if someone replaces the
-    // derivation with a literal — which leaves every case below green while a
-    // scanned tree goes unwatched, because they only check the entries present.
-    expect(CALL_SITE_ROOT_GLOBS.map(glob => glob.root)).toEqual([
-      ...SCAN_ROOT_NAMES,
-    ]);
-
-    // Each glob must recurse from the ROOT itself, with no directory segment
-    // in between. Measured against the installed matcher rather than inferred:
-    // `../*/**` does not match a file placed directly under `packages`, so a
-    // prefix of that shape leaves those files unwatched while this contract —
-    // comparing strings — reported them covered.
-    for (const { root, prefix } of CALL_SITE_ROOT_GLOBS) {
-      expect({ root, prefix }).toEqual({
-        root,
-        prefix: expect.stringMatching(/(^|\/)\*\*\/\*\.$/),
-      });
-    }
-
-    const missing = CALL_SITE_ROOT_GLOBS.flatMap(({ root, prefix }) =>
-      CALL_SITE_EXTENSIONS.map(extension => extension.slice(1))
-        .filter(
-          extension =>
-            !triggers.some(
-              trigger =>
-                trigger.prefix === prefix &&
-                trigger.extensions.includes(extension)
-            )
-        )
-        .map(extension => `${root}:${extension}`)
-    );
-
-    expect(missing).toEqual([]);
+    // Every file the scan reads has to trigger a rerun, because every one of
+    // them can gain a violation this suite would otherwise keep reporting
+    // clean. Named individually: the list is only ever wrong for a whole tree
+    // at a time, and a bare count says nothing about which.
+    const unwatched = scanned().filter(file => !isMatch(file, triggers));
+    expect(unwatched).toEqual([]);
   });
 
   it("finds a violation in a .jsx call site", () => {

--- a/packages/ui/src/components/__tests__/tabs-contract.test.ts
+++ b/packages/ui/src/components/__tests__/tabs-contract.test.ts
@@ -1465,13 +1465,46 @@ function styleObjectsFor(attribute: ts.JsxAttribute): {
  * past it — the same shape as the shorthand entry beside it. A computed key
  * built from a variable is not decidable here and is left alone.
  */
-function propertyNameOf(name: ts.PropertyName): string | undefined {
+function propertyNameOf(
+  name: ts.PropertyName,
+  resolver: ReturnType<typeof styleResolver>
+): string | undefined {
   if (ts.isIdentifier(name) || ts.isStringLiteral(name)) return name.text;
   if (ts.isComputedPropertyName(name)) {
-    const key = name.expression;
-    if (ts.isStringLiteral(key) || ts.isNoSubstitutionTemplateLiteral(key)) {
-      return key.text;
-    }
+    return staticKeyOf(name.expression, resolver);
+  }
+  return undefined;
+}
+
+/**
+ * The property a computed key names, when that is decidable without running it.
+ *
+ * A literal is the easy case. A local constant is the one that matters:
+ * `const key = "borderBottomColor"; style={{ [key]: "red" }}` repaints the
+ * indicator exactly as the literal spelling does, and reading only the literal
+ * form walked past it — so the check reported clean on a call site that paints.
+ *
+ * Followed through the same resolver the values use, so a key and a value
+ * declared side by side are read the same way, and wrappers are peeled first so
+ * `[key as string]` resolves like a bare `key`.
+ *
+ * `seen` stops a self-referential binding from recursing. Anything else — a
+ * template with substitutions, a call, a member access — stays undecidable and
+ * returns undefined, which leaves the property unnamed rather than guessed.
+ */
+function staticKeyOf(
+  expression: ts.Expression,
+  resolver: ReturnType<typeof styleResolver>,
+  seen = new Set<string>()
+): string | undefined {
+  const value = withoutTypeWrappers(expression);
+  if (ts.isStringLiteral(value) || ts.isNoSubstitutionTemplateLiteral(value)) {
+    return value.text;
+  }
+  if (ts.isIdentifier(value) && !seen.has(value.text)) {
+    seen.add(value.text);
+    const bound = resolver.valueOf(value.text);
+    if (bound) return staticKeyOf(bound, resolver, seen);
   }
   return undefined;
 }
@@ -1572,7 +1605,7 @@ function declaredProperties(
       continue;
     }
     if (ts.isPropertyAssignment(property)) {
-      const name = propertyNameOf(property.name);
+      const name = propertyNameOf(property.name, resolver);
       if (name) setOnEach(name, emitsValue(property.initializer, resolver));
       continue;
     }
@@ -1589,7 +1622,7 @@ function declaredProperties(
     // written at the key. What it returns is not decidable here, so it counts
     // as emitting.
     if (ts.isGetAccessorDeclaration(property)) {
-      const name = propertyNameOf(property.name);
+      const name = propertyNameOf(property.name, resolver);
       if (name) setOnEach(name, true);
     }
   }
@@ -2074,6 +2107,22 @@ describe("the tab indicator contract", () => {
     [
       "an owned property declared through a getter",
       '<TabsTrigger style={{ get borderBottomColor() { return "red"; } }} />',
+    ],
+    // A computed key built from a local constant names the property exactly as
+    // the literal spelling does, and React emits the same declaration. Reading
+    // only the literal form walked past it and reported clean on a call site
+    // that repaints the indicator.
+    [
+      "an owned property behind a computed key bound to a constant",
+      'const key = "borderBottomColor";\n<TabsTrigger style={{ [key]: "red" }} />',
+    ],
+    [
+      "the same constant behind a type assertion",
+      'const key = "borderBottomColor" as const;\n<TabsTrigger style={{ [key as string]: "red" }} />',
+    ],
+    [
+      "a getter whose name is a computed constant",
+      'const key = "borderBottomColor";\n<TabsTrigger style={{ get [key]() { return "red"; } }} />',
     ],
     [
       "a shorthand that replaces an owned longhand",

--- a/packages/ui/src/components/__tests__/tabs-contract.test.ts
+++ b/packages/ui/src/components/__tests__/tabs-contract.test.ts
@@ -1930,7 +1930,11 @@ function selectedByLiteralCondition(
   return decided ? node.left : node.right;
 }
 
-function literalStrings(node: ts.Node, found: string[] = []): string[] {
+function literalStrings(
+  node: ts.Node,
+  found: string[] = [],
+  resolver?: { declarationOf(i: ts.Identifier): ts.Declaration | undefined }
+): string[] {
   // Asked before any operand is visited, so a concatenation contributes the
   // string it evaluates to rather than its halves. Splitting on whitespace
   // happens downstream, and by then two pieces are indistinguishable from two
@@ -1948,7 +1952,7 @@ function literalStrings(node: ts.Node, found: string[] = []): string[] {
     found.push(node.head.text);
     for (const span of node.templateSpans) {
       found.push(span.literal.text);
-      literalStrings(span.expression, found);
+      literalStrings(span.expression, found, resolver);
     }
     return found;
   }
@@ -1958,7 +1962,7 @@ function literalStrings(node: ts.Node, found: string[] = []): string[] {
   // it does not apply.
   if (ts.isExpression(node)) {
     const selected = selectedByLiteralCondition(node);
-    if (selected) return literalStrings(selected, found);
+    if (selected) return literalStrings(selected, found, resolver);
   }
   // `cn({ "border-b-0": false })` applies nothing. In this form the KEY is the
   // class and the VALUE is the condition, so walking the object as plain text
@@ -1971,12 +1975,12 @@ function literalStrings(node: ts.Node, found: string[] = []): string[] {
       // kind walked past it, and the shorthand is the shorter spelling most
       // callers reach for.
       if (ts.isShorthandPropertyAssignment(property)) {
-        if (staticTruthiness(property.name) !== false)
+        if (staticTruthiness(property.name, resolver) !== false)
           found.push(property.name.text);
         continue;
       }
       if (!ts.isPropertyAssignment(property)) continue;
-      if (staticTruthiness(property.initializer) === false) continue;
+      if (staticTruthiness(property.initializer, resolver) === false) continue;
       // Asked through the one reader that answers "what property is this",
       // rather than restating two of the node kinds it knows about. Restating
       // them meant `cn({ ["border-b-0"]: true })` named no class here while
@@ -1991,7 +1995,7 @@ function literalStrings(node: ts.Node, found: string[] = []): string[] {
   // returns something truthy, so a concise arrow returning the accumulator
   // visits one child and reports the rest as absent.
   ts.forEachChild(node, child => {
-    literalStrings(child, found);
+    literalStrings(child, found, resolver);
   });
   return found;
 }
@@ -2312,7 +2316,12 @@ function staticStringOf(
  * `undefined` for anything whose truthiness depends on what it holds at
  * runtime, which keeps the write it guards in play.
  */
-function staticTruthiness(value: ts.Expression): boolean | undefined {
+function staticTruthiness(
+  value: ts.Expression,
+  // Optional because two callers reach this without one. Absent, a bare
+  // `undefined` stays undecided rather than assumed unshadowed.
+  resolver?: { declarationOf(i: ts.Identifier): ts.Declaration | undefined }
+): boolean | undefined {
   const inner = withoutTypeWrappers(value);
   if (
     ts.isObjectLiteralExpression(inner) ||
@@ -2324,6 +2333,26 @@ function staticTruthiness(value: ts.Expression): boolean | undefined {
     return inner.text.length > 0;
   }
   if (ts.isNumericLiteral(inner)) return Number(inner.text) !== 0;
+  // `undefined` is falsy to clsx exactly as `null` and `false` are, and it is
+  // an ordinary IDENTIFIER rather than a keyword, so the kind tests below walk
+  // past it -- leaving `cn({ "border-b-0": undefined })` reported as displacing
+  // a class clsx never applies, which is the ordinary spelling of an optional
+  // condition. The resolver settles shadowing: a local binding named
+  // `undefined` is a value this cannot decide.
+  //
+  // Only this one case is borrowed from `isDefinitelyNothing`, NOT the whole
+  // predicate. That helper answers "does React paint anything for this style
+  // value", under which `true` paints nothing -- while `true` in a class-map
+  // condition is TRUTHY and applies the class. The two questions overlap and
+  // are not the same, and delegating wholesale inverted this one.
+  if (
+    resolver &&
+    ts.isIdentifier(inner) &&
+    inner.text === "undefined" &&
+    !resolver.declarationOf(inner)
+  ) {
+    return false;
+  }
   if (inner.kind === ts.SyntaxKind.TrueKeyword) return true;
   if (inner.kind === ts.SyntaxKind.FalseKeyword) return false;
   if (inner.kind === ts.SyntaxKind.NullKeyword) return false;
@@ -2733,7 +2762,7 @@ function violationsIn(file: string, source: string): Violation[] {
           if (!classValue) continue;
           const displaced = displacedBy(
             exported,
-            literalStrings(classValue).join(" ")
+            literalStrings(classValue, [], styleResolver(checker)).join(" ")
           );
           if (displaced.length > 0) {
             report(
@@ -3721,6 +3750,13 @@ import { TabsList, TabsTrigger } from "@nextlyhq/ui";\n`;
     [
       "a border image source reset to initial",
       '<TabsTrigger style={{ borderImageSource: "initial" }} />',
+    ],
+    // clsx omits a key whose condition is falsy, and `undefined` is the
+    // ordinary spelling of an optional one. It is an IDENTIFIER rather than a
+    // keyword, so a test on node kind walks past it.
+    [
+      "a class map whose condition is undefined",
+      '<TabsTrigger className={cn({ "border-b-0": undefined })} />',
     ],
   ])("does not report %s", (_label, body) => {
     // The complement, and the reason this is a contract rather than a ban. A

--- a/packages/ui/src/components/__tests__/tabs-contract.test.ts
+++ b/packages/ui/src/components/__tests__/tabs-contract.test.ts
@@ -1633,6 +1633,36 @@ function styleResolver(
   };
 
   /**
+   * Whether a node runs every time its execution unit does.
+   *
+   * Only a write that definitely happens can be said to have replaced what came
+   * before it. One inside an `if`, a loop, a `switch`, a `try` or the right of
+   * a short-circuit may be skipped, so it ADDS a value the binding might hold
+   * without removing any.
+   *
+   * Written as a list of constructs that introduce a choice rather than a list
+   * of ones that do not, so an unfamiliar node fails towards "may be skipped" —
+   * which keeps earlier values in play, and keeping them is the reporting side.
+   */
+  const alwaysRuns = (node: ts.Node, unit: ts.Node | undefined): boolean => {
+    for (let at = node.parent; at && at !== unit; at = at.parent) {
+      if (
+        ts.isIfStatement(at) ||
+        ts.isIterationStatement(at, /* lookInLabeledStatements */ true) ||
+        ts.isSwitchStatement(at) ||
+        ts.isCaseOrDefaultClause(at) ||
+        ts.isTryStatement(at) ||
+        ts.isCatchClause(at) ||
+        ts.isConditionalExpression(at) ||
+        ts.isBinaryExpression(at)
+      ) {
+        return false;
+      }
+    }
+    return true;
+  };
+
+  /**
    * Every value assigned to a binding that the element could actually see.
    *
    * A declaration initializer is only the FIRST value a mutable binding holds:
@@ -1648,36 +1678,58 @@ function styleResolver(
    * Across different units the order is not decidable and the write is kept,
    * which is the reporting side and therefore the safe one.
    */
-  const assignedValues = (declaration: ts.Declaration): ts.Expression[] => {
+  const writesTo = (
+    declaration: ts.Declaration
+  ): Array<{ value: ts.Expression; straightLine: boolean; at: number }> => {
     const elementUnit = executionUnitOf(element);
-    const values: ts.Expression[] = [];
+    const found: Array<{
+      value: ts.Expression;
+      straightLine: boolean;
+      at: number;
+    }> = [];
     const visit = (node: ts.Node): void => {
       if (
         ts.isBinaryExpression(node) &&
         node.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
         ts.isIdentifier(node.left) &&
-        declarationOf(node.left, checker) === declaration &&
-        (executionUnitOf(node) !== elementUnit ||
-          node.getStart() < element.getStart())
+        declarationOf(node.left, checker) === declaration
       ) {
-        values.push(node.right);
+        const sameUnit = executionUnitOf(node) === elementUnit;
+        const before = node.getStart() < element.getStart();
+        if (!sameUnit || before) {
+          found.push({
+            value: node.right,
+            // Definite only when it shares the element's execution unit, runs
+            // before it, and no branch stands between: those three together are
+            // what let a write be said to have HAPPENED.
+            straightLine:
+              sameUnit && before && alwaysRuns(node, elementUnit ?? undefined),
+            at: node.getStart(),
+          });
+        }
       }
       ts.forEachChild(node, visit);
     };
     visit(declaration.getSourceFile());
-    return values;
+    return found.sort((a, b) => a.at - b.at);
   };
 
   /**
    * Every value a name can hold at the element.
    *
-   * The declaration's initializer and every write that can reach here, which is
-   * the whole answer to "what does this name hold" — so both the object
+   * The declaration's initializer and every write that can still reach here,
+   * which is the whole answer to "what does this name hold" — so the object
    * question and the property-value question are asked of this one list rather
    * than each assembling its own. A mutable binding whose initializer is the
    * only value it ever holds is fully decidable, and discarding it purely
    * because the declaration said `let` reported `let colour = undefined` as a
    * colour React never receives.
+   *
+   * A write KILLS what came before it. `let style = {}; style = { ...owned };
+   * style = {}` holds the empty object at the element, and carrying the middle
+   * value along rejected a call site for a style it had already discarded. Only
+   * a write that definitely runs can kill, so a reset inside an `if` narrows
+   * nothing and every earlier value stays in play.
    *
    * An empty list means the name resolved to a declaration that carries no
    * readable value — a parameter, an import — which the callers treat as
@@ -1686,11 +1738,18 @@ function styleResolver(
   const reachingValues = (identifier: ts.Identifier): ts.Expression[] => {
     const declaration = declarationOf(identifier, checker);
     if (!declaration) return [];
-    const values: ts.Expression[] = [];
-    const initializer = bindingOf(identifier)?.initializer;
-    if (initializer) values.push(initializer);
-    values.push(...assignedValues(declaration));
-    return values;
+    const writes = writesTo(declaration);
+    const lastDefinite = writes.map(w => w.straightLine).lastIndexOf(true);
+    if (lastDefinite === -1) {
+      const initializer = bindingOf(identifier)?.initializer;
+      return [
+        ...(initializer ? [initializer] : []),
+        ...writes.map(w => w.value),
+      ];
+    }
+    // The initializer and everything before that write are values the binding
+    // has already stopped holding.
+    return writes.slice(lastDefinite).map(w => w.value);
   };
 
   /**
@@ -2596,6 +2655,13 @@ describe("the tab indicator contract", () => {
       "an owned property assigned to a style binding after it is declared",
       'let style = {};\nstyle = { borderBottomColor: "red" };\n<TabsTrigger style={style} />',
     ],
+    // A reset that MIGHT not happen clears nothing. Only a write that
+    // definitely runs replaces what came before it, so the owned value is still
+    // one the element can render and the call site is still reported.
+    [
+      "an owned property a conditional reset does not certainly clear",
+      'let style = { borderBottomColor: "red" };\nif (window.innerWidth > 0) {\n  style = {};\n}\n<TabsTrigger style={style} />',
+    ],
     // `undefined` is a NAME. Shadowed by a local declaration it is an ordinary
     // colour, and reading the spelling alone cleared a call site that paints.
     [
@@ -2876,6 +2942,14 @@ describe("the tab indicator contract", () => {
       "an owned property in a statically unreachable branch",
       '<TabsTrigger style={true ? {} : { borderBottomColor: "red" }} />',
     ],
+    // A binding reset before it renders. The middle value is one it has
+    // already stopped holding, and carrying it along rejected an element that
+    // passes an empty object. Paired with the reassignment case above, this
+    // separates "a write happened" from "this write is the one that survives".
+    [
+      "an owned property overwritten before the element renders",
+      'let style = {};\nstyle = { borderBottomColor: "red" };\nstyle = {};\n<TabsTrigger style={style} />',
+    ],
     // A mutable binding nothing ever writes to. Its initializer IS what the
     // element receives, so discarding it for being `let` reported a property
     // React never emits. This is the counterpart to the reassignment cases
@@ -3095,10 +3169,17 @@ describe("which files the call-site scan reads", () => {
     //
     // Both depths, because they fail differently: a `**/src/**` trigger covers
     // the nested one and silently misses a file directly under the root.
+    // Three depths, because they fail differently and each one has a trigger
+    // shape that covers the others and misses it: a `**/src/**` glob covers the
+    // nested file and misses the package-level one, and a glob requiring at
+    // least one child directory covers both and misses a file sitting directly
+    // in the root — which `sourceFiles` reaches, since it recurses from the
+    // root itself rather than from the packages inside it.
     const probes = SCAN_ROOT_NAMES.flatMap(root =>
       CALL_SITE_EXTENSIONS.flatMap(extension => [
         resolve(REPO, root, `probe-package/src/nested/probe${extension}`),
         resolve(REPO, root, `probe-package/probe${extension}`),
+        resolve(REPO, root, `probe${extension}`),
       ])
     );
     const unwatchedProbes = probes

--- a/packages/ui/src/components/__tests__/tabs-contract.test.ts
+++ b/packages/ui/src/components/__tests__/tabs-contract.test.ts
@@ -952,29 +952,47 @@ function spreadAttributes(
   attribute: ts.JsxSpreadAttribute,
   checker: ts.TypeChecker
 ): {
-  attributes: Array<{ name: string; value: ts.Expression }>;
+  /**
+   * One entry per object the spread can resolve to.
+   *
+   * Kept apart rather than flattened, because the objects are ALTERNATIVES:
+   * `{...(flag ? a : b)}` renders one of them, and merging the two let a safe
+   * value from one branch stand in for a forbidden value in the other.
+   */
+  alternatives: Array<Array<{ name: string; value: ts.Expression }>>;
   readable: boolean;
 } {
   const { objects, readable } = styleResolver(checker).objectsFrom(
     attribute.expression
   );
-  if (!readable) return { attributes: [], readable: false };
-  const attributes: Array<{ name: string; value: ts.Expression }> = [];
+  if (!readable) return { alternatives: [], readable: false };
+  const alternatives: Array<Array<{ name: string; value: ts.Expression }>> = [];
   for (const object of objects) {
+    const attributes: Array<{ name: string; value: ts.Expression }> = [];
     for (const property of object.properties) {
+      // A shorthand names its key, and that is all this needs when the key is
+      // not a prop the contract owns: `{...{ value }}` is the ordinary way to
+      // pass Radix's `value`, and reporting the whole spread as unreadable
+      // rejected it on the strength of syntax that proves it harmless.
+      if (ts.isShorthandPropertyAssignment(property)) {
+        if (!OWNED_PROPS.includes(property.name.text)) continue;
+        // An owned prop carried as a shorthand still hides its VALUE.
+        return { alternatives: [], readable: false };
+      }
       if (!ts.isPropertyAssignment(property)) {
-        // A shorthand or a spread inside the spread is a value this does not
-        // read, and the props it carries are unknown rather than absent.
-        return { attributes: [], readable: false };
+        // A spread inside the spread is a value this does not read, and the
+        // props it carries are unknown rather than absent.
+        return { alternatives: [], readable: false };
       }
       const name = property.name;
       if (!ts.isIdentifier(name) && !ts.isStringLiteral(name)) {
-        return { attributes: [], readable: false };
+        return { alternatives: [], readable: false };
       }
       attributes.push({ name: name.text, value: property.initializer });
     }
+    alternatives.push(attributes);
   }
-  return { attributes, readable: true };
+  return { alternatives, readable: true };
 }
 
 /** Which of a component's owned classes a caller's `className` takes over. */
@@ -1528,7 +1546,10 @@ interface Ownership {
  * name from another library, would otherwise be held to this contract and fail
  * for a corner it is entitled to.
  */
-function ownershipIn(sourceFile: ts.SourceFile): {
+function ownershipIn(
+  sourceFile: ts.SourceFile,
+  checker: ts.TypeChecker
+): {
   ownership: Ownership;
   exportedNameOf: Map<string, string>;
   owning: Map<ts.Node, string>;
@@ -1622,9 +1643,10 @@ function ownershipIn(sourceFile: ts.SourceFile): {
     if (ts.isVariableDeclaration(node) && node.initializer) {
       const exported = exportedFrom(
         node.initializer,
-        names,
         namespaces,
-        exportedNameOf
+        owning,
+        exportedNameOf,
+        checker
       );
       if (exported && ts.isIdentifier(node.name)) {
         names.add(node.name.text);
@@ -1708,12 +1730,26 @@ function requiredFrom(
  */
 function exportedFrom(
   initializer: ts.Expression,
-  names: Set<string>,
   namespaces: Set<string>,
-  exportedNameOf: Map<string, string>
+  owning: Map<ts.Node, string>,
+  exportedNameOf: Map<string, string>,
+  checker: ts.TypeChecker
 ): string | undefined {
-  if (ts.isIdentifier(initializer) && names.has(initializer.text)) {
-    return exportedNameOf.get(initializer.text);
+  // Which binding the name REFERS to, not how it is spelled. Matching the
+  // text against the file-wide set held a LOCAL component to the contract of
+  // an import it shadows — `const TabsTrigger = Other; const Local =
+  // TabsTrigger` recorded `Local` as owning the primitive. The JSX tag is
+  // already resolved this way, and an alias has to be resolved the same way
+  // or the two disagree about what a name means in one file.
+  if (ts.isIdentifier(initializer)) {
+    const declaration = declarationOf(initializer, checker);
+    // A resolved declaration answers on its own. Nothing resolving is the
+    // ordinary case for an import of a module this program never loads, and
+    // the text is all there is then — the same fallback, and the same order,
+    // that `exportedTagOf` applies to the JSX tag.
+    if (!declaration) return exportedNameOf.get(initializer.text);
+    const declared = (declaration as { name?: ts.Node }).name;
+    return declared ? owning.get(declared) : undefined;
   }
   if (
     ts.isPropertyAccessExpression(initializer) &&
@@ -1819,6 +1855,17 @@ function selectedByLiteralCondition(
 }
 
 function literalStrings(node: ts.Node, found: string[] = []): string[] {
+  // Asked before any operand is visited, so a concatenation contributes the
+  // string it evaluates to rather than its halves. Splitting on whitespace
+  // happens downstream, and by then two pieces are indistinguishable from two
+  // separate classes.
+  if (ts.isExpression(node)) {
+    const whole = staticStringOf(node);
+    if (whole !== undefined) {
+      found.push(whole);
+      return found;
+    }
+  }
   if (ts.isStringLiteral(node) || ts.isNoSubstitutionTemplateLiteral(node)) {
     found.push(node.text);
   } else if (ts.isTemplateExpression(node)) {
@@ -1843,6 +1890,15 @@ function literalStrings(node: ts.Node, found: string[] = []): string[] {
   // key's value as though it were a class name too.
   if (ts.isObjectLiteralExpression(node)) {
     for (const property of node.properties) {
+      // `cn({ rounded })` is `{ rounded: rounded }` to clsx, so the KEY names
+      // the class exactly as the written-out form does. A filter on the node
+      // kind walked past it, and the shorthand is the shorter spelling most
+      // callers reach for.
+      if (ts.isShorthandPropertyAssignment(property)) {
+        if (staticTruthiness(property.name) !== false)
+          found.push(property.name.text);
+        continue;
+      }
       if (!ts.isPropertyAssignment(property)) continue;
       if (staticTruthiness(property.initializer) === false) continue;
       const name = property.name;
@@ -2116,6 +2172,18 @@ function staticStringOf(
   const inner = withoutTypeWrappers(expression);
   if (ts.isStringLiteral(inner) || ts.isNoSubstitutionTemplateLiteral(inner)) {
     return inner.text;
+  }
+  // `"border-b-" + "0"` is ONE class at runtime. Read as two operands it is
+  // two names that are each harmless, so a caller passing an owned class in
+  // pieces scanned clean — the concatenation has to be performed here, where
+  // both halves are known, rather than left to whoever splits on whitespace.
+  if (
+    ts.isBinaryExpression(inner) &&
+    inner.operatorToken.kind === ts.SyntaxKind.PlusToken
+  ) {
+    const left = staticStringOf(inner.left, resolver, seen);
+    const right = staticStringOf(inner.right, resolver, seen);
+    return left !== undefined && right !== undefined ? left + right : undefined;
   }
   // A name holding the value is the same value. `const noImage = "none"` draws
   // no border image exactly as the literal spelling does, and reading only the
@@ -2439,8 +2507,10 @@ type PropSource =
 
 function violationsIn(file: string, source: string): Violation[] {
   const { sourceFile, checker } = parse(file, source);
-  const { ownership, exportedNameOf, owning, owningNamespaces } =
-    ownershipIn(sourceFile);
+  const { ownership, exportedNameOf, owning, owningNamespaces } = ownershipIn(
+    sourceFile,
+    checker
+  );
   const found: Violation[] = [];
   const at = (node: ts.Node): number =>
     sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile)).line +
@@ -2463,12 +2533,15 @@ function violationsIn(file: string, source: string): Violation[] {
         // where it appears asked about values the element never receives, so
         // the surviving source of each owned prop is resolved first and only
         // that one is read.
-        const effective = new Map<string, PropSource>();
+        // A LIST per prop, not one source: a spread between object literals
+        // supplies alternatives rather than a sequence, and every alternative
+        // is a value the element can render.
+        const effective = new Map<string, PropSource[]>();
         // A spread whose contents cannot be read may carry either owned prop,
         // so it stops mattering only once BOTH are written again after it.
         const unread: Array<{ at: ts.Node; awaiting: Set<string> }> = [];
-        const take = (name: string, source: PropSource): void => {
-          effective.set(name, source);
+        const take = (name: string, sources: PropSource[]): void => {
+          effective.set(name, sources);
           for (const spread of unread) spread.awaiting.delete(name);
         };
 
@@ -2482,20 +2555,34 @@ function violationsIn(file: string, source: string): Violation[] {
               unread.push({ at: attribute, awaiting: new Set(OWNED_PROPS) });
               continue;
             }
-            for (const carried of spread.attributes) {
-              if (!OWNED_PROPS.includes(carried.name)) continue;
-              take(carried.name, {
-                kind: "spread",
-                at: attribute,
-                value: carried.value,
-              });
+            for (const name of OWNED_PROPS) {
+              const carried = spread.alternatives
+                .map(alternative => alternative.find(a => a.name === name))
+                .filter(found => found !== undefined)
+                .map(
+                  (found): PropSource => ({
+                    kind: "spread",
+                    at: attribute,
+                    value: found.value,
+                  })
+                );
+              if (carried.length === 0) continue;
+              // Only a spread EVERY alternative supplies replaces what came
+              // before. When one branch omits the prop, that branch renders
+              // the earlier value, so the earlier value is still in play.
+              take(
+                name,
+                carried.length === spread.alternatives.length
+                  ? carried
+                  : [...(effective.get(name) ?? []), ...carried]
+              );
             }
             continue;
           }
           if (!ts.isJsxAttribute(attribute)) continue;
           const name = attribute.name.getText(sourceFile);
           if (OWNED_PROPS.includes(name)) {
-            take(name, { kind: "attribute", attribute });
+            take(name, [{ kind: "attribute", attribute }]);
           }
         }
 
@@ -2511,27 +2598,36 @@ function violationsIn(file: string, source: string): Violation[] {
           });
         }
 
-        const className = effective.get("className");
-        const classValue =
-          className?.kind === "attribute"
-            ? className.attribute.initializer
-            : className?.value;
-        if (className && classValue) {
+        // Reported once per distinct sentence. Two alternatives of one spread
+        // sit on the same line, and repeating an identical message for each
+        // says nothing the first did not.
+        const said = new Set<string>();
+        const report = (line: number, why: string): void => {
+          const key = `${line}:${why}`;
+          if (said.has(key)) return;
+          said.add(key);
+          found.push({ file, line, why });
+        };
+
+        for (const className of effective.get("className") ?? []) {
+          const classValue =
+            className.kind === "attribute"
+              ? className.attribute.initializer
+              : className.value;
+          if (!classValue) continue;
           const displaced = displacedBy(
             exported,
             literalStrings(classValue).join(" ")
           );
           if (displaced.length > 0) {
-            found.push({
-              file,
-              line: lineOf(className),
-              why: `${className.kind === "spread" ? "spreads" : "displaces"} ${displaced.join(", ")} — the primitive owns that appearance, and every surface should change with it`,
-            });
+            report(
+              lineOf(className),
+              `${className.kind === "spread" ? "spreads" : "displaces"} ${displaced.join(", ")} — the primitive owns that appearance, and every surface should change with it`
+            );
           }
         }
 
-        const style = effective.get("style");
-        if (style) {
+        for (const style of effective.get("style") ?? []) {
           const line = lineOf(style);
           const verb = style.kind === "spread" ? "spreads" : "sets";
           const { objects, readable, resolver } =
@@ -2544,11 +2640,10 @@ function violationsIn(file: string, source: string): Violation[] {
           // and staying silent about it would mean "no violation" and "could
           // not tell" looked the same from outside.
           if (!readable) {
-            found.push({
-              file,
+            report(
               line,
-              why: `${verb} an inline style this scan cannot read — write it as a literal object, or move it to \`className\` so the primitive keeps its appearance`,
-            });
+              `${verb} an inline style this scan cannot read — write it as a literal object, or move it to \`className\` so the primitive keeps its appearance`
+            );
           } else {
             const spreadUnreadable = { value: false };
             const property = objects
@@ -2557,17 +2652,15 @@ function violationsIn(file: string, source: string): Violation[] {
               )
               .find(Boolean);
             if (property) {
-              found.push({
-                file,
+              report(
                 line,
-                why: `${verb} \`${property}\` inline, which beats every class the primitive applies`,
-              });
+                `${verb} \`${property}\` inline, which beats every class the primitive applies`
+              );
             } else if (spreadUnreadable.value) {
-              found.push({
-                file,
+              report(
                 line,
-                why: "spreads an inline style this scan cannot read — write it as a literal object, or move it to `className` so the primitive keeps its appearance",
-              });
+                "spreads an inline style this scan cannot read — write it as a literal object, or move it to `className` so the primitive keeps its appearance"
+              );
             }
           }
         }
@@ -3109,6 +3202,30 @@ describe("the tab indicator contract", () => {
       "an unreadable spread with only one owned prop written after it",
       '<TabsTrigger {...rest} className="w-full" />',
     ],
+    // The objects a conditional spread chooses between are ALTERNATIVES: one
+    // of them renders, so a safe value in one branch does not excuse a
+    // forbidden value in the other.
+    [
+      "a class in one branch of a conditional spread",
+      '<TabsTrigger {...(flag ? { className: "border-b-0" } : { className: "w-full" })} />',
+    ],
+    // Only a spread every alternative supplies replaces what came before; a
+    // branch that omits the prop renders the earlier value.
+    [
+      "a class a spread replaces in only one of its branches",
+      '<TabsTrigger className="border-b-0" {...(flag ? { style: {} } : { className: "w-full" })} />',
+    ],
+    // `cn({ rounded })` is `{ rounded: rounded }` to clsx, so the key names
+    // the class exactly as the written-out form does.
+    [
+      "an owned class named by a class-map shorthand",
+      "const rounded = true;\n<TabsList className={cn({ rounded })} />",
+    ],
+    // One class at runtime, whichever way it is spelled in the source.
+    [
+      "an owned class written as a concatenation",
+      '<TabsTrigger className={"border-b-" + "0"} />',
+    ],
   ])("catches %s", (_label, body) => {
     // The positive controls. Each is a shape an earlier version returned clean
     // on, or a category it never read. Without these, a check that can never
@@ -3436,6 +3553,22 @@ describe("the tab indicator contract", () => {
     [
       "an unreadable spread with both owned props written after it",
       '<TabsTrigger {...rest} className="w-full" style={{ width: 2 }} />',
+    ],
+    // A shorthand names its key, and a key that is not an owned prop cannot
+    // carry one. `{...{ value }}` is the ordinary way to pass Radix's `value`.
+    [
+      "a spread carrying an unrelated prop as a shorthand",
+      'const value = "a";\n<TabsTrigger {...{ value }} />',
+    ],
+    [
+      "a spread carrying an unrelated prop written out",
+      '<TabsTrigger {...{ role: "tab" }} />',
+    ],
+    // Ownership follows the BINDING, not the spelling. A local component that
+    // shadows the import is a different component, and so is an alias of it.
+    [
+      "an alias of a name that shadows the import",
+      'function Row() {\n  const TabsTrigger = Other;\n  const Local = TabsTrigger;\n  return <Local className="border-b-0" />;\n}',
     ],
   ])("does not report %s", (_label, body) => {
     // The complement, and the reason this is a contract rather than a ban. A

--- a/packages/ui/src/components/__tests__/tabs-contract.test.ts
+++ b/packages/ui/src/components/__tests__/tabs-contract.test.ts
@@ -90,6 +90,20 @@ const REPO = resolve(HERE, "../../../../..");
  */
 const SCAN_ROOT_NAMES = ["packages", "apps", "templates"] as const;
 
+/**
+ * The watch-trigger prefix that subscribes to each scanned root.
+ *
+ * Vitest resolves `forceRerunTriggers` relative to the package, so the roots
+ * the scan walks are reached by relative path here rather than by the
+ * `$TURBO_ROOT$` the Turbo inputs use. Two spellings of one fact, which is why
+ * the contract below checks them against each other rather than trusting both.
+ */
+const CALL_SITE_ROOT_GLOBS = [
+  { root: "packages", prefix: "../*/src/**/*." },
+  { root: "apps", prefix: "../../apps/*/src/**/*." },
+  { root: "templates", prefix: "../../templates/**/*." },
+] as const;
+
 const SCAN_ROOTS = SCAN_ROOT_NAMES.map(r => resolve(REPO, r));
 
 /** The primitive itself declares the contract; it is not a call site. */
@@ -1355,6 +1369,18 @@ function styleResolver(attribute: ts.JsxAttribute): {
       // sibling function is not mistaken for one in this scope.
       ts.forEachChild(scope, statement => {
         if (!ts.isVariableStatement(statement)) return;
+        // `const` only. A `let` or `var` binding's declaration initializer is
+        // not what the element renders — `let c = undefined; c = "red";` paints,
+        // and following the initializer alone concludes the opposite. Reading a
+        // reassignable binding as its first value turns a check into a false
+        // NEGATIVE, which is the direction that lets a real violation ship.
+        //
+        // Undecidable is the honest answer for those, and undecidable here
+        // means "keep reporting": the callers treat an unresolvable binding as
+        // emitting, which is the conservative side.
+        const isConst =
+          (statement.declarationList.flags & ts.NodeFlags.Const) !== 0;
+        if (!isConst) return;
         for (const declaration of statement.declarationList.declarations) {
           if (
             ts.isIdentifier(declaration.name) &&
@@ -1491,6 +1517,19 @@ function propertyNameOf(
  * `seen` stops a self-referential binding from recursing. Anything else — a
  * template with substitutions, a call, a member access — stays undecidable and
  * returns undefined, which leaves the property unnamed rather than guessed.
+ *
+ * KNOWN LIMIT, and it is a hole rather than a decision to be comfortable with:
+ * a reassignable key escapes. `let k = "x"; k = "borderBottomColor";
+ * style={{ [k]: "red" }}` paints the indicator and is not reported, because the
+ * binding is not `const` and its declaration initializer is not what runs.
+ *
+ * The asymmetry with values is deliberate. For a VALUE the property is already
+ * known to be owned, so undecidable defaults to "it emits" and the call site is
+ * reported — the conservative side. For a KEY, undecidable means the property
+ * is not known at all, and defaulting to "owned" would report every computed
+ * key in the repository, including the overwhelming majority that name nothing
+ * this primitive draws. Closing this needs the assignments in scope to be read,
+ * not a change of default.
  */
 function staticKeyOf(
   expression: ts.Expression,
@@ -2132,6 +2171,18 @@ describe("the tab indicator contract", () => {
       "a destructured namespace member",
       'import * as UI from "@nextlyhq/ui";\nconst { TabsTrigger: Trigger } = UI;\n<Trigger className="border-b-0" />',
     ],
+    // A reassignable binding is not its declaration initializer. Reading it as
+    // one concludes the element paints nothing while it paints — a false
+    // NEGATIVE, which is the direction that lets a real violation ship, and the
+    // one an immutable-binding control cannot see.
+    [
+      "a reassigned binding that held nothing at its declaration",
+      'let c: string | undefined = undefined;\nc = "red";\n<TabsTrigger style={{ borderBottomColor: c }} />',
+    ],
+    [
+      "the same reassigned binding behind an assertion",
+      'let c: string | undefined = undefined;\nc = "red";\n<TabsTrigger style={{ borderBottomColor: c as string | undefined }} />',
+    ],
   ])("catches %s", (_label, body) => {
     // The positive controls. Each is a shape an earlier version returned clean
     // on, or a category it never read. Without these, a check that can never
@@ -2514,26 +2565,44 @@ describe("which files the call-site scan reads", () => {
     }
   });
 
-  it("reruns in watch mode for every extension it reads", () => {
+  it("reruns in watch mode for every root and extension it reads", () => {
     // The scan reaches call sites with `readFileSync`, so Vitest has no module
     // dependency on them: without an explicit trigger a watch session keeps
-    // displaying the previous green after a real violation is added to a `.js`
-    // or `.jsx` file. `forceRerunTriggers` is what supplies that dependency,
-    // and it is a second list of extensions — so it is checked against the
-    // first rather than trusted to stay in step.
+    // displaying the previous green after a real violation is added.
+    //
+    // Both halves matter, and the ROOT half is the one that is easy to miss.
+    // The triggers are resolved relative to this package, so a glob under
+    // `**/src` subscribes to `packages/ui` alone — a call site in
+    // `packages/admin`, an app or a template could gain a violation and the
+    // suite reporting on it would never rerun.
     const config = readFileSync(
       resolve(HERE, "../../../vitest.config.ts"),
       "utf8"
     );
-    const trigger = /"\*\*\/src\/\*\*\/\*\.\{([^}]+)\}"/.exec(config)?.[1];
 
-    // Proves the pattern found something before anything is concluded from it:
-    // a renamed option or a reformatted config would otherwise read as a pass.
-    expect(trigger).toBeDefined();
+    const triggers = [...config.matchAll(/"([^"]*)\{([^}]+)\}"/g)].map(
+      match => ({
+        prefix: match[1],
+        extensions: match[2].split(",").map(part => part.trim()),
+      })
+    );
 
-    const covered = (trigger ?? "").split(",").map(part => part.trim());
-    const missing = CALL_SITE_EXTENSIONS.map(e => e.slice(1)).filter(
-      extension => !covered.includes(extension)
+    // Proves the pattern matched something before anything is concluded from
+    // it: a renamed option or a reformatted config would otherwise read as a
+    // pass, which is the failure this whole case exists to prevent.
+    expect(triggers.length).toBeGreaterThan(0);
+
+    const missing = CALL_SITE_ROOT_GLOBS.flatMap(({ root, prefix }) =>
+      CALL_SITE_EXTENSIONS.map(extension => extension.slice(1))
+        .filter(
+          extension =>
+            !triggers.some(
+              trigger =>
+                trigger.prefix === prefix &&
+                trigger.extensions.includes(extension)
+            )
+        )
+        .map(extension => `${root}:${extension}`)
     );
 
     expect(missing).toEqual([]);

--- a/packages/ui/src/components/__tests__/tabs-contract.test.ts
+++ b/packages/ui/src/components/__tests__/tabs-contract.test.ts
@@ -1328,8 +1328,12 @@ function expandsTo(property: string, value?: string): string[] {
     // "reset to the initial value", which for this property IS `none`. Matching
     // the one spelling asked how the value was written rather than what it
     // does, and reported a call site that covers nothing.
+    // `initial` and `unset` both name the initial value, which for
+    // `border-image-source` IS `none`. They differ only for INHERITED
+    // properties, where `unset` means `inherit` -- and this one is not
+    // inherited, so both supply no image and cover nothing.
     const drawn = value?.trim().toLowerCase();
-    if (drawn === "none" || drawn === "initial") {
+    if (drawn === "none" || drawn === "initial" || drawn === "unset") {
       return [kebab];
     }
     return BORDER_ASPECTS.map(aspect => `border-bottom-${aspect}`);
@@ -1584,8 +1588,23 @@ function reachesThePrimitive(specifier: string, importer: string): boolean {
   if (OWNING_MODULES.includes(specifier)) return true;
   if (!specifier.startsWith(".")) return false;
   const target = resolve(dirname(resolve(REPO, importer)), specifier);
-  // A module specifier carries no extension; the primitive is a `.tsx` file.
-  return `${target}.tsx` === PRIMITIVE || target === PRIMITIVE;
+  // Three spellings reach the same file and all are in use here.
+  //
+  // Extensionless is the common one. An exact path covers a specifier that
+  // already names the file. And a `.js` specifier resolves to the adjacent
+  // TypeScript SOURCE under NodeNext resolution -- `../tabs.js` IS `tabs.tsx`
+  // -- which is not an exotic spelling: 33 files in the scanned roots import
+  // that way. Appending `.tsx` to an already-suffixed path produced
+  // `tabs.js.tsx`, so every one of those call sites scanned clean.
+  //
+  // The substitution is anchored to the END of the string, so a directory
+  // named `foo.js/` cannot have its interior rewritten.
+  const asSource = target.replace(/\.(js|jsx|mjs|cjs)$/, "");
+  return (
+    target === PRIMITIVE ||
+    `${target}.tsx` === PRIMITIVE ||
+    `${asSource}.tsx` === PRIMITIVE
+  );
 }
 
 interface Ownership {
@@ -2923,6 +2942,26 @@ describe("the tab indicator lint", () => {
     expect(violationsIn("packages/ui/src/components/probe.tsx", real)).toEqual(
       []
     );
+
+    // A `.js` specifier resolves to the adjacent TypeScript SOURCE under
+    // NodeNext, so `../tabs.js` IS `tabs.tsx`. Not an exotic spelling: 33 files
+    // in the scanned roots import that way, and appending `.tsx` to an
+    // already-suffixed path produced `tabs.js.tsx`, so every one scanned clean.
+    //
+    // Asserted HERE rather than in the tables above, because those prepend a
+    // real `@nextlyhq/ui` import to every fixture — which owns the tag on its
+    // own and would have made this pass whether or not the specifier resolved.
+    const runtime = `import { TabsTrigger } from "../tabs.js";\n${body}`;
+    expect(
+      violationsIn("packages/ui/src/components/probe/probe.tsx", runtime)
+    ).not.toEqual([]);
+
+    // And the substitution must not widen the match: a sibling module whose
+    // name merely ENDS in `tabs` is a different file.
+    const sibling = `import { TabsTrigger } from "../other-tabs.js";\n${body}`;
+    expect(
+      violationsIn("packages/ui/src/components/probe/probe.tsx", sibling)
+    ).toEqual([]);
   });
 
   it("finds files to check, so a clean result means conforming and not unscanned", () => {
@@ -3757,6 +3796,12 @@ import { TabsList, TabsTrigger } from "@nextlyhq/ui";\n`;
     [
       "a class map whose condition is undefined",
       '<TabsTrigger className={cn({ "border-b-0": undefined })} />',
+    ],
+    // `unset` on a NON-inherited property is its initial value, which for
+    // `border-image-source` is `none`, so it covers nothing.
+    [
+      "a border image source reset to unset",
+      '<TabsTrigger style={{ borderImageSource: "unset" }} />',
     ],
   ])("does not report %s", (_label, body) => {
     // The complement, and the reason this is a contract rather than a ban. A

--- a/packages/ui/src/components/__tests__/tabs-contract.test.ts
+++ b/packages/ui/src/components/__tests__/tabs-contract.test.ts
@@ -91,23 +91,27 @@ const REPO = resolve(HERE, "../../../../..");
 const SCAN_ROOT_NAMES = ["packages", "apps", "templates"] as const;
 
 /**
- * The watch-trigger prefix that subscribes to each scanned root.
+ * The watch-trigger glob that subscribes to each scanned root.
  *
- * Vitest resolves `forceRerunTriggers` relative to the package, so the roots
- * the scan walks are reached by relative path here rather than by the
- * `$TURBO_ROOT$` the Turbo inputs use. Two spellings of one fact, which is why
- * the contract below checks them against each other rather than trusting both.
+ * DERIVED from `SCAN_ROOT_NAMES` rather than listed beside it, so a root added
+ * to the traversal appears here without anyone remembering to add it. An
+ * independently maintained copy would stay green while the newly scanned tree
+ * went unwatched, which is the failure this mapping exists to prevent wearing
+ * the mapping's own clothes.
  *
- * Each prefix covers the WHOLE root. `sourceFiles` recurses from the root, so
- * `packages/foo/examples/demo.jsx` is a file it reads — narrowing these to
- * `src` would make the contract green while leaving that file unwatched, which
- * is the contract certifying a gap rather than closing it.
+ * Vitest resolves `forceRerunTriggers` relative to the package, so each root is
+ * reached by relative path here rather than by the `$TURBO_ROOT$` the Turbo
+ * inputs use — `packages` is this package's parent, the rest are siblings of it.
+ *
+ * The recursive wildcard follows the root immediately, with no directory
+ * segment in between. A file placed DIRECTLY under a root is one the traversal
+ * reads, and a glob requiring a package or app directory first does not match
+ * it — measured against the installed matcher, not assumed from the shape.
  */
-const CALL_SITE_ROOT_GLOBS = [
-  { root: "packages", prefix: "../*/**/*." },
-  { root: "apps", prefix: "../../apps/*/**/*." },
-  { root: "templates", prefix: "../../templates/**/*." },
-] as const;
+const CALL_SITE_ROOT_GLOBS = SCAN_ROOT_NAMES.map(root => ({
+  root,
+  prefix: root === "packages" ? "../**/*." : `../../${root}/**/*.`,
+}));
 
 const SCAN_ROOTS = SCAN_ROOT_NAMES.map(r => resolve(REPO, r));
 
@@ -2209,10 +2213,10 @@ describe("the tab indicator contract", () => {
       "an owned property declared through a getter",
       '<TabsTrigger style={{ get borderBottomColor() { return "red"; } }} />',
     ],
-    // A computed key built from a local constant names the property exactly as
-    // the literal spelling does, and React emits the same declaration. Reading
-    // only the literal form walked past it and reported clean on a call site
-    // that repaints the indicator.
+    // A constant-computed key names the property exactly as the literal
+    // spelling does, and React emits the same declaration — so the two must be
+    // treated identically. The distinguishing property is that the key is
+    // decidable without running the code, not how it is spelled.
     [
       "an owned property behind a computed key bound to a constant",
       'const key = "borderBottomColor";\n<TabsTrigger style={{ [key]: "red" }} />',
@@ -2675,6 +2679,26 @@ describe("which files the call-site scan reads", () => {
     // it: a renamed option or a reformatted config would otherwise read as a
     // pass, which is the failure this whole case exists to prevent.
     expect(triggers.length).toBeGreaterThan(0);
+
+    // The watched roots ARE the scanned roots. Deriving the list is what keeps
+    // them in step today; asserting it is what notices if someone replaces the
+    // derivation with a literal — which leaves every case below green while a
+    // scanned tree goes unwatched, because they only check the entries present.
+    expect(CALL_SITE_ROOT_GLOBS.map(glob => glob.root)).toEqual([
+      ...SCAN_ROOT_NAMES,
+    ]);
+
+    // Each glob must recurse from the ROOT itself, with no directory segment
+    // in between. Measured against the installed matcher rather than inferred:
+    // `../*/**` does not match a file placed directly under `packages`, so a
+    // prefix of that shape leaves those files unwatched while this contract —
+    // comparing strings — reported them covered.
+    for (const { root, prefix } of CALL_SITE_ROOT_GLOBS) {
+      expect({ root, prefix }).toEqual({
+        root,
+        prefix: expect.stringMatching(/(^|\/)\*\*\/\*\.$/),
+      });
+    }
 
     const missing = CALL_SITE_ROOT_GLOBS.flatMap(({ root, prefix }) =>
       CALL_SITE_EXTENSIONS.map(extension => extension.slice(1))

--- a/packages/ui/src/components/__tests__/tabs-contract.test.ts
+++ b/packages/ui/src/components/__tests__/tabs-contract.test.ts
@@ -675,15 +675,53 @@ function restates(owned: Utility, caller: Utility): boolean {
 function excludeEachOther(a: string, b: string): boolean {
   const negatedIn = (selector: string): string[] =>
     [...selector.matchAll(/:not\(([^)]*)\)/g)].map(match =>
-      (match[1] ?? "").trim()
+      // A leading `*` is the universal selector Tailwind writes inside the
+      // negation — `not-disabled:` compiles to `&:not(*:disabled)` while the
+      // required side is a bare `&:disabled`. Compared verbatim the two never
+      // met, so the clearest disjoint pair in the vocabulary read as coexisting.
+      (match[1] ?? "").trim().replace(/^\*/, "")
     );
   const requires = (selector: string, qualifier: string): boolean =>
     qualifier.length > 0 &&
     selector.replace(/:not\([^)]*\)/g, "").includes(qualifier);
-  return (
+  if (
     negatedIn(a).some(qualifier => requires(b, qualifier)) ||
     negatedIn(b).some(qualifier => requires(a, qualifier))
-  );
+  ) {
+    return true;
+  }
+  return attributesConflict(a, b);
+}
+
+/**
+ * Whether two selectors demand different values of the SAME attribute.
+ *
+ * An element has one value per attribute, so `[data-state="active"]` and
+ * `[data-state="inactive"]` never match together — the form the primitive's own
+ * active and inactive rules are written in, and one no negation appears in.
+ *
+ * Read outside any `:not()`, because a negated attribute states the opposite
+ * requirement and the negation is already compared above.
+ */
+function attributesConflict(a: string, b: string): boolean {
+  const required = (selector: string): Map<string, Set<string>> => {
+    const found = new Map<string, Set<string>>();
+    for (const match of selector
+      .replace(/:not\([^)]*\)/g, "")
+      .matchAll(/\[([a-zA-Z0-9_-]+)\s*=\s*"([^"]*)"\]/g)) {
+      const name = match[1] ?? "";
+      const values = found.get(name) ?? new Set<string>();
+      values.add(match[2] ?? "");
+      found.set(name, values);
+    }
+    return found;
+  };
+  const other = required(b);
+  for (const [name, values] of required(a)) {
+    const theirs = other.get(name);
+    if (theirs && ![...values].some(value => theirs.has(value))) return true;
+  }
+  return false;
 }
 
 /**
@@ -1539,6 +1577,7 @@ function styleResolver(
     seen?: Set<ts.Node>
   ): ts.ObjectLiteralExpression[];
   valueOf(identifier: ts.Identifier): ts.Expression | undefined;
+  reachingValues(identifier: ts.Identifier): ts.Expression[];
   declarationOf(identifier: ts.Identifier): ts.Declaration | undefined;
 } {
   /**
@@ -1630,6 +1669,31 @@ function styleResolver(
   };
 
   /**
+   * Every value a name can hold at the element.
+   *
+   * The declaration's initializer and every write that can reach here, which is
+   * the whole answer to "what does this name hold" — so both the object
+   * question and the property-value question are asked of this one list rather
+   * than each assembling its own. A mutable binding whose initializer is the
+   * only value it ever holds is fully decidable, and discarding it purely
+   * because the declaration said `let` reported `let colour = undefined` as a
+   * colour React never receives.
+   *
+   * An empty list means the name resolved to a declaration that carries no
+   * readable value — a parameter, an import — which the callers treat as
+   * undecidable in whichever direction is conservative for them.
+   */
+  const reachingValues = (identifier: ts.Identifier): ts.Expression[] => {
+    const declaration = declarationOf(identifier, checker);
+    if (!declaration) return [];
+    const values: ts.Expression[] = [];
+    const initializer = bindingOf(identifier)?.initializer;
+    if (initializer) values.push(initializer);
+    values.push(...assignedValues(declaration));
+    return values;
+  };
+
+  /**
    * Every object an expression can evaluate to HERE.
    *
    * A style prop routinely selects between shapes, and every branch a
@@ -1687,10 +1751,7 @@ function styleResolver(
       // `let style = { ... }` is a false negative, the opposite polarity to an
       // unresolved property value.
       if (ts.isIdentifier(node)) {
-        const declaration = declarationOf(node, checker);
-        if (!declaration) return;
-        walk(bindingOf(node)?.initializer);
-        for (const assigned of assignedValues(declaration)) walk(assigned);
+        for (const value of reachingValues(node)) walk(value);
       }
     };
     walk(root);
@@ -1718,6 +1779,7 @@ function styleResolver(
   return {
     objectsFrom,
     valueOf,
+    reachingValues,
     declarationOf: identifier => declarationOf(identifier, checker),
   };
 }
@@ -1984,8 +2046,14 @@ function emitsValue(
     // entries and a chain crossing a shadow is not mistaken for a cycle.
     if (!declaration || seen.has(declaration)) return true;
     seen.add(declaration);
-    const bound = resolver.valueOf(inner);
-    if (bound) return emitsValue(bound, resolver, seen);
+    // Any value the name can hold here is a value React can receive, so the
+    // property emits unless EVERY one of them is written as nothing. Each
+    // branch carries its own trail, or one branch's visits would cut another's
+    // short and report it as emitting.
+    const reaching = resolver.reachingValues(inner);
+    if (reaching.length > 0) {
+      return reaching.some(value => emitsValue(value, resolver, new Set(seen)));
+    }
   }
   return true;
 }
@@ -2808,6 +2876,22 @@ describe("the tab indicator contract", () => {
       "an owned property in a statically unreachable branch",
       '<TabsTrigger style={true ? {} : { borderBottomColor: "red" }} />',
     ],
+    // A mutable binding nothing ever writes to. Its initializer IS what the
+    // element receives, so discarding it for being `let` reported a property
+    // React never emits. This is the counterpart to the reassignment cases
+    // above: together they separate "the declaration decides" from "a write
+    // decides", which neither shows alone.
+    [
+      "an owned property held by an unchanged mutable binding",
+      "let colour: string | undefined = undefined;\n<TabsTrigger style={{ borderBottomColor: colour }} />",
+    ],
+    // A rule that can never apply beside the owned one it matches. `disabled:`
+    // and `not-disabled:` select complementary states, so neither can restate
+    // or override the other however the cascade ranks them.
+    [
+      "an equal declaration under a negated form of the owned qualifier",
+      '<TabsTrigger className="not-disabled:opacity-50" />',
+    ],
   ])("does not report %s", (_label, body) => {
     // The complement, and the reason this is a contract rather than a ban. A
     // check that flags a documented example or a legitimate layout class gets
@@ -2971,17 +3055,15 @@ describe("which files the call-site scan reads", () => {
     // `**/src` subscribes to `packages/ui` alone — a call site in
     // `packages/admin`, an app or a template could gain a violation and the
     // suite reporting on it would never rerun.
-    // The REAL triggers and the REAL matcher, on the REAL paths.
+    // The REAL triggers and the REAL matcher, on REAL paths.
     //
-    // Every earlier version of this case compared the config's strings against
-    // strings assembled here, and a comparison between two things written in
-    // the same change proves nothing about either: the triggers were relative,
-    // matched none of the absolute paths Vitest hands the matcher, and this
-    // contract stayed green throughout because it never ran one.
-    //
-    // So the config is IMPORTED rather than parsed, picomatch is resolved
-    // through Vitest so it is the same version and cannot drift, and the paths
-    // are the ones the traversal actually returns.
+    // Each of those three is what makes the answer mean anything. The config is
+    // IMPORTED rather than parsed, so the assertion reads the value Vitest
+    // loads instead of a rendering of it. picomatch is resolved THROUGH Vitest,
+    // so the matcher here is the one that decides at runtime and cannot drift
+    // to a different version. And the paths are ABSOLUTE, because absolute is
+    // what the watcher emits: a glob is only covering a file if it matches the
+    // string the matcher is actually handed.
     const { default: config } = (await import("../../../vitest.config")) as {
       default: { test?: { forceRerunTriggers?: string[] } };
     };
@@ -3029,6 +3111,33 @@ describe("which files the call-site scan reads", () => {
     // whole tree at a time, and a bare count says nothing about which.
     const unwatched = scanned().filter(file => !isMatch(file, triggers));
     expect(unwatched).toEqual([]);
+  });
+
+  it("treats complementary states as unable to apply together", () => {
+    // Asserted on the coexistence test directly, because through `violationsIn`
+    // it cannot be isolated: every disjoint pair in this primitive's vocabulary
+    // also meets a rule it genuinely DOES coexist with, so the call site is
+    // reported either way and the outcome cannot separate the two causes.
+    // `data-[state=active]:border-transparent` is the worked example — it is
+    // disjoint from the inactive border, and at the same time a real override
+    // of `hover:border-primary`, which an active hovered tab matches.
+    //
+    // Both spellings the vocabulary produces, taken from what Tailwind actually
+    // compiles rather than from how the variants are written:
+    //   `not-disabled:` -> `&:not(*:disabled)`   against `&:disabled`
+    //   `data-[state=active]:` -> `&[data-state="active"]`
+    expect(excludeEachOther("&:not(*:disabled)", "&:disabled")).toBe(true);
+    expect(
+      excludeEachOther('&[data-state="active"]', '&[data-state="inactive"]')
+    ).toBe(true);
+
+    // The positive control. Without it a test that answered `true` to
+    // everything would pass both cases above, and every comparison in the
+    // contract would be silently skipped as "cannot apply together".
+    expect(excludeEachOther("&:hover", '&[data-state="active"]')).toBe(false);
+    expect(
+      excludeEachOther('&[data-state="active"]', '&[data-state="active"]')
+    ).toBe(false);
   });
 
   it("finds a violation in a .jsx call site", () => {

--- a/packages/ui/src/components/__tests__/tabs-contract.test.ts
+++ b/packages/ui/src/components/__tests__/tabs-contract.test.ts
@@ -56,8 +56,15 @@
  * overridable, so completeness was never available.
  */
 
-import { readFileSync, readdirSync } from "node:fs";
+import {
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { createRequire } from "node:module";
+import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -1022,6 +1029,20 @@ function ownsStyleProperty(slot: string, property: string): boolean {
  * not hypothetical — the store is full of links — so the traversal only follows
  * real directories.
  */
+/**
+ * Whether a file can hold a JSX call site.
+ *
+ * Both extensions, and neither `.ts` nor `.js`: an element cannot appear in
+ * those, so reading them would cost time and find nothing. Named rather than
+ * inlined so the traversal and the Turbo input globs can be checked against one
+ * list instead of two that agree until someone edits one.
+ */
+const CALL_SITE_EXTENSIONS = [".tsx", ".jsx"] as const;
+
+function isCallSite(name: string): boolean {
+  return CALL_SITE_EXTENSIONS.some(extension => name.endsWith(extension));
+}
+
 function sourceFiles(dir: string, found: string[] = []): string[] {
   for (const entry of readdirSync(dir, { withFileTypes: true })) {
     const name = entry.name;
@@ -1034,7 +1055,12 @@ function sourceFiles(dir: string, found: string[] = []): string[] {
       // markup on purpose to show a rule fires, and scanning it would report
       // the proof as the problem.
       if (name !== "__tests__") sourceFiles(full, found);
-    } else if (entry.isFile() && name.endsWith(".tsx") && full !== PRIMITIVE) {
+      // `.jsx` as well as `.tsx`. JSX is a supported source form here —
+      // `create-nextly-app` scaffolds JavaScript projects — and an extension
+      // this scan does not name is a call site it never reads. That failure is
+      // silent in the worst way: the file-count control still passes, because
+      // the `.tsx` files it counts are all still there.
+    } else if (entry.isFile() && isCallSite(name) && full !== PRIMITIVE) {
       found.push(full);
     }
   }
@@ -2246,5 +2272,42 @@ function b() { const s = { borderBottomColor: c }; return <div style={s} />; }`;
         "needs a different indicator, change `packages/ui/src/components/tabs.tsx` " +
         "so every surface changes with it."
     ).toEqual([]);
+  });
+});
+
+/**
+ * The traversal reads every file a call site can live in.
+ *
+ * A scan is only as wide as its extension list, and an extension it does not
+ * name is a call site it never reads. That gap is invisible from the outside:
+ * the repository-wide contract still passes, and so does a control that counts
+ * how many files were scanned, because the `.tsx` files it counts are all still
+ * there. Only asking the traversal directly separates the two.
+ */
+describe("which files the call-site scan reads", () => {
+  it("reads .jsx as well as .tsx, and nothing that cannot hold an element", () => {
+    const dir = mkdtempSync(join(tmpdir(), "tabs-scan-"));
+    try {
+      for (const name of ["a.tsx", "b.jsx", "c.ts", "d.js", "e.css"]) {
+        writeFileSync(join(dir, name), "");
+      }
+
+      const found = sourceFiles(dir).map(path => path.slice(dir.length + 1));
+
+      expect(found.sort()).toEqual(["a.tsx", "b.jsx"].sort());
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("finds a violation in a .jsx call site", () => {
+    // The positive control the extension list exists for. Parsed as TSX, which
+    // handles JSX, so the only thing that decides this is whether the file was
+    // read at all.
+    const source =
+      'import { TabsTrigger } from "@nextlyhq/ui";\n' +
+      '<TabsTrigger className="border-b-0" />';
+
+    expect(violationsIn("probe.jsx", source)).not.toEqual([]);
   });
 });

--- a/packages/ui/src/components/__tests__/tabs-contract.test.ts
+++ b/packages/ui/src/components/__tests__/tabs-contract.test.ts
@@ -1496,6 +1496,7 @@ function ownershipIn(sourceFile: ts.SourceFile): {
   ownership: Ownership;
   exportedNameOf: Map<string, string>;
   owning: Map<ts.Node, string>;
+  owningNamespaces: Set<ts.Declaration>;
 } {
   const names = new Set<string>();
   const namespaces = new Set<string>();
@@ -1505,6 +1506,11 @@ function ownershipIn(sourceFile: ts.SourceFile): {
   // spelled. A local component may legitimately reuse an imported name, and
   // holding it to this contract failed a component entitled to its own classes.
   const owning = new Map<ts.Node, string>();
+  // The DECLARATIONS that bind an owned namespace, in either spelling. A name
+  // set cannot answer this: `import * as UI` and `const UI = require(...)`
+  // resolve to different node kinds, and testing for one of them silently
+  // dropped the other.
+  const owningNamespaces = new Set<ts.Declaration>();
 
   const visit = (node: ts.Node): void => {
     if (
@@ -1527,6 +1533,7 @@ function ownershipIn(sourceFile: ts.SourceFile): {
       }
       if (bindings && ts.isNamespaceImport(bindings)) {
         namespaces.add(bindings.name.text);
+        owningNamespaces.add(bindings);
       }
     }
     // `require` is the same two imports in JavaScript's other spelling, and
@@ -1538,7 +1545,10 @@ function ownershipIn(sourceFile: ts.SourceFile): {
         required !== undefined &&
         reachesThePrimitive(required, sourceFile.fileName)
       ) {
-        if (ts.isIdentifier(node.name)) namespaces.add(node.name.text);
+        if (ts.isIdentifier(node.name)) {
+          namespaces.add(node.name.text);
+          owningNamespaces.add(node);
+        }
         if (ts.isObjectBindingPattern(node.name)) {
           for (const element of node.name.elements) {
             const source = element.propertyName ?? element.name;
@@ -1594,7 +1604,12 @@ function ownershipIn(sourceFile: ts.SourceFile): {
     ts.forEachChild(node, visit);
   };
   visit(sourceFile);
-  return { ownership: { names, namespaces }, exportedNameOf, owning };
+  return {
+    ownership: { names, namespaces },
+    exportedNameOf,
+    owning,
+    owningNamespaces,
+  };
 }
 
 /**
@@ -1651,6 +1666,7 @@ function exportedTagOf(
   ownership: Ownership,
   exportedNameOf: Map<string, string>,
   owning: Map<ts.Node, string>,
+  owningNamespaces: Set<ts.Declaration>,
   checker: ts.TypeChecker
 ): string | undefined {
   if (ts.isIdentifier(tag)) {
@@ -1677,7 +1693,7 @@ function exportedTagOf(
     // file-wide set of names.
     const declaration = declarationOf(tag.expression, checker);
     if (declaration) {
-      return ts.isNamespaceImport(declaration) ? tag.name.text : undefined;
+      return owningNamespaces.has(declaration) ? tag.name.text : undefined;
     }
     if (ownership.namespaces.has(tag.expression.text)) return tag.name.text;
   }
@@ -1716,7 +1732,7 @@ function selectedByLiteralCondition(
   const operator = node.operatorToken.kind;
   // `??` chooses on presence rather than on truth, so it is asked separately.
   if (operator === ts.SyntaxKind.QuestionQuestionToken) {
-    return isDefinitelyPresent(node.left) ? node.left : undefined;
+    return isDefinitelyPresent(node.left, resolver) ? node.left : undefined;
   }
   if (
     operator !== ts.SyntaxKind.AmpersandAmpersandToken &&
@@ -2215,7 +2231,10 @@ function styleResolver(
       name: string;
       emits: boolean;
       value: string | undefined;
+      at: number;
     }> = [];
+    const targets = new Set<ts.Node>(objectsFrom(identifier));
+    if (targets.size === 0) return [];
     const unit = executionUnitOf(identifier);
     const visit = (node: ts.Node): void => {
       if (
@@ -2224,7 +2243,10 @@ function styleResolver(
         (ts.isPropertyAccessExpression(node.left) ||
           ts.isElementAccessExpression(node.left)) &&
         ts.isIdentifier(node.left.expression) &&
-        declarationOf(node.left.expression, checker) === declaration
+        // Any binding holding the SAME object, not only the one the element
+        // names. `const saved = style; saved.x = ...` mutates one object
+        // through two names, and React receives it either way.
+        objectsFrom(node.left.expression).some(object => targets.has(object))
       ) {
         // The mutation belongs to whatever object the binding held at the
         // moment of the write. A later write REPLACES that object, so a
@@ -2247,13 +2269,21 @@ function styleResolver(
             name,
             emits: emitsValue(node.right, api),
             value: staticStringOf(node.right, api),
+            at: node.getStart(),
           });
         }
       }
       ts.forEachChild(node, visit);
     };
     visit(declaration.getSourceFile());
-    return found;
+    // Only the LAST write to each property survives: `style.x = "red"` followed
+    // by `style.x = undefined` hands React the second one, and keeping both
+    // reported a colour the element never receives.
+    const last = new Map<string, (typeof found)[number]>();
+    for (const write of found.sort((a, b) => a.at - b.at)) {
+      last.set(write.name, write);
+    }
+    return [...last.values()];
   };
 
   // Named so the resolver can ask ITSELF: deciding a branch or a logical
@@ -2453,7 +2483,7 @@ function cannotFire(
   resolver: ReturnType<typeof styleResolver>
 ): boolean {
   if (operator === ts.SyntaxKind.QuestionQuestionEqualsToken) {
-    return held.every(isDefinitelyPresent);
+    return held.every(value => isDefinitelyPresent(value, resolver));
   }
   if (operator === ts.SyntaxKind.BarBarEqualsToken) {
     return held.every(value => staticTruthiness(value, resolver) === true);
@@ -2471,8 +2501,22 @@ function cannotFire(
  * removes a value from consideration. Only forms that cannot be nullish however
  * they are read qualify, so anything unfamiliar keeps the write in play.
  */
-function isDefinitelyPresent(value: ts.Expression): boolean {
+function isDefinitelyPresent(
+  value: ts.Expression,
+  resolver?: ReturnType<typeof styleResolver>
+): boolean {
   const inner = withoutTypeWrappers(value);
+  // A name holding a present value is present. Reading only the syntax meant
+  // `style ?? { ...owned }` kept a fallback that cannot run, exactly as the
+  // assignment form did before it was resolved.
+  if (resolver && ts.isIdentifier(inner)) {
+    const reaching = resolver.reachingValues(inner);
+    return (
+      reaching.exhaustive &&
+      reaching.values.length > 0 &&
+      reaching.values.every(each => isDefinitelyPresent(each, resolver))
+    );
+  }
   return (
     ts.isObjectLiteralExpression(inner) ||
     ts.isArrayLiteralExpression(inner) ||
@@ -2721,7 +2765,8 @@ interface Violation {
 
 function violationsIn(file: string, source: string): Violation[] {
   const { sourceFile, checker } = parse(file, source);
-  const { ownership, exportedNameOf, owning } = ownershipIn(sourceFile);
+  const { ownership, exportedNameOf, owning, owningNamespaces } =
+    ownershipIn(sourceFile);
   const found: Violation[] = [];
   const at = (node: ts.Node): number =>
     sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile)).line +
@@ -2734,6 +2779,7 @@ function violationsIn(file: string, source: string): Violation[] {
         ownership,
         exportedNameOf,
         owning,
+        owningNamespaces,
         checker
       );
       if (exported) {
@@ -3364,6 +3410,17 @@ describe("the tab indicator contract", () => {
       "an owned property a do-body reset behind a break does not clear",
       'let style: Record<string, string> = { borderBottomColor: "red" };\ndo {\n  if (Math.random() > 0) break;\n  style = {};\n} while (false);\n<TabsTrigger style={style} />',
     ],
+    // Two names for one object. The mutation reaches React whichever name it
+    // was written through.
+    [
+      "an owned property written through an alias of the style object",
+      'const style: Record<string, string> = {};\nconst saved = style;\nsaved.borderBottomColor = "red";\n<TabsTrigger style={style} />',
+    ],
+    // The CommonJS spelling of a namespace import.
+    [
+      "a class on a namespace member behind a CommonJS require",
+      'const UI = require("@nextlyhq/ui");\n<UI.TabsTrigger className="border-b-0" />',
+    ],
   ])("catches %s", (_label, body) => {
     // The positive controls. Each is a shape an earlier version returned clean
     // on, or a category it never read. Without these, a check that can never
@@ -3754,6 +3811,16 @@ describe("the tab indicator contract", () => {
     [
       "an attribute value that merely contains a hash",
       '<TabsTrigger className="not-data-[foo=#bar]:opacity-100" />',
+    ],
+    // The last write to a property is what React receives.
+    [
+      "an owned property a later in-place write clears",
+      'const style: Record<string, string | undefined> = {};\nstyle.borderBottomColor = "red";\nstyle.borderBottomColor = undefined;\n<TabsTrigger style={style} />',
+    ],
+    // A constant object is definitely present, so the fallback cannot run.
+    [
+      "an owned property in a nullish fallback that cannot run",
+      'const style = {};\n<TabsTrigger style={style ?? { borderBottomColor: "red" }} />',
     ],
   ])("does not report %s", (_label, body) => {
     // The complement, and the reason this is a contract rather than a ban. A

--- a/packages/ui/src/components/__tests__/tabs-contract.test.ts
+++ b/packages/ui/src/components/__tests__/tabs-contract.test.ts
@@ -57,6 +57,7 @@
  */
 
 import {
+  mkdirSync,
   mkdtempSync,
   readFileSync,
   readdirSync,
@@ -1050,6 +1051,34 @@ function ownsStyleProperty(slot: string, property: string): boolean {
  */
 const CALL_SITE_EXTENSIONS = [".tsx", ".jsx", ".js"] as const;
 
+/**
+ * The roots the scan walks, and the roots the Turbo inputs must cover.
+ *
+ * Both halves of a pair matter. A glob covering `packages` says nothing about a
+ * call site under `apps`, so the two are enumerated rather than summarised.
+ */
+const CALL_SITE_ROOTS = ["packages", "apps"] as const;
+
+/**
+ * Directories whose contents are generated rather than written.
+ *
+ * `.next` is the one that makes this load-bearing rather than tidy: a
+ * contributor who has run the playground dev server has thousands of generated
+ * `.js` chunks under it, and a scan that reads JavaScript would parse every one
+ * of them. That is slow, and worse, it makes the result depend on whether
+ * somebody happened to build locally — a suite that reads generated output is
+ * reading a different repository on each machine.
+ */
+const GENERATED_DIRECTORIES = new Set([
+  "node_modules",
+  "dist",
+  ".turbo",
+  ".next",
+  "coverage",
+  "out",
+  "build",
+]);
+
 function isCallSite(name: string): boolean {
   return CALL_SITE_EXTENSIONS.some(extension => name.endsWith(extension));
 }
@@ -1057,9 +1086,7 @@ function isCallSite(name: string): boolean {
 function sourceFiles(dir: string, found: string[] = []): string[] {
   for (const entry of readdirSync(dir, { withFileTypes: true })) {
     const name = entry.name;
-    if (name === "node_modules" || name === "dist" || name === ".turbo") {
-      continue;
-    }
+    if (GENERATED_DIRECTORIES.has(name)) continue;
     const full = join(dir, name);
     if (entry.isDirectory()) {
       // `__tests__` is skipped deliberately: a test may construct violating
@@ -2377,6 +2404,11 @@ describe("which files the call-site scan reads", () => {
         writeFileSync(join(dir, name), "");
       }
 
+      // Generated output, which reading JavaScript would otherwise pull in by
+      // the thousand on any machine where the playground has been built.
+      mkdirSync(join(dir, ".next"));
+      writeFileSync(join(dir, ".next", "chunk.js"), "");
+
       const found = sourceFiles(dir).map(path => path.slice(dir.length + 1));
 
       expect(found.sort()).toEqual(["a.tsx", "b.jsx", "d.js"].sort());
@@ -2385,16 +2417,19 @@ describe("which files the call-site scan reads", () => {
     }
   });
 
-  it("has a Turbo input glob for every extension it reads", () => {
-    // The claim this replaces was a comment saying the list was "named once and
-    // read by both". It was not: the extensions were repeated by hand in two
-    // task input lists, and `turbo.json` is static JSON that cannot import a
-    // constant. So the tie is asserted here instead of asserted in prose.
+  it("covers every scan root and extension in both Turbo tasks", () => {
+    // The traversal and the cache have to agree about which files matter. An
+    // extension or a root the scan reads but the hash does not cover is a file
+    // that can change while Turbo replays a cached green, and a replayed pass
+    // is indistinguishable from one that ran.
     //
-    // What it protects is the same silent gap this PR closes from the other
-    // side: an extension the scan reads but the hash does not cover is a file
-    // that can change behind a cached green, and the cached pass looks exactly
-    // like a real one.
+    // `turbo.json` is static JSON and cannot import the lists above, so the
+    // agreement is asserted here rather than assumed.
+    //
+    // Every ROOT-and-extension pair, not merely every extension: a glob for
+    // `packages/**/*.js` says nothing about a call site under `apps`, and a
+    // check that only asks "is this extension mentioned anywhere" stays green
+    // while half the coverage is gone.
     const config = JSON.parse(
       readFileSync(resolve(HERE, "../../../turbo.json"), "utf8").replace(
         // The file carries `//` comments, which `JSON.parse` rejects.
@@ -2403,19 +2438,21 @@ describe("which files the call-site scan reads", () => {
       )
     ) as { tasks: Record<string, { inputs?: string[] }> };
 
-    // BOTH tasks, because a coverage gap in either replays a stale green.
+    const required = CALL_SITE_ROOTS.flatMap(root =>
+      CALL_SITE_EXTENSIONS.map(
+        extension => `$TURBO_ROOT$/${root}/**/*${extension}`
+      )
+    );
+
+    // Both tasks: a gap in either replays a stale result for that task alone.
     for (const task of ["test", "test:coverage"]) {
-      const inputs = config.tasks[task]?.inputs ?? [];
-      for (const extension of CALL_SITE_EXTENSIONS) {
-        const covered = inputs.filter(glob => glob.endsWith(`*${extension}`));
-        // Named in the failure, so a reader is told WHICH extension and WHICH
-        // task rather than being handed a false.
-        expect(
-          covered.length > 0
-            ? `${task} covers ${extension}`
-            : { task, extension }
-        ).toBe(`${task} covers ${extension}`);
-      }
+      const inputs = new Set(config.tasks[task]?.inputs ?? []);
+      const missing = required.filter(glob => !inputs.has(glob));
+
+      // The missing globs are named, because this rule is only ever broken by
+      // someone adding an extension or a root who does not know the second
+      // task list exists — and a bare `false` tells them nothing.
+      expect({ task, missing }).toEqual({ task, missing: [] });
     }
   });
 

--- a/packages/ui/src/components/__tests__/tabs-contract.test.ts
+++ b/packages/ui/src/components/__tests__/tabs-contract.test.ts
@@ -88,7 +88,9 @@ const REPO = resolve(HERE, "../../../../..");
  * first-party consumer. Omitting them would mean reporting repository-wide
  * conformance from a subset of the repository.
  */
-const SCAN_ROOTS = ["packages", "apps", "templates"].map(r => resolve(REPO, r));
+const SCAN_ROOT_NAMES = ["packages", "apps", "templates"] as const;
+
+const SCAN_ROOTS = SCAN_ROOT_NAMES.map(r => resolve(REPO, r));
 
 /** The primitive itself declares the contract; it is not a call site. */
 const PRIMITIVE = resolve(REPO, "packages/ui/src/components/tabs.tsx");
@@ -1033,31 +1035,18 @@ function ownsStyleProperty(slot: string, property: string): boolean {
 /**
  * Whether a file can hold a JSX call site.
  *
- * `.js` is on the list and that is not an oversight corrected — it is the case
- * an earlier version of this test actively certified as SAFE. A JavaScript
- * Next.js app puts JSX in `.js` routinely, so a first-party `page.js` importing
- * `TabsTrigger` was invisible to the scan while a control asserted that
- * invisibility was correct. A test that ratifies a gap is worse than no test,
- * because it answers the question and closes it.
+ * Every extension in which JSX is legal, which is the three below and not only
+ * the TypeScript ones: a JavaScript Next.js app writes JSX in `.js` and `.jsx`
+ * routinely, so `app/page.js` is an ordinary place for a call site to live.
+ * `.ts` is excluded because an element cannot appear there at all.
  *
- * `.ts` stays off: an element cannot appear there, so reading those files would
- * cost time and find nothing.
- *
- * Named once because the Turbo input globs must cover exactly these — an
+ * Named once because the Turbo input globs must cover exactly these. An
  * extension the scan reads but the hash does not cover is a file that can
- * change behind a cached green, which is the same silent gap wearing different
- * clothes. `turbo.json` is static JSON and cannot import this, so the two are
- * tied together by a contract test below rather than by a claim in a comment.
+ * change while a cached result is replayed, and a replayed pass is
+ * indistinguishable from one that ran. `turbo.json` is static JSON and cannot
+ * import this list, so a contract test below asserts the two agree.
  */
 const CALL_SITE_EXTENSIONS = [".tsx", ".jsx", ".js"] as const;
-
-/**
- * The roots the scan walks, and the roots the Turbo inputs must cover.
- *
- * Both halves of a pair matter. A glob covering `packages` says nothing about a
- * call site under `apps`, so the two are enumerated rather than summarised.
- */
-const CALL_SITE_ROOTS = ["packages", "apps"] as const;
 
 /**
  * Directories whose contents are generated rather than written.
@@ -2438,16 +2427,22 @@ describe("which files the call-site scan reads", () => {
       )
     ) as { tasks: Record<string, { inputs?: string[] }> };
 
-    const required = CALL_SITE_ROOTS.flatMap(root =>
-      CALL_SITE_EXTENSIONS.map(
+    // Derived from the roots the traversal actually walks, so a root added
+    // there cannot be forgotten here. `templates` is covered by a single broad
+    // glob rather than per-extension ones, which is why a root is satisfied by
+    // EITHER spelling: what matters is that every file the scan reads is
+    // hashed, not how the glob is written.
+    const satisfies = (inputs: Set<string>, root: string): string[] => {
+      if (inputs.has(`$TURBO_ROOT$/${root}/**`)) return [];
+      return CALL_SITE_EXTENSIONS.map(
         extension => `$TURBO_ROOT$/${root}/**/*${extension}`
-      )
-    );
+      ).filter(glob => !inputs.has(glob));
+    };
 
     // Both tasks: a gap in either replays a stale result for that task alone.
     for (const task of ["test", "test:coverage"]) {
       const inputs = new Set(config.tasks[task]?.inputs ?? []);
-      const missing = required.filter(glob => !inputs.has(glob));
+      const missing = SCAN_ROOT_NAMES.flatMap(root => satisfies(inputs, root));
 
       // The missing globs are named, because this rule is only ever broken by
       // someone adding an extension or a root who does not know the second

--- a/packages/ui/src/components/__tests__/tabs-contract.test.ts
+++ b/packages/ui/src/components/__tests__/tabs-contract.test.ts
@@ -1720,11 +1720,10 @@ function exportedTagOf(
  * condition around a class was correctly ignored.
  */
 function selectedByLiteralCondition(
-  node: ts.Expression,
-  resolver?: ReturnType<typeof styleResolver>
+  node: ts.Expression
 ): ts.Expression | undefined {
   if (ts.isConditionalExpression(node)) {
-    const decided = staticTruthiness(node.condition, resolver);
+    const decided = staticTruthiness(node.condition);
     if (decided === undefined) return undefined;
     return decided ? node.whenTrue : node.whenFalse;
   }
@@ -1732,7 +1731,7 @@ function selectedByLiteralCondition(
   const operator = node.operatorToken.kind;
   // `??` chooses on presence rather than on truth, so it is asked separately.
   if (operator === ts.SyntaxKind.QuestionQuestionToken) {
-    return isDefinitelyPresent(node.left, resolver) ? node.left : undefined;
+    return isDefinitelyPresent(node.left) ? node.left : undefined;
   }
   if (
     operator !== ts.SyntaxKind.AmpersandAmpersandToken &&
@@ -1745,7 +1744,7 @@ function selectedByLiteralCondition(
   // one truthiness evaluator, so `false`, `0`, `null` and `""` are decided the
   // same way rather than only the boolean spelling — and so a name holding a
   // known value is decided at all.
-  const decided = staticTruthiness(node.left, resolver);
+  const decided = staticTruthiness(node.left);
   if (decided === undefined) return undefined;
   if (operator === ts.SyntaxKind.AmpersandAmpersandToken) {
     return decided ? node.right : node.left;
@@ -1753,18 +1752,14 @@ function selectedByLiteralCondition(
   return decided ? node.left : node.right;
 }
 
-function literalStrings(
-  node: ts.Node,
-  found: string[] = [],
-  resolver?: ReturnType<typeof styleResolver>
-): string[] {
+function literalStrings(node: ts.Node, found: string[] = []): string[] {
   if (ts.isStringLiteral(node) || ts.isNoSubstitutionTemplateLiteral(node)) {
     found.push(node.text);
   } else if (ts.isTemplateExpression(node)) {
     found.push(node.head.text);
     for (const span of node.templateSpans) {
       found.push(span.literal.text);
-      literalStrings(span.expression, found, resolver);
+      literalStrings(span.expression, found);
     }
     return found;
   }
@@ -1773,8 +1768,8 @@ function literalStrings(
   // receives the second string — collecting it reported a call site for a class
   // it does not apply.
   if (ts.isExpression(node)) {
-    const selected = selectedByLiteralCondition(node, resolver);
-    if (selected) return literalStrings(selected, found, resolver);
+    const selected = selectedByLiteralCondition(node);
+    if (selected) return literalStrings(selected, found);
   }
   // `cn({ "border-b-0": false })` applies nothing. In this form the KEY is the
   // class and the VALUE is the condition, so walking the object as plain text
@@ -1783,7 +1778,7 @@ function literalStrings(
   if (ts.isObjectLiteralExpression(node)) {
     for (const property of node.properties) {
       if (!ts.isPropertyAssignment(property)) continue;
-      if (staticTruthiness(property.initializer, resolver) === false) continue;
+      if (staticTruthiness(property.initializer) === false) continue;
       const name = property.name;
       if (ts.isStringLiteral(name) || ts.isIdentifier(name))
         found.push(name.text);
@@ -1794,7 +1789,7 @@ function literalStrings(
   // returns something truthy, so a concise arrow returning the accumulator
   // visits one child and reports the rest as absent.
   ts.forEachChild(node, child => {
-    literalStrings(child, found, resolver);
+    literalStrings(child, found);
   });
   return found;
 }
@@ -1811,365 +1806,94 @@ function literalStrings(
  * in the other order, invents one. Which declaration a name refers to is a
  * lexical question, and the answer is the nearest enclosing one.
  */
-function styleResolver(
-  checker: ts.TypeChecker,
-  element: ts.JsxAttribute
-): {
-  objectsFrom(
-    expression: ts.Expression | undefined,
-    seen?: Set<ts.Node>
-  ): ts.ObjectLiteralExpression[];
-  valueOf(identifier: ts.Identifier): ts.Expression | undefined;
-  reachingValues(identifier: ts.Identifier): {
-    values: ts.Expression[];
-    exhaustive: boolean;
+/**
+ * Resolve the objects a `style` prop can hand React, and what they declare.
+ *
+ * An inline style on an owned element must be written where it can be READ:
+ * an object literal, or a choice between object literals. Anything that has to
+ * be traced to know its value — a name, a call, a member access — is reported
+ * as unresolvable rather than analysed.
+ *
+ * That is a deliberate limit, and the reason is worth stating because the
+ * alternative was tried at length. Answering "what does this variable hold at
+ * this point" is reaching-definitions analysis: assignments, branches, loops,
+ * closures, aliases and in-place mutation, each interacting with the others.
+ * Written by hand it grew to roughly seven hundred lines and kept producing
+ * defects of a kind no test here could see, because a wrong answer looks
+ * exactly like a right one. The compiler does not expose that analysis, and a
+ * test file is the wrong place to reimplement it.
+ *
+ * The narrower question this asks instead is decidable by construction: the
+ * expression either IS a literal, or it is not. What it costs is that a
+ * computed style must be written inline or moved to a class, which is a rule a
+ * reader can follow. What it buys is that "no violation" means the scan read
+ * the value, rather than that it failed to find one.
+ *
+ * Property VALUES inside the literal are still followed through a `const`
+ * binding, because that is a single lookup with no flow to model, and the
+ * binder resolves shadowing correctly on its own. A `let` is not followed: its
+ * value depends on what ran, which is the question this stops asking.
+ */
+function styleResolver(checker: ts.TypeChecker): {
+  objectsFrom(expression: ts.Expression | undefined): {
+    objects: ts.ObjectLiteralExpression[];
+    /** False when the expression has to be traced to know what it holds. */
+    readable: boolean;
   };
-  propertyWrites(identifier: ts.Identifier): Array<{
-    name: string;
-    emits: boolean;
-    value: string | undefined;
-  }>;
+  valueOf(identifier: ts.Identifier): ts.Expression | undefined;
   declarationOf(identifier: ts.Identifier): ts.Declaration | undefined;
 } {
   /**
-   * What a name holds, for a name the binder resolved to a declaration here.
+   * What a `const` holds, for a name the binder resolves to one here.
    *
-   * Mutability is REPORTED rather than filtered on, because the right answer
-   * depends on the CALLER. For a property value, unresolved means "assume it
-   * emits" and reporting is the safe side. For the style object itself,
-   * unresolved means an empty object list and therefore silence — so the same
-   * filter that protects one caller blinds the other.
-   *
-   * A declaration with no initializer is still a binding. It stops the question
-   * at the right place: a parameter shadowing an outer constant means the name
-   * is the parameter, whose value the caller supplies, so the property is
-   * undecidable rather than the outer constant's.
+   * `undefined` for anything else — a `let`, a parameter, an import — because
+   * each can hold a different value by the time the element renders.
    */
-  interface Binding {
-    /** The declaration's own initializer, where it has one. */
-    initializer: ts.Expression | undefined;
-    /** The initializer is not necessarily what the name holds at the element. */
-    mutable: boolean;
-  }
-
-  const bindingOf = (identifier: ts.Identifier): Binding | undefined => {
+  const valueOf = (identifier: ts.Identifier): ts.Expression | undefined => {
     const declaration = declarationOf(identifier, checker);
-    if (!declaration) return undefined;
-    if (ts.isVariableDeclaration(declaration)) {
-      const list = declaration.parent;
-      // `const` is the only form whose initializer is still the value later on.
-      const mutable =
-        !ts.isVariableDeclarationList(list) ||
-        (list.flags & ts.NodeFlags.Const) === 0;
-      return { initializer: declaration.initializer, mutable };
-    }
-    // A parameter's default IS one of the values it holds — rendering the
-    // component without an argument passes exactly that object — so it counts
-    // as a value the element can receive. It is `mutable` because it is only
-    // ONE of them: a caller supplying an argument replaces it, which is why the
-    // key question, needing a single answer, still treats it as undecidable.
-    //
-    // An import, a function or a catch binding has no initializer to read.
-    if (ts.isParameter(declaration)) {
-      return { initializer: declaration.initializer, mutable: true };
-    }
-    return { initializer: undefined, mutable: true };
+    if (!declaration || !ts.isVariableDeclaration(declaration))
+      return undefined;
+    const list = declaration.parent;
+    const isConst =
+      ts.isVariableDeclarationList(list) &&
+      (list.flags & ts.NodeFlags.Const) !== 0;
+    return isConst ? declaration.initializer : undefined;
   };
 
-  /**
-   * The function whose body a node runs in, or undefined at the top level.
-   *
-   * What it separates is EXECUTION UNITS. Two nodes in the same one run in
-   * source order; two in different ones do not, because calling a function is
-   * what decides when its body runs and the call can appear anywhere.
-   */
-  const executionUnitOf = (node: ts.Node): ts.Node | undefined => {
-    for (let at = node.parent; at; at = at.parent) {
-      if (ts.isFunctionLike(at)) return at;
-    }
-    return undefined;
-  };
-
-  /**
-   * Whether a node runs every time its execution unit does.
-   *
-   * Only a write that definitely happens can be said to have replaced what came
-   * before it. One inside an `if`, a loop, a `switch`, a `try` or the right of
-   * a short-circuit may be skipped, so it ADDS a value the binding might hold
-   * without removing any.
-   *
-   * Written as a list of constructs that introduce a choice rather than a list
-   * of ones that do not, so an unfamiliar node fails towards "may be skipped" —
-   * which keeps earlier values in play, and keeping them is the reporting side.
-   */
-  const alwaysRuns = (node: ts.Node, unit: ts.Node | undefined): boolean => {
-    for (let at = node.parent; at && at !== unit; at = at.parent) {
-      // A write at the START of a `try` runs whenever control reaches the
-      // block: nothing inside it has had the chance to throw yet.
-      if (
-        ts.isTryStatement(at) &&
-        at.tryBlock.statements.length > 0 &&
-        node.getStart() >= (at.tryBlock.statements[0]?.getStart() ?? 0) &&
-        node.getEnd() <= (at.tryBlock.statements[0]?.getEnd() ?? 0)
-      ) {
-        continue;
-      }
-      // A `do` BODY runs before its condition is ever asked, so it executes at
-      // least once however the condition later answers.
-      // Only the FIRST statement of a `do` body, for the same reason as a
-      // `try`: a `break`, `continue` or `return` written above it can carry
-      // control out before it runs, so a later write may be skipped.
-      if (
-        ts.isDoStatement(at) &&
-        ts.isBlock(at.statement) &&
-        at.statement.statements.length > 0 &&
-        node.getStart() >= (at.statement.statements[0]?.getStart() ?? 0) &&
-        node.getEnd() <= (at.statement.statements[0]?.getEnd() ?? 0)
-      ) {
-        continue;
-      }
-      // A `for` INITIALIZER runs once before the condition is ever asked, so it
-      // is unconditional even though the body beside it is not.
-      if (
-        ts.isForStatement(at) &&
-        at.initializer &&
-        node.getStart() >= at.initializer.getStart() &&
-        node.getEnd() <= at.initializer.getEnd()
-      ) {
-        continue;
-      }
-      if (
-        ts.isIfStatement(at) ||
-        ts.isIterationStatement(at, /* lookInLabeledStatements */ true) ||
-        ts.isSwitchStatement(at) ||
-        ts.isCaseOrDefaultClause(at) ||
-        ts.isTryStatement(at) ||
-        ts.isCatchClause(at) ||
-        ts.isConditionalExpression(at) ||
-        ts.isBinaryExpression(at)
-      ) {
-        return false;
-      }
-    }
-    return true;
-  };
-
-  /**
-   * Every value assigned to a binding that the element could actually see.
-   *
-   * A declaration initializer is only the FIRST value a mutable binding holds:
-   * `let style = {}; style = { borderBottomColor: "red" }` renders the second
-   * one, and reading the declaration alone reported nothing at all. Matched by
-   * DECLARATION identity rather than by name, so a same-named binding in
-   * another scope contributes nothing and the whole file can be searched.
-   *
-   * Ordering is what stops that search over-reaching. An assignment sharing the
-   * element's execution unit runs in source order, so one written AFTER the
-   * element cannot have reached it — React already holds the earlier value, and
-   * collecting the later one reported an element for a style it never received.
-   * Across different units the order is not decidable and the write is kept,
-   * which is the reporting side and therefore the safe one.
-   */
-  interface Write {
-    value: ts.Expression;
-    operator: ts.SyntaxKind;
-    /** Shares the element's execution unit, so it runs in source order. */
-    sameUnit: boolean;
-    /** Runs before the element every time, so it replaces what came before. */
-    straightLine: boolean;
-    at: number;
-  }
-
-  /**
-   * The operators that give a binding a new value.
-   *
-   * A logical assignment writes only when the current value passes its test, so
-   * it ADDS a value the binding might hold. `=` is the only one that can be
-   * said to have replaced what was there.
-   */
-  const ASSIGNMENT_OPERATORS = new Map<ts.SyntaxKind, boolean>([
-    [ts.SyntaxKind.EqualsToken, true],
-    [ts.SyntaxKind.QuestionQuestionEqualsToken, false],
-    [ts.SyntaxKind.BarBarEqualsToken, false],
-    [ts.SyntaxKind.AmpersandAmpersandEqualsToken, false],
-  ]);
-
-  const writesTo = (declaration: ts.Declaration, at: ts.Node): Write[] => {
-    const elementUnit = executionUnitOf(at);
-    const found: Write[] = [];
-    const visit = (node: ts.Node): void => {
-      if (
-        ts.isBinaryExpression(node) &&
-        ASSIGNMENT_OPERATORS.has(node.operatorToken.kind) &&
-        ts.isIdentifier(node.left) &&
-        declarationOf(node.left, checker) === declaration
-      ) {
-        const sameUnit = executionUnitOf(node) === elementUnit;
-        const before = node.getStart() < at.getStart();
-        // A write is not its own antecedent. While `style = style || {...}` is
-        // being evaluated the binding still holds what it held before, so a
-        // program point INSIDE this write must not see it as already done —
-        // counting it made the right-hand side undecidable and both branches
-        // were then read as reachable.
-        const evaluatingThisWrite =
-          at.getStart() >= node.getStart() && at.getEnd() <= node.getEnd();
-        if (!evaluatingThisWrite && (!sameUnit || before)) {
-          found.push({
-            value: node.right,
-            operator: node.operatorToken.kind,
-            sameUnit,
-            // Definite only when it shares the element's execution unit, runs
-            // before it, no branch stands between, and the operator always
-            // writes: those together are what let a write be said to have
-            // HAPPENED, which is what killing an earlier value requires.
-            straightLine:
-              sameUnit &&
-              before &&
-              (ASSIGNMENT_OPERATORS.get(node.operatorToken.kind) ?? false) &&
-              alwaysRuns(node, elementUnit ?? undefined),
-            at: node.getStart(),
-          });
-        }
-      }
-      ts.forEachChild(node, visit);
-    };
-    visit(declaration.getSourceFile());
-    return found.sort((a, b) => a.at - b.at);
-  };
-
-  /**
-   * Every value a name can hold at the element.
-   *
-   * The declaration's initializer and every write that can still reach here,
-   * which is the whole answer to "what does this name hold" — so the object
-   * question and the property-value question are asked of this one list rather
-   * than each assembling its own. A mutable binding whose initializer is the
-   * only value it ever holds is fully decidable, and discarding it purely
-   * because the declaration said `let` reported `let colour = undefined` as a
-   * colour React never receives.
-   *
-   * A write KILLS what came before it. `let style = {}; style = { ...owned };
-   * style = {}` holds the empty object at the element, and carrying the middle
-   * value along rejected a call site for a style it had already discarded. Only
-   * a write that definitely runs can kill, so a reset inside an `if` narrows
-   * nothing and every earlier value stays in play.
-   *
-   * Killing reaches only the element's OWN execution unit. A write inside a
-   * function runs when that function is called, which the source order does not
-   * tell you: `function paint() { style = { ...owned } }` written above a
-   * `style = {}` still paints when `paint()` is called after it. Those writes
-   * survive whatever their position.
-   *
-   * Resolved AT THE IDENTIFIER, not at the element. An identifier is evaluated
-   * where it is written, so `const saved = style; style = {}` holds whatever
-   * `style` was on the line the alias was written — reading it beside the
-   * element instead applied a later reset to a value already captured.
-   *
-   * `exhaustive` says whether the list is the whole story. A variable's writes
-   * are all visible in the file, so its list is complete and a property emits
-   * only if one of them emits. A parameter or an import receives values from
-   * outside, so its list is a sample: the default a parameter declares is one
-   * value the element can receive, never the only one.
-   */
-  interface Reaching {
-    values: ts.Expression[];
-    /** No value can arrive from outside the ones listed. */
-    exhaustive: boolean;
-  }
-
-  const reachingValues = (identifier: ts.Identifier): Reaching => {
-    const declaration = declarationOf(identifier, checker);
-    if (!declaration) return { values: [], exhaustive: false };
-    // A parameter is written to like any other binding, so its writes are
-    // collected the same way; what stays different is that the list can never
-    // be complete, because the caller supplies a value this file cannot see.
-    if (!ts.isVariableDeclaration(declaration)) {
-      const binding = bindingOf(identifier);
-      return {
-        values: [
-          ...(binding?.initializer ? [binding.initializer] : []),
-          ...writesTo(declaration, identifier).map(write => write.value),
-        ],
-        exhaustive: false,
-      };
-    }
-    const writes = writesTo(declaration, identifier);
-    // Order across units is not decidable, so nothing here can rule them out.
-    const elsewhere = writes
-      .filter(write => !write.sameUnit)
-      .map(write => write.value);
-    const initializer = bindingOf(identifier)?.initializer;
-    // A `var` is hoisted but its INITIALIZER runs where it is written, so an
-    // element evaluated above it receives `undefined`. Treated as a write at
-    // its own position, which for `let` and `const` changes nothing: reading
-    // either before its declaration is a temporal-dead-zone error, so the case
-    // cannot arise in code that runs.
-    const initializerReaches =
-      !initializer ||
-      executionUnitOf(initializer) !== executionUnitOf(identifier) ||
-      initializer.getStart() < identifier.getStart();
-    let held: ts.Expression[] =
-      initializer && initializerReaches ? [initializer] : [];
-    for (const write of writes.filter(write => write.sameUnit)) {
-      if (write.straightLine) {
-        // Everything before is a value the binding has stopped holding.
-        held = [write.value];
-        continue;
-      }
-      // A logical assignment whose test the current value already settles
-      // cannot fire, so its right side is not a value the binding can hold —
-      // filling a style object only when nothing filled it yet is the ordinary
-      // reason to write one.
-      if (held.length > 0 && cannotFire(write.operator, held, api)) continue;
-      held = [...held, write.value];
-    }
-    return { values: [...held, ...elsewhere], exhaustive: true };
-  };
-
-  /**
-   * Every object an expression can evaluate to HERE.
-   *
-   * A style prop routinely selects between shapes, and every branch a
-   * conditional can take is a shape the element can render, so each is
-   * returned. Spreads are deliberately NOT followed here: a spread's contents
-   * are not a separate style object, they are earlier entries of the one being
-   * built, and treating them as separate reported a source whose value the
-   * outer object had already replaced.
-   */
   const objectsFrom = (
-    root: ts.Expression | undefined,
-    seen = new Set<ts.Node>()
-  ): ts.ObjectLiteralExpression[] => {
+    root: ts.Expression | undefined
+  ): { objects: ts.ObjectLiteralExpression[]; readable: boolean } => {
     const objects: ts.ObjectLiteralExpression[] = [];
+    const seen = new Set<ts.Node>();
+    let readable = true;
     const walk = (node: ts.Expression | undefined): void => {
-      // Bounded so a `const a = b, b = a` cycle cannot loop forever, and so one
-      // identifier is not expanded twice through two paths.
-      if (!node || seen.has(node)) return;
+      if (!node) {
+        readable = false;
+        return;
+      }
+      if (seen.has(node)) return;
       seen.add(node);
+      // Parentheses, `as`, `satisfies` and `!` are erased before the code runs,
+      // so what they wrap is what React receives.
+      const unwrapped = withoutTypeWrappers(node);
+      if (unwrapped !== node) return walk(unwrapped);
       if (ts.isObjectLiteralExpression(node)) {
         objects.push(node);
         return;
       }
-      // Parentheses, `as`, `satisfies` and `!` all wrap the value without
-      // changing it. Peeled by the SAME helper the property-value side uses, so
-      // the two cannot come to disagree about which syntax is erased — listing
-      // them here independently left `style={style!}` unread while the value
-      // side understood it.
-      const unwrapped = withoutTypeWrappers(node);
-      if (unwrapped !== node) return walk(unwrapped);
-      // A literal condition decides the branch, and the branch it excludes is
+      // A literal condition decides its branch, and the branch it excludes is
       // one React never receives. Asked through the same helper the class half
-      // uses, so one spelling of "this cannot be taken" cannot be resolved on
-      // one side of the contract and reported on the other.
-      const selected = selectedByLiteralCondition(node, api);
+      // uses, so one spelling of "this cannot be taken" is not resolved on one
+      // side of the contract and reported on the other.
+      const selected = selectedByLiteralCondition(node);
       if (selected) return walk(selected);
+      // A choice between shapes is still readable: every branch is written
+      // here, so each is a style the element can render and all are checked.
       if (ts.isConditionalExpression(node)) {
         walk(node.whenTrue);
         walk(node.whenFalse);
         return;
       }
-      // `&&`, `||` and `??` each choose between their operands at runtime, so
-      // both sides are shapes the element can render.
       if (
         ts.isBinaryExpression(node) &&
         (node.operatorToken.kind === ts.SyntaxKind.AmpersandAmpersandToken ||
@@ -2180,124 +1904,21 @@ function styleResolver(
         walk(node.right);
         return;
       }
-      // Followed whether or not the binding is mutable, and through every
-      // ASSIGNMENT as well as the declaration. An unresolved object yields an
-      // EMPTY list here, and an empty list reports nothing — so dropping a
-      // `let style = { ... }` is a false negative, the opposite polarity to an
-      // unresolved property value.
-      if (ts.isIdentifier(node)) {
-        for (const value of reachingValues(node).values) walk(value);
-      }
+      // A name, a call, a member access, a spread of one: knowing what this
+      // holds means tracing it, which is the analysis this deliberately does
+      // not do. Reported as unreadable rather than assumed empty — an empty
+      // object list reports nothing, which is the silent direction.
+      readable = false;
     };
     walk(root);
-    return objects;
+    return { objects, readable };
   };
 
-  /**
-   * The value a name holds, when that is decidable.
-   *
-   * `undefined` for a mutable binding — including one that merely SHADOWS a
-   * constant — because the declaration initializer is not what runs. Callers
-   * treat an unresolved value as emitting, so undecidable errs towards
-   * reporting.
-   *
-   * The identifier itself is the input, never its text: the binder resolves it
-   * at its own position, so an alias is followed from where it was WRITTEN
-   * without the caller having to carry a scope along with it.
-   */
-  const valueOf = (identifier: ts.Identifier): ts.Expression | undefined => {
-    const binding = bindingOf(identifier);
-    if (!binding || binding.mutable) return undefined;
-    return binding.initializer;
-  };
-
-  /**
-   * Properties written onto a binding after the object was created.
-   *
-   * `const style = {}; style.borderBottomColor = "red"` hands React the owned
-   * colour just as writing it inside the literal does, and a search for
-   * assignments TO the binding sees nothing — the binding still holds the same
-   * object, which is precisely why the mutation reaches the element.
-   *
-   * Both spellings, since `style["borderBottomColor"]` is the same write with a
-   * different node kind. Ordering is the same rule as any other write.
-   */
-  const propertyWrites = (
-    identifier: ts.Identifier
-  ): Array<{ name: string; emits: boolean; value: string | undefined }> => {
-    const declaration = declarationOf(identifier, checker);
-    if (!declaration) return [];
-    const found: Array<{
-      name: string;
-      emits: boolean;
-      value: string | undefined;
-      at: number;
-    }> = [];
-    const targets = new Set<ts.Node>(objectsFrom(identifier));
-    if (targets.size === 0) return [];
-    const unit = executionUnitOf(identifier);
-    const visit = (node: ts.Node): void => {
-      if (
-        ts.isBinaryExpression(node) &&
-        node.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
-        (ts.isPropertyAccessExpression(node.left) ||
-          ts.isElementAccessExpression(node.left)) &&
-        ts.isIdentifier(node.left.expression) &&
-        // Any binding holding the SAME object, not only the one the element
-        // names. `const saved = style; saved.x = ...` mutates one object
-        // through two names, and React receives it either way.
-        objectsFrom(node.left.expression).some(object => targets.has(object))
-      ) {
-        // The mutation belongs to whatever object the binding held at the
-        // moment of the write. A later write REPLACES that object, so a
-        // mutation made before it landed on something the element never sees.
-        const replacedSince = writesTo(declaration, identifier).some(
-          write =>
-            write.straightLine &&
-            write.at > node.getStart() &&
-            write.at < identifier.getStart()
-        );
-        const reaches =
-          !replacedSince &&
-          (executionUnitOf(node) !== unit ||
-            node.getStart() < identifier.getStart());
-        const name = ts.isPropertyAccessExpression(node.left)
-          ? node.left.name.text
-          : staticStringOf(node.left.argumentExpression, api);
-        if (reaches && name !== undefined) {
-          found.push({
-            name,
-            emits: emitsValue(node.right, api),
-            value: staticStringOf(node.right, api),
-            at: node.getStart(),
-          });
-        }
-      }
-      ts.forEachChild(node, visit);
-    };
-    visit(declaration.getSourceFile());
-    // Only the LAST write to each property survives: `style.x = "red"` followed
-    // by `style.x = undefined` hands React the second one, and keeping both
-    // reported a colour the element never receives.
-    const last = new Map<string, (typeof found)[number]>();
-    for (const write of found.sort((a, b) => a.at - b.at)) {
-      last.set(write.name, write);
-    }
-    return [...last.values()];
-  };
-
-  // Named so the resolver can ask ITSELF: deciding a branch or a logical
-  // assignment needs the value a name holds, which is the same question this
-  // object already answers. A second copy of that logic is how the file came to
-  // hold two truthiness evaluators that disagreed.
-  const api: ReturnType<typeof styleResolver> = {
+  return {
     objectsFrom,
     valueOf,
-    reachingValues,
-    propertyWrites,
     declarationOf: identifier => declarationOf(identifier, checker),
   };
-  return api;
 }
 
 /** The objects an element's `style` prop can resolve to here. */
@@ -2306,14 +1927,18 @@ function styleObjectsFor(
   checker: ts.TypeChecker
 ): {
   objects: ts.ObjectLiteralExpression[];
+  readable: boolean;
   resolver: ReturnType<typeof styleResolver>;
 } {
-  const resolver = styleResolver(checker, attribute);
+  const resolver = styleResolver(checker);
   const initializer = attribute.initializer;
+  // `style` with no expression at all — `style="x"` or a bare `style` — is not
+  // an object React can read, and is not this contract's business either.
   if (!initializer || !ts.isJsxExpression(initializer)) {
-    return { objects: [], resolver };
+    return { objects: [], readable: true, resolver };
   }
-  return { objects: resolver.objectsFrom(initializer.expression), resolver };
+  const { objects, readable } = resolver.objectsFrom(initializer.expression);
+  return { objects, readable, resolver };
 }
 
 /**
@@ -2416,12 +2041,8 @@ function staticStringOf(
   const declaration = resolver.declarationOf(inner);
   if (!declaration || seen.has(declaration)) return undefined;
   seen.add(declaration);
-  const reaching = resolver.reachingValues(inner);
-  const only = reaching.values[0];
-  if (!reaching.exhaustive || reaching.values.length !== 1 || !only) {
-    return undefined;
-  }
-  return staticStringOf(only, resolver, seen);
+  const bound = resolver.valueOf(inner);
+  return bound ? staticStringOf(bound, resolver, seen) : undefined;
 }
 
 /**
@@ -2430,10 +2051,7 @@ function staticStringOf(
  * `undefined` for anything whose truthiness depends on what it holds at
  * runtime, which keeps the write it guards in play.
  */
-function staticTruthiness(
-  value: ts.Expression,
-  resolver?: ReturnType<typeof styleResolver>
-): boolean | undefined {
+function staticTruthiness(value: ts.Expression): boolean | undefined {
   const inner = withoutTypeWrappers(value);
   if (
     ts.isObjectLiteralExpression(inner) ||
@@ -2449,49 +2067,7 @@ function staticTruthiness(
   if (inner.kind === ts.SyntaxKind.FalseKeyword) return false;
   if (inner.kind === ts.SyntaxKind.NullKeyword) return false;
   if (ts.isVoidExpression(inner)) return false;
-  if (!ts.isIdentifier(inner)) return undefined;
-  // `undefined` is a name like any other, so it is the global value only when
-  // it resolves to no declaration here. Without a resolver the question cannot
-  // be asked, and undecidable keeps whatever it guards in play.
-  if (inner.text === "undefined") {
-    if (!resolver) return undefined;
-    return resolver.declarationOf(inner) ? undefined : false;
-  }
-  if (!resolver) return undefined;
-  // A name is worth what it holds. Every value it can hold has to agree, or the
-  // answer depends on which one arrives.
-  const reaching = resolver.reachingValues(inner);
-  if (!reaching.exhaustive || reaching.values.length === 0) return undefined;
-  const answers = reaching.values.map(each => staticTruthiness(each, resolver));
-  return answers.every(answer => answer === answers[0])
-    ? answers[0]
-    : undefined;
-}
-
-/**
- * Whether a logical assignment's test is already settled by what is held.
- *
- * Each operator writes only when its own test passes, so a value that settles
- * that test the other way makes the write unreachable: `??=` writes when the
- * current value is nullish, `||=` when it is falsy, `&&=` when it is truthy.
- * Every held value has to agree, since any one of them reaching the write is
- * enough for it to run.
- */
-function cannotFire(
-  operator: ts.SyntaxKind,
-  held: ts.Expression[],
-  resolver: ReturnType<typeof styleResolver>
-): boolean {
-  if (operator === ts.SyntaxKind.QuestionQuestionEqualsToken) {
-    return held.every(value => isDefinitelyPresent(value, resolver));
-  }
-  if (operator === ts.SyntaxKind.BarBarEqualsToken) {
-    return held.every(value => staticTruthiness(value, resolver) === true);
-  }
-  if (operator === ts.SyntaxKind.AmpersandAmpersandEqualsToken) {
-    return held.every(value => staticTruthiness(value, resolver) === false);
-  }
-  return false;
+  return undefined;
 }
 
 /**
@@ -2501,22 +2077,8 @@ function cannotFire(
  * removes a value from consideration. Only forms that cannot be nullish however
  * they are read qualify, so anything unfamiliar keeps the write in play.
  */
-function isDefinitelyPresent(
-  value: ts.Expression,
-  resolver?: ReturnType<typeof styleResolver>
-): boolean {
+function isDefinitelyPresent(value: ts.Expression): boolean {
   const inner = withoutTypeWrappers(value);
-  // A name holding a present value is present. Reading only the syntax meant
-  // `style ?? { ...owned }` kept a fallback that cannot run, exactly as the
-  // assignment form did before it was resolved.
-  if (resolver && ts.isIdentifier(inner)) {
-    const reaching = resolver.reachingValues(inner);
-    return (
-      reaching.exhaustive &&
-      reaching.values.length > 0 &&
-      reaching.values.every(each => isDefinitelyPresent(each, resolver))
-    );
-  }
   return (
     ts.isObjectLiteralExpression(inner) ||
     ts.isArrayLiteralExpression(inner) ||
@@ -2630,7 +2192,12 @@ interface DeclaredProperty {
 function declaredProperties(
   object: ts.ObjectLiteralExpression,
   resolver: ReturnType<typeof styleResolver>,
-  onPath = new Set<ts.Node>()
+  onPath = new Set<ts.Node>(),
+  // Set when a spread source cannot be read. A spread's contents are entries of
+  // the object being built, so an unreadable one leaves the object itself only
+  // partly known — and dropping it silently is the direction that reports
+  // nothing, which is how a spread carrying an owned property would vanish.
+  unreadable = { value: false }
 ): Array<Map<string, DeclaredProperty>> {
   // A LIST of possible results, not one. A spread whose source is chosen at
   // runtime — `active ? { borderBottomColor: c } : {}` — produces different
@@ -2655,9 +2222,11 @@ function declaredProperties(
 
   for (const property of object.properties) {
     if (ts.isSpreadAssignment(property)) {
-      const branches = resolver
-        .objectsFrom(property.expression)
-        .flatMap(source => declaredProperties(source, resolver, onPath));
+      const spread = resolver.objectsFrom(property.expression);
+      if (!spread.readable) unreadable.value = true;
+      const branches = spread.objects.flatMap(source =>
+        declaredProperties(source, resolver, onPath, unreadable)
+      );
       if (branches.length === 0) continue;
       variants = variants.flatMap(base =>
         branches.map(branch => new Map([...base, ...branch]))
@@ -2731,13 +2300,11 @@ function emitsValue(
     // property emits unless EVERY one of them is written as nothing. Each
     // branch carries its own trail, or one branch's visits would cut another's
     // short and report it as emitting.
-    const reaching = resolver.reachingValues(inner);
-    // A name fed from outside — a parameter, an import — can hold a value this
-    // file never shows, so the list is a sample and cannot clear the property.
-    if (!reaching.exhaustive) return true;
-    return reaching.values.some(value =>
-      emitsValue(value, resolver, new Set(seen))
-    );
+    // Followed only through a `const`. Anything else can hold a different
+    // value by the time the element renders, and assuming it emits is the
+    // reporting side.
+    const bound = resolver.valueOf(inner);
+    if (bound) return emitsValue(bound, resolver, new Set(seen));
   }
   return true;
 }
@@ -2746,9 +2313,15 @@ function emitsValue(
 function ownedStyleProperty(
   slot: string,
   object: ts.ObjectLiteralExpression,
-  resolver: ReturnType<typeof styleResolver>
+  resolver: ReturnType<typeof styleResolver>,
+  unreadable = { value: false }
 ): string | undefined {
-  for (const variant of declaredProperties(object, resolver)) {
+  for (const variant of declaredProperties(
+    object,
+    resolver,
+    undefined,
+    unreadable
+  )) {
     for (const [name, state] of variant) {
       if (state.emits && ownsStyleProperty(slot, name, state.value))
         return name;
@@ -2787,32 +2360,37 @@ function violationsIn(file: string, source: string): Violation[] {
           if (!ts.isJsxAttribute(attribute)) continue;
           const name = attribute.name.getText(sourceFile);
           if (name === "style") {
-            const { objects, resolver } = styleObjectsFor(attribute, checker);
-            // A property written onto the object AFTER it was created reaches
-            // React the same way one written inside the literal does.
-            const initializer = attribute.initializer;
-            // Unwrapped first, so `style={style!}` reaches the same binding a
-            // bare `style` does. The wrappers are erased before the code runs,
-            // and reading the outer node saw an assertion rather than a name.
-            const held =
-              initializer &&
-              ts.isJsxExpression(initializer) &&
-              initializer.expression
-                ? withoutTypeWrappers(initializer.expression)
-                : undefined;
-            const named =
-              held && ts.isIdentifier(held)
-                ? resolver.propertyWrites(held)
-                : [];
-            const property =
-              objects
-                .map(object => ownedStyleProperty(exported, object, resolver))
-                .find(Boolean) ??
-              named.find(
-                write =>
-                  write.emits &&
-                  ownsStyleProperty(exported, write.name, write.value)
-              )?.name;
+            const { objects, readable, resolver } = styleObjectsFor(
+              attribute,
+              checker
+            );
+            // An expression the scan cannot read is reported for BEING
+            // unreadable, rather than passed over. Tracing what a name holds
+            // at this point is the analysis this contract deliberately does
+            // not do, and staying silent about it would mean "no violation"
+            // and "could not tell" looked the same from outside.
+            if (!readable) {
+              found.push({
+                file,
+                line: at(attribute),
+                why: "sets an inline style this scan cannot read — write it as a literal object, or move it to `className` so the primitive keeps its appearance",
+              });
+              continue;
+            }
+            const spreadUnreadable = { value: false };
+            const property = objects
+              .map(object =>
+                ownedStyleProperty(exported, object, resolver, spreadUnreadable)
+              )
+              .find(Boolean);
+            if (!property && spreadUnreadable.value) {
+              found.push({
+                file,
+                line: at(attribute),
+                why: "spreads an inline style this scan cannot read — write it as a literal object, or move it to `className` so the primitive keeps its appearance",
+              });
+              continue;
+            }
             if (property) {
               found.push({
                 file,
@@ -3275,21 +2853,6 @@ describe("the tab indicator contract", () => {
       "the same reassigned binding behind an assertion",
       'let c: string | undefined = undefined;\nc = "red";\n<TabsTrigger style={{ borderBottomColor: c as string | undefined }} />',
     ],
-    // A mutable binding SHADOWING a constant. Skipping the inner declaration
-    // and continuing outward does not fall back to "undecidable" — it resolves
-    // the use to a completely different binding, and reads `undefined` from an
-    // outer constant the element never mentions.
-    [
-      "a mutable binding shadowing an outer constant",
-      'const colour = undefined;\nfunction Row() {\n  let colour = "red";\n  return <TabsTrigger style={{ borderBottomColor: colour }} />;\n}',
-    ],
-    // The style OBJECT in a mutable binding. Dropping the declaration leaves an
-    // empty object list, and an empty list reports nothing — the opposite
-    // polarity to an unresolved property VALUE, where unresolved means report.
-    [
-      "an owned property inside a mutable style binding",
-      'let style = { borderBottomColor: "red" };\n<TabsTrigger style={style} />',
-    ],
     // An alias resolved in the WRONG scope. `key` means what `sourceKey` meant
     // where the alias was written; resolving it beside the element picks up an
     // inner `sourceKey` the alias never saw.
@@ -3304,53 +2867,6 @@ describe("the tab indicator contract", () => {
       "a computed key aliased through a second binding of the same name",
       'const key = "borderBottomColor";\nfunction Row() {\n  const alias = key;\n  {\n    const key = alias;\n    return <TabsTrigger style={{ [key]: "red" }} />;\n  }\n}',
     ],
-    // The value a mutable binding holds at the element is the last one ASSIGNED
-    // to it, not the one it was declared with. Reading only the declaration saw
-    // an empty object and reported nothing.
-    [
-      "an owned property assigned to a style binding after it is declared",
-      'let style = {};\nstyle = { borderBottomColor: "red" };\n<TabsTrigger style={style} />',
-    ],
-    // A write inside a function runs when that function is CALLED, which the
-    // source order does not tell you. Written above a reset and called below
-    // it, it is still the value the element renders — so a straight-line reset
-    // cannot rule it out.
-    [
-      "an owned property written by a closure called after a reset",
-      'let style: Record<string, string> = {};\nfunction paint() {\n  style = { borderBottomColor: "red" };\n}\nstyle = {};\npaint();\n<TabsTrigger style={style} />',
-    ],
-    // A logical assignment writes when its test passes, so it is one of the
-    // values the binding can hold. Accepting only `=` left the binding
-    // resolving to no object at all.
-    [
-      "an owned property supplied by a logical assignment",
-      'let style;\nstyle ??= { borderBottomColor: "red" };\n<TabsTrigger style={style} />',
-    ],
-    // Rendering the component without an argument passes exactly the default,
-    // so the default is a value the element receives.
-    [
-      "an owned property in a parameter's default object",
-      'function Row(style = { borderBottomColor: "red" }) {\n  return <TabsTrigger style={style} />;\n}',
-    ],
-    // `!` is erased before the code runs, so the element receives the object
-    // itself. The property-value side already read through it.
-    [
-      "an owned property behind a non-null assertion on the style object",
-      'const style = { borderBottomColor: "red" };\n<TabsTrigger style={style!} />',
-    ],
-    // A reset that MIGHT not happen clears nothing. Only a write that
-    // definitely runs replaces what came before it, so the owned value is still
-    // one the element can render and the call site is still reported.
-    [
-      "an owned property a conditional reset does not certainly clear",
-      'let style = { borderBottomColor: "red" };\nif (window.innerWidth > 0) {\n  style = {};\n}\n<TabsTrigger style={style} />',
-    ],
-    // `undefined` is a NAME. Shadowed by a local declaration it is an ordinary
-    // colour, and reading the spelling alone cleared a call site that paints.
-    [
-      "an owned property set to a locally shadowed undefined",
-      'function Row() {\n  const undefined = "red";\n  return <TabsTrigger style={{ borderBottomColor: undefined }} />;\n}',
-    ],
     // A second copy of an owned appearance, declared with the same value under
     // a different variant. Nothing is displaced and nothing conflicts today,
     // which is exactly why no comparison saw it — and the day the primitive
@@ -3359,50 +2875,11 @@ describe("the tab indicator contract", () => {
       "an owned declaration restated under a different variant",
       '<TabsTrigger className="aria-[controls]:outline-none" />',
     ],
-    // A parameter default is one value among many. A caller supplying a real
-    // colour is a value this file cannot see, so the default cannot clear it.
-    [
-      "an owned property whose parameter default a caller can replace",
-      'function Row(colour = undefined) {\n  return <TabsTrigger style={{ borderBottomColor: colour }} />;\n}\n<Row colour="red" />',
-    ],
-    // An alias captures the value at the line it is WRITTEN. A later reset of
-    // the source does not reach into what was already snapshotted.
-    [
-      "an owned property captured by an alias before the source is reset",
-      'let style = { borderBottomColor: "red" };\nconst saved = style;\nstyle = {};\n<TabsTrigger style={saved} />',
-    ],
-    // `undefined` shadowed by a truthy value makes the assignment run, so the
-    // owned style is what the element receives.
-    [
-      "an owned property behind an and-assignment on a shadowed undefined",
-      'const undefined = {};\nlet style = undefined;\nstyle &&= { borderBottomColor: "red" };\n<TabsTrigger style={style} />',
-    ],
     // Pseudo-class TEXT inside an attribute value is data. This rule really can
     // apply beside the primitive's disabled one.
     [
       "a rule whose attribute value merely spells a state",
       '<TabsTrigger className="data-[foo=:enabled]:opacity-100" />',
-    ],
-    // A parameter can be written to like any other binding.
-    [
-      "an owned property assigned to a parameter before the element",
-      'function Row(style = {}) {\n  style = { borderBottomColor: "red" };\n  return <TabsTrigger style={style} />;\n}',
-    ],
-    // Mutating the object reaches React exactly as writing it inline does; the
-    // binding never changes, which is why a search for writes TO it sees none.
-    [
-      "an owned property written onto the style object",
-      'const style: Record<string, string> = {};\nstyle.borderBottomColor = "red";\n<TabsTrigger style={style} />',
-    ],
-    [
-      "an owned property written onto the style object by index",
-      'const style: Record<string, string> = {};\nstyle["borderBottomColor"] = "red";\n<TabsTrigger style={style} />',
-    ],
-    // The wrappers are erased before the code runs, so the element receives the
-    // mutated object exactly as a bare name would hand it over.
-    [
-      "an owned property written onto a non-null asserted style object",
-      'const style: Record<string, string> = {};\nstyle.borderBottomColor = "red";\n<TabsTrigger style={style!} />',
     ],
     // A `break` above the reset can carry control out of the `do` body before
     // it runs, so the owned value is still one the element can render.
@@ -3410,16 +2887,32 @@ describe("the tab indicator contract", () => {
       "an owned property a do-body reset behind a break does not clear",
       'let style: Record<string, string> = { borderBottomColor: "red" };\ndo {\n  if (Math.random() > 0) break;\n  style = {};\n} while (false);\n<TabsTrigger style={style} />',
     ],
-    // Two names for one object. The mutation reaches React whichever name it
-    // was written through.
-    [
-      "an owned property written through an alias of the style object",
-      'const style: Record<string, string> = {};\nconst saved = style;\nsaved.borderBottomColor = "red";\n<TabsTrigger style={style} />',
-    ],
     // The CommonJS spelling of a namespace import.
     [
       "a class on a namespace member behind a CommonJS require",
       'const UI = require("@nextlyhq/ui");\n<UI.TabsTrigger className="border-b-0" />',
+    ],
+    // A spread of a NAME. The outer object does clear the property, so nothing
+    // is repainted today — but knowing that requires reading what the name
+    // holds, and `const` does not settle it: an object is mutable in place
+    // whatever the binding says. Reported for being unreadable, which is the
+    // honest answer rather than a guess in either direction.
+    [
+      "a spread of a name the scan cannot read",
+      'const inherited = { borderBottomColor: "red" };\n<TabsTrigger style={{ ...inherited, borderBottomColor: undefined }} />',
+    ],
+    // The shapes that used to be traced. Each is now reported for what it is —
+    // an inline style whose value this scan does not read — rather than
+    // analysed by a flow model. One per kind, because they all reach the same
+    // branch and a longer list would only restate it.
+    [
+      "an inline style held in a mutable binding",
+      'let style = { borderBottomColor: "red" };\n<TabsTrigger style={style} />',
+    ],
+    ["an inline style built by a call", "<TabsTrigger style={buildStyle()} />"],
+    [
+      "an inline style read from a member access",
+      "<TabsTrigger style={theme.tab} />",
     ],
   ])("catches %s", (_label, body) => {
     // The positive controls. Each is a shape an earlier version returned clean
@@ -3646,10 +3139,6 @@ describe("the tab indicator contract", () => {
       "a class literal behind a statically false guard",
       '<TabsTrigger className={cn("w-full", false && "border-b-0")} />',
     ],
-    [
-      "a spread whose owned property the object then clears",
-      'const inherited = { borderBottomColor: "red" };\n<TabsTrigger style={{ ...inherited, borderBottomColor: undefined }} />',
-    ],
     // A PARAMETER shadowing an outer constant. The name is the parameter, whose
     // value the caller supplies, so the property is undecidable — not the outer
     // constant's. Walking past the parameter named an owned property for an
@@ -3664,13 +3153,6 @@ describe("the tab indicator contract", () => {
     [
       "border-image longhands with no source to draw",
       '<TabsTrigger style={{ borderImageRepeat: "round", borderImageSlice: "30", borderImageWidth: "4px", borderImageOutset: "2px" }} />',
-    ],
-    // An assignment the element cannot have seen. React already received the
-    // empty object; collecting every write in the file regardless of where it
-    // sits reported the element for a value assigned after it.
-    [
-      "a style binding assigned an owned property after the element",
-      'let style = {};\n<TabsTrigger style={style} />;\nstyle = { borderBottomColor: "red" };',
     ],
     // React emits no declaration for an empty string, verified with
     // `renderToStaticMarkup`: `{ borderBottomColor: "" }` renders no `style`
@@ -3687,51 +3169,12 @@ describe("the tab indicator contract", () => {
       "an owned property in a statically unreachable branch",
       '<TabsTrigger style={true ? {} : { borderBottomColor: "red" }} />',
     ],
-    // A binding reset before it renders. The middle value is one it has
-    // already stopped holding, and carrying it along rejected an element that
-    // passes an empty object. Paired with the reassignment case above, this
-    // separates "a write happened" from "this write is the one that survives".
-    [
-      "an owned property overwritten before the element renders",
-      'let style = {};\nstyle = { borderBottomColor: "red" };\nstyle = {};\n<TabsTrigger style={style} />',
-    ],
-    // A mutable binding nothing ever writes to. Its initializer IS what the
-    // element receives, so discarding it for being `let` reported a property
-    // React never emits. This is the counterpart to the reassignment cases
-    // above: together they separate "the declaration decides" from "a write
-    // decides", which neither shows alone.
-    [
-      "an owned property held by an unchanged mutable binding",
-      "let colour: string | undefined = undefined;\n<TabsTrigger style={{ borderBottomColor: colour }} />",
-    ],
     // A rule that can never apply beside the owned one it matches. `disabled:`
     // and `not-disabled:` select complementary states, so neither can restate
     // or override the other however the cascade ranks them.
     [
       "an equal declaration under a negated form of the owned qualifier",
       '<TabsTrigger className="not-disabled:opacity-50" />',
-    ],
-    // A `??=` whose binding already holds a value cannot fire, so its right
-    // side is never what the element receives.
-    [
-      "an owned property behind a logical assignment that cannot fire",
-      'let style = {};\nstyle ??= { borderBottomColor: "red" };\n<TabsTrigger style={style} />',
-    ],
-    // A `for` initializer runs once before the condition is ever asked, so it
-    // is unconditional even though the body beside it is not.
-    [
-      "an owned property reset in a loop initializer",
-      'let style: Record<string, string> = { borderBottomColor: "red" };\nfor (style = {}; false; ) {\n  break;\n}\n<TabsTrigger style={style} />',
-    ],
-    // A logical assignment whose test the current value already settles never
-    // runs, so its right side is not what the element receives.
-    [
-      "an owned property behind an or-assignment that cannot fire",
-      'let style = {};\nstyle ||= { borderBottomColor: "red" };\n<TabsTrigger style={style} />',
-    ],
-    [
-      "an owned property behind an and-assignment that cannot fire",
-      'let style = null;\nstyle &&= { borderBottomColor: "red" };\n<TabsTrigger style={style} />',
     ],
     // React emits no declaration for a boolean, the same as for an empty
     // string: both render an element carrying no `style` attribute at all.
@@ -3751,32 +3194,10 @@ describe("the tab indicator contract", () => {
       "a border image explicitly set to none",
       '<TabsTrigger style={{ borderImageSource: "none" }} />',
     ],
-    // A `do` body runs before its condition is ever asked, so this reset
-    // certainly happened and the earlier value is gone.
-    [
-      "an owned property reset in a do-while body",
-      'let style: Record<string, string> = { borderBottomColor: "red" };\ndo {\n  style = {};\n} while (false);\n<TabsTrigger style={style} />',
-    ],
-    // A `var` is hoisted but its INITIALIZER runs where it is written, so an
-    // element evaluated above it receives `undefined`.
-    [
-      "an owned property in a var initializer written below the element",
-      '<TabsTrigger style={style} />;\nvar style = { borderBottomColor: "red" };',
-    ],
-    // The explicit spelling of a logical assignment, decided the same way.
-    [
-      "an owned property behind an explicit short-circuit that cannot run",
-      'let style = {};\nstyle = style || { borderBottomColor: "red" };\n<TabsTrigger style={style} />',
-    ],
     // A constant holding `none` draws no border image, as the literal does.
     [
       "a border image whose none is written as a constant",
       'const noImage = "none";\n<TabsTrigger style={{ borderImageSource: noImage }} />',
-    ],
-    // The first statement of a `try` runs whenever control reaches the block.
-    [
-      "an owned property reset at the start of a try block",
-      'let style: Record<string, string> = { borderBottomColor: "red" };\ntry {\n  style = {};\n} finally {\n}\n<TabsTrigger style={style} />',
     ],
     // Guards that are not spelled as booleans are still statically decided.
     [
@@ -3795,12 +3216,6 @@ describe("the tab indicator contract", () => {
       "a class on a namespace member shadowing an imported namespace",
       'import * as UI from "@nextlyhq/ui";\nfunction Row() {\n  const UI = { TabsTrigger: (p: Record<string, unknown>) => <div {...p} /> };\n  return <UI.TabsTrigger className="border-b-0" />;\n}',
     ],
-    // A mutation belongs to the object held when it happened. A later write
-    // replaces that object, so the element never sees the mutation.
-    [
-      "a property written onto an object the binding then replaces",
-      'let style: Record<string, string> = {};\nstyle.borderBottomColor = "red";\nstyle = {};\n<TabsTrigger style={style} />',
-    ],
     // In an object map the KEY is the class and the VALUE is the condition, so
     // a key switched off applies nothing.
     [
@@ -3812,16 +3227,6 @@ describe("the tab indicator contract", () => {
       "an attribute value that merely contains a hash",
       '<TabsTrigger className="not-data-[foo=#bar]:opacity-100" />',
     ],
-    // The last write to a property is what React receives.
-    [
-      "an owned property a later in-place write clears",
-      'const style: Record<string, string | undefined> = {};\nstyle.borderBottomColor = "red";\nstyle.borderBottomColor = undefined;\n<TabsTrigger style={style} />',
-    ],
-    // A constant object is definitely present, so the fallback cannot run.
-    [
-      "an owned property in a nullish fallback that cannot run",
-      'const style = {};\n<TabsTrigger style={style ?? { borderBottomColor: "red" }} />',
-    ],
   ])("does not report %s", (_label, body) => {
     // The complement, and the reason this is a contract rather than a ban. A
     // check that flags a documented example or a legitimate layout class gets
@@ -3830,18 +3235,16 @@ describe("the tab indicator contract", () => {
     expect(violationsIn("probe.tsx", IMPORT + body)).toEqual([]);
   });
 
-  it("resolves a style identifier in its own scope, not by name", () => {
-    // A whole-file name search takes whichever declaration is visited last, so
-    // an unrelated `const s` in a LATER function hid this violation. Both
-    // orders are asserted, because the defect is symmetric: the other order
-    // invents a violation on a tab whose own style is harmless.
-    const hidden = `${IMPORT}function a() { const s = { borderBottomColor: c }; return <TabsTrigger style={s} />; }
-function b() { const s = { width: 2 }; return <div style={s} />; }`;
-    expect(violationsIn("probe.tsx", hidden)).not.toEqual([]);
+  it("does not read an inline style held under a name", () => {
+    // Replaces a case that asserted WHICH declaration a style identifier
+    // resolved to. Objects are no longer traced through bindings at all, so the
+    // question that test answered is one the scan has stopped asking; what
+    // matters now is that both spellings are reported rather than silently
+    // resolved to the wrong one.
+    const both = `${IMPORT}function a() { const s = { borderBottomColor: c }; return <TabsTrigger style={s} />; }
+function b() { const s = { width: 2 }; return <TabsTrigger style={s} />; }`;
 
-    const invented = `${IMPORT}function a() { const s = { width: 2 }; return <TabsTrigger style={s} />; }
-function b() { const s = { borderBottomColor: c }; return <div style={s} />; }`;
-    expect(violationsIn("probe.tsx", invented)).toEqual([]);
+    expect(violationsIn("probe.tsx", both)).toHaveLength(2);
   });
 
   it("still reads a style declared beside the element", () => {

--- a/packages/ui/src/components/__tests__/tabs-contract.test.ts
+++ b/packages/ui/src/components/__tests__/tabs-contract.test.ts
@@ -499,13 +499,19 @@ function specificityOf(selector: string): Specificity {
             .reduce((best, one) => (compare(one, best) > 0 ? one : best), ZERO);
     return add(contribution, specificityOf(rest));
   }
-  const ids = selector.match(/#[\w-]+/g)?.length ?? 0;
+  // An attribute selector counts as ONE, and what it holds is data: a `#` or a
+  // `.` inside `[data-foo="#bar"]` is a character in a value, not an id or a
+  // class. Counted verbatim it inflated the caller's rank and overrode a
+  // source-order result that had already decided the question.
+  const attributes = selector.match(/\[[^\]]*\]/g)?.length ?? 0;
+  const structure = selector.replace(/\[[^\]]*\]/g, "");
+  const ids = structure.match(/#[\w-]+/g)?.length ?? 0;
   const classes =
-    (selector.match(/(?<!\\\\)&/g)?.length ?? 0) +
-    (selector.match(/\.[\w-]+/g)?.length ?? 0) +
-    (selector.match(/\[[^\]]*\]/g)?.length ?? 0) +
-    (selector.match(/(?<!:):[\w-]+/g)?.length ?? 0);
-  const elements = selector.match(/::[\w-]+/g)?.length ?? 0;
+    (structure.match(/(?<!\\\\)&/g)?.length ?? 0) +
+    (structure.match(/\.[\w-]+/g)?.length ?? 0) +
+    attributes +
+    (structure.match(/(?<!:):[\w-]+/g)?.length ?? 0);
+  const elements = structure.match(/::[\w-]+/g)?.length ?? 0;
   return [ids, classes, elements];
 }
 
@@ -1663,10 +1669,17 @@ function exportedTagOf(
   if (
     ts.isPropertyAccessExpression(tag) &&
     ts.isIdentifier(tag.expression) &&
-    ownership.namespaces.has(tag.expression.text) &&
     OWNED_EXPORTS.includes(tag.name.text)
   ) {
-    return tag.name.text;
+    // The namespace is a binding too, and a local object can shadow the import
+    // exactly as a local component can shadow a named one. Resolved the same
+    // way, so both spellings answer from the binder rather than from a
+    // file-wide set of names.
+    const declaration = declarationOf(tag.expression, checker);
+    if (declaration) {
+      return ts.isNamespaceImport(declaration) ? tag.name.text : undefined;
+    }
+    if (ownership.namespaces.has(tag.expression.text)) return tag.name.text;
   }
   return undefined;
 }
@@ -1746,6 +1759,20 @@ function literalStrings(
   if (ts.isExpression(node)) {
     const selected = selectedByLiteralCondition(node, resolver);
     if (selected) return literalStrings(selected, found, resolver);
+  }
+  // `cn({ "border-b-0": false })` applies nothing. In this form the KEY is the
+  // class and the VALUE is the condition, so walking the object as plain text
+  // collected a class the caller switched off — and collected an unrelated
+  // key's value as though it were a class name too.
+  if (ts.isObjectLiteralExpression(node)) {
+    for (const property of node.properties) {
+      if (!ts.isPropertyAssignment(property)) continue;
+      if (staticTruthiness(property.initializer, resolver) === false) continue;
+      const name = property.name;
+      if (ts.isStringLiteral(name) || ts.isIdentifier(name))
+        found.push(name.text);
+    }
+    return found;
   }
   // The braces matter. `ts.forEachChild` stops at the first callback that
   // returns something truthy, so a concise arrow returning the accumulator
@@ -1873,7 +1900,18 @@ function styleResolver(
       }
       // A `do` BODY runs before its condition is ever asked, so it executes at
       // least once however the condition later answers.
-      if (ts.isDoStatement(at)) continue;
+      // Only the FIRST statement of a `do` body, for the same reason as a
+      // `try`: a `break`, `continue` or `return` written above it can carry
+      // control out before it runs, so a later write may be skipped.
+      if (
+        ts.isDoStatement(at) &&
+        ts.isBlock(at.statement) &&
+        at.statement.statements.length > 0 &&
+        node.getStart() >= (at.statement.statements[0]?.getStart() ?? 0) &&
+        node.getEnd() <= (at.statement.statements[0]?.getEnd() ?? 0)
+      ) {
+        continue;
+      }
       // A `for` INITIALIZER runs once before the condition is ever asked, so it
       // is unconditional even though the body beside it is not.
       if (
@@ -2188,9 +2226,19 @@ function styleResolver(
         ts.isIdentifier(node.left.expression) &&
         declarationOf(node.left.expression, checker) === declaration
       ) {
+        // The mutation belongs to whatever object the binding held at the
+        // moment of the write. A later write REPLACES that object, so a
+        // mutation made before it landed on something the element never sees.
+        const replacedSince = writesTo(declaration, identifier).some(
+          write =>
+            write.straightLine &&
+            write.at > node.getStart() &&
+            write.at < identifier.getStart()
+        );
         const reaches =
-          executionUnitOf(node) !== unit ||
-          node.getStart() < identifier.getStart();
+          !replacedSince &&
+          (executionUnitOf(node) !== unit ||
+            node.getStart() < identifier.getStart());
         const name = ts.isPropertyAccessExpression(node.left)
           ? node.left.name.text
           : staticStringOf(node.left.argumentExpression, api);
@@ -2697,12 +2745,18 @@ function violationsIn(file: string, source: string): Violation[] {
             // A property written onto the object AFTER it was created reaches
             // React the same way one written inside the literal does.
             const initializer = attribute.initializer;
-            const named =
+            // Unwrapped first, so `style={style!}` reaches the same binding a
+            // bare `style` does. The wrappers are erased before the code runs,
+            // and reading the outer node saw an assertion rather than a name.
+            const held =
               initializer &&
               ts.isJsxExpression(initializer) &&
-              initializer.expression &&
-              ts.isIdentifier(initializer.expression)
-                ? resolver.propertyWrites(initializer.expression)
+              initializer.expression
+                ? withoutTypeWrappers(initializer.expression)
+                : undefined;
+            const named =
+              held && ts.isIdentifier(held)
+                ? resolver.propertyWrites(held)
                 : [];
             const property =
               objects
@@ -3298,6 +3352,18 @@ describe("the tab indicator contract", () => {
       "an owned property written onto the style object by index",
       'const style: Record<string, string> = {};\nstyle["borderBottomColor"] = "red";\n<TabsTrigger style={style} />',
     ],
+    // The wrappers are erased before the code runs, so the element receives the
+    // mutated object exactly as a bare name would hand it over.
+    [
+      "an owned property written onto a non-null asserted style object",
+      'const style: Record<string, string> = {};\nstyle.borderBottomColor = "red";\n<TabsTrigger style={style!} />',
+    ],
+    // A `break` above the reset can carry control out of the `do` body before
+    // it runs, so the owned value is still one the element can render.
+    [
+      "an owned property a do-body reset behind a break does not clear",
+      'let style: Record<string, string> = { borderBottomColor: "red" };\ndo {\n  if (Math.random() > 0) break;\n  style = {};\n} while (false);\n<TabsTrigger style={style} />',
+    ],
   ])("catches %s", (_label, body) => {
     // The positive controls. Each is a shape an earlier version returned clean
     // on, or a category it never read. Without these, a check that can never
@@ -3666,6 +3732,29 @@ describe("the tab indicator contract", () => {
       "a class on a local component shadowing an imported name",
       'function Row() {\n  const TabsTrigger = (p: Record<string, unknown>) => <div {...p} />;\n  return <TabsTrigger className="border-b-0" />;\n}',
     ],
+    // A local object may shadow a namespace import exactly as a local component
+    // may shadow a named one; the tag refers to the local binding.
+    [
+      "a class on a namespace member shadowing an imported namespace",
+      'import * as UI from "@nextlyhq/ui";\nfunction Row() {\n  const UI = { TabsTrigger: (p: Record<string, unknown>) => <div {...p} /> };\n  return <UI.TabsTrigger className="border-b-0" />;\n}',
+    ],
+    // A mutation belongs to the object held when it happened. A later write
+    // replaces that object, so the element never sees the mutation.
+    [
+      "a property written onto an object the binding then replaces",
+      'let style: Record<string, string> = {};\nstyle.borderBottomColor = "red";\nstyle = {};\n<TabsTrigger style={style} />',
+    ],
+    // In an object map the KEY is the class and the VALUE is the condition, so
+    // a key switched off applies nothing.
+    [
+      "a class map entry switched off by its value",
+      '<TabsTrigger className={cn({ "border-b-0": false })} />',
+    ],
+    // A `#` inside an attribute VALUE is data, not an id selector.
+    [
+      "an attribute value that merely contains a hash",
+      '<TabsTrigger className="not-data-[foo=#bar]:opacity-100" />',
+    ],
   ])("does not report %s", (_label, body) => {
     // The complement, and the reason this is a contract rather than a ban. A
     // check that flags a documented example or a legitimate layout class gets
@@ -3906,6 +3995,40 @@ describe("which files the call-site scan reads", () => {
       .filter(path => !isMatch(path, triggers))
       .map(path => path.replace(`${REPO}/`, ""));
     expect(unwatchedProbes).toEqual([]);
+
+    // Matching is only HALF the mechanism, and the half that was never checked
+    // is the one that failed three times: Vitest reruns when its watcher emits
+    // an event AND a trigger matches the path. The server is rooted at this
+    // package, so nothing outside it was watched at all and the matcher was
+    // never consulted for the call sites this suite reads.
+    //
+    // chokidar removed glob support in v4, so a watched entry has to be a REAL
+    // PATH. That is what this asserts, and it is what separates the three
+    // broken generations from the working one: `../**/*.tsx` is not a path,
+    // `<root>/packages/**/*.tsx` is not a path, `<root>/packages` is.
+    const watched: string[] = [];
+    const plugins = (config as { plugins?: unknown[] }).plugins ?? [];
+    for (const plugin of plugins) {
+      const configureServer = (
+        plugin as { configureServer?: (server: unknown) => void }
+      ).configureServer;
+      configureServer?.({
+        watcher: { add: (path: string) => watched.push(path) },
+      });
+    }
+
+    // Proves the hook ran at all before anything is concluded from what it
+    // recorded: an empty list would otherwise satisfy every assertion below.
+    expect(watched.length).toBeGreaterThan(0);
+
+    const notReal = watched.filter(path => !existsSync(path));
+    expect(notReal).toEqual([]);
+
+    const unwatchedRoots = SCAN_ROOTS.filter(
+      root =>
+        !watched.some(path => root === path || root.startsWith(`${path}/`))
+    ).map(root => root.replace(`${REPO}/`, ""));
+    expect(unwatchedRoots).toEqual([]);
 
     // And every file the scan actually reads, which covers shapes no synthetic
     // path anticipates. Named individually: the list is only ever wrong for a

--- a/packages/ui/src/components/__tests__/tabs-contract.test.ts
+++ b/packages/ui/src/components/__tests__/tabs-contract.test.ts
@@ -1454,10 +1454,41 @@ function propertyNameOf(name: ts.PropertyName): string | undefined {
  * the inline half was written.
  */
 function isDefinitelyNothing(initializer: ts.Expression): boolean {
-  if (ts.isIdentifier(initializer)) return initializer.text === "undefined";
-  if (initializer.kind === ts.SyntaxKind.NullKeyword) return true;
+  const value = withoutTypeWrappers(initializer);
+  if (ts.isIdentifier(value)) return value.text === "undefined";
+  if (value.kind === ts.SyntaxKind.NullKeyword) return true;
   // `void 0` is the other spelling of the same intent.
-  return ts.isVoidExpression(initializer);
+  return ts.isVoidExpression(value);
+}
+
+/**
+ * An expression with the wrappers that emit nothing peeled away.
+ *
+ * `as`, `satisfies`, `!` and parentheses are all erased before the code runs,
+ * so `undefined as string | undefined` and `(undefined)` reach React as exactly
+ * `undefined` — and React emits no declaration for either. Reading only the
+ * outer node saw an `AsExpression`, decided it was not written as nothing, and
+ * reported a call site that paints nothing at all.
+ *
+ * A false positive here is worse than it looks: `undefined as string |
+ * undefined` is the ORDINARY way to write an optional style in a typed
+ * codebase, so the check was rejecting the idiomatic spelling of the very thing
+ * it exists to permit.
+ *
+ * Applied where the question is "what does this evaluate to", never where the
+ * question is about the written type — nothing here reads types.
+ */
+function withoutTypeWrappers(expression: ts.Expression): ts.Expression {
+  let value = expression;
+  while (
+    ts.isAsExpression(value) ||
+    ts.isSatisfiesExpression(value) ||
+    ts.isParenthesizedExpression(value) ||
+    ts.isNonNullExpression(value)
+  ) {
+    value = value.expression;
+  }
+  return value;
 }
 
 /**
@@ -1553,10 +1584,13 @@ function emitsValue(
   resolver: ReturnType<typeof styleResolver>,
   seen = new Set<string>()
 ): boolean {
-  if (isDefinitelyNothing(value)) return false;
-  if (ts.isIdentifier(value) && !seen.has(value.text)) {
-    seen.add(value.text);
-    const bound = resolver.valueOf(value.text);
+  const inner = withoutTypeWrappers(value);
+  if (isDefinitelyNothing(inner)) return false;
+  // Unwrapped before the binding lookup too, so `(colour as string)` resolves
+  // through the same identifier path a bare `colour` does.
+  if (ts.isIdentifier(inner) && !seen.has(inner.text)) {
+    seen.add(inner.text);
+    const bound = resolver.valueOf(inner.text);
     if (bound) return emitsValue(bound, resolver, seen);
   }
   return true;
@@ -2152,6 +2186,26 @@ describe("the tab indicator contract", () => {
     [
       "an inline property set to null",
       "<TabsTrigger style={{ borderBottomColor: null }} />",
+    ],
+    // Erased before the code runs, so React receives exactly `undefined` and
+    // emits no declaration. `undefined as string | undefined` is the ORDINARY
+    // way to write an optional style in a typed codebase, so reporting it
+    // rejected the idiomatic spelling of the thing this check exists to permit.
+    [
+      "an inline property widened with an `as` assertion",
+      "<TabsTrigger style={{ borderBottomColor: undefined as string | undefined }} />",
+    ],
+    [
+      "an inline property widened with `satisfies`",
+      "<TabsTrigger style={{ borderBottomColor: undefined satisfies string | undefined }} />",
+    ],
+    [
+      "an inline property wrapped in parentheses",
+      "<TabsTrigger style={{ borderBottomColor: (undefined) }} />",
+    ],
+    [
+      "the same assertion around a parenthesised nothing",
+      "<TabsTrigger style={{ borderBottomColor: (undefined) as string | undefined }} />",
     ],
     // Tailwind's own child variants. `*` compiles to `:is(& > *)` and `**` to
     // `:is(& *)`, so both land on children and neither can repaint the tab.

--- a/packages/ui/src/components/__tests__/tabs-contract.test.ts
+++ b/packages/ui/src/components/__tests__/tabs-contract.test.ts
@@ -658,6 +658,24 @@ const exclusiveDeclarationsOf = perClass(exclusiveDeclarationsUncached);
  * the primitive draws.
  */
 function restates(owned: Utility, caller: Utility): boolean {
+  // An UNQUALIFIED caller declaration against a STATE-QUALIFIED owned one is
+  // not a second copy of anything, and this is the one pairing where the
+  // restatement route was wrong.
+  //
+  // `disabled:opacity-50` styles a state; a caller's plain `opacity-50`
+  // states the base. They name the same declaration in different
+  // circumstances: the variant rule is more specific and still wins while
+  // disabled, and if the primitive later fades to `opacity-40` the owned rule
+  // keeps winning there, so nothing the caller wrote suppresses the change.
+  // Reporting it asked whether two declarations look alike rather than
+  // whether one takes the other over.
+  //
+  // A caller carrying its OWN variant is the case this route exists for, and
+  // it stays: `aria-[controls]:outline-none` beside an owned
+  // `focus-visible:outline-none` is one appearance written twice for two
+  // states, and the copies drift the moment either changes. A caller carrying
+  // the owned variants exactly is already decided by `asQualified` above.
+  if (owned.variants.length > 0 && caller.variants.length === 0) return false;
   const ownedDeclarations = expandDeclarations(
     exclusiveDeclarationsOf(owned.full)
   );
@@ -962,9 +980,8 @@ function spreadAttributes(
   alternatives: Array<Array<{ name: string; value: ts.Expression }>>;
   readable: boolean;
 } {
-  const { objects, readable } = styleResolver(checker).objectsFrom(
-    attribute.expression
-  );
+  const resolver = styleResolver(checker);
+  const { objects, readable } = resolver.objectsFrom(attribute.expression);
   if (!readable) return { alternatives: [], readable: false };
   const alternatives: Array<Array<{ name: string; value: ts.Expression }>> = [];
   for (const object of objects) {
@@ -984,11 +1001,14 @@ function spreadAttributes(
         // props it carries are unknown rather than absent.
         return { alternatives: [], readable: false };
       }
-      const name = property.name;
-      if (!ts.isIdentifier(name) && !ts.isStringLiteral(name)) {
+      // Same reader again: a computed key that is statically a string names
+      // its prop as plainly as an identifier does, and treating it as unknown
+      // rejected `{...{ ["value"]: "a" }}` on syntax that decides it.
+      const named = propertyNameOf(property.name, resolver);
+      if (named === undefined) {
         return { alternatives: [], readable: false };
       }
-      attributes.push({ name: name.text, value: property.initializer });
+      attributes.push({ name: named, value: property.initializer });
     }
     alternatives.push(attributes);
   }
@@ -1267,10 +1287,17 @@ function expandsTo(property: string, value?: string): string[] {
   // stood for itself — a name that intersects nothing the primitive owns, while
   // a gradient painted straight over the underline on every tab.
   if (BORDER_IMAGE.test(kebab)) {
-    // `none` is the initial value: it supplies no image, so the primitive's
-    // ordinary border renders exactly as it did. Owning the property whatever
-    // it holds reported the spelling that explicitly draws NOTHING.
-    if (value !== undefined && value.trim().toLowerCase() === "none") {
+    // `none` is the initial value of `border-image-source`, so it supplies no
+    // image and the primitive's ordinary border renders exactly as it did.
+    // Owning the property whatever it holds reported the spelling that draws
+    // NOTHING.
+    //
+    // `initial` is the same state named a different way: CSS defines it as
+    // "reset to the initial value", which for this property IS `none`. Matching
+    // the one spelling asked how the value was written rather than what it
+    // does, and reported a call site that covers nothing.
+    const drawn = value?.trim().toLowerCase();
+    if (drawn === "none" || drawn === "initial") {
       return [kebab];
     }
     return BORDER_ASPECTS.map(aspect => `border-bottom-${aspect}`);
@@ -1645,6 +1672,7 @@ function ownershipIn(
         node.initializer,
         namespaces,
         owning,
+        owningNamespaces,
         exportedNameOf,
         checker
       );
@@ -1732,6 +1760,7 @@ function exportedFrom(
   initializer: ts.Expression,
   namespaces: Set<string>,
   owning: Map<ts.Node, string>,
+  owningNamespaces: Set<ts.Declaration>,
   exportedNameOf: Map<string, string>,
   checker: ts.TypeChecker
 ): string | undefined {
@@ -1754,10 +1783,25 @@ function exportedFrom(
   if (
     ts.isPropertyAccessExpression(initializer) &&
     ts.isIdentifier(initializer.expression) &&
-    namespaces.has(initializer.expression.text) &&
     OWNED_EXPORTS.includes(initializer.name.text)
   ) {
-    return initializer.name.text;
+    // The namespace half resolves by BINDING too, for the same reason the
+    // alias half above does: a local `const UI = { TabsTrigger: Other }` that
+    // shadows `import * as UI` is a different object, and matching the text
+    // held its member to the primitive's contract. `owningNamespaces` holds
+    // the DECLARATIONS the namespace imports introduced, so membership in it
+    // is the question, not membership in a set of spellings.
+    const declaration = declarationOf(initializer.expression, checker);
+    if (declaration) {
+      return owningNamespaces.has(declaration)
+        ? initializer.name.text
+        : undefined;
+    }
+    // Nothing resolved: the module was never loaded, and the text is all
+    // there is — the same fallback, in the same order, as the alias half.
+    if (namespaces.has(initializer.expression.text)) {
+      return initializer.name.text;
+    }
   }
   return undefined;
 }
@@ -1901,9 +1945,13 @@ function literalStrings(node: ts.Node, found: string[] = []): string[] {
       }
       if (!ts.isPropertyAssignment(property)) continue;
       if (staticTruthiness(property.initializer) === false) continue;
-      const name = property.name;
-      if (ts.isStringLiteral(name) || ts.isIdentifier(name))
-        found.push(name.text);
+      // Asked through the one reader that answers "what property is this",
+      // rather than restating two of the node kinds it knows about. Restating
+      // them meant `cn({ ["border-b-0"]: true })` named no class here while
+      // the style half read the identical form — one question with two
+      // implementations, and they had already drifted.
+      const named = propertyNameOf(property.name);
+      if (named !== undefined) found.push(named);
     }
     return found;
   }
@@ -1961,6 +2009,14 @@ function styleResolver(checker: ts.TypeChecker): {
     objects: ts.ObjectLiteralExpression[];
     /** False when the expression has to be traced to know what it holds. */
     readable: boolean;
+    /**
+     * True when one alternative supplies NO object at all.
+     *
+     * Distinct from an empty object list, which says every alternative
+     * supplies nothing. This says SOME branch does, and the caller has to
+     * keep whatever preceded the spread reachable on that branch.
+     */
+    absent: boolean;
   };
   valueOf(identifier: ts.Identifier): ts.Expression | undefined;
   declarationOf(identifier: ts.Identifier): ts.Declaration | undefined;
@@ -1990,14 +2046,23 @@ function styleResolver(checker: ts.TypeChecker): {
 
   const objectsFrom = (
     root: ts.Expression | undefined
-  ): { objects: ts.ObjectLiteralExpression[]; readable: boolean } => {
+  ): {
+    objects: ts.ObjectLiteralExpression[];
+    readable: boolean;
+    absent: boolean;
+  } => {
     const objects: ts.ObjectLiteralExpression[] = [];
     const seen = new Set<ts.Node>();
     let readable = true;
+    let absent = false;
     const walk = (node: ts.Expression | undefined): void => {
       // `style={}` carries no expression, and React receives no style. There
-      // is nothing here to trace, so it is read rather than reported.
-      if (!node) return;
+      // is nothing here to trace, so it is read rather than reported — but it
+      // IS a branch that supplies nothing, which the caller has to know.
+      if (!node) {
+        absent = true;
+        return;
+      }
       if (seen.has(node)) return;
       seen.add(node);
       // Parentheses, `as`, `satisfies` and `!` are erased before the code runs,
@@ -2021,6 +2086,12 @@ function styleResolver(checker: ts.TypeChecker): {
         walk(node.whenFalse);
         return;
       }
+      // A branch that contributes NOTHING is still a branch the element can
+      // take, and it leaves whatever came before it standing. Spreading
+      // `...(flag ? { x: undefined } : undefined)` was read as the clearing
+      // branch alone, so a property the other branch preserves looked cleared
+      // on every render. Recorded as an empty alternative rather than as no
+      // alternative at all, which is what made the difference invisible.
       if (
         ts.isBinaryExpression(node) &&
         (node.operatorToken.kind === ts.SyntaxKind.AmpersandAmpersandToken ||
@@ -2038,7 +2109,10 @@ function styleResolver(checker: ts.TypeChecker): {
       // unreadable when it is the whole prop — which rejected both
       // `style={undefined}` and the branch of a literal condition that
       // resolves to it.
-      if (isDefinitelyNothing(node, declarations)) return;
+      if (isDefinitelyNothing(node, declarations)) {
+        absent = true;
+        return;
+      }
       // A name, a call, a member access, a spread of one: knowing what this
       // holds means tracing it, which is the analysis this deliberately does
       // not do. Reported as unreadable rather than assumed empty — an empty
@@ -2046,7 +2120,7 @@ function styleResolver(checker: ts.TypeChecker): {
       readable = false;
     };
     walk(root);
-    return { objects, readable };
+    return { objects, readable, absent };
   };
 
   return { objectsFrom, valueOf, ...declarations };
@@ -2095,7 +2169,10 @@ function styleObjectsFor(
  */
 function propertyNameOf(
   name: ts.PropertyName,
-  resolver: ReturnType<typeof styleResolver>
+  // Optional, because two callers ask this question without one in hand. A
+  // literal computed key is decidable regardless; only following a key through
+  // a `const` binding needs the resolver.
+  resolver?: ReturnType<typeof styleResolver>
 ): string | undefined {
   if (ts.isIdentifier(name) || ts.isStringLiteral(name)) return name.text;
   if (ts.isComputedPropertyName(name)) {
@@ -2138,7 +2215,7 @@ function propertyNameOf(
  */
 function staticKeyOf(
   expression: ts.Expression,
-  resolver: ReturnType<typeof styleResolver>,
+  resolver: ReturnType<typeof styleResolver> | undefined,
   seen = new Set<ts.Declaration>()
 ): string | undefined {
   const value = withoutTypeWrappers(expression);
@@ -2146,6 +2223,7 @@ function staticKeyOf(
     return value.text;
   }
   if (ts.isIdentifier(value)) {
+    if (!resolver) return undefined;
     const declaration = resolver.declarationOf(value);
     if (!declaration || seen.has(declaration)) return undefined;
     seen.add(declaration);
@@ -2382,6 +2460,12 @@ function declaredProperties(
       const branches = spread.objects.flatMap(source =>
         declaredProperties(source, resolver, onPath, unreadable)
       );
+      // The branch that supplies nothing is an alternative like any other, and
+      // on it every property set before this spread survives untouched.
+      // Dropping it meant `...(flag ? { x: undefined } : undefined)` was read
+      // as though the clearing branch always ran, so a value the other branch
+      // preserves looked cleared on every render.
+      if (spread.absent) branches.push(new Map());
       if (branches.length === 0) continue;
       variants = variants.flatMap(base =>
         branches.map(branch => new Map([...base, ...branch]))
@@ -2791,7 +2875,8 @@ describe("the tab indicator contract", () => {
   });
 
   /** Every probe imports the way a real call site does, so tags resolve. */
-  const IMPORT = `import { TabsList, TabsTrigger } from "@nextlyhq/ui";\n`;
+  const IMPORT = `import * as UI from "@nextlyhq/ui";
+import { TabsList, TabsTrigger } from "@nextlyhq/ui";\n`;
 
   it.each([
     // The shapes a pattern-based scan returned clean on. Each removes the
@@ -3226,6 +3311,18 @@ describe("the tab indicator contract", () => {
       "an owned class written as a concatenation",
       '<TabsTrigger className={"border-b-" + "0"} />',
     ],
+    // clsx reads a computed literal key as the class it spells, exactly as the
+    // written-out key beside it.
+    [
+      "an owned class named by a computed key in a class map",
+      '<TabsTrigger className={cn({ ["border-b-0"]: true })} />',
+    ],
+    // The branch that supplies no object still renders, and on it the value
+    // set before the spread survives.
+    [
+      "an owned property a conditional spread clears in only one branch",
+      '<TabsTrigger style={{ borderBottomColor: "red", ...(flag ? { borderBottomColor: undefined } : undefined) }} />',
+    ],
   ])("catches %s", (_label, body) => {
     // The positive controls. Each is a shape an earlier version returned clean
     // on, or a category it never read. Without these, a check that can never
@@ -3570,6 +3667,29 @@ describe("the tab indicator contract", () => {
       "an alias of a name that shadows the import",
       'function Row() {\n  const TabsTrigger = Other;\n  const Local = TabsTrigger;\n  return <Local className="border-b-0" />;\n}',
     ],
+    // Ownership follows the BINDING for a namespace exactly as it does for a
+    // plain alias: a local object that shadows `import * as UI` is not it.
+    [
+      "a member of an object that shadows a namespace import",
+      'function Row() {\n  const UI = { TabsTrigger: Other };\n  const Trigger = UI.TabsTrigger;\n  return <Trigger className="border-b-0" />;\n}',
+    ],
+    // A computed key that is statically a string names its prop as plainly as
+    // an identifier does.
+    [
+      "a spread carrying an unrelated prop under a computed key",
+      '<TabsTrigger {...{ ["value"]: "a" }} />',
+    ],
+    // The base state, not a copy of the disabled treatment: the owned variant
+    // rule is more specific and keeps winning while disabled.
+    [
+      "an unqualified class restating a state-qualified owned rule",
+      '<TabsTrigger className="opacity-50" />',
+    ],
+    // CSS defines `initial` for this property AS `none`, so it draws nothing.
+    [
+      "a border image source reset to initial",
+      '<TabsTrigger style={{ borderImageSource: "initial" }} />',
+    ],
   ])("does not report %s", (_label, body) => {
     // The complement, and the reason this is a contract rather than a ban. A
     // check that flags a documented example or a legitimate layout class gets
@@ -3797,16 +3917,25 @@ describe("which files the call-site scan reads", () => {
     // least one child directory covers both and misses a file sitting directly
     // in the root — which `sourceFiles` reaches, since it recurses from the
     // root itself rather than from the packages inside it.
+    // Forward slashes, because that is the string the matcher is handed at
+    // runtime: Vitest normalises a watcher path with `slash(id)` before
+    // testing it, and picomatch reads a backslash as an ESCAPE rather than a
+    // separator. Handing it a native Windows path would put every probe in
+    // `unwatchedProbes` and fail this suite on a correctly configured watch.
+    const forwardSlashes = (path: string): string => path.replace(/\\/g, "/");
+    const repoRoot = forwardSlashes(REPO);
     const probes = SCAN_ROOT_NAMES.flatMap(root =>
-      CALL_SITE_EXTENSIONS.flatMap(extension => [
-        resolve(REPO, root, `probe-package/src/nested/probe${extension}`),
-        resolve(REPO, root, `probe-package/probe${extension}`),
-        resolve(REPO, root, `probe${extension}`),
-      ])
+      CALL_SITE_EXTENSIONS.flatMap(extension =>
+        [
+          `probe-package/src/nested/probe${extension}`,
+          `probe-package/probe${extension}`,
+          `probe${extension}`,
+        ].map(leaf => forwardSlashes(resolve(REPO, root, leaf)))
+      )
     );
     const unwatchedProbes = probes
       .filter(path => !isMatch(path, triggers))
-      .map(path => path.replace(`${REPO}/`, ""));
+      .map(path => path.replace(`${repoRoot}/`, ""));
     expect(unwatchedProbes).toEqual([]);
 
     // Matching is only HALF the mechanism, and the half that was never checked

--- a/packages/ui/src/components/__tests__/tabs-contract.test.ts
+++ b/packages/ui/src/components/__tests__/tabs-contract.test.ts
@@ -97,10 +97,15 @@ const SCAN_ROOT_NAMES = ["packages", "apps", "templates"] as const;
  * the scan walks are reached by relative path here rather than by the
  * `$TURBO_ROOT$` the Turbo inputs use. Two spellings of one fact, which is why
  * the contract below checks them against each other rather than trusting both.
+ *
+ * Each prefix covers the WHOLE root. `sourceFiles` recurses from the root, so
+ * `packages/foo/examples/demo.jsx` is a file it reads — narrowing these to
+ * `src` would make the contract green while leaving that file unwatched, which
+ * is the contract certifying a gap rather than closing it.
  */
 const CALL_SITE_ROOT_GLOBS = [
-  { root: "packages", prefix: "../*/src/**/*." },
-  { root: "apps", prefix: "../../apps/*/src/**/*." },
+  { root: "packages", prefix: "../*/**/*." },
+  { root: "apps", prefix: "../../apps/*/**/*." },
   { root: "templates", prefix: "../../templates/**/*." },
 ] as const;
 
@@ -1360,50 +1365,73 @@ function styleResolver(attribute: ts.JsxAttribute): {
     expression: ts.Expression | undefined,
     seen?: Set<ts.Node>
   ): ts.ObjectLiteralExpression[];
-  valueOf(name: string): ts.Expression | undefined;
+  valueOf(
+    name: string,
+    from?: ts.Node
+  ): { value: ts.Expression; scope: ts.Node } | undefined;
 } {
-  const initializerOf = (name: string): ts.Expression | undefined => {
-    const declared = (scope: ts.Node): ts.Expression | undefined => {
-      let found: ts.Expression | undefined;
-      // Only the scope's OWN statements, so a declaration nested inside a
-      // sibling function is not mistaken for one in this scope.
-      ts.forEachChild(scope, statement => {
-        if (!ts.isVariableStatement(statement)) return;
-        // `const` only. A `let` or `var` binding's declaration initializer is
-        // not what the element renders — `let c = undefined; c = "red";` paints,
-        // and following the initializer alone concludes the opposite. Reading a
-        // reassignable binding as its first value turns a check into a false
-        // NEGATIVE, which is the direction that lets a real violation ship.
-        //
-        // Undecidable is the honest answer for those, and undecidable here
-        // means "keep reporting": the callers treat an unresolvable binding as
-        // emitting, which is the conservative side.
-        const isConst =
-          (statement.declarationList.flags & ts.NodeFlags.Const) !== 0;
-        if (!isConst) return;
-        for (const declaration of statement.declarationList.declarations) {
-          if (
-            ts.isIdentifier(declaration.name) &&
-            declaration.name.text === name &&
-            declaration.initializer
-          ) {
-            found = declaration.initializer;
-          }
+  /**
+   * The nearest declaration of a name, and whether it can be trusted.
+   *
+   * Two things this deliberately does NOT do, each of which was a false
+   * negative:
+   *
+   * - It stops at the FIRST scope declaring the name, even when that
+   *   declaration is mutable. Skipping a mutable shadow and continuing outward
+   *   resolves the use to a completely different binding: an inner
+   *   `let colour = "red"` under an outer `const colour = undefined` rendered
+   *   red while the scan read the outer `undefined` and stayed silent. A shadow
+   *   makes the name undecidable; it does not make it the outer one.
+   * - It reports mutability rather than filtering on it, because the right
+   *   answer depends on the CALLER. For a property value, unresolved means
+   *   "assume it emits" and reporting is the safe side. For the style object
+   *   itself, unresolved means an empty object list and therefore silence — so
+   *   the same filter that protects one caller blinds the other.
+   *
+   * The declaration's own scope comes back with it, so an alias is followed
+   * from where it was WRITTEN. `const key = sourceKey` must resolve `sourceKey`
+   * against the alias's scope; resolving it against the element's picks up an
+   * inner `sourceKey` that the alias never saw.
+   */
+  interface Binding {
+    initializer: ts.Expression;
+    /** The declaration is `let` or `var`, so its initializer is not final. */
+    mutable: boolean;
+    /** Where the declaration lives, for following aliases from there. */
+    scope: ts.Node;
+  }
+
+  const declaredIn = (scope: ts.Node, name: string): Binding | undefined => {
+    let found: Binding | undefined;
+    // Only the scope's OWN statements, so a declaration nested inside a
+    // sibling function is not mistaken for one in this scope.
+    ts.forEachChild(scope, statement => {
+      if (!ts.isVariableStatement(statement)) return;
+      const mutable =
+        (statement.declarationList.flags & ts.NodeFlags.Const) === 0;
+      for (const declaration of statement.declarationList.declarations) {
+        if (
+          ts.isIdentifier(declaration.name) &&
+          declaration.name.text === name &&
+          declaration.initializer
+        ) {
+          found = { initializer: declaration.initializer, mutable, scope };
         }
-      });
-      return found;
-    };
-    for (
-      let scope: ts.Node | undefined = attribute;
-      scope;
-      scope = scope.parent
-    ) {
+      }
+    });
+    return found;
+  };
+
+  const bindingOf = (name: string, from: ts.Node): Binding | undefined => {
+    for (let scope: ts.Node | undefined = from; scope; scope = scope.parent) {
       if (
         ts.isBlock(scope) ||
         ts.isSourceFile(scope) ||
         ts.isCaseClause(scope)
       ) {
-        const found = declared(scope);
+        // The FIRST scope that declares it wins, mutable or not. Continuing
+        // past a shadow is what reads the wrong binding.
+        const found = declaredIn(scope, name);
         if (found) return found;
       }
     }
@@ -1456,13 +1484,39 @@ function styleResolver(attribute: ts.JsxAttribute): {
         walk(node.right);
         return;
       }
-      if (ts.isIdentifier(node)) walk(initializerOf(node.text));
+      // Followed whether or not the binding is mutable. An unresolved object
+      // yields an EMPTY list here, and an empty list reports nothing — so
+      // dropping a `let style = { ... }` is a false negative, the opposite
+      // polarity to an unresolved property value.
+      if (ts.isIdentifier(node)) {
+        walk(bindingOf(node.text, node)?.initializer);
+      }
     };
     walk(root);
     return objects;
   };
 
-  return { objectsFrom, valueOf: initializerOf };
+  /**
+   * The value a name holds, when that is decidable.
+   *
+   * `undefined` for a mutable binding — including one that merely SHADOWS a
+   * constant — because the declaration initializer is not what runs. Callers
+   * treat an unresolved value as emitting, so undecidable errs towards
+   * reporting.
+   *
+   * `from` is where the name was written, so an alias resolves against its own
+   * scope rather than the element's.
+   */
+  const valueOf = (
+    name: string,
+    from: ts.Node = attribute
+  ): { value: ts.Expression; scope: ts.Node } | undefined => {
+    const binding = bindingOf(name, from);
+    if (!binding || binding.mutable) return undefined;
+    return { value: binding.initializer, scope: binding.scope };
+  };
+
+  return { objectsFrom, valueOf };
 }
 
 /** The objects an element's `style` prop can resolve to here. */
@@ -1534,7 +1588,8 @@ function propertyNameOf(
 function staticKeyOf(
   expression: ts.Expression,
   resolver: ReturnType<typeof styleResolver>,
-  seen = new Set<string>()
+  seen = new Set<string>(),
+  from?: ts.Node
 ): string | undefined {
   const value = withoutTypeWrappers(expression);
   if (ts.isStringLiteral(value) || ts.isNoSubstitutionTemplateLiteral(value)) {
@@ -1542,8 +1597,12 @@ function staticKeyOf(
   }
   if (ts.isIdentifier(value) && !seen.has(value.text)) {
     seen.add(value.text);
-    const bound = resolver.valueOf(value.text);
-    if (bound) return staticKeyOf(bound, resolver, seen);
+    const bound = resolver.valueOf(value.text, from);
+    // Followed from the DECLARATION's scope, not the element's. An alias like
+    // `const key = sourceKey` refers to whatever `sourceKey` meant where the
+    // alias was written, and resolving it beside the element instead picks up
+    // an inner `sourceKey` the alias never saw.
+    if (bound) return staticKeyOf(bound.value, resolver, seen, bound.scope);
   }
   return undefined;
 }
@@ -1686,7 +1745,8 @@ function declaredProperties(
 function emitsValue(
   value: ts.Expression,
   resolver: ReturnType<typeof styleResolver>,
-  seen = new Set<string>()
+  seen = new Set<string>(),
+  from?: ts.Node
 ): boolean {
   const inner = withoutTypeWrappers(value);
   if (isDefinitelyNothing(inner)) return false;
@@ -1694,8 +1754,10 @@ function emitsValue(
   // through the same identifier path a bare `colour` does.
   if (ts.isIdentifier(inner) && !seen.has(inner.text)) {
     seen.add(inner.text);
-    const bound = resolver.valueOf(inner.text);
-    if (bound) return emitsValue(bound, resolver, seen);
+    const bound = resolver.valueOf(inner.text, from);
+    // Same lexical rule as a computed key: an alias is resolved from where it
+    // was declared.
+    if (bound) return emitsValue(bound.value, resolver, seen, bound.scope);
   }
   return true;
 }
@@ -2182,6 +2244,28 @@ describe("the tab indicator contract", () => {
     [
       "the same reassigned binding behind an assertion",
       'let c: string | undefined = undefined;\nc = "red";\n<TabsTrigger style={{ borderBottomColor: c as string | undefined }} />',
+    ],
+    // A mutable binding SHADOWING a constant. Skipping the inner declaration
+    // and continuing outward does not fall back to "undecidable" — it resolves
+    // the use to a completely different binding, and reads `undefined` from an
+    // outer constant the element never mentions.
+    [
+      "a mutable binding shadowing an outer constant",
+      'const colour = undefined;\nfunction Row() {\n  let colour = "red";\n  return <TabsTrigger style={{ borderBottomColor: colour }} />;\n}',
+    ],
+    // The style OBJECT in a mutable binding. Dropping the declaration leaves an
+    // empty object list, and an empty list reports nothing — the opposite
+    // polarity to an unresolved property VALUE, where unresolved means report.
+    [
+      "an owned property inside a mutable style binding",
+      'let style = { borderBottomColor: "red" };\n<TabsTrigger style={style} />',
+    ],
+    // An alias resolved in the WRONG scope. `key` means what `sourceKey` meant
+    // where the alias was written; resolving it beside the element picks up an
+    // inner `sourceKey` the alias never saw.
+    [
+      "a computed key aliasing a constant shadowed near the element",
+      'const sourceKey = "borderBottomColor";\nconst key = sourceKey;\nfunction Row() {\n  const sourceKey = "width";\n  return <TabsTrigger style={{ [key]: "red" }} />;\n}',
     ],
   ])("catches %s", (_label, body) => {
     // The positive controls. Each is a shape an earlier version returned clean

--- a/packages/ui/src/components/__tests__/tabs-contract.test.ts
+++ b/packages/ui/src/components/__tests__/tabs-contract.test.ts
@@ -773,7 +773,12 @@ function complementaryStates(a: string, b: string): boolean {
   // read outside any negation, which the test above already compares.
   const has = (selector: string, state: string): boolean =>
     new RegExp(`${state}(?![a-z-])`).test(
-      selector.replace(/:not\([^)]*\)/g, "")
+      selector
+        // A quoted attribute value is DATA. `data-[foo=:enabled]:` compiles to
+        // `&[data-foo=":enabled"]`, which says nothing about the element's
+        // state, and matching the text inside it invented a contradiction.
+        .replace(/"[^"]*"|'[^']*'/g, '""')
+        .replace(/:not\([^)]*\)/g, "")
     );
   return COMPLEMENTARY_STATES.some(
     ([one, other]) =>
@@ -1484,10 +1489,16 @@ interface Ownership {
 function ownershipIn(sourceFile: ts.SourceFile): {
   ownership: Ownership;
   exportedNameOf: Map<string, string>;
+  owning: Map<ts.Node, string>;
 } {
   const names = new Set<string>();
   const namespaces = new Set<string>();
   const exportedNameOf = new Map<string, string>();
+  // Keyed on the NAME NODE each owning binding declares, so a tag can be
+  // matched by which declaration it resolves to rather than by how it is
+  // spelled. A local component may legitimately reuse an imported name, and
+  // holding it to this contract failed a component entitled to its own classes.
+  const owning = new Map<ts.Node, string>();
 
   const visit = (node: ts.Node): void => {
     if (
@@ -1504,11 +1515,38 @@ function ownershipIn(sourceFile: ts.SourceFile): {
           if (OWNED_EXPORTS.includes(exported)) {
             names.add(specifier.name.text);
             exportedNameOf.set(specifier.name.text, exported);
+            owning.set(specifier.name, exported);
           }
         }
       }
       if (bindings && ts.isNamespaceImport(bindings)) {
         namespaces.add(bindings.name.text);
+      }
+    }
+    // `require` is the same two imports in JavaScript's other spelling, and
+    // `.js`/`.jsx` call sites are scanned, so a CommonJS consumer reaches this
+    // primitive exactly as an ESM one does.
+    if (ts.isVariableDeclaration(node) && node.initializer) {
+      const required = requiredModuleOf(node.initializer);
+      if (
+        required !== undefined &&
+        reachesThePrimitive(required, sourceFile.fileName)
+      ) {
+        if (ts.isIdentifier(node.name)) namespaces.add(node.name.text);
+        if (ts.isObjectBindingPattern(node.name)) {
+          for (const element of node.name.elements) {
+            const source = element.propertyName ?? element.name;
+            if (
+              ts.isIdentifier(source) &&
+              ts.isIdentifier(element.name) &&
+              OWNED_EXPORTS.includes(source.text)
+            ) {
+              names.add(element.name.text);
+              exportedNameOf.set(element.name.text, source.text);
+              owning.set(element.name, source.text);
+            }
+          }
+        }
       }
     }
     // An alias carries ownership forward, and it can be written three ways.
@@ -1525,6 +1563,7 @@ function ownershipIn(sourceFile: ts.SourceFile): {
       if (exported && ts.isIdentifier(node.name)) {
         names.add(node.name.text);
         exportedNameOf.set(node.name.text, exported);
+        owning.set(node.name, exported);
       }
       // `const { TabsTrigger: Trigger } = UI` names the same component again.
       if (
@@ -1541,6 +1580,7 @@ function ownershipIn(sourceFile: ts.SourceFile): {
           ) {
             names.add(element.name.text);
             exportedNameOf.set(element.name.text, source.text);
+            owning.set(element.name, source.text);
           }
         }
       }
@@ -1548,7 +1588,28 @@ function ownershipIn(sourceFile: ts.SourceFile): {
     ts.forEachChild(node, visit);
   };
   visit(sourceFile);
-  return { ownership: { names, namespaces }, exportedNameOf };
+  return { ownership: { names, namespaces }, exportedNameOf, owning };
+}
+
+/**
+ * The module a `require(...)` call names, when the initializer is one.
+ *
+ * Both spellings reach the same place: `require("x")` and a member access on
+ * it, so `const UI = require("x")` and `const { TabsTrigger } = require("x")`
+ * are the CommonJS forms of the two imports read above.
+ */
+function requiredModuleOf(initializer: ts.Expression): string | undefined {
+  const call = withoutTypeWrappers(initializer);
+  if (
+    ts.isCallExpression(call) &&
+    ts.isIdentifier(call.expression) &&
+    call.expression.text === "require" &&
+    call.arguments.length === 1
+  ) {
+    const first = call.arguments[0];
+    if (first && ts.isStringLiteral(first)) return first.text;
+  }
+  return undefined;
 }
 
 /**
@@ -1582,9 +1643,21 @@ function exportedFrom(
 function exportedTagOf(
   tag: ts.JsxTagNameExpression,
   ownership: Ownership,
-  exportedNameOf: Map<string, string>
+  exportedNameOf: Map<string, string>,
+  owning: Map<ts.Node, string>,
+  checker: ts.TypeChecker
 ): string | undefined {
-  if (ts.isIdentifier(tag)) return exportedNameOf.get(tag.text);
+  if (ts.isIdentifier(tag)) {
+    // Which binding the tag REFERS to, not how it is spelled. An imported name
+    // can be shadowed by a local component, and reading the text alone held
+    // that component to a contract about a different one entirely.
+    const declaration = declarationOf(tag, checker);
+    if (!declaration) return exportedNameOf.get(tag.text);
+    const declared = (declaration as { name?: ts.Node }).name;
+    // A resolved declaration answers on its own; falling back to the text here
+    // would restore exactly the shadowing this replaces.
+    return declared ? owning.get(declared) : undefined;
+  }
   // `<UI.TabsTrigger>` is a property access, not an identifier, so a traversal
   // testing only for identifiers walks straight past a namespace import.
   if (
@@ -1618,38 +1691,51 @@ function exportedTagOf(
  * condition around a class was correctly ignored.
  */
 function selectedByLiteralCondition(
-  node: ts.Expression
+  node: ts.Expression,
+  resolver?: ReturnType<typeof styleResolver>
 ): ts.Expression | undefined {
   if (ts.isConditionalExpression(node)) {
-    if (node.condition.kind === ts.SyntaxKind.TrueKeyword) return node.whenTrue;
-    if (node.condition.kind === ts.SyntaxKind.FalseKeyword) {
-      return node.whenFalse;
-    }
-    return undefined;
+    const decided = staticTruthiness(node.condition, resolver);
+    if (decided === undefined) return undefined;
+    return decided ? node.whenTrue : node.whenFalse;
   }
   if (!ts.isBinaryExpression(node)) return undefined;
-  const left = node.left.kind;
-  // The operand each operator YIELDS, not merely the one it evaluates: `false &&
-  // x` is the value `false`, which names no class and is no style object.
-  if (node.operatorToken.kind === ts.SyntaxKind.AmpersandAmpersandToken) {
-    if (left === ts.SyntaxKind.FalseKeyword) return node.left;
-    if (left === ts.SyntaxKind.TrueKeyword) return node.right;
+  const operator = node.operatorToken.kind;
+  // `??` chooses on presence rather than on truth, so it is asked separately.
+  if (operator === ts.SyntaxKind.QuestionQuestionToken) {
+    return isDefinitelyPresent(node.left) ? node.left : undefined;
   }
-  if (node.operatorToken.kind === ts.SyntaxKind.BarBarToken) {
-    if (left === ts.SyntaxKind.TrueKeyword) return node.left;
-    if (left === ts.SyntaxKind.FalseKeyword) return node.right;
+  if (
+    operator !== ts.SyntaxKind.AmpersandAmpersandToken &&
+    operator !== ts.SyntaxKind.BarBarToken
+  ) {
+    return undefined;
   }
-  return undefined;
+  // The operand each operator YIELDS, not merely the one it evaluates: `0 && x`
+  // is the value `0`, which names no class and is no style object. Asked of the
+  // one truthiness evaluator, so `false`, `0`, `null` and `""` are decided the
+  // same way rather than only the boolean spelling — and so a name holding a
+  // known value is decided at all.
+  const decided = staticTruthiness(node.left, resolver);
+  if (decided === undefined) return undefined;
+  if (operator === ts.SyntaxKind.AmpersandAmpersandToken) {
+    return decided ? node.right : node.left;
+  }
+  return decided ? node.left : node.right;
 }
 
-function literalStrings(node: ts.Node, found: string[] = []): string[] {
+function literalStrings(
+  node: ts.Node,
+  found: string[] = [],
+  resolver?: ReturnType<typeof styleResolver>
+): string[] {
   if (ts.isStringLiteral(node) || ts.isNoSubstitutionTemplateLiteral(node)) {
     found.push(node.text);
   } else if (ts.isTemplateExpression(node)) {
     found.push(node.head.text);
     for (const span of node.templateSpans) {
       found.push(span.literal.text);
-      literalStrings(span.expression, found);
+      literalStrings(span.expression, found, resolver);
     }
     return found;
   }
@@ -1658,14 +1744,14 @@ function literalStrings(node: ts.Node, found: string[] = []): string[] {
   // receives the second string — collecting it reported a call site for a class
   // it does not apply.
   if (ts.isExpression(node)) {
-    const selected = selectedByLiteralCondition(node);
-    if (selected) return literalStrings(selected, found);
+    const selected = selectedByLiteralCondition(node, resolver);
+    if (selected) return literalStrings(selected, found, resolver);
   }
   // The braces matter. `ts.forEachChild` stops at the first callback that
   // returns something truthy, so a concise arrow returning the accumulator
   // visits one child and reports the rest as absent.
   ts.forEachChild(node, child => {
-    literalStrings(child, found);
+    literalStrings(child, found, resolver);
   });
   return found;
 }
@@ -1695,6 +1781,11 @@ function styleResolver(
     values: ts.Expression[];
     exhaustive: boolean;
   };
+  propertyWrites(identifier: ts.Identifier): Array<{
+    name: string;
+    emits: boolean;
+    value: string | undefined;
+  }>;
   declarationOf(identifier: ts.Identifier): ts.Declaration | undefined;
 } {
   /**
@@ -1770,6 +1861,16 @@ function styleResolver(
    */
   const alwaysRuns = (node: ts.Node, unit: ts.Node | undefined): boolean => {
     for (let at = node.parent; at && at !== unit; at = at.parent) {
+      // A write at the START of a `try` runs whenever control reaches the
+      // block: nothing inside it has had the chance to throw yet.
+      if (
+        ts.isTryStatement(at) &&
+        at.tryBlock.statements.length > 0 &&
+        node.getStart() >= (at.tryBlock.statements[0]?.getStart() ?? 0) &&
+        node.getEnd() <= (at.tryBlock.statements[0]?.getEnd() ?? 0)
+      ) {
+        continue;
+      }
       // A `do` BODY runs before its condition is ever asked, so it executes at
       // least once however the condition later answers.
       if (ts.isDoStatement(at)) continue;
@@ -1851,7 +1952,14 @@ function styleResolver(
       ) {
         const sameUnit = executionUnitOf(node) === elementUnit;
         const before = node.getStart() < at.getStart();
-        if (!sameUnit || before) {
+        // A write is not its own antecedent. While `style = style || {...}` is
+        // being evaluated the binding still holds what it held before, so a
+        // program point INSIDE this write must not see it as already done —
+        // counting it made the right-hand side undecidable and both branches
+        // were then read as reachable.
+        const evaluatingThisWrite =
+          at.getStart() >= node.getStart() && at.getEnd() <= node.getEnd();
+        if (!evaluatingThisWrite && (!sameUnit || before)) {
           found.push({
             value: node.right,
             operator: node.operatorToken.kind,
@@ -1918,10 +2026,16 @@ function styleResolver(
   const reachingValues = (identifier: ts.Identifier): Reaching => {
     const declaration = declarationOf(identifier, checker);
     if (!declaration) return { values: [], exhaustive: false };
+    // A parameter is written to like any other binding, so its writes are
+    // collected the same way; what stays different is that the list can never
+    // be complete, because the caller supplies a value this file cannot see.
     if (!ts.isVariableDeclaration(declaration)) {
       const binding = bindingOf(identifier);
       return {
-        values: binding?.initializer ? [binding.initializer] : [],
+        values: [
+          ...(binding?.initializer ? [binding.initializer] : []),
+          ...writesTo(declaration, identifier).map(write => write.value),
+        ],
         exhaustive: false,
       };
     }
@@ -1952,7 +2066,7 @@ function styleResolver(
       // cannot fire, so its right side is not a value the binding can hold —
       // filling a style object only when nothing filled it yet is the ordinary
       // reason to write one.
-      if (held.length > 0 && cannotFire(write.operator, held)) continue;
+      if (held.length > 0 && cannotFire(write.operator, held, api)) continue;
       held = [...held, write.value];
     }
     return { values: [...held, ...elsewhere], exhaustive: true };
@@ -1993,7 +2107,7 @@ function styleResolver(
       // one React never receives. Asked through the same helper the class half
       // uses, so one spelling of "this cannot be taken" cannot be resolved on
       // one side of the contract and reported on the other.
-      const selected = selectedByLiteralCondition(node);
+      const selected = selectedByLiteralCondition(node, api);
       if (selected) return walk(selected);
       if (ts.isConditionalExpression(node)) {
         walk(node.whenTrue);
@@ -2043,12 +2157,69 @@ function styleResolver(
     return binding.initializer;
   };
 
-  return {
+  /**
+   * Properties written onto a binding after the object was created.
+   *
+   * `const style = {}; style.borderBottomColor = "red"` hands React the owned
+   * colour just as writing it inside the literal does, and a search for
+   * assignments TO the binding sees nothing — the binding still holds the same
+   * object, which is precisely why the mutation reaches the element.
+   *
+   * Both spellings, since `style["borderBottomColor"]` is the same write with a
+   * different node kind. Ordering is the same rule as any other write.
+   */
+  const propertyWrites = (
+    identifier: ts.Identifier
+  ): Array<{ name: string; emits: boolean; value: string | undefined }> => {
+    const declaration = declarationOf(identifier, checker);
+    if (!declaration) return [];
+    const found: Array<{
+      name: string;
+      emits: boolean;
+      value: string | undefined;
+    }> = [];
+    const unit = executionUnitOf(identifier);
+    const visit = (node: ts.Node): void => {
+      if (
+        ts.isBinaryExpression(node) &&
+        node.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
+        (ts.isPropertyAccessExpression(node.left) ||
+          ts.isElementAccessExpression(node.left)) &&
+        ts.isIdentifier(node.left.expression) &&
+        declarationOf(node.left.expression, checker) === declaration
+      ) {
+        const reaches =
+          executionUnitOf(node) !== unit ||
+          node.getStart() < identifier.getStart();
+        const name = ts.isPropertyAccessExpression(node.left)
+          ? node.left.name.text
+          : staticStringOf(node.left.argumentExpression, api);
+        if (reaches && name !== undefined) {
+          found.push({
+            name,
+            emits: emitsValue(node.right, api),
+            value: staticStringOf(node.right, api),
+          });
+        }
+      }
+      ts.forEachChild(node, visit);
+    };
+    visit(declaration.getSourceFile());
+    return found;
+  };
+
+  // Named so the resolver can ask ITSELF: deciding a branch or a logical
+  // assignment needs the value a name holds, which is the same question this
+  // object already answers. A second copy of that logic is how the file came to
+  // hold two truthiness evaluators that disagreed.
+  const api: ReturnType<typeof styleResolver> = {
     objectsFrom,
     valueOf,
     reachingValues,
+    propertyWrites,
     declarationOf: identifier => declarationOf(identifier, checker),
   };
+  return api;
 }
 
 /** The objects an element's `style` prop can resolve to here. */
@@ -2151,12 +2322,28 @@ function staticKeyOf(
  * Some properties are owned or not depending on what they hold, so the value
  * travels with the name rather than being discarded at the key.
  */
-function staticStringOf(expression: ts.Expression): string | undefined {
+function staticStringOf(
+  expression: ts.Expression,
+  resolver?: ReturnType<typeof styleResolver>,
+  seen = new Set<ts.Declaration>()
+): string | undefined {
   const inner = withoutTypeWrappers(expression);
   if (ts.isStringLiteral(inner) || ts.isNoSubstitutionTemplateLiteral(inner)) {
     return inner.text;
   }
-  return undefined;
+  // A name holding the value is the same value. `const noImage = "none"` draws
+  // no border image exactly as the literal spelling does, and reading only the
+  // literal form reported a call site that paints nothing.
+  if (!resolver || !ts.isIdentifier(inner)) return undefined;
+  const declaration = resolver.declarationOf(inner);
+  if (!declaration || seen.has(declaration)) return undefined;
+  seen.add(declaration);
+  const reaching = resolver.reachingValues(inner);
+  const only = reaching.values[0];
+  if (!reaching.exhaustive || reaching.values.length !== 1 || !only) {
+    return undefined;
+  }
+  return staticStringOf(only, resolver, seen);
 }
 
 /**
@@ -2165,7 +2352,10 @@ function staticStringOf(expression: ts.Expression): string | undefined {
  * `undefined` for anything whose truthiness depends on what it holds at
  * runtime, which keeps the write it guards in play.
  */
-function staticTruthiness(value: ts.Expression): boolean | undefined {
+function staticTruthiness(
+  value: ts.Expression,
+  resolver?: ReturnType<typeof styleResolver>
+): boolean | undefined {
   const inner = withoutTypeWrappers(value);
   if (
     ts.isObjectLiteralExpression(inner) ||
@@ -2180,8 +2370,24 @@ function staticTruthiness(value: ts.Expression): boolean | undefined {
   if (inner.kind === ts.SyntaxKind.TrueKeyword) return true;
   if (inner.kind === ts.SyntaxKind.FalseKeyword) return false;
   if (inner.kind === ts.SyntaxKind.NullKeyword) return false;
-  if (ts.isIdentifier(inner) && inner.text === "undefined") return false;
-  return undefined;
+  if (ts.isVoidExpression(inner)) return false;
+  if (!ts.isIdentifier(inner)) return undefined;
+  // `undefined` is a name like any other, so it is the global value only when
+  // it resolves to no declaration here. Without a resolver the question cannot
+  // be asked, and undecidable keeps whatever it guards in play.
+  if (inner.text === "undefined") {
+    if (!resolver) return undefined;
+    return resolver.declarationOf(inner) ? undefined : false;
+  }
+  if (!resolver) return undefined;
+  // A name is worth what it holds. Every value it can hold has to agree, or the
+  // answer depends on which one arrives.
+  const reaching = resolver.reachingValues(inner);
+  if (!reaching.exhaustive || reaching.values.length === 0) return undefined;
+  const answers = reaching.values.map(each => staticTruthiness(each, resolver));
+  return answers.every(answer => answer === answers[0])
+    ? answers[0]
+    : undefined;
 }
 
 /**
@@ -2193,15 +2399,19 @@ function staticTruthiness(value: ts.Expression): boolean | undefined {
  * Every held value has to agree, since any one of them reaching the write is
  * enough for it to run.
  */
-function cannotFire(operator: ts.SyntaxKind, held: ts.Expression[]): boolean {
+function cannotFire(
+  operator: ts.SyntaxKind,
+  held: ts.Expression[],
+  resolver: ReturnType<typeof styleResolver>
+): boolean {
   if (operator === ts.SyntaxKind.QuestionQuestionEqualsToken) {
     return held.every(isDefinitelyPresent);
   }
   if (operator === ts.SyntaxKind.BarBarEqualsToken) {
-    return held.every(value => staticTruthiness(value) === true);
+    return held.every(value => staticTruthiness(value, resolver) === true);
   }
   if (operator === ts.SyntaxKind.AmpersandAmpersandEqualsToken) {
-    return held.every(value => staticTruthiness(value) === false);
+    return held.every(value => staticTruthiness(value, resolver) === false);
   }
   return false;
 }
@@ -2367,7 +2577,7 @@ function declaredProperties(
       if (name) {
         setOnEach(name, {
           emits: emitsValue(property.initializer, resolver),
-          value: staticStringOf(property.initializer),
+          value: staticStringOf(property.initializer, resolver),
         });
       }
       continue;
@@ -2463,7 +2673,7 @@ interface Violation {
 
 function violationsIn(file: string, source: string): Violation[] {
   const { sourceFile, checker } = parse(file, source);
-  const { ownership, exportedNameOf } = ownershipIn(sourceFile);
+  const { ownership, exportedNameOf, owning } = ownershipIn(sourceFile);
   const found: Violation[] = [];
   const at = (node: ts.Node): number =>
     sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile)).line +
@@ -2471,16 +2681,38 @@ function violationsIn(file: string, source: string): Violation[] {
 
   const visit = (node: ts.Node): void => {
     if (ts.isJsxOpeningElement(node) || ts.isJsxSelfClosingElement(node)) {
-      const exported = exportedTagOf(node.tagName, ownership, exportedNameOf);
+      const exported = exportedTagOf(
+        node.tagName,
+        ownership,
+        exportedNameOf,
+        owning,
+        checker
+      );
       if (exported) {
         for (const attribute of node.attributes.properties) {
           if (!ts.isJsxAttribute(attribute)) continue;
           const name = attribute.name.getText(sourceFile);
           if (name === "style") {
             const { objects, resolver } = styleObjectsFor(attribute, checker);
-            const property = objects
-              .map(object => ownedStyleProperty(exported, object, resolver))
-              .find(Boolean);
+            // A property written onto the object AFTER it was created reaches
+            // React the same way one written inside the literal does.
+            const initializer = attribute.initializer;
+            const named =
+              initializer &&
+              ts.isJsxExpression(initializer) &&
+              initializer.expression &&
+              ts.isIdentifier(initializer.expression)
+                ? resolver.propertyWrites(initializer.expression)
+                : [];
+            const property =
+              objects
+                .map(object => ownedStyleProperty(exported, object, resolver))
+                .find(Boolean) ??
+              named.find(
+                write =>
+                  write.emits &&
+                  ownsStyleProperty(exported, write.name, write.value)
+              )?.name;
             if (property) {
               found.push({
                 file,
@@ -3039,6 +3271,33 @@ describe("the tab indicator contract", () => {
       "an owned property captured by an alias before the source is reset",
       'let style = { borderBottomColor: "red" };\nconst saved = style;\nstyle = {};\n<TabsTrigger style={saved} />',
     ],
+    // `undefined` shadowed by a truthy value makes the assignment run, so the
+    // owned style is what the element receives.
+    [
+      "an owned property behind an and-assignment on a shadowed undefined",
+      'const undefined = {};\nlet style = undefined;\nstyle &&= { borderBottomColor: "red" };\n<TabsTrigger style={style} />',
+    ],
+    // Pseudo-class TEXT inside an attribute value is data. This rule really can
+    // apply beside the primitive's disabled one.
+    [
+      "a rule whose attribute value merely spells a state",
+      '<TabsTrigger className="data-[foo=:enabled]:opacity-100" />',
+    ],
+    // A parameter can be written to like any other binding.
+    [
+      "an owned property assigned to a parameter before the element",
+      'function Row(style = {}) {\n  style = { borderBottomColor: "red" };\n  return <TabsTrigger style={style} />;\n}',
+    ],
+    // Mutating the object reaches React exactly as writing it inline does; the
+    // binding never changes, which is why a search for writes TO it sees none.
+    [
+      "an owned property written onto the style object",
+      'const style: Record<string, string> = {};\nstyle.borderBottomColor = "red";\n<TabsTrigger style={style} />',
+    ],
+    [
+      "an owned property written onto the style object by index",
+      'const style: Record<string, string> = {};\nstyle["borderBottomColor"] = "red";\n<TabsTrigger style={style} />',
+    ],
   ])("catches %s", (_label, body) => {
     // The positive controls. Each is a shape an earlier version returned clean
     // on, or a category it never read. Without these, a check that can never
@@ -3381,6 +3640,32 @@ describe("the tab indicator contract", () => {
       "an owned property in a var initializer written below the element",
       '<TabsTrigger style={style} />;\nvar style = { borderBottomColor: "red" };',
     ],
+    // The explicit spelling of a logical assignment, decided the same way.
+    [
+      "an owned property behind an explicit short-circuit that cannot run",
+      'let style = {};\nstyle = style || { borderBottomColor: "red" };\n<TabsTrigger style={style} />',
+    ],
+    // A constant holding `none` draws no border image, as the literal does.
+    [
+      "a border image whose none is written as a constant",
+      'const noImage = "none";\n<TabsTrigger style={{ borderImageSource: noImage }} />',
+    ],
+    // The first statement of a `try` runs whenever control reaches the block.
+    [
+      "an owned property reset at the start of a try block",
+      'let style: Record<string, string> = { borderBottomColor: "red" };\ntry {\n  style = {};\n} finally {\n}\n<TabsTrigger style={style} />',
+    ],
+    // Guards that are not spelled as booleans are still statically decided.
+    [
+      "a class literal behind a statically falsy non-boolean guard",
+      '<TabsTrigger className={cn(0 && "border-b-0")} />',
+    ],
+    // A local component may reuse an imported name and is entitled to its own
+    // appearance; the tag refers to the local binding, not the import.
+    [
+      "a class on a local component shadowing an imported name",
+      'function Row() {\n  const TabsTrigger = (p: Record<string, unknown>) => <div {...p} />;\n  return <TabsTrigger className="border-b-0" />;\n}',
+    ],
   ])("does not report %s", (_label, body) => {
     // The complement, and the reason this is a contract rather than a ban. A
     // check that flags a documented example or a legitimate layout class gets
@@ -3662,6 +3947,16 @@ describe("which files the call-site scan reads", () => {
     expect(
       excludeEachOther('&[data-state="active"]', '&[data-state="active"]')
     ).toBe(false);
+  });
+
+  it("finds a violation behind a CommonJS require", () => {
+    // `.js` and `.jsx` are scanned, so a CommonJS consumer reaches this
+    // primitive exactly as an ESM one does and is held to the same contract.
+    const source =
+      'const { TabsTrigger } = require("@nextlyhq/ui");\n' +
+      '<TabsTrigger className="border-b-0" />';
+
+    expect(violationsIn("probe.js", source)).not.toEqual([]);
   });
 
   it("finds a violation in a .jsx call site", () => {

--- a/packages/ui/src/components/__tests__/tabs-contract.test.ts
+++ b/packages/ui/src/components/__tests__/tabs-contract.test.ts
@@ -1576,16 +1576,30 @@ function ownershipIn(sourceFile: ts.SourceFile): {
     // `.js`/`.jsx` call sites are scanned, so a CommonJS consumer reaches this
     // primitive exactly as an ESM one does.
     if (ts.isVariableDeclaration(node) && node.initializer) {
-      const required = requiredModuleOf(node.initializer);
+      const required = requiredFrom(node.initializer);
       if (
         required !== undefined &&
-        reachesThePrimitive(required, sourceFile.fileName)
+        reachesThePrimitive(required.module, sourceFile.fileName)
       ) {
-        if (ts.isIdentifier(node.name)) {
+        // `const TabsTrigger = require("x").TabsTrigger` selects one export, so
+        // the binding names that component rather than the module.
+        if (required.exported !== undefined) {
+          if (
+            ts.isIdentifier(node.name) &&
+            OWNED_EXPORTS.includes(required.exported)
+          ) {
+            names.add(node.name.text);
+            exportedNameOf.set(node.name.text, required.exported);
+            owning.set(node.name, required.exported);
+          }
+        } else if (ts.isIdentifier(node.name)) {
           namespaces.add(node.name.text);
           owningNamespaces.add(node);
         }
-        if (ts.isObjectBindingPattern(node.name)) {
+        if (
+          required.exported === undefined &&
+          ts.isObjectBindingPattern(node.name)
+        ) {
           for (const element of node.name.elements) {
             const source = element.propertyName ?? element.name;
             if (
@@ -1649,22 +1663,38 @@ function ownershipIn(sourceFile: ts.SourceFile): {
 }
 
 /**
- * The module a `require(...)` call names, when the initializer is one.
+ * What a `require(...)` initializer names: the module, and the export selected
+ * from it when one is.
  *
- * Both spellings reach the same place: `require("x")` and a member access on
- * it, so `const UI = require("x")` and `const { TabsTrigger } = require("x")`
- * are the CommonJS forms of the two imports read above.
+ * Three spellings reach the same place. `const UI = require("x")` and
+ * `const { TabsTrigger } = require("x")` are the CommonJS forms of the two
+ * imports read above, and `const TabsTrigger = require("x").TabsTrigger` is a
+ * third that neither describes — it binds ONE export under a plain name, so
+ * reading it as the namespace form would hold the wrong shape, and reading it
+ * as nothing let a CommonJS call site through untouched.
+ *
+ * A member access is followed for the same reason `exportedFrom` follows one
+ * off a namespace import, and no further: element access is read by neither,
+ * so the two agree on what a member is.
  */
-function requiredModuleOf(initializer: ts.Expression): string | undefined {
-  const call = withoutTypeWrappers(initializer);
+function requiredFrom(
+  initializer: ts.Expression
+): { module: string; exported?: string } | undefined {
+  const value = withoutTypeWrappers(initializer);
+  if (ts.isPropertyAccessExpression(value)) {
+    const required = requiredFrom(value.expression);
+    // Only one member deep: `require("x").a.b` names no export of `x`.
+    if (!required || required.exported !== undefined) return undefined;
+    return { module: required.module, exported: value.name.text };
+  }
   if (
-    ts.isCallExpression(call) &&
-    ts.isIdentifier(call.expression) &&
-    call.expression.text === "require" &&
-    call.arguments.length === 1
+    ts.isCallExpression(value) &&
+    ts.isIdentifier(value.expression) &&
+    value.expression.text === "require" &&
+    value.arguments.length === 1
   ) {
-    const first = call.arguments[0];
-    if (first && ts.isStringLiteral(first)) return first.text;
+    const first = value.arguments[0];
+    if (first && ts.isStringLiteral(first)) return { module: first.text };
   }
   return undefined;
 }
@@ -1896,6 +1926,12 @@ function styleResolver(checker: ts.TypeChecker): {
     return isConst ? declaration.initializer : undefined;
   };
 
+  /** The one lookup `isDefinitelyNothing` reads, usable before the API exists. */
+  const declarations = {
+    declarationOf: (identifier: ts.Identifier): ts.Declaration | undefined =>
+      declarationOf(identifier, checker),
+  };
+
   const objectsFrom = (
     root: ts.Expression | undefined
   ): { objects: ts.ObjectLiteralExpression[]; readable: boolean } => {
@@ -1903,10 +1939,9 @@ function styleResolver(checker: ts.TypeChecker): {
     const seen = new Set<ts.Node>();
     let readable = true;
     const walk = (node: ts.Expression | undefined): void => {
-      if (!node) {
-        readable = false;
-        return;
-      }
+      // `style={}` carries no expression, and React receives no style. There
+      // is nothing here to trace, so it is read rather than reported.
+      if (!node) return;
       if (seen.has(node)) return;
       seen.add(node);
       // Parentheses, `as`, `satisfies` and `!` are erased before the code runs,
@@ -1940,6 +1975,14 @@ function styleResolver(checker: ts.TypeChecker): {
         walk(node.right);
         return;
       }
+      // `undefined`, `null` and the other spellings of nothing are VALUES
+      // React receives as no style, not names that have to be traced. Asked
+      // through the helper the property half uses, so one spelling of "paints
+      // nothing" is not accepted as a property value and then reported as
+      // unreadable when it is the whole prop — which rejected both
+      // `style={undefined}` and the branch of a literal condition that
+      // resolves to it.
+      if (isDefinitelyNothing(node, declarations)) return;
       // A name, a call, a member access, a spread of one: knowing what this
       // holds means tracing it, which is the analysis this deliberately does
       // not do. Reported as unreadable rather than assumed empty — an empty
@@ -1950,16 +1993,12 @@ function styleResolver(checker: ts.TypeChecker): {
     return { objects, readable };
   };
 
-  return {
-    objectsFrom,
-    valueOf,
-    declarationOf: identifier => declarationOf(identifier, checker),
-  };
+  return { objectsFrom, valueOf, ...declarations };
 }
 
-/** The objects an element's `style` prop can resolve to here. */
-function styleObjectsFor(
-  attribute: ts.JsxAttribute,
+/** The objects a `style` expression can resolve to here. */
+function styleObjectsFrom(
+  value: ts.Expression | undefined,
   checker: ts.TypeChecker
 ): {
   objects: ts.ObjectLiteralExpression[];
@@ -1967,14 +2006,22 @@ function styleObjectsFor(
   resolver: ReturnType<typeof styleResolver>;
 } {
   const resolver = styleResolver(checker);
+  return { ...resolver.objectsFrom(value), resolver };
+}
+
+/** The objects an element's `style` attribute can resolve to here. */
+function styleObjectsFor(
+  attribute: ts.JsxAttribute,
+  checker: ts.TypeChecker
+): ReturnType<typeof styleObjectsFrom> {
   const initializer = attribute.initializer;
-  // `style` with no expression at all — `style="x"` or a bare `style` — is not
-  // an object React can read, and is not this contract's business either.
-  if (!initializer || !ts.isJsxExpression(initializer)) {
-    return { objects: [], readable: true, resolver };
+  // `style` written as a plain string — `style="x"` — is not an object React
+  // can read, and is not this contract's business either. A bare `style` has
+  // no initializer and paints nothing, which the resolver reads on its own.
+  if (initializer && !ts.isJsxExpression(initializer)) {
+    return { objects: [], readable: true, resolver: styleResolver(checker) };
   }
-  const { objects, readable } = resolver.objectsFrom(initializer.expression);
-  return { objects, readable, resolver };
+  return styleObjectsFrom(initializer?.expression, checker);
 }
 
 /**
@@ -2148,7 +2195,11 @@ function isDefinitelyPresent(value: ts.Expression): boolean {
  */
 function isDefinitelyNothing(
   initializer: ts.Expression,
-  resolver: ReturnType<typeof styleResolver>
+  // Only the binder lookup is read, and declaring that is what lets the
+  // resolver ask this question while it is still being built.
+  resolver: {
+    declarationOf(identifier: ts.Identifier): ts.Declaration | undefined;
+  }
 ): boolean {
   const value = withoutTypeWrappers(initializer);
   if (ts.isIdentifier(value)) {
@@ -2372,6 +2423,20 @@ interface Violation {
   why: string;
 }
 
+/** The props this contract reads on an owned element. */
+const OWNED_PROPS = ["className", "style"];
+
+/**
+ * Where an owned prop's value comes from, once the attribute list is resolved.
+ *
+ * The two spellings are kept apart rather than normalised to an expression,
+ * because a report says which one it read — `displaces` for an attribute
+ * written on the element, `spreads` for one carried in by an object.
+ */
+type PropSource =
+  | { kind: "attribute"; attribute: ts.JsxAttribute }
+  | { kind: "spread"; at: ts.Node; value: ts.Expression };
+
 function violationsIn(file: string, source: string): Violation[] {
   const { sourceFile, checker } = parse(file, source);
   const { ownership, exportedNameOf, owning, owningNamespaces } =
@@ -2392,6 +2457,21 @@ function violationsIn(file: string, source: string): Violation[] {
         checker
       );
       if (exported) {
+        // JSX props are one object built left to right, so a later attribute
+        // REPLACES an earlier one of the same name: `{...props} className="x"`
+        // renders `x` however `props` was written. Checking each attribute
+        // where it appears asked about values the element never receives, so
+        // the surviving source of each owned prop is resolved first and only
+        // that one is read.
+        const effective = new Map<string, PropSource>();
+        // A spread whose contents cannot be read may carry either owned prop,
+        // so it stops mattering only once BOTH are written again after it.
+        const unread: Array<{ at: ts.Node; awaiting: Set<string> }> = [];
+        const take = (name: string, source: PropSource): void => {
+          effective.set(name, source);
+          for (const spread of unread) spread.awaiting.delete(name);
+        };
+
         for (const attribute of node.attributes.properties) {
           // `<TabsTrigger {...props} />` carries whatever `props` holds, which
           // includes `style` and `className`. Skipping spreads left the whole
@@ -2399,105 +2479,96 @@ function violationsIn(file: string, source: string): Violation[] {
           if (ts.isJsxSpreadAttribute(attribute)) {
             const spread = spreadAttributes(attribute, checker);
             if (!spread.readable) {
-              found.push({
-                file,
-                line: at(attribute),
-                why: "spreads props this scan cannot read, which may carry `style` or `className` — spread an object literal, or pass the props this primitive owns explicitly",
-              });
+              unread.push({ at: attribute, awaiting: new Set(OWNED_PROPS) });
               continue;
             }
             for (const carried of spread.attributes) {
-              const carriedName = carried.name;
-              if (carriedName === "className") {
-                const classes = literalStrings(carried.value).join(" ");
-                const displaced = displacedBy(exported, classes);
-                if (displaced.length > 0) {
-                  found.push({
-                    file,
-                    line: at(attribute),
-                    why: `spreads ${displaced.join(", ")} — the primitive owns that appearance, and every surface should change with it`,
-                  });
-                }
-              }
-              if (carriedName === "style") {
-                const resolver = styleResolver(checker);
-                const { objects, readable } = resolver.objectsFrom(
-                  carried.value
-                );
-                if (!readable) {
-                  found.push({
-                    file,
-                    line: at(attribute),
-                    why: "spreads an inline style this scan cannot read — write it as a literal object, or move it to `className` so the primitive keeps its appearance",
-                  });
-                  continue;
-                }
-                const owned = objects
-                  .map(object => ownedStyleProperty(exported, object, resolver))
-                  .find(Boolean);
-                if (owned) {
-                  found.push({
-                    file,
-                    line: at(attribute),
-                    why: `spreads \`${owned}\` inline, which beats every class the primitive applies`,
-                  });
-                }
-              }
+              if (!OWNED_PROPS.includes(carried.name)) continue;
+              take(carried.name, {
+                kind: "spread",
+                at: attribute,
+                value: carried.value,
+              });
             }
             continue;
           }
           if (!ts.isJsxAttribute(attribute)) continue;
           const name = attribute.name.getText(sourceFile);
-          if (name === "style") {
-            const { objects, readable, resolver } = styleObjectsFor(
-              attribute,
-              checker
-            );
-            // An expression the scan cannot read is reported for BEING
-            // unreadable, rather than passed over. Tracing what a name holds
-            // at this point is the analysis this contract deliberately does
-            // not do, and staying silent about it would mean "no violation"
-            // and "could not tell" looked the same from outside.
-            if (!readable) {
-              found.push({
-                file,
-                line: at(attribute),
-                why: "sets an inline style this scan cannot read — write it as a literal object, or move it to `className` so the primitive keeps its appearance",
-              });
-              continue;
-            }
+          if (OWNED_PROPS.includes(name)) {
+            take(name, { kind: "attribute", attribute });
+          }
+        }
+
+        const lineOf = (source: PropSource): number =>
+          at(source.kind === "attribute" ? source.attribute : source.at);
+
+        for (const spread of unread) {
+          if (spread.awaiting.size === 0) continue;
+          found.push({
+            file,
+            line: at(spread.at),
+            why: "spreads props this scan cannot read, which may carry `style` or `className` — spread an object literal, or pass the props this primitive owns explicitly",
+          });
+        }
+
+        const className = effective.get("className");
+        const classValue =
+          className?.kind === "attribute"
+            ? className.attribute.initializer
+            : className?.value;
+        if (className && classValue) {
+          const displaced = displacedBy(
+            exported,
+            literalStrings(classValue).join(" ")
+          );
+          if (displaced.length > 0) {
+            found.push({
+              file,
+              line: lineOf(className),
+              why: `${className.kind === "spread" ? "spreads" : "displaces"} ${displaced.join(", ")} — the primitive owns that appearance, and every surface should change with it`,
+            });
+          }
+        }
+
+        const style = effective.get("style");
+        if (style) {
+          const line = lineOf(style);
+          const verb = style.kind === "spread" ? "spreads" : "sets";
+          const { objects, readable, resolver } =
+            style.kind === "attribute"
+              ? styleObjectsFor(style.attribute, checker)
+              : styleObjectsFrom(style.value, checker);
+          // An expression the scan cannot read is reported for BEING
+          // unreadable, rather than passed over. Tracing what a name holds at
+          // this point is the analysis this contract deliberately does not do,
+          // and staying silent about it would mean "no violation" and "could
+          // not tell" looked the same from outside.
+          if (!readable) {
+            found.push({
+              file,
+              line,
+              why: `${verb} an inline style this scan cannot read — write it as a literal object, or move it to \`className\` so the primitive keeps its appearance`,
+            });
+          } else {
             const spreadUnreadable = { value: false };
             const property = objects
               .map(object =>
                 ownedStyleProperty(exported, object, resolver, spreadUnreadable)
               )
               .find(Boolean);
-            if (!property && spreadUnreadable.value) {
-              found.push({
-                file,
-                line: at(attribute),
-                why: "spreads an inline style this scan cannot read — write it as a literal object, or move it to `className` so the primitive keeps its appearance",
-              });
-              continue;
-            }
             if (property) {
               found.push({
                 file,
-                line: at(attribute),
-                why: `sets \`${property}\` inline, which beats every class the primitive applies`,
+                line,
+                why: `${verb} \`${property}\` inline, which beats every class the primitive applies`,
+              });
+            } else if (spreadUnreadable.value) {
+              found.push({
+                file,
+                line,
+                why: "spreads an inline style this scan cannot read — write it as a literal object, or move it to `className` so the primitive keeps its appearance",
               });
             }
-            continue;
-          }
-          if (name !== "className" || !attribute.initializer) continue;
-          const classes = literalStrings(attribute.initializer).join(" ");
-          const displaced = displacedBy(exported, classes);
-          if (displaced.length > 0) {
-            found.push({
-              file,
-              line: at(attribute),
-              why: `displaces ${displaced.join(", ")} — the primitive owns that appearance, and every surface should change with it`,
-            });
           }
         }
       }
@@ -3020,6 +3091,24 @@ describe("the tab indicator contract", () => {
       "a spread of props the scan cannot read",
       'const props = { className: "border-b-0" };\n<TabsTrigger {...props} />',
     ],
+    // The CommonJS spelling of a NAMED import: one export selected off the
+    // require call, bound under a plain name rather than a namespace.
+    [
+      "a class on a component required as a member",
+      'const TabsTrigger = require("@nextlyhq/ui").TabsTrigger;\n<TabsTrigger className="border-b-0" />',
+    ],
+    // A later attribute only replaces the prop it NAMES. `className` leaves the
+    // spread's `style` exactly where it was.
+    [
+      "a spread style a later className does not replace",
+      '<TabsTrigger {...{ style: { borderBottomColor: "red" } }} className="w-full" />',
+    ],
+    // An unreadable spread may carry either owned prop, so writing one of them
+    // again afterwards leaves the other still coming from the spread.
+    [
+      "an unreadable spread with only one owned prop written after it",
+      '<TabsTrigger {...rest} className="w-full" />',
+    ],
   ])("catches %s", (_label, body) => {
     // The positive controls. Each is a shape an earlier version returned clean
     // on, or a category it never read. Without these, a check that can never
@@ -3332,6 +3421,21 @@ describe("the tab indicator contract", () => {
     [
       "an attribute value that merely contains a hash",
       '<TabsTrigger className="not-data-[foo=#bar]:opacity-100" />',
+    ],
+    // `undefined` is a VALUE React receives as no style, not a name that has
+    // to be traced, so there is nothing here the scan failed to read.
+    ["a style prop written as undefined", "<TabsTrigger style={undefined} />"],
+    // Props are one object built left to right, so both later attributes
+    // replace what the spread carried and neither spread value is rendered.
+    [
+      "a spread whose owned props are both written again after it",
+      '<TabsTrigger {...{ className: "border-b-0", style: { borderBottomColor: "red" } }} className="w-full" style={{ width: 2 }} />',
+    ],
+    // The same rule reaches an unreadable spread: once both owned props are
+    // written after it, nothing it could have carried survives.
+    [
+      "an unreadable spread with both owned props written after it",
+      '<TabsTrigger {...rest} className="w-full" style={{ width: 2 }} />',
     ],
   ])("does not report %s", (_label, body) => {
     // The complement, and the reason this is a contract rather than a ban. A

--- a/packages/ui/src/components/__tests__/tabs-contract.test.ts
+++ b/packages/ui/src/components/__tests__/tabs-contract.test.ts
@@ -57,6 +57,7 @@
  */
 
 import {
+  existsSync,
   mkdirSync,
   mkdtempSync,
   readFileSync,
@@ -588,7 +589,11 @@ function expandDeclarations(
 ): Map<string, string> {
   const flat = new Map<string, string>();
   for (const [property, value] of declarations) {
-    for (const longhand of expandsTo(property)) flat.set(longhand, value);
+    // The value decides ownership for some properties, so it is passed rather
+    // than only recorded — a `border-image-source: none` names the property
+    // while supplying no image at all.
+    for (const longhand of expandsTo(property, value))
+      flat.set(longhand, value);
   }
   return flat;
 }
@@ -742,7 +747,39 @@ function excludeEachOther(whole: string, other: string): boolean {
   ) {
     return true;
   }
-  return attributesConflict(a, b);
+  if (attributesConflict(a, b)) return true;
+  return complementaryStates(a, b);
+}
+
+/**
+ * Pseudo-classes that describe the two sides of one state.
+ *
+ * An element is on exactly one side of each, so a rule qualified by one can
+ * never apply beside a rule qualified by the other. Written positively, which
+ * is why neither the negation test nor the attribute test above sees them:
+ * `enabled:` and `disabled:` contradict each other without a `:not()` or an
+ * attribute value anywhere in either selector.
+ */
+const COMPLEMENTARY_STATES = [
+  [":enabled", ":disabled"],
+  [":read-only", ":read-write"],
+  [":required", ":optional"],
+  [":valid", ":invalid"],
+  [":in-range", ":out-of-range"],
+];
+
+function complementaryStates(a: string, b: string): boolean {
+  // Matched on a boundary so `:enabled` is not found inside a longer name, and
+  // read outside any negation, which the test above already compares.
+  const has = (selector: string, state: string): boolean =>
+    new RegExp(`${state}(?![a-z-])`).test(
+      selector.replace(/:not\([^)]*\)/g, "")
+    );
+  return COMPLEMENTARY_STATES.some(
+    ([one, other]) =>
+      (has(a, one ?? "") && has(b, other ?? "")) ||
+      (has(a, other ?? "") && has(b, one ?? ""))
+  );
 }
 
 /**
@@ -1058,7 +1095,7 @@ function compiled(bare: string): string | null {
 function propertiesOfUncached(cls: string): string[] {
   const css = compiled(cls);
   if (css == null) return [];
-  return [...new Set(setBy(css).flatMap(expandsTo))];
+  return [...new Set(setBy(css).flatMap(property => expandsTo(property)))];
 }
 
 const propertiesOf = perClass(propertiesOfUncached);
@@ -1078,7 +1115,11 @@ const propertiesOf = perClass(propertiesOfUncached);
 function reachedByUncached(cls: string): string[] {
   const css = compiled(cls);
   if (css == null) return [];
-  return [...new Set([...setBy(css), ...readBy(css)].flatMap(expandsTo))];
+  return [
+    ...new Set(
+      [...setBy(css), ...readBy(css)].flatMap(property => expandsTo(property))
+    ),
+  ];
 }
 
 const reachedBy = perClass(reachedByUncached);
@@ -1153,7 +1194,7 @@ const BORDER_IMAGE = /^border-image(?:-source)?$/;
 const ANY_CORNER = /^border(-[a-z]+)*-radius$/;
 const BOTTOM_OFFSET = /^margin(-(bottom|block-end|block|y))?$/;
 
-function expandsTo(property: string): string[] {
+function expandsTo(property: string, value?: string): string[] {
   const kebab = property.replace(/([A-Z])/g, "-$1").toLowerCase();
   // A border IMAGE replaces what the border draws, on every edge it covers.
   // Checked before the shorthand split because it is not one: `border-image`
@@ -1161,6 +1202,12 @@ function expandsTo(property: string): string[] {
   // stood for itself — a name that intersects nothing the primitive owns, while
   // a gradient painted straight over the underline on every tab.
   if (BORDER_IMAGE.test(kebab)) {
+    // `none` is the initial value: it supplies no image, so the primitive's
+    // ordinary border renders exactly as it did. Owning the property whatever
+    // it holds reported the spelling that explicitly draws NOTHING.
+    if (value !== undefined && value.trim().toLowerCase() === "none") {
+      return [kebab];
+    }
     return BORDER_ASPECTS.map(aspect => `border-bottom-${aspect}`);
   }
   const border = BORDER_PROPERTY.exec(kebab);
@@ -1200,12 +1247,16 @@ function expandsTo(property: string): string[] {
  */
 const RESETS_EVERYTHING = "all";
 
-function ownsStyleProperty(slot: string, property: string): boolean {
+function ownsStyleProperty(
+  slot: string,
+  property: string,
+  value?: string
+): boolean {
   const owned = ownedCssProperties()[slot];
   if (!owned) return false;
   const kebab = property.replace(/([A-Z])/g, "-$1").toLowerCase();
   if (kebab === RESETS_EVERYTHING) return owned.size > 0;
-  return expandsTo(property).some(p => owned.has(p));
+  return expandsTo(property, value).some(p => owned.has(p));
 }
 
 /**
@@ -1251,12 +1302,23 @@ const CALL_SITE_EXTENSIONS = [".tsx", ".jsx", ".js"] as const;
  * tree would drop it before the extension check ran — a false green produced by
  * the very list meant to keep the scan honest.
  */
-const GENERATED_DIRECTORIES = new Set([
-  "node_modules",
-  "dist",
-  ".turbo",
-  ".next",
-]);
+const GENERATED_DIRECTORIES = new Set(["node_modules", ".turbo", ".next"]);
+
+/**
+ * `dist` is pruned only where it is a package's build output.
+ *
+ * It does not belong in the list above, by that list's own rule: `dist` is an
+ * output convention at a particular location AND an ordinary Next.js route
+ * segment, so `app/dist/page.js` is a real call site and pruning by basename
+ * dropped it before the extension check ever ran — the same failure the list
+ * documents for `app/build/page.js`.
+ *
+ * What separates the two is not the name but the position: a build directory
+ * sits beside the `package.json` of the package it was built from.
+ */
+function isBuildOutput(directory: string, parent: string): boolean {
+  return directory === "dist" && existsSync(join(parent, "package.json"));
+}
 
 function isCallSite(name: string): boolean {
   return CALL_SITE_EXTENSIONS.some(extension => name.endsWith(extension));
@@ -1265,7 +1327,7 @@ function isCallSite(name: string): boolean {
 function sourceFiles(dir: string, found: string[] = []): string[] {
   for (const entry of readdirSync(dir, { withFileTypes: true })) {
     const name = entry.name;
-    if (GENERATED_DIRECTORIES.has(name)) continue;
+    if (GENERATED_DIRECTORIES.has(name) || isBuildOutput(name, dir)) continue;
     const full = join(dir, name);
     if (entry.isDirectory()) {
       // `__tests__` is skipped deliberately: a test may construct violating
@@ -1708,6 +1770,9 @@ function styleResolver(
    */
   const alwaysRuns = (node: ts.Node, unit: ts.Node | undefined): boolean => {
     for (let at = node.parent; at && at !== unit; at = at.parent) {
+      // A `do` BODY runs before its condition is ever asked, so it executes at
+      // least once however the condition later answers.
+      if (ts.isDoStatement(at)) continue;
       // A `for` INITIALIZER runs once before the condition is ever asked, so it
       // is unconditional even though the body beside it is not.
       if (
@@ -1866,23 +1931,28 @@ function styleResolver(
       .filter(write => !write.sameUnit)
       .map(write => write.value);
     const initializer = bindingOf(identifier)?.initializer;
-    let held: ts.Expression[] = initializer ? [initializer] : [];
+    // A `var` is hoisted but its INITIALIZER runs where it is written, so an
+    // element evaluated above it receives `undefined`. Treated as a write at
+    // its own position, which for `let` and `const` changes nothing: reading
+    // either before its declaration is a temporal-dead-zone error, so the case
+    // cannot arise in code that runs.
+    const initializerReaches =
+      !initializer ||
+      executionUnitOf(initializer) !== executionUnitOf(identifier) ||
+      initializer.getStart() < identifier.getStart();
+    let held: ts.Expression[] =
+      initializer && initializerReaches ? [initializer] : [];
     for (const write of writes.filter(write => write.sameUnit)) {
       if (write.straightLine) {
         // Everything before is a value the binding has stopped holding.
         held = [write.value];
         continue;
       }
-      // A `??=` whose current value is already there cannot fire, so its right
-      // side is not a value the binding can hold — the ordinary way to fill a
-      // style object only when nothing filled it yet.
-      if (
-        write.operator === ts.SyntaxKind.QuestionQuestionEqualsToken &&
-        held.length > 0 &&
-        held.every(isDefinitelyPresent)
-      ) {
-        continue;
-      }
+      // A logical assignment whose test the current value already settles
+      // cannot fire, so its right side is not a value the binding can hold —
+      // filling a style object only when nothing filled it yet is the ordinary
+      // reason to write one.
+      if (held.length > 0 && cannotFire(write.operator, held)) continue;
       held = [...held, write.value];
     }
     return { values: [...held, ...elsewhere], exhaustive: true };
@@ -2076,6 +2146,67 @@ function staticKeyOf(
 }
 
 /**
+ * The string a value is written as, when it is written as one.
+ *
+ * Some properties are owned or not depending on what they hold, so the value
+ * travels with the name rather than being discarded at the key.
+ */
+function staticStringOf(expression: ts.Expression): string | undefined {
+  const inner = withoutTypeWrappers(expression);
+  if (ts.isStringLiteral(inner) || ts.isNoSubstitutionTemplateLiteral(inner)) {
+    return inner.text;
+  }
+  return undefined;
+}
+
+/**
+ * What a value is worth in a boolean test, when that is decidable.
+ *
+ * `undefined` for anything whose truthiness depends on what it holds at
+ * runtime, which keeps the write it guards in play.
+ */
+function staticTruthiness(value: ts.Expression): boolean | undefined {
+  const inner = withoutTypeWrappers(value);
+  if (
+    ts.isObjectLiteralExpression(inner) ||
+    ts.isArrayLiteralExpression(inner)
+  ) {
+    return true;
+  }
+  if (ts.isStringLiteral(inner) || ts.isNoSubstitutionTemplateLiteral(inner)) {
+    return inner.text.length > 0;
+  }
+  if (ts.isNumericLiteral(inner)) return Number(inner.text) !== 0;
+  if (inner.kind === ts.SyntaxKind.TrueKeyword) return true;
+  if (inner.kind === ts.SyntaxKind.FalseKeyword) return false;
+  if (inner.kind === ts.SyntaxKind.NullKeyword) return false;
+  if (ts.isIdentifier(inner) && inner.text === "undefined") return false;
+  return undefined;
+}
+
+/**
+ * Whether a logical assignment's test is already settled by what is held.
+ *
+ * Each operator writes only when its own test passes, so a value that settles
+ * that test the other way makes the write unreachable: `??=` writes when the
+ * current value is nullish, `||=` when it is falsy, `&&=` when it is truthy.
+ * Every held value has to agree, since any one of them reaching the write is
+ * enough for it to run.
+ */
+function cannotFire(operator: ts.SyntaxKind, held: ts.Expression[]): boolean {
+  if (operator === ts.SyntaxKind.QuestionQuestionEqualsToken) {
+    return held.every(isDefinitelyPresent);
+  }
+  if (operator === ts.SyntaxKind.BarBarEqualsToken) {
+    return held.every(value => staticTruthiness(value) === true);
+  }
+  if (operator === ts.SyntaxKind.AmpersandAmpersandEqualsToken) {
+    return held.every(value => staticTruthiness(value) === false);
+  }
+  return false;
+}
+
+/**
  * Whether a value is certainly neither `null` nor `undefined`.
  *
  * Narrow on purpose: it decides whether a `??=` can fire, and answering "yes"
@@ -2126,6 +2257,15 @@ function isDefinitelyNothing(
   if (ts.isStringLiteral(value) || ts.isNoSubstitutionTemplateLiteral(value)) {
     return value.text === "";
   }
+  // React emits no declaration for a boolean either, verified the same way:
+  // `{ borderBottomColor: false }` and `true` both render an element with no
+  // `style` attribute at all.
+  if (
+    value.kind === ts.SyntaxKind.TrueKeyword ||
+    value.kind === ts.SyntaxKind.FalseKeyword
+  ) {
+    return true;
+  }
   if (value.kind === ts.SyntaxKind.NullKeyword) return true;
   // `void 0` is the other spelling of the same intent.
   return ts.isVoidExpression(value);
@@ -2162,6 +2302,19 @@ function withoutTypeWrappers(expression: ts.Expression): ts.Expression {
 }
 
 /**
+ * One property an object declares: whether React emits it, and what it holds.
+ *
+ * The value travels with the name because ownership is not always decided by
+ * the property alone — `border-image-source` replaces the border when it names
+ * an image and leaves it alone when it names `none`.
+ */
+interface DeclaredProperty {
+  emits: boolean;
+  /** The value when it is written as a literal string, else undefined. */
+  value: string | undefined;
+}
+
+/**
  * What an object literal actually declares, after spreads and overwrites.
  *
  * An object is built in source order and a later key replaces an earlier one,
@@ -2176,7 +2329,7 @@ function declaredProperties(
   object: ts.ObjectLiteralExpression,
   resolver: ReturnType<typeof styleResolver>,
   onPath = new Set<ts.Node>()
-): Array<Map<string, boolean>> {
+): Array<Map<string, DeclaredProperty>> {
   // A LIST of possible results, not one. A spread whose source is chosen at
   // runtime — `active ? { borderBottomColor: c } : {}` — produces different
   // objects on different renders, and merging them into a single map let the
@@ -2193,9 +2346,9 @@ function declaredProperties(
   if (onPath.has(object)) return [new Map()];
   onPath.add(object);
 
-  let variants: Array<Map<string, boolean>> = [new Map()];
-  const setOnEach = (name: string, emits: boolean): void => {
-    for (const variant of variants) variant.set(name, emits);
+  let variants: Array<Map<string, DeclaredProperty>> = [new Map()];
+  const setOnEach = (name: string, state: DeclaredProperty): void => {
+    for (const variant of variants) variant.set(name, state);
   };
 
   for (const property of object.properties) {
@@ -2211,7 +2364,12 @@ function declaredProperties(
     }
     if (ts.isPropertyAssignment(property)) {
       const name = propertyNameOf(property.name, resolver);
-      if (name) setOnEach(name, emitsValue(property.initializer, resolver));
+      if (name) {
+        setOnEach(name, {
+          emits: emitsValue(property.initializer, resolver),
+          value: staticStringOf(property.initializer),
+        });
+      }
       continue;
     }
     // A shorthand entry is a different node kind with the same effect:
@@ -2219,7 +2377,10 @@ function declaredProperties(
     // does, and a visitor keyed on `PropertyAssignment` alone walks past it. Its
     // value lives in the binding, which `emitsValue` follows.
     if (ts.isShorthandPropertyAssignment(property)) {
-      setOnEach(property.name.text, emitsValue(property.name, resolver));
+      setOnEach(property.name.text, {
+        emits: emitsValue(property.name, resolver),
+        value: undefined,
+      });
       continue;
     }
     // A getter is a third spelling again: React reads the property and emits
@@ -2228,7 +2389,7 @@ function declaredProperties(
     // as emitting.
     if (ts.isGetAccessorDeclaration(property)) {
       const name = propertyNameOf(property.name, resolver);
-      if (name) setOnEach(name, true);
+      if (name) setOnEach(name, { emits: true, value: undefined });
     }
   }
   onPath.delete(object);
@@ -2286,8 +2447,9 @@ function ownedStyleProperty(
   resolver: ReturnType<typeof styleResolver>
 ): string | undefined {
   for (const variant of declaredProperties(object, resolver)) {
-    for (const [name, emits] of variant) {
-      if (emits && ownsStyleProperty(slot, name)) return name;
+    for (const [name, state] of variant) {
+      if (state.emits && ownsStyleProperty(slot, name, state.value))
+        return name;
     }
   }
   return undefined;
@@ -3179,6 +3341,46 @@ describe("the tab indicator contract", () => {
       "an owned property reset in a loop initializer",
       'let style: Record<string, string> = { borderBottomColor: "red" };\nfor (style = {}; false; ) {\n  break;\n}\n<TabsTrigger style={style} />',
     ],
+    // A logical assignment whose test the current value already settles never
+    // runs, so its right side is not what the element receives.
+    [
+      "an owned property behind an or-assignment that cannot fire",
+      'let style = {};\nstyle ||= { borderBottomColor: "red" };\n<TabsTrigger style={style} />',
+    ],
+    [
+      "an owned property behind an and-assignment that cannot fire",
+      'let style = null;\nstyle &&= { borderBottomColor: "red" };\n<TabsTrigger style={style} />',
+    ],
+    // React emits no declaration for a boolean, the same as for an empty
+    // string: both render an element carrying no `style` attribute at all.
+    [
+      "an owned property set to a boolean",
+      "<TabsTrigger style={{ borderBottomColor: false }} />",
+    ],
+    // One element cannot be both enabled and disabled, so these rules never
+    // apply together however the cascade ranks them.
+    [
+      "a rule qualified by the complement of an owned state",
+      '<TabsTrigger className="enabled:opacity-50" />',
+    ],
+    // `none` is the initial value of `border-image-source`: it supplies no
+    // image, so the primitive's ordinary bottom border renders unchanged.
+    [
+      "a border image explicitly set to none",
+      '<TabsTrigger style={{ borderImageSource: "none" }} />',
+    ],
+    // A `do` body runs before its condition is ever asked, so this reset
+    // certainly happened and the earlier value is gone.
+    [
+      "an owned property reset in a do-while body",
+      'let style: Record<string, string> = { borderBottomColor: "red" };\ndo {\n  style = {};\n} while (false);\n<TabsTrigger style={style} />',
+    ],
+    // A `var` is hoisted but its INITIALIZER runs where it is written, so an
+    // element evaluated above it receives `undefined`.
+    [
+      "an owned property in a var initializer written below the element",
+      '<TabsTrigger style={style} />;\nvar style = { borderBottomColor: "red" };',
+    ],
   ])("does not report %s", (_label, body) => {
     // The complement, and the reason this is a contract rather than a ban. A
     // check that flags a documented example or a legitimate layout class gets
@@ -3277,10 +3479,30 @@ describe("which files the call-site scan reads", () => {
       mkdirSync(join(dir, "build"));
       writeFileSync(join(dir, "build", "page.js"), "");
 
+      // `dist` is the same shape and was pruned by name anyway. Both spellings
+      // are here because they fail apart: this one has no `package.json`
+      // beside it, so it is a route rather than build output.
+      mkdirSync(join(dir, "dist"));
+      writeFileSync(join(dir, "dist", "page.js"), "");
+
+      // The same name WITH a manifest beside it is a package's build output,
+      // and stays pruned. Without this the fix reads as "never prune dist",
+      // which would walk every built package in the repository.
+      mkdirSync(join(dir, "pkg"));
+      writeFileSync(join(dir, "pkg", "package.json"), "{}");
+      mkdirSync(join(dir, "pkg", "dist"));
+      writeFileSync(join(dir, "pkg", "dist", "bundle.js"), "");
+
       const found = sourceFiles(dir).map(path => path.slice(dir.length + 1));
 
       expect(found.sort()).toEqual(
-        ["a.tsx", "b.jsx", "d.js", join("build", "page.js")].sort()
+        [
+          "a.tsx",
+          "b.jsx",
+          "d.js",
+          join("build", "page.js"),
+          join("dist", "page.js"),
+        ].sort()
       );
     } finally {
       rmSync(dir, { recursive: true, force: true });

--- a/packages/ui/src/components/__tests__/tabs-contract.test.ts
+++ b/packages/ui/src/components/__tests__/tabs-contract.test.ts
@@ -1454,6 +1454,42 @@ function exportedTagOf(
  * covered. A bare identifier contributes nothing, which is the documented hole
  * rather than a silent one.
  */
+/**
+ * The operand a LITERAL condition selects, when the condition decides it.
+ *
+ * `undefined` when the condition is not written as a literal, which means both
+ * operands stay in play — anything depending on state can be taken.
+ *
+ * One implementation for both halves of the contract. The class side resolved
+ * these and the style side did not, so `true ? {} : { borderBottomColor: "red" }`
+ * was reported for a branch the condition can never reach, while the same
+ * condition around a class was correctly ignored.
+ */
+function selectedByLiteralCondition(
+  node: ts.Expression
+): ts.Expression | undefined {
+  if (ts.isConditionalExpression(node)) {
+    if (node.condition.kind === ts.SyntaxKind.TrueKeyword) return node.whenTrue;
+    if (node.condition.kind === ts.SyntaxKind.FalseKeyword) {
+      return node.whenFalse;
+    }
+    return undefined;
+  }
+  if (!ts.isBinaryExpression(node)) return undefined;
+  const left = node.left.kind;
+  // The operand each operator YIELDS, not merely the one it evaluates: `false &&
+  // x` is the value `false`, which names no class and is no style object.
+  if (node.operatorToken.kind === ts.SyntaxKind.AmpersandAmpersandToken) {
+    if (left === ts.SyntaxKind.FalseKeyword) return node.left;
+    if (left === ts.SyntaxKind.TrueKeyword) return node.right;
+  }
+  if (node.operatorToken.kind === ts.SyntaxKind.BarBarToken) {
+    if (left === ts.SyntaxKind.TrueKeyword) return node.left;
+    if (left === ts.SyntaxKind.FalseKeyword) return node.right;
+  }
+  return undefined;
+}
+
 function literalStrings(node: ts.Node, found: string[] = []): string[] {
   if (ts.isStringLiteral(node) || ts.isNoSubstitutionTemplateLiteral(node)) {
     found.push(node.text);
@@ -1468,30 +1504,10 @@ function literalStrings(node: ts.Node, found: string[] = []): string[] {
   // A branch that can never be taken contributes no class. `cn("w-full", false &&
   // "border-b-0")` is the ordinary conditional-class form, and `cn` never
   // receives the second string — collecting it reported a call site for a class
-  // it does not apply. Only literal conditions are decided here; anything whose
-  // value depends on state stays collected, because it can be taken.
-  if (
-    ts.isBinaryExpression(node) &&
-    node.operatorToken.kind === ts.SyntaxKind.AmpersandAmpersandToken &&
-    node.left.kind === ts.SyntaxKind.FalseKeyword
-  ) {
-    return found;
-  }
-  if (
-    ts.isBinaryExpression(node) &&
-    node.operatorToken.kind === ts.SyntaxKind.BarBarToken &&
-    node.left.kind === ts.SyntaxKind.TrueKeyword
-  ) {
-    literalStrings(node.left, found);
-    return found;
-  }
-  if (ts.isConditionalExpression(node)) {
-    if (node.condition.kind === ts.SyntaxKind.TrueKeyword) {
-      return literalStrings(node.whenTrue, found);
-    }
-    if (node.condition.kind === ts.SyntaxKind.FalseKeyword) {
-      return literalStrings(node.whenFalse, found);
-    }
+  // it does not apply.
+  if (ts.isExpression(node)) {
+    const selected = selectedByLiteralCondition(node);
+    if (selected) return literalStrings(selected, found);
   }
   // The braces matter. `ts.forEachChild` stops at the first callback that
   // returns something truthy, so a concise arrow returning the accumulator
@@ -1514,7 +1530,10 @@ function literalStrings(node: ts.Node, found: string[] = []): string[] {
  * in the other order, invents one. Which declaration a name refers to is a
  * lexical question, and the answer is the nearest enclosing one.
  */
-function styleResolver(checker: ts.TypeChecker): {
+function styleResolver(
+  checker: ts.TypeChecker,
+  element: ts.JsxAttribute
+): {
   objectsFrom(
     expression: ts.Expression | undefined,
     seen?: Set<ts.Node>
@@ -1561,22 +1580,46 @@ function styleResolver(checker: ts.TypeChecker): {
   };
 
   /**
-   * Every value assigned to a binding anywhere in the file.
+   * The function whose body a node runs in, or undefined at the top level.
+   *
+   * What it separates is EXECUTION UNITS. Two nodes in the same one run in
+   * source order; two in different ones do not, because calling a function is
+   * what decides when its body runs and the call can appear anywhere.
+   */
+  const executionUnitOf = (node: ts.Node): ts.Node | undefined => {
+    for (let at = node.parent; at; at = at.parent) {
+      if (ts.isFunctionLike(at)) return at;
+    }
+    return undefined;
+  };
+
+  /**
+   * Every value assigned to a binding that the element could actually see.
    *
    * A declaration initializer is only the FIRST value a mutable binding holds:
    * `let style = {}; style = { borderBottomColor: "red" }` renders the second
    * one, and reading the declaration alone reported nothing at all. Matched by
    * DECLARATION identity rather than by name, so a same-named binding in
    * another scope contributes nothing and the whole file can be searched.
+   *
+   * Ordering is what stops that search over-reaching. An assignment sharing the
+   * element's execution unit runs in source order, so one written AFTER the
+   * element cannot have reached it — React already holds the earlier value, and
+   * collecting the later one reported an element for a style it never received.
+   * Across different units the order is not decidable and the write is kept,
+   * which is the reporting side and therefore the safe one.
    */
   const assignedValues = (declaration: ts.Declaration): ts.Expression[] => {
+    const elementUnit = executionUnitOf(element);
     const values: ts.Expression[] = [];
     const visit = (node: ts.Node): void => {
       if (
         ts.isBinaryExpression(node) &&
         node.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
         ts.isIdentifier(node.left) &&
-        declarationOf(node.left, checker) === declaration
+        declarationOf(node.left, checker) === declaration &&
+        (executionUnitOf(node) !== elementUnit ||
+          node.getStart() < element.getStart())
       ) {
         values.push(node.right);
       }
@@ -1615,6 +1658,12 @@ function styleResolver(checker: ts.TypeChecker): {
       if (ts.isAsExpression(node) || ts.isSatisfiesExpression(node)) {
         return walk(node.expression);
       }
+      // A literal condition decides the branch, and the branch it excludes is
+      // one React never receives. Asked through the same helper the class half
+      // uses, so one spelling of "this cannot be taken" cannot be resolved on
+      // one side of the contract and reported on the other.
+      const selected = selectedByLiteralCondition(node);
+      if (selected) return walk(selected);
       if (ts.isConditionalExpression(node)) {
         walk(node.whenTrue);
         walk(node.whenFalse);
@@ -1681,7 +1730,7 @@ function styleObjectsFor(
   objects: ts.ObjectLiteralExpression[];
   resolver: ReturnType<typeof styleResolver>;
 } {
-  const resolver = styleResolver(checker);
+  const resolver = styleResolver(checker, attribute);
   const initializer = attribute.initializer;
   if (!initializer || !ts.isJsxExpression(initializer)) {
     return { objects: [], resolver };
@@ -1778,6 +1827,13 @@ function staticKeyOf(
  * `undefined` is a NAME, not a keyword, so a local declaration of it is a
  * colour like any other. It counts as nothing only when it resolves to no
  * declaration in this file, which is what the global one does.
+ *
+ * The empty string is React's own spelling of absence, not an assumption made
+ * here: `renderToStaticMarkup(<div style={{ borderBottomColor: "" }} />)`
+ * emits no `style` attribute at all, while the same property with a colour
+ * emits `border-bottom-color:red`. Clearing a style with `""` is an ordinary
+ * conditional form, so reporting it rejected the idiom the check exists to
+ * permit.
  */
 function isDefinitelyNothing(
   initializer: ts.Expression,
@@ -1786,6 +1842,9 @@ function isDefinitelyNothing(
   const value = withoutTypeWrappers(initializer);
   if (ts.isIdentifier(value)) {
     return value.text === "undefined" && !resolver.declarationOf(value);
+  }
+  if (ts.isStringLiteral(value) || ts.isNoSubstitutionTemplateLiteral(value)) {
+    return value.text === "";
   }
   if (value.kind === ts.SyntaxKind.NullKeyword) return true;
   // `void 0` is the other spelling of the same intent.
@@ -2727,6 +2786,28 @@ describe("the tab indicator contract", () => {
       "border-image longhands with no source to draw",
       '<TabsTrigger style={{ borderImageRepeat: "round", borderImageSlice: "30", borderImageWidth: "4px", borderImageOutset: "2px" }} />',
     ],
+    // An assignment the element cannot have seen. React already received the
+    // empty object; collecting every write in the file regardless of where it
+    // sits reported the element for a value assigned after it.
+    [
+      "a style binding assigned an owned property after the element",
+      'let style = {};\n<TabsTrigger style={style} />;\nstyle = { borderBottomColor: "red" };',
+    ],
+    // React emits no declaration for an empty string, verified with
+    // `renderToStaticMarkup`: `{ borderBottomColor: "" }` renders no `style`
+    // attribute at all. Clearing a style with `""` is an ordinary conditional
+    // spelling, so reporting it rejects the idiom the check exists to permit.
+    [
+      "an owned property cleared with an empty string",
+      '<TabsTrigger style={{ borderBottomColor: "" }} />',
+    ],
+    // A branch the condition can never take. The class half already resolves
+    // literal conditions, so reading both branches of a style prop held the two
+    // halves of one contract to different standards.
+    [
+      "an owned property in a statically unreachable branch",
+      '<TabsTrigger style={true ? {} : { borderBottomColor: "red" }} />',
+    ],
   ])("does not report %s", (_label, body) => {
     // The complement, and the reason this is a contract rather than a ban. A
     // check that flags a documented example or a legitimate layout class gets
@@ -2920,10 +3001,32 @@ describe("which files the call-site scan reads", () => {
       false
     );
 
-    // Every file the scan reads has to trigger a rerun, because every one of
-    // them can gain a violation this suite would otherwise keep reporting
-    // clean. Named individually: the list is only ever wrong for a whole tree
-    // at a time, and a bare count says nothing about which.
+    // Every root-and-extension pair the scan CAN read, whether or not the
+    // repository currently holds such a file.
+    //
+    // Checking only the files that exist today is an assertion satisfied by
+    // absence: there is no `.jsx` call site anywhere under a scan root, so
+    // removing `jsx` from every trigger left this case green while the next
+    // `.jsx` file added would change without rerunning the suite. The pairs are
+    // derived from the same two lists the traversal uses, so a root or an
+    // extension added there arrives here on its own.
+    //
+    // Both depths, because they fail differently: a `**/src/**` trigger covers
+    // the nested one and silently misses a file directly under the root.
+    const probes = SCAN_ROOT_NAMES.flatMap(root =>
+      CALL_SITE_EXTENSIONS.flatMap(extension => [
+        resolve(REPO, root, `probe-package/src/nested/probe${extension}`),
+        resolve(REPO, root, `probe-package/probe${extension}`),
+      ])
+    );
+    const unwatchedProbes = probes
+      .filter(path => !isMatch(path, triggers))
+      .map(path => path.replace(`${REPO}/`, ""));
+    expect(unwatchedProbes).toEqual([]);
+
+    // And every file the scan actually reads, which covers shapes no synthetic
+    // path anticipates. Named individually: the list is only ever wrong for a
+    // whole tree at a time, and a bare count says nothing about which.
     const unwatched = scanned().filter(file => !isMatch(file, triggers));
     expect(unwatched).toEqual([]);
   });

--- a/packages/ui/turbo.json
+++ b/packages/ui/turbo.json
@@ -50,6 +50,13 @@
         "$TURBO_ROOT$/templates/**",
         "$TURBO_ROOT$/packages/**/*.tsx",
         "$TURBO_ROOT$/apps/**/*.tsx",
+        // `.jsx` for the same reason as `.tsx`, and it is the extension the
+        // scan reads rather than the one this repo happens to use today:
+        // `create-nextly-app` scaffolds JavaScript projects, so a call site can
+        // arrive in a `.jsx` file. An input the hash does not cover is a file
+        // that can change behind a cached pass.
+        "$TURBO_ROOT$/packages/**/*.jsx",
+        "$TURBO_ROOT$/apps/**/*.jsx",
         // The RSC-matrix suite reads the root manifest and the package-smoke
         // workflow, comparing the job's Node legs against `engines.node`. Listed
         // here rather than on the root task: there they become inputs to every
@@ -77,6 +84,13 @@
         "$TURBO_ROOT$/templates/**",
         "$TURBO_ROOT$/packages/**/*.tsx",
         "$TURBO_ROOT$/apps/**/*.tsx",
+        // `.jsx` for the same reason as `.tsx`, and it is the extension the
+        // scan reads rather than the one this repo happens to use today:
+        // `create-nextly-app` scaffolds JavaScript projects, so a call site can
+        // arrive in a `.jsx` file. An input the hash does not cover is a file
+        // that can change behind a cached pass.
+        "$TURBO_ROOT$/packages/**/*.jsx",
+        "$TURBO_ROOT$/apps/**/*.jsx",
         // The RSC-matrix suite reads the root manifest and the package-smoke
         // workflow, comparing the job's Node legs against `engines.node`. Listed
         // here rather than on the root task: there they become inputs to every

--- a/packages/ui/turbo.json
+++ b/packages/ui/turbo.json
@@ -57,6 +57,8 @@
         // that can change behind a cached pass.
         "$TURBO_ROOT$/packages/**/*.jsx",
         "$TURBO_ROOT$/apps/**/*.jsx",
+        "$TURBO_ROOT$/packages/**/*.js",
+        "$TURBO_ROOT$/apps/**/*.js",
         // The RSC-matrix suite reads the root manifest and the package-smoke
         // workflow, comparing the job's Node legs against `engines.node`. Listed
         // here rather than on the root task: there they become inputs to every
@@ -91,6 +93,8 @@
         // that can change behind a cached pass.
         "$TURBO_ROOT$/packages/**/*.jsx",
         "$TURBO_ROOT$/apps/**/*.jsx",
+        "$TURBO_ROOT$/packages/**/*.js",
+        "$TURBO_ROOT$/apps/**/*.js",
         // The RSC-matrix suite reads the root manifest and the package-smoke
         // workflow, comparing the job's Node legs against `engines.node`. Listed
         // here rather than on the root task: there they become inputs to every

--- a/packages/ui/vitest.config.ts
+++ b/packages/ui/vitest.config.ts
@@ -18,6 +18,17 @@ export default defineConfig({
       // `src/components/__tests__/tabs-contract.test.ts`, which asserts this
       // list covers it.
       "**/src/**/*.{ts,tsx,js,jsx}",
+      // And every ROOT that scan walks, not only this package. The glob above
+      // is relative to `packages/ui`, so a call site in `packages/admin`,
+      // `apps/playground` or a template changed nothing in watch mode — the
+      // suite that reports on those files never reran.
+      //
+      // Kept in step with `CALL_SITE_ROOT_GLOBS` in
+      // `src/components/__tests__/tabs-contract.test.ts`, which asserts this
+      // list covers every root-and-extension pair the scan reads.
+      "../*/src/**/*.{ts,tsx,js,jsx}",
+      "../../apps/*/src/**/*.{ts,tsx,js,jsx}",
+      "../../templates/**/*.{ts,tsx,js,jsx}",
       "**/src/**/*.css",
       // The declaration build runs through both tsup configs, and a child
       // process loads them — they are in no module graph Vitest can invalidate,

--- a/packages/ui/vitest.config.ts
+++ b/packages/ui/vitest.config.ts
@@ -28,8 +28,8 @@ export default defineConfig({
       // Kept in step with `CALL_SITE_ROOT_GLOBS` in
       // `src/components/__tests__/tabs-contract.test.ts`, which asserts this
       // list covers every root-and-extension pair the scan reads.
-      "../*/**/*.{ts,tsx,js,jsx}",
-      "../../apps/*/**/*.{ts,tsx,js,jsx}",
+      "../**/*.{ts,tsx,js,jsx}",
+      "../../apps/**/*.{ts,tsx,js,jsx}",
       "../../templates/**/*.{ts,tsx,js,jsx}",
       "**/src/**/*.css",
       // The declaration build runs through both tsup configs, and a child

--- a/packages/ui/vitest.config.ts
+++ b/packages/ui/vitest.config.ts
@@ -2,6 +2,18 @@ import { fileURLToPath } from "node:url";
 import { defineConfig } from "vitest/config";
 
 /**
+ * The directories the tab-contract scan walks.
+ *
+ * Real paths, not globs, because these are handed to the WATCHER. chokidar
+ * removed glob support in v4, so `watcher.add("<root>/packages/**")` subscribes
+ * to a literal path of that name — which does not exist — and no event is ever
+ * emitted for anything beneath it.
+ */
+const SCAN_ROOTS = ["packages", "apps", "templates"].map(root =>
+  fileURLToPath(new URL(`../../${root}`, import.meta.url)).replace(/\\/g, "/")
+);
+
+/**
  * The repository root, as an absolute path with forward slashes.
  *
  * Vitest matches a rerun trigger against the path its watcher emits, which is
@@ -20,6 +32,22 @@ const REPO_ROOT = fileURLToPath(new URL("../..", import.meta.url)).replace(
 );
 
 export default defineConfig({
+  plugins: [
+    {
+      name: "watch-the-scanned-roots",
+      // Two different mechanisms have to agree before a watch session reruns:
+      // the watcher must EMIT an event for the file, and `forceRerunTriggers`
+      // must MATCH the path it emits. The triggers below only ever answered the
+      // second question. Vitest's server is rooted at this package, so nothing
+      // outside it was watched at all and the matcher was never consulted for
+      // the call sites this suite exists to read — measured with a real
+      // `vitest --watch` session, where touching a `packages/admin` file
+      // produced no rerun while touching one in `packages/ui` did.
+      configureServer(server) {
+        for (const root of SCAN_ROOTS) server.watcher.add(root);
+      },
+    },
+  ],
   test: {
     // The suites read `theme.css` and the package sources through the
     // filesystem rather than importing them, so Vitest has no module

--- a/packages/ui/vitest.config.ts
+++ b/packages/ui/vitest.config.ts
@@ -1,4 +1,23 @@
+import { fileURLToPath } from "node:url";
 import { defineConfig } from "vitest/config";
+
+/**
+ * The repository root, as an absolute path with forward slashes.
+ *
+ * Vitest matches a rerun trigger against the path its watcher emits, which is
+ * ABSOLUTE, so a relative glob cannot match one however it is spelled: measured
+ * against the picomatch Vitest resolves, `../**` + `/*.tsx` against
+ * `<root>/packages/admin/src/ApiKeyTable.tsx` is false. A glob beginning `**` +
+ * `/` matches an absolute path because the leading `**` absorbs the prefix,
+ * which is why the `src`-scoped triggers below work and hid this for the roots.
+ *
+ * Backslashes are replaced because picomatch treats one as an escape rather
+ * than a separator, so a Windows path would match nothing.
+ */
+const REPO_ROOT = fileURLToPath(new URL("../..", import.meta.url)).replace(
+  /\\/g,
+  "/"
+);
 
 export default defineConfig({
   test: {
@@ -25,12 +44,13 @@ export default defineConfig({
       // suite never rerunning. The scan's reach is what these have to match,
       // not the convention most files happen to follow.
       //
-      // Kept in step with `CALL_SITE_ROOT_GLOBS` in
-      // `src/components/__tests__/tabs-contract.test.ts`, which asserts this
-      // list covers every root-and-extension pair the scan reads.
-      "../**/*.{ts,tsx,js,jsx}",
-      "../../apps/**/*.{ts,tsx,js,jsx}",
-      "../../templates/**/*.{ts,tsx,js,jsx}",
+      // Absolute for the reason given above. The contract in
+      // `src/components/__tests__/tabs-contract.test.ts` runs every file the
+      // scan actually reads through the matcher Vitest uses, so a glob that
+      // matches nothing fails there rather than passing as a string.
+      `${REPO_ROOT}packages/**/*.{ts,tsx,js,jsx}`,
+      `${REPO_ROOT}apps/**/*.{ts,tsx,js,jsx}`,
+      `${REPO_ROOT}templates/**/*.{ts,tsx,js,jsx}`,
       "**/src/**/*.css",
       // The declaration build runs through both tsup configs, and a child
       // process loads them — they are in no module graph Vitest can invalidate,

--- a/packages/ui/vitest.config.ts
+++ b/packages/ui/vitest.config.ts
@@ -10,7 +10,14 @@ export default defineConfig({
       "**/package.json/**",
       "**/vitest.config.*/**",
       "**/vite.config.*/**",
-      "**/src/**/*.{ts,tsx}",
+      // Every extension the tab-contract scan reads, not only the TypeScript
+      // ones. That scan walks the repository with `readFileSync`, so a `.js` or
+      // `.jsx` call site is in no module graph Vitest can invalidate — without
+      // this a watch session keeps showing the previous green after a real
+      // violation is added. Kept in step with `CALL_SITE_EXTENSIONS` in
+      // `src/components/__tests__/tabs-contract.test.ts`, which asserts this
+      // list covers it.
+      "**/src/**/*.{ts,tsx,js,jsx}",
       "**/src/**/*.css",
       // The declaration build runs through both tsup configs, and a child
       // process loads them — they are in no module graph Vitest can invalidate,

--- a/packages/ui/vitest.config.ts
+++ b/packages/ui/vitest.config.ts
@@ -18,16 +18,18 @@ export default defineConfig({
       // `src/components/__tests__/tabs-contract.test.ts`, which asserts this
       // list covers it.
       "**/src/**/*.{ts,tsx,js,jsx}",
-      // And every ROOT that scan walks, not only this package. The glob above
-      // is relative to `packages/ui`, so a call site in `packages/admin`,
-      // `apps/playground` or a template changed nothing in watch mode — the
-      // suite that reports on those files never reran.
+      // And every ROOT that scan walks, not only this package, and the WHOLE
+      // of each root rather than its `src`. The traversal recurses from the
+      // root, so `packages/foo/examples/demo.jsx` is a call site it reads — and
+      // a `src`-only trigger left that file able to gain a violation with the
+      // suite never rerunning. The scan's reach is what these have to match,
+      // not the convention most files happen to follow.
       //
       // Kept in step with `CALL_SITE_ROOT_GLOBS` in
       // `src/components/__tests__/tabs-contract.test.ts`, which asserts this
       // list covers every root-and-extension pair the scan reads.
-      "../*/src/**/*.{ts,tsx,js,jsx}",
-      "../../apps/*/src/**/*.{ts,tsx,js,jsx}",
+      "../*/**/*.{ts,tsx,js,jsx}",
+      "../../apps/*/**/*.{ts,tsx,js,jsx}",
       "../../templates/**/*.{ts,tsx,js,jsx}",
       "**/src/**/*.css",
       // The declaration build runs through both tsup configs, and a child


### PR DESCRIPTION
Follow-up to #721, working its open review findings. Four of five here; the remaining one is described at the bottom rather than left silent.

## A whole file type was invisible to the scan

The call-site traversal read `.tsx` and nothing else. A `.jsx` file writing `border-b-0` on a `TabsTrigger` passed the repository-wide contract in silence.

What makes this worth more than a one-character fix is why it survived: the suite already has a control that counts how many files were scanned, and **that control passed** — the `.tsx` files it counts were all still there. A count-based guard cannot see an extension it never named. The number is right and the coverage is not.

JSX is a supported source form here; `create-nextly-app` scaffolds JavaScript projects, so a call site can arrive in a `.jsx` or `.js` file even though the repo has none today (verified, not assumed).

**Corrected after review, and the correction matters more than the original fix.** The first version of this PR read `.tsx` and `.jsx` only, and its control explicitly certified `.js` as unable to hold an element. That is false — a JavaScript Next.js app puts JSX in `.js` routinely, so a first-party `page.js` importing `TabsTrigger` stayed invisible while a test asserted the invisibility was correct. A test that ratifies a gap is worse than no test, because it answers the question and closes it. `.js` is now scanned.

That version also *claimed* the extension list was "named once and read by both the traversal and the Turbo inputs". It was not: the globs were repeated by hand in two task input lists, and `turbo.json` is static JSON that cannot import a constant. The claim lived only in a comment.

There is now a contract test that reads `turbo.json` and asserts **both** the `test` and `test:coverage` input lists carry a glob for every extension in `CALL_SITE_EXTENSIONS`, naming the offending task and extension when it fails. An extension the scan reads but the hash does not cover is a file that can change behind a cached green, and a cached pass is indistinguishable from a real one.

**How it is pinned.** A temp directory holding `a.tsx b.jsx c.ts d.js e.css` must yield exactly `a.tsx`, `b.jsx`, `d.js`. Removing an extension from the list turns that red; removing a glob from either Turbo task turns the contract red.

One honest limit, stated because it would otherwise read as stronger than it is: the second case (`violationsIn("probe.jsx", …)`) names the file directly rather than going through the traversal, so it proves the parser handles JSX — not that the scan finds it. The temp-directory case is the discriminating one.

## The idiomatic spelling of an optional style was reported

`style={{ borderBottomColor: undefined as string | undefined }}` was reported as repainting the indicator. It paints nothing: `as`, `satisfies`, `!` and parentheses are all erased before the code runs, so React receives exactly `undefined` and emits no declaration.

The check read the outer node, saw an `AsExpression`, concluded it was not written as nothing, and reported a call site that does nothing at all. A false positive is the worse direction here — `undefined as string | undefined` is the ordinary way to write an optional style in a typed codebase, so the check was rejecting the idiomatic spelling of the very thing it exists to permit.

Unwrapping now happens in one helper that both `isDefinitelyNothing` and `emitsValue` go through, so a binding lookup sees `(colour as string)` the same way it sees a bare `colour`.

**How it is pinned.** Seven spellings now. The first four — `as`, `satisfies`, parentheses, and an assertion around a parenthesised nothing — did not reach two of the branches I had added: the non-null path, and the unwrapping in front of the *binding* lookup. Both were untested code, and review named the exact mutations that would survive. Added `undefined!`, a bound nothing behind an assertion, and a bound nothing behind a non-null assertion; deleting `ts.isNonNullExpression` fails two cases, and replacing `withoutTypeWrappers(value)` with `value` fails two others.

## A computed key built from a constant was walked past

`const key = "borderBottomColor"; style={{ [key]: "red" }}` returned clean. React emits exactly the declaration the literal spelling emits, so the call site repaints the indicator and the check said nothing — only a literal *inside* a computed name was recognised.

Computed keys now resolve through the same resolver the values use, so a key and a value declared side by side are read the same way, and wrappers are peeled first: `[key as string]` resolves like a bare `key`. Anything genuinely undecidable — a template with substitutions, a call, a member access — stays unnamed rather than guessed.

**How it is pinned.** Three cases: the plain constant, the constant behind an assertion, and a *getter* whose name is a computed constant. Removing the binding lookup fails all three.

## A border image repainted the underline without naming it

`[border-image:linear-gradient(red,red)_1]` returned clean. A border image replaces what the border *draws*, on every edge it covers — including the underline on every tab, active and inactive alike — and it names neither an edge nor an aspect, so the shorthand split never matched it and it stood for itself. `border-image` intersects no `border-bottom-*` property, so the check saw nothing.

The shorthand and all five longhands now expand to the bottom border's aspects. `border-image-source` alone is enough to replace the drawn border, so the longhands are not a lesser case.

**How it is pinned.** Three cases: the Tailwind arbitrary property, the inline shorthand, and a bare `borderImageSource`. Removing the expansion fails all three.

## Deliberately not in this PR

One finding from #721 remains open, and I would rather name it than let this read as the whole set:

- **Equivalent property restatements.** `aria-[controls]:outline-none` is byte-identical to the primitive's focused declaration, so `disagree()` rejects the comparison — while still being a second copy of owned appearance.

It interacts with the cascade-modelling narrowing and needs a decision rather than a patch: it argues against a `disagree()` restriction that now has a proven red input, so closing it one way weakens a guard that earns its place.

## On that narrowing, since it was the original plan for this PR

I measured every piece of the round-12 cascade modelling by stubbing it: `outranks` has 3 tests that go red without it, `disagree` has 1, `specificityOf` has 1 — and `emittedAfter` has **none**. Every test that reaches the source-order tiebreak expects it to return `true`, so nothing separates it from a constant.

I tried to close that gap rather than cut the code, and could not. The tiebreak needs a caller emitted before *every* owned rule sharing the property, and the primitive's border-colour rules span both an early variant (`hover:`) and a late one (`data-[state=inactive]:`), so a candidate that ties with one outranks the other. I also confirmed the obvious escape hatch does not apply: tailwind-merge displacement and the cascade path never overlap, because classes sharing a merge group share variants, and the variant-subset test is already vacuously true there.

So nothing is cut in this PR. I did not want to manufacture a removal just because one was authorised.

## Verification

`packages/ui`: 36 files, 952 tests, all passing. `check-types` clean. Every fix carries a control that was run in both directions — the fix reverted, the intended test red for the intended reason, then restored.
