### PR TITLE
docs(root): record that the merge-verification steps cannot see a lost tail

### DIFF
--- a/.claude/rules/verifying-merged-work.md
+++ b/.claude/rules/verifying-merged-work.md
@@ -69,7 +69,23 @@ git diff "$CAND^..$CAND" -- "$PATHS"          # what the stranded commit did
 git diff "$MERGE^..$MERGE" -- "$PATHS"        # what the squash contains
 ```
 
-Its hunks appearing in the second is the evidence. Their absence is the loss. When it matters — a
+Its hunks appearing in the second is the evidence. Their absence is the loss —
+**unless a later candidate cancels it.**
+
+Judge the tail's NET effect, not each commit alone. When the screen names
+several commits and a later one reverts or supersedes an earlier one, neither
+individual patch need appear in the squash, and checking them one at a time
+reports an intentionally cancelled intermediate as lost work. That is the same
+correction step 4 already makes for a pull request as a whole, applied to the
+candidate list:
+
+```sh
+FIRST=$(git log --format=%H "$GH..$TIP" | tail -1)
+git diff "$GH..$TIP" -- "$PATHS"              # what the tail did, on net
+```
+
+Compare THAT against the squash. A tail whose net effect is empty lost nothing,
+however many commits the screen listed. When it matters — a
 release, an incident, a PR whose tail you have reason to doubt — verify the
 commits you intended to land by content, per the numbered steps below, and do
 not let an empty range stand in for that.
@@ -325,24 +341,33 @@ missing its last commit, reading as complete with every thread resolved.
 after something has already shipped. Merge with the head you verified as a
 PRECONDITION, so the merge itself refuses when the branch has moved:
 
-This runs BEFORE a merge exists, so it cannot borrow `$GH` from the block above:
-that one reads `mergeCommit` and exits when there is none, which is every open
-PR. Acquire the head on its own:
+This runs BEFORE a merge exists, so it cannot borrow from the block above: that
+one reads `mergeCommit` and exits when there is none, which is every open PR.
+
+**Pass in the revision you VERIFIED. Do not re-read the head here.** Re-reading
+returns whatever is newest, which after a push is exactly the unverified
+revision the flag exists to reject — so a fresh read turns the precondition into
+a rubber stamp for the newest commit. The value to pass is the one the green
+checks and the clean review belong to:
 
 ```sh
 set -euo pipefail
 PR=<number>
-GH=$(gh pr view "$PR" --json headRefOid --jq .headRefOid) || {
-  echo "PR#$PR: head query failed — do not merge" >&2
-  exit 2
+VERIFIED=<the sha whose checks were green and whose review was clean>
+
+# Confirms the branch has not moved since, and refuses rather than merging on.
+NOW=$(gh pr view "$PR" --json headRefOid --jq .headRefOid) || {
+  echo "PR#$PR: head query failed — do not merge" >&2; exit 2
 }
-[ -n "$GH" ] || { echo "PR#$PR: empty head — do not merge" >&2; exit 2; }
-gh pr merge "$PR" --squash --match-head-commit "$GH"
+[ "$NOW" = "$VERIFIED" ] || {
+  echo "PR#$PR: head moved $VERIFIED -> $NOW; re-run the gate" >&2; exit 2
+}
+gh pr merge "$PR" --squash --match-head-commit "$VERIFIED"
 ```
 
-`$GH` must be the revision the green checks and the clean review belong to, so
-read it in the SAME step that merges — a value carried from an earlier step is
-the stale head this flag exists to reject. Bind it to that variable rather than retyping a SHA:
+The comparison is a courtesy that yields a readable message; `--match-head-commit`
+is what makes it safe, because it is the server that refuses. Both take
+`$VERIFIED`, never `$NOW`. Bind it to that variable rather than retyping a SHA:
 a merge precondition naming the wrong revision either refuses a correct merge or,
 worse, permits the one it was added to stop.
 

--- a/.claude/rules/verifying-merged-work.md
+++ b/.claude/rules/verifying-merged-work.md
@@ -55,7 +55,21 @@ not a property a mutable ref can answer.
 
 So use it as a SCREEN and take the verdict from CONTENT. Any commit it names is
 worth confirming against the merge commit; an empty result means only that this
-cheap look found nothing, never that nothing was lost. When it matters — a
+cheap look found nothing, never that nothing was lost.
+
+**Settle a named candidate against the CANDIDATE, not against the PR head.** The
+numbered steps below are written for the PR as a whole, and step 3's PR side
+ends at `<headRefOid>` — which excludes a stranded commit by definition, so its
+two deltas come out identical whether or not that commit's change landed. When
+the candidate has a unique marker, grep for it as in step 2. When it does not —
+a binary, a rename, a mode change — compare its own patch:
+
+```sh
+git diff "$CAND^..$CAND" -- "$PATHS"          # what the stranded commit did
+git diff "$MERGE^..$MERGE" -- "$PATHS"        # what the squash contains
+```
+
+Its hunks appearing in the second is the evidence. Their absence is the loss. When it matters — a
 release, an incident, a PR whose tail you have reason to doubt — verify the
 commits you intended to land by content, per the numbered steps below, and do
 not let an empty range stand in for that.
@@ -208,8 +222,10 @@ They are easy to run together and none substitutes for another:
 
 - **Did my code land?** — content, from the final commit. What the numbered
   steps below answer.
-- **Did EVERY commit land?** — the `ls-remote` comparison above. Content from a
-  commit that merged cannot reach a commit that did not.
+- **Did EVERY commit land?** — no single command answers this. The `ls-remote`
+  screen above NAMES candidates and cannot certify their absence; each candidate
+  is then settled by content. Content taken from a commit that merged can never
+  reach a commit that did not, so the screen is what supplies the list to check.
 - **Was the job green?** — the merge commit's own check-runs, asserted as
   `success`. A PR merged here with two `Integration` jobs failing and left
   `main` red for hours; its author had verified the content correctly and that
@@ -309,12 +325,24 @@ missing its last commit, reading as complete with every thread resolved.
 after something has already shipped. Merge with the head you verified as a
 PRECONDITION, so the merge itself refuses when the branch has moved:
 
+This runs BEFORE a merge exists, so it cannot borrow `$GH` from the block above:
+that one reads `mergeCommit` and exits when there is none, which is every open
+PR. Acquire the head on its own:
+
 ```sh
+set -euo pipefail
+PR=<number>
+GH=$(gh pr view "$PR" --json headRefOid --jq .headRefOid) || {
+  echo "PR#$PR: head query failed — do not merge" >&2
+  exit 2
+}
+[ -n "$GH" ] || { echo "PR#$PR: empty head — do not merge" >&2; exit 2; }
 gh pr merge "$PR" --squash --match-head-commit "$GH"
 ```
 
-`$GH` is `headRefOid` from the block above — the revision the green checks and
-the clean review belong to. Bind it to that variable rather than retyping a SHA:
+`$GH` must be the revision the green checks and the clean review belong to, so
+read it in the SAME step that merges — a value carried from an earlier step is
+the stale head this flag exists to reject. Bind it to that variable rather than retyping a SHA:
 a merge precondition naming the wrong revision either refuses a correct merge or,
 worse, permits the one it was added to stop.
 

--- a/.claude/rules/verifying-merged-work.md
+++ b/.claude/rules/verifying-merged-work.md
@@ -35,19 +35,50 @@ from the merge, absent from `headRefOid`, and therefore absent from both sides
 of every comparison here. Each step then confirms that everything which merged,
 merged.
 
-The independent source is the ref itself. The guard is part of the check, not a
-note beside it, because the failure it prevents looks exactly like a pass:
+The branch is the only place a stranded commit still exists, so it is where to
+LOOK. It is not a place that can certify, and that limit is structural rather
+than a gap to be patched.
 
-Two remotes are in play and they are not interchangeable. `BASE_REMOTE` holds
-`main` and the merge commit; `HEAD_REMOTE` holds the PR's branch, and for a fork
-that is a different repository entirely:
+**A branch cannot prove a negative.** It is mutable, it is remote, and every
+observation of it is a separate round trip. Each of these erases a tail and
+leaves the range empty, indistinguishable from a branch that never had one:
+
+- a force-push resetting `B` back to merged head `A`;
+- deleting the branch and recreating the same ref at `A`;
+- any reset landing between the timeline read and the `ls-remote` — the two are
+  separate requests and nothing holds the ref still between them.
+
+Enumerating those is not a fix. Three were found by patching this block three
+times, and the fourth is whatever nobody has thought of, because the property
+being asked for — "no commit ever existed here that is not in the merge" — is
+not a property a mutable ref can answer.
+
+So use it as a SCREEN and take the verdict from CONTENT. Any commit it names is
+worth confirming against the merge commit; an empty result means only that this
+cheap look found nothing, never that nothing was lost. When it matters — a
+release, an incident, a PR whose tail you have reason to doubt — verify the
+commits you intended to land by content, per the numbered steps below, and do
+not let an empty range stand in for that.
+
+The guards are inside the block rather than beside it, because the failures they
+prevent all look exactly like a pass. `BASE_REMOTE` holds `main` and the merge
+commit; `HEAD_REMOTE` holds the PR's branch, and for a fork that is a different
+repository entirely:
 
 ```sh
+set -euo pipefail
 PR=<number>
-read -r CROSS OWNER REPO BR GH MERGE < <(gh pr view "$PR" \
+# Captured to a variable first. `read < <(...)` reports the status of `read`,
+# not of the command inside, so a failed `gh` there sets empty fields and the
+# script carries on with them under `set -e`.
+META=$(gh pr view "$PR" \
   --json isCrossRepository,headRepositoryOwner,headRepository,headRefName,headRefOid,mergeCommit \
   --jq '[.isCrossRepository,.headRepositoryOwner.login,.headRepository.name,
-         .headRefName,.headRefOid,.mergeCommit.oid]|@tsv')
+         .headRefName,.headRefOid,.mergeCommit.oid]|@tsv') || {
+  echo "PR#$PR: metadata query failed — NOT CHECKABLE, which is not clean" >&2
+  exit 2
+}
+IFS=$'\t' read -r CROSS OWNER REPO BR GH MERGE <<<"$META"
 BASE_REMOTE=origin                        # must point at the BASE repository
 HEAD_REMOTE=origin
 [ "$CROSS" = true ] && HEAD_REMOTE="https://github.com/$OWNER/$REPO.git"
@@ -57,14 +88,18 @@ HEAD_REMOTE=origin
 # 100 and long PRs here run to three pages: an unpaginated query reads page one
 # and answers zero, which is the reassuring direction. It emits one count per
 # page, hence the sum.
+# Deletion and recreation erases a tail exactly as a force-push does, and the
+# recreated ref reads as ordinary — so both events disqualify. This list is a
+# floor, not a proof: see the note above on why enumeration cannot close this.
 PAGES=$(gh api --paginate "repos/nextlyhq/nextly/issues/$PR/timeline?per_page=100" \
-  --jq '[.[]|select(.event=="head_ref_force_pushed")]|length') || {
+  --jq '[.[]|select(.event=="head_ref_force_pushed" or .event=="head_ref_deleted"
+                    or .event=="head_ref_restored")]|length') || {
   echo "PR#$PR: timeline query failed — NOT CHECKABLE, which is not clean" >&2
   exit 2
 }
 FORCED=$(printf '%s\n' "$PAGES" | awk '{s+=$1} END{print s+0}')
 if [ "${FORCED:-1}" -gt 0 ]; then
-  echo "PR#$PR: $FORCED force-push(es) — NOT CHECKABLE, which is not clean" >&2
+  echo "PR#$PR: $FORCED history-rewrite event(s) — NOT CHECKABLE, not clean" >&2
   exit 2
 fi
 
@@ -73,8 +108,16 @@ if [ -z "$TIP" ]; then
   echo "PR#$PR: no such ref on $HEAD_REMOTE — NOT CHECKABLE, which is not clean" >&2
   exit 2
 fi
-git fetch "$HEAD_REMOTE" "$TIP" --quiet
-git fetch "$BASE_REMOTE" "$MERGE" --quiet
+# Unchecked, these leave `git log` reading whatever objects happen to be local
+# already — a stale answer wearing the same shape as a fresh one.
+git fetch "$HEAD_REMOTE" "$TIP" --quiet || {
+  echo "PR#$PR: could not fetch $TIP — NOT CHECKABLE, which is not clean" >&2
+  exit 2
+}
+git fetch "$BASE_REMOTE" "$MERGE" --quiet || {
+  echo "PR#$PR: could not fetch $MERGE — NOT CHECKABLE, which is not clean" >&2
+  exit 2
+}
 git log --oneline "$GH..$TIP"          # candidates: commits absent from the merge
 ```
 

--- a/.claude/rules/verifying-merged-work.md
+++ b/.claude/rules/verifying-merged-work.md
@@ -35,20 +35,35 @@ from the merge, absent from `headRefOid`, and therefore absent from both sides
 of every comparison here. Each step then confirms that everything which merged,
 merged.
 
-The independent source is the ref itself:
+The independent source is the ref itself. The guard is part of the check, not a
+note beside it, because the failure it prevents looks exactly like a pass:
 
 ```sh
-BR=$(gh pr view N --json headRefName --jq .headRefName)
-TIP=$(git ls-remote origin "refs/heads/$BR" | cut -f1)   # the branch
-GH=$(gh pr view N --json headRefOid --jq .headRefOid)    # what actually merged
+PR=<number>
+BR=$(gh pr view "$PR" --json headRefName --jq .headRefName)   # ASK, never recall
+TIP=$(git ls-remote origin "refs/heads/$BR" | cut -f1)
+if [ -z "$TIP" ]; then
+  echo "PR#$PR: no such ref on origin — NOT CHECKABLE, which is not clean" >&2
+  exit 2
+fi
+GH=$(gh pr view "$PR" --json headRefOid --jq .headRefOid)     # what actually merged
 git fetch origin "$TIP" --quiet
 git log --oneline "$GH..$TIP"          # any output = commits that never merged
 ```
 
-**Empty output is evidence only when `TIP` is non-empty.** A deleted branch
-yields an empty `TIP`, the range degenerates, and the check reports clean
-without having looked. Deleted branch means NOT CHECKABLE, and must be said
-that way rather than passed.
+**An empty `TIP` degenerates the range and the check reports clean without
+having looked.** Two things produce it, and the second is far likelier than the
+first:
+
+- the branch was deleted after merging — the answer is NOT CHECKABLE;
+- **`$BR` names no ref**, because it was typed from memory or from a task file
+  rather than read from `headRefName`. Measured here: a lane checked a PR that
+  HAD stranded a commit, used a branch name one word off from the real head ref,
+  got an empty tip, and concluded the branch had been auto-deleted. The branch
+  existed the whole time, and the correct query reports the stranded commit.
+
+Derive the name in the same command that uses it, and treat an empty tip as a
+refusal to answer.
 
 Measured against a PR known to have lost two commits and one known intact:
 
@@ -56,17 +71,33 @@ Measured against a PR known to have lost two commits and one known intact:
 | --------------------------------------- | -------------- | --------- |
 | `headRefOid`'s date predates the merge  | "clean"        | "clean"   |
 | step 3's delta comparison               | IDENTICAL      | IDENTICAL |
+| `gh api pulls/N/commits`                | 2 commits only | complete  |
 | `git log <headRefOid>..<ls-remote tip>` | 2 STRANDED     | empty     |
 
-The first two are not weak checks; they cannot see this class of defect at all,
-because each derives both of its sides from the snapshot being audited. That is
-worth stating because the delta comparison is the most rigorous-looking option
-on offer, and its thoroughness is what earns the trust it does not deserve here.
+The first three are not weak checks; they cannot see this class of defect at
+all, because each derives from the snapshot being audited. That is worth stating
+because the delta comparison is the most rigorous-looking option on offer, and
+its thoroughness is what earns the trust it does not deserve here. The commits
+API is the most tempting of the three — it is named as though it lists what the
+branch contained, and it lists what merged.
 
 Three PRs lost tails on a single day in this repository, one of them carrying a
 P1 and one leaving `main` red, and none was found by the procedure below.
 
-1. Confirm what was actually merged, then FETCH the object before probing it:
+### Three different questions, and content answers only one
+
+They are easy to run together and none substitutes for another:
+
+1. **Did my code land?** — content, from the final commit. What the numbered
+   steps below answer.
+2. **Did EVERY commit land?** — the `ls-remote` comparison above. Content from a
+   commit that merged cannot reach a commit that did not.
+3. **Was the job green?** — the merge commit's own check-runs, asserted as
+   `success`. A PR merged here with two `Integration` jobs failing and left
+   `main` red for hours; its author had verified the content correctly and that
+   check had nothing to say about the failure.
+
+4. Confirm what was actually merged, then FETCH the object before probing it:
 
    ```
    gh pr view N --json headRefOid,mergeCommit
@@ -88,7 +119,7 @@ P1 and one leaving `main` red, and none was found by the procedure below.
    falsely; run after `main` advances and a later commit can make omitted
    content look present.
 
-2. Take the check from the **final** commit, in whichever direction it changed
+5. Take the check from the **final** commit, in whichever direction it changed
    things. A marker only proves anything if it is UNIQUE to that commit and the
    search is SCOPED to the path it changed — a string that also occurs elsewhere
    answers the same way whether or not the commit landed. Match it as a FIXED
@@ -125,7 +156,7 @@ P1 and one leaving `main` red, and none was found by the procedure below.
 
    - it changed a file mode, a binary, or a rename → text search cannot see it.
 
-3. When nothing is unique to the commit, or the change is a mode/binary/rename,
+6. When nothing is unique to the commit, or the change is a mode/binary/rename,
    compare the PR's **delta** — not the whole object. Diffing the merged path
    entry against the branch-head entry (`git ls-tree`, blob ids) is wrong as soon
    as `main` changed ANOTHER hunk of the same file after the branch point: a
@@ -146,7 +177,7 @@ P1 and one leaving `main` red, and none was found by the procedure below.
    the merge was computed is outside the comparison and it returns IDENTICAL.
    Run the `ls-remote` check above first; this one is not a substitute for it.
 
-4. If the final commit is a pure revert of an earlier one in the same PR, check the
+7. If the final commit is a pure revert of an earlier one in the same PR, check the
    NET effect, not the last hunk.
 
 The danger window is push-a-fix-then-merge-immediately, which is what everyone

--- a/.claude/rules/verifying-merged-work.md
+++ b/.claude/rules/verifying-merged-work.md
@@ -88,16 +88,16 @@ P1 and one leaving `main` red, and none was found by the procedure below.
 
 They are easy to run together and none substitutes for another:
 
-1. **Did my code land?** — content, from the final commit. What the numbered
-   steps below answer.
-2. **Did EVERY commit land?** — the `ls-remote` comparison above. Content from a
-   commit that merged cannot reach a commit that did not.
-3. **Was the job green?** — the merge commit's own check-runs, asserted as
-   `success`. A PR merged here with two `Integration` jobs failing and left
-   `main` red for hours; its author had verified the content correctly and that
-   check had nothing to say about the failure.
+- **Did my code land?** — content, from the final commit. What the numbered
+  steps below answer.
+- **Did EVERY commit land?** — the `ls-remote` comparison above. Content from a
+  commit that merged cannot reach a commit that did not.
+- **Was the job green?** — the merge commit's own check-runs, asserted as
+  `success`. A PR merged here with two `Integration` jobs failing and left
+  `main` red for hours; its author had verified the content correctly and that
+  check had nothing to say about the failure.
 
-4. Confirm what was actually merged, then FETCH the object before probing it:
+1. Confirm what was actually merged, then FETCH the object before probing it:
 
    ```
    gh pr view N --json headRefOid,mergeCommit
@@ -119,7 +119,7 @@ They are easy to run together and none substitutes for another:
    falsely; run after `main` advances and a later commit can make omitted
    content look present.
 
-5. Take the check from the **final** commit, in whichever direction it changed
+2. Take the check from the **final** commit, in whichever direction it changed
    things. A marker only proves anything if it is UNIQUE to that commit and the
    search is SCOPED to the path it changed — a string that also occurs elsewhere
    answers the same way whether or not the commit landed. Match it as a FIXED
@@ -156,7 +156,7 @@ They are easy to run together and none substitutes for another:
 
    - it changed a file mode, a binary, or a rename → text search cannot see it.
 
-6. When nothing is unique to the commit, or the change is a mode/binary/rename,
+3. When nothing is unique to the commit, or the change is a mode/binary/rename,
    compare the PR's **delta** — not the whole object. Diffing the merged path
    entry against the branch-head entry (`git ls-tree`, blob ids) is wrong as soon
    as `main` changed ANOTHER hunk of the same file after the branch point: a
@@ -177,7 +177,7 @@ They are easy to run together and none substitutes for another:
    the merge was computed is outside the comparison and it returns IDENTICAL.
    Run the `ls-remote` check above first; this one is not a substitute for it.
 
-7. If the final commit is a pure revert of an earlier one in the same PR, check the
+4. If the final commit is a pure revert of an earlier one in the same PR, check the
    NET effect, not the last hunk.
 
 The danger window is push-a-fix-then-merge-immediately, which is what everyone

--- a/.claude/rules/verifying-merged-work.md
+++ b/.claude/rules/verifying-merged-work.md
@@ -40,30 +40,51 @@ note beside it, because the failure it prevents looks exactly like a pass:
 
 ```sh
 PR=<number>
-BR=$(gh pr view "$PR" --json headRefName --jq .headRefName)   # ASK, never recall
-TIP=$(git ls-remote origin "refs/heads/$BR" | cut -f1)
+read -r CROSS OWNER REPO BR GH < <(gh pr view "$PR" \
+  --json isCrossRepository,headRepositoryOwner,headRepository,headRefName,headRefOid \
+  --jq '[.isCrossRepository,.headRepositoryOwner.login,.headRepository.name,
+         .headRefName,.headRefOid]|@tsv')
+# A fork's branch does not exist on `origin`, and asking origin for it returns
+# the same empty string a deleted branch does.
+REMOTE=origin
+[ "$CROSS" = true ] && REMOTE="https://github.com/$OWNER/$REPO.git"
+TIP=$(git ls-remote "$REMOTE" "refs/heads/$BR" | cut -f1)
 if [ -z "$TIP" ]; then
-  echo "PR#$PR: no such ref on origin — NOT CHECKABLE, which is not clean" >&2
+  echo "PR#$PR: no such ref on $REMOTE — NOT CHECKABLE, which is not clean" >&2
   exit 2
 fi
-GH=$(gh pr view "$PR" --json headRefOid --jq .headRefOid)     # what actually merged
-git fetch origin "$TIP" --quiet
-git log --oneline "$GH..$TIP"          # any output = commits that never merged
+git fetch "$REMOTE" "$TIP" --quiet
+git log --oneline "$GH..$TIP"          # candidates: commits absent from the merge
 ```
 
 **An empty `TIP` degenerates the range and the check reports clean without
-having looked.** Two things produce it, and the second is far likelier than the
-first:
+having looked.** Three things produce it, and only the first is unanswerable:
 
-- the branch was deleted after merging — the answer is NOT CHECKABLE;
+- the branch was deleted after merging — NOT CHECKABLE;
+- **the PR came from a FORK**, so its branch was never on `origin` at all. This
+  one is the trap, because the empty result is indistinguishable from deletion
+  and invites exactly the wrong conclusion. `isCrossRepository` is what settles
+  it, so query the head repository rather than the base;
 - **`$BR` names no ref**, because it was typed from memory or from a task file
   rather than read from `headRefName`. Measured here: a lane checked a PR that
   HAD stranded a commit, used a branch name one word off from the real head ref,
   got an empty tip, and concluded the branch had been auto-deleted. The branch
   existed the whole time, and the correct query reports the stranded commit.
 
-Derive the name in the same command that uses it, and treat an empty tip as a
+Derive every field in the same command that uses it, and treat an empty tip as a
 refusal to answer.
+
+**Output is a CANDIDATE LIST, not a verdict.** The range says only "absent from
+the merged head", and a surviving branch collects commits for other reasons: it
+was force-pushed or rebased, it was reused for follow-up work, or someone kept
+pushing after the merge. Each is legitimately absent from the squash and none is
+a lost tail. Screen with this, then confirm each named commit by CONTENT against
+the merge commit — a marker unique to it, scoped to the path it changed — before
+calling anything lost. Cheap in both directions: the screen costs one command
+and the confirmation is what you can put in a claim.
+
+The symmetry is the point. Reading the range as a verdict OVER-reports; every
+instrument in the table below UNDER-reports. Only the pairing answers.
 
 Measured against a PR known to have lost two commits and one known intact:
 
@@ -184,10 +205,22 @@ The danger window is push-a-fix-then-merge-immediately, which is what everyone
 does once CI is green and threads are cleared. A PR has already merged here
 missing its last commit, reading as complete with every thread resolved.
 
-**Detection is cleanup; the gate is the fix.** Re-read `git ls-remote` in the
-SAME step as the merge and confirm the tip still matches the revision the green
-checks belong to, restarting the gate if it moved. Everything in this file runs
-after something has already shipped.
+**Detection is cleanup; the gate is the fix.** Everything else in this file runs
+after something has already shipped. Merge with the head you verified as a
+PRECONDITION, so the merge itself refuses when the branch has moved:
+
+```sh
+gh pr merge "$PR" --squash --admin --match-head-commit "$SHA"
+```
+
+`$SHA` is the revision the green checks and the clean review belong to.
+
+Re-reading `ls-remote` immediately before merging is better than not, and it is
+still two operations: a push arriving between the read and the merge is exactly
+the window being closed, and narrowing a race is not closing one. `--match-head-commit`
+makes the check and the merge a single atomic operation on GitHub's side, which
+is the difference between a boundary and a look — and this file exists because a
+look was taken and the branch moved anyway.
 
 ## A red head is grounds to look, not a finding
 

--- a/.claude/rules/verifying-merged-work.md
+++ b/.claude/rules/verifying-merged-work.md
@@ -38,24 +38,38 @@ merged.
 The independent source is the ref itself. The guard is part of the check, not a
 note beside it, because the failure it prevents looks exactly like a pass:
 
+Two remotes are in play and they are not interchangeable. `BASE_REMOTE` holds
+`main` and the merge commit; `HEAD_REMOTE` holds the PR's branch, and for a fork
+that is a different repository entirely:
+
 ```sh
 PR=<number>
-read -r CROSS OWNER REPO BR GH < <(gh pr view "$PR" \
-  --json isCrossRepository,headRepositoryOwner,headRepository,headRefName,headRefOid \
+read -r CROSS OWNER REPO BR GH MERGE < <(gh pr view "$PR" \
+  --json isCrossRepository,headRepositoryOwner,headRepository,headRefName,headRefOid,mergeCommit \
   --jq '[.isCrossRepository,.headRepositoryOwner.login,.headRepository.name,
-         .headRefName,.headRefOid]|@tsv')
-# A fork's branch does not exist on `origin`, and asking origin for it returns
-# the same empty string a deleted branch does.
-REMOTE=origin
-[ "$CROSS" = true ] && REMOTE="https://github.com/$OWNER/$REPO.git"
-TIP=$(git ls-remote "$REMOTE" "refs/heads/$BR" | cut -f1)
+         .headRefName,.headRefOid,.mergeCommit.oid]|@tsv')
+BASE_REMOTE=origin                        # must point at the BASE repository
+HEAD_REMOTE=origin
+[ "$CROSS" = true ] && HEAD_REMOTE="https://github.com/$OWNER/$REPO.git"
+
+# History rewritten? Then the range below cannot certify anything — see next note.
+FORCED=$(gh api "repos/nextlyhq/nextly/issues/$PR/timeline?per_page=100" \
+  --jq '[.[]|select(.event=="head_ref_force_pushed")]|length')
+
+TIP=$(git ls-remote "$HEAD_REMOTE" "refs/heads/$BR" | cut -f1)
 if [ -z "$TIP" ]; then
-  echo "PR#$PR: no such ref on $REMOTE — NOT CHECKABLE, which is not clean" >&2
+  echo "PR#$PR: no such ref on $HEAD_REMOTE — NOT CHECKABLE, which is not clean" >&2
   exit 2
 fi
-git fetch "$REMOTE" "$TIP" --quiet
+git fetch "$HEAD_REMOTE" "$TIP" --quiet
+git fetch "$BASE_REMOTE" "$MERGE" --quiet
 git log --oneline "$GH..$TIP"          # candidates: commits absent from the merge
 ```
+
+Fetch each object from the remote that HAS it. The head commit of a fork PR is
+not on `origin`, so fetching it from there fails and the procedure stops before
+the content checks — reading as a broken verification rather than as a lookup
+pointed at the wrong repository.
 
 **An empty `TIP` degenerates the range and the check reports clean without
 having looked.** Three things produce it, and only the first is unanswerable:
@@ -73,6 +87,23 @@ having looked.** Three things produce it, and only the first is unanswerable:
 
 Derive every field in the same command that uses it, and treat an empty tip as a
 refusal to answer.
+
+**A force-push can erase the evidence, and the range then reports clean.** If
+merged head `A` was followed by stranded commit `B`, and the branch was later
+reset back to `A`, the range is `A..A` — empty, and indistinguishable from a
+branch that never had `B`. Nothing local can recover `B`, because the ref that
+pointed at it is gone.
+
+So `FORCED` is not decoration. A non-zero count means the tip you are comparing
+against is not the history that was pushed, and this check CANNOT certify the
+PR — say NOT CHECKABLE and fall back to content, per-commit, from whatever
+record of the intended commits exists. The timeline reports the event
+(`head_ref_force_pushed`, with the actor and the resulting `commit_id`) but not
+the history it replaced, so detection is all it offers.
+
+Do not reach for the timeline's `committed` entries to recover them: measured on
+a PR with two force-pushes, they number exactly what `pulls/N/commits` returns —
+both describe the current head's history, neither the erased one.
 
 **Output is a CANDIDATE LIST, not a verdict.** The range says only "absent from
 the merged head", and a surviving branch collects commits for other reasons: it
@@ -194,9 +225,12 @@ They are easy to run together and none substitutes for another:
    any earlier commit in the same PR already guarantees.
 
    **This step answers "was the squash rewritten", never "did every commit
-   land".** Both its sides derive from `<headRefOid>`, so a commit pushed after
-   the merge was computed is outside the comparison and it returns IDENTICAL.
-   Run the `ls-remote` check above first; this one is not a substitute for it.
+   land".** The two sides are different objects — the PR side is bounded by
+   `<headRefOid>`, the squash side is `main`'s own history at
+   `<mergeCommit>^..<mergeCommit>` — but neither can contain a commit that never
+   merged, so a commit pushed after the merge was computed is outside both and
+   the comparison returns IDENTICAL. Run the `ls-remote` check above first; this
+   one is not a substitute for it.
 
 4. If the final commit is a pure revert of an earlier one in the same PR, check the
    NET effect, not the last hunk.
@@ -210,10 +244,13 @@ after something has already shipped. Merge with the head you verified as a
 PRECONDITION, so the merge itself refuses when the branch has moved:
 
 ```sh
-gh pr merge "$PR" --squash --admin --match-head-commit "$SHA"
+gh pr merge "$PR" --squash --match-head-commit "$GH"
 ```
 
-`$SHA` is the revision the green checks and the clean review belong to.
+`$GH` is `headRefOid` from the block above — the revision the green checks and
+the clean review belong to. Bind it to that variable rather than retyping a SHA:
+a merge precondition naming the wrong revision either refuses a correct merge or,
+worse, permits the one it was added to stop.
 
 Re-reading `ls-remote` immediately before merging is better than not, and it is
 still two operations: a push arriving between the read and the merge is exactly
@@ -221,6 +258,14 @@ the window being closed, and narrowing a race is not closing one. `--match-head-
 makes the check and the merge a single atomic operation on GitHub's side, which
 is the difference between a boundary and a look — and this file exists because a
 look was taken and the branch moved anyway.
+
+**No `--admin` here, deliberately.** It merges a PR that does not meet the
+repository's requirements — the pending or failing checks and the missing
+reviews — which is precisely what the verified `$GH` exists to protect. Pairing
+them writes a command that pins the exact revision and then waives the reasons
+for pinning it. Where a project genuinely needs the override, add it as its own
+decision and keep `--match-head-commit`: the two flags answer different
+questions, and only one of them is a bypass.
 
 ## A red head is grounds to look, not a finding
 

--- a/.claude/rules/verifying-merged-work.md
+++ b/.claude/rules/verifying-merged-work.md
@@ -52,9 +52,17 @@ BASE_REMOTE=origin                        # must point at the BASE repository
 HEAD_REMOTE=origin
 [ "$CROSS" = true ] && HEAD_REMOTE="https://github.com/$OWNER/$REPO.git"
 
-# History rewritten? Then the range below cannot certify anything — see next note.
-FORCED=$(gh api "repos/nextlyhq/nextly/issues/$PR/timeline?per_page=100" \
-  --jq '[.[]|select(.event=="head_ref_force_pushed")]|length')
+# History rewritten? Then the range below cannot certify anything, so this
+# EXITS rather than annotating. `--paginate` because the timeline is paged at
+# 100 and long PRs here run to three pages: an unpaginated query reads page one
+# and answers zero, which is the reassuring direction. It emits one count per
+# page, hence the sum.
+FORCED=$(gh api --paginate "repos/nextlyhq/nextly/issues/$PR/timeline?per_page=100" \
+  --jq '[.[]|select(.event=="head_ref_force_pushed")]|length' | awk '{s+=$1} END{print s+0}')
+if [ "${FORCED:-1}" -gt 0 ]; then
+  echo "PR#$PR: $FORCED force-push(es) — NOT CHECKABLE, which is not clean" >&2
+  exit 2
+fi
 
 TIP=$(git ls-remote "$HEAD_REMOTE" "refs/heads/$BR" | cut -f1)
 if [ -z "$TIP" ]; then

--- a/.claude/rules/verifying-merged-work.md
+++ b/.claude/rules/verifying-merged-work.md
@@ -57,8 +57,12 @@ HEAD_REMOTE=origin
 # 100 and long PRs here run to three pages: an unpaginated query reads page one
 # and answers zero, which is the reassuring direction. It emits one count per
 # page, hence the sum.
-FORCED=$(gh api --paginate "repos/nextlyhq/nextly/issues/$PR/timeline?per_page=100" \
-  --jq '[.[]|select(.event=="head_ref_force_pushed")]|length' | awk '{s+=$1} END{print s+0}')
+PAGES=$(gh api --paginate "repos/nextlyhq/nextly/issues/$PR/timeline?per_page=100" \
+  --jq '[.[]|select(.event=="head_ref_force_pushed")]|length') || {
+  echo "PR#$PR: timeline query failed — NOT CHECKABLE, which is not clean" >&2
+  exit 2
+}
+FORCED=$(printf '%s\n' "$PAGES" | awk '{s+=$1} END{print s+0}')
 if [ "${FORCED:-1}" -gt 0 ]; then
   echo "PR#$PR: $FORCED force-push(es) — NOT CHECKABLE, which is not clean" >&2
   exit 2
@@ -95,6 +99,17 @@ having looked.** Three things produce it, and only the first is unanswerable:
 
 Derive every field in the same command that uses it, and treat an empty tip as a
 refusal to answer.
+
+**Every step in that block either produces an answer or exits 2, and it is worth
+stating as the block's rule rather than leaving it to be rediscovered.** Three
+separate ways of failing open have now been found in these few lines: a branch
+name that resolved to nothing, a force-push count that was computed and never
+read, and an API failure whose exit status was swallowed by the `awk` that
+summed its output — each one turning "I could not look" into "nothing to see".
+A pipeline is the specific trap there, since its status is the LAST command's:
+capture the query's output in its own substitution, check it, and sum
+afterwards. When a third instance of one shape appears, the shape is a property
+of the design rather than of the instances.
 
 **A force-push can erase the evidence, and the range then reports clean.** If
 merged head `A` was followed by stranded commit `B`, and the branch was later

--- a/.claude/rules/verifying-merged-work.md
+++ b/.claude/rules/verifying-merged-work.md
@@ -26,6 +26,46 @@ final-commit marker, and the check passes over content that was rewritten
 underneath it. When history was rewritten, compare the delta (step 3) rather
 than trusting any single marker.
 
+### None of the steps below can detect a lost tail
+
+They all read `headRefOid`, and **`headRefOid` is the MERGED head** — the
+snapshot GitHub took when it computed the merge, not the branch's current tip.
+A commit pushed after that snapshot is outside the procedure entirely: absent
+from the merge, absent from `headRefOid`, and therefore absent from both sides
+of every comparison here. Each step then confirms that everything which merged,
+merged.
+
+The independent source is the ref itself:
+
+```sh
+BR=$(gh pr view N --json headRefName --jq .headRefName)
+TIP=$(git ls-remote origin "refs/heads/$BR" | cut -f1)   # the branch
+GH=$(gh pr view N --json headRefOid --jq .headRefOid)    # what actually merged
+git fetch origin "$TIP" --quiet
+git log --oneline "$GH..$TIP"          # any output = commits that never merged
+```
+
+**Empty output is evidence only when `TIP` is non-empty.** A deleted branch
+yields an empty `TIP`, the range degenerates, and the check reports clean
+without having looked. Deleted branch means NOT CHECKABLE, and must be said
+that way rather than passed.
+
+Measured against a PR known to have lost two commits and one known intact:
+
+| instrument                              | lost 2 commits | intact    |
+| --------------------------------------- | -------------- | --------- |
+| `headRefOid`'s date predates the merge  | "clean"        | "clean"   |
+| step 3's delta comparison               | IDENTICAL      | IDENTICAL |
+| `git log <headRefOid>..<ls-remote tip>` | 2 STRANDED     | empty     |
+
+The first two are not weak checks; they cannot see this class of defect at all,
+because each derives both of its sides from the snapshot being audited. That is
+worth stating because the delta comparison is the most rigorous-looking option
+on offer, and its thoroughness is what earns the trust it does not deserve here.
+
+Three PRs lost tails on a single day in this repository, one of them carrying a
+P1 and one leaving `main` red, and none was found by the procedure below.
+
 1. Confirm what was actually merged, then FETCH the object before probing it:
 
    ```
@@ -100,12 +140,42 @@ than trusting any single marker.
    them. Whole-object equality is sound only when `main` never touched the
    path. `--stat` is never sound: it reports only that a path was touched, which
    any earlier commit in the same PR already guarantees.
+
+   **This step answers "was the squash rewritten", never "did every commit
+   land".** Both its sides derive from `<headRefOid>`, so a commit pushed after
+   the merge was computed is outside the comparison and it returns IDENTICAL.
+   Run the `ls-remote` check above first; this one is not a substitute for it.
+
 4. If the final commit is a pure revert of an earlier one in the same PR, check the
    NET effect, not the last hunk.
 
 The danger window is push-a-fix-then-merge-immediately, which is what everyone
 does once CI is green and threads are cleared. A PR has already merged here
 missing its last commit, reading as complete with every thread resolved.
+
+**Detection is cleanup; the gate is the fix.** Re-read `git ls-remote` in the
+SAME step as the merge and confirm the tip still matches the revision the green
+checks belong to, restarting the gate if it moved. Everything in this file runs
+after something has already shipped.
+
+## A red head is grounds to look, not a finding
+
+The other half of the same window: the merge snapshots a head, and CI on that
+head is independent of the snapshot. So a PR can merge from a head whose jobs
+had already concluded `failure` — one did here, leaving `main` red.
+
+It does not follow in general. The merge commit is a different tree from the
+head, and it is the one that decides. So establish the state of `main` by
+CONTENT — does it carry the failing assertion, and does it carry the fix —
+rather than by reading a job colour belonging to a tree that was never merged.
+
+**Reading the merge commit's checks instead has its own trap, and it is the one
+that bites.** Querying for `conclusion == "failure"` and finding none reads as
+green and is not: measured on one merge commit here, `Integration (postgres)`,
+`Integration (mysql)`, `Integration (sqlite)` and `Lint / Typecheck / Test /
+Build` were all still `queued` hours later, with two unrelated jobs `completed`.
+Zero failures, because nothing had finished. Assert `success` on each job you
+name; never infer it from the absence of a failure.
 
 ## Before calling a red run flake, name the mechanism
 


### PR DESCRIPTION
## Why

`.claude/rules/verifying-merged-work.md` prescribes a procedure for confirming a merged PR landed whole. **The procedure cannot detect the failure it names as the commonest one.**

The file already says the commonest shape is a lost TAIL — "commits land on the branch after GitHub computed the merge". Every numbered step then reads `headRefOid`, which *is* that snapshot. A commit pushed after it is absent from the merge, absent from `headRefOid`, and therefore absent from both sides of every comparison the file prescribes. Each step confirms that what merged, merged.

## Measured, not argued

Against a PR known to have dropped two commits (#765, whose stranded fix is #772) and one known intact (#760):

| instrument | lost 2 commits | intact |
| --- | --- | --- |
| `headRefOid`'s date predates the merge | "clean" | "clean" |
| **step 3's delta comparison** | **IDENTICAL** (188 lines both sides) | IDENTICAL |
| `git log <headRefOid>..<ls-remote tip>` | **2 STRANDED** | empty |

Step 3 is the file's own recommendation for the case a marker cannot cover — "compare the PR's delta, not the whole object". It returns IDENTICAL on a PR that lost its last two commits. The documented fallback certifies the defect it exists to catch, and does so wearing the authority of being the rigorous option.

This is not theoretical. **Three PRs lost tails on one day**, found only because people went looking:

- **#765** — two commits; left `main` red on `Browser tests`
- **#769** — `9875c9d59`, re-landed as #771
- **#767** — `18a5d26ef`, a P1: scaffolded projects on pnpm ≤9.3 refusing `pnpm add`; re-landed as #773

None was found by this file's procedure.

## What changed

1. **A new section before step 1** stating that none of the steps can see a lost tail, with the `ls-remote` check that can — and its precondition: a deleted branch yields an empty tip, the range degenerates, and the check reports clean without reading anything. Deleted branch is NOT CHECKABLE, not clean.
2. **Step 3 states its own scope** where it is used: it answers "was the squash rewritten", never "did every commit land".
3. **The gate over the detector.** Everything in the file runs after something shipped. Re-reading `ls-remote` in the same step as the merge is what prevents this.
4. **A red head separated from a red `main`.** The merge commit is a different tree and is what decides, so a red head is grounds to look and never the finding itself.

## One claim removed during review

A peer lane reported a merge commit that was green despite a red head, and I had written it in as the counterexample. Checking before shipping it: those four jobs (`Integration (postgres|mysql|sqlite)`, `Lint / Typecheck / Test / Build`) are **`queued`**, not successful — two unrelated jobs had completed, so a `conclusion == "failure"` filter returned nothing while nothing had run.

The corrected text carries that instead, because it is the sharper lesson and it is measured: querying a merge commit for failures and finding none is not green. Assert `success` on each job you name.

Docs-only: no changeset.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded guidance for verifying merged changes and detecting commits added after a merge snapshot, including force pushes.
  * Added instructions for checking branch references across forked repositories and handling missing references or API failures.
  * Clarified the distinction between content landing, complete commit landing, and merge status.
  * Documented candidate-content confirmation, exact head-commit matching, and explicit successful merge checks.
  * Clarified guarded merge requirements and restrictions on administrative overrides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->