### PR TITLE
feat(nextly): expire and renew the field-group migration lock

### DIFF
--- a/.changeset/migration-lock-liveness.md
+++ b/.changeset/migration-lock-liveness.md
@@ -1,0 +1,28 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+The field-group migration lock now expires. A run renews its claim while it works, so a run that crashes or is killed no longer leaves a lock only an operator can clear, while a run that is still working keeps the lock for as long as it needs it. A run whose claim is taken over or can no longer be renewed fails loudly instead of continuing unprotected.

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/helpers/locking-adapter.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/helpers/locking-adapter.ts
@@ -13,7 +13,11 @@
 import type { DrizzleAdapter } from "@nextlyhq/adapter-drizzle";
 import type { SQL } from "drizzle-orm";
 
-import { createLockRow, interpretLockStatement } from "./migration-lock-double";
+import {
+  createLockRow,
+  interpretLockStatement,
+  type LockClock,
+} from "./migration-lock-double";
 
 export interface LockingAdapterOptions {
   /** Marker value the `nextly_meta` read returns, or `undefined` for none. */
@@ -31,13 +35,19 @@ export interface LockingAdapterOptions {
    * Empty by default, which is what a fixture that never created a companion actually has.
    */
   companionTables?: readonly string[];
+  /** The database's clock, so a suite can let a seeded claim lapse, and that claim's expiry. */
+  clock?: LockClock;
+  expiresAt?: number | null;
 }
 
 /** The probe {@link createLockingAdapter} has to answer honestly. */
 const COMPANION_PROBE = /^SELECT 1 FROM ["`](\w+_locales)["`] LIMIT 0$/;
 
 export function createLockingAdapter(options: LockingAdapterOptions = {}) {
-  const lock = createLockRow(options.heldBy);
+  const lock = createLockRow(options.heldBy, {
+    clock: options.clock,
+    expiresAt: options.expiresAt,
+  });
   const ddl: string[] = [];
 
   // The lock's own semantics live in one place, shared with the surface that adds them to other
@@ -85,6 +95,8 @@ export function createLockingAdapter(options: LockingAdapterOptions = {}) {
         insert: (_table: string, data: { owner: string | null }) => {
           lock.seeded = true;
           lock.owner = data.owner;
+          // The seed names no expiry, so the column takes its default.
+          lock.expiresAt = null;
           return Promise.resolve(data);
         },
         runStatement: (statement: SQL) => {
@@ -96,5 +108,11 @@ export function createLockingAdapter(options: LockingAdapterOptions = {}) {
       }),
   } as unknown as DrizzleAdapter;
 
-  return { adapter, ownerNow: () => lock.owner, ddlIssued: () => [...ddl] };
+  return {
+    adapter,
+    ownerNow: () => lock.owner,
+    expiresAtNow: () => lock.expiresAt,
+    clock: lock.clock,
+    ddlIssued: () => [...ddl],
+  };
 }

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/helpers/migration-lock-double.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/helpers/migration-lock-double.ts
@@ -95,6 +95,22 @@ export function isClaimLive(lock: LockRow): boolean {
   );
 }
 
+/**
+ * Whether the claim would still be there when its next renewal falls due.
+ *
+ * The stricter of the two questions the real statement answers: a lease can be live at the instant
+ * it is read and gone before anything renews it, so a claimant needs this one rather than
+ * {@link isClaimLive}. The margin is READ FROM THE STATEMENT rather than restated here — a copy
+ * would keep agreeing with the session's constant right up until someone retuned it.
+ */
+export function isClaimUsable(lock: LockRow, marginSeconds: number): boolean {
+  return (
+    lock.owner !== null &&
+    (lock.expiresAt === null ||
+      lock.expiresAt > lock.clock.now() + marginSeconds)
+  );
+}
+
 // Built from the constant rather than spelled out, so a rename of the table moves these with it.
 const TABLE = MIGRATION_LOCK_TABLE;
 
@@ -111,7 +127,7 @@ const NOW = String.raw`(?:clock_timestamp\(\)|NOW\(\)|unixepoch\(\))`;
 const EXPIRY = String.raw`(?:clock_timestamp\(\) \+ make_interval\(secs => \$(?<ttlPg>\d+)\)|DATE_ADD\(NOW\(\), INTERVAL \$(?<ttlMysql>\d+) SECOND\)|unixepoch\(\) \+ \$(?<ttlSqlite>\d+))`;
 
 const LOCK_STATE = new RegExp(
-  String.raw`^SELECT "owner", CASE WHEN "owner" IS NOT NULL AND \("expires_at" IS NULL OR "expires_at" > ${NOW}\) THEN 1 ELSE 0 END AS "live" FROM "${TABLE}" WHERE "id" = \$\d+$`
+  String.raw`^SELECT "owner", CASE WHEN "owner" IS NOT NULL AND \("expires_at" IS NULL OR "expires_at" > ${NOW}\) THEN 1 ELSE 0 END AS "live", CASE WHEN "owner" IS NOT NULL AND \("expires_at" IS NULL OR "expires_at" > ${EXPIRY}\) THEN 1 ELSE 0 END AS "usable" FROM "${TABLE}" WHERE "id" = \$\d+$`
 );
 const ROW_EXISTS = new RegExp(
   String.raw`^SELECT "id" FROM "${TABLE}" WHERE "id" = \$\d+$`
@@ -219,7 +235,13 @@ export function interpretLockStatement(
     // reported whether or not the claim has lapsed — the row still holds the name of whoever wrote
     // it last, and it is the flag rather than the absence of a name that says the claim is dead.
     return lock.seeded
-      ? [{ owner: lock.owner, live: isClaimLive(lock) ? 1 : 0 }]
+      ? [
+          {
+            owner: lock.owner,
+            live: isClaimLive(lock) ? 1 : 0,
+            usable: isClaimUsable(lock, boundTtl(groups, params)) ? 1 : 0,
+          },
+        ]
       : [];
   }
   if (matched?.kind === "claim") {

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/helpers/migration-lock-double.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/helpers/migration-lock-double.ts
@@ -128,6 +128,45 @@ const RELEASE = new RegExp(
 
 type Groups = Record<string, string | undefined> | undefined;
 
+/** The statements this module issues, named. */
+export type LockStatementKind =
+  | "exists"
+  | "state"
+  | "claim"
+  | "renew"
+  | "release";
+
+/**
+ * What a statement IS, separately from what it DOES.
+ *
+ * One matcher for both questions. A suite that needs to observe a particular statement — count the
+ * reads, fail only the renewal — asks this rather than carrying a regex of its own, so there is
+ * exactly one place that can be wrong about which statement is which.
+ */
+function matchLockStatement(
+  flat: string
+): { kind: LockStatementKind; groups: Groups } | undefined {
+  for (const [kind, pattern] of [
+    ["exists", ROW_EXISTS],
+    ["state", LOCK_STATE],
+    ["claim", CLAIM],
+    ["renew", RENEW],
+    ["release", RELEASE],
+  ] as const) {
+    const match = pattern.exec(flat);
+    if (match) return { kind, groups: match.groups };
+  }
+  return undefined;
+}
+
+/** Compile a statement and say which of the lock's statements it is, if any. */
+export function classifyLockStatement(
+  statement: SQL
+): LockStatementKind | undefined {
+  const { sql: text } = new PgDialect().sqlToQuery(statement);
+  return matchLockStatement(text.replace(/\s+/g, " ").trim())?.kind;
+}
+
 /** The value a captured `$n` placeholder was bound to. */
 function bound(
   groups: Groups,
@@ -169,10 +208,13 @@ export function interpretLockStatement(
   const { sql: text, params } = new PgDialect().sqlToQuery(statement);
   const flat = text.replace(/\s+/g, " ").trim();
 
-  if (ROW_EXISTS.test(flat)) {
+  const matched = matchLockStatement(flat);
+  const groups = matched?.groups;
+
+  if (matched?.kind === "exists") {
     return lock.seeded ? [{ id: 1 }] : [];
   }
-  if (LOCK_STATE.test(flat)) {
+  if (matched?.kind === "state") {
     // Liveness is answered here because the real query answers it in the database, and the owner is
     // reported whether or not the claim has lapsed — the row still holds the name of whoever wrote
     // it last, and it is the flag rather than the absence of a name that says the claim is dead.
@@ -180,30 +222,24 @@ export function interpretLockStatement(
       ? [{ owner: lock.owner, live: isClaimLive(lock) ? 1 : 0 }]
       : [];
   }
-
-  const claim = CLAIM.exec(flat);
-  if (claim) {
+  if (matched?.kind === "claim") {
     // 🔴 Unconditional, because the real statement is: `acquire` decides under a row lock and then
     // writes without naming an owner, so a takeover of a lapsed claim overwrites an occupied row.
     // A model that refused an occupied row would agree with the real one on the day it was written
     // and would then quietly certify that no takeover is possible.
     if (!lock.seeded) return [];
-    lock.owner = bound(claim.groups, params, "claim") as string | null;
-    lock.expiresAt = lock.clock.now() + boundTtl(claim.groups, params);
+    lock.owner = bound(groups, params, "claim") as string | null;
+    lock.expiresAt = lock.clock.now() + boundTtl(groups, params);
     return [];
   }
-
-  const renew = RENEW.exec(flat);
-  if (renew) {
-    if (lock.seeded && lock.owner === bound(renew.groups, params, "owner")) {
-      lock.expiresAt = lock.clock.now() + boundTtl(renew.groups, params);
+  if (matched?.kind === "renew") {
+    if (lock.seeded && lock.owner === bound(groups, params, "owner")) {
+      lock.expiresAt = lock.clock.now() + boundTtl(groups, params);
     }
     return [];
   }
-
-  const release = RELEASE.exec(flat);
-  if (release) {
-    if (lock.owner === bound(release.groups, params, "owner")) {
+  if (matched?.kind === "release") {
+    if (lock.owner === bound(groups, params, "owner")) {
       lock.owner = null;
       lock.expiresAt = null;
     }
@@ -229,8 +265,7 @@ export function interpretLockStatement(
  * that has nothing to do with renewal.
  */
 export function isRenewalStatement(statement: SQL): boolean {
-  const { sql: text } = new PgDialect().sqlToQuery(statement);
-  return RENEW.test(text.replace(/\s+/g, " ").trim());
+  return classifyLockStatement(statement) === "renew";
 }
 
 /**

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/helpers/migration-lock-double.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/helpers/migration-lock-double.ts
@@ -115,7 +115,7 @@ export function isClaimUsable(lock: LockRow, marginSeconds: number): boolean {
 const TABLE = MIGRATION_LOCK_TABLE;
 
 /** Each dialect's word for "now", as the session compiles it. */
-const NOW = String.raw`(?:clock_timestamp\(\)|NOW\(\)|unixepoch\(\))`;
+const NOW = String.raw`(?:clock_timestamp\(\)|UTC_TIMESTAMP\(\)|unixepoch\(\))`;
 
 /**
  * Each dialect's expiry expression, capturing the placeholder that carries the TTL.
@@ -124,7 +124,7 @@ const NOW = String.raw`(?:clock_timestamp\(\)|NOW\(\)|unixepoch\(\))`;
  * applies the number the statement actually carried. Importing the constant would agree with a
  * statement that had stopped binding it at all.
  */
-const EXPIRY = String.raw`(?:clock_timestamp\(\) \+ make_interval\(secs => \$(?<ttlPg>\d+)\)|DATE_ADD\(NOW\(\), INTERVAL \$(?<ttlMysql>\d+) SECOND\)|unixepoch\(\) \+ \$(?<ttlSqlite>\d+))`;
+const EXPIRY = String.raw`(?:clock_timestamp\(\) \+ make_interval\(secs => \$(?<ttlPg>\d+)\)|DATE_ADD\(UTC_TIMESTAMP\(\), INTERVAL \$(?<ttlMysql>\d+) SECOND\)|unixepoch\(\) \+ \$(?<ttlSqlite>\d+))`;
 
 const LOCK_STATE = new RegExp(
   String.raw`^SELECT "owner", CASE WHEN "owner" IS NOT NULL AND \("expires_at" IS NULL OR "expires_at" > ${NOW}\) THEN 1 ELSE 0 END AS "live", CASE WHEN "owner" IS NOT NULL AND \("expires_at" IS NULL OR "expires_at" > ${EXPIRY}\) THEN 1 ELSE 0 END AS "usable" FROM "${TABLE}" WHERE "id" = \$\d+$`

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/helpers/migration-lock-double.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/helpers/migration-lock-double.ts
@@ -99,7 +99,7 @@ export function isClaimLive(lock: LockRow): boolean {
 const TABLE = MIGRATION_LOCK_TABLE;
 
 /** Each dialect's word for "now", as the session compiles it. */
-const NOW = String.raw`(?:now\(\)|NOW\(\)|unixepoch\(\))`;
+const NOW = String.raw`(?:clock_timestamp\(\)|NOW\(\)|unixepoch\(\))`;
 
 /**
  * Each dialect's expiry expression, capturing the placeholder that carries the TTL.
@@ -108,7 +108,7 @@ const NOW = String.raw`(?:now\(\)|NOW\(\)|unixepoch\(\))`;
  * applies the number the statement actually carried. Importing the constant would agree with a
  * statement that had stopped binding it at all.
  */
-const EXPIRY = String.raw`(?:now\(\) \+ make_interval\(secs => \$(?<ttlPg>\d+)\)|DATE_ADD\(NOW\(\), INTERVAL \$(?<ttlMysql>\d+) SECOND\)|unixepoch\(\) \+ \$(?<ttlSqlite>\d+))`;
+const EXPIRY = String.raw`(?:clock_timestamp\(\) \+ make_interval\(secs => \$(?<ttlPg>\d+)\)|DATE_ADD\(NOW\(\), INTERVAL \$(?<ttlMysql>\d+) SECOND\)|unixepoch\(\) \+ \$(?<ttlSqlite>\d+))`;
 
 const LOCK_STATE = new RegExp(
   String.raw`^SELECT "owner", CASE WHEN "owner" IS NOT NULL AND \("expires_at" IS NULL OR "expires_at" > ${NOW}\) THEN 1 ELSE 0 END AS "live" FROM "${TABLE}" WHERE "id" = \$\d+$`

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/helpers/migration-lock-double.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/helpers/migration-lock-double.ts
@@ -22,26 +22,138 @@ import { PgDialect } from "drizzle-orm/pg-core";
 import { NextlyError } from "../../../../../errors/nextly-error";
 import { MIGRATION_LOCK_TABLE } from "../../session";
 
-/** The single row the lock is: whether it has been seeded at all, and who holds it. */
+/**
+ * The database's clock, in seconds, under the test's control.
+ *
+ * 🔴 A model clock rather than the real one, and that is the whole reason this can test expiry at
+ * all. The session asks the DATABASE for the time in every statement it issues, so the model has to
+ * own a clock for the same reason the database does — and a test that had to wait two minutes for a
+ * claim to lapse would simply never be written. Advancing it is the only way time passes here, so
+ * every liveness outcome in a suite is one the test asked for rather than one the machine happened
+ * to produce.
+ */
+export interface LockClock {
+  now: () => number;
+  /** Move the database's clock forward, so live claims can genuinely lapse. */
+  advance: (seconds: number) => void;
+}
+
+/** Starts at a fixed instant: a model whose results depend on when it ran is not a model. */
+export function createLockClock(startSeconds = 1_000_000): LockClock {
+  let current = startSeconds;
+  return {
+    now: () => current,
+    advance: (seconds: number) => {
+      current += seconds;
+    },
+  };
+}
+
+/** The single row the lock is: whether it has been seeded at all, who holds it, and until when. */
 export interface LockRow {
   seeded: boolean;
   owner: string | null;
+  /**
+   * When this claim lapses, on {@link LockRow.clock}'s scale, or `null` for a claim that never does.
+   *
+   * `null` is the row a release before this column existed left behind, and the session treats it as
+   * LIVE. Modelled rather than normalised away, because "an old row blocks forever" is the
+   * behaviour, and a double that quietly expired it would certify a takeover the real lock refuses.
+   */
+  expiresAt: number | null;
+  readonly clock: LockClock;
+}
+
+export interface LockRowOptions {
+  /** Shared with the suite so a test can advance it; its own by default. */
+  clock?: LockClock;
+  /** The seeded claim's expiry. Absent means `null`, which the session reads as never expiring. */
+  expiresAt?: number | null;
 }
 
 /**
  * `heldBy` absent means the row has never been seeded, which is what a database that has never run
  * a migration has. Passing `null` seeds it free, and a string seeds it held by someone else.
  */
-export function createLockRow(heldBy?: string | null): LockRow {
-  return { seeded: heldBy !== undefined, owner: heldBy ?? null };
+export function createLockRow(
+  heldBy?: string | null,
+  options: LockRowOptions = {}
+): LockRow {
+  return {
+    seeded: heldBy !== undefined,
+    owner: heldBy ?? null,
+    expiresAt: options.expiresAt ?? null,
+    clock: options.clock ?? createLockClock(),
+  };
 }
 
-const SELECT_OWNER =
-  /^SELECT "\w+" FROM "nextly_field_group_lock" WHERE "id" = \$1$/;
-const CLAIM =
-  /^UPDATE "nextly_field_group_lock" SET "owner" = \$1 WHERE "id" = \$2$/;
-const RELEASE =
-  /^UPDATE "nextly_field_group_lock" SET "owner" = NULL WHERE "id" = \$1 AND "owner" = \$2$/;
+/** Whether the claim in the row would still exclude a contender, on the model's clock. */
+export function isClaimLive(lock: LockRow): boolean {
+  return (
+    lock.owner !== null &&
+    (lock.expiresAt === null || lock.expiresAt > lock.clock.now())
+  );
+}
+
+// Built from the constant rather than spelled out, so a rename of the table moves these with it.
+const TABLE = MIGRATION_LOCK_TABLE;
+
+/** Each dialect's word for "now", as the session compiles it. */
+const NOW = String.raw`(?:now\(\)|NOW\(\)|unixepoch\(\))`;
+
+/**
+ * Each dialect's expiry expression, capturing the placeholder that carries the TTL.
+ *
+ * The TTL is read from the BOUND PARAMETER rather than imported from the session, so the model
+ * applies the number the statement actually carried. Importing the constant would agree with a
+ * statement that had stopped binding it at all.
+ */
+const EXPIRY = String.raw`(?:now\(\) \+ make_interval\(secs => \$(?<ttlPg>\d+)\)|DATE_ADD\(NOW\(\), INTERVAL \$(?<ttlMysql>\d+) SECOND\)|unixepoch\(\) \+ \$(?<ttlSqlite>\d+))`;
+
+const LOCK_STATE = new RegExp(
+  String.raw`^SELECT "owner", CASE WHEN "owner" IS NOT NULL AND \("expires_at" IS NULL OR "expires_at" > ${NOW}\) THEN 1 ELSE 0 END AS "live" FROM "${TABLE}" WHERE "id" = \$\d+$`
+);
+const ROW_EXISTS = new RegExp(
+  String.raw`^SELECT "id" FROM "${TABLE}" WHERE "id" = \$\d+$`
+);
+const CLAIM = new RegExp(
+  String.raw`^UPDATE "${TABLE}" SET "owner" = \$(?<claim>\d+), "expires_at" = ${EXPIRY} WHERE "id" = \$\d+$`
+);
+const RENEW = new RegExp(
+  String.raw`^UPDATE "${TABLE}" SET "expires_at" = ${EXPIRY} WHERE "id" = \$\d+ AND "owner" = \$(?<owner>\d+)$`
+);
+const RELEASE = new RegExp(
+  String.raw`^UPDATE "${TABLE}" SET "owner" = NULL, "expires_at" = NULL WHERE "id" = \$\d+ AND "owner" = \$(?<owner>\d+)$`
+);
+
+type Groups = Record<string, string | undefined> | undefined;
+
+/** The value a captured `$n` placeholder was bound to. */
+function bound(
+  groups: Groups,
+  params: readonly unknown[],
+  ...names: string[]
+): unknown {
+  for (const name of names) {
+    const placeholder = groups?.[name];
+    if (placeholder !== undefined) return params[Number(placeholder) - 1];
+  }
+  return undefined;
+}
+
+/** The TTL the statement bound, refusing anything that is not a number of seconds. */
+function boundTtl(groups: Groups, params: readonly unknown[]): number {
+  const ttl = bound(groups, params, "ttlPg", "ttlMysql", "ttlSqlite");
+  if (typeof ttl !== "number") {
+    throw NextlyError.internal({
+      logContext: {
+        reason: "migration lock expiry did not bind a numeric ttl",
+        bound: String(ttl),
+      },
+    });
+  }
+  return ttl;
+}
 
 /**
  * Apply one statement to the lock row and answer as the database would.
@@ -57,16 +169,44 @@ export function interpretLockStatement(
   const { sql: text, params } = new PgDialect().sqlToQuery(statement);
   const flat = text.replace(/\s+/g, " ").trim();
 
-  if (SELECT_OWNER.test(flat)) {
-    return lock.seeded ? [{ id: 1, owner: lock.owner }] : [];
+  if (ROW_EXISTS.test(flat)) {
+    return lock.seeded ? [{ id: 1 }] : [];
   }
-  if (CLAIM.test(flat)) {
-    // An occupied row refuses a new claim, exactly as the real one does.
-    if (lock.owner === null) lock.owner = params[0] as string | null;
+  if (LOCK_STATE.test(flat)) {
+    // Liveness is answered here because the real query answers it in the database, and the owner is
+    // reported whether or not the claim has lapsed — the row still holds the name of whoever wrote
+    // it last, and it is the flag rather than the absence of a name that says the claim is dead.
+    return lock.seeded
+      ? [{ owner: lock.owner, live: isClaimLive(lock) ? 1 : 0 }]
+      : [];
+  }
+
+  const claim = CLAIM.exec(flat);
+  if (claim) {
+    // 🔴 Unconditional, because the real statement is: `acquire` decides under a row lock and then
+    // writes without naming an owner, so a takeover of a lapsed claim overwrites an occupied row.
+    // A model that refused an occupied row would agree with the real one on the day it was written
+    // and would then quietly certify that no takeover is possible.
+    if (!lock.seeded) return [];
+    lock.owner = bound(claim.groups, params, "claim") as string | null;
+    lock.expiresAt = lock.clock.now() + boundTtl(claim.groups, params);
     return [];
   }
-  if (RELEASE.test(flat)) {
-    if (lock.owner === params[1]) lock.owner = null;
+
+  const renew = RENEW.exec(flat);
+  if (renew) {
+    if (lock.seeded && lock.owner === bound(renew.groups, params, "owner")) {
+      lock.expiresAt = lock.clock.now() + boundTtl(renew.groups, params);
+    }
+    return [];
+  }
+
+  const release = RELEASE.exec(flat);
+  if (release) {
+    if (lock.owner === bound(release.groups, params, "owner")) {
+      lock.owner = null;
+      lock.expiresAt = null;
+    }
     return [];
   }
   // `NextlyError.internal` rather than a bare `Error`: this fires only when the statements the
@@ -78,6 +218,19 @@ export function interpretLockStatement(
       statement: flat,
     },
   });
+}
+
+/**
+ * Whether a statement is the renewal a holder issues while it works.
+ *
+ * Exported so a suite can fail exactly that statement and nothing else. Selecting it by shape,
+ * through the same regex the interpreter uses, is what keeps such a test honest: failing every write
+ * for a window would also fail the claim or the release, and the run would then abort for a reason
+ * that has nothing to do with renewal.
+ */
+export function isRenewalStatement(statement: SQL): boolean {
+  const { sql: text } = new PgDialect().sqlToQuery(statement);
+  return RENEW.test(text.replace(/\s+/g, " ").trim());
 }
 
 /**
@@ -102,6 +255,9 @@ export interface MigrationLockSurfaceOptions {
   heldBy?: string | null;
   /** Whether the lock table is already there. */
   lockTableExists?: boolean;
+  /** The seeded claim's expiry, and the clock it is measured against. */
+  clock?: LockClock;
+  expiresAt?: number | null;
 }
 
 /** The adapter methods this composes with; anything else the double declares is carried through. */
@@ -129,9 +285,17 @@ export function withMigrationLockSurface<T extends AdapterDoubleBase>(
 ): T & {
   queryStatement: (statement: SQL) => Promise<Record<string, unknown>[]>;
   transaction: (work: (ctx: unknown) => Promise<unknown>) => Promise<unknown>;
-  migrationLock: { ownerNow: () => string | null };
+  migrationLock: {
+    ownerNow: () => string | null;
+    /** The database's clock in this model; advance it to let a claim lapse. */
+    clock: LockClock;
+    expiresAtNow: () => number | null;
+  };
 } {
-  const lock = createLockRow(options.heldBy);
+  const lock = createLockRow(options.heldBy, {
+    clock: options.clock,
+    expiresAt: options.expiresAt,
+  });
 
   const readMarker = (): Promise<Record<string, unknown>[]> =>
     Promise.resolve(
@@ -160,6 +324,9 @@ export function withMigrationLockSurface<T extends AdapterDoubleBase>(
         insert: (_table: string, data: { owner: string | null }) => {
           lock.seeded = true;
           lock.owner = data.owner;
+          // The seed names no expiry, so the column takes its default: a free row with nothing to
+          // expire. Writing a live one here would seed a lock nobody could take.
+          lock.expiresAt = null;
           return Promise.resolve(data);
         },
         runStatement: (statement: SQL) => {
@@ -169,6 +336,10 @@ export function withMigrationLockSurface<T extends AdapterDoubleBase>(
         queryStatement: (statement: SQL) =>
           Promise.resolve(interpretLockStatement(lock, statement)),
       }),
-    migrationLock: { ownerNow: () => lock.owner },
+    migrationLock: {
+      ownerNow: () => lock.owner,
+      clock: lock.clock,
+      expiresAtNow: () => lock.expiresAt,
+    },
   };
 }

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/run.test.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/run.test.ts
@@ -1664,7 +1664,7 @@ describe("a preview that meets a writer mid-run", () => {
     expect(outcome.renames.length).toBeGreaterThan(0);
   });
 
-  // 🔴 The control Codex asked for: owners rotate, storage does not. Several invocations acquiring
+  // 🔴 The control that separates the two: owners rotate, storage does not. Several invocations acquiring
   // the lock in turn and failing on ONE permanent conflict each present a fresh claim UUID, so an
   // owner folded into the movement signature makes an unmoving database look like a moving one —
   // and a persistent storage conflict is then reported as contention.

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/run.test.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/run.test.ts
@@ -35,6 +35,11 @@ import {
 } from "../manifest";
 import { readRegistryRows, runFieldGroupMigration } from "../run";
 import { MIGRATION_LOCK_TABLE } from "../session";
+import {
+  classifyLockStatement,
+  createLockRow,
+  interpretLockStatement,
+} from "./helpers/migration-lock-double";
 
 const PRESERVING = identifierCaseRules({ dialect: "postgresql" });
 
@@ -162,44 +167,33 @@ function createRunWorld(world: RunWorld) {
   const writes = { marker: 0 };
   let lockReads = 0;
   let catalogReads = 0;
-  const lock: { seeded: boolean; owner: string | null } = {
-    seeded: true,
-    owner: world.lockOwner ?? null,
-  };
+  // Seeded with a NULL expiry, which the session reads as a claim that has not lapsed — so a world
+  // declaring `lockOwner` still means "somebody holds this", exactly as it did before the column
+  // existed. A test that wants a LAPSED claim is a different world and says so.
+  const lock = createLockRow(world.lockOwner ?? null);
 
   function interpret(statement: SQL): Record<string, unknown>[] {
     const { sql: text, params } = new PgDialect().sqlToQuery(statement);
     const flat = text.replace(/\s+/g, " ").trim();
 
-    if (
-      /^SELECT "\w+" FROM "nextly_field_group_lock" WHERE "id" = \$1$/.test(
-        flat
-      )
-    ) {
-      const answer = lock.seeded ? [{ id: 1, owner: lock.owner }] : [];
-      lockReads += 1;
-      world.onLockRead?.(lockReads);
-      return answer;
-    }
-    if (
-      /^UPDATE "nextly_field_group_lock" SET "owner" = \$1 WHERE "id" = \$2$/.test(
-        flat
-      )
-    ) {
-      // An occupied row refuses a new claim, exactly as the real one does.
-      if (lock.owner === null) {
-        lock.owner = params[0] as string | null;
+    // The lock's own semantics come from the shared model rather than a copy kept here. A second
+    // interpreter of the same statements agrees the day it is written and drifts silently
+    // afterwards, and this file only ever needed to OBSERVE the lock, not to define it.
+    const lockKind = classifyLockStatement(statement);
+    if (lockKind !== undefined) {
+      const heldBefore = lock.owner;
+      const answer = interpretLockStatement(lock, statement);
+      if (lockKind === "state") {
+        // Counted and reported AFTER the answer is computed, so a callback that hands the lock to
+        // somebody changes what the NEXT read sees rather than the one in flight — which is what
+        // lets a test place a writer's arrival at a chosen point.
+        lockReads += 1;
+        world.onLockRead?.(lockReads);
+      }
+      if (lockKind === "claim" && heldBefore === null && lock.owner !== null) {
         trace.push("lock");
       }
-      return [];
-    }
-    if (
-      /^UPDATE "nextly_field_group_lock" SET "owner" = NULL WHERE "id" = \$1 AND "owner" = \$2$/.test(
-        flat
-      )
-    ) {
-      if (lock.owner === params[1]) lock.owner = null;
-      return [];
+      return answer;
     }
     // Two spellings, because production tries the localized column first and
     // falls back when the database predates it. A double that answered only one
@@ -355,6 +349,9 @@ function createRunWorld(world: RunWorld) {
      */
     claimLock: (owner: string | null) => {
       lock.owner = owner;
+      // A claim handed over mid-test is a live one, and a row handed back is free: NULL means
+      // "nothing to expire" in both readings, which is what these worlds meant before the column.
+      lock.expiresAt = null;
     },
   };
 }
@@ -1694,9 +1691,11 @@ describe("a preview that meets a writer mid-run", () => {
     );
   });
 
-  // 🔴 THE control for the durable-claim hole. This lock has no TTL and no auto-steal by design, so
-  // a process that dies holding it leaves the row held until an operator clears it. A held row
-  // therefore proves ownership was RECORDED, not that anyone is moving — and combined with a
+  // 🔴 THE control for the durable-claim hole. A claim outlives the process that made it until its
+  // expiry passes, and a run that dies stops renewing rather than releasing — so for that window
+  // the row still reads as held with nobody behind it, and every attempt of a retry cycle falls
+  // inside it. A held row therefore proves ownership was RECORDED, not that anyone is moving — and
+  // combined with a
   // genuinely permanent mismatch it would spend three attempts and then report a storage conflict
   // as contention, which is the answer this whole path exists to remove arriving by another door.
   // Nothing changes across the attempts here, and an unchanged world is the signature of a claim

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/session.integration.test.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/session.integration.test.ts
@@ -24,6 +24,7 @@ import type { SupportedDialect } from "@nextlyhq/adapter-drizzle/types";
 
 import { NextlyError } from "../../../../errors/nextly-error";
 import {
+  getMigrationLockDdl,
   MIGRATION_LOCK_TABLE,
   withMigrationSession,
   type MigrationSession,
@@ -152,6 +153,97 @@ describe.each(DIALECTS)(
           session("failing", () => Promise.reject(new Error("boom")))
         ).rejects.toThrow();
         expect(await ownerNow()).toBeNull();
+      });
+
+      /**
+       * Put the row in a chosen state, with the expiry computed by the SERVER.
+       *
+       * 🔴 Spelled independently of `expiryExpression` on purpose. A fixture built from the same
+       * expression the code under test uses would agree with a broken one — the two would be wrong
+       * together and the comparison would still look correct. The offset is applied by the database
+       * so no client clock enters the fixture either.
+       */
+      async function seedClaim(
+        owner: string | null,
+        expiresInSeconds: number | null
+      ): Promise<void> {
+        for (const statement of getMigrationLockDdl(dialect)) {
+          await adapter.executeQuery(statement);
+        }
+        await adapter.executeQuery(
+          `INSERT INTO ${MIGRATION_LOCK_TABLE} (id, owner) SELECT 1, NULL WHERE NOT EXISTS (SELECT 1 FROM ${MIGRATION_LOCK_TABLE} WHERE id = 1)`
+        );
+        const expiry =
+          expiresInSeconds === null
+            ? "NULL"
+            : dialect === "sqlite"
+              ? `unixepoch() + (${expiresInSeconds})`
+              : dialect === "mysql"
+                ? `DATE_ADD(NOW(), INTERVAL ${expiresInSeconds} SECOND)`
+                : `now() + (${expiresInSeconds} * interval '1 second')`;
+        await adapter.executeQuery(
+          `UPDATE ${MIGRATION_LOCK_TABLE} SET owner = ${owner === null ? "NULL" : `'${owner}'`}, expires_at = ${expiry} WHERE id = 1`
+        );
+      }
+
+      // 🔴 The two tests below are each other's control, and BOTH are needed on EVERY dialect. The
+      // column is a different type on each — `timestamptz`, `datetime`, and an integer of unix
+      // seconds — so `expires_at > now()` is a different comparison every time. A predicate that
+      // always answered "expired" would let two runs migrate at once and would pass the takeover
+      // test alone; one that always answered "live" would wedge every database forever and would
+      // pass the refusal test alone. Only the pair separates a working comparison from either.
+      it("takes over a claim whose expiry has passed", async () => {
+        await seedClaim("dead-run", -1);
+
+        let ownerDuringRun: string | null = null;
+        await session("takeover", async () => {
+          ownerDuringRun = await ownerNow();
+        });
+
+        expect(ownerDuringRun).toContain("takeover");
+        expect(await ownerNow()).toBeNull();
+      });
+
+      it("refuses a claim whose expiry has not passed", async () => {
+        await seedClaim("live-run", 600);
+
+        const error = await session("contender", () =>
+          Promise.resolve("should not run")
+        ).catch((caught: unknown) => caught);
+
+        expect(NextlyError.is(error)).toBe(true);
+        // Untouched: the refusal must not disturb a claim that is still live.
+        expect(await ownerNow()).toBe("live-run");
+      });
+
+      // The row a release before this column existed left behind. Its writer may still be running,
+      // so age alone never makes it claimable — an operator clears it.
+      it("refuses a claim whose expiry is null", async () => {
+        await seedClaim("legacy-run", null);
+
+        const error = await session("contender", () =>
+          Promise.resolve("should not run")
+        ).catch((caught: unknown) => caught);
+
+        expect(NextlyError.is(error)).toBe(true);
+        expect(await ownerNow()).toBe("legacy-run");
+      });
+
+      // The claim has to WRITE an expiry for any of the above to mean anything: a claim that left
+      // the column NULL would read as a lock that never lapses, and every takeover test would then
+      // be exercising a state the code cannot actually produce.
+      it("writes an expiry that the server reads as still ahead", async () => {
+        await seedClaim(null, null);
+
+        let liveDuringRun: unknown;
+        await session("expiring", async () => {
+          const rows = await adapter.executeQuery<{ live: unknown }>(
+            `SELECT CASE WHEN expires_at > ${dialect === "sqlite" ? "unixepoch()" : dialect === "mysql" ? "NOW()" : "now()"} THEN 1 ELSE 0 END AS live FROM ${MIGRATION_LOCK_TABLE} WHERE id = 1`
+          );
+          liveDuringRun = rows[0]?.live;
+        });
+
+        expect(Number(liveDuringRun)).toBe(1);
       });
     });
   }

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/session.integration.test.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/session.integration.test.ts
@@ -162,6 +162,12 @@ describe.each(DIALECTS)(
        * expression the code under test uses would agree with a broken one — the two would be wrong
        * together and the comparison would still look correct. The offset is applied by the database
        * so no client clock enters the fixture either.
+       *
+       * 🔴 Independently SPELLED, on the same SCALE. MySQL's `NOW()` is session-local and
+       * `expires_at` is a zone-less `DATETIME`, so a fixture written with `NOW()` and a lease
+       * written with `UTC_TIMESTAMP()` differ by the session's offset — and every TTL comparison
+       * here inverts on any connection that is not UTC. Independence has to be in the expression,
+       * never in the frame of reference.
        */
       async function seedClaim(
         owner: string | null,
@@ -179,7 +185,7 @@ describe.each(DIALECTS)(
             : dialect === "sqlite"
               ? `unixepoch() + (${expiresInSeconds})`
               : dialect === "mysql"
-                ? `DATE_ADD(NOW(), INTERVAL ${expiresInSeconds} SECOND)`
+                ? `DATE_ADD(UTC_TIMESTAMP(), INTERVAL ${expiresInSeconds} SECOND)`
                 : `now() + (${expiresInSeconds} * interval '1 second')`;
         await adapter.executeQuery(
           `UPDATE ${MIGRATION_LOCK_TABLE} SET owner = ${owner === null ? "NULL" : `'${owner}'`}, expires_at = ${expiry} WHERE id = 1`
@@ -238,7 +244,7 @@ describe.each(DIALECTS)(
         let liveDuringRun: unknown;
         await session("expiring", async () => {
           const rows = await adapter.executeQuery<{ live: unknown }>(
-            `SELECT CASE WHEN expires_at > ${dialect === "sqlite" ? "unixepoch()" : dialect === "mysql" ? "NOW()" : "now()"} THEN 1 ELSE 0 END AS live FROM ${MIGRATION_LOCK_TABLE} WHERE id = 1`
+            `SELECT CASE WHEN expires_at > ${dialect === "sqlite" ? "unixepoch()" : dialect === "mysql" ? "UTC_TIMESTAMP()" : "now()"} THEN 1 ELSE 0 END AS live FROM ${MIGRATION_LOCK_TABLE} WHERE id = 1`
           );
           liveDuringRun = rows[0]?.live;
         });

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/session.test.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/session.test.ts
@@ -805,6 +805,71 @@ describe("field-group migration session", () => {
     }
   });
 
+  // Being told you lost the lock AFTER the lease already expired is not a warning, it is a report:
+  // by then a contender could have taken the row and started writing. The margin has to leave the
+  // caller time to stop, so the loss is declared while the claim is still live.
+  //
+  // 🔴 This asserts the OBSERVABLE property — the row's expiry is still in the future on the
+  // database's own clock at the moment the run is told — rather than comparing constants. A test
+  // written in terms of `LOCK_LOSS_AFTER_MS` moves with the code when that constant changes and can
+  // never fail: measured, widening the margin back to the full TTL left the whole suite green.
+  it("declares the loss while the lease still has time on it", async () => {
+    vi.useFakeTimers();
+    try {
+      const h = createAdapter({ heldBy: null });
+      const realRunStatement = h.ctx.runStatement.getMockImplementation();
+      h.ctx.runStatement.mockImplementation(async (statement: SQL) => {
+        if (isRenewalStatement(statement)) throw new Error("connection reset");
+        await realRunStatement?.(statement);
+      });
+
+      let expiryAtLoss: number | null = null;
+      let nowAtLoss: number | null = null;
+      const run = withMigrationSession(
+        { adapter: h.adapter, dialect: "postgresql", label: "run-1" },
+        // Never settles: the callback is still working when the claim is given up, which is the
+        // whole situation the margin exists for.
+        () => new Promise<void>(() => undefined)
+      ).catch((error: unknown) => {
+        expiryAtLoss = h.expiresAt();
+        nowAtLoss = h.clock.now();
+        throw error;
+      });
+
+      // 🔴 Let the claim land BEFORE the clock starts moving. Acquisition is asynchronous, so
+      // without this it completes after the first step and writes its expiry from an
+      // already-advanced clock — measured, that put the row 15s further ahead than the run really
+      // held, which is exactly the slack that made this test pass on a broken margin.
+      await vi.advanceTimersByTimeAsync(0);
+
+      // The model database's clock is separate from the timers, so it is stepped WITH them —
+      // otherwise the row never actually ages and its expiry means nothing.
+      for (
+        let elapsed = 0;
+        elapsed < LOCK_TTL_SECONDS * 1000 && expiryAtLoss === null;
+        elapsed += LOCK_RENEW_INTERVAL_MS
+      ) {
+        // 🔴 The database's clock moves FIRST. Advancing the timers first fires the tick that
+        // declares the loss while the model row is still a step behind, so the expiry compared
+        // below is read against a stale clock and looks live whatever the margin is — measured:
+        // in that order this test passed even with the margin widened to the whole TTL.
+        h.clock.advance(LOCK_RENEW_INTERVAL_MS / 1000);
+        await vi.advanceTimersByTimeAsync(LOCK_RENEW_INTERVAL_MS);
+      }
+
+      await expect(run).rejects.toMatchObject({ code: "SERVICE_UNAVAILABLE" });
+
+      // Positive control: the loss actually happened inside the loop above, so the comparison
+      // below is reading values a rejection wrote rather than initialisers.
+      expect(expiryAtLoss).not.toBeNull();
+      expect(expiryAtLoss as unknown as number).toBeGreaterThan(
+        nowAtLoss as unknown as number
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   // `setInterval` fires on a schedule, not on completion, so a renewal slower than the interval
   // would have a second started underneath it and then a third. Two costs, and the second is the
   // one that bites: attempts pile up against the connection pool — with `pool.max: 1` each new one

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/session.test.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/session.test.ts
@@ -1,5 +1,4 @@
 import type { SQL } from "drizzle-orm";
-import { PgDialect } from "drizzle-orm/pg-core";
 import { describe, expect, it, vi } from "vitest";
 
 import type { DrizzleAdapter } from "@nextlyhq/adapter-drizzle";
@@ -7,67 +6,20 @@ import type { DrizzleAdapter } from "@nextlyhq/adapter-drizzle";
 import { NextlyError } from "../../../../errors/nextly-error";
 import {
   getMigrationLockDdl,
+  LOCK_RENEW_INTERVAL_MS,
+  LOCK_TTL_SECONDS,
   MIGRATION_LOCK_TABLE,
+  observeMigrationLock,
   withMigrationSession,
   type LockObservation,
   type MigrationDialect,
 } from "../session";
-
-/**
- * Interpret a statement the way a driver would, against a one-row lock table.
- *
- * The statement is compiled through a real `PgDialect` first, so the double is
- * exercising the SQL and the bound parameters an adapter would actually hand
- * its driver. Reimplementing the query-builder calls instead is what let this
- * module pass its tests while being unable to run at all: the typed CRUD path
- * resolves a table through the schema registry, which has never declared this
- * one.
- */
-function interpret(
-  statement: SQL,
-  rows: Map<number, { id: number; owner: string | null }>
-): Record<string, unknown>[] {
-  const { sql: text, params } = new PgDialect().sqlToQuery(statement);
-  const flat = text.replace(/\s+/g, " ").trim();
-
-  const select = /^SELECT "(\w+)" FROM "([^"]+)" WHERE "id" = \$1$/.exec(flat);
-  if (select) {
-    assertLockTable(select[2]);
-    const row = rows.get(params[0] as number);
-    return row === undefined ? [] : [{ ...row }];
-  }
-
-  const claim = /^UPDATE "([^"]+)" SET "owner" = \$1 WHERE "id" = \$2$/.exec(
-    flat
-  );
-  if (claim) {
-    assertLockTable(claim[1]);
-    const row = rows.get(params[1] as number);
-    if (row === undefined) return [];
-    row.owner = params[0] as string | null;
-    return [];
-  }
-
-  const release =
-    /^UPDATE "([^"]+)" SET "owner" = NULL WHERE "id" = \$1 AND "owner" = \$2$/.exec(
-      flat
-    );
-  if (release) {
-    assertLockTable(release[1]);
-    const row = rows.get(params[0] as number);
-    // A release naming an owner must not clear a row held by someone else.
-    if (row !== undefined && row.owner === params[1]) row.owner = null;
-    return [];
-  }
-
-  throw new Error(`unrecognised statement: ${flat}`);
-}
-
-function assertLockTable(name: string | undefined): void {
-  if (name !== MIGRATION_LOCK_TABLE) {
-    throw new Error(`relation "${String(name)}" does not exist`);
-  }
-}
+import {
+  createLockClock,
+  createLockRow,
+  interpretLockStatement,
+  isRenewalStatement,
+} from "./helpers/migration-lock-double";
 
 /**
  * A single-row lock table backed by an object, plus the two behaviours of the
@@ -77,6 +29,12 @@ function assertLockTable(name: string | undefined): void {
  *   error thrown inside one does NOT come back out intact;
  * - each `transaction()` call takes a connection, so a fake that never counts
  *   them cannot show that the lock stops holding one.
+ *
+ * The lock's own semantics come from {@link interpretLockStatement}, shared with the other suites
+ * that drive this module. Statements reach it compiled through a real `PgDialect`, so the double
+ * exercises the SQL and the bound parameters an adapter would actually hand its driver — which is
+ * what this module needs, having once passed its tests while being unable to run at all because the
+ * typed CRUD path resolves a table through a registry that never declared this one.
  */
 function createAdapter(
   options: {
@@ -84,12 +42,21 @@ function createAdapter(
     lockReadError?: unknown;
     /** Model a database on which no migration has ever run, so the lock table is absent. */
     lockTableMissing?: boolean;
+    /**
+     * Seconds from now until the seeded claim lapses; negative for one that already has.
+     *
+     * Absent leaves the expiry NULL, which is the row a release before this column existed left
+     * behind and which the session reads as live.
+     */
+    expiresIn?: number;
   } = {}
 ) {
-  const rows = new Map<number, { id: number; owner: string | null }>();
-  if (options.heldBy !== undefined) {
-    rows.set(1, { id: 1, owner: options.heldBy });
-  }
+  const clock = createLockClock();
+  const lock = createLockRow(options.heldBy, {
+    clock,
+    expiresAt:
+      options.expiresIn === undefined ? null : clock.now() + options.expiresIn,
+  });
   const ddl: string[] = [];
   let open = 0;
   let peakOpen = 0;
@@ -97,15 +64,18 @@ function createAdapter(
   const ctx = {
     lockRow: vi.fn(async () => undefined),
     insert: vi.fn(async (_t: string, data: Record<string, unknown>) => {
-      const id = data.id as number;
-      if (rows.has(id)) throw new Error("duplicate key");
-      rows.set(id, { id, owner: (data.owner as string | null) ?? null });
+      if (lock.seeded) throw new Error("duplicate key");
+      lock.seeded = true;
+      lock.owner = (data.owner as string | null) ?? null;
+      lock.expiresAt = null;
       return data;
     }),
     runStatement: vi.fn(async (statement: SQL) => {
-      interpret(statement, rows);
+      interpretLockStatement(lock, statement);
     }),
-    queryStatement: vi.fn(async (statement: SQL) => interpret(statement, rows)),
+    queryStatement: vi.fn(async (statement: SQL) =>
+      interpretLockStatement(lock, statement)
+    ),
   };
 
   const adapter = {
@@ -119,7 +89,7 @@ function createAdapter(
       // Models a role that may read the marker and registry but not the lock
       // table -- the case `tableExists` cannot distinguish from absence.
       if (options.lockReadError !== undefined) throw options.lockReadError;
-      return interpret(statement, rows);
+      return interpretLockStatement(lock, statement);
     }),
     tableExists: vi.fn(async () => options.lockTableMissing !== true),
     transaction: vi.fn(async (work: (c: unknown) => Promise<unknown>) => {
@@ -142,11 +112,12 @@ function createAdapter(
     adapter,
     ctx,
     ddl,
-    owner: () => rows.get(1)?.owner ?? null,
+    clock,
+    owner: () => lock.owner,
+    expiresAt: () => lock.expiresAt,
     /** Model another process claiming the row mid-run. */
     takeOver: (owner: string | null) => {
-      const row = rows.get(1);
-      if (row !== undefined) row.owner = owner;
+      if (lock.seeded) lock.owner = owner;
     },
     peakOpen: () => peakOpen,
   };
@@ -602,6 +573,180 @@ describe("field-group migration session", () => {
     );
 
     expect(observed).toEqual({ kind: "not-held" });
+  });
+
+  // 🔴 The claim carries an expiry, and this is the positive control for every test below it: if
+  // the claim stopped writing one, the column would be NULL, every liveness assertion would read
+  // "never expires", and a lock that can no longer be taken over would pass as one that renews.
+  it("writes an expiry with the claim", async () => {
+    const h = createAdapter({ heldBy: null });
+    let expiryDuringRun: number | null = null;
+    await withMigrationSession(
+      { adapter: h.adapter, dialect: "postgresql", label: "run-1" },
+      async () => {
+        expiryDuringRun = h.expiresAt();
+      }
+    );
+    expect(expiryDuringRun).toBe(h.clock.now() + LOCK_TTL_SECONDS);
+    // And the release takes it away again, so a freed row cannot read as a lapsed claim.
+    expect(h.expiresAt()).toBeNull();
+  });
+
+  // A run that died holding the row stopped renewing, so its expiry passing is an OBSERVATION that
+  // it stopped rather than a guess about how long a migration should take. Before this, the only
+  // remedy was an operator clearing the row by hand.
+  it("takes over a claim whose expiry has passed", async () => {
+    const h = createAdapter({ heldBy: "dead-run", expiresIn: -1 });
+    let ownerDuringRun: string | null = null;
+
+    await withMigrationSession(
+      { adapter: h.adapter, dialect: "postgresql", label: "run-2" },
+      async () => {
+        ownerDuringRun = h.owner();
+      }
+    );
+
+    expect(ownerDuringRun).toMatch(/^run-2#/);
+  });
+
+  // 🔴 The deliberate asymmetry. A NULL expiry is the row a release before this column existed left
+  // behind, and the process that wrote it may still be running: stealing the lock from a live
+  // migration is unrecoverable, while refusing until an operator clears a stale row is merely
+  // inconvenient. So age alone never makes that row claimable.
+  it("refuses a claim with no expiry however much time has passed", async () => {
+    const h = createAdapter({ heldBy: "pre-expiry-run" });
+    h.clock.advance(LOCK_TTL_SECONDS * 1000);
+    const ran = vi.fn();
+
+    await expect(
+      withMigrationSession(
+        { adapter: h.adapter, dialect: "postgresql", label: "run-2" },
+        async () => ran()
+      )
+    ).rejects.toMatchObject({ code: "SERVICE_UNAVAILABLE" });
+    expect(ran).not.toHaveBeenCalled();
+    expect(h.owner()).toBe("pre-expiry-run");
+  });
+
+  // The observation and the acquisition answer the same question, so they must not be able to
+  // disagree: naming a dead claim's owner would report contention that no contender would meet, and
+  // the dry-run outcome carrying it would explain a torn read with a run that had already stopped.
+  it("observes a lapsed claim as not-held, exactly as a contender would find it", async () => {
+    const h = createAdapter({ heldBy: "dead-run", expiresIn: -1 });
+    let observed: LockObservation | undefined;
+
+    await withMigrationSession(
+      {
+        adapter: h.adapter,
+        dialect: "postgresql",
+        label: "preview-7",
+        mode: "observe",
+      },
+      async session => {
+        observed = session.lock;
+      }
+    );
+
+    expect(observed).toEqual({ kind: "not-held" });
+  });
+
+  // 🔴 What makes the short TTL safe. Without the renewal a migration outliving its TTL would have
+  // the row taken from underneath it and two runs would rename the same objects — strictly worse
+  // than the refuse-always behaviour this replaces.
+  it("keeps its claim live through a run that outlasts the ttl", async () => {
+    vi.useFakeTimers();
+    try {
+      const h = createAdapter({ heldBy: null });
+      let observedMidRun: LockObservation | undefined;
+
+      await withMigrationSession(
+        { adapter: h.adapter, dialect: "postgresql", label: "long-run" },
+        async () => {
+          // Twice the TTL passes on the database's clock, with the renewal firing as it would in a
+          // migration that genuinely takes this long.
+          const step = LOCK_RENEW_INTERVAL_MS / 1000;
+          for (
+            let elapsed = 0;
+            elapsed < LOCK_TTL_SECONDS * 2;
+            elapsed += step
+          ) {
+            h.clock.advance(step);
+            await vi.advanceTimersByTimeAsync(LOCK_RENEW_INTERVAL_MS);
+          }
+          // Read through the production observation rather than the model's field: this is the
+          // answer a second run would get, which is the property that matters.
+          observedMidRun = await observeMigrationLock(h.adapter, "postgresql");
+        }
+      );
+
+      expect(observedMidRun).toMatchObject({ kind: "held" });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  // A renewal that comes back saying the row names someone else means the work in flight is no
+  // longer protected. The run fails loudly rather than finishing against a database another run may
+  // already be rewriting.
+  it("fails the run when its claim was taken over", async () => {
+    vi.useFakeTimers();
+    try {
+      const h = createAdapter({ heldBy: null });
+      const reachedTheEnd = vi.fn();
+
+      const run = withMigrationSession(
+        { adapter: h.adapter, dialect: "postgresql", label: "run-1" },
+        async () => {
+          h.takeOver("someone-else");
+          await vi.advanceTimersByTimeAsync(LOCK_RENEW_INTERVAL_MS);
+          reachedTheEnd();
+        }
+      );
+
+      await expect(run).rejects.toMatchObject({ code: "SERVICE_UNAVAILABLE" });
+
+      // 🔴 The caller sees the refusal while the work is STILL RUNNING — `reachedTheEnd` has not
+      // been reached at the moment the rejection lands, and runs to completion afterwards anyway.
+      // Asserted in both directions rather than left implicit, because it is the documented limit
+      // of this mechanism: JavaScript has no preemption, so losing the claim stops the run being
+      // WAITED on and cannot stop what it had already started. A reader who assumed cancellation
+      // would be building on a guarantee that is not here.
+      expect(reachedTheEnd).not.toHaveBeenCalled();
+      await vi.advanceTimersByTimeAsync(0);
+      expect(reachedTheEnd).toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  // A renewal that fails is not proof the claim is gone, but it is proof it is no longer being
+  // maintained — and the next attempt may not arrive before the TTL. The safe error is stopping a
+  // run that still holds the lock, not continuing one that does not.
+  it("fails the run when a renewal cannot be made at all", async () => {
+    vi.useFakeTimers();
+    try {
+      const h = createAdapter({ heldBy: null });
+      const realRunStatement = h.ctx.runStatement.getMockImplementation();
+      h.ctx.runStatement.mockImplementation(async (statement: SQL) => {
+        // Only the renewal fails. Failing every write for a window would also break the claim or
+        // the release, and the run would then abort for a reason that has nothing to do with this.
+        if (isRenewalStatement(statement)) {
+          throw new Error("connection reset");
+        }
+        await realRunStatement?.(statement);
+      });
+
+      await expect(
+        withMigrationSession(
+          { adapter: h.adapter, dialect: "postgresql", label: "run-1" },
+          async () => {
+            await vi.advanceTimersByTimeAsync(LOCK_RENEW_INTERVAL_MS);
+          }
+        )
+      ).rejects.toMatchObject({ code: "SERVICE_UNAVAILABLE" });
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("uses a lock table distinct from the schema pipeline's", () => {

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/session.test.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/session.test.ts
@@ -277,15 +277,22 @@ describe("field-group migration session", () => {
   // A run that already lost the lock must not free it on its way out: by then
   // the row belongs to whoever took it next, and clearing it would let a third
   // run start while that one is mid-migration.
-  it("releases only a lock it still owns", async () => {
+  it("releases only a lock it still owns, and refuses to call that a success", async () => {
     const h = createAdapter({ heldBy: null });
-    await withMigrationSession(
-      { adapter: h.adapter, dialect: "postgresql", label: "run-1" },
-      async () => {
-        // Someone else takes the row over while this run is in flight.
-        h.takeOver("run-2");
-      }
-    );
+    await expect(
+      withMigrationSession(
+        { adapter: h.adapter, dialect: "postgresql", label: "run-1" },
+        async () => {
+          // Someone else takes the row over while this run is in flight.
+          h.takeOver("run-2");
+        }
+      )
+      // 🔴 The callback COMPLETED, and the run still fails. Completing is not the same as having
+      // been protected while completing: this run was writing with no exclusion from the moment the
+      // row moved, which is the outcome the lock exists to prevent, so returning the callback's
+      // value would hand back a result the lock never covered.
+    ).rejects.toMatchObject({ code: "SERVICE_UNAVAILABLE" });
+    // And the release still leaves the contender's claim alone, which is the other half.
     expect(h.owner()).toBe("run-2");
   });
 

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/session.test.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/session.test.ts
@@ -817,12 +817,18 @@ describe("field-group migration session", () => {
     // reason it is about.
     const REMAINING = LOCK_RENEW_INTERVAL_MS / 1000 + 1;
     let paused = false;
+    // 🔴 Captured AT the moment the claim is judged, not after the run. A refused acquisition now
+    // clears its own row, so reading the lease afterwards observes the rollback rather than the
+    // state the decision was made on — and the controls below would be asserting about the wrong
+    // instant entirely.
+    let remainingWhenJudged: number | null = null;
     const h = createAdapter({
       heldBy: null,
       onStatement: kind => {
         if (kind === "claim" && !paused) {
           paused = true;
           h.clock.advance(LOCK_TTL_SECONDS - REMAINING);
+          remainingWhenJudged = (h.expiresAt() as number) - h.clock.now();
         }
       },
     });
@@ -844,9 +850,16 @@ describe("field-group migration session", () => {
     // accepted it too. Without the third this test passes on the previous implementation and proves
     // nothing about the change it exists for.
     expect(paused).toBe(true);
-    const remaining = (h.expiresAt() as number) - h.clock.now();
-    expect(remaining).toBeGreaterThan(0);
-    expect(remaining).toBeGreaterThan(LOCK_RENEW_INTERVAL_MS / 1000);
+    expect(remainingWhenJudged as unknown as number).toBeGreaterThan(0);
+    expect(remainingWhenJudged as unknown as number).toBeGreaterThan(
+      LOCK_RENEW_INTERVAL_MS / 1000
+    );
+
+    // 🔴 And the refusal must not leave OUR name on the row. The claim UPDATE has already committed
+    // by this point, so a refusal that simply returned would block every contender for the residual
+    // lease with nothing renewing it and no callback ever starting.
+    expect(h.owner()).toBeNull();
+    expect(h.expiresAt()).toBeNull();
   });
 
   // Being told you lost the lock AFTER the lease already expired is not a warning, it is a report:

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/session.test.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/session.test.ts
@@ -7,7 +7,7 @@ import { NextlyError } from "../../../../errors/nextly-error";
 import {
   getMigrationLockDdl,
   LOCK_RENEW_INTERVAL_MS,
-  LOCK_RENEWALS_BEFORE_LOSS,
+  LOCK_LOSS_AFTER_MS,
   LOCK_TTL_SECONDS,
   MIGRATION_LOCK_TABLE,
   observeMigrationLock,
@@ -805,75 +805,47 @@ describe("field-group migration session", () => {
     }
   });
 
-  // Losing the claim and finishing the work are concurrent events, so they can land in either
-  // order — and the order decides which mechanism reports the loss. When loss wins, the race
-  // rejects and the test above covers it. When COMPLETION wins, the race carries the callback's
-  // value and the loss arrives afterwards, with nothing left watching for it: the release is
-  // skipped (the work was still running when the row stopped being maintained), which leaves
-  // `heldToTheEnd` at its initial `true`. Both guards therefore pass and the run reports success
-  // on a claim it had already declared lost.
-  it("fails a completed run whose claim was declared lost as it finished", async () => {
+  // `setInterval` fires on a schedule, not on completion, so a renewal slower than the interval
+  // would have a second started underneath it and then a third. Two costs, and the second is the
+  // one that bites: attempts pile up against the connection pool — with `pool.max: 1` each new one
+  // queues behind the last and makes it later still — and their completions arrive out of order,
+  // so any judgement made from the ORDER of results is judging something else.
+  it("never starts a second renewal while one is in flight", async () => {
     vi.useFakeTimers();
     try {
-      // Transaction 1 is the acquisition, 2..5 are the four renewals the TTL allows, 6 is the
-      // release. Sequence numbers rather than call-order guesses, so a change in how many
-      // transactions the session takes fails this loudly instead of silently retargeting it.
-      const ACQUIRE = 1;
-      const LAST_RENEWAL = 1 + LOCK_RENEWALS_BEFORE_LOSS;
-      const RELEASE = LAST_RENEWAL + 1;
+      let started = 0;
+      let startedWhileHung = 0;
+      let ungate: (() => void) | undefined;
+      const hung = new Promise<void>(resolve => {
+        ungate = resolve;
+      });
 
       const h = createAdapter({
         heldBy: null,
         onTransaction: async seq => {
-          if (seq === ACQUIRE) return;
-          if (seq === RELEASE) {
-            // 🔴 The interleaving this test exists for. The final renewal is still in flight when
-            // the release opens, so yielding here lets its failure — and the loss it declares —
-            // land while the release is between its own awaits. That is exactly the window where
-            // the callback has already produced a value and nothing is watching the claim.
-            for (let turn = 0; turn < 50; turn++) await Promise.resolve();
-            return;
-          }
-          // Every renewal fails to reach the database. Not proof the claim is gone, which is why
-          // it takes all four before the session gives up on it.
-          throw new Error("connection reset");
+          // Sequence 1 is the acquisition and must complete, or nothing holds the lock at all.
+          if (seq === 1) return;
+          started += 1;
+          await hung;
         },
       });
 
-      const run = withMigrationSession(
-        { adapter: h.adapter, dialect: "postgresql", label: "run-1" },
-        async () => {
-          // Spend the first three attempts, awaiting each so the failures are genuinely
-          // consecutive rather than overlapping.
-          for (
-            let attempt = 1;
-            attempt < LOCK_RENEWALS_BEFORE_LOSS;
-            attempt++
-          ) {
-            await vi.advanceTimersByTimeAsync(LOCK_RENEW_INTERVAL_MS);
+      await expect(
+        withMigrationSession(
+          { adapter: h.adapter, dialect: "postgresql", label: "run-1" },
+          async () => {
+            // Several intervals, all inside the margin, so nothing here is a loss — the only
+            // question is how many attempts were STARTED while the first had not come back.
+            await vi.advanceTimersByTimeAsync(LOCK_RENEW_INTERVAL_MS * 4);
+            startedWhileHung = started;
+            ungate?.();
           }
-          // 🔴 Synchronous, and NOT awaited. It starts the fourth renewal and returns before that
-          // renewal can settle, which is what makes completion win the race. Awaiting here would
-          // let the loss land first and exercise the other path entirely.
-          vi.advanceTimersByTime(LOCK_RENEW_INTERVAL_MS);
-          return "migrated";
-        }
-      );
+        )
+      ).resolves.toBeUndefined();
 
-      // 🔴 The REASON, not just the code. `heldToTheEnd` reports a different reason from the same
-      // factory, so asserting SERVICE_UNAVAILABLE alone would pass on the guard that was already
-      // there and prove nothing about this one.
-      await expect(run).rejects.toMatchObject({
-        code: "SERVICE_UNAVAILABLE",
-        logContext: {
-          reason: "migration lock claim was lost before completion",
-        },
-      });
-
-      // 🔴 Positive control on WHICH guard fired. The release ran and cleared the row, so it found
-      // the claim still ours and still live and reported `heldToTheEnd` — the pre-existing
-      // completion check had nothing to object to. That is what makes the rejection above evidence
-      // about this race rather than about a takeover the older guard would have caught anyway.
+      // 🔴 Read INSIDE the run, before the release opens its own transaction — otherwise this
+      // counts the release too and the number stops meaning what it says.
+      expect(startedWhileHung).toBe(1);
       expect(h.owner()).toBeNull();
     } finally {
       vi.useRealTimers();
@@ -902,9 +874,7 @@ describe("field-group migration session", () => {
           { adapter: h.adapter, dialect: "postgresql", label: "run-1" },
           async () => {
             // The whole margin, because one failure is deliberately survivable.
-            await vi.advanceTimersByTimeAsync(
-              LOCK_RENEW_INTERVAL_MS * LOCK_RENEWALS_BEFORE_LOSS
-            );
+            await vi.advanceTimersByTimeAsync(LOCK_LOSS_AFTER_MS);
           }
         )
       ).rejects.toMatchObject({ code: "SERVICE_UNAVAILABLE" });
@@ -933,9 +903,7 @@ describe("field-group migration session", () => {
       const run = withMigrationSession(
         { adapter: h.adapter, dialect: "postgresql", label: "run-1" },
         async () => {
-          await vi.advanceTimersByTimeAsync(
-            LOCK_RENEW_INTERVAL_MS * LOCK_RENEWALS_BEFORE_LOSS
-          );
+          await vi.advanceTimersByTimeAsync(LOCK_LOSS_AFTER_MS);
         }
       );
       await expect(run).rejects.toMatchObject({ code: "SERVICE_UNAVAILABLE" });
@@ -958,12 +926,17 @@ describe("field-group migration session", () => {
     try {
       const h = createAdapter({ heldBy: null });
       const realRunStatement = h.ctx.runStatement.getMockImplementation();
+      // Ticks fire every interval, and the one AT the margin declares loss instead of attempting —
+      // so this many attempts actually reach the database before the session gives up. Derived from
+      // the constants rather than written as a number, so retuning either keeps this a blip instead
+      // of silently turning it into a loss.
+      const ATTEMPTS_BEFORE_LOSS =
+        Math.floor(LOCK_LOSS_AFTER_MS / LOCK_RENEW_INTERVAL_MS) - 1;
       let failures = 0;
       h.ctx.runStatement.mockImplementation(async (statement: SQL) => {
-        // One short of the margin, then recovery — the shape of a blip.
         if (
           isRenewalStatement(statement) &&
-          failures < LOCK_RENEWALS_BEFORE_LOSS - 1
+          failures < ATTEMPTS_BEFORE_LOSS - 1
         ) {
           failures += 1;
           throw new Error("connection reset");
@@ -975,14 +948,17 @@ describe("field-group migration session", () => {
         withMigrationSession(
           { adapter: h.adapter, dialect: "postgresql", label: "run-1" },
           async () => {
+            // Past the margin, so a run that had NOT recovered would have been declared lost.
             await vi.advanceTimersByTimeAsync(
-              LOCK_RENEW_INTERVAL_MS * (LOCK_RENEWALS_BEFORE_LOSS + 1)
+              LOCK_LOSS_AFTER_MS + LOCK_RENEW_INTERVAL_MS
             );
           }
         )
       ).resolves.toBeUndefined();
 
-      expect(failures).toBe(LOCK_RENEWALS_BEFORE_LOSS - 1);
+      // 🔴 The blip has to have actually happened, or this passes on a run that never failed a
+      // renewal at all — the assertion that would be satisfied by absence.
+      expect(failures).toBe(ATTEMPTS_BEFORE_LOSS - 1);
       // Released normally, because the claim was never lost.
       expect(h.owner()).toBeNull();
     } finally {

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/session.test.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/session.test.ts
@@ -806,21 +806,23 @@ describe("field-group migration session", () => {
     }
   });
 
-  // "Not yet expired" is not "safe to start work on". The claim UPDATE and its read-back are two
-  // statements, and a process descheduled between them can spend most of the TTL there — coming back
-  // to a lease that is genuinely live and has less left than the interval before anything renews it.
-  // Starting a migration on that is starting it unprotected: the row lapses while `fn` is running
-  // and a contender takes it.
-  it("refuses a claim whose lease cannot survive to its first renewal", async () => {
+  // "Not yet expired" is not "safe to start work on", and neither is "lasts past the next renewal".
+  // The claim UPDATE and its read-back are two statements, and a process descheduled between them
+  // comes back to a lease that is live, outlives the first renewal, and still cannot cover the
+  // window in which this session will not ask again — so the row lapses mid-run and a contender
+  // takes it while `fn` is still writing.
+  it("refuses a claim whose lease cannot cover the loss window", async () => {
+    // One second past the first renewal, and far short of the loss deadline. Chosen to sit in the
+    // gap BETWEEN the two thresholds, which is the only region where this test can fail for the
+    // reason it is about.
+    const REMAINING = LOCK_RENEW_INTERVAL_MS / 1000 + 1;
     let paused = false;
     const h = createAdapter({
       heldBy: null,
       onStatement: kind => {
         if (kind === "claim" && !paused) {
           paused = true;
-          // Long enough to eat most of the lease, short enough to leave it LIVE — which is the
-          // whole point: the previous check passes here and the work still ends up unprotected.
-          h.clock.advance(LOCK_TTL_SECONDS - LOCK_RENEW_MARGIN_SECONDS + 5);
+          h.clock.advance(LOCK_TTL_SECONDS - REMAINING);
         }
       },
     });
@@ -836,11 +838,15 @@ describe("field-group migration session", () => {
     // The migration never started, which is the outcome that matters.
     expect(ran).not.toHaveBeenCalled();
 
-    // 🔴 The controls that make this about the MARGIN rather than about expiry. The pause happened,
-    // and the lease was still live when it was judged — so a plain liveness test would have accepted
-    // this claim and let the run proceed.
+    // 🔴 Three controls, each ruling out a WEAKER check that would also have gone green here. The
+    // pause happened at all; the lease was still LIVE when judged, so a plain liveness test would
+    // have accepted it; and it outlived the first renewal, so a one-interval margin would have
+    // accepted it too. Without the third this test passes on the previous implementation and proves
+    // nothing about the change it exists for.
     expect(paused).toBe(true);
-    expect(h.expiresAt() as number).toBeGreaterThan(h.clock.now());
+    const remaining = (h.expiresAt() as number) - h.clock.now();
+    expect(remaining).toBeGreaterThan(0);
+    expect(remaining).toBeGreaterThan(LOCK_RENEW_INTERVAL_MS / 1000);
   });
 
   // Being told you lost the lock AFTER the lease already expired is not a warning, it is a report:

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/session.test.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/session.test.ts
@@ -1,4 +1,5 @@
 import type { SQL } from "drizzle-orm";
+import { PgDialect } from "drizzle-orm/pg-core";
 import { describe, expect, it, vi } from "vitest";
 
 import type { DrizzleAdapter } from "@nextlyhq/adapter-drizzle";
@@ -801,6 +802,82 @@ describe("field-group migration session", () => {
       // the green above cannot be a renewal that was never reached.
       expect(h.owner()).toMatch(/^run-1#/);
       expect(suspended).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  // MySQL's `NOW()` is the SESSION's local time and `expires_at` is a `DATETIME`, which stores no
+  // zone. Two sessions configured with different `time_zone` therefore write and read the same
+  // column on different scales: a holder in UTC writes an expiry a contender in UTC+05 reads as
+  // hours in the past, takes the live claim, and both migrations run. Nothing about the row looks
+  // wrong afterwards, which is what makes it worth pinning.
+  it("uses a timezone-independent clock for MySQL leases", async () => {
+    const h = createAdapter({ heldBy: null });
+    await withMigrationSession(
+      { adapter: h.adapter, dialect: "mysql", label: "run-1" },
+      async () => undefined
+    );
+
+    const compiled = [
+      ...h.ctx.runStatement.mock.calls,
+      ...h.ctx.queryStatement.mock.calls,
+    ].map(([statement]) => new PgDialect().sqlToQuery(statement as SQL).sql);
+
+    // Positive control: the run has to have issued clock-bearing statements at all, or the loop
+    // below iterates over nothing and passes by vacuity.
+    const clockBearing = compiled.filter(text =>
+      /UTC_TIMESTAMP\(\)|NOW\(\)/.test(text)
+    );
+    expect(clockBearing.length).toBeGreaterThan(0);
+
+    for (const text of clockBearing) {
+      expect(text).toContain("UTC_TIMESTAMP()");
+      // Session-local `NOW()` must not survive anywhere in the statement. Stripping the UTC form
+      // first is what stops this matching the tail of `UTC_TIMESTAMP()` itself.
+      expect(text.replace(/UTC_TIMESTAMP\(\)/g, "")).not.toContain("NOW()");
+    }
+  });
+
+  // `acquire` makes its decision INSIDE the transaction. Getting back out is a separate step that
+  // can take arbitrarily long — the commit, the driver resolving, this process being scheduled
+  // again — and none of it is visible to the checks made in there. The first elapsed-time check is
+  // a whole interval away, so the callback would otherwise start on a lease that may have lapsed.
+  it("refuses when acquisition itself outlasts the safety window", async () => {
+    vi.useFakeTimers();
+    try {
+      let stalled = false;
+      const h = createAdapter({
+        heldBy: null,
+        onStatement: kind => {
+          if (kind === "claim" && !stalled) {
+            stalled = true;
+            // 🔴 Only the PROCESS clock moves. The model database clock stays put, so the row is
+            // still comfortably usable when `acquire` judges it — which is what makes this test
+            // about the post-acquisition age check rather than about the usable-lease check.
+            vi.advanceTimersByTime(LOCK_LOSS_AFTER_MS + 1000);
+          }
+        },
+      });
+
+      const ran = vi.fn();
+      await expect(
+        withMigrationSession(
+          { adapter: h.adapter, dialect: "postgresql", label: "run-1" },
+          async () => ran()
+        )
+      ).rejects.toMatchObject({
+        code: "SERVICE_UNAVAILABLE",
+        logContext: {
+          reason:
+            "migration lock claim aged past its safety window during acquisition",
+        },
+      });
+
+      expect(ran).not.toHaveBeenCalled();
+      expect(stalled).toBe(true);
+      // Cleared, so a run that refused its own claim does not block contenders.
+      expect(h.owner()).toBeNull();
     } finally {
       vi.useRealTimers();
     }

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/session.test.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/session.test.ts
@@ -1094,12 +1094,16 @@ describe("field-group migration session", () => {
     }
   });
 
-  // 🔴 THE case a renewal makes worse if the exit path is naive. A renewal that fails on a blip
-  // leaves the row STILL OWNED by this claim, so an owner-scoped release matches and frees it —
-  // while `fn`, which nothing here can stop, carries on rewriting tables. The next contender would
-  // then start against a database this run is still writing to, which is worse than never having
-  // renewed at all. The claim is left to lapse instead.
-  it("does not free a row it still owns after losing the claim", async () => {
+  // 🔴 THE case a renewal makes worse if the exit path is naive, in BOTH directions. A renewal that
+  // failed on a blip leaves the row still owned by this claim, so an owner-scoped release matches
+  // and frees it — while `fn`, which nothing here can stop, carries on rewriting tables. Freeing it
+  // there hands the next contender a database this run is still writing to. But leaving it alone
+  // forever is the opposite failure: a renewal that was blocked when the claim was abandoned still
+  // runs its UPDATE when the connection frees up, re-extending the row by a whole TTL with nobody
+  // renewing it afterwards — a live claim owned by a process that gave up.
+  //
+  // The row is therefore held for exactly as long as the work runs, and cleared once it stops.
+  it("holds a lost claim while the work runs, then clears it", async () => {
     vi.useFakeTimers();
     try {
       const h = createAdapter({ heldBy: null });
@@ -1111,19 +1115,37 @@ describe("field-group migration session", () => {
         await realRunStatement?.(statement);
       });
 
+      // The callback stays pending until this test says otherwise, which is what lets the two
+      // halves below be observed as separate moments rather than inferred from one.
+      let finishWork: (() => void) | undefined;
+      const working = new Promise<void>(resolve => {
+        finishWork = resolve;
+      });
+
       const run = withMigrationSession(
         { adapter: h.adapter, dialect: "postgresql", label: "run-1" },
-        async () => {
-          await vi.advanceTimersByTimeAsync(LOCK_LOSS_AFTER_MS);
-        }
+        () => working
       );
-      await expect(run).rejects.toMatchObject({ code: "SERVICE_UNAVAILABLE" });
-      await vi.advanceTimersByTimeAsync(0);
+      // Attached before the timers move: the rejection lands during the advance below, and with no
+      // handler yet in place it would be an unhandled rejection that exits the suite non-zero.
+      const settled = run.then(
+        () => undefined,
+        (error: unknown) => error
+      );
 
-      // Still claimed by this run, because the work it protects has not stopped. Left to expire on
-      // its own rather than handed over while that work is in flight.
+      await vi.advanceTimersByTimeAsync(LOCK_LOSS_AFTER_MS);
+      expect(await settled).toMatchObject({ code: "SERVICE_UNAVAILABLE" });
+
+      // Half one: the caller has been told, and the row is STILL OURS, because the callback it
+      // protects has not stopped. Handing it over here is the outcome the lock exists to prevent.
       expect(h.owner()).toMatch(/^run-1#/);
       expect(h.expiresAt()).not.toBeNull();
+
+      // Half two: once the work actually stops, the claim is cleared rather than left to sit as a
+      // phantom holder that later runs cannot distinguish from a healthy one.
+      finishWork?.();
+      await vi.advanceTimersByTimeAsync(0);
+      expect(h.owner()).toBeNull();
     } finally {
       vi.useRealTimers();
     }

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/session.test.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/session.test.ts
@@ -7,6 +7,7 @@ import { NextlyError } from "../../../../errors/nextly-error";
 import {
   getMigrationLockDdl,
   LOCK_RENEW_INTERVAL_MS,
+  LOCK_RENEW_MARGIN_SECONDS,
   LOCK_LOSS_AFTER_MS,
   LOCK_TTL_SECONDS,
   MIGRATION_LOCK_TABLE,
@@ -805,6 +806,43 @@ describe("field-group migration session", () => {
     }
   });
 
+  // "Not yet expired" is not "safe to start work on". The claim UPDATE and its read-back are two
+  // statements, and a process descheduled between them can spend most of the TTL there — coming back
+  // to a lease that is genuinely live and has less left than the interval before anything renews it.
+  // Starting a migration on that is starting it unprotected: the row lapses while `fn` is running
+  // and a contender takes it.
+  it("refuses a claim whose lease cannot survive to its first renewal", async () => {
+    let paused = false;
+    const h = createAdapter({
+      heldBy: null,
+      onStatement: kind => {
+        if (kind === "claim" && !paused) {
+          paused = true;
+          // Long enough to eat most of the lease, short enough to leave it LIVE — which is the
+          // whole point: the previous check passes here and the work still ends up unprotected.
+          h.clock.advance(LOCK_TTL_SECONDS - LOCK_RENEW_MARGIN_SECONDS + 5);
+        }
+      },
+    });
+
+    const ran = vi.fn();
+    await expect(
+      withMigrationSession(
+        { adapter: h.adapter, dialect: "postgresql", label: "run-1" },
+        async () => ran()
+      )
+    ).rejects.toMatchObject({ code: "SERVICE_UNAVAILABLE" });
+
+    // The migration never started, which is the outcome that matters.
+    expect(ran).not.toHaveBeenCalled();
+
+    // 🔴 The controls that make this about the MARGIN rather than about expiry. The pause happened,
+    // and the lease was still live when it was judged — so a plain liveness test would have accepted
+    // this claim and let the run proceed.
+    expect(paused).toBe(true);
+    expect(h.expiresAt() as number).toBeGreaterThan(h.clock.now());
+  });
+
   // Being told you lost the lock AFTER the lease already expired is not a warning, it is a report:
   // by then a contender could have taken the row and started writing. The margin has to leave the
   // caller time to stop, so the loss is declared while the claim is still live.
@@ -830,11 +868,21 @@ describe("field-group migration session", () => {
         // Never settles: the callback is still working when the claim is given up, which is the
         // whole situation the margin exists for.
         () => new Promise<void>(() => undefined)
-      ).catch((error: unknown) => {
-        expiryAtLoss = h.expiresAt();
-        nowAtLoss = h.clock.now();
-        throw error;
-      });
+      );
+
+      // 🔴 The rejection handler is attached HERE, synchronously, and returns the error as a VALUE
+      // rather than rethrowing. The loop below drives the timers for many turns before anything
+      // awaits this, and a rejection that lands with no handler attached is an unhandled rejection:
+      // vitest reports it as an error and EXITS 1 while still printing every test as passed. Awaiting
+      // the assertion after the loop is what creates that gap, so the handler cannot wait for it.
+      const settled = run.then(
+        () => undefined,
+        (error: unknown) => {
+          expiryAtLoss = h.expiresAt();
+          nowAtLoss = h.clock.now();
+          return error;
+        }
+      );
 
       // 🔴 Let the claim land BEFORE the clock starts moving. Acquisition is asynchronous, so
       // without this it completes after the first step and writes its expiry from an
@@ -857,7 +905,9 @@ describe("field-group migration session", () => {
         await vi.advanceTimersByTimeAsync(LOCK_RENEW_INTERVAL_MS);
       }
 
-      await expect(run).rejects.toMatchObject({ code: "SERVICE_UNAVAILABLE" });
+      // `undefined` here would mean the run RESOLVED, which is its own failure and must not read as
+      // a missing rejection.
+      expect(await settled).toMatchObject({ code: "SERVICE_UNAVAILABLE" });
 
       // Positive control: the loss actually happened inside the loop above, so the comparison
       // below is reading values a rejection wrote rather than initialisers.

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/session.test.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/session.test.ts
@@ -830,6 +830,56 @@ describe("field-group migration session", () => {
     }
   });
 
+  // 🔴 `CREATE TABLE IF NOT EXISTS` is a no-op against a table that already exists, so an install
+  // holding the two-column lock row never gains `expires_at` and every liveness read then names a
+  // missing column. The upgrade path deadlocks on its own repair: this lock is taken BEFORE the
+  // schema sync that would reconcile the column.
+  it.each<MigrationDialect>(["postgresql", "mysql", "sqlite"])(
+    "adds the expiry column to a pre-existing lock table on %s",
+    async dialect => {
+      const h = createAdapter({ heldBy: null });
+      await withMigrationSession(
+        { adapter: h.adapter, dialect, label: "run-1" },
+        async () => undefined
+      );
+      const altered = h.ddl.filter(s => /ALTER TABLE/i.test(s));
+      expect(altered).toHaveLength(1);
+      expect(altered[0]).toContain("expires_at");
+    }
+  );
+
+  // The upgrade runs unconditionally, so the SECOND run always meets a column that is already
+  // there. Tolerating that by CODE is what makes the statement safe to issue every time — and a
+  // failure that is NOT a duplicate must still surface, or a genuinely broken ALTER would be
+  // swallowed and every later read would fail on the missing column.
+  it("tolerates the expiry column already existing, but not other failures", async () => {
+    const duplicate = createAdapter({ heldBy: null });
+    duplicate.adapter.executeQuery = vi.fn(async (sql: string) => {
+      if (/ALTER TABLE/i.test(sql))
+        throw new Error("duplicate column name: expires_at");
+      return [];
+    }) as unknown as typeof duplicate.adapter.executeQuery;
+    await expect(
+      withMigrationSession(
+        { adapter: duplicate.adapter, dialect: "sqlite", label: "run-1" },
+        async () => undefined
+      )
+    ).resolves.toBeUndefined();
+
+    const denied = createAdapter({ heldBy: null });
+    denied.adapter.executeQuery = vi.fn(async (sql: string) => {
+      if (/ALTER TABLE/i.test(sql))
+        throw new Error("permission denied for table");
+      return [];
+    }) as unknown as typeof denied.adapter.executeQuery;
+    await expect(
+      withMigrationSession(
+        { adapter: denied.adapter, dialect: "sqlite", label: "run-1" },
+        async () => undefined
+      )
+    ).rejects.toThrowError(/permission denied/);
+  });
+
   it("uses a lock table distinct from the schema pipeline's", () => {
     expect(MIGRATION_LOCK_TABLE).toBe("nextly_field_group_lock");
     expect(MIGRATION_LOCK_TABLE).not.toBe("nextly_migrate_lock");

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/session.test.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/session.test.ts
@@ -749,6 +749,41 @@ describe("field-group migration session", () => {
     }
   });
 
+  // 🔴 THE case a renewal makes worse if the exit path is naive. A renewal that fails on a blip
+  // leaves the row STILL OWNED by this claim, so an owner-scoped release matches and frees it —
+  // while `fn`, which nothing here can stop, carries on rewriting tables. The next contender would
+  // then start against a database this run is still writing to, which is worse than never having
+  // renewed at all. The claim is left to lapse instead.
+  it("does not free a row it still owns after losing the claim", async () => {
+    vi.useFakeTimers();
+    try {
+      const h = createAdapter({ heldBy: null });
+      const realRunStatement = h.ctx.runStatement.getMockImplementation();
+      h.ctx.runStatement.mockImplementation(async (statement: SQL) => {
+        if (isRenewalStatement(statement)) {
+          throw new Error("connection reset");
+        }
+        await realRunStatement?.(statement);
+      });
+
+      const run = withMigrationSession(
+        { adapter: h.adapter, dialect: "postgresql", label: "run-1" },
+        async () => {
+          await vi.advanceTimersByTimeAsync(LOCK_RENEW_INTERVAL_MS);
+        }
+      );
+      await expect(run).rejects.toMatchObject({ code: "SERVICE_UNAVAILABLE" });
+      await vi.advanceTimersByTimeAsync(0);
+
+      // Still claimed by this run, because the work it protects has not stopped. Left to expire on
+      // its own rather than handed over while that work is in flight.
+      expect(h.owner()).toMatch(/^run-1#/);
+      expect(h.expiresAt()).not.toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("uses a lock table distinct from the schema pipeline's", () => {
     expect(MIGRATION_LOCK_TABLE).toBe("nextly_field_group_lock");
     expect(MIGRATION_LOCK_TABLE).not.toBe("nextly_migrate_lock");

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/session.test.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/session.test.ts
@@ -7,6 +7,7 @@ import { NextlyError } from "../../../../errors/nextly-error";
 import {
   getMigrationLockDdl,
   LOCK_RENEW_INTERVAL_MS,
+  LOCK_RENEWALS_BEFORE_LOSS,
   LOCK_TTL_SECONDS,
   MIGRATION_LOCK_TABLE,
   observeMigrationLock,
@@ -740,7 +741,10 @@ describe("field-group migration session", () => {
         withMigrationSession(
           { adapter: h.adapter, dialect: "postgresql", label: "run-1" },
           async () => {
-            await vi.advanceTimersByTimeAsync(LOCK_RENEW_INTERVAL_MS);
+            // The whole margin, because one failure is deliberately survivable.
+            await vi.advanceTimersByTimeAsync(
+              LOCK_RENEW_INTERVAL_MS * LOCK_RENEWALS_BEFORE_LOSS
+            );
           }
         )
       ).rejects.toMatchObject({ code: "SERVICE_UNAVAILABLE" });
@@ -769,7 +773,9 @@ describe("field-group migration session", () => {
       const run = withMigrationSession(
         { adapter: h.adapter, dialect: "postgresql", label: "run-1" },
         async () => {
-          await vi.advanceTimersByTimeAsync(LOCK_RENEW_INTERVAL_MS);
+          await vi.advanceTimersByTimeAsync(
+            LOCK_RENEW_INTERVAL_MS * LOCK_RENEWALS_BEFORE_LOSS
+          );
         }
       );
       await expect(run).rejects.toMatchObject({ code: "SERVICE_UNAVAILABLE" });
@@ -779,6 +785,46 @@ describe("field-group migration session", () => {
       // its own rather than handed over while that work is in flight.
       expect(h.owner()).toMatch(/^run-1#/);
       expect(h.expiresAt()).not.toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  // 🔴 The margin the TTL exists to buy, actually spent. The interval is a quarter of the TTL so
+  // that several attempts can fail before a claim lapses; treating the FIRST error as fatal threw
+  // that away and let a brief connection reset abort a healthy, half-finished migration.
+  it("survives renewal failures short of the margin", async () => {
+    vi.useFakeTimers();
+    try {
+      const h = createAdapter({ heldBy: null });
+      const realRunStatement = h.ctx.runStatement.getMockImplementation();
+      let failures = 0;
+      h.ctx.runStatement.mockImplementation(async (statement: SQL) => {
+        // One short of the margin, then recovery — the shape of a blip.
+        if (
+          isRenewalStatement(statement) &&
+          failures < LOCK_RENEWALS_BEFORE_LOSS - 1
+        ) {
+          failures += 1;
+          throw new Error("connection reset");
+        }
+        await realRunStatement?.(statement);
+      });
+
+      await expect(
+        withMigrationSession(
+          { adapter: h.adapter, dialect: "postgresql", label: "run-1" },
+          async () => {
+            await vi.advanceTimersByTimeAsync(
+              LOCK_RENEW_INTERVAL_MS * (LOCK_RENEWALS_BEFORE_LOSS + 1)
+            );
+          }
+        )
+      ).resolves.toBeUndefined();
+
+      expect(failures).toBe(LOCK_RENEWALS_BEFORE_LOSS - 1);
+      // Released normally, because the claim was never lost.
+      expect(h.owner()).toBeNull();
     } finally {
       vi.useRealTimers();
     }

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/session.test.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/session.test.ts
@@ -16,10 +16,12 @@ import {
   type MigrationDialect,
 } from "../session";
 import {
+  classifyLockStatement,
   createLockClock,
   createLockRow,
   interpretLockStatement,
   isRenewalStatement,
+  type LockStatementKind,
 } from "./helpers/migration-lock-double";
 
 /**
@@ -64,6 +66,16 @@ function createAdapter(
      * see in production rather than the error the test wrote.
      */
     onTransaction?: (seq: number) => Promise<void> | void;
+    /**
+     * Called after each lock statement is interpreted, with what that statement WAS.
+     *
+     * The renewal writes an expiry and reads it back inside ONE transaction, so a test modelling
+     * time passing between those two — a process suspended or descheduled mid-transaction — has
+     * nowhere else to stand: every other lever moves the clock between transactions, which is a
+     * different question. Classified through {@link classifyLockStatement} rather than a regex of
+     * this suite's own, so the double cannot disagree with itself about which statement is which.
+     */
+    onStatement?: (kind: LockStatementKind | undefined) => void;
   } = {}
 ) {
   const clock = createLockClock();
@@ -88,10 +100,13 @@ function createAdapter(
     }),
     runStatement: vi.fn(async (statement: SQL) => {
       interpretLockStatement(lock, statement);
+      options.onStatement?.(classifyLockStatement(statement));
     }),
-    queryStatement: vi.fn(async (statement: SQL) =>
-      interpretLockStatement(lock, statement)
-    ),
+    queryStatement: vi.fn(async (statement: SQL) => {
+      const rows = interpretLockStatement(lock, statement);
+      options.onStatement?.(classifyLockStatement(statement));
+      return rows;
+    }),
   };
 
   const adapter = {
@@ -740,6 +755,51 @@ describe("field-group migration session", () => {
       expect(reachedTheEnd).not.toHaveBeenCalled();
       await vi.advanceTimersByTimeAsync(0);
       expect(reachedTheEnd).toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  // A renewal writes an expiry and reads it back in ONE transaction, and the gap between those two
+  // statements is not zero: a suspended or descheduled process can spend longer there than the whole
+  // TTL. The row then still NAMES this claim while the lease it just wrote is already in the past,
+  // so ownership alone reports a successful renewal on a lock a contender may take the instant the
+  // transaction commits — and the callback carries on believing it is protected.
+  it("treats a renewal whose lease expired mid-transaction as lost", async () => {
+    vi.useFakeTimers();
+    try {
+      let suspended = false;
+      const h = createAdapter({
+        heldBy: null,
+        onStatement: kind => {
+          // 🔴 Once, and only after the renewal's UPDATE — so the readback that follows it inside
+          // the SAME transaction is the statement that sees the advanced clock. Advancing anywhere
+          // else models time passing BETWEEN transactions, which the other tests already cover and
+          // which this property is not about.
+          if (kind === "renew" && !suspended) {
+            suspended = true;
+            h.clock.advance(LOCK_TTL_SECONDS + 1);
+          }
+        },
+      });
+
+      const run = withMigrationSession(
+        { adapter: h.adapter, dialect: "postgresql", label: "run-1" },
+        async () => {
+          await vi.advanceTimersByTimeAsync(LOCK_RENEW_INTERVAL_MS);
+        }
+      );
+
+      await expect(run).rejects.toMatchObject({
+        code: "SERVICE_UNAVAILABLE",
+        logContext: { reason: "migration lock claim lapsed or was taken over" },
+      });
+
+      // 🔴 Positive controls separating this from the takeover case, which a different guard
+      // already covers. The row still names this run — nobody took it — and the hook did fire, so
+      // the green above cannot be a renewal that was never reached.
+      expect(h.owner()).toMatch(/^run-1#/);
+      expect(suspended).toBe(true);
     } finally {
       vi.useRealTimers();
     }

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/session.test.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/session.test.ts
@@ -50,6 +50,20 @@ function createAdapter(
      * behind and which the session reads as live.
      */
     expiresIn?: number;
+    /**
+     * Called as each transaction opens, with its 1-based sequence number.
+     *
+     * Awaited before the body runs, so returning a pending promise HOLDS that transaction open.
+     * That is the only way to place one transaction's completion at a chosen point relative to
+     * another's, which several properties here are ABOUT: a renewal and the work it protects are
+     * concurrent by construction, and asserting what happens when they interleave a particular way
+     * needs the interleaving to be chosen rather than hoped for.
+     *
+     * Throwing models a transaction that could not reach the database at all. The wrapper below
+     * rewraps it exactly as a real adapter does, so a caller sees the same opaque failure it would
+     * see in production rather than the error the test wrote.
+     */
+    onTransaction?: (seq: number) => Promise<void> | void;
   } = {}
 ) {
   const clock = createLockClock();
@@ -61,6 +75,7 @@ function createAdapter(
   const ddl: string[] = [];
   let open = 0;
   let peakOpen = 0;
+  let transactions = 0;
 
   const ctx = {
     lockRow: vi.fn(async () => undefined),
@@ -96,7 +111,10 @@ function createAdapter(
     transaction: vi.fn(async (work: (c: unknown) => Promise<unknown>) => {
       open += 1;
       peakOpen = Math.max(peakOpen, open);
+      transactions += 1;
+      const seq = transactions;
       try {
+        await options.onTransaction?.(seq);
         return await work(ctx);
       } catch (error) {
         // What the real adapters do: anything that is not already a
@@ -722,6 +740,81 @@ describe("field-group migration session", () => {
       expect(reachedTheEnd).not.toHaveBeenCalled();
       await vi.advanceTimersByTimeAsync(0);
       expect(reachedTheEnd).toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  // Losing the claim and finishing the work are concurrent events, so they can land in either
+  // order — and the order decides which mechanism reports the loss. When loss wins, the race
+  // rejects and the test above covers it. When COMPLETION wins, the race carries the callback's
+  // value and the loss arrives afterwards, with nothing left watching for it: the release is
+  // skipped (the work was still running when the row stopped being maintained), which leaves
+  // `heldToTheEnd` at its initial `true`. Both guards therefore pass and the run reports success
+  // on a claim it had already declared lost.
+  it("fails a completed run whose claim was declared lost as it finished", async () => {
+    vi.useFakeTimers();
+    try {
+      // Transaction 1 is the acquisition, 2..5 are the four renewals the TTL allows, 6 is the
+      // release. Sequence numbers rather than call-order guesses, so a change in how many
+      // transactions the session takes fails this loudly instead of silently retargeting it.
+      const ACQUIRE = 1;
+      const LAST_RENEWAL = 1 + LOCK_RENEWALS_BEFORE_LOSS;
+      const RELEASE = LAST_RENEWAL + 1;
+
+      const h = createAdapter({
+        heldBy: null,
+        onTransaction: async seq => {
+          if (seq === ACQUIRE) return;
+          if (seq === RELEASE) {
+            // 🔴 The interleaving this test exists for. The final renewal is still in flight when
+            // the release opens, so yielding here lets its failure — and the loss it declares —
+            // land while the release is between its own awaits. That is exactly the window where
+            // the callback has already produced a value and nothing is watching the claim.
+            for (let turn = 0; turn < 50; turn++) await Promise.resolve();
+            return;
+          }
+          // Every renewal fails to reach the database. Not proof the claim is gone, which is why
+          // it takes all four before the session gives up on it.
+          throw new Error("connection reset");
+        },
+      });
+
+      const run = withMigrationSession(
+        { adapter: h.adapter, dialect: "postgresql", label: "run-1" },
+        async () => {
+          // Spend the first three attempts, awaiting each so the failures are genuinely
+          // consecutive rather than overlapping.
+          for (
+            let attempt = 1;
+            attempt < LOCK_RENEWALS_BEFORE_LOSS;
+            attempt++
+          ) {
+            await vi.advanceTimersByTimeAsync(LOCK_RENEW_INTERVAL_MS);
+          }
+          // 🔴 Synchronous, and NOT awaited. It starts the fourth renewal and returns before that
+          // renewal can settle, which is what makes completion win the race. Awaiting here would
+          // let the loss land first and exercise the other path entirely.
+          vi.advanceTimersByTime(LOCK_RENEW_INTERVAL_MS);
+          return "migrated";
+        }
+      );
+
+      // 🔴 The REASON, not just the code. `heldToTheEnd` reports a different reason from the same
+      // factory, so asserting SERVICE_UNAVAILABLE alone would pass on the guard that was already
+      // there and prove nothing about this one.
+      await expect(run).rejects.toMatchObject({
+        code: "SERVICE_UNAVAILABLE",
+        logContext: {
+          reason: "migration lock claim was lost before completion",
+        },
+      });
+
+      // 🔴 Positive control on WHICH guard fired. The release ran and cleared the row, so it found
+      // the claim still ours and still live and reported `heldToTheEnd` — the pre-existing
+      // completion check had nothing to object to. That is what makes the rejection above evidence
+      // about this race rather than about a takeover the older guard would have caught anyway.
+      expect(h.owner()).toBeNull();
     } finally {
       vi.useRealTimers();
     }

--- a/packages/nextly/src/domains/field-groups/migration/run.ts
+++ b/packages/nextly/src/domains/field-groups/migration/run.ts
@@ -400,9 +400,11 @@ export async function runFieldGroupMigration(
   /**
    * What the last attempt saw, so the next one can tell whether anything moved.
    *
-   * 🔴 A held lock is NOT evidence of a live writer. This lock has no TTL and no auto-steal by
-   * design — a process that dies holding it leaves it held until an operator clears it — so
-   * `{ kind: "held" }` proves that ownership was once RECORDED, not that anyone is moving now.
+   * 🔴 A held lock is NOT evidence of a live writer. A claim outlives the process that made it: it
+   * is only reported held until its expiry passes, and a run that dies stops renewing rather than
+   * releasing, so for that whole window a dead holder is indistinguishable from a working one by
+   * the row alone. `{ kind: "held" }` proves that ownership was once RECORDED, not that anyone is
+   * moving now — and every attempt of a retry cycle falls well inside that window.
    * Judging contention on that alone lets a stale row plus a genuinely permanent mismatch (a
    * restored marker whose rename was never applied) spend three attempts and then be reported as
    * contention, which is precisely the storage-conflict-as-traffic answer this path exists to
@@ -619,9 +621,11 @@ export async function runFieldGroupMigration(
               // 🔴 A preview REPORTS this, a run that writes refuses it — but reporting it requires
               // the same evidence every other contended answer does: that something MOVED.
               //
-              // Answering on the first look was wrong. This lock has no TTL and survives process
-              // death, so a CRASHED `down` run leaves both its migrating marker and its held row
-              // behind. Read once, that is indistinguishable from a live one, and a preview would
+              // Answering on the first look was wrong. A claim survives the process that made it
+              // until its expiry passes, so a CRASHED `down` run leaves both its migrating marker
+              // and a still-live row behind — and the marker outlives the claim, so the stranded
+              // state remains long after the row frees. Read once, that is indistinguishable from
+              // a live run, and a preview would
               // describe a stranded migration awaiting recovery as ordinary traffic — the operator
               // most needing to act being told to wait.
               //

--- a/packages/nextly/src/domains/field-groups/migration/session.ts
+++ b/packages/nextly/src/domains/field-groups/migration/session.ts
@@ -704,6 +704,26 @@ export async function withMigrationSession<T>(
 
   // Reached only when `fn` RESOLVED — a rejection propagated out of the block above and never gets
   // here, which is the ordering that keeps the caller's own failure primary.
+  //
+  // 🔴 That same ordering is what makes `claimWasLost` decisive HERE, with no record of which
+  // promise won the race required. `claimLost` only ever REJECTS, so it cannot have won and still
+  // arrive at this line; reaching it with the flag set means the loss was observed while the
+  // callback was finishing — the race took `fn`'s value, and the renewal reporting a takeover ran
+  // before the block above resumed. The release is then skipped for the right reason (work was
+  // still running when the row stopped being ours) which leaves `heldToTheEnd` at its initial
+  // `true`, so the check below cannot see it and the run would report success on a claim a
+  // contender already holds. Completing is not the same as having been protected while completing.
+  if (claimWasLost) {
+    throw NextlyError.serviceUnavailable({
+      logMessage:
+        "field-group migration lost its lock as it finished; another run may have overlapped it",
+      logContext: {
+        reason: "migration lock claim was lost before completion",
+        label,
+      },
+    });
+  }
+
   if (!heldToTheEnd && !releasedOnSignal) {
     throw NextlyError.serviceUnavailable({
       logMessage:

--- a/packages/nextly/src/domains/field-groups/migration/session.ts
+++ b/packages/nextly/src/domains/field-groups/migration/session.ts
@@ -741,6 +741,9 @@ export async function withMigrationSession<T>(
   // a single-connection pool those queue against each other, each making the next later still.
   let renewing = false;
 
+  // The attempt currently in flight, or a settled placeholder when there is none.
+  let outstandingRenewal: Promise<unknown> = Promise.resolve();
+
   const renewal = setInterval(() => {
     // Asked BEFORE attempting, because this is the question the attempt cannot answer: a renewal
     // that never comes back reports nothing at all, and the lease drains while it hangs.
@@ -765,7 +768,10 @@ export async function withMigrationSession<T>(
     // surplus and the callback is then delayed past it. The change is kept because its direction is
     // unconditionally safe: an earlier stamp can only shorten this session's own window.
     const attemptStartedAt = performance.now();
-    void renew(adapter, dialect, claim).then(
+    // Kept rather than discarded: a renewal blocked on the connection or the row lock can land long
+    // after this session gave up, and its UPDATE re-extends the row whether or not anyone is still
+    // waiting for it. The abandonment path below needs to know when that attempt has finished.
+    outstandingRenewal = renew(adapter, dialect, claim).then(
       held => {
         renewing = false;
         // Ownership DISPROVED is not a margin question. The row names someone else, so no amount of
@@ -783,6 +789,7 @@ export async function withMigrationSession<T>(
         renewing = false;
       }
     );
+    void outstandingRenewal;
   }, LOCK_RENEW_INTERVAL_MS);
   // Never a reason for the process to stay alive: this timer exists to protect work that is already
   // running, so if nothing else is pending there is nothing left to protect.
@@ -794,8 +801,15 @@ export async function withMigrationSession<T>(
   // instead, which is the hazard `no-unsafe-finally` names.
   let heldToTheEnd = true;
   let result: T;
+  let work: Promise<T> | undefined;
   try {
-    result = await Promise.race([fn(session), claimLost]);
+    // Held in its own binding so the abandonment path can wait for it. Its rejection is claimed
+    // here as well: when `claimLost` wins the race nothing else is awaiting `work`, and an
+    // unobserved rejection there would surface as an unhandled rejection rather than as this
+    // session's failure.
+    work = fn(session);
+    work.catch(() => undefined);
+    result = await Promise.race([work, claimLost]);
   } finally {
     clearInterval(renewal);
     // Removed before releasing, so a signal arriving during an orderly release
@@ -812,7 +826,30 @@ export async function withMigrationSession<T>(
     // callback's value stand. Completing is not the same as having been protected while completing:
     // the exclusion promises no other run touched these tables meanwhile, and a claim that lapsed
     // or was taken over means that promise was not kept.
-    if (!claimWasLost) heldToTheEnd = await release(adapter, dialect, claim);
+    if (!claimWasLost) {
+      heldToTheEnd = await release(adapter, dialect, claim);
+    } else {
+      // 🔴 The row is still not freed HERE, for the reason above — but leaving it entirely alone is
+      // not enough either. A renewal already in flight when the claim was abandoned still runs its
+      // UPDATE when the connection frees up, re-extending the row by a whole TTL; and because
+      // nothing renews it afterwards, the next run sees a live claim owned by a process that gave
+      // up, with no way to tell it from a healthy one.
+      //
+      // So the row is cleared once BOTH the callback and that outstanding attempt have settled.
+      // Waiting for the callback is what keeps the original guarantee: while `fn` is still writing,
+      // a late extension is protecting it and must stand. Once it has finished, an extended row
+      // protects nobody. The release is owner-scoped, so a claim a contender has since taken is
+      // left untouched.
+      //
+      // Detached deliberately: the caller has already been told the claim was lost, and this
+      // clean-up may outlive the callback by as long as the blocked renewal takes.
+      const abandoned = [work, outstandingRenewal].filter(
+        (pending): pending is Promise<unknown> => pending !== undefined
+      );
+      void Promise.allSettled(abandoned).then(() =>
+        release(adapter, dialect, claim).catch(() => undefined)
+      );
+    }
   }
 
   // Reached only when `fn` RESOLVED — a rejection propagated out of the block above and never gets

--- a/packages/nextly/src/domains/field-groups/migration/session.ts
+++ b/packages/nextly/src/domains/field-groups/migration/session.ts
@@ -588,13 +588,18 @@ export async function withMigrationSession<T>(
   // to stop watch mode is Ctrl+C and a stuck claim would block every later sync.
   // Releasing on the signal keeps the durable-claim design and removes its cost
   // on the path people actually interrupt — but only for callers that opt in.
+  // Set by the signal path so the completion check below can tell a claim this run GAVE UP
+  // deliberately from one a contender took. Both leave the row not-ours at the end and only the
+  // second is a failure — an interrupt is an orderly shutdown that already signalled its outcome.
+  let releasedOnSignal = false;
   const releaseOnSignal = (signal: NodeJS.Signals): void => {
+    releasedOnSignal = true;
     // The signal is re-raised whether or not the release succeeded: a pool torn
     // down by the same interrupt is the likely failure, and an unobserved
     // rejection there would surface as an unhandled rejection instead of
     // letting the process stop. A claim left behind by a failed release is the
     // ordinary stuck-claim case an operator already has a remedy for.
-    void release(adapter, claim)
+    void release(adapter, dialect, claim)
       .catch(() => undefined)
       .finally(() => {
         process.kill(process.pid, signal);
@@ -678,8 +683,14 @@ export async function withMigrationSession<T>(
   // running, so if nothing else is pending there is nothing left to protect.
   renewal.unref?.();
 
+  // Captured rather than returned from inside the `try`, so the lock verification below can run
+  // AFTER the release without throwing from a `finally`. A throw there would discard an exception
+  // `fn` had already raised — the caller would lose their real failure and be told about the lock
+  // instead, which is the hazard `no-unsafe-finally` names.
+  let heldToTheEnd = true;
+  let result: T;
   try {
-    return await Promise.race([fn(session), claimLost]);
+    result = await Promise.race([fn(session), claimLost]);
   } finally {
     clearInterval(renewal);
     // Removed before releasing, so a signal arriving during an orderly release
@@ -691,8 +702,27 @@ export async function withMigrationSession<T>(
     // is still writing to, which is the precise outcome the lock exists to prevent. Doing nothing
     // is self-correcting: the renewal has stopped, so the claim lapses on its own and the next run
     // takes it over through the ordinary expiry path.
-    if (!claimWasLost) await release(adapter, claim);
+    //
+    // 🔴 A release that finds the row already gone REJECTS the run rather than letting the
+    // callback's value stand. Completing is not the same as having been protected while completing:
+    // the exclusion promises no other run touched these tables meanwhile, and a claim that lapsed
+    // or was taken over means that promise was not kept.
+    if (!claimWasLost) heldToTheEnd = await release(adapter, dialect, claim);
   }
+
+  // Reached only when `fn` RESOLVED — a rejection propagated out of the block above and never gets
+  // here, which is the ordering that keeps the caller's own failure primary.
+  if (!heldToTheEnd && !releasedOnSignal) {
+    throw NextlyError.serviceUnavailable({
+      logMessage:
+        "field-group migration finished without holding its lock; another run may have overlapped it",
+      logContext: {
+        reason: "migration lock was not held at completion",
+        label,
+      },
+    });
+  }
+  return result;
 }
 
 /**
@@ -815,9 +845,21 @@ async function acquire(
 }
 
 /** Release only what we hold, so a late finaliser cannot free someone else's run. */
-async function release(adapter: DrizzleAdapter, claim: string): Promise<void> {
-  await adapter.transaction(async ctx => {
+async function release(
+  adapter: DrizzleAdapter,
+  dialect: MigrationDialect,
+  claim: string
+): Promise<boolean> {
+  return adapter.transaction(async ctx => {
     await ctx.lockRow(MIGRATION_LOCK_TABLE, LOCK_ROW_ID);
+    // 🔴 Read BEFORE clearing, and report it, because the owner-filtered UPDATE below cannot.
+    //
+    // That statement silently affects nothing when the row has moved on — correct as a release,
+    // useless as an ANSWER. A run whose callback finished before a queued renewal reported the
+    // takeover reaches here with `claimWasLost` still false, releases nothing, and returns the
+    // callback's value as though the work had been protected. This is the last observable moment.
+    const before = await readLockState(ctx, dialect);
+    const heldToTheEnd = before?.owner === claim && before.live;
     // Naming the owner as well makes a release affect only a row we still hold.
     await ctx.runStatement(
       sql`UPDATE ${sql.identifier(MIGRATION_LOCK_TABLE)}
@@ -826,5 +868,6 @@ async function release(adapter: DrizzleAdapter, claim: string): Promise<void> {
           WHERE ${sql.identifier("id")} = ${LOCK_ROW_ID}
             AND ${sql.identifier("owner")} = ${claim}`
     );
+    return heldToTheEnd;
   });
 }

--- a/packages/nextly/src/domains/field-groups/migration/session.ts
+++ b/packages/nextly/src/domains/field-groups/migration/session.ts
@@ -607,6 +607,11 @@ export async function withMigrationSession<T>(
     await ensureLockRow(adapter, dialect);
   }
 
+  // Stamped before the attempt for the same reason the renewal is: the lease this claim grants
+  // begins when the database runs the statement, so dating it from here can only understate what is
+  // left. Reading the clock after `acquire` resolves would credit the claim with time it spent
+  // waiting for a connection or for this process to be scheduled again.
+  const claimStartedAt = performance.now();
   const acquired = await acquire(adapter, dialect, claim);
   if (!acquired.ok) {
     // Raised outside the transaction on purpose: the adapters route every error
@@ -701,7 +706,7 @@ export async function withMigrationSession<T>(
   // its own progress, and asks only "how long have I been unable to confirm my lease" — a question
   // no other machine participates in. `performance.now()` rather than `Date.now()` because it does
   // not step: an NTP correction mid-migration would otherwise expire or extend a claim by accident.
-  let leaseConfirmedAt = performance.now();
+  let leaseConfirmedAt = claimStartedAt;
 
   // Only ever one attempt in flight. `setInterval` fires on a schedule, not on completion, so a
   // renewal slower than the interval would otherwise have a second started underneath it — and with
@@ -717,6 +722,14 @@ export async function withMigrationSession<T>(
     }
     if (renewing) return;
     renewing = true;
+    // 🔴 Stamped BEFORE the attempt, and used as the confirmation time if it succeeds. The lease
+    // this renewal grants starts when the database runs the statement, which is at or after this
+    // instant — so dating the confirmation from here can only UNDERSTATE how much lease is left,
+    // which is the safe direction. Reading the clock in the success handler instead dates it from
+    // whenever this process next got scheduled, and a pause between the database's read-back and
+    // that callback would start a fresh full-length window over a lease that had been ageing
+    // throughout it.
+    const attemptStartedAt = performance.now();
     void renew(adapter, dialect, claim).then(
       held => {
         renewing = false;
@@ -726,10 +739,7 @@ export async function withMigrationSession<T>(
           onLost();
           return;
         }
-        // The lease is confirmed as of NOW rather than as of when this attempt started: the
-        // database extended it when the statement ran, and dating it earlier would only ever
-        // shorten the margin.
-        leaseConfirmedAt = performance.now();
+        leaseConfirmedAt = attemptStartedAt;
       },
       () => {
         // An error is not proof the claim is gone — only proof this attempt could not ask. It moves
@@ -925,10 +935,39 @@ async function acquire(
     // was empty.
     const after = await readLockState(ctx, dialect);
     if (after?.owner !== claim || !after.usable) {
+      // 🔴 A refused acquisition must not leave OUR name on the row. The claim UPDATE above has
+      // already happened, and returning a result rather than throwing commits it — so without this
+      // a run that declined its own claim would still block every contender until the residual
+      // lease expired, with nothing renewing it and no callback ever starting. Nobody would even be
+      // able to attribute the block: the owner is a UUID belonging to a process that gave up.
+      //
+      // Cleared rather than rolled back because the adapters reclassify anything thrown out of a
+      // transaction callback, which would turn a precise refusal into an opaque database error.
+      // Owner-filtered, so a row a contender legitimately took in the meantime is left alone.
+      if (after?.owner === claim) {
+        await ctx.runStatement(clearClaimStatement(claim));
+        return { ok: false, heldBy: null };
+      }
       return { ok: false, heldBy: after?.owner ?? null };
     }
     return { ok: true };
   });
+}
+
+/**
+ * Free the row, but only while we still hold it.
+ *
+ * Naming the owner as well makes this affect only a row this claim owns, so a late finaliser cannot
+ * free a run that has since taken over. Shared by the ordinary release and by the rollback of an
+ * acquisition that turned out unusable: those are the same act on the row, and two spellings of it
+ * could disagree about the owner filter — which is the half that makes it safe.
+ */
+function clearClaimStatement(claim: string): SQL {
+  return sql`UPDATE ${sql.identifier(MIGRATION_LOCK_TABLE)}
+      SET ${sql.identifier("owner")} = NULL,
+          ${sql.identifier("expires_at")} = NULL
+      WHERE ${sql.identifier("id")} = ${LOCK_ROW_ID}
+        AND ${sql.identifier("owner")} = ${claim}`;
 }
 
 /** Release only what we hold, so a late finaliser cannot free someone else's run. */
@@ -947,14 +986,7 @@ async function release(
     // callback's value as though the work had been protected. This is the last observable moment.
     const before = await readLockState(ctx, dialect);
     const heldToTheEnd = before?.owner === claim && before.live;
-    // Naming the owner as well makes a release affect only a row we still hold.
-    await ctx.runStatement(
-      sql`UPDATE ${sql.identifier(MIGRATION_LOCK_TABLE)}
-          SET ${sql.identifier("owner")} = NULL,
-              ${sql.identifier("expires_at")} = NULL
-          WHERE ${sql.identifier("id")} = ${LOCK_ROW_ID}
-            AND ${sql.identifier("owner")} = ${claim}`
-    );
+    await ctx.runStatement(clearClaimStatement(claim));
     return heldToTheEnd;
   });
 }

--- a/packages/nextly/src/domains/field-groups/migration/session.ts
+++ b/packages/nextly/src/domains/field-groups/migration/session.ts
@@ -656,13 +656,13 @@ export async function withMigrationSession<T>(
     });
   }
 
-  // A terminated process never reaches `finally`, and this lock has no expiry by
-  // design, so an interrupted holder would leave a claim that only an operator
-  // could clear. That is the right trade for a migration, which is rare and
-  // deliberate; it is the wrong one for a schema sync, where the documented way
-  // to stop watch mode is Ctrl+C and a stuck claim would block every later sync.
-  // Releasing on the signal keeps the durable-claim design and removes its cost
-  // on the path people actually interrupt — but only for callers that opt in.
+  // A terminated process never reaches `finally`, so an interrupted holder leaves a claim behind.
+  // The expiry means that claim now LAPSES on its own rather than waiting for an operator — but it
+  // takes the whole TTL to do so, because nothing is renewing it and nothing knows it is dead.
+  // That wait is the right trade for a migration, which is rare and deliberate; it is the wrong one
+  // for a schema sync, where the documented way to stop watch mode is Ctrl+C and a stale claim would
+  // stall every later sync for two minutes. Releasing on the signal removes that wait on the path
+  // people actually interrupt — but only for callers that opt in.
   // Set by the signal path so the completion check below can tell a claim this run GAVE UP
   // deliberately from one a contender took. Both leave the row not-ours at the end and only the
   // second is a failure — an interrupt is an orderly shutdown that already signalled its outcome.

--- a/packages/nextly/src/domains/field-groups/migration/session.ts
+++ b/packages/nextly/src/domains/field-groups/migration/session.ts
@@ -90,8 +90,8 @@ function lockStateQuery(dialect: MigrationDialect): SQL {
  * Two answers rather than one, because two callers ask genuinely different questions and collapsing
  * them would make one of them wrong. `live` is "would this claim still exclude a contender right
  * now", which is what an OBSERVER reports to an operator. `usable` is the stricter "will this claim
- * still be here when its next renewal is due", which is what a claimant needs before it starts
- * work: a lease with less than one renewal interval left is live and is about to lapse unrenewed.
+ * outlast the window in which its holder will not ask again", which is what a claimant needs before
+ * it starts work: a lease shorter than that window is live and gone before anything re-checks it.
  *
  * Both are computed in the same statement, on the database's own clock, so no part of either
  * depends on this process's idea of the time.

--- a/packages/nextly/src/domains/field-groups/migration/session.ts
+++ b/packages/nextly/src/domains/field-groups/migration/session.ts
@@ -729,6 +729,13 @@ export async function withMigrationSession<T>(
     // whenever this process next got scheduled, and a pause between the database's read-back and
     // that callback would start a fresh full-length window over a lease that had been ageing
     // throughout it.
+    //
+    // 🔴 UNVERIFIED by any test, said here rather than left to read as covered. Reproducing it needs
+    // the database clock and this process's clock to diverge BETWEEN a renewal's read-back and its
+    // callback, which no lever in the double reaches; and the `usable` check above already refuses
+    // the large-pause case, so what remains is the narrow band where a lease passes with little
+    // surplus and the callback is then delayed past it. The change is kept because its direction is
+    // unconditionally safe: an earlier stamp can only shorten this session's own window.
     const attemptStartedAt = performance.now();
     void renew(adapter, dialect, claim).then(
       held => {

--- a/packages/nextly/src/domains/field-groups/migration/session.ts
+++ b/packages/nextly/src/domains/field-groups/migration/session.ts
@@ -221,8 +221,19 @@ export interface MigrationSession {
  */
 export function getMigrationLockDdl(dialect: MigrationDialect): string[] {
   const idType = dialect === "mysql" ? "int" : "integer";
+  // `expires_at` is what separates a run that is still working from one that died holding the row.
+  // A holder renews it while it works, so an expired value is an OBSERVATION that the holder stopped
+  // rather than a guess from a threshold. The type follows each dialect's existing convention for a
+  // timestamp column, and must stay in step with the Drizzle declaration in
+  // `schemas/field-group-lock/` — the round-trip guard is what holds them there.
+  const expiresType =
+    dialect === "postgresql"
+      ? "timestamptz"
+      : dialect === "mysql"
+        ? "datetime"
+        : "integer";
   return [
-    `CREATE TABLE IF NOT EXISTS ${MIGRATION_LOCK_TABLE} (id ${idType} PRIMARY KEY, owner text)`,
+    `CREATE TABLE IF NOT EXISTS ${MIGRATION_LOCK_TABLE} (id ${idType} PRIMARY KEY, owner text, expires_at ${expiresType})`,
   ];
 }
 

--- a/packages/nextly/src/domains/field-groups/migration/session.ts
+++ b/packages/nextly/src/domains/field-groups/migration/session.ts
@@ -33,6 +33,7 @@ import { sql, type SQL } from "drizzle-orm";
 
 import { safeCode } from "../../../database/errors";
 import { NextlyError } from "../../../errors/nextly-error";
+import { fieldGroupLockColumnTypes } from "../../../schemas/field-group-lock";
 
 /** Dialects the migration runs on. */
 export type MigrationDialect = "postgresql" | "mysql" | "sqlite";
@@ -354,20 +355,13 @@ export interface MigrationSession {
  * hand-copying CREATE TABLE statements that drift.
  */
 export function getMigrationLockDdl(dialect: MigrationDialect): string[] {
-  const idType = dialect === "mysql" ? "int" : "integer";
   // `expires_at` is what separates a run that is still working from one that died holding the row.
   // A holder renews it while it works, so an expired value is an OBSERVATION that the holder stopped
-  // rather than a guess from a threshold. The type follows each dialect's existing convention for a
-  // timestamp column, and must stay in step with the Drizzle declaration in
-  // `schemas/field-group-lock/` — the round-trip guard is what holds them there.
-  const expiresType =
-    dialect === "postgresql"
-      ? "timestamptz"
-      : dialect === "mysql"
-        ? "datetime"
-        : "integer";
+  // rather than a guess from a threshold. Every type here comes from the Drizzle declaration in
+  // `schemas/field-group-lock/`, so the bootstrap and the reconcile cannot describe two shapes.
+  const types = fieldGroupLockColumnTypes(dialect);
   return [
-    `CREATE TABLE IF NOT EXISTS ${MIGRATION_LOCK_TABLE} (id ${idType} PRIMARY KEY, owner text, expires_at ${expiresType})`,
+    `CREATE TABLE IF NOT EXISTS ${MIGRATION_LOCK_TABLE} (id ${types.id} PRIMARY KEY, owner ${types.owner}, expires_at ${types.expires_at})`,
   ];
 }
 
@@ -384,12 +378,10 @@ export function getMigrationLockDdl(dialect: MigrationDialect): string[] {
  * questions, and a caller forbidden from issuing DDL needs to be able to skip both.
  */
 export function getMigrationLockUpgradeDdl(dialect: MigrationDialect): string {
-  const expiresType =
-    dialect === "postgresql"
-      ? "timestamptz"
-      : dialect === "mysql"
-        ? "datetime"
-        : "integer";
+  // Same source as the CREATE above, so the column an old installation gains is the column a new
+  // one is born with. Two independent mappings here would leave upgraded databases a different
+  // shape from fresh ones, and nothing downstream distinguishes them.
+  const expiresType = fieldGroupLockColumnTypes(dialect).expires_at;
   // PostgreSQL can say IF NOT EXISTS here; MySQL and SQLite cannot at the versions this supports,
   // so the duplicate is tolerated by CODE below rather than by syntax.
   const guard = dialect === "postgresql" ? "IF NOT EXISTS " : "";

--- a/packages/nextly/src/domains/field-groups/migration/session.ts
+++ b/packages/nextly/src/domains/field-groups/migration/session.ts
@@ -131,7 +131,16 @@ export const LOCK_RENEWALS_BEFORE_LOSS = Math.max(
  */
 function nowExpression(dialect: MigrationDialect): SQL {
   if (dialect === "sqlite") return sql`unixepoch()`;
-  return dialect === "mysql" ? sql`NOW()` : sql`now()`;
+  // 🔴 PostgreSQL uses `clock_timestamp()`, NOT `now()`, and the difference decides correctness
+  // here rather than precision. `now()` is TRANSACTION start time and is frozen for the whole
+  // transaction, so a statement that waits on this row — which is exactly what contention means —
+  // reads the instant it began queueing rather than the instant it was admitted. A claim judged
+  // live by that stale reading can already have expired, and an expiry written from it can be in
+  // the past before the row is even updated.
+  //
+  // MySQL's `NOW()` and SQLite's `unixepoch()` are statement-time, so they already answer the
+  // question this asks and need no equivalent.
+  return dialect === "mysql" ? sql`NOW()` : sql`clock_timestamp()`;
 }
 
 function expiryExpression(dialect: MigrationDialect): SQL {
@@ -141,7 +150,10 @@ function expiryExpression(dialect: MigrationDialect): SQL {
   if (dialect === "mysql") {
     return sql`DATE_ADD(NOW(), INTERVAL ${LOCK_TTL_SECONDS} SECOND)`;
   }
-  return sql`now() + make_interval(secs => ${LOCK_TTL_SECONDS})`;
+  // The same clock as `nowExpression`, deliberately: an expiry written from transaction time and a
+  // liveness test taken at statement time would disagree about when the lease ends, and the pair
+  // has to share one frame of reference to mean anything.
+  return sql`clock_timestamp() + make_interval(secs => ${LOCK_TTL_SECONDS})`;
 }
 
 /** The row, read inside the transaction that is about to decide the claim. */

--- a/packages/nextly/src/domains/field-groups/migration/session.ts
+++ b/packages/nextly/src/domains/field-groups/migration/session.ts
@@ -107,6 +107,18 @@ export const LOCK_TTL_SECONDS = 120;
 export const LOCK_RENEW_INTERVAL_MS = (LOCK_TTL_SECONDS / 4) * 1000;
 
 /**
+ * How many renewals must fail IN A ROW before the claim is treated as lost.
+ *
+ * DERIVED from the two constants above rather than written as 4, so the margin the comment
+ * describes and the number the code enforces cannot drift apart when either is retuned. This is
+ * the whole value of the interval being a fraction of the TTL: it buys exactly this many attempts.
+ */
+export const LOCK_RENEWALS_BEFORE_LOSS = Math.max(
+  1,
+  Math.floor((LOCK_TTL_SECONDS * 1000) / LOCK_RENEW_INTERVAL_MS)
+);
+
+/**
  * The database's own clock, and an expiry computed from it, per dialect.
  *
  * 🔴 Never the application's clock. Two processes contending for this row can sit on machines whose
@@ -553,16 +565,31 @@ export async function withMigrationSession<T>(
       })
     );
   };
+  // 🔴 Consecutive FAILURES, not failures. The TTL is four intervals wide precisely so a slow query
+  // or a dropped connection cannot lose a lock that is still held, and treating the first error as
+  // fatal spent that margin without using it — a brief blip aborted a healthy, half-finished
+  // migration. Counted rather than timed: the margin is defined as a number of renewals, so
+  // counting renewals states it directly and keeps the application's clock out of a decision that
+  // has no business depending on it.
+  let consecutiveFailures = 0;
   const renewal = setInterval(() => {
     void renew(adapter, dialect, claim).then(
       held => {
-        if (!held) onLost();
+        // Ownership DISPROVED is not a margin question. The row names someone else, so no number of
+        // retries can win it back and the work is already unprotected.
+        if (!held) {
+          onLost();
+          return;
+        }
+        consecutiveFailures = 0;
       },
-      // A failed renewal is not proof the claim is gone, but it is proof it is no longer being
-      // maintained, and the next one may not arrive before the TTL. Treated as lost, because the
-      // safe error here is stopping a run that still holds the lock rather than continuing one that
-      // does not.
-      onLost
+      () => {
+        // An error is not proof the claim is gone — only proof this attempt could not ask. Retry
+        // while the lease can still be kept alive, and give up once enough have failed in a row
+        // that the next success could no longer land before the claim lapses.
+        consecutiveFailures += 1;
+        if (consecutiveFailures >= LOCK_RENEWALS_BEFORE_LOSS) onLost();
+      }
     );
   }, LOCK_RENEW_INTERVAL_MS);
   // Never a reason for the process to stay alive: this timer exists to protect work that is already

--- a/packages/nextly/src/domains/field-groups/migration/session.ts
+++ b/packages/nextly/src/domains/field-groups/migration/session.ts
@@ -101,23 +101,30 @@ function toLockState(
  * decides how quickly a dead holder's row becomes claimable. A long TTL there would mean a crash
  * wedges the next run for that long, which is the cost the renewal exists to avoid paying.
  *
- * The interval is a quarter of the TTL, so four consecutive renewals have to fail before the claim
- * lapses. A single slow query or a brief connection blip cannot lose a lock that is still held.
+ * The interval is a small fraction of the TTL so that several attempts fit inside it: a slow query
+ * or a brief connection blip must not lose a lock that is still held. Attempts cost one single-row
+ * update each and never pile up, because only one is ever in flight.
  */
 export const LOCK_TTL_SECONDS = 120;
-export const LOCK_RENEW_INTERVAL_MS = (LOCK_TTL_SECONDS / 4) * 1000;
+export const LOCK_RENEW_INTERVAL_MS = (LOCK_TTL_SECONDS / 8) * 1000;
 
 /**
- * How many renewals must fail IN A ROW before the claim is treated as lost.
+ * How long the session may go without CONFIRMING its lease before it declares the claim lost.
  *
- * DERIVED from the two constants above rather than written as 4, so the margin the comment
- * describes and the number the code enforces cannot drift apart when either is retuned. This is
- * the whole value of the interval being a fraction of the TTL: it buys exactly this many attempts.
+ * 🔴 Elapsed time, NOT a count of failed attempts. A count answers "how many renewals went wrong",
+ * which is only a proxy for the question that decides safety — "how much lease is left" — and it is
+ * a proxy that fails in two independent ways. Attempts can OVERLAP, so completions arrive out of
+ * order and a stale failure can be counted against a lease a later success already extended; and
+ * the count reaches its limit at the moment the lease expires rather than before it, so the work
+ * runs unprotected right up to the deadline and is told only once it is already past.
+ *
+ * Measuring the gap since the last confirmation has neither problem. A late success moves the
+ * confirmation forward and a late failure moves nothing, so ordering stops mattering; and the
+ * threshold can sit wherever the margin needs to be. Here it leaves TWO renewal intervals of lease
+ * still in hand, so the caller is told while it is still protected rather than after.
  */
-export const LOCK_RENEWALS_BEFORE_LOSS = Math.max(
-  1,
-  Math.floor((LOCK_TTL_SECONDS * 1000) / LOCK_RENEW_INTERVAL_MS)
-);
+export const LOCK_LOSS_AFTER_MS =
+  LOCK_TTL_SECONDS * 1000 - 2 * LOCK_RENEW_INTERVAL_MS;
 
 /**
  * The database's own clock, and an expiry computed from it, per dialect.
@@ -644,30 +651,48 @@ export async function withMigrationSession<T>(
       })
     );
   };
-  // 🔴 Consecutive FAILURES, not failures. The TTL is four intervals wide precisely so a slow query
-  // or a dropped connection cannot lose a lock that is still held, and treating the first error as
-  // fatal spent that margin without using it — a brief blip aborted a healthy, half-finished
-  // migration. Counted rather than timed: the margin is defined as a number of renewals, so
-  // counting renewals states it directly and keeps the application's clock out of a decision that
-  // has no business depending on it.
-  let consecutiveFailures = 0;
+  // 🔴 A MONOTONIC clock, and an ELAPSED span rather than an instant. The module comment forbids
+  // deciding anything from the application's clock, and this does not break that rule: the ban is
+  // on comparing an instant here against an instant the database wrote, which two machines whose
+  // clocks disagree would answer differently. This compares two readings taken by THIS process, of
+  // its own progress, and asks only "how long have I been unable to confirm my lease" — a question
+  // no other machine participates in. `performance.now()` rather than `Date.now()` because it does
+  // not step: an NTP correction mid-migration would otherwise expire or extend a claim by accident.
+  let leaseConfirmedAt = performance.now();
+
+  // Only ever one attempt in flight. `setInterval` fires on a schedule, not on completion, so a
+  // renewal slower than the interval would otherwise have a second started underneath it — and with
+  // a single-connection pool those queue against each other, each making the next later still.
+  let renewing = false;
+
   const renewal = setInterval(() => {
+    // Asked BEFORE attempting, because this is the question the attempt cannot answer: a renewal
+    // that never comes back reports nothing at all, and the lease drains while it hangs.
+    if (performance.now() - leaseConfirmedAt >= LOCK_LOSS_AFTER_MS) {
+      onLost();
+      return;
+    }
+    if (renewing) return;
+    renewing = true;
     void renew(adapter, dialect, claim).then(
       held => {
-        // Ownership DISPROVED is not a margin question. The row names someone else, so no number of
-        // retries can win it back and the work is already unprotected.
+        renewing = false;
+        // Ownership DISPROVED is not a margin question. The row names someone else, so no amount of
+        // remaining lease can win it back and the work is already unprotected.
         if (!held) {
           onLost();
           return;
         }
-        consecutiveFailures = 0;
+        // The lease is confirmed as of NOW rather than as of when this attempt started: the
+        // database extended it when the statement ran, and dating it earlier would only ever
+        // shorten the margin.
+        leaseConfirmedAt = performance.now();
       },
       () => {
-        // An error is not proof the claim is gone — only proof this attempt could not ask. Retry
-        // while the lease can still be kept alive, and give up once enough have failed in a row
-        // that the next success could no longer land before the claim lapses.
-        consecutiveFailures += 1;
-        if (consecutiveFailures >= LOCK_RENEWALS_BEFORE_LOSS) onLost();
+        // An error is not proof the claim is gone — only proof this attempt could not ask. It moves
+        // nothing: the confirmation stands where the last success left it, and the elapsed check
+        // above is what eventually gives up.
+        renewing = false;
       }
     );
   }, LOCK_RENEW_INTERVAL_MS);
@@ -705,14 +730,21 @@ export async function withMigrationSession<T>(
   // Reached only when `fn` RESOLVED — a rejection propagated out of the block above and never gets
   // here, which is the ordering that keeps the caller's own failure primary.
   //
-  // 🔴 That same ordering is what makes `claimWasLost` decisive HERE, with no record of which
-  // promise won the race required. `claimLost` only ever REJECTS, so it cannot have won and still
-  // arrive at this line; reaching it with the flag set means the loss was observed while the
-  // callback was finishing — the race took `fn`'s value, and the renewal reporting a takeover ran
-  // before the block above resumed. The release is then skipped for the right reason (work was
-  // still running when the row stopped being ours) which leaves `heldToTheEnd` at its initial
-  // `true`, so the check below cannot see it and the run would report success on a claim a
-  // contender already holds. Completing is not the same as having been protected while completing.
+  // `claimWasLost` is decisive HERE without any record of which promise won the race: `claimLost`
+  // only ever REJECTS, so it cannot have won and still arrive at this line. Reaching it with the
+  // flag set would mean the loss was observed while the callback was finishing, which skips the
+  // release for the right reason (work still running when the row stopped being ours) and leaves
+  // `heldToTheEnd` at its initial `true` — so without this the run would report success on a claim
+  // it had already given up. Completing is not the same as having been protected while completing.
+  //
+  // 🔴 DEFENSIVE, and currently UNREACHABLE — stated rather than left to read as covered. Loss is
+  // declared either by the elapsed check, which runs on a timer callback and therefore cannot
+  // interleave into the microtask gap between the race settling and the line below, or by a renewal
+  // reporting the row is no longer ours-and-live, which the release then reads the same way and
+  // reports through `heldToTheEnd`. No test exercises this branch, because none can reach it. It is
+  // kept because reachability is a property of the current call graph rather than of the code: it
+  // costs one comparison over a value already in hand, and the invariant it states — never report
+  // success on a claim we declared lost — is one the next change to this loop could easily reopen.
   if (claimWasLost) {
     throw NextlyError.serviceUnavailable({
       logMessage:

--- a/packages/nextly/src/domains/field-groups/migration/session.ts
+++ b/packages/nextly/src/domains/field-groups/migration/session.ts
@@ -183,9 +183,14 @@ function nowExpression(dialect: MigrationDialect): SQL {
   // live by that stale reading can already have expired, and an expiry written from it can be in
   // the past before the row is even updated.
   //
-  // MySQL's `NOW()` and SQLite's `unixepoch()` are statement-time, so they already answer the
-  // question this asks and need no equivalent.
-  return dialect === "mysql" ? sql`NOW()` : sql`clock_timestamp()`;
+  // 🔴 MySQL uses `UTC_TIMESTAMP()`, NOT `NOW()`. `NOW()` returns the SESSION's local time, and
+  // `expires_at` is a `DATETIME`, which stores no zone — so a holder whose session is UTC writes an
+  // expiry a contender whose session is UTC+05 reads as five hours in the past, and takes a live
+  // claim instantly. Nothing about the row would look wrong afterwards: both runs believe they hold
+  // it. `UTC_TIMESTAMP()` is the same instant for every session whatever its `time_zone`.
+  //
+  // Both are statement-time rather than transaction-time, so neither needs Postgres's distinction.
+  return dialect === "mysql" ? sql`UTC_TIMESTAMP()` : sql`clock_timestamp()`;
 }
 
 function futureExpression(dialect: MigrationDialect, seconds: number): SQL {
@@ -193,7 +198,7 @@ function futureExpression(dialect: MigrationDialect, seconds: number): SQL {
     return sql`unixepoch() + ${seconds}`;
   }
   if (dialect === "mysql") {
-    return sql`DATE_ADD(NOW(), INTERVAL ${seconds} SECOND)`;
+    return sql`DATE_ADD(UTC_TIMESTAMP(), INTERVAL ${seconds} SECOND)`;
   }
   // The same clock as `nowExpression`, deliberately: an expiry written from transaction time and a
   // liveness test taken at statement time would disagree about when the lease ends, and the pair
@@ -624,6 +629,29 @@ export async function withMigrationSession<T>(
       logContext: {
         reason: "migration lock is held elsewhere",
         heldBy: acquired.heldBy,
+      },
+    });
+  }
+
+  // 🔴 The claim passed its checks INSIDE the transaction; getting back here is a separate step that
+  // can take arbitrarily long — the commit itself, the driver resolving, this process being
+  // scheduled again. `acquire` cannot see any of that, and the first elapsed-time check is a whole
+  // interval away, so without this the callback starts on a lease that may already have lapsed and
+  // nothing notices until a renewal disproves ownership.
+  //
+  // Refuses rather than renewing: a run that has already spent its safety margin before doing any
+  // work has nothing to lose by starting over, and re-extending here would paper over whatever
+  // stalled. The row is cleared for the same reason a refused acquisition clears it — leaving this
+  // claim behind would block contenders with nothing renewing it.
+  if (performance.now() - claimStartedAt >= LOCK_LOSS_AFTER_MS) {
+    await release(adapter, dialect, claim);
+    throw NextlyError.serviceUnavailable({
+      logMessage:
+        "field-group migration took too long to take its lock; the claim may already have lapsed",
+      logContext: {
+        reason:
+          "migration lock claim aged past its safety window during acquisition",
+        label,
       },
     });
   }

--- a/packages/nextly/src/domains/field-groups/migration/session.ts
+++ b/packages/nextly/src/domains/field-groups/migration/session.ts
@@ -353,6 +353,69 @@ export function getMigrationLockDdl(dialect: MigrationDialect): string[] {
 }
 
 /**
+ * Add `expires_at` to a lock table created before that column existed.
+ *
+ * 🔴 `CREATE TABLE IF NOT EXISTS` is a NO-OP against an existing table, so every installation that
+ * has run a Schema Builder change since the lock was introduced holds a two-column row that the
+ * liveness read then references a missing column on. That is not a cosmetic upgrade wrinkle: the
+ * exclusion takes this lock BEFORE the schema sync that would reconcile the column, so the
+ * reconciliation which repairs it can never run — the upgrade path deadlocks on its own repair.
+ *
+ * Emitted separately from the CREATE rather than folded into it because the two answer different
+ * questions, and a caller forbidden from issuing DDL needs to be able to skip both.
+ */
+export function getMigrationLockUpgradeDdl(dialect: MigrationDialect): string {
+  const expiresType =
+    dialect === "postgresql"
+      ? "timestamptz"
+      : dialect === "mysql"
+        ? "datetime"
+        : "integer";
+  // PostgreSQL can say IF NOT EXISTS here; MySQL and SQLite cannot at the versions this supports,
+  // so the duplicate is tolerated by CODE below rather than by syntax.
+  const guard = dialect === "postgresql" ? "IF NOT EXISTS " : "";
+  return `ALTER TABLE ${MIGRATION_LOCK_TABLE} ADD COLUMN ${guard}expires_at ${expiresType}`;
+}
+
+/**
+ * Whether a failed ALTER means the column is already there.
+ *
+ * Classified by the driver's own code where one exists, at the specificity the claim needs — the
+ * same discipline {@link isMissingTable} follows. A wrong answer here is not cosmetic in either
+ * direction: swallowing a real failure would leave the column absent and every later read broken,
+ * while treating "already present" as fatal would refuse every second run.
+ */
+function isDuplicateColumn(error: unknown, dialect: MigrationDialect): boolean {
+  let link: unknown = error;
+  for (
+    let depth = 0;
+    depth < 5 && link !== null && link !== undefined;
+    depth++
+  ) {
+    const code = safeCode(link);
+    const message = link instanceof Error ? link.message : "";
+
+    // 42701 duplicate_column. Postgres also accepts IF NOT EXISTS, so this is the belt to that
+    // brace rather than the only guard.
+    if (dialect === "postgresql" && code === "42701") return true;
+    if (
+      dialect === "mysql" &&
+      (code === "ER_DUP_FIELDNAME" || code === "1060" || code === "42S21")
+    ) {
+      return true;
+    }
+    // SQLite has no distinct code for this, and unlike the missing-table case there is no privilege
+    // model to confuse it with: a duplicate column name is the only thing that produces this text.
+    if (dialect === "sqlite" && /duplicate column name/i.test(message)) {
+      return true;
+    }
+
+    link = (link as { cause?: unknown }).cause;
+  }
+  return false;
+}
+
+/**
  * Hold the migration lock for the duration of `fn`.
  *
  * Refuses rather than continuing when the lock is held. The schema pipeline's
@@ -626,6 +689,16 @@ async function ensureLockRow(
   for (const statement of getMigrationLockDdl(dialect)) {
     await adapter.executeQuery(statement);
   }
+
+  // Runs unconditionally rather than behind a "does the column exist" probe, because the probe and
+  // the ALTER would be two round trips racing each other — and the duplicate this may raise is
+  // precisely the answer that probe would have returned.
+  try {
+    await adapter.executeQuery(getMigrationLockUpgradeDdl(dialect));
+  } catch (error) {
+    if (!isDuplicateColumn(error, dialect)) throw error;
+  }
+
   await seedLockRow(adapter);
 }
 

--- a/packages/nextly/src/domains/field-groups/migration/session.ts
+++ b/packages/nextly/src/domains/field-groups/migration/session.ts
@@ -59,9 +59,48 @@ const LOCK_ROW_ID = 1;
  * free to disagree about which row the owner lives in.
  */
 function ownerQuery(): SQL {
-  return sql`SELECT ${sql.identifier("owner")}
+  return sql`SELECT ${sql.identifier("owner")}, ${sql.identifier("expires_at")}
       FROM ${sql.identifier(MIGRATION_LOCK_TABLE)}
       WHERE ${sql.identifier("id")} = ${LOCK_ROW_ID}`;
+}
+
+/**
+ * How long a claim stays valid without being renewed, and how often it is renewed.
+ *
+ * The TTL is short BECAUSE the holder renews: liveness is maintained by the renewal, so the TTL only
+ * decides how quickly a dead holder's row becomes claimable. A long TTL there would mean a crash
+ * wedges the next run for that long, which is the cost the renewal exists to avoid paying.
+ *
+ * The interval is a quarter of the TTL, so four consecutive renewals have to fail before the claim
+ * lapses. A single slow query or a brief connection blip cannot lose a lock that is still held.
+ */
+const LOCK_TTL_SECONDS = 120;
+const LOCK_RENEW_INTERVAL_MS = (LOCK_TTL_SECONDS / 4) * 1000;
+
+/**
+ * The database's own clock, and an expiry computed from it, per dialect.
+ *
+ * 🔴 Never the application's clock. Two processes contending for this row can sit on machines whose
+ * clocks disagree, and a claim written from one clock and judged against another is decided by that
+ * skew rather than by who holds the lock. Asking the server for both values means every comparison
+ * happens in one frame of reference.
+ *
+ * SQLite stores this column as unix SECONDS (the Drizzle declaration uses `mode: "timestamp"`), so
+ * its expressions are integer arithmetic rather than interval arithmetic.
+ */
+function nowExpression(dialect: MigrationDialect): SQL {
+  if (dialect === "sqlite") return sql`unixepoch()`;
+  return dialect === "mysql" ? sql`NOW()` : sql`now()`;
+}
+
+function expiryExpression(dialect: MigrationDialect): SQL {
+  if (dialect === "sqlite") {
+    return sql`unixepoch() + ${LOCK_TTL_SECONDS}`;
+  }
+  if (dialect === "mysql") {
+    return sql`DATE_ADD(NOW(), INTERVAL ${LOCK_TTL_SECONDS} SECOND)`;
+  }
+  return sql`now() + make_interval(secs => ${LOCK_TTL_SECONDS})`;
 }
 
 /** The owner, read inside the transaction that is about to decide the claim. */
@@ -70,6 +109,28 @@ async function readOwner(
 ): Promise<{ owner: string | null } | undefined> {
   const rows = await ctx.queryStatement<{ owner: string | null }>(ownerQuery());
   return rows[0];
+}
+
+/** Renew this claim, and report whether it is still ours. */
+async function renew(
+  adapter: DrizzleAdapter,
+  dialect: MigrationDialect,
+  claim: string
+): Promise<boolean> {
+  return adapter.transaction(async ctx => {
+    await ctx.lockRow(MIGRATION_LOCK_TABLE, LOCK_ROW_ID);
+    await ctx.runStatement(
+      sql`UPDATE ${sql.identifier(MIGRATION_LOCK_TABLE)}
+          SET ${sql.identifier("expires_at")} = ${expiryExpression(dialect)}
+          WHERE ${sql.identifier("id")} = ${LOCK_ROW_ID}
+            AND ${sql.identifier("owner")} = ${claim}`
+    );
+    // Read back rather than trusting the update's affected-row count, which dialects report
+    // inconsistently. If the row no longer names this claim, someone took the lock over and the work
+    // this renewal was protecting is no longer protected.
+    const after = await readOwner(ctx);
+    return after?.owner === claim;
+  });
 }
 
 /**
@@ -368,7 +429,7 @@ export async function withMigrationSession<T>(
     await ensureLockRow(adapter, dialect);
   }
 
-  const acquired = await acquire(adapter, claim);
+  const acquired = await acquire(adapter, dialect, claim);
   if (!acquired.ok) {
     // Raised outside the transaction on purpose: the adapters route every error
     // escaping a transaction callback through `classifyError`, which rewraps
@@ -414,9 +475,51 @@ export async function withMigrationSession<T>(
     process.once("SIGTERM", onTerminate);
   }
 
+  // 🔴 Renew for as long as the work runs. This is what makes the short TTL above safe: without it,
+  // a migration outliving its TTL would have the row taken from underneath it and two runs would
+  // rename the same objects — strictly worse than the refuse-always behaviour this replaces.
+  //
+  // What this CANNOT do is stop `fn`. JavaScript has no preemption, so a lost claim rejects the
+  // caller's await and leaves whatever `fn` had already started running to completion. That is
+  // stated rather than hidden: the guarantee here is that a run which loses its lock FAILS LOUDLY
+  // and stops being waited on, not that its in-flight statement is cancelled. A step runner wanting
+  // stronger behaviour should re-check between steps, which is the only place a cancellation could
+  // land intact.
+  let lostClaim: ((reason: unknown) => void) | undefined;
+  const claimLost = new Promise<never>((_, reject) => {
+    lostClaim = reject;
+  });
+  const onLost = (): void =>
+    lostClaim?.(
+      NextlyError.serviceUnavailable({
+        logMessage:
+          "field-group migration lost its lock while running; another run may hold it",
+        logContext: {
+          reason: "migration lock claim lapsed or was taken over",
+          label,
+        },
+      })
+    );
+  const renewal = setInterval(() => {
+    void renew(adapter, dialect, claim).then(
+      held => {
+        if (!held) onLost();
+      },
+      // A failed renewal is not proof the claim is gone, but it is proof it is no longer being
+      // maintained, and the next one may not arrive before the TTL. Treated as lost, because the
+      // safe error here is stopping a run that still holds the lock rather than continuing one that
+      // does not.
+      onLost
+    );
+  }, LOCK_RENEW_INTERVAL_MS);
+  // Never a reason for the process to stay alive: this timer exists to protect work that is already
+  // running, so if nothing else is pending there is nothing left to protect.
+  renewal.unref?.();
+
   try {
-    return await fn(session);
+    return await Promise.race([fn(session), claimLost]);
   } finally {
+    clearInterval(renewal);
     // Removed before releasing, so a signal arriving during an orderly release
     // cannot start a second one.
     process.off("SIGINT", onInterrupt);
@@ -483,6 +586,7 @@ type Acquisition = { ok: true } | { ok: false; heldBy: string | null };
  */
 async function acquire(
   adapter: DrizzleAdapter,
+  dialect: MigrationDialect,
   claim: string
 ): Promise<Acquisition> {
   return adapter.transaction(async ctx => {
@@ -491,17 +595,36 @@ async function acquire(
     await ctx.lockRow(MIGRATION_LOCK_TABLE, LOCK_ROW_ID);
 
     const row = await readOwner(ctx);
+    if (row === undefined) return { ok: false, heldBy: null };
 
-    // Any occupied row refuses, including one that appears to be ours. Claims
-    // are unique per invocation, so a match would mean something other than
-    // this call wrote it.
-    if (row === undefined || row.owner !== null) {
-      return { ok: false, heldBy: row?.owner ?? null };
+    // 🔴 An occupied row refuses only while its claim is still LIVE. The holder renews for as long
+    // as it is working, so an expiry in the past is an observation that the holder stopped — a
+    // crashed run, or one killed between renewals — rather than a threshold guess about how long a
+    // migration ought to take.
+    //
+    // A NULL expiry is treated as NOT expired, and that asymmetry is deliberate. It is the row a
+    // previous release wrote, before this column existed, and the process that wrote it may still be
+    // running. Stealing the lock from a live migration is unrecoverable; refusing until an operator
+    // clears a stale row is merely inconvenient, and the state is transient anyway.
+    //
+    // The comparison is made by the DATABASE, in one expression, so nothing depends on the two
+    // contenders' clocks agreeing.
+    const stillLive = await ctx.queryStatement<{ live: unknown }>(
+      sql`SELECT 1 AS ${sql.identifier("live")}
+          FROM ${sql.identifier(MIGRATION_LOCK_TABLE)}
+          WHERE ${sql.identifier("id")} = ${LOCK_ROW_ID}
+            AND ${sql.identifier("owner")} IS NOT NULL
+            AND (${sql.identifier("expires_at")} IS NULL
+                 OR ${sql.identifier("expires_at")} > ${nowExpression(dialect)})`
+    );
+    if (stillLive.length > 0) {
+      return { ok: false, heldBy: row.owner };
     }
 
     await ctx.runStatement(
       sql`UPDATE ${sql.identifier(MIGRATION_LOCK_TABLE)}
-          SET ${sql.identifier("owner")} = ${claim}
+          SET ${sql.identifier("owner")} = ${claim},
+              ${sql.identifier("expires_at")} = ${expiryExpression(dialect)}
           WHERE ${sql.identifier("id")} = ${LOCK_ROW_ID}`
     );
 
@@ -524,7 +647,8 @@ async function release(adapter: DrizzleAdapter, claim: string): Promise<void> {
     // Naming the owner as well makes a release affect only a row we still hold.
     await ctx.runStatement(
       sql`UPDATE ${sql.identifier(MIGRATION_LOCK_TABLE)}
-          SET ${sql.identifier("owner")} = NULL
+          SET ${sql.identifier("owner")} = NULL,
+              ${sql.identifier("expires_at")} = NULL
           WHERE ${sql.identifier("id")} = ${LOCK_ROW_ID}
             AND ${sql.identifier("owner")} = ${claim}`
     );

--- a/packages/nextly/src/domains/field-groups/migration/session.ts
+++ b/packages/nextly/src/domains/field-groups/migration/session.ts
@@ -75,23 +75,43 @@ function lockStateQuery(dialect: MigrationDialect): SQL {
       CASE WHEN ${sql.identifier("owner")} IS NOT NULL
             AND (${sql.identifier("expires_at")} IS NULL
                  OR ${sql.identifier("expires_at")} > ${nowExpression(dialect)})
-           THEN 1 ELSE 0 END AS ${sql.identifier("live")}
+           THEN 1 ELSE 0 END AS ${sql.identifier("live")},
+      CASE WHEN ${sql.identifier("owner")} IS NOT NULL
+            AND (${sql.identifier("expires_at")} IS NULL
+                 OR ${sql.identifier("expires_at")} > ${futureExpression(dialect, LOCK_RENEW_MARGIN_SECONDS)})
+           THEN 1 ELSE 0 END AS ${sql.identifier("usable")}
       FROM ${sql.identifier(MIGRATION_LOCK_TABLE)}
       WHERE ${sql.identifier("id")} = ${LOCK_ROW_ID}`;
 }
 
-/** The lock row as the database reports it, with liveness already decided there. */
+/**
+ * The lock row as the database reports it, with both liveness questions already decided there.
+ *
+ * Two answers rather than one, because two callers ask genuinely different questions and collapsing
+ * them would make one of them wrong. `live` is "would this claim still exclude a contender right
+ * now", which is what an OBSERVER reports to an operator. `usable` is the stricter "will this claim
+ * still be here when its next renewal is due", which is what a claimant needs before it starts
+ * work: a lease with less than one renewal interval left is live and is about to lapse unrenewed.
+ *
+ * Both are computed in the same statement, on the database's own clock, so no part of either
+ * depends on this process's idea of the time.
+ */
 interface LockState {
   readonly owner: string | null;
   readonly live: boolean;
+  readonly usable: boolean;
 }
 
 /** Read the row, or `undefined` when there is no row to read. */
 function toLockState(
-  row: { owner: string | null; live: unknown } | undefined
+  row: { owner: string | null; live: unknown; usable: unknown } | undefined
 ): LockState | undefined {
   if (row === undefined) return undefined;
-  return { owner: row.owner, live: Number(row.live) === 1 };
+  return {
+    owner: row.owner,
+    live: Number(row.live) === 1,
+    usable: Number(row.usable) === 1,
+  };
 }
 
 /**
@@ -127,6 +147,20 @@ export const LOCK_LOSS_AFTER_MS =
   LOCK_TTL_SECONDS * 1000 - 2 * LOCK_RENEW_INTERVAL_MS;
 
 /**
+ * How much lease a claim must still have for its holder to rely on it.
+ *
+ * 🔴 "Not yet expired" is not the same as "safe to start work on". A claim is renewed on a timer, so
+ * the first renewal is a whole interval away; a lease with less than that left is live at the
+ * instant it is read and gone before anything renews it. That gap is not hypothetical — the write
+ * and the read-back are separate statements, and a process descheduled between them can spend most
+ * of the TTL there, coming back to a claim that passes a liveness test and cannot survive to its
+ * own first renewal.
+ *
+ * One interval, so the requirement is exactly "this will still be here when I next touch it".
+ */
+export const LOCK_RENEW_MARGIN_SECONDS = LOCK_RENEW_INTERVAL_MS / 1000;
+
+/**
  * The database's own clock, and an expiry computed from it, per dialect.
  *
  * 🔴 Never the application's clock. Two processes contending for this row can sit on machines whose
@@ -151,17 +185,21 @@ function nowExpression(dialect: MigrationDialect): SQL {
   return dialect === "mysql" ? sql`NOW()` : sql`clock_timestamp()`;
 }
 
-function expiryExpression(dialect: MigrationDialect): SQL {
+function futureExpression(dialect: MigrationDialect, seconds: number): SQL {
   if (dialect === "sqlite") {
-    return sql`unixepoch() + ${LOCK_TTL_SECONDS}`;
+    return sql`unixepoch() + ${seconds}`;
   }
   if (dialect === "mysql") {
-    return sql`DATE_ADD(NOW(), INTERVAL ${LOCK_TTL_SECONDS} SECOND)`;
+    return sql`DATE_ADD(NOW(), INTERVAL ${seconds} SECOND)`;
   }
   // The same clock as `nowExpression`, deliberately: an expiry written from transaction time and a
   // liveness test taken at statement time would disagree about when the lease ends, and the pair
   // has to share one frame of reference to mean anything.
-  return sql`clock_timestamp() + make_interval(secs => ${LOCK_TTL_SECONDS})`;
+  return sql`clock_timestamp() + make_interval(secs => ${seconds})`;
+}
+
+function expiryExpression(dialect: MigrationDialect): SQL {
+  return futureExpression(dialect, LOCK_TTL_SECONDS);
 }
 
 /** The row, read inside the transaction that is about to decide the claim. */
@@ -172,6 +210,7 @@ async function readLockState(
   const rows = await ctx.queryStatement<{
     owner: string | null;
     live: unknown;
+    usable: unknown;
   }>(lockStateQuery(dialect));
   return toLockState(rows[0]);
 }
@@ -201,7 +240,7 @@ async function renew(
     // says so — reporting a successful renewal on a lease a contender may take the instant this
     // commits, while the callback carries on believing it is protected.
     const after = await readLockState(ctx, dialect);
-    return after?.owner === claim && after.live;
+    return after?.owner === claim && after.usable;
   });
 }
 
@@ -221,6 +260,7 @@ async function readLockStateOutsideTransaction(
   const rows = await adapter.queryStatement<{
     owner: string | null;
     live: unknown;
+    usable: unknown;
   }>(lockStateQuery(dialect));
   return toLockState(rows[0]);
 }
@@ -881,7 +921,7 @@ async function acquire(
     // because the honest answer is that acquisition did not establish exclusion, not that the row
     // was empty.
     const after = await readLockState(ctx, dialect);
-    if (after?.owner !== claim || !after.live) {
+    if (after?.owner !== claim || !after.usable) {
       return { ok: false, heldBy: after?.owner ?? null };
     }
     return { ok: true };

--- a/packages/nextly/src/domains/field-groups/migration/session.ts
+++ b/packages/nextly/src/domains/field-groups/migration/session.ts
@@ -13,11 +13,14 @@
  * all three dialects, and is reached through the adapter's typed API instead of
  * dialect-specific SQL.
  *
- * There is deliberately no TTL and no auto-steal. Expiry needs a trusted clock,
- * and skew between application servers is precisely the case where two runs
- * would both conclude the lock had expired and proceed together. A run that
- * dies holding the lock leaves it held, and an operator clears it. For
- * something that rewrites customer data, refusing is the correct failure.
+ * A claim carries an expiry that its holder RENEWS for as long as it is working,
+ * so an expired claim is an observation that the holder stopped rather than a
+ * guess about how long a migration ought to take. Every comparison is made by
+ * the database, in one expression, so no part of it depends on two application
+ * servers' clocks agreeing — which is what makes expiry safe here and is exactly
+ * what a bare TTL cannot promise. A row whose expiry is NULL predates this
+ * column and is treated as live: refusing until an operator clears it is
+ * recoverable, and stealing the lock from a run that is still writing is not.
  *
  * @module domains/field-groups/migration/session
  */
@@ -47,7 +50,7 @@ export const MIGRATION_LOCK_TABLE = "nextly_field_group_lock";
 const LOCK_ROW_ID = 1;
 
 /**
- * The single statement that reads the lock row's owner.
+ * The single statement that reads the lock row: who holds it, and whether that claim is still live.
  *
  * Issued as a Drizzle statement rather than through the typed query builder:
  * that resolves a table through the schema registry and rejects any name the
@@ -55,13 +58,39 @@ const LOCK_ROW_ID = 1;
  * rather than declared in the static schema — the same shape the schema
  * pipeline's own `nextly_migrate_lock` has.
  *
- * Held as one function because two executors run it, and a second copy would be
- * free to disagree about which row the owner lives in.
+ * 🔴 Liveness is decided HERE, in the same row read, because two callers ask it and they must not be
+ * able to disagree. `acquire` uses it to decide whether to refuse; `observeMigrationLock` uses it to
+ * tell an operator who holds the lock. A second spelling of "is this claim still live" would let a
+ * preview report contention from a claim that a run would have taken over, and the two would look
+ * correct read separately.
+ *
+ * The liveness test is a CASE rather than a boolean expression because the dialects return booleans
+ * differently — `true`, `1` and `"1"` all occur — and a caller comparing against one of those three
+ * is a per-dialect defect that unit doubles cannot see. An integer normalises through `Number()` on
+ * every driver.
  */
-function ownerQuery(): SQL {
-  return sql`SELECT ${sql.identifier("owner")}, ${sql.identifier("expires_at")}
+function lockStateQuery(dialect: MigrationDialect): SQL {
+  return sql`SELECT ${sql.identifier("owner")},
+      CASE WHEN ${sql.identifier("owner")} IS NOT NULL
+            AND (${sql.identifier("expires_at")} IS NULL
+                 OR ${sql.identifier("expires_at")} > ${nowExpression(dialect)})
+           THEN 1 ELSE 0 END AS ${sql.identifier("live")}
       FROM ${sql.identifier(MIGRATION_LOCK_TABLE)}
       WHERE ${sql.identifier("id")} = ${LOCK_ROW_ID}`;
+}
+
+/** The lock row as the database reports it, with liveness already decided there. */
+interface LockState {
+  readonly owner: string | null;
+  readonly live: boolean;
+}
+
+/** Read the row, or `undefined` when there is no row to read. */
+function toLockState(
+  row: { owner: string | null; live: unknown } | undefined
+): LockState | undefined {
+  if (row === undefined) return undefined;
+  return { owner: row.owner, live: Number(row.live) === 1 };
 }
 
 /**
@@ -74,8 +103,8 @@ function ownerQuery(): SQL {
  * The interval is a quarter of the TTL, so four consecutive renewals have to fail before the claim
  * lapses. A single slow query or a brief connection blip cannot lose a lock that is still held.
  */
-const LOCK_TTL_SECONDS = 120;
-const LOCK_RENEW_INTERVAL_MS = (LOCK_TTL_SECONDS / 4) * 1000;
+export const LOCK_TTL_SECONDS = 120;
+export const LOCK_RENEW_INTERVAL_MS = (LOCK_TTL_SECONDS / 4) * 1000;
 
 /**
  * The database's own clock, and an expiry computed from it, per dialect.
@@ -103,12 +132,16 @@ function expiryExpression(dialect: MigrationDialect): SQL {
   return sql`now() + make_interval(secs => ${LOCK_TTL_SECONDS})`;
 }
 
-/** The owner, read inside the transaction that is about to decide the claim. */
-async function readOwner(
-  ctx: TransactionContext
-): Promise<{ owner: string | null } | undefined> {
-  const rows = await ctx.queryStatement<{ owner: string | null }>(ownerQuery());
-  return rows[0];
+/** The row, read inside the transaction that is about to decide the claim. */
+async function readLockState(
+  ctx: TransactionContext,
+  dialect: MigrationDialect
+): Promise<LockState | undefined> {
+  const rows = await ctx.queryStatement<{
+    owner: string | null;
+    live: unknown;
+  }>(lockStateQuery(dialect));
+  return toLockState(rows[0]);
 }
 
 /** Renew this claim, and report whether it is still ours. */
@@ -128,7 +161,7 @@ async function renew(
     // Read back rather than trusting the update's affected-row count, which dialects report
     // inconsistently. If the row no longer names this claim, someone took the lock over and the work
     // this renewal was protecting is no longer protected.
-    const after = await readOwner(ctx);
+    const after = await readLockState(ctx, dialect);
     return after?.owner === claim;
   });
 }
@@ -136,19 +169,21 @@ async function renew(
 /**
  * The same read, on the adapter's own connection.
  *
- * Separate executor rather than a separate query — both issue `ownerQuery()`,
- * so the two cannot drift into disagreeing about which row the owner lives in.
- * An observing caller wants no transaction at all: opening one to read a single
- * row asks a read-only role for more than the read needs, which is the entire
- * failure this path exists to avoid.
+ * Separate executor rather than a separate query — both issue `lockStateQuery()`,
+ * so the two cannot drift into disagreeing about which row the owner lives in
+ * or about when a claim has lapsed. An observing caller wants no transaction at
+ * all: opening one to read a single row asks a read-only role for more than the
+ * read needs, which is the entire failure this path exists to avoid.
  */
-async function readOwnerOutsideTransaction(
-  adapter: DrizzleAdapter
-): Promise<{ owner: string | null } | undefined> {
-  const rows = await adapter.queryStatement<{ owner: string | null }>(
-    ownerQuery()
-  );
-  return rows[0];
+async function readLockStateOutsideTransaction(
+  adapter: DrizzleAdapter,
+  dialect: MigrationDialect
+): Promise<LockState | undefined> {
+  const rows = await adapter.queryStatement<{
+    owner: string | null;
+    live: unknown;
+  }>(lockStateQuery(dialect));
+  return toLockState(rows[0]);
 }
 
 /** Whether the single lock row is present, read outside any transaction. */
@@ -231,14 +266,21 @@ export function isMissingTable(
  * through `information_schema`, which is filtered by privilege on Postgres and MySQL: a table the
  * role cannot see is reported absent, and the caller would then be told nothing holds the lock
  * while a migration was holding it.
+ *
+ * A LAPSED claim reports `not-held`, because that is what a run contending for the row would find:
+ * `acquire` takes it over. Reporting the dead claim's owner instead would name a holder that
+ * excludes nobody, and the dry-run outcome that carries this observation would explain a torn read
+ * with contention that cannot happen.
  */
 export async function observeMigrationLock(
   adapter: DrizzleAdapter,
   dialect: MigrationDialect
 ): Promise<LockObservation> {
   try {
-    const owner = (await readOwnerOutsideTransaction(adapter))?.owner ?? null;
-    return owner === null ? { kind: "not-held" } : { kind: "held", owner };
+    const state = await readLockStateOutsideTransaction(adapter, dialect);
+    return state?.live === true && state.owner !== null
+      ? { kind: "held", owner: state.owner }
+      : { kind: "not-held" };
   } catch (error) {
     // The lock table is created by the first run that ever claims it, so its absence is a complete
     // answer: nothing can hold a lock whose table does not exist.
@@ -594,7 +636,7 @@ async function acquire(
     // ends, so the read below cannot be overtaken between reading and writing.
     await ctx.lockRow(MIGRATION_LOCK_TABLE, LOCK_ROW_ID);
 
-    const row = await readOwner(ctx);
+    const row = await readLockState(ctx, dialect);
     if (row === undefined) return { ok: false, heldBy: null };
 
     // 🔴 An occupied row refuses only while its claim is still LIVE. The holder renews for as long
@@ -607,20 +649,13 @@ async function acquire(
     // running. Stealing the lock from a live migration is unrecoverable; refusing until an operator
     // clears a stale row is merely inconvenient, and the state is transient anyway.
     //
-    // The comparison is made by the DATABASE, in one expression, so nothing depends on the two
-    // contenders' clocks agreeing.
-    const stillLive = await ctx.queryStatement<{ live: unknown }>(
-      sql`SELECT 1 AS ${sql.identifier("live")}
-          FROM ${sql.identifier(MIGRATION_LOCK_TABLE)}
-          WHERE ${sql.identifier("id")} = ${LOCK_ROW_ID}
-            AND ${sql.identifier("owner")} IS NOT NULL
-            AND (${sql.identifier("expires_at")} IS NULL
-                 OR ${sql.identifier("expires_at")} > ${nowExpression(dialect)})`
-    );
-    if (stillLive.length > 0) {
-      return { ok: false, heldBy: row.owner };
-    }
+    // The comparison was made by the DATABASE inside `lockStateQuery`, in one expression, so nothing
+    // depends on the two contenders' clocks agreeing.
+    if (row.live) return { ok: false, heldBy: row.owner };
 
+    // The row is free or its claim has lapsed, and the row lock above means nothing can change that
+    // before this commits — so the write names no owner. Predicating it on the owner we just read
+    // would fail to take over a lapsed claim, which is the state this whole column exists to resolve.
     await ctx.runStatement(
       sql`UPDATE ${sql.identifier(MIGRATION_LOCK_TABLE)}
           SET ${sql.identifier("owner")} = ${claim},
@@ -632,7 +667,7 @@ async function acquire(
     // inconsistently across dialects, and an absent row would otherwise update
     // nothing and still look like a successful claim, running the migration
     // with no exclusion at all.
-    const after = await readOwner(ctx);
+    const after = await readLockState(ctx, dialect);
     if (after?.owner !== claim) {
       return { ok: false, heldBy: after?.owner ?? null };
     }

--- a/packages/nextly/src/domains/field-groups/migration/session.ts
+++ b/packages/nextly/src/domains/field-groups/migration/session.ts
@@ -528,10 +528,20 @@ export async function withMigrationSession<T>(
   // stronger behaviour should re-check between steps, which is the only place a cancellation could
   // land intact.
   let lostClaim: ((reason: unknown) => void) | undefined;
+  // 🔴 Whether the claim was reported lost, and it is what decides the RELEASE below.
+  //
+  // Losing the claim does not stop `fn`, so a release on the way out would hand the row to the next
+  // contender while this run is still renaming tables. That is not hypothetical for the transient
+  // case: a renewal that failed on a blip leaves the row still owned by this claim, so the
+  // owner-scoped release below matches and clears it. The run then continues writing with the lock
+  // free. Leaving it alone is both safer and self-correcting — nothing renews it any more, so it
+  // lapses on its own and the TTL performs exactly the recovery it exists for.
+  let claimWasLost = false;
   const claimLost = new Promise<never>((_, reject) => {
     lostClaim = reject;
   });
-  const onLost = (): void =>
+  const onLost = (): void => {
+    claimWasLost = true;
     lostClaim?.(
       NextlyError.serviceUnavailable({
         logMessage:
@@ -542,6 +552,7 @@ export async function withMigrationSession<T>(
         },
       })
     );
+  };
   const renewal = setInterval(() => {
     void renew(adapter, dialect, claim).then(
       held => {
@@ -566,7 +577,12 @@ export async function withMigrationSession<T>(
     // cannot start a second one.
     process.off("SIGINT", onInterrupt);
     process.off("SIGTERM", onTerminate);
-    await release(adapter, claim);
+    // 🔴 Not released once the claim was reported lost. `fn` is still running — nothing here can
+    // stop it — so freeing the row would let the next contender start against a database this run
+    // is still writing to, which is the precise outcome the lock exists to prevent. Doing nothing
+    // is self-correcting: the renewal has stopped, so the claim lapses on its own and the next run
+    // takes it over through the ordinary expiry path.
+    if (!claimWasLost) await release(adapter, claim);
   }
 }
 

--- a/packages/nextly/src/domains/field-groups/migration/session.ts
+++ b/packages/nextly/src/domains/field-groups/migration/session.ts
@@ -147,18 +147,21 @@ export const LOCK_LOSS_AFTER_MS =
   LOCK_TTL_SECONDS * 1000 - 2 * LOCK_RENEW_INTERVAL_MS;
 
 /**
- * How much lease a claim must still have for its holder to rely on it.
+ * How much lease a confirmation must actually grant for the holder to rely on it.
  *
- * 🔴 "Not yet expired" is not the same as "safe to start work on". A claim is renewed on a timer, so
- * the first renewal is a whole interval away; a lease with less than that left is live at the
- * instant it is read and gone before anything renews it. That gap is not hypothetical — the write
- * and the read-back are separate statements, and a process descheduled between them can spend most
- * of the TTL there, coming back to a claim that passes a liveness test and cannot survive to its
- * own first renewal.
+ * 🔴 "Not yet expired" is not the same as "safe to work on", and neither is "lasts until the next
+ * renewal". The write and the read-back are separate statements, so a process descheduled between
+ * them comes back to a claim that passes a liveness test with almost nothing left.
  *
- * One interval, so the requirement is exactly "this will still be here when I next touch it".
+ * 🔴 DERIVED from the loss deadline, not chosen alongside it. Confirming a lease is what STARTS the
+ * window in which this session will not ask again, so a confirmation granting less than that window
+ * is a promise the row cannot keep: the session sits for the whole window believing it is protected
+ * while the row expires partway through, and a contender takes it. Two independently chosen numbers
+ * would only have to differ for that gap to open — with a one-interval margin the confirmed lease
+ * could be 16 seconds while the session went 90 without checking, leaving 74 seconds unprotected.
+ * Tying the requirement to the window makes them agree by construction instead.
  */
-export const LOCK_RENEW_MARGIN_SECONDS = LOCK_RENEW_INTERVAL_MS / 1000;
+export const LOCK_RENEW_MARGIN_SECONDS = LOCK_LOSS_AFTER_MS / 1000;
 
 /**
  * The database's own clock, and an expiry computed from it, per dialect.

--- a/packages/nextly/src/domains/field-groups/migration/session.ts
+++ b/packages/nextly/src/domains/field-groups/migration/session.ts
@@ -185,8 +185,15 @@ async function renew(
     // Read back rather than trusting the update's affected-row count, which dialects report
     // inconsistently. If the row no longer names this claim, someone took the lock over and the work
     // this renewal was protecting is no longer protected.
+    //
+    // 🔴 OWNERSHIP AND LIVENESS, not ownership alone. The row can name this claim and still be
+    // expired: if the transaction is suspended, descheduled or simply slow between writing the
+    // expiry and reading it back, more than the TTL can elapse inside it. `readLockState` reports
+    // that correctly as `live: false`, and an owner-only check discards exactly the field that
+    // says so — reporting a successful renewal on a lease a contender may take the instant this
+    // commits, while the callback carries on believing it is protected.
     const after = await readLockState(ctx, dialect);
-    return after?.owner === claim;
+    return after?.owner === claim && after.live;
   });
 }
 
@@ -795,8 +802,12 @@ async function acquire(
     // inconsistently across dialects, and an absent row would otherwise update
     // nothing and still look like a successful claim, running the migration
     // with no exclusion at all.
+    // The same pair as the renewal readback, for the same reason: a claim that is ours but already
+    // expired is not a claim. Treated as held by whoever the row names — which is this process —
+    // because the honest answer is that acquisition did not establish exclusion, not that the row
+    // was empty.
     const after = await readLockState(ctx, dialect);
-    if (after?.owner !== claim) {
+    if (after?.owner !== claim || !after.live) {
       return { ok: false, heldBy: after?.owner ?? null };
     }
     return { ok: true };

--- a/packages/nextly/src/schemas/field-group-lock/__tests__/lock-declaration-parity.test.ts
+++ b/packages/nextly/src/schemas/field-group-lock/__tests__/lock-declaration-parity.test.ts
@@ -19,18 +19,31 @@ import { getTableConfig as pgTableConfig } from "drizzle-orm/pg-core";
 import { getTableConfig as sqliteTableConfig } from "drizzle-orm/sqlite-core";
 import { describe, expect, it } from "vitest";
 
-import { getMigrationLockDdl } from "../../../domains/field-groups/migration/session";
+import {
+  getMigrationLockDdl,
+  getMigrationLockUpgradeDdl,
+} from "../../../domains/field-groups/migration/session";
 import { nextlyFieldGroupLock as myLock } from "../mysql";
 import { nextlyFieldGroupLock as pgLock } from "../postgres";
 import { nextlyFieldGroupLock as slLock } from "../sqlite";
 
 import type { SupportedDialect } from "@nextlyhq/adapter-drizzle/types";
 
+/** Each dialect's declared columns, read through the dialect's own config reader. */
+const DECLARED_COLUMNS: Record<
+  SupportedDialect,
+  () => { name: string; getSQLType: () => string }[]
+> = {
+  postgresql: () => pgTableConfig(pgLock).columns,
+  mysql: () => mysqlTableConfig(myLock).columns,
+  sqlite: () => sqliteTableConfig(slLock).columns,
+};
+
 /** Each dialect's declared table, normalised to the one thing this compares. */
 const DECLARED: Record<SupportedDialect, () => string[]> = {
-  postgresql: () => pgTableConfig(pgLock).columns.map(c => c.name),
-  mysql: () => mysqlTableConfig(myLock).columns.map(c => c.name),
-  sqlite: () => sqliteTableConfig(slLock).columns.map(c => c.name),
+  postgresql: () => DECLARED_COLUMNS.postgresql().map(c => c.name),
+  mysql: () => DECLARED_COLUMNS.mysql().map(c => c.name),
+  sqlite: () => DECLARED_COLUMNS.sqlite().map(c => c.name),
 };
 
 /** The dialects a lock is ever created on. */
@@ -50,7 +63,57 @@ function columnsInDdl(statement: string): string[] {
     .filter(name => name.length > 0);
 }
 
+/**
+ * The type each column is given in the bootstrap statement, keyed by column name.
+ *
+ * The trailing key clause belongs to the column's definition rather than to its type, so it is
+ * removed before comparing; leaving it in would compare `integer PRIMARY KEY` against `integer`
+ * and fail on a statement that is correct.
+ */
+function typesInDdl(statement: string): Map<string, string> {
+  const body = /\(([\s\S]*)\)/.exec(statement)?.[1] ?? "";
+  const types = new Map<string, string>();
+  for (const part of body.split(",")) {
+    const [name, ...rest] = part.trim().split(/\s+/);
+    if (name === undefined || name.length === 0) continue;
+    types.set(name, rest.join(" ").replace(/\s+PRIMARY KEY$/i, ""));
+  }
+  return types;
+}
+
 describe("the bootstrap DDL and the declared table agree", () => {
+  it.each(DIALECTS)("gives every column its declared type on %s", dialect => {
+    const [statement] = getMigrationLockDdl(dialect);
+    const inDdl = typesInDdl(statement as string);
+
+    // 🔴 Positive control on the parser: without it, a body that parsed to nothing would make every
+    // comparison below vacuous, since a loop over zero declared columns asserts nothing.
+    const declared = DECLARED_COLUMNS[dialect]();
+    expect(declared.length).toBeGreaterThan(0);
+    expect([...inDdl.keys()].sort()).toEqual(declared.map(c => c.name).sort());
+
+    for (const column of declared) {
+      expect(inDdl.get(column.name)).toBe(column.getSQLType());
+    }
+  });
+
+  it.each(DIALECTS)(
+    "adds the same expiry column on upgrade as it creates on %s",
+    dialect => {
+      // An installation that gains `expires_at` by ALTER must end up the shape a fresh install is
+      // born with, or the two populations diverge and nothing downstream can tell them apart.
+      const created = typesInDdl(getMigrationLockDdl(dialect)[0] as string).get(
+        "expires_at"
+      );
+      const added = /\bexpires_at\s+([\s\S]+)$/.exec(
+        getMigrationLockUpgradeDdl(dialect)
+      )?.[1];
+
+      expect(created).toBeDefined();
+      expect(added).toBe(created);
+    }
+  );
+
   it.each(DIALECTS)("declares the same columns on %s", dialect => {
     const [statement, ...rest] = getMigrationLockDdl(
       dialect === "postgresql" ? "postgresql" : dialect

--- a/packages/nextly/src/schemas/field-group-lock/index.ts
+++ b/packages/nextly/src/schemas/field-group-lock/index.ts
@@ -5,6 +5,9 @@
  */
 
 import type { SupportedDialect } from "@nextlyhq/adapter-drizzle/types";
+import { getTableConfig as mysqlTableConfig } from "drizzle-orm/mysql-core";
+import { getTableConfig as pgTableConfig } from "drizzle-orm/pg-core";
+import { getTableConfig as sqliteTableConfig } from "drizzle-orm/sqlite-core";
 
 import { NextlyError } from "../../errors/nextly-error";
 
@@ -13,6 +16,56 @@ import * as pg from "./postgres";
 import * as sl from "./sqlite";
 
 export { pg, my, sl };
+
+/** A column the lock table is made of. */
+export type FieldGroupLockColumn = "id" | "owner" | "expires_at";
+
+/**
+ * The physical type each lock column is declared with, read out of the declaration itself.
+ *
+ * The bootstrap DDL has to name a type per column, and the declarations above already carry one.
+ * Restating them there would be a second answer to the same question, drifting silently: the
+ * bootstrap would keep creating the old shape while a reconcile proposed the new one on every run.
+ * Reading `getSQLType()` makes the declaration the only place a type is chosen.
+ *
+ * Read through each dialect's own `getTableConfig` rather than the table object's own accessor,
+ * which the drizzle-v1 gate bars, following the prior art in the declaration-parity test.
+ */
+export function fieldGroupLockColumnTypes(
+  dialect: SupportedDialect
+): Record<FieldGroupLockColumn, string> {
+  const columns =
+    dialect === "postgresql"
+      ? pgTableConfig(pg.nextlyFieldGroupLock).columns
+      : dialect === "mysql"
+        ? mysqlTableConfig(my.nextlyFieldGroupLock).columns
+        : sqliteTableConfig(sl.nextlyFieldGroupLock).columns;
+  const declared = new Map(
+    columns.map(column => [column.name, column.getSQLType()])
+  );
+
+  const read = (name: FieldGroupLockColumn): string => {
+    const type = declared.get(name);
+    if (type === undefined) {
+      // The declaration lost a column the bootstrap needs. `internal` because only a code change
+      // can produce it, and failing here beats emitting a CREATE with a hole in it.
+      throw NextlyError.internal({
+        logContext: {
+          reason: "field-group lock declaration is missing a column",
+          dialect,
+          column: name,
+        },
+      });
+    }
+    return type;
+  };
+
+  return {
+    id: read("id"),
+    owner: read("owner"),
+    expires_at: read("expires_at"),
+  };
+}
 
 /** The lock table for the requested dialect. */
 export function fieldGroupLockTables(dialect: SupportedDialect) {

--- a/packages/nextly/src/schemas/field-group-lock/index.ts
+++ b/packages/nextly/src/schemas/field-group-lock/index.ts
@@ -34,14 +34,11 @@ export type FieldGroupLockColumn = "id" | "owner" | "expires_at";
 export function fieldGroupLockColumnTypes(
   dialect: SupportedDialect
 ): Record<FieldGroupLockColumn, string> {
-  const columns =
-    dialect === "postgresql"
-      ? pgTableConfig(pg.nextlyFieldGroupLock).columns
-      : dialect === "mysql"
-        ? mysqlTableConfig(my.nextlyFieldGroupLock).columns
-        : sqliteTableConfig(sl.nextlyFieldGroupLock).columns;
   const declared = new Map(
-    columns.map(column => [column.name, column.getSQLType()])
+    lockForDialect(dialect).columns.map(column => [
+      column.name,
+      column.getSQLType(),
+    ])
   );
 
   const read = (name: FieldGroupLockColumn): string => {
@@ -67,15 +64,32 @@ export function fieldGroupLockColumnTypes(
   };
 }
 
-/** The lock table for the requested dialect. */
-export function fieldGroupLockTables(dialect: SupportedDialect) {
+/**
+ * The ONE place a dialect is turned into a lock table, with the columns that table declares.
+ *
+ * 🔴 Both public functions below are views of this, rather than two selections that happen to
+ * agree. A second selection does not need to be wrong to be dangerous: written as a ternary chain
+ * ending in a bare `else`, it silently ASSIGNS every future dialect to whichever branch is last, so
+ * adding one to `SupportedDialect` would compile and emit another dialect's column types. Here the
+ * `never` assignment below makes the compiler demand a case instead.
+ */
+function lockForDialect(dialect: SupportedDialect) {
   switch (dialect) {
     case "postgresql":
-      return { nextlyFieldGroupLock: pg.nextlyFieldGroupLock };
+      return {
+        table: pg.nextlyFieldGroupLock,
+        columns: pgTableConfig(pg.nextlyFieldGroupLock).columns,
+      };
     case "mysql":
-      return { nextlyFieldGroupLock: my.nextlyFieldGroupLock };
+      return {
+        table: my.nextlyFieldGroupLock,
+        columns: mysqlTableConfig(my.nextlyFieldGroupLock).columns,
+      };
     case "sqlite":
-      return { nextlyFieldGroupLock: sl.nextlyFieldGroupLock };
+      return {
+        table: sl.nextlyFieldGroupLock,
+        columns: sqliteTableConfig(sl.nextlyFieldGroupLock).columns,
+      };
     default: {
       // Exhaustiveness check — TypeScript flags any missing dialect at compile time, so reaching
       // here at runtime means a dialect was added without a table for it. `internal` because that
@@ -89,4 +103,9 @@ export function fieldGroupLockTables(dialect: SupportedDialect) {
       });
     }
   }
+}
+
+/** The lock table for the requested dialect, as a schema fragment. */
+export function fieldGroupLockTables(dialect: SupportedDialect) {
+  return { nextlyFieldGroupLock: lockForDialect(dialect).table };
 }

--- a/packages/nextly/src/schemas/field-group-lock/mysql.ts
+++ b/packages/nextly/src/schemas/field-group-lock/mysql.ts
@@ -9,9 +9,10 @@
  * @module schemas/field-group-lock/mysql
  */
 
-import { int, mysqlTable, text } from "drizzle-orm/mysql-core";
+import { datetime, int, mysqlTable, text } from "drizzle-orm/mysql-core";
 
 export const nextlyFieldGroupLock = mysqlTable("nextly_field_group_lock", {
   id: int("id").primaryKey(),
   owner: text("owner"),
+  expiresAt: datetime("expires_at"),
 });

--- a/packages/nextly/src/schemas/field-group-lock/postgres.ts
+++ b/packages/nextly/src/schemas/field-group-lock/postgres.ts
@@ -18,9 +18,10 @@
  * @module schemas/field-group-lock/postgres
  */
 
-import { integer, pgTable, text } from "drizzle-orm/pg-core";
+import { integer, pgTable, text, timestamp } from "drizzle-orm/pg-core";
 
 export const nextlyFieldGroupLock = pgTable("nextly_field_group_lock", {
   id: integer("id").primaryKey(),
   owner: text("owner"),
+  expiresAt: timestamp("expires_at", { withTimezone: true }),
 });

--- a/packages/nextly/src/schemas/field-group-lock/sqlite.ts
+++ b/packages/nextly/src/schemas/field-group-lock/sqlite.ts
@@ -10,4 +10,5 @@ import { integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
 export const nextlyFieldGroupLock = sqliteTable("nextly_field_group_lock", {
   id: integer("id").primaryKey(),
   owner: text("owner"),
+  expiresAt: integer("expires_at", { mode: "timestamp" }),
 });


### PR DESCRIPTION
The field-group migration lock could be held by a process that no longer exists. A run
that crashed, or was killed between steps, left its claim in the row with no way to
reach it — every later run refused until an operator cleared it by hand. For a lock
that guards a table-renaming, row-rewriting migration, refusing was the right default,
but "refuse forever" was never the only safe answer.

## What changes

A claim now carries an expiry, and **its holder renews it for as long as it is
working**. That is the part that makes a short TTL safe: liveness is maintained by the
renewal, so the TTL only decides how quickly a *dead* holder's row becomes claimable,
never how long a live migration is allowed to take.

- TTL 120s, renewed every 30s, so **four consecutive renewals must fail** before a claim
  lapses. One slow query or a brief connection blip cannot lose a lock that is still held.
- A run whose claim is taken over, or whose renewal cannot be made at all, **fails
  loudly** rather than continuing against a database another run may already be rewriting.
- **Every comparison is made by the database**, in one expression. Two contenders can sit
  on machines whose clocks disagree, and a claim written from one clock and judged against
  another is decided by that skew rather than by who holds the lock. This is what makes
  expiry safe here and is exactly what a bare TTL cannot promise.
- **A NULL expiry counts as NOT expired.** That row predates this column and the process
  that wrote it may still be running. Stealing the lock from a live migration is
  unrecoverable; refusing until an operator clears a stale row is merely inconvenient.

## One question, one implementation

Modelling expiry surfaced a real divergence. `observeMigrationLock` decided "held" from
`owner !== null` while `acquire` decided it from liveness — so a preview would have
reported contention from a dead claim that a run would have taken over, and `run.ts`
feeds that observation into the dry-run contention explanation. Both now read one
`lockStateQuery(dialect)`, which decides liveness in the database inside the same row
read.

Liveness comes back as `CASE ... THEN 1 ELSE 0` rather than a boolean, because the three
dialects return `true`, `1` and `"1"`. A caller comparing against one of those is a
per-dialect defect no unit double can see.

## What it does NOT do

It **cannot stop `fn`**. JavaScript has no preemption, so a lost claim rejects the
caller's await and leaves whatever the run had already started running to completion. The
guarantee is that a run which loses its lock fails loudly and stops being waited on, not
that its in-flight statement is cancelled. This is stated in the code and pinned by a
test that asserts it in both directions.

## Evidence

Seven new unit tests, each proven by breaking the code and confirming the intended test
goes red:

| break | fails |
| --- | --- |
| `acquire` ignores liveness | takes over a claim whose expiry has passed |
| the renewal never fires | all three renewal tests |
| `acquire` never refuses | refuses a claim with no expiry |
| observe names a dead claim's owner | observes a lapsed claim as not-held |
| the claim binds `ttl=1` instead of the constant | writes an expiry with the claim |

The last one is load-bearing beyond itself: the double reads the TTL from the **bound
parameter** rather than importing the constant, so a statement that stopped binding it
would be caught. Importing it would have made that break invisible.

**The unit doubles mirror the SQL predicate; they do not prove it.** A comparison that
always answered "expired" would let two runs migrate at once, and one that always answered
"live" would wedge every database forever — neither is visible to a double. So the
predicate is proven where it can be: `session.integration.test.ts` runs four expiry cases
on **all three dialects**, with the fixture's expiry computed by the server and spelled
independently of `expiryExpression` (a fixture built from the expression under test agrees
with a broken one).

The takeover and live-refusal cases are each other's control. The column is `timestamptz`,
`datetime` and integer unix-seconds respectively, so `expires_at > now()` is a different
comparison on each dialect, and only the pair separates a working one from either failure
direction. Verified by inverting the comparison (9 failures across all three dialects) and
by removing it (3 failures, all three dialects).

## Four interpreters became one

Four separate doubles interpreted these same statements. Two were quietly wrong: the claim
UPDATE was modelled as refusing an occupied row, when the real statement has no owner
predicate — `acquire` decides under a row lock and then writes unconditionally — so no
double could ever have shown a takeover. They agreed with production by luck. Statement
identity and statement semantics now each live in one place, and all 26 pre-existing
session tests still pass, which is what shows the convergence preserved their meaning.

## Verification

- `build`, `check-types --force`, `lint`, `check-drizzle-v1-legacy`,
  `check:storage-format-literals` — all exit 0
- full `packages/nextly` unit suite, JSON reporter, diffed per test name against a
  baseline measured at this branch's own merge base with matching timeout flags:
  **0 regressions, 361 failing unchanged, +7 passing** — exactly the tests added
- integration on postgres, mysql and sqlite: `session.integration.test.ts` 21 passed
- `upgrade-sim-045` re-verified on this branch, since it changes the lock's DDL


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Migration locks now expire automatically and renew while migrations remain active.
  * Expired locks can be safely reclaimed, while active or indefinite locks remain protected.
  * Added support for observing live migration locks without opening transactions.
  * Added lock-expiry upgrades and consistent schema support across PostgreSQL, MySQL, and SQLite.

* **Bug Fixes**
  * Improved handling of lost locks, failed acquisitions, crashed processes, and deferred cleanup.
  * Migration completion now verifies ownership and lock liveness before releasing claims.

* **Documentation**
  * Clarified lock expiration and retry behavior after interrupted migrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->