### PR TITLE
test(nextly): declare the field-group lock in the upgrade sim

### DIFF
--- a/packages/nextly/src/domains/schema/pipeline/__tests__/v1-golden/upgrade-sim-045.integration.test.ts
+++ b/packages/nextly/src/domains/schema/pipeline/__tests__/v1-golden/upgrade-sim-045.integration.test.ts
@@ -105,6 +105,13 @@ const POST_045_TABLES = [
   // indexes and (on PostgreSQL) its foreign key, and this list is what marks
   // those statements legitimate rather than phantom diffs.
   "email_deliveries",
+  // The field-group migration's lock. It was created on demand by the migration
+  // and invisible to the pipeline until it was declared in the core schema and
+  // the dialect bundles; from that point an existing install legitimately gains
+  // it on upgrade, exactly like the tables above. Listing it here is not a
+  // waiver — the pass-2 assertion below is what proves the declaration then
+  // round-trips to silence instead of being re-proposed on every reconcile.
+  "nextly_field_group_lock",
 ];
 
 // The post-045 names are static identifiers, but escape defensively so the


### PR DESCRIPTION
`main` has been red on `Integration (postgres)` and `Integration (mysql)` since #766
(`29e812978`). This restores it.

## What broke

#766 declared `nextly_field_group_lock` in the core schema and the three dialect
bundles, so the pipeline now proposes it for a database that predates it. That is
the intended behaviour — it is how an existing install gains a new core table.

`upgrade-sim-045.integration.test.ts` replays a 0.45 DDL dump and asserts pass 1
emits **only** additive statements for tables an upgrade legitimately gains, via the
`POST_045_TABLES` allowlist. The lock was never added to that list, so its
`CREATE TABLE` was read as a phantom diff.

`nextly_i18n_archive` has the same history and the same entry, added when its
bundle wiring landed.

## Why sqlite passed

The sqlite leg asserts only that no *destructive* statement appears
(`findUnexpectedDestructiveStatements`); it does not use the additive allowlist. The
two legs check different properties, so the split is expected rather than a
dialect-specific defect.

## Not a round-trip failure

The failure was in pass 1's allowlist, not pass 2. With the entry added, pass 2 is
silent on both dialects, which is the positive proof that the declaration
round-trips through the postgres and mysql introspectors rather than being
re-proposed on every reconcile. Adding the name to the allowlist also *arms* the
`hasCreateTableFor` loop, so a future change that stops emitting the table fails
here rather than passing vacuously.

## Verification

Ran locally against the throwaway containers (pg 5435, mysql 3307):

| state | result |
| --- | --- |
| before the fix | `Tests 2 failed \| 1 passed` — postgres + mysql, matching CI exactly |
| after the fix | `Tests 3 passed (3)` |

Reproducing the failure first is what shows the run can detect it, rather than
assuming the fix worked because the suite is green.

Test-only, so no changeset.
