### PR TITLE
test(builder): read the chrome's alpha from its separator, not its function

### DIFF
--- a/e2e/tests/shell/driver.ts
+++ b/e2e/tests/shell/driver.ts
@@ -129,13 +129,22 @@ export async function measureShellRender(
     //
     // A colour carrying neither separator is opaque. `alpha` stays null only
     // when there is no colour to read at all, which callers treat as unknown.
+    //
+    // `none` is an alpha too, and a transparent one. A modern colour may carry
+    // a MISSING component, which Chromium preserves through the computed value
+    // as the keyword — `oklch(0.7 0.1 200 / none)`. Outside interpolation a
+    // missing component behaves as zero, and it draws nothing: composited over
+    // white it measures `rgb(255, 255, 255)`, identical to `/ 0`. A
+    // numbers-only pattern leaves it unmatched, which this function would
+    // otherwise read as "no alpha present" and therefore as fully opaque.
     const parseAlpha = (colour: string): number | null => {
       const raw =
-        /\/\s*([\d.]+%?)\s*\)\s*$/.exec(colour)?.[1] ??
+        /\/\s*(none|[\d.]+%?)\s*\)\s*$/.exec(colour)?.[1] ??
         /^rgba\(\s*[^,]+,\s*[^,]+,\s*[^,]+,\s*([\d.]+%?)\s*\)$/.exec(
           colour
         )?.[1];
       if (raw === undefined) return 1;
+      if (raw === "none") return 0;
       return raw.endsWith("%") ? Number(raw.slice(0, -1)) / 100 : Number(raw);
     };
     const alpha = background === "" ? null : parseAlpha(background);

--- a/e2e/tests/shell/driver.ts
+++ b/e2e/tests/shell/driver.ts
@@ -89,8 +89,9 @@ export interface ShellRenderMeasurement {
   /** The resolved `display`, which only this package's stylesheet sets. */
   display: string | null;
   /**
-   * The background's alpha as the BROWSER computes it, or null when it could
-   * not be determined. Never derived by matching colour syntax in Node.
+   * The alpha of the browser's own computed background, or null when there is
+   * no colour to read. Read from the alpha SEPARATOR, so it does not depend on
+   * which colour function the browser chose to serialize into.
    */
   backgroundAlpha: number | null;
 }
@@ -113,29 +114,31 @@ export async function measureShellRender(
   const styles = await chrome.evaluate(element => {
     const computed = getComputedStyle(element);
     const background = computed.backgroundColor;
-    // The alpha is decided by the BROWSER, not by matching colour syntax here.
-    // `getComputedStyle` does not universally serialize to legacy `rgba(...)`:
-    // this repository's tokens are authored in `oklch`, and a computed value can
-    // preserve a modern colour function — which a syntax matcher reads as
-    // "unrecognised" and therefore, fatally, as "painted".
+    // `getComputedStyle` returns a colour the browser has ALREADY serialized,
+    // and CSS gives that serialization exactly two places to put an alpha:
     //
-    // Canvas `fillStyle` is the browser's own normaliser: assigning any colour
-    // it can parse and reading it back yields `#rrggbb` when opaque and
-    // `rgba(r, g, b, a)` when not. A sentinel detects the case where the
-    // assignment was REJECTED, so an unparseable value reports `null` — unknown
-    // — rather than silently borrowing the sentinel's own opacity.
-    const SENTINEL = "#010203";
-    const context = document.createElement("canvas").getContext("2d");
-    let alpha: number | null = null;
-    if (context !== null) {
-      context.fillStyle = SENTINEL;
-      context.fillStyle = background;
-      const normalised = context.fillStyle;
-      if (normalised !== SENTINEL || background === SENTINEL) {
-        const parsed = /^rgba?\([^)]*,\s*([\d.]+)\s*\)$/.exec(normalised);
-        alpha = parsed === null ? 1 : Number(parsed[1]);
-      }
-    }
+    //   legacy   rgba(r, g, b, A)       — a fourth comma-separated value
+    //   modern   oklch(l c h / A)       — a value after a slash
+    //            color(srgb r g b / A)
+    //
+    // So the alpha is read from the SEPARATOR rather than from the colour
+    // function's name. Enumerating names is what fails here: this repository
+    // authors its tokens in `oklch`, Chromium preserves that function in the
+    // computed value, and a matcher that knows only `rgba(...)` reads a fully
+    // transparent chrome as "unrecognised" and therefore, fatally, as painted.
+    //
+    // A colour carrying neither separator is opaque. `alpha` stays null only
+    // when there is no colour to read at all, which callers treat as unknown.
+    const parseAlpha = (colour: string): number | null => {
+      const raw =
+        /\/\s*([\d.]+%?)\s*\)\s*$/.exec(colour)?.[1] ??
+        /^rgba\(\s*[^,]+,\s*[^,]+,\s*[^,]+,\s*([\d.]+%?)\s*\)$/.exec(
+          colour
+        )?.[1];
+      if (raw === undefined) return 1;
+      return raw.endsWith("%") ? Number(raw.slice(0, -1)) / 100 : Number(raw);
+    };
+    const alpha = background === "" ? null : parseAlpha(background);
     return { background, display: computed.display, alpha };
   });
   return {
@@ -150,11 +153,11 @@ export async function measureShellRender(
 /**
  * A chrome that draws nothing, whatever colour it nominally is.
  *
- * Takes the MEASUREMENT rather than a colour string, because the only reliable
- * reader of a computed colour is the browser that computed it. An earlier
- * version compared two literal spellings and then parsed legacy `rgba(...)` in
- * Node; both were claims about how a value happens to be written, and this
- * repository's `oklch` tokens are exactly the case that breaks them.
+ * Takes the MEASUREMENT rather than a colour string, so the decision is made
+ * from a value the browser resolved. Two earlier versions instead asked how the
+ * colour was SPELT — first comparing literal strings, then matching legacy
+ * `rgba(...)` — and this repository's `oklch` tokens are exactly the case that
+ * breaks both.
  *
  * An UNKNOWN alpha is treated as painted on purpose: the readiness check exists
  * to explain a broken page, and reporting "the chrome drew nothing" because a

--- a/e2e/tests/shell/shell.spec.ts
+++ b/e2e/tests/shell/shell.spec.ts
@@ -325,7 +325,34 @@ test.describe("the unpainted predicate", () => {
     // separates "handles the slash form" from "handles oklch".
     await page.setContent(chromeWith("color(srgb 1 0 0 / 0)"));
 
-    expect(isUnpainted(await measureShellRender(page))).toBe(true);
+    const measurement = await measureShellRender(page);
+
+    // The fixture has to REACH the mechanism. A browser that rejected this
+    // declaration would leave the initial background — `rgba(0, 0, 0, 0)` —
+    // which is also unpainted, so the verdict below would be identical while
+    // no `color()` value was ever parsed. Asserting the serialization survived
+    // is what separates the two.
+    expect(measurement.background).toContain("color(");
+    expect(isUnpainted(measurement)).toBe(true);
+  });
+
+  test("reads a MISSING alpha as transparent, not as absent", async ({
+    page,
+  }) => {
+    // `none` is a valid alpha and it draws nothing: outside interpolation a
+    // missing component behaves as zero, and this composites over white to
+    // `rgb(255, 255, 255)` exactly as `/ 0` does. It is the case a
+    // numbers-only pattern silently reclassifies, because an unmatched alpha
+    // is indistinguishable from a colour that carries no alpha at all.
+    await page.setContent(chromeWith("oklch(0.7 0.1 200 / none)"));
+
+    const measurement = await measureShellRender(page);
+
+    // Same reasoning as above: without this the test passes on a browser that
+    // dropped the declaration entirely.
+    expect(measurement.background).toContain("none");
+    expect(measurement.backgroundAlpha).toBe(0);
+    expect(isUnpainted(measurement)).toBe(true);
   });
 
   test("sees a zero-alpha non-black legacy colour as unpainted", async ({

--- a/e2e/tests/shell/shell.spec.ts
+++ b/e2e/tests/shell/shell.spec.ts
@@ -316,6 +316,18 @@ test.describe("the unpainted predicate", () => {
     expect(isUnpainted(measurement)).toBe(true);
   });
 
+  test("sees a zero-alpha colour from a SECOND modern function", async ({
+    page,
+  }) => {
+    // `oklch` alone would leave the predicate looking like it recognises one
+    // function rather than one alpha SEPARATOR. `color()` serializes the same
+    // way and shares no function name with it, so passing both is what
+    // separates "handles the slash form" from "handles oklch".
+    await page.setContent(chromeWith("color(srgb 1 0 0 / 0)"));
+
+    expect(isUnpainted(await measureShellRender(page))).toBe(true);
+  });
+
   test("sees a zero-alpha non-black legacy colour as unpainted", async ({
     page,
   }) => {


### PR DESCRIPTION
## Why

`Browser tests` is failing on `main`. [#765](https://github.com/nextlyhq/nextly/pull/765) was squash-merged from `0dbcb9470`, a head whose `Browser tests` job had already concluded `failure`; the two commits that fixed it landed on the branch afterwards and were never merged. `main` therefore carries the test and not the fix.

```
1) [chromium] › tests/shell/shell.spec.ts:306:3 › the unpainted predicate
   › sees a zero-alpha MODERN colour as unpainted

   Expected: true
   Received: false
```

## What was wrong

`isUnpainted` decides whether the editor shell's chrome drew anything, which is the only diagnosis that separates "a stylesheet is missing" from "the chrome's own rule regressed". It read the alpha by matching the legacy `rgba(...)` form and treated everything else as opaque.

Measured on Chromium 149 (`e2e`'s own pinned browser), `getComputedStyle().backgroundColor` does not normalise to that form:

| authored | computed |
| --- | --- |
| `oklch(0.7 0.1 200 / 0)` | `oklch(0.7 0.1 200 / 0)` |
| `color(srgb 1 0 0 / 0)` | `color(srgb 1 0 0 / 0)` |
| `rgb(255 0 0 / 0)` | `rgba(255, 0, 0, 0)` |
| `transparent` | `rgba(0, 0, 0, 0)` |
| `color-mix(in oklch, ...)` | `oklch(0 0 200 / 0)` |

`packages/ui/src/styles/theme.css` authors 121 `oklch` declarations, so a chrome whose token chain resolves to a transparent `oklch` is the realistic shape of this failure, not a synthetic one — and the predicate could not see it.

## What changed

Read the alpha from its **separator**. CSS gives a serialized colour exactly two places to carry one:

- legacy — a fourth comma-separated value: `rgba(r, g, b, A)`
- modern — a value after a slash: `oklch(l c h / A)`, `color(srgb r g b / A)`

Neither present means opaque. This is complete over the serialization grammar rather than over a list of function names, so a colour space this repo has not adopted yet cannot reintroduce the same blindness. That is the third attempt at this predicate and the first two both failed the same way: each identified the value by **how the browser happened to spell it**.

### Also removes the canvas `fillStyle` normaliser

The previous version routed the computed value through a canvas 2D context on the grounds that it is "the browser's own normaliser". Measured across all nine colour forms above, `ctx.fillStyle` returned its input **unchanged every time** — `getComputedStyle` has already serialized the value it was being asked to normalise. It contributed no coverage and one failure mode: a colour canvas could not parse reported an unknown alpha, which the predicate reads as painted.

## Verification

Run against real Chromium locally (`setContent` only, so no dev server is involved):

```
5 passed
  ✓ sees a zero-alpha MODERN colour as unpainted
  ✓ sees a zero-alpha colour from a SECOND modern function
  ✓ sees a zero-alpha non-black legacy colour as unpainted
  ✓ counts a barely-visible colour as painted
  ✓ counts an opaque modern colour as painted
```

**Mutation** — removing the slash branch fails exactly one test, the one that targets it:

```
✘ sees a zero-alpha MODERN colour as unpainted
✓ (the other four)
```

**New coverage.** `color(srgb ...)` shares no function name with `oklch`, so passing both is what separates "handles the slash form" from "handles `oklch`". The existing opaque-modern-colour case remains the positive control: without it, a predicate that failed to parse anything would report every case here as painted and three of the five would still pass.

`e2e` `check-types` and `lint` both exit 0. Both needed `pnpm --filter @nextlyhq/builder... build` first — on a stale `dist` they fail in `packages/builder` with errors that look like real regressions on `main` and are not.

No changeset: test-only.
