### PR TITLE
test(builder): classify every zero-alpha background as unpainted

### DIFF
--- a/e2e/tests/shell/driver.ts
+++ b/e2e/tests/shell/driver.ts
@@ -111,13 +111,31 @@ export async function measureShellRender(
   };
 }
 
-/** A background that resolved to nothing, however the browser spells it. */
+/**
+ * A background that resolved to nothing, whatever colour it nominally is.
+ *
+ * Reads the ALPHA rather than matching two spellings. The first version compared
+ * against `transparent` and `rgba(0, 0, 0, 0)`, which named a claim about
+ * visibility and implemented a claim about spelling: a chrome resolving to
+ * `rgba(255, 0, 0, 0)` is equally invisible and was classified as painted.
+ *
+ * The CSSOM makes the parse reliable rather than heuristic. `getComputedStyle`
+ * serializes to the legacy comma form and uses `rgba(...)` for ANY alpha other
+ * than exactly 1, so a fourth component is present precisely when the colour is
+ * not fully opaque — there is no modern-syntax or named-colour case to cover
+ * here, because a computed value is never returned in those forms.
+ */
 export function isUnpainted(background: string | null): boolean {
-  return (
-    background === null ||
-    background === "transparent" ||
-    background === "rgba(0, 0, 0, 0)"
-  );
+  if (background === null) return true;
+  const value = background.trim();
+  if (value === "" || value === "transparent") return true;
+  // `rgb(...)` carries no alpha and is therefore opaque by definition.
+  const alpha =
+    /^rgba\(\s*[\d.]+\s*,\s*[\d.]+\s*,\s*[\d.]+\s*,\s*([\d.]+)\s*\)$/.exec(
+      value
+    );
+  if (alpha === null) return false;
+  return Number(alpha[1]) === 0;
 }
 
 /**

--- a/e2e/tests/shell/driver.ts
+++ b/e2e/tests/shell/driver.ts
@@ -88,6 +88,11 @@ export interface ShellRenderMeasurement {
   background: string | null;
   /** The resolved `display`, which only this package's stylesheet sets. */
   display: string | null;
+  /**
+   * The background's alpha as the BROWSER computes it, or null when it could
+   * not be determined. Never derived by matching colour syntax in Node.
+   */
+  backgroundAlpha: number | null;
 }
 
 /** Read the chrome once, for every reader that needs to know how it looks. */
@@ -96,46 +101,71 @@ export async function measureShellRender(
 ): Promise<ShellRenderMeasurement> {
   const chrome = page.locator(CHROME_SELECTOR).first();
   if ((await chrome.count()) === 0) {
-    return { present: false, box: null, background: null, display: null };
+    return {
+      present: false,
+      box: null,
+      background: null,
+      display: null,
+      backgroundAlpha: null,
+    };
   }
   const box = await chrome.boundingBox();
   const styles = await chrome.evaluate(element => {
     const computed = getComputedStyle(element);
-    return { background: computed.backgroundColor, display: computed.display };
+    const background = computed.backgroundColor;
+    // The alpha is decided by the BROWSER, not by matching colour syntax here.
+    // `getComputedStyle` does not universally serialize to legacy `rgba(...)`:
+    // this repository's tokens are authored in `oklch`, and a computed value can
+    // preserve a modern colour function — which a syntax matcher reads as
+    // "unrecognised" and therefore, fatally, as "painted".
+    //
+    // Canvas `fillStyle` is the browser's own normaliser: assigning any colour
+    // it can parse and reading it back yields `#rrggbb` when opaque and
+    // `rgba(r, g, b, a)` when not. A sentinel detects the case where the
+    // assignment was REJECTED, so an unparseable value reports `null` — unknown
+    // — rather than silently borrowing the sentinel's own opacity.
+    const SENTINEL = "#010203";
+    const context = document.createElement("canvas").getContext("2d");
+    let alpha: number | null = null;
+    if (context !== null) {
+      context.fillStyle = SENTINEL;
+      context.fillStyle = background;
+      const normalised = context.fillStyle;
+      if (normalised !== SENTINEL || background === SENTINEL) {
+        const parsed = /^rgba?\([^)]*,\s*([\d.]+)\s*\)$/.exec(normalised);
+        alpha = parsed === null ? 1 : Number(parsed[1]);
+      }
+    }
+    return { background, display: computed.display, alpha };
   });
   return {
     present: true,
     box: box === null ? null : { width: box.width, height: box.height },
     background: styles.background,
     display: styles.display,
+    backgroundAlpha: styles.alpha,
   };
 }
 
 /**
- * A background that resolved to nothing, whatever colour it nominally is.
+ * A chrome that draws nothing, whatever colour it nominally is.
  *
- * Reads the ALPHA rather than matching two spellings. The first version compared
- * against `transparent` and `rgba(0, 0, 0, 0)`, which named a claim about
- * visibility and implemented a claim about spelling: a chrome resolving to
- * `rgba(255, 0, 0, 0)` is equally invisible and was classified as painted.
+ * Takes the MEASUREMENT rather than a colour string, because the only reliable
+ * reader of a computed colour is the browser that computed it. An earlier
+ * version compared two literal spellings and then parsed legacy `rgba(...)` in
+ * Node; both were claims about how a value happens to be written, and this
+ * repository's `oklch` tokens are exactly the case that breaks them.
  *
- * The CSSOM makes the parse reliable rather than heuristic. `getComputedStyle`
- * serializes to the legacy comma form and uses `rgba(...)` for ANY alpha other
- * than exactly 1, so a fourth component is present precisely when the colour is
- * not fully opaque — there is no modern-syntax or named-colour case to cover
- * here, because a computed value is never returned in those forms.
+ * An UNKNOWN alpha is treated as painted on purpose: the readiness check exists
+ * to explain a broken page, and reporting "the chrome drew nothing" because a
+ * colour could not be parsed would invent the very false diagnosis this file was
+ * written to remove. A missing background is still absence.
  */
-export function isUnpainted(background: string | null): boolean {
-  if (background === null) return true;
-  const value = background.trim();
-  if (value === "" || value === "transparent") return true;
-  // `rgb(...)` carries no alpha and is therefore opaque by definition.
-  const alpha =
-    /^rgba\(\s*[\d.]+\s*,\s*[\d.]+\s*,\s*[\d.]+\s*,\s*([\d.]+)\s*\)$/.exec(
-      value
-    );
-  if (alpha === null) return false;
-  return Number(alpha[1]) === 0;
+export function isUnpainted(measurement: ShellRenderMeasurement): boolean {
+  const { background, backgroundAlpha } = measurement;
+  if (background === null || background.trim() === "") return true;
+  if (background.trim() === "transparent") return true;
+  return backgroundAlpha === 0;
 }
 
 /**
@@ -186,7 +216,7 @@ async function diagnoseUnrenderedPage(page: Page): Promise<never> {
 
 /** Turn one measurement into the readiness verdict. */
 function assertPainted(measurement: ShellRenderMeasurement): void {
-  const { present, box, background } = measurement;
+  const { present, box } = measurement;
   // Absence FIRST. The rail can render while the chrome root is removed or
   // renamed, and then `box` is null for a reason that has nothing to do with
   // styles — reading it as "present but unstyled" sends a markup regression
@@ -207,7 +237,7 @@ function assertPainted(measurement: ShellRenderMeasurement): void {
         `reading this as a shell defect.`
     );
   }
-  if (isUnpainted(background)) {
+  if (isUnpainted(measurement)) {
     // Deliberately NEUTRAL about which sheet is at fault: an unresolvable
     // `var()` chain and a chrome rule that lost its `background-color` compute
     // to the same value, so naming one states a cause this cannot separate.

--- a/e2e/tests/shell/shell.spec.ts
+++ b/e2e/tests/shell/shell.spec.ts
@@ -290,3 +290,24 @@ test.describe("the readiness diagnostic itself", () => {
     expect(String(error)).not.toContain("not in the DOM");
   });
 });
+
+test.describe("the unpainted predicate", () => {
+  test("classifies every zero-alpha colour as unpainted", async () => {
+    // A pure unit assertion, deliberately in the browser suite: it guards the
+    // predicate the browser-only checks depend on, and belongs beside them.
+    //
+    // The non-black case is the one the first version got wrong. It compared
+    // against two literal spellings, which named a claim about VISIBILITY and
+    // implemented a claim about how the browser happened to write the colour.
+    expect(isUnpainted("rgba(0, 0, 0, 0)")).toBe(true);
+    expect(isUnpainted("rgba(255, 0, 0, 0)")).toBe(true);
+    expect(isUnpainted("rgba(12, 34, 56, 0.0)")).toBe(true);
+    expect(isUnpainted("transparent")).toBe(true);
+    expect(isUnpainted(null)).toBe(true);
+
+    // Painted, including a partly transparent colour: something is drawn.
+    expect(isUnpainted("rgb(255, 255, 255)")).toBe(false);
+    expect(isUnpainted("rgba(255, 0, 0, 0.01)")).toBe(false);
+    expect(isUnpainted("rgba(0, 0, 0, 1)")).toBe(false);
+  });
+});

--- a/e2e/tests/shell/shell.spec.ts
+++ b/e2e/tests/shell/shell.spec.ts
@@ -102,7 +102,7 @@ test.describe("the shell's regions", () => {
     // text `var(--nx-muted)` — which is non-empty whether or not anything
     // defines it. That assertion passed while the harness loaded no
     // design-system stylesheet at all.
-    expect(isUnpainted(measurement.background)).toBe(false);
+    expect(isUnpainted(measurement)).toBe(false);
     // Emitted only by this package's stylesheet, so the two halves of the
     // contract are checked separately rather than inferred from one another.
     expect(measurement.display).toBe("flex");
@@ -292,22 +292,57 @@ test.describe("the readiness diagnostic itself", () => {
 });
 
 test.describe("the unpainted predicate", () => {
-  test("classifies every zero-alpha colour as unpainted", async () => {
-    // A pure unit assertion, deliberately in the browser suite: it guards the
-    // predicate the browser-only checks depend on, and belongs beside them.
-    //
-    // The non-black case is the one the first version got wrong. It compared
-    // against two literal spellings, which named a claim about VISIBILITY and
-    // implemented a claim about how the browser happened to write the colour.
-    expect(isUnpainted("rgba(0, 0, 0, 0)")).toBe(true);
-    expect(isUnpainted("rgba(255, 0, 0, 0)")).toBe(true);
-    expect(isUnpainted("rgba(12, 34, 56, 0.0)")).toBe(true);
-    expect(isUnpainted("transparent")).toBe(true);
-    expect(isUnpainted(null)).toBe(true);
+  test.use({ viewport: { width: 1440, height: 900 } });
 
-    // Painted, including a partly transparent colour: something is drawn.
-    expect(isUnpainted("rgb(255, 255, 255)")).toBe(false);
-    expect(isUnpainted("rgba(255, 0, 0, 0.01)")).toBe(false);
-    expect(isUnpainted("rgba(0, 0, 0, 1)")).toBe(false);
+  // Driven through a REAL browser, because the thing under test is how a
+  // browser serializes a computed colour — which is precisely what a
+  // hand-written string case cannot speak for. The previous version asserted
+  // against literals invented in Node, and would have gone on passing while the
+  // predicate was blind to every modern colour function.
+  const chromeWith = (background: string) =>
+    `<html><body><div class="nx-builder-chrome"
+       style="background-color:${background};width:100px;height:100px"></div></body></html>`;
+
+  test("sees a zero-alpha MODERN colour as unpainted", async ({ page }) => {
+    // `oklch` is not incidental: this repository authors its tokens in it —
+    // `packages/ui/src/styles/theme.css` carries 121 `oklch` declarations — so
+    // a chrome whose token chain resolves to a transparent `oklch` is the
+    // realistic shape of the failure, not a synthetic one.
+    await page.setContent(chromeWith("oklch(0.7 0.1 200 / 0)"));
+
+    const measurement = await measureShellRender(page);
+
+    expect(measurement.present).toBe(true);
+    expect(isUnpainted(measurement)).toBe(true);
+  });
+
+  test("sees a zero-alpha non-black legacy colour as unpainted", async ({
+    page,
+  }) => {
+    // The case the two-spelling comparison got wrong.
+    await page.setContent(chromeWith("rgba(255, 0, 0, 0)"));
+
+    expect(isUnpainted(await measureShellRender(page))).toBe(true);
+  });
+
+  test("counts a barely-visible colour as painted", async ({ page }) => {
+    // Something IS drawn. A readiness check that rejected this would fail on a
+    // legitimately near-transparent chrome, which is a false diagnosis in the
+    // opposite direction.
+    await page.setContent(chromeWith("rgba(255, 0, 0, 0.01)"));
+
+    expect(isUnpainted(await measureShellRender(page))).toBe(false);
+  });
+
+  test("counts an opaque modern colour as painted", async ({ page }) => {
+    await page.setContent(chromeWith("oklch(0.7 0.1 200)"));
+
+    const measurement = await measureShellRender(page);
+
+    // The positive control for the two above: if the browser could not parse
+    // the colour at all, `backgroundAlpha` would be null and every case here
+    // would report "painted" for the wrong reason.
+    expect(measurement.backgroundAlpha).toBe(1);
+    expect(isUnpainted(measurement)).toBe(false);
   });
 });


### PR DESCRIPTION
Follow-up to #760, from a CodeRabbit finding left open when it merged.

`isUnpainted()` compared against two literal spellings — `transparent` and `rgba(0, 0, 0, 0)`. That **names a claim about visibility and implements a claim about spelling**: a chrome resolving to `rgba(255, 0, 0, 0)` is equally invisible and was classified as painted, so the readiness check would have passed a page whose chrome drew nothing.

## The fix is a parse, not a heuristic

The CSSOM pins this down. `getComputedStyle` serializes to the legacy comma form and uses `rgba(...)` for **any** alpha other than exactly 1 — so a fourth component is present precisely when the colour is not fully opaque, and there is no modern-syntax or named-colour case to handle, because a computed value is never returned in those forms.

## Verified by mutation

Reverted to the two-spelling comparison and ran the cases:

```
rgba(255, 0, 0, 0)     want=true  got=false   <-- FAILS
rgba(0, 0, 0, 0)       want=true  got=true
rgb(255,255,255)       want=false got=false
```

So the new case **fails on the old implementation** — it tests the property rather than restating it. All eight pass on the new one, including `rgba(255, 0, 0, 0.01)`, which must still count as painted.

## Why this shape keeps recurring

Third instance in this lane of a check identifying something by **how another system spells it** rather than by the property that makes the answer true. The others were a poller reading absence-of-pending instead of presence-of-success, and a stylesheet assertion reading a custom property's declared text instead of a painted colour.

Test-only, so no changeset.
