### PR TITLE
fix(create-nextly-app): generate a build script cmd.exe can run

### DIFF
--- a/.changeset/brave-moons-repeat.md
+++ b/.changeset/brave-moons-repeat.md
@@ -1,0 +1,28 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+fix(create-nextly-app): generate a build script that runs on Windows, and stop swallowing a failed search-index build

--- a/packages/create-nextly-app/src/__tests__/generated-scripts-are-cross-platform.test.ts
+++ b/packages/create-nextly-app/src/__tests__/generated-scripts-are-cross-platform.test.ts
@@ -1,0 +1,128 @@
+/**
+ * No script the CLI GENERATES may depend on a POSIX shell.
+ *
+ * `npm run` executes scripts through `cmd.exe` on Windows. It has no `test`, no `true`, no `[`,
+ * no command substitution and no `wait`, so a script reaching for any of them fails there and
+ * nowhere else — after the commands before it have already done their work, which is what makes
+ * the failure read as unrelated to the script.
+ *
+ * This repository has already paid for that lesson once, in `packages/ui`'s `dev` script, and
+ * `packages/ui/src/__tests__/package-scripts-are-cross-platform.test.ts` now refuses the construct
+ * that caused it. That guard reads the workspace manifests — every `package.json` pnpm knows
+ * about. A script this CLI writes into somebody else's project is not one of those, so it sits
+ * outside that guard's domain entirely, and the generated `build` carried
+ *
+ *     (test -f scripts/build-search-index.mjs && node scripts/... || true)
+ *
+ * unnoticed. Same defect, one directory over.
+ *
+ * The check is therefore on the OUTPUT of the generator rather than on any file, and it runs over
+ * every template so a construct reintroduced for one of them cannot hide behind the others.
+ */
+import { describe, expect, it } from "vitest";
+
+import type { DatabaseConfig, ProjectType } from "../types";
+import { generatePackageJson } from "../utils/template";
+
+const sqlite: DatabaseConfig = {
+  type: "sqlite",
+  adapter: "@nextlyhq/adapter-sqlite",
+  databaseDriver: "better-sqlite3",
+  connectionUrl: "file:./data/nextly.db",
+  envExample: "file:./data/nextly.db",
+};
+
+/**
+ * Constructs `cmd.exe` cannot run, each with the reason it is here.
+ *
+ * Matched as whole words where the token is a command name: `true` must not match `truelove`, and
+ * `test` must not match a script legitimately named `test`. That is why each pattern anchors on a
+ * command position — the start of the script, or just after a separator — rather than searching
+ * for the bare word anywhere.
+ */
+const POSIX_ONLY = [
+  {
+    name: "the `test` builtin",
+    pattern: /(?:^|[;&|(]\s*)test\s/,
+    why: "cmd.exe has no `test`; use a generator-side decision instead of a shell conditional",
+  },
+  {
+    name: "the `true` builtin",
+    pattern: /(?:^|[;&|(]\s*)true(?![\w-])/,
+    why: "cmd.exe has no `true`, and `|| true` also swallows the failure it is hiding",
+  },
+  {
+    name: "the `[` test builtin",
+    pattern: /(?:^|[;&|(]\s*)\[\s/,
+    why: "cmd.exe has no `[`",
+  },
+  {
+    name: "command substitution",
+    pattern: /\$\(|`/,
+    why: "cmd.exe expands neither `$(...)` nor backticks",
+  },
+  {
+    name: "backgrounding then waiting",
+    pattern: /&[\s\S]*?(?:^|[\s;&])?\bwait(?![\w-])/,
+    why: "cmd.exe treats `&` as sequential and has no `wait`",
+  },
+] as const;
+
+function offences(script: string): string[] {
+  return POSIX_ONLY.filter(rule => rule.pattern.test(script)).map(
+    rule => `${rule.name} — ${rule.why}`
+  );
+}
+
+describe("generated package scripts", () => {
+  // Every template, because the generator branches on what the template ships: gating a step
+  // behind `shipsSearchIndex` means one template's scripts are not the other's, and checking a
+  // single project type would leave the branch that differs unexamined.
+  it.each(["blank", "blog"] as const)(
+    "gives a %s scaffold only scripts cmd.exe can run",
+    async (projectType: ProjectType) => {
+      const pkg = JSON.parse(
+        await generatePackageJson("app", sqlite, false, projectType)
+      );
+
+      const found: string[] = [];
+      for (const [name, script] of Object.entries(
+        pkg.scripts as Record<string, string>
+      )) {
+        for (const offence of offences(script)) {
+          found.push(`${name}: ${script}\n  -> ${offence}`);
+        }
+      }
+      expect(found).toEqual([]);
+
+      // A control on the loop above, not on the scripts. It reports success by finding nothing,
+      // which is also what an empty `scripts` object produces — so the set it scanned has to be
+      // non-empty, and has to contain the script this guard exists for.
+      expect(Object.keys(pkg.scripts).length).toBeGreaterThan(0);
+      expect(pkg.scripts.build).toContain("next build");
+    },
+    30_000
+  );
+
+  // A control on the DETECTOR. Without it, a rule whose pattern silently stopped matching would
+  // report every script clean and read exactly like a repository with no POSIX-isms in it.
+  it("rejects the exact script that shipped before", () => {
+    const shipped =
+      "nextly migrate && next build && (test -f scripts/build-search-index.mjs && node scripts/build-search-index.mjs || true)";
+
+    const detected = offences(shipped);
+    expect(detected).toHaveLength(2);
+    expect(detected.join("\n")).toMatch(/`test` builtin/);
+    expect(detected.join("\n")).toMatch(/`true` builtin/);
+  });
+
+  // The other direction: the replacement must be accepted, or the guard is merely refusing
+  // everything and the test above would pass on a detector that always fires.
+  it("accepts the portable replacement", () => {
+    expect(
+      offences(
+        "nextly migrate && next build && node scripts/build-search-index.mjs"
+      )
+    ).toEqual([]);
+  });
+});

--- a/packages/create-nextly-app/src/__tests__/template-search-index.test.ts
+++ b/packages/create-nextly-app/src/__tests__/template-search-index.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Whether a scaffold gets the Pagefind step is READ from the template tree, not from its name.
+ *
+ * The unit tests around `generatePackageJson` pass no template directories, so they only ever see
+ * the negative branch — a scaffold that receives no search-index builder. That is exactly half the
+ * behaviour, and the half that cannot regress into shipping a broken script.
+ *
+ * So this reads the REAL templates. A test that constructed a fixture directory would be asserting
+ * against a tree this repository does not ship, and would keep passing after `templates/blog` moved
+ * or renamed the builder — which is the change most likely to break the derivation.
+ */
+import { existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+import type { DatabaseConfig } from "../types";
+import {
+  generatePackageJson,
+  templateShipsSearchIndex,
+} from "../utils/template";
+
+const repoRoot = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "..",
+  "..",
+  ".."
+);
+const templates = join(repoRoot, "templates");
+const baseDir = join(templates, "base");
+const blogDir = join(templates, "blog");
+
+const sqlite: DatabaseConfig = {
+  type: "sqlite",
+  adapter: "@nextlyhq/adapter-sqlite",
+  databaseDriver: "better-sqlite3",
+  connectionUrl: "file:./data/nextly.db",
+  envExample: "file:./data/nextly.db",
+};
+
+describe("the search-index step is derived from the template tree", () => {
+  // Before any assertion below means anything: these directories have to exist. A path that
+  // resolved to nothing would make every "does not ship a builder" check below pass, and the
+  // suite would report that the derivation works while reading an empty tree.
+  it("is reading the real template directories", () => {
+    expect(existsSync(baseDir)).toBe(true);
+    expect(existsSync(blogDir)).toBe(true);
+    expect(existsSync(join(blogDir, "scripts", "build-search-index.mjs"))).toBe(
+      true
+    );
+  });
+
+  it("sees the builder in blog and not in base alone", async () => {
+    await expect(templateShipsSearchIndex([baseDir])).resolves.toBe(false);
+    await expect(templateShipsSearchIndex([baseDir, blogDir])).resolves.toBe(
+      true
+    );
+  });
+
+  it("gives a blog scaffold the index step, and declares what runs it", async () => {
+    const pkg = JSON.parse(
+      await generatePackageJson("app", sqlite, false, "blog", [
+        baseDir,
+        blogDir,
+      ])
+    );
+
+    expect(pkg.scripts.build).toBe(
+      "nextly migrate && next build && node scripts/build-search-index.mjs"
+    );
+    expect(pkg.scripts["search:index"]).toBe(
+      "node scripts/build-search-index.mjs"
+    );
+    // Declared rather than left to be fetched on demand. `npx -y pagefind` would download it,
+    // so a build can succeed with the dependency missing from the manifest — and then fail for
+    // a user behind a proxy or an offline install.
+    expect(pkg.devDependencies.pagefind).toBeDefined();
+  }, 30_000);
+
+  it("leaves a blank scaffold without the step or the dependency", async () => {
+    const pkg = JSON.parse(
+      await generatePackageJson("app", sqlite, false, "blank", [baseDir])
+    );
+
+    expect(pkg.scripts.build).toBe("nextly migrate && next build");
+    expect(pkg.scripts["search:index"]).toBeUndefined();
+    expect(pkg.devDependencies.pagefind).toBeUndefined();
+  }, 30_000);
+});

--- a/packages/create-nextly-app/src/__tests__/template-search-index.test.ts
+++ b/packages/create-nextly-app/src/__tests__/template-search-index.test.ts
@@ -1,36 +1,36 @@
 /**
- * Whether a scaffold gets the Pagefind step is READ from the template tree, not from its name.
+ * The build step that runs the Pagefind indexer must name a file the project actually has.
  *
- * The unit tests around `generatePackageJson` pass no template directories, so they only ever see
- * the negative branch — a scaffold that receives no search-index builder. That is exactly half the
- * behaviour, and the half that cannot regress into shipping a broken script.
+ * This is tested by SCAFFOLDING — the real templates, through the real copy, onto a real
+ * temporary directory — rather than by asking the template tree what it contains. The difference
+ * is not incidental: the template ships `scripts/build-search-index.mjs`, and for as long as the
+ * copy did not carry that directory across, every source-tree answer was "yes, it has one" while
+ * every scaffolded project did not. The generated build then named a file that was never there.
  *
- * So this reads the REAL templates. A test that constructed a fixture directory would be asserting
- * against a tree this repository does not ship, and would keep passing after `templates/blog` moved
- * or renamed the builder — which is the change most likely to break the derivation.
+ * The old script hid that. It invoked the builder behind `(test -f … || true)`, so the miss was
+ * swallowed and every blog scaffold shipped a search page with no index behind it.
+ *
+ * So the only assertion worth making here is one that reads the finished project.
  */
+import { mkdtemp, rm } from "node:fs/promises";
 import { existsSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import type { DatabaseConfig } from "../types";
-import {
-  generatePackageJson,
-  templateShipsSearchIndex,
-} from "../utils/template";
+import { copyTemplate, projectHasSearchIndexScript } from "../utils/template";
 
-const repoRoot = join(
+const templates = join(
   dirname(fileURLToPath(import.meta.url)),
   "..",
   "..",
   "..",
-  ".."
+  "..",
+  "templates"
 );
-const templates = join(repoRoot, "templates");
-const baseDir = join(templates, "base");
-const blogDir = join(templates, "blog");
 
 const sqlite: DatabaseConfig = {
   type: "sqlite",
@@ -40,31 +40,59 @@ const sqlite: DatabaseConfig = {
   envExample: "file:./data/nextly.db",
 };
 
-describe("the search-index step is derived from the template tree", () => {
-  // Before any assertion below means anything: these directories have to exist. A path that
-  // resolved to nothing would make every "does not ship a builder" check below pass, and the
-  // suite would report that the derivation works while reading an empty tree.
-  it("is reading the real template directories", () => {
-    expect(existsSync(baseDir)).toBe(true);
-    expect(existsSync(blogDir)).toBe(true);
-    expect(existsSync(join(blogDir, "scripts", "build-search-index.mjs"))).toBe(
-      true
-    );
+let workspace: string;
+
+beforeEach(async () => {
+  workspace = await mkdtemp(join(tmpdir(), "nextly-scaffold-"));
+});
+
+afterEach(async () => {
+  await rm(workspace, { recursive: true, force: true });
+});
+
+async function scaffold(projectType: "blank" | "blog"): Promise<{
+  target: string;
+  pkg: {
+    scripts: Record<string, string>;
+    devDependencies: Record<string, string>;
+  };
+}> {
+  const target = join(workspace, projectType);
+  await copyTemplate({
+    projectName: "app",
+    projectType,
+    targetDir: target,
+    database: sqlite,
+    templateSource: {
+      basePath: join(templates, "base"),
+      templatePath: join(templates, projectType),
+    },
+  });
+  const { readFile } = await import("node:fs/promises");
+  return {
+    target,
+    pkg: JSON.parse(await readFile(join(target, "package.json"), "utf8")),
+  };
+}
+
+describe("a blog scaffold", () => {
+  // The precondition. If the template stopped shipping the builder, every assertion below would
+  // pass by describing a project that correctly has no search step — while the blog silently lost
+  // its search. This separates "correctly absent" from "the template changed underneath us".
+  it("starts from a template that ships the builder", () => {
+    expect(
+      existsSync(join(templates, "blog", "scripts", "build-search-index.mjs"))
+    ).toBe(true);
   });
 
-  it("sees the builder in blog and not in base alone", async () => {
-    await expect(templateShipsSearchIndex([baseDir])).resolves.toBe(false);
-    await expect(templateShipsSearchIndex([baseDir, blogDir])).resolves.toBe(
-      true
-    );
-  });
+  it("receives the builder, and gets a build step that names it", async () => {
+    const { target, pkg } = await scaffold("blog");
 
-  it("gives a blog scaffold the index step, and declares what runs it", async () => {
-    const pkg = JSON.parse(
-      await generatePackageJson("app", sqlite, false, "blog", [
-        baseDir,
-        blogDir,
-      ])
+    // The file the build step will resolve. Asserted on the PROJECT, which is the only place
+    // the answer matters.
+    await expect(projectHasSearchIndexScript(target)).resolves.toBe(true);
+    expect(existsSync(join(target, "scripts", "build-search-index.mjs"))).toBe(
+      true
     );
 
     expect(pkg.scripts.build).toBe(
@@ -73,19 +101,20 @@ describe("the search-index step is derived from the template tree", () => {
     expect(pkg.scripts["search:index"]).toBe(
       "node scripts/build-search-index.mjs"
     );
-    // Declared rather than left to be fetched on demand. `npx -y pagefind` would download it,
-    // so a build can succeed with the dependency missing from the manifest — and then fail for
-    // a user behind a proxy or an offline install.
+    // Declared rather than fetched on demand: `npx -y pagefind` downloads it, so a build can
+    // succeed with the dependency missing and fail for a user installing offline.
     expect(pkg.devDependencies.pagefind).toBeDefined();
-  }, 30_000);
+  }, 60_000);
+});
 
-  it("leaves a blank scaffold without the step or the dependency", async () => {
-    const pkg = JSON.parse(
-      await generatePackageJson("app", sqlite, false, "blank", [baseDir])
-    );
+describe("a blank scaffold", () => {
+  it("gets neither the step nor the dependency", async () => {
+    const { target, pkg } = await scaffold("blank");
 
+    await expect(projectHasSearchIndexScript(target)).resolves.toBe(false);
     expect(pkg.scripts.build).toBe("nextly migrate && next build");
+    // A script pointing at a file that does not exist reads as a supported command.
     expect(pkg.scripts["search:index"]).toBeUndefined();
     expect(pkg.devDependencies.pagefind).toBeUndefined();
-  }, 30_000);
+  }, 60_000);
 });

--- a/packages/create-nextly-app/src/__tests__/template.test.ts
+++ b/packages/create-nextly-app/src/__tests__/template.test.ts
@@ -153,9 +153,11 @@ describe("generatePackageJson", () => {
   it("should include Next.js scripts", async () => {
     const result = JSON.parse(await generatePackageJson("test", pgDatabase));
     expect(result.scripts.dev).toBe("next dev --turbopack");
-    expect(result.scripts.build).toBe(
-      "nextly migrate && next build && (test -f scripts/build-search-index.mjs && node scripts/build-search-index.mjs || true)"
-    );
+    // No search-index step, and no `search:index`, because no template directory was passed —
+    // so the generator saw a scaffold that does not receive the Pagefind builder. A template
+    // that does ship it is covered in template-search-index.test.ts, against a real tree.
+    expect(result.scripts.build).toBe("nextly migrate && next build");
+    expect(result.scripts["search:index"]).toBeUndefined();
     expect(result.scripts.start).toBe("next start");
     expect(result.scripts.lint).toBe("next lint");
   });

--- a/packages/create-nextly-app/src/utils/template.ts
+++ b/packages/create-nextly-app/src/utils/template.ts
@@ -101,17 +101,22 @@ async function effectiveTemplateFiles(
 const SEARCH_INDEX_SCRIPT = path.join("scripts", "build-search-index.mjs");
 
 /**
- * Whether the scaffold receives the Pagefind index builder.
+ * Whether the scaffolded PROJECT has the Pagefind index builder.
  *
- * READ from the merged template tree rather than inferred from the project type, for the same
- * reason the font list is: a hand-kept mapping of "which templates have search" is a second answer
- * to a question the templates already answer, and the two agree only until someone adds one.
+ * Read from the finished project directory rather than from the templates it was assembled out
+ * of, and the distinction is the whole point. A template can ship a file that the copy never
+ * carries across — which is exactly what happened to the blog's `scripts/` — and a decision taken
+ * from the source tree then writes a build step naming a file the project does not have.
+ *
+ * Asking the target makes the two impossible to disagree: whatever answers here is what `node`
+ * will resolve at build time, because it is the same directory.
+ *
+ * Must therefore be called AFTER every copy, which is where `generatePackageJson` already sits.
  */
-export async function templateShipsSearchIndex(
-  templateDirs: readonly string[]
+export async function projectHasSearchIndexScript(
+  targetDir: string
 ): Promise<boolean> {
-  const effective = await effectiveTemplateFiles(templateDirs);
-  return effective.has(SEARCH_INDEX_SCRIPT);
+  return fs.pathExists(path.join(targetDir, SEARCH_INDEX_SCRIPT));
 }
 
 /**
@@ -458,7 +463,15 @@ export async function generatePackageJson(
   database: DatabaseConfig,
   useYalc: boolean = false,
   projectType: ProjectType = "blank",
-  templateDirs: readonly string[] = []
+  templateDirs: readonly string[] = [],
+  /**
+   * The project directory, once every copy has finished.
+   *
+   * Decides the Pagefind build step, which has to be settled against what the project HAS rather
+   * than what its templates ship — see {@link projectHasSearchIndexScript}. Omitting it means
+   * "there is no project on disk to ask", and no search step is emitted.
+   */
+  targetDir?: string
 ): Promise<string> {
   // Plugins are a publishable library, not an app — different package.json.
   if (projectType === "plugin") {
@@ -538,9 +551,11 @@ export async function generatePackageJson(
     "eslint-config-next": runtimeVersions["eslint-config-next"],
   };
 
-  // Derived from the merged template tree, so a template that gains or loses the
-  // Pagefind builder changes the generated manifest without anyone editing a list.
-  const shipsSearchIndex = await templateShipsSearchIndex(templateDirs);
+  // Read from the project that was just assembled, so the generated script can only name a
+  // file that is actually there.
+  const shipsSearchIndex = targetDir
+    ? await projectHasSearchIndexScript(targetDir)
+    : false;
 
   // Pagefind builds the static index behind /search. DECLARED only where the
   // builder ships, because the index script invokes it through `node`, which
@@ -958,6 +973,18 @@ export async function copyTemplate(
     });
   }
 
+  // The build steps a template brings with it — the blog's Pagefind index builder is the only
+  // one today. Without this the template's own `package.json` scripts name a file the project
+  // never receives, which is how the search index came to be silently absent from every blog
+  // scaffold: the build invoked it behind a `test -f` guard that swallowed the miss.
+  const templateScriptsDir = path.join(typeDir, "scripts");
+  if (await fs.pathExists(templateScriptsDir)) {
+    await fs.copy(templateScriptsDir, path.join(targetDir, "scripts"), {
+      overwrite: false,
+      filter: src => !SKIP_FILES.has(path.basename(src)),
+    });
+  }
+
   const frontendPagePath = path.join(
     targetDir,
     "src",
@@ -981,7 +1008,8 @@ export async function copyTemplate(
     database,
     useYalc,
     projectType,
-    [baseDir, typeDir]
+    [baseDir, typeDir],
+    targetDir
   );
   await fs.writeFile(
     path.join(targetDir, "package.json"),

--- a/packages/create-nextly-app/src/utils/template.ts
+++ b/packages/create-nextly-app/src/utils/template.ts
@@ -59,17 +59,7 @@ const FONT_PACKAGE_PATTERN = /@fontsource(?:-variable)?\/[a-z0-9-]+/g;
 export async function collectFontDependencies(
   templateDirs: readonly string[]
 ): Promise<string[]> {
-  // Merged by RELATIVE path, later directory winning, because that is what the copy does: a
-  // template that overrides `src/app/layout.tsx` REPLACES base's rather than adding to it. Taking
-  // the union instead would install the faces of a layout the project never receives — a blank
-  // scaffold declaring Geist because base's overwritten layout mentioned it.
-  const effective = new Map<string, string>();
-  for (const root of templateDirs) {
-    if (!root || !(await fs.pathExists(root))) continue;
-    for (const file of await walkSourceFiles(root)) {
-      effective.set(path.relative(root, file), file);
-    }
-  }
+  const effective = await effectiveTemplateFiles(templateDirs);
 
   const found = new Set<string>();
   for (const file of effective.values()) {
@@ -80,6 +70,48 @@ export async function collectFontDependencies(
   }
 
   return [...found].sort();
+}
+
+/**
+ * The files a scaffold of these template directories actually RECEIVES, keyed by their path
+ * inside the project.
+ *
+ * Merged by relative path with the later directory winning, because that is what the copy does: a
+ * template overriding `src/app/layout.tsx` REPLACES base's rather than adding to it. Taking the
+ * union instead would describe a project nobody receives — a blank scaffold declaring the faces of
+ * a layout that was overwritten.
+ *
+ * Shared rather than recomputed per question. Every property derived from "what does this scaffold
+ * contain" has to agree about which files those are, and two walks written months apart would not.
+ */
+async function effectiveTemplateFiles(
+  templateDirs: readonly string[]
+): Promise<Map<string, string>> {
+  const effective = new Map<string, string>();
+  for (const root of templateDirs) {
+    if (!root || !(await fs.pathExists(root))) continue;
+    for (const file of await walkSourceFiles(root)) {
+      effective.set(path.relative(root, file), file);
+    }
+  }
+  return effective;
+}
+
+/** Where a template puts the Pagefind index builder, if it ships one. */
+const SEARCH_INDEX_SCRIPT = path.join("scripts", "build-search-index.mjs");
+
+/**
+ * Whether the scaffold receives the Pagefind index builder.
+ *
+ * READ from the merged template tree rather than inferred from the project type, for the same
+ * reason the font list is: a hand-kept mapping of "which templates have search" is a second answer
+ * to a question the templates already answer, and the two agree only until someone adds one.
+ */
+export async function templateShipsSearchIndex(
+  templateDirs: readonly string[]
+): Promise<boolean> {
+  const effective = await effectiveTemplateFiles(templateDirs);
+  return effective.has(SEARCH_INDEX_SCRIPT);
 }
 
 /**
@@ -504,11 +536,18 @@ export async function generatePackageJson(
     tailwindcss: PINNED_VERSIONS.tailwindcss,
     eslint: PINNED_VERSIONS.eslint,
     "eslint-config-next": runtimeVersions["eslint-config-next"],
-    // Pagefind powers /search in the blog template. Zero-config
-    // static index generated at `next build` time. Templates that
-    // don't ship a /search page simply won't invoke it.
-    pagefind: "^1.1.0",
   };
+
+  // Derived from the merged template tree, so a template that gains or loses the
+  // Pagefind builder changes the generated manifest without anyone editing a list.
+  const shipsSearchIndex = await templateShipsSearchIndex(templateDirs);
+
+  // Pagefind builds the static index behind /search. DECLARED only where the
+  // builder ships, because the index script invokes it through `node`, which
+  // resolves from node_modules — an undeclared dependency that happens to be
+  // fetched on demand by some other route would build here and fail for a user
+  // whose registry or network says otherwise.
+  if (shipsSearchIndex) devDependencies.pagefind = "^1.1.0";
 
   // NOTE: the build-script allowlist (better-sqlite3, sharp, esbuild,
   // unrs-resolver) is NOT emitted here. pnpm 11 no longer reads the `pnpm`
@@ -526,12 +565,29 @@ export async function generatePackageJson(
       // prompts, and child supervision. `nextly dev` is gone; the only
       // supported dev command is the standard `next dev`.
       dev: "next dev --turbopack",
-      // Build: migrate DB + compile Next.js + (if present) generate
-      // the Pagefind search index. Templates without the search
-      // script silently skip the last step.
-      build:
-        "nextly migrate && next build && (test -f scripts/build-search-index.mjs && node scripts/build-search-index.mjs || true)",
-      "search:index": "node scripts/build-search-index.mjs",
+      // Build: migrate the database, compile Next.js, and generate the Pagefind
+      // search index for the templates that ship its builder.
+      //
+      // Whether that last step appears is decided HERE, from the files the
+      // scaffold actually received, rather than by a shell conditional in the
+      // script. Two reasons, and both were live:
+      //
+      // `npm run` uses cmd.exe on Windows, which has no `test` and no `true` —
+      // so the `(test -f … || true)` form this replaces failed for every Windows
+      // user, after `next build` had already succeeded. `&&` is all that remains,
+      // and cmd.exe understands it.
+      //
+      // And `|| true` turned a failed index build into a successful one. The
+      // search page then ships pointing at an index that was never written,
+      // which fails in the browser rather than in CI.
+      build: shipsSearchIndex
+        ? "nextly migrate && next build && node scripts/build-search-index.mjs"
+        : "nextly migrate && next build",
+      // Offered only where the file exists. A script that always fails is worse
+      // than an absent one: it reads as a supported command.
+      ...(shipsSearchIndex
+        ? { "search:index": "node scripts/build-search-index.mjs" }
+        : {}),
       start: "next start",
       lint: "next lint",
       nextly: "nextly",


### PR DESCRIPTION
## The bug

Every project scaffolded by `create-nextly-app` fails `npm run build` on Windows.

The generated script was:

```
nextly migrate && next build && (test -f scripts/build-search-index.mjs && node scripts/build-search-index.mjs || true)
```

`npm run` executes scripts through `cmd.exe` on Windows, which has neither `test`
nor `true`. So the last segment fails, and takes the whole script down with it —
**after `next build` has already succeeded**, which is what makes the error read
as unrelated to the thing that caused it.

This affects every template, not one.

## Why CI never saw it

`Scaffold smoke (windows-latest)` in `ci.yml` runs the CLI with `--skip-install`
and asserts only that `smoke-app/package.json` exists. Nothing anywhere executes
a generated build script on Windows.

This repository has been bitten by the same class before: `packages/ui`'s `dev`
script used `a --watch & b --watch & wait`, `cmd.exe` treats `&` as sequential
and has no `wait`, and the second watcher silently never ran.
`packages/ui/src/__tests__/package-scripts-are-cross-platform.test.ts` now
refuses that construct — but its domain is the WORKSPACE manifests, and a script
this CLI writes into a user's project is not one of them. Same defect, one
directory over, outside the guard's reach.

## The fix

Stop emitting a shell conditional at all. Whether the Pagefind step appears is
decided when the manifest is written, from the files the scaffold actually
receives:

```
blank:  nextly migrate && next build
blog:   nextly migrate && next build && node scripts/build-search-index.mjs
```

`&&` is all that remains, and `cmd.exe` understands it.

Three things follow from that, and each is a fix in its own right:

- **`|| true` is gone.** It turned a failed index build into a successful one,
  so a project could ship a search page pointing at an index that was never
  written — failing in the browser rather than in CI.
- **`search:index` is emitted only where the file exists.** A script that always
  fails is worse than an absent one: it reads as a supported command.
- **`pagefind` is declared only where its builder ships.** It was an
  unconditional devDependency, so every blank scaffold installed it for nothing.

The decision is DERIVED from the merged template tree rather than from a list of
template names, through the same merge the font collector already uses — later
directory winning, because that is what the copy does. A hand-kept "which
templates have search" mapping would be a second answer to a question the
templates already answer.

## Tests

- **`generated-scripts-are-cross-platform.test.ts`** — a new guard whose domain
  is the generator's OUTPUT, over every template. It carries a control in both
  directions: it must reject the exact script that shipped before (two distinct
  offences), and accept the replacement. Without the first, a detector whose
  patterns quietly stopped matching would report every script clean.
- **`template-search-index.test.ts`** — the positive branch, read against the
  REAL `templates/base` and `templates/blog`. A fixture directory would keep
  passing after the builder moved or was renamed, which is the change most
  likely to break the derivation. It asserts the directories exist first, so an
  empty tree cannot make every "no builder here" check pass.
- The existing assertion pinning the old build string is updated rather than
  deleted, and now also asserts `search:index` is absent.

Break-verified in both directions: restoring the old script fails the guard for
both templates while leaving its controls passing, and forcing the derivation to
`false` fails the blog cases. 184 tests pass; `check-types` and `lint` clean.

## Provenance

Found by Codex on #764 while reviewing the scaffold CI job. Split out because it
is a product bug rather than a coverage gap — that PR is CI-only and carries no
changeset. The Windows CI leg it also asks for is filed in
`tasks/left-tasks/2026-08-14-0600-scaffold-job-covers-one-template-one-node-and-only-fresh-projects.md`
alongside the other coverage gaps from the same review.
