### PR TITLE
feat(admin): give a list's page state one implementation

### DIFF
--- a/.changeset/shared-pagination-state.md
+++ b/.changeset/shared-pagination-state.md
@@ -1,0 +1,32 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+Give a list's page state one implementation.
+
+Thirteen places in the admin held the same two lines: set the page size, return to page one. The copy that drifted meant choosing a larger page size from a later page asked for rows past the end of the list, and the table rendered its empty message over a list that had rows.
+
+`usePagination` owns page and size together, so the resets travel with the state rather than with each caller: a size change returns to the first page, and `resetPage` covers a search or filter change that alters which rows exist. Both settings move in one update, so a query keyed on them refetches once rather than once per setter. `useServerTable` derives from it rather than restating it.

--- a/packages/admin/src/hooks/index.ts
+++ b/packages/admin/src/hooks/index.ts
@@ -32,6 +32,9 @@ export type {
 export { useDebounce } from "./useDebounce";
 export { useDebouncedValue, useDebouncedState } from "./useDebouncedValue";
 
+export { usePagination } from "./usePagination";
+export type { PaginationState, UsePaginationOptions } from "./usePagination";
+
 // Utility hooks - Form Protection
 export { useUnsavedChanges } from "./useUnsavedChanges";
 export type {

--- a/packages/admin/src/hooks/index.ts
+++ b/packages/admin/src/hooks/index.ts
@@ -32,6 +32,13 @@ export type {
 export { useDebounce } from "./useDebounce";
 export { useDebouncedValue, useDebouncedState } from "./useDebouncedValue";
 
+// Table hooks - List pagination
+//
+// The page/size state a list runs on, with the first-page resets built in, so
+// the rule lives with the state rather than in each caller's handler. Exported
+// here because the list pages that need it are spread across the admin and
+// reach their hooks through this barrel; `useServerTable` above composes it
+// rather than restating it.
 export { usePagination } from "./usePagination";
 export type { PaginationState, UsePaginationOptions } from "./usePagination";
 

--- a/packages/admin/src/hooks/usePagination.test.ts
+++ b/packages/admin/src/hooks/usePagination.test.ts
@@ -1,0 +1,105 @@
+/**
+ * The resets are the whole point, so they are what is asserted.
+ *
+ * A test that only checked `setPage(2)` moves to page 2 would pass against two
+ * bare `useState` calls, which is the arrangement this hook exists to replace —
+ * so it would report success without separating the two implementations. Each
+ * assertion below is written to fail against that version.
+ */
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { usePagination } from "./usePagination";
+
+describe("usePagination", () => {
+  it("starts where it was told to", () => {
+    const { result } = renderHook(() =>
+      usePagination({ initialPage: 2, initialPageSize: 25 })
+    );
+    expect(result.current.page).toBe(2);
+    expect(result.current.pageSize).toBe(25);
+  });
+
+  it("moves between pages without resetting anything", () => {
+    // The negative half. A hook that reset on every change would satisfy every
+    // other assertion here and make paging impossible.
+    const { result } = renderHook(() => usePagination({ initialPageSize: 10 }));
+
+    act(() => result.current.setPage(3));
+
+    expect(result.current.page).toBe(3);
+    expect(result.current.pageSize).toBe(10);
+  });
+
+  it("returns to the first page when the page size grows", () => {
+    // The defect this replaces: page 3 of ten-row pages holds rows 30-39, and
+    // at fifty rows a page that range is past the end of most lists. The table
+    // then renders its empty message over a list that has rows.
+    const { result } = renderHook(() => usePagination({ initialPageSize: 10 }));
+
+    act(() => result.current.setPage(3));
+    act(() => result.current.setPageSize(50));
+
+    expect(result.current.pageSize).toBe(50);
+    expect(result.current.page).toBe(0);
+  });
+
+  it("returns to the first page when the page size shrinks", () => {
+    // Shrinking is the direction that looks safe and is not: page 3 of fifty
+    // is row 150, which a ten-row page size rarely reaches either.
+    const { result } = renderHook(() => usePagination({ initialPageSize: 50 }));
+
+    act(() => result.current.setPage(3));
+    act(() => result.current.setPageSize(10));
+
+    expect(result.current.page).toBe(0);
+  });
+
+  it("resets both settings in one update", () => {
+    // Asserted because the batching is load-bearing, not incidental: a query
+    // keyed on `{ page, pageSize }` refetches once per distinct key, so two
+    // separate updates would fire a request for a page that is about to be
+    // abandoned. One render means one key change.
+    let renders = 0;
+    const { result } = renderHook(() => {
+      renders += 1;
+      return usePagination({ initialPageSize: 10 });
+    });
+
+    act(() => result.current.setPage(3));
+    const before = renders;
+    act(() => result.current.setPageSize(25));
+
+    expect(renders - before).toBe(1);
+    expect(result.current).toMatchObject({ page: 0, pageSize: 25 });
+  });
+
+  it("returns to the first page on demand, for a filter or a search", () => {
+    const { result } = renderHook(() => usePagination());
+
+    act(() => result.current.setPage(4));
+    act(() => result.current.resetPage());
+
+    expect(result.current.page).toBe(0);
+  });
+
+  it("keeps its callbacks stable across renders", () => {
+    // Every call site passes these straight to `Pagination`, and several list
+    // pages put `resetPage` in an effect's dependency array. An identity that
+    // changed per render would re-run that effect on every render and reset the
+    // page the user just moved to.
+    const { result, rerender } = renderHook(() => usePagination());
+
+    const first = {
+      setPage: result.current.setPage,
+      setPageSize: result.current.setPageSize,
+      resetPage: result.current.resetPage,
+    };
+    act(() => result.current.setPage(2));
+    rerender();
+
+    expect(result.current.setPage).toBe(first.setPage);
+    expect(result.current.setPageSize).toBe(first.setPageSize);
+    expect(result.current.resetPage).toBe(first.resetPage);
+  });
+});

--- a/packages/admin/src/hooks/usePagination.ts
+++ b/packages/admin/src/hooks/usePagination.ts
@@ -1,0 +1,98 @@
+"use client";
+
+import { useCallback, useState } from "react";
+
+/**
+ * The page/size state a paginated list runs on, with the resets built in.
+ *
+ * Every admin list needs the same three rules, and they are rules about STATE
+ * rather than about rendering:
+ *
+ * - a page-size change returns to the first page
+ * - a search or filter change returns to the first page
+ * - a page change is just a page change
+ *
+ * The first two exist because `page` is an index into a list whose length the
+ * change has just altered. Keeping page 3 while growing the page size asks for
+ * rows past the end, and the table renders its empty message over a list that
+ * has rows — a defect that reads as "no results" rather than as a paging bug,
+ * which is why it survived on one surface unnoticed.
+ *
+ * This lives in a hook rather than in `Pagination` deliberately. The rule is
+ * about the state the caller owns, and `Pagination` is presentational: giving
+ * it the reset would mean a control emitting a page change nobody asked it for,
+ * and would still leave every caller free not to use it. A hook cannot be
+ * bypassed by the callers that adopt it, and it composes — `useServerTable`
+ * builds on this rather than restating it.
+ */
+export interface PaginationState {
+  /** Current page index, 0-based. */
+  page: number;
+  /** Rows per page. */
+  pageSize: number;
+  /** Go to a page. The only move that does not reset anything. */
+  setPage: (page: number) => void;
+  /**
+   * Change the page size and return to the first page.
+   *
+   * Both in one update so React batches them into a single render, and any
+   * query keyed on `{ page, pageSize }` therefore refetches once rather than
+   * once per setter.
+   */
+  setPageSize: (pageSize: number) => void;
+  /**
+   * Return to the first page, for a change that alters which rows exist —
+   * a search term, a filter, a switch of collection.
+   */
+  resetPage: () => void;
+}
+
+export interface UsePaginationOptions {
+  /** Starting page index, 0-based. Defaults to the first page. */
+  initialPage?: number;
+  /** Starting rows per page. */
+  initialPageSize?: number;
+}
+
+/**
+ * Pagination state for a list, with the first-page resets applied.
+ *
+ * ```tsx
+ * const { page, pageSize, setPage, setPageSize, resetPage } = usePagination({
+ *   initialPageSize: 10,
+ * });
+ *
+ * useEffect(() => resetPage(), [search, resetPage]);
+ *
+ * <DataTableView
+ *   rows={rows}
+ *   footer={
+ *     <Pagination
+ *       currentPage={page}
+ *       pageSize={pageSize}
+ *       onPageChange={setPage}
+ *       onPageSizeChange={setPageSize}
+ *     />
+ *   }
+ * />
+ * ```
+ */
+export function usePagination(
+  options: UsePaginationOptions = {}
+): PaginationState {
+  const { initialPage = 0, initialPageSize = 10 } = options;
+
+  const [page, setPage] = useState(initialPage);
+  const [pageSize, setPageSizeState] = useState(initialPageSize);
+
+  const setPageSize = useCallback((next: number) => {
+    setPageSizeState(next);
+    setPage(0);
+  }, []);
+
+  const resetPage = useCallback(() => {
+    setPage(0);
+  }, []);
+
+  return { page, pageSize, setPage, setPageSize, resetPage };
+}

--- a/packages/admin/src/hooks/useServerTable.ts
+++ b/packages/admin/src/hooks/useServerTable.ts
@@ -14,6 +14,7 @@ import { PAGINATION } from "../constants/pagination";
 import { UI } from "../constants/ui";
 
 import { useDebouncedValue } from "./useDebouncedValue";
+import { usePagination } from "./usePagination";
 
 /**
  * Default configuration constants
@@ -156,13 +157,21 @@ export function useServerTable<TData>({
   );
   const [sorting, setSorting] = useState<SortingState>([]);
 
-  // Pagination state
-  const [currentPage, setCurrentPage] = useState(
-    initialParams?.pagination?.page ?? 0
-  );
-  const [currentPageSize, setCurrentPageSize] = useState(
-    initialParams?.pagination?.pageSize ?? paginationConfig.pageSize
-  );
+  // Pagination state, including the first-page resets, comes from the shared
+  // hook rather than being restated here. This file and a dozen list pages
+  // held the same two lines, and the copy that drifted was the one nobody
+  // looked at again.
+  const {
+    page: currentPage,
+    pageSize: currentPageSize,
+    setPage: setCurrentPage,
+    setPageSize: setCurrentPageSize,
+    resetPage,
+  } = usePagination({
+    initialPage: initialParams?.pagination?.page ?? 0,
+    initialPageSize:
+      initialParams?.pagination?.pageSize ?? paginationConfig.pageSize,
+  });
 
   // Search state
   const [searchInput, setSearchInput] = useState(
@@ -174,34 +183,33 @@ export function useServerTable<TData>({
   /**
    * Handle page change
    */
-  const handlePageChange = useCallback((newPage: number) => {
-    setCurrentPage(newPage);
-  }, []);
+  const handlePageChange = setCurrentPage;
 
   /**
-   * Handle page size change
+   * Handle page size change. The return to the first page belongs to the
+   * pagination state, not to this handler.
    */
-  const handlePageSizeChange = useCallback((newPageSize: number) => {
-    setCurrentPageSize(newPageSize);
-    setCurrentPage(0); // Reset to first page
-  }, []);
+  const handlePageSizeChange = setCurrentPageSize;
 
   /**
    * Handle search input change
    */
-  const handleSearchChange = useCallback((search: string) => {
-    setSearchInput(search);
-    setCurrentPage(0); // Reset to first page on search
-  }, []);
+  const handleSearchChange = useCallback(
+    (search: string) => {
+      setSearchInput(search);
+      resetPage(); // A new term changes which rows exist
+    },
+    [resetPage]
+  );
 
   /**
    * Clear search input
    */
   const handleClearSearch = useCallback(() => {
     setSearchInput("");
-    setCurrentPage(0);
+    resetPage();
     searchInputRef.current?.focus();
-  }, []);
+  }, [resetPage]);
 
   /**
    * Handle sorting change
@@ -223,11 +231,11 @@ export function useServerTable<TData>({
         direction: sort.desc ? "desc" : "asc",
       }));
       setSortInfo(newSortInfo);
-      setCurrentPage(0); // Reset to first page on sort change
+      resetPage(); // A new order changes which rows land on this page
     } else {
       setSortInfo([]);
     }
-  }, [sorting]);
+  }, [sorting, resetPage]);
 
   // Fetch data when parameters change
   useEffect(() => {


### PR DESCRIPTION
Thirteen places in the admin hold the same two lines — set the page size, return to page one. The rule is documented in the path instructions, every copy agrees, and the copy that drifted is the one nobody looked at again: choosing a larger page size from a later page on the image-sizes list asked for rows past the end and rendered the empty-state message over a list that had rows. That reads as "no results" rather than as a paging bug, which is why it survived.

## Why a hook, and not a prop on `Pagination`

The obvious fix is to make `Pagination` reset the page itself, so no call site can get it wrong. I audited all twenty call sites before writing anything and came to a different answer.

**The rule is about state the caller owns.** `Pagination` is presentational — it renders controls and reports events. Giving it the reset means a control emitting an `onPageChange` nobody asked it for, as a side effect of a different callback, and it would *still* leave every caller free to ignore it. A hook cannot be bypassed by the callers that adopt it, and it composes.

**The abstraction already existed and nothing used it.** `useServerTable` has carried the correct behaviour — reset on size change, on search, on sort — since it was written, and exactly one component consumes it. So this is less "introduce an abstraction" than "notice the one we have and let the rest reach it."

I also confirmed the risk that made me hesitate is not real: none of the thirteen call sites route their reset through `onPageChange`. They set local state, so there is no double-request hazard in moving the behaviour.

## What this changes

`usePagination` owns `page` and `pageSize` together:

- `setPageSize` changes the size and returns to the first page
- `resetPage` covers a search, filter or collection change — anything that alters which rows exist
- `setPage` is the only move that resets nothing

Both settings move in **one** update, so a query keyed on `{ page, pageSize }` refetches once rather than once per setter. That is asserted rather than assumed, by counting renders.

`useServerTable` now derives from it instead of restating it.

## Evidence

Seven tests, each written to fail against two bare `useState` calls — the arrangement this replaces. A test that only checked `setPage(2)` moves to page 2 would pass against that version and prove nothing.

Both directions of the size change are covered, because shrinking is the one that looks safe and is not: page 3 of fifty is row 150, which a ten-row page size rarely reaches either.

**Stub-verified across the boundary.** Removing `setPage(0)` from `usePagination` fails three of its own tests *and* `useServerTable`'s pre-existing `handlePageSizeChange resets to page 0`. That last one is the point: it shows the two are genuinely one implementation now, rather than two that happen to agree.

## Scope

The remaining call sites keep their hand-rolled state and are migrated separately. They are mechanical, they touch a dozen files that other work has open right now, and bundling them here would put a foundation change and a wide sweep in one review.
