### PR TITLE
fix(create-nextly-app): load template fonts from packages, not Google Fonts

### DIFF
--- a/.changeset/self-host-template-fonts.md
+++ b/.changeset/self-host-template-fonts.md
@@ -1,0 +1,28 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+Load template and playground fonts from packages instead of fetching them from Google Fonts during the build.

--- a/apps/playground/package.json
+++ b/apps/playground/package.json
@@ -19,6 +19,8 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "@fontsource-variable/geist": "^5.3.0",
+    "@fontsource-variable/geist-mono": "^5.3.0",
     "@nextlyhq/adapter-drizzle": "workspace:^",
     "@nextlyhq/adapter-mysql": "workspace:^",
     "@nextlyhq/adapter-postgres": "workspace:^",

--- a/apps/playground/src/app/globals.css
+++ b/apps/playground/src/app/globals.css
@@ -1,5 +1,15 @@
 @import "tailwindcss";
 
+/* The families the imported font stylesheets declare, bound to the variables the rules
+   below read. Named here rather than by `next/font`, which used to inject them: the faces
+   now arrive as ordinary stylesheets, so the binding has to be written down somewhere, and
+   the name is load-bearing — the admin theme reads `--font-geist`. Quoted family names, so
+   the two-word values stay one identifier. */
+:root {
+  --font-geist: "Geist Variable";
+  --font-geist-mono: "Geist Mono Variable";
+}
+
 /* Playground frontend theme only. The admin (mounted at /admin) ships its
  * own scoped design tokens via @nextlyhq/admin/style.css, so this file must
  * NOT redefine the design-system color tokens (--primary, --card, --muted,

--- a/apps/playground/src/app/layout.tsx
+++ b/apps/playground/src/app/layout.tsx
@@ -6,27 +6,33 @@ import {
   QueryProvider,
   ThemeProvider,
 } from "@nextlyhq/admin";
-import { Geist, Geist_Mono } from "next/font/google";
+import localFont from "next/font/local";
 import "./globals.css";
 
-// Self-hosted at build time by `next/font`, which exposes the face only as a
-// CSS variable -- the admin theme names that variable first for exactly this
-// reason. Weights are the four the design system declares; the rest would ship
-// bytes nothing renders.
-const geistSans = Geist({
+// The face ships in `node_modules` rather than being fetched from
+// fonts.googleapis.com at BUILD time, which made every build -- and the browser
+// suite's global setup, which builds first -- depend on reaching a third party.
+// It is still self-hosted from the app's own origin at runtime, and still
+// exposed only as a CSS variable; the admin theme names that variable first for
+// exactly this reason.
+//
+// One variable file covers the whole weight axis, which replaces the four
+// static cuts the design system declares. That is fewer requests rather than
+// more bytes: the discarded weights were separate files.
+const geistSans = localFont({
+  src: "../../node_modules/@fontsource-variable/geist/files/geist-latin-wght-normal.woff2",
   variable: "--font-geist",
-  subsets: ["latin"],
   display: "swap",
-  weight: ["400", "500", "600", "700"],
+  weight: "100 900",
 });
 
 // The mono face the admin reaches for on code surfaces: the API playground
 // editor, ids, and inline code.
-const geistMono = Geist_Mono({
+const geistMono = localFont({
+  src: "../../node_modules/@fontsource-variable/geist-mono/files/geist-mono-latin-wght-normal.woff2",
   variable: "--font-geist-mono",
-  subsets: ["latin"],
   display: "swap",
-  weight: ["400", "500"],
+  weight: "100 900",
 });
 
 export default function RootLayout({

--- a/apps/playground/src/app/layout.tsx
+++ b/apps/playground/src/app/layout.tsx
@@ -25,7 +25,13 @@ import "./globals.css";
  *
  * The trade is `next/font`'s metric-adjusted fallback, so text can shift
  * slightly as the face arrives. The families are bound to this app's `--font-*`
- * variables in `globals.css`, which is what every rule downstream reads.
+ * variables in `globals.css`, which is what every rule downstream reads. *
+ * Importing the package root ships every subset the face offers — Latin, Latin
+ * Extended, Cyrillic, Vietnamese — but each `@font-face` carries a
+ * `unicode-range`, so a browser downloads only the subsets the page actually
+ * uses. The deployed bundle is larger than a single hand-picked file; what a
+ * reader fetches is not, and a page in Cyrillic now gets its face instead of a
+ * fallback.
  */
 export default function RootLayout({
   children,

--- a/apps/playground/src/app/layout.tsx
+++ b/apps/playground/src/app/layout.tsx
@@ -6,35 +6,27 @@ import {
   QueryProvider,
   ThemeProvider,
 } from "@nextlyhq/admin";
-import localFont from "next/font/local";
+import "@fontsource-variable/geist";
+import "@fontsource-variable/geist-mono";
 import "./globals.css";
 
-// The face ships in `node_modules` rather than being fetched from
-// fonts.googleapis.com at BUILD time, which made every build -- and the browser
-// suite's global setup, which builds first -- depend on reaching a third party.
-// It is still self-hosted from the app's own origin at runtime, and still
-// exposed only as a CSS variable; the admin theme names that variable first for
-// exactly this reason.
-//
-// One variable file covers the whole weight axis, which replaces the four
-// static cuts the design system declares. That is fewer requests rather than
-// more bytes: the discarded weights were separate files.
-const geistSans = localFont({
-  src: "../../node_modules/@fontsource-variable/geist/files/geist-latin-wght-normal.woff2",
-  variable: "--font-geist",
-  display: "swap",
-  weight: "100 900",
-});
-
-// The mono face the admin reaches for on code surfaces: the API playground
-// editor, ids, and inline code.
-const geistMono = localFont({
-  src: "../../node_modules/@fontsource-variable/geist-mono/files/geist-mono-latin-wght-normal.woff2",
-  variable: "--font-geist-mono",
-  display: "swap",
-  weight: "100 900",
-});
-
+/**
+ * The faces are imported as STYLESHEETS from packages in `node_modules`, rather
+ * than fetched from fonts.googleapis.com by `next/font/google` while
+ * `next build` runs — which made every build depend on reaching a third party
+ * and fail behind a proxy, on a locked-down runner, or offline.
+ *
+ * A bare package import rather than `next/font/local` pointing INTO
+ * `node_modules`: a literal path asserts where the package physically lives,
+ * and that assertion is false under Yarn's Plug'n'Play linker (no
+ * `node_modules` at all), under npm/Yarn workspace hoisting (the package moves
+ * to the workspace root), and under pnpm's own symlinked store. An import asks
+ * the resolver instead, which is correct under every layout.
+ *
+ * The trade is `next/font`'s metric-adjusted fallback, so text can shift
+ * slightly as the face arrives. The families are bound to this app's `--font-*`
+ * variables in `globals.css`, which is what every rule downstream reads.
+ */
 export default function RootLayout({
   children,
 }: Readonly<{
@@ -43,7 +35,6 @@ export default function RootLayout({
   return (
     <html
       lang="en"
-      className={`${geistSans.variable} ${geistMono.variable}`}
       /**
        * suppressHydrationWarning is needed to prevent hydration errors caused by
        * browser extensions (e.g., Bitwarden, password managers) that inject

--- a/packages/create-nextly-app/src/__tests__/fonts.test.ts
+++ b/packages/create-nextly-app/src/__tests__/fonts.test.ts
@@ -118,6 +118,59 @@ describe("no template fetches a font at build time", () => {
   });
 });
 
+describe("every template feeds the admin theme", () => {
+  /** The `:root` block a template's `globals.css` declares, where the theme resolves. */
+  function rootBlock(template: string): string {
+    const css = fs.readFileSync(
+      path.join(TEMPLATES_ROOT, template, "src/app/globals.css"),
+      "utf8"
+    );
+    const start = css.indexOf(":root {");
+    expect(start).toBeGreaterThanOrEqual(0);
+    // Comments stripped first. The comments here QUOTE the theme's declarations by name, so a
+    // scan over raw text matches the prose explaining a rule and reports the rule itself —
+    // which is what pushes the next reader to delete the explanation to get a green.
+    return css
+      .slice(start, css.indexOf("}", start))
+      .replace(/\/\*[\s\S]*?\*\//g, "");
+  }
+
+  it("reads declarations rather than the comments about them", () => {
+    // Positive control for the stripping above: the shadow assertions are satisfied by ABSENCE,
+    // and prose naming a token looks identical to a declaration of it.
+    const blank = rootBlock("blank");
+    expect(blank).toMatch(/--font-geist\s*:/);
+    expect(blank).not.toContain("theme's OWN token");
+  });
+
+  it.each(APP_TEMPLATES)(
+    "%s exposes the variables the admin reads",
+    template => {
+      // `packages/ui/src/styles/theme.css` declares
+      // `--font-sans: var(--font-geist, Geist), ...` and
+      // `--font-mono: var(--font-geist-mono, "Geist Mono"), ...` in a NON-INLINE `@theme`, so they
+      // are emitted into `:root` and substitute there. A template that loads a different face still
+      // has to publish it under these names, or its admin panel renders in a system fallback while
+      // its own pages render correctly — which is easy to miss, because only /admin looks wrong.
+      const root = rootBlock(template);
+      expect(root).toMatch(/--font-geist\s*:/);
+      expect(root).toMatch(/--font-geist-mono\s*:/);
+    }
+  );
+
+  it.each(APP_TEMPLATES)(
+    "%s does not shadow the theme's own tokens",
+    template => {
+      // `--font-sans` and `--font-mono` are the THEME's tokens, declared at `:root`. A template
+      // redefining one at the same scope replaces the theme's whole fallback chain with a single
+      // family rather than feeding it — a broken stack rather than a missing font.
+      const root = rootBlock(template);
+      expect(root).not.toMatch(/--font-sans\s*:/);
+      expect(root).not.toMatch(/--font-mono\s*:/);
+    }
+  );
+});
+
 describe("the scaffold installs the fonts its templates import", () => {
   /** The faces each scaffold's FINAL layout references, after the type overlays base. */
   const EXPECTED: Record<(typeof APP_TEMPLATES)[number], string[]> = {

--- a/packages/create-nextly-app/src/__tests__/fonts.test.ts
+++ b/packages/create-nextly-app/src/__tests__/fonts.test.ts
@@ -52,6 +52,9 @@ const APP_TEMPLATES = ["base", "blank", "blog"] as const;
  * plain substring search flags that explanation — which would push the next
  * person to delete the comment that stops the fetch being reintroduced.
  */
+/** A literal path into `node_modules`, which assumes a physical install layout. */
+const NODE_MODULES_PATH = /["\x27][^"\x27]*node_modules\//;
+
 const BUILD_TIME_FONT_IMPORT =
   /(?:from\s*|require\(\s*|import\(\s*)["']next\/font\/google["']/;
 
@@ -82,6 +85,28 @@ describe("no template fetches a font at build time", () => {
         " * `next/font/google`, which fetches them from fonts.googleapis.com"
       )
     ).toBe(false);
+  });
+
+  it("recognises a node_modules path when it sees one", () => {
+    // Positive control for the assertion below, which is satisfied by ABSENCE.
+    expect(
+      NODE_MODULES_PATH.test('src: "../../node_modules/@fontsource/x.woff2"')
+    ).toBe(true);
+    expect(NODE_MODULES_PATH.test('import "@fontsource-variable/inter";')).toBe(
+      false
+    );
+  });
+
+  it.each(APP_TEMPLATES)("%s names no node_modules path", template => {
+    // A literal path asserts where a package physically lives. That is false under Yarn PnP
+    // (no node_modules at all), under npm/Yarn workspace hoisting (the package moves to the
+    // workspace root), and under pnpm's symlinked store — and the failure is a build error in
+    // the user's project, not here.
+    const offenders = sourceFiles(path.join(TEMPLATES_ROOT, template)).filter(
+      file => NODE_MODULES_PATH.test(fs.readFileSync(file, "utf8"))
+    );
+
+    expect(offenders.map(f => path.relative(TEMPLATES_ROOT, f))).toEqual([]);
   });
 
   it.each(APP_TEMPLATES)("%s imports no build-time font fetch", template => {

--- a/packages/create-nextly-app/src/__tests__/fonts.test.ts
+++ b/packages/create-nextly-app/src/__tests__/fonts.test.ts
@@ -36,7 +36,10 @@ function sourceFiles(root: string): string[] {
     if (entry.isDirectory()) {
       if (entry.name === "node_modules" || entry.name === ".next") continue;
       out.push(...sourceFiles(full));
-    } else if (/\.(?:tsx?|jsx?|mjs|cjs)$/.test(entry.name)) {
+      // `.css` included, because the production collector treats CSS as import-bearing and a
+      // template can name a path from `@import` or `url()`. A traversal narrower than the code it
+      // guards reports clean over exactly the files it never opened.
+    } else if (/\.(?:tsx?|jsx?|mjs|cjs|css)$/.test(entry.name)) {
       out.push(full);
     }
   }

--- a/packages/create-nextly-app/src/__tests__/fonts.test.ts
+++ b/packages/create-nextly-app/src/__tests__/fonts.test.ts
@@ -8,6 +8,7 @@
  * browser suite with it, because its global setup builds first. Both properties
  * below exist to keep that from coming back.
  */
+import os from "os";
 import path from "path";
 import { fileURLToPath } from "url";
 
@@ -16,6 +17,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   collectFontDependencies,
+  copyTemplate,
   generatePackageJson,
 } from "../utils/template";
 import type { DatabaseConfig } from "../types";
@@ -129,6 +131,44 @@ describe("the scaffold installs the fonts its templates import", () => {
       // Exact, not a superset. The overlay REPLACES base's layout, so a union would install the
       // faces of a layout this scaffold never receives.
       expect(declared).toEqual([...EXPECTED[template]].sort());
+    }
+  );
+
+  it.each(APP_TEMPLATES)(
+    "%s scaffolds a project whose manifest carries its fonts",
+    async template => {
+      // Through `copyTemplate`, which is where the directories are chosen. The manifest test
+      // above passes them explicitly, so it cannot see the CALL SITE regress — measured: reverting
+      // that argument to `[]` left every other case in this file green.
+      const targetDir = await fs.mkdtemp(
+        path.join(os.tmpdir(), `nextly-fonts-${template}-`)
+      );
+      try {
+        await copyTemplate({
+          projectName: "font-fixture",
+          projectType: template,
+          targetDir,
+          database: { type: "sqlite" } as DatabaseConfig,
+          useYalc: true,
+          allowExistingTarget: true,
+          templateSource: {
+            basePath: path.join(TEMPLATES_ROOT, "base"),
+            templatePath: path.join(TEMPLATES_ROOT, template),
+          },
+        });
+
+        const manifest = JSON.parse(
+          await fs.readFile(path.join(targetDir, "package.json"), "utf8")
+        ) as { dependencies: Record<string, string> };
+
+        expect(
+          Object.keys(manifest.dependencies)
+            .filter(name => name.startsWith("@fontsource"))
+            .sort()
+        ).toEqual([...EXPECTED[template]].sort());
+      } finally {
+        await fs.remove(targetDir);
+      }
     }
   );
 

--- a/packages/create-nextly-app/src/__tests__/fonts.test.ts
+++ b/packages/create-nextly-app/src/__tests__/fonts.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Fonts must not be fetched at build time, and the scaffold must install the
+ * ones its templates import.
+ *
+ * `next/font/google` downloads the face from fonts.googleapis.com while
+ * `next build` runs. That makes a build depend on reaching a third party, so it
+ * fails behind a proxy, on a locked-down runner, and offline — and it took the
+ * browser suite with it, because its global setup builds first. Both properties
+ * below exist to keep that from coming back.
+ */
+import path from "path";
+import { fileURLToPath } from "url";
+
+import fs from "fs-extra";
+import { describe, expect, it } from "vitest";
+
+import { collectFontDependencies } from "../utils/template";
+
+const TEMPLATES_ROOT = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../../../../templates"
+);
+
+/** Every file a template ships that could carry an import specifier. */
+function sourceFiles(root: string): string[] {
+  const out: string[] = [];
+  if (!fs.existsSync(root)) return out;
+  for (const entry of fs.readdirSync(root, { withFileTypes: true })) {
+    const full = path.join(root, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === "node_modules" || entry.name === ".next") continue;
+      out.push(...sourceFiles(full));
+    } else if (/\.(?:tsx?|jsx?|mjs|cjs)$/.test(entry.name)) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+const APP_TEMPLATES = ["base", "blank", "blog"] as const;
+
+/**
+ * An IMPORT of the build-time font loader, not a mention of it.
+ *
+ * The layouts explain in prose why they no longer use `next/font/google`, and a
+ * plain substring search flags that explanation — which would push the next
+ * person to delete the comment that stops the fetch being reintroduced.
+ */
+const BUILD_TIME_FONT_IMPORT =
+  /(?:from\s*|require\(\s*|import\(\s*)["']next\/font\/google["']/;
+
+describe("no template fetches a font at build time", () => {
+  it("finds the template sources it is about to assert over", () => {
+    // The positive control. `next/font/google` is asserted by ABSENCE below, and
+    // absence is also what a wrong path, a renamed directory or a glob that
+    // matches nothing produces — each of which would certify every template as
+    // clean without reading a line.
+    const files = APP_TEMPLATES.flatMap(t =>
+      sourceFiles(path.join(TEMPLATES_ROOT, t))
+    );
+    expect(files.length).toBeGreaterThan(0);
+    expect(
+      files.some(f => f.endsWith(path.join("src", "app", "layout.tsx")))
+    ).toBe(true);
+  });
+
+  it("recognises a build-time font import when it sees one", () => {
+    // The pattern is what every assertion below trusts, and it is asserted by
+    // ABSENCE — so it is checked against a line it must match, and against the
+    // prose in the layouts it must NOT.
+    expect(
+      BUILD_TIME_FONT_IMPORT.test('import { Inter } from "next/font/google";')
+    ).toBe(true);
+    expect(
+      BUILD_TIME_FONT_IMPORT.test(
+        " * `next/font/google`, which fetches them from fonts.googleapis.com"
+      )
+    ).toBe(false);
+  });
+
+  it.each(APP_TEMPLATES)("%s imports no build-time font fetch", template => {
+    const offenders = sourceFiles(path.join(TEMPLATES_ROOT, template)).filter(
+      file => BUILD_TIME_FONT_IMPORT.test(fs.readFileSync(file, "utf8"))
+    );
+
+    expect(offenders.map(f => path.relative(TEMPLATES_ROOT, f))).toEqual([]);
+  });
+});
+
+describe("the scaffold installs the fonts its templates import", () => {
+  it.each(APP_TEMPLATES)(
+    "%s declares every font package its sources reference",
+    async template => {
+      const dirs = [
+        path.join(TEMPLATES_ROOT, "base"),
+        path.join(TEMPLATES_ROOT, template),
+      ];
+
+      // What the templates actually import, read independently of the
+      // collector — a test that called the collector twice would agree with
+      // itself no matter what either one did.
+      const imported = new Set<string>();
+      for (const dir of dirs) {
+        for (const file of sourceFiles(dir)) {
+          for (const match of fs
+            .readFileSync(file, "utf8")
+            .matchAll(/@fontsource(?:-variable)?\/[a-z0-9-]+/g)) {
+            imported.add(match[0]);
+          }
+        }
+      }
+
+      // Every template loads at least one face, so an empty set here means the
+      // read found nothing rather than that nothing is needed.
+      expect(imported.size).toBeGreaterThan(0);
+      expect((await collectFontDependencies(dirs)).sort()).toEqual(
+        [...imported].sort()
+      );
+    }
+  );
+
+  it("reads the directories it is given rather than resolving its own", async () => {
+    // The collector is handed the dirs the scaffold is COPYING. A downloaded or
+    // --local-template source is a different tree from the bundled one, and a
+    // collector that resolved its own path would install the fonts of templates
+    // the project never receives.
+    expect(await collectFontDependencies([])).toEqual([]);
+    expect(
+      await collectFontDependencies([path.join(TEMPLATES_ROOT, "base")])
+    ).not.toEqual([]);
+  });
+});

--- a/packages/create-nextly-app/src/__tests__/fonts.test.ts
+++ b/packages/create-nextly-app/src/__tests__/fonts.test.ts
@@ -46,6 +46,21 @@ function sourceFiles(root: string): string[] {
 const APP_TEMPLATES = ["base", "blank", "blog"] as const;
 
 /**
+ * Every source root the build-time-fetch bans apply to.
+ *
+ * The playground is not a template and is never scaffolded, but it IS built by CI, and its
+ * `next/font/google` call is what reddened unrelated pull requests. A scan rooted only under
+ * `templates/` stays green while half of this change is reverted.
+ */
+const SCANNED_ROOTS: readonly (readonly [string, string])[] = [
+  ...APP_TEMPLATES.map(t => [t, path.join(TEMPLATES_ROOT, t)] as const),
+  [
+    "playground",
+    path.resolve(TEMPLATES_ROOT, "..", "apps", "playground", "src"),
+  ] as const,
+];
+
+/**
  * An IMPORT of the build-time font loader, not a mention of it.
  *
  * The layouts explain in prose why they no longer use `next/font/google`, and a
@@ -59,14 +74,18 @@ const BUILD_TIME_FONT_IMPORT =
   /(?:from\s*|require\(\s*|import\(\s*)["']next\/font\/google["']/;
 
 describe("no template fetches a font at build time", () => {
-  it("finds the template sources it is about to assert over", () => {
+  it("finds the sources it is about to assert over", () => {
     // The positive control. `next/font/google` is asserted by ABSENCE below, and
     // absence is also what a wrong path, a renamed directory or a glob that
     // matches nothing produces — each of which would certify every template as
     // clean without reading a line.
-    const files = APP_TEMPLATES.flatMap(t =>
-      sourceFiles(path.join(TEMPLATES_ROOT, t))
-    );
+    const files = SCANNED_ROOTS.flatMap(([, root]) => sourceFiles(root));
+    // Asserted per ROOT as well as in aggregate: one root silently resolving to nothing would
+    // otherwise hide behind the others' files, and its absence check would pass having read
+    // nothing.
+    for (const [, root] of SCANNED_ROOTS) {
+      expect(sourceFiles(root).length).toBeGreaterThan(0);
+    }
     expect(files.length).toBeGreaterThan(0);
     expect(
       files.some(f => f.endsWith(path.join("src", "app", "layout.tsx")))
@@ -97,25 +116,28 @@ describe("no template fetches a font at build time", () => {
     );
   });
 
-  it.each(APP_TEMPLATES)("%s names no node_modules path", template => {
+  it.each(SCANNED_ROOTS)("%s names no node_modules path", (_name, root) => {
     // A literal path asserts where a package physically lives. That is false under Yarn PnP
     // (no node_modules at all), under npm/Yarn workspace hoisting (the package moves to the
     // workspace root), and under pnpm's symlinked store — and the failure is a build error in
     // the user's project, not here.
-    const offenders = sourceFiles(path.join(TEMPLATES_ROOT, template)).filter(
-      file => NODE_MODULES_PATH.test(fs.readFileSync(file, "utf8"))
+    const offenders = sourceFiles(root).filter(file =>
+      NODE_MODULES_PATH.test(fs.readFileSync(file, "utf8"))
     );
 
-    expect(offenders.map(f => path.relative(TEMPLATES_ROOT, f))).toEqual([]);
+    expect(offenders.map(f => path.relative(root, f))).toEqual([]);
   });
 
-  it.each(APP_TEMPLATES)("%s imports no build-time font fetch", template => {
-    const offenders = sourceFiles(path.join(TEMPLATES_ROOT, template)).filter(
-      file => BUILD_TIME_FONT_IMPORT.test(fs.readFileSync(file, "utf8"))
-    );
+  it.each(SCANNED_ROOTS)(
+    "%s imports no build-time font fetch",
+    (_name, root) => {
+      const offenders = sourceFiles(root).filter(file =>
+        BUILD_TIME_FONT_IMPORT.test(fs.readFileSync(file, "utf8"))
+      );
 
-    expect(offenders.map(f => path.relative(TEMPLATES_ROOT, f))).toEqual([]);
-  });
+      expect(offenders.map(f => path.relative(root, f))).toEqual([]);
+    }
+  );
 });
 
 describe("every template feeds the admin theme", () => {

--- a/packages/create-nextly-app/src/__tests__/fonts.test.ts
+++ b/packages/create-nextly-app/src/__tests__/fonts.test.ts
@@ -274,41 +274,6 @@ describe("the scaffold installs the fonts its templates import", () => {
     }
   );
 
-  it.each(APP_TEMPLATES)(
-    "%s scaffolds a node-modules linker so the font paths exist",
-    async template => {
-      // `next/font/local` reads its `src` off disk rather than through the module resolver, so a
-      // Yarn Berry PnP install — which has no physical node_modules — fails to build on a
-      // dependency the manifest correctly declares. Yarn is a package manager this CLI detects
-      // and installs with, so the scaffold pins the linker.
-      const targetDir = await fs.mkdtemp(
-        path.join(os.tmpdir(), `nextly-linker-${template}-`)
-      );
-      try {
-        await copyTemplate({
-          projectName: "linker-fixture",
-          projectType: template,
-          targetDir,
-          database: { type: "sqlite" } as DatabaseConfig,
-          useYalc: true,
-          allowExistingTarget: true,
-          templateSource: {
-            basePath: path.join(TEMPLATES_ROOT, "base"),
-            templatePath: path.join(TEMPLATES_ROOT, template),
-          },
-        });
-
-        const yarnrc = await fs.readFile(
-          path.join(targetDir, ".yarnrc.yml"),
-          "utf8"
-        );
-        expect(yarnrc).toContain("nodeLinker: node-modules");
-      } finally {
-        await fs.remove(targetDir);
-      }
-    }
-  );
-
   it("declares nothing when the caller passes no template directories", () => {
     // The collector is handed the dirs the scaffold is COPYING. A downloaded or
     // --local-template source is a different tree from the bundled one, and a collector that

--- a/packages/create-nextly-app/src/__tests__/fonts.test.ts
+++ b/packages/create-nextly-app/src/__tests__/fonts.test.ts
@@ -172,6 +172,41 @@ describe("the scaffold installs the fonts its templates import", () => {
     }
   );
 
+  it.each(APP_TEMPLATES)(
+    "%s scaffolds a node-modules linker so the font paths exist",
+    async template => {
+      // `next/font/local` reads its `src` off disk rather than through the module resolver, so a
+      // Yarn Berry PnP install — which has no physical node_modules — fails to build on a
+      // dependency the manifest correctly declares. Yarn is a package manager this CLI detects
+      // and installs with, so the scaffold pins the linker.
+      const targetDir = await fs.mkdtemp(
+        path.join(os.tmpdir(), `nextly-linker-${template}-`)
+      );
+      try {
+        await copyTemplate({
+          projectName: "linker-fixture",
+          projectType: template,
+          targetDir,
+          database: { type: "sqlite" } as DatabaseConfig,
+          useYalc: true,
+          allowExistingTarget: true,
+          templateSource: {
+            basePath: path.join(TEMPLATES_ROOT, "base"),
+            templatePath: path.join(TEMPLATES_ROOT, template),
+          },
+        });
+
+        const yarnrc = await fs.readFile(
+          path.join(targetDir, ".yarnrc.yml"),
+          "utf8"
+        );
+        expect(yarnrc).toContain("nodeLinker: node-modules");
+      } finally {
+        await fs.remove(targetDir);
+      }
+    }
+  );
+
   it("declares nothing when the caller passes no template directories", () => {
     // The collector is handed the dirs the scaffold is COPYING. A downloaded or
     // --local-template source is a different tree from the bundled one, and a collector that

--- a/packages/create-nextly-app/src/__tests__/fonts.test.ts
+++ b/packages/create-nextly-app/src/__tests__/fonts.test.ts
@@ -171,6 +171,30 @@ describe("every template feeds the admin theme", () => {
   );
 });
 
+describe("a template's own utilities reach the face it loads", () => {
+  it.each(APP_TEMPLATES)("%s binds font-mono if its pages use it", template => {
+    const dir = path.join(TEMPLATES_ROOT, template);
+    const usesMonoUtility = sourceFiles(dir).some(
+      file =>
+        file.endsWith(".tsx") &&
+        /\bfont-mono\b/.test(fs.readFileSync(file, "utf8"))
+    );
+    if (!usesMonoUtility) return;
+
+    // Frontend routes do not load the admin stylesheet, so nothing else binds this utility. It
+    // has to be bound in an `@theme inline` block: a plain `@theme` emits the variable into
+    // `:root`, where the admin declares its own, and would replace that fallback chain instead of
+    // feeding it.
+    const css = fs.readFileSync(path.join(dir, "src/app/globals.css"), "utf8");
+    const inlineBlocks = [
+      ...css.matchAll(/@theme\s+inline\s*\{([^}]*)\}/g),
+    ].map(m => m[1] ?? "");
+    expect(inlineBlocks.some(block => /--font-mono\s*:/.test(block))).toBe(
+      true
+    );
+  });
+});
+
 describe("the scaffold installs the fonts its templates import", () => {
   /** The faces each scaffold's FINAL layout references, after the type overlays base. */
   const EXPECTED: Record<(typeof APP_TEMPLATES)[number], string[]> = {

--- a/packages/create-nextly-app/src/__tests__/fonts.test.ts
+++ b/packages/create-nextly-app/src/__tests__/fonts.test.ts
@@ -14,7 +14,11 @@ import { fileURLToPath } from "url";
 import fs from "fs-extra";
 import { describe, expect, it } from "vitest";
 
-import { collectFontDependencies } from "../utils/template";
+import {
+  collectFontDependencies,
+  generatePackageJson,
+} from "../utils/template";
+import type { DatabaseConfig } from "../types";
 
 const TEMPLATES_ROOT = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
@@ -88,45 +92,80 @@ describe("no template fetches a font at build time", () => {
 });
 
 describe("the scaffold installs the fonts its templates import", () => {
+  /** The faces each scaffold's FINAL layout references, after the type overlays base. */
+  const EXPECTED: Record<(typeof APP_TEMPLATES)[number], string[]> = {
+    base: ["@fontsource-variable/geist", "@fontsource-variable/geist-mono"],
+    blank: [
+      "@fontsource-variable/inter",
+      "@fontsource-variable/jetbrains-mono",
+    ],
+    blog: ["@fontsource-variable/geist-mono", "@fontsource-variable/inter"],
+  };
+
   it.each(APP_TEMPLATES)(
-    "%s declares every font package its sources reference",
+    "%s emits a manifest carrying exactly the faces it renders",
+    async template => {
+      // Asserted against the GENERATED manifest, not against another scan of the same sources.
+      // Comparing the collector with a second reader agrees with itself however the scaffold is
+      // wired: deleting the dependency loop, or passing the caller no directories, left that
+      // version green while every generated app was missing its fonts and failed to build.
+      const manifest = JSON.parse(
+        await generatePackageJson(
+          "font-fixture",
+          { type: "sqlite" } as DatabaseConfig,
+          true,
+          template,
+          [
+            path.join(TEMPLATES_ROOT, "base"),
+            path.join(TEMPLATES_ROOT, template),
+          ]
+        )
+      ) as { dependencies: Record<string, string> };
+
+      const declared = Object.keys(manifest.dependencies)
+        .filter(name => name.startsWith("@fontsource"))
+        .sort();
+
+      // Exact, not a superset. The overlay REPLACES base's layout, so a union would install the
+      // faces of a layout this scaffold never receives.
+      expect(declared).toEqual([...EXPECTED[template]].sort());
+    }
+  );
+
+  it("declares nothing when the caller passes no template directories", () => {
+    // The collector is handed the dirs the scaffold is COPYING. A downloaded or
+    // --local-template source is a different tree from the bundled one, and a collector that
+    // resolved its own path would install the fonts of templates the project never receives.
+    expect(collectFontDependencies([])).resolves.toEqual([]);
+  });
+
+  it.each(APP_TEMPLATES)(
+    "%s collector output matches what its merged sources import",
     async template => {
       const dirs = [
         path.join(TEMPLATES_ROOT, "base"),
         path.join(TEMPLATES_ROOT, template),
       ];
-
-      // What the templates actually import, read independently of the
-      // collector — a test that called the collector twice would agree with
-      // itself no matter what either one did.
-      const imported = new Set<string>();
+      // The overlay wins per relative path, mirroring the copy.
+      const effective = new Map<string, string>();
       for (const dir of dirs) {
         for (const file of sourceFiles(dir)) {
-          for (const match of fs
-            .readFileSync(file, "utf8")
-            .matchAll(/@fontsource(?:-variable)?\/[a-z0-9-]+/g)) {
-            imported.add(match[0]);
-          }
+          effective.set(path.relative(dir, file), file);
+        }
+      }
+      const imported = new Set<string>();
+      for (const file of effective.values()) {
+        for (const match of fs
+          .readFileSync(file, "utf8")
+          .matchAll(/@fontsource(?:-variable)?\/[a-z0-9-]+/g)) {
+          imported.add(match[0]);
         }
       }
 
-      // Every template loads at least one face, so an empty set here means the
-      // read found nothing rather than that nothing is needed.
       expect(imported.size).toBeGreaterThan(0);
       expect((await collectFontDependencies(dirs)).sort()).toEqual(
         [...imported].sort()
       );
     }
   );
-
-  it("reads the directories it is given rather than resolving its own", async () => {
-    // The collector is handed the dirs the scaffold is COPYING. A downloaded or
-    // --local-template source is a different tree from the bundled one, and a
-    // collector that resolved its own path would install the fonts of templates
-    // the project never receives.
-    expect(await collectFontDependencies([])).toEqual([]);
-    expect(
-      await collectFontDependencies([path.join(TEMPLATES_ROOT, "base")])
-    ).not.toEqual([]);
-  });
 });

--- a/packages/create-nextly-app/src/utils/template.ts
+++ b/packages/create-nextly-app/src/utils/template.ts
@@ -17,6 +17,73 @@ const PROJECT_TYPES_WITH_FORM_BUILDER: ReadonlySet<ProjectType> = new Set([
   "blog",
 ]);
 
+/**
+ * The version range every font package is scaffolded at. One range because they
+ * are released together and a project mixing lines would ship two copies of the
+ * same metric-adjusted fallback.
+ */
+const FONT_PACKAGE_RANGE = "^5.3.0";
+
+/** Matches a font package specifier wherever a template imports one. */
+const FONT_PACKAGE_PATTERN = /@fontsource(?:-variable)?\/[a-z0-9-]+/g;
+
+/**
+ * The font packages a scaffold of `projectType` actually needs.
+ *
+ * READ from the template sources rather than listed here. A hand-kept list is a
+ * second answer to a question the templates already answer, and the two only
+ * agree until someone changes a face: a template importing a package the
+ * scaffold never installs fails at `next build` with a module it cannot
+ * resolve, and one installing a package nothing imports ships dead bytes.
+ *
+ * The type's own directory is read as well as `base`'s, because a template that
+ * overrides `layout.tsx` chooses its own faces — reading only `base` would
+ * install Geist for a scaffold that renders in Inter.
+ *
+ * The caller passes the directories it is about to COPY, rather than this
+ * resolving its own. A downloaded or `--local-template` source is a different
+ * tree from the published one, and reading the wrong tree would install the
+ * fonts of templates the project never receives.
+ */
+export async function collectFontDependencies(
+  templateDirs: readonly string[]
+): Promise<string[]> {
+  const found = new Set<string>();
+
+  for (const root of templateDirs) {
+    if (!root || !(await fs.pathExists(root))) continue;
+    for (const file of await walkSourceFiles(root)) {
+      const contents = await fs.readFile(file, "utf8");
+      for (const match of contents.matchAll(FONT_PACKAGE_PATTERN)) {
+        found.add(match[0]);
+      }
+    }
+  }
+
+  return [...found].sort();
+}
+
+/**
+ * Every file under `root` that could carry an import specifier.
+ *
+ * Async, and through the same `fs-extra` surface the rest of this module uses,
+ * so a caller that substitutes the filesystem substitutes this too.
+ */
+async function walkSourceFiles(root: string): Promise<string[]> {
+  const out: string[] = [];
+  const entries = await fs.readdir(root, { withFileTypes: true });
+  for (const entry of entries) {
+    const full = path.join(root, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === "node_modules" || entry.name === ".next") continue;
+      out.push(...(await walkSourceFiles(full)));
+    } else if (/\.(?:tsx?|jsx?|mjs|cjs|css)$/.test(entry.name)) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
 export function projectUsesFormBuilder(projectType: ProjectType): boolean {
   return PROJECT_TYPES_WITH_FORM_BUILDER.has(projectType);
 }
@@ -331,12 +398,16 @@ async function resolveRuntimeVersions(): Promise<Record<string, string>> {
  * @param useYalc - When true, omits @nextlyhq/* packages (they'll be yalc-added)
  * @param projectType - Selected template. Determines optional plugin deps
  *   (e.g. `@nextlyhq/plugin-form-builder` ships only with `blog`).
+ * @param templateDirs - The directories being copied for this scaffold. The
+ *   font packages are read from these, so they match the templates the project
+ *   actually receives.
  */
 export async function generatePackageJson(
   projectName: string,
   database: DatabaseConfig,
   useYalc: boolean = false,
-  projectType: ProjectType = "blank"
+  projectType: ProjectType = "blank",
+  templateDirs: readonly string[] = []
 ): Promise<string> {
   // Plugins are a publishable library, not an app — different package.json.
   if (projectType === "plugin") {
@@ -360,6 +431,15 @@ export async function generatePackageJson(
   // to provide it. Admin bundles its own copy, which does not satisfy that peer
   // under isolated node_modules layouts.
   dependencies["lucide-react"] = "^0.544.0";
+
+  // The faces the template's own layout imports. Scaffolded as dependencies
+  // because the layout loads them from `node_modules` rather than fetching them
+  // from fonts.googleapis.com, which made every `next build` — including the
+  // one a CI run does before its browser tests — depend on reaching a third
+  // party, and fail behind a proxy or offline.
+  for (const font of await collectFontDependencies(templateDirs)) {
+    dependencies[font] = FONT_PACKAGE_RANGE;
+  }
 
   if (!useYalc) {
     // Content templates (blog) track the `alpha` dist-tag so they always get a
@@ -792,11 +872,14 @@ export async function copyTemplate(
   }
 
   // Step 6: Generate package.json
+  // The dirs copied above, so the fonts installed are the fonts this scaffold
+  // actually received rather than whatever a separately-resolved tree holds.
   const packageJsonContent = await generatePackageJson(
     projectName,
     database,
     useYalc,
-    projectType
+    projectType,
+    [baseDir, typeDir]
   );
   await fs.writeFile(
     path.join(targetDir, "package.json"),

--- a/packages/create-nextly-app/src/utils/template.ts
+++ b/packages/create-nextly-app/src/utils/template.ts
@@ -695,6 +695,32 @@ export function generatePnpmWorkspaceYaml(): string {
   );
 }
 
+/**
+ * Generate the `.yarnrc.yml` for a scaffolded project.
+ *
+ * Yarn Berry defaults to its Plug'n'Play linker, under which there is no
+ * physical `node_modules` directory at all. The root layout loads its fonts
+ * with `next/font/local` from a path INTO `node_modules`, and `next/font/local`
+ * reads that path off disk rather than through the module resolver — so under
+ * PnP the file is simply not there and `next build` fails on a dependency the
+ * manifest correctly declares.
+ *
+ * Yarn 1 already uses a node-modules layout and ignores this key; npm, pnpm and
+ * bun ignore the file entirely, so it ships in every scaffold for the same
+ * reason `pnpm-workspace.yaml` does.
+ */
+export function generateYarnRcYml(): string {
+  return (
+    "# Yarn Berry defaults to Plug'n'Play, which has no physical node_modules.\n" +
+    "# The root layout loads its fonts with `next/font/local` from a path inside\n" +
+    "# node_modules, and that path is read off disk rather than resolved, so a\n" +
+    "# PnP install has nothing for it to open.\n" +
+    "#\n" +
+    "# Ignored by npm, pnpm, bun, and Yarn 1.\n" +
+    "nodeLinker: node-modules\n"
+  );
+}
+
 // ============================================================
 // Copy Template (Main Orchestrator)
 // ============================================================
@@ -904,6 +930,11 @@ export async function copyTemplate(
     generatePnpmWorkspaceYaml(),
     "utf-8"
   );
+  await fs.writeFile(
+    path.join(targetDir, ".yarnrc.yml"),
+    generateYarnRcYml(),
+    "utf-8"
+  );
 
   // Step 7: Create SQLite data directory if needed
   // SQLite stores its database file at ./data/nextly.db and the parent
@@ -978,6 +1009,11 @@ async function copyPluginTemplate(opts: {
   await fs.writeFile(
     path.join(targetDir, "pnpm-workspace.yaml"),
     generatePnpmWorkspaceYaml(),
+    "utf-8"
+  );
+  await fs.writeFile(
+    path.join(targetDir, ".yarnrc.yml"),
+    generateYarnRcYml(),
     "utf-8"
   );
 

--- a/packages/create-nextly-app/src/utils/template.ts
+++ b/packages/create-nextly-app/src/utils/template.ts
@@ -18,9 +18,20 @@ const PROJECT_TYPES_WITH_FORM_BUILDER: ReadonlySet<ProjectType> = new Set([
 ]);
 
 /**
- * The version range every font package is scaffolded at. One range because they
- * are released together and a project mixing lines would ship two copies of the
- * same metric-adjusted fallback.
+ * The version range every font package is scaffolded at.
+ *
+ * One range because they are released together, and a project mixing lines would ship two copies
+ * of the same face.
+ *
+ * Safe to state here rather than carry per-template because the layouts import the package ROOT
+ * (`@fontsource-variable/inter`) rather than a file inside it. There is no asset path that a
+ * different release line could rename out from under the import, so a skew cannot produce a
+ * missing-file build failure.
+ *
+ * What it would NOT cover, stated so the limit is visible rather than discovered: a template
+ * importing a SUBPATH such as `.../wght.css`, or one needing a different MAJOR. No template does
+ * either, so the range stays a constant until one does — at which point it belongs with the
+ * template rather than here.
  */
 const FONT_PACKAGE_RANGE = "^5.3.0";
 

--- a/packages/create-nextly-app/src/utils/template.ts
+++ b/packages/create-nextly-app/src/utils/template.ts
@@ -48,15 +48,23 @@ const FONT_PACKAGE_PATTERN = /@fontsource(?:-variable)?\/[a-z0-9-]+/g;
 export async function collectFontDependencies(
   templateDirs: readonly string[]
 ): Promise<string[]> {
-  const found = new Set<string>();
-
+  // Merged by RELATIVE path, later directory winning, because that is what the copy does: a
+  // template that overrides `src/app/layout.tsx` REPLACES base's rather than adding to it. Taking
+  // the union instead would install the faces of a layout the project never receives — a blank
+  // scaffold declaring Geist because base's overwritten layout mentioned it.
+  const effective = new Map<string, string>();
   for (const root of templateDirs) {
     if (!root || !(await fs.pathExists(root))) continue;
     for (const file of await walkSourceFiles(root)) {
-      const contents = await fs.readFile(file, "utf8");
-      for (const match of contents.matchAll(FONT_PACKAGE_PATTERN)) {
-        found.add(match[0]);
-      }
+      effective.set(path.relative(root, file), file);
+    }
+  }
+
+  const found = new Set<string>();
+  for (const file of effective.values()) {
+    const contents = await fs.readFile(file, "utf8");
+    for (const match of contents.matchAll(FONT_PACKAGE_PATTERN)) {
+      found.add(match[0]);
     }
   }
 

--- a/packages/create-nextly-app/src/utils/template.ts
+++ b/packages/create-nextly-app/src/utils/template.ts
@@ -706,56 +706,6 @@ export function generatePnpmWorkspaceYaml(): string {
   );
 }
 
-/**
- * Generate the `.yarnrc.yml` for a scaffolded project.
- *
- * Yarn Berry defaults to its Plug'n'Play linker, under which there is no
- * physical `node_modules` directory at all. The root layout loads its fonts
- * with `next/font/local` from a path INTO `node_modules`, and `next/font/local`
- * reads that path off disk rather than through the module resolver — so under
- * PnP the file is simply not there and `next build` fails on a dependency the
- * manifest correctly declares.
- *
- * Yarn 1 already uses a node-modules layout and ignores this key; npm, pnpm and
- * bun ignore the file entirely, so it ships in every scaffold for the same
- * reason `pnpm-workspace.yaml` does.
- */
-export async function writeYarnRcYml(targetDir: string): Promise<void> {
-  const target = path.join(targetDir, ".yarnrc.yml");
-
-  // MERGED, never replaced. The "ignore files and continue" path scaffolds into a directory that
-  // already has contents, and a `.yarnrc.yml` there can carry private-registry credentials,
-  // `npmScopes`, plugins or `packageExtensions` — losing them immediately before the install
-  // either breaks it or silently changes what resolves.
-  if (await fs.pathExists(target)) {
-    const existing = await fs.readFile(target, "utf8");
-    // An explicit choice already on the file is the user's, including `pnp`. Overriding it would
-    // be this scaffold deciding something the project has already decided.
-    if (/^\s*nodeLinker\s*:/m.test(existing)) return;
-    const separator = existing.endsWith("\n") || existing === "" ? "" : "\n";
-    await fs.writeFile(
-      target,
-      existing + separator + generateYarnRcYml(),
-      "utf-8"
-    );
-    return;
-  }
-
-  await fs.writeFile(target, generateYarnRcYml(), "utf-8");
-}
-
-export function generateYarnRcYml(): string {
-  return (
-    "# Yarn Berry defaults to Plug'n'Play, which has no physical node_modules.\n" +
-    "# The root layout loads its fonts with `next/font/local` from a path inside\n" +
-    "# node_modules, and that path is read off disk rather than resolved, so a\n" +
-    "# PnP install has nothing for it to open.\n" +
-    "#\n" +
-    "# Ignored by npm, pnpm, bun, and Yarn 1.\n" +
-    "nodeLinker: node-modules\n"
-  );
-}
-
 // ============================================================
 // Copy Template (Main Orchestrator)
 // ============================================================
@@ -965,7 +915,6 @@ export async function copyTemplate(
     generatePnpmWorkspaceYaml(),
     "utf-8"
   );
-  await writeYarnRcYml(targetDir);
 
   // Step 7: Create SQLite data directory if needed
   // SQLite stores its database file at ./data/nextly.db and the parent
@@ -1042,7 +991,6 @@ async function copyPluginTemplate(opts: {
     generatePnpmWorkspaceYaml(),
     "utf-8"
   );
-  await writeYarnRcYml(targetDir);
 
   // Fill plugin placeholders across the copied tree (src/ + dev/).
   const nextlyRange = await resolvePluginNextlyRange(useYalc);

--- a/packages/create-nextly-app/src/utils/template.ts
+++ b/packages/create-nextly-app/src/utils/template.ts
@@ -709,6 +709,30 @@ export function generatePnpmWorkspaceYaml(): string {
  * bun ignore the file entirely, so it ships in every scaffold for the same
  * reason `pnpm-workspace.yaml` does.
  */
+export async function writeYarnRcYml(targetDir: string): Promise<void> {
+  const target = path.join(targetDir, ".yarnrc.yml");
+
+  // MERGED, never replaced. The "ignore files and continue" path scaffolds into a directory that
+  // already has contents, and a `.yarnrc.yml` there can carry private-registry credentials,
+  // `npmScopes`, plugins or `packageExtensions` — losing them immediately before the install
+  // either breaks it or silently changes what resolves.
+  if (await fs.pathExists(target)) {
+    const existing = await fs.readFile(target, "utf8");
+    // An explicit choice already on the file is the user's, including `pnp`. Overriding it would
+    // be this scaffold deciding something the project has already decided.
+    if (/^\s*nodeLinker\s*:/m.test(existing)) return;
+    const separator = existing.endsWith("\n") || existing === "" ? "" : "\n";
+    await fs.writeFile(
+      target,
+      existing + separator + generateYarnRcYml(),
+      "utf-8"
+    );
+    return;
+  }
+
+  await fs.writeFile(target, generateYarnRcYml(), "utf-8");
+}
+
 export function generateYarnRcYml(): string {
   return (
     "# Yarn Berry defaults to Plug'n'Play, which has no physical node_modules.\n" +
@@ -930,11 +954,7 @@ export async function copyTemplate(
     generatePnpmWorkspaceYaml(),
     "utf-8"
   );
-  await fs.writeFile(
-    path.join(targetDir, ".yarnrc.yml"),
-    generateYarnRcYml(),
-    "utf-8"
-  );
+  await writeYarnRcYml(targetDir);
 
   // Step 7: Create SQLite data directory if needed
   // SQLite stores its database file at ./data/nextly.db and the parent
@@ -1011,11 +1031,7 @@ async function copyPluginTemplate(opts: {
     generatePnpmWorkspaceYaml(),
     "utf-8"
   );
-  await fs.writeFile(
-    path.join(targetDir, ".yarnrc.yml"),
-    generateYarnRcYml(),
-    "utf-8"
-  );
+  await writeYarnRcYml(targetDir);
 
   // Fill plugin placeholders across the copied tree (src/ + dev/).
   const nextlyRange = await resolvePluginNextlyRange(useYalc);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -141,6 +141,12 @@ importers:
 
   apps/playground:
     dependencies:
+      '@fontsource-variable/geist':
+        specifier: ^5.3.0
+        version: 5.3.0
+      '@fontsource-variable/geist-mono':
+        specifier: ^5.3.0
+        version: 5.3.0
       '@nextlyhq/adapter-drizzle':
         specifier: workspace:^
         version: link:../../packages/adapter-drizzle
@@ -2749,6 +2755,12 @@ packages:
 
   '@floating-ui/utils@0.2.12':
     resolution: {integrity: sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==}
+
+  '@fontsource-variable/geist-mono@5.3.0':
+    resolution: {integrity: sha512-vBbuwDEo9AkrqADMXOrlAR3DFcJi4/JxeuU43FoiQERnNwsfXNnvxvReZG02cQKmyk4DZkZdBZX3oTDvy2zBAw==}
+
+  '@fontsource-variable/geist@5.3.0':
+    resolution: {integrity: sha512-j0m+vLQuG5XAYoHtGCVu0spvlGreR3EzpECUVzkFmI1mTVnAO38l/NEPDCFgZ177JxzYJCLSmTQibIiYPilGrA==}
 
   '@hookform/resolvers@5.2.2':
     resolution: {integrity: sha512-A/IxlMLShx3KjV/HeTcTfaMxdwy690+L/ZADoeaTltLx+CVuzkeVIPuybK3jrRfw7YZnmdKsVVHAlEPIAEUNlA==}
@@ -10035,6 +10047,10 @@ snapshots:
   '@floating-ui/utils@0.2.10': {}
 
   '@floating-ui/utils@0.2.12': {}
+
+  '@fontsource-variable/geist-mono@5.3.0': {}
+
+  '@fontsource-variable/geist@5.3.0': {}
 
   '@hookform/resolvers@5.2.2(react-hook-form@7.66.0(react@19.2.0))':
     dependencies:

--- a/templates/base/src/app/globals.css
+++ b/templates/base/src/app/globals.css
@@ -1,5 +1,15 @@
 @import "tailwindcss";
 
+/* The families the imported font stylesheets declare, bound to the variables the rules
+   below read. Named here rather than by `next/font`, which used to inject them: the faces
+   now arrive as ordinary stylesheets, so the binding has to be written down somewhere, and
+   the name is load-bearing — the admin theme reads `--font-geist`. Quoted family names, so
+   the two-word values stay one identifier. */
+:root {
+  --font-geist: "Geist Variable";
+  --font-geist-mono: "Geist Mono Variable";
+}
+
 :root {
   --background: #ffffff;
   --foreground: #171717;

--- a/templates/base/src/app/layout.tsx
+++ b/templates/base/src/app/layout.tsx
@@ -18,7 +18,13 @@ import "./globals.css";
  *
  * The trade is `next/font`'s metric-adjusted fallback, so text can shift
  * slightly as the face arrives. The families are bound to this app's `--font-*`
- * variables in `globals.css`, which is what every rule downstream reads.
+ * variables in `globals.css`, which is what every rule downstream reads. *
+ * Importing the package root ships every subset the face offers — Latin, Latin
+ * Extended, Cyrillic, Vietnamese — but each `@font-face` carries a
+ * `unicode-range`, so a browser downloads only the subsets the page actually
+ * uses. The deployed bundle is larger than a single hand-picked file; what a
+ * reader fetches is not, and a page in Cyrillic now gets its face instead of a
+ * fallback.
  */
 
 /**

--- a/templates/base/src/app/layout.tsx
+++ b/templates/base/src/app/layout.tsx
@@ -1,21 +1,35 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
+import localFont from "next/font/local";
 import "./globals.css";
 
 /**
+ * The faces come from packages in `node_modules` rather than from
+ * `next/font/google`, which fetches them from fonts.googleapis.com at BUILD
+ * time — so a build behind a proxy, on a locked-down CI runner, or simply
+ * offline fails at a step that has nothing to do with the app's code.
+ *
+ * `next/font/local` rather than the packages' own stylesheets, because the
+ * variable NAMES below are load-bearing and a stylesheet fixes its own.
+ *
  * Named `--font-geist` rather than `--font-geist-sans` because that is the
- * variable the admin theme reads. `next/font` self-hosts the face and exposes it
- * only through this variable, so a name the theme does not know leaves the admin
- * falling back to the system sans while the app's own pages render in Geist.
+ * variable the admin theme reads. The face is exposed only through this
+ * variable, so a name the theme does not know leaves the admin falling back to
+ * the system sans while the app's own pages render in Geist.
  */
-const geistSans = Geist({
+const geistSans = localFont({
+  src: "../../node_modules/@fontsource-variable/geist/files/geist-latin-wght-normal.woff2",
   variable: "--font-geist",
-  subsets: ["latin"],
+  display: "swap",
+  // One file spanning the whole weight axis; the filename carries no weight
+  // for Next to infer, so the range is declared.
+  weight: "100 900",
 });
 
-const geistMono = Geist_Mono({
+const geistMono = localFont({
+  src: "../../node_modules/@fontsource-variable/geist-mono/files/geist-mono-latin-wght-normal.woff2",
   variable: "--font-geist-mono",
-  subsets: ["latin"],
+  display: "swap",
+  weight: "100 900",
 });
 
 /**

--- a/templates/base/src/app/layout.tsx
+++ b/templates/base/src/app/layout.tsx
@@ -1,36 +1,25 @@
 import type { Metadata } from "next";
-import localFont from "next/font/local";
+import "@fontsource-variable/geist";
+import "@fontsource-variable/geist-mono";
 import "./globals.css";
 
 /**
- * The faces come from packages in `node_modules` rather than from
- * `next/font/google`, which fetches them from fonts.googleapis.com at BUILD
- * time — so a build behind a proxy, on a locked-down CI runner, or simply
- * offline fails at a step that has nothing to do with the app's code.
+ * The faces are imported as STYLESHEETS from packages in `node_modules`, rather
+ * than fetched from fonts.googleapis.com by `next/font/google` while
+ * `next build` runs — which made every build depend on reaching a third party
+ * and fail behind a proxy, on a locked-down runner, or offline.
  *
- * `next/font/local` rather than the packages' own stylesheets, because the
- * variable NAMES below are load-bearing and a stylesheet fixes its own.
+ * A bare package import rather than `next/font/local` pointing INTO
+ * `node_modules`: a literal path asserts where the package physically lives,
+ * and that assertion is false under Yarn's Plug'n'Play linker (no
+ * `node_modules` at all), under npm/Yarn workspace hoisting (the package moves
+ * to the workspace root), and under pnpm's own symlinked store. An import asks
+ * the resolver instead, which is correct under every layout.
  *
- * Named `--font-geist` rather than `--font-geist-sans` because that is the
- * variable the admin theme reads. The face is exposed only through this
- * variable, so a name the theme does not know leaves the admin falling back to
- * the system sans while the app's own pages render in Geist.
+ * The trade is `next/font`'s metric-adjusted fallback, so text can shift
+ * slightly as the face arrives. The families are bound to this app's `--font-*`
+ * variables in `globals.css`, which is what every rule downstream reads.
  */
-const geistSans = localFont({
-  src: "../../node_modules/@fontsource-variable/geist/files/geist-latin-wght-normal.woff2",
-  variable: "--font-geist",
-  display: "swap",
-  // One file spanning the whole weight axis; the filename carries no weight
-  // for Next to infer, so the range is declared.
-  weight: "100 900",
-});
-
-const geistMono = localFont({
-  src: "../../node_modules/@fontsource-variable/geist-mono/files/geist-mono-latin-wght-normal.woff2",
-  variable: "--font-geist-mono",
-  display: "swap",
-  weight: "100 900",
-});
 
 /**
  * `metadataBase` tells Next.js how to resolve relative URLs in OpenGraph
@@ -56,11 +45,7 @@ export default function RootLayout({
     // in a non-inline @theme, which emits it into :root and resolves the
     // reference THERE. A variable exposed lower down, on <body>, is invisible to
     // that declaration however it is spelled.
-    <html
-      lang="en"
-      className={`${geistSans.variable} ${geistMono.variable}`}
-      suppressHydrationWarning
-    >
+    <html lang="en" suppressHydrationWarning>
       <body className="antialiased">{children}</body>
     </html>
   );

--- a/templates/blank/src/app/globals.css
+++ b/templates/blank/src/app/globals.css
@@ -48,6 +48,18 @@
   --color-foreground: #f9fafb;
 }
 
+/* `@theme inline` on purpose, and it is the whole point of this block. An inline theme
+   SUBSTITUTES the value where the utility is used; a plain `@theme` emits the variable into
+   `:root`, which is where `@nextlyhq/admin` declares its own `--font-mono` — redefining it there
+   would replace the admin's entire fallback chain with this one family.
+   
+   Needed because the frontend routes do not load the admin stylesheet, so nothing else binds the
+   `font-mono` utility this template uses on its badge and file-path text; without it they fall
+   back to Tailwind's default mono rather than the face the template loads. */
+@theme inline {
+  --font-mono: var(--font-geist-mono, ui-monospace), monospace;
+}
+
 @theme {
   --color-background: var(--color-background);
   --color-foreground: var(--color-foreground);

--- a/templates/blank/src/app/globals.css
+++ b/templates/blank/src/app/globals.css
@@ -6,8 +6,18 @@
    the name is load-bearing — the admin theme reads `--font-geist`. Quoted family names, so
    the two-word values stay one identifier. */
 :root {
+  /* `--font-geist` and `--font-geist-mono` are the names the ADMIN theme reads
+     (`--font-sans: var(--font-geist, Geist), ...` in a non-inline `@theme`, so
+     it resolves at `:root`). A template that loads a different face still has to
+     expose it under these names or the admin renders in a system fallback while
+     the app's own pages render correctly. */
+  --font-geist: "Inter Variable";
+  --font-geist-mono: "JetBrains Mono Variable";
+  /* This template's own display face, read by `.font-display` below. NOT named
+     `--font-mono` for its mono face: that is the theme's OWN token, declared at
+     `:root`, and redefining it here replaces the theme's whole fallback chain
+     rather than feeding it. */
   --font-display: "Inter Variable";
-  --font-mono: "JetBrains Mono Variable";
 }
 
 /**

--- a/templates/blank/src/app/globals.css
+++ b/templates/blank/src/app/globals.css
@@ -1,5 +1,15 @@
 @import "tailwindcss";
 
+/* The families the imported font stylesheets declare, bound to the variables the rules
+   below read. Named here rather than by `next/font`, which used to inject them: the faces
+   now arrive as ordinary stylesheets, so the binding has to be written down somewhere, and
+   the name is load-bearing — the admin theme reads `--font-geist`. Quoted family names, so
+   the two-word values stay one identifier. */
+:root {
+  --font-display: "Inter Variable";
+  --font-mono: "JetBrains Mono Variable";
+}
+
 /**
  * Blank-template global styles.
  *

--- a/templates/blank/src/app/layout.tsx
+++ b/templates/blank/src/app/layout.tsx
@@ -1,18 +1,32 @@
 import type { Metadata } from "next";
-import { Inter, JetBrains_Mono } from "next/font/google";
+import localFont from "next/font/local";
 
 import "./globals.css";
 
-const display = Inter({
+/**
+ * The faces come from packages in `node_modules` rather than from
+ * `next/font/google`, which fetches them from fonts.googleapis.com at BUILD
+ * time — so a build behind a proxy, on a locked-down CI runner, or simply
+ * offline fails at a step that has nothing to do with the app's code.
+ *
+ * `next/font/local` rather than the packages' own stylesheets, so the fonts
+ * keep the same CSS variables the styles already reference, and keep the
+ * metric-adjusted fallback that stops text reflowing once the face arrives.
+ */
+const display = localFont({
+  src: "../../node_modules/@fontsource-variable/inter/files/inter-latin-wght-normal.woff2",
   variable: "--font-display",
-  subsets: ["latin"],
   display: "swap",
+  // A variable font covering the whole axis in one file. Declared because the
+  // filename is not something Next can infer a weight range from.
+  weight: "100 900",
 });
 
-const mono = JetBrains_Mono({
+const mono = localFont({
+  src: "../../node_modules/@fontsource-variable/jetbrains-mono/files/jetbrains-mono-latin-wght-normal.woff2",
   variable: "--font-mono",
-  subsets: ["latin"],
   display: "swap",
+  weight: "100 800",
 });
 
 /**

--- a/templates/blank/src/app/layout.tsx
+++ b/templates/blank/src/app/layout.tsx
@@ -19,7 +19,13 @@ import "./globals.css";
  *
  * The trade is `next/font`'s metric-adjusted fallback, so text can shift
  * slightly as the face arrives. The families are bound to this app's `--font-*`
- * variables in `globals.css`, which is what every rule downstream reads.
+ * variables in `globals.css`, which is what every rule downstream reads. *
+ * Importing the package root ships every subset the face offers — Latin, Latin
+ * Extended, Cyrillic, Vietnamese — but each `@font-face` carries a
+ * `unicode-range`, so a browser downloads only the subsets the page actually
+ * uses. The deployed bundle is larger than a single hand-picked file; what a
+ * reader fetches is not, and a page in Cyrillic now gets its face instead of a
+ * fallback.
  */
 
 /**

--- a/templates/blank/src/app/layout.tsx
+++ b/templates/blank/src/app/layout.tsx
@@ -1,33 +1,26 @@
 import type { Metadata } from "next";
-import localFont from "next/font/local";
+import "@fontsource-variable/inter";
+import "@fontsource-variable/jetbrains-mono";
 
 import "./globals.css";
 
 /**
- * The faces come from packages in `node_modules` rather than from
- * `next/font/google`, which fetches them from fonts.googleapis.com at BUILD
- * time — so a build behind a proxy, on a locked-down CI runner, or simply
- * offline fails at a step that has nothing to do with the app's code.
+ * The faces are imported as STYLESHEETS from packages in `node_modules`, rather
+ * than fetched from fonts.googleapis.com by `next/font/google` while
+ * `next build` runs — which made every build depend on reaching a third party
+ * and fail behind a proxy, on a locked-down runner, or offline.
  *
- * `next/font/local` rather than the packages' own stylesheets, so the fonts
- * keep the same CSS variables the styles already reference, and keep the
- * metric-adjusted fallback that stops text reflowing once the face arrives.
+ * A bare package import rather than `next/font/local` pointing INTO
+ * `node_modules`: a literal path asserts where the package physically lives,
+ * and that assertion is false under Yarn's Plug'n'Play linker (no
+ * `node_modules` at all), under npm/Yarn workspace hoisting (the package moves
+ * to the workspace root), and under pnpm's own symlinked store. An import asks
+ * the resolver instead, which is correct under every layout.
+ *
+ * The trade is `next/font`'s metric-adjusted fallback, so text can shift
+ * slightly as the face arrives. The families are bound to this app's `--font-*`
+ * variables in `globals.css`, which is what every rule downstream reads.
  */
-const display = localFont({
-  src: "../../node_modules/@fontsource-variable/inter/files/inter-latin-wght-normal.woff2",
-  variable: "--font-display",
-  display: "swap",
-  // A variable font covering the whole axis in one file. Declared because the
-  // filename is not something Next can infer a weight range from.
-  weight: "100 900",
-});
-
-const mono = localFont({
-  src: "../../node_modules/@fontsource-variable/jetbrains-mono/files/jetbrains-mono-latin-wght-normal.woff2",
-  variable: "--font-mono",
-  display: "swap",
-  weight: "100 800",
-});
 
 /**
  * Blank-template root layout.
@@ -52,9 +45,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en" suppressHydrationWarning>
-      <body className={`${display.variable} ${mono.variable} antialiased`}>
-        {children}
-      </body>
+      <body className="antialiased">{children}</body>
     </html>
   );
 }

--- a/templates/blog/src/app/globals.css
+++ b/templates/blog/src/app/globals.css
@@ -6,6 +6,11 @@
    the name is load-bearing — the admin theme reads `--font-geist`. Quoted family names, so
    the two-word values stay one identifier. */
 :root {
+  /* `--font-geist` is the name the ADMIN theme reads for its sans
+     (`--font-sans: var(--font-geist, Geist), ...`), so this template's face has
+     to be exposed under it as well as under its own name — otherwise the admin
+     renders in a system fallback while the blog renders in Inter. */
+  --font-geist: "Inter Variable";
   --font-inter: "Inter Variable";
   --font-geist-mono: "Geist Mono Variable";
 }

--- a/templates/blog/src/app/globals.css
+++ b/templates/blog/src/app/globals.css
@@ -1,5 +1,15 @@
 @import "tailwindcss";
 
+/* The families the imported font stylesheets declare, bound to the variables the rules
+   below read. Named here rather than by `next/font`, which used to inject them: the faces
+   now arrive as ordinary stylesheets, so the binding has to be written down somewhere, and
+   the name is load-bearing — the admin theme reads `--font-geist`. Quoted family names, so
+   the two-word values stay one identifier. */
+:root {
+  --font-inter: "Inter Variable";
+  --font-geist-mono: "Geist Mono Variable";
+}
+
 /* ================================================================
    The Antigravity Standard - Design Tokens
    ----------------------------------------------------------------

--- a/templates/blog/src/app/layout.tsx
+++ b/templates/blog/src/app/layout.tsx
@@ -19,7 +19,13 @@ import "./globals.css";
  *
  * The trade is `next/font`'s metric-adjusted fallback, so text can shift
  * slightly as the face arrives. The families are bound to this app's `--font-*`
- * variables in `globals.css`, which is what every rule downstream reads.
+ * variables in `globals.css`, which is what every rule downstream reads. *
+ * Importing the package root ships every subset the face offers — Latin, Latin
+ * Extended, Cyrillic, Vietnamese — but each `@font-face` carries a
+ * `unicode-range`, so a browser downloads only the subsets the page actually
+ * uses. The deployed bundle is larger than a single hand-picked file; what a
+ * reader fetches is not, and a page in Cyrillic now gets its face instead of a
+ * fallback.
  */
 
 /**

--- a/templates/blog/src/app/layout.tsx
+++ b/templates/blog/src/app/layout.tsx
@@ -1,33 +1,26 @@
 import type { Metadata } from "next";
-import localFont from "next/font/local";
+import "@fontsource-variable/inter";
+import "@fontsource-variable/geist-mono";
 
 import "./globals.css";
 
 /**
- * The faces come from packages in `node_modules` rather than from
- * `next/font/google`, which fetches them from fonts.googleapis.com at BUILD
- * time — so a build behind a proxy, on a locked-down CI runner, or simply
- * offline fails at a step that has nothing to do with the app's code.
+ * The faces are imported as STYLESHEETS from packages in `node_modules`, rather
+ * than fetched from fonts.googleapis.com by `next/font/google` while
+ * `next build` runs — which made every build depend on reaching a third party
+ * and fail behind a proxy, on a locked-down runner, or offline.
  *
- * `next/font/local` rather than the packages' own stylesheets, so the faces
- * keep the CSS variables the styles already reference, and keep the
- * metric-adjusted fallback that stops text reflowing once the face arrives.
+ * A bare package import rather than `next/font/local` pointing INTO
+ * `node_modules`: a literal path asserts where the package physically lives,
+ * and that assertion is false under Yarn's Plug'n'Play linker (no
+ * `node_modules` at all), under npm/Yarn workspace hoisting (the package moves
+ * to the workspace root), and under pnpm's own symlinked store. An import asks
+ * the resolver instead, which is correct under every layout.
+ *
+ * The trade is `next/font`'s metric-adjusted fallback, so text can shift
+ * slightly as the face arrives. The families are bound to this app's `--font-*`
+ * variables in `globals.css`, which is what every rule downstream reads.
  */
-const inter = localFont({
-  src: "../../node_modules/@fontsource-variable/inter/files/inter-latin-wght-normal.woff2",
-  variable: "--font-inter",
-  display: "swap",
-  // One file spanning the whole weight axis; the filename carries no weight
-  // for Next to infer, so the range is declared.
-  weight: "100 900",
-});
-
-const geistMono = localFont({
-  src: "../../node_modules/@fontsource-variable/geist-mono/files/geist-mono-latin-wght-normal.woff2",
-  variable: "--font-geist-mono",
-  display: "swap",
-  weight: "100 900",
-});
 
 /**
  * `metadataBase` tells Next.js how to resolve relative URLs in
@@ -83,10 +76,7 @@ export default function RootLayout({
         element; React still flags hydration mismatches in the rest of
         the tree.
       */}
-      <body
-        className={`${inter.variable} ${geistMono.variable} antialiased`}
-        suppressHydrationWarning
-      >
+      <body className="antialiased" suppressHydrationWarning>
         {children}
       </body>
     </html>

--- a/templates/blog/src/app/layout.tsx
+++ b/templates/blog/src/app/layout.tsx
@@ -1,16 +1,32 @@
 import type { Metadata } from "next";
-import { Inter, Geist_Mono } from "next/font/google";
+import localFont from "next/font/local";
 
 import "./globals.css";
 
-const inter = Inter({
+/**
+ * The faces come from packages in `node_modules` rather than from
+ * `next/font/google`, which fetches them from fonts.googleapis.com at BUILD
+ * time — so a build behind a proxy, on a locked-down CI runner, or simply
+ * offline fails at a step that has nothing to do with the app's code.
+ *
+ * `next/font/local` rather than the packages' own stylesheets, so the faces
+ * keep the CSS variables the styles already reference, and keep the
+ * metric-adjusted fallback that stops text reflowing once the face arrives.
+ */
+const inter = localFont({
+  src: "../../node_modules/@fontsource-variable/inter/files/inter-latin-wght-normal.woff2",
   variable: "--font-inter",
-  subsets: ["latin"],
+  display: "swap",
+  // One file spanning the whole weight axis; the filename carries no weight
+  // for Next to infer, so the range is declared.
+  weight: "100 900",
 });
 
-const geistMono = Geist_Mono({
+const geistMono = localFont({
+  src: "../../node_modules/@fontsource-variable/geist-mono/files/geist-mono-latin-wght-normal.woff2",
   variable: "--font-geist-mono",
-  subsets: ["latin"],
+  display: "swap",
+  weight: "100 900",
 });
 
 /**


### PR DESCRIPTION
`next/font/google` downloads each face from fonts.googleapis.com **while `next build` runs**. Every scaffolded project therefore needed to reach a third party to build, and failed behind a proxy, on a locked-down runner, or offline.

It is worse than an inconvenience: another lane reports this is one of three non-code causes of red browser tests. The e2e global setup builds first, so the fetch times out and **zero tests run** — which reads as a total suite failure rather than a network problem.

## What changed

Four layouts move from `next/font/google` to `next/font/local`, reading `.woff2` from `@fontsource-variable/*` packages:

| file | faces |
| --- | --- |
| `templates/base` | Geist, Geist Mono |
| `templates/blog` | Inter, Geist Mono |
| `templates/blank` | Inter, JetBrains Mono |
| `apps/playground` | Geist, Geist Mono |

**Every face is unchanged** — this is a delivery change, not a design one. No `.woff2` binaries are committed.

`next/font/local` rather than each package's own stylesheet, for two reasons: the CSS variable names are load-bearing (`--font-geist` is what the admin theme reads, and a stylesheet fixes its own name), and it keeps the metric-adjusted fallback that stops text reflowing when the face arrives.

## The scaffold DERIVES its font dependencies

Templates have no `package.json` — `generatePackageJson` builds one. Rather than keep a list of font packages beside the templates, the scaffold READS the templates it is copying and installs what they import.

A hand-kept list is a second answer to a question the templates already answer, and the two agree only until someone changes a face: a template importing a package the scaffold never installs fails at the user's first build, and one installing a package nothing imports ships dead bytes.

The collector is handed the directories being copied rather than resolving its own path — a downloaded or `--local-template` source is a different tree from the bundled one, and reading the wrong tree would install the fonts of templates the project never receives.

## Tests

New `fonts.test.ts`, 9 cases, with the controls the assertions need:

- a **positive control** that the sweep finds template sources at all, since the main property is asserted by ABSENCE and a wrong path produces the same empty result;
- a control that the detection pattern matches a real import and does **not** match the layouts' own prose explaining why the fetch was removed — the first version matched that prose, which would have pushed the next person to delete the comment that stops it coming back;
- per-template equality between what the sources import and what the collector returns, read independently of the collector.

Break-verified both ways: reintroducing `next/font/google` in `blog` fails; making the collector ignore the type overlay fails for `blank` and `blog`.

## Notes

- `templates` is **not** a pnpm workspace (`pnpm-workspace.yaml` lists only `apps/*`, `packages/*`, `e2e`), so a guard that walks workspace packages sees three of the four affected files as clean.
- The playground's four static weights become one variable file covering the whole axis — fewer requests, not more bytes.
- Full `create-nextly-app` suite: 152 passing. Lint and check-types clean.