### PR TITLE
feat(nextly): route every field-group update through one service

### DIFF
--- a/.changeset/converge-field-group-update.md
+++ b/.changeset/converge-field-group-update.md
@@ -1,0 +1,28 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+Updating a field group now changes its table wherever the update comes from. The mounted PATCH route and the Direct API previously stored the new fields without moving the physical schema, so only the admin panel performed the whole operation. A companion-table transition that fails now refuses the update instead of recording it as done, and the Direct API can toggle a field group localized.

--- a/packages/nextly/src/api/field-groups-detail.ts
+++ b/packages/nextly/src/api/field-groups-detail.ts
@@ -17,12 +17,11 @@
  * @module api/field-groups-detail
  */
 
-import type { FieldConfig } from "@nextly/collections";
-
 import { getService } from "../di";
-import { calculateSchemaHash } from "../domains/schema/services/schema-hash";
+import type { FieldGroupMetadataService } from "../domains/field-groups/services/field-group-metadata-service";
 import { NextlyError } from "../errors/nextly-error";
 import { getCachedNextly } from "../init";
+import type { FieldDefinition } from "../schemas/dynamic-collections";
 import type { FieldGroupRegistryService } from "../services/field-groups/field-group-registry-service";
 import { requireBuilderEnabled } from "../shared/builder-access";
 
@@ -37,6 +36,59 @@ import { withErrorHandler } from "./with-error-handler";
  */
 interface RouteContext {
   params: Promise<{ slug: string }>;
+}
+
+/**
+ * The service that owns a field group's physical schema and its registry row together.
+ *
+ * Mirrors `api/field-groups.ts`, deliberately: a mounted route reaching the registry directly is
+ * how this transport came to write metadata without the DDL it describes.
+ */
+async function getFieldGroupMetadataService(): Promise<FieldGroupMetadataService> {
+  await getCachedNextly();
+  return getService("fieldGroupMetadataService");
+}
+
+/**
+ * Read one property of a parsed body at the type the service expects, or refuse.
+ *
+ * The body arrives as `Record<string, unknown>` because it is whatever the client sent. Passing a
+ * value of the wrong type straight through — which this route did — stores it: a numeric `label`
+ * reached the registry and became the field group's display name. Refusing names the offending
+ * property, which is also what makes the failure fixable from the client side.
+ *
+ * `undefined` stays `undefined` rather than becoming an error, because absent means UNTOUCHED for
+ * every property of a PATCH.
+ */
+function expect<T extends "string" | "boolean" | "object">(
+  body: Record<string, unknown>,
+  key: string,
+  kind: T
+):
+  | (T extends "string"
+      ? string
+      : T extends "boolean"
+        ? boolean
+        : Record<string, unknown>)
+  | undefined {
+  const value = body[key];
+  if (value === undefined) return undefined;
+  const matches =
+    kind === "object"
+      ? typeof value === "object" && value !== null && !Array.isArray(value)
+      : typeof value === kind;
+  if (!matches) {
+    throw NextlyError.validation({
+      errors: [
+        {
+          path: key,
+          code: "invalid_type",
+          message: `Expected ${key} to be ${kind === "object" ? "an object" : `a ${kind}`}.`,
+        },
+      ],
+    });
+  }
+  return value as never;
 }
 
 async function getComponentRegistry(): Promise<FieldGroupRegistryService> {
@@ -84,7 +136,6 @@ export const PATCH = withErrorHandler(
     ]);
 
     const { slug } = await context.params;
-    const registry = await getComponentRegistry();
 
     // Body parse failure is a client error; surface as a single-issue
     // validation rather than letting the SyntaxError become a 500.
@@ -103,37 +154,30 @@ export const PATCH = withErrorHandler(
       });
     }
 
-    const updateData: Record<string, unknown> = {};
-
-    if (body.label !== undefined) {
-      updateData.label = body.label;
-    }
-
-    if (body.description !== undefined) {
-      updateData.description = body.description;
-    }
-
     if (body.fields !== undefined) {
       // Same rules as the ui-schema.json mirror (see api/fields-payload).
       assertValidFieldsPayload(body.fields);
-      updateData.fields = body.fields;
-      // The registry re-validates the field config; cast through `unknown`
-      // to avoid `any` while keeping the existing trust boundary.
-      updateData.schemaHash = calculateSchemaHash(
-        body.fields as unknown as FieldConfig[]
-      );
     }
 
-    if (body.admin !== undefined) {
-      updateData.admin = body.admin;
-    }
-
-    // Update component (source: "ui" to enforce locking rules)
-    const updated = await registry.updateComponent(slug, updateData, {
+    // 🔴 Through the metadata service, not the registry. Writing the registry directly is what made
+    // this route store a new field set and a matching `schema_hash` while running no DDL — the
+    // table kept its old columns, and only the dispatcher's copy of this operation ever moved them.
+    // The service owns the physical change and the row write together, so every transport that
+    // edits a field group now performs the whole operation.
+    const metadata = await getFieldGroupMetadataService();
+    const { record } = await metadata.updateFieldGroup({
+      slug,
+      label: expect(body, "label", "string"),
+      description: expect(body, "description", "string"),
+      admin: expect(body, "admin", "object"),
+      // Already validated in shape by `assertValidFieldsPayload` above, which is the same check the
+      // ui-schema mirror applies; the cast carries that result across the untyped body boundary.
+      fields: body.fields as FieldDefinition[] | undefined,
+      localized: expect(body, "localized", "boolean"),
       source: "ui",
     });
 
-    return respondMutation("Field group updated.", updated);
+    return respondMutation("Field group updated.", record);
   }
 );
 

--- a/packages/nextly/src/direct-api/namespaces/field-groups.ts
+++ b/packages/nextly/src/direct-api/namespaces/field-groups.ts
@@ -12,6 +12,7 @@ import type { FieldConfig } from "../../collections/fields/types";
 import { resolveComponentTableName } from "../../domains/schema/utils/resolve-table-name";
 import { NextlyError } from "../../errors/nextly-error";
 import { assertValidFieldGroupConfig } from "../../field-groups/config/validate-field-group";
+import type { FieldDefinition } from "../../schemas/dynamic-collections";
 import type {
   FieldGroupDefinition,
   CreateFieldGroupArgs,
@@ -218,15 +219,7 @@ export function createFieldGroupsNamespace(
         });
       }
 
-      const updateData: Record<string, unknown> = {};
-
-      if (args.data.label !== undefined) {
-        updateData.label = args.data.label;
-      }
-
-      if (args.data.description !== undefined) {
-        updateData.description = args.data.description;
-      }
+      let validatedFields: FieldConfig[] | undefined;
 
       if (args.data.fields !== undefined) {
         const fieldsTyped = args.data.fields as unknown as FieldConfig[];
@@ -243,26 +236,27 @@ export function createFieldGroupsNamespace(
               : { singular: args.slug },
           fields: fieldsTyped,
         });
-        updateData.fields = fieldsTyped;
-        const { calculateSchemaHash } = await import(
-          "../../domains/schema/services/schema-hash"
-        );
-        updateData.schemaHash = calculateSchemaHash(fieldsTyped);
+        validatedFields = fieldsTyped;
       }
 
-      if (args.data.admin !== undefined) {
-        updateData.admin = args.data.admin;
-      }
-
-      const component = await ctx.fieldGroupRegistryService.updateComponent(
-        args.slug,
-        updateData,
-        { source: "ui" }
-      );
+      // 🔴 Through the metadata service, not the registry. Writing the registry directly is what
+      // made this transport store a new field set and a matching `schema_hash` while running no
+      // DDL at all — the table kept its old columns and only the dispatcher's copy of this
+      // operation ever moved them. The service owns both halves, so all three transports now do
+      // the same thing.
+      const { record } = await ctx.fieldGroupMetadataService.updateFieldGroup({
+        slug: args.slug,
+        label: args.data.label,
+        description: args.data.description,
+        admin: args.data.admin,
+        fields: validatedFields as unknown as FieldDefinition[] | undefined,
+        localized: args.data.localized,
+        source: "ui",
+      });
 
       return {
         message: "Field group updated.",
-        item: mapFieldGroupRecord(component),
+        item: mapFieldGroupRecord(record),
       };
     },
 

--- a/packages/nextly/src/direct-api/types/field-groups.ts
+++ b/packages/nextly/src/direct-api/types/field-groups.ts
@@ -257,6 +257,16 @@ export interface UpdateFieldGroupArgs extends DirectAPIConfig {
     /** Updated field configurations */
     fields?: Record<string, unknown>[];
 
+    /**
+     * Whether this field group stores translatable values per locale.
+     *
+     * Omitted leaves the persisted setting alone. Changing it MOVES DATA: enabling seeds the
+     * companion table from the main one and drops those columns, disabling restores and archives
+     * them. Enabling requires the app's `localization` config, without which the tables would take
+     * a shape the runtime cannot write to.
+     */
+    localized?: boolean;
+
     /** Updated admin configuration */
     admin?: {
       category?: string;

--- a/packages/nextly/src/dispatcher/handlers/__tests__/component-dispatcher-shapes.test.ts
+++ b/packages/nextly/src/dispatcher/handlers/__tests__/component-dispatcher-shapes.test.ts
@@ -250,6 +250,35 @@ describe("dispatchComponents, mutations (respondMutation)", () => {
     ];
     expect(Object.keys(patch)).toEqual(["description"]);
   });
+
+  // 🔴 The body is a type ASSERTION over whatever JSON arrived, so a non-boolean survives it. The
+  // string "false" is truthy, which would take the ENABLED branch and drop the main table's
+  // translatable columns — while the registry, which stores `localized === true`, recorded the
+  // group DISABLED. Refusing is the only outcome that keeps those two agreeing.
+  it("updateComponent refuses a non-boolean localized rather than acting on it", async () => {
+    const existing = {
+      slug: "hero",
+      tableName: "comp_hero",
+      fields: [],
+      localized: false,
+      migrationStatus: "applied" as const,
+    };
+    const registry = makeRegistry({
+      isLocked: vi.fn().mockResolvedValue(false),
+      getComponent: vi.fn().mockResolvedValue(existing),
+      updateComponent: vi.fn().mockResolvedValue(existing),
+    });
+    wireRegistry(registry);
+
+    await expect(
+      dispatchComponents("updateComponent", { slug: "hero" }, {
+        localized: "false",
+      } as unknown as Record<string, unknown>)
+    ).rejects.toMatchObject({ code: "VALIDATION_ERROR" });
+
+    // Nothing was written: the refusal has to happen before the row moves, not after.
+    expect(registry.updateComponent).not.toHaveBeenCalled();
+  });
 });
 
 describe("dispatchComponents, actions (respondAction)", () => {

--- a/packages/nextly/src/dispatcher/handlers/__tests__/component-dispatcher-shapes.test.ts
+++ b/packages/nextly/src/dispatcher/handlers/__tests__/component-dispatcher-shapes.test.ts
@@ -204,12 +204,51 @@ describe("dispatchComponents, mutations (respondMutation)", () => {
     const response = result as Response;
     expect(response.status).toBe(200);
     const body = await response.json();
-    // No fields update + existing migrationStatus "applied" carries
-    // through, so the toast picks the "applied successfully" branch.
     expect(body).toEqual({
-      message: 'Component "hero" updated and migration applied successfully.',
+      message: 'Component "hero" updated.',
       item: updated,
     });
+
+    // 🔴 The handler is a transport now, so what makes this test load-bearing is WHERE the write
+    // went. Asserting only the body would keep passing if the handler wrote the registry itself
+    // again — which is the state that let two other transports skip the schema half entirely.
+    // Observing the real call's arguments is what pins the delegation.
+    expect(registry.updateComponent).toHaveBeenCalledWith(
+      "hero",
+      { label: "Hero (renamed)" },
+      { source: "ui" }
+    );
+  });
+
+  // A property of the SERVICE, asserted through the dispatcher because that is where a caller meets
+  // it: a PATCH naming only `label` must not clear the description, the admin block or the fields.
+  // The registry translates absent-means-untouched, so handing it an explicit `undefined` for every
+  // unsent property would erase them.
+  it("updateComponent sends only the properties the request carried", async () => {
+    const existing = {
+      slug: "hero",
+      tableName: "comp_hero",
+      fields: [],
+      migrationStatus: "applied" as const,
+    };
+    const registry = makeRegistry({
+      isLocked: vi.fn().mockResolvedValue(false),
+      getComponent: vi.fn().mockResolvedValue(existing),
+      updateComponent: vi.fn().mockResolvedValue(existing),
+    });
+    wireRegistry(registry);
+
+    await dispatchComponents(
+      "updateComponent",
+      { slug: "hero" },
+      { description: "Only this." }
+    );
+
+    const [, patch] = registry.updateComponent.mock.calls[0] as [
+      string,
+      Record<string, unknown>,
+    ];
+    expect(Object.keys(patch)).toEqual(["description"]);
   });
 });
 

--- a/packages/nextly/src/dispatcher/handlers/__tests__/component-dispatcher-shapes.test.ts
+++ b/packages/nextly/src/dispatcher/handlers/__tests__/component-dispatcher-shapes.test.ts
@@ -270,11 +270,25 @@ describe("dispatchComponents, mutations (respondMutation)", () => {
     });
     wireRegistry(registry);
 
+    // 🔴 Asserted on the REASON, not the code. Reading the raw body instead makes `"false"` truthy,
+    // which takes the enable branch and is refused by the localization-config gate — also a
+    // VALIDATION_ERROR. A code-only assertion passes on both the fixed and the broken code and
+    // certifies nothing; the path is what separates them.
     await expect(
       dispatchComponents("updateComponent", { slug: "hero" }, {
         localized: "false",
       } as unknown as Record<string, unknown>)
-    ).rejects.toMatchObject({ code: "VALIDATION_ERROR" });
+    ).rejects.toMatchObject({
+      code: "VALIDATION_ERROR",
+      publicData: {
+        errors: [
+          expect.objectContaining({
+            path: "localized",
+            code: "invalid_type",
+          }),
+        ],
+      },
+    });
 
     // Nothing was written: the refusal has to happen before the row moves, not after.
     expect(registry.updateComponent).not.toHaveBeenCalled();

--- a/packages/nextly/src/dispatcher/handlers/component-dispatcher.ts
+++ b/packages/nextly/src/dispatcher/handlers/component-dispatcher.ts
@@ -11,8 +11,6 @@
  * through unchanged. See spec §5.1 for the canonical shape contract.
  */
 
-import type { DrizzleAdapter } from "@nextlyhq/adapter-drizzle";
-
 import {
   assertValidFieldsPayload,
   assertValidPluginFieldOptions,
@@ -25,15 +23,12 @@ import {
   respondMutation,
 } from "../../api/response-shapes";
 import type { FieldConfig } from "../../collections/fields/types";
-import { container } from "../../di/container";
 import {
   reconcileComponentCompanion,
   registerComponentRuntimeSchema,
+  resolveComponentTypeColumn,
 } from "../../domains/field-groups/services/field-group-table-provisioning";
-import {
-  resolveFieldGroupRegistryName,
-  resolveTypeColumns,
-} from "../../domains/field-groups/storage/resolve-storage-names";
+import { resolveFieldGroupRegistryName } from "../../domains/field-groups/storage/resolve-storage-names";
 import { assertLocalizationConfigured } from "../../domains/i18n/config/require-app-config";
 import { translatePipelinePreviewToLegacy } from "../../domains/schema/legacy-preview/translate";
 import { RealClassifier } from "../../domains/schema/pipeline/classifier/classifier";
@@ -59,7 +54,6 @@ import { resolveComponentTableName } from "../../domains/schema/utils/resolve-ta
 import { NextlyError } from "../../errors";
 import { getProductionNotifier } from "../../runtime/notifications/index";
 import type { FieldDefinition } from "../../schemas/dynamic-collections";
-import { STORAGE_FORMAT } from "../../schemas/storage-format";
 import type { FieldGroupRegistryService } from "../../services/field-groups/field-group-registry-service";
 import { buildFullDesiredSchema } from "../helpers/desired-schema";
 import {
@@ -107,32 +101,9 @@ function offsetPaginationToMeta(args: {
   };
 }
 
-// Refresh the cached Drizzle table so the next entry query joining this
-// component uses the new column layout without a server restart.
-/**
- * The discriminator a component table carries, resolved BEFORE its DDL runs.
- *
- * 🔴 Deliberately not inside `registerComponentRuntimeSchema`. That function's
- * `catch` is a cache-refresh failsafe — it suppresses so a refresh problem does
- * not fail a request whose schema change already committed — and a catalog
- * probe inside it inherits that policy, letting a handler report success while
- * leaving the runtime table unregistered or holding obsolete columns.
- *
- * Resolving first is equivalent and safer: the schema change only ever alters
- * user columns, so the discriminator is the same before and after, and a probe
- * that cannot answer now fails the request before anything is committed.
- */
-async function resolveComponentTypeColumn(
-  adapter: DrizzleAdapter,
-  tableName: string
-): Promise<string> {
-  const typeColumns = await resolveTypeColumns(adapter, [tableName]);
-  return typeColumns.get(tableName) ?? STORAGE_FORMAT.columns.type;
-}
-
-// Both helpers now live beside the field-group schema service, so every transport that creates a
-// field group reaches the same table provisioning rather than only the one that happened to hold
-// them privately.
+// Every helper these handlers use to provision or rebind a table now lives beside the field-group
+// schema service, so each transport reaches the same provisioning rather than only the one that
+// happened to hold it privately.
 
 const COMPONENTS_METHODS: Record<string, MethodHandler<ComponentsServices>> = {
   listComponents: {
@@ -258,98 +229,30 @@ const COMPONENTS_METHODS: Record<string, MethodHandler<ComponentsServices>> = {
           }
         | undefined;
 
-      const isLocked = await svc.registry.isLocked(slug);
-      if (isLocked) {
-        // Throw a NextlyError so the dispatcher's error path emits the
-        // canonical singular `{ error: ... }` shape with a 403 status.
-        // Slug stays in logContext per §13.8 (never on the wire).
-        throw NextlyError.forbidden({
+      // 🔴 A transport, and nothing more. The lock check, the localization gate, the plugin-option
+      // validation, the companion transition and the registry write all live in the metadata
+      // service, so this path and the two that never ran DDL now perform the SAME operation. What
+      // used to be here could not be shared, which is exactly why they diverged.
+      const metadataService = getFieldGroupMetadataServiceFromDI();
+      if (!metadataService) {
+        throw NextlyError.internal({
           logContext: {
-            reason: "component-locked",
+            reason: "field-group-metadata-service-unavailable",
             slug,
           },
         });
       }
+      const { record } = await metadataService.updateFieldGroup({
+        slug,
+        label: b?.label,
+        description: b?.description,
+        admin: b?.admin,
+        fields: b?.fields as unknown as FieldDefinition[] | undefined,
+        localized: b?.localized,
+        source: "ui",
+      });
 
-      const existing = await svc.registry.getComponent(slug);
-      if (!existing) {
-        throw new Error(`Component "${slug}" not found`);
-      }
-
-      const updateData: Record<string, unknown> = {};
-      if (b?.label) updateData.label = b.label;
-      if (b?.admin) updateData.admin = b.admin;
-      if (b?.description) updateData.description = b.description;
-      // i18n: persist the Internationalization toggle. `isLocalized` drives the companion
-      // provisioning below (create when newly localized, ADD/DROP as translatable fields change).
-      if (b?.localized !== undefined) updateData.localized = b.localized;
-      const wasLocalized =
-        (existing as { localized?: boolean }).localized === true;
-      const isLocalized =
-        b?.localized !== undefined ? b.localized === true : wasLocalized;
-      // i18n: gate the Internationalization enable on the app-level
-      // `localization` config (false→true transition only).
-      if (!wasLocalized && isLocalized) {
-        assertLocalizationConfigured("component", slug);
-      }
-
-      if (b?.fields) {
-        assertValidPluginFieldOptions(b.fields);
-        updateData.fields = b.fields;
-        updateData.schemaHash = calculateSchemaHash(b.fields);
-      }
-
-      // Run the companion reconcile when fields changed OR the Internationalization flag toggled
-      // (a flag-only save still needs the enable/disable data move: enabling seeds + drops main
-      // columns, disabling restores + archives them). Without the transition on a flag-only
-      // toggle, `localized` was persisted while the physical schema stayed put and content
-      // stranded in the wrong table.
-      if (b?.fields || isLocalized !== wasLocalized) {
-        // Schema changes (rename, drop, add required column) must go through
-        // applyComponentSchemaChanges which runs PushSchemaPipeline. Here we
-        // only store the updated fields JSON — this path is reached when
-        // previewComponentSchemaChanges returned hasChanges: false (labels,
-        // descriptions, or field reordering changed but no DDL is needed).
-        if (container.has("adapter")) {
-          const adapter = container.get<DrizzleAdapter>("adapter");
-          const newFields = b?.fields ?? existing.fields;
-          registerComponentRuntimeSchema(
-            adapter,
-            adapter.getCapabilities().dialect,
-            existing.tableName,
-            newFields,
-            await resolveComponentTypeColumn(adapter, existing.tableName),
-            // i18n: main runtime table omits translatable columns when localized.
-            isLocalized
-          );
-          // i18n: provision/alter the companion comp_<slug>_locales table for the new localized
-          // field set: enabling seeds the default locale from main then drops those columns,
-          // disabling restores + archives them, a field change ADDs/DROPs columns.
-          try {
-            await reconcileComponentCompanion({
-              slug,
-              tableName: existing.tableName,
-              oldFields: existing.fields as unknown as FieldDefinition[],
-              newFields: newFields as unknown as FieldDefinition[],
-              localized: isLocalized,
-              wasLocalized,
-              adapter,
-            });
-          } catch (companionErr) {
-            const m =
-              companionErr instanceof Error
-                ? companionErr.message
-                : String(companionErr);
-            console.error(
-              `[Components] Companion reconcile failed for "${existing.tableName}": ${m}`
-            );
-          }
-        }
-      }
-
-      const updated = await svc.registry.updateComponent(slug, updateData);
-
-      return respondMutation(`Component "${slug}" updated.`, updated);
+      return respondMutation(`Component "${slug}" updated.`, record);
     },
   },
 

--- a/packages/nextly/src/dispatcher/handlers/component-dispatcher.ts
+++ b/packages/nextly/src/dispatcher/handlers/component-dispatcher.ts
@@ -62,6 +62,7 @@ import {
   getFieldGroupMetadataServiceFromDI,
   getMigrationJournalFromDI,
 } from "../helpers/di";
+import { readRequestLocalized } from "../helpers/request-localized";
 import { requireParam, toNumber } from "../helpers/validation";
 import type { MethodHandler, Params } from "../types";
 
@@ -248,7 +249,12 @@ const COMPONENTS_METHODS: Record<string, MethodHandler<ComponentsServices>> = {
         description: b?.description,
         admin: b?.admin,
         fields: b?.fields as unknown as FieldDefinition[] | undefined,
-        localized: b?.localized,
+        // 🔴 Read through the shared helper, never off the cast body. `b` is a type assertion over
+        // whatever JSON arrived, so `localized: "false"` survives it as a truthy string: the
+        // transition would take the ENABLED branch and drop the main table's translatable columns
+        // while the registry, which stores `data.localized === true`, recorded the group disabled.
+        // The collection and single dispatchers already read it this way.
+        localized: readRequestLocalized(b),
         source: "ui",
       });
 

--- a/packages/nextly/src/domains/field-groups/services/field-group-metadata-service.ts
+++ b/packages/nextly/src/domains/field-groups/services/field-group-metadata-service.ts
@@ -75,6 +75,34 @@ export interface CreateFieldGroupResult {
   migrationStatus: FieldGroupMigrationStatus;
 }
 
+/**
+ * A field group's metadata edit, with the physical change it implies.
+ *
+ * Every property is optional and `undefined` means UNTOUCHED rather than cleared, which is the
+ * shape all three transports already spoke — a PATCH that omits `label` must not erase it. The
+ * distinction matters most for `localized`: absent leaves the persisted value alone, while `false`
+ * is a request to disable and moves data back out of the companion table.
+ */
+export interface UpdateFieldGroupInput {
+  slug: string;
+  label?: string;
+  description?: string;
+  admin?: Record<string, unknown>;
+  fields?: FieldDefinition[];
+  localized?: boolean;
+  /**
+   * Who is asking, which decides whether a LOCKED field group may be written.
+   *
+   * A locked field group is owned by code, so only the code-first sync may change it. Defaulting to
+   * `"ui"` means a transport that forgets to say gets the restrictive answer.
+   */
+  source?: "ui" | "code";
+}
+
+export interface UpdateFieldGroupResult {
+  record: DynamicFieldGroupRecord;
+}
+
 export class FieldGroupMetadataService {
   constructor(
     private readonly registry: FieldGroupRegistryService,
@@ -192,6 +220,182 @@ export class FieldGroupMetadataService {
     }
 
     return { record, migrationStatus };
+  }
+
+  /**
+   * Change a field group's schema and its registry row, as one operation.
+   *
+   * 🔴 The founding defect of this service, still live on the UPDATE path until now. Three
+   * transports edit a field group and only the dispatcher moved the physical schema: the mounted
+   * route and the Direct API wrote new `fields` and a new `schema_hash` to the registry and ran no
+   * DDL at all, because the provisioning was private to the dispatcher. The row then described
+   * columns the table did not have. Bounded rather than silent — the registry marks
+   * `migration_status: "pending"` and a preview introspects the live database — but two transports
+   * performing different halves of one operation is not a difference any caller can be expected to
+   * know about.
+   *
+   * Inside the exclusion for the same reasons the create is, and one more. Rendering the companion
+   * transition consults the process-global field-type registry, which an HMR reload replaces
+   * wholesale from inside this same exclusion; and the OLD fields this diffs against are read here
+   * rather than passed in, so a concurrent writer cannot make the transition describe a shape that
+   * is no longer current.
+   */
+  async updateFieldGroup(
+    input: UpdateFieldGroupInput
+  ): Promise<UpdateFieldGroupResult> {
+    return withSchemaChangeExcluded(
+      {
+        adapter: this.adapter,
+        logger: this.logger,
+        label: `update field group "${input.slug}"`,
+        // A metadata-only edit issues none, but that is not known until the stored fields have been
+        // read — which happens inside. Claiming otherwise here would decide the question from the
+        // request shape, and a request that only toggles `localized` carries no fields while moving
+        // every translatable column.
+        issuesDdl: true,
+      },
+      () => this.updateFieldGroupExcluded(input)
+    );
+  }
+
+  private async updateFieldGroupExcluded(
+    input: UpdateFieldGroupInput
+  ): Promise<UpdateFieldGroupResult> {
+    // 0. RE-ESTABLISH every precondition, against the state as it is NOW.
+    //
+    // Read inside the exclusion rather than accepted from the caller: whether the field group
+    // exists, whether it is locked, and what its current fields are all decide what this does, and
+    // all three can change while a request waits for the lock.
+    // Raises NOT_FOUND itself when the slug is gone, so there is no absence branch here. One that
+    // existed would be a guard that can never fire, and a guard that cannot fire reads as coverage
+    // while proving nothing.
+    const existing = await this.registry.getComponent(input.slug);
+    if (existing.locked && input.source !== "code") {
+      throw NextlyError.forbidden({
+        logContext: {
+          reason: "component-locked",
+          slug: input.slug,
+          source: input.source ?? "ui",
+        },
+      });
+    }
+    if (input.fields !== undefined) {
+      const { assertValidPluginFieldOptions } = await import(
+        "../../../api/fields-payload"
+      );
+      assertValidPluginFieldOptions(input.fields);
+    }
+
+    const wasLocalized = existing.localized === true;
+    const localized = input.localized ?? wasLocalized;
+    const fields = (input.fields ??
+      existing.fields) as unknown as FieldDefinition[];
+
+    // Gated only on the false -> true transition: a field group that is ALREADY localized must stay
+    // editable after the app's localization config is removed, or its content becomes unreachable.
+    if (!wasLocalized && localized) {
+      const { assertLocalizationConfigured } = await import(
+        "../../i18n/config/require-app-config"
+      );
+      assertLocalizationConfigured("component", input.slug);
+    }
+
+    // 1. MOVE the physical schema, when this edit implies one. A `localized` toggle alone does:
+    // enabling seeds the companion from the main table and drops those columns, disabling restores
+    // and archives them. A save that skipped that would persist the flag while the content stayed
+    // where the runtime no longer looks for it.
+    if (input.fields !== undefined || localized !== wasLocalized) {
+      await this.reconcileCompanion({
+        existing,
+        fields,
+        localized,
+        wasLocalized,
+      });
+    }
+
+    // 2. RECORD, after the physical change succeeded.
+    const record = await this.registry.updateComponent(
+      input.slug,
+      {
+        ...(input.label !== undefined ? { label: input.label } : {}),
+        ...(input.description !== undefined
+          ? { description: input.description }
+          : {}),
+        ...(input.admin !== undefined ? { admin: input.admin } : {}),
+        ...(input.localized !== undefined
+          ? { localized: input.localized }
+          : {}),
+        ...(input.fields !== undefined
+          ? {
+              fields:
+                input.fields as unknown as DynamicFieldGroupInsert["fields"],
+              schemaHash: await this.hashFields(input.fields),
+            }
+          : {}),
+      },
+      { source: input.source ?? "ui" }
+    );
+
+    return { record };
+  }
+
+  /** The stored hash for a field set, from the one implementation the whole pipeline uses. */
+  private async hashFields(fields: FieldDefinition[]): Promise<string> {
+    const { calculateSchemaHash } = await import(
+      "../../schema/services/schema-hash"
+    );
+    return calculateSchemaHash(fields as never);
+  }
+
+  /**
+   * Apply the companion-table transition this edit implies, and let a failure be a failure.
+   *
+   * 🔴 NOT swallowed, and that is a deliberate change from the dispatcher this replaces. It logged
+   * the error and fell through to the registry write, so a transition that failed still committed a
+   * row saying the field group was localized with the new field set — the exact state whose
+   * consequence the code above it describes as content stranded in the wrong table. Refusing leaves
+   * the registry describing the old shape, which is the shape the table still has.
+   *
+   * The runtime rebinding happens only after the move succeeds, for the reason the create path
+   * gives: the binding DESCRIBES the table, so describing a change that did not happen points the
+   * running process at columns nothing created.
+   */
+  private async reconcileCompanion(args: {
+    existing: DynamicFieldGroupRecord;
+    fields: FieldDefinition[];
+    localized: boolean;
+    wasLocalized: boolean;
+  }): Promise<void> {
+    const adapter = this.adapter;
+    if (!adapter) return;
+
+    const {
+      reconcileComponentCompanion,
+      registerComponentRuntimeSchema,
+      resolveComponentTypeColumn,
+    } = await import("./field-group-table-provisioning");
+
+    await reconcileComponentCompanion({
+      slug: args.existing.slug,
+      tableName: args.existing.tableName,
+      oldFields: args.existing.fields as unknown as FieldDefinition[],
+      newFields: args.fields,
+      localized: args.localized,
+      wasLocalized: args.wasLocalized,
+      adapter,
+    });
+
+    registerComponentRuntimeSchema(
+      adapter,
+      this.dialect,
+      args.existing.tableName,
+      args.fields as never,
+      // PROBED, not the constant: unlike the create path this table already exists and the storage
+      // migration may have moved it, so which discriminator column it carries is a fact about the
+      // database rather than something this code can infer from its own version.
+      await resolveComponentTypeColumn(adapter, args.existing.tableName),
+      args.localized
+    );
   }
 
   /**

--- a/packages/nextly/src/domains/field-groups/services/field-group-metadata-service.ts
+++ b/packages/nextly/src/domains/field-groups/services/field-group-metadata-service.ts
@@ -291,8 +291,19 @@ export class FieldGroupMetadataService {
       assertValidPluginFieldOptions(input.fields);
     }
 
+    // 🔴 Validated HERE, at the boundary every transport crosses, not in each transport. Fixing
+    // the dispatcher alone left the Direct API able to pass `localized: "false"` from JavaScript:
+    // the string is truthy, so the transition would enable and drop the main table's translatable
+    // columns while the registry, storing `data.localized === true`, recorded the group disabled.
+    // The declared type stops a TypeScript caller and stops nothing at runtime, which is exactly
+    // the difference this service exists to stop mattering.
+    const { readRequestLocalized } = await import(
+      "../../../dispatcher/helpers/request-localized"
+    );
+    const requestedLocalized = readRequestLocalized(input);
+
     const wasLocalized = existing.localized === true;
-    const localized = input.localized ?? wasLocalized;
+    const localized = requestedLocalized ?? wasLocalized;
     const fields = (input.fields ??
       existing.fields) as unknown as FieldDefinition[];
 
@@ -327,8 +338,8 @@ export class FieldGroupMetadataService {
           ? { description: input.description }
           : {}),
         ...(input.admin !== undefined ? { admin: input.admin } : {}),
-        ...(input.localized !== undefined
-          ? { localized: input.localized }
+        ...(requestedLocalized !== undefined
+          ? { localized: requestedLocalized }
           : {}),
         ...(input.fields !== undefined
           ? {

--- a/packages/nextly/src/domains/field-groups/services/field-group-metadata-service.ts
+++ b/packages/nextly/src/domains/field-groups/services/field-group-metadata-service.ts
@@ -248,11 +248,16 @@ export class FieldGroupMetadataService {
         adapter: this.adapter,
         logger: this.logger,
         label: `update field group "${input.slug}"`,
-        // A metadata-only edit issues none, but that is not known until the stored fields have been
-        // read — which happens inside. Claiming otherwise here would decide the question from the
-        // request shape, and a request that only toggles `localized` carries no fields while moving
-        // every translatable column.
-        issuesDdl: true,
+        // 🔴 Derived from the request, CONSERVATIVELY, because claiming DDL is not free: the
+        // exclusion may create and seed its lock table, and a deployment whose role holds DML but
+        // not DDL then fails an otherwise valid metadata edit on that `CREATE TABLE`.
+        //
+        // `fields` or `localized` being PRESENT is the conservative test, not whether they turn out
+        // to differ from what is stored. A `localized` toggle carries no fields while moving every
+        // translatable column, so reading the request for "does this touch schema" has to treat the
+        // key's presence as a yes — the comparison that would say otherwise needs the stored row,
+        // which cannot be read before deciding whether to take the lock that protects reading it.
+        issuesDdl: input.fields !== undefined || input.localized !== undefined,
       },
       () => this.updateFieldGroupExcluded(input)
     );
@@ -375,6 +380,16 @@ export class FieldGroupMetadataService {
       resolveComponentTypeColumn,
     } = await import("./field-group-table-provisioning");
 
+    // 🔴 Probed BEFORE the transition, which is the helper's own documented contract. Resolving it
+    // afterwards means a probe that cannot answer rejects the request with the physical move
+    // already committed — an enable that dropped the main table's columns while the registry still
+    // records the group as non-localized. The discriminator is unaffected by the transition, so
+    // asking first is equivalent and fails while nothing has moved.
+    const typeColumn = await resolveComponentTypeColumn(
+      adapter,
+      args.existing.tableName
+    );
+
     await reconcileComponentCompanion({
       slug: args.existing.slug,
       tableName: args.existing.tableName,
@@ -393,7 +408,7 @@ export class FieldGroupMetadataService {
       // PROBED, not the constant: unlike the create path this table already exists and the storage
       // migration may have moved it, so which discriminator column it carries is a fact about the
       // database rather than something this code can infer from its own version.
-      await resolveComponentTypeColumn(adapter, args.existing.tableName),
+      typeColumn,
       args.localized
     );
   }

--- a/packages/nextly/src/domains/field-groups/services/field-group-metadata-service.ts
+++ b/packages/nextly/src/domains/field-groups/services/field-group-metadata-service.ts
@@ -32,6 +32,7 @@
 
 import type { DrizzleAdapter } from "@nextlyhq/adapter-drizzle";
 
+import { readRequestLocalized } from "../../../dispatcher/helpers/request-localized";
 import { NextlyError } from "../../../errors";
 import type { FieldDefinition } from "../../../schemas/dynamic-collections";
 import type {
@@ -243,6 +244,14 @@ export class FieldGroupMetadataService {
   async updateFieldGroup(
     input: UpdateFieldGroupInput
   ): Promise<UpdateFieldGroupResult> {
+    // 🔴 Validated BEFORE the exclusion, because it is a PRECONDITION and preconditions run first.
+    // Inside, the flag below has already given this request permission to create the lock table, so
+    // a deployment whose role holds DML but not DDL answers an invalid `localized` with a database
+    // permission error instead of the validation error that actually describes it — a caller told
+    // the wrong thing about their own mistake. Nothing here reads the database, so there is no
+    // reason for it to wait behind a lock.
+    const requestedLocalized = readRequestLocalized(input);
+
     return withSchemaChangeExcluded(
       {
         adapter: this.adapter,
@@ -259,12 +268,14 @@ export class FieldGroupMetadataService {
         // which cannot be read before deciding whether to take the lock that protects reading it.
         issuesDdl: input.fields !== undefined || input.localized !== undefined,
       },
-      () => this.updateFieldGroupExcluded(input)
+      () => this.updateFieldGroupExcluded(input, requestedLocalized)
     );
   }
 
   private async updateFieldGroupExcluded(
-    input: UpdateFieldGroupInput
+    input: UpdateFieldGroupInput,
+    /** Already validated by the caller, which runs outside the lock. */
+    requestedLocalized: boolean | undefined
   ): Promise<UpdateFieldGroupResult> {
     // 0. RE-ESTABLISH every precondition, against the state as it is NOW.
     //
@@ -290,17 +301,6 @@ export class FieldGroupMetadataService {
       );
       assertValidPluginFieldOptions(input.fields);
     }
-
-    // 🔴 Validated HERE, at the boundary every transport crosses, not in each transport. Fixing
-    // the dispatcher alone left the Direct API able to pass `localized: "false"` from JavaScript:
-    // the string is truthy, so the transition would enable and drop the main table's translatable
-    // columns while the registry, storing `data.localized === true`, recorded the group disabled.
-    // The declared type stops a TypeScript caller and stops nothing at runtime, which is exactly
-    // the difference this service exists to stop mattering.
-    const { readRequestLocalized } = await import(
-      "../../../dispatcher/helpers/request-localized"
-    );
-    const requestedLocalized = readRequestLocalized(input);
 
     const wasLocalized = existing.localized === true;
     const localized = requestedLocalized ?? wasLocalized;

--- a/packages/nextly/src/domains/field-groups/services/field-group-table-provisioning.ts
+++ b/packages/nextly/src/domains/field-groups/services/field-group-table-provisioning.ts
@@ -208,3 +208,35 @@ export async function reconcileComponentCompanion(args: {
   // Runtime registration of the companion is handled by registerComponentRuntimeSchema(localized)
   // in the calling handlers, so no separate registration is needed here.
 }
+
+/**
+ * Which discriminator column a field group's table actually carries.
+ *
+ * PROBED rather than assumed, because the storage migration renames these tables and their
+ * columns: which spelling a given database uses is a fact about that database, not something a
+ * release can infer from its own version. The constant is the fallback for a table the probe
+ * cannot see, which is the shape a fresh install has.
+ *
+ * Here rather than private to a transport for the reason the rest of this module exists: the
+ * dispatcher held it, so every other transport that rebinds a runtime schema either reimplemented
+ * it or skipped it.
+ *
+ * 🔴 Call it BEFORE the DDL, never from inside `registerComponentRuntimeSchema`. That function's
+ * `catch` is a cache-refresh failsafe — it suppresses so a refresh problem cannot fail a request
+ * whose schema change already committed — and a catalog probe placed inside it inherits that
+ * policy, letting a caller report success while leaving the runtime table unregistered or holding
+ * obsolete columns. Resolving first is equivalent and safer: a schema change only ever alters user
+ * columns, so the discriminator is the same either side of it, and a probe that cannot answer
+ * fails the request before anything is committed.
+ */
+export async function resolveComponentTypeColumn(
+  adapter: DrizzleAdapter,
+  tableName: string
+): Promise<string> {
+  const { resolveTypeColumns } = await import(
+    "../storage/resolve-storage-names"
+  );
+  const { STORAGE_FORMAT } = await import("../../../schemas/storage-format");
+  const typeColumns = await resolveTypeColumns(adapter, [tableName]);
+  return typeColumns.get(tableName) ?? STORAGE_FORMAT.columns.type;
+}


### PR DESCRIPTION
Updating a field group could be done three ways, and only one of them changed the table.

## The defect

| transport | registry row | physical schema |
| --- | --- | --- |
| `dispatcher/handlers/component-dispatcher.ts` | written | moved |
| `api/field-groups-detail.ts` PATCH | written | **untouched** |
| `direct-api/namespaces/field-groups.ts` | written | **untouched** |

`field-group-registry-service.ts` imports no DDL machinery and issues none, so the latter two
stored a new field set and a matching `schema_hash` describing columns the table did not have.
The cause was structural rather than careless: the provisioning was private to the dispatcher,
so nothing else could reach it. This is the **same defect the create path already fixed** — its
own comment describes the other two transports "shipping a registry row describing a table that
was never made". It was still live on update.

Severity was bounded, and I checked both bounds rather than assuming them: the registry sets
`migration_status: "pending"` whenever fields change, and `previewComponentSchemaChanges` builds
its diff by introspecting the LIVE database rather than reading the stored hash. My first
hypothesis was that the hash update made the drift self-concealing. **It does not** — a preview
still sees the truth.

## Second defect, fixed by the same change

The dispatcher caught a failed companion reconcile, wrote `console.error`, and fell through to
the registry write. So a transition that FAILED still committed a row saying the field group was
localized with the new fields — precisely the state the comment four lines above warns strands
content in the wrong table. It now refuses, leaving the registry describing the shape the table
still has. (It was also a bare `console.error` inside `packages/nextly/**`.)

## What changed

`FieldGroupMetadataService.updateFieldGroup()` owns the lock check, the localization gate, the
plugin-option validation, the companion transition and the registry write, wrapped in
`withSchemaChangeExcluded`. All three transports call it and nothing else.

- Preconditions are re-read INSIDE the exclusion. Whether the group exists, whether it is locked
  and what its current fields are all decide what this does, and all three can change while a
  request waits for the lock.
- The companion transition runs BEFORE the runtime rebinding, because the binding *describes* the
  table — describing a change that did not happen points the process at columns nothing created.
- `resolveComponentTypeColumn` moves out of the dispatcher to sit beside the provisioning, so
  every transport that rebinds a schema reaches the same probe. Its rationale (call it before the
  DDL, never inside `registerComponentRuntimeSchema`, whose `catch` is a refresh failsafe) travels
  with it rather than being left behind as an orphaned comment.
- The mounted route now validates body property types instead of passing `unknown` through — a
  numeric `label` previously reached the registry and became the display name.
- `localized` is added to the Direct API's update args. The dispatcher could toggle it and the
  Direct API could not, which is the same asymmetry in a smaller form.

## On the exclusion

This takes field-group operations covered by `withSchemaChangeExcluded` from **4 of 12 to 5 of
12** (measured by enumeration, not memory: the only two files importing it are
`field-group-metadata-service.ts:130` and `single-metadata-service.ts:311,375,470`). The standing
blocker on arming the `nextly` CLI storage-migration entry point stays in place until all 12.

## Evidence

Two new assertions, each proven by breaking the code:

| break | fails |
| --- | --- |
| always send a property the request omitted | sends only the properties the request carried |
| write the registry with the wrong source | updateComponent returns `{ message, item }` |

A third break — unconditionally sending the property the test *does* send — **passed**, and is
recorded rather than hidden: it was the wrong break, aimed where the test could not see it. The
corrected one fails as intended.

One previously-failing test is fixed rather than left: `updateComponent returns { message, item }`
expected a message the handler stopped producing some releases ago. It sits on the exact handler
this PR converges, so a stale red there is what would have hidden a real regression from me.

- `build`, `check-types --force`, `lint`, `check-drizzle-v1-legacy`,
  `check:storage-format-literals` — all exit 0 from the worktree root
- affected suites (`field-groups`, `dispatcher`, `api`, `direct-api`): **8 failing → 7**, all 7
  confirmed present in the baseline measured at this branch's merge base; +1 test added
