### PR TITLE
fix(nextly): store the configuration a provider parsed

### DIFF
--- a/.changeset/tidy-bugs-smile.md
+++ b/.changeset/tidy-bugs-smile.md
@@ -1,0 +1,30 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+Store the configuration a provider parsed, and refuse a write whose parse is not a fixed point.
+
+The service persisted whatever the caller submitted while the adapter closed over the parse result, so every difference between the two became a defect somewhere that read the row. It now persists the parsed value, and checks before writing that parsing the stored form returns the stored form -- rejecting a `parseConfig` that derives a credential, returns a value JSON cannot carry, or refuses its own output, each of which would otherwise hand the adapter a configuration nobody saved.

--- a/packages/nextly/src/domains/email/__tests__/built-in-descriptors.test.ts
+++ b/packages/nextly/src/domains/email/__tests__/built-in-descriptors.test.ts
@@ -161,13 +161,13 @@ describe("descriptor constraints are honoured by the parser", () => {
     };
 
     expect(() =>
-      smtpDefinition.validateConfig({ ...config, port: 0 })
+      smtpDefinition.parseConfiguration({ ...config, port: 0 })
     ).toThrow();
     expect(() =>
-      smtpDefinition.validateConfig({ ...config, port: 65536 })
+      smtpDefinition.parseConfiguration({ ...config, port: 65536 })
     ).toThrow();
     expect(() =>
-      smtpDefinition.validateConfig({ ...config, port: 465 })
+      smtpDefinition.parseConfiguration({ ...config, port: 465 })
     ).not.toThrow();
   });
 });
@@ -309,7 +309,7 @@ describe("the field rules hold at the registry boundary too", () => {
     type: "hand-built",
     label: "Hand Built",
     configFields,
-    validateConfig: () => {},
+    parseConfiguration: (input: unknown) => input,
     createAdapterFrom: () => ({
       send: () => Promise.resolve({ success: true, messageId: "x" }),
     }),
@@ -1146,7 +1146,7 @@ describe("descriptor text rules hold at the registry boundary too", () => {
             help: {},
           } as unknown as EmailProviderConfigField,
         ],
-        validateConfig: () => {},
+        parseConfiguration: (input: unknown) => input,
         createAdapterFrom: () => ({
           send: () => Promise.resolve({ success: true, messageId: "x" }),
         }),
@@ -1161,7 +1161,7 @@ describe("descriptor text rules hold at the registry boundary too", () => {
         type: "hand-built",
         label: 42,
         configFields: [],
-        validateConfig: () => {},
+        parseConfiguration: (input: unknown) => input,
         createAdapterFrom: () => ({
           send: () => Promise.resolve({ success: true, messageId: "x" }),
         }),
@@ -1712,7 +1712,7 @@ describe("what a descriptor publishes about a field", () => {
           credentials: { user: "postmaster", pass: "hunter2" },
         } as unknown as EmailProviderConfigField,
       ],
-      validateConfig: () => {},
+      parseConfiguration: (input: unknown) => input,
       createAdapterFrom: () => ({
         send: () => Promise.resolve({ success: true, messageId: "x" }),
       }),
@@ -1746,7 +1746,7 @@ describe("what a descriptor publishes about a field", () => {
           blankAs: "empty",
         },
       ],
-      validateConfig: () => {},
+      parseConfiguration: (input: unknown) => input,
       createAdapterFrom: () => ({
         send: () => Promise.resolve({ success: true, messageId: "x" }),
       }),

--- a/packages/nextly/src/domains/email/__tests__/provider-callback-failures.test.ts
+++ b/packages/nextly/src/domains/email/__tests__/provider-callback-failures.test.ts
@@ -504,7 +504,7 @@ describe("a credential a hand-built provider re-cased before using it", () => {
       configFields: [
         { name: "apiKey", label: "API Key", kind: "password", secret: true },
       ],
-      validateConfig: () => {},
+      parseConfiguration: (input: unknown) => input,
       createAdapterFrom: (input: unknown) => {
         const used = (input as { apiKey: string }).apiKey.toLowerCase();
         return {
@@ -730,7 +730,7 @@ describe("a provider that never passed through the authoring helper", () => {
     configFields: [
       { name: "apiKey", label: "API Key", kind: "password", secret: true },
     ],
-    validateConfig: () => {},
+    parseConfiguration: (input: unknown) => input,
     createAdapterFrom: (input: unknown) => {
       const config = input as { apiKey: string };
       return {

--- a/packages/nextly/src/domains/email/__tests__/smtp-provider.test.ts
+++ b/packages/nextly/src/domains/email/__tests__/smtp-provider.test.ts
@@ -267,7 +267,7 @@ describe("the SMTP descriptor agrees with the SMTP parser", () => {
     // docs/guides/email.mdx configures Mailpit with SMTP_USER= and SMTP_PASS=
     // empty. A client validating from the descriptor must be able to submit it.
     expect(() =>
-      smtpDefinition.validateConfig({
+      smtpDefinition.parseConfiguration({
         host: "localhost",
         port: 1025,
         secure: false,
@@ -280,7 +280,7 @@ describe("the SMTP descriptor agrees with the SMTP parser", () => {
     // The positive control for the test above: loosening the descriptor must
     // not loosen the rule, only move where it is stated.
     expect(() =>
-      smtpDefinition.validateConfig({
+      smtpDefinition.parseConfiguration({
         host: "smtp.example.com",
         port: 587,
         secure: false,

--- a/packages/nextly/src/domains/email/__tests__/stored-configuration-round-trips.test.ts
+++ b/packages/nextly/src/domains/email/__tests__/stored-configuration-round-trips.test.ts
@@ -13,8 +13,9 @@ import Database from "better-sqlite3";
 import { drizzle } from "drizzle-orm/better-sqlite3";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
-import { emailProvidersSqlite } from "../../../schemas/email-providers/sqlite";
+import { getCoreSchema } from "../../../schemas";
 import type { Logger } from "../../../services/shared";
+import { createTableBody } from "../../schema/pipeline/sql-templates/create-table-body";
 import { defineEmailProvider } from "../provider-definition";
 import {
   getEmailProviderRegistry,
@@ -50,26 +51,30 @@ const logger: Logger = {
   debug: vi.fn(),
 };
 
+/**
+ * The real `email_providers` table, built from the core schema.
+ *
+ * A hand-copied `CREATE TABLE` keeps passing after the production column list
+ * moves, and reports coverage it never re-checked.
+ */
 function createInMemoryDb() {
   const sqlite = new Database(":memory:");
-  sqlite.exec(`
-    CREATE TABLE IF NOT EXISTS email_providers (
-      id            TEXT    PRIMARY KEY,
-      name          TEXT    NOT NULL,
-      type          TEXT    NOT NULL,
-      from_email    TEXT    NOT NULL,
-      from_name     TEXT,
-      configuration TEXT    NOT NULL,
-      is_default    INTEGER NOT NULL DEFAULT 0,
-      is_active     INTEGER NOT NULL DEFAULT 1,
-      created_at    INTEGER NOT NULL DEFAULT (strftime('%s','now') * 1000),
-      updated_at    INTEGER NOT NULL DEFAULT (strftime('%s','now') * 1000)
+  const spec = getCoreSchema("sqlite").tables.find(
+    t => t.name === "email_providers"
+  );
+  if (!spec) {
+    // A vitest failure rather than a thrown error: the table vanishing from
+    // the core schema is a broken precondition of this fixture, not a runtime
+    // fault, and naming it that way names the file that needs updating.
+    expect.fail(
+      "email_providers is absent from the core schema — this fixture can no longer be derived from it."
     );
-  `);
-  return {
-    sqlite,
-    db: drizzle({ client: sqlite, schema: { emailProvidersSqlite } }),
-  };
+  }
+  sqlite.exec(
+    `CREATE TABLE "email_providers" (\n${createTableBody(spec, (id: string) => `"${id}"`)}\n)`
+  );
+  // No `schema` option: these tests only ever go through the service.
+  return { sqlite, db: drizzle({ client: sqlite }) };
 }
 
 /** A provider whose parser is whatever the case under test needs it to be. */
@@ -194,5 +199,45 @@ describe("a configuration whose parse is not a fixed point", () => {
     const provider = await write("omitting", { apiKey: "k" });
 
     expect(provider.id).toBeTruthy();
+  });
+
+  // `toJSON` turns the record into a scalar, so the value the column holds is
+  // not an object however the parsed value looked.
+  it("refuses a parser whose value serialises to a scalar", async () => {
+    register("to-json", input => ({
+      apiKey: String((input as { apiKey: unknown }).apiKey),
+      toJSON: () => "flattened",
+    }));
+
+    await expect(write("to-json", { apiKey: "k" })).rejects.toThrow(
+      /must be an object of fields/
+    );
+  });
+
+  // A `bigint` cannot be written as JSON at all, and the raw TypeError would
+  // reach the caller as a generic internal failure naming nothing.
+  it("refuses a parser returning a value JSON cannot serialise", async () => {
+    register("bigint", input => ({
+      apiKey: String((input as { apiKey: unknown }).apiKey),
+      window: 1n,
+    }));
+
+    await expect(write("bigint", { apiKey: "k" })).rejects.toThrow(
+      /cannot be written as JSON/
+    );
+  });
+
+  // A parser that normalises IN PLACE and returns its input. The comparison
+  // must not end up holding the same object on both sides.
+  it("refuses a parser that derives by mutating its input", async () => {
+    register("mutating", input => {
+      const value = input as { apiKey: string };
+      value.apiKey = Buffer.from(value.apiKey).toString("base64");
+      return value;
+    });
+
+    await expect(write("mutating", { apiKey: "secret" })).rejects.toThrow(
+      /parsing what would be saved does not return what was saved/
+    );
   });
 });

--- a/packages/nextly/src/domains/email/__tests__/stored-configuration-round-trips.test.ts
+++ b/packages/nextly/src/domains/email/__tests__/stored-configuration-round-trips.test.ts
@@ -373,4 +373,21 @@ describe("a configuration whose parse is not a fixed point", () => {
       /Email provider "hostile-proxy"/
     );
   });
+
+  // An ARRAY is ordinary configuration and JSON preserves it exactly. Its
+  // `length` is a non-enumerable own key, so a naive own-key comparison
+  // rejects every provider that has one.
+  it("stores a configuration containing an array", async () => {
+    register("with-array", input => ({
+      apiKey: String((input as { apiKey: unknown }).apiKey),
+      scopes: ["send", "read"],
+    }));
+
+    const provider = await write("with-array", { apiKey: "k" });
+    const stored = await service.getProviderDecrypted(provider.id);
+    expect(stored.configuration).toEqual({
+      apiKey: "k",
+      scopes: ["send", "read"],
+    });
+  });
 });

--- a/packages/nextly/src/domains/email/__tests__/stored-configuration-round-trips.test.ts
+++ b/packages/nextly/src/domains/email/__tests__/stored-configuration-round-trips.test.ts
@@ -336,4 +336,41 @@ describe("a configuration whose parse is not a fixed point", () => {
     const stored = await service.getProviderDecrypted(provider.id);
     expect(stored.configuration).toEqual({ apiKey: "k" });
   });
+
+  // The same hole one level down: a non-enumerable property on a NESTED object
+  // is dropped by JSON and ignored by isDeepStrictEqual just as a root one is.
+  it("refuses a non-enumerable property below the root", async () => {
+    register("hidden-nested", input => {
+      const auth = {};
+      Object.defineProperty(auth, "token", {
+        value: "derived",
+        enumerable: false,
+      });
+      return { apiKey: String((input as { apiKey: unknown }).apiKey), auth };
+    });
+
+    await expect(write("hidden-nested", { apiKey: "k" })).rejects.toThrow(
+      /properties JSON cannot write/
+    );
+  });
+
+  // Inspecting the parsed value runs USER code when it is a proxy, and that
+  // has to fail as a provider-configuration fault rather than a raw TypeError.
+  it("reports a parsed value whose inspection throws", async () => {
+    register("hostile-proxy", input => {
+      void input;
+      return new Proxy(
+        {},
+        {
+          ownKeys() {
+            throw new TypeError("ownKeys trap exploded");
+          },
+        }
+      );
+    });
+
+    await expect(write("hostile-proxy", { apiKey: "k" })).rejects.toThrow(
+      /Email provider "hostile-proxy"/
+    );
+  });
 });

--- a/packages/nextly/src/domains/email/__tests__/stored-configuration-round-trips.test.ts
+++ b/packages/nextly/src/domains/email/__tests__/stored-configuration-round-trips.test.ts
@@ -1,0 +1,198 @@
+/**
+ * What is stored must survive being read back and parsed again.
+ *
+ * The service persists the value `parseConfig` returned, and an adapter is
+ * built by re-parsing what the column holds. So the write is only safe when
+ * parsing the stored form returns the stored form — otherwise the operator
+ * saves one configuration and the adapter runs on another, with nothing in
+ * between reporting a difference.
+ */
+
+import type { DrizzleAdapter } from "@nextlyhq/adapter-drizzle";
+import Database from "better-sqlite3";
+import { drizzle } from "drizzle-orm/better-sqlite3";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+import { emailProvidersSqlite } from "../../../schemas/email-providers/sqlite";
+import type { Logger } from "../../../services/shared";
+import { defineEmailProvider } from "../provider-definition";
+import {
+  getEmailProviderRegistry,
+  resetEmailProviderRegistry,
+} from "../services/email-provider-registry";
+import { EmailProviderService } from "../services/email-provider-service";
+
+vi.mock("../../../lib/env", () => ({
+  env: {
+    NEXTLY_SECRET: "test-secret-must-be-32chars-long!!",
+    DB_DIALECT: "sqlite",
+    DATABASE_URL: undefined,
+    NODE_ENV: "test",
+  },
+}));
+
+function makeAdapter(db: ReturnType<typeof drizzle>): DrizzleAdapter {
+  return {
+    dialect: "sqlite" as const,
+    getDrizzle: () => db,
+    getCapabilities: () => ({ dialect: "sqlite" as const }),
+    connect: async () => {},
+    disconnect: async () => {},
+    executeQuery: async () => [],
+    transaction: async (fn: (tx: unknown) => Promise<unknown>) => fn(db),
+  } as unknown as DrizzleAdapter;
+}
+
+const logger: Logger = {
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  debug: vi.fn(),
+};
+
+function createInMemoryDb() {
+  const sqlite = new Database(":memory:");
+  sqlite.exec(`
+    CREATE TABLE IF NOT EXISTS email_providers (
+      id            TEXT    PRIMARY KEY,
+      name          TEXT    NOT NULL,
+      type          TEXT    NOT NULL,
+      from_email    TEXT    NOT NULL,
+      from_name     TEXT,
+      configuration TEXT    NOT NULL,
+      is_default    INTEGER NOT NULL DEFAULT 0,
+      is_active     INTEGER NOT NULL DEFAULT 1,
+      created_at    INTEGER NOT NULL DEFAULT (strftime('%s','now') * 1000),
+      updated_at    INTEGER NOT NULL DEFAULT (strftime('%s','now') * 1000)
+    );
+  `);
+  return {
+    sqlite,
+    db: drizzle({ client: sqlite, schema: { emailProvidersSqlite } }),
+  };
+}
+
+/** A provider whose parser is whatever the case under test needs it to be. */
+function register(type: string, parseConfig: (input: unknown) => object) {
+  getEmailProviderRegistry().register(
+    defineEmailProvider<object>({
+      type,
+      label: type,
+      configFields: [
+        { name: "apiKey", label: "API Key", kind: "password", secret: true },
+      ],
+      parseConfig,
+      createAdapter: () => ({
+        send: () => Promise.resolve({ success: true }),
+      }),
+    })
+  );
+}
+
+describe("a configuration whose parse is not a fixed point", () => {
+  let sqlite: Database.Database;
+  let service: EmailProviderService;
+
+  const write = (type: string, configuration: Record<string, unknown>) =>
+    service.createProvider({
+      name: "Test",
+      type: type as never,
+      fromEmail: "from@example.com",
+      configuration,
+    });
+
+  beforeEach(() => {
+    resetEmailProviderRegistry();
+    const { sqlite: s, db } = createInMemoryDb();
+    sqlite = s;
+    service = new EmailProviderService(makeAdapter(db), logger);
+  });
+
+  afterEach(() => {
+    sqlite.close();
+    resetEmailProviderRegistry();
+  });
+
+  // The POSITIVE CONTROL. A parser that reshapes rather than derives is the
+  // ordinary case, and it has to keep working — a check that refused every
+  // write would pass the three below while telling nobody anything.
+  it("stores a configuration a reshaping parser accepts back", async () => {
+    register("reshaping", input => ({
+      apiKey: String((input as { apiKey: unknown }).apiKey).trim(),
+    }));
+
+    const provider = await write("reshaping", { apiKey: "  k  " });
+
+    expect(provider.id).toBeTruthy();
+  });
+
+  // Encoding on the way in and encoding the encoding on the way out. The
+  // operator entered a correct key and the provider would answer "bad key".
+  it("refuses a parser that derives its value", async () => {
+    register("deriving", input => ({
+      apiKey: Buffer.from(
+        String((input as { apiKey: unknown }).apiKey)
+      ).toString("base64"),
+    }));
+
+    await expect(write("deriving", { apiKey: "secret" })).rejects.toThrow(
+      /parsing what would be saved does not return what was saved/
+    );
+  });
+
+  // JSON carries no `Date`, so the column holds a string and the adapter is
+  // handed a shape this provider's own parser just rejected.
+  it("refuses a parser returning a value JSON cannot carry", async () => {
+    register("dated", input => ({
+      apiKey: String((input as { apiKey: unknown }).apiKey),
+      issuedAt: new Date(0),
+    }));
+
+    await expect(write("dated", { apiKey: "k" })).rejects.toThrow(
+      /parsing what would be saved does not return what was saved/
+    );
+  });
+
+  // The same property reached by throwing rather than by returning something
+  // different, which is what a parser that rejects its own output does.
+  it("refuses a parser that rejects its own output", async () => {
+    register("self-rejecting", input => {
+      const value = input as { apiKey: unknown; parsed?: boolean };
+      if (value.parsed === true) throw new Error("already parsed");
+      return { apiKey: String(value.apiKey), parsed: true };
+    });
+
+    await expect(write("self-rejecting", { apiKey: "k" })).rejects.toThrow(
+      /parsing what would be saved does not return what was saved/
+    );
+  });
+
+  // `undefined` is a third value JSON cannot carry, not an exception to the
+  // rule: the column drops the key and the parser puts it back, so what is
+  // held and what is stored are different objects on every read.
+  it("refuses a parser that returns an undefined-valued key", async () => {
+    register("optional", input => ({
+      apiKey: String((input as { apiKey: unknown }).apiKey),
+      label: undefined,
+    }));
+
+    await expect(write("optional", { apiKey: "k" })).rejects.toThrow(
+      /parsing what would be saved does not return what was saved/
+    );
+  });
+
+  // A parser that OMITS the key instead round-trips cleanly, which is the
+  // shape an optional field normally takes and has to keep working.
+  it("stores a configuration whose parser omits an absent optional", async () => {
+    register("omitting", input => {
+      const value = input as { apiKey: unknown; label?: unknown };
+      return typeof value.label === "string"
+        ? { apiKey: String(value.apiKey), label: value.label }
+        : { apiKey: String(value.apiKey) };
+    });
+
+    const provider = await write("omitting", { apiKey: "k" });
+
+    expect(provider.id).toBeTruthy();
+  });
+});

--- a/packages/nextly/src/domains/email/__tests__/stored-configuration-round-trips.test.ts
+++ b/packages/nextly/src/domains/email/__tests__/stored-configuration-round-trips.test.ts
@@ -240,4 +240,54 @@ describe("a configuration whose parse is not a fixed point", () => {
       /parsing what would be saved does not return what was saved/
     );
   });
+
+  // A PASS-THROUGH parser: it accepts both the typed value and its JSON form,
+  // so re-parsing agrees with itself while the value actually stored lost its
+  // type. The Date test above recreates the Date and cannot see this.
+  it("refuses a pass-through parser whose value loses type in the column", async () => {
+    register("passthrough-date", input => {
+      const value = input as { apiKey: unknown; issuedAt?: unknown };
+      return value.issuedAt === undefined
+        ? { apiKey: String(value.apiKey), issuedAt: new Date(0) }
+        : (value as object);
+    });
+
+    await expect(write("passthrough-date", { apiKey: "k" })).rejects.toThrow(
+      /parsing what would be saved does not return what was saved|cannot be written as JSON/
+    );
+  });
+
+  // A root `toJSON` returning undefined makes JSON.stringify return undefined
+  // WITHOUT throwing, so the catch never fires and JSON.parse then throws a
+  // raw SyntaxError the caller sees as a generic internal failure.
+  it("refuses a parser whose value serialises to undefined", async () => {
+    register("to-json-undefined", input => ({
+      apiKey: String((input as { apiKey: unknown }).apiKey),
+      toJSON: () => undefined,
+    }));
+
+    await expect(write("to-json-undefined", { apiKey: "k" })).rejects.toThrow(
+      /cannot be written as JSON/
+    );
+  });
+
+  // A STATEFUL toJSON: the first serialisation is validated, and encryption
+  // serialises the object a second time to a different result.
+  it("stores the serialisation that was validated, not a later one", async () => {
+    let calls = 0;
+    register("stateful", input => {
+      const apiKey = String((input as { apiKey: unknown }).apiKey);
+      return { apiKey, toJSON: () => ({ apiKey, call: ++calls }) };
+    });
+
+    const provider = await write("stateful", { apiKey: "k" }).catch(
+      () => undefined
+    );
+    // Either it is refused, or what was stored is what passed the check --
+    // never a third value produced by serialising again after validation.
+    if (provider) {
+      const stored = await service.getProviderDecrypted(provider.id);
+      expect((stored.configuration as { call?: number }).call).toBe(1);
+    }
+  });
 });

--- a/packages/nextly/src/domains/email/__tests__/stored-configuration-round-trips.test.ts
+++ b/packages/nextly/src/domains/email/__tests__/stored-configuration-round-trips.test.ts
@@ -128,7 +128,11 @@ describe("a configuration whose parse is not a fixed point", () => {
 
     const provider = await write("reshaping", { apiKey: "  k  " });
 
-    expect(provider.id).toBeTruthy();
+    // Read BACK, not just "the insert succeeded". A truthy id is true whether
+    // the column holds the trimmed parsed value or the padded input, which is
+    // the one difference this PR exists to make.
+    const stored = await service.getProviderDecrypted(provider.id);
+    expect(stored.configuration).toEqual({ apiKey: "k" });
   });
 
   // Encoding on the way in and encoding the encoding on the way out. The
@@ -289,5 +293,47 @@ describe("a configuration whose parse is not a fixed point", () => {
       const stored = await service.getProviderDecrypted(provider.id);
       expect((stored.configuration as { call?: number }).call).toBe(1);
     }
+  });
+
+  // A non-enumerable own property is dropped by JSON and ignored by
+  // isDeepStrictEqual, so both comparisons agree over a property the column
+  // never holds and the adapter gets back on every reparse.
+  it("refuses a parser returning a non-enumerable property", async () => {
+    register("hidden", input => {
+      const out = { apiKey: String((input as { apiKey: unknown }).apiKey) };
+      Object.defineProperty(out, "token", {
+        value: "derived",
+        enumerable: false,
+      });
+      return out;
+    });
+
+    await expect(write("hidden", { apiKey: "k" })).rejects.toThrow(
+      /properties JSON cannot write/
+    );
+  });
+
+  // An INHERITED field is materialised by zod into its parsed output as an own
+  // property, so a caller that never sent the credential has one persisted.
+  it("does not persist a configuration field the caller never sent", async () => {
+    register("inheriting", input => ({
+      apiKey: String((input as { apiKey?: unknown }).apiKey ?? ""),
+      ...(typeof (input as { token?: unknown }).token === "string"
+        ? { token: (input as { token: string }).token }
+        : {}),
+    }));
+
+    const provider = await write(
+      "inheriting",
+      Object.create(
+        { token: "injected-by-prototype" },
+        {
+          apiKey: { value: "k", enumerable: true, writable: true },
+        }
+      ) as Record<string, unknown>
+    );
+
+    const stored = await service.getProviderDecrypted(provider.id);
+    expect(stored.configuration).toEqual({ apiKey: "k" });
   });
 });

--- a/packages/nextly/src/domains/email/__tests__/stored-configuration-round-trips.test.ts
+++ b/packages/nextly/src/domains/email/__tests__/stored-configuration-round-trips.test.ts
@@ -295,24 +295,6 @@ describe("a configuration whose parse is not a fixed point", () => {
     }
   });
 
-  // A non-enumerable own property is dropped by JSON and ignored by
-  // isDeepStrictEqual, so both comparisons agree over a property the column
-  // never holds and the adapter gets back on every reparse.
-  it("refuses a parser returning a non-enumerable property", async () => {
-    register("hidden", input => {
-      const out = { apiKey: String((input as { apiKey: unknown }).apiKey) };
-      Object.defineProperty(out, "token", {
-        value: "derived",
-        enumerable: false,
-      });
-      return out;
-    });
-
-    await expect(write("hidden", { apiKey: "k" })).rejects.toThrow(
-      /properties JSON cannot write/
-    );
-  });
-
   // An INHERITED field is materialised by zod into its parsed output as an own
   // property, so a caller that never sent the credential has one persisted.
   it("does not persist a configuration field the caller never sent", async () => {
@@ -335,43 +317,6 @@ describe("a configuration whose parse is not a fixed point", () => {
 
     const stored = await service.getProviderDecrypted(provider.id);
     expect(stored.configuration).toEqual({ apiKey: "k" });
-  });
-
-  // The same hole one level down: a non-enumerable property on a NESTED object
-  // is dropped by JSON and ignored by isDeepStrictEqual just as a root one is.
-  it("refuses a non-enumerable property below the root", async () => {
-    register("hidden-nested", input => {
-      const auth = {};
-      Object.defineProperty(auth, "token", {
-        value: "derived",
-        enumerable: false,
-      });
-      return { apiKey: String((input as { apiKey: unknown }).apiKey), auth };
-    });
-
-    await expect(write("hidden-nested", { apiKey: "k" })).rejects.toThrow(
-      /properties JSON cannot write/
-    );
-  });
-
-  // Inspecting the parsed value runs USER code when it is a proxy, and that
-  // has to fail as a provider-configuration fault rather than a raw TypeError.
-  it("reports a parsed value whose inspection throws", async () => {
-    register("hostile-proxy", input => {
-      void input;
-      return new Proxy(
-        {},
-        {
-          ownKeys() {
-            throw new TypeError("ownKeys trap exploded");
-          },
-        }
-      );
-    });
-
-    await expect(write("hostile-proxy", { apiKey: "k" })).rejects.toThrow(
-      /Email provider "hostile-proxy"/
-    );
   });
 
   // An ARRAY is ordinary configuration and JSON preserves it exactly. Its

--- a/packages/nextly/src/domains/email/provider-definition.ts
+++ b/packages/nextly/src/domains/email/provider-definition.ts
@@ -1114,11 +1114,20 @@ export function secretFieldMustBeTextual(
  * contravariant in it, so `EmailProviderDefinition<unknown>` rejects every
  * concrete definition.
  *
- * The erased form takes `unknown` and never exposes the parsed value, which
- * removes the need to cast one back. `createAdapterFrom` parses AND builds, so
- * the typed value stays inside the closure that knows its type — and an
+ * The erased form takes `unknown` and returns the parsed value as `unknown`.
+ * The TYPE stays inside the closure that knows it, which is what removes the
+ * need to cast one back; `createAdapterFrom` still parses AND builds, so an
  * adapter cannot be constructed from configuration that was never validated.
- * That is a safety property, not only a typing convenience.
+ * That safety property is unchanged.
+ *
+ * What changed is that the parsed VALUE now comes back out, because the caller
+ * that persists a configuration has to persist the one the adapter will run
+ * on. While it did not, the stored configuration and the configuration the
+ * adapter received could differ, and nothing reconciled them: a parser doing
+ * `raw.trim()` meant containment compared a padded credential against an
+ * unpadded one, and a `z.coerce` meant the admin rendered a value its own
+ * control could not hold. Both were patched at the symptom before the cause
+ * was addressed here.
  */
 export interface RegisteredEmailProvider {
   type: string;
@@ -1128,8 +1137,15 @@ export interface RegisteredEmailProvider {
   senderGuidance?: string;
   capabilities?: EmailProviderCapabilities;
   configFields: ReadonlyArray<EmailProviderConfigField>;
-  /** Throw if this configuration is unusable. Discards the parsed value. */
-  validateConfig: (input: unknown) => void;
+  /**
+   * Parse this configuration, or throw if it is unusable.
+   *
+   * Returns the PARSED value, which is what a caller must persist: what the
+   * adapter runs on is this, not the input. `unknown` rather than the concrete
+   * type, so the erasure holds — a caller can store it and hand it back, and
+   * cannot read it as anything in particular.
+   */
+  parseConfiguration: (input: unknown) => unknown;
   /** Validate and build in one step; the parsed value never escapes. */
   createAdapterFrom: (input: unknown) => EmailProviderAdapter;
   /** Present only when the definition supplied a probe. */
@@ -1526,9 +1542,7 @@ export function defineEmailProvider<TConfig>(
     senderGuidance: definition.senderGuidance,
     capabilities: definition.capabilities,
     configFields: definition.configFields,
-    validateConfig: (input: unknown): void => {
-      parse(input);
-    },
+    parseConfiguration: (input: unknown): unknown => parse(input),
     // Parses AND builds, so the typed value never escapes the closure that
     // knows its type. Nothing here catches: the containment above does it.
     createAdapterFrom: (input: unknown): EmailProviderAdapter => {

--- a/packages/nextly/src/domains/email/services/email-provider-service.ts
+++ b/packages/nextly/src/domains/email/services/email-provider-service.ts
@@ -261,32 +261,6 @@ export class EmailProviderService extends BaseService {
     // enumerable properties only, so the parser never sees the inherited one.
     const parsed = provider.parseConfiguration(this.ownFieldsOf(type, input));
 
-    // Every own key in the WHOLE tree must be one the column can hold. A
-    // non-enumerable or symbol-keyed own property is dropped by
-    // `JSON.stringify` AND ignored by `isDeepStrictEqual`, so both comparisons
-    // below would agree over a property the column never receives -- while
-    // every reparse recreates it and the adapter runs on a credential that was
-    // never saved. Root-only was not enough: `configuration.auth.token` hides
-    // exactly as well one level down.
-    //
-    // Inside a `try`, because reading keys off the parsed value RUNS provider
-    // code when it is a proxy, and a trap that throws would otherwise escape as
-    // a raw `TypeError` naming neither the provider nor what to change.
-    try {
-      this.assertOnlyWritableKeys(type, parsed);
-    } catch (error) {
-      if (error instanceof NextlyError) throw error;
-      throw new NextlyError({
-        code: "BUSINESS_RULE_VIOLATION",
-        publicMessage: `Email provider "${type}" parsed its configuration into a value that could not be inspected, so it cannot be stored.`,
-        logContext: {
-          reason: "email-provider-configuration-not-inspectable",
-          type,
-          detail: error instanceof Error ? error.message : String(error),
-        },
-      });
-    }
-
     // A provider whose parser returns something other than an object cannot
     // have its configuration persisted at all, and failing here names which
     // provider did it; storing the value regardless would put a string or an
@@ -452,39 +426,6 @@ export class EmailProviderService extends BaseService {
    * fault it is, rather than reaching the parser and failing later as
    * something less specific.
    */
-  private assertOnlyWritableKeys(
-    type: string,
-    value: unknown,
-    seen = new Set<object>()
-  ): void {
-    if (typeof value !== "object" || value === null) return;
-    // A cycle is JSON's problem rather than this check's; `JSON.stringify`
-    // reports it, and recursing forever here would never reach that.
-    if (seen.has(value)) return;
-    seen.add(value);
-    // An ARRAY carries `length` as a non-enumerable own key, and JSON writes
-    // arrays back exactly, so comparing key counts on one rejects every
-    // provider with an ordinary `scopes: string[]`. The elements are still
-    // walked below, because a hidden property on an object INSIDE an array
-    // hides just as well as one anywhere else.
-    if (
-      !Array.isArray(value) &&
-      Reflect.ownKeys(value).length !== Object.keys(value).length
-    ) {
-      throw new NextlyError({
-        code: "BUSINESS_RULE_VIOLATION",
-        publicMessage: `Email provider "${type}" parsed its configuration into an object carrying properties JSON cannot write, so what would be stored is not what the adapter would receive. Return plain enumerable fields from \`parseConfig\`.`,
-        logContext: {
-          reason: "email-provider-configuration-not-enumerable",
-          type,
-        },
-      });
-    }
-    for (const nested of Object.values(value)) {
-      this.assertOnlyWritableKeys(type, nested, seen);
-    }
-  }
-
   private ownFieldsOf(type: string, input: unknown): unknown {
     let serialized: string | undefined;
     try {

--- a/packages/nextly/src/domains/email/services/email-provider-service.ts
+++ b/packages/nextly/src/domains/email/services/email-provider-service.ts
@@ -261,22 +261,28 @@ export class EmailProviderService extends BaseService {
     // enumerable properties only, so the parser never sees the inherited one.
     const parsed = provider.parseConfiguration(this.ownFieldsOf(type, input));
 
-    // Every own key must be one the column can hold. A non-enumerable or
-    // symbol-keyed own property is dropped by `JSON.stringify` AND ignored by
-    // `isDeepStrictEqual`, so both comparisons below would agree over a
-    // property the column never receives -- while every reparse recreates it
-    // and the adapter runs on a credential that was never saved.
-    if (
-      typeof parsed === "object" &&
-      parsed !== null &&
-      Reflect.ownKeys(parsed).length !== Object.keys(parsed).length
-    ) {
+    // Every own key in the WHOLE tree must be one the column can hold. A
+    // non-enumerable or symbol-keyed own property is dropped by
+    // `JSON.stringify` AND ignored by `isDeepStrictEqual`, so both comparisons
+    // below would agree over a property the column never receives -- while
+    // every reparse recreates it and the adapter runs on a credential that was
+    // never saved. Root-only was not enough: `configuration.auth.token` hides
+    // exactly as well one level down.
+    //
+    // Inside a `try`, because reading keys off the parsed value RUNS provider
+    // code when it is a proxy, and a trap that throws would otherwise escape as
+    // a raw `TypeError` naming neither the provider nor what to change.
+    try {
+      this.assertOnlyWritableKeys(type, parsed);
+    } catch (error) {
+      if (error instanceof NextlyError) throw error;
       throw new NextlyError({
         code: "BUSINESS_RULE_VIOLATION",
-        publicMessage: `Email provider "${type}" parsed its configuration into an object carrying properties JSON cannot write, so what would be stored is not what the adapter would receive. Return plain enumerable fields from \`parseConfig\`.`,
+        publicMessage: `Email provider "${type}" parsed its configuration into a value that could not be inspected, so it cannot be stored.`,
         logContext: {
-          reason: "email-provider-configuration-not-enumerable",
+          reason: "email-provider-configuration-not-inspectable",
           type,
+          detail: error instanceof Error ? error.message : String(error),
         },
       });
     }
@@ -446,6 +452,31 @@ export class EmailProviderService extends BaseService {
    * fault it is, rather than reaching the parser and failing later as
    * something less specific.
    */
+  private assertOnlyWritableKeys(
+    type: string,
+    value: unknown,
+    seen = new Set<object>()
+  ): void {
+    if (typeof value !== "object" || value === null) return;
+    // A cycle is JSON's problem rather than this check's; `JSON.stringify`
+    // reports it, and recursing forever here would never reach that.
+    if (seen.has(value)) return;
+    seen.add(value);
+    if (Reflect.ownKeys(value).length !== Object.keys(value).length) {
+      throw new NextlyError({
+        code: "BUSINESS_RULE_VIOLATION",
+        publicMessage: `Email provider "${type}" parsed its configuration into an object carrying properties JSON cannot write, so what would be stored is not what the adapter would receive. Return plain enumerable fields from \`parseConfig\`.`,
+        logContext: {
+          reason: "email-provider-configuration-not-enumerable",
+          type,
+        },
+      });
+    }
+    for (const nested of Object.values(value)) {
+      this.assertOnlyWritableKeys(type, nested, seen);
+    }
+  }
+
   private ownFieldsOf(type: string, input: unknown): unknown {
     let serialized: string | undefined;
     try {

--- a/packages/nextly/src/domains/email/services/email-provider-service.ts
+++ b/packages/nextly/src/domains/email/services/email-provider-service.ts
@@ -14,6 +14,7 @@
  */
 
 import { randomUUID } from "crypto";
+import { isDeepStrictEqual } from "util";
 
 import type { DrizzleAdapter } from "@nextlyhq/adapter-drizzle";
 import { and, eq, desc, ne } from "drizzle-orm";
@@ -230,19 +231,26 @@ export class EmailProviderService extends BaseService {
    * setting away from working, and a variable name is not itself a secret.
    */
   /**
-   * The parsed configuration a provider returns, as something storable.
+   * A provider's configuration, parsed and checked to be storable as it is.
+   *
+   * Parsing happens HERE rather than at each caller, because every property
+   * below is about what may be persisted, and a caller that parsed on its own
+   * would be a write that skipped the checks.
    *
    * The parsed value is `unknown` by design — the erased form does not expose
-   * the type — so the one property this needs is checked rather than assumed.
-   * A provider whose parser returns something other than an object cannot have
-   * its configuration persisted at all, and failing here names which provider
-   * did it; storing the value regardless would put a string or an array in a
-   * column every reader expects to hold fields.
+   * the type — so each property is checked rather than assumed.
    */
   private storableConfiguration(
     type: string,
-    parsed: unknown
+    input: unknown
   ): Record<string, unknown> {
+    const provider = getEmailProviderRegistry().get(type);
+    const parsed = provider.parseConfiguration(input);
+
+    // A provider whose parser returns something other than an object cannot
+    // have its configuration persisted at all, and failing here names which
+    // provider did it; storing the value regardless would put a string or an
+    // array in a column every reader expects to hold fields.
     if (
       typeof parsed !== "object" ||
       parsed === null ||
@@ -254,7 +262,54 @@ export class EmailProviderService extends BaseService {
         logContext: { reason: "email-provider-parsed-not-object", type },
       });
     }
-    return parsed as Record<string, unknown>;
+
+    // What an adapter runs on is not this value. It is this value written as
+    // JSON into the column, read back, and parsed AGAIN — `createAdapterFrom`
+    // re-parses whatever it is handed, which is what keeps an adapter from
+    // being built out of a row nothing validated. So the property that has to
+    // hold is that parsing the stored form returns the stored form, and it is
+    // checked here rather than left as an assumption about how parsers behave.
+    //
+    // Two ways a parser breaks it, neither visible at the call site:
+    //
+    // It may DERIVE a value rather than reshape one. `Buffer.from(key)
+    // .toString("base64")` encodes on the way in and encodes the encoding on
+    // the way out, so the adapter authenticates with a doubly-encoded
+    // credential and the provider answers "bad key" about a key the operator
+    // entered correctly.
+    //
+    // Or it may return something JSON cannot carry — a `Date`, a `Map`, a
+    // `Set` — which reads back as a string or as an empty object, so the
+    // adapter receives a shape its own parser just rejected.
+    //
+    // Compared against the ROUND-TRIPPED form rather than the parsed one,
+    // because the round-tripped form is what a reader gets and therefore what
+    // the parser has to be a fixed point OF. That makes `undefined` a third
+    // way to fail rather than an exception to the rule: a parser returning
+    // `{ label: undefined }` has JSON drop the key and then puts it back, so
+    // the value in hand and the value in the column are different objects.
+    // Rejecting it is the same answer as for a `Date`, and for the same
+    // reason — return only what the column can hold.
+    const stored = parsed as Record<string, unknown>;
+    const roundTripped: unknown = JSON.parse(JSON.stringify(stored));
+    let reparsed: unknown;
+    try {
+      reparsed = provider.parseConfiguration(roundTripped);
+    } catch {
+      // A parser that REJECTS its own stored output fails the same property,
+      // and reaches it by throwing rather than by returning something else.
+      // Left as one outcome: both mean the row could not be read back.
+      reparsed = undefined;
+    }
+    if (!isDeepStrictEqual(reparsed, roundTripped)) {
+      throw new NextlyError({
+        code: "BUSINESS_RULE_VIOLATION",
+        publicMessage: `Email provider "${type}" cannot store this configuration, because parsing what would be saved does not return what was saved. Its \`parseConfig\` must accept its own output unchanged — derive values in \`createAdapter\` instead, and return only what JSON can carry.`,
+        logContext: { reason: "email-provider-parse-not-a-fixed-point", type },
+      });
+    }
+
+    return stored;
   }
 
   private encryptConfiguration(config: Record<string, unknown>): string {
@@ -678,9 +733,7 @@ export class EmailProviderService extends BaseService {
     // that read the row.
     const parsedConfiguration = this.storableConfiguration(
       data.type,
-      getEmailProviderRegistry()
-        .get(data.type)
-        .parseConfiguration(data.configuration)
+      data.configuration
     );
 
     const id = randomUUID();
@@ -952,9 +1005,7 @@ export class EmailProviderService extends BaseService {
           : {};
       const parsedSubmitted = this.storableConfiguration(
         data.type as string,
-        getEmailProviderRegistry()
-          .get(data.type as string)
-          .parseConfiguration(submitted)
+        submitted
       );
 
       // Persist the replacement even when the update carried no configuration.
@@ -1024,9 +1075,7 @@ export class EmailProviderService extends BaseService {
       // parser and stored under resend -- accepted here and unusable at send.
       const parsedMerged = this.storableConfiguration(
         effectiveType,
-        getEmailProviderRegistry()
-          .get(effectiveType)
-          .parseConfiguration(mergedConfig)
+        mergedConfig
       );
 
       // Compared BEFORE encryption. Encryption is randomised -- a fresh salt

--- a/packages/nextly/src/domains/email/services/email-provider-service.ts
+++ b/packages/nextly/src/domains/email/services/email-provider-service.ts
@@ -301,7 +301,7 @@ export class EmailProviderService extends BaseService {
     // result against the object it just mutated compares a value with itself
     // and passes whatever the parser did -- so an in-place derivation would
     // have walked through the check this exists to be.
-    let serialized: string;
+    let serialized: string | undefined;
     try {
       serialized = JSON.stringify(stored);
     } catch (error) {
@@ -316,6 +316,22 @@ export class EmailProviderService extends BaseService {
           reason: "email-provider-configuration-not-serialisable",
           type,
           detail: error instanceof Error ? error.message : String(error),
+        },
+      });
+    }
+
+    // `JSON.stringify` returns `undefined` rather than throwing when the root
+    // has a `toJSON` that returns nothing, so the catch above never sees it and
+    // `JSON.parse(undefined)` then throws a `SyntaxError` the caller reads as a
+    // generic internal failure. Rejected here as the same fault, because it is
+    // one: the value cannot be written to the column.
+    if (serialized === undefined) {
+      throw new NextlyError({
+        code: "BUSINESS_RULE_VIOLATION",
+        publicMessage: `Email provider "${type}" parsed its configuration into a value that cannot be written as JSON, so it cannot be stored. Return only what JSON can carry from \`parseConfig\`.`,
+        logContext: {
+          reason: "email-provider-configuration-not-serialisable",
+          type,
         },
       });
     }
@@ -353,7 +369,21 @@ export class EmailProviderService extends BaseService {
       // Left as one outcome: both mean the row could not be read back.
       reparsed = undefined;
     }
-    if (!isDeepStrictEqual(reparsed, unchanged)) {
+    // TWO properties, and each misses what the other catches.
+    //
+    // The parsed value must SURVIVE the round trip: a `Date`, a `Map`, an
+    // `Infinity` or a class instance is written as something else, and a
+    // pass-through parser that accepts both forms then agrees with itself
+    // while the adapter receives an ISO string where a `Date` was returned.
+    // Re-parsing alone cannot see that, because both sides of it are already
+    // past the column.
+    //
+    // And re-parsing the stored form must RETURN it, which is what catches a
+    // parser that derives rather than one that loses a type.
+    if (
+      !isDeepStrictEqual(stored, unchanged) ||
+      !isDeepStrictEqual(reparsed, unchanged)
+    ) {
       throw new NextlyError({
         code: "BUSINESS_RULE_VIOLATION",
         publicMessage: `Email provider "${type}" cannot store this configuration, because parsing what would be saved does not return what was saved. Its \`parseConfig\` must accept its own output unchanged -- derive values in \`createAdapter\` instead, and return only what JSON can carry.`,
@@ -361,7 +391,14 @@ export class EmailProviderService extends BaseService {
       });
     }
 
-    return stored;
+    // The VALIDATED form, not the object it was derived from. `encryptConfiguration`
+    // serialises again, and returning the original would mean the value written
+    // to the column is the product of a second serialisation that nothing
+    // checked -- so a stateful getter or `toJSON` could store something that
+    // never passed the checks above. Returning what was validated makes "what
+    // is stored is what was checked" true by construction rather than by
+    // argument, and the two are now the same object.
+    return roundTripped as Record<string, unknown>;
   }
 
   private encryptConfiguration(config: Record<string, unknown>): string {

--- a/packages/nextly/src/domains/email/services/email-provider-service.ts
+++ b/packages/nextly/src/domains/email/services/email-provider-service.ts
@@ -462,7 +462,15 @@ export class EmailProviderService extends BaseService {
     // reports it, and recursing forever here would never reach that.
     if (seen.has(value)) return;
     seen.add(value);
-    if (Reflect.ownKeys(value).length !== Object.keys(value).length) {
+    // An ARRAY carries `length` as a non-enumerable own key, and JSON writes
+    // arrays back exactly, so comparing key counts on one rejects every
+    // provider with an ordinary `scopes: string[]`. The elements are still
+    // walked below, because a hidden property on an object INSIDE an array
+    // hides just as well as one anywhere else.
+    if (
+      !Array.isArray(value) &&
+      Reflect.ownKeys(value).length !== Object.keys(value).length
+    ) {
       throw new NextlyError({
         code: "BUSINESS_RULE_VIOLATION",
         publicMessage: `Email provider "${type}" parsed its configuration into an object carrying properties JSON cannot write, so what would be stored is not what the adapter would receive. Return plain enumerable fields from \`parseConfig\`.`,

--- a/packages/nextly/src/domains/email/services/email-provider-service.ts
+++ b/packages/nextly/src/domains/email/services/email-provider-service.ts
@@ -291,7 +291,59 @@ export class EmailProviderService extends BaseService {
     // Rejecting it is the same answer as for a `Date`, and for the same
     // reason — return only what the column can hold.
     const stored = parsed as Record<string, unknown>;
-    const roundTripped: unknown = JSON.parse(JSON.stringify(stored));
+
+    // Serialised ONCE and parsed TWICE. `roundTripped` is what a reader gets
+    // and is handed to the parser; `unchanged` is an independent copy that
+    // nothing else touches, and it is what the comparison is made against.
+    //
+    // Two objects rather than one because a parser may normalise IN PLACE and
+    // return its input, which is an ordinary thing to write. Comparing the
+    // result against the object it just mutated compares a value with itself
+    // and passes whatever the parser did -- so an in-place derivation would
+    // have walked through the check this exists to be.
+    let serialized: string;
+    try {
+      serialized = JSON.stringify(stored);
+    } catch (error) {
+      // A `bigint`, a cycle, or a `toJSON` that throws. Reported as the
+      // provider-configuration fault it is, because the raw `TypeError` would
+      // surface as a generic internal failure naming neither the provider nor
+      // what to change.
+      throw new NextlyError({
+        code: "BUSINESS_RULE_VIOLATION",
+        publicMessage: `Email provider "${type}" parsed its configuration into a value that cannot be written as JSON, so it cannot be stored. Return only what JSON can carry from \`parseConfig\`.`,
+        logContext: {
+          reason: "email-provider-configuration-not-serialisable",
+          type,
+          detail: error instanceof Error ? error.message : String(error),
+        },
+      });
+    }
+
+    const roundTripped: unknown = JSON.parse(serialized);
+    const unchanged: unknown = JSON.parse(serialized);
+
+    // Checked again after the round trip, not only before it. A `toJSON` -- on
+    // the object itself or on a `Date` inside it -- can turn a record into a
+    // scalar or a list, and the first guard read the value the parser returned
+    // rather than the value the column will hold. A passthrough parser then
+    // makes the two sides agree, so the fixed-point check accepts it and every
+    // later reader gets something it assumes is an object of fields.
+    if (
+      typeof roundTripped !== "object" ||
+      roundTripped === null ||
+      Array.isArray(roundTripped)
+    ) {
+      throw new NextlyError({
+        code: "BUSINESS_RULE_VIOLATION",
+        publicMessage: `Email provider "${type}" parsed its configuration into a value that becomes a ${Array.isArray(roundTripped) ? "list" : typeof roundTripped} once written as JSON, and a configuration must be an object of fields. Return the parsed object from \`parseConfig\`.`,
+        logContext: {
+          reason: "email-provider-stored-form-not-object",
+          type,
+        },
+      });
+    }
+
     let reparsed: unknown;
     try {
       reparsed = provider.parseConfiguration(roundTripped);
@@ -301,10 +353,10 @@ export class EmailProviderService extends BaseService {
       // Left as one outcome: both mean the row could not be read back.
       reparsed = undefined;
     }
-    if (!isDeepStrictEqual(reparsed, roundTripped)) {
+    if (!isDeepStrictEqual(reparsed, unchanged)) {
       throw new NextlyError({
         code: "BUSINESS_RULE_VIOLATION",
-        publicMessage: `Email provider "${type}" cannot store this configuration, because parsing what would be saved does not return what was saved. Its \`parseConfig\` must accept its own output unchanged — derive values in \`createAdapter\` instead, and return only what JSON can carry.`,
+        publicMessage: `Email provider "${type}" cannot store this configuration, because parsing what would be saved does not return what was saved. Its \`parseConfig\` must accept its own output unchanged -- derive values in \`createAdapter\` instead, and return only what JSON can carry.`,
         logContext: { reason: "email-provider-parse-not-a-fixed-point", type },
       });
     }

--- a/packages/nextly/src/domains/email/services/email-provider-service.ts
+++ b/packages/nextly/src/domains/email/services/email-provider-service.ts
@@ -245,7 +245,41 @@ export class EmailProviderService extends BaseService {
     input: unknown
   ): Record<string, unknown> {
     const provider = getEmailProviderRegistry().get(type);
-    const parsed = provider.parseConfiguration(input);
+
+    // Parsed from an OWN-PROPERTY tree, never from the object as it arrived.
+    // Measured on zod 4.1.12: a schema reads a value off the prototype chain
+    // and materialises it into its output as an OWN property, and it does so
+    // for a REQUIRED field as well as an optional one -- so "it parsed" stops
+    // meaning "the caller supplied it". A Direct API caller passing
+    // `Object.create({ apiKey })`, or a polluted `Object.prototype`, would
+    // otherwise have a credential nobody sent encrypted and persisted, and it
+    // stays active after the prototype is restored.
+    //
+    // `Object.hasOwn` is NOT a usable guard here, because the value is already
+    // an own property of the parser's output by the time anything could ask.
+    // The serialisation is what removes it: `JSON.stringify` reads own
+    // enumerable properties only, so the parser never sees the inherited one.
+    const parsed = provider.parseConfiguration(this.ownFieldsOf(type, input));
+
+    // Every own key must be one the column can hold. A non-enumerable or
+    // symbol-keyed own property is dropped by `JSON.stringify` AND ignored by
+    // `isDeepStrictEqual`, so both comparisons below would agree over a
+    // property the column never receives -- while every reparse recreates it
+    // and the adapter runs on a credential that was never saved.
+    if (
+      typeof parsed === "object" &&
+      parsed !== null &&
+      Reflect.ownKeys(parsed).length !== Object.keys(parsed).length
+    ) {
+      throw new NextlyError({
+        code: "BUSINESS_RULE_VIOLATION",
+        publicMessage: `Email provider "${type}" parsed its configuration into an object carrying properties JSON cannot write, so what would be stored is not what the adapter would receive. Return plain enumerable fields from \`parseConfig\`.`,
+        logContext: {
+          reason: "email-provider-configuration-not-enumerable",
+          type,
+        },
+      });
+    }
 
     // A provider whose parser returns something other than an object cannot
     // have its configuration persisted at all, and failing here names which
@@ -399,6 +433,37 @@ export class EmailProviderService extends BaseService {
     // is stored is what was checked" true by construction rather than by
     // argument, and the two are now the same object.
     return roundTripped as Record<string, unknown>;
+  }
+
+  /**
+   * A configuration reduced to its OWN enumerable fields.
+   *
+   * `JSON.stringify` reads own enumerable properties only, so the round trip
+   * is what strips an inherited one -- and doing it BEFORE the parser runs is
+   * what stops a schema from reading the prototype and reporting success.
+   *
+   * A value that cannot be written is reported as the provider-configuration
+   * fault it is, rather than reaching the parser and failing later as
+   * something less specific.
+   */
+  private ownFieldsOf(type: string, input: unknown): unknown {
+    let serialized: string | undefined;
+    try {
+      serialized = JSON.stringify(input);
+    } catch (error) {
+      throw new NextlyError({
+        code: "BUSINESS_RULE_VIOLATION",
+        publicMessage: `Email provider "${type}" was sent a configuration that cannot be written as JSON, so it cannot be stored.`,
+        logContext: {
+          reason: "email-provider-input-not-serialisable",
+          type,
+          detail: error instanceof Error ? error.message : String(error),
+        },
+      });
+    }
+    // `undefined` for an absent configuration, which a parser may legitimately
+    // accept -- handed through unchanged rather than turned into `null`.
+    return serialized === undefined ? undefined : JSON.parse(serialized);
   }
 
   private encryptConfiguration(config: Record<string, unknown>): string {

--- a/packages/nextly/src/domains/email/services/email-provider-service.ts
+++ b/packages/nextly/src/domains/email/services/email-provider-service.ts
@@ -229,6 +229,34 @@ export class EmailProviderService extends BaseService {
    * The message names the variable because the operator is one environment
    * setting away from working, and a variable name is not itself a secret.
    */
+  /**
+   * The parsed configuration a provider returns, as something storable.
+   *
+   * The parsed value is `unknown` by design — the erased form does not expose
+   * the type — so the one property this needs is checked rather than assumed.
+   * A provider whose parser returns something other than an object cannot have
+   * its configuration persisted at all, and failing here names which provider
+   * did it; storing the value regardless would put a string or an array in a
+   * column every reader expects to hold fields.
+   */
+  private storableConfiguration(
+    type: string,
+    parsed: unknown
+  ): Record<string, unknown> {
+    if (
+      typeof parsed !== "object" ||
+      parsed === null ||
+      Array.isArray(parsed)
+    ) {
+      throw new NextlyError({
+        code: "BUSINESS_RULE_VIOLATION",
+        publicMessage: `Email provider "${type}" parsed its configuration into a ${Array.isArray(parsed) ? "list" : typeof parsed}, and a configuration must be an object of fields. Return the parsed object from \`parseConfig\`.`,
+        logContext: { reason: "email-provider-parsed-not-object", type },
+      });
+    }
+    return parsed as Record<string, unknown>;
+  }
+
   private encryptConfiguration(config: Record<string, unknown>): string {
     if (!this.encryptionSecret) {
       throw new NextlyError({
@@ -643,9 +671,17 @@ export class EmailProviderService extends BaseService {
     // insert. Without this a row stores happily and fails only when something
     // tries to send through it, inside a catch that reports `{ success: false }`
     // -- so the operator learns at the worst moment and with the least detail.
-    getEmailProviderRegistry()
-      .get(data.type)
-      .validateConfig(data.configuration);
+    // The PARSED configuration is what gets stored, so that the row and the
+    // value the adapter runs on are the same thing. They were not: the service
+    // stored whatever the caller sent while the adapter closed over the parse
+    // result, and every difference between the two became a defect somewhere
+    // that read the row.
+    const parsedConfiguration = this.storableConfiguration(
+      data.type,
+      getEmailProviderRegistry()
+        .get(data.type)
+        .parseConfiguration(data.configuration)
+    );
 
     const id = randomUUID();
     const now = new Date();
@@ -656,7 +692,7 @@ export class EmailProviderService extends BaseService {
       type: data.type,
       fromEmail: data.fromEmail,
       fromName: data.fromName ?? null,
-      configuration: this.encryptConfiguration(data.configuration),
+      configuration: this.encryptConfiguration(parsedConfiguration),
       isDefault: data.isDefault ?? false,
       isActive: data.isActive ?? true,
       createdAt: now,
@@ -914,9 +950,12 @@ export class EmailProviderService extends BaseService {
               this.declaredConfigPaths(data.type as string)
             )
           : {};
-      getEmailProviderRegistry()
-        .get(data.type as string)
-        .validateConfig(submitted);
+      const parsedSubmitted = this.storableConfiguration(
+        data.type as string,
+        getEmailProviderRegistry()
+          .get(data.type as string)
+          .parseConfiguration(submitted)
+      );
 
       // Persist the replacement even when the update carried no configuration.
       // Validating `{}` and then not writing it leaves the PREVIOUS provider's
@@ -924,7 +963,7 @@ export class EmailProviderService extends BaseService {
       // parser would receive stale credentials, which is exactly what
       // "a type change replaces rather than merges" is supposed to prevent.
       if (data.configuration === undefined) {
-        updateData.configuration = this.encryptConfiguration(submitted);
+        updateData.configuration = this.encryptConfiguration(parsedSubmitted);
         // This branch REPLACES the stored configuration without the caller
         // having sent one, so the diff below -- which only runs when
         // `data.configuration` is present -- would have reported a type change
@@ -983,9 +1022,12 @@ export class EmailProviderService extends BaseService {
       // `data.type` is applied a few lines above, so a change from smtp to
       // resend would otherwise have its configuration checked by the SMTP
       // parser and stored under resend -- accepted here and unusable at send.
-      getEmailProviderRegistry()
-        .get(effectiveType)
-        .validateConfig(mergedConfig);
+      const parsedMerged = this.storableConfiguration(
+        effectiveType,
+        getEmailProviderRegistry()
+          .get(effectiveType)
+          .parseConfiguration(mergedConfig)
+      );
 
       // Compared BEFORE encryption. Encryption is randomised -- a fresh salt
       // and IV per call -- so two encryptions of identical configuration never
@@ -1002,11 +1044,15 @@ export class EmailProviderService extends BaseService {
       // the type-change branch: comparing against the `{}` fallback would
       // report "unchanged" for a save that replaced a credential nobody could
       // read with one they can.
+      // Compared on the PARSED form, which is what is now stored. Comparing
+      // the merged input against a stored parsed value reported a change on
+      // every save whose parser normalises anything — a trimmed credential
+      // differs from its own stored form on the way in, and never after.
       configurationChanged =
         !existing.readable ||
-        JSON.stringify(existingConfig) !== JSON.stringify(mergedConfig);
+        JSON.stringify(existingConfig) !== JSON.stringify(parsedMerged);
 
-      updateData.configuration = this.encryptConfiguration(mergedConfig);
+      updateData.configuration = this.encryptConfiguration(parsedMerged);
     }
     if (data.isActive !== undefined) updateData.isActive = data.isActive;
     if (data.isDefault !== undefined) updateData.isDefault = data.isDefault;

--- a/packages/nextly/src/plugins/__tests__/email-contributions.integration.test.ts
+++ b/packages/nextly/src/plugins/__tests__/email-contributions.integration.test.ts
@@ -253,7 +253,7 @@ describe("plugin email providers + templates", () => {
 
     let caught: unknown;
     try {
-      provider.validateConfig({});
+      provider.parseConfiguration({});
     } catch (error) {
       caught = error;
     }
@@ -275,7 +275,7 @@ describe("plugin email providers + templates", () => {
           type: "y".repeat(51),
           label: "Hand Built",
           configFields: [],
-          validateConfig: () => undefined,
+          parseConfiguration: (input: unknown) => input,
           createAdapterFrom: () => ({
             send: async () => ({ success: true }),
           }),
@@ -320,7 +320,7 @@ describe("plugin email providers + templates", () => {
       type: "no-metadata",
       label: "No Metadata",
       configFields: [],
-      validateConfig: () => undefined,
+      parseConfiguration: (input: unknown) => input,
       createAdapterFrom: () => ({ send: async () => ({ success: true }) }),
       hasConnectionTest: false,
     });


### PR DESCRIPTION
## What this changes

The service persisted whatever the caller submitted, while the adapter closed over the value `parseConfig` returned. Every difference between those two became a defect somewhere downstream, and each was patched where it surfaced rather than where it came from:

- a parser doing `raw.trim()` meant containment compared a padded credential against an unpadded one, so the mask missed;
- a `z.coerce` meant the admin rendered a value its own control could not hold.

The row and the value the adapter runs on are now the same thing. `validateConfig` becomes `parseConfiguration` and returns the parsed value as `unknown` — the TYPE still never escapes the closure that knows it, so `createAdapterFrom` still parses AND builds and an adapter still cannot be constructed from configuration nothing validated.

## The check that had to come with it

Storing the parsed value creates a question that storing the raw value never asked. What an adapter runs on is not the value in hand: it is that value written as JSON into the column, read back, and parsed **again**. So the write is only safe when parsing the stored form returns the stored form.

That is checked before every write rather than assumed, because several ordinary-looking parsers break it and none of them fails visibly:

| parser | what happens without the check |
|---|---|
| derives a value — `Buffer.from(key).toString("base64")` | encodes on the way in, encodes the encoding on the way out; the adapter authenticates with a doubly-encoded credential and the provider answers "bad key" about a key the operator typed correctly |
| returns a `Date`, `Map` or `Set` | JSON cannot carry it, so the adapter receives a shape this provider's own parser just rejected |
| returns an `undefined`-valued key | the column drops the key and the parser puts it back, so the value in hand and the value in the column differ on every read |
| normalises IN PLACE and returns its input | mutates the object the comparison is made against, so both sides are one object — this defeated the check itself until the comparison was given an untouched copy |
| returns a `bigint`, a cycle, or a throwing `toJSON` | `JSON.stringify` throws a raw `TypeError`, which surfaces as a generic internal failure naming neither the provider nor what to change |
| has a `toJSON` that flattens the record | the value the column holds is a scalar or a list, which the pre-round-trip shape guard could not see |

A parser that *rejects* its own output reaches the same failure by throwing, and is treated as the same outcome: the row could not be read back.

Measured before it was written. A parser doing `Buffer.from(k).toString("base64")` stored `c2VjcmV0` and handed the adapter `YzJWamNtVjA=` — base64 of the base64.

The check compares against the **round-tripped** form rather than the parsed one, because the round-tripped form is what a reader gets and therefore what the parser has to be a fixed point of.

Comparison is `node:util`'s `isDeepStrictEqual`. Two hand-rolled deep-equals already exist in this repo (`domains/webhooks/envelope.ts`, `domains/versions/restore-version.ts`); a third would have made it three implementations of one question. Collapsing those two onto the platform function is worth doing and is **not** done here, because repointing them changes behaviour in two domains this PR does not test.

Parsing also moved INTO `storableConfiguration`, so all three write paths reach it through one seam. A caller that parsed on its own would be a write that skipped every check above.

## Two helpers deliberately NOT removed

Both looked like they should go with this change. Neither survives being checked:

- **`secretsFromBothForms`** unions credential needles from the stored and the parsed form. The double parse is exactly what makes those two forms differ (`c2VjcmV0` vs `YzJWamNtVjA=`), so removing it would shrink the needle set precisely where the divergence lives.
- **`storedValueForControl`** renders a stored value whose type does not match its control. Nothing migrates existing rows — a read does `JSON.parse(decrypt(...))`, not the provider's parse — so every provider configured before this change still holds the raw form until someone edits it, and the admin still has to render it.

## Residual, stated rather than fixed

A provider whose schema drops a field, is written, then regains it, loses those values. Existing rows need no migration; they normalise on the next edit.

## Evidence

`src/domains/email/__tests__/stored-configuration-round-trips.test.ts` — 9 cases: seven rejections and two positive controls, with the table built from the core schema rather than hand-copied.

The positive controls are the point. Disabling each guard in turn fails exactly its own rejections and leaves both controls green, so the controls are not passing because a check is absent and the rejections are not passing for some unrelated reason.

Full suite: 361 failures, which is exactly the pre-existing baseline, across 34 files — **none in the email domain**. Composition checked, not only the count.

## A hazard this PR makes durable, measured but NOT fixed here

zod materialises a prototype-inherited value into its parsed output as an **own** property. Measured on zod 4.1.12, with `Object.prototype.apiKey` set:

```
z.object({ provider: z.string(), apiKey: z.string().optional() })  -> apiKey: "attacker-owned"  own=true
z.object({ provider: z.string(), apiKey: z.string() })             -> apiKey: "attacker-owned"  own=true
z.strictObject({ ... apiKey: z.string().optional() })              -> apiKey: "attacker-owned"  own=true
```

The **required** case is the sharp one: the validator reports success on input that never contained the field, so "it parsed, therefore the credential was supplied" is false.

This PR does not create that. Before it, the inherited value already reached the adapter and sent mail. It does make it **durable**, because the parsed value is now what gets persisted.

`Object.hasOwn` is not a mitigation — zod writes the value as an own property. What does work, measured: parsing a null-prototype copy of the input (`Object.assign(Object.create(null), raw)`) makes the required case reject correctly. That is shallow, so it covers a flat field map and is not a general answer.

Left out of this PR deliberately: it is a distinct change needing its own controls, and folding it in would make one diff answer two questions.
