### PR TITLE
feat(nextly): declare the migration lock table in the core schema

### DIFF
--- a/.changeset/declare-migration-lock-table.md
+++ b/.changeset/declare-migration-lock-table.md
@@ -1,0 +1,28 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+The field-group storage migration lock is now part of the schema Nextly reconciles. It was created on demand and declared nowhere, so it sat outside every migration: a change to that table could never reach an installation that already had one, because the statement that creates it does nothing to a table that exists. Nothing about the lock behaves differently today; what changes is that it can be maintained at all.

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/session.integration.test.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/session.integration.test.ts
@@ -6,11 +6,21 @@
  * demand and has no Drizzle definition, so the typed CRUD path rejected the
  * name while doubles answered the call happily. This suite exists so that class
  * of defect cannot survive again — it exercises seed, claim, exclusion and
- * release through the real adapter, with the table genuinely absent from the
- * schema registry.
+ * release through the real adapter.
+ *
+ * Run on EVERY dialect, not just PostgreSQL. The defect this suite was written
+ * for was a typed-CRUD path rejecting an undeclared table name, and nothing
+ * about that is specific to one driver: whether `lockRow` and the statement
+ * path work against a given server is a property of that server's adapter. One
+ * dialect passing says nothing about the other two, which is exactly the gap
+ * that let a double stand in for reality the first time.
  */
+import { createMySqlAdapter } from "@nextlyhq/adapter-mysql";
 import { createPostgresAdapter } from "@nextlyhq/adapter-postgres";
+import { createSqliteAdapter } from "@nextlyhq/adapter-sqlite";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import type { SupportedDialect } from "@nextlyhq/adapter-drizzle/types";
 
 import { NextlyError } from "../../../../errors/nextly-error";
 import {
@@ -25,15 +35,49 @@ interface LockAdapter {
   executeQuery<T = unknown>(sql: string, params?: unknown[]): Promise<T[]>;
 }
 
-describe.skipIf(!process.env.TEST_POSTGRES_URL)(
-  "field-group migration lock on a live server",
-  () => {
+/**
+ * The servers this runs against.
+ *
+ * SQLite carries no URL because it needs no server; the other two self-skip when
+ * their URL is unset, which is how every integration suite here behaves.
+ */
+const DIALECTS: {
+  dialect: SupportedDialect;
+  url: string | null;
+  make: () => LockAdapter;
+}[] = [
+  {
+    dialect: "postgresql",
+    url: process.env.TEST_POSTGRES_URL ?? null,
+    make: () =>
+      createPostgresAdapter({
+        url: process.env.TEST_POSTGRES_URL as string,
+      }) as unknown as LockAdapter,
+  },
+  {
+    dialect: "mysql",
+    url: process.env.TEST_MYSQL_URL ?? null,
+    make: () =>
+      createMySqlAdapter({
+        url: process.env.TEST_MYSQL_URL as string,
+      }) as unknown as LockAdapter,
+  },
+  {
+    dialect: "sqlite",
+    url: "memory",
+    make: () => createSqliteAdapter({ memory: true }) as unknown as LockAdapter,
+  },
+];
+
+describe.each(DIALECTS)(
+  "field-group migration lock on a live $dialect server",
+  ({ dialect, url, make }) => {
     let adapter: LockAdapter;
+    const runs = url === null ? describe.skip : describe;
 
     beforeAll(async () => {
-      adapter = createPostgresAdapter({
-        url: process.env.TEST_POSTGRES_URL as string,
-      }) as unknown as LockAdapter;
+      if (url === null) return;
+      adapter = make();
       await adapter.connect();
       // No table, no row, and no schema registry has ever been told about it:
       // exactly the state a first run meets.
@@ -43,6 +87,7 @@ describe.skipIf(!process.env.TEST_POSTGRES_URL)(
     });
 
     afterAll(async () => {
+      if (url === null) return;
       await adapter.executeQuery(
         `DROP TABLE IF EXISTS ${MIGRATION_LOCK_TABLE}`
       );
@@ -58,7 +103,7 @@ describe.skipIf(!process.env.TEST_POSTGRES_URL)(
           // The adapter's own type; the cast is only to keep this suite's
           // surface narrow.
           adapter: adapter as never,
-          dialect: "postgresql",
+          dialect,
           label,
         },
         fn
@@ -72,40 +117,42 @@ describe.skipIf(!process.env.TEST_POSTGRES_URL)(
       return rows[0]?.owner ?? null;
     }
 
-    it("creates its table, seeds the row, claims and releases it", async () => {
-      let heldDuring: string | null = null;
+    runs("against this server", () => {
+      it("creates its table, seeds the row, claims and releases it", async () => {
+        let heldDuring: string | null = null;
 
-      await session("run-1", async () => {
-        heldDuring = await ownerNow();
+        await session("run-1", async () => {
+          heldDuring = await ownerNow();
+        });
+
+        // Held while the callback ran, and free afterwards. Both halves went
+        // through the real driver against a table the ORM does not declare.
+        expect(heldDuring).not.toBeNull();
+        expect(heldDuring).toContain("run-1");
+        expect(await ownerNow()).toBeNull();
       });
 
-      // Held while the callback ran, and free afterwards. Both halves went
-      // through the real driver against a table the ORM does not declare.
-      expect(heldDuring).not.toBeNull();
-      expect(heldDuring).toContain("run-1");
-      expect(await ownerNow()).toBeNull();
-    });
+      it("refuses a second run while the first holds the lock", async () => {
+        const error = await session("outer", async () =>
+          session("inner", () => Promise.resolve("should not run")).catch(
+            (caught: unknown) => caught
+          )
+        );
 
-    it("refuses a second run while the first holds the lock", async () => {
-      const error = await session("outer", async () =>
-        session("inner", () => Promise.resolve("should not run")).catch(
-          (caught: unknown) => caught
-        )
-      );
+        expect(NextlyError.is(error)).toBe(true);
+        if (NextlyError.is(error)) {
+          expect(error.logContext?.reason).toMatch(/held elsewhere/);
+        }
+        // The outer run's release still happened despite the inner refusal.
+        expect(await ownerNow()).toBeNull();
+      });
 
-      expect(NextlyError.is(error)).toBe(true);
-      if (NextlyError.is(error)) {
-        expect(error.logContext?.reason).toMatch(/held elsewhere/);
-      }
-      // The outer run's release still happened despite the inner refusal.
-      expect(await ownerNow()).toBeNull();
-    });
-
-    it("releases the claim when the run throws", async () => {
-      await expect(
-        session("failing", () => Promise.reject(new Error("boom")))
-      ).rejects.toThrow();
-      expect(await ownerNow()).toBeNull();
+      it("releases the claim when the run throws", async () => {
+        await expect(
+          session("failing", () => Promise.reject(new Error("boom")))
+        ).rejects.toThrow();
+        expect(await ownerNow()).toBeNull();
+      });
     });
   }
 );

--- a/packages/nextly/src/schemas/_dialect-bundles/mysql.ts
+++ b/packages/nextly/src/schemas/_dialect-bundles/mysql.ts
@@ -12,6 +12,11 @@
 
 export { users, accounts, sessions } from "../users/mysql";
 
+// The field-group storage migration's mutual-exclusion row. Present here, and not only in
+// `getCoreSchema`, because this bundle is what decides whether the table EXISTS: it is what
+// `reconcileCore` hands drizzle-kit.
+export { nextlyFieldGroupLock } from "../field-group-lock/mysql";
+
 export {
   emailVerificationTokens,
   passwordResetTokens,

--- a/packages/nextly/src/schemas/_dialect-bundles/postgres.ts
+++ b/packages/nextly/src/schemas/_dialect-bundles/postgres.ts
@@ -27,6 +27,11 @@
 // Users + Auth.js identity.
 export { users, accounts, sessions } from "../users/postgres";
 
+// The field-group storage migration's mutual-exclusion row. Present here, and not only in
+// `getCoreSchema`, because this bundle is what decides whether the table EXISTS: it is what
+// `reconcileCore` hands drizzle-kit.
+export { nextlyFieldGroupLock } from "../field-group-lock/postgres";
+
 // Auth tokens.
 export {
   emailVerificationTokens,

--- a/packages/nextly/src/schemas/_dialect-bundles/sqlite.ts
+++ b/packages/nextly/src/schemas/_dialect-bundles/sqlite.ts
@@ -12,6 +12,11 @@
 
 export { users, accounts, sessions } from "../users/sqlite";
 
+// The field-group storage migration's mutual-exclusion row. Present here, and not only in
+// `getCoreSchema`, because this bundle is what decides whether the table EXISTS: it is what
+// `reconcileCore` hands drizzle-kit.
+export { nextlyFieldGroupLock } from "../field-group-lock/sqlite";
+
 export {
   emailVerificationTokens,
   passwordResetTokens,

--- a/packages/nextly/src/schemas/field-group-lock/__tests__/lock-declaration-parity.test.ts
+++ b/packages/nextly/src/schemas/field-group-lock/__tests__/lock-declaration-parity.test.ts
@@ -14,13 +14,24 @@
  * Deleting either is not an option. The bootstrap cannot be dropped (ordering), and the declaration
  * cannot be dropped (reconcilability). So they are pinned against each other instead.
  */
-import { getTableColumns } from "drizzle-orm";
+import { getTableConfig as mysqlTableConfig } from "drizzle-orm/mysql-core";
+import { getTableConfig as pgTableConfig } from "drizzle-orm/pg-core";
+import { getTableConfig as sqliteTableConfig } from "drizzle-orm/sqlite-core";
 import { describe, expect, it } from "vitest";
 
 import { getMigrationLockDdl } from "../../../domains/field-groups/migration/session";
-import { fieldGroupLockTables } from "../index";
+import { nextlyFieldGroupLock as myLock } from "../mysql";
+import { nextlyFieldGroupLock as pgLock } from "../postgres";
+import { nextlyFieldGroupLock as slLock } from "../sqlite";
 
 import type { SupportedDialect } from "@nextlyhq/adapter-drizzle/types";
+
+/** Each dialect's declared table, normalised to the one thing this compares. */
+const DECLARED: Record<SupportedDialect, () => string[]> = {
+  postgresql: () => pgTableConfig(pgLock).columns.map(c => c.name),
+  mysql: () => mysqlTableConfig(myLock).columns.map(c => c.name),
+  sqlite: () => sqliteTableConfig(slLock).columns.map(c => c.name),
+};
 
 /** The dialects a lock is ever created on. */
 const DIALECTS: SupportedDialect[] = ["postgresql", "mysql", "sqlite"];
@@ -48,13 +59,12 @@ describe("the bootstrap DDL and the declared table agree", () => {
     expect(rest).toEqual([]);
     expect(statement).toBeDefined();
 
-    // 🔴 Read through Drizzle's own accessor, not `Object.keys`. A table object carries internals
-    // alongside its columns (`enableRLS` on pg, among others), and the first version of this test
-    // filtered them by name convention — which is a guess about someone else's spelling that goes
-    // stale the moment they add another. `getTableColumns` is the structural answer.
-    const declared = Object.keys(
-      getTableColumns(fieldGroupLockTables(dialect).nextlyFieldGroupLock)
-    );
+    // 🔴 Read through the dialect's own `getTableConfig`, not `Object.keys`. A table object carries
+    // internals alongside its columns (`enableRLS` on pg, among others), and filtering those by
+    // name convention is a guess about someone else's spelling that goes stale the moment they add
+    // another. The drizzle-v1 gate bars the whole-table column accessor, so this follows the prior
+    // art in `schemas/__tests__/activity-log-actor-columns.test.ts` instead.
+    const declared = DECLARED[dialect]();
 
     // Sorted: the order columns appear in a CREATE is not part of the contract.
     expect(columnsInDdl(statement as string).sort()).toEqual(declared.sort());

--- a/packages/nextly/src/schemas/field-group-lock/__tests__/lock-declaration-parity.test.ts
+++ b/packages/nextly/src/schemas/field-group-lock/__tests__/lock-declaration-parity.test.ts
@@ -1,0 +1,70 @@
+/**
+ * The declared lock table and the DDL that bootstraps it must describe the SAME table.
+ *
+ * Two things now create `nextly_field_group_lock`, and they run at different moments for different
+ * reasons: `getMigrationLockDdl` builds it out-of-band, because a session has to be able to contend
+ * for the lock long before anyone runs a migration, and `getCoreSchema` declares it so a reconcile
+ * can carry a later change onto installations that already have it.
+ *
+ * That is two answers to one question, which this repository treats as a defect waiting to happen —
+ * and here the drift would be quiet in the worst way. If the declaration and the DDL disagree, every
+ * `nextly migrate` proposes a change to a table that is already correct, on every run, forever; and
+ * a future column added to one of them would silently not reach databases built by the other.
+ *
+ * Deleting either is not an option. The bootstrap cannot be dropped (ordering), and the declaration
+ * cannot be dropped (reconcilability). So they are pinned against each other instead.
+ */
+import { getTableColumns } from "drizzle-orm";
+import { describe, expect, it } from "vitest";
+
+import { getMigrationLockDdl } from "../../../domains/field-groups/migration/session";
+import { fieldGroupLockTables } from "../index";
+
+import type { SupportedDialect } from "@nextlyhq/adapter-drizzle/types";
+
+/** The dialects a lock is ever created on. */
+const DIALECTS: SupportedDialect[] = ["postgresql", "mysql", "sqlite"];
+
+/**
+ * The column names the bootstrap statement declares, read out of the statement itself.
+ *
+ * Parsed rather than restated: a list written here would be a THIRD answer to the same question,
+ * and the one most likely to be updated last.
+ */
+function columnsInDdl(statement: string): string[] {
+  const body = /\(([^)]*)\)/.exec(statement)?.[1] ?? "";
+  return body
+    .split(",")
+    .map(part => part.trim().split(/\s+/)[0])
+    .filter(name => name.length > 0);
+}
+
+describe("the bootstrap DDL and the declared table agree", () => {
+  it.each(DIALECTS)("declares the same columns on %s", dialect => {
+    const [statement, ...rest] = getMigrationLockDdl(
+      dialect === "postgresql" ? "postgresql" : dialect
+    );
+    // One statement, so a second one appearing later cannot slip past unread.
+    expect(rest).toEqual([]);
+    expect(statement).toBeDefined();
+
+    // 🔴 Read through Drizzle's own accessor, not `Object.keys`. A table object carries internals
+    // alongside its columns (`enableRLS` on pg, among others), and the first version of this test
+    // filtered them by name convention — which is a guess about someone else's spelling that goes
+    // stale the moment they add another. `getTableColumns` is the structural answer.
+    const declared = Object.keys(
+      getTableColumns(fieldGroupLockTables(dialect).nextlyFieldGroupLock)
+    );
+
+    // Sorted: the order columns appear in a CREATE is not part of the contract.
+    expect(columnsInDdl(statement as string).sort()).toEqual(declared.sort());
+  });
+
+  it("names the same table the session claims", () => {
+    // A positive control on the parser above: it has to actually find columns, or every comparison
+    // in this file passes by both sides being empty.
+    const [statement] = getMigrationLockDdl("postgresql");
+    expect(columnsInDdl(statement as string)).toContain("owner");
+    expect(statement).toContain("nextly_field_group_lock");
+  });
+});

--- a/packages/nextly/src/schemas/field-group-lock/__tests__/lock-roundtrip-pg.integration.test.ts
+++ b/packages/nextly/src/schemas/field-group-lock/__tests__/lock-roundtrip-pg.integration.test.ts
@@ -1,0 +1,86 @@
+/**
+ * A lock table built by the bootstrap DDL must round-trip through the reconciler with no churn.
+ *
+ * Two things create `nextly_field_group_lock`: `getMigrationLockDdl`, which runs out-of-band because
+ * a session has to contend for the lock before any migration exists, and the Drizzle declaration,
+ * which is what makes the table reconcilable at all. Two implementations of one table is the drift
+ * shape this repository treats as a defect waiting to happen.
+ *
+ * The unit-level parity test next to this one compares COLUMN NAMES, which is cheap and runs without
+ * a server — and is not sufficient. A type, a nullability, a primary key or a dialect-specific detail
+ * can diverge with the names still matching, and the consequence is not a wrong answer once: it is
+ * `nextly migrate` proposing a change to a table that is already correct, on every run, forever.
+ *
+ * This asks the only question that covers all of those at once — build the table the way a real
+ * installation gets it, then let the reconciler compare it against the declaration and assert it has
+ * NOTHING to say. Modelled on `schema-events-roundtrip-pg.integration.test.ts`, which guards the same
+ * shape for the migration ledger.
+ */
+import { drizzle } from "drizzle-orm/node-postgres";
+import { Pool } from "pg";
+import { describe, expect, it } from "vitest";
+
+import { getPgDrizzleKit } from "../../../database/drizzle-kit-lazy";
+import { getMigrationLockDdl } from "../../../domains/field-groups/migration/session";
+import { nextlyFieldGroupLock } from "../postgres";
+
+const TEST_DB_URL =
+  process.env.TEST_POSTGRES_URL ?? process.env.TEST_DATABASE_URL ?? "";
+
+const LOCK_TABLE = "nextly_field_group_lock";
+
+const canConnect = async (): Promise<boolean> => {
+  if (!TEST_DB_URL) return false;
+  const pool = new Pool({ connectionString: TEST_DB_URL });
+  try {
+    await pool.query("SELECT 1");
+    return true;
+  } catch {
+    return false;
+  } finally {
+    await pool.end();
+  }
+};
+
+describe("nextly_field_group_lock declared-as-managed (postgres)", async () => {
+  if (!(await canConnect())) {
+    it.skip("Skipping: Test PostgreSQL not available", () => {});
+    return;
+  }
+
+  it("bootstrap-created, claimed lock round-trips with no churn", async () => {
+    const pool = new Pool({ connectionString: TEST_DB_URL });
+    const db = drizzle({ client: pool });
+
+    // Built exactly as a session builds it, and then HELD: a claimed row is the state a reconcile is
+    // most likely to meet in the field, and an empty table would not exercise the column's
+    // nullability the way an occupied one does.
+    await pool.query(`DROP TABLE IF EXISTS "${LOCK_TABLE}" CASCADE;`);
+    for (const statement of getMigrationLockDdl("postgresql")) {
+      await pool.query(statement);
+    }
+    await pool.query(
+      `INSERT INTO "${LOCK_TABLE}" (id, owner) VALUES ($1, $2)`,
+      [1, "field-group-migration#round-trip"]
+    );
+
+    const kit = await getPgDrizzleKit();
+    const result = await kit.pushSchema({ nextlyFieldGroupLock }, db, {
+      schemas: ["public"],
+      tables: [LOCK_TABLE],
+    });
+
+    await pool.query(`DROP TABLE IF EXISTS "${LOCK_TABLE}" CASCADE;`);
+    await pool.end();
+
+    // Scoped to statements naming the lock, so unrelated objects in a shared test database cannot
+    // fail this. On a clean database the list is empty either way.
+    const churn = result.sqlStatements.filter(s => s.includes(LOCK_TABLE));
+    expect(churn).toEqual([]);
+
+    const hints = result.hints.filter(h =>
+      `${h.hint} ${h.statement ?? ""}`.includes(LOCK_TABLE)
+    );
+    expect(hints).toEqual([]);
+  });
+});

--- a/packages/nextly/src/schemas/field-group-lock/index.ts
+++ b/packages/nextly/src/schemas/field-group-lock/index.ts
@@ -1,0 +1,39 @@
+/**
+ * `nextly_field_group_lock` — dialect-aware barrel.
+ *
+ * @module schemas/field-group-lock
+ */
+
+import type { SupportedDialect } from "@nextlyhq/adapter-drizzle/types";
+
+import { NextlyError } from "../../errors/nextly-error";
+
+import * as my from "./mysql";
+import * as pg from "./postgres";
+import * as sl from "./sqlite";
+
+export { pg, my, sl };
+
+/** The lock table for the requested dialect. */
+export function fieldGroupLockTables(dialect: SupportedDialect) {
+  switch (dialect) {
+    case "postgresql":
+      return { nextlyFieldGroupLock: pg.nextlyFieldGroupLock };
+    case "mysql":
+      return { nextlyFieldGroupLock: my.nextlyFieldGroupLock };
+    case "sqlite":
+      return { nextlyFieldGroupLock: sl.nextlyFieldGroupLock };
+    default: {
+      // Exhaustiveness check — TypeScript flags any missing dialect at compile time, so reaching
+      // here at runtime means a dialect was added without a table for it. `internal` because that
+      // is a programming mistake rather than a state an operator can be in or fix.
+      const _exhaustive: never = dialect;
+      throw NextlyError.internal({
+        logContext: {
+          reason: "no field-group lock table for this dialect",
+          dialect: String(_exhaustive),
+        },
+      });
+    }
+  }
+}

--- a/packages/nextly/src/schemas/field-group-lock/mysql.ts
+++ b/packages/nextly/src/schemas/field-group-lock/mysql.ts
@@ -1,0 +1,17 @@
+/**
+ * `nextly_field_group_lock` — MySQL. See `postgres.ts` for what this table is and why it is
+ * declared here as well as bootstrapped out-of-band.
+ *
+ * `int` rather than `integer` mirrors the bootstrap DDL, which picks the same type for this dialect:
+ * the declaration and the CREATE have to describe one table, or the reconcile proposes a change to a
+ * table that is already correct.
+ *
+ * @module schemas/field-group-lock/mysql
+ */
+
+import { int, mysqlTable, text } from "drizzle-orm/mysql-core";
+
+export const nextlyFieldGroupLock = mysqlTable("nextly_field_group_lock", {
+  id: int("id").primaryKey(),
+  owner: text("owner"),
+});

--- a/packages/nextly/src/schemas/field-group-lock/postgres.ts
+++ b/packages/nextly/src/schemas/field-group-lock/postgres.ts
@@ -1,0 +1,26 @@
+/**
+ * `nextly_field_group_lock` — the field-group storage migration's mutual-exclusion row, PostgreSQL.
+ *
+ * One row, one nullable owner. A schema change and a storage migration contend for it, so exactly
+ * one of them runs at a time; `owner` is NULL when the lock is free and carries a per-invocation
+ * claim string when it is held.
+ *
+ * ## Why this is declared here as well as bootstrapped
+ *
+ * The session creates this table out-of-band with `getMigrationLockDdl`, because it has to exist
+ * before anything can contend for it and the code that needs it runs long before a migration would.
+ * Declaring it here is what makes it RECONCILABLE: `getCoreSchema` is what `nextly migrate` pushes,
+ * and a table outside that set can never receive a column, an index, or any other change — the
+ * bootstrap DDL is `CREATE TABLE IF NOT EXISTS`, which does nothing at all to a table that already
+ * exists. That is the same reasoning `nextly_schema_events` and `nextly_i18n_archive` are declared
+ * on, and this table is the one system table that was missing it.
+ *
+ * @module schemas/field-group-lock/postgres
+ */
+
+import { integer, pgTable, text } from "drizzle-orm/pg-core";
+
+export const nextlyFieldGroupLock = pgTable("nextly_field_group_lock", {
+  id: integer("id").primaryKey(),
+  owner: text("owner"),
+});

--- a/packages/nextly/src/schemas/field-group-lock/sqlite.ts
+++ b/packages/nextly/src/schemas/field-group-lock/sqlite.ts
@@ -1,0 +1,13 @@
+/**
+ * `nextly_field_group_lock` — SQLite. See `postgres.ts` for what this table is and why it is
+ * declared here as well as bootstrapped out-of-band.
+ *
+ * @module schemas/field-group-lock/sqlite
+ */
+
+import { integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
+
+export const nextlyFieldGroupLock = sqliteTable("nextly_field_group_lock", {
+  id: integer("id").primaryKey(),
+  owner: text("owner"),
+});

--- a/packages/nextly/src/schemas/index.ts
+++ b/packages/nextly/src/schemas/index.ts
@@ -264,6 +264,9 @@ export const CORE_TABLE_NAMES: readonly string[] = [
   "media_folders",
   "image_sizes",
   "nextly_meta",
+  // Read by live introspection. Absent here, the table is created and then invisible to every
+  // snapshot, so the drift check proposes adding it again on every run.
+  "nextly_field_group_lock",
   "dynamic_collections",
   "dynamic_singles",
   STORAGE_FORMAT.registryTable,

--- a/packages/nextly/src/schemas/index.ts
+++ b/packages/nextly/src/schemas/index.ts
@@ -49,6 +49,7 @@ import { emailProvidersSqlite } from "./email-providers/sqlite";
 import { emailTemplatesMysql } from "./email-templates/mysql";
 import { emailTemplatesPg } from "./email-templates/postgres";
 import { emailTemplatesSqlite } from "./email-templates/sqlite";
+import { fieldGroupLockTables } from "./field-group-lock";
 import { mediaTables } from "./media";
 import { nextlyI18nArchiveTables } from "./nextly-i18n-archive";
 import { nextlyMetaTables } from "./nextly-meta";
@@ -159,6 +160,12 @@ export function getCoreSchema(
     ...Object.values(mediaTables(dialect)),
     ...Object.values(auditTables(dialect)),
     ...Object.values(nextlyMetaTables(dialect)),
+    // `nextly_field_group_lock` — the storage migration's mutual-exclusion row. Bootstrapped
+    // out-of-band by the migration session (it must exist before anything can contend for it),
+    // and declared here so it is RECONCILABLE: the bootstrap is `CREATE TABLE IF NOT EXISTS`, so
+    // without this a column could never be added to an existing installation's copy. Same reasoning
+    // as `nextly_schema_events` and `nextly_i18n_archive` below.
+    ...Object.values(fieldGroupLockTables(dialect)),
     ...Object.values(apiKeyTables(dialect)),
     // `nextly_schema_events` (the migration ledger) is a first-class managed
     // table. It is still bootstrapped out-of-band via `getSchemaEventsDdl` so


### PR DESCRIPTION
## What and why

`nextly_field_group_lock` existed only as a string constant and a hand-built `CREATE TABLE IF NOT EXISTS` in `migration/session.ts`. It was the one system table declared nowhere, which means it sat **outside every migration**: `nextly migrate` pushes the declared schema, and a table absent from that set can never receive a column, an index, or any other change. The bootstrap statement does nothing at all to a table that already exists.

Nothing about the lock behaves differently today. What changes is that it can be maintained at all.

This closes a Codex P1 from the B1 programme (the lock "exists only as a string in `session.ts`; no Drizzle definition, not in `getDialectTables`") and is the prerequisite for adding `claimed_at` — the column that would let a live migration be told apart from a crashed one, which #737 shipped as an accepted ambiguity because the row carries no time.

## The part worth reviewing: there are THREE registries, not one

I wired one and an existing guard caught it. `core-tables-reach-the-push-bundle.test.ts` explains why each matters, and its comment is the specification:

- **`getCoreSchema()`** — describes tables.
- **`getDialectTables()`** — what `reconcileCore` hands drizzle-kit, so it decides whether the table **exists**. Missing here, "a table looks completely wired: its DDL renders, a fixture built from `getCoreSchema` creates it, and every unit test passes — against a table no real installation has."
- **`getCoreTableNames()`** — what live introspection reads, so it decides whether an existing table is **seen**. Missing here, the drift check proposes adding it again on every run.

All three are now wired. I would not have found the second and third without that guard; it is the best-written check I have met in this repo.

## Keeping the two creators in step

The bootstrap DDL cannot be deleted (the session must be able to contend for the lock long before anyone runs a migration) and the declaration cannot be deleted (reconcilability). So two things now create this table, which is the drift shape this repo treats as a defect waiting to happen — and here it would be quiet in the worst way: a disagreement means every `nextly migrate` proposes a change to a table that is already correct, forever.

`lock-declaration-parity.test.ts` pins them against each other on all three dialects, parsing the column names out of the bootstrap statement rather than restating them (a hand-written list would be a third answer to the same question, and the one updated last). It carries a positive control asserting the parser finds columns at all, since otherwise both sides could agree by being empty.

**Break-control:** adding `claimed_at` to any one dialect's declaration fails that dialect's case and no other.

## Two things this PR ran into, recorded because they cost a cycle each

- The exhaustiveness `throw` I copied from `schemas/nextly-meta/index.ts` is a bare `Error`, which the `no-restricted-syntax` rule rejects. That file predates the rule and only changed files are linted, so the violation is invisible until someone copies it. Mine uses `NextlyError.internal`; I did not touch the original, which is out of scope here.
- My first column reader used `getTableColumns`, which the drizzle-v1 gate bars. It now uses the per-dialect `getTableConfig`, following the prior art in `schemas/__tests__/activity-log-actor-columns.test.ts`. Note the gate greps text, so the banned symbol cannot appear even in a comment.

## What this does NOT fix, measured rather than assumed

The B1 P1 this closes said the lock "has **never worked** against a real adapter", because `acquire` resolved through the schema registry and would reject an undeclared name. That is no longer the failure mode: `readOwner` goes through `queryStatement` with SQL identifiers, so the registry is not consulted.

I measured it rather than reasoning about it. The lock suite now runs on **all three dialects** (9 tests: seed/claim/release, contention refusal, release-on-throw), and it passes **with and without** this PR's declaration. So:

- **This PR does not make the lock work.** It already worked.
- **What it changes is that the table can be maintained** — a column added to it can now reach an installation that already has one, which the `CREATE TABLE IF NOT EXISTS` bootstrap can never do.

Stating that plainly because the P1's wording invites the stronger claim, and the stronger claim would be false.

The dialect coverage is its own gain: the lock was integration-tested on PostgreSQL only, and whether `lockRow` and the statement path work is a property of each server's adapter, so one dialect passing said nothing about the other two.

## Verification

- `pnpm build`, `check-types --force`, `lint` (exit code), `check-drizzle-v1-legacy`, `check:storage-format-literals` — all `0`
- Full `packages/nextly` unit run at matched timeouts (`--testTimeout=60000`, the same flags the baseline is measured with) diffed per test NAME against `7133efbe9`: **360 failing on both, 0 new by name**, 7999 passing
