### PR TITLE
fix(ui): point the dev watchers at src, and require a rebuild in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -542,19 +542,12 @@ jobs:
           pnpm dev > /tmp/dev.log 2>&1 &
           dev_pid=$!
 
-          # Wait for both watchers to ANNOUNCE they are watching, not for their artifacts to
-          # appear. tsup writes `dist` before it arms its file watcher, so an edit made in that
-          # gap is never seen and the rebuild below cannot happen — the artifact is present and
-          # the watcher is not yet listening, which is precisely the state a one-shot build is
-          # also in. Each config prints this line once, so two occurrences means both are armed.
-          #
-          # `|| true` rather than `|| echo 0`: grep PRINTS 0 and exits 1 when it matches nothing,
-          # so a fallback that echoes as well makes the substitution "0\n0" and the numeric
-          # comparison never succeeds. The empty default then covers the file not existing yet,
-          # where grep prints nothing at all.
+          # Wait for the artifacts to exist, which is only enough to take a baseline from. It is
+          # NOT evidence that anything is watching: tsup writes `dist` before it arms its file
+          # watcher, so an edit made in this gap is absorbed by chokidar's initial scan and never
+          # reported. The probe below is what establishes readiness.
           for _ in $(seq 1 120); do
-            armed=$(grep -c 'Watching for changes' /tmp/dev.log 2>/dev/null || true)
-            if [ "${armed:-0}" -ge 2 ]; then break; fi
+            if [ -f dist/index.mjs ] && [ -f dist/color.mjs ]; then break; fi
             sleep 1
           done
 
@@ -579,12 +572,24 @@ jobs:
           # detect one in either direction.
           before_client=$(cksum dist/index.mjs | awk '{print $1"-"$2}')
           before_server=$(cksum dist/color.mjs | awk '{print $1"-"$2}')
-          printf '\nexport const __clientWatcherProbe = "probe";\n' >> src/index.ts
-          printf '\nexport const __serverWatcherProbe = "probe";\n' >> src/lib/color/index.ts
 
+          # The edit is REPEATED until a rebuild is seen, rather than made once against a signal
+          # that claims the watcher is ready. tsup logs "Watching for changes" before it expands
+          # the watch path and constructs chokidar, so that line is a proxy: on a slow runner both
+          # configs can log it while neither is listening, and a single edit made then is swallowed
+          # by the initial scan. Retrying removes the proxy — the first rebuild IS the readiness
+          # signal, and nothing has to be assumed about when it arrives.
+          #
+          # Each probe carries the attempt number so repeated appends stay distinct declarations
+          # rather than a redeclaration error that would fail the build for the wrong reason.
           client_rebuilt=no
           server_rebuilt=no
-          for _ in $(seq 1 90); do
+          for i in $(seq 1 45); do
+            [ "$client_rebuilt" = "no" ] &&
+              printf '\nexport const __clientWatcherProbe%s = "probe";\n' "$i" >> src/index.ts
+            [ "$server_rebuilt" = "no" ] &&
+              printf '\nexport const __serverWatcherProbe%s = "probe";\n' "$i" >> src/lib/color/index.ts
+            sleep 2
             if [ "$(cksum dist/index.mjs | awk '{print $1"-"$2}')" != "$before_client" ]; then
               client_rebuilt=yes
             fi
@@ -592,7 +597,6 @@ jobs:
               server_rebuilt=yes
             fi
             if [ "$client_rebuilt" = "yes" ] && [ "$server_rebuilt" = "yes" ]; then break; fi
-            sleep 1
           done
 
           # Liveness AFTER the rebuild, which is a different question from liveness before it: a

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -553,27 +553,34 @@ jobs:
           missing=""
           [ -f dist/index.mjs ] || missing="$missing client(dist/index.mjs)"
           [ -f dist/color.mjs ] || missing="$missing server-safe(dist/color.mjs)"
-          # Still running when the artifacts appear, checked BEFORE the kill.
+          # Producing the artifacts is not the claim. tsup writes them before its declaration
+          # phase, so a pair of ONE-SHOT builds is still alive when they appear and would pass any
+          # check made at this moment. What separates a watcher from a one-shot build is that it
+          # REBUILDS, so a source is edited and the artifact it produces is required to change.
           #
-          # Stated plainly, because it is weaker than it looks: this does NOT separate a watcher
-          # from a one-shot build. tsup writes these files before its declaration phase, so a pair
-          # of one-shot builds is still alive at this moment too.
-          #
-          # The check that WOULD separate them is editing a source and requiring a rebuild. It is
-          # not here because `tsup --watch` in this package does not currently rebuild at all — it
-          # logs `Change detected` and emits nothing, measured on one watcher and on two, and on
-          # the shell script this replaced. That is a real defect and it is filed separately; a
-          # control that fails for a reason this pull request does not cause would only teach
-          # people to ignore it.
-          alive=yes
-          kill -0 "$dev_pid" 2>/dev/null || alive=no
+          # An added export rather than a comment: tsup strips comments, so a comment-only edit
+          # leaves the output byte-identical whether or not a rebuild ran, and the probe could not
+          # detect one in either direction.
+          before=$(cksum dist/color.mjs | awk '{print $1"-"$2}')
+          printf '\nexport const __watcherProbe = "probe";\n' >> src/lib/color/index.ts
+
+          rebuilt=no
+          for _ in $(seq 1 60); do
+            if [ "$(cksum dist/color.mjs | awk '{print $1"-"$2}')" != "$before" ]; then
+              rebuilt=yes
+              break
+            fi
+            sleep 1
+          done
+
+          git checkout -- src/lib/color/index.ts
           kill "$dev_pid" 2>/dev/null || true
 
-          if [ -n "$missing" ] || [ "$alive" = "no" ]; then
-            [ -n "$missing" ] && echo "The dev script did not produce output for:$missing"
-            [ "$alive" = "no" ] && echo "The dev script exited before its outputs were complete."
+          if [ "$rebuilt" = "no" ]; then
+            echo "Editing a source did not change the artifact it produces, so that command built"
+            echo "once rather than watching."
             echo "--- dev script output ---"
             cat /tmp/dev.log
             exit 1
           fi
-          echo "Both commands produced their output and the script was still running."
+          echo "Both commands produced their output, and an edit triggered a rebuild."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -542,45 +542,71 @@ jobs:
           pnpm dev > /tmp/dev.log 2>&1 &
           dev_pid=$!
 
-          # One artifact per watcher: `index.mjs` is the client config's, and
-          # `color.mjs` belongs to the server-safe config — the one the broken
-          # script never reached.
+          # Wait for both watchers to ANNOUNCE they are watching, not for their artifacts to
+          # appear. tsup writes `dist` before it arms its file watcher, so an edit made in that
+          # gap is never seen and the rebuild below cannot happen — the artifact is present and
+          # the watcher is not yet listening, which is precisely the state a one-shot build is
+          # also in. Each config prints this line once, so two occurrences means both are armed.
+          #
+          # `|| true` rather than `|| echo 0`: grep PRINTS 0 and exits 1 when it matches nothing,
+          # so a fallback that echoes as well makes the substitution "0\n0" and the numeric
+          # comparison never succeeds. The empty default then covers the file not existing yet,
+          # where grep prints nothing at all.
           for _ in $(seq 1 120); do
-            if [ -f dist/index.mjs ] && [ -f dist/color.mjs ]; then break; fi
+            armed=$(grep -c 'Watching for changes' /tmp/dev.log 2>/dev/null || true)
+            if [ "${armed:-0}" -ge 2 ]; then break; fi
             sleep 1
           done
 
+          # One artifact per watcher: `index.mjs` is the client config's, and
+          # `color.mjs` belongs to the server-safe config — the one the broken
+          # script never reached.
           missing=""
           [ -f dist/index.mjs ] || missing="$missing client(dist/index.mjs)"
           [ -f dist/color.mjs ] || missing="$missing server-safe(dist/color.mjs)"
-          # Producing the artifacts is not the claim. tsup writes them before its declaration
-          # phase, so a pair of ONE-SHOT builds is still alive when they appear and would pass any
-          # check made at this moment. What separates a watcher from a one-shot build is that it
-          # REBUILDS, so a source is edited and the artifact it produces is required to change.
+
+          # Producing the artifacts is not the claim. What separates a watcher from a one-shot
+          # build is that it REBUILDS, so a source is edited and the artifact it produces is
+          # required to change.
+          #
+          # BOTH configs are probed through a source only they own. Editing the server-safe entry
+          # alone would leave the client watcher's argument uncovered: the root barrel re-exports
+          # colour, so that edit rebuilds `index.mjs` as a side effect and a client command
+          # regressed to a one-shot build would still be reported as watching.
           #
           # An added export rather than a comment: tsup strips comments, so a comment-only edit
           # leaves the output byte-identical whether or not a rebuild ran, and the probe could not
           # detect one in either direction.
-          before=$(cksum dist/color.mjs | awk '{print $1"-"$2}')
-          printf '\nexport const __watcherProbe = "probe";\n' >> src/lib/color/index.ts
+          before_client=$(cksum dist/index.mjs | awk '{print $1"-"$2}')
+          before_server=$(cksum dist/color.mjs | awk '{print $1"-"$2}')
+          printf '\nexport const __clientWatcherProbe = "probe";\n' >> src/index.ts
+          printf '\nexport const __serverWatcherProbe = "probe";\n' >> src/lib/color/index.ts
 
-          rebuilt=no
-          for _ in $(seq 1 60); do
-            if [ "$(cksum dist/color.mjs | awk '{print $1"-"$2}')" != "$before" ]; then
-              rebuilt=yes
-              break
+          client_rebuilt=no
+          server_rebuilt=no
+          for _ in $(seq 1 90); do
+            if [ "$(cksum dist/index.mjs | awk '{print $1"-"$2}')" != "$before_client" ]; then
+              client_rebuilt=yes
             fi
+            if [ "$(cksum dist/color.mjs | awk '{print $1"-"$2}')" != "$before_server" ]; then
+              server_rebuilt=yes
+            fi
+            if [ "$client_rebuilt" = "yes" ] && [ "$server_rebuilt" = "yes" ]; then break; fi
             sleep 1
           done
 
-          git checkout -- src/lib/color/index.ts
+          git checkout -- src/index.ts src/lib/color/index.ts
           kill "$dev_pid" 2>/dev/null || true
 
-          if [ "$rebuilt" = "no" ]; then
-            echo "Editing a source did not change the artifact it produces, so that command built"
-            echo "once rather than watching."
+          # A missing artifact fails here too. Without it, a watcher that produced nothing at all
+          # leaves its `before` checksum empty, every later read differs from it, and absence
+          # reports itself as a successful rebuild.
+          if [ -n "$missing" ] || [ "$client_rebuilt" = "no" ] || [ "$server_rebuilt" = "no" ]; then
+            [ -n "$missing" ] && echo "No artifact from:$missing"
+            [ "$client_rebuilt" = "no" ] && echo "Editing src/index.ts did not change dist/index.mjs, so the client command built once rather than watching."
+            [ "$server_rebuilt" = "no" ] && echo "Editing src/lib/color/index.ts did not change dist/color.mjs, so the server-safe command built once rather than watching."
             echo "--- dev script output ---"
             cat /tmp/dev.log
             exit 1
           fi
-          echo "Both commands produced their output, and an edit triggered a rebuild."
+          echo "Both commands produced their output, and an edit rebuilt each one."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -595,14 +595,23 @@ jobs:
             sleep 1
           done
 
+          # Liveness AFTER the rebuild, which is a different question from liveness before it: a
+          # watcher that serves one change and then dies leaves contributors editing against
+          # artifacts that stopped updating, and every check above has already passed by then.
+          # The `kill` below is unconditional and succeeds either way, so this has to be asked
+          # first or the answer is lost.
+          alive=yes
+          kill -0 "$dev_pid" 2>/dev/null || alive=no
+
           git checkout -- src/index.ts src/lib/color/index.ts
           kill "$dev_pid" 2>/dev/null || true
 
           # A missing artifact fails here too. Without it, a watcher that produced nothing at all
           # leaves its `before` checksum empty, every later read differs from it, and absence
           # reports itself as a successful rebuild.
-          if [ -n "$missing" ] || [ "$client_rebuilt" = "no" ] || [ "$server_rebuilt" = "no" ]; then
+          if [ -n "$missing" ] || [ "$client_rebuilt" = "no" ] || [ "$server_rebuilt" = "no" ] || [ "$alive" = "no" ]; then
             [ -n "$missing" ] && echo "No artifact from:$missing"
+            [ "$alive" = "no" ] && echo "The dev script exited after rebuilding, so its artifacts stop updating from here."
             [ "$client_rebuilt" = "no" ] && echo "Editing src/index.ts did not change dist/index.mjs, so the client command built once rather than watching."
             [ "$server_rebuilt" = "no" ] && echo "Editing src/lib/color/index.ts did not change dist/color.mjs, so the server-safe command built once rather than watching."
             echo "--- dev script output ---"

--- a/packages/ui/scripts/dev.mjs
+++ b/packages/ui/scripts/dev.mjs
@@ -66,11 +66,22 @@ function tsupEntry() {
  * Named so a failure says which output stopped being rebuilt. "the server-safe watcher exited" is
  * actionable in a way that a bare exit code is not.
  */
+/**
+ * `--watch src`, not a bare `--watch`.
+ *
+ * tsup's default watch root is the package directory, and from there it notices nothing: measured
+ * on this package, an edit to `src/lib/color/index.ts` produced no rebuild and the artifact was
+ * byte-identical 25 seconds later. Pointing the root at `src` makes the same edit rebuild.
+ *
+ * The failure it removes is silent, which is why the argument is worth a comment: the watcher
+ * prints `Watching for changes in "."` and keeps running, so a contributor has positive evidence
+ * that it works while consuming a `dist` that stopped changing.
+ */
 const WATCHERS = [
-  { label: "client", args: ["--watch"] },
+  { label: "client", args: ["--watch", "src"] },
   {
     label: "server-safe",
-    args: ["--config", "tsup.server-safe.config.ts", "--watch"],
+    args: ["--config", "tsup.server-safe.config.ts", "--watch", "src"],
   },
 ];
 


### PR DESCRIPTION
The dev loop for `packages/ui` has not existed. `tsup --watch` defaults its watch root to the package directory, and from there it sees nothing.

## The fix is one argument

```diff
-{ label: "client", args: ["--watch"] },
+{ label: "client", args: ["--watch", "src"] },
```

Measured on this package, back to back, same probe:

```
--config tsup.server-safe.config.ts --watch        rebuilt=no   detected=0
--config tsup.server-safe.config.ts --watch src    rebuilt=yes  detected=2
```

Found by the builder-shell lane on `packages/builder`; **verified here independently** rather than inherited. The two packages showed *different* symptoms from one cause — `ui` logged `Change detected` and never rebuilt, `builder` never detected at all.

## Why it was expensive to find

The failure is silent and self-certifying. The watcher prints `Watching for changes in "."` and keeps running, so a contributor has **positive evidence it works** while consuming a `dist` that stopped changing. Anything they then debug is code that was never rebuilt.

## The CI assertion is now viable, so it is back

#750 deliberately left this out and said so inline: the rebuild check failed for a cause #750 did not create, and a control that is permanently red teaches people to ignore it. **This is that cause.**

The smoke job now asserts the property that actually distinguishes a watcher from a one-shot build. Artifacts appearing does not — tsup writes them before its declaration phase, so a pair of one-shot builds produces exactly those files and is still alive when they appear.

**Verified in both directions:**

| | rebuilt |
| --- | --- |
| with `--watch src` | **yes** |
| without it | **no** |

An added export rather than a comment, because tsup strips comments — a comment-only probe leaves the output byte-identical whether or not a rebuild ran, and cannot detect one in either direction. That mistake cost me a wrong conclusion earlier today.

## Notes

- **No changeset**: `scripts/` does not ship (`files` is `["dist","docs"]`) and this changes no published behaviour. The CI job is CI-only.
- `packages/builder` has its own fix from the builder-shell lane on `fix/hook-tsup-watch-root`.
- Task note renamed to `2026-08-13-1600-tsup-watch-root-defaults-to-the-package-dir-and-sees-nothing.md` — the old title named only one of the two symptoms, so someone hitting the other would not have found it.