### PR TITLE
fix(create-nextly-app): keep pnpm add working in a pnpm scaffold

### DIFF
--- a/.changeset/lucky-donkeys-clap.md
+++ b/.changeset/lucky-donkeys-clap.md
@@ -1,0 +1,28 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+fix(create-nextly-app): keep pnpm add working in a pnpm scaffold

--- a/packages/create-nextly-app/src/__tests__/scaffold-npmrc.test.ts
+++ b/packages/create-nextly-app/src/__tests__/scaffold-npmrc.test.ts
@@ -1,0 +1,133 @@
+/**
+ * The `.npmrc` a pnpm scaffold needs must reach the PROJECT, and must not destroy one already
+ * there.
+ *
+ * Both halves are tested by scaffolding onto a real temporary directory rather than by calling
+ * the generator. A test that calls `generateNpmrc` directly stays green if the `copyTemplate`
+ * wiring is deleted outright — it proves a string is produced, not that any project receives it —
+ * and the wiring is the part that can regress.
+ *
+ * The overwrite half matters because a scaffold does not always land on an empty directory: the
+ * CLI can overlay an existing project, and a `--local-template` can carry its own `.npmrc`. That
+ * file is where private registries, auth tokens and proxies live, so replacing it would break the
+ * install that runs moments later — and break it by reaching the wrong registry rather than by
+ * failing outright.
+ */
+import { mkdtemp, readFile, rm, writeFile, mkdir } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import type { DatabaseConfig, PackageManager } from "../types";
+import { copyTemplate } from "../utils/template";
+
+const templates = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "..",
+  "..",
+  "..",
+  "templates"
+);
+
+const sqlite: DatabaseConfig = {
+  type: "sqlite",
+  adapter: "@nextlyhq/adapter-sqlite",
+  databaseDriver: "better-sqlite3",
+  connectionUrl: "file:./data/nextly.db",
+  envExample: "file:./data/nextly.db",
+};
+
+let workspace: string;
+
+beforeEach(async () => {
+  workspace = await mkdtemp(join(tmpdir(), "nextly-npmrc-"));
+});
+
+afterEach(async () => {
+  await rm(workspace, { recursive: true, force: true });
+});
+
+/** Scaffolds a blank project and returns its `.npmrc`, or null when none was written. */
+async function scaffold(
+  packageManager: PackageManager,
+  seedNpmrc?: string
+): Promise<string | null> {
+  const target = join(workspace, "app");
+  if (seedNpmrc !== undefined) {
+    await mkdir(target, { recursive: true });
+    await writeFile(join(target, ".npmrc"), seedNpmrc, "utf-8");
+  }
+
+  await copyTemplate({
+    projectName: "app",
+    projectType: "blank",
+    targetDir: target,
+    database: sqlite,
+    packageManager,
+    templateSource: {
+      basePath: join(templates, "base"),
+      templatePath: join(templates, "blank"),
+    },
+    // Set by the installer once it has settled a directory conflict with the user, which is the
+    // situation the overlay cases below are standing in for.
+    allowExistingTarget: seedNpmrc !== undefined,
+  });
+
+  const npmrcPath = join(target, ".npmrc");
+  return existsSync(npmrcPath) ? readFile(npmrcPath, "utf-8") : null;
+}
+
+describe("a pnpm scaffold", () => {
+  it("receives the workspace-root opt-out", async () => {
+    const npmrc = await scaffold("pnpm");
+    expect(npmrc).not.toBeNull();
+    expect(npmrc).toMatch(/^ignore-workspace-root-check=true$/m);
+  }, 60_000);
+
+  it("keeps the settings an existing .npmrc already carried", async () => {
+    const npmrc = await scaffold(
+      "pnpm",
+      "@acme:registry=https://npm.acme.internal/\nnode-linker=hoisted\n"
+    );
+
+    // The point of the case: these decide which registry the install about to run will contact.
+    expect(npmrc).toContain("@acme:registry=https://npm.acme.internal/");
+    expect(npmrc).toContain("node-linker=hoisted");
+    expect(npmrc).toMatch(/^ignore-workspace-root-check=true$/m);
+  }, 60_000);
+
+  it("does not overrule a deliberate setting of the same key", async () => {
+    const npmrc = await scaffold("pnpm", "ignore-workspace-root-check=false\n");
+
+    expect(npmrc).toContain("ignore-workspace-root-check=false");
+    expect(npmrc).not.toContain("ignore-workspace-root-check=true");
+  }, 60_000);
+
+  it("does not mangle a file with no trailing newline", async () => {
+    const npmrc = await scaffold("pnpm", "node-linker=hoisted");
+    expect(npmrc).toContain("node-linker=hoisted\n");
+    expect(npmrc).toMatch(/^ignore-workspace-root-check=true$/m);
+  }, 60_000);
+});
+
+describe("every other package manager", () => {
+  // npm reads `.npmrc` too and answers every command with `npm warn Unknown project config
+  // "ignore-workspace-root-check"`. A permanent warning for the majority, buying them a setting
+  // they cannot use.
+  it.each(["npm", "yarn", "bun"] as const)(
+    "gets no .npmrc from a %s scaffold",
+    async manager => {
+      expect(await scaffold(manager)).toBeNull();
+    },
+    60_000
+  );
+
+  it("leaves an existing .npmrc untouched", async () => {
+    const seeded = "@acme:registry=https://npm.acme.internal/\n";
+    expect(await scaffold("npm", seeded)).toBe(seeded);
+  }, 60_000);
+});

--- a/packages/create-nextly-app/src/__tests__/scaffold-npmrc.test.ts
+++ b/packages/create-nextly-app/src/__tests__/scaffold-npmrc.test.ts
@@ -13,7 +13,15 @@
  * install that runs moments later — and break it by reaching the wrong registry rather than by
  * failing outright.
  */
-import { mkdtemp, readFile, rm, writeFile, mkdir } from "node:fs/promises";
+import {
+  mkdtemp,
+  readFile,
+  rm,
+  writeFile,
+  mkdir,
+  symlink,
+  lstat,
+} from "node:fs/promises";
 import { existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
@@ -111,6 +119,38 @@ describe("a pnpm scaffold", () => {
     const npmrc = await scaffold("pnpm", "node-linker=hoisted");
     expect(npmrc).toContain("node-linker=hoisted\n");
     expect(npmrc).toMatch(/^ignore-workspace-root-check=true$/m);
+  }, 60_000);
+});
+
+describe("an existing .npmrc that is a symlink", () => {
+  // Left untouched, because reading and writing it back would follow the link. The realistic
+  // shape is a link to a shared or home-directory config, so appending would edit settings
+  // belonging to every other project on the machine — a scaffold has no business doing that.
+  it("is not followed, and its target keeps its contents", async () => {
+    const target = join(workspace, "app");
+    const shared = join(workspace, "shared-npmrc");
+    const original = "@acme:registry=https://npm.acme.internal/\n";
+    await writeFile(shared, original, "utf-8");
+    await mkdir(target, { recursive: true });
+    await symlink(shared, join(target, ".npmrc"));
+
+    await copyTemplate({
+      projectName: "app",
+      projectType: "blank",
+      targetDir: target,
+      database: sqlite,
+      packageManager: "pnpm",
+      templateSource: {
+        basePath: join(templates, "base"),
+        templatePath: join(templates, "blank"),
+      },
+      allowExistingTarget: true,
+    });
+
+    // The referent is what an unnoticed follow would have modified.
+    expect(await readFile(shared, "utf-8")).toBe(original);
+    // And the link is still a link, rather than having been replaced by a regular file.
+    expect((await lstat(join(target, ".npmrc"))).isSymbolicLink()).toBe(true);
   }, 60_000);
 });
 

--- a/packages/create-nextly-app/src/__tests__/scaffold-npmrc.test.ts
+++ b/packages/create-nextly-app/src/__tests__/scaffold-npmrc.test.ts
@@ -21,6 +21,7 @@ import {
   mkdir,
   symlink,
   lstat,
+  link as hardLink,
 } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -62,7 +63,8 @@ afterEach(async () => {
 /** Scaffolds a blank project and returns its `.npmrc`, or null when none was written. */
 async function scaffold(
   packageManager: PackageManager,
-  seedNpmrc?: string
+  seedNpmrc?: string,
+  projectType: "blank" | "plugin" = "blank"
 ): Promise<string | null> {
   const target = join(workspace, "app");
   if (seedNpmrc !== undefined) {
@@ -72,13 +74,13 @@ async function scaffold(
 
   await copyTemplate({
     projectName: "app",
-    projectType: "blank",
+    projectType,
     targetDir: target,
     database: sqlite,
     packageManager,
     templateSource: {
       basePath: join(templates, "base"),
-      templatePath: join(templates, "blank"),
+      templatePath: join(templates, projectType),
     },
     // Set by the installer once it has settled a directory conflict with the user, which is the
     // situation the overlay cases below are standing in for.
@@ -151,6 +153,48 @@ describe("an existing .npmrc that is a symlink", () => {
     expect(await readFile(shared, "utf-8")).toBe(original);
     // And the link is still a link, rather than having been replaced by a regular file.
     expect((await lstat(join(target, ".npmrc"))).isSymbolicLink()).toBe(true);
+  }, 60_000);
+});
+
+describe("a plugin scaffold", () => {
+  // The plugin branch returns EARLY from copyTemplate, so it writes the file through its own
+  // call. Covering only `blank` leaves that call deletable with the whole suite green — and a
+  // plugin scaffold on pnpm 9 would go back to refusing `pnpm add`.
+  it("gets the same opt-out as an app scaffold", async () => {
+    const npmrc = await scaffold("pnpm", undefined, "plugin");
+    expect(npmrc).toMatch(/^ignore-workspace-root-check=true$/m);
+  }, 60_000);
+
+  it("gets none for npm", async () => {
+    expect(await scaffold("npm", undefined, "plugin")).toBeNull();
+  }, 60_000);
+});
+
+describe("an existing .npmrc that is a HARD link", () => {
+  // `lstat` cannot see this one: a hard link IS a regular file. Both paths are one inode, so
+  // appending would edit the shared config every other project reads. `nlink` is the tell.
+  it("is not modified, and the shared file keeps its contents", async () => {
+    const target = join(workspace, "app");
+    const shared = join(workspace, "shared-npmrc");
+    const original = "@acme:registry=https://npm.acme.internal/\n";
+    await writeFile(shared, original, "utf-8");
+    await mkdir(target, { recursive: true });
+    await hardLink(shared, join(target, ".npmrc"));
+
+    await copyTemplate({
+      projectName: "app",
+      projectType: "blank",
+      targetDir: target,
+      database: sqlite,
+      packageManager: "pnpm",
+      templateSource: {
+        basePath: join(templates, "base"),
+        templatePath: join(templates, "blank"),
+      },
+      allowExistingTarget: true,
+    });
+
+    expect(await readFile(shared, "utf-8")).toBe(original);
   }, 60_000);
 });
 

--- a/packages/create-nextly-app/src/__tests__/template.test.ts
+++ b/packages/create-nextly-app/src/__tests__/template.test.ts
@@ -11,6 +11,7 @@ import type { DatabaseConfig } from "../types";
 import {
   copyTemplate,
   generatePackageJson,
+  generateNpmrc,
   generatePnpmWorkspaceYaml,
   NATIVE_BUILD_DEPENDENCIES,
 } from "../utils/template";
@@ -218,6 +219,22 @@ describe("generatePnpmWorkspaceYaml", () => {
   it("always includes better-sqlite3 in the allowlist", () => {
     expect(NATIVE_BUILD_DEPENDENCIES).toContain("better-sqlite3");
   });
+});
+
+describe("generateNpmrc", () => {
+  // The setting is not npm's. npm reads .npmrc too and answers every command
+  // with `npm warn Unknown project config "ignore-workspace-root-check". This
+  // will stop working in the next major version of npm.` — a permanent warning
+  // for the majority of users, buying them nothing.
+  it.each(["npm", "yarn", "bun"] as const)("writes nothing for %s", manager => {
+    expect(generateNpmrc(manager)).toBeNull();
+  });
+
+  it("opts a pnpm scaffold out of the workspace-root check", () => {
+    const npmrc = generateNpmrc("pnpm");
+    expect(npmrc).not.toBeNull();
+    expect(npmrc).toMatch(/^ignore-workspace-root-check=true$/m);
+  });
 
   // pnpm 9 treats the presence of this file as declaring a workspace and
   // refuses to install without a `packages` key
@@ -227,6 +244,17 @@ describe("generatePnpmWorkspaceYaml", () => {
   it("declares packages, so pnpm 9 can install the scaffold", () => {
     const yaml = generatePnpmWorkspaceYaml();
     expect(yaml).toMatch(/^packages: \[\]$/m);
+  });
+
+  // Emitting this file has a cost on the same pnpm versions it is emitted for:
+  // it makes the project a workspace ROOT, so `pnpm add <pkg>` is refused with
+  // ERR_PNPM_ADDING_TO_ROOT. generateNpmrc pays that cost back, and these two
+  // are only correct together — hence the pointer.
+  it("is paired with an npmrc that keeps pnpm add working", () => {
+    expect(generatePnpmWorkspaceYaml()).toMatch(/^packages: \[\]$/m);
+    expect(generateNpmrc("pnpm")).toMatch(
+      /^ignore-workspace-root-check=true$/m
+    );
   });
 
   // A scaffolded app is a single package. Naming any member would claim a

--- a/packages/create-nextly-app/src/create-nextly.ts
+++ b/packages/create-nextly-app/src/create-nextly.ts
@@ -39,7 +39,7 @@ import type {
   ProjectApproach,
   ProjectType,
 } from "./types";
-import { detectProject } from "./utils/detect";
+import { detectPackageManager, detectProject } from "./utils/detect";
 import { emptyDirectory, isDirectoryNotEmpty } from "./utils/fs";
 import { copyTemplate } from "./utils/template";
 
@@ -361,6 +361,12 @@ export async function createNextly(
         s.start("Scaffolding project...");
       }
 
+      // Decides whether the scaffold gets a `.npmrc`. Resolved from the user
+      // agent of the command that invoked this CLI, which is the package
+      // manager that will run the install a moment later; the target has no
+      // lockfile yet, so nothing else could answer.
+      const scaffoldPackageManager = await detectPackageManager(targetDir);
+
       await copyTemplate({
         projectName,
         projectType,
@@ -370,6 +376,7 @@ export async function createNextly(
         useYalc,
         approach,
         templateSource,
+        packageManager: scaffoldPackageManager,
         // Suppress copyTemplate's "directory already exists" guard when the
         // installer has already negotiated the conflict with the user
         // (either by emptying the dir or accepting an overlay). Without

--- a/packages/create-nextly-app/src/utils/template.ts
+++ b/packages/create-nextly-app/src/utils/template.ts
@@ -844,9 +844,20 @@ async function writeScaffoldNpmrc(
   if (!addition) return;
 
   const npmrcPath = path.join(targetDir, ".npmrc");
-  const existing = (await fs.pathExists(npmrcPath))
-    ? await fs.readFile(npmrcPath, "utf-8")
-    : "";
+
+  // A SYMLINK here is left completely alone. Reading and writing it back would follow the link
+  // and append to whatever it points at — commonly a shared or home-directory config — so a
+  // scaffold would silently edit settings belonging to every other project on the machine.
+  // `lstat` reports the link itself rather than its target, which is the only way to see this:
+  // `pathExists` and `readFile` both resolve it and report the referent as though it were here.
+  //
+  // Skipping means a pnpm 9 user with a linked `.npmrc` still meets ERR_PNPM_ADDING_TO_ROOT on
+  // their first `pnpm add`. That error names its own remedy; silently rewriting a file outside
+  // the project does not, and is not the scaffolder's to make.
+  const link = await fs.lstat(npmrcPath).catch(() => null);
+  if (link?.isSymbolicLink()) return;
+
+  const existing = link ? await fs.readFile(npmrcPath, "utf-8") : "";
 
   // Matched at the start of a line so a value mentioning the key, or a commented-out example,
   // is not read as a declaration.

--- a/packages/create-nextly-app/src/utils/template.ts
+++ b/packages/create-nextly-app/src/utils/template.ts
@@ -857,6 +857,15 @@ async function writeScaffoldNpmrc(
   const link = await fs.lstat(npmrcPath).catch(() => null);
   if (link?.isSymbolicLink()) return;
 
+  // A HARD link is the same hazard wearing a disguise `lstat` cannot see through: it reports a
+  // regular file, because that is exactly what a hard link is. The shared config and the path
+  // here are one inode, so appending would edit every project pointing at it.
+  //
+  // `nlink` is what separates them — an ordinary file has one directory entry. Checked after the
+  // symlink test rather than instead of it: the two are different relationships and a file can
+  // only be one of them, so neither check subsumes the other.
+  if (link && link.nlink > 1) return;
+
   const existing = link ? await fs.readFile(npmrcPath, "utf-8") : "";
 
   // Matched at the start of a line so a value mentioning the key, or a commented-out example,

--- a/packages/create-nextly-app/src/utils/template.ts
+++ b/packages/create-nextly-app/src/utils/template.ts
@@ -897,11 +897,17 @@ export interface CopyTemplateOptions {
   templateSource?: { basePath: string; templatePath: string };
   /**
    * The package manager the project will be installed with, which decides
-   * whether a `.npmrc` is written — see {@link generateNpmrc}. Omitted is
-   * treated as npm, so a caller that does not know writes nothing rather than
-   * writing a file the wrong tool will warn about.
+   * whether a `.npmrc` is written — see {@link generateNpmrc}.
+   *
+   * REQUIRED, and deliberately so. As an optional field defaulting to npm, the
+   * CLI's one line wiring the detected manager through could be deleted and
+   * every scaffold would silently lose its `.npmrc` — a default is a decision
+   * made for a caller that never stated one, and here the wrong decision is
+   * indistinguishable from the right one until a user runs `pnpm add`. Required
+   * makes that deletion a compile error instead of something a test has to
+   * notice.
    */
-  packageManager?: PackageManager;
+  packageManager: PackageManager;
   /**
    * Suppress the internal "directory already exists" guard. Set by the
    * installer when it has already negotiated a directory conflict with
@@ -936,7 +942,7 @@ export async function copyTemplate(
     useYalc = false,
     approach,
     templateSource,
-    packageManager = "npm",
+    packageManager,
     allowExistingTarget = false,
   } = options;
 

--- a/packages/create-nextly-app/src/utils/template.ts
+++ b/packages/create-nextly-app/src/utils/template.ts
@@ -4,7 +4,12 @@ import { fileURLToPath } from "url";
 import fs from "fs-extra";
 
 import { buildNextConfigTemplate } from "../generators/next-config";
-import type { DatabaseConfig, ProjectApproach, ProjectType } from "../types";
+import type {
+  DatabaseConfig,
+  PackageManager,
+  ProjectApproach,
+  ProjectType,
+} from "../types";
 
 /**
  * Templates whose `nextly.config.ts` registers `formBuilderPlugin`. The
@@ -765,6 +770,52 @@ export function generatePnpmWorkspaceYaml(): string {
   );
 }
 
+/**
+ * Generate the `.npmrc` for a scaffolded project, or `null` when it needs none.
+ *
+ * Written only for pnpm scaffolds, and only to undo a side effect of shipping
+ * `pnpm-workspace.yaml`: through pnpm 9.3 the presence of that file makes the
+ * project a workspace ROOT, so an ordinary
+ *
+ *     pnpm add zod
+ *
+ * is refused with `ERR_PNPM_ADDING_TO_ROOT` and a suggestion to pass `-w`. The
+ * check exists to stop a dependency landing in a monorepo's root instead of the
+ * package that wanted it; a scaffolded app has no other package, so there is
+ * nothing for it to protect and it only obstructs.
+ *
+ * Measured: 9.0.0 refuses `pnpm add` without this and accepts it with; 10.18.3
+ * and 11.0.0 accept it either way. Two alternatives were measured and rejected —
+ * declaring the root as a member (`packages: ["."]`) is refused identically, and
+ * the same setting written into `pnpm-workspace.yaml` is not read by pnpm 9 at
+ * all, since that file only became the settings home in 10.6.
+ *
+ * NOT written for npm, yarn or bun, which is the whole reason this is a separate
+ * function rather than an unconditional file: npm reads `.npmrc` too and prints
+ *
+ *     npm warn Unknown project config "ignore-workspace-root-check".
+ *     This will stop working in the next major version of npm.
+ *
+ * on every command. A permanent warning for the majority is a poor trade for a
+ * setting they cannot use.
+ *
+ * The residual gap, stated rather than left to be discovered: a project
+ * scaffolded with npm and later opened with pnpm 9.3 or older still meets
+ * `ERR_PNPM_ADDING_TO_ROOT`. That error names its own remedy, and the affected
+ * pnpm range is closed and shrinking.
+ */
+export function generateNpmrc(packageManager: PackageManager): string | null {
+  if (packageManager !== "pnpm") return null;
+
+  return (
+    "# This project is a single package, not a monorepo. pnpm 9 treats the\n" +
+    "# pnpm-workspace.yaml shipped for its build allowlist as declaring a\n" +
+    "# workspace root, which makes `pnpm add <pkg>` demand a -w flag. There is no\n" +
+    "# other package here for that check to protect.\n" +
+    "ignore-workspace-root-check=true\n"
+  );
+}
+
 // ============================================================
 // Copy Template (Main Orchestrator)
 // ============================================================
@@ -780,6 +831,13 @@ export interface CopyTemplateOptions {
   approach?: ProjectApproach;
   /** Explicit paths to base and template directories (from download or --local-template) */
   templateSource?: { basePath: string; templatePath: string };
+  /**
+   * The package manager the project will be installed with, which decides
+   * whether a `.npmrc` is written — see {@link generateNpmrc}. Omitted is
+   * treated as npm, so a caller that does not know writes nothing rather than
+   * writing a file the wrong tool will warn about.
+   */
+  packageManager?: PackageManager;
   /**
    * Suppress the internal "directory already exists" guard. Set by the
    * installer when it has already negotiated a directory conflict with
@@ -814,6 +872,7 @@ export async function copyTemplate(
     useYalc = false,
     approach,
     templateSource,
+    packageManager = "npm",
     allowExistingTarget = false,
   } = options;
 
@@ -850,7 +909,13 @@ export async function copyTemplate(
   // app — no base app, no next.config/.env generation, no frontend page. Copy
   // the plugin tree as-is, generate its package.json, fill placeholders, done.
   if (projectType === "plugin") {
-    await copyPluginTemplate({ projectName, typeDir, targetDir, useYalc });
+    await copyPluginTemplate({
+      projectName,
+      typeDir,
+      targetDir,
+      useYalc,
+      packageManager,
+    });
     return;
   }
 
@@ -978,6 +1043,14 @@ export async function copyTemplate(
   // Step 6c: Give the project back the ignore file npm strips out of the tarball.
   await restoreIgnoreFile(targetDir);
 
+  // Step 6d: Undo the side effect of the workspace file above for the pnpm versions that
+  // read it as a workspace declaration. Only for pnpm, because npm warns about the setting
+  // on every command — see generateNpmrc.
+  const npmrc = generateNpmrc(packageManager);
+  if (npmrc) {
+    await fs.writeFile(path.join(targetDir, ".npmrc"), npmrc, "utf-8");
+  }
+
   // Step 7: Create SQLite data directory if needed
   // SQLite stores its database file at ./data/nextly.db and the parent
   // directory must exist before the adapter can create the file.
@@ -1012,8 +1085,9 @@ async function copyPluginTemplate(opts: {
   typeDir: string;
   targetDir: string;
   useYalc: boolean;
+  packageManager: PackageManager;
 }): Promise<void> {
-  const { projectName, typeDir, targetDir, useYalc } = opts;
+  const { projectName, typeDir, targetDir, useYalc, packageManager } = opts;
 
   if (!(await fs.pathExists(typeDir))) {
     throw new Error(
@@ -1047,7 +1121,6 @@ async function copyPluginTemplate(opts: {
   // pnpm 11 ignores the package.json `pnpm` field, and the embedded dev/
   // playground uses better-sqlite3 (native build) — so this file is what lets
   // `pnpm install` build it instead of aborting with ERR_PNPM_IGNORED_BUILDS.
-  // Harmless for npm/yarn/pnpm 9.
   await fs.writeFile(
     path.join(targetDir, "pnpm-workspace.yaml"),
     generatePnpmWorkspaceYaml(),
@@ -1056,6 +1129,13 @@ async function copyPluginTemplate(opts: {
 
   // The plugin scaffold is a git repository too, and npm strips its ignore file the same way.
   await restoreIgnoreFile(targetDir);
+
+  // It installs like any other project too, so it meets the same workspace-root refusal the
+  // pnpm workspace file provokes on pnpm 9 — see generateNpmrc.
+  const npmrc = generateNpmrc(packageManager);
+  if (npmrc) {
+    await fs.writeFile(path.join(targetDir, ".npmrc"), npmrc, "utf-8");
+  }
 
   // Fill plugin placeholders across the copied tree (src/ + dev/).
   const nextlyRange = await resolvePluginNextlyRange(useYalc);

--- a/packages/create-nextly-app/src/utils/template.ts
+++ b/packages/create-nextly-app/src/utils/template.ts
@@ -812,8 +812,52 @@ export function generateNpmrc(packageManager: PackageManager): string | null {
     "# pnpm-workspace.yaml shipped for its build allowlist as declaring a\n" +
     "# workspace root, which makes `pnpm add <pkg>` demand a -w flag. There is no\n" +
     "# other package here for that check to protect.\n" +
-    "ignore-workspace-root-check=true\n"
+    `${NPMRC_WORKSPACE_ROOT_KEY}=true\n`
   );
+}
+
+/** The setting {@link generateNpmrc} exists to add, named once so the writer can look for it. */
+const NPMRC_WORKSPACE_ROOT_KEY = "ignore-workspace-root-check";
+
+/**
+ * Give a scaffolded project the `.npmrc` its package manager needs, WITHOUT destroying one that
+ * is already there.
+ *
+ * Appends rather than writes. A scaffold does not always land on an empty directory — the CLI
+ * can overlay an existing project, and a `--local-template` can carry its own `.npmrc` — and that
+ * file is where private registries, auth tokens, proxies and `node-linker` live. Replacing it
+ * would break the install that runs moments later, and would do it by pointing at the wrong
+ * registry rather than by failing loudly.
+ *
+ * An existing declaration of the key WINS, whatever its value. Someone who has written
+ * `ignore-workspace-root-check=false` on purpose means it, and a scaffold is not the right place
+ * to overrule them.
+ *
+ * One helper for both scaffold types, because two copies of "write this file" drift: a correction
+ * to the app path that misses the plugin path is invisible until someone scaffolds a plugin.
+ */
+async function writeScaffoldNpmrc(
+  targetDir: string,
+  packageManager: PackageManager
+): Promise<void> {
+  const addition = generateNpmrc(packageManager);
+  if (!addition) return;
+
+  const npmrcPath = path.join(targetDir, ".npmrc");
+  const existing = (await fs.pathExists(npmrcPath))
+    ? await fs.readFile(npmrcPath, "utf-8")
+    : "";
+
+  // Matched at the start of a line so a value mentioning the key, or a commented-out example,
+  // is not read as a declaration.
+  const alreadyDeclared = new RegExp(
+    `^\\s*${NPMRC_WORKSPACE_ROOT_KEY}\\s*=`,
+    "m"
+  ).test(existing);
+  if (alreadyDeclared) return;
+
+  const separator = existing === "" || existing.endsWith("\n") ? "" : "\n";
+  await fs.writeFile(npmrcPath, existing + separator + addition, "utf-8");
 }
 
 // ============================================================
@@ -1046,10 +1090,7 @@ export async function copyTemplate(
   // Step 6d: Undo the side effect of the workspace file above for the pnpm versions that
   // read it as a workspace declaration. Only for pnpm, because npm warns about the setting
   // on every command — see generateNpmrc.
-  const npmrc = generateNpmrc(packageManager);
-  if (npmrc) {
-    await fs.writeFile(path.join(targetDir, ".npmrc"), npmrc, "utf-8");
-  }
+  await writeScaffoldNpmrc(targetDir, packageManager);
 
   // Step 7: Create SQLite data directory if needed
   // SQLite stores its database file at ./data/nextly.db and the parent
@@ -1131,11 +1172,8 @@ async function copyPluginTemplate(opts: {
   await restoreIgnoreFile(targetDir);
 
   // It installs like any other project too, so it meets the same workspace-root refusal the
-  // pnpm workspace file provokes on pnpm 9 — see generateNpmrc.
-  const npmrc = generateNpmrc(packageManager);
-  if (npmrc) {
-    await fs.writeFile(path.join(targetDir, ".npmrc"), npmrc, "utf-8");
-  }
+  // pnpm workspace file provokes on pnpm 9 — through the same writer as the app path.
+  await writeScaffoldNpmrc(targetDir, packageManager);
 
   // Fill plugin placeholders across the copied tree (src/ + dev/).
   const nextlyRange = await resolvePluginNextlyRange(useYalc);


### PR DESCRIPTION
## What this is

A re-landing. #767 was squash-merged from a **stale head**, and its final commit
did not reach `main`.

Measured after the fact:

```
git ls-remote origin fix/scaffold-pnpm-workspace-packages  -> 18a5d26ef   (the real tip)
gh pr view 767 --json headRefOid                           -> 8a581a4b7   (one commit behind)
git grep generateNpmrc origin/main -- .../utils/template.ts -> no match
git grep 'packages: []' origin/main -- .../utils/template.ts -> 1 match   (positive control)
```

The control matters: the earlier commit's marker IS in `main`, so the search
works and the absence of the later one is a real loss rather than a bad query.

## The fix it restores

Shipping `pnpm-workspace.yaml` for the build allowlist makes a scaffolded
project a workspace **root** through pnpm 9.3. So `pnpm install` succeeds and
then:

```
$ pnpm add zod
 ERR_PNPM_ADDING_TO_ROOT  ... run this command again with the -w flag
```

A scaffolded app has no second package for that check to protect. The scaffold
opts out of it via `.npmrc`, **written only for pnpm** — npm reads `.npmrc` too
and answers every command with `npm warn Unknown project config
"ignore-workspace-root-check"`, which is a permanent warning for the majority
buying them a setting they cannot use.

Measured across versions: 9.0.0 refuses `pnpm add` without this and accepts it
with; 10.18.3 and 11.0.0 accept either way. Two alternatives were measured and
rejected — `packages: ["."]` is refused identically, and the same setting inside
`pnpm-workspace.yaml` is not read by pnpm 9 at all, since that file only became
the settings home in 10.6.

Verified end to end against a real scaffold built from the packed CLI under
pnpm 9.0.0: with the file, `pnpm add zod` exits 0 and lands `"zod": "^4.4.3"`;
with it removed from the same scaffold, `pnpm add` exits 1 with
`ERR_PNPM_ADDING_TO_ROOT` and adds nothing.

## Conflict resolution

`main` has since gained #770's `restoreIgnoreFile` call at both of the sites this
commit touches. **Both are kept** — they solve different problems and run one
after the other. Confirmed present in the resolved file: 6 `generateNpmrc`
references and 3 `restoreIgnoreFile` references, 185 tests passing.

## How it was caught

The builder lane flagged that a squash can capture a stale head, and that
`gh`'s `head.sha` disagrees with `git ls-remote`. That is exactly what happened
here. Every other PR from this lane was re-checked the same way — #752, #770 and
#768 all carry their final commits.
