### PR TITLE
fix(nextly): report the booted plugin list only while services are registered

### DIFF
--- a/packages/nextly/src/route-handler/__tests__/registration-input-stays-raw.test.ts
+++ b/packages/nextly/src/route-handler/__tests__/registration-input-stays-raw.test.ts
@@ -78,6 +78,10 @@ describe("the request-path registration input", () => {
    */
   it("still reports the booted list to readers of the config", async () => {
     const { getHandlerConfig } = await import("../auth-handler");
+    // The read is gated on a registered runtime, because the booted list
+    // describes one. This half of the pair is about what the store RECORDS, so
+    // it stands in the state where that gate is open.
+    isServicesRegistered.mockReturnValue(true);
 
     setHandlerConfig(raw);
     setHandlerPlugins(plugins("@acme/declared", "@acme/added-by-setup"));

--- a/packages/nextly/src/route-handler/auth-handler.ts
+++ b/packages/nextly/src/route-handler/auth-handler.ts
@@ -93,7 +93,16 @@ let _bootViewInputs: {
  */
 function bootView(): SanitizedNextlyConfig | null {
   const config = _storedConfig;
-  const plugins = globalForBoot.__nextly_bootPlugins;
+  // Gated on the canonical registration state rather than on the list having
+  // been cleared by whoever tore services down. The list describes a RUNNING
+  // runtime, so it is meaningful exactly while one is registered — and two
+  // functions clear that state (`shutdownServices`, `clearServices`), so a
+  // remembered-to-clear approach would be one edit away from the stale-read it
+  // is meant to prevent. Derived here, a teardown, a failed re-boot, and a
+  // process that never booted all fall back to the declared list on their own.
+  const plugins = isServicesRegistered()
+    ? globalForBoot.__nextly_bootPlugins
+    : undefined;
   if (!config || !plugins) return config;
 
   if (

--- a/packages/nextly/src/route-handler/set-handler-plugins.test.ts
+++ b/packages/nextly/src/route-handler/set-handler-plugins.test.ts
@@ -15,9 +15,10 @@ import type { PluginDefinition } from "../plugins/plugin-context";
 // a fresh store, and without this that re-import pulls the whole dependency
 // graph six times — measured at 10.07s against vitest's 10s default, which is
 // a timeout waiting for a loaded CI machine rather than a real failure.
+const servicesRegistered = vi.fn(() => true);
 vi.mock("../di", () => ({
   registerServices: vi.fn(),
-  isServicesRegistered: () => true,
+  isServicesRegistered: () => servicesRegistered(),
   shutdownServices: vi.fn(),
   getService: () => undefined,
 }));
@@ -63,6 +64,7 @@ describe("the handler config store", () => {
     vi.resetModules();
     delete (globalThis as { __nextly_bootPlugins?: unknown })
       .__nextly_bootPlugins;
+    servicesRegistered.mockReturnValue(true);
     store = await import("./auth-handler");
   });
 
@@ -156,6 +158,29 @@ describe("the handler config store", () => {
     store.setHandlerPlugins(plugins("@acme/transformed"));
 
     expect(store.getHandlerConfig()).toBeNull();
+  });
+
+  /**
+   * The list describes a RUNNING runtime. `shutdownServices()` and
+   * `clearServices()` both reset the registration flag, and a re-boot that then
+   * FAILS leaves no runtime at all — so continuing to substitute the previous
+   * boot's plugins would report a plugin set and route state that nothing is
+   * serving, indefinitely, since admin-meta never initializes services.
+   */
+  it("stops reporting the booted list once services are no longer registered", () => {
+    store.setHandlerConfig(stored);
+    store.setHandlerPlugins(plugins("@acme/transformed"));
+    expect(store.getHandlerConfig()?.plugins?.map(p => p.name)).toEqual([
+      "@acme/transformed",
+    ]);
+
+    servicesRegistered.mockReturnValue(false);
+
+    // Back to what the author declared, which is the honest answer when no
+    // successful boot stands behind the store.
+    expect(store.getHandlerConfig()?.plugins?.map(p => p.name)).toEqual([
+      "@acme/raw",
+    ]);
   });
 
   /**


### PR DESCRIPTION
Re-lands the final commit of #753, which was stranded when that PR merged.

## What was lost

`#753` merged as `85d526e39` from head `8cb7d8cfe`, but the branch tip was `fd3098ed2`. The last commit landed on the branch while GitHub was computing the merge, so it is on a merged branch and not on `main`.

Verified by content rather than inferred:

```
git grep -F -e 'const plugins = isServicesRegistered()' origin/main -- packages/nextly/src/route-handler/auth-handler.ts
  -> ABSENT
git log --oneline <ghHeadRefOid>..<ls-remote tip>
  -> fd3098ed2  fix(nextly): report the booted plugin list only while services are registered
```

The control for that search: the same marker IS found on `fd3098ed2`, so the absence is a real absence and not a mistyped path.

## What it fixes

`bootView()` substitutes the booted plugin list into the stored config. Publication already waited for a successful registration, but nothing stopped it on teardown: `shutdownServices()` and `clearServices()` both reset `__nextly_isRegistered` and neither cleared `__nextly_bootPlugins`. A re-boot that then FAILS left `/admin-meta` substituting the previous boot's plugins into the current stored config indefinitely — reporting a plugin set and route state that nothing is serving, and admin-meta never initializes services, so nothing downstream corrects it.

The read is now gated on `isServicesRegistered()` rather than on the list being cleared. Deriving from the canonical state rather than clearing at each teardown means a third teardown added later cannot reintroduce this — there is nothing to remember.

## Tests

`stops reporting the booted list once services are no longer registered` — record a boot, read the transformed list, flip registration off, get the author's declared list back. Break-verified: ungating the read fails it.

`still reports the booted list to readers of the config` in `registration-input-stays-raw.test.ts` now sets registration true explicitly. It had been passing on an ungated read, so leaving it would have quietly become a test of nothing.

## Changeset

None: this re-lands a commit whose changeset merged with #753.