### PR TITLE
fix(blocks-engine): say why a document cannot be stored, not only that it cannot

### DIFF
--- a/.changeset/measure-bytes-brand-and-bound.md
+++ b/.changeset/measure-bytes-brand-and-bound.md
@@ -1,0 +1,28 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+Decide a boxed BigInt by its internal slot rather than by `Symbol.toStringTag`, so a document cannot tag itself unstorable, and skip the whole-document serialization for a document the engine already refused as too large.

--- a/packages/blocks-engine/src/index.ts
+++ b/packages/blocks-engine/src/index.ts
@@ -70,6 +70,11 @@ export {
 export type { NodeLocation, TreePosition } from "./tree";
 
 export { validate, ISSUE_CODES, measureBytes } from "./validation";
+// The measurement's return type travels with the function. Without it a
+// consumer naming `measureBytes`'s result has to rebuild the union by hand or
+// reach for `ReturnType`, and a hand-rebuilt copy is the second statement of a
+// contract that then drifts from the first.
+export type { ByteMeasurement } from "./validation";
 /**
  * The registry-independent facts about a node, exported so a caller holding no
  * block registry can still refuse a malformed one. The editor's op layer is the

--- a/packages/blocks-engine/src/validation.test.ts
+++ b/packages/blocks-engine/src/validation.test.ts
@@ -1934,6 +1934,28 @@ describe("measureBytes says WHY a value cannot be stored", () => {
     });
   });
 
+  it("writes an object that only CLAIMS to be a BigInt", () => {
+    // `Symbol.toStringTag` is an ordinary writable property of the document
+    // under inspection, so `Object.prototype.toString` reports whatever the
+    // document says. This value tags itself `[object BigInt]` and the writer
+    // stores it regardless, which is why the refusal is decided by the internal
+    // slot instead: classifying by the tag would let block props declare
+    // themselves unstorable and lock their own author out.
+    const spoof = { [Symbol.toStringTag]: "BigInt", x: 1 };
+    const written = JSON.stringify({ v: spoof });
+
+    // The positive control for the pair: the writer really does store one and
+    // really does refuse the other, so the two cases are genuinely different
+    // rather than both being accepted.
+    expect(written).toBe('{"v":{"x":1}}');
+    expect(() => JSON.stringify({ v: Object(1n) })).toThrow(TypeError);
+
+    expect(measureBytes({ v: spoof }, 1_000)).toEqual({
+      bytes: Buffer.byteLength(written, "utf8"),
+      exceeded: false,
+    });
+  });
+
   it("still says over-limit when the document is merely too big", () => {
     // The distinction is the whole point: these two need opposite advice, and
     // a single boolean cannot tell an author which one they have.

--- a/packages/blocks-engine/src/validation.test.ts
+++ b/packages/blocks-engine/src/validation.test.ts
@@ -1910,25 +1910,3 @@ describe("measureBytes agrees with the serializer on hooks and cycles", () => {
     expect(measureBytes(value, 1_000).bytes).toBe(written);
   });
 });
-
-describe("measureBytes reports what the writer refuses", () => {
-  it("calls a BigInt unstorable rather than counting it", () => {
-    // `JSON.stringify` THROWS on a BigInt — it neither writes nor drops it — so
-    // counting it as an ordinary value reports a document as fitting that the
-    // writer refuses entirely.
-    expect(measureBytes({ x: 1n }, 100)).toEqual({
-      bytes: expect.any(Number) as number,
-      exceeded: true,
-    });
-  });
-
-  it("calls a boxed BigInt unstorable too", () => {
-    // `Object(1n)` is a BigInt OBJECT, so `typeof` reports "object" and the walk
-    // would otherwise treat it as an ordinary record with no own keys — two
-    // bytes for a value the writer will not write at all.
-    expect(measureBytes({ x: Object(1n) }, 100)).toEqual({
-      bytes: expect.any(Number) as number,
-      exceeded: true,
-    });
-  });
-});

--- a/packages/blocks-engine/src/validation.test.ts
+++ b/packages/blocks-engine/src/validation.test.ts
@@ -1992,3 +1992,42 @@ describe("measureBytes says WHY a value cannot be stored", () => {
     });
   });
 });
+
+describe("measureBytes stays cheap on ordinary objects", () => {
+  it("does not throw once per record while looking for boxed BigInts", () => {
+    // The unspoofable brand check costs a thrown exception for every value that
+    // is not a BigInt, so running it on every record would pay that across the
+    // whole document. `props` is not covered by the node cap, so an ordinary
+    // request can carry hundreds of thousands of small objects.
+    //
+    // Asserted as a RATIO against the same walk over primitives rather than as
+    // a wall-clock bound, because an absolute millisecond figure measures the
+    // machine. A throw per record is a ~100x cost and shows up either way.
+    const records = Array.from({ length: 20_000 }, () => ({}));
+    const numbers = Array.from({ length: 20_000 }, () => 0);
+
+    const startRecords = performance.now();
+    measureBytes({ v: records }, Number.POSITIVE_INFINITY);
+    const recordsMs = performance.now() - startRecords;
+
+    const startNumbers = performance.now();
+    measureBytes({ v: numbers }, Number.POSITIVE_INFINITY);
+    const numbersMs = performance.now() - startNumbers;
+
+    expect(
+      recordsMs / Math.max(numbersMs, 0.01),
+      `walking ${String(records.length)} records took ${recordsMs.toFixed(1)}ms ` +
+        `against ${numbersMs.toFixed(1)}ms for the same count of numbers`
+    ).toBeLessThan(20);
+  });
+
+  it("still refuses a boxed BigInt and still writes a tag that only claims to be one", () => {
+    // The positive control for the pre-filter: it must not have bought its
+    // speed by giving up either answer.
+    expect(measureBytes({ x: Object(1n) }, 100).exceeded).toBe(true);
+    expect(
+      measureBytes({ v: { [Symbol.toStringTag]: "BigInt", x: 1 } }, 1_000)
+        .exceeded
+    ).toBe(false);
+  });
+});

--- a/packages/blocks-engine/src/validation.test.ts
+++ b/packages/blocks-engine/src/validation.test.ts
@@ -1994,36 +1994,39 @@ describe("measureBytes says WHY a value cannot be stored", () => {
 });
 
 describe("measureBytes stays cheap on ordinary objects", () => {
-  it("does not throw once per record while looking for boxed BigInts", () => {
-    // The unspoofable brand check costs a thrown exception for every value that
-    // is not a BigInt, so running it on every record would pay that across the
-    // whole document. `props` is not covered by the node cap, so an ordinary
-    // request can carry hundreds of thousands of small objects.
+  it("never reaches the slot check for a value that is not tagged a BigInt", () => {
+    // The mechanism, counted, rather than the wall clock. The slot check costs
+    // a thrown exception per call, so the defect is "it runs on every record" —
+    // and that is a count, not a duration. Measured as a timing ratio the same
+    // code produced 3.3x and 58x on one machine minutes apart, so a threshold
+    // between them is noise either way; a count separates exactly.
     //
-    // Asserted as a RATIO against the same walk over primitives rather than as
-    // a wall-clock bound, because an absolute millisecond figure measures the
-    // machine. A throw per record is a ~100x cost and shows up either way.
+    // `props` is not covered by the node cap, so an ordinary request can carry
+    // hundreds of thousands of small records through here.
     const records = Array.from({ length: 20_000 }, () => ({}));
-    const numbers = Array.from({ length: 20_000 }, () => 0);
+    const original = BigInt.prototype.valueOf;
+    let calls = 0;
+    BigInt.prototype.valueOf = function countingValueOf(this: unknown): bigint {
+      calls += 1;
+      return original.call(this);
+    };
 
-    const startRecords = performance.now();
-    measureBytes({ v: records }, Number.POSITIVE_INFINITY);
-    const recordsMs = performance.now() - startRecords;
-
-    const startNumbers = performance.now();
-    measureBytes({ v: numbers }, Number.POSITIVE_INFINITY);
-    const numbersMs = performance.now() - startNumbers;
+    try {
+      measureBytes({ v: records }, Number.POSITIVE_INFINITY);
+    } finally {
+      BigInt.prototype.valueOf = original;
+    }
 
     expect(
-      recordsMs / Math.max(numbersMs, 0.01),
-      `walking ${String(records.length)} records took ${recordsMs.toFixed(1)}ms ` +
-        `against ${numbersMs.toFixed(1)}ms for the same count of numbers`
-    ).toBeLessThan(20);
+      calls,
+      `the slot check ran ${String(calls)} times for ${String(records.length)} ` +
+        `ordinary records, each one a thrown exception`
+    ).toBe(0);
   });
 
   it("still refuses a boxed BigInt and still writes a tag that only claims to be one", () => {
     // The positive control for the pre-filter: it must not have bought its
-    // speed by giving up either answer.
+    // cheapness by giving up either answer.
     expect(measureBytes({ x: Object(1n) }, 100).exceeded).toBe(true);
     expect(
       measureBytes({ v: { [Symbol.toStringTag]: "BigInt", x: 1 } }, 1_000)

--- a/packages/blocks-engine/src/validation.test.ts
+++ b/packages/blocks-engine/src/validation.test.ts
@@ -1993,48 +1993,6 @@ describe("measureBytes says WHY a value cannot be stored", () => {
   });
 });
 
-describe("measureBytes stays cheap on ordinary objects", () => {
-  it("never reaches the slot check for a value that is not tagged a BigInt", () => {
-    // The mechanism, counted, rather than the wall clock. The slot check costs
-    // a thrown exception per call, so the defect is "it runs on every record" —
-    // and that is a count, not a duration. Measured as a timing ratio the same
-    // code produced 3.3x and 58x on one machine minutes apart, so a threshold
-    // between them is noise either way; a count separates exactly.
-    //
-    // `props` is not covered by the node cap, so an ordinary request can carry
-    // hundreds of thousands of small records through here.
-    const records = Array.from({ length: 20_000 }, () => ({}));
-    const original = BigInt.prototype.valueOf;
-    let calls = 0;
-    BigInt.prototype.valueOf = function countingValueOf(this: unknown): bigint {
-      calls += 1;
-      return original.call(this);
-    };
-
-    try {
-      measureBytes({ v: records }, Number.POSITIVE_INFINITY);
-    } finally {
-      BigInt.prototype.valueOf = original;
-    }
-
-    expect(
-      calls,
-      `the slot check ran ${String(calls)} times for ${String(records.length)} ` +
-        `ordinary records, each one a thrown exception`
-    ).toBe(0);
-  });
-
-  it("still refuses a boxed BigInt and still writes a tag that only claims to be one", () => {
-    // The positive control for the pre-filter: it must not have bought its
-    // cheapness by giving up either answer.
-    expect(measureBytes({ x: Object(1n) }, 100).exceeded).toBe(true);
-    expect(
-      measureBytes({ v: { [Symbol.toStringTag]: "BigInt", x: 1 } }, 1_000)
-        .exceeded
-    ).toBe(false);
-  });
-});
-
 describe("measureBytes reads nothing the writer would not", () => {
   it("does not invoke a Symbol.toStringTag getter the document defined", () => {
     // `JSON.stringify` ignores symbol keys, so it never runs this getter and
@@ -2084,5 +2042,45 @@ describe("measureBytes reads nothing the writer would not", () => {
       configurable: true,
     });
     expect(measureBytes({ v: tagged }, 1_000).exceeded).toBe(true);
+  });
+});
+
+describe("measureBytes probes a value only where the writer does", () => {
+  it("does not execute a proxy's descriptor trap", () => {
+    // The writer reads `toJSON` and own keys, and never asks for
+    // `Symbol.toStringTag`. A probe that does is observable through a Proxy
+    // trap even when no ordinary getter is involved, and a trap that throws
+    // turns a document the writer stores into a raised error.
+    const trapped: string[] = [];
+    const hostile = new Proxy(
+      { x: 1 },
+      {
+        getOwnPropertyDescriptor(target, key) {
+          trapped.push(String(key));
+          if (key === Symbol.toStringTag) throw new Error("descriptor trap");
+          return Reflect.getOwnPropertyDescriptor(target, key);
+        },
+      }
+    );
+
+    // The control: the writer really does accept it, so raising here would be
+    // a disagreement with the thing being counted.
+    expect(JSON.stringify({ v: hostile })).toBe('{"v":{"x":1}}');
+    expect(() => measureBytes({ v: hostile }, 1_000)).not.toThrow();
+    expect(
+      trapped.filter(key => key.includes("toStringTag")),
+      "the counter asked for a symbol the writer never asks for"
+    ).toEqual([]);
+  });
+
+  it("refuses a boxed BigInt whose prototype was replaced", () => {
+    // A prototype-based filter would call this an ordinary object. The writer
+    // still refuses it, so the counter has to as well or the two disagree
+    // about a document that cannot be stored.
+    const disguised = Object(1n) as object;
+    Object.setPrototypeOf(disguised, Object.prototype);
+
+    expect(() => JSON.stringify({ v: disguised })).toThrow(TypeError);
+    expect(measureBytes({ v: disguised }, 1_000).exceeded).toBe(true);
   });
 });

--- a/packages/blocks-engine/src/validation.test.ts
+++ b/packages/blocks-engine/src/validation.test.ts
@@ -1887,6 +1887,7 @@ describe("measureBytes agrees with the serializer on hooks and cycles", () => {
     expect(measureBytes(value, Number.POSITIVE_INFINITY)).toEqual({
       bytes: expect.any(Number) as number,
       exceeded: true,
+      reason: "unwritable",
     });
   });
 
@@ -1908,5 +1909,40 @@ describe("measureBytes agrees with the serializer on hooks and cycles", () => {
     const written = Buffer.byteLength(JSON.stringify(value), "utf8");
 
     expect(measureBytes(value, 1_000).bytes).toBe(written);
+  });
+});
+
+describe("measureBytes says WHY a value cannot be stored", () => {
+  it("calls a BigInt unwritable rather than counting it", () => {
+    // `JSON.stringify` THROWS on a BigInt — it neither writes nor drops it — so
+    // counting it as an ordinary value reports a document as fitting that the
+    // writer refuses entirely.
+    expect(measureBytes({ x: 1n }, 100)).toEqual({
+      bytes: expect.any(Number) as number,
+      exceeded: true,
+      reason: "unwritable",
+    });
+  });
+
+  it("calls a boxed BigInt unwritable too", () => {
+    // `Object(1n)` is a BigInt OBJECT, so `typeof` reports "object" and the
+    // walk would treat it as an ordinary record with no own keys.
+    expect(measureBytes({ x: Object(1n) }, 100)).toEqual({
+      bytes: expect.any(Number) as number,
+      exceeded: true,
+      reason: "unwritable",
+    });
+  });
+
+  it("still says over-limit when the document is merely too big", () => {
+    // The distinction is the whole point: these two need opposite advice, and
+    // a single boolean cannot tell an author which one they have.
+    const measured = measureBytes({ x: "y".repeat(500) }, 100);
+
+    expect(measured).toEqual({
+      bytes: expect.any(Number) as number,
+      exceeded: true,
+      reason: "over-limit",
+    });
   });
 });

--- a/packages/blocks-engine/src/validation.test.ts
+++ b/packages/blocks-engine/src/validation.test.ts
@@ -2034,3 +2034,55 @@ describe("measureBytes stays cheap on ordinary objects", () => {
     ).toBe(false);
   });
 });
+
+describe("measureBytes reads nothing the writer would not", () => {
+  it("does not invoke a Symbol.toStringTag getter the document defined", () => {
+    // `JSON.stringify` ignores symbol keys, so it never runs this getter and
+    // stores the object as `{}`. A measurement that runs it is executing
+    // document-supplied code the writer does not, which lets a throwing getter
+    // escape a function contracted to report rather than raise, and lets a
+    // getter with side effects mutate a document while it is being measured.
+    let reads = 0;
+    const watched = { x: 1 };
+    Object.defineProperty(watched, Symbol.toStringTag, {
+      get: () => {
+        reads += 1;
+        return "BigInt";
+      },
+      configurable: true,
+    });
+
+    const measured = measureBytes({ v: watched }, 1_000);
+
+    expect(reads, "the tag getter ran during measurement").toBe(0);
+    // And the verdict still matches the writer, which stores it.
+    expect(measured.exceeded).toBe(false);
+  });
+
+  it("does not raise when a tag getter throws, because the writer stores it", () => {
+    const hostile = { x: 1 };
+    Object.defineProperty(hostile, Symbol.toStringTag, {
+      get: () => {
+        throw new Error("tag getter");
+      },
+      configurable: true,
+    });
+
+    // The control: the writer really does accept this value, so refusing it
+    // or raising here would be a disagreement with the thing being counted.
+    expect(JSON.stringify({ v: hostile })).toBe('{"v":{"x":1}}');
+    expect(() => measureBytes({ v: hostile }, 1_000)).not.toThrow();
+    expect(measureBytes({ v: hostile }, 1_000).exceeded).toBe(false);
+  });
+
+  it("still refuses a boxed BigInt that carries a tag of its own", () => {
+    // The slot check is what a declared tag falls through to, so this is the
+    // case proving the fall-through still reaches the right answer.
+    const tagged = Object(1n) as object;
+    Object.defineProperty(tagged, Symbol.toStringTag, {
+      value: "Object",
+      configurable: true,
+    });
+    expect(measureBytes({ v: tagged }, 1_000).exceeded).toBe(true);
+  });
+});

--- a/packages/blocks-engine/src/validation.test.ts
+++ b/packages/blocks-engine/src/validation.test.ts
@@ -1910,3 +1910,25 @@ describe("measureBytes agrees with the serializer on hooks and cycles", () => {
     expect(measureBytes(value, 1_000).bytes).toBe(written);
   });
 });
+
+describe("measureBytes reports what the writer refuses", () => {
+  it("calls a BigInt unstorable rather than counting it", () => {
+    // `JSON.stringify` THROWS on a BigInt — it neither writes nor drops it — so
+    // counting it as an ordinary value reports a document as fitting that the
+    // writer refuses entirely.
+    expect(measureBytes({ x: 1n }, 100)).toEqual({
+      bytes: expect.any(Number) as number,
+      exceeded: true,
+    });
+  });
+
+  it("calls a boxed BigInt unstorable too", () => {
+    // `Object(1n)` is a BigInt OBJECT, so `typeof` reports "object" and the walk
+    // would otherwise treat it as an ordinary record with no own keys — two
+    // bytes for a value the writer will not write at all.
+    expect(measureBytes({ x: Object(1n) }, 100)).toEqual({
+      bytes: expect.any(Number) as number,
+      exceeded: true,
+    });
+  });
+});

--- a/packages/blocks-engine/src/validation.test.ts
+++ b/packages/blocks-engine/src/validation.test.ts
@@ -1934,6 +1934,30 @@ describe("measureBytes says WHY a value cannot be stored", () => {
     });
   });
 
+  it("reports whichever refusal the bounded walk reaches first", () => {
+    // A document can be BOTH unwritable and over the limit, and one `reason`
+    // can only carry one of them. Which one surfaces is decided by traversal:
+    // the walk returns at the FIRST refusal it reaches and never looks further,
+    // because establishing that no unwritable value exists anywhere would mean
+    // reading the whole document — exactly the unbounded pass this counter
+    // exists to avoid.
+    //
+    // The traversal is a LIFO stack, so an object's LAST entry is visited
+    // first. That makes the answer depend on declaration order, which is
+    // pinned here as the measured behaviour rather than defended as a policy:
+    // nothing outside this walk can predict it, so no caller may rely on which
+    // reason arrives for a document that is both.
+    const reached = measureBytes({ pad: "x".repeat(500), bad: 1n }, 100);
+    const notReached = measureBytes({ bad: 1n, pad: "x".repeat(500) }, 100);
+
+    expect(reached.exceeded && reached.reason).toBe("unwritable");
+    expect(notReached.exceeded && notReached.reason).toBe("over-limit");
+
+    // What a caller MAY rely on, and the reason both spellings are safe to
+    // reject on: either way the document is refused.
+    expect([reached.exceeded, notReached.exceeded]).toEqual([true, true]);
+  });
+
   it("writes an object that only CLAIMS to be a BigInt", () => {
     // `Symbol.toStringTag` is an ordinary writable property of the document
     // under inspection, so `Object.prototype.toString` reports whatever the

--- a/packages/blocks-engine/src/validation.ts
+++ b/packages/blocks-engine/src/validation.ts
@@ -560,6 +560,30 @@ function serializesAs(value: unknown): boolean {
 }
 
 /**
+ * A value `JSON.stringify` REFUSES outright, rather than writes or drops.
+ *
+ * The third of the three things the writer can do with a value, and the one
+ * this counter had no way to express: `undefined`, functions and symbols are
+ * DROPPED ({@link serializesAs}); everything else is written; and a BigInt makes
+ * `JSON.stringify` throw. Counting it as an ordinary value reports
+ * `measureBytes({ x: 1n }, 100)` as `{ bytes: 6, exceeded: false }` while the
+ * writer refuses the whole document — so a caller using this as the documented
+ * storage-cap check admits data that cannot be persisted.
+ *
+ * The boxed form is included because `Object(1n)` is a `BigInt` object rather
+ * than a primitive, so `typeof` reports `"object"` and the walk would treat it
+ * as an ordinary record with no own keys.
+ */
+function refusedByWriter(value: unknown): boolean {
+  return (
+    typeof value === "bigint" ||
+    (typeof value === "object" &&
+      value !== null &&
+      Object.prototype.toString.call(value) === "[object BigInt]")
+  );
+}
+
+/**
  * A value as `JSON.stringify` will SEE it: through `toJSON` when one exists.
  *
  * The hook runs before the writer decides anything else about the value —
@@ -626,6 +650,10 @@ export function measureBytes(
     // not open. A public caller has made no such promise.
     const value =
       entry.normalized === true ? popped : asSerialized(popped, entry.key);
+    // REFUSED, not counted. Reported through the same `exceeded` verdict a
+    // cycle uses, rather than thrown, because the callers here are validators
+    // that must turn an unstorable document into an issue.
+    if (refusedByWriter(value)) return { bytes, exceeded: true };
     if (typeof value === "object" && value !== null) {
       // REPORTED, not thrown. A cyclic value has no serialized form, so it
       // cannot be stored — which is a verdict this function already has a way

--- a/packages/blocks-engine/src/validation.ts
+++ b/packages/blocks-engine/src/validation.ts
@@ -560,30 +560,6 @@ function serializesAs(value: unknown): boolean {
 }
 
 /**
- * A value `JSON.stringify` REFUSES outright, rather than writes or drops.
- *
- * The third of the three things the writer can do with a value, and the one
- * this counter had no way to express: `undefined`, functions and symbols are
- * DROPPED ({@link serializesAs}); everything else is written; and a BigInt makes
- * `JSON.stringify` throw. Counting it as an ordinary value reports
- * `measureBytes({ x: 1n }, 100)` as `{ bytes: 6, exceeded: false }` while the
- * writer refuses the whole document — so a caller using this as the documented
- * storage-cap check admits data that cannot be persisted.
- *
- * The boxed form is included because `Object(1n)` is a `BigInt` object rather
- * than a primitive, so `typeof` reports `"object"` and the walk would treat it
- * as an ordinary record with no own keys.
- */
-function refusedByWriter(value: unknown): boolean {
-  return (
-    typeof value === "bigint" ||
-    (typeof value === "object" &&
-      value !== null &&
-      Object.prototype.toString.call(value) === "[object BigInt]")
-  );
-}
-
-/**
  * A value as `JSON.stringify` will SEE it: through `toJSON` when one exists.
  *
  * The hook runs before the writer decides anything else about the value —
@@ -650,10 +626,6 @@ export function measureBytes(
     // not open. A public caller has made no such promise.
     const value =
       entry.normalized === true ? popped : asSerialized(popped, entry.key);
-    // REFUSED, not counted. Reported through the same `exceeded` verdict a
-    // cycle uses, rather than thrown, because the callers here are validators
-    // that must turn an unstorable document into an issue.
-    if (refusedByWriter(value)) return { bytes, exceeded: true };
     if (typeof value === "object" && value !== null) {
       // REPORTED, not thrown. A cyclic value has no serialized form, so it
       // cannot be stored — which is a verdict this function already has a way

--- a/packages/blocks-engine/src/validation.ts
+++ b/packages/blocks-engine/src/validation.ts
@@ -623,10 +623,42 @@ export type ByteMeasurement =
  * while a spoofed one passes the tag and is then correctly refused. Neither
  * check is sufficient alone: the tag over-reports and the slot is expensive.
  */
+function definesToStringTag(value: object): boolean {
+  for (
+    let link: object | null = value;
+    link !== null;
+    link = Object.getPrototypeOf(link) as object | null
+  ) {
+    if (
+      Object.getOwnPropertyDescriptor(link, Symbol.toStringTag) !== undefined
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
 function refusedByWriter(value: unknown): boolean {
   if (typeof value === "bigint") return true;
   if (typeof value !== "object" || value === null) return false;
-  if (Object.prototype.toString.call(value) !== "[object BigInt]") return false;
+  // The tag is consulted only where the DOCUMENT has not defined one, which is
+  // the ordinary case and the cheap one. There the tag is the engine's own
+  // answer, no accessor exists to run, and no builtin other than a BigInt
+  // object reports `[object BigInt]`.
+  //
+  // Presence is decided by descriptor lookup rather than by reading the value,
+  // because reading it would invoke a document-supplied getter — code
+  // `JSON.stringify` never runs, since it ignores symbol keys entirely. A
+  // throwing getter would escape a function whose whole contract is to report
+  // rather than raise, and a getter with side effects would let a document
+  // mutate itself while being measured.
+  if (!definesToStringTag(value)) {
+    return Object.prototype.toString.call(value) === "[object BigInt]";
+  }
+  // A document-defined tag decides nothing, so the internal slot does. This
+  // costs a thrown exception, and it is reached only by values that declare a
+  // tag — rare in a block document, and the only place the cost can be
+  // provoked deliberately.
   try {
     BigInt.prototype.valueOf.call(value);
     return true;

--- a/packages/blocks-engine/src/validation.ts
+++ b/packages/blocks-engine/src/validation.ts
@@ -160,6 +160,8 @@ export const ISSUE_CODES = {
   "node-count-exceeded":
     "The document has more nodes than the allowed maximum.",
   "document-too-large": "The serialized document exceeds the byte limit.",
+  "document-unwritable":
+    "The document holds a value JSON cannot write, so it has no stored form.",
   "document-size-warning":
     "The serialized document is approaching the byte limit.",
   "missing-node-id": "A node is missing its id or the id is empty.",
@@ -575,10 +577,46 @@ function asSerialized(value: unknown, key: string): unknown {
     : value;
 }
 
-export function measureBytes(
-  root: unknown,
-  limit: number
-): { bytes: number; exceeded: boolean } {
+/**
+ * What a byte measurement can say, and the two answers are different questions.
+ *
+ * `exceeded` means "this will not fit", and `reason` says WHY it cannot be
+ * stored — which the caller needs, because the two causes deserve opposite
+ * advice. A document over the limit is fixed by removing content; one holding a
+ * BigInt is not made smaller by deleting blocks, and telling its author it is
+ * "too large" sends them to work that cannot help.
+ *
+ * The union keeps `exceeded` a boolean, so a caller that only asks "does it
+ * fit?" is unchanged, while a caller that reports the problem can narrow on it.
+ */
+export type ByteMeasurement =
+  | { bytes: number; exceeded: false }
+  | { bytes: number; exceeded: true; reason: "over-limit" | "unwritable" };
+
+/**
+ * A value `JSON.stringify` REFUSES, rather than writes or drops.
+ *
+ * The third thing the writer can do with a value, and the one this counter had
+ * no way to express: `undefined`, functions and symbols are DROPPED
+ * ({@link serializesAs}); everything else is written; and a BigInt makes
+ * `JSON.stringify` throw. Counting it as an ordinary value reports
+ * `measureBytes({ x: 1n }, 100)` as fitting in 6 bytes while the writer refuses
+ * the whole document.
+ *
+ * The boxed form is included because `Object(1n)` is a BigInt OBJECT, so
+ * `typeof` reports `"object"` and the walk would treat it as an ordinary record
+ * with no own keys — two bytes for a value that cannot be written at all.
+ */
+function refusedByWriter(value: unknown): boolean {
+  return (
+    typeof value === "bigint" ||
+    (typeof value === "object" &&
+      value !== null &&
+      Object.prototype.toString.call(value) === "[object BigInt]")
+  );
+}
+
+export function measureBytes(root: unknown, limit: number): ByteMeasurement {
   let bytes = 0;
   // Each entry carries the KEY it sits under, because `toJSON` receives it.
   // `JSON.stringify` passes the containing property name — the index as a
@@ -626,6 +664,9 @@ export function measureBytes(
     // not open. A public caller has made no such promise.
     const value =
       entry.normalized === true ? popped : asSerialized(popped, entry.key);
+    if (refusedByWriter(value)) {
+      return { bytes, exceeded: true, reason: "unwritable" };
+    }
     if (typeof value === "object" && value !== null) {
       // REPORTED, not thrown. A cyclic value has no serialized form, so it
       // cannot be stored — which is a verdict this function already has a way
@@ -638,7 +679,9 @@ export function measureBytes(
       // added bytes until the cap stopped the walk. The cycle set is what makes
       // the exact-count mode (`limit` of `Infinity`) reach the same answer
       // instead of never terminating.
-      if (open.has(value)) return { bytes, exceeded: true };
+      if (open.has(value)) {
+        return { bytes, exceeded: true, reason: "unwritable" };
+      }
       open.add(value);
       stack.push({ value, key: entry.key, exiting: value });
     }
@@ -659,7 +702,7 @@ export function measureBytes(
       // BEFORE enqueuing elements: a huge array's comma count alone can exceed
       // the cap, so millions of entries must never be pushed first.
       bytes += 2 + Math.max(0, value.length - 1);
-      if (bytes > limit) return { bytes, exceeded: true };
+      if (bytes > limit) return { bytes, exceeded: true, reason: "over-limit" };
       // An element JSON cannot represent becomes `null` IN AN ARRAY, because an
       // array's length is part of its meaning. The same value inside an object
       // is dropped instead — see below. Normalised here so the walk never has
@@ -703,14 +746,15 @@ export function measureBytes(
       // the validator, which decides the same question with this counter, then
       // does not catch it either.
       bytes += 2 + Math.max(0, entries.length - 1);
-      if (bytes > limit) return { bytes, exceeded: true };
+      if (bytes > limit) return { bytes, exceeded: true, reason: "over-limit" };
       for (const [key, val] of entries) {
         bytes += utf8ByteLength(key, limit) + 3; // quotes + colon
-        if (bytes > limit) return { bytes, exceeded: true };
+        if (bytes > limit)
+          return { bytes, exceeded: true, reason: "over-limit" };
         stack.push({ value: val, key, normalized: true });
       }
     }
-    if (bytes > limit) return { bytes, exceeded: true };
+    if (bytes > limit) return { bytes, exceeded: true, reason: "over-limit" };
   }
   return { bytes, exceeded: false };
 }
@@ -748,8 +792,21 @@ function checkLimits(
   // Measure serialized size with a bounded, non-materializing counter: a
   // document that stays under the node/depth caps but hides a huge string must
   // still be rejected without allocating a full JSON copy of it.
-  const { bytes, exceeded } = measureBytes(doc, limits.maxBytes);
-  if (exceeded) {
+  const measured = measureBytes(doc, limits.maxBytes);
+  const bytes = measured.bytes;
+  // The CAUSE, not just the refusal. A document over the limit is fixed by
+  // removing content; one holding a value JSON cannot write is not made smaller
+  // by deleting blocks, and reporting it as "too large" sends its author to
+  // work that cannot help.
+  if (measured.exceeded && measured.reason === "unwritable") {
+    issues.push({
+      path: "",
+      code: "document-unwritable",
+      severity: "error",
+      message:
+        "Document holds a value JSON cannot write, so it has no stored form.",
+    });
+  } else if (measured.exceeded) {
     issues.push({
       path: "",
       code: "document-too-large",

--- a/packages/blocks-engine/src/validation.ts
+++ b/packages/blocks-engine/src/validation.ts
@@ -606,14 +606,25 @@ export type ByteMeasurement =
  * The boxed form is included because `Object(1n)` is a BigInt OBJECT, so
  * `typeof` reports `"object"` and the walk would treat it as an ordinary record
  * with no own keys — two bytes for a value that cannot be written at all.
+ *
+ * That boxed form is recognised by its internal slot rather than by its tag.
+ * `Object.prototype.toString` reads `Symbol.toStringTag`, which is an ordinary
+ * writable property of the document under inspection: `{ [Symbol.toStringTag]:
+ * "BigInt", x: 1 }` reports `[object BigInt]` and yet `JSON.stringify` writes it
+ * as `{"x":1}`. Classifying by the tag therefore lets block props declare
+ * themselves unstorable. `BigInt.prototype.valueOf` reaches the slot instead and
+ * throws for anything that does not have one, so no property the document can
+ * set changes the answer.
  */
 function refusedByWriter(value: unknown): boolean {
-  return (
-    typeof value === "bigint" ||
-    (typeof value === "object" &&
-      value !== null &&
-      Object.prototype.toString.call(value) === "[object BigInt]")
-  );
+  if (typeof value === "bigint") return true;
+  if (typeof value !== "object" || value === null) return false;
+  try {
+    BigInt.prototype.valueOf.call(value);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 export function measureBytes(root: unknown, limit: number): ByteMeasurement {

--- a/packages/blocks-engine/src/validation.ts
+++ b/packages/blocks-engine/src/validation.ts
@@ -607,58 +607,37 @@ export type ByteMeasurement =
  * `typeof` reports `"object"` and the walk would treat it as an ordinary record
  * with no own keys — two bytes for a value that cannot be written at all.
  *
- * That boxed form is decided by TWO checks, and the order is what keeps this
- * cheap. `Object.prototype.toString` reads `Symbol.toStringTag`, an ordinary
- * writable property of the document under inspection — `{ [Symbol.toStringTag]:
- * "BigInt", x: 1 }` reports `[object BigInt]` while `JSON.stringify` writes it
- * as `{"x":1}` — so the tag alone would let block props declare themselves
- * unstorable. `BigInt.prototype.valueOf` reaches the internal slot instead and
- * cannot be spoofed by any property the document sets.
- *
- * The slot check costs a thrown exception for every value that is not a BigInt,
- * so running it first would pay that on every ordinary object in the document.
- * Measured over 100,000 empty objects: 439ms as the only check, 3ms behind the
- * tag. The tag is therefore the cheap PRE-FILTER and the slot is the
- * CONFIRMATION — an ordinary object fails the tag and never reaches the throw,
- * while a spoofed one passes the tag and is then correctly refused. Neither
- * check is sufficient alone: the tag over-reports and the slot is expensive.
+ * How that boxed form is detected is stated at the check itself, because the
+ * cheap-looking alternatives are all wrong in ways that are not visible from
+ * here.
  */
-function definesToStringTag(value: object): boolean {
-  for (
-    let link: object | null = value;
-    link !== null;
-    link = Object.getPrototypeOf(link) as object | null
-  ) {
-    if (
-      Object.getOwnPropertyDescriptor(link, Symbol.toStringTag) !== undefined
-    ) {
-      return true;
-    }
-  }
-  return false;
-}
-
 function refusedByWriter(value: unknown): boolean {
   if (typeof value === "bigint") return true;
   if (typeof value !== "object" || value === null) return false;
-  // The tag is consulted only where the DOCUMENT has not defined one, which is
-  // the ordinary case and the cheap one. There the tag is the engine's own
-  // answer, no accessor exists to run, and no builtin other than a BigInt
-  // object reports `[object BigInt]`.
+  // The internal slot, and NOTHING else. Every cheaper test asks the value a
+  // question, and a value in a block document is untrusted input:
   //
-  // Presence is decided by descriptor lookup rather than by reading the value,
-  // because reading it would invoke a document-supplied getter — code
-  // `JSON.stringify` never runs, since it ignores symbol keys entirely. A
-  // throwing getter would escape a function whose whole contract is to report
-  // rather than raise, and a getter with side effects would let a document
-  // mutate itself while being measured.
-  if (!definesToStringTag(value)) {
-    return Object.prototype.toString.call(value) === "[object BigInt]";
-  }
-  // A document-defined tag decides nothing, so the internal slot does. This
-  // costs a thrown exception, and it is reached only by values that declare a
-  // tag — rare in a block document, and the only place the cost can be
-  // provoked deliberately.
+  // - `Symbol.toStringTag` is an ordinary writable property, so the tag both
+  //   over-reports — `{ [Symbol.toStringTag]: "BigInt", x: 1 }` is written as
+  //   `{"x":1}` — and runs a document-supplied getter that `JSON.stringify`
+  //   never runs, since it ignores symbol keys entirely.
+  // - Reading that tag's DESCRIPTOR instead avoids the getter and still
+  //   executes a Proxy's `getOwnPropertyDescriptor` trap. Measured: an empty
+  //   proxy whose trap throws only for `Symbol.toStringTag` is written as `{}`
+  //   by the writer while the probe raises out of a function contracted to
+  //   report rather than throw.
+  // - The prototype chain cannot decide it either. Measured:
+  //   `setPrototypeOf(Object(1n), Object.prototype)` is still refused by the
+  //   writer, so a prototype filter reports a storable document that the
+  //   writer then rejects — the counter and the writer disagreeing, which is
+  //   the one thing this function exists to prevent.
+  //
+  // `BigInt.prototype.valueOf` reads an internal slot: measured against a Proxy
+  // logging every trap, it triggers none, and it cannot be spoofed by any
+  // property the document sets. It costs a thrown exception per non-BigInt
+  // object, which is the price of asking a question the value cannot answer
+  // dishonestly; the count is bounded by the byte cap that admits those objects
+  // in the first place.
   try {
     BigInt.prototype.valueOf.call(value);
     return true;

--- a/packages/blocks-engine/src/validation.ts
+++ b/packages/blocks-engine/src/validation.ts
@@ -607,18 +607,26 @@ export type ByteMeasurement =
  * `typeof` reports `"object"` and the walk would treat it as an ordinary record
  * with no own keys — two bytes for a value that cannot be written at all.
  *
- * That boxed form is recognised by its internal slot rather than by its tag.
- * `Object.prototype.toString` reads `Symbol.toStringTag`, which is an ordinary
- * writable property of the document under inspection: `{ [Symbol.toStringTag]:
- * "BigInt", x: 1 }` reports `[object BigInt]` and yet `JSON.stringify` writes it
- * as `{"x":1}`. Classifying by the tag therefore lets block props declare
- * themselves unstorable. `BigInt.prototype.valueOf` reaches the slot instead and
- * throws for anything that does not have one, so no property the document can
- * set changes the answer.
+ * That boxed form is decided by TWO checks, and the order is what keeps this
+ * cheap. `Object.prototype.toString` reads `Symbol.toStringTag`, an ordinary
+ * writable property of the document under inspection — `{ [Symbol.toStringTag]:
+ * "BigInt", x: 1 }` reports `[object BigInt]` while `JSON.stringify` writes it
+ * as `{"x":1}` — so the tag alone would let block props declare themselves
+ * unstorable. `BigInt.prototype.valueOf` reaches the internal slot instead and
+ * cannot be spoofed by any property the document sets.
+ *
+ * The slot check costs a thrown exception for every value that is not a BigInt,
+ * so running it first would pay that on every ordinary object in the document.
+ * Measured over 100,000 empty objects: 439ms as the only check, 3ms behind the
+ * tag. The tag is therefore the cheap PRE-FILTER and the slot is the
+ * CONFIRMATION — an ordinary object fails the tag and never reaches the throw,
+ * while a spoofed one passes the tag and is then correctly refused. Neither
+ * check is sufficient alone: the tag over-reports and the slot is expensive.
  */
 function refusedByWriter(value: unknown): boolean {
   if (typeof value === "bigint") return true;
   if (typeof value !== "object" || value === null) return false;
+  if (Object.prototype.toString.call(value) !== "[object BigInt]") return false;
   try {
     BigInt.prototype.valueOf.call(value);
     return true;

--- a/packages/builder/src/ops.test.ts
+++ b/packages/builder/src/ops.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { applyOp, OpError, type BuilderOp, type NodePatch } from "./ops";
 
@@ -2716,5 +2716,82 @@ describe("an inverse that names a parent held twice", () => {
     expect(() =>
       applyOp(doc(), { kind: "insert", node: root, at: { index: 0 } }, deep)
     ).toThrow(/cannot be edited/);
+  });
+});
+
+describe("an inherited field is refused only when it would change the edit", () => {
+  const page = (nodes: BlockNode[]): BlockDocument => ({
+    formatVersion: DOCUMENT_FORMAT_VERSION,
+    kind: "page",
+    nodes,
+  });
+  const box = (id: string): BlockNode => ({
+    id,
+    type: "core/box",
+    version: 1,
+    props: {},
+  });
+
+  afterEach(() => {
+    delete (Object.prototype as Record<string, unknown>).slot;
+    delete (Object.prototype as Record<string, unknown>).parentId;
+  });
+
+  it("places at the top level while the prototype carries an undefined slot", () => {
+    // A top-level position owns no `slot`, so `"slot" in at` becomes true the
+    // moment anything assigns `undefined` to `Object.prototype`. Refusing on
+    // presence alone turned that into an editor that could not place a node
+    // anywhere — and the inherited `undefined` is exactly what a replay of the
+    // stored op resolves to, so nothing about the placement is unreproducible.
+    (Object.prototype as Record<string, unknown>).slot = undefined;
+
+    const applied = applyOp(page([box("a")]), {
+      kind: "insert",
+      node: box("b"),
+      at: { index: 1 },
+    });
+
+    expect(applied.document.nodes.map(n => n.id)).toEqual(["a", "b"]);
+  });
+
+  it("still refuses an inherited value that WOULD change the placement", () => {
+    // The control for the case above: the guard has to keep rejecting the
+    // pollution it was written for, or the fix has simply removed it.
+    (Object.prototype as Record<string, unknown>).parentId = "a";
+
+    expect(() =>
+      applyOp(page([box("a")]), {
+        kind: "insert",
+        node: box("b"),
+        at: { index: 0 },
+      })
+    ).toThrow(OpError);
+  });
+
+  it("refuses an inherited ACCESSOR without invoking it", () => {
+    // What a getter returns is unknowable without running it, and running
+    // document-supplied code inside a guard whose purpose is to reject before
+    // anything happens is the thing to avoid. So it is assumed significant.
+    let reads = 0;
+    Object.defineProperty(Object.prototype, "slot", {
+      get: () => {
+        reads += 1;
+        return undefined;
+      },
+      configurable: true,
+    });
+
+    try {
+      expect(() =>
+        applyOp(page([box("a")]), {
+          kind: "insert",
+          node: box("b"),
+          at: { index: 0 },
+        })
+      ).toThrow(OpError);
+      expect(reads, "the guard invoked the inherited getter").toBe(0);
+    } finally {
+      delete (Object.prototype as Record<string, unknown>).slot;
+    }
   });
 });

--- a/packages/builder/src/ops.ts
+++ b/packages/builder/src/ops.ts
@@ -907,6 +907,42 @@ export type BuilderOp =
  * already treats as absent — so the rule is applied by READING through this
  * rather than by adding a check beside each read.
  */
+/**
+ * Whether a field resolved through the PROTOTYPE would change what happens.
+ *
+ * The ownership guards exist because a value reached through the prototype is
+ * absent from what `JSON.stringify` writes, so the edit happens and the stored
+ * op cannot reproduce it. That argument needs the inherited value to mean
+ * something. An inherited `undefined` means exactly what an absent field means:
+ * the replayed op resolves it to `undefined` too, so the placement it
+ * reproduces IS the placement that happened, and refusing it turns harmless
+ * pollution into an editor that cannot place anything at the top level —
+ * `Object.prototype.slot = undefined` rejects every insert and move.
+ *
+ * Read through the DESCRIPTOR rather than the property, because an inherited
+ * accessor would otherwise run while this decides whether to refuse the op —
+ * document-supplied code executed by a guard, on a path whose whole purpose is
+ * to reject before anything happens. An accessor is treated as significant
+ * without being invoked: what it would return is unknowable without running it,
+ * and a value that cannot be shown to be absent has to be assumed present.
+ */
+function inheritedValueWouldBeLost(
+  record: Record<string, unknown>,
+  field: string
+): boolean {
+  if (!(field in record) || Object.hasOwn(record, field)) return false;
+  for (
+    let link: object | null = Object.getPrototypeOf(record) as object | null;
+    link !== null;
+    link = Object.getPrototypeOf(link) as object | null
+  ) {
+    const descriptor = Object.getOwnPropertyDescriptor(link, field);
+    if (descriptor === undefined) continue;
+    return !(holdsAValue(descriptor) && descriptor.value === undefined);
+  }
+  return false;
+}
+
 function ownValue(record: Record<string, unknown>, field: string): unknown {
   return Object.hasOwn(record, field) ? record[field] : undefined;
 }
@@ -2164,7 +2200,7 @@ function assertPosition(at: TreePosition, verb: string): void {
   // in this file reached nine sites because each round added a guard next to
   // whichever instance it was shown, and this is the ownership class's fifth.
   for (const field of ["index", "parentId", "slot"] as const) {
-    if (field in at && !Object.hasOwn(at, field)) {
+    if (inheritedValueWouldBeLost(at, field)) {
       throw new OpError(
         `${verb}: a position whose ${field} comes from the prototype rather ` +
           `than from the position cannot be applied: the placement would ` +
@@ -2617,7 +2653,7 @@ export function applyOp(
   // Checked against the vocabulary rather than per branch, so a field added to
   // an op later cannot be dispatched on without being owned.
   for (const field of OP_VOCABULARY) {
-    if (field in op && !Object.hasOwn(op, field)) {
+    if (inheritedValueWouldBeLost(op, field)) {
       throw new OpError(
         `an op whose ${describe(field)} comes from the prototype rather than ` +
           `from the op cannot be applied: the edit would run and the op would ` +

--- a/packages/plugin-page-builder/src/fields/blocks-validator.json-values.test.ts
+++ b/packages/plugin-page-builder/src/fields/blocks-validator.json-values.test.ts
@@ -5,8 +5,11 @@
  * symbol is silently dropped, so the check belongs before the value is
  * accepted rather than after it reaches the serializer.
  */
-import { DOCUMENT_FORMAT_VERSION } from "@nextlyhq/blocks-engine";
-import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_MAX_DOCUMENT_BYTES,
+  DOCUMENT_FORMAT_VERSION,
+} from "@nextlyhq/blocks-engine";
+import { describe, expect, it, vi } from "vitest";
 
 import { validateBlocksValue } from "./blocks-validator";
 
@@ -55,6 +58,35 @@ describe("unserializable values in a document", () => {
     );
     expect(issues[0].message).toContain("a");
     expect(issues[0].message).toContain("b");
+  });
+
+  it("does not serialize a document the engine already refused as too large", () => {
+    // The engine counts bytes without materializing, and stops at the cap — so
+    // an oversized document may be arbitrarily larger than the limit it broke.
+    // Serializing it here to name an offending key would allocate the full copy
+    // the counter exists to avoid, immediately before rejecting the document
+    // anyway.
+    const oversized = withProps({
+      big: "x".repeat(DEFAULT_MAX_DOCUMENT_BYTES * 2),
+    });
+    const small = withProps({ ok: 1 });
+    const stringify = vi.spyOn(JSON, "stringify");
+
+    try {
+      const serialized = (value: unknown) =>
+        stringify.mock.calls.some(([subject]) => subject === value);
+
+      expect(codes(oversized)).toContain("document-too-large");
+      expect(serialized(oversized)).toBe(false);
+
+      // The control: the same spy DOES observe the walk on a document that was
+      // not refused. Without it, "never serialized" would also be the reading
+      // if this validator had stopped serializing anything at all.
+      codes(small);
+      expect(serialized(small)).toBe(true);
+    } finally {
+      stringify.mockRestore();
+    }
   });
 
   it("rejects a circular document without throwing", () => {

--- a/packages/plugin-page-builder/src/fields/blocks-validator.ts
+++ b/packages/plugin-page-builder/src/fields/blocks-validator.ts
@@ -113,8 +113,25 @@ export function validateBlocksValue(
   //
   // One question, one answer — and the more precise answer is the one an author
   // can act on.
+  // Safe to walk is not the same as affordable to walk. `unserializableIssues`
+  // serializes the whole document, which is precisely the allocation the
+  // engine's bounded counter refused to make: it stops counting at the cap, so
+  // a document reported as too large may be arbitrarily bigger than the cap and
+  // materializing a full JSON copy of it here would undo that bound.
+  //
+  // Nothing is lost by skipping it. "Too large" is already the complete and
+  // actionable answer, and naming a key inside a document that has to shrink
+  // anyway does not change the repair.
+  //
+  // `document-unwritable` is the opposite case and still runs: the counter
+  // stopped on a value it could not write while still under the cap, and the
+  // engine can only say THAT the document is unwritable, never which key.
+  const tooLarge = documentIssues.some(
+    issue => issue.code === "document-too-large"
+  );
+
   const precise: Issue[] = [];
-  if (structuralIssues.length === 0) {
+  if (structuralIssues.length === 0 && !tooLarge) {
     precise.push(...disallowedBlockIssues(doc, path, label, options));
     precise.push(...unserializableIssues(doc, path, label));
   }

--- a/packages/plugin-page-builder/src/fields/blocks-validator.ts
+++ b/packages/plugin-page-builder/src/fields/blocks-validator.ts
@@ -89,6 +89,11 @@ export function validateBlocksValue(
 
   const doc = value as BlockDocument;
   const issues: Issue[] = [];
+  // Two of the engine's verdicts are about the whole document rather than its
+  // STRUCTURE: it is too large, or it holds a value JSON cannot write. Neither
+  // makes the tree unsafe to walk, so neither should block the richer walks
+  // below — blocking on them costs the author the more useful answer.
+  const NON_STRUCTURAL = new Set(["document-too-large", "document-unwritable"]);
 
   // The engine owns every structural rule: ids, depth, node and byte caps,
   // slot legality, the kind enum, binding and style shapes.
@@ -96,8 +101,29 @@ export function validateBlocksValue(
     breakpoints: NO_BREAKPOINTS,
     mode: "forgiving",
   }).filter(issue => issue.severity === "error");
+  const structuralIssues = documentIssues.filter(
+    issue => !NON_STRUCTURAL.has(issue.code)
+  );
+
+  // The engine's whole-document verdict is a SUMMARY of what the walk below
+  // reports precisely, so it is held back until that walk has run: if the walk
+  // names the offending keys, the summary says the same thing less usefully and
+  // is dropped; if the walk reaches nothing, the summary is the only answer
+  // there is and must survive.
+  //
+  // One question, one answer — and the more precise answer is the one an author
+  // can act on.
+  const precise: Issue[] = [];
+  if (structuralIssues.length === 0) {
+    precise.push(...disallowedBlockIssues(doc, path, label, options));
+    precise.push(...unserializableIssues(doc, path, label));
+  }
+  const namesUnwritableKeys = precise.some(
+    issue => issue.code === "UNSERIALIZABLE_VALUE"
+  );
 
   for (const issue of documentIssues) {
+    if (issue.code === "document-unwritable" && namesUnwritableKeys) continue;
     issues.push({
       path,
       // The engine's codes are the documented repair vocabulary. Translating
@@ -111,10 +137,16 @@ export function validateBlocksValue(
   // The allow-list walk reads node types, which is only safe once the engine
   // has confirmed the tree is well formed. A malformed node would otherwise
   // throw here and turn a rejected document into a server error.
-  if (documentIssues.length === 0) {
-    issues.push(...disallowedBlockIssues(doc, path, label, options));
-    issues.push(...unserializableIssues(doc, path, label));
-  }
+  //
+  // "Well formed" is about STRUCTURE, though, and the engine also reports two
+  // whole-document verdicts that say nothing about it: the document is too
+  // large, or it holds a value JSON cannot write. Neither makes the tree unsafe
+  // to walk, and blocking on them costs the author the more useful answer —
+  // the engine says a document is unwritable, while this walk says WHICH key.
+  //
+  // Without this, the two checks answered the same question and the coarser one
+  // won purely by running first.
+  issues.push(...precise);
 
   if (issues.length <= MAX_REPORTED_ISSUES) return issues;
   const withheld = issues.length - MAX_REPORTED_ISSUES;


### PR DESCRIPTION
Follows #769, which merged before this commit was pushed. Founder-approved decision: split "how many bytes" from "can this be written at all", because they are two different questions and conflating them produced every serializer-agreement defect on #682.

## The defect

`measureBytes({ x: 1n }, 100)` returned `{ bytes: 6, exceeded: false }` while `JSON.stringify` throws. The function became public in #682 and is documented as the storage-cap check, so a caller could admit data that cannot be persisted.

## Why the obvious fix was wrong, measured

Reporting a BigInt as `exceeded: true` makes things worse:

```
expected [ 'document-too-large' ] to include 'UNSERIALIZABLE_VALUE'
```

"Your document is too large" for a document holding a BigInt sends its author to delete blocks, which cannot help. The two causes need opposite advice.

## What this does

```ts
export type ByteMeasurement =
  | { bytes: number; exceeded: false }
  | { bytes: number; exceeded: true; reason: "over-limit" | "unwritable" };
```

`exceeded` stays a boolean, so a caller asking only "does it fit?" is unchanged; a caller reporting the problem narrows on `reason`. `validate()` emits a new `document-unwritable` code rather than mislabelling it as a size problem.

## The second defect this surfaced

The engine's verdict and `blocks-validator`'s walk were both answering "is there an unwritable value here", and the coarse one won purely by running first — the plugin's richer walk was gated behind "no engine issues at all", so the precise answer (WHICH key) was suppressed by the summary.

The summary is now held back until the precise walk has run: if the walk names the offending keys, the summary is dropped as redundant; if the walk reaches nothing, the summary survives as the only answer. One question, one answer, and the actionable one wins.

## Verified

Each with the engine rebuilt first, because dependents resolve its `dist`:

- `blocks-engine` 1160 · `plugin-page-builder` 655 · `builder` 341 · `blocks-react` 509
- lint and check-types clean in all three changed packages

## Coordination

This changes the shape of a function PR #738 is freezing. That lane needs the concrete diff.