### PR TITLE
fix(admin): show a disabled plugin's permissions, which stay granted

### DIFF
--- a/.changeset/disabled-plugin-permissions.md
+++ b/.changeset/disabled-plugin-permissions.md
@@ -1,0 +1,31 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+Show a disabled plugin's permissions on its detail page. They are seeded and
+granted whatever the plugin's enabled state, so withholding them made the page
+disagree with the database. Routes stay withheld — those genuinely are not
+mounted — and are disclosed separately as pending.

--- a/packages/admin/src/pages/dashboard/plugins/[slug].tsx
+++ b/packages/admin/src/pages/dashboard/plugins/[slug].tsx
@@ -449,9 +449,15 @@ function Contributions({ plugin }: { plugin: PluginMetadata }) {
         What this plugin adds
       </h2>
       {!enabled && (
+        // Names which parts survive being disabled and which do not, because
+        // this section now lists both. Permissions are seeded and granted for
+        // every plugin, disabled included, so calling them inactive here would
+        // contradict the roles UI that still offers them.
         <p className="mb-3 text-xs text-muted-foreground">
-          This plugin is disabled: its collections and data are retained, but
-          its behavior does not load.
+          This plugin is disabled: its collections, data and permissions are
+          retained — its permissions stay granted, though what they protect is
+          not loaded — while its behavior, including its API routes, does not
+          run.
         </p>
       )}
       {/* Auto-fitting tracks rather than a breakpoint. These cards sit inside

--- a/packages/admin/src/pages/dashboard/plugins/[slug].tsx
+++ b/packages/admin/src/pages/dashboard/plugins/[slug].tsx
@@ -453,11 +453,18 @@ function Contributions({ plugin }: { plugin: PluginMetadata }) {
         // this section now lists both. Permissions are seeded and granted for
         // every plugin, disabled included, so calling them inactive here would
         // contradict the roles UI that still offers them.
+        //
+        // The surfaces named as stopped are the ones the payload itself gates
+        // on the enabled flag — routes, menu, pages and settings. It does not
+        // say a grant is inert: a permission is a global slug, any component
+        // may test it through the SDK's `useCan`, and a disabled plugin keeps
+        // its field editors mounted for collections that already use them.
         <p className="mb-3 text-xs text-muted-foreground">
           This plugin is disabled: its collections, data and permissions are
-          retained — its permissions stay granted, though what they protect is
-          not loaded — while its behavior, including its API routes, does not
-          run.
+          retained, and its permissions stay granted. Its API routes, admin
+          pages, menu items and settings panel are not registered — though the
+          field editors it contributes stay available to collections that use
+          them.
         </p>
       )}
       {/* Auto-fitting tracks rather than a breakpoint. These cards sit inside

--- a/packages/admin/src/pages/dashboard/plugins/plugin-detail.test.tsx
+++ b/packages/admin/src/pages/dashboard/plugins/plugin-detail.test.tsx
@@ -45,6 +45,14 @@ const plugins: PluginMetadata[] = [
     enabled: false,
     placement: "plugins",
     collections: ["retained"],
+    permissions: [
+      {
+        action: "purge",
+        resource: "archive",
+        label: "Purge Archive",
+        danger: true,
+      },
+    ],
     whenEnabled: {
       routes: [
         {
@@ -161,7 +169,11 @@ describe("PluginDetailPage", () => {
   it("marks a disabled plugin and explains that its behavior does not load", () => {
     render(<PluginDetailPage params={{ slug: "acme-disabled" }} />);
     expect(screen.getByText("Disabled")).toBeInTheDocument();
-    expect(screen.getByText(/its behavior does not load/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /its behavior, including its API routes, does not\s+run/i
+      )
+    ).toBeInTheDocument();
   });
 
   /**
@@ -240,5 +252,44 @@ describe("PluginDetailPage dormant disclosure", () => {
     expect(
       screen.getByText("GET /admin/api/plugins/@acme/forms/submissions/export")
     ).toBeInTheDocument();
+  });
+});
+
+/**
+ * A disabled plugin's permissions are seeded and granted like any other's, so
+ * the page must show them. Its routes are not mounted, so those must not be
+ * shown as current. These pin both halves of that split on one plugin.
+ */
+describe("PluginDetailPage disabled plugin permissions", () => {
+  it("lists a disabled plugin's permissions as things it has", () => {
+    render(<PluginDetailPage params={{ slug: "acme-disabled" }} />);
+
+    const contributions = screen
+      .getByText("What this plugin adds")
+      .closest("section");
+    expect(
+      within(contributions!).getByText("Purge Archive")
+    ).toBeInTheDocument();
+  });
+
+  /**
+   * The separating assertion. If the enabled flag simply stopped mattering,
+   * routes would show here too — they must not, because they are not mounted.
+   */
+  it("still withholds a disabled plugin's routes from that section", () => {
+    render(<PluginDetailPage params={{ slug: "acme-disabled" }} />);
+
+    const contributions = screen
+      .getByText("What this plugin adds")
+      .closest("section");
+    expect(within(contributions!).queryByText("API routes")).toBeNull();
+    // They are disclosed as pending instead, not dropped.
+    expect(screen.getByText("Would serve when enabled")).toBeInTheDocument();
+  });
+
+  it("says the permissions stay granted while the plugin is off", () => {
+    render(<PluginDetailPage params={{ slug: "acme-disabled" }} />);
+
+    expect(screen.getByText(/permissions stay granted/i)).toBeInTheDocument();
   });
 });

--- a/packages/admin/src/pages/dashboard/plugins/plugin-detail.test.tsx
+++ b/packages/admin/src/pages/dashboard/plugins/plugin-detail.test.tsx
@@ -166,12 +166,12 @@ describe("PluginDetailPage", () => {
     expect(screen.getByText("@acme/core ^1.0.0")).toBeInTheDocument();
   });
 
-  it("marks a disabled plugin and explains that its behavior does not load", () => {
+  it("marks a disabled plugin and names the surfaces that stop", () => {
     render(<PluginDetailPage params={{ slug: "acme-disabled" }} />);
     expect(screen.getByText("Disabled")).toBeInTheDocument();
     expect(
       screen.getByText(
-        /its behavior, including its API routes, does not\s+run/i
+        /API routes, admin\s+pages, menu items and settings panel are not registered/i
       )
     ).toBeInTheDocument();
   });
@@ -291,5 +291,21 @@ describe("PluginDetailPage disabled plugin permissions", () => {
     render(<PluginDetailPage params={{ slug: "acme-disabled" }} />);
 
     expect(screen.getByText(/permissions stay granted/i)).toBeInTheDocument();
+  });
+
+  /**
+   * A permission is a global slug that any component may test through the
+   * SDK's `useCan`, and a disabled plugin keeps its field editors mounted, so
+   * a grant is not inert just because the plugin is off. The retained-editor
+   * sentence is the positive half: it makes the narrower claim observable, so
+   * this cannot pass by the whole paragraph having gone missing.
+   */
+  it("does not claim everything the permissions protect is unloaded", () => {
+    render(<PluginDetailPage params={{ slug: "acme-disabled" }} />);
+
+    expect(
+      screen.getByText(/field editors it contributes stay available/i)
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/what they protect is not loaded/i)).toBeNull();
   });
 });

--- a/packages/nextly/src/di/__tests__/boot-plugins-published-on-success.test.ts
+++ b/packages/nextly/src/di/__tests__/boot-plugins-published-on-success.test.ts
@@ -12,10 +12,10 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { PluginDefinition } from "../../plugins/plugin-context";
 
-const setHandlerPlugins = vi.fn();
+const setBootedConfig = vi.fn();
 
 vi.mock("../../route-handler/auth-handler", () => ({
-  setHandlerPlugins: (plugins: unknown) => setHandlerPlugins(plugins),
+  setBootedConfig: (config: unknown) => setBootedConfig(config),
 }));
 
 const { registerServices } = await import("../register");
@@ -48,6 +48,6 @@ describe("publishing the booted plugin list", () => {
       } as unknown as Parameters<typeof registerServices>[0])
     ).rejects.toThrow();
 
-    expect(setHandlerPlugins).not.toHaveBeenCalled();
+    expect(setBootedConfig).not.toHaveBeenCalled();
   });
 });

--- a/packages/nextly/src/di/register.ts
+++ b/packages/nextly/src/di/register.ts
@@ -129,7 +129,7 @@ import {
 } from "../plugins/services/plugin-services-registry";
 import { clearPluginSubscriptions } from "../plugins/subscription-tracker";
 import { validatePluginSlugs } from "../plugins/validate-slugs";
-import { setHandlerPlugins } from "../route-handler/auth-handler";
+import { setBootedConfig } from "../route-handler/auth-handler";
 import type {
   CollectionSource,
   FieldDefinition,
@@ -1116,7 +1116,16 @@ export async function registerServices(
   //
   // Unconditional: a config whose transformers removed every plugin must clear
   // the store rather than leave the author's raw list standing there.
-  setHandlerPlugins(transformedConfig.plugins);
+  setBootedConfig({
+    plugins: transformedConfig.plugins,
+    // The entity slugs too, because a `setup` transformer may ADD a top-level
+    // collection or single — and the permission fold decides whether a
+    // `publish` declaration names an entity, so folding against the raw route
+    // config would report a declaration on a transformer-added entity as a
+    // plugin-owned custom permission that boot drops.
+    collections: transformedConfig.collections,
+    singles: transformedConfig.singles,
+  });
 }
 
 // ============================================================

--- a/packages/nextly/src/di/register.ts
+++ b/packages/nextly/src/di/register.ts
@@ -1116,16 +1116,12 @@ export async function registerServices(
   //
   // Unconditional: a config whose transformers removed every plugin must clear
   // the store rather than leave the author's raw list standing there.
-  setBootedConfig({
-    plugins: transformedConfig.plugins,
-    // The entity slugs too, because a `setup` transformer may ADD a top-level
-    // collection or single — and the permission fold decides whether a
-    // `publish` declaration names an entity, so folding against the raw route
-    // config would report a declaration on a transformer-added entity as a
-    // plugin-owned custom permission that boot drops.
-    collections: transformedConfig.collections,
-    singles: transformedConfig.singles,
-  });
+  // The WHOLE transformed config, not a hand-picked field list. A `setup`
+  // transformer may add a top-level collection or single as well as change the
+  // plugin list, and the permission fold decides whether a `publish`
+  // declaration names an entity — so anything left out here silently leaves the
+  // endpoint folding against the raw route config for that field.
+  setBootedConfig(transformedConfig);
 }
 
 // ============================================================

--- a/packages/nextly/src/domains/auth/services/seed-system-permissions.integration.test.ts
+++ b/packages/nextly/src/domains/auth/services/seed-system-permissions.integration.test.ts
@@ -195,6 +195,7 @@ describe("a plugin declaring a permission on a Builder entity", () => {
       slug: `${overrides.action}-${overrides.resource}`,
       name: `${overrides.action} ${overrides.resource}`,
       owner: "some-plugin",
+      source: "plugin",
       group: "Plugin",
       danger: false,
       ...overrides,

--- a/packages/nextly/src/init/__tests__/seed-permissions.test.ts
+++ b/packages/nextly/src/init/__tests__/seed-permissions.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Both boot paths seed through one function, so what it seeds is what every
+ * boot leaves behind. The request-path boot used to carry its own shorter copy
+ * that never reached the custom permissions, which is the case these assertions
+ * are here to hold.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const seedSystemPermissions = vi.fn();
+const seedAllCollectionPermissions = vi.fn();
+const seedAllSinglePermissions = vi.fn();
+const seedCustomPermissions = vi.fn();
+const markOrphanedPermissions = vi.fn();
+const assignNewPermissionsToSuperAdmin = vi.fn();
+
+const config: Record<string, unknown> = {};
+
+vi.mock("../../di/register", () => ({
+  getService: (name: string) =>
+    name === "config"
+      ? config
+      : {
+          seedSystemPermissions,
+          seedAllCollectionPermissions,
+          seedAllSinglePermissions,
+          seedCustomPermissions,
+          markOrphanedPermissions,
+          assignNewPermissionsToSuperAdmin,
+        },
+}));
+
+const { seedAllPermissions } = await import("../seed-permissions");
+
+const exportSubmissions = {
+  action: "export",
+  resource: "submissions",
+} as const;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  seedSystemPermissions.mockResolvedValue({ newPermissionIds: ["sys-1"] });
+  seedAllCollectionPermissions.mockResolvedValue({ newPermissionIds: [] });
+  seedAllSinglePermissions.mockResolvedValue({ newPermissionIds: [] });
+  seedCustomPermissions.mockResolvedValue({ newPermissionIds: [] });
+  config.collections = undefined;
+  config.plugins = undefined;
+});
+
+describe("seedAllPermissions", () => {
+  it("seeds the permissions a plugin declares", async () => {
+    config.plugins = [
+      {
+        name: "@acme/p",
+        version: "1.0.0",
+        contributes: { permissions: [exportSubmissions] },
+      },
+    ];
+
+    await seedAllPermissions();
+
+    expect(seedCustomPermissions).toHaveBeenCalledTimes(1);
+    expect(seedCustomPermissions.mock.calls[0][0]).toEqual([
+      expect.objectContaining({
+        action: "export",
+        resource: "submissions",
+        owner: "@acme/p",
+      }),
+    ]);
+  });
+
+  /**
+   * Marking reads attribution off the rows, so it has to run against the list
+   * that was just seeded rather than a separately collected one — a second walk
+   * over the declarations is a second chance for them to disagree.
+   */
+  it("marks orphans against the same list it seeded", async () => {
+    config.plugins = [
+      {
+        name: "@acme/p",
+        version: "1.0.0",
+        contributes: { permissions: [exportSubmissions] },
+      },
+    ];
+
+    await seedAllPermissions();
+
+    expect(markOrphanedPermissions).toHaveBeenCalledWith(
+      seedCustomPermissions.mock.calls[0][0]
+    );
+  });
+
+  /**
+   * A new custom permission is worthless without the grant: super_admin is the
+   * only role seeding assigns to, so a row created without this is one nobody
+   * holds. The positive control is `sys-1`, which the system seeder reported —
+   * its presence shows the grant call is reached at all, so the assertion is
+   * about the custom id specifically rather than about the call happening.
+   */
+  it("grants a newly seeded custom permission to super_admin", async () => {
+    seedCustomPermissions.mockResolvedValue({ newPermissionIds: ["custom-1"] });
+
+    await seedAllPermissions();
+
+    expect(assignNewPermissionsToSuperAdmin).toHaveBeenCalledWith([
+      "sys-1",
+      "custom-1",
+    ]);
+  });
+
+  /** Nothing new means nothing to grant, rather than an empty grant call. */
+  it("does not grant when no permission was created", async () => {
+    seedSystemPermissions.mockResolvedValue({ newPermissionIds: [] });
+
+    await seedAllPermissions();
+
+    expect(assignNewPermissionsToSuperAdmin).not.toHaveBeenCalled();
+  });
+});

--- a/packages/nextly/src/init/post-init-tasks.ts
+++ b/packages/nextly/src/init/post-init-tasks.ts
@@ -14,9 +14,10 @@ import {
 } from "../database/repair-sqlite-timestamps";
 import { seedRolePresets } from "../database/seeders/role-presets";
 import { getService } from "../di/register";
-import { collectCustomPermissions } from "../plugins/permissions/collect-permissions";
 import { collectRoles } from "../plugins/roles/collect-roles";
 import { seedPluginRoles } from "../plugins/roles/seed-roles";
+
+import { seedAllPermissions } from "./seed-permissions";
 
 /**
  * Run idempotent post-initialization tasks after services are registered.
@@ -85,34 +86,7 @@ export async function runPostInitTasks(): Promise<void> {
   // plus all system resource permissions and plugin-declared custom permissions
   // (D36). New permissions are auto-assigned to super_admin.
   try {
-    const permissionSeedService = getService("permissionSeedService");
-    const systemResult = await permissionSeedService.seedSystemPermissions();
-    const collectionResult =
-      await permissionSeedService.seedAllCollectionPermissions();
-    const singleResult = await permissionSeedService.seedAllSinglePermissions();
-
-    const config = getService("config");
-    const declared = collectCustomPermissions(config, config.plugins ?? []);
-    const customResult =
-      await permissionSeedService.seedCustomPermissions(declared);
-
-    // Seeding only ever adds. A permission whose package has stopped declaring
-    // it keeps the attribution it had, which is read to decide whether it is a
-    // plugin's — so a declaration that goes away quietly changes what the
-    // presets grant. Marked here, against the same list that was just seeded;
-    // grants are untouched and nothing is deleted.
-    await permissionSeedService.markOrphanedPermissions(declared);
-
-    const allNewIds = [
-      ...systemResult.newPermissionIds,
-      ...collectionResult.newPermissionIds,
-      ...singleResult.newPermissionIds,
-      ...customResult.newPermissionIds,
-    ];
-
-    if (allNewIds.length > 0) {
-      await permissionSeedService.assignNewPermissionsToSuperAdmin(allNewIds);
-    }
+    await seedAllPermissions();
   } catch {
     // Silently skip — permissions table may not exist yet (migrations not run),
     // or permissionSeedService may not be registered

--- a/packages/nextly/src/init/seed-permissions.ts
+++ b/packages/nextly/src/init/seed-permissions.ts
@@ -1,0 +1,60 @@
+/**
+ * The permission seeding every boot performs, in one place.
+ *
+ * Nextly has two boot paths that both have to leave the same rows behind: the
+ * instrumentation boot, which runs post-init tasks explicitly, and the lazy
+ * request-path boot in `createDynamicHandlers`, which registers services on the
+ * first request. They were separate implementations, and the request path was
+ * the shorter one — it seeded system, collection and single permissions but
+ * never the plugin-declared custom ones, so an app that cold-booted only
+ * through the route handler had no row and no super-admin grant for a
+ * permission the admin was already describing.
+ *
+ * @module init/seed-permissions
+ */
+
+import { getService } from "../di/register";
+import { collectCustomPermissions } from "../plugins/permissions/collect-permissions";
+
+/**
+ * Seed system, collection, single and plugin-declared permissions, then grant
+ * whatever is new to super_admin.
+ *
+ * Idempotent, and safe to run on every startup: each seeder matches existing
+ * rows rather than inserting blindly, and only the ids it reports as new are
+ * granted.
+ *
+ * Throws nothing of its own — callers boot regardless of whether the
+ * permissions table exists yet — but deliberately does not catch, so the two
+ * boot paths keep their own logging.
+ */
+export async function seedAllPermissions(): Promise<void> {
+  const permissionSeedService = getService("permissionSeedService");
+  const systemResult = await permissionSeedService.seedSystemPermissions();
+  const collectionResult =
+    await permissionSeedService.seedAllCollectionPermissions();
+  const singleResult = await permissionSeedService.seedAllSinglePermissions();
+
+  const config = getService("config");
+  const declared = collectCustomPermissions(config, config.plugins ?? []);
+  const customResult =
+    await permissionSeedService.seedCustomPermissions(declared);
+
+  // Seeding only ever adds. A permission whose package has stopped declaring
+  // it keeps the attribution it had, which is read to decide whether it is a
+  // plugin's — so a declaration that goes away quietly changes what the
+  // presets grant. Marked here, against the same list that was just seeded;
+  // grants are untouched and nothing is deleted.
+  await permissionSeedService.markOrphanedPermissions(declared);
+
+  const allNewIds = [
+    ...systemResult.newPermissionIds,
+    ...collectionResult.newPermissionIds,
+    ...singleResult.newPermissionIds,
+    ...customResult.newPermissionIds,
+  ];
+
+  if (allNewIds.length > 0) {
+    await permissionSeedService.assignNewPermissionsToSuperAdmin(allNewIds);
+  }
+}

--- a/packages/nextly/src/plugins/admin-meta.test.ts
+++ b/packages/nextly/src/plugins/admin-meta.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 
+import type { CollectedPermission } from "./permissions/collect-permissions";
 import type { PluginDefinition } from "./plugin-context";
 
 import { NEXTLY_ERROR_STATUS } from "../errors/error-codes";
@@ -15,6 +16,26 @@ const base = {
 
 function asPlugins(defs: unknown[]): PluginDefinition[] {
   return defs as PluginDefinition[];
+}
+
+/**
+ * One entry of the collected set, as `collectCustomPermissions` produces it.
+ * Defaults to a plugin-owned permission belonging to `base`, since that is what
+ * most cases here are about.
+ */
+function collectedPermission(
+  overrides: Partial<CollectedPermission> &
+    Pick<CollectedPermission, "action" | "resource">
+): CollectedPermission {
+  return {
+    slug: `${overrides.action}-${overrides.resource}`,
+    name: `${overrides.action} ${overrides.resource}`,
+    owner: base.name,
+    source: "plugin",
+    group: "General",
+    danger: false,
+    ...overrides,
+  };
 }
 
 describe("buildPluginAdminMeta", () => {
@@ -36,7 +57,7 @@ describe("buildPluginAdminMeta", () => {
         },
       ]),
       undefined,
-      {}
+      []
     );
     expect(meta[0].fieldTypes?.[0]).toMatchObject({
       type: "page-builder",
@@ -67,7 +88,7 @@ describe("buildPluginAdminMeta", () => {
         },
       ]),
       undefined,
-      {}
+      []
     );
     expect(meta[0].fieldTypes?.[0]).toEqual({
       type: "rating",
@@ -94,7 +115,7 @@ describe("buildPluginAdminMeta", () => {
         },
       ]),
       undefined,
-      {}
+      []
     );
     expect(meta[0].fieldTypes?.[0]).toEqual({
       type: "rating",
@@ -114,7 +135,7 @@ describe("buildPluginAdminMeta", () => {
         },
       ]),
       undefined,
-      {}
+      []
     );
     expect(enabled[0].schemaBuilderSlot).toBe("@acme/p/admin#Toggle");
 
@@ -127,7 +148,7 @@ describe("buildPluginAdminMeta", () => {
         },
       ]),
       undefined,
-      {}
+      []
     );
     expect(disabled[0].schemaBuilderSlot).toBeUndefined();
   });
@@ -141,7 +162,7 @@ describe("buildPluginAdminMeta", () => {
         },
       ]),
       undefined,
-      {}
+      []
     );
     expect(enabled[0].entryFormToolbarSlot).toBe("@acme/p/admin#Bar");
 
@@ -154,7 +175,7 @@ describe("buildPluginAdminMeta", () => {
         },
       ]),
       undefined,
-      {}
+      []
     );
     expect(disabled[0].entryFormToolbarSlot).toBeUndefined();
   });
@@ -187,7 +208,7 @@ describe("buildPluginAdminMeta", () => {
         },
       ]),
       undefined,
-      {}
+      []
     );
 
     expect(meta[0].menu).toEqual([
@@ -227,7 +248,7 @@ describe("buildPluginAdminMeta", () => {
         },
       ]),
       undefined,
-      {}
+      []
     );
     expect(meta[0].headerSlot).toBe("@acme/p/admin#HeaderBadge");
     expect(meta[0].widgets?.[0]).toMatchObject({
@@ -255,7 +276,7 @@ describe("buildPluginAdminMeta", () => {
         },
       ]),
       undefined,
-      {}
+      []
     );
     expect(meta[0].header).toEqual({
       slot: "@acme/p/admin#Publish",
@@ -275,7 +296,7 @@ describe("buildPluginAdminMeta", () => {
         },
       ]),
       undefined,
-      {}
+      []
     );
     expect(meta[0].header?.slot).toBe("@acme/p/admin#Badge");
     expect(meta[0].headerSlot).toBe("@acme/p/admin#Badge");
@@ -295,7 +316,7 @@ describe("buildPluginAdminMeta", () => {
         },
       ]),
       undefined,
-      {}
+      []
     );
     expect(meta[0].header).toBeUndefined();
     expect(meta[0].headerSlot).toBeUndefined();
@@ -316,7 +337,7 @@ describe("buildPluginAdminMeta", () => {
         },
       ]),
       undefined,
-      {}
+      []
     );
     expect(meta[0].headerSlot).toBeUndefined();
     expect(meta[0].widgets).toBeUndefined();
@@ -329,7 +350,7 @@ describe("buildPluginAdminMeta", () => {
     const enabled = buildPluginAdminMeta(
       asPlugins([{ ...base, contributes: { fieldTypes } }]),
       undefined,
-      {}
+      []
     );
     expect(enabled[0].fieldTypes).toEqual([
       { type: "rating", component: "@acme/p/admin#Rating", storage: "number" },
@@ -340,7 +361,7 @@ describe("buildPluginAdminMeta", () => {
     const disabled = buildPluginAdminMeta(
       asPlugins([{ ...base, enabled: false, contributes: { fieldTypes } }]),
       undefined,
-      {}
+      []
     );
     expect(disabled[0].fieldTypes).toEqual([
       { type: "rating", component: "@acme/p/admin#Rating", storage: "number" },
@@ -359,7 +380,7 @@ describe("buildPluginAdminMeta", () => {
         },
       ]),
       undefined,
-      {}
+      []
     );
     // The plugin entry still exists (its schema still applies), but its
     // behavioral admin UI (menu/pages/settings) is skipped per D49.
@@ -383,7 +404,7 @@ describe("buildPluginAdminMeta", () => {
         },
       ]),
       { "acme-p": { order: 5, appearance: { badge: "Beta" } } },
-      {}
+      []
     );
 
     expect(meta[0].placement).toBe("users");
@@ -397,7 +418,7 @@ describe("buildPluginAdminMeta", () => {
   });
 
   it("defaults placement to 'plugins' and has no admin keys when none declared", () => {
-    const meta = buildPluginAdminMeta(asPlugins([{ ...base }]), undefined, {});
+    const meta = buildPluginAdminMeta(asPlugins([{ ...base }]), undefined, []);
     expect(meta[0].placement).toBe("plugins");
     expect(meta[0].menu).toBeUndefined();
     expect(meta[0].pages).toBeUndefined();
@@ -419,7 +440,7 @@ describe("buildPluginAdminMeta", () => {
         },
       ]),
       undefined,
-      {}
+      []
     );
     expect(meta[0]).toMatchObject({
       author: "Acme Inc.",
@@ -438,20 +459,20 @@ describe("buildPluginAdminMeta", () => {
         { ...base, enabled: false, author: "Acme Inc.", license: "MIT" },
       ]),
       undefined,
-      {}
+      []
     );
     expect(meta[0].author).toBe("Acme Inc.");
     expect(meta[0].license).toBe("MIT");
   });
 
   it("serializes the enabled state explicitly", () => {
-    const on = buildPluginAdminMeta(asPlugins([{ ...base }]), undefined, {});
+    const on = buildPluginAdminMeta(asPlugins([{ ...base }]), undefined, []);
     expect(on[0].enabled).toBe(true);
 
     const off = buildPluginAdminMeta(
       asPlugins([{ ...base, enabled: false }]),
       undefined,
-      {}
+      []
     );
     expect(off[0].enabled).toBe(false);
   });
@@ -460,7 +481,7 @@ describe("buildPluginAdminMeta", () => {
     const meta = buildPluginAdminMeta(
       asPlugins([{ ...base, dependsOn: { "@acme/core": "^1.2.0" } }]),
       undefined,
-      {}
+      []
     );
     expect(meta[0].dependsOn).toEqual({ "@acme/core": "^1.2.0" });
   });
@@ -482,10 +503,18 @@ describe("buildPluginAdminMeta", () => {
         },
       ],
     };
+    const collected = [
+      collectedPermission({
+        action: "export",
+        resource: "submissions",
+        name: "Export submissions",
+        danger: true,
+      }),
+    ];
     const enabled = buildPluginAdminMeta(
       asPlugins([{ ...base, contributes }]),
       undefined,
-      {}
+      collected
     );
     expect(enabled[0].permissions).toEqual([
       {
@@ -499,7 +528,7 @@ describe("buildPluginAdminMeta", () => {
     const disabled = buildPluginAdminMeta(
       asPlugins([{ ...base, enabled: false, contributes }]),
       undefined,
-      {}
+      collected
     );
     // Identical to the enabled case. The separating assertion for the split is
     // below: routes DO disappear when disabled, so this is not simply "the
@@ -509,17 +538,18 @@ describe("buildPluginAdminMeta", () => {
   });
 
   /**
-   * A `publish` declaration whose resource is a configured collection is one
-   * the seeder now owns: the permission fold drops it and the row it creates
-   * carries no owner. Reading the declaration instead would put this plugin's
-   * label and danger flag on a permission the roles data does not attribute to
-   * it, and the page would explain a grant that is not the plugin's to explain.
+   * The separating property for taking the collected set rather than
+   * recomputing one. `collectCustomPermissions` DROPS a `publish` declaration
+   * whose resource is a configured collection, because the seeder emits that
+   * slug itself and keeps the row ownerless — so the collected set here holds
+   * only `export`, while the plugin's own `contributes.permissions` still holds
+   * both. Serializing the declaration would put this plugin's label and danger
+   * flag on a permission the roles data does not attribute to it.
    *
-   * The positive control is in the same call. `export` is a genuine custom
-   * permission and survives, so the assertion cannot pass by the whole list
-   * having been dropped.
+   * `export` is the positive control: it is present in both, so the assertion
+   * cannot pass by the whole list having been dropped.
    */
-  it("omits a declaration the seeder owns, keeping the plugin's own", () => {
+  it("serializes the collected set, not the plugin's own declaration", () => {
     const meta = buildPluginAdminMeta(
       asPlugins([
         {
@@ -533,18 +563,39 @@ describe("buildPluginAdminMeta", () => {
         },
       ]),
       undefined,
-      { collections: [{ slug: "posts" }] }
+      [collectedPermission({ action: "export", resource: "submissions" })]
     );
 
     expect(meta[0].permissions).toEqual([
-      // Named from the action and resource, because this declaration carried no
-      // label — the same name the seeded row gets.
       {
         action: "export",
         resource: "submissions",
-        label: "Export Submissions",
+        label: "export submissions",
       },
     ]);
+  });
+
+  /**
+   * The host's sentinel owner is the literal string `"app"`, so a plugin
+   * legitimately named `app` shares it. Grouping by `owner` alone would file
+   * every host-declared permission under that plugin and report the
+   * application's own permissions as the plugin's contributions.
+   */
+  it("does not attribute host-declared permissions to a plugin named app", () => {
+    const meta = buildPluginAdminMeta(
+      asPlugins([{ ...base, name: "app" }]),
+      undefined,
+      [
+        collectedPermission({
+          action: "purge",
+          resource: "cache",
+          owner: "app",
+          source: "app",
+        }),
+      ]
+    );
+
+    expect(meta[0].permissions).toBeUndefined();
   });
 
   it("summarizes declared routes (method + path only) for enabled plugins only", () => {
@@ -561,7 +612,7 @@ describe("buildPluginAdminMeta", () => {
     const enabled = buildPluginAdminMeta(
       asPlugins([{ ...base, contributes }]),
       undefined,
-      {}
+      []
     );
     // `fullPath` travels too: it is the namespace the dispatcher mounts the
     // route at, derived from the raw package name, and the admin renders it
@@ -577,7 +628,7 @@ describe("buildPluginAdminMeta", () => {
     const disabled = buildPluginAdminMeta(
       asPlugins([{ ...base, enabled: false, contributes }]),
       undefined,
-      {}
+      []
     );
     expect(disabled[0].routes).toBeUndefined();
   });
@@ -595,7 +646,7 @@ describe("buildPluginAdminMeta", () => {
         },
       ]),
       undefined,
-      {}
+      []
     );
     expect(meta[0].collections).toEqual(["forms"]);
     expect(meta[0].singles).toEqual(["form-settings"]);
@@ -616,7 +667,7 @@ describe("buildPluginAdminMeta — clientConfig", () => {
         remotePatterns: [{ protocol: "https", hostname: "a.example" }],
       }),
       undefined,
-      {}
+      []
     );
     expect(meta[0]?.clientConfig).toEqual({
       remotePatterns: [{ protocol: "https", hostname: "a.example" }],
@@ -640,7 +691,7 @@ describe("buildPluginAdminMeta — clientConfig", () => {
         },
       ]),
       undefined,
-      {}
+      []
     );
     expect(meta[0]?.enabled).toBe(false);
     expect(meta[0]?.clientConfig).toEqual({ a: 1 });
@@ -665,7 +716,7 @@ describe("buildPluginAdminMeta — clientConfig", () => {
       // live in the log context, which is where a boot failure is read.
       let thrown: unknown;
       try {
-        buildPluginAdminMeta(withConfig(bad), undefined, {});
+        buildPluginAdminMeta(withConfig(bad), undefined, []);
       } catch (error) {
         thrown = error;
       }
@@ -686,7 +737,7 @@ describe("buildPluginAdminMeta — clientConfig", () => {
     // client receives is missing a key the plugin wrote. That is a silent
     // shape change, not a harmless omission.
     expect(() =>
-      buildPluginAdminMeta(withConfig({ a: 1, gone: undefined }), undefined, {})
+      buildPluginAdminMeta(withConfig({ a: 1, gone: undefined }), undefined, [])
     ).toThrow(NextlyError);
   });
 
@@ -699,7 +750,7 @@ describe("buildPluginAdminMeta — clientConfig", () => {
       arr: [1, "two", { three: 3 }],
       nested: { deep: { deeper: [true] } },
     };
-    const meta = buildPluginAdminMeta(withConfig(config), undefined, {});
+    const meta = buildPluginAdminMeta(withConfig(config), undefined, []);
     expect(meta[0]?.clientConfig).toEqual(config);
   });
 
@@ -707,7 +758,7 @@ describe("buildPluginAdminMeta — clientConfig", () => {
     const cyclic: Record<string, unknown> = { a: 1 };
     cyclic.self = cyclic;
     expect(() =>
-      buildPluginAdminMeta(withConfig(cyclic), undefined, {})
+      buildPluginAdminMeta(withConfig(cyclic), undefined, [])
     ).toThrow(NextlyError);
   });
 });
@@ -724,7 +775,7 @@ describe("buildPluginAdminMeta — clientConfig runtime shapes", () => {
     // it — and every reader downstream assumes an object it can destructure.
     for (const bad of [null, [1, 2], "a string", 42, true]) {
       expect(
-        () => buildPluginAdminMeta(withConfig(bad), undefined, {}),
+        () => buildPluginAdminMeta(withConfig(bad), undefined, []),
         JSON.stringify(bad)
       ).toThrow(NextlyError);
     }
@@ -734,7 +785,7 @@ describe("buildPluginAdminMeta — clientConfig runtime shapes", () => {
     // Observable in the browser as `1 / value`, so it is a mangled copy like
     // any other rather than a rounding detail.
     expect(() =>
-      buildPluginAdminMeta(withConfig({ n: -0 }), undefined, {})
+      buildPluginAdminMeta(withConfig({ n: -0 }), undefined, [])
     ).toThrow(NextlyError);
   });
 
@@ -750,7 +801,7 @@ describe("buildPluginAdminMeta — clientConfig runtime shapes", () => {
     };
     let thrown: unknown;
     try {
-      buildPluginAdminMeta(withConfig(config), undefined, {});
+      buildPluginAdminMeta(withConfig(config), undefined, []);
     } catch (error) {
       thrown = error;
     }
@@ -763,7 +814,7 @@ describe("buildPluginAdminMeta — clientConfig runtime shapes", () => {
   it("resolves its status from the canonical table, not an inline literal", () => {
     let thrown: unknown;
     try {
-      buildPluginAdminMeta(withConfig({ when: new Date() }), undefined, {});
+      buildPluginAdminMeta(withConfig({ when: new Date() }), undefined, []);
     } catch (error) {
       thrown = error;
     }
@@ -796,7 +847,7 @@ describe("dormant routes", () => {
     const [meta] = buildPluginAdminMeta(
       [{ ...declaring, enabled: false } as PluginDefinition],
       undefined,
-      {}
+      []
     );
 
     expect(meta.whenEnabled?.routes).toEqual([
@@ -815,7 +866,7 @@ describe("dormant routes", () => {
     const [meta] = buildPluginAdminMeta(
       [{ ...declaring, enabled: false } as PluginDefinition],
       undefined,
-      {}
+      []
     );
 
     expect(Object.keys(meta.whenEnabled ?? {})).toEqual(["routes"]);
@@ -825,7 +876,7 @@ describe("dormant routes", () => {
     const [meta] = buildPluginAdminMeta(
       [{ ...declaring, enabled: true } as PluginDefinition],
       undefined,
-      {}
+      []
     );
 
     expect(meta.routes).toEqual([
@@ -840,7 +891,7 @@ describe("dormant routes", () => {
       const [meta] = buildPluginAdminMeta(
         [{ ...declaring, enabled } as PluginDefinition],
         undefined,
-        {}
+        []
       );
 
       const active = Boolean(meta.routes);
@@ -867,7 +918,7 @@ describe("dormant routes", () => {
         } as unknown as PluginDefinition,
       ],
       undefined,
-      {}
+      []
     );
 
     expect(meta.whenEnabled).toBeUndefined();
@@ -895,7 +946,7 @@ describe("dormant routes", () => {
         } as unknown as PluginDefinition,
       ],
       undefined,
-      {}
+      []
     );
 
     expect(meta.whenEnabled).toBeUndefined();
@@ -911,7 +962,7 @@ describe("dormant routes", () => {
         } as PluginDefinition,
       ],
       undefined,
-      {}
+      []
     );
 
     expect(meta.whenEnabled).toBeUndefined();
@@ -943,7 +994,7 @@ describe("dormant routes against the enabled set", () => {
     const metas = buildPluginAdminMeta(
       [enabledOwner, disabledClaimant],
       undefined,
-      {}
+      []
     );
     const claimant = metas.find(m => m.name === "foo/bar");
 
@@ -956,7 +1007,7 @@ describe("dormant routes against the enabled set", () => {
    * than about a route that was never valid.
    */
   it("keeps it when no enabled plugin holds that path", () => {
-    const metas = buildPluginAdminMeta([disabledClaimant], undefined, {});
+    const metas = buildPluginAdminMeta([disabledClaimant], undefined, []);
     const claimant = metas.find(m => m.name === "foo/bar");
 
     expect(claimant?.whenEnabled?.routes).toEqual([
@@ -968,7 +1019,7 @@ describe("dormant routes against the enabled set", () => {
     const metas = buildPluginAdminMeta(
       [enabledOwner, disabledClaimant],
       undefined,
-      {}
+      []
     );
 
     expect(metas.find(m => m.name === "foo")?.routes).toEqual([

--- a/packages/nextly/src/plugins/admin-meta.test.ts
+++ b/packages/nextly/src/plugins/admin-meta.test.ts
@@ -1100,6 +1100,37 @@ describe("adminMetaPermissions", () => {
   });
 
   /**
+   * A host may remap a contributed entity with the public
+   * `plugin.rename({ forms: "contact-forms" })` API, and the schema fold seeds
+   * against the RENAMED slug. Widening with the declared name would leave a
+   * `publish` declaration on the renamed entity looking plugin-owned.
+   *
+   * `export` on the renamed slug is the positive control: still a genuine
+   * custom permission, so the assertion cannot pass by everything being
+   * dropped.
+   */
+  it("counts a renamed contributed collection under its resolved slug", () => {
+    const collected = adminMetaPermissions({
+      plugins: asPlugins([
+        {
+          name: "@acme/forms",
+          version: "1.0.0",
+          renameMap: { forms: "contact-forms" },
+          contributes: {
+            collections: [{ slug: "forms" }],
+            permissions: [
+              { action: "publish", resource: "contact-forms" },
+              { action: "export", resource: "contact-forms" },
+            ],
+          },
+        },
+      ]),
+    });
+
+    expect(collected.map(p => p.slug)).toEqual(["export-contact-forms"]);
+  });
+
+  /**
    * A reserved system resource is a different REASON but the same rejection,
    * and it is judged against the same pre-transform list — a transformer can
    * drop the offending plugin just as it can resolve a duplicate. Boot still

--- a/packages/nextly/src/plugins/admin-meta.test.ts
+++ b/packages/nextly/src/plugins/admin-meta.test.ts
@@ -6,7 +6,8 @@ import type { PluginDefinition } from "./plugin-context";
 import { NEXTLY_ERROR_STATUS } from "../errors/error-codes";
 import { NextlyError } from "../errors/nextly-error";
 
-import { buildPluginAdminMeta } from "./admin-meta";
+import { adminMetaPermissions, buildPluginAdminMeta } from "./admin-meta";
+import { isPermissionCollision } from "./permission-error";
 
 const base = {
   name: "@acme/p",
@@ -1025,5 +1026,99 @@ describe("dormant routes against the enabled set", () => {
     expect(metas.find(m => m.name === "foo")?.routes).toEqual([
       { method: "GET", path: "/bar/x", fullPath: "/plugins/foo/bar/x" },
     ]);
+  });
+});
+
+/**
+ * The public admin-meta payload is served WITHOUT initializing services, so the
+ * config it folds is the one the route module stored — before any plugin
+ * `setup` transformer has run.
+ */
+describe("adminMetaPermissions", () => {
+  const colliding = asPlugins([
+    {
+      name: "@acme/a",
+      version: "1.0.0",
+      contributes: { permissions: [{ action: "purge", resource: "cache" }] },
+    },
+    {
+      name: "@acme/b",
+      version: "1.0.0",
+      contributes: { permissions: [{ action: "purge", resource: "cache" }] },
+    },
+  ]);
+
+  /**
+   * A transformer may legitimately resolve this collision, so the raw list can
+   * hold one boot never sees. Throwing here would blank the whole endpoint —
+   * branding included — for an app that boots perfectly well.
+   */
+  it("describes no permissions when the raw declarations collide", () => {
+    expect(adminMetaPermissions({ plugins: colliding })).toEqual([]);
+  });
+
+  /**
+   * The positive control. Without it the assertion above is satisfied by a
+   * function that returns `[]` for every input, which would be the endpoint
+   * silently describing nothing rather than degrading only on a collision.
+   */
+  it("returns the collected set when the declarations are valid", () => {
+    const [a] = colliding;
+    expect(adminMetaPermissions({ plugins: [a] }).map(p => p.slug)).toEqual([
+      "purge-cache",
+    ]);
+  });
+
+  /**
+   * A reserved system resource is a different REASON but the same rejection,
+   * and it is judged against the same pre-transform list — a transformer can
+   * drop the offending plugin just as it can resolve a duplicate. Boot still
+   * refuses if the declaration survives, which is where the operator sees it;
+   * blanking the admin as well reports it twice and helps nobody.
+   */
+  it("degrades on a reserved system resource too", () => {
+    expect(
+      adminMetaPermissions({
+        plugins: asPlugins([
+          {
+            name: "@acme/a",
+            version: "1.0.0",
+            contributes: {
+              permissions: [{ action: "read", resource: "users" }],
+            },
+          },
+        ]),
+      })
+    ).toEqual([]);
+  });
+
+  /**
+   * What the degradation must NOT absorb. Asserted on the guard rather than by
+   * provoking a non-collision throw out of the collector, which config alone
+   * cannot do — so this pins the discrimination itself rather than leaving the
+   * rethrow branch as an untested claim.
+   */
+  it("discriminates a collision from any other NextlyError", () => {
+    expect(
+      isPermissionCollision(
+        new NextlyError({
+          code: "NEXTLY_PERMISSION_COLLISION",
+          statusCode: 409,
+          publicMessage: "x",
+          logMessage: "x",
+        })
+      )
+    ).toBe(true);
+    expect(
+      isPermissionCollision(
+        new NextlyError({
+          code: "NEXTLY_ROUTE_COLLISION",
+          statusCode: 409,
+          publicMessage: "x",
+          logMessage: "x",
+        })
+      )
+    ).toBe(false);
+    expect(isPermissionCollision(new Error("boom"))).toBe(false);
   });
 });

--- a/packages/nextly/src/plugins/admin-meta.test.ts
+++ b/packages/nextly/src/plugins/admin-meta.test.ts
@@ -35,7 +35,8 @@ describe("buildPluginAdminMeta", () => {
           },
         },
       ]),
-      undefined
+      undefined,
+      {}
     );
     expect(meta[0].fieldTypes?.[0]).toMatchObject({
       type: "page-builder",
@@ -65,7 +66,8 @@ describe("buildPluginAdminMeta", () => {
           },
         },
       ]),
-      undefined
+      undefined,
+      {}
     );
     expect(meta[0].fieldTypes?.[0]).toEqual({
       type: "rating",
@@ -91,7 +93,8 @@ describe("buildPluginAdminMeta", () => {
           },
         },
       ]),
-      undefined
+      undefined,
+      {}
     );
     expect(meta[0].fieldTypes?.[0]).toEqual({
       type: "rating",
@@ -110,7 +113,8 @@ describe("buildPluginAdminMeta", () => {
           contributes: { admin: { schemaBuilderSlot: "@acme/p/admin#Toggle" } },
         },
       ]),
-      undefined
+      undefined,
+      {}
     );
     expect(enabled[0].schemaBuilderSlot).toBe("@acme/p/admin#Toggle");
 
@@ -122,7 +126,8 @@ describe("buildPluginAdminMeta", () => {
           contributes: { admin: { schemaBuilderSlot: "@acme/p/admin#Toggle" } },
         },
       ]),
-      undefined
+      undefined,
+      {}
     );
     expect(disabled[0].schemaBuilderSlot).toBeUndefined();
   });
@@ -135,7 +140,8 @@ describe("buildPluginAdminMeta", () => {
           contributes: { admin: { entryFormToolbarSlot: "@acme/p/admin#Bar" } },
         },
       ]),
-      undefined
+      undefined,
+      {}
     );
     expect(enabled[0].entryFormToolbarSlot).toBe("@acme/p/admin#Bar");
 
@@ -147,7 +153,8 @@ describe("buildPluginAdminMeta", () => {
           contributes: { admin: { entryFormToolbarSlot: "@acme/p/admin#Bar" } },
         },
       ]),
-      undefined
+      undefined,
+      {}
     );
     expect(disabled[0].entryFormToolbarSlot).toBeUndefined();
   });
@@ -179,7 +186,8 @@ describe("buildPluginAdminMeta", () => {
           },
         },
       ]),
-      undefined
+      undefined,
+      {}
     );
 
     expect(meta[0].menu).toEqual([
@@ -218,7 +226,8 @@ describe("buildPluginAdminMeta", () => {
           },
         },
       ]),
-      undefined
+      undefined,
+      {}
     );
     expect(meta[0].headerSlot).toBe("@acme/p/admin#HeaderBadge");
     expect(meta[0].widgets?.[0]).toMatchObject({
@@ -245,7 +254,8 @@ describe("buildPluginAdminMeta", () => {
           },
         },
       ]),
-      undefined
+      undefined,
+      {}
     );
     expect(meta[0].header).toEqual({
       slot: "@acme/p/admin#Publish",
@@ -264,7 +274,8 @@ describe("buildPluginAdminMeta", () => {
           contributes: { admin: { headerSlot: "@acme/p/admin#Badge" } },
         },
       ]),
-      undefined
+      undefined,
+      {}
     );
     expect(meta[0].header?.slot).toBe("@acme/p/admin#Badge");
     expect(meta[0].headerSlot).toBe("@acme/p/admin#Badge");
@@ -283,7 +294,8 @@ describe("buildPluginAdminMeta", () => {
           },
         },
       ]),
-      undefined
+      undefined,
+      {}
     );
     expect(meta[0].header).toBeUndefined();
     expect(meta[0].headerSlot).toBeUndefined();
@@ -303,7 +315,8 @@ describe("buildPluginAdminMeta", () => {
           },
         },
       ]),
-      undefined
+      undefined,
+      {}
     );
     expect(meta[0].headerSlot).toBeUndefined();
     expect(meta[0].widgets).toBeUndefined();
@@ -315,7 +328,8 @@ describe("buildPluginAdminMeta", () => {
     ];
     const enabled = buildPluginAdminMeta(
       asPlugins([{ ...base, contributes: { fieldTypes } }]),
-      undefined
+      undefined,
+      {}
     );
     expect(enabled[0].fieldTypes).toEqual([
       { type: "rating", component: "@acme/p/admin#Rating", storage: "number" },
@@ -325,7 +339,8 @@ describe("buildPluginAdminMeta", () => {
     // can still render fields of retained collections.
     const disabled = buildPluginAdminMeta(
       asPlugins([{ ...base, enabled: false, contributes: { fieldTypes } }]),
-      undefined
+      undefined,
+      {}
     );
     expect(disabled[0].fieldTypes).toEqual([
       { type: "rating", component: "@acme/p/admin#Rating", storage: "number" },
@@ -343,7 +358,8 @@ describe("buildPluginAdminMeta", () => {
           },
         },
       ]),
-      undefined
+      undefined,
+      {}
     );
     // The plugin entry still exists (its schema still applies), but its
     // behavioral admin UI (menu/pages/settings) is skipped per D49.
@@ -366,7 +382,8 @@ describe("buildPluginAdminMeta", () => {
           contributes: { collections: [{ slug: "forms" }] },
         },
       ]),
-      { "acme-p": { order: 5, appearance: { badge: "Beta" } } }
+      { "acme-p": { order: 5, appearance: { badge: "Beta" } } },
+      {}
     );
 
     expect(meta[0].placement).toBe("users");
@@ -380,7 +397,7 @@ describe("buildPluginAdminMeta", () => {
   });
 
   it("defaults placement to 'plugins' and has no admin keys when none declared", () => {
-    const meta = buildPluginAdminMeta(asPlugins([{ ...base }]), undefined);
+    const meta = buildPluginAdminMeta(asPlugins([{ ...base }]), undefined, {});
     expect(meta[0].placement).toBe("plugins");
     expect(meta[0].menu).toBeUndefined();
     expect(meta[0].pages).toBeUndefined();
@@ -401,7 +418,8 @@ describe("buildPluginAdminMeta", () => {
           tags: ["forms", "email"],
         },
       ]),
-      undefined
+      undefined,
+      {}
     );
     expect(meta[0]).toMatchObject({
       author: "Acme Inc.",
@@ -419,19 +437,21 @@ describe("buildPluginAdminMeta", () => {
       asPlugins([
         { ...base, enabled: false, author: "Acme Inc.", license: "MIT" },
       ]),
-      undefined
+      undefined,
+      {}
     );
     expect(meta[0].author).toBe("Acme Inc.");
     expect(meta[0].license).toBe("MIT");
   });
 
   it("serializes the enabled state explicitly", () => {
-    const on = buildPluginAdminMeta(asPlugins([{ ...base }]), undefined);
+    const on = buildPluginAdminMeta(asPlugins([{ ...base }]), undefined, {});
     expect(on[0].enabled).toBe(true);
 
     const off = buildPluginAdminMeta(
       asPlugins([{ ...base, enabled: false }]),
-      undefined
+      undefined,
+      {}
     );
     expect(off[0].enabled).toBe(false);
   });
@@ -439,7 +459,8 @@ describe("buildPluginAdminMeta", () => {
   it("serializes dependsOn ranges for the detail page", () => {
     const meta = buildPluginAdminMeta(
       asPlugins([{ ...base, dependsOn: { "@acme/core": "^1.2.0" } }]),
-      undefined
+      undefined,
+      {}
     );
     expect(meta[0].dependsOn).toEqual({ "@acme/core": "^1.2.0" });
   });
@@ -463,7 +484,8 @@ describe("buildPluginAdminMeta", () => {
     };
     const enabled = buildPluginAdminMeta(
       asPlugins([{ ...base, contributes }]),
-      undefined
+      undefined,
+      {}
     );
     expect(enabled[0].permissions).toEqual([
       {
@@ -476,13 +498,53 @@ describe("buildPluginAdminMeta", () => {
 
     const disabled = buildPluginAdminMeta(
       asPlugins([{ ...base, enabled: false, contributes }]),
-      undefined
+      undefined,
+      {}
     );
     // Identical to the enabled case. The separating assertion for the split is
     // below: routes DO disappear when disabled, so this is not simply "the
     // enabled flag changes nothing".
     expect(disabled[0].permissions).toEqual(enabled[0].permissions);
     expect(disabled[0].permissions).toHaveLength(1);
+  });
+
+  /**
+   * A `publish` declaration whose resource is a configured collection is one
+   * the seeder now owns: the permission fold drops it and the row it creates
+   * carries no owner. Reading the declaration instead would put this plugin's
+   * label and danger flag on a permission the roles data does not attribute to
+   * it, and the page would explain a grant that is not the plugin's to explain.
+   *
+   * The positive control is in the same call. `export` is a genuine custom
+   * permission and survives, so the assertion cannot pass by the whole list
+   * having been dropped.
+   */
+  it("omits a declaration the seeder owns, keeping the plugin's own", () => {
+    const meta = buildPluginAdminMeta(
+      asPlugins([
+        {
+          ...base,
+          contributes: {
+            permissions: [
+              { action: "publish", resource: "posts", label: "Publish posts" },
+              { action: "export", resource: "submissions" },
+            ],
+          },
+        },
+      ]),
+      undefined,
+      { collections: [{ slug: "posts" }] }
+    );
+
+    expect(meta[0].permissions).toEqual([
+      // Named from the action and resource, because this declaration carried no
+      // label — the same name the seeded row gets.
+      {
+        action: "export",
+        resource: "submissions",
+        label: "Export Submissions",
+      },
+    ]);
   });
 
   it("summarizes declared routes (method + path only) for enabled plugins only", () => {
@@ -498,7 +560,8 @@ describe("buildPluginAdminMeta", () => {
     };
     const enabled = buildPluginAdminMeta(
       asPlugins([{ ...base, contributes }]),
-      undefined
+      undefined,
+      {}
     );
     // `fullPath` travels too: it is the namespace the dispatcher mounts the
     // route at, derived from the raw package name, and the admin renders it
@@ -513,7 +576,8 @@ describe("buildPluginAdminMeta", () => {
 
     const disabled = buildPluginAdminMeta(
       asPlugins([{ ...base, enabled: false, contributes }]),
-      undefined
+      undefined,
+      {}
     );
     expect(disabled[0].routes).toBeUndefined();
   });
@@ -530,7 +594,8 @@ describe("buildPluginAdminMeta", () => {
           },
         },
       ]),
-      undefined
+      undefined,
+      {}
     );
     expect(meta[0].collections).toEqual(["forms"]);
     expect(meta[0].singles).toEqual(["form-settings"]);
@@ -550,7 +615,8 @@ describe("buildPluginAdminMeta — clientConfig", () => {
       withConfig({
         remotePatterns: [{ protocol: "https", hostname: "a.example" }],
       }),
-      undefined
+      undefined,
+      {}
     );
     expect(meta[0]?.clientConfig).toEqual({
       remotePatterns: [{ protocol: "https", hostname: "a.example" }],
@@ -573,7 +639,8 @@ describe("buildPluginAdminMeta — clientConfig", () => {
           },
         },
       ]),
-      undefined
+      undefined,
+      {}
     );
     expect(meta[0]?.enabled).toBe(false);
     expect(meta[0]?.clientConfig).toEqual({ a: 1 });
@@ -598,7 +665,7 @@ describe("buildPluginAdminMeta — clientConfig", () => {
       // live in the log context, which is where a boot failure is read.
       let thrown: unknown;
       try {
-        buildPluginAdminMeta(withConfig(bad), undefined);
+        buildPluginAdminMeta(withConfig(bad), undefined, {});
       } catch (error) {
         thrown = error;
       }
@@ -619,7 +686,7 @@ describe("buildPluginAdminMeta — clientConfig", () => {
     // client receives is missing a key the plugin wrote. That is a silent
     // shape change, not a harmless omission.
     expect(() =>
-      buildPluginAdminMeta(withConfig({ a: 1, gone: undefined }), undefined)
+      buildPluginAdminMeta(withConfig({ a: 1, gone: undefined }), undefined, {})
     ).toThrow(NextlyError);
   });
 
@@ -632,16 +699,16 @@ describe("buildPluginAdminMeta — clientConfig", () => {
       arr: [1, "two", { three: 3 }],
       nested: { deep: { deeper: [true] } },
     };
-    const meta = buildPluginAdminMeta(withConfig(config), undefined);
+    const meta = buildPluginAdminMeta(withConfig(config), undefined, {});
     expect(meta[0]?.clientConfig).toEqual(config);
   });
 
   it("survives a cycle by refusing rather than by hanging", () => {
     const cyclic: Record<string, unknown> = { a: 1 };
     cyclic.self = cyclic;
-    expect(() => buildPluginAdminMeta(withConfig(cyclic), undefined)).toThrow(
-      NextlyError
-    );
+    expect(() =>
+      buildPluginAdminMeta(withConfig(cyclic), undefined, {})
+    ).toThrow(NextlyError);
   });
 });
 
@@ -657,7 +724,7 @@ describe("buildPluginAdminMeta — clientConfig runtime shapes", () => {
     // it — and every reader downstream assumes an object it can destructure.
     for (const bad of [null, [1, 2], "a string", 42, true]) {
       expect(
-        () => buildPluginAdminMeta(withConfig(bad), undefined),
+        () => buildPluginAdminMeta(withConfig(bad), undefined, {}),
         JSON.stringify(bad)
       ).toThrow(NextlyError);
     }
@@ -667,7 +734,7 @@ describe("buildPluginAdminMeta — clientConfig runtime shapes", () => {
     // Observable in the browser as `1 / value`, so it is a mangled copy like
     // any other rather than a rounding detail.
     expect(() =>
-      buildPluginAdminMeta(withConfig({ n: -0 }), undefined)
+      buildPluginAdminMeta(withConfig({ n: -0 }), undefined, {})
     ).toThrow(NextlyError);
   });
 
@@ -683,7 +750,7 @@ describe("buildPluginAdminMeta — clientConfig runtime shapes", () => {
     };
     let thrown: unknown;
     try {
-      buildPluginAdminMeta(withConfig(config), undefined);
+      buildPluginAdminMeta(withConfig(config), undefined, {});
     } catch (error) {
       thrown = error;
     }
@@ -696,7 +763,7 @@ describe("buildPluginAdminMeta — clientConfig runtime shapes", () => {
   it("resolves its status from the canonical table, not an inline literal", () => {
     let thrown: unknown;
     try {
-      buildPluginAdminMeta(withConfig({ when: new Date() }), undefined);
+      buildPluginAdminMeta(withConfig({ when: new Date() }), undefined, {});
     } catch (error) {
       thrown = error;
     }
@@ -728,7 +795,8 @@ describe("dormant routes", () => {
   it("reports a disabled plugin's routes as dormant, not active", () => {
     const [meta] = buildPluginAdminMeta(
       [{ ...declaring, enabled: false } as PluginDefinition],
-      undefined
+      undefined,
+      {}
     );
 
     expect(meta.whenEnabled?.routes).toEqual([
@@ -746,7 +814,8 @@ describe("dormant routes", () => {
   it("never presents permissions as pending on being enabled", () => {
     const [meta] = buildPluginAdminMeta(
       [{ ...declaring, enabled: false } as PluginDefinition],
-      undefined
+      undefined,
+      {}
     );
 
     expect(Object.keys(meta.whenEnabled ?? {})).toEqual(["routes"]);
@@ -755,7 +824,8 @@ describe("dormant routes", () => {
   it("reports an enabled plugin's routes as active, not dormant", () => {
     const [meta] = buildPluginAdminMeta(
       [{ ...declaring, enabled: true } as PluginDefinition],
-      undefined
+      undefined,
+      {}
     );
 
     expect(meta.routes).toEqual([
@@ -769,7 +839,8 @@ describe("dormant routes", () => {
     enabled => {
       const [meta] = buildPluginAdminMeta(
         [{ ...declaring, enabled } as PluginDefinition],
-        undefined
+        undefined,
+        {}
       );
 
       const active = Boolean(meta.routes);
@@ -795,7 +866,8 @@ describe("dormant routes", () => {
           contributes: { routes: [{ method: "GET", path: "export" }] },
         } as unknown as PluginDefinition,
       ],
-      undefined
+      undefined,
+      {}
     );
 
     expect(meta.whenEnabled).toBeUndefined();
@@ -822,7 +894,8 @@ describe("dormant routes", () => {
           },
         } as unknown as PluginDefinition,
       ],
-      undefined
+      undefined,
+      {}
     );
 
     expect(meta.whenEnabled).toBeUndefined();
@@ -837,7 +910,8 @@ describe("dormant routes", () => {
           enabled: false,
         } as PluginDefinition,
       ],
-      undefined
+      undefined,
+      {}
     );
 
     expect(meta.whenEnabled).toBeUndefined();

--- a/packages/nextly/src/plugins/admin-meta.test.ts
+++ b/packages/nextly/src/plugins/admin-meta.test.ts
@@ -942,7 +942,8 @@ describe("dormant routes against the enabled set", () => {
     // Both resolve to /plugins/foo/bar/x.
     const metas = buildPluginAdminMeta(
       [enabledOwner, disabledClaimant],
-      undefined
+      undefined,
+      {}
     );
     const claimant = metas.find(m => m.name === "foo/bar");
 
@@ -955,7 +956,7 @@ describe("dormant routes against the enabled set", () => {
    * than about a route that was never valid.
    */
   it("keeps it when no enabled plugin holds that path", () => {
-    const metas = buildPluginAdminMeta([disabledClaimant], undefined);
+    const metas = buildPluginAdminMeta([disabledClaimant], undefined, {});
     const claimant = metas.find(m => m.name === "foo/bar");
 
     expect(claimant?.whenEnabled?.routes).toEqual([
@@ -966,7 +967,8 @@ describe("dormant routes against the enabled set", () => {
   it("leaves the enabled owner's own route reported", () => {
     const metas = buildPluginAdminMeta(
       [enabledOwner, disabledClaimant],
-      undefined
+      undefined,
+      {}
     );
 
     expect(metas.find(m => m.name === "foo")?.routes).toEqual([

--- a/packages/nextly/src/plugins/admin-meta.test.ts
+++ b/packages/nextly/src/plugins/admin-meta.test.ts
@@ -1079,8 +1079,14 @@ describe("adminMetaPermissions", () => {
    * `export` is the positive control: a genuine custom permission on the same
    * plugin, which must survive the widening.
    */
-  it("counts a plugin's own contributed collection as an entity", () => {
+  it("counts a contributed collection boot merged as an entity", () => {
     const collected = adminMetaPermissions({
+      // As the booted config arrives: `registerServices` folds
+      // `contributes.collections` into `collections` before publishing, so the
+      // contribution is already here. This fold reads that rather than
+      // re-deriving entity slugs from the declarations, which would be a second
+      // answer to which entities exist.
+      collections: [{ slug: "submissions" }],
       plugins: asPlugins([
         {
           name: "@acme/forms",
@@ -1100,34 +1106,29 @@ describe("adminMetaPermissions", () => {
   });
 
   /**
-   * A host may remap a contributed entity with the public
-   * `plugin.rename({ forms: "contact-forms" })` API, and the schema fold seeds
-   * against the RENAMED slug. Widening with the declared name would leave a
-   * `publish` declaration on the renamed entity looking plugin-owned.
-   *
-   * `export` on the renamed slug is the positive control: still a genuine
-   * custom permission, so the assertion cannot pass by everything being
-   * dropped.
+   * The separating case for reading the merged config rather than the
+   * declarations. Boot's schema fold runs over the PRE-transform plugin list,
+   * so a plugin a `setup` transformer added has its contributions skipped — its
+   * collection is absent from the booted `collections`. Re-deriving here would
+   * classify `reports` as an entity and drop the declaration as adopted, while
+   * the seeder writes it as a plugin-owned custom permission.
    */
-  it("counts a renamed contributed collection under its resolved slug", () => {
+  it("does not invent an entity boot never merged", () => {
     const collected = adminMetaPermissions({
+      collections: [],
       plugins: asPlugins([
         {
-          name: "@acme/forms",
+          name: "@acme/added-by-setup",
           version: "1.0.0",
-          renameMap: { forms: "contact-forms" },
           contributes: {
-            collections: [{ slug: "forms" }],
-            permissions: [
-              { action: "publish", resource: "contact-forms" },
-              { action: "export", resource: "contact-forms" },
-            ],
+            collections: [{ slug: "reports" }],
+            permissions: [{ action: "publish", resource: "reports" }],
           },
         },
       ]),
     });
 
-    expect(collected.map(p => p.slug)).toEqual(["export-contact-forms"]);
+    expect(collected.map(p => p.slug)).toEqual(["publish-reports"]);
   });
 
   /**

--- a/packages/nextly/src/plugins/admin-meta.test.ts
+++ b/packages/nextly/src/plugins/admin-meta.test.ts
@@ -1070,6 +1070,36 @@ describe("adminMetaPermissions", () => {
   });
 
   /**
+   * Boot merges a plugin's contributed entities into the config before asking
+   * whether a `publish` declaration names one; this endpoint reads a config
+   * where they are still absent. Without widening, a plugin publishing to a
+   * collection IT contributes is reported as owning a permission the seeder
+   * takes over and keeps ownerless.
+   *
+   * `export` is the positive control: a genuine custom permission on the same
+   * plugin, which must survive the widening.
+   */
+  it("counts a plugin's own contributed collection as an entity", () => {
+    const collected = adminMetaPermissions({
+      plugins: asPlugins([
+        {
+          name: "@acme/forms",
+          version: "1.0.0",
+          contributes: {
+            collections: [{ slug: "submissions" }],
+            permissions: [
+              { action: "publish", resource: "submissions" },
+              { action: "export", resource: "submissions" },
+            ],
+          },
+        },
+      ]),
+    });
+
+    expect(collected.map(p => p.slug)).toEqual(["export-submissions"]);
+  });
+
+  /**
    * A reserved system resource is a different REASON but the same rejection,
    * and it is judged against the same pre-transform list — a transformer can
    * drop the offending plugin just as it can resolve a duplicate. Boot still

--- a/packages/nextly/src/plugins/admin-meta.test.ts
+++ b/packages/nextly/src/plugins/admin-meta.test.ts
@@ -1093,10 +1093,29 @@ describe("adminMetaPermissions", () => {
   });
 
   /**
-   * What the degradation must NOT absorb. Asserted on the guard rather than by
-   * provoking a non-collision throw out of the collector, which config alone
-   * cannot do — so this pins the discrimination itself rather than leaving the
-   * rethrow branch as an untested claim.
+   * What the degradation must NOT absorb, asserted at the CALL SITE. Without
+   * this the `catch` can be widened to swallow everything and the suite stays
+   * green — measured, so it is the case this exists for. The plugin throws on
+   * the property the fold reads, standing in for any unexpected failure inside
+   * it; a defect there must reach the caller rather than be reported as an app
+   * with no custom permissions.
+   */
+  it("rethrows a failure that is not a rejected declaration", () => {
+    const exploding = new Proxy({} as PluginDefinition, {
+      get(target, prop) {
+        if (prop === "contributes") throw new TypeError("boom");
+        return Reflect.get(target, prop);
+      },
+    });
+
+    expect(() => adminMetaPermissions({ plugins: [exploding] })).toThrow(
+      TypeError
+    );
+  });
+
+  /**
+   * The guard itself, so a widened code match is caught as well as a widened
+   * catch.
    */
   it("discriminates a collision from any other NextlyError", () => {
     expect(

--- a/packages/nextly/src/plugins/admin-meta.test.ts
+++ b/packages/nextly/src/plugins/admin-meta.test.ts
@@ -444,7 +444,13 @@ describe("buildPluginAdminMeta", () => {
     expect(meta[0].dependsOn).toEqual({ "@acme/core": "^1.2.0" });
   });
 
-  it("summarizes declared permissions for enabled plugins only", () => {
+  /**
+   * Whatever the enabled state, because the ROWS exist whatever the enabled
+   * state: the permission fold covers disabled plugins (D49), the seeder
+   * creates them, and new ones are granted to super_admin. Reporting them only
+   * while enabled made this payload disagree with the database.
+   */
+  it("summarizes declared permissions whether or not the plugin is enabled", () => {
     const contributes = {
       permissions: [
         {
@@ -472,7 +478,11 @@ describe("buildPluginAdminMeta", () => {
       asPlugins([{ ...base, enabled: false, contributes }]),
       undefined
     );
-    expect(disabled[0].permissions).toBeUndefined();
+    // Identical to the enabled case. The separating assertion for the split is
+    // below: routes DO disappear when disabled, so this is not simply "the
+    // enabled flag changes nothing".
+    expect(disabled[0].permissions).toEqual(enabled[0].permissions);
+    expect(disabled[0].permissions).toHaveLength(1);
   });
 
   it("summarizes declared routes (method + path only) for enabled plugins only", () => {

--- a/packages/nextly/src/plugins/admin-meta.ts
+++ b/packages/nextly/src/plugins/admin-meta.ts
@@ -19,6 +19,11 @@ import type {
   PluginMenuItem,
 } from "./admin-contributions";
 import type { FieldSurface } from "./contributions";
+import {
+  type CollectedPermission,
+  collectCustomPermissions,
+  type PermissionConfigSource,
+} from "./permissions/collect-permissions";
 import { pluginCollectionSlugs } from "./plugin-admin-meta";
 import type {
   PluginAdminAppearance,
@@ -248,8 +253,24 @@ function mountableRoutes(
 
 export function buildPluginAdminMeta(
   plugins: PluginDefinition[],
-  pluginOverrides: Record<string, PluginOverride> | undefined
+  pluginOverrides: Record<string, PluginOverride> | undefined,
+  config: PermissionConfigSource
 ): PluginAdminMeta[] {
+  // The permissions that actually become rows, indexed by the plugin that owns
+  // them. Folded once for the whole list rather than read off each plugin's own
+  // declaration, because a declaration and a seeded permission are not the same
+  // set: `collectCustomPermissions` drops a `publish`/`unpublish` declaration
+  // whose resource is a collection or single, since the seeder emits that slug
+  // itself and keeps the row ownerless. Reading the declaration instead would
+  // put the plugin's label and danger flag on a permission no plugin owns, and
+  // the page would describe a grant the roles data does not have.
+  const ownedPermissions = new Map<string, CollectedPermission[]>();
+  for (const permission of collectCustomPermissions(config, plugins)) {
+    const owned = ownedPermissions.get(permission.owner);
+    if (owned) owned.push(permission);
+    else ownedPermissions.set(permission.owner, [permission]);
+  }
+
   // Here, and not only at boot, because this is the one place a plugin list
   // becomes ADDRESSES: the slug below is the admin's URL for the plugin and
   // the key its host override is read by. Two boot paths do not reach it —
@@ -360,12 +381,16 @@ export function buildPluginAdminMeta(
     // disabled plugins, so a disabled plugin serves none. Those move to
     // `whenEnabled`, and the `if/else` is what stops a route being reported as
     // both served and pending.
-    const permissions = plugin.contributes?.permissions;
+    const permissions = ownedPermissions.get(plugin.name);
     if (permissions && permissions.length > 0) {
       meta.permissions = permissions.map(p => ({
         action: p.action,
         resource: p.resource,
-        ...(p.label ? { label: p.label } : {}),
+        // The name the row carries, which the collector already resolved from
+        // the declared label or composed from the action and resource. Sending
+        // it under `label` keeps this page and the roles UI naming the same
+        // permission the same way.
+        label: p.name,
         ...(p.description ? { description: p.description } : {}),
         ...(p.danger ? { danger: p.danger } : {}),
       }));

--- a/packages/nextly/src/plugins/admin-meta.ts
+++ b/packages/nextly/src/plugins/admin-meta.ts
@@ -76,8 +76,13 @@ export interface PluginAdminMeta {
    */
   clientConfig?: Record<string, unknown>;
   /**
-   * Declared custom permissions (identity + display fields only) — present
-   * only for enabled plugins, like the rest of the behavioral surface.
+   * Declared custom permissions (identity + display fields only).
+   *
+   * Present whatever the enabled state, unlike the rest of the behavioral
+   * surface, because these rows exist whatever the enabled state: the
+   * permission fold covers disabled plugins too, the seeder creates them, and
+   * new ones are granted to super_admin. A disabled plugin's permission is
+   * held and assignable; what it protects is simply not mounted.
    */
   permissions?: Array<{
     action: string;
@@ -343,29 +348,32 @@ export function buildPluginAdminMeta(
         meta.entryFormToolbarSlot = admin.entryFormToolbarSlot;
     }
 
-    // Behavioral contributions summarized for the detail page, enabled only:
-    // a disabled plugin's routes are not mounted and its permissions grant
-    // nothing, so listing them would overstate what the install does.
-    // One shaper, two destinations. Which name the routes travel under is the
-    // difference between "this plugin serves these" and "enabling it would
-    // serve these", and an `if/else` is what stops both being true at once.
+    // Permissions are serialized whatever the enabled state, because they
+    // EXIST whatever the enabled state: `collectCustomPermissions` folds over
+    // every plugin including disabled ones (D49), the post-init seeder creates
+    // the rows, and new ones are assigned to super_admin. Withholding them
+    // here made the page disagree with the database — an operator could hold a
+    // plugin's permission, see it in the roles UI, and find nothing on the
+    // owning plugin's page to explain where it came from.
     //
-    // Permissions are NOT part of this: they are folded over every plugin,
-    // disabled included, so they are already seeded and are not pending on
-    // anything. Only their listing here is withheld while disabled.
+    // Routes are the genuinely absent half: `collectPluginRoutes` skips
+    // disabled plugins, so a disabled plugin serves none. Those move to
+    // `whenEnabled`, and the `if/else` is what stops a route being reported as
+    // both served and pending.
+    const permissions = plugin.contributes?.permissions;
+    if (permissions && permissions.length > 0) {
+      meta.permissions = permissions.map(p => ({
+        action: p.action,
+        resource: p.resource,
+        ...(p.label ? { label: p.label } : {}),
+        ...(p.description ? { description: p.description } : {}),
+        ...(p.danger ? { danger: p.danger } : {}),
+      }));
+    }
+
     const declaredRoutes = mountableRoutes(plugin, plugins);
     if (isEnabled) {
       if (declaredRoutes) meta.routes = declaredRoutes;
-      const permissions = plugin.contributes?.permissions;
-      if (permissions && permissions.length > 0) {
-        meta.permissions = permissions.map(p => ({
-          action: p.action,
-          resource: p.resource,
-          ...(p.label ? { label: p.label } : {}),
-          ...(p.description ? { description: p.description } : {}),
-          ...(p.danger ? { danger: p.danger } : {}),
-        }));
-      }
     } else if (declaredRoutes) {
       meta.whenEnabled = { routes: declaredRoutes };
     }

--- a/packages/nextly/src/plugins/admin-meta.ts
+++ b/packages/nextly/src/plugins/admin-meta.ts
@@ -19,11 +19,7 @@ import type {
   PluginMenuItem,
 } from "./admin-contributions";
 import type { FieldSurface } from "./contributions";
-import {
-  type CollectedPermission,
-  collectCustomPermissions,
-  type PermissionConfigSource,
-} from "./permissions/collect-permissions";
+import type { CollectedPermission } from "./permissions/collect-permissions";
 import { pluginCollectionSlugs } from "./plugin-admin-meta";
 import type {
   PluginAdminAppearance,
@@ -254,18 +250,26 @@ function mountableRoutes(
 export function buildPluginAdminMeta(
   plugins: PluginDefinition[],
   pluginOverrides: Record<string, PluginOverride> | undefined,
-  config: PermissionConfigSource
+  permissions: readonly CollectedPermission[]
 ): PluginAdminMeta[] {
   // The permissions that actually become rows, indexed by the plugin that owns
-  // them. Folded once for the whole list rather than read off each plugin's own
-  // declaration, because a declaration and a seeded permission are not the same
-  // set: `collectCustomPermissions` drops a `publish`/`unpublish` declaration
-  // whose resource is a collection or single, since the seeder emits that slug
-  // itself and keeps the row ownerless. Reading the declaration instead would
-  // put the plugin's label and danger flag on a permission no plugin owns, and
-  // the page would describe a grant the roles data does not have.
+  // them.
+  //
+  // TAKEN rather than folded here. A declaration and a seeded permission are
+  // not the same set — `collectCustomPermissions` drops a `publish`/`unpublish`
+  // declaration whose resource is a collection or single, since the seeder
+  // emits that slug itself and keeps the row ownerless — so this must read the
+  // collected set rather than `contributes.permissions`. But collecting it here
+  // as well as at the caller would compute one authoritative answer twice and
+  // leave two projections of it free to drift; `collectPluginInfo` already
+  // collects the same set for the CLI's slug summary.
+  //
+  // `source` rather than `owner` decides what belongs to a plugin: the host's
+  // sentinel owner is the literal `"app"`, and a plugin may legally be named
+  // that, which would file every host-declared permission under it.
   const ownedPermissions = new Map<string, CollectedPermission[]>();
-  for (const permission of collectCustomPermissions(config, plugins)) {
+  for (const permission of permissions) {
+    if (permission.source !== "plugin") continue;
     const owned = ownedPermissions.get(permission.owner);
     if (owned) owned.push(permission);
     else ownedPermissions.set(permission.owner, [permission]);

--- a/packages/nextly/src/plugins/admin-meta.ts
+++ b/packages/nextly/src/plugins/admin-meta.ts
@@ -34,7 +34,6 @@ import type {
 import { pluginAdminSlug } from "./plugin-slug";
 import { collectPluginRoutes } from "./routes/collect-routes";
 import { isRouteError } from "./routes/route-error";
-import { resolvePluginSelf } from "./self";
 import { validatedClientConfig } from "./validate-client-config";
 import { validatePluginSlugs } from "./validate-slugs";
 
@@ -297,26 +296,18 @@ export function adminMetaPermissions(
   config: PermissionConfigSource & { plugins?: PluginDefinition[] }
 ): CollectedPermission[] {
   const plugins = config.plugins ?? [];
-  const withContributed: PermissionConfigSource = {
-    ...config,
-    collections: [
-      ...(config.collections ?? []),
-      ...plugins.flatMap(plugin =>
-        Object.values(resolvePluginSelf(plugin).collections).map(slug => ({
-          slug,
-        }))
-      ),
-    ],
-    singles: [
-      ...(config.singles ?? []),
-      ...plugins.flatMap(plugin =>
-        Object.values(resolvePluginSelf(plugin).singles).map(slug => ({ slug }))
-      ),
-    ],
-  };
 
   try {
-    return collectCustomPermissions(withContributed, plugins);
+    // The config AS GIVEN. No widening from plugin declarations: the booted
+    // config's `collections` and `singles` are already contribution-merged —
+    // `registerServices` folds `contributes.{collections,singles}` in before it
+    // publishes — and boot's own `collectCustomPermissions` call reads exactly
+    // this shape. Re-deriving entity slugs here would be a second answer to
+    // "which entities exist", and it would be the WRONG one: it classifies a
+    // contribution from a plugin the schema fold never merged, so a lifecycle
+    // declaration on it reads as adopted here while the seeder makes it a
+    // plugin-owned custom permission.
+    return collectCustomPermissions(config, plugins);
   } catch (error) {
     if (isPermissionCollision(error)) return [];
     throw error;

--- a/packages/nextly/src/plugins/admin-meta.ts
+++ b/packages/nextly/src/plugins/admin-meta.ts
@@ -271,12 +271,45 @@ function mountableRoutes(
  * an invalid config should be reported, here it should not blank the admin.
  *
  * Only the collision is absorbed. Anything else is a defect, and rethrows.
+ *
+ * The entity slugs are widened with each plugin's CONTRIBUTED collections and
+ * singles before folding. Whether a `publish` declaration is the plugin's own
+ * or one the seeder owns is decided by whether its resource names an entity —
+ * and boot merges contributed entities into the config before that question is
+ * asked, while this endpoint reads a config where they are still absent. Folded
+ * against the narrow view, a plugin declaring `publish` for a collection it
+ * contributes itself would be reported as owning a permission the seeder takes
+ * over.
+ *
+ * This closes the CONFIG half of that gap and not the database half: a Schema
+ * Builder collection lives in `dynamic_collections` and is unknowable here, so
+ * a declaration naming one is still collected as plugin-owned. That limit is
+ * the collector's own and predates this function — see the Builder-entity case
+ * in `seed-system-permissions.integration.test.ts`.
  */
 export function adminMetaPermissions(
   config: PermissionConfigSource & { plugins?: PluginDefinition[] }
 ): CollectedPermission[] {
+  const plugins = config.plugins ?? [];
+  const withContributed: PermissionConfigSource = {
+    ...config,
+    collections: [
+      ...(config.collections ?? []),
+      ...plugins.flatMap(plugin =>
+        pluginCollectionSlugs(plugin).map(slug => ({ slug }))
+      ),
+    ],
+    singles: [
+      ...(config.singles ?? []),
+      ...plugins.flatMap(
+        plugin =>
+          plugin.contributes?.singles?.map(s => ({ slug: s.slug })) ?? []
+      ),
+    ],
+  };
+
   try {
-    return collectCustomPermissions(config, config.plugins ?? []);
+    return collectCustomPermissions(withContributed, plugins);
   } catch (error) {
     if (isPermissionCollision(error)) return [];
     throw error;

--- a/packages/nextly/src/plugins/admin-meta.ts
+++ b/packages/nextly/src/plugins/admin-meta.ts
@@ -19,7 +19,12 @@ import type {
   PluginMenuItem,
 } from "./admin-contributions";
 import type { FieldSurface } from "./contributions";
-import type { CollectedPermission } from "./permissions/collect-permissions";
+import { isPermissionCollision } from "./permission-error";
+import {
+  type CollectedPermission,
+  collectCustomPermissions,
+  type PermissionConfigSource,
+} from "./permissions/collect-permissions";
 import { pluginCollectionSlugs } from "./plugin-admin-meta";
 import type {
   PluginAdminAppearance,
@@ -245,6 +250,37 @@ function mountableRoutes(
         fullPath: c.fullPath,
       }))
     : undefined;
+}
+
+/**
+ * The custom permissions to describe on the PUBLIC admin-meta payload.
+ *
+ * That endpoint is served WITHOUT initializing services, so the config it reads
+ * is whatever the route module stored — before any plugin `setup` transformer
+ * has run. A transformer may legitimately resolve a collision between two
+ * declarations, so the raw list can hold one that boot never sees, and
+ * `collectCustomPermissions` throws on it. Letting that escape would take the
+ * whole endpoint down — branding included — over a configuration that boots.
+ *
+ * Degrades to describing NO custom permissions rather than to describing the
+ * raw declarations: a set that cannot be folded is a set this cannot attribute,
+ * and attributing it wrongly is the thing the fold exists to prevent.
+ *
+ * Deliberately a different failure semantic from `collectPluginInfo`, which
+ * folds the same declarations for the CLI and lets the collision throw — there
+ * an invalid config should be reported, here it should not blank the admin.
+ *
+ * Only the collision is absorbed. Anything else is a defect, and rethrows.
+ */
+export function adminMetaPermissions(
+  config: PermissionConfigSource & { plugins?: PluginDefinition[] }
+): CollectedPermission[] {
+  try {
+    return collectCustomPermissions(config, config.plugins ?? []);
+  } catch (error) {
+    if (isPermissionCollision(error)) return [];
+    throw error;
+  }
 }
 
 export function buildPluginAdminMeta(

--- a/packages/nextly/src/plugins/admin-meta.ts
+++ b/packages/nextly/src/plugins/admin-meta.ts
@@ -34,6 +34,7 @@ import type {
 import { pluginAdminSlug } from "./plugin-slug";
 import { collectPluginRoutes } from "./routes/collect-routes";
 import { isRouteError } from "./routes/route-error";
+import { resolvePluginSelf } from "./self";
 import { validatedClientConfig } from "./validate-client-config";
 import { validatePluginSlugs } from "./validate-slugs";
 
@@ -273,7 +274,12 @@ function mountableRoutes(
  * Only the collision is absorbed. Anything else is a defect, and rethrows.
  *
  * The entity slugs are widened with each plugin's CONTRIBUTED collections and
- * singles before folding. Whether a `publish` declaration is the plugin's own
+ * singles before folding, taken from `resolvePluginSelf` so they are the slugs
+ * the entities RESOLVE to. A host may remap one with the public
+ * `plugin.rename({ forms: "contact-forms" })` API and the schema fold seeds
+ * against the renamed slug, so widening with the declared name instead would
+ * leave a `publish:contact-forms` declaration looking plugin-owned while boot
+ * drops it as an adopted lifecycle permission. Whether a `publish` declaration is the plugin's own
  * or one the seeder owns is decided by whether its resource names an entity —
  * and boot merges contributed entities into the config before that question is
  * asked, while this endpoint reads a config where they are still absent. Folded
@@ -296,14 +302,15 @@ export function adminMetaPermissions(
     collections: [
       ...(config.collections ?? []),
       ...plugins.flatMap(plugin =>
-        pluginCollectionSlugs(plugin).map(slug => ({ slug }))
+        Object.values(resolvePluginSelf(plugin).collections).map(slug => ({
+          slug,
+        }))
       ),
     ],
     singles: [
       ...(config.singles ?? []),
-      ...plugins.flatMap(
-        plugin =>
-          plugin.contributes?.singles?.map(s => ({ slug: s.slug })) ?? []
+      ...plugins.flatMap(plugin =>
+        Object.values(resolvePluginSelf(plugin).singles).map(slug => ({ slug }))
       ),
     ],
   };

--- a/packages/nextly/src/plugins/permission-error.ts
+++ b/packages/nextly/src/plugins/permission-error.ts
@@ -26,3 +26,18 @@ export function permissionCollisionError(
     logContext: { reason, action, resource, owners },
   });
 }
+
+/**
+ * Whether an error is the boot-time rejection of a custom-permission
+ * declaration, as opposed to any other failure the collector might surface.
+ *
+ * Exported so a caller that must DEGRADE on an invalid declaration — the public
+ * admin-meta payload, which is served before any transformer has run — can
+ * absorb exactly that and let a real defect through. Matched on the code rather
+ * than by catching everything, for the same reason the codes exist.
+ */
+export function isPermissionCollision(error: unknown): boolean {
+  return (
+    error instanceof NextlyError && error.code === "NEXTLY_PERMISSION_COLLISION"
+  );
+}

--- a/packages/nextly/src/plugins/permissions/collect-permissions.test.ts
+++ b/packages/nextly/src/plugins/permissions/collect-permissions.test.ts
@@ -46,6 +46,7 @@ describe("collectCustomPermissions", () => {
         name: "Manage SEO",
         description: undefined,
         owner: "@acme/seo",
+        source: "plugin",
         group: "General",
         danger: false,
       },
@@ -121,6 +122,9 @@ describe("collectCustomPermissions", () => {
         name: "Export Reports",
         description: undefined,
         owner: "app",
+        // The host's declarations are discriminated from a plugin's by this
+        // rather than by `owner`, which a plugin named `app` would share.
+        source: "app",
         group: "General",
         danger: false,
       },

--- a/packages/nextly/src/plugins/permissions/collect-permissions.test.ts
+++ b/packages/nextly/src/plugins/permissions/collect-permissions.test.ts
@@ -427,3 +427,58 @@ describe("a CRUD collision on a config entity", () => {
     ).toBe("crud-permission-reserved");
   });
 });
+
+/**
+ * The seeder matches an existing row with `LOWER(action)` and `LOWER(resource)`,
+ * so two declarations differing only by case are ONE row in the database. The
+ * collector has to agree, or two owners both claim a permission the database
+ * attributes to whichever was seeded last.
+ */
+describe("collectCustomPermissions — identity is case-insensitive", () => {
+  it("rejects two declarations that differ only by case", () => {
+    expect(() =>
+      collectCustomPermissions({}, [
+        {
+          name: "@acme/a",
+          version: "1.0.0",
+          contributes: {
+            permissions: [{ action: "Export", resource: "Reports" }],
+          },
+        },
+        {
+          name: "@acme/b",
+          version: "1.0.0",
+          contributes: {
+            permissions: [{ action: "export", resource: "reports" }],
+          },
+        },
+      ] as unknown as PluginDefinition[])
+    ).toThrow();
+  });
+
+  /**
+   * The control: identities that genuinely differ still both collect, so the
+   * rejection above is about the case-folded collision and not about the
+   * collector having become intolerant of two plugins declaring permissions.
+   */
+  it("still collects two genuinely distinct identities", () => {
+    const out = collectCustomPermissions({}, [
+      {
+        name: "@acme/a",
+        version: "1.0.0",
+        contributes: {
+          permissions: [{ action: "Export", resource: "Reports" }],
+        },
+      },
+      {
+        name: "@acme/b",
+        version: "1.0.0",
+        contributes: {
+          permissions: [{ action: "export", resource: "invoices" }],
+        },
+      },
+    ] as unknown as PluginDefinition[]);
+
+    expect(out.map(p => p.slug)).toEqual(["Export-Reports", "export-invoices"]);
+  });
+});

--- a/packages/nextly/src/plugins/permissions/collect-permissions.ts
+++ b/packages/nextly/src/plugins/permissions/collect-permissions.ts
@@ -114,7 +114,16 @@ export function collectCustomPermissions(
     source: "app" | "plugin"
   ): void => {
     const { action, resource } = perm;
-    const key = `${action}:${resource}`;
+    // Compared in lower case, because the SEEDER decides this same question
+    // that way: `ensurePermission` matches an existing row with
+    // `LOWER(action) = LOWER(action)` and `LOWER(resource) = LOWER(resource)`.
+    // Left case-sensitive, `Export:Reports` and `export:reports` are collected
+    // as two permissions from two owners while the database holds ONE row —
+    // attributed to whichever was seeded last — so a plugin's detail page can
+    // claim a permission the roles data gives to someone else. The stored
+    // action and resource keep their declared casing; only the identity used
+    // to dedupe is normalized.
+    const key = `${action.toLowerCase()}:${resource.toLowerCase()}`;
 
     const prev = seen.get(key);
     if (prev !== undefined) {

--- a/packages/nextly/src/plugins/permissions/collect-permissions.ts
+++ b/packages/nextly/src/plugins/permissions/collect-permissions.ts
@@ -18,6 +18,16 @@ export interface CollectedPermission {
   /** Declaring plugin name ("app" for app-declared). Persisted on the row. */
   owner: string;
   /**
+   * Which KIND of declaration this came from, host or plugin.
+   *
+   * Carried beside `owner` rather than read out of it, because `owner` cannot
+   * answer the question: the host's sentinel is the literal string `"app"`, and
+   * a plugin may legally be named `app`. Anything grouping these by plugin would
+   * then file every host-declared permission under that plugin. Not persisted —
+   * `owner` remains the stored attribution, so no row changes shape.
+   */
+  source: "app" | "plugin";
+  /**
    * Heading within the owner's section. Defaulted here rather than left
    * undefined, so grouping never has to decide what an absent group means.
    */
@@ -98,7 +108,11 @@ export function collectCustomPermissions(
 
   // One declared custom permission from a given owner ("app" or a plugin name).
   // Shared by the app and plugin passes so both validate + collide identically.
-  const consider = (perm: PluginPermission, owner: string): void => {
+  const consider = (
+    perm: PluginPermission,
+    owner: string,
+    source: "app" | "plugin"
+  ): void => {
     const { action, resource } = perm;
     const key = `${action}:${resource}`;
 
@@ -166,6 +180,7 @@ export function collectCustomPermissions(
       name: perm.label ?? permissionName(action, resource),
       description: perm.description,
       owner,
+      source,
       // `group` was accepted and dropped: the interface documented it, the
       // canonical example set it, and nothing ever read it.
       group: perm.group?.trim() || DEFAULT_PERMISSION_GROUP,
@@ -187,12 +202,16 @@ export function collectCustomPermissions(
 function eachDeclaredPermission(
   config: PermissionConfigSource,
   plugins: PluginDefinition[],
-  visit: (perm: PluginPermission, owner: string) => void
+  visit: (
+    perm: PluginPermission,
+    owner: string,
+    source: "app" | "plugin"
+  ) => void
 ): void {
-  for (const perm of config.permissions ?? []) visit(perm, "app");
+  for (const perm of config.permissions ?? []) visit(perm, "app", "app");
   for (const plugin of plugins) {
     for (const perm of plugin.contributes?.permissions ?? []) {
-      visit(perm, plugin.name);
+      visit(perm, plugin.name, "plugin");
     }
   }
 }

--- a/packages/nextly/src/plugins/plugin-introspection.ts
+++ b/packages/nextly/src/plugins/plugin-introspection.ts
@@ -84,7 +84,10 @@ export function collectPluginInfo(
   // Admin menu/page/settings (host overrides only affect placement/appearance,
   // not these counts, so we fold with no overrides).
   const adminMetaByName = new Map(
-    buildPluginAdminMeta(resolved, undefined).map(meta => [meta.name, meta])
+    buildPluginAdminMeta(resolved, undefined, config).map(meta => [
+      meta.name,
+      meta,
+    ])
   );
 
   return resolved.map(plugin => {

--- a/packages/nextly/src/plugins/plugin-introspection.ts
+++ b/packages/nextly/src/plugins/plugin-introspection.ts
@@ -64,9 +64,14 @@ export function collectPluginInfo(
 ): PluginInfo[] {
   const resolved = resolvePlugins(plugins, { coreVersion: opts.coreVersion });
 
+  // Collected ONCE. Both views below derive from this list — the slug summary
+  // here and the display metadata `buildPluginAdminMeta` serializes — so the
+  // CLI and the admin cannot disagree about which permissions a plugin owns.
+  const collectedPermissions = collectCustomPermissions(config, resolved);
+
   // Custom permissions across all plugins, grouped by declaring owner (plugin name).
   const permissionsByOwner = new Map<string, string[]>();
-  for (const perm of collectCustomPermissions(config, resolved)) {
+  for (const perm of collectedPermissions) {
     const list = permissionsByOwner.get(perm.owner) ?? [];
     list.push(perm.slug);
     permissionsByOwner.set(perm.owner, list);
@@ -84,10 +89,9 @@ export function collectPluginInfo(
   // Admin menu/page/settings (host overrides only affect placement/appearance,
   // not these counts, so we fold with no overrides).
   const adminMetaByName = new Map(
-    buildPluginAdminMeta(resolved, undefined, config).map(meta => [
-      meta.name,
-      meta,
-    ])
+    buildPluginAdminMeta(resolved, undefined, collectedPermissions).map(
+      meta => [meta.name, meta]
+    )
   );
 
   return resolved.map(plugin => {

--- a/packages/nextly/src/plugins/validate-slugs.test.ts
+++ b/packages/nextly/src/plugins/validate-slugs.test.ts
@@ -115,7 +115,7 @@ describe("buildPluginAdminMeta", () => {
     const meta = buildPluginAdminMeta(
       [plugin("@acme/one"), plugin("@acme/two")],
       undefined,
-      {}
+      []
     );
 
     // The positive control: it really does produce metadata for both, so the
@@ -130,7 +130,7 @@ describe("buildPluginAdminMeta", () => {
       buildPluginAdminMeta(
         [plugin("@acme/plugin-seo"), plugin("acme_plugin_seo")],
         undefined,
-        {}
+        []
       );
     } catch (error) {
       reason = (error as { logContext?: { reason?: string } }).logContext

--- a/packages/nextly/src/plugins/validate-slugs.test.ts
+++ b/packages/nextly/src/plugins/validate-slugs.test.ts
@@ -114,7 +114,8 @@ describe("buildPluginAdminMeta", () => {
   it("addresses plugins whose slugs differ", () => {
     const meta = buildPluginAdminMeta(
       [plugin("@acme/one"), plugin("@acme/two")],
-      undefined
+      undefined,
+      {}
     );
 
     // The positive control: it really does produce metadata for both, so the
@@ -128,7 +129,8 @@ describe("buildPluginAdminMeta", () => {
     try {
       buildPluginAdminMeta(
         [plugin("@acme/plugin-seo"), plugin("acme_plugin_seo")],
-        undefined
+        undefined,
+        {}
       );
     } catch (error) {
       reason = (error as { logContext?: { reason?: string } }).logContext

--- a/packages/nextly/src/route-handler/__tests__/registration-input-stays-raw.test.ts
+++ b/packages/nextly/src/route-handler/__tests__/registration-input-stays-raw.test.ts
@@ -16,6 +16,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { SanitizedNextlyConfig } from "../../collections/config/define-config";
+import type { NextlyServiceConfig } from "../../di/register";
 import type { PluginDefinition } from "../../plugins/plugin-context";
 
 const registerServices = vi.fn();
@@ -40,6 +41,15 @@ vi.mock("../../storage/image-processor", () => ({
 const { ensureServicesInitialized, setHandlerConfig, setBootedConfig } =
   await import("../auth-handler");
 
+/**
+ * A boot result in the shape `registerServices` publishes. Only the blocks the
+ * store republishes matter here; the rest of `NextlyServiceConfig` is adapter
+ * and processor wiring this seam never reads.
+ */
+function booted(config: Partial<NextlyServiceConfig>): NextlyServiceConfig {
+  return config as NextlyServiceConfig;
+}
+
 function plugins(...names: string[]): PluginDefinition[] {
   return names.map(
     name => ({ name, version: "1.0.0" }) as unknown as PluginDefinition
@@ -60,9 +70,9 @@ describe("the request-path registration input", () => {
     setHandlerConfig(raw);
     // A previous boot in this process reported its transformed list, exactly
     // as `registerServices` does at the end of a successful registration.
-    setBootedConfig({
-      plugins: plugins("@acme/declared", "@acme/added-by-setup"),
-    });
+    setBootedConfig(
+      booted({ plugins: plugins("@acme/declared", "@acme/added-by-setup") })
+    );
 
     await ensureServicesInitialized();
 
@@ -86,9 +96,9 @@ describe("the request-path registration input", () => {
     isServicesRegistered.mockReturnValue(true);
 
     setHandlerConfig(raw);
-    setBootedConfig({
-      plugins: plugins("@acme/declared", "@acme/added-by-setup"),
-    });
+    setBootedConfig(
+      booted({ plugins: plugins("@acme/declared", "@acme/added-by-setup") })
+    );
 
     expect(getHandlerConfig()?.plugins?.map(p => p.name)).toEqual([
       "@acme/declared",

--- a/packages/nextly/src/route-handler/__tests__/registration-input-stays-raw.test.ts
+++ b/packages/nextly/src/route-handler/__tests__/registration-input-stays-raw.test.ts
@@ -37,7 +37,7 @@ vi.mock("../../storage/image-processor", () => ({
   getImageProcessor: () => undefined,
 }));
 
-const { ensureServicesInitialized, setHandlerConfig, setHandlerPlugins } =
+const { ensureServicesInitialized, setHandlerConfig, setBootedConfig } =
   await import("../auth-handler");
 
 function plugins(...names: string[]): PluginDefinition[] {
@@ -60,7 +60,9 @@ describe("the request-path registration input", () => {
     setHandlerConfig(raw);
     // A previous boot in this process reported its transformed list, exactly
     // as `registerServices` does at the end of a successful registration.
-    setHandlerPlugins(plugins("@acme/declared", "@acme/added-by-setup"));
+    setBootedConfig({
+      plugins: plugins("@acme/declared", "@acme/added-by-setup"),
+    });
 
     await ensureServicesInitialized();
 
@@ -84,7 +86,9 @@ describe("the request-path registration input", () => {
     isServicesRegistered.mockReturnValue(true);
 
     setHandlerConfig(raw);
-    setHandlerPlugins(plugins("@acme/declared", "@acme/added-by-setup"));
+    setBootedConfig({
+      plugins: plugins("@acme/declared", "@acme/added-by-setup"),
+    });
 
     expect(getHandlerConfig()?.plugins?.map(p => p.name)).toEqual([
       "@acme/declared",

--- a/packages/nextly/src/route-handler/auth-handler.ts
+++ b/packages/nextly/src/route-handler/auth-handler.ts
@@ -171,6 +171,10 @@ export function setBootedConfig(config: {
   collections?: ReadonlyArray<{ slug: string }>;
   singles?: ReadonlyArray<{ slug: string }>;
 }): void {
+  // Takes the whole transformed config rather than a field list assembled by
+  // the caller. A call site that names the fields is a call site that can omit
+  // one, and the omission is invisible — the endpoint just keeps folding
+  // against the raw route config for whatever was left out.
   globalForBoot.__nextly_bootPlugins = config.plugins ?? [];
   globalForBoot.__nextly_bootEntities = {
     collections: (config.collections ?? []).map(c => c.slug),

--- a/packages/nextly/src/route-handler/auth-handler.ts
+++ b/packages/nextly/src/route-handler/auth-handler.ts
@@ -18,6 +18,7 @@ import {
 } from "../di";
 import type { NextlyServiceConfig } from "../di/register";
 import { buildServiceConfig } from "../init/build-service-config";
+import { seedAllPermissions } from "../init/seed-permissions";
 import type { PluginDefinition } from "../plugins/plugin-context";
 import { ensureHmrListener } from "../runtime/hmr-listener";
 import { getImageProcessor } from "../storage/image-processor";
@@ -369,28 +370,14 @@ async function initializeServicesOnce(): Promise<void> {
       // Silently skip — email_templates table may not exist yet
     }
 
-    // Seed system + collection + single permissions (idempotent).
-    // This mirrors init.ts runPostInitTasks() so external apps using
-    // createDynamicHandlers() get permissions auto-seeded on first request.
-    // Without this, permissions like "update-api-keys" won't exist and
-    // the admin UI will block access to protected settings tabs.
+    // The same seeding the instrumentation boot performs, so an app that cold
+    // boots only through `createDynamicHandlers` ends up with the same rows.
+    // Shared rather than mirrored: this path used to seed system, collection
+    // and single permissions and stop there, which left a plugin's declared
+    // permission with no row and no super-admin grant on the one boot path
+    // that never runs post-init tasks.
     try {
-      const permissionSeedService = getService("permissionSeedService");
-      const systemResult = await permissionSeedService.seedSystemPermissions();
-      const collectionResult =
-        await permissionSeedService.seedAllCollectionPermissions();
-      const singleResult =
-        await permissionSeedService.seedAllSinglePermissions();
-
-      const allNewIds = [
-        ...systemResult.newPermissionIds,
-        ...collectionResult.newPermissionIds,
-        ...singleResult.newPermissionIds,
-      ];
-
-      if (allNewIds.length > 0) {
-        await permissionSeedService.assignNewPermissionsToSuperAdmin(allNewIds);
-      }
+      await seedAllPermissions();
     } catch {
       // Silently skip — permissions table may not exist yet (migrations not run),
       // or permissionSeedService may not be registered

--- a/packages/nextly/src/route-handler/auth-handler.ts
+++ b/packages/nextly/src/route-handler/auth-handler.ts
@@ -47,7 +47,7 @@ let _storedConfig: SanitizedNextlyConfig | null = null;
  * On `globalThis`, and NOT module-local, for the same reason `register.ts`
  * keeps its registration state there: Next.js and Turbopack can evaluate this
  * module in more than one server module graph, so instrumentation's boot may
- * call `setHandlerPlugins` on one copy while `/admin-meta` reads another. A
+ * call `setBootedConfig` on one copy while `/admin-meta` reads another. A
  * module-local value is `null` in the reading copy, and the endpoint falls back
  * to disclosing the raw, pre-`setup` list — which is the defect this whole seam
  * exists to remove, reappearing only under a bundler that duplicates modules.
@@ -58,6 +58,15 @@ let _storedConfig: SanitizedNextlyConfig | null = null;
  */
 const globalForBoot = globalThis as unknown as {
   __nextly_bootPlugins?: PluginDefinition[];
+  /**
+   * The ENTITY slugs boot registered, plugin contributions and `setup`
+   * transformer additions included.
+   *
+   * Slugs only: the sole reader is the permission fold, which asks whether a
+   * resource names an entity. Keeping whole definitions here would put hooks
+   * and access rules in a process-global for no caller.
+   */
+  __nextly_bootEntities?: { collections: string[]; singles: string[] };
 };
 
 /**
@@ -73,6 +82,7 @@ let _bootView: SanitizedNextlyConfig | null = null;
 let _bootViewInputs: {
   config: SanitizedNextlyConfig;
   plugins: PluginDefinition[];
+  entities?: { collections: string[]; singles: string[] };
 } | null = null;
 
 /**
@@ -106,13 +116,28 @@ function bootView(): SanitizedNextlyConfig | null {
     : undefined;
   if (!config || !plugins) return config;
 
+  const entities = globalForBoot.__nextly_bootEntities;
   if (
     !_bootView ||
     _bootViewInputs?.config !== config ||
-    _bootViewInputs?.plugins !== plugins
+    _bootViewInputs?.plugins !== plugins ||
+    _bootViewInputs?.entities !== entities
   ) {
-    _bootView = { ...config, plugins };
-    _bootViewInputs = { config, plugins };
+    _bootView = {
+      ...config,
+      plugins,
+      // Entity slugs travel as the minimal shape the permission fold reads.
+      // The definitions themselves stay whatever the route config carries: a
+      // reader wanting hooks or access rules must go through the container,
+      // and this store has never claimed to hold them.
+      ...(entities
+        ? {
+            collections: entities.collections.map(slug => ({ slug })),
+            singles: entities.singles.map(slug => ({ slug })),
+          }
+        : {}),
+    } as SanitizedNextlyConfig;
+    _bootViewInputs = { config, plugins, entities };
   }
   return _bootView;
 }
@@ -141,10 +166,16 @@ export function setHandlerConfig(config: SanitizedNextlyConfig): void {
  * advertising the plugins the author declared — and normalizing here rather
  * than at the call site leaves the caller no branch in which to disagree.
  */
-export function setHandlerPlugins(
-  plugins: PluginDefinition[] | undefined
-): void {
-  globalForBoot.__nextly_bootPlugins = plugins ?? [];
+export function setBootedConfig(config: {
+  plugins?: PluginDefinition[];
+  collections?: ReadonlyArray<{ slug: string }>;
+  singles?: ReadonlyArray<{ slug: string }>;
+}): void {
+  globalForBoot.__nextly_bootPlugins = config.plugins ?? [];
+  globalForBoot.__nextly_bootEntities = {
+    collections: (config.collections ?? []).map(c => c.slug),
+    singles: (config.singles ?? []).map(s => s.slug),
+  };
 }
 
 /**

--- a/packages/nextly/src/route-handler/auth-handler.ts
+++ b/packages/nextly/src/route-handler/auth-handler.ts
@@ -19,7 +19,6 @@ import {
 import type { NextlyServiceConfig } from "../di/register";
 import { buildServiceConfig } from "../init/build-service-config";
 import { seedAllPermissions } from "../init/seed-permissions";
-import type { PluginDefinition } from "../plugins/plugin-context";
 import { ensureHmrListener } from "../runtime/hmr-listener";
 import { getImageProcessor } from "../storage/image-processor";
 
@@ -57,17 +56,58 @@ let _storedConfig: SanitizedNextlyConfig | null = null;
  * same copy serves the request, so it has no cross-graph reader.
  */
 const globalForBoot = globalThis as unknown as {
-  __nextly_bootPlugins?: PluginDefinition[];
-  /**
-   * The ENTITY slugs boot registered, plugin contributions and `setup`
-   * transformer additions included.
-   *
-   * Slugs only: the sole reader is the permission fold, which asks whether a
-   * resource names an entity. Keeping whole definitions here would put hooks
-   * and access rules in a process-global for no caller.
-   */
-  __nextly_bootEntities?: { collections: string[]; singles: string[] };
+  __nextly_bootConfig?: BootedConfigView;
 };
+
+/**
+ * The blocks of the booted config this store republishes, WHOLE.
+ *
+ * An earlier version kept entity SLUGS only, reasoning that the permission fold
+ * was the sole reader. It is not: `getHandlerConfig()` has six readers, and one
+ * hands its result to `runProdMigrationsIfEnabled`, whose `resolveDeclaredSchema`
+ * reads `dbName` and a relationship's `junctionTable`. Projecting those away
+ * made drift verification look for a table that never existed.
+ *
+ * So what is bounded here is WHICH blocks travel, never how much of each. The
+ * bound is type compatibility and the compiler checks it: the transformed
+ * config is a `NextlyServiceConfig`, whose `auth` is the UNSANITIZED
+ * `AuthConfig`, so overlaying that onto a `SanitizedNextlyConfig` would hand
+ * readers a shape they are typed against and do not have. Widening this list
+ * means checking a field's type across the two, not adding a name to it.
+ *
+ * These are also the blocks a `setup` transformer meaningfully rewrites: the
+ * plugin list, the entities plugins contribute, and the app-level permission
+ * declarations that can collide with them.
+ */
+type BootedConfigView = Partial<
+  Pick<
+    SanitizedNextlyConfig,
+    "plugins" | "collections" | "singles" | "permissions"
+  >
+>;
+
+/**
+ * `booted`'s explicitly-set keys laid over `base`.
+ *
+ * Key by key rather than a spread: a present-but-`undefined` key would
+ * otherwise delete a field the stored config legitimately holds.
+ */
+function overlayDefined(
+  base: SanitizedNextlyConfig,
+  booted: BootedConfigView
+): SanitizedNextlyConfig {
+  return {
+    ...base,
+    ...(booted.plugins !== undefined ? { plugins: booted.plugins } : {}),
+    ...(booted.collections !== undefined
+      ? { collections: booted.collections }
+      : {}),
+    ...(booted.singles !== undefined ? { singles: booted.singles } : {}),
+    ...(booted.permissions !== undefined
+      ? { permissions: booted.permissions }
+      : {}),
+  };
+}
 
 /**
  * The merged view, and the exact inputs it was built from.
@@ -81,8 +121,7 @@ const globalForBoot = globalThis as unknown as {
 let _bootView: SanitizedNextlyConfig | null = null;
 let _bootViewInputs: {
   config: SanitizedNextlyConfig;
-  plugins: PluginDefinition[];
-  entities?: { collections: string[]; singles: string[] };
+  booted: BootedConfigView;
 } | null = null;
 
 /**
@@ -111,33 +150,18 @@ function bootView(): SanitizedNextlyConfig | null {
   // remembered-to-clear approach would be one edit away from the stale-read it
   // is meant to prevent. Derived here, a teardown, a failed re-boot, and a
   // process that never booted all fall back to the declared list on their own.
-  const plugins = isServicesRegistered()
-    ? globalForBoot.__nextly_bootPlugins
+  const booted = isServicesRegistered()
+    ? globalForBoot.__nextly_bootConfig
     : undefined;
-  if (!config || !plugins) return config;
+  if (!config || !booted) return config;
 
-  const entities = globalForBoot.__nextly_bootEntities;
   if (
     !_bootView ||
     _bootViewInputs?.config !== config ||
-    _bootViewInputs?.plugins !== plugins ||
-    _bootViewInputs?.entities !== entities
+    _bootViewInputs?.booted !== booted
   ) {
-    _bootView = {
-      ...config,
-      plugins,
-      // Entity slugs travel as the minimal shape the permission fold reads.
-      // The definitions themselves stay whatever the route config carries: a
-      // reader wanting hooks or access rules must go through the container,
-      // and this store has never claimed to hold them.
-      ...(entities
-        ? {
-            collections: entities.collections.map(slug => ({ slug })),
-            singles: entities.singles.map(slug => ({ slug })),
-          }
-        : {}),
-    } as SanitizedNextlyConfig;
-    _bootViewInputs = { config, plugins, entities };
+    _bootView = overlayDefined(config, booted);
+    _bootViewInputs = { config, booted };
   }
   return _bootView;
 }
@@ -166,19 +190,19 @@ export function setHandlerConfig(config: SanitizedNextlyConfig): void {
  * advertising the plugins the author declared — and normalizing here rather
  * than at the call site leaves the caller no branch in which to disagree.
  */
-export function setBootedConfig(config: {
-  plugins?: PluginDefinition[];
-  collections?: ReadonlyArray<{ slug: string }>;
-  singles?: ReadonlyArray<{ slug: string }>;
-}): void {
-  // Takes the whole transformed config rather than a field list assembled by
-  // the caller. A call site that names the fields is a call site that can omit
-  // one, and the omission is invisible — the endpoint just keeps folding
-  // against the raw route config for whatever was left out.
-  globalForBoot.__nextly_bootPlugins = config.plugins ?? [];
-  globalForBoot.__nextly_bootEntities = {
-    collections: (config.collections ?? []).map(c => c.slug),
-    singles: (config.singles ?? []).map(s => s.slug),
+export function setBootedConfig(config: NextlyServiceConfig): void {
+  // Takes the WHOLE transformed config, and narrows here rather than at the
+  // call site. A caller that named the blocks to publish would be one omission
+  // from the endpoint folding against raw values for whatever it forgot.
+  //
+  // `plugins` is normalized because an absent list and an emptied one are the
+  // same fact: a boot whose transformers removed every plugin must stop this
+  // store advertising the ones the author declared.
+  globalForBoot.__nextly_bootConfig = {
+    plugins: config.plugins ?? [],
+    collections: config.collections,
+    singles: config.singles,
+    permissions: config.permissions,
   };
 }
 

--- a/packages/nextly/src/route-handler/auth-handler.ts
+++ b/packages/nextly/src/route-handler/auth-handler.ts
@@ -79,12 +79,11 @@ const globalForBoot = globalThis as unknown as {
  * plugin list, the entities plugins contribute, and the app-level permission
  * declarations that can collide with them.
  */
-type BootedConfigView = Partial<
-  Pick<
-    SanitizedNextlyConfig,
-    "plugins" | "collections" | "singles" | "permissions"
-  >
->;
+type BootedConfigView = Pick<
+  SanitizedNextlyConfig,
+  "plugins" | "collections" | "singles"
+> &
+  Pick<SanitizedNextlyConfig, "permissions">;
 
 /**
  * `booted`'s explicitly-set keys laid over `base`.
@@ -96,16 +95,23 @@ function overlayDefined(
   base: SanitizedNextlyConfig,
   booted: BootedConfigView
 ): SanitizedNextlyConfig {
+  // Every key of `BootedConfigView` is taken, `undefined` included. These four
+  // are blocks boot OWNS, so its answer is authoritative in both directions: a
+  // transformer that removes the last app-level permission returns
+  // `permissions: undefined`, and skipping that would preserve the raw
+  // declaration — leaving `/admin-meta` folding against a collision the running
+  // config resolved, and degrading to an empty set that hides every seeded
+  // plugin permission.
+  //
+  // Skipping `undefined` was right when this overlaid the WHOLE config, where
+  // it protected `typescript`, `db` and `storage` from a transformed value that
+  // never carries them. Narrowing the type to what boot owns removed the reason.
   return {
     ...base,
-    ...(booted.plugins !== undefined ? { plugins: booted.plugins } : {}),
-    ...(booted.collections !== undefined
-      ? { collections: booted.collections }
-      : {}),
-    ...(booted.singles !== undefined ? { singles: booted.singles } : {}),
-    ...(booted.permissions !== undefined
-      ? { permissions: booted.permissions }
-      : {}),
+    plugins: booted.plugins,
+    collections: booted.collections,
+    singles: booted.singles,
+    permissions: booted.permissions,
   };
 }
 
@@ -199,9 +205,17 @@ export function setBootedConfig(config: NextlyServiceConfig): void {
   // same fact: a boot whose transformers removed every plugin must stop this
   // store advertising the ones the author declared.
   globalForBoot.__nextly_bootConfig = {
+    // Normalized, because the sanitized shape these overlay onto requires them
+    // and an absent list means the same as an empty one: a boot whose
+    // transformers removed every plugin, collection or single must stop the
+    // store advertising the ones the author declared.
     plugins: config.plugins ?? [],
-    collections: config.collections,
-    singles: config.singles,
+    collections: config.collections ?? [],
+    singles: config.singles ?? [],
+    // NOT normalized: `permissions` is genuinely optional on the sanitized
+    // config, so `undefined` is a value here — "boot registered no app-level
+    // permissions" — and the overlay must carry it rather than fall back to the
+    // author's raw declaration.
     permissions: config.permissions,
   };
 }

--- a/packages/nextly/src/route-handler/set-handler-plugins.test.ts
+++ b/packages/nextly/src/route-handler/set-handler-plugins.test.ts
@@ -62,8 +62,14 @@ describe("the handler config store", () => {
    */
   beforeEach(async () => {
     vi.resetModules();
-    delete (globalThis as { __nextly_bootPlugins?: unknown })
-      .__nextly_bootPlugins;
+    // BOTH, or a value left by an earlier test satisfies the next one's
+    // assertion and the suite reports coverage it does not have.
+    const g = globalThis as {
+      __nextly_bootPlugins?: unknown;
+      __nextly_bootEntities?: unknown;
+    };
+    delete g.__nextly_bootPlugins;
+    delete g.__nextly_bootEntities;
     servicesRegistered.mockReturnValue(true);
     store = await import("./auth-handler");
   });

--- a/packages/nextly/src/route-handler/set-handler-plugins.test.ts
+++ b/packages/nextly/src/route-handler/set-handler-plugins.test.ts
@@ -199,6 +199,33 @@ describe("the handler config store", () => {
     expect(view?.collections?.[0]).toMatchObject({ dbName: "acme_reports" });
   });
 
+  /**
+   * App-level `config.permissions` too, not just plugin declarations. A `setup`
+   * transformer may remove or replace a top-level declaration that collides
+   * with a plugin's — registration then validates the transformed config and
+   * succeeds, but if the raw declaration is what this store keeps reporting,
+   * `adminMetaPermissions()` sees a collision that no longer exists and
+   * degrades to an empty set, hiding every seeded plugin permission from the
+   * detail page.
+   */
+  it("reports the app permissions boot registered, not the declared ones", () => {
+    store.setHandlerConfig({
+      ...stored,
+      permissions: [{ action: "purge", resource: "cache" }],
+    } as unknown as SanitizedNextlyConfig);
+
+    store.setBootedConfig(
+      booted({
+        plugins: plugins("@acme/transformed"),
+        permissions: [{ action: "archive", resource: "reports" }],
+      })
+    );
+
+    expect(store.getHandlerConfig()?.permissions?.map(p => p.action)).toEqual([
+      "archive",
+    ]);
+  });
+
   it("reports no config when only a plugin list has been recorded", () => {
     store.setBootedConfig(booted({ plugins: plugins("@acme/transformed") }));
 

--- a/packages/nextly/src/route-handler/set-handler-plugins.test.ts
+++ b/packages/nextly/src/route-handler/set-handler-plugins.test.ts
@@ -160,6 +160,27 @@ describe("the handler config store", () => {
    * branding, no `db` and no `storage` to report, and a plugin list alone must
    * not be dressed up as a config.
    */
+  /**
+   * A `setup` transformer may ADD a top-level collection or single, and the
+   * permission fold decides whether a `publish` declaration names an entity.
+   * Publishing only the plugin half leaves the endpoint folding against the raw
+   * route config, so a declaration on a transformer-added entity reads as a
+   * plugin-owned custom permission that boot actually drops.
+   */
+  it("reports the entity slugs boot registered, not the declared ones", () => {
+    store.setHandlerConfig(stored);
+
+    store.setBootedConfig({
+      plugins: plugins("@acme/transformed"),
+      collections: [{ slug: "reports" }],
+      singles: [{ slug: "site" }],
+    });
+
+    const view = store.getHandlerConfig();
+    expect(view?.collections?.map(c => c.slug)).toEqual(["reports"]);
+    expect(view?.singles?.map(s => s.slug)).toEqual(["site"]);
+  });
+
   it("reports no config when only a plugin list has been recorded", () => {
     store.setBootedConfig({ plugins: plugins("@acme/transformed") });
 

--- a/packages/nextly/src/route-handler/set-handler-plugins.test.ts
+++ b/packages/nextly/src/route-handler/set-handler-plugins.test.ts
@@ -71,7 +71,7 @@ describe("the handler config store", () => {
   it("replaces the plugin list when boot runs after the route module", () => {
     store.setHandlerConfig(stored);
 
-    store.setHandlerPlugins(plugins("@acme/transformed"));
+    store.setBootedConfig({ plugins: plugins("@acme/transformed") });
 
     expect(names(store)).toEqual(["@acme/transformed"]);
   });
@@ -85,7 +85,7 @@ describe("the handler config store", () => {
   it("leaves every other field of the stored config intact", () => {
     store.setHandlerConfig(stored);
 
-    store.setHandlerPlugins(plugins("@acme/transformed"));
+    store.setBootedConfig({ plugins: plugins("@acme/transformed") });
 
     const after = store.getHandlerConfig();
     expect(after?.typescript).toEqual({ enabled: true });
@@ -100,7 +100,7 @@ describe("the handler config store", () => {
    * there is no stored config to correct at the moment boot reports its list.
    */
   it("applies a plugin list recorded before any config was stored", () => {
-    store.setHandlerPlugins(plugins("@acme/transformed"));
+    store.setBootedConfig({ plugins: plugins("@acme/transformed") });
 
     store.setHandlerConfig(stored);
 
@@ -113,7 +113,7 @@ describe("the handler config store", () => {
    */
   it("keeps the booted list when the raw config is stored again", () => {
     store.setHandlerConfig(stored);
-    store.setHandlerPlugins(plugins("@acme/transformed"));
+    store.setBootedConfig({ plugins: plugins("@acme/transformed") });
 
     store.setHandlerConfig(stored);
 
@@ -129,7 +129,7 @@ describe("the handler config store", () => {
   it("clears the declared plugins when boot produced none", () => {
     store.setHandlerConfig(stored);
 
-    store.setHandlerPlugins([]);
+    store.setBootedConfig({ plugins: [] });
 
     expect(names(store)).toEqual([]);
   });
@@ -143,7 +143,7 @@ describe("the handler config store", () => {
   it("clears the declared plugins when boot reported no list at all", () => {
     store.setHandlerConfig(stored);
 
-    store.setHandlerPlugins(undefined);
+    store.setBootedConfig({});
 
     expect(names(store)).toEqual([]);
   });
@@ -155,7 +155,7 @@ describe("the handler config store", () => {
    * not be dressed up as a config.
    */
   it("reports no config when only a plugin list has been recorded", () => {
-    store.setHandlerPlugins(plugins("@acme/transformed"));
+    store.setBootedConfig({ plugins: plugins("@acme/transformed") });
 
     expect(store.getHandlerConfig()).toBeNull();
   });
@@ -194,7 +194,7 @@ describe("the handler config store", () => {
    */
   it("shares the booted list across duplicate copies of the module", async () => {
     const booting = store;
-    booting.setHandlerPlugins(plugins("@acme/transformed"));
+    booting.setBootedConfig({ plugins: plugins("@acme/transformed") });
 
     vi.resetModules();
     const serving: HandlerStore = await import("./auth-handler");
@@ -213,12 +213,12 @@ describe("the handler config store", () => {
    */
   it("re-derives the view when a later boot replaces the list", () => {
     store.setHandlerConfig(stored);
-    store.setHandlerPlugins(plugins("@acme/first"));
+    store.setBootedConfig({ plugins: plugins("@acme/first") });
     expect(store.getHandlerConfig()?.plugins?.map(p => p.name)).toEqual([
       "@acme/first",
     ]);
 
-    store.setHandlerPlugins(plugins("@acme/second"));
+    store.setBootedConfig({ plugins: plugins("@acme/second") });
 
     expect(store.getHandlerConfig()?.plugins?.map(p => p.name)).toEqual([
       "@acme/second",

--- a/packages/nextly/src/route-handler/set-handler-plugins.test.ts
+++ b/packages/nextly/src/route-handler/set-handler-plugins.test.ts
@@ -226,6 +226,25 @@ describe("the handler config store", () => {
     ]);
   });
 
+  /**
+   * The removal case, and the reason the overlay takes `permissions` even when
+   * it is `undefined`. A transformer that drops the LAST app-level declaration
+   * returns `permissions: undefined`; preserving the author's raw list there
+   * leaves `adminMetaPermissions()` folding against a collision the running
+   * config resolved, and it degrades to an empty set — hiding every seeded
+   * plugin permission from the detail page.
+   */
+  it("clears the declared app permissions when boot registered none", () => {
+    store.setHandlerConfig({
+      ...stored,
+      permissions: [{ action: "purge", resource: "cache" }],
+    } as unknown as SanitizedNextlyConfig);
+
+    store.setBootedConfig(booted({ plugins: plugins("@acme/transformed") }));
+
+    expect(store.getHandlerConfig()?.permissions).toBeUndefined();
+  });
+
   it("reports no config when only a plugin list has been recorded", () => {
     store.setBootedConfig(booted({ plugins: plugins("@acme/transformed") }));
 

--- a/packages/nextly/src/route-handler/set-handler-plugins.test.ts
+++ b/packages/nextly/src/route-handler/set-handler-plugins.test.ts
@@ -8,6 +8,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { SanitizedNextlyConfig } from "../collections/config/define-config";
+import type { NextlyServiceConfig } from "../di/register";
 import type { PluginDefinition } from "../plugins/plugin-context";
 
 // The store is module state and nothing here reaches the service layer, so the
@@ -41,6 +42,15 @@ const stored = {
   plugins: [{ name: "@acme/raw", version: "1.0.0" }],
 } as unknown as SanitizedNextlyConfig;
 
+/**
+ * A boot result in the shape `registerServices` publishes. Only the blocks the
+ * store republishes matter here; the rest of `NextlyServiceConfig` is adapter
+ * and processor wiring this seam never reads.
+ */
+function booted(config: Partial<NextlyServiceConfig>): NextlyServiceConfig {
+  return config as NextlyServiceConfig;
+}
+
 function plugins(...names: string[]): PluginDefinition[] {
   return names.map(
     name => ({ name, version: "1.0.0" }) as unknown as PluginDefinition
@@ -64,12 +74,8 @@ describe("the handler config store", () => {
     vi.resetModules();
     // BOTH, or a value left by an earlier test satisfies the next one's
     // assertion and the suite reports coverage it does not have.
-    const g = globalThis as {
-      __nextly_bootPlugins?: unknown;
-      __nextly_bootEntities?: unknown;
-    };
-    delete g.__nextly_bootPlugins;
-    delete g.__nextly_bootEntities;
+    delete (globalThis as { __nextly_bootConfig?: unknown })
+      .__nextly_bootConfig;
     servicesRegistered.mockReturnValue(true);
     store = await import("./auth-handler");
   });
@@ -77,7 +83,7 @@ describe("the handler config store", () => {
   it("replaces the plugin list when boot runs after the route module", () => {
     store.setHandlerConfig(stored);
 
-    store.setBootedConfig({ plugins: plugins("@acme/transformed") });
+    store.setBootedConfig(booted({ plugins: plugins("@acme/transformed") }));
 
     expect(names(store)).toEqual(["@acme/transformed"]);
   });
@@ -91,7 +97,7 @@ describe("the handler config store", () => {
   it("leaves every other field of the stored config intact", () => {
     store.setHandlerConfig(stored);
 
-    store.setBootedConfig({ plugins: plugins("@acme/transformed") });
+    store.setBootedConfig(booted({ plugins: plugins("@acme/transformed") }));
 
     const after = store.getHandlerConfig();
     expect(after?.typescript).toEqual({ enabled: true });
@@ -106,7 +112,7 @@ describe("the handler config store", () => {
    * there is no stored config to correct at the moment boot reports its list.
    */
   it("applies a plugin list recorded before any config was stored", () => {
-    store.setBootedConfig({ plugins: plugins("@acme/transformed") });
+    store.setBootedConfig(booted({ plugins: plugins("@acme/transformed") }));
 
     store.setHandlerConfig(stored);
 
@@ -119,7 +125,7 @@ describe("the handler config store", () => {
    */
   it("keeps the booted list when the raw config is stored again", () => {
     store.setHandlerConfig(stored);
-    store.setBootedConfig({ plugins: plugins("@acme/transformed") });
+    store.setBootedConfig(booted({ plugins: plugins("@acme/transformed") }));
 
     store.setHandlerConfig(stored);
 
@@ -135,7 +141,7 @@ describe("the handler config store", () => {
   it("clears the declared plugins when boot produced none", () => {
     store.setHandlerConfig(stored);
 
-    store.setBootedConfig({ plugins: [] });
+    store.setBootedConfig(booted({ plugins: [] }));
 
     expect(names(store)).toEqual([]);
   });
@@ -149,7 +155,7 @@ describe("the handler config store", () => {
   it("clears the declared plugins when boot reported no list at all", () => {
     store.setHandlerConfig(stored);
 
-    store.setBootedConfig({});
+    store.setBootedConfig(booted({}));
 
     expect(names(store)).toEqual([]);
   });
@@ -167,22 +173,34 @@ describe("the handler config store", () => {
    * route config, so a declaration on a transformer-added entity reads as a
    * plugin-owned custom permission that boot actually drops.
    */
-  it("reports the entity slugs boot registered, not the declared ones", () => {
+  it("reports the entities boot registered, whole", () => {
     store.setHandlerConfig(stored);
 
-    store.setBootedConfig({
-      plugins: plugins("@acme/transformed"),
-      collections: [{ slug: "reports" }],
-      singles: [{ slug: "site" }],
-    });
+    store.setBootedConfig(
+      booted({
+        plugins: plugins("@acme/transformed"),
+        collections: [
+          { slug: "reports", dbName: "acme_reports", fields: [] },
+        ] as unknown as NextlyServiceConfig["collections"],
+        singles: [
+          { slug: "site", fields: [] },
+        ] as unknown as NextlyServiceConfig["singles"],
+      })
+    );
 
     const view = store.getHandlerConfig();
     expect(view?.collections?.map(c => c.slug)).toEqual(["reports"]);
     expect(view?.singles?.map(s => s.slug)).toEqual(["site"]);
+    // The DEFINITION, not a slug projection of it. `runProdMigrationsIfEnabled`
+    // reads this store and passes it to `resolveDeclaredSchema`, which resolves
+    // a table name from `dbName`; an earlier version rebuilt these entries as
+    // `{ slug }` and made drift verification look for a table that never
+    // existed. This assertion is what stops that returning.
+    expect(view?.collections?.[0]).toMatchObject({ dbName: "acme_reports" });
   });
 
   it("reports no config when only a plugin list has been recorded", () => {
-    store.setBootedConfig({ plugins: plugins("@acme/transformed") });
+    store.setBootedConfig(booted({ plugins: plugins("@acme/transformed") }));
 
     expect(store.getHandlerConfig()).toBeNull();
   });
@@ -196,7 +214,7 @@ describe("the handler config store", () => {
    */
   it("stops reporting the booted list once services are no longer registered", () => {
     store.setHandlerConfig(stored);
-    store.setHandlerPlugins(plugins("@acme/transformed"));
+    store.setBootedConfig(booted({ plugins: plugins("@acme/transformed") }));
     expect(store.getHandlerConfig()?.plugins?.map(p => p.name)).toEqual([
       "@acme/transformed",
     ]);
@@ -221,7 +239,7 @@ describe("the handler config store", () => {
    */
   it("shares the booted list across duplicate copies of the module", async () => {
     const booting = store;
-    booting.setBootedConfig({ plugins: plugins("@acme/transformed") });
+    booting.setBootedConfig(booted({ plugins: plugins("@acme/transformed") }));
 
     vi.resetModules();
     const serving: HandlerStore = await import("./auth-handler");
@@ -240,12 +258,12 @@ describe("the handler config store", () => {
    */
   it("re-derives the view when a later boot replaces the list", () => {
     store.setHandlerConfig(stored);
-    store.setBootedConfig({ plugins: plugins("@acme/first") });
+    store.setBootedConfig(booted({ plugins: plugins("@acme/first") }));
     expect(store.getHandlerConfig()?.plugins?.map(p => p.name)).toEqual([
       "@acme/first",
     ]);
 
-    store.setBootedConfig({ plugins: plugins("@acme/second") });
+    store.setBootedConfig(booted({ plugins: plugins("@acme/second") }));
 
     expect(store.getHandlerConfig()?.plugins?.map(p => p.name)).toEqual([
       "@acme/second",

--- a/packages/nextly/src/routeHandler.ts
+++ b/packages/nextly/src/routeHandler.ts
@@ -93,6 +93,10 @@ import { createCorsMiddleware } from "./middleware/cors";
 import { createRateLimiter } from "./middleware/rate-limit";
 import { createSecurityHeadersMiddleware } from "./middleware/security-headers";
 import { buildPluginAdminMeta } from "./plugins/admin-meta";
+import {
+  type CollectedPermission,
+  collectCustomPermissions,
+} from "./plugins/permissions/collect-permissions";
 import { runPluginRoute } from "./plugins/routes/dispatch";
 import { getPluginRouteRegistry } from "./plugins/routes/route-registry";
 import { assertClientConfigs } from "./plugins/validate-client-config";
@@ -1229,6 +1233,39 @@ async function handleServiceRequest(
  * be complete colors: the `--nx-*` tokens are consumed directly by the theme,
  * so a bare "H S% L%" triplet would be an invalid value and get dropped.
  */
+/**
+ * The custom permissions to describe on the public admin-meta payload.
+ *
+ * This endpoint is served WITHOUT initializing services, so the config it reads
+ * is whatever the route module stored — before any plugin `setup` transformer
+ * has run. A transformer may legitimately resolve a collision between two
+ * declarations, so the raw list can contain one that boot never sees, and
+ * `collectCustomPermissions` throws on it. Letting that escape would take the
+ * whole endpoint down (branding, plugins, the lot) over a configuration that
+ * boots perfectly well.
+ *
+ * Degrades to describing no custom permissions rather than to describing the
+ * raw declarations: a set that cannot be folded is a set this cannot attribute,
+ * and attributing it wrongly is what the fold exists to prevent. Only the
+ * collision error is absorbed; anything else is a defect and rethrows.
+ */
+function adminMetaPermissions(
+  config: SanitizedNextlyConfig | null
+): CollectedPermission[] {
+  if (!config) return [];
+  try {
+    return collectCustomPermissions(config, config.plugins ?? []);
+  } catch (error) {
+    if (
+      error instanceof NextlyError &&
+      error.code === "NEXTLY_PERMISSION_COLLISION"
+    ) {
+      return [];
+    }
+    throw error;
+  }
+}
+
 async function handleAdminMetaRequest(): Promise<Response> {
   const config = getHandlerConfig();
   const branding = config?.admin?.branding;
@@ -1276,13 +1313,10 @@ async function handleAdminMetaRequest(): Promise<Response> {
   // Collect plugin metadata from registered plugins with host override
   // resolution + contributes.admin menu/pages/settings folding (D20/D21/D49).
   const pluginOverrides = config?.admin?.pluginOverrides;
-  // The config is forwarded because the permission fold reads it: whether a
-  // `publish` declaration is the plugin's own or one the seeder owns depends on
-  // whether its resource names a configured collection or single.
   const plugins = buildPluginAdminMeta(
     config?.plugins ?? [],
     pluginOverrides,
-    config ?? {}
+    adminMetaPermissions(config)
   );
   if (plugins.length > 0) {
     payload.plugins = plugins;

--- a/packages/nextly/src/routeHandler.ts
+++ b/packages/nextly/src/routeHandler.ts
@@ -1276,7 +1276,14 @@ async function handleAdminMetaRequest(): Promise<Response> {
   // Collect plugin metadata from registered plugins with host override
   // resolution + contributes.admin menu/pages/settings folding (D20/D21/D49).
   const pluginOverrides = config?.admin?.pluginOverrides;
-  const plugins = buildPluginAdminMeta(config?.plugins ?? [], pluginOverrides);
+  // The config is forwarded because the permission fold reads it: whether a
+  // `publish` declaration is the plugin's own or one the seeder owns depends on
+  // whether its resource names a configured collection or single.
+  const plugins = buildPluginAdminMeta(
+    config?.plugins ?? [],
+    pluginOverrides,
+    config ?? {}
+  );
   if (plugins.length > 0) {
     payload.plugins = plugins;
   }

--- a/packages/nextly/src/routeHandler.ts
+++ b/packages/nextly/src/routeHandler.ts
@@ -92,11 +92,10 @@ import { withTimezoneFormatting } from "./lib/date-formatting";
 import { createCorsMiddleware } from "./middleware/cors";
 import { createRateLimiter } from "./middleware/rate-limit";
 import { createSecurityHeadersMiddleware } from "./middleware/security-headers";
-import { buildPluginAdminMeta } from "./plugins/admin-meta";
 import {
-  type CollectedPermission,
-  collectCustomPermissions,
-} from "./plugins/permissions/collect-permissions";
+  adminMetaPermissions,
+  buildPluginAdminMeta,
+} from "./plugins/admin-meta";
 import { runPluginRoute } from "./plugins/routes/dispatch";
 import { getPluginRouteRegistry } from "./plugins/routes/route-registry";
 import { assertClientConfigs } from "./plugins/validate-client-config";
@@ -1233,39 +1232,6 @@ async function handleServiceRequest(
  * be complete colors: the `--nx-*` tokens are consumed directly by the theme,
  * so a bare "H S% L%" triplet would be an invalid value and get dropped.
  */
-/**
- * The custom permissions to describe on the public admin-meta payload.
- *
- * This endpoint is served WITHOUT initializing services, so the config it reads
- * is whatever the route module stored — before any plugin `setup` transformer
- * has run. A transformer may legitimately resolve a collision between two
- * declarations, so the raw list can contain one that boot never sees, and
- * `collectCustomPermissions` throws on it. Letting that escape would take the
- * whole endpoint down (branding, plugins, the lot) over a configuration that
- * boots perfectly well.
- *
- * Degrades to describing no custom permissions rather than to describing the
- * raw declarations: a set that cannot be folded is a set this cannot attribute,
- * and attributing it wrongly is what the fold exists to prevent. Only the
- * collision error is absorbed; anything else is a defect and rethrows.
- */
-function adminMetaPermissions(
-  config: SanitizedNextlyConfig | null
-): CollectedPermission[] {
-  if (!config) return [];
-  try {
-    return collectCustomPermissions(config, config.plugins ?? []);
-  } catch (error) {
-    if (
-      error instanceof NextlyError &&
-      error.code === "NEXTLY_PERMISSION_COLLISION"
-    ) {
-      return [];
-    }
-    throw error;
-  }
-}
-
 async function handleAdminMetaRequest(): Promise<Response> {
   const config = getHandlerConfig();
   const branding = config?.admin?.branding;
@@ -1316,7 +1282,7 @@ async function handleAdminMetaRequest(): Promise<Response> {
   const plugins = buildPluginAdminMeta(
     config?.plugins ?? [],
     pluginOverrides,
-    adminMetaPermissions(config)
+    adminMetaPermissions(config ?? {})
   );
   if (plugins.length > 0) {
     payload.plugins = plugins;


### PR DESCRIPTION
Decision D9. **Stacked on #753** — base it there, not `main`; it continues that PR's split of routes from permissions.

## The defect

`admin-meta.ts` gated `permissions` and `routes` behind one `isEnabled` check, justified by a comment saying *"a disabled plugin's routes are not mounted and its permissions grant nothing"*.

The first half is true. The second is not, and I measured it rather than reasoning about it:

- `collect-permissions.ts` folds over **all** plugins including disabled ones — *"so declarative permissions stay deterministic across environments (D49 — same policy as the schema fold)"*.
- `post-init-tasks.ts` calls `seedCustomPermissions(declared)` on that list, then `assignNewPermissionsToSuperAdmin(...)`.
- `markOrphanedPermissions` only marks permissions whose **declaration** has gone. A disabled plugin still declares, so its rows are never orphaned. Grants are untouched and nothing is deleted.

So a disabled plugin's permissions are real rows, owned, and granted to super_admin — and its own page said nothing about them.

## Why it matters

The roles UI already reads the `owner` column, but only to sort the permission into a "plugins" category (`useRoleForm.ts:292`) — it never names **which** plugin. So an operator holding `purge-archive` could see it was plugin-owned, and had nowhere to find out whose: the categoriser does not say, and the owning plugin's page did not list it.

That is an audit gap, not a display preference.

## The change

The guard is **split, not removed**. Permissions serialize whatever the enabled state; routes stay gated and continue to travel as `whenEnabled` from #753. The false half of the comment is gone.

Admin copy names which parts survive being disabled:

> This plugin is disabled: its collections, data and permissions are retained — its permissions stay granted, though what they protect is not loaded — while its behavior, including its API routes, does not run.

## Tests

An existing core test asserted `disabled[0].permissions` was `undefined` — it was pinning the behaviour this corrects, and now asserts the disabled payload equals the enabled one. The separating assertion lives beside it: **routes still disappear when disabled**, so this is not "the enabled flag stopped mattering".

Three admin cases on one disabled plugin: its permissions appear in "What this plugin adds"; its routes do **not**, and are disclosed as pending instead; and the copy says the permissions stay granted.

Break-verified: restoring the `isEnabled` gate on permissions fails one core test and nothing else.

## Not covered

Whether the roles UI should name the owning plugin rather than only categorising it. That is the other half of the same audit gap and is a separate surface.