### PR TITLE
feat(nextly): hold the storage migration out of a schema builder change

### DIFF
--- a/.changeset/schema-change-holds-the-migration-out.md
+++ b/.changeset/schema-change-holds-the-migration-out.md
@@ -25,7 +25,10 @@
 "@nextlyhq/module-specifiers": patch
 ---
 
-A Schema Builder change to a single or a field group now holds the field-group storage migration out for its whole duration, rather than being able to start one halfway through. The exclusion is taken before the change plans anything, so a create, an update or a delete either runs against storage nothing is renaming or is refused outright — and a change that is refused has written no row and built no table. A database that has never run a migration is covered too: these paths may create the lock table, so a first migration cannot claim it and start renaming underneath a change already in progress.
+A Schema Builder change to a single or a field group now holds the field-group storage migration out for its whole duration, rather than being able to start one halfway through. The exclusion is taken before the change plans anything, so a create, an update or a delete either runs against storage nothing is renaming or is refused
+outright — and a change that is refused has written no row and built no table of its own. Taking
+the exclusion can still create the migration lock's own table, which is empty, holds no content,
+and would have been created by the next successful change anyway. A database that has never run a migration is covered too: these paths may create the lock table, so a first migration cannot claim it and start renaming underneath a change already in progress.
 
 Not every way of changing schema is covered yet. The Admin's confirmed apply, the standalone
 schema routes, collections and user fields still write without the exclusion, so they can run

--- a/.changeset/schema-change-holds-the-migration-out.md
+++ b/.changeset/schema-change-holds-the-migration-out.md
@@ -1,0 +1,30 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+A Schema Builder change to a single or a field group now holds the field-group storage migration out for its whole duration, rather than being able to start one halfway through. The exclusion is taken before the change plans anything, so a create, an update or a delete either runs against storage nothing is renaming or is refused outright — and a change that is refused has written no row and built no table. A database that has never run a migration is covered too: these paths may create the lock table, so a first migration cannot claim it and start renaming underneath a change already in progress.
+
+Collections and user fields are not covered yet and can still run alongside a storage migration.

--- a/.changeset/schema-change-holds-the-migration-out.md
+++ b/.changeset/schema-change-holds-the-migration-out.md
@@ -27,4 +27,6 @@
 
 A Schema Builder change to a single or a field group now holds the field-group storage migration out for its whole duration, rather than being able to start one halfway through. The exclusion is taken before the change plans anything, so a create, an update or a delete either runs against storage nothing is renaming or is refused outright — and a change that is refused has written no row and built no table. A database that has never run a migration is covered too: these paths may create the lock table, so a first migration cannot claim it and start renaming underneath a change already in progress.
 
-Collections and user fields are not covered yet and can still run alongside a storage migration.
+Not every way of changing schema is covered yet. The Admin's confirmed apply, the standalone
+schema routes, collections and user fields still write without the exclusion, so they can run
+alongside a storage migration.

--- a/packages/nextly/src/cli/commands/db-sync.ts
+++ b/packages/nextly/src/cli/commands/db-sync.ts
@@ -322,6 +322,9 @@ export async function runDbSync(
         logger,
         label: "db:sync",
         mayCreateLock: options.autoSync !== false,
+        // A sync is idempotent and was never mutually exclusive with another sync, so dropping the
+        // claim on an interrupt costs nothing a rerun does not fix.
+        releaseOnInterrupt: true,
       },
       async () =>
         await runWithFieldTypes(configResult.fieldTypes, async () => {

--- a/packages/nextly/src/cli/commands/dev-watcher.ts
+++ b/packages/nextly/src/cli/commands/dev-watcher.ts
@@ -91,6 +91,9 @@ export function createDebouncedSync(
             logger,
             label: "db:sync watch",
             mayCreateLock: options.autoSync !== false,
+            // Ctrl+C is the documented way to stop watch mode, and a sync is idempotent, so a
+            // claim stuck behind a dead watcher would block every later sync for no gain.
+            releaseOnInterrupt: true,
           },
           async () => {
             // Before the pushes, for the same reason the one-shot `db:sync` does it: a watched

--- a/packages/nextly/src/dispatcher/handlers/__tests__/component-dispatcher-ddl.test.ts
+++ b/packages/nextly/src/dispatcher/handlers/__tests__/component-dispatcher-ddl.test.ts
@@ -35,7 +35,10 @@ const executed: string[] = [];
  * passes through `executeQuery`.
  */
 function makeAdapter(dialect: "postgresql" | "mysql" | "sqlite") {
-  return {
+  // A field-group schema change runs inside the storage migration's lock, so the double has to
+  // answer the lock's reads and writes as well as its own. Added rather than stubbed: a surface
+  // that let every claim succeed would certify an exclusion that is not there.
+  return withMigrationLockSurface({
     dialect,
     getCapabilities: () => ({ dialect }),
     // Answers the way a fresh create finds the database: the main table is there once its CREATE
@@ -48,7 +51,7 @@ function makeAdapter(dialect: "postgresql" | "mysql" | "sqlite") {
       return [];
     }),
     getDrizzle: () => ({}),
-  };
+  });
 }
 
 let adapter: ReturnType<typeof makeAdapter>;
@@ -69,6 +72,7 @@ vi.mock("../../../di/container", () => ({
   },
 }));
 
+import { withMigrationLockSurface } from "../../../domains/field-groups/migration/__tests__/helpers/migration-lock-double";
 import { FieldGroupMetadataService } from "../../../domains/field-groups/services/field-group-metadata-service";
 import type { FieldGroupRegistryService } from "../../../services/field-groups/field-group-registry-service";
 import type { Logger } from "../../../shared/types";

--- a/packages/nextly/src/dispatcher/handlers/__tests__/single-dispatcher-ddl.test.ts
+++ b/packages/nextly/src/dispatcher/handlers/__tests__/single-dispatcher-ddl.test.ts
@@ -43,7 +43,10 @@ const executed: string[] = [];
  * runtime re-registration and keeps this focused on the statements.
  */
 function makeAdapter(dialect: "postgresql" | "mysql" | "sqlite") {
-  return {
+  // A single's schema change runs inside the storage migration's lock, so the double has to answer
+  // the lock's reads and writes as well as its own. Added rather than stubbed: a surface that let
+  // every claim succeed would certify an exclusion that is not there.
+  return withMigrationLockSurface({
     dialect,
     getCapabilities: () => ({ dialect }),
     // Answers the way a fresh create finds the database: the main table is there once its CREATE
@@ -60,7 +63,7 @@ function makeAdapter(dialect: "postgresql" | "mysql" | "sqlite") {
       executed.push(sql);
       return [];
     }),
-  };
+  });
 }
 
 let adapter: ReturnType<typeof makeAdapter>;
@@ -82,6 +85,7 @@ vi.mock("../../../di/container", () => ({
   },
 }));
 
+import { withMigrationLockSurface } from "../../../domains/field-groups/migration/__tests__/helpers/migration-lock-double";
 import { SingleMetadataService } from "../../../domains/singles/services/single-metadata-service";
 import type { SingleRegistryService } from "../../../domains/singles/services/single-registry-service";
 import type { Logger } from "../../../shared/types";

--- a/packages/nextly/src/dispatcher/handlers/__tests__/single-dispatcher-delete.test.ts
+++ b/packages/nextly/src/dispatcher/handlers/__tests__/single-dispatcher-delete.test.ts
@@ -126,7 +126,13 @@ describe("the metadata service tolerates one failure and no others", () => {
   };
 
   function serviceOver(deleteSingle: () => Promise<void>) {
-    const registry = { deleteSingle: vi.fn(deleteSingle) };
+    const registry = {
+      // Read INSIDE the exclusion before anything is dropped, so a Single that became code-first
+      // while the request waited is refused rather than force-deleted. Answers `null` here: these
+      // cases are about a row that is already gone, which delete tolerates by intent.
+      getSingleBySlug: vi.fn().mockResolvedValue(null),
+      deleteSingle: vi.fn(deleteSingle),
+    };
     return {
       registry,
       service: new SingleMetadataService(

--- a/packages/nextly/src/dispatcher/handlers/__tests__/single-dispatcher-update-ddl.test.ts
+++ b/packages/nextly/src/dispatcher/handlers/__tests__/single-dispatcher-update-ddl.test.ts
@@ -54,7 +54,10 @@ function makeAdapter(
   // before recording "applied", so a double answering a flat `false` would report every rebuild as
   // failed — the test would then pass for the wrong reason, describing a create that did not work.
   let created = false;
-  return {
+  // A single's schema change runs inside the storage migration's lock, so the double has to answer
+  // the lock's reads and writes as well as its own. Added rather than stubbed: a surface that let
+  // every claim succeed would certify an exclusion that is not there.
+  return withMigrationLockSurface({
     dialect,
     getCapabilities: () => ({ dialect }),
     tableExists: vi.fn(async (name: string) =>
@@ -81,12 +84,16 @@ function makeAdapter(
       execute: async () => ({ rows: [] }),
     })),
     executeQuery: vi.fn(async (sql: string) => {
+      // The lock's own DDL is a `CREATE TABLE` too, and it runs BEFORE the single's. Letting it
+      // through would flip `created` while the main table still did not exist, so the apply would
+      // record every rebuild as applied against a table nothing had built.
+      if (isMigrationLockStatement(sql)) return [];
       executed.push(sql);
       onStatement?.(sql);
       if (/CREATE TABLE/i.test(sql)) created = true;
       return [];
     }),
-  };
+  });
 }
 
 let adapter: ReturnType<typeof makeAdapter>;
@@ -167,6 +174,10 @@ vi.mock(
 );
 
 import { NextlyError } from "../../../errors";
+import {
+  isMigrationLockStatement,
+  withMigrationLockSurface,
+} from "../../../domains/field-groups/migration/__tests__/helpers/migration-lock-double";
 import { SingleMetadataService } from "../../../domains/singles/services/single-metadata-service";
 import type { SingleRegistryService } from "../../../domains/singles/services/single-registry-service";
 import type { Logger } from "../../../shared/types";

--- a/packages/nextly/src/dispatcher/handlers/single-dispatcher.ts
+++ b/packages/nextly/src/dispatcher/handlers/single-dispatcher.ts
@@ -900,6 +900,10 @@ const SINGLES_METHODS: Record<string, MethodHandler<SinglesServices>> = {
           fields: schemaFields,
           isLocalized,
           wasLocalized,
+          // Whether the request SET the toggle, mirroring `statusRequested`. The service re-reads
+          // the record inside its exclusion and needs to tell an explicit `localized: false` from
+          // this handler having filled in the value it read.
+          localizedRequested: b.localized !== undefined,
           hasStatus,
           wasStatus,
           // Whether the request SET the toggle, which is not the same as changing it: saving it at

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/helpers/locking-adapter.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/helpers/locking-adapter.ts
@@ -12,7 +12,8 @@
  */
 import type { DrizzleAdapter } from "@nextlyhq/adapter-drizzle";
 import type { SQL } from "drizzle-orm";
-import { PgDialect } from "drizzle-orm/pg-core";
+
+import { createLockRow, interpretLockStatement } from "./migration-lock-double";
 
 export interface LockingAdapterOptions {
   /** Marker value the `nextly_meta` read returns, or `undefined` for none. */
@@ -36,42 +37,14 @@ export interface LockingAdapterOptions {
 const COMPANION_PROBE = /^SELECT 1 FROM ["`](\w+_locales)["`] LIMIT 0$/;
 
 export function createLockingAdapter(options: LockingAdapterOptions = {}) {
-  const lock: { seeded: boolean; owner: string | null } = {
-    seeded: options.heldBy !== undefined,
-    owner: options.heldBy ?? null,
-  };
+  const lock = createLockRow(options.heldBy);
   const ddl: string[] = [];
 
-  function interpret(statement: SQL): Record<string, unknown>[] {
-    const { sql: text, params } = new PgDialect().sqlToQuery(statement);
-    const flat = text.replace(/\s+/g, " ").trim();
-
-    if (
-      /^SELECT "\w+" FROM "nextly_field_group_lock" WHERE "id" = \$1$/.test(
-        flat
-      )
-    ) {
-      return lock.seeded ? [{ id: 1, owner: lock.owner }] : [];
-    }
-    if (
-      /^UPDATE "nextly_field_group_lock" SET "owner" = \$1 WHERE "id" = \$2$/.test(
-        flat
-      )
-    ) {
-      // An occupied row refuses a new claim, exactly as the real one does.
-      if (lock.owner === null) lock.owner = params[0] as string | null;
-      return [];
-    }
-    if (
-      /^UPDATE "nextly_field_group_lock" SET "owner" = NULL WHERE "id" = \$1 AND "owner" = \$2$/.test(
-        flat
-      )
-    ) {
-      if (lock.owner === params[1]) lock.owner = null;
-      return [];
-    }
-    throw new Error(`unrecognised statement: ${flat}`);
-  }
+  // The lock's own semantics live in one place, shared with the surface that adds them to other
+  // suites' doubles. Two interpreters of the same statements would agree the day they were written
+  // and drift silently afterwards, because each looks correct read on its own.
+  const interpret = (statement: SQL): Record<string, unknown>[] =>
+    interpretLockStatement(lock, statement);
 
   const adapter = {
     dialect: "postgresql" as const,

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/helpers/migration-lock-double.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/helpers/migration-lock-double.ts
@@ -19,6 +19,7 @@
 import type { SQL } from "drizzle-orm";
 import { PgDialect } from "drizzle-orm/pg-core";
 
+import { NextlyError } from "../../../../../errors/nextly-error";
 import { MIGRATION_LOCK_TABLE } from "../../session";
 
 /** The single row the lock is: whether it has been seeded at all, and who holds it. */
@@ -68,7 +69,13 @@ export function interpretLockStatement(
     if (lock.owner === params[1]) lock.owner = null;
     return [];
   }
-  throw new Error(`unrecognised statement: ${flat}`);
+  // `NextlyError.internal` rather than a bare `Error`: this fires only when the statements the
+  // session issues have moved and this interpreter has not, which is a programming mistake in the
+  // same sense the session's own `internal` refusals are.
+  throw NextlyError.internal({
+    logMessage: `migration lock double met an unrecognised statement: ${flat}`,
+    logContext: { reason: "unrecognised migration lock statement", flat },
+  });
 }
 
 /**

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/helpers/migration-lock-double.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/helpers/migration-lock-double.ts
@@ -73,8 +73,10 @@ export function interpretLockStatement(
   // session issues have moved and this interpreter has not, which is a programming mistake in the
   // same sense the session's own `internal` refusals are.
   throw NextlyError.internal({
-    logMessage: `migration lock double met an unrecognised statement: ${flat}`,
-    logContext: { reason: "unrecognised migration lock statement", flat },
+    logContext: {
+      reason: "unrecognised migration lock statement",
+      statement: flat,
+    },
   });
 }
 

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/helpers/migration-lock-double.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/helpers/migration-lock-double.ts
@@ -1,0 +1,165 @@
+/**
+ * The migration lock, as an in-memory double that can be added to an existing adapter double.
+ *
+ * A Schema Builder change now runs inside the storage migration's lock, so every suite that drives
+ * one of those services through a double reaches the lock's reads and writes — even suites whose
+ * subject is the entity DDL and nothing else. Two ways of answering that are wrong in opposite
+ * directions, and this exists to avoid both. A double missing the methods makes every schema change
+ * look broken, which is what happens today. A double that resolves everything makes every claim
+ * succeed, which certifies exclusion that is not there.
+ *
+ * So the lock is modelled rather than stubbed: one row, claimed by whoever finds it free, refused to
+ * everyone else. Statements are compiled through a real dialect, so this reads the SQL and the bound
+ * parameters an adapter would hand its driver rather than a shape agreed between test and helper.
+ *
+ * Shared, and shaped as an ADDITION to a double rather than a replacement for one, because the
+ * suites that need it already model their own entity's surface and have nothing to gain by
+ * re-modelling it here.
+ */
+import type { SQL } from "drizzle-orm";
+import { PgDialect } from "drizzle-orm/pg-core";
+
+import { MIGRATION_LOCK_TABLE } from "../../session";
+
+/** The single row the lock is: whether it has been seeded at all, and who holds it. */
+export interface LockRow {
+  seeded: boolean;
+  owner: string | null;
+}
+
+/**
+ * `heldBy` absent means the row has never been seeded, which is what a database that has never run
+ * a migration has. Passing `null` seeds it free, and a string seeds it held by someone else.
+ */
+export function createLockRow(heldBy?: string | null): LockRow {
+  return { seeded: heldBy !== undefined, owner: heldBy ?? null };
+}
+
+const SELECT_OWNER =
+  /^SELECT "\w+" FROM "nextly_field_group_lock" WHERE "id" = \$1$/;
+const CLAIM =
+  /^UPDATE "nextly_field_group_lock" SET "owner" = \$1 WHERE "id" = \$2$/;
+const RELEASE =
+  /^UPDATE "nextly_field_group_lock" SET "owner" = NULL WHERE "id" = \$1 AND "owner" = \$2$/;
+
+/**
+ * Apply one statement to the lock row and answer as the database would.
+ *
+ * Unrecognised statements throw rather than resolving empty. A lock read that quietly returned no
+ * rows would be indistinguishable from an unseeded row, so a change to the statements this module
+ * issues would silently start certifying the wrong state instead of failing here.
+ */
+export function interpretLockStatement(
+  lock: LockRow,
+  statement: SQL
+): Record<string, unknown>[] {
+  const { sql: text, params } = new PgDialect().sqlToQuery(statement);
+  const flat = text.replace(/\s+/g, " ").trim();
+
+  if (SELECT_OWNER.test(flat)) {
+    return lock.seeded ? [{ id: 1, owner: lock.owner }] : [];
+  }
+  if (CLAIM.test(flat)) {
+    // An occupied row refuses a new claim, exactly as the real one does.
+    if (lock.owner === null) lock.owner = params[0] as string | null;
+    return [];
+  }
+  if (RELEASE.test(flat)) {
+    if (lock.owner === params[1]) lock.owner = null;
+    return [];
+  }
+  throw new Error(`unrecognised statement: ${flat}`);
+}
+
+/**
+ * Whether a statement belongs to the lock rather than to the entity under test.
+ *
+ * Exported because the suites need it: taking the lock issues `CREATE TABLE IF NOT EXISTS` for the
+ * lock's own table, so a schema change that executes no DDL of its own no longer executes nothing
+ * at all. Asked in one place so a suite asserting "this path issued no DDL" keeps saying that, and
+ * keeps saying it accurately, rather than each suite carrying its own idea of what to ignore.
+ */
+export function isMigrationLockStatement(sql: string): boolean {
+  return sql.includes(MIGRATION_LOCK_TABLE);
+}
+
+export interface MigrationLockSurfaceOptions {
+  /**
+   * The `nextly_meta` migration marker the exclusion reads after taking the lock, or absent for a
+   * database with no run recorded — which is the state a schema change is expected to proceed from.
+   */
+  marker?: unknown;
+  /** A claim already in the row, so the lock reads as held by another run. */
+  heldBy?: string | null;
+  /** Whether the lock table is already there. */
+  lockTableExists?: boolean;
+}
+
+/** The adapter methods this composes with; anything else the double declares is carried through. */
+interface AdapterDoubleBase {
+  tableExists: (name: string) => Promise<boolean>;
+  getDrizzle?: () => Record<string, unknown>;
+}
+
+/**
+ * Add the lock's surface to an adapter double.
+ *
+ * `tableExists` is wrapped so the lock table answers from this helper and every other name still
+ * answers from the double, whose own answer is usually load-bearing. `getDrizzle` is EXTENDED
+ * rather than replaced, because the marker read is one call among several a double may already
+ * serve through it.
+ *
+ * `executeQuery` is deliberately left alone. The lock's DDL is real DDL and belongs in whatever the
+ * double records, so a suite can see that taking the lock created a table; {@link
+ * isMigrationLockStatement} is how a suite separates that from its own. Absorbing it here would
+ * hide a schema change the services now make on every call.
+ */
+export function withMigrationLockSurface<T extends AdapterDoubleBase>(
+  base: T,
+  options: MigrationLockSurfaceOptions = {}
+): T & {
+  queryStatement: (statement: SQL) => Promise<Record<string, unknown>[]>;
+  transaction: (work: (ctx: unknown) => Promise<unknown>) => Promise<unknown>;
+  migrationLock: { ownerNow: () => string | null };
+} {
+  const lock = createLockRow(options.heldBy);
+
+  const readMarker = (): Promise<Record<string, unknown>[]> =>
+    Promise.resolve(
+      options.marker === undefined
+        ? []
+        : [{ key: "k", value: JSON.stringify(options.marker) }]
+    );
+
+  return {
+    ...base,
+    tableExists: (name: string) =>
+      name === MIGRATION_LOCK_TABLE
+        ? Promise.resolve(options.lockTableExists ?? true)
+        : base.tableExists(name),
+    getDrizzle: () => ({
+      ...(base.getDrizzle?.() ?? {}),
+      select: () => ({
+        from: () => ({ where: () => ({ limit: readMarker }) }),
+      }),
+    }),
+    queryStatement: (statement: SQL) =>
+      Promise.resolve(interpretLockStatement(lock, statement)),
+    transaction: (work: (ctx: unknown) => Promise<unknown>) =>
+      work({
+        lockRow: () => Promise.resolve(undefined),
+        insert: (_table: string, data: { owner: string | null }) => {
+          lock.seeded = true;
+          lock.owner = data.owner;
+          return Promise.resolve(data);
+        },
+        runStatement: (statement: SQL) => {
+          interpretLockStatement(lock, statement);
+          return Promise.resolve();
+        },
+        queryStatement: (statement: SQL) =>
+          Promise.resolve(interpretLockStatement(lock, statement)),
+      }),
+    migrationLock: { ownerNow: () => lock.owner },
+  };
+}

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/sync-guard.test.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/sync-guard.test.ts
@@ -175,7 +175,13 @@ describe("holding the exclusion for the whole sync", () => {
     let ownerDuringWork: string | null = null;
 
     await withMigrationExcluded(
-      { adapter, logger, label: "db:sync", mayCreateLock: true },
+      {
+        adapter,
+        logger,
+        label: "db:sync",
+        mayCreateLock: true,
+        releaseOnInterrupt: true,
+      },
       () => {
         ownerDuringWork = ownerNow();
         return Promise.resolve();
@@ -193,7 +199,13 @@ describe("holding the exclusion for the whole sync", () => {
     const work = vi.fn(() => Promise.resolve());
 
     const error = await withMigrationExcluded(
-      { adapter, logger, label: "db:sync", mayCreateLock: true },
+      {
+        adapter,
+        logger,
+        label: "db:sync",
+        mayCreateLock: true,
+        releaseOnInterrupt: true,
+      },
       work
     ).catch((caught: unknown) => caught);
 
@@ -207,7 +219,13 @@ describe("holding the exclusion for the whole sync", () => {
   it("issues no DDL when the caller may not change schema", async () => {
     const { adapter, ddlIssued } = createLockingAdapter({});
     await withMigrationExcluded(
-      { adapter, logger, label: "db:sync", mayCreateLock: false },
+      {
+        adapter,
+        logger,
+        label: "db:sync",
+        mayCreateLock: false,
+        releaseOnInterrupt: true,
+      },
       () => Promise.resolve()
     );
     expect(ddlIssued().filter(sql => /CREATE TABLE/i.test(sql))).toEqual([]);
@@ -223,7 +241,13 @@ describe("holding the exclusion for the whole sync", () => {
     const work = vi.fn(() => Promise.resolve());
 
     await withMigrationExcluded(
-      { adapter, logger, label: "db:sync", mayCreateLock: false },
+      {
+        adapter,
+        logger,
+        label: "db:sync",
+        mayCreateLock: false,
+        releaseOnInterrupt: true,
+      },
       work
     );
 
@@ -248,7 +272,13 @@ describe("holding the exclusion for the whole sync", () => {
     try {
       let ownerWhileHeld: string | null = null;
       await withMigrationExcluded(
-        { adapter, logger, label: "db:sync watch", mayCreateLock: true },
+        {
+          adapter,
+          logger,
+          label: "db:sync watch",
+          mayCreateLock: true,
+          releaseOnInterrupt: true,
+        },
         async () => {
           ownerWhileHeld = ownerNow();
           process.emit("SIGINT");
@@ -276,7 +306,13 @@ describe("holding the exclusion for the whole sync", () => {
     let ownerDuringWork: string | null = null;
 
     await withMigrationExcluded(
-      { adapter, logger, label: "db:sync", mayCreateLock: true },
+      {
+        adapter,
+        logger,
+        label: "db:sync",
+        mayCreateLock: true,
+        releaseOnInterrupt: true,
+      },
       () => {
         ownerDuringWork = ownerNow();
         return Promise.resolve();
@@ -295,7 +331,13 @@ describe("holding the exclusion for the whole sync", () => {
     const work = vi.fn(() => Promise.resolve());
 
     const error = await withMigrationExcluded(
-      { adapter, logger, label: "db:sync", mayCreateLock: true },
+      {
+        adapter,
+        logger,
+        label: "db:sync",
+        mayCreateLock: true,
+        releaseOnInterrupt: true,
+      },
       work
     ).catch((caught: unknown) => caught);
 

--- a/packages/nextly/src/domains/field-groups/migration/sync-guard.ts
+++ b/packages/nextly/src/domains/field-groups/migration/sync-guard.ts
@@ -111,6 +111,23 @@ export async function withMigrationExcluded<T>(
      * sync, which is narrower than refusing the command outright.
      */
     mayCreateLock: boolean;
+    /**
+     * Whether an interrupt may hand the claim away while `work` is still running.
+     *
+     * Stated by every caller rather than defaulted, because the two answers protect different
+     * things and the safe one depends on what the work does, which this cannot see.
+     *
+     * A schema SYNC opts in: the documented way to stop watch mode is Ctrl+C, its work is
+     * idempotent, and two syncs overlapping is the state that existed before this exclusion, so a
+     * claim stuck behind a dead process is the worse outcome.
+     *
+     * A schema CHANGE must not. Its DDL and its registry write are neither atomic nor idempotent,
+     * and the signal does not stop `work` — another listener delaying termination is enough for a
+     * migration to take the row and start renaming while the change is still finishing. That is
+     * precisely the overlap the exclusion exists to prevent, so the claim is held to the end and a
+     * killed process leaves a claim for an operator, which is the trade a migration already makes.
+     */
+    releaseOnInterrupt: boolean;
   },
   work: () => Promise<T>
 ): Promise<T> {
@@ -120,10 +137,7 @@ export async function withMigrationExcluded<T>(
       dialect: args.adapter.getCapabilities().dialect,
       label: args.label,
       requireExistingLock: !args.mayCreateLock,
-      // A sync's claim is safe to drop on a signal: two syncs overlapping is
-      // the state that existed before this exclusion, whereas a migration's
-      // claim must survive interruption.
-      releaseOnInterrupt: true,
+      releaseOnInterrupt: args.releaseOnInterrupt,
     },
     async () => {
       await assertNoMigrationInFlight({

--- a/packages/nextly/src/domains/field-groups/services/__tests__/field-group-metadata-apply-contract.test.ts
+++ b/packages/nextly/src/domains/field-groups/services/__tests__/field-group-metadata-apply-contract.test.ts
@@ -84,7 +84,9 @@ function registryDouble() {
 function adapterDouble(tableExists: () => Promise<boolean>) {
   return withMigrationLockSurface({
     getCapabilities: () => ({ dialect: "postgresql" as const }),
-    executeQuery: vi.fn(async () => []),
+    // The parameter is declared even though nothing here reads it: `entityStatements` reads the
+    // recorded calls, and a mock with no declared parameters records them as an empty tuple.
+    executeQuery: vi.fn(async (_sql: string) => []),
     tableExists: vi.fn(async (name: string) =>
       name === "nextly_meta" ? false : tableExists()
     ),
@@ -99,7 +101,7 @@ function adapterDouble(tableExists: () => Promise<boolean>) {
  */
 function entityStatements(adapter: ReturnType<typeof adapterDouble>): string[] {
   return adapter.executeQuery.mock.calls
-    .map(([sql]) => sql as string)
+    .map(([sql]) => sql)
     .filter(sql => !isMigrationLockStatement(sql));
 }
 

--- a/packages/nextly/src/domains/field-groups/services/__tests__/field-group-metadata-apply-contract.test.ts
+++ b/packages/nextly/src/domains/field-groups/services/__tests__/field-group-metadata-apply-contract.test.ts
@@ -34,6 +34,10 @@ import type { DrizzleAdapter } from "@nextlyhq/adapter-drizzle";
 
 import { NextlyError } from "../../../../errors";
 import type { Logger } from "../../../../shared/types";
+import {
+  isMigrationLockStatement,
+  withMigrationLockSurface,
+} from "../../migration/__tests__/helpers/migration-lock-double";
 import type { FieldGroupRegistryService } from "../field-group-registry-service";
 import {
   FieldGroupMetadataService,
@@ -68,13 +72,35 @@ function registryDouble() {
   };
 }
 
-/** An adapter that runs DDL happily and answers the verification however the test needs. */
+/**
+ * An adapter that runs DDL happily and answers the verification however the test needs.
+ *
+ * A create now runs inside the storage migration's lock, so the double carries the lock's surface
+ * too, and `nextly_meta` answers absent — a fixture that has never recorded a migration marker.
+ * That leaves the supplied `tableExists` governing the VERIFICATION probe alone, which is the
+ * failure these tests inject; routing it into the exclusion's probe as well would refuse the create
+ * before it started, and every assertion below would be describing a different path.
+ */
 function adapterDouble(tableExists: () => Promise<boolean>) {
-  return {
+  return withMigrationLockSurface({
     getCapabilities: () => ({ dialect: "postgresql" as const }),
     executeQuery: vi.fn(async () => []),
-    tableExists: vi.fn(tableExists),
-  };
+    tableExists: vi.fn(async (name: string) =>
+      name === "nextly_meta" ? false : tableExists()
+    ),
+  });
+}
+
+/**
+ * The statements the create issued for its OWN table.
+ *
+ * Taking the lock issues DDL for the lock's table, so "the adapter executed nothing" no longer
+ * separates a create that built a table from one that never got that far. This does.
+ */
+function entityStatements(adapter: ReturnType<typeof adapterDouble>): string[] {
+  return adapter.executeQuery.mock.calls
+    .map(([sql]) => sql as string)
+    .filter(sql => !isMigrationLockStatement(sql));
 }
 
 function serviceOver(
@@ -144,7 +170,7 @@ describe("a field-group create records its outcome rather than raising it", () =
 
     // Nothing ran and nothing was written. A refusal that has already touched the table would have
     // rebound the existing field group's storage to this request's fields.
-    expect(adapter.executeQuery).not.toHaveBeenCalled();
+    expect(entityStatements(adapter)).toEqual([]);
     expect(registry.registerComponent).not.toHaveBeenCalled();
   });
 });
@@ -224,7 +250,7 @@ describe("a create whose generated names would not fit is refused", () => {
 
     // Before any DDL, which is the whole point: a refusal that has already run statements leaves
     // exactly the half-made field group this exists to prevent.
-    expect(adapter.executeQuery).not.toHaveBeenCalled();
+    expect(entityStatements(adapter)).toEqual([]);
     expect(registry.registerComponent).not.toHaveBeenCalled();
   });
 
@@ -242,7 +268,7 @@ describe("a create whose generated names would not fit is refused", () => {
       })
     ).rejects.toMatchObject({ code: "VALIDATION_ERROR" });
 
-    expect(adapter.executeQuery).not.toHaveBeenCalled();
+    expect(entityStatements(adapter)).toEqual([]);
   });
 
   it("counts the column's own name, not only names derived from it", async () => {
@@ -258,7 +284,7 @@ describe("a create whose generated names would not fit is refused", () => {
       })
     ).rejects.toMatchObject({ code: "VALIDATION_ERROR" });
 
-    expect(adapter.executeQuery).not.toHaveBeenCalled();
+    expect(entityStatements(adapter)).toEqual([]);
   });
 
   it("does not count an index the renderer never emits", async () => {

--- a/packages/nextly/src/domains/field-groups/services/field-group-metadata-service.ts
+++ b/packages/nextly/src/domains/field-groups/services/field-group-metadata-service.ts
@@ -108,9 +108,20 @@ export class FieldGroupMetadataService {
   async createFieldGroup(
     input: CreateFieldGroupInput
   ): Promise<CreateFieldGroupResult> {
+    // 1. PLAN, and refuse a request the input itself makes impossible, BEFORE any exclusion is
+    // taken. Both steps are derived from the input and this connection's dialect — neither reads
+    // anything a storage migration could move — so running them under the lock would buy nothing
+    // and cost something real: taking the exclusion may CREATE the lock table, and a create
+    // rejected for a malformed field would then have written to a database it was about to tell
+    // the caller it had left untouched.
+    const migrationSQL = await this.planCreate(input);
+    await this.assertIdentifiersFit(input, migrationSQL);
+
     // 🔴 The exclusion wraps the ownership check too, not only the DDL. That check reads which
     // table names are taken, and a storage migration renaming tables is exactly what makes such a
-    // read stale — a name that looked free can be claimed by the rename a moment later.
+    // read stale — a name that looked free can be claimed by the rename a moment later. That is
+    // also why it stays INSIDE while the planning above moved out: one asks about the input, the
+    // other asks about the database.
     return withSchemaChangeExcluded(
       {
         adapter: this.adapter,
@@ -118,22 +129,16 @@ export class FieldGroupMetadataService {
         label: `create field group "${input.slug}"`,
         issuesDdl: true,
       },
-      () => this.createFieldGroupExcluded(input)
+      () => this.createFieldGroupExcluded(input, migrationSQL)
     );
   }
 
   private async createFieldGroupExcluded(
-    input: CreateFieldGroupInput
+    input: CreateFieldGroupInput,
+    migrationSQL: string
   ): Promise<CreateFieldGroupResult> {
     // 0. REFUSE a table another field group owns, before anything is executed.
     await this.assertTableUnowned(input);
-
-    // 1. PLAN, before anything is persisted or executed. The generator validates as well as
-    // renders, so a request it refuses leaves nothing behind at all.
-    const migrationSQL = await this.planCreate(input);
-
-    // 1a. REFUSE names the database would not store, read from the statements themselves.
-    await this.assertIdentifiersFit(input, migrationSQL);
 
     // 2. APPLY. Never throws; a failure is reported as a status so the row can still record it.
     const migrationStatus = await this.applyCreateDdl(input, migrationSQL);

--- a/packages/nextly/src/domains/field-groups/services/field-group-metadata-service.ts
+++ b/packages/nextly/src/domains/field-groups/services/field-group-metadata-service.ts
@@ -40,6 +40,7 @@ import type {
 } from "../../../schemas/dynamic-field-groups/types";
 import { STORAGE_FORMAT } from "../../../schemas/storage-format";
 import type { Logger } from "../../../shared/types";
+import { withSchemaChangeExcluded } from "../../schema/services/schema-change-exclusion";
 
 import type { FieldGroupRegistryService } from "./field-group-registry-service";
 
@@ -105,6 +106,23 @@ export class FieldGroupMetadataService {
    * The caller has already validated the input's shape.
    */
   async createFieldGroup(
+    input: CreateFieldGroupInput
+  ): Promise<CreateFieldGroupResult> {
+    // 🔴 The exclusion wraps the ownership check too, not only the DDL. That check reads which
+    // table names are taken, and a storage migration renaming tables is exactly what makes such a
+    // read stale — a name that looked free can be claimed by the rename a moment later.
+    return withSchemaChangeExcluded(
+      {
+        adapter: this.adapter,
+        logger: this.logger,
+        label: `create field group "${input.slug}"`,
+        issuesDdl: true,
+      },
+      () => this.createFieldGroupExcluded(input)
+    );
+  }
+
+  private async createFieldGroupExcluded(
     input: CreateFieldGroupInput
   ): Promise<CreateFieldGroupResult> {
     // 0. REFUSE a table another field group owns, before anything is executed.

--- a/packages/nextly/src/domains/field-groups/services/field-group-metadata-service.ts
+++ b/packages/nextly/src/domains/field-groups/services/field-group-metadata-service.ts
@@ -141,8 +141,20 @@ export class FieldGroupMetadataService {
   private async createFieldGroupExcluded(
     input: CreateFieldGroupInput
   ): Promise<CreateFieldGroupResult> {
-    // 0. REFUSE a table another field group owns, before anything is executed.
+    // 0. RE-ESTABLISH every precondition the caller checked outside this exclusion.
+    //
+    // 🔴 One step, deliberately, and the place a NEW precondition goes. Both of these were checked
+    // by the transport before the lock existed: a table another field group owns, and whether each
+    // plugin field's options satisfy that plugin. The second is the subtle one — what changes while
+    // this request waits is not the input but the JUDGE, because an HMR reload replaces the
+    // process-global field-type registry from inside this same exclusion. A declaration the old
+    // registration accepted would otherwise be built and stored against the new one, and every
+    // later write to the field group would fail on options the active plugin rejects.
     await this.assertTableUnowned(input);
+    const { assertValidPluginFieldOptions } = await import(
+      "../../../api/fields-payload"
+    );
+    assertValidPluginFieldOptions(input.fields);
 
     // 1. PLAN. The generator validates as well as renders, so a request it refuses leaves no table
     // and no row behind.

--- a/packages/nextly/src/domains/field-groups/services/field-group-metadata-service.ts
+++ b/packages/nextly/src/domains/field-groups/services/field-group-metadata-service.ts
@@ -108,20 +108,25 @@ export class FieldGroupMetadataService {
   async createFieldGroup(
     input: CreateFieldGroupInput
   ): Promise<CreateFieldGroupResult> {
-    // 1. PLAN, and refuse a request the input itself makes impossible, BEFORE any exclusion is
-    // taken. Both steps are derived from the input and this connection's dialect — neither reads
-    // anything a storage migration could move — so running them under the lock would buy nothing
-    // and cost something real: taking the exclusion may CREATE the lock table, and a create
-    // rejected for a malformed field would then have written to a database it was about to tell
-    // the caller it had left untouched.
-    const migrationSQL = await this.planCreate(input);
-    await this.assertIdentifiersFit(input, migrationSQL);
-
-    // 🔴 The exclusion wraps the ownership check too, not only the DDL. That check reads which
-    // table names are taken, and a storage migration renaming tables is exactly what makes such a
-    // read stale — a name that looked free can be claimed by the rename a moment later. That is
-    // also why it stays INSIDE while the planning above moved out: one asks about the input, the
-    // other asks about the database.
+    // 🔴 Everything is inside, including the planning, and the reason planning is inside is not the
+    // storage migration.
+    //
+    // Rendering DDL consults the PROCESS-GLOBAL field-type registry for plugin fields
+    // (`pluginEmptyColumnDefault` -> `getFieldType`), and an HMR reload replaces that registry
+    // wholesale — `clearFieldTypes()` then re-registration — from inside this same exclusion. Plan
+    // outside it and a create can render its columns against one mapping while the binding below
+    // uses another, leaving a registered schema that disagrees with the column that was created.
+    // Worse, the swap has a window where the registry is EMPTY, so a plan running through it can
+    // refuse a field type that is perfectly valid.
+    //
+    // The ownership check is inside for its own reason: it reads which table names are taken, and a
+    // migration renaming tables is what makes such a read stale.
+    //
+    // What that costs, stated rather than glossed: taking the exclusion may CREATE and seed the
+    // lock table, so a create refused for a malformed field can leave that table behind. It is
+    // empty, it holds no user data, its creation is idempotent, and the next valid request would
+    // have made it anyway — a far smaller price than a column whose type disagrees with the schema
+    // bound to it.
     return withSchemaChangeExcluded(
       {
         adapter: this.adapter,
@@ -129,16 +134,22 @@ export class FieldGroupMetadataService {
         label: `create field group "${input.slug}"`,
         issuesDdl: true,
       },
-      () => this.createFieldGroupExcluded(input, migrationSQL)
+      () => this.createFieldGroupExcluded(input)
     );
   }
 
   private async createFieldGroupExcluded(
-    input: CreateFieldGroupInput,
-    migrationSQL: string
+    input: CreateFieldGroupInput
   ): Promise<CreateFieldGroupResult> {
     // 0. REFUSE a table another field group owns, before anything is executed.
     await this.assertTableUnowned(input);
+
+    // 1. PLAN. The generator validates as well as renders, so a request it refuses leaves no table
+    // and no row behind.
+    const migrationSQL = await this.planCreate(input);
+
+    // 1a. REFUSE names the database would not store, read from the statements themselves.
+    await this.assertIdentifiersFit(input, migrationSQL);
 
     // 2. APPLY. Never throws; a failure is reported as a status so the row can still record it.
     const migrationStatus = await this.applyCreateDdl(input, migrationSQL);

--- a/packages/nextly/src/domains/schema/services/__tests__/schema-change-exclusion-composition.test.ts
+++ b/packages/nextly/src/domains/schema/services/__tests__/schema-change-exclusion-composition.test.ts
@@ -13,9 +13,20 @@
  */
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+/** Set to make the plugin-option validator refuse, standing in for a registry swapped underneath. */
+const pluginOptionRefusal: { error: unknown } = { error: undefined };
+
+vi.mock("../../../../api/fields-payload", () => ({
+  assertValidPluginFieldOptions: vi.fn(() => {
+    if (pluginOptionRefusal.error !== undefined)
+      throw pluginOptionRefusal.error;
+  }),
+}));
+
 import type { DrizzleAdapter } from "@nextlyhq/adapter-drizzle";
 
 import { STORAGE_FORMAT } from "../../../../schemas/storage-format";
+import { NextlyError } from "../../../../errors/nextly-error";
 import type { Logger } from "../../../../shared/types";
 import {
   hashManifest,
@@ -138,6 +149,7 @@ const createSingle = (service: SingleMetadataService) =>
 
 beforeEach(() => {
   executed.length = 0;
+  pluginOptionRefusal.error = undefined;
 });
 
 describe("a schema change and the storage migration contend for one row", () => {
@@ -279,6 +291,33 @@ describe("a field-group create contends for the same row", () => {
 
     expect(ownerDuringWork).toMatch(/^create field group "hero"#/);
     expect(adapter.migrationLock.ownerNow()).toBeNull();
+  });
+
+  it("re-judges plugin field options inside the exclusion", async () => {
+    // 🔴 The field-group twin of the Single create check. It was the call site LEFT BEHIND when the
+    // Single one was fixed, so it gets its own assertion rather than sharing one: a test that only
+    // proves "the validator runs somewhere" is exactly what let this sit unfixed for a round.
+    //
+    // What changes while the request waits is the JUDGE, not the input — an HMR reload replaces the
+    // process-global field-type registry from inside this same exclusion.
+    const adapter = makeAdapter();
+    const { service, registry } = makeFieldGroupService(adapter);
+    pluginOptionRefusal.error = NextlyError.validation({
+      errors: [
+        {
+          path: "fields.0.options",
+          code: "invalid_options",
+          message: "plugin rejected its own options",
+        },
+      ],
+    });
+
+    await expect(createFieldGroup(service)).rejects.toMatchObject({
+      code: "VALIDATION_ERROR",
+    });
+
+    expect(executed.filter(sql => !isMigrationLockStatement(sql))).toEqual([]);
+    expect(registry.registerComponent).not.toHaveBeenCalled();
   });
 
   it("refuses, and builds nothing, while another run holds the lock", async () => {

--- a/packages/nextly/src/domains/schema/services/__tests__/schema-change-exclusion-composition.test.ts
+++ b/packages/nextly/src/domains/schema/services/__tests__/schema-change-exclusion-composition.test.ts
@@ -104,6 +104,18 @@ function makeService(
   onRegister?: () => void
 ) {
   const registry = {
+    // Both are read inside the exclusion now: the create re-asserts table ownership, and the update
+    // and delete re-read the record they were handed.
+    getAllSingles: vi.fn(
+      async (): Promise<{ slug: string; tableName: string }[]> => []
+    ),
+    getSingleBySlug: vi.fn(async (slug: string) => ({
+      slug,
+      tableName: "single_page",
+      fields: [] as unknown[],
+      locked: false,
+      schemaHash: "unchanged",
+    })),
     registerSingle: vi.fn(async (row: unknown) => {
       onRegister?.();
       return row;

--- a/packages/nextly/src/domains/schema/services/__tests__/schema-change-exclusion-composition.test.ts
+++ b/packages/nextly/src/domains/schema/services/__tests__/schema-change-exclusion-composition.test.ts
@@ -243,13 +243,11 @@ describe("a field-group create contends for the same row", () => {
     expect(registry.registerComponent).not.toHaveBeenCalled();
   });
 
-  it("writes nothing at all when the input itself is impossible", async () => {
-    // Taking the exclusion may CREATE and seed the lock table, so a request rejected on its own
-    // contents must be rejected BEFORE that. Otherwise a create refused for a name the database
-    // could never store has still written to the database it is about to report leaving untouched.
-    //
-    // Asserted over EVERY statement rather than only the entity's: here the lock's own DDL is the
-    // thing that must not have run, so filtering it out would remove the evidence.
+  it("builds no table and writes no row when the input itself is impossible", async () => {
+    // What an impossible input must not leave behind is a TABLE and a ROW. The lock's own table is
+    // a deliberate exception and is asserted separately below, because planning has to happen
+    // inside the exclusion: rendering DDL reads the process-global field-type registry, which an
+    // HMR reload replaces from inside this same lock.
     const adapter = makeAdapter({ lockTableExists: false });
     const { service, registry } = makeFieldGroupService(adapter);
 
@@ -260,7 +258,25 @@ describe("a field-group create contends for the same row", () => {
       } as unknown as Parameters<typeof service.createFieldGroup>[0])
     ).rejects.toMatchObject({ code: "VALIDATION_ERROR" });
 
-    expect(executed).toEqual([]);
+    expect(executed.filter(sql => !isMigrationLockStatement(sql))).toEqual([]);
     expect(registry.registerComponent).not.toHaveBeenCalled();
+  });
+
+  it("leaves behind only the lock's own table when it refuses an impossible input", async () => {
+    // The cost of planning inside the exclusion, pinned rather than described. If this ever starts
+    // failing because NOTHING was written, planning has moved back outside the lock and the plugin
+    // field-type race is open again.
+    const adapter = makeAdapter({ lockTableExists: false });
+    const { service } = makeFieldGroupService(adapter);
+
+    await expect(
+      service.createFieldGroup({
+        ...FIELD_GROUP_INPUT,
+        tableName: `comp_${"x".repeat(80)}`,
+      } as unknown as Parameters<typeof service.createFieldGroup>[0])
+    ).rejects.toMatchObject({ code: "VALIDATION_ERROR" });
+
+    expect(executed.every(isMigrationLockStatement)).toBe(true);
+    expect(executed.length).toBeGreaterThan(0);
   });
 });

--- a/packages/nextly/src/domains/schema/services/__tests__/schema-change-exclusion-composition.test.ts
+++ b/packages/nextly/src/domains/schema/services/__tests__/schema-change-exclusion-composition.test.ts
@@ -21,6 +21,8 @@ import {
   withMigrationLockSurface,
   type MigrationLockSurfaceOptions,
 } from "../../../field-groups/migration/__tests__/helpers/migration-lock-double";
+import { FieldGroupMetadataService } from "../../../field-groups/services/field-group-metadata-service";
+import type { FieldGroupRegistryService } from "../../../field-groups/services/field-group-registry-service";
 import { SingleMetadataService } from "../../../singles/services/single-metadata-service";
 import type { SingleRegistryService } from "../../../singles/services/single-registry-service";
 
@@ -172,5 +174,93 @@ describe("a schema change and the storage migration contend for one row", () => 
     expect(registry.registerSingle).not.toHaveBeenCalled();
     // Released on the way out, so a refusal does not strand the row it took to make the decision.
     expect(adapter.migrationLock.ownerNow()).toBeNull();
+  });
+});
+
+/**
+ * The same properties for the other service that was wrapped.
+ *
+ * Kept as its own block rather than folded into the singles cases, because "the singles wrapper
+ * works" says nothing about the field-group one — they are separate call sites and either could be
+ * removed with every assertion above still passing.
+ */
+describe("a field-group create contends for the same row", () => {
+  function makeFieldGroupService(adapter: ReturnType<typeof makeAdapter>) {
+    const registry = {
+      // Answers "no field group owns that table" so the create reaches the DDL path.
+      getAllComponents: vi.fn().mockResolvedValue([]),
+      registerComponent: vi.fn(async (row: unknown) => row),
+    };
+    const service = new FieldGroupMetadataService(
+      registry as unknown as FieldGroupRegistryService,
+      logger,
+      adapter as unknown as DrizzleAdapter
+    );
+    return { service, registry };
+  }
+
+  const FIELD_GROUP_INPUT = {
+    slug: "hero",
+    label: "Hero",
+    tableName: "comp_hero",
+    fields: [{ name: "heading", type: "text" }],
+    source: "ui",
+    locked: false,
+    schemaHash: "hash-for-the-fields-above",
+  };
+
+  const createFieldGroup = (service: FieldGroupMetadataService) =>
+    service.createFieldGroup(
+      FIELD_GROUP_INPUT as unknown as Parameters<
+        typeof service.createFieldGroup
+      >[0]
+    );
+
+  it("holds the lock while the work runs", async () => {
+    const adapter = makeAdapter();
+    let ownerDuringWork: string | null = null;
+    const { service, registry } = makeFieldGroupService(adapter);
+    registry.registerComponent.mockImplementation(async (row: unknown) => {
+      ownerDuringWork = adapter.migrationLock.ownerNow();
+      return row;
+    });
+
+    await createFieldGroup(service);
+
+    expect(ownerDuringWork).toMatch(/^create field group "hero"#/);
+    expect(adapter.migrationLock.ownerNow()).toBeNull();
+  });
+
+  it("refuses, and builds nothing, while another run holds the lock", async () => {
+    const adapter = makeAdapter({ heldBy: "storage migration#other-run" });
+    const { service, registry } = makeFieldGroupService(adapter);
+
+    await expect(createFieldGroup(service)).rejects.toMatchObject({
+      code: "SERVICE_UNAVAILABLE",
+    });
+
+    expect(executed.filter(sql => !isMigrationLockStatement(sql))).toEqual([]);
+    expect(registry.registerComponent).not.toHaveBeenCalled();
+  });
+
+  it("writes nothing at all when the input itself is impossible", async () => {
+    // Taking the exclusion may CREATE and seed the lock table, so a request rejected on its own
+    // contents must be rejected BEFORE that. Otherwise a create refused for a name the database
+    // could never store has still written to the database it is about to report leaving untouched.
+    //
+    // Asserted over EVERY statement rather than only the entity's: here the lock's own DDL is the
+    // thing that must not have run, so filtering it out would remove the evidence.
+    const adapter = makeAdapter({ lockTableExists: false });
+    const { service, registry } = makeFieldGroupService(adapter);
+
+    await expect(
+      service.createFieldGroup({
+        ...FIELD_GROUP_INPUT,
+        tableName: `comp_${"x".repeat(80)}`,
+      } as unknown as Parameters<typeof service.createFieldGroup>[0])
+    ).rejects.toMatchObject({ code: "VALIDATION_ERROR" });
+
+    expect(executed).toEqual([]);
+    expect(registry.registerComponent).not.toHaveBeenCalled();
   });
 });

--- a/packages/nextly/src/domains/schema/services/__tests__/schema-change-exclusion-composition.test.ts
+++ b/packages/nextly/src/domains/schema/services/__tests__/schema-change-exclusion-composition.test.ts
@@ -1,0 +1,176 @@
+/**
+ * The exclusion a Schema Builder change asks for, composed with the real lock rather than a stand-in.
+ *
+ * Its sibling `schema-change-exclusion.test.ts` replaces `withMigrationExcluded` so it can assert
+ * ORDER — that the exclusion is taken before any DDL or any row. That substitution is what makes
+ * those assertions readable, and it is also what they cannot check: a service could ask for an
+ * exclusion that never claims anything and every one of them would still pass.
+ *
+ * So these run the real primitive against an in-memory lock. What they establish is the part the
+ * mocked suite has to assume — that asking actually claims the row, that the claim is held while the
+ * work runs and given back afterwards, and that a run already holding it turns the schema change
+ * away before it has touched a table.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { DrizzleAdapter } from "@nextlyhq/adapter-drizzle";
+
+import type { Logger } from "../../../../shared/types";
+import {
+  isMigrationLockStatement,
+  withMigrationLockSurface,
+  type MigrationLockSurfaceOptions,
+} from "../../../field-groups/migration/__tests__/helpers/migration-lock-double";
+import { SingleMetadataService } from "../../../singles/services/single-metadata-service";
+import type { SingleRegistryService } from "../../../singles/services/single-registry-service";
+
+const logger: Logger = {
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+};
+
+/** Every statement the create issued, in order, so the lock's own DDL can be told from the table's. */
+const executed: string[] = [];
+
+/**
+ * `tableExists` answers the way a fresh create finds the database — the main table present once its
+ * CREATE has run, the companion absent — because a create that reported `failed` would leave these
+ * describing a run that gave up rather than one that worked.
+ *
+ * `nextly_meta` answers present, so the marker read inside the lock is genuinely performed rather
+ * than skipped by a database that has no meta table at all.
+ */
+function makeAdapter(options: MigrationLockSurfaceOptions = {}) {
+  let created = false;
+  return withMigrationLockSurface(
+    {
+      dialect: "postgresql" as const,
+      getCapabilities: () => ({ dialect: "postgresql" as const }),
+      tableExists: vi.fn(async (name: string) => {
+        if (name === "nextly_meta") return true;
+        return name.includes("_locales") ? false : created;
+      }),
+      selectOne: vi.fn(async (): Promise<{ id: string } | null> => null),
+      executeQuery: vi.fn(async (sql: string) => {
+        executed.push(sql);
+        // The lock's DDL is a `CREATE TABLE` too, and it runs first. Letting it set this flag would
+        // report the single's table as present before anything had built it.
+        if (!isMigrationLockStatement(sql) && /CREATE TABLE/i.test(sql)) {
+          created = true;
+        }
+        return [];
+      }),
+    },
+    options
+  );
+}
+
+const INPUT = {
+  slug: "page",
+  label: "Page",
+  tableName: "single_page",
+  fields: [{ name: "heading", type: "text" }],
+};
+
+function makeService(
+  adapter: ReturnType<typeof makeAdapter>,
+  onRegister?: () => void
+) {
+  const registry = {
+    registerSingle: vi.fn(async (row: unknown) => {
+      onRegister?.();
+      return row;
+    }),
+    updateSingle: vi.fn(async () => ({})),
+    deleteSingle: vi.fn(async () => {}),
+  };
+  const service = new SingleMetadataService(
+    registry as unknown as SingleRegistryService,
+    logger,
+    adapter as unknown as DrizzleAdapter
+  );
+  return { service, registry };
+}
+
+const createSingle = (service: SingleMetadataService) =>
+  service.createSingle(
+    INPUT as unknown as Parameters<typeof service.createSingle>[0]
+  );
+
+beforeEach(() => {
+  executed.length = 0;
+});
+
+describe("a schema change and the storage migration contend for one row", () => {
+  it("holds the lock while the work runs, and gives it back", async () => {
+    // Sampled from INSIDE the work rather than after it. A claim taken and released around nothing
+    // would leave the same empty row behind as one that never claimed at all, so the only moment
+    // that separates the two is while the create is still writing.
+    const adapter = makeAdapter();
+    let ownerDuringWork: string | null = null;
+    const { service } = makeService(adapter, () => {
+      ownerDuringWork = adapter.migrationLock.ownerNow();
+    });
+
+    await createSingle(service);
+
+    expect(ownerDuringWork).toMatch(/^create single "page"#/);
+    expect(adapter.migrationLock.ownerNow()).toBeNull();
+  });
+
+  it("creates the lock table on a database that has never run a migration", async () => {
+    // `mayCreateLock` is what makes this path safe on a fresh database: without the table, a first
+    // storage migration would create it, claim it, and start renaming while this change was already
+    // under way. The DDL is the observable form of that decision.
+    const adapter = makeAdapter({ lockTableExists: false });
+    const { service } = makeService(adapter);
+
+    await createSingle(service);
+
+    expect(executed.filter(isMigrationLockStatement).length).toBeGreaterThan(0);
+  });
+
+  it("refuses, and builds nothing, while another run holds the lock", async () => {
+    const adapter = makeAdapter({ heldBy: "storage migration#other-run" });
+    const { service, registry } = makeService(adapter);
+
+    await expect(createSingle(service)).rejects.toMatchObject({
+      code: "SERVICE_UNAVAILABLE",
+    });
+
+    // The refusal has to arrive before the table, not after it. Asserting the throw alone would
+    // pass on a create that built its table and then discovered the contention.
+    expect(executed.filter(sql => !isMigrationLockStatement(sql))).toEqual([]);
+    expect(registry.registerSingle).not.toHaveBeenCalled();
+  });
+
+  it("refuses, and builds nothing, while a migration marker is in flight", async () => {
+    // A free lock is not sufficient. A run that died mid-migration leaves the marker behind and the
+    // row unclaimed, and the storage it half-renamed is exactly what this change must not touch.
+    const adapter = makeAdapter({
+      heldBy: null,
+      marker: {
+        version: 2,
+        status: "migrating",
+        direction: "up",
+        migrationId: "run-1",
+        step: 1,
+        registryHash: "r",
+        manifestHash: "m",
+        appliedManifest: [],
+      },
+    });
+    const { service, registry } = makeService(adapter);
+
+    await expect(createSingle(service)).rejects.toMatchObject({
+      code: "SERVICE_UNAVAILABLE",
+    });
+
+    expect(executed.filter(sql => !isMigrationLockStatement(sql))).toEqual([]);
+    expect(registry.registerSingle).not.toHaveBeenCalled();
+    // Released on the way out, so a refusal does not strand the row it took to make the decision.
+    expect(adapter.migrationLock.ownerNow()).toBeNull();
+  });
+});

--- a/packages/nextly/src/domains/schema/services/__tests__/schema-change-exclusion-composition.test.ts
+++ b/packages/nextly/src/domains/schema/services/__tests__/schema-change-exclusion-composition.test.ts
@@ -15,7 +15,14 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { DrizzleAdapter } from "@nextlyhq/adapter-drizzle";
 
+import { STORAGE_FORMAT } from "../../../../schemas/storage-format";
 import type { Logger } from "../../../../shared/types";
+import {
+  hashManifest,
+  MIGRATION_TARGET,
+  type ManifestEntry,
+} from "../../../field-groups/migration/manifest";
+import { MIGRATION_MARKER_VERSION } from "../../../field-groups/migration/state";
 import {
   isMigrationLockStatement,
   withMigrationLockSurface,
@@ -68,6 +75,22 @@ function makeAdapter(options: MigrationLockSurfaceOptions = {}) {
     options
   );
 }
+
+/**
+ * The smallest plan a marker can carry: the registry rename every run performs.
+ *
+ * Spelled from the catalog and the target rather than written out, so it stays a VALID plan if
+ * either name moves. A marker whose manifest does not rename the registry exactly once is rejected
+ * before its status is read, and that rejection carries the same error code as the refusal this
+ * fixture exists to reach.
+ */
+const IN_FLIGHT_PLAN: ManifestEntry[] = [
+  {
+    kind: "registry",
+    from: STORAGE_FORMAT.registryTable,
+    to: MIGRATION_TARGET.registryTable,
+  },
+];
 
 const INPUT = {
   slug: "page",
@@ -151,23 +174,38 @@ describe("a schema change and the storage migration contend for one row", () => 
   it("refuses, and builds nothing, while a migration marker is in flight", async () => {
     // A free lock is not sufficient. A run that died mid-migration leaves the marker behind and the
     // row unclaimed, and the storage it half-renamed is exactly what this change must not touch.
+    //
+    // 🔴 `version` and `manifestHash` are DERIVED, not written out. A hand-written marker is
+    // rejected as unreadable before its status is ever consulted, and the refusal that produces is
+    // a different one wearing the same error code — so the test passes while exercising nothing it
+    // claims to. Deriving both means a future marker-format change moves this fixture with it
+    // instead of silently turning the test back into a version check.
     const adapter = makeAdapter({
       heldBy: null,
       marker: {
-        version: 2,
+        version: MIGRATION_MARKER_VERSION,
         status: "migrating",
         direction: "up",
         migrationId: "run-1",
         step: 1,
         registryHash: "r",
-        manifestHash: "m",
-        appliedManifest: [],
+        manifestHash: hashManifest(IN_FLIGHT_PLAN),
+        appliedManifest: IN_FLIGHT_PLAN,
       },
     });
     const { service, registry } = makeService(adapter);
 
-    await expect(createSingle(service)).rejects.toMatchObject({
+    const error = await createSingle(service).catch(
+      (caught: unknown) => caught
+    );
+
+    // 🔴 The REASON is asserted, not just the code. An unreadable marker refuses with the same
+    // `SERVICE_UNAVAILABLE`, so a fixture the parser rejects would satisfy a code-only assertion
+    // while never reaching the in-flight check this test exists for — which is exactly what it did
+    // before the fixture was derived above.
+    expect(error).toMatchObject({
       code: "SERVICE_UNAVAILABLE",
+      logContext: { reason: "field group storage migration is in flight" },
     });
 
     expect(executed.filter(sql => !isMigrationLockStatement(sql))).toEqual([]);

--- a/packages/nextly/src/domains/schema/services/__tests__/schema-change-exclusion.test.ts
+++ b/packages/nextly/src/domains/schema/services/__tests__/schema-change-exclusion.test.ts
@@ -407,7 +407,14 @@ describe("a Schema Builder change and the storage migration exclude each other",
     const adapter = makeAdapter();
     const { service, registry } = makeService(adapter);
     pluginOptionRefusal.error = NextlyError.validation({
-      logContext: { reason: "plugin rejected its own options" },
+      // The real shape: `validateOptions` reports per-field problems, and the factory requires them.
+      errors: [
+        {
+          path: "fields.0.options",
+          code: "invalid_options",
+          message: "plugin rejected its own options",
+        },
+      ],
     });
 
     await expect(

--- a/packages/nextly/src/domains/schema/services/__tests__/schema-change-exclusion.test.ts
+++ b/packages/nextly/src/domains/schema/services/__tests__/schema-change-exclusion.test.ts
@@ -16,17 +16,26 @@ const trace: string[] = [];
 /** Set to make the exclusion refuse, standing in for a migration already in flight. */
 const refusal: { error: unknown } = { error: undefined };
 /** What the services asked for, so the arguments are observed rather than assumed. */
-const excludeArgs: { label?: string; mayCreateLock?: boolean }[] = [];
+const excludeArgs: {
+  label?: string;
+  mayCreateLock?: boolean;
+  releaseOnInterrupt?: boolean;
+}[] = [];
 
 vi.mock("../../../field-groups/migration/sync-guard", () => ({
   withMigrationExcluded: vi.fn(
     async (
-      args: { label: string; mayCreateLock: boolean },
+      args: {
+        label: string;
+        mayCreateLock: boolean;
+        releaseOnInterrupt: boolean;
+      },
       work: () => Promise<unknown>
     ) => {
       excludeArgs.push({
         label: args.label,
         mayCreateLock: args.mayCreateLock,
+        releaseOnInterrupt: args.releaseOnInterrupt,
       });
       if (refusal.error !== undefined) throw refusal.error;
       trace.push("exclusion:held");
@@ -37,6 +46,7 @@ vi.mock("../../../field-groups/migration/sync-guard", () => ({
 
 import type { DrizzleAdapter } from "@nextlyhq/adapter-drizzle";
 
+import { NextlyError } from "../../../../errors/nextly-error";
 import type { Logger } from "../../../../shared/types";
 import { SingleMetadataService } from "../../../singles/services/single-metadata-service";
 import type { SingleRegistryService } from "../../../singles/services/single-registry-service";
@@ -136,7 +146,12 @@ describe("a Schema Builder change and the storage migration exclude each other",
     // alone would pass on a service that created the table and then refused.
     const adapter = makeAdapter();
     const { service, registry } = makeService(adapter);
-    refusal.error = new Error("a field group storage migration is in flight");
+    // The error production actually raises, not a bare stand-in: a test that asserts a refusal
+    // propagates should propagate the shape callers will meet.
+    refusal.error = NextlyError.serviceUnavailable({
+      logMessage: "a field group storage migration is in flight",
+      logContext: { reason: "field group storage migration is in flight" },
+    });
 
     await expect(
       service.createSingle({
@@ -145,7 +160,7 @@ describe("a Schema Builder change and the storage migration exclude each other",
         tableName: "single_page",
         fields: [{ name: "heading", type: "text" }],
       } as unknown as Parameters<typeof service.createSingle>[0])
-    ).rejects.toThrow(/in flight/);
+    ).rejects.toMatchObject({ code: "SERVICE_UNAVAILABLE" });
 
     expect(trace).toEqual([]);
     expect(adapter.executeQuery).not.toHaveBeenCalled();
@@ -166,10 +181,23 @@ describe("a Schema Builder change and the storage migration exclude each other",
       fields: [],
     } as unknown as Parameters<typeof service.createSingle>[0]);
     await service.deleteSingle("page", "single_page");
+    // A flags-only save: `fields` absent means the plan renders no DDL, which is the update shape
+    // most likely to be thought too small to need the exclusion.
+    await service.updateSingleSchema({
+      slug: "page",
+      existing: { slug: "page", tableName: "single_page", fields: [] },
+      updateData: { label: "Page renamed" },
+      isLocalized: false,
+      wasLocalized: false,
+      hasStatus: false,
+      wasStatus: false,
+      statusRequested: false,
+    } as unknown as Parameters<typeof service.updateSingleSchema>[0]);
 
     expect(excludeArgs.map(a => a.label)).toEqual([
       'create single "page"',
       'delete single "page"',
+      'update single schema "page"',
     ]);
   });
 
@@ -183,5 +211,19 @@ describe("a Schema Builder change and the storage migration exclude each other",
     await service.deleteSingle("page", "single_page");
 
     expect(excludeArgs[0]?.mayCreateLock).toBe(true);
+  });
+
+  it("keeps the claim through an interrupt, because the work is not idempotent", async () => {
+    // The signal does not stop the work. A session that released here would hand the row to a
+    // storage migration while this change was still between its DDL and its registry write, which
+    // is the overlap the exclusion exists to prevent — so a schema change opts OUT of the release a
+    // schema SYNC opts into. Observed from the arguments the service actually passes rather than
+    // restated here, so rewording the option cannot leave this asserting a value nobody reads.
+    const adapter = makeAdapter();
+    const { service } = makeService(adapter);
+
+    await service.deleteSingle("page", "single_page");
+
+    expect(excludeArgs[0]?.releaseOnInterrupt).toBe(false);
   });
 });

--- a/packages/nextly/src/domains/schema/services/__tests__/schema-change-exclusion.test.ts
+++ b/packages/nextly/src/domains/schema/services/__tests__/schema-change-exclusion.test.ts
@@ -101,6 +101,11 @@ function makeService(adapter: ReturnType<typeof makeAdapter>) {
     // Read INSIDE the exclusion, so an update plans from the record as it is once the lock is held
     // rather than as the caller found it. Answers the same shape the caller passed in, which is the
     // uncontended case; the contended one is covered where the lock itself is modelled.
+    // Read INSIDE the exclusion by the create path, which re-asserts that no other Single has
+    // claimed this table while the request waited. Empty is the uncontended answer.
+    getAllSingles: vi.fn(
+      async (): Promise<{ slug: string; tableName: string }[]> => []
+    ),
     getSingleBySlug: vi.fn(async (slug: string) => ({
       slug,
       tableName: "single_page",
@@ -292,6 +297,82 @@ describe("a Schema Builder change and the storage migration exclude each other",
     ).rejects.toMatchObject({ code: "FORBIDDEN" });
 
     expect(registry.updateSingle).not.toHaveBeenCalled();
+  });
+
+  it("takes the PRIOR flags from the refreshed record, keeping only what the request set", async () => {
+    // 🔴 Two overlapping Builder saves. The first enables Draft/Published; the second was composed
+    // before that and carries `wasStatus: false` plus a `hasStatus: false` the CALLER filled in
+    // because the request said nothing about status. Planning from those would create the companion
+    // without `_status` while the row ends up saying it has one.
+    //
+    // The request DID set localization, so that value survives the refresh; it said nothing about
+    // status, so the refreshed record decides. Asserting through the plan's own inputs would be
+    // circular, so this observes what the service passes on: `updateData` must not carry a status
+    // change nobody asked for, and the localization the request did ask for must still be applied.
+    const adapter = makeAdapter({ mainTableExists: true });
+    const { service, registry } = makeService(adapter);
+    registry.getSingleBySlug.mockResolvedValue({
+      slug: "page",
+      tableName: "single_page",
+      fields: [],
+      locked: false,
+      schemaHash: "unchanged",
+      status: true,
+      localized: false,
+    });
+
+    await service.updateSingleSchema({
+      slug: "page",
+      existing: {
+        slug: "page",
+        tableName: "single_page",
+        fields: [],
+        schemaHash: "unchanged",
+        status: false,
+        localized: false,
+      },
+      updateData: { localized: true },
+      isLocalized: true,
+      wasLocalized: false,
+      localizedRequested: true,
+      hasStatus: false,
+      wasStatus: false,
+      statusRequested: false,
+    } as unknown as Parameters<typeof service.updateSingleSchema>[0]);
+
+    const [, written] = registry.updateSingle.mock.calls[0] as [
+      string,
+      Record<string, unknown>,
+    ];
+    expect(written.localized).toBe(true);
+    // The stale `hasStatus: false` must not have become a DROP of a column the live record has.
+    const statements = adapter.executeQuery.mock.calls.map(([sql]) => sql);
+    expect(statements.join("\n")).not.toMatch(/DROP COLUMN[^\n]*_status/i);
+  });
+
+  it("refuses to CREATE onto a table claimed while it waited", async () => {
+    // 🔴 The registry insert at the end already rejects the duplicate row, which is why this looks
+    // unnecessary and is not. Before that insert the create has already run `CREATE TABLE IF NOT
+    // EXISTS` against the table the config now owns and REBOUND THE RUNTIME SCHEMA to this
+    // request's fields — and the runtime stays rebound until the process restarts. The insert makes
+    // the row safe; it does not make the process safe.
+    const adapter = makeAdapter();
+    const { service, registry } = makeService(adapter);
+    registry.getAllSingles.mockResolvedValue([
+      { slug: "page_from_code", tableName: "single_page" },
+    ]);
+
+    await expect(
+      service.createSingle({
+        slug: "page",
+        label: "Page",
+        tableName: "single_page",
+        fields: [{ name: "heading", type: "text" }],
+      } as unknown as Parameters<typeof service.createSingle>[0])
+    ).rejects.toMatchObject({ code: "DUPLICATE" });
+
+    expect(trace).toEqual(["exclusion:held"]);
+    expect(registry.registerSingle).not.toHaveBeenCalled();
   });
 
   it("refuses to DELETE a Single that became code-first while it waited", async () => {

--- a/packages/nextly/src/domains/schema/services/__tests__/schema-change-exclusion.test.ts
+++ b/packages/nextly/src/domains/schema/services/__tests__/schema-change-exclusion.test.ts
@@ -430,6 +430,47 @@ describe("a Schema Builder change and the storage migration exclude each other",
     expect(registry.registerSingle).not.toHaveBeenCalled();
   });
 
+  it("re-judges plugin field options on UPDATE too, not only on create", async () => {
+    // 🔴 Its own test rather than a parameter on the create one. The create fix was applied and the
+    // two sibling call sites — this and the field-group create — were left behind, which is the
+    // defect this file keeps catching: a fix landing in one location while identical code stands a
+    // few lines away. A shared test would have hidden that by covering "the validator runs" rather
+    // than "it runs HERE".
+    const adapter = makeAdapter({ mainTableExists: true });
+    const { service, registry } = makeService(adapter);
+    pluginOptionRefusal.error = NextlyError.validation({
+      errors: [
+        {
+          path: "fields.0.options",
+          code: "invalid_options",
+          message: "plugin rejected its own options",
+        },
+      ],
+    });
+
+    await expect(
+      service.updateSingleSchema({
+        slug: "page",
+        existing: {
+          slug: "page",
+          tableName: "single_page",
+          fields: [],
+          schemaHash: "unchanged",
+        },
+        updateData: { fields: [{ name: "hero", type: "plugin_thing" }] },
+        fields: [{ name: "hero", type: "plugin_thing" }],
+        isLocalized: false,
+        wasLocalized: false,
+        localizedRequested: false,
+        hasStatus: false,
+        wasStatus: false,
+        statusRequested: false,
+      } as unknown as Parameters<typeof service.updateSingleSchema>[0])
+    ).rejects.toMatchObject({ code: "VALIDATION_ERROR" });
+
+    expect(registry.updateSingle).not.toHaveBeenCalled();
+  });
+
   it("refuses to CREATE onto a table claimed while it waited", async () => {
     // 🔴 The registry insert at the end already rejects the duplicate row, which is why this looks
     // unnecessary and is not. Before that insert the create has already run `CREATE TABLE IF NOT

--- a/packages/nextly/src/domains/schema/services/__tests__/schema-change-exclusion.test.ts
+++ b/packages/nextly/src/domains/schema/services/__tests__/schema-change-exclusion.test.ts
@@ -213,6 +213,36 @@ describe("a Schema Builder change and the storage migration exclude each other",
     expect(excludeArgs[0]?.mayCreateLock).toBe(true);
   });
 
+  it("claims DDL rights only when the save can actually change schema", async () => {
+    // Taking the exclusion with `mayCreateLock` runs `CREATE TABLE IF NOT EXISTS` for the lock's own
+    // table. A deployment that deliberately gives the application role DML but not DDL would then
+    // start refusing metadata edits — a label change, a webhook toggle — that worked before. Both
+    // directions are asserted: a false that should be true would leave a real schema change with no
+    // lock table to claim, which is the worse error of the two.
+    const adapter = makeAdapter();
+    const { service } = makeService(adapter);
+    const base = {
+      slug: "page",
+      existing: { slug: "page", tableName: "single_page", fields: [] },
+      updateData: { label: "Page renamed" },
+      isLocalized: false,
+      wasLocalized: false,
+      hasStatus: false,
+      wasStatus: false,
+      statusRequested: false,
+    };
+
+    await service.updateSingleSchema(
+      base as unknown as Parameters<typeof service.updateSingleSchema>[0]
+    );
+    await service.updateSingleSchema({
+      ...base,
+      fields: [{ name: "heading", type: "text" }],
+    } as unknown as Parameters<typeof service.updateSingleSchema>[0]);
+
+    expect(excludeArgs.map(a => a.mayCreateLock)).toEqual([false, true]);
+  });
+
   it("keeps the claim through an interrupt, because the work is not idempotent", async () => {
     // The signal does not stop the work. A session that released here would hand the row to a
     // storage migration while this change was still between its DDL and its registry write, which

--- a/packages/nextly/src/domains/schema/services/__tests__/schema-change-exclusion.test.ts
+++ b/packages/nextly/src/domains/schema/services/__tests__/schema-change-exclusion.test.ts
@@ -104,8 +104,11 @@ function makeService(adapter: ReturnType<typeof makeAdapter>) {
     getSingleBySlug: vi.fn(async (slug: string) => ({
       slug,
       tableName: "single_page",
-      fields: [],
+      fields: [] as unknown[],
       locked: false,
+      // Present in the default shape because the lost-update check reads it. Omitting it here and
+      // supplying it per test would type the double without the field and reject those overrides.
+      schemaHash: "unchanged",
     })),
     registerSingle: vi.fn(async (row: unknown) => {
       trace.push("registry:write");
@@ -271,6 +274,9 @@ describe("a Schema Builder change and the storage migration exclude each other",
       tableName: "single_page",
       fields: [],
       locked: false,
+      // Matches what the caller saw, so the lost-update check passes and this test is left asserting
+      // the property it is named for rather than a conflict.
+      schemaHash: "unchanged",
     });
 
     await service.updateSingleSchema({

--- a/packages/nextly/src/domains/schema/services/__tests__/schema-change-exclusion.test.ts
+++ b/packages/nextly/src/domains/schema/services/__tests__/schema-change-exclusion.test.ts
@@ -303,6 +303,38 @@ describe("a Schema Builder change and the storage migration exclude each other",
     expect(excludeArgs.map(a => a.mayCreateLock)).toEqual([false, true]);
   });
 
+  it("claims DDL rights for a requested TOGGLE, even when it looks like a no-op", async () => {
+    // 🔴 The lock decision happens BEFORE the record is re-read, so it cannot see the transition the
+    // plan will actually make. A `localized: false` save composed while the Single was unlocalized
+    // looks like no change against the caller's flags — and if another save enabled localization in
+    // the meantime, the refreshed flags make it a true→false transition whose DDL DROPS the
+    // companion. Deciding from the stale flags would run that unclaimed.
+    //
+    // So the question asked here is "did the request set a toggle", not "does the toggle change
+    // anything": the first is answerable without the refresh, the second is not.
+    const adapter = makeAdapter();
+    const { service } = makeService(adapter);
+
+    await service.updateSingleSchema({
+      slug: "page",
+      existing: {
+        slug: "page",
+        tableName: "single_page",
+        fields: [],
+        schemaHash: "unchanged",
+      },
+      updateData: { localized: false },
+      isLocalized: false,
+      wasLocalized: false,
+      localizedRequested: true,
+      hasStatus: false,
+      wasStatus: false,
+      statusRequested: false,
+    } as unknown as Parameters<typeof service.updateSingleSchema>[0]);
+
+    expect(excludeArgs[0]?.mayCreateLock).toBe(true);
+  });
+
   it("refuses when the Single became locked while it waited", async () => {
     // Replaces an earlier test that asserted planning uses the refreshed record. That property can
     // no longer be OBSERVED: a refreshed record whose definitions differ is now refused outright,

--- a/packages/nextly/src/domains/schema/services/__tests__/schema-change-exclusion.test.ts
+++ b/packages/nextly/src/domains/schema/services/__tests__/schema-change-exclusion.test.ts
@@ -105,6 +105,24 @@ function makeAdapter(options: { mainTableExists?: boolean } = {}) {
   };
 }
 
+/**
+ * The registry row shape these doubles answer with.
+ *
+ * Named, with the fields the service reads OPTIONAL, so a test can override just the property it is
+ * about. Inferring it from the default object instead pins the exact key set, and every override
+ * then has to restate keys it does not care about — which is how a fixture drifts away from the
+ * case it is describing.
+ */
+interface SingleRowDouble {
+  slug: string;
+  tableName: string;
+  fields?: unknown[];
+  locked?: boolean;
+  schemaHash?: string;
+  status?: boolean;
+  localized?: boolean;
+}
+
 function makeService(adapter: ReturnType<typeof makeAdapter>) {
   const registry = {
     // Read INSIDE the exclusion, so an update plans from the record as it is once the lock is held
@@ -115,15 +133,19 @@ function makeService(adapter: ReturnType<typeof makeAdapter>) {
     getAllSingles: vi.fn(
       async (): Promise<{ slug: string; tableName: string }[]> => []
     ),
-    getSingleBySlug: vi.fn(async (slug: string) => ({
-      slug,
-      tableName: "single_page",
-      fields: [] as unknown[],
-      locked: false,
-      // Present in the default shape because the lost-update check reads it. Omitting it here and
-      // supplying it per test would type the double without the field and reject those overrides.
-      schemaHash: "unchanged",
-    })),
+    getSingleBySlug: vi.fn(
+      async (slug: string): Promise<SingleRowDouble> => ({
+        slug,
+        tableName: "single_page",
+        fields: [] as unknown[],
+        locked: false,
+        // Present in the default shape because the service reads them. Omitting a field here and
+        // supplying it per test would type the double without it and reject those overrides.
+        schemaHash: "unchanged",
+        status: false,
+        localized: false,
+      })
+    ),
     registerSingle: vi.fn(async (row: unknown) => {
       trace.push("registry:write");
       return row;

--- a/packages/nextly/src/domains/schema/services/__tests__/schema-change-exclusion.test.ts
+++ b/packages/nextly/src/domains/schema/services/__tests__/schema-change-exclusion.test.ts
@@ -65,8 +65,8 @@ const logger: Logger = {
  * CREATE has run, the companion absent — because a create that reports `failed` would leave the
  * ordering assertions describing a run that gave up rather than one that worked.
  */
-function makeAdapter() {
-  let created = false;
+function makeAdapter(options: { mainTableExists?: boolean } = {}) {
+  let created = options.mainTableExists === true;
   return {
     getCapabilities: () => ({ dialect: "postgresql" as const }),
     dialect: "postgresql" as const,
@@ -98,6 +98,15 @@ function makeAdapter() {
 
 function makeService(adapter: ReturnType<typeof makeAdapter>) {
   const registry = {
+    // Read INSIDE the exclusion, so an update plans from the record as it is once the lock is held
+    // rather than as the caller found it. Answers the same shape the caller passed in, which is the
+    // uncontended case; the contended one is covered where the lock itself is modelled.
+    getSingleBySlug: vi.fn(async (slug: string) => ({
+      slug,
+      tableName: "single_page",
+      fields: [],
+      locked: false,
+    })),
     registerSingle: vi.fn(async (row: unknown) => {
       trace.push("registry:write");
       return row;
@@ -241,6 +250,47 @@ describe("a Schema Builder change and the storage migration exclude each other",
     } as unknown as Parameters<typeof service.updateSingleSchema>[0]);
 
     expect(excludeArgs.map(a => a.mayCreateLock)).toEqual([false, true]);
+  });
+
+  it("plans from the record as it is INSIDE the exclusion, not as the caller found it", async () => {
+    // 🔴 The caller reads the Single before this lock exists, and a storage migration completing in
+    // between rewrites `dynamic_singles.fields`. Planning from the caller's copy would derive the
+    // change from definitions the database no longer holds, and the registry write would put the
+    // old spelling back under a settled marker.
+    //
+    // The two records are made to DISAGREE so the assertion can tell which one was used: the
+    // caller's copy already lists `heading`, the live one does not. Planning from the caller's copy
+    // sees no new field and emits nothing; planning from the live record has to add the column.
+    // The table has to already EXIST, or the plan is a whole-table CREATE derived from the
+    // requested fields and both records produce the same statements — a fixture that never reaches
+    // the comparison it is written to make.
+    const adapter = makeAdapter({ mainTableExists: true });
+    const { service, registry } = makeService(adapter);
+    registry.getSingleBySlug.mockResolvedValue({
+      slug: "page",
+      tableName: "single_page",
+      fields: [],
+      locked: false,
+    });
+
+    await service.updateSingleSchema({
+      slug: "page",
+      existing: {
+        slug: "page",
+        tableName: "single_page",
+        fields: [{ name: "heading", type: "text" }],
+      },
+      updateData: {},
+      fields: [{ name: "heading", type: "text" }],
+      isLocalized: false,
+      wasLocalized: false,
+      hasStatus: false,
+      wasStatus: false,
+      statusRequested: false,
+    } as unknown as Parameters<typeof service.updateSingleSchema>[0]);
+
+    const statements = adapter.executeQuery.mock.calls.map(([sql]) => sql);
+    expect(statements.join("\n")).toMatch(/ADD COLUMN[^\n]*heading/i);
   });
 
   it("keeps the claim through an interrupt, because the work is not idempotent", async () => {

--- a/packages/nextly/src/domains/schema/services/__tests__/schema-change-exclusion.test.ts
+++ b/packages/nextly/src/domains/schema/services/__tests__/schema-change-exclusion.test.ts
@@ -300,15 +300,15 @@ describe("a Schema Builder change and the storage migration exclude each other",
   });
 
   it("takes the PRIOR flags from the refreshed record, keeping only what the request set", async () => {
-    // 🔴 Two overlapping Builder saves. The first enables Draft/Published; the second was composed
-    // before that and carries `wasStatus: false` plus a `hasStatus: false` the CALLER filled in
-    // because the request said nothing about status. Planning from those would create the companion
-    // without `_status` while the row ends up saying it has one.
+    // 🔴 Two overlapping Builder saves. The first enabled Draft/Published and committed. The second
+    // was composed before that, so it carries `wasStatus: false`, and it DOES ask for status — so
+    // the plan compares "off" against "on" and emits an ADD COLUMN for `_status` on a table that
+    // already has one.
     //
-    // The request DID set localization, so that value survives the refresh; it said nothing about
-    // status, so the refreshed record decides. Asserting through the plan's own inputs would be
-    // circular, so this observes what the service passes on: `updateData` must not carry a status
-    // change nobody asked for, and the localization the request did ask for must still be applied.
+    // The first version of this test used a scenario whose difference showed up only in the
+    // COMPANION table, which this harness reaches through Drizzle rather than `executeQuery` — so
+    // the break-control passed and the test proved nothing. This scenario lands on the MAIN table,
+    // which is observable here.
     const adapter = makeAdapter({ mainTableExists: true });
     const { service, registry } = makeService(adapter);
     registry.getSingleBySlug.mockResolvedValue({
@@ -331,23 +331,19 @@ describe("a Schema Builder change and the storage migration exclude each other",
         status: false,
         localized: false,
       },
-      updateData: { localized: true },
-      isLocalized: true,
+      updateData: { status: true },
+      isLocalized: false,
       wasLocalized: false,
-      localizedRequested: true,
-      hasStatus: false,
+      localizedRequested: false,
+      hasStatus: true,
       wasStatus: false,
-      statusRequested: false,
+      statusRequested: true,
     } as unknown as Parameters<typeof service.updateSingleSchema>[0]);
 
-    const [, written] = registry.updateSingle.mock.calls[0] as [
-      string,
-      Record<string, unknown>,
-    ];
-    expect(written.localized).toBe(true);
-    // The stale `hasStatus: false` must not have become a DROP of a column the live record has.
-    const statements = adapter.executeQuery.mock.calls.map(([sql]) => sql);
-    expect(statements.join("\n")).not.toMatch(/DROP COLUMN[^\n]*_status/i);
+    const statements = adapter.executeQuery.mock.calls
+      .map(([sql]) => sql)
+      .join("\n");
+    expect(statements).not.toMatch(/ADD COLUMN[^\n]*_status/i);
   });
 
   it("refuses to CREATE onto a table claimed while it waited", async () => {

--- a/packages/nextly/src/domains/schema/services/__tests__/schema-change-exclusion.test.ts
+++ b/packages/nextly/src/domains/schema/services/__tests__/schema-change-exclusion.test.ts
@@ -22,6 +22,15 @@ const excludeArgs: {
   releaseOnInterrupt?: boolean;
 }[] = [];
 
+/** The flags the companion is built from, captured where the service actually passes them. */
+const companionCalls: Record<string, unknown>[] = [];
+
+vi.mock("../../../singles/services/reconcile-single-companion", () => ({
+  reconcileSingleCompanion: vi.fn(async (args: Record<string, unknown>) => {
+    companionCalls.push(args);
+  }),
+}));
+
 vi.mock("../../../field-groups/migration/sync-guard", () => ({
   withMigrationExcluded: vi.fn(
     async (
@@ -134,6 +143,7 @@ function makeService(adapter: ReturnType<typeof makeAdapter>) {
 
 beforeEach(() => {
   trace.length = 0;
+  companionCalls.length = 0;
   excludeArgs.length = 0;
   refusal.error = undefined;
 });
@@ -300,15 +310,15 @@ describe("a Schema Builder change and the storage migration exclude each other",
   });
 
   it("takes the PRIOR flags from the refreshed record, keeping only what the request set", async () => {
-    // 🔴 Two overlapping Builder saves. The first enabled Draft/Published and committed. The second
-    // was composed before that, so it carries `wasStatus: false`, and it DOES ask for status — so
-    // the plan compares "off" against "on" and emits an ADD COLUMN for `_status` on a table that
-    // already has one.
+    // 🔴 Codex's scenario exactly. One save enabled Draft/Published and committed. This save was
+    // composed before that, so it carries `wasStatus: false` and a `hasStatus: false` the CALLER
+    // filled in because the request said nothing about status — it asks only for localization.
+    // Planning from those builds the companion WITHOUT `_status` while the row says it has one.
     //
-    // The first version of this test used a scenario whose difference showed up only in the
-    // COMPANION table, which this harness reaches through Drizzle rather than `executeQuery` — so
-    // the break-control passed and the test proved nothing. This scenario lands on the MAIN table,
-    // which is observable here.
+    // Observed at the seam the service actually passes the flags to, rather than through emitted
+    // SQL: two earlier attempts asserted on `executeQuery`, and this path issues none at all, so
+    // the break-control passed and the tests proved nothing. The companion is where these flags
+    // are consumed, so that is where they are read.
     const adapter = makeAdapter({ mainTableExists: true });
     const { service, registry } = makeService(adapter);
     registry.getSingleBySlug.mockResolvedValue({
@@ -331,19 +341,24 @@ describe("a Schema Builder change and the storage migration exclude each other",
         status: false,
         localized: false,
       },
-      updateData: { status: true },
-      isLocalized: false,
+      updateData: { localized: true },
+      isLocalized: true,
       wasLocalized: false,
-      localizedRequested: false,
-      hasStatus: true,
+      localizedRequested: true,
+      hasStatus: false,
       wasStatus: false,
-      statusRequested: true,
+      statusRequested: false,
+      fields: [{ name: "heading", type: "text" }],
     } as unknown as Parameters<typeof service.updateSingleSchema>[0]);
 
-    const statements = adapter.executeQuery.mock.calls
-      .map(([sql]) => sql)
-      .join("\n");
-    expect(statements).not.toMatch(/ADD COLUMN[^\n]*_status/i);
+    expect(companionCalls).toHaveLength(1);
+    expect(companionCalls[0]).toMatchObject({
+      // From the refreshed record: this Single HAS status, whatever the caller last saw.
+      status: true,
+      wasStatus: true,
+      // From the request, which did ask for this one.
+      localized: true,
+    });
   });
 
   it("refuses to CREATE onto a table claimed while it waited", async () => {

--- a/packages/nextly/src/domains/schema/services/__tests__/schema-change-exclusion.test.ts
+++ b/packages/nextly/src/domains/schema/services/__tests__/schema-change-exclusion.test.ts
@@ -255,48 +255,66 @@ describe("a Schema Builder change and the storage migration exclude each other",
     expect(excludeArgs.map(a => a.mayCreateLock)).toEqual([false, true]);
   });
 
-  it("plans from the record as it is INSIDE the exclusion, not as the caller found it", async () => {
-    // 🔴 The caller reads the Single before this lock exists, and a storage migration completing in
-    // between rewrites `dynamic_singles.fields`. Planning from the caller's copy would derive the
-    // change from definitions the database no longer holds, and the registry write would put the
-    // old spelling back under a settled marker.
-    //
-    // The two records are made to DISAGREE so the assertion can tell which one was used: the
-    // caller's copy already lists `heading`, the live one does not. Planning from the caller's copy
-    // sees no new field and emits nothing; planning from the live record has to add the column.
-    // The table has to already EXIST, or the plan is a whole-table CREATE derived from the
-    // requested fields and both records produce the same statements — a fixture that never reaches
-    // the comparison it is written to make.
+  it("refuses when the Single became locked while it waited", async () => {
+    // Replaces an earlier test that asserted planning uses the refreshed record. That property can
+    // no longer be OBSERVED: a refreshed record whose definitions differ is now refused outright,
+    // and one whose definitions match plans identically either way, so nothing distinguishes the
+    // two. What the refresh still decides on its own is this — a Single that became code-first
+    // while the request waited must not receive a UI edit, because the config is about to
+    // contradict the row.
     const adapter = makeAdapter({ mainTableExists: true });
     const { service, registry } = makeService(adapter);
     registry.getSingleBySlug.mockResolvedValue({
       slug: "page",
       tableName: "single_page",
       fields: [],
-      locked: false,
-      // Matches what the caller saw, so the lost-update check passes and this test is left asserting
-      // the property it is named for rather than a conflict.
+      locked: true,
       schemaHash: "unchanged",
     });
 
-    await service.updateSingleSchema({
-      slug: "page",
-      existing: {
+    await expect(
+      service.updateSingleSchema({
         slug: "page",
-        tableName: "single_page",
-        fields: [{ name: "heading", type: "text" }],
-      },
-      updateData: {},
-      fields: [{ name: "heading", type: "text" }],
-      isLocalized: false,
-      wasLocalized: false,
-      hasStatus: false,
-      wasStatus: false,
-      statusRequested: false,
-    } as unknown as Parameters<typeof service.updateSingleSchema>[0]);
+        existing: {
+          slug: "page",
+          tableName: "single_page",
+          fields: [],
+          locked: false,
+          schemaHash: "unchanged",
+        },
+        updateData: { label: "Page renamed" },
+        isLocalized: false,
+        wasLocalized: false,
+        hasStatus: false,
+        wasStatus: false,
+        statusRequested: false,
+      } as unknown as Parameters<typeof service.updateSingleSchema>[0])
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
 
-    const statements = adapter.executeQuery.mock.calls.map(([sql]) => sql);
-    expect(statements.join("\n")).toMatch(/ADD COLUMN[^\n]*heading/i);
+    expect(registry.updateSingle).not.toHaveBeenCalled();
+  });
+
+  it("refuses to DELETE a Single that became code-first while it waited", async () => {
+    // 🔴 The most dangerous of the stale-input cases, because the delete path calls
+    // `deleteSingle(..., { force: true })` — which walks past the registry's own protection for
+    // code-owned records. An HMR reload turning an unlocked UI Single into a locked code-first one
+    // between the caller's check and this claim would otherwise drop a table the config owns.
+    const adapter = makeAdapter();
+    const { service, registry } = makeService(adapter);
+    registry.getSingleBySlug.mockResolvedValue({
+      slug: "page",
+      tableName: "single_page",
+      fields: [],
+      locked: true,
+      schemaHash: "unchanged",
+    });
+
+    await expect(
+      service.deleteSingle("page", "single_page")
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
+
+    expect(registry.deleteSingle).not.toHaveBeenCalled();
+    expect(adapter.dropTable).not.toHaveBeenCalled();
   });
 
   it("refuses the WRITE when the stored schema moved while it waited", async () => {
@@ -307,12 +325,16 @@ describe("a Schema Builder change and the storage migration exclude each other",
     // {}` and therefore never touches the writeback path this guards.
     const adapter = makeAdapter({ mainTableExists: true });
     const { service, registry } = makeService(adapter);
+    // Models what a storage migration ACTUALLY does: it rewrites the stored field definitions into
+    // the new vocabulary and leaves `schema_hash` untouched, because its registry step projects only
+    // id / fields / config_path. A fixture that moved the hash instead would be testing a state the
+    // migration never produces — which is what the first version of this test did.
     registry.getSingleBySlug.mockResolvedValue({
       slug: "page",
       tableName: "single_page",
-      fields: [],
+      fields: [{ name: "hero", type: "fieldGroup" }],
       locked: false,
-      schemaHash: "after-the-migration",
+      schemaHash: "unchanged",
     });
 
     await expect(
@@ -321,8 +343,9 @@ describe("a Schema Builder change and the storage migration exclude each other",
         existing: {
           slug: "page",
           tableName: "single_page",
-          fields: [],
-          schemaHash: "before-the-migration",
+          // The caller's copy still carries the pre-migration spelling.
+          fields: [{ name: "hero", type: "component" }],
+          schemaHash: "unchanged",
         },
         updateData: { fields: [{ name: "hero", type: "component" }] },
         fields: [{ name: "hero", type: "component" }],

--- a/packages/nextly/src/domains/schema/services/__tests__/schema-change-exclusion.test.ts
+++ b/packages/nextly/src/domains/schema/services/__tests__/schema-change-exclusion.test.ts
@@ -293,6 +293,77 @@ describe("a Schema Builder change and the storage migration exclude each other",
     expect(statements.join("\n")).toMatch(/ADD COLUMN[^\n]*heading/i);
   });
 
+  it("refuses the WRITE when the stored schema moved while it waited", async () => {
+    // 🔴 Refreshing the record fixes what the update PLANS from and not what it WRITES. The caller
+    // composes `updateData.fields` from the definitions it read, and those go back verbatim — so a
+    // storage migration that renamed the field-group vocabulary in between would be undone by this
+    // save. Exercised through `updateData` on purpose: the sibling test above passes `updateData:
+    // {}` and therefore never touches the writeback path this guards.
+    const adapter = makeAdapter({ mainTableExists: true });
+    const { service, registry } = makeService(adapter);
+    registry.getSingleBySlug.mockResolvedValue({
+      slug: "page",
+      tableName: "single_page",
+      fields: [],
+      locked: false,
+      schemaHash: "after-the-migration",
+    });
+
+    await expect(
+      service.updateSingleSchema({
+        slug: "page",
+        existing: {
+          slug: "page",
+          tableName: "single_page",
+          fields: [],
+          schemaHash: "before-the-migration",
+        },
+        updateData: { fields: [{ name: "hero", type: "component" }] },
+        fields: [{ name: "hero", type: "component" }],
+        isLocalized: false,
+        wasLocalized: false,
+        hasStatus: false,
+        wasStatus: false,
+        statusRequested: false,
+      } as unknown as Parameters<typeof service.updateSingleSchema>[0])
+    ).rejects.toMatchObject({ code: "CONFLICT" });
+
+    // Nothing written: the stale payload must not reach the registry at all.
+    expect(registry.updateSingle).not.toHaveBeenCalled();
+  });
+
+  it("still allows an update when the stored schema did not move", async () => {
+    // The positive control. Without it, a check that refused EVERY update would satisfy the test
+    // above, and the refusal would look like coverage while breaking ordinary saves.
+    const adapter = makeAdapter({ mainTableExists: true });
+    const { service, registry } = makeService(adapter);
+    registry.getSingleBySlug.mockResolvedValue({
+      slug: "page",
+      tableName: "single_page",
+      fields: [],
+      locked: false,
+      schemaHash: "unchanged",
+    });
+
+    await service.updateSingleSchema({
+      slug: "page",
+      existing: {
+        slug: "page",
+        tableName: "single_page",
+        fields: [],
+        schemaHash: "unchanged",
+      },
+      updateData: { label: "Page renamed" },
+      isLocalized: false,
+      wasLocalized: false,
+      hasStatus: false,
+      wasStatus: false,
+      statusRequested: false,
+    } as unknown as Parameters<typeof service.updateSingleSchema>[0]);
+
+    expect(registry.updateSingle).toHaveBeenCalled();
+  });
+
   it("keeps the claim through an interrupt, because the work is not idempotent", async () => {
     // The signal does not stop the work. A session that released here would hand the row to a
     // storage migration while this change was still between its DDL and its registry write, which

--- a/packages/nextly/src/domains/schema/services/__tests__/schema-change-exclusion.test.ts
+++ b/packages/nextly/src/domains/schema/services/__tests__/schema-change-exclusion.test.ts
@@ -1,0 +1,187 @@
+/**
+ * A Schema Builder change holds the storage migration out, and holds it from the START.
+ *
+ * The design this implements rejected a lock taken inside the registry service, because by then the
+ * tables have already changed: it would sample the state rather than hold it. So "the exclusion is
+ * taken" is not the property worth asserting — ORDER is. These record the sequence of what the
+ * service did, and require the lock to be first.
+ *
+ * The exclusion primitive itself is covered where it lives; what can be forgotten, and what these
+ * exist for, is a service method that never asks for it.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/** Everything the service did, in order: the lock, then whatever ran inside it. */
+const trace: string[] = [];
+/** Set to make the exclusion refuse, standing in for a migration already in flight. */
+const refusal: { error: unknown } = { error: undefined };
+/** What the services asked for, so the arguments are observed rather than assumed. */
+const excludeArgs: { label?: string; mayCreateLock?: boolean }[] = [];
+
+vi.mock("../../../field-groups/migration/sync-guard", () => ({
+  withMigrationExcluded: vi.fn(
+    async (
+      args: { label: string; mayCreateLock: boolean },
+      work: () => Promise<unknown>
+    ) => {
+      excludeArgs.push({
+        label: args.label,
+        mayCreateLock: args.mayCreateLock,
+      });
+      if (refusal.error !== undefined) throw refusal.error;
+      trace.push("exclusion:held");
+      return work();
+    }
+  ),
+}));
+
+import type { DrizzleAdapter } from "@nextlyhq/adapter-drizzle";
+
+import type { Logger } from "../../../../shared/types";
+import { SingleMetadataService } from "../../../singles/services/single-metadata-service";
+import type { SingleRegistryService } from "../../../singles/services/single-registry-service";
+
+const logger: Logger = {
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+};
+
+/**
+ * An adapter that records every statement, so DDL appears in the same trace as the lock.
+ *
+ * `tableExists` answers the way a fresh create finds the database — the main table present once its
+ * CREATE has run, the companion absent — because a create that reports `failed` would leave the
+ * ordering assertions describing a run that gave up rather than one that worked.
+ */
+function makeAdapter() {
+  let created = false;
+  return {
+    getCapabilities: () => ({ dialect: "postgresql" as const }),
+    dialect: "postgresql" as const,
+    tableExists: vi.fn(async (name: string) =>
+      name.includes("_locales") ? false : created
+    ),
+    selectOne: vi.fn(async (): Promise<{ id: string } | null> => null),
+    // The delete path sweeps embedded field-group data and the i18n companion before dropping the
+    // table, and both ask the adapter what exists. An empty database is the simplest state that
+    // reaches the drop, which is the statement these tests order against.
+    listTables: vi.fn(async (): Promise<string[]> => []),
+    dropTable: vi.fn(async () => {
+      trace.push("ddl");
+    }),
+    // The i18n teardown reaches the database through Drizzle rather than `executeQuery`, so its
+    // own work is not part of the trace. What the trace needs from the delete path is the DROP,
+    // which arrives through `dropTable` above.
+    getDrizzle: vi.fn(() => ({
+      execute: async () => ({ rows: [] }),
+      delete: () => ({ where: async () => [] }),
+    })),
+    executeQuery: vi.fn(async (sql: string) => {
+      trace.push("ddl");
+      if (/CREATE TABLE/i.test(sql)) created = true;
+      return [];
+    }),
+  };
+}
+
+function makeService(adapter: ReturnType<typeof makeAdapter>) {
+  const registry = {
+    registerSingle: vi.fn(async (row: unknown) => {
+      trace.push("registry:write");
+      return row;
+    }),
+    updateSingle: vi.fn(async () => ({})),
+    deleteSingle: vi.fn(async () => {
+      trace.push("registry:write");
+    }),
+  };
+  const service = new SingleMetadataService(
+    registry as unknown as SingleRegistryService,
+    logger,
+    adapter as unknown as DrizzleAdapter
+  );
+  return { service, registry };
+}
+
+beforeEach(() => {
+  trace.length = 0;
+  excludeArgs.length = 0;
+  refusal.error = undefined;
+});
+
+describe("a Schema Builder change and the storage migration exclude each other", () => {
+  it("holds the exclusion BEFORE it writes any DDL or any row", async () => {
+    // 🔴 The ordering IS the property. A lock acquired after the tables changed answers whether a
+    // migration had started by the instant of the read, which is what the design rejected: the
+    // create would already have built a table the migration's manifest was assembled without.
+    const adapter = makeAdapter();
+    const { service } = makeService(adapter);
+
+    await service.createSingle({
+      slug: "page",
+      label: "Page",
+      tableName: "single_page",
+      fields: [{ name: "heading", type: "text" }],
+    } as unknown as Parameters<typeof service.createSingle>[0]);
+
+    expect(trace[0]).toBe("exclusion:held");
+    expect(trace).toContain("ddl");
+    expect(trace).toContain("registry:write");
+  });
+
+  it("writes nothing at all when a migration is already in flight", async () => {
+    // The refusal has to arrive before anything, not after the table exists. Asserting the throw
+    // alone would pass on a service that created the table and then refused.
+    const adapter = makeAdapter();
+    const { service, registry } = makeService(adapter);
+    refusal.error = new Error("a field group storage migration is in flight");
+
+    await expect(
+      service.createSingle({
+        slug: "page",
+        label: "Page",
+        tableName: "single_page",
+        fields: [{ name: "heading", type: "text" }],
+      } as unknown as Parameters<typeof service.createSingle>[0])
+    ).rejects.toThrow(/in flight/);
+
+    expect(trace).toEqual([]);
+    expect(adapter.executeQuery).not.toHaveBeenCalled();
+    expect(registry.registerSingle).not.toHaveBeenCalled();
+  });
+
+  it("asks for the exclusion on every schema-changing method, not only create", async () => {
+    // What this guards is a method that never asks. The three are listed by their observed LABELS
+    // rather than by a call count, so a fourth method added without the exclusion shows up as a
+    // missing name instead of an off-by-one nobody reads.
+    const adapter = makeAdapter();
+    const { service } = makeService(adapter);
+
+    await service.createSingle({
+      slug: "page",
+      label: "Page",
+      tableName: "single_page",
+      fields: [],
+    } as unknown as Parameters<typeof service.createSingle>[0]);
+    await service.deleteSingle("page", "single_page");
+
+    expect(excludeArgs.map(a => a.label)).toEqual([
+      'create single "page"',
+      'delete single "page"',
+    ]);
+  });
+
+  it("may create the lock table, because these paths issue DDL", async () => {
+    // `mayCreateLock` is not a formality. Answering false here would leave a database that has
+    // never run a migration entirely unprotected: the first storage migration would create the
+    // lock table, claim it, and start renaming while this change was already under way.
+    const adapter = makeAdapter();
+    const { service } = makeService(adapter);
+
+    await service.deleteSingle("page", "single_page");
+
+    expect(excludeArgs[0]?.mayCreateLock).toBe(true);
+  });
+});

--- a/packages/nextly/src/domains/schema/services/__tests__/schema-change-exclusion.test.ts
+++ b/packages/nextly/src/domains/schema/services/__tests__/schema-change-exclusion.test.ts
@@ -25,6 +25,16 @@ const excludeArgs: {
 /** The flags the companion is built from, captured where the service actually passes them. */
 const companionCalls: Record<string, unknown>[] = [];
 
+/** Set to make the plugin-option validator refuse, standing in for a registry swapped underneath. */
+const pluginOptionRefusal: { error: unknown } = { error: undefined };
+
+vi.mock("../../../../api/fields-payload", () => ({
+  assertValidPluginFieldOptions: vi.fn(() => {
+    if (pluginOptionRefusal.error !== undefined)
+      throw pluginOptionRefusal.error;
+  }),
+}));
+
 vi.mock("../../../singles/services/reconcile-single-companion", () => ({
   reconcileSingleCompanion: vi.fn(async (args: Record<string, unknown>) => {
     companionCalls.push(args);
@@ -166,6 +176,7 @@ function makeService(adapter: ReturnType<typeof makeAdapter>) {
 beforeEach(() => {
   trace.length = 0;
   companionCalls.length = 0;
+  pluginOptionRefusal.error = undefined;
   excludeArgs.length = 0;
   refusal.error = undefined;
 });
@@ -381,6 +392,35 @@ describe("a Schema Builder change and the storage migration exclude each other",
       // From the request, which did ask for this one.
       localized: true,
     });
+  });
+
+  it("re-judges plugin field options INSIDE the exclusion", async () => {
+    // 🔴 The caller validated these already. What can change in between is the JUDGE: a plugin
+    // field's options are checked by that plugin's own `validateOptions`, read from the
+    // process-global registry, and an HMR reload replaces that registry from inside this same
+    // exclusion. A declaration the old registration accepted would otherwise be built and persisted
+    // against the new one, and every later write to the Single would fail.
+    //
+    // The refusal is injected rather than staged through a real plugin swap: what this asserts is
+    // WHERE the check runs, and the trace shows that — the exclusion is held, and nothing else
+    // happened.
+    const adapter = makeAdapter();
+    const { service, registry } = makeService(adapter);
+    pluginOptionRefusal.error = NextlyError.validation({
+      logContext: { reason: "plugin rejected its own options" },
+    });
+
+    await expect(
+      service.createSingle({
+        slug: "page",
+        label: "Page",
+        tableName: "single_page",
+        fields: [{ name: "heading", type: "text" }],
+      } as unknown as Parameters<typeof service.createSingle>[0])
+    ).rejects.toMatchObject({ code: "VALIDATION_ERROR" });
+
+    expect(trace).toEqual(["exclusion:held"]);
+    expect(registry.registerSingle).not.toHaveBeenCalled();
   });
 
   it("refuses to CREATE onto a table claimed while it waited", async () => {

--- a/packages/nextly/src/domains/schema/services/schema-change-exclusion.ts
+++ b/packages/nextly/src/domains/schema/services/schema-change-exclusion.ts
@@ -66,6 +66,10 @@ export async function withSchemaChangeExcluded<T>(
       logger: args.logger,
       label: args.label,
       mayCreateLock: args.issuesDdl,
+      // A schema change holds its claim to the end. The signal does not stop `work`, so releasing
+      // here would hand the row to a migration while this change was still writing its DDL and its
+      // registry row — neither atomic nor idempotent, and the exact overlap being prevented.
+      releaseOnInterrupt: false,
     },
     work
   );

--- a/packages/nextly/src/domains/schema/services/schema-change-exclusion.ts
+++ b/packages/nextly/src/domains/schema/services/schema-change-exclusion.ts
@@ -1,0 +1,72 @@
+/**
+ * Hold the storage migration out for the whole of a Schema Builder change.
+ *
+ * ## Why this is one function rather than a line in each service
+ *
+ * Three services change schema — singles, collections and field groups — and each does it from
+ * several methods. Restating the exclusion at every one of them is a rule with nine chances to be
+ * forgotten, and the ninth is indistinguishable from the other eight until a migration runs. Asking
+ * one function means a new method inherits the decision instead of re-making it.
+ *
+ * ## Why the SERVICE is the right depth
+ *
+ * Each entity is reachable through three transports — the REST dispatcher, the route handlers and
+ * the Direct API — and they all converge on the same service method. An exclusion taken at the
+ * request layer would have to be repeated per transport and would miss any transport added later;
+ * taken here it covers all of them at once.
+ *
+ * The depth also has to be where the DDL and the registry row are written TOGETHER. A lock acquired
+ * inside the registry service would be taken after the tables had already changed, which samples
+ * the state rather than holding it.
+ */
+
+import type { DrizzleAdapter } from "@nextlyhq/adapter-drizzle";
+
+import type { Logger } from "../../../shared/types";
+
+/**
+ * Run a schema change with a field-group storage migration excluded throughout.
+ *
+ * `issuesDdl` decides whether the lock table may be CREATED when it is missing, and the two answers
+ * are not interchangeable. A path that issues DDL must be able to create it: otherwise a first-ever
+ * storage migration could create the table, claim it, and start renaming while this change was
+ * already running unprotected. A path that only writes a registry row must not, because creating a
+ * table is itself DDL, and a deployment whose application role has DML but no DDL rights would
+ * start failing writes that used to succeed. Collections take that second shape outside
+ * development, where they record a migration file instead of executing it.
+ */
+export async function withSchemaChangeExcluded<T>(
+  args: {
+    /**
+     * Absent on an app with no database configured. The services already run in that mode with
+     * their statements generated and never executed, so there is nothing to exclude and nothing to
+     * exclude it from — running the work unguarded is the same behaviour, not a weaker one.
+     */
+    adapter: DrizzleAdapter | undefined;
+    logger: Logger;
+    /** Names the operation in the refusal's log line, so an operator can see what was held off. */
+    label: string;
+    issuesDdl: boolean;
+  },
+  work: () => Promise<T>
+): Promise<T> {
+  const { adapter } = args;
+  if (!adapter) return work();
+
+  // Loaded on demand for the reason the services' own imports are: this module is reached from DI
+  // registration, and a static import would pull the migration machinery into the boot graph of
+  // every process, including those that never change a schema.
+  const { withMigrationExcluded } = await import(
+    "../../field-groups/migration/sync-guard"
+  );
+
+  return withMigrationExcluded(
+    {
+      adapter,
+      logger: args.logger,
+      label: args.label,
+      mayCreateLock: args.issuesDdl,
+    },
+    work
+  );
+}

--- a/packages/nextly/src/domains/schema/services/schema-change-exclusion.ts
+++ b/packages/nextly/src/domains/schema/services/schema-change-exclusion.ts
@@ -10,14 +10,27 @@
  *
  * ## Why the SERVICE is the right depth
  *
- * Each entity is reachable through three transports — the REST dispatcher, the route handlers and
- * the Direct API — and they all converge on the same service method. An exclusion taken at the
- * request layer would have to be repeated per transport and would miss any transport added later;
- * taken here it covers all of them at once.
- *
- * The depth also has to be where the DDL and the registry row are written TOGETHER. A lock acquired
+ * The depth has to be where the DDL and the registry row are written TOGETHER. A lock acquired
  * inside the registry service would be taken after the tables had already changed, which samples
- * the state rather than holding it.
+ * the state rather than holding it. Taken at the request layer it would have to be restated for
+ * every transport that reaches the same operation.
+ *
+ * ## What this depth does NOT cover, and why that is not a reason to move it
+ *
+ * The transports do not all converge here yet, so wrapping a service method does not protect every
+ * way of invoking it. `shared/builder-access.ts` enumerates the schema-changing operations in
+ * `BUILDER_METHODS`; the exclusion reaches the ones whose transports already route through a
+ * metadata service, and not the rest. Two shapes are open today:
+ *
+ * - a dispatcher handler that does the schema work itself instead of calling a service, which is
+ *   how the Admin's confirmed apply saves both singles and field groups;
+ * - a standalone route that writes the registry row directly, which changes what describes storage
+ *   without touching storage, so nothing about it is visible in DDL.
+ *
+ * Convergence is its own work, and until it lands an exclusion here is incomplete rather than
+ * wrong: it is taken at the only depth where the two halves of a schema change are written
+ * together, and the uncovered paths need to REACH that depth rather than to grow a second lock
+ * site each. Counting what is covered means reading `BUILDER_METHODS`, not this comment.
  */
 
 import type { DrizzleAdapter } from "@nextlyhq/adapter-drizzle";

--- a/packages/nextly/src/domains/singles/services/single-metadata-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-metadata-service.ts
@@ -226,6 +226,18 @@ function requestsSchemaWork(input: UpdateSingleSchemaInput): boolean {
   );
 }
 
+/**
+ * One comparable spelling of a stored field list.
+ *
+ * Compared as JSON rather than deeply walked because both sides are the SAME stored value read
+ * twice: if nothing rewrote it, the two are identical, so there is no normalisation to get wrong.
+ * `undefined` and an empty list are deliberately the same answer — a row that has never held field
+ * definitions and one holding none describe the same schema.
+ */
+function stableFieldDefinitions(fields: unknown): string {
+  return JSON.stringify(fields ?? []);
+}
+
 export class SingleMetadataService {
   constructor(
     private readonly registry: SingleRegistryService,
@@ -328,8 +340,28 @@ export class SingleMetadataService {
 
   private async deleteSingleExcluded(
     slug: string,
-    tableName: string | undefined
+    callerTableName: string | undefined
   ): Promise<void> {
+    // 🔴 Re-read before dropping anything. The caller checked `locked` outside this exclusion, and
+    // an HMR reload can turn an unlocked UI Single into a locked code-first one in between — after
+    // which this would drop the table and call `deleteSingle(..., { force: true })`, walking past
+    // the registry's own protection for code-owned records. The table name is taken from the fresh
+    // record for the same reason: the caller's copy describes storage as it was.
+    //
+    // A record that has already gone is NOT an error here. Delete is idempotent by intent, and
+    // refusing a second delete would turn a retry into a failure; the teardown below still runs
+    // against the caller's table name so a half-finished delete can be completed.
+    const current = await this.registry.getSingleBySlug(slug);
+    if (current?.locked === true) {
+      throw NextlyError.forbidden({
+        logContext: {
+          reason: "single became locked while awaiting the exclusion",
+          slug,
+        },
+      });
+    }
+    const tableName = current?.tableName ?? callerTableName;
+
     const adapter = this.adapter;
     if (tableName && adapter) {
       // Embedded field-group instances point back at this table by a plain string with no foreign
@@ -493,30 +525,27 @@ export class SingleMetadataService {
       });
     }
 
-    // 🔴 Refreshing the record fixes what this request PLANS from. It does not fix what the request
-    // WRITES: the caller composed `updateData.fields` against the definitions it read, and those are
-    // written back verbatim at the end. A storage migration that renamed the field-group vocabulary
-    // in between would be undone by this save, under a marker that now says it settled.
+    // 🔴 Refreshing the record fixes what this request PLANS from. It does not fix what it WRITES:
+    // the caller composed `updateData.fields` against the definitions it read, and those are written
+    // back verbatim at the end. A storage migration that renamed the field-group vocabulary in
+    // between would be undone by this save, under a marker that now says it settled.
     //
-    // Answered as a lost update rather than as a vocabulary problem, deliberately. Comparing the
-    // stored schema hash the caller saw against the one that is there now catches the migration AND
-    // the ordinary case of two people editing the same Single, in one check that cannot disagree
-    // with the vocabulary it is meant to police. Translating the payload instead would mean this
-    // service silently rewriting a user's submitted definitions, which is a guess about intent.
+    // The DEFINITIONS are compared, not a hash of them. `schema_hash` looks like the cheaper
+    // question and cannot answer this one: the migration's registry step projects only
+    // `["id", fields, config_path]` and rewrites `fields` without recomputing the hash, so the
+    // pre- and post-migration hashes are equal precisely when the vocabulary changed. Comparing the
+    // thing itself needs nothing to be maintained alongside it.
     //
-    // Compared only when BOTH hashes are present: a record stored before the hash existed cannot be
-    // checked, and refusing those would break every update to them. That gap is real and is the
-    // reason this is a check rather than a guarantee.
-    const seenHash = input.existing.schemaHash;
-    const liveHash = current.schemaHash;
-    if (seenHash && liveHash && seenHash !== liveHash) {
+    // This also catches the case nobody had named: two people editing one Single, where the second
+    // save silently discarded the first.
+    const seen = stableFieldDefinitions(input.existing.fields);
+    const live = stableFieldDefinitions(current.fields);
+    if (seen !== live) {
       throw NextlyError.conflict({
         logContext: {
           reason:
-            "single's stored schema changed while this request awaited the exclusion",
+            "single's stored field definitions changed while this request awaited the exclusion",
           slug: input.slug,
-          seenSchemaHash: seenHash,
-          currentSchemaHash: liveHash,
         },
       });
     }

--- a/packages/nextly/src/domains/singles/services/single-metadata-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-metadata-service.ts
@@ -53,6 +53,7 @@ import type {
 } from "../../../schemas/dynamic-singles/types";
 import type { Logger } from "../../../shared/types";
 import { applyMigrationStatements } from "../../schema/services/apply-migration-statements";
+import { withSchemaChangeExcluded } from "../../schema/services/schema-change-exclusion";
 
 import type { SingleRegistryService } from "./single-registry-service";
 
@@ -231,6 +232,23 @@ export class SingleMetadataService {
    * table name. Rejecting after this point would leave a `pending` row behind.
    */
   async createSingle(input: CreateSingleInput): Promise<CreateSingleResult> {
+    // 🔴 The exclusion wraps ALL THREE phases, not just the apply. A storage migration renaming
+    // tables between the plan and the row write would leave this create describing storage that
+    // moved underneath it, and the row is as much a part of the schema as the table is.
+    return withSchemaChangeExcluded(
+      {
+        adapter: this.adapter,
+        logger: this.logger,
+        label: `create single "${input.slug}"`,
+        issuesDdl: true,
+      },
+      () => this.createSingleExcluded(input)
+    );
+  }
+
+  private async createSingleExcluded(
+    input: CreateSingleInput
+  ): Promise<CreateSingleResult> {
     // 1. PLAN, before anything is persisted or executed. The generator is a validator as well as a
     // renderer, so a request it refuses leaves nothing behind at all — no row, no table — and the
     // corrected retry is a fresh create rather than a collision with its own wreckage.
@@ -268,6 +286,21 @@ export class SingleMetadataService {
    * tables survive: the row is what makes the tables findable.
    */
   async deleteSingle(
+    slug: string,
+    tableName: string | undefined
+  ): Promise<void> {
+    return withSchemaChangeExcluded(
+      {
+        adapter: this.adapter,
+        logger: this.logger,
+        label: `delete single "${slug}"`,
+        issuesDdl: true,
+      },
+      () => this.deleteSingleExcluded(slug, tableName)
+    );
+  }
+
+  private async deleteSingleExcluded(
     slug: string,
     tableName: string | undefined
   ): Promise<void> {
@@ -329,6 +362,20 @@ export class SingleMetadataService {
    * recorded rather than a request that never began.
    */
   async updateSingleSchema(
+    input: UpdateSingleSchemaInput
+  ): Promise<UpdateSingleSchemaResult> {
+    return withSchemaChangeExcluded(
+      {
+        adapter: this.adapter,
+        logger: this.logger,
+        label: `update single schema "${input.slug}"`,
+        issuesDdl: true,
+      },
+      () => this.updateSingleSchemaExcluded(input)
+    );
+  }
+
+  private async updateSingleSchemaExcluded(
     input: UpdateSingleSchemaInput
   ): Promise<UpdateSingleSchemaResult> {
     // 1. PLAN. May reject; nothing is persisted and no statement has run.

--- a/packages/nextly/src/domains/singles/services/single-metadata-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-metadata-service.ts
@@ -492,6 +492,35 @@ export class SingleMetadataService {
         },
       });
     }
+
+    // 🔴 Refreshing the record fixes what this request PLANS from. It does not fix what the request
+    // WRITES: the caller composed `updateData.fields` against the definitions it read, and those are
+    // written back verbatim at the end. A storage migration that renamed the field-group vocabulary
+    // in between would be undone by this save, under a marker that now says it settled.
+    //
+    // Answered as a lost update rather than as a vocabulary problem, deliberately. Comparing the
+    // stored schema hash the caller saw against the one that is there now catches the migration AND
+    // the ordinary case of two people editing the same Single, in one check that cannot disagree
+    // with the vocabulary it is meant to police. Translating the payload instead would mean this
+    // service silently rewriting a user's submitted definitions, which is a guess about intent.
+    //
+    // Compared only when BOTH hashes are present: a record stored before the hash existed cannot be
+    // checked, and refusing those would break every update to them. That gap is real and is the
+    // reason this is a check rather than a guarantee.
+    const seenHash = input.existing.schemaHash;
+    const liveHash = current.schemaHash;
+    if (seenHash && liveHash && seenHash !== liveHash) {
+      throw NextlyError.conflict({
+        logContext: {
+          reason:
+            "single's stored schema changed while this request awaited the exclusion",
+          slug: input.slug,
+          seenSchemaHash: seenHash,
+          currentSchemaHash: liveHash,
+        },
+      });
+    }
+
     return current;
   }
 

--- a/packages/nextly/src/domains/singles/services/single-metadata-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-metadata-service.ts
@@ -1047,6 +1047,20 @@ export class SingleMetadataService {
     if (adapter) {
       await assertGlobalResourceSlugAvailable(adapter, input.slug);
     }
+
+    // 🔴 Re-judged here, not only by the caller, because the thing that judges it can CHANGE while
+    // this request waits. A plugin field's options are validated by the plugin's own
+    // `validateOptions`, read from the process-global field-type registry — and an HMR reload
+    // replaces that registry wholesale from inside this same exclusion. A declaration the previous
+    // registration accepted would otherwise be planned, built and persisted against the new one,
+    // and every later write to the Single would fail on options it rejects.
+    //
+    // Placed alongside the ownership checks so the whole precondition set is re-established in one
+    // place: this method is what a new precondition should be added to.
+    const { assertValidPluginFieldOptions } = await import(
+      "../../../api/fields-payload"
+    );
+    assertValidPluginFieldOptions(input.fields);
   }
 
   private async planCreate(input: CreateSingleInput): Promise<CreateDdlPlan> {

--- a/packages/nextly/src/domains/singles/services/single-metadata-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-metadata-service.ts
@@ -477,6 +477,15 @@ export class SingleMetadataService {
     // the caller's.
     const current = await this.refreshForUpdate(args);
 
+    // 🔴 The plugin judge is re-consulted here for the same reason the create re-consults it: an
+    // HMR reload can replace the process-global field-type registry while this request waits, and
+    // `planUpdate` below renders DDL against the NEW registration while `updateData.fields` still
+    // carries options only the old one accepted.
+    const { assertValidPluginFieldOptions } = await import(
+      "../../../api/fields-payload"
+    );
+    assertValidPluginFieldOptions(args.fields ?? []);
+
     // The `was*` flags describe the state being transitioned FROM, so they follow the refreshed
     // record. The `is*`/`has*` flags describe what the request asked for — but only where it
     // actually asked: the caller resolves an absent toggle to the value it read, and that value can

--- a/packages/nextly/src/domains/singles/services/single-metadata-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-metadata-service.ts
@@ -200,6 +200,32 @@ interface UpdateDdlPlan {
   ownsMigrationStatus: boolean;
 }
 
+/**
+ * Whether an update request can reach schema DDL at all, from the input alone.
+ *
+ * Two callers need this answer and they need it at different moments, which is why it is a function
+ * rather than a condition written twice. `planUpdate` uses it to decide there is nothing to plan.
+ * `updateSingleSchema` needs it BEFORE the exclusion is taken, to decide whether this operation may
+ * create the lock table — and it cannot ask `planUpdate`, because planning reads the live table and
+ * so has to happen inside the exclusion it is being consulted about.
+ *
+ * A save with no field change still has companion work when the single crosses the
+ * Internationalization boundary, or when Draft/Published is saved on a single that is localized in
+ * either state, because that toggle ADDs or DROPs the companion's own `_status`.
+ *
+ * Conservative in the direction that matters: it answers yes whenever DDL is possible, not only
+ * when it is certain. A wrong yes costs one `CREATE TABLE IF NOT EXISTS` for the lock; a wrong no
+ * would let a schema change run with no lock table to claim.
+ */
+function requestsSchemaWork(input: UpdateSingleSchemaInput): boolean {
+  const { fields, isLocalized, wasLocalized, statusRequested } = input;
+  if (fields !== undefined) return true;
+  return (
+    isLocalized !== wasLocalized ||
+    (statusRequested && (isLocalized || wasLocalized))
+  );
+}
+
 export class SingleMetadataService {
   constructor(
     private readonly registry: SingleRegistryService,
@@ -369,7 +395,11 @@ export class SingleMetadataService {
         adapter: this.adapter,
         logger: this.logger,
         label: `update single schema "${input.slug}"`,
-        issuesDdl: true,
+        // A save that changes only labels, admin options, versioning, revalidation or webhooks
+        // writes a registry row and nothing else. Claiming DDL rights for it would make a
+        // deployment whose role has DML but not DDL start refusing metadata edits that worked
+        // before, because taking the exclusion would try to CREATE the lock table.
+        issuesDdl: requestsSchemaWork(input),
       },
       () => this.updateSingleSchemaExcluded(input)
     );
@@ -424,21 +454,16 @@ export class SingleMetadataService {
       wasLocalized,
       hasStatus,
       wasStatus,
-      statusRequested,
     } = input;
     const previousFields = (existing.fields ??
       []) as unknown as FieldDefinition[];
 
+    // Asked through the shared predicate rather than restated here. `updateSingleSchema` needs the
+    // same answer BEFORE it takes the exclusion, and two copies of this condition would agree today
+    // and drift silently — with the drift showing up as a schema change running unprotected.
+    if (!requestsSchemaWork(input)) return null;
+
     if (fields === undefined) {
-      // A save with no field change still has companion work when the single is crossing the
-      // Internationalization boundary, or when Draft/Published is saved on a single that is
-      // localized in either state — that toggle ADDs or DROPs the companion's own `_status`.
-      // Without this the flag persisted while the physical schema stayed as it was, stranding
-      // data in the table the new flag says it does not live in.
-      const needsCompanionWork =
-        isLocalized !== wasLocalized ||
-        (statusRequested && (isLocalized || wasLocalized));
-      if (!needsCompanionWork) return null;
       return {
         migrationSQL: "",
         fields: previousFields,

--- a/packages/nextly/src/domains/singles/services/single-metadata-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-metadata-service.ts
@@ -406,8 +406,28 @@ export class SingleMetadataService {
   }
 
   private async updateSingleSchemaExcluded(
-    input: UpdateSingleSchemaInput
+    args: UpdateSingleSchemaInput
   ): Promise<UpdateSingleSchemaResult> {
+    // 0. RE-READ the record, now that the exclusion is held.
+    //
+    // 🔴 The caller read it BEFORE this lock existed, and a storage migration can complete in
+    // between. Its `data:registry-definitions` step rewrites `dynamic_singles.fields` into the new
+    // field-group vocabulary, so planning from the caller's copy would derive the change from
+    // definitions the database no longer holds — and the registry write at the end would put the
+    // legacy spelling back, under a marker that now says the migration settled.
+    //
+    // Holding a lock over the WORK is not enough when the INPUT was sampled outside it. This is the
+    // same sampled-versus-held argument the exclusion itself rests on, applied one level up.
+    //
+    // Only the record is refreshed. The `is*` / `was*` flags describe what the REQUEST asked for and
+    // what it is transitioning from, which a migration does not touch — it renames vocabulary, not
+    // toggles — so re-deriving them here would substitute this service's reading of the request for
+    // the caller's.
+    const input: UpdateSingleSchemaInput = {
+      ...args,
+      existing: await this.refreshForUpdate(args),
+    };
+
     // 1. PLAN. May reject; nothing is persisted and no statement has run.
     const plan = await this.planUpdate(input);
 
@@ -444,6 +464,39 @@ export class SingleMetadataService {
    * SQLite cannot detach — and refusing here, before the apply, is what leaves the table untouched
    * and the caller's field list unsaved.
    */
+  /**
+   * Read the Single again inside the exclusion, and re-check what the caller checked outside it.
+   *
+   * Both refusals are re-checked rather than trusted: a delete that lands while this request waited
+   * leaves nothing to update, and a Single that became `locked` in the same window is code-first
+   * now, so applying a UI edit to it would write a row the config is about to contradict.
+   */
+  private async refreshForUpdate(
+    input: UpdateSingleSchemaInput
+  ): Promise<DynamicSingleRecord> {
+    const current = await this.registry.getSingleBySlug(input.slug);
+
+    if (!current) {
+      throw NextlyError.notFound({
+        logMessage: `single "${input.slug}" was removed before its schema change could run`,
+        logContext: {
+          reason: "single disappeared while awaiting the exclusion",
+          slug: input.slug,
+        },
+      });
+    }
+    if (current.locked) {
+      throw NextlyError.forbidden({
+        logMessage: `single "${input.slug}" became locked before its schema change could run`,
+        logContext: {
+          reason: "single became locked while awaiting the exclusion",
+          slug: input.slug,
+        },
+      });
+    }
+    return current;
+  }
+
   private async planUpdate(
     input: UpdateSingleSchemaInput
   ): Promise<UpdateDdlPlan | null> {

--- a/packages/nextly/src/domains/singles/services/single-metadata-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-metadata-service.ts
@@ -227,6 +227,31 @@ interface UpdateDdlPlan {
  * when it is certain. A wrong yes costs one `CREATE TABLE IF NOT EXISTS` for the lock; a wrong no
  * would let a schema change run with no lock table to claim.
  */
+/**
+ * Could this request reach schema DDL at all? Answered from the request ALONE, before the refresh.
+ *
+ * 🔴 Deliberately a SECOND function rather than a reuse of {@link requestsSchemaWork}, because the
+ * two answer different questions at different moments and the repository's one-question-one-answer
+ * rule is about the same question being computed twice.
+ *
+ * This one decides whether the exclusion may CREATE the lock table, so it has to be settled BEFORE
+ * the lock is taken — which is before the record can be re-read. It therefore cannot look at any
+ * `was*` flag: those describe a state the caller sampled and another save may already have changed.
+ * Asking only what the REQUEST set keeps it correct under that ignorance.
+ *
+ * The invariant that makes the pair safe: everything `requestsSchemaWork` calls schema work, this
+ * calls possible schema work. A false here must mean no DDL under any refreshed state. A label,
+ * admin, versioning, revalidation or webhook save sets none of these three and still claims no DDL
+ * rights, which is what keeps a DML-only deployment able to make those edits.
+ */
+function mayIssueSchemaDdl(input: UpdateSingleSchemaInput): boolean {
+  return (
+    input.fields !== undefined ||
+    input.localizedRequested ||
+    input.statusRequested
+  );
+}
+
 function requestsSchemaWork(input: UpdateSingleSchemaInput): boolean {
   const { fields, isLocalized, wasLocalized, statusRequested } = input;
   if (fields !== undefined) return true;
@@ -451,7 +476,12 @@ export class SingleMetadataService {
         // writes a registry row and nothing else. Claiming DDL rights for it would make a
         // deployment whose role has DML but not DDL start refusing metadata edits that worked
         // before, because taking the exclusion would try to CREATE the lock table.
-        issuesDdl: requestsSchemaWork(input),
+        //
+        // 🔴 Asked CONSERVATIVELY, and of the request rather than of the transition. This is decided
+        // before the lock, so before the record is re-read — and a toggle that looks like a no-op
+        // against the caller's stale flags can become a real transition against the refreshed ones,
+        // whose DDL would then run with no claim held.
+        issuesDdl: mayIssueSchemaDdl(input),
       },
       () => this.updateSingleSchemaExcluded(input)
     );

--- a/packages/nextly/src/domains/singles/services/single-metadata-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-metadata-service.ts
@@ -51,6 +51,7 @@ import type {
   DynamicSingleRecord,
   SingleMigrationStatus,
 } from "../../../schemas/dynamic-singles/types";
+import { assertGlobalResourceSlugAvailable } from "../../../services/lib/resource-slug-guard";
 import type { Logger } from "../../../shared/types";
 import { applyMigrationStatements } from "../../schema/services/apply-migration-statements";
 import { withSchemaChangeExcluded } from "../../schema/services/schema-change-exclusion";
@@ -145,6 +146,15 @@ export interface UpdateSingleSchemaInput {
   fields?: FieldDefinition[];
   isLocalized: boolean;
   wasLocalized: boolean;
+  /**
+   * Whether the request SET the Internationalization toggle, as opposed to leaving it alone.
+   *
+   * The mirror of {@link UpdateSingleSchemaInput.statusRequested}, and required for the same
+   * reason: `isLocalized` falls back to the value the CALLER read, so once this service re-reads
+   * the record it cannot tell "the user asked for localized: false" from "the user said nothing and
+   * the caller filled in what it saw". Only the first should survive a refresh.
+   */
+  localizedRequested: boolean;
   hasStatus: boolean;
   wasStatus: boolean;
   /**
@@ -287,6 +297,16 @@ export class SingleMetadataService {
   private async createSingleExcluded(
     input: CreateSingleInput
   ): Promise<CreateSingleResult> {
+    // 0. RE-ASSERT ownership, now that the exclusion is held.
+    //
+    // 🔴 The caller checked this outside the lock, and an HMR reload can register a code-first
+    // Single onto the same table or slug in between. Without repeating it, the apply below runs
+    // `CREATE TABLE IF NOT EXISTS` against a table the config now owns, reconciles its companion,
+    // and rebinds the RUNTIME schema to this request's fields — and the runtime stays rebound until
+    // the process restarts, even though the registry insert afterwards correctly rejects the
+    // duplicate. The insert is what makes the row safe; it is not what makes the process safe.
+    await this.assertCreateStillPossible(input);
+
     // 1. PLAN, before anything is persisted or executed. The generator is a validator as well as a
     // renderer, so a request it refuses leaves nothing behind at all — no row, no table — and the
     // corrected retry is a fresh create rather than a collision with its own wreckage.
@@ -455,9 +475,25 @@ export class SingleMetadataService {
     // what it is transitioning from, which a migration does not touch — it renames vocabulary, not
     // toggles — so re-deriving them here would substitute this service's reading of the request for
     // the caller's.
+    const current = await this.refreshForUpdate(args);
+
+    // The `was*` flags describe the state being transitioned FROM, so they follow the refreshed
+    // record. The `is*`/`has*` flags describe what the request asked for — but only where it
+    // actually asked: the caller resolves an absent toggle to the value it read, and that value can
+    // be stale. Where the request said nothing, the refreshed record decides.
+    //
+    // Without this, two overlapping Builder saves plan from mutually inconsistent state: one enables
+    // Draft/Published, the next enables localization carrying `hasStatus: false` from before, and
+    // the companion is created without `_status` while the row ends up saying it has one.
+    const wasLocalized = current.localized === true;
+    const wasStatus = current.status === true;
     const input: UpdateSingleSchemaInput = {
       ...args,
-      existing: await this.refreshForUpdate(args),
+      existing: current,
+      wasLocalized,
+      wasStatus,
+      isLocalized: args.localizedRequested ? args.isLocalized : wasLocalized,
+      hasStatus: args.statusRequested ? args.hasStatus : wasStatus,
     };
 
     // 1. PLAN. May reject; nothing is persisted and no statement has run.
@@ -981,6 +1017,38 @@ export class SingleMetadataService {
    * REJECT the request and must do so before anything is persisted, while the apply must never
    * throw so a failure is still recorded against a row.
    */
+  /**
+   * Re-run the create's ownership preconditions, inside the exclusion.
+   *
+   * Asks the same two questions the caller asked and re-uses the same shared guard for the second,
+   * rather than restating either: a table another Single already owns, and a slug some other
+   * resource kind has taken.
+   */
+  private async assertCreateStillPossible(
+    input: CreateSingleInput
+  ): Promise<void> {
+    const owner = (await this.registry.getAllSingles()).find(
+      single =>
+        single.tableName === input.tableName && single.slug !== input.slug
+    );
+    if (owner) {
+      throw NextlyError.duplicate({
+        logContext: {
+          reason:
+            "another single claimed this table while awaiting the exclusion",
+          slug: input.slug,
+          tableName: input.tableName,
+          ownedBy: owner.slug,
+        },
+      });
+    }
+
+    const adapter = this.adapter;
+    if (adapter) {
+      await assertGlobalResourceSlugAvailable(adapter, input.slug);
+    }
+  }
+
   private async planCreate(input: CreateSingleInput): Promise<CreateDdlPlan> {
     const isLocalized = input.localized === true;
     const hasStatus = input.status === true;

--- a/packages/nextly/src/domains/singles/services/single-metadata-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-metadata-service.ts
@@ -478,7 +478,6 @@ export class SingleMetadataService {
 
     if (!current) {
       throw NextlyError.notFound({
-        logMessage: `single "${input.slug}" was removed before its schema change could run`,
         logContext: {
           reason: "single disappeared while awaiting the exclusion",
           slug: input.slug,
@@ -487,7 +486,6 @@ export class SingleMetadataService {
     }
     if (current.locked) {
       throw NextlyError.forbidden({
-        logMessage: `single "${input.slug}" became locked before its schema change could run`,
         logContext: {
           reason: "single became locked while awaiting the exclusion",
           slug: input.slug,

--- a/packages/nextly/src/init/__tests__/reload-config.test.ts
+++ b/packages/nextly/src/init/__tests__/reload-config.test.ts
@@ -18,6 +18,22 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 
 import { createLockingAdapter } from "../../domains/field-groups/migration/__tests__/helpers/locking-adapter";
 import {
+  hashManifest,
+  MIGRATION_TARGET,
+  type ManifestEntry,
+} from "../../domains/field-groups/migration/manifest";
+import { MIGRATION_MARKER_VERSION } from "../../domains/field-groups/migration/state";
+import { STORAGE_FORMAT } from "../../schemas/storage-format";
+
+/** The registry rename every run performs, spelled from the catalog so it stays a valid plan. */
+const IN_FLIGHT_PLAN: ManifestEntry[] = [
+  {
+    kind: "registry",
+    from: STORAGE_FORMAT.registryTable,
+    to: MIGRATION_TARGET.registryTable,
+  },
+];
+import {
   HookRegistry,
   getHookRegistry,
   setActiveHookRegistry,
@@ -303,21 +319,18 @@ describe("reloadNextlyConfig", () => {
       },
     });
     const resolver = buildResolver({
+      // 🔴 `version` and `manifestHash` are DERIVED. Written out by hand, the marker is rejected as
+      // unreadable before its status is read — and an unreadable marker abandons the reload too, so
+      // this test passed while never reaching the in-flight check it is named for.
       migrationMarker: {
-        version: 2,
+        version: MIGRATION_MARKER_VERSION,
         status: "migrating",
         direction: "up",
         migrationId: "run-1",
         step: 1,
         registryHash: "r",
-        manifestHash: "m",
-        appliedManifest: [
-          {
-            kind: "registry",
-            from: "dynamic_components",
-            to: "dynamic_field_groups",
-          },
-        ],
+        manifestHash: hashManifest(IN_FLIGHT_PLAN),
+        appliedManifest: IN_FLIGHT_PLAN,
       },
     });
 

--- a/packages/nextly/src/init/__tests__/reload-config.test.ts
+++ b/packages/nextly/src/init/__tests__/reload-config.test.ts
@@ -338,8 +338,12 @@ describe("reloadNextlyConfig", () => {
     await reloadNextlyConfig({ resolver });
 
     expect(pipelineApplySpy).not.toHaveBeenCalled();
+    // 🔴 The warning's REASON is matched, not just the fact that one was logged. A marker the
+    // parser rejects abandons the reload and logs the same "schema reload skipped" prefix, so the
+    // prefix alone cannot tell an in-flight migration from an unreadable marker — and for a while
+    // this test was reporting the second while claiming the first.
     expect(warnSpy).toHaveBeenCalledWith(
-      expect.stringContaining("schema reload skipped")
+      expect.stringContaining("migration is in flight")
     );
   });
 

--- a/packages/nextly/src/init/reload-config.ts
+++ b/packages/nextly/src/init/reload-config.ts
@@ -1220,6 +1220,12 @@ async function runReload(opts?: {
         // This path applies DDL by design, so it may establish the lock table
         // rather than proceeding unprotected without one.
         mayCreateLock: true,
+        // Kept, and it is a trade rather than an oversight. This runs only under `next dev`,
+        // where Ctrl+C is how the server is stopped and a claim stranded behind a killed dev
+        // process would refuse every later reload until an operator cleared it by hand. The
+        // residual is a storage migration overlapping the tail of a reload, which takes someone
+        // deliberately running one against a development database.
+        releaseOnInterrupt: true,
       },
       () => {
         reloadStarted = true;


### PR DESCRIPTION
## What this does

A Schema Builder change to a **single** or a **field group** now runs inside the field-group storage migration's lock, held for the whole operation rather than sampled at the start.

The design choice worth reviewing is the DEPTH. The exclusion is taken in the **service**, not in the registry and not per transport:

- Each entity is reachable through three transports (REST dispatcher, route handlers, Direct API) and they all converge on the same service method. Taken at the request layer it would have to be repeated per transport and would miss any transport added later.
- A lock acquired inside the registry service would be taken *after* the tables had already changed, which samples the state rather than holding it.
- It wraps the ownership and planning checks too, not only the DDL. Those checks read which table names are taken, and a storage migration renaming tables is exactly what makes such a read stale.

`issuesDdl: true` on these paths is deliberate: they may create the lock table. Without that, a first-ever storage migration could create the table, claim it, and start renaming while a schema change was already running unprotected.

## Why the test changes are most of the diff

Wiring the exclusion made 34 tests fail across 4 files with `adapter.queryStatement is not a function` — each file's local `makeAdapter` models only the DDL surface. Two ways of answering that are wrong in opposite directions: a double missing the methods makes every schema change look broken, and a double that resolves everything makes every claim succeed and certifies exclusion that is not there.

So the lock is **modelled**, in one shared place (`migration-lock-double.ts`): one row, claimed by whoever finds it free, refused to everyone else, with statements compiled through a real dialect. `locking-adapter.ts` now derives its lock semantics from the same interpreter rather than carrying a second copy.

One contamination caught on the way: the lock's own DDL is a `CREATE TABLE` too and runs first, which flipped a double's `created` flag and made the entity's table look present before anything had built it. `isMigrationLockStatement` is the one shared answer to "is this the lock's statement or mine".

## The load-bearing test

`schema-change-exclusion-composition.test.ts` runs the **real** primitive against the in-memory lock. Its sibling `schema-change-exclusion.test.ts` mocks `withMigrationExcluded` so it can assert ordering — which is exactly what it cannot check: a service could ask for an exclusion that never claims anything and every one of those tests would still pass.

The composition suite asserts the claim is held **while the work runs** (sampled from inside the registry write, since a claim taken and released around nothing leaves the same empty row behind), that the lock table is created on a fresh database, and that a held lock or an in-flight marker refuses before any table is built.

**Break-control:** bypassing `withSchemaChangeExcluded` in `createSingle` fails all 4.

## What this does NOT cover

**Corrected after review, and it changes what this PR claims.** The original body said the exclusion sits in the service because all three transports converge there. Codex showed that premise is false for singles today, and I verified both cases in code:

- `applySingleSchemaChanges` (`single-dispatcher.ts:1004`) runs the pipeline apply and writes `dynamic_singles` itself. `packages/admin/.../singles/builder/[slug].tsx:235` calls it, so **the Admin's primary save path never reaches this wrapper**.
- `api/singles-schema-detail.ts:242` and `:271` call `SingleRegistryService` directly, changing what describes storage without touching storage — invisible in DDL.

Counted against the repo's own enumeration (`BUILDER_METHODS` in `shared/builder-access.ts`, 12 mutating operations): **this PR covers 4**. The module comment now says this rather than asserting convergence.

I did not wrap the remaining call sites here on purpose. Convergence is already tracked (task 116 relocates dispatcher DDL into services; task 137 is the same non-convergence as two field-group create routes that write a row and never create a table). Adding per-handler and per-route exclusions now would create sites that work has to unpick, while still leaving other doors open — and would make the exclusion look complete when it is not. **Say if you would rather I extend this PR instead.**

### Also not covered

- **Collections and user fields are not excluded yet.** Collections need `issuesDdl` computed rather than fixed, because outside development they record a migration file instead of executing DDL, and a path that only writes a registry row must not create tables. Follow-up.
- The field-group **update** path is not covered here either: it runs companion DDL directly from the dispatcher rather than through the metadata service. Relocating it is its own change.
- Nothing is exposed in the meantime: `runFieldGroupMigration` still has zero production callers, so no database can change shape today.

## Verification

- `pnpm build`, `check-types --force`, `lint` (by exit code), `check-drizzle-v1-legacy`, `check:storage-format-literals` — all `0`
- Full `packages/nextly` unit run diffed per test NAME against a freshly measured `791a08e36` baseline: **360 failing on both, 0 new by name**, 7876 passing (+8: 4 new composition tests, 4 exclusion tests that are branch-only, and 2 trust-bound tests that embed the worktree path in their name)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Schema-changing operations now coordinate through migration exclusion, helping prevent conflicting changes during field, single, and field-group updates.
  * Interrupted development synchronization and reload operations can release their migration claims, reducing the risk of stale locks blocking future work.
  * Schema changes are prevented before database updates when another migration is active or a migration is already in progress.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->