### PR TITLE
fix(create-nextly-app): declare packages in the generated pnpm workspace

### DIFF
--- a/.changeset/silly-pugs-smash.md
+++ b/.changeset/silly-pugs-smash.md
@@ -1,0 +1,28 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+fix(create-nextly-app): declare `packages` in the generated pnpm-workspace.yaml so scaffolded projects install on pnpm 9

--- a/packages/create-nextly-app/src/__tests__/template.test.ts
+++ b/packages/create-nextly-app/src/__tests__/template.test.ts
@@ -217,6 +217,30 @@ describe("generatePnpmWorkspaceYaml", () => {
   it("always includes better-sqlite3 in the allowlist", () => {
     expect(NATIVE_BUILD_DEPENDENCIES).toContain("better-sqlite3");
   });
+
+  // pnpm 9 treats the presence of this file as declaring a workspace and
+  // refuses to install without a `packages` key
+  // (ERR_PNPM_INVALID_WORKSPACE_CONFIGURATION). A scaffold that ships the
+  // allowlist alone cannot be installed at all on that line, so the key is
+  // what makes the file safe to emit unconditionally.
+  it("declares packages, so pnpm 9 can install the scaffold", () => {
+    const yaml = generatePnpmWorkspaceYaml();
+    expect(yaml).toMatch(/^packages: \[\]$/m);
+  });
+
+  // A scaffolded app is a single package. Naming any member would claim a
+  // repository layout the scaffold does not create, and pnpm would then look
+  // for manifests that are not there.
+  it("declares no workspace members", () => {
+    const yaml = generatePnpmWorkspaceYaml();
+    const packagesLine = yaml
+      .split("\n")
+      .findIndex(line => line.startsWith("packages:"));
+    expect(packagesLine).toBeGreaterThanOrEqual(0);
+    // A YAML list continues on indented lines; the next top-level key ends it.
+    const next = yaml.split("\n")[packagesLine + 1] ?? "";
+    expect(next).not.toMatch(/^\s+-/);
+  });
 });
 
 // ============================================================

--- a/packages/create-nextly-app/src/utils/template.ts
+++ b/packages/create-nextly-app/src/utils/template.ts
@@ -693,12 +693,18 @@ export const NATIVE_BUILD_DEPENDENCIES = [
  *   ERR_PNPM_INVALID_WORKSPACE_CONFIGURATION  packages field missing or empty
  *
  * so a scaffold shipping the allowlist alone could not be installed at all on
- * that line. Measured across the versions a user is plausibly on: 9.0.0 refuses
- * the file without this key; 10.5.2, 10.6.1, 10.18.3 and 11.0.0 all accept it
- * either way. The empty list is the honest value — a scaffolded app has no
- * workspace members — and it leaves `pnpm add` behaving normally, which
- * declaring the project's own root as a member would also have done but with a
- * claim about the layout that is not true.
+ * those versions.
+ *
+ * Measured, installing the file exactly as generated: 8.15.9, 9.0.0, 9.0.6,
+ * 9.1.0, 9.2.0 and 9.3.0 all refuse it; 9.4.0, 9.7.0, 9.15.9, 10.5.2, 10.6.1,
+ * 10.18.3 and 11.0.0 all accept it with or without the key. So the affected
+ * range is pnpm 8 through 9.3 — which includes the 9.0.0 this repository pins,
+ * and therefore the pnpm a contributor following the setup instructions has.
+ *
+ * The empty list is the honest value — a scaffolded app has no workspace
+ * members — and it leaves `pnpm add` behaving normally, which declaring the
+ * project's own root as a member would also have done but with a claim about
+ * the layout that is not true.
  */
 export function generatePnpmWorkspaceYaml(): string {
   const allowBuilds = NATIVE_BUILD_DEPENDENCIES.map(
@@ -718,8 +724,8 @@ export function generatePnpmWorkspaceYaml(): string {
     "# build scripts by default.\n" +
     "#\n" +
     "# It does still READ the file, which is what the empty `packages` list is\n" +
-    "# for: on pnpm 9 the presence of this file declares a workspace, and a\n" +
-    "# missing `packages` key fails the install outright. This app has no\n" +
+    "# for: through pnpm 9.3 the presence of this file declares a workspace, and\n" +
+    "# a missing `packages` key fails the install outright. This app has no\n" +
     "# workspace members.\n" +
     "packages: []\n" +
     `allowBuilds:\n${allowBuilds}\n` +

--- a/packages/create-nextly-app/src/utils/template.ts
+++ b/packages/create-nextly-app/src/utils/template.ts
@@ -682,9 +682,23 @@ export const NATIVE_BUILD_DEPENDENCIES = [
  *     reads the `pnpm` field from package.json at all.
  *   - pnpm 10.6+ reads `onlyBuiltDependencies` (an array; deprecated in 11).
  *
- * Both keys are emitted so native deps compile on any pnpm 10.6+/11. pnpm 9
- * runs build scripts by default and ignores this file; npm/yarn ignore it too,
- * so it is safe to ship in every scaffold regardless of package manager.
+ * Both keys are emitted so native deps compile on any pnpm 10.6+/11. npm and
+ * yarn ignore the file entirely, and pnpm 9 runs build scripts by default, so
+ * it is safe to ship in every scaffold regardless of package manager.
+ *
+ * `packages` is emitted for pnpm 9 specifically. Before pnpm repurposed this
+ * file as the general settings home, its mere presence declared a workspace
+ * and a missing `packages` key was fatal:
+ *
+ *   ERR_PNPM_INVALID_WORKSPACE_CONFIGURATION  packages field missing or empty
+ *
+ * so a scaffold shipping the allowlist alone could not be installed at all on
+ * that line. Measured across the versions a user is plausibly on: 9.0.0 refuses
+ * the file without this key; 10.5.2, 10.6.1, 10.18.3 and 11.0.0 all accept it
+ * either way. The empty list is the honest value — a scaffolded app has no
+ * workspace members — and it leaves `pnpm add` behaving normally, which
+ * declaring the project's own root as a member would also have done but with a
+ * claim about the layout that is not true.
  */
 export function generatePnpmWorkspaceYaml(): string {
   const allowBuilds = NATIVE_BUILD_DEPENDENCIES.map(
@@ -700,7 +714,14 @@ export function generatePnpmWorkspaceYaml(): string {
     "# compiled binding (sqlite apps crash at boot) and sharp/esbuild degrade.\n" +
     "#\n" +
     "# pnpm 11+ reads `allowBuilds`; pnpm 10.6+ reads `onlyBuiltDependencies`.\n" +
-    "# npm, yarn, and pnpm 9 ignore this file (they run build scripts by default).\n" +
+    "# npm and yarn ignore this file; pnpm 9 needs neither key, because it runs\n" +
+    "# build scripts by default.\n" +
+    "#\n" +
+    "# It does still READ the file, which is what the empty `packages` list is\n" +
+    "# for: on pnpm 9 the presence of this file declares a workspace, and a\n" +
+    "# missing `packages` key fails the install outright. This app has no\n" +
+    "# workspace members.\n" +
+    "packages: []\n" +
     `allowBuilds:\n${allowBuilds}\n` +
     `onlyBuiltDependencies:\n${onlyBuilt}\n`
   );


### PR DESCRIPTION
## The bug

Every project scaffolded by `create-nextly-app` fails to install under pnpm 9:

```
 ERR_PNPM_INVALID_WORKSPACE_CONFIGURATION  packages field missing or empty
```

`generatePnpmWorkspaceYaml` emits a `pnpm-workspace.yaml` carrying only
`allowBuilds` and `onlyBuiltDependencies`. On pnpm 9 the presence of that file
declares a workspace, and a missing `packages` key is fatal — so the install the
CLI runs on the user's behalf aborts, and the scaffold never completes.

pnpm 9 is not an exotic target: it is the version this repository itself pins in
`packageManager`.

## What is actually affected — measured, not assumed

A version sweep, installing the file exactly as generated:

| pnpm | as generated today |
| --- | --- |
| 8.15.9 | **fails** `ERR_PNPM_INVALID_WORKSPACE_CONFIGURATION` |
| 9.0.0 | **fails** |
| 9.0.6 | **fails** |
| 9.1.0 | **fails** |
| 9.2.0 | **fails** |
| 9.3.0 | **fails** |
| 9.4.0 | ok |
| 9.7.0 | ok |
| 9.15.9 | ok |
| 10.5.2 | ok |
| 10.6.1 | ok |
| 10.18.3 | ok |
| 11.0.0 | ok |

So the affected range is **pnpm 8 through 9.3**, not the whole 9 line — pnpm
relaxed the requirement in 9.4, when it began repurposing this file as the
general settings home. My first reading of this said "pnpm 9", which is wider
than what reproduces; the bound above is what was measured.

That range still includes the **9.0.0 this repository pins**, so it reproduces
for anyone set up per the contributor instructions. The doc comment claiming
"pnpm 9 ... ignores this file" was the false premise, and it is corrected here.

## The fix

Emit `packages: []`.

The empty list is the honest value: a scaffolded app has no workspace members.
Declaring the project's own root (`packages: ["."]`) also installs and also
leaves `pnpm add` working — both were measured — but it asserts a repository
layout the scaffold does not create.

Verified end to end, with the file produced by the function under test rather
than a hand-copy: pnpm 9.0.0 installs, and a positive control confirms the
dependency actually landed in `node_modules` rather than the install merely
exiting 0.

## Tests

Two, both break-verified — removing the emitted line fails exactly these two and
leaves the other 26 in the file passing:

- `packages` is declared, which is the property pnpm 9 requires
- no workspace members are declared, so the value stays honest as the file grows

## Provenance

Found by the per-PR scaffold job in #764, on its first run — this is one of
three product bugs that job surfaced. It is split out here because it is
independent of that job and of the other two, which concern the `blog` template
and are filed separately.
