### PR TITLE
fix(builder): write a node's own fields in the declared order

### DIFF
--- a/.changeset/op-node-field-order.md
+++ b/.changeset/op-node-field-order.md
@@ -1,0 +1,28 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+Write a block node's own fields in the declared order when an op rewrites it, so undoing a removed field restores the document rather than only its values.

--- a/packages/builder/src/ops.field-order.test.ts
+++ b/packages/builder/src/ops.field-order.test.ts
@@ -1,0 +1,182 @@
+/**
+ * A node's own fields are written in one order, so an inverse restores the
+ * DOCUMENT rather than only its values.
+ *
+ * A document is compared, stored and hashed as JSON, where key order is part of
+ * the bytes. An inverse that restores every value at a different key position
+ * has produced a different document, and the round-trip promise `applyOp` makes
+ * is about the document.
+ *
+ * These are examples; `ops.property.test.ts` is where the same property is
+ * asserted over generated input. Both exist because the generator's nodes carry
+ * no optional fields today, so nothing it produces can reach this mechanism —
+ * a fixture that never reaches the mechanism passes for the wrong reason.
+ */
+import { DOCUMENT_FORMAT_VERSION } from "@nextlyhq/blocks-engine";
+import type { BlockDocument, BlockNode } from "@nextlyhq/blocks-engine";
+import { describe, expect, it } from "vitest";
+
+import { applyOp, type BuilderOp } from "./ops";
+
+function doc(nodes: BlockNode[]): BlockDocument {
+  return { formatVersion: DOCUMENT_FORMAT_VERSION, kind: "page", nodes };
+}
+
+/** The key sequence of the single root node, which is what these tests are about. */
+function rootKeys(document: BlockDocument): string[] {
+  const [first] = document.nodes;
+  if (first === undefined) throw new Error("fixture has no root node");
+  return Object.keys(first);
+}
+
+describe("a node's own fields are written in the declared order", () => {
+  it("restores an unset field to its original position, not to the end", () => {
+    // `locked` precedes `name` in the node's declared shape, so this fixture is
+    // already canonical and the ONLY thing that can disturb the sequence is the
+    // op. Unsetting the LAST field would round trip on a broken implementation
+    // too, because appending it lands where it started.
+    const before = doc([
+      {
+        id: "a",
+        type: "core/box",
+        version: 1,
+        props: {},
+        locked: true,
+        name: "hello",
+      },
+    ]);
+    const op: BuilderOp = {
+      kind: "update",
+      id: "a",
+      patch: {},
+      unset: ["locked"],
+    };
+
+    const applied = applyOp(before, op);
+    const undone = applyOp(applied.document, applied.inverse);
+
+    expect(rootKeys(undone.document)).toEqual(rootKeys(before));
+    // The document, not the values. Restoring every value at a different key
+    // position is what this exists to catch, and only a whole-document
+    // comparison sees it.
+    expect(JSON.stringify(undone.document)).toBe(JSON.stringify(before));
+  });
+
+  it("writes a node's fields in declared order even when the input is not", () => {
+    // Author input arrives in whatever order it was written in. The first edit
+    // normalises the node it touches, which is the stated cost of ordering by
+    // declaration rather than recording each original sequence on its inverse.
+    const before = doc([
+      {
+        id: "a",
+        type: "core/box",
+        version: 1,
+        props: {},
+        name: "hello",
+        locked: true,
+      },
+    ]);
+
+    const applied = applyOp(before, {
+      kind: "update",
+      id: "a",
+      patch: { name: "renamed" },
+    });
+
+    expect(rootKeys(applied.document)).toEqual([
+      "id",
+      "type",
+      "version",
+      "props",
+      "locked",
+      "name",
+    ]);
+  });
+
+  it("appends a field the declared shape does not know, keeping its order", () => {
+    // A document written by a NEWER editor carries fields this one has never
+    // heard of. Dropping them would silently discard an author's work on the
+    // first edit made in an older tab; ordering them ahead of the known fields
+    // would let a future field name decide where `id` goes.
+    const forward = {
+      id: "a",
+      type: "core/box",
+      version: 1,
+      props: {},
+      locked: true,
+      futureOne: 1,
+      futureTwo: 2,
+    } as unknown as BlockNode;
+
+    const applied = applyOp(doc([forward]), {
+      kind: "update",
+      id: "a",
+      patch: { name: "renamed" },
+    });
+
+    expect(rootKeys(applied.document)).toEqual([
+      "id",
+      "type",
+      "version",
+      "props",
+      "locked",
+      "name",
+      "futureOne",
+      "futureTwo",
+    ]);
+  });
+
+  it("keeps a field named __proto__ as an own property", () => {
+    // Plain assignment to `__proto__` sets the prototype instead of creating an
+    // own property, so a forward-compatible field with that name would vanish
+    // from what is stored while every check upstream still saw it.
+    const hostile = {
+      id: "a",
+      type: "core/box",
+      version: 1,
+      props: {},
+      locked: true,
+    } as unknown as BlockNode;
+    Object.defineProperty(hostile, "__proto__", {
+      value: "carried",
+      writable: true,
+      enumerable: true,
+      configurable: true,
+    });
+
+    const applied = applyOp(doc([hostile]), {
+      kind: "update",
+      id: "a",
+      patch: { name: "renamed" },
+    });
+
+    const [root] = applied.document.nodes;
+    if (root === undefined) throw new Error("the update dropped the node");
+    expect(Object.hasOwn(root, "__proto__")).toBe(true);
+    expect(Object.getPrototypeOf(root)).toBe(Object.prototype);
+  });
+
+  it("leaves the order INSIDE props alone", () => {
+    // `props` is author data and its key order is observable through
+    // `Object.entries`, so canonicalising it would rewrite content rather than
+    // structure.
+    const before = doc([
+      {
+        id: "a",
+        type: "core/box",
+        version: 1,
+        props: { zebra: 1, apple: 2 },
+      },
+    ]);
+
+    const applied = applyOp(before, {
+      kind: "update",
+      id: "a",
+      patch: { name: "renamed" },
+    });
+
+    const [root] = applied.document.nodes;
+    if (root === undefined) throw new Error("the update dropped the node");
+    expect(Object.keys(root.props)).toEqual(["zebra", "apple"]);
+  });
+});

--- a/packages/builder/src/ops.field-order.test.ts
+++ b/packages/builder/src/ops.field-order.test.ts
@@ -130,6 +130,11 @@ describe("a node's own fields are written in the declared order", () => {
     // Plain assignment to `__proto__` sets the prototype instead of creating an
     // own property, so a forward-compatible field with that name would vanish
     // from what is stored while every check upstream still saw it.
+    //
+    // This one separates on a DIFFERENT break from the cases above: removing
+    // the canonicalisation call leaves it green, because an untouched node is
+    // never rebuilt. Verified against the break it does detect — replacing
+    // `defineProperty` with `out[field] = ...` fails it and nothing else.
     const hostile = {
       id: "a",
       type: "core/box",
@@ -160,6 +165,12 @@ describe("a node's own fields are written in the declared order", () => {
     // `props` is author data and its key order is observable through
     // `Object.entries`, so canonicalising it would rewrite content rather than
     // structure.
+    //
+    // Stated plainly because it matters to whoever reads this next: this case
+    // passes with AND without the canonicalisation, so it is not coverage of
+    // the current implementation. It guards the boundary of the change — a
+    // later attempt to sort props, which is the obvious next step for someone
+    // who reads "canonical order" and applies it one level deeper.
     const before = doc([
       {
         id: "a",

--- a/packages/builder/src/ops.ts
+++ b/packages/builder/src/ops.ts
@@ -1902,6 +1902,58 @@ function rebuild(
   });
 }
 
+/**
+ * A node whose own fields are written in the DECLARED order.
+ *
+ * An inverse restores a removed field by writing it again, and a written key
+ * lands at the END of the object. So undoing an `unset` of a field that was not
+ * last gives back every value and a different key sequence — and a document is
+ * compared, stored and hashed as JSON, where that is a different document. The
+ * round trip then fails on an edit that restored the data perfectly.
+ *
+ * Ordering the fields the same way every time removes the question rather than
+ * tracking the answer: the alternative is recording the original key sequence on
+ * each inverse, which makes the property hold only while that bookkeeping stays
+ * correct. JSON objects are formally unordered and mature document models do not
+ * treat a node's own field order as meaningful — Automerge's maps have no
+ * insertion order at all, and ProseMirror builds `attrs` from its schema.
+ *
+ * The order comes from {@link NODE_FIELDS}, so there is one statement of the
+ * node's shape rather than a second list that drifts from it. Fields the table
+ * does not know follow, keeping their existing relative order, so a document
+ * written by a newer editor survives a round trip through an older one.
+ *
+ * Order INSIDE a value is untouched. `props` is author data, observable through
+ * `Object.entries`, and {@link equalWithin} compares it order-sensitively for
+ * that reason.
+ *
+ * Assigned through `defineProperty` rather than `out[field] = ...` because a
+ * forward-compatible field could be named `__proto__`, where plain assignment
+ * sets the prototype instead of creating an own property and the field vanishes
+ * from what is stored.
+ */
+function canonicalNode(node: BlockNode): BlockNode {
+  const source = node as unknown as Record<string, unknown>;
+  const out: Record<string, unknown> = {};
+  const write = (field: string): void => {
+    Object.defineProperty(out, field, {
+      value: source[field],
+      writable: true,
+      enumerable: true,
+      configurable: true,
+    });
+  };
+  for (const field of Object.keys(NODE_FIELDS)) {
+    if (Object.hasOwn(source, field)) write(field);
+  }
+  for (const field of Object.keys(source)) {
+    if (!Object.hasOwn(out, field)) write(field);
+  }
+  // Asserted rather than narrowed: every own field of a validated node is
+  // carried across unchanged, so the result holds exactly what the input did.
+  return out as unknown as BlockNode;
+}
+
 /** A node without the named keys, for an update that removed fields. */
 function withoutKeys(node: BlockNode, keys: readonly string[]): BlockNode {
   const next: Record<string, unknown> = { ...node };
@@ -2885,12 +2937,18 @@ export function applyOp(
       // same document — but every reader between here and storage sees the
       // difference, and this module's own value check is one of them.
       const cleared = op.unset ?? [];
-      const updated =
-        cleared.length === 0
-          ? written
-          : rebuild(written, current =>
-              current.id === op.id ? withoutKeys(current, cleared) : current
-            );
+      // Canonicalised unconditionally, not only when fields were removed. A
+      // patch that WRITES a field the node already had leaves it where it was,
+      // while one that adds a field appends it — so two documents holding the
+      // same values differ by which edit produced them, and the inverse of the
+      // second does not restore the first.
+      const updated = rebuild(written, current =>
+        current.id === op.id
+          ? canonicalNode(
+              cleared.length === 0 ? current : withoutKeys(current, cleared)
+            )
+          : current
+      );
       assertFitsCaps(document, withNodes(document, updated), "update", limits);
       return {
         document: withNodes(document, updated),


### PR DESCRIPTION
An inverse restores a removed field by writing it again, and a written key lands at the END of the object. So undoing an `unset` of a field that was not last gave back every value and a **different key sequence** — and a document is compared, stored and hashed as JSON, where that is a different document.

Measured before the fix:

```
before  ["id","type","version","props","locked","name"]
undone  ["id","type","version","props","name","locked"]
round trips: false
```

## The fix

A node's own fields are written in the order `NODE_FIELDS` declares. The order is **read from that table rather than restated**, so the node contract has one statement and cannot drift from a second list.

- Fields the table does not know follow, keeping their existing relative order — a document written by a newer editor survives an edit made in an older one instead of losing the fields it does not recognise.
- Order INSIDE `props` is untouched. That is author data, observable through `Object.entries`, and `equalWithin` already compares it order-sensitively.
- Assignment goes through `defineProperty`, because a forward-compatible field named `__proto__` would otherwise set the prototype rather than become an own property, and vanish from what is stored while every check upstream still saw it.

The stated cost: the first edit to a non-canonical document rewrites the touched node's key sequence. Same data, different byte order. The alternative — recording each original key sequence on its inverse — makes the round trip hold only while that bookkeeping stays correct, which is the category of hand-maintained invariant that produced most of the op store's findings.

## Why not a schema library

The design this came from named Zod for the shape half. Measured against this codebase's actual input, it is the wrong tool, and the reason is worth recording:

```js
Object.prototype.parentId = "attacker-owned";
z.object({ type: z.literal("move"), nodeId: z.string(), parentId: z.string().optional() })
  .strict()
  .safeParse({ type: "move", nodeId: "a" })
// -> { type: "move", nodeId: "a", parentId: "attacker-owned" }
//    Object.hasOwn(output, "parentId") === true
```

Zod does not merely read through the prototype — it copies inherited values into its output as OWN properties. One polluted key turns "move to the root" into "move under an attacker-chosen node", and the result is storable, so it persists. `.strict()` does not help: the key is declared, not unknown. The op store guards this today by reading through `ownValue`/`Object.hasOwn`.

The second reason is that the declared schema already exists. `NODE_FIELDS` is a declarative table whose completeness is enforced by `Required<BlockNode>` at compile time — a field added to the engine fails this file until someone says what it is. That is a stronger guarantee than a runtime schema, with no dependency added to a package whose imports are an allowlist.

## Evidence

- 5 new cases in `packages/builder/src/ops.field-order.test.ts`; full builder suite 346 passed.
- Proven by isolated revert: removing ONLY the canonicalisation call fails 3 of the 5 for the intended reason.
- The other 2 pass with and without it, and the file says so rather than letting the green read as coverage. One separates on a different break (verified: `defineProperty` → plain assignment fails it and nothing else); the other guards the boundary of the change, against a later attempt to sort `props` too.

## Not in this PR

`ops.property.test.ts` asserts the same property over generated input, and its nodes carry no optional fields — so nothing it generates can reach this mechanism, which is why it passed over this defect. Extending that corpus is the natural follow-up and is deliberately separate: it changes the input to a 60-seed property test, and any failure it surfaces should be judged on its own rather than inside a fix.