### PR TITLE
test(builder): tell an unrendered app apart from a layout regression

### DIFF
--- a/e2e/tests/shell/driver.ts
+++ b/e2e/tests/shell/driver.ts
@@ -64,6 +64,59 @@ function regionLocator(page: Page, region: keyof typeof REGION_NAMES): Locator {
   }
 }
 
+/**
+ * Fail with the CAUSE when the application did not come up, before any
+ * assertion gets the chance to report a symptom instead.
+ *
+ * Every geometric check in this file reads a measured box, which is what makes
+ * them honest — but it also means a page that never styled produces "the
+ * inspector region has no layout box", which reads exactly like a layout
+ * regression in the shell. That has now cost two other lanes an afternoon each:
+ * their diffs could not reach `packages/builder`, the web server had logged
+ * `TypeError: The database connection is not open`, and three assertions
+ * observing ONE broken page were read as three independent regressions.
+ *
+ * Three unrelated regressions in a single run is implausible; one page that
+ * failed to render, seen three times, is not. This check encodes that reading
+ * so the next person does not have to arrive at it.
+ *
+ * Deliberately placed in `goto`, not in `widthOf`: by the time a width is being
+ * measured the test is already asking a question that presupposes a working
+ * page, and the answer to a presupposition failure belongs before the question.
+ */
+async function assertAppRendered(page: Page): Promise<void> {
+  const chrome = page.locator(".nx-builder-chrome").first();
+  const box = await chrome.boundingBox();
+  if (box === null || box.width === 0 || box.height === 0) {
+    throw new Error(
+      `The editor shell mounted but has no layout box, so the APPLICATION did ` +
+        `not render — this is not a layout regression in the shell.\n` +
+        `Check the web-server log first. Known causes, all outside any PR's ` +
+        `diff: the playground's database failing to open ` +
+        `("TypeError: The database connection is not open"), and ` +
+        `\`next/font/google\` fetching at BUILD time from fonts.googleapis.com, ` +
+        `which fails a blocked or slow network while naming an internal ` +
+        `turbopack module.`
+    );
+  }
+
+  // Painted, not merely boxed. A `var()` chain that cannot resolve computes to
+  // transparent, which is what a missing design-system stylesheet produces —
+  // and that renders a full-size, correctly-structured, entirely unstyled page
+  // whose region widths are all wrong for a reason no shell change caused.
+  const background = await chrome.evaluate(
+    element => getComputedStyle(element).backgroundColor
+  );
+  if (background === "rgba(0, 0, 0, 0)" || background === "transparent") {
+    throw new Error(
+      `The editor shell rendered but its chrome resolved to no colour, so a ` +
+        `STYLESHEET is missing rather than a layout being wrong. The shell's ` +
+        `own sheet supplements the design system's: the harness must import ` +
+        `"@nextlyhq/ui/styles.css" alongside "@nextlyhq/builder/styles.css".`
+    );
+  }
+}
+
 export function createShellDriver(page: Page): ShellDriver {
   return {
     async goto() {
@@ -74,6 +127,7 @@ export function createShellDriver(page: Page): ShellDriver {
       await page
         .getByRole("navigation", { name: REGION_NAMES.rail })
         .waitFor({ state: "visible" });
+      await assertAppRendered(page);
     },
 
     railItem(label) {

--- a/e2e/tests/shell/driver.ts
+++ b/e2e/tests/shell/driver.ts
@@ -168,7 +168,19 @@ async function diagnoseUnrenderedPage(page: Page): Promise<never> {
 
 /** Turn one measurement into the readiness verdict. */
 function assertPainted(measurement: ShellRenderMeasurement): void {
-  const { box, background } = measurement;
+  const { present, box, background } = measurement;
+  // Absence FIRST. The rail can render while the chrome root is removed or
+  // renamed, and then `box` is null for a reason that has nothing to do with
+  // styles — reading it as "present but unstyled" sends a markup regression
+  // down the CSS investigation path, which is the failure this file exists to
+  // stop rather than commit.
+  if (!present) {
+    throw new Error(
+      `The rail rendered but no element matches "${CHROME_SELECTOR}", so the ` +
+        `shell's ROOT is missing or renamed — a markup change, not a styling ` +
+        `one. Every geometric check here is addressed from that element.`
+    );
+  }
   if (box === null || box.width === 0 || box.height === 0) {
     throw new Error(
       `The editor shell is in the DOM but has no layout box, so the page ` +

--- a/e2e/tests/shell/driver.ts
+++ b/e2e/tests/shell/driver.ts
@@ -64,55 +64,76 @@ function regionLocator(page: Page, region: keyof typeof REGION_NAMES): Locator {
   }
 }
 
+/** How long the shell is given to appear before the page is diagnosed instead. */
+const SHELL_READY_TIMEOUT_MS = 15_000;
+
 /**
- * Fail with the CAUSE when the application did not come up, before any
- * assertion gets the chance to report a symptom instead.
+ * Explain a page that did not come up, rather than letting a later assertion
+ * report a symptom of it.
  *
- * Every geometric check in this file reads a measured box, which is what makes
- * them honest — but it also means a page that never styled produces "the
- * inspector region has no layout box", which reads exactly like a layout
- * regression in the shell. That has now cost two other lanes an afternoon each:
- * their diffs could not reach `packages/builder`, the web server had logged
- * `TypeError: The database connection is not open`, and three assertions
- * observing ONE broken page were read as three independent regressions.
+ * Every geometric check in this file reads a MEASURED box, which is what makes
+ * it honest about an unstyled page — and it means a page that never rendered
+ * reports "the inspector region has no layout box", which is indistinguishable
+ * from a real layout regression in the shell.
  *
- * Three unrelated regressions in a single run is implausible; one page that
- * failed to render, seen three times, is not. This check encodes that reading
- * so the next person does not have to arrive at it.
- *
- * Deliberately placed in `goto`, not in `widthOf`: by the time a width is being
- * measured the test is already asking a question that presupposes a working
- * page, and the answer to a presupposition failure belongs before the question.
+ * Called when the shell fails to appear, and again once it has. The two paths
+ * are different failures and neither implies the other: a route that never
+ * rendered produces no shell at all, while a rendered one can still be missing
+ * its styles.
  */
-async function assertAppRendered(page: Page): Promise<void> {
+async function diagnoseUnrenderedPage(page: Page): Promise<never> {
+  const bodyText = (
+    await page
+      .locator("body")
+      .innerText()
+      .catch(() => "")
+  ).slice(0, 300);
+  const status = page.url();
+  throw new Error(
+    `The editor shell never appeared, so the APPLICATION did not come up — ` +
+      `this is not a layout regression in the shell.\n` +
+      `URL: ${status}\n` +
+      `Body text (first 300 chars): ${bodyText || "<empty>"}\n` +
+      `Check the web-server log before the code. A blank body points at the ` +
+      `server failing to boot; an error screen usually names its own cause.`
+  );
+}
+
+/**
+ * Whether the chrome has a real box and a resolved colour.
+ *
+ * Read as a PAINTED colour rather than as a custom property: asking for
+ * `--nx-builder-surface` returns the declared token stream — the literal text
+ * `var(--nx-muted)` — which is non-empty whether or not anything defines it.
+ * Only the resolved value distinguishes a working style chain from a broken one.
+ */
+async function assertChromePainted(page: Page): Promise<void> {
   const chrome = page.locator(".nx-builder-chrome").first();
   const box = await chrome.boundingBox();
   if (box === null || box.width === 0 || box.height === 0) {
     throw new Error(
-      `The editor shell mounted but has no layout box, so the APPLICATION did ` +
-        `not render — this is not a layout regression in the shell.\n` +
-        `Check the web-server log first. Known causes, all outside any PR's ` +
-        `diff: the playground's database failing to open ` +
-        `("TypeError: The database connection is not open"), and ` +
-        `\`next/font/google\` fetching at BUILD time from fonts.googleapis.com, ` +
-        `which fails a blocked or slow network while naming an internal ` +
-        `turbopack module.`
+      `The editor shell is in the DOM but has no layout box, so the page ` +
+        `rendered without usable styles rather than the shell laying out ` +
+        `wrongly. Check that the document loaded both stylesheets before ` +
+        `reading this as a shell defect.`
     );
   }
 
-  // Painted, not merely boxed. A `var()` chain that cannot resolve computes to
-  // transparent, which is what a missing design-system stylesheet produces —
-  // and that renders a full-size, correctly-structured, entirely unstyled page
-  // whose region widths are all wrong for a reason no shell change caused.
   const background = await chrome.evaluate(
     element => getComputedStyle(element).backgroundColor
   );
   if (background === "rgba(0, 0, 0, 0)" || background === "transparent") {
+    // Deliberately NEUTRAL about which stylesheet is at fault. An unresolvable
+    // `var()` chain and a chrome rule that lost its `background-color` compute
+    // to the same transparent value, so naming one of them would state a cause
+    // this check cannot tell apart — and send the reader to the wrong file.
     throw new Error(
-      `The editor shell rendered but its chrome resolved to no colour, so a ` +
-        `STYLESHEET is missing rather than a layout being wrong. The shell's ` +
-        `own sheet supplements the design system's: the harness must import ` +
-        `"@nextlyhq/ui/styles.css" alongside "@nextlyhq/builder/styles.css".`
+      `The editor shell rendered but its chrome resolved to no colour, so the ` +
+        `style chain is broken somewhere between the design system's tokens ` +
+        `and this package's rules. Either a required stylesheet is absent ` +
+        `("@nextlyhq/ui/styles.css" alongside "@nextlyhq/builder/styles.css") ` +
+        `or the chrome's own declaration regressed. The "both stylesheets ` +
+        `actually loaded" test separates those two.`
     );
   }
 }
@@ -124,10 +145,18 @@ export function createShellDriver(page: Page): ShellDriver {
       // Waits for the shell rather than for the network: the shell restores
       // preferences in an effect after mount, so a test that measured on
       // `load` would read the defaults and call them the restored values.
-      await page
-        .getByRole("navigation", { name: REGION_NAMES.rail })
-        .waitFor({ state: "visible" });
-      await assertAppRendered(page);
+      // The wait is what DIAGNOSES a failed boot, rather than a precondition
+      // for diagnosing one. Waiting first and probing afterwards meant the
+      // central case — a route that never rendered — timed out here and never
+      // reached the probe, so it still surfaced as a bare locator timeout.
+      try {
+        await page
+          .getByRole("navigation", { name: REGION_NAMES.rail })
+          .waitFor({ state: "visible", timeout: SHELL_READY_TIMEOUT_MS });
+      } catch {
+        await diagnoseUnrenderedPage(page);
+      }
+      await assertChromePainted(page);
     },
 
     railItem(label) {

--- a/e2e/tests/shell/driver.ts
+++ b/e2e/tests/shell/driver.ts
@@ -67,20 +67,86 @@ function regionLocator(page: Page, region: keyof typeof REGION_NAMES): Locator {
 /** How long the shell is given to appear before the page is diagnosed instead. */
 const SHELL_READY_TIMEOUT_MS = 15_000;
 
+/** The chrome root, named once so every reader of it agrees on the selector. */
+const CHROME_SELECTOR = ".nx-builder-chrome";
+
 /**
- * Explain a page that did not come up, rather than letting a later assertion
- * report a symptom of it.
+ * Everything one look at the chrome can tell us.
  *
- * Every geometric check in this file reads a MEASURED box, which is what makes
- * it honest about an unstyled page — and it means a page that never rendered
- * reports "the inspector region has no layout box", which is indistinguishable
- * from a real layout regression in the shell.
- *
- * Called when the shell fails to appear, and again once it has. The two paths
- * are different failures and neither implies the other: a route that never
- * rendered produces no shell at all, while a rendered one can still be missing
- * its styles.
+ * ONE measurement, because two readers of the same element drift: the readiness
+ * check and the stylesheet test both need the box, the painted background and
+ * the layout mode, and a second implementation of "what does the chrome look
+ * like" agrees on the day it is written and not afterwards. Both derive their
+ * verdicts from this rather than each asking the DOM again.
  */
+export interface ShellRenderMeasurement {
+  /** Whether the chrome is in the DOM at all, however it looks. */
+  present: boolean;
+  /** Null when absent, or when it is present with no layout box. */
+  box: { width: number; height: number } | null;
+  /** The RESOLVED background, never the custom property behind it. */
+  background: string | null;
+  /** The resolved `display`, which only this package's stylesheet sets. */
+  display: string | null;
+}
+
+/** Read the chrome once, for every reader that needs to know how it looks. */
+export async function measureShellRender(
+  page: Page
+): Promise<ShellRenderMeasurement> {
+  const chrome = page.locator(CHROME_SELECTOR).first();
+  if ((await chrome.count()) === 0) {
+    return { present: false, box: null, background: null, display: null };
+  }
+  const box = await chrome.boundingBox();
+  const styles = await chrome.evaluate(element => {
+    const computed = getComputedStyle(element);
+    return { background: computed.backgroundColor, display: computed.display };
+  });
+  return {
+    present: true,
+    box: box === null ? null : { width: box.width, height: box.height },
+    background: styles.background,
+    display: styles.display,
+  };
+}
+
+/** A background that resolved to nothing, however the browser spells it. */
+export function isUnpainted(background: string | null): boolean {
+  return (
+    background === null ||
+    background === "transparent" ||
+    background === "rgba(0, 0, 0, 0)"
+  );
+}
+
+/**
+ * Wait for the shell, and explain the page when it does not arrive.
+ *
+ * Exported separately from navigation so a test can drive this branch against a
+ * page it controls. Without that, the diagnostic path runs only during a real
+ * outage — the one moment nobody is placed to discover the diagnostic is itself
+ * wrong.
+ */
+export async function assertShellReady(page: Page): Promise<void> {
+  try {
+    await page
+      .getByRole("navigation", { name: REGION_NAMES.rail })
+      .waitFor({ state: "visible", timeout: SHELL_READY_TIMEOUT_MS });
+  } catch (error) {
+    // Only an ABSENCE is evidence that the page did not render the shell. A
+    // strict-mode violation (two matching rails), a rail hidden by CSS, and a
+    // closed page all reject here too — each a real failure with a real cause
+    // that must not be overwritten by a guess about booting.
+    const measurement = await measureShellRender(page).catch(() => null);
+    if (measurement === null || measurement.present) throw error;
+    await diagnoseUnrenderedPage(page);
+  }
+
+  assertPainted(await measureShellRender(page));
+}
+
+/** Report a page with no shell in it, without naming a cause it cannot see. */
 async function diagnoseUnrenderedPage(page: Page): Promise<never> {
   const bodyText = (
     await page
@@ -88,28 +154,21 @@ async function diagnoseUnrenderedPage(page: Page): Promise<never> {
       .innerText()
       .catch(() => "")
   ).slice(0, 300);
-  const status = page.url();
   throw new Error(
-    `The editor shell never appeared, so the APPLICATION did not come up — ` +
+    `The editor shell is not in the DOM, so the page did not render it — ` +
       `this is not a layout regression in the shell.\n` +
-      `URL: ${status}\n` +
+      `URL: ${page.url()}\n` +
       `Body text (first 300 chars): ${bodyText || "<empty>"}\n` +
-      `Check the web-server log before the code. A blank body points at the ` +
-      `server failing to boot; an error screen usually names its own cause.`
+      `An empty body does NOT by itself mean the server failed to boot: a ` +
+      `route-level exception, a hydration failure, and an intentionally empty ` +
+      `response all look identical from here. Read the web-server log and the ` +
+      `response status before choosing between them.`
   );
 }
 
-/**
- * Whether the chrome has a real box and a resolved colour.
- *
- * Read as a PAINTED colour rather than as a custom property: asking for
- * `--nx-builder-surface` returns the declared token stream — the literal text
- * `var(--nx-muted)` — which is non-empty whether or not anything defines it.
- * Only the resolved value distinguishes a working style chain from a broken one.
- */
-async function assertChromePainted(page: Page): Promise<void> {
-  const chrome = page.locator(".nx-builder-chrome").first();
-  const box = await chrome.boundingBox();
+/** Turn one measurement into the readiness verdict. */
+function assertPainted(measurement: ShellRenderMeasurement): void {
+  const { box, background } = measurement;
   if (box === null || box.width === 0 || box.height === 0) {
     throw new Error(
       `The editor shell is in the DOM but has no layout box, so the page ` +
@@ -118,19 +177,14 @@ async function assertChromePainted(page: Page): Promise<void> {
         `reading this as a shell defect.`
     );
   }
-
-  const background = await chrome.evaluate(
-    element => getComputedStyle(element).backgroundColor
-  );
-  if (background === "rgba(0, 0, 0, 0)" || background === "transparent") {
-    // Deliberately NEUTRAL about which stylesheet is at fault. An unresolvable
+  if (isUnpainted(background)) {
+    // Deliberately NEUTRAL about which sheet is at fault: an unresolvable
     // `var()` chain and a chrome rule that lost its `background-color` compute
-    // to the same transparent value, so naming one of them would state a cause
-    // this check cannot tell apart — and send the reader to the wrong file.
+    // to the same value, so naming one states a cause this cannot separate.
     throw new Error(
       `The editor shell rendered but its chrome resolved to no colour, so the ` +
-        `style chain is broken somewhere between the design system's tokens ` +
-        `and this package's rules. Either a required stylesheet is absent ` +
+        `style chain is broken between the design system's tokens and this ` +
+        `package's rules. Either a required stylesheet is absent ` +
         `("@nextlyhq/ui/styles.css" alongside "@nextlyhq/builder/styles.css") ` +
         `or the chrome's own declaration regressed. The "both stylesheets ` +
         `actually loaded" test separates those two.`
@@ -145,18 +199,7 @@ export function createShellDriver(page: Page): ShellDriver {
       // Waits for the shell rather than for the network: the shell restores
       // preferences in an effect after mount, so a test that measured on
       // `load` would read the defaults and call them the restored values.
-      // The wait is what DIAGNOSES a failed boot, rather than a precondition
-      // for diagnosing one. Waiting first and probing afterwards meant the
-      // central case — a route that never rendered — timed out here and never
-      // reached the probe, so it still surfaced as a bare locator timeout.
-      try {
-        await page
-          .getByRole("navigation", { name: REGION_NAMES.rail })
-          .waitFor({ state: "visible", timeout: SHELL_READY_TIMEOUT_MS });
-      } catch {
-        await diagnoseUnrenderedPage(page);
-      }
-      await assertChromePainted(page);
+      await assertShellReady(page);
     },
 
     railItem(label) {

--- a/e2e/tests/shell/shell.spec.ts
+++ b/e2e/tests/shell/shell.spec.ts
@@ -20,7 +20,12 @@ import {
 } from "@nextlyhq/builder/shell-state";
 import { expect, test } from "@playwright/test";
 
-import { createShellDriver } from "./driver";
+import {
+  assertShellReady,
+  createShellDriver,
+  isUnpainted,
+  measureShellRender,
+} from "./driver";
 
 /**
  * The bounds come from the package, not from a second copy of the numbers.
@@ -80,38 +85,27 @@ test.describe("the shell's regions", () => {
   test("both stylesheets actually loaded", async ({ page }) => {
     // The control for every measurement above, and not redundant with them: a
     // shell whose CSS never shipped still renders its markup, still carries its
-    // class names, and lays out as a stack of full-width blocks. Regions would
-    // have boxes; they would simply be the wrong ones.
+    // class names, and lays out as a stack of full-width blocks.
     //
-    // Read as a PAINTED colour rather than as the custom property. Asking for
-    // `--nx-builder-surface` returns the declared token stream — the literal
-    // text `var(--nx-muted)` — which is a non-empty string whether or not
-    // `--nx-muted` is defined anywhere. That assertion passed while the harness
-    // was loading no design-system stylesheet at all, certifying the one thing
-    // it existed to rule out. `background-color` is resolved by the browser, so
-    // it can only be a real colour once the whole chain is present.
+    // Derived from the SAME measurement `goto()` takes, rather than reading the
+    // element again. Two readers of one element drift, and this one would drift
+    // silently because `goto()` runs first — its verdict decides whether this
+    // test evaluates at all.
     const shell = createShellDriver(page);
     await shell.goto();
 
-    const painted = await page.evaluate(() => {
-      const chrome = document.querySelector(".nx-builder-chrome");
-      if (chrome === null) return null;
-      const styles = getComputedStyle(chrome);
-      return {
-        background: styles.backgroundColor,
-        // Proves the editor's own sheet is present too: this class is emitted
-        // only by the builder's stylesheet, so the two halves of the contract
-        // are checked separately rather than inferred from one another.
-        display: styles.display,
-      };
-    });
+    const measurement = await measureShellRender(page);
 
-    expect(painted).not.toBeNull();
-    // An unresolvable `var()` computes to the initial value — transparent —
-    // which is exactly what a missing design system produces.
-    expect(painted?.background).not.toBe("rgba(0, 0, 0, 0)");
-    expect(painted?.background).not.toBe("transparent");
-    expect(painted?.display).toBe("flex");
+    expect(measurement.present).toBe(true);
+    // A painted colour, never the custom property: asking for
+    // `--nx-builder-surface` returns the declared token stream — the literal
+    // text `var(--nx-muted)` — which is non-empty whether or not anything
+    // defines it. That assertion passed while the harness loaded no
+    // design-system stylesheet at all.
+    expect(isUnpainted(measurement.background)).toBe(false);
+    // Emitted only by this package's stylesheet, so the two halves of the
+    // contract are checked separately rather than inferred from one another.
+    expect(measurement.display).toBe("flex");
   });
 });
 
@@ -230,5 +224,58 @@ test.describe("a viewport below the supported width", () => {
       page.getByRole("button", { name: "Exit editor" })
     ).toBeVisible();
     void shell;
+  });
+});
+
+test.describe("the readiness diagnostic itself", () => {
+  test.use({ viewport: { width: 1440, height: 900 } });
+
+  test("names an unrendered page instead of reporting a missing box", async ({
+    page,
+  }) => {
+    // THE POSITIVE CONTROL for the diagnostic added alongside it.
+    //
+    // On a healthy run the shell always appears, so the diagnostic branch never
+    // executes — which would leave an ordering mistake, an unreachable probe or
+    // a diagnostic that throws for the wrong reason invisible until a real
+    // outage, the one moment nobody can afford to debug the instrument. This
+    // drives that branch against a page under the test's control.
+    await page.setContent("<html><body></body></html>");
+
+    await expect(assertShellReady(page)).rejects.toThrow(
+      /shell is not in the DOM/
+    );
+  });
+
+  test("does not claim a boot failure it cannot observe", async ({ page }) => {
+    // The message must describe what was seen and stop there. An empty body is
+    // produced by a route-level exception, a hydration failure and a server that
+    // never booted alike, and Playwright's own `webServer.url` gate has already
+    // proven the server answers — so naming boot as the cause would send the
+    // reader past the actual fault.
+    await page.setContent("<html><body></body></html>");
+
+    const error = await assertShellReady(page).catch(
+      (thrown: unknown) => thrown
+    );
+
+    expect(String(error)).toContain("does NOT by itself mean");
+    expect(String(error)).not.toMatch(/the server failed to boot\b(?!:)/);
+  });
+
+  test("preserves a failure that is not an absence", async ({ page }) => {
+    // A rail that IS present but never visible is a real shell defect with a
+    // real Playwright error. Replacing it with "the application did not come up"
+    // would discard the cause in favour of a guess.
+    await page.setContent(
+      `<html><body><nav aria-label="Editor panels" style="display:none"></nav>
+       <div class="nx-builder-chrome"></div></body></html>`
+    );
+
+    const error = await assertShellReady(page).catch(
+      (thrown: unknown) => thrown
+    );
+
+    expect(String(error)).not.toContain("not in the DOM");
   });
 });

--- a/e2e/tests/shell/shell.spec.ts
+++ b/e2e/tests/shell/shell.spec.ts
@@ -133,9 +133,10 @@ test.describe("panel widths survive a reload", () => {
     // split across two tests, the second would start clean and pass or fail for
     // a reason that has nothing to do with persistence.
     await page.reload();
-    await page
-      .getByRole("navigation", { name: "Editor panels" })
-      .waitFor({ state: "visible" });
+    // The SAME readiness implementation the first navigation uses. A second,
+    // raw `waitFor` here would mean a page that fails to render only AFTER a
+    // reload still reports the generic timeout this change exists to replace.
+    await assertShellReady(page);
 
     expect(await shell.panelIsOpen()).toBe(true);
     expect(await shell.widthOf("panel")).toBeCloseTo(dragged, -1);
@@ -162,9 +163,10 @@ test.describe("panel widths survive a reload", () => {
     expect(Math.abs(dragged - before)).toBeGreaterThan(20);
 
     await page.reload();
-    await page
-      .getByRole("navigation", { name: "Editor panels" })
-      .waitFor({ state: "visible" });
+    // The SAME readiness implementation the first navigation uses. A second,
+    // raw `waitFor` here would mean a page that fails to render only AFTER a
+    // reload still reports the generic timeout this change exists to replace.
+    await assertShellReady(page);
 
     expect(await shell.panelIsOpen()).toBe(false);
     expect(await shell.widthOf("inspector")).toBeCloseTo(dragged, -1);
@@ -272,10 +274,19 @@ test.describe("the readiness diagnostic itself", () => {
        <div class="nx-builder-chrome"></div></body></html>`
     );
 
-    const error = await assertShellReady(page).catch(
+    // Asserted as a REJECTION first. Checking only that the message lacks a
+    // string passes when the promise RESOLVES — `error` is then `undefined`
+    // and `String(undefined)` contains nothing — so the weaker form would
+    // certify a readiness check that had silently stopped failing at all.
+    const error = await assertShellReady(page).then(
+      () => null,
       (thrown: unknown) => thrown
     );
 
+    expect(error).not.toBeNull();
+    // Playwright's OWN timeout, not ours: the rail is present, so the absence
+    // path must not have run and the original failure must survive intact.
+    expect(String(error)).toMatch(/Timeout|exceeded/i);
     expect(String(error)).not.toContain("not in the DOM");
   });
 });


### PR DESCRIPTION
`e2e/tests/shell/shell.spec.ts` is failing on heads that cannot reach it, and it is blocking merges across the repo.

## Evidence, from three lanes

| head | diff | result |
|---|---|---|
| #738 `fbc072bcd` | `blocks-engine`, `codegen`, docs | 2 failed, 87 passed |
| #737 `6828d6a3d` | `field-groups/migration/**` (zero production callers) | same 4 failures |

Same failures, unrelated diffs, neither able to change a panel's layout box. The web-server log carried `TypeError: The database connection is not open` immediately before three of the four.

## The actual problem is not the red

Every geometric check in `driver.ts` reads a **measured box** — deliberately, so an unstyled page cannot pass. The cost is that a page which never rendered reports `The inspector region has no layout box`, which is indistinguishable from a real regression. **Three independent layout regressions in one run is implausible; one broken page observed by three assertions is not** — but you only see that after opening all three.

Two lanes lost an afternoon each to this. Once that happens twice, people start re-running past reds, which is how a genuine regression eventually gets waved through.

## What this changes

`goto()` now verifies the application came up **before** any test asks a question that presupposes it:

1. the chrome has a non-zero box → otherwise "the APPLICATION did not render — this is not a layout regression in the shell", naming the database and `next/font/google` causes;
2. its background resolves to a real colour → otherwise a **stylesheet** is missing, not a layout wrong. A `var()` chain that cannot resolve computes to transparent, which renders a full-size, correctly-structured, entirely unstyled page.

## This is diagnosis, not tolerance

Nothing is retried, no assertion is loosened, no failure is swallowed. A real layout regression fails exactly as it did before — it just stops being the only explanation on offer for a broken environment.

Reported by lanes `20637` and `21524`; the `next/font/google` cause was filed by `23490` and is unclaimed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shell loading detection to identify missing, unstyled, or unpainted application shells.
  * Added clearer diagnostics, including the current URL and page content, when shell loading fails.
  * Improved navigation and reload readiness handling with a defined timeout.
  * Added coverage for missing shell markup, unrelated page errors, stylesheet rendering, and layout readiness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->