### PR TITLE
fix(nextly): refuse to start when boot migrations did not run

### DIFF
--- a/.changeset/boot-refuses-unrun-migrations.md
+++ b/.changeset/boot-refuses-unrun-migrations.md
@@ -1,0 +1,40 @@
+---
+"nextly": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+"create-nextly-app": patch
+---
+
+Refuse to start when boot migrations did not run. With `db.runMigrationsOnBoot`,
+an instance that could not take the migrate lock before its wait deadline used
+to log `Boot migrations complete (0 applied)` and serve traffic — `applied` is 0
+there and 0 on an up-to-date database, so nothing distinguished them. On a
+rolling deploy that is the second replica serving against a schema it never
+migrated. It now fails startup, which an orchestrator retries once the other
+instance finishes; a genuinely stale lock is cleared with
+`nextly migrate --force-unlock`.
+
+`withMigrateLock` reports whether its body ran instead of returning `undefined`
+for both "returned nothing" and "never ran", so every caller has to decide. Its
+wait-timeout message said "proceeding without it" while returning without
+running the migrations, and now says they were skipped.

--- a/packages/nextly/src/__tests__/serving-waits-for-boot-migrations.test.ts
+++ b/packages/nextly/src/__tests__/serving-waits-for-boot-migrations.test.ts
@@ -1,0 +1,53 @@
+/**
+ * The gate is only worth anything if the SERVING surfaces consult it.
+ *
+ * `getCachedNextly()` is the one that made the race real: it builds and returns
+ * an instance on `isServicesRegistered()` alone, and that flag is true
+ * throughout another surface's migration wait. Wiring the gate into the module
+ * that owns it is not the same as wiring it into the callers, and only the
+ * second one stops a request being served.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const awaitBootMigrations = vi.fn();
+
+vi.mock("../init/boot-migrations-gate", () => ({
+  awaitBootMigrations: () => awaitBootMigrations(),
+  beginBootMigrations: () => ({ allow: vi.fn(), refuse: vi.fn() }),
+}));
+
+const { getCachedNextly } = await import("../init");
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  awaitBootMigrations.mockResolvedValue(undefined);
+  // The cached instance is the FIRST early return in `getCachedNextly`, so it
+  // is the hardest case for the gate: the check has to precede it.
+  (
+    globalThis as { __nextly_cachedInstance?: unknown }
+  ).__nextly_cachedInstance = { find: vi.fn() };
+});
+
+describe("serving surfaces consult the boot-migrations gate", () => {
+  it("refuses a cached instance when the gate refuses", async () => {
+    awaitBootMigrations.mockRejectedValue(
+      Object.assign(new Error("refused"), {
+        code: "NEXTLY_BOOT_MIGRATIONS_NOT_RUN",
+      })
+    );
+
+    await expect(getCachedNextly()).rejects.toMatchObject({
+      code: "NEXTLY_BOOT_MIGRATIONS_NOT_RUN",
+    });
+  });
+
+  /**
+   * The control. Without it the assertion above is satisfied by a function that
+   * throws unconditionally, and by one that never returns the cached instance
+   * at all.
+   */
+  it("returns the cached instance when the gate allows", async () => {
+    await expect(getCachedNextly()).resolves.toBeDefined();
+    expect(awaitBootMigrations).toHaveBeenCalled();
+  });
+});

--- a/packages/nextly/src/__tests__/serving-waits-for-boot-migrations.test.ts
+++ b/packages/nextly/src/__tests__/serving-waits-for-boot-migrations.test.ts
@@ -10,6 +10,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const awaitBootMigrations = vi.fn();
+let cached: { find: unknown };
 
 vi.mock("../init/boot-migrations-gate", () => ({
   awaitBootMigrations: () => awaitBootMigrations(),
@@ -23,9 +24,10 @@ beforeEach(() => {
   awaitBootMigrations.mockResolvedValue(undefined);
   // The cached instance is the FIRST early return in `getCachedNextly`, so it
   // is the hardest case for the gate: the check has to precede it.
+  cached = { find: vi.fn() };
   (
     globalThis as { __nextly_cachedInstance?: unknown }
-  ).__nextly_cachedInstance = { find: vi.fn() };
+  ).__nextly_cachedInstance = cached;
 });
 
 describe("serving surfaces consult the boot-migrations gate", () => {
@@ -47,7 +49,10 @@ describe("serving surfaces consult the boot-migrations gate", () => {
    * at all.
    */
   it("returns the cached instance when the gate allows", async () => {
-    await expect(getCachedNextly()).resolves.toBeDefined();
+    // Identity, not `toBeDefined()`: that also passed when `getCachedNextly`
+    // built a fallback instance or returned something unrelated, so it did not
+    // pin the property it was named for.
+    await expect(getCachedNextly()).resolves.toBe(cached);
     expect(awaitBootMigrations).toHaveBeenCalled();
   });
 });

--- a/packages/nextly/src/cli/commands/__tests__/migrate-core.test.ts
+++ b/packages/nextly/src/cli/commands/__tests__/migrate-core.test.ts
@@ -17,9 +17,17 @@ function deps(over: Record<string, unknown> = {}) {
     lockMode: "fail-fast" as const,
     reconcileCoreFn: vi.fn(async () => ({ changed: false })),
     runFileMigrationsFn: vi.fn(async () => 0),
-    // pass-through lock that just runs fn (so we test the core, not the lock)
-    withLock: async (_db: unknown, _d: unknown, fn: () => Promise<unknown>) =>
-      fn(),
+    // Pass-through lock that just runs fn (so we test the core, not the lock),
+    // in the real shape: the outcome is discriminated so a caller cannot
+    // confuse "returned undefined" with "never ran".
+    withLock: async (
+      _db: unknown,
+      _d: unknown,
+      fn: () => Promise<unknown>
+    ) => ({
+      ran: true as const,
+      value: await fn(),
+    }),
     ...over,
   };
 }

--- a/packages/nextly/src/cli/commands/__tests__/migrate-down.test.ts
+++ b/packages/nextly/src/cli/commands/__tests__/migrate-down.test.ts
@@ -75,7 +75,7 @@ function baseDeps(overrides: Record<string, unknown> = {}) {
         _db: unknown,
         _d: unknown,
         fn: () => Promise<T>
-      ): Promise<T> => fn(),
+      ): Promise<{ ran: true; value: T }> => ({ ran: true, value: await fn() }),
       ...overrides,
     },
   };

--- a/packages/nextly/src/cli/commands/migrate-baseline.ts
+++ b/packages/nextly/src/cli/commands/migrate-baseline.ts
@@ -600,11 +600,11 @@ export async function baselineCore(
     { ttlSeconds: deps.ttlSeconds }
   );
 
-  // `withMigrateLock` resolves without running its body only in "wait" mode,
-  // where another process is expected to have done the work. Adoption is never
-  // that: nobody else is going to baseline this database, so an empty result
-  // here would mean reporting success for a history that was never started.
-  if (result === undefined) {
+  // `withMigrateLock` reports `ran: false` only in "wait" mode. Adoption is
+  // never a case where someone else did the work: nobody else is going to
+  // baseline this database, so returning here would mean reporting success for
+  // a history that was never started.
+  if (!result.ran) {
     throw new NextlyError({
       code: "NEXTLY_BASELINE_LOCK_NOT_HELD",
       publicMessage:
@@ -612,7 +612,7 @@ export async function baselineCore(
         "Nothing was written; retry once no other schema operation is running.",
     });
   }
-  return result;
+  return result.value;
 }
 
 export async function runMigrateBaseline(

--- a/packages/nextly/src/cli/commands/migrate-resolve.ts
+++ b/packages/nextly/src/cli/commands/migrate-resolve.ts
@@ -27,7 +27,7 @@ import { introspectLiveSnapshot } from "../../domains/schema/pipeline/diff/intro
 import type { NextlySchemaSnapshot } from "../../domains/schema/pipeline/diff/types";
 import { withMigrateLock } from "../../domains/schema/pipeline/locks";
 import { snapshotComparableTables } from "../../domains/schema/pipeline/managed-tables";
-import { describeError } from "../../errors/index";
+import { describeError, NextlyError } from "../../errors/index";
 import { createContext, type CommandContext } from "../program";
 import {
   createAdapter,
@@ -151,9 +151,7 @@ export async function runMigrateResolve(
     // this flag, and recovery is exactly when a stale lock is most likely.
     await maybeForceUnlock(options, db, dialect);
 
-    // fail-fast mode (the default) never returns undefined — it runs fn or
-    // throws — so the non-null assertion below is safe.
-    const result = (await withMigrateLock(db, dialect, () =>
+    const outcome = await withMigrateLock(db, dialect, () =>
       resolveMigration({
         mode,
         filename,
@@ -204,7 +202,20 @@ export async function runMigrateResolve(
           return introspectLiveSnapshot(db, dialect, managed);
         },
       })
-    ))!;
+    );
+
+    // Fail-fast mode: a busy lock throws rather than reporting `ran: false`, so
+    // this branch is unreachable today. Asserted rather than assumed, because
+    // "unreachable" is a property of the caller's options and those move.
+    if (!outcome.ran) {
+      throw new NextlyError({
+        code: "NEXTLY_RESOLVE_LOCK_NOT_HELD",
+        publicMessage:
+          "The migrate lock was released without resolving the migration. " +
+          "Nothing was written; retry once no other schema operation is running.",
+      });
+    }
+    const result = outcome.value;
 
     switch (result.kind) {
       case "applied":

--- a/packages/nextly/src/cli/commands/migrate.ts
+++ b/packages/nextly/src/cli/commands/migrate.ts
@@ -421,6 +421,16 @@ export interface MigrateCoreDeps {
 export interface MigrateCoreResult {
   applied: number;
   coreChanged: boolean;
+  /**
+   * Whether the migration body actually RAN.
+   *
+   * `false` only in `"wait"` mode, where the lock stayed held past the wait
+   * deadline. `applied` is 0 in that case and so is it on an up-to-date
+   * database — the two are indistinguishable without this flag, which is how
+   * production boot came to log `Boot migrations complete (0 applied)` for
+   * migrations that never started.
+   */
+  ran: boolean;
 }
 
 /** Clear a stale migrate lock when `--force-unlock` was passed (else no-op). */
@@ -442,7 +452,7 @@ export async function migrateCore(
   let applied = 0;
   let coreChanged = false;
 
-  await lock(
+  const outcome = await lock(
     deps.db,
     deps.dialect,
     async () => {
@@ -490,7 +500,7 @@ export async function migrateCore(
     }
   );
 
-  return { applied, coreChanged };
+  return { applied, coreChanged, ran: outcome.ran };
 }
 
 /**

--- a/packages/nextly/src/di/register.ts
+++ b/packages/nextly/src/di/register.ts
@@ -97,6 +97,7 @@ import {
 import { registerCollectionHooks } from "../hooks/register-collection-hooks";
 import { registerSingleHooks } from "../hooks/register-single-hooks";
 import { createSanitizationHook } from "../hooks/sanitization-hooks";
+import { openBootMigrationsGate } from "../init/boot-migrations-gate";
 import type { PluginPermission, PluginRole } from "../plugins/contributions";
 import { getCoreVersion } from "../plugins/core-version";
 import { warnUndescribedPlugins } from "../plugins/describe-check";
@@ -235,6 +236,15 @@ export interface NextlyServiceConfig {
 
   /** Optional directory for dynamic collection schemas. */
   schemasDir?: string;
+  /**
+   * Whether this boot will run migrations, so registration can open the
+   * boot-migrations gate before it publishes the container.
+   *
+   * Carried on the SERVICE config rather than read from `db` — which this shape
+   * flattens away — because `buildServiceConfig` is the one builder both boot
+   * paths use, so threading it there reaches both without either remembering.
+   */
+  runMigrationsOnBoot?: boolean;
 
   /** Optional directory for dynamic collection migrations. */
   migrationsDir?: string;
@@ -542,6 +552,15 @@ export async function registerServices(
   // would newly refuse pre-existing declarations that boot fine today, whereas a
   // rule that can fire here has to have been written against a field type in
   // this same process.
+  // Opened HERE, before anything publishes the container, because this is the
+  // only boundary both boot paths cross. The request path publishes services
+  // and calls the migration helper afterwards, so opening it there left a
+  // window in which registration was visible and the gate was not yet closed —
+  // a concurrent `getNextly()` served inside it. No-op unless production boot
+  // migrations are configured, so the CLI and the test harness never open a
+  // gate nothing would settle.
+  openBootMigrationsGate(transformedConfig.runMigrationsOnBoot === true);
+
   assertPluginFieldDeclarations(transformedConfig);
 
   const {

--- a/packages/nextly/src/di/register.ts
+++ b/packages/nextly/src/di/register.ts
@@ -552,14 +552,6 @@ export async function registerServices(
   // would newly refuse pre-existing declarations that boot fine today, whereas a
   // rule that can fire here has to have been written against a field type in
   // this same process.
-  // Opened HERE, before anything publishes the container, because this is the
-  // only boundary both boot paths cross. The request path publishes services
-  // and calls the migration helper afterwards, so opening it there left a
-  // window in which registration was visible and the gate was not yet closed —
-  // a concurrent `getNextly()` served inside it. No-op unless production boot
-  // migrations are configured, so the CLI and the test harness never open a
-  // gate nothing would settle.
-  openBootMigrationsGate(transformedConfig.runMigrationsOnBoot === true);
 
   assertPluginFieldDeclarations(transformedConfig);
 
@@ -1114,6 +1106,22 @@ export async function registerServices(
   if (!container.has("nextlyDirectAPI")) {
     container.register("nextlyDirectAPI", () => getNextly());
   }
+
+  // Opened immediately BEFORE registration publishes, which is the last point
+  // that is both late enough and early enough.
+  //
+  // Early enough: the window this closes is "registered but schema unverified",
+  // and the flag below is what opens that window — so a consumer can never see
+  // registration without also seeing the gate.
+  //
+  // Late enough: everything that can abort a registration — adapter connection,
+  // schema synchronisation, plugin init — has already run. An abort therefore
+  // never leaves a gate open with nobody left to settle it, which would block
+  // every later retry forever on a gate whose owner died.
+  //
+  // No-op unless production boot migrations are configured, so the CLI and the
+  // test harness never open a gate nothing would close.
+  openBootMigrationsGate(transformedConfig.runMigrationsOnBoot === true);
 
   globalForReg.__nextly_isRegistered = true;
 

--- a/packages/nextly/src/di/register.ts
+++ b/packages/nextly/src/di/register.ts
@@ -1121,7 +1121,15 @@ export async function registerServices(
   //
   // No-op unless production boot migrations are configured, so the CLI and the
   // test harness never open a gate nothing would close.
-  openBootMigrationsGate(transformedConfig.runMigrationsOnBoot === true);
+  // The UNTRANSFORMED flag, matching what `runProdMigrationsIfEnabled` reads.
+  // `transformedConfig` is the config after plugin `setup` transformers have
+  // run, and that side decides from the nested `db` block, so reading the
+  // transformed value here lets a transformer make the two disagree — opening
+  // no gate while migrations run, or a gate nothing settles. No first-party
+  // transformer touches it today, which is a property of the current plugin set
+  // rather than of the code, and this PR exists because of a window nobody
+  // thought reachable.
+  openBootMigrationsGate(config.runMigrationsOnBoot === true);
 
   globalForReg.__nextly_isRegistered = true;
 

--- a/packages/nextly/src/direct-api/__tests__/gate-before-direct-api.test.ts
+++ b/packages/nextly/src/direct-api/__tests__/gate-before-direct-api.test.ts
@@ -16,7 +16,13 @@ const assertBootMigrationsSettled = vi.fn();
 vi.mock("../../init/boot-migrations-gate", () => ({
   assertBootMigrationsSettled: () => assertBootMigrationsSettled(),
 }));
-vi.mock("../../di", () => ({ isServicesRegistered: () => true }));
+// `../di/register`, which is what `nextly.ts` actually imports — mocking
+// `../di` left the real one in place and it returned false, so the control
+// failed for a reason that had nothing to do with the gate.
+vi.mock("../../di/register", () => ({
+  isServicesRegistered: () => true,
+  getService: () => undefined,
+}));
 
 const { getNextly } = await import("../nextly");
 

--- a/packages/nextly/src/direct-api/__tests__/gate-before-direct-api.test.ts
+++ b/packages/nextly/src/direct-api/__tests__/gate-before-direct-api.test.ts
@@ -1,0 +1,52 @@
+/**
+ * The Direct API's `getNextly()` is exported from the package root, so a Server
+ * Component can call `nextly.find()` on it. It is SYNCHRONOUS, so it cannot
+ * wait for boot migrations the way the async surfaces do — and it decided
+ * readiness from `isServicesRegistered()` alone, which is true throughout a
+ * production boot's migration wait.
+ *
+ * Wiring the assertion into the gate module is not the same as wiring it into
+ * this caller, and only the second one stops a query reaching an unverified
+ * schema.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const assertBootMigrationsSettled = vi.fn();
+
+vi.mock("../../init/boot-migrations-gate", () => ({
+  assertBootMigrationsSettled: () => assertBootMigrationsSettled(),
+}));
+vi.mock("../../di", () => ({ isServicesRegistered: () => true }));
+
+const { getNextly } = await import("../nextly");
+
+beforeEach(() => {
+  // `mockReset`, not `clearAllMocks`: the latter clears recorded CALLS but
+  // leaves the implementation in place, so the throwing stub from one case
+  // leaked into the control below and made it fail for the wrong reason.
+  assertBootMigrationsSettled.mockReset();
+});
+
+describe("the Direct API consults the boot-migrations gate", () => {
+  it("refuses while the gate is unsettled", () => {
+    assertBootMigrationsSettled.mockImplementation(() => {
+      throw Object.assign(new Error("pending"), {
+        code: "NEXTLY_BOOT_MIGRATIONS_PENDING",
+      });
+    });
+
+    expect(() => getNextly()).toThrow(
+      expect.objectContaining({ code: "NEXTLY_BOOT_MIGRATIONS_PENDING" })
+    );
+  });
+
+  /**
+   * The control. Without it the assertion above is satisfied by a `getNextly`
+   * that throws unconditionally — which would break every Direct API call in
+   * development and in any app that does not run boot migrations.
+   */
+  it("returns an instance once the gate has settled", () => {
+    expect(() => getNextly()).not.toThrow();
+    expect(assertBootMigrationsSettled).toHaveBeenCalled();
+  });
+});

--- a/packages/nextly/src/direct-api/nextly.ts
+++ b/packages/nextly/src/direct-api/nextly.ts
@@ -59,6 +59,7 @@ import { RolePermissionService } from "../domains/auth/services/role-permission-
 import { RoleService } from "../domains/auth/services/role-service";
 import type { FieldGroupMetadataService } from "../domains/field-groups/services/field-group-metadata-service";
 import { NextlyError } from "../errors/nextly-error";
+import { assertBootMigrationsSettled } from "../init/boot-migrations-gate";
 import { buildPluginServicesNamespace } from "../plugins/services/plugin-services-registry";
 import type { CollectionsHandler } from "../services/collections-handler";
 import type { EmailProviderService } from "../services/email/email-provider-service";
@@ -662,6 +663,12 @@ const globalForDirectApi = globalThis as unknown as {
  * ```
  */
 export function getNextly(config?: DirectAPIConfig): Nextly {
+  // Registration is not readiness. A production boot publishes services and
+  // THEN waits for the migrate lock, so this flag is true throughout a window
+  // in which the schema is unverified — and this getter is synchronous, so it
+  // cannot wait for the answer the way the async surfaces do.
+  assertBootMigrationsSettled();
+
   if (!isServicesRegistered()) {
     throw new NextlyError({
       code: "INTERNAL_ERROR",

--- a/packages/nextly/src/domains/schema/pipeline/__tests__/locks.test.ts
+++ b/packages/nextly/src/domains/schema/pipeline/__tests__/locks.test.ts
@@ -54,11 +54,16 @@ describe("withMigrateLock (mysql named lock)", () => {
       maxWaitMs: 30_000,
     });
 
+    // `db.calls` holds `JSON.stringify` of the drizzle `sql` object, so the
+    // timeout arrives as a PARAMETER rather than inside the SQL text. Asserting
+    // on the rendered string `GET_LOCK(?, 0)` matched nothing either way, so it
+    // could not fail — the params are where the value actually is.
     const get = db.calls.find(c => c.includes("GET_LOCK"));
     expect(get).toBeDefined();
-    // 30s, not 0. A 0 here is the fail-fast call wearing wait mode's name.
-    expect(get).toContain("30");
-    expect(get).not.toMatch(/"GET_LOCK\(\?, 0\)"/);
+    const params = JSON.parse(get as string) as { queryChunks?: unknown[] };
+    const serialized = JSON.stringify(params);
+    expect(serialized).toContain("30");
+    expect(serialized).not.toContain('"value":[0]');
   });
 
   it("reports a busy lock as not-run in wait mode, rather than throwing", async () => {

--- a/packages/nextly/src/domains/schema/pipeline/__tests__/locks.test.ts
+++ b/packages/nextly/src/domains/schema/pipeline/__tests__/locks.test.ts
@@ -29,8 +29,8 @@ function fakeDb(opts: { acquireRows: number[] }) {
 describe("withMigrateLock (postgres lock row)", () => {
   it("acquires (row returned), runs fn, releases", async () => {
     const db = fakeDb({ acquireRows: [1] });
-    const ran = await withMigrateLock(db, "postgresql", async () => "ok");
-    expect(ran).toBe("ok");
+    const outcome = await withMigrateLock(db, "postgresql", async () => "ok");
+    expect(outcome).toEqual({ ran: true, value: "ok" });
     expect(
       db.calls.some(
         c => c.includes("CREATE TABLE") && c.includes("nextly_migrate_lock")
@@ -53,13 +53,15 @@ describe("withMigrateLock (postgres lock row)", () => {
   it("wait mode: settles via isSettled() even if never acquired (does not run fn)", async () => {
     const db = fakeDb({ acquireRows: [0] });
     const fn = vi.fn(async () => "applied");
-    const ran = await withMigrateLock(db, "postgresql", fn, {
+    const outcome = await withMigrateLock(db, "postgresql", fn, {
       mode: "wait",
       maxWaitMs: 50,
       pollMs: 10,
       isSettled: async () => true,
     });
-    expect(ran).toBeUndefined();
+    // Reported as NOT RUN rather than as an undefined value, so a caller
+    // cannot read it as "the body ran and returned nothing".
+    expect(outcome).toEqual({ ran: false, reason: "lock-held" });
     expect(fn).not.toHaveBeenCalled();
   });
 
@@ -75,6 +77,9 @@ describe("withMigrateLock (postgres lock row)", () => {
 
   it("sqlite is a no-op pass-through", async () => {
     const db = fakeDb({ acquireRows: [0] });
-    expect(await withMigrateLock(db, "sqlite", async () => "s")).toBe("s");
+    expect(await withMigrateLock(db, "sqlite", async () => "s")).toEqual({
+      ran: true,
+      value: "s",
+    });
   });
 });

--- a/packages/nextly/src/domains/schema/pipeline/__tests__/locks.test.ts
+++ b/packages/nextly/src/domains/schema/pipeline/__tests__/locks.test.ts
@@ -26,6 +26,67 @@ function fakeDb(opts: { acquireRows: number[] }) {
   };
 }
 
+/**
+ * MySQL takes its wait as `GET_LOCK`'s second argument. Passing 0
+ * unconditionally made `mode: "wait"` silently fail-fast there — it THREW where
+ * Postgres reports `ran: false`, so the two dialects disagreed about what a busy
+ * lock is, and a boot handling one outcome was unprotected on the other.
+ */
+function fakeMysql(locked: 0 | 1) {
+  const calls: string[] = [];
+  return {
+    calls,
+    execute: vi.fn(async (q: unknown) => {
+      const text = JSON.stringify(q);
+      calls.push(text);
+      if (text.includes("GET_LOCK")) return { rows: [{ locked }] };
+      return { rows: [] };
+    }),
+  };
+}
+
+describe("withMigrateLock (mysql named lock)", () => {
+  it("waits with a real timeout instead of polling with 0", async () => {
+    const db = fakeMysql(1);
+
+    await withMigrateLock(db, "mysql", async () => "ok", {
+      mode: "wait",
+      maxWaitMs: 30_000,
+    });
+
+    const get = db.calls.find(c => c.includes("GET_LOCK"));
+    expect(get).toBeDefined();
+    // 30s, not 0. A 0 here is the fail-fast call wearing wait mode's name.
+    expect(get).toContain("30");
+    expect(get).not.toMatch(/"GET_LOCK\(\?, 0\)"/);
+  });
+
+  it("reports a busy lock as not-run in wait mode, rather than throwing", async () => {
+    const db = fakeMysql(0);
+    const fn = vi.fn(async () => "applied");
+
+    const outcome = await withMigrateLock(db, "mysql", fn, {
+      mode: "wait",
+      maxWaitMs: 1_000,
+    });
+
+    expect(outcome).toEqual({ ran: false, reason: "lock-held" });
+    expect(fn).not.toHaveBeenCalled();
+  });
+
+  /**
+   * The control: fail-fast still THROWS on a busy lock. Without it the test
+   * above is satisfied by a dialect that never reports busy at all.
+   */
+  it("still throws on a busy lock in fail-fast mode", async () => {
+    const db = fakeMysql(0);
+
+    await expect(
+      withMigrateLock(db, "mysql", async () => "x")
+    ).rejects.toMatchObject({ code: "NEXTLY_MIGRATE_LOCK_BUSY" });
+  });
+});
+
 describe("withMigrateLock (postgres lock row)", () => {
   it("acquires (row returned), runs fn, releases", async () => {
     const db = fakeDb({ acquireRows: [1] });

--- a/packages/nextly/src/domains/schema/pipeline/locks.ts
+++ b/packages/nextly/src/domains/schema/pipeline/locks.ts
@@ -183,11 +183,36 @@ export async function withMigrateLock<T>(
     }
     case "mysql": {
       const my = db as PgLike;
+      // `GET_LOCK`'s second argument IS the wait: 0 returns immediately, a
+      // positive number blocks for that many seconds. Passing 0 unconditionally
+      // meant `mode: "wait"` was silently fail-fast on MySQL — it threw
+      // `NEXTLY_MIGRATE_LOCK_BUSY` where Postgres reports `ran: false`, so the
+      // two dialects disagreed about what a busy lock even IS, and a caller
+      // handling one outcome was unprotected on the other.
+      const waitSeconds =
+        opts?.mode === "wait"
+          ? Math.ceil(
+              (opts.maxWaitMs ??
+                (opts.ttlSeconds ?? DEFAULT_TTL_SECONDS) * 1000) / 1000
+            )
+          : 0;
       const acquired = toRows(
-        await my.execute(sql`SELECT GET_LOCK(${MYSQL_LOCK_NAME}, 0) AS locked`)
+        await my.execute(
+          sql`SELECT GET_LOCK(${MYSQL_LOCK_NAME}, ${waitSeconds}) AS locked`
+        )
       );
       const v = acquired[0]?.locked;
-      if (!(v === 1 || v === true)) lockBusy();
+      if (!(v === 1 || v === true)) {
+        // Same split as Postgres: waiting and still not getting it is an
+        // OUTCOME the caller decides on; fail-fast is an error.
+        if (opts?.mode === "wait") {
+          opts.logger?.warn?.(
+            "[Nextly] migrate lock still held after waiting; migrations SKIPPED."
+          );
+          return { ran: false, reason: "lock-held" };
+        }
+        lockBusy();
+      }
       try {
         return { ran: true, value: await fn() };
       } finally {

--- a/packages/nextly/src/domains/schema/pipeline/locks.ts
+++ b/packages/nextly/src/domains/schema/pipeline/locks.ts
@@ -125,12 +125,26 @@ export async function forceUnlock(
  * `undefined` if wait mode settled without running `fn` (another process applied
  * the migrations while we waited).
  */
+/**
+ * Whether the guarded body RAN, and its value if it did.
+ *
+ * A discriminated result rather than `T | undefined`, because `undefined` was
+ * doing double duty: "your function returned undefined" and "your function
+ * never ran". Only one caller ever distinguished them, by convention, and the
+ * one that did not was production boot — which logged
+ * `Boot migrations complete (0 applied)` for migrations that never started.
+ * The compiler now makes every call site decide.
+ */
+export type MigrateLockOutcome<T> =
+  | { ran: true; value: T }
+  | { ran: false; reason: "lock-held" };
+
 export async function withMigrateLock<T>(
   db: unknown,
   dialect: SupportedDialect,
   fn: () => Promise<T>,
   opts?: MigrateLockOptions
-): Promise<T | undefined> {
+): Promise<MigrateLockOutcome<T>> {
   switch (dialect) {
     case "postgresql": {
       const pg = db as PgLike;
@@ -143,21 +157,26 @@ export async function withMigrateLock<T>(
         const deadline = Date.now() + (opts.maxWaitMs ?? ttl * 1000);
         const pollMs = opts.pollMs ?? POLL_MS;
         while (!acquired && Date.now() < deadline) {
-          if (opts.isSettled && (await opts.isSettled())) return undefined;
+          if (opts.isSettled && (await opts.isSettled()))
+            return { ran: false, reason: "lock-held" };
           await new Promise(r => setTimeout(r, pollMs));
           acquired = await tryAcquirePg(pg, ttl);
         }
         if (!acquired) {
+          // Says SKIPPED, because that is what happens. The previous wording,
+          // "proceeding without it", described running the migrations anyway —
+          // the opposite of the `return` beneath it — and a caller reading the
+          // log had no way to tell the difference from "already up to date".
           opts.logger?.warn?.(
-            "[Nextly] migrate lock still held after waiting; proceeding without it."
+            "[Nextly] migrate lock still held after waiting; migrations SKIPPED."
           );
-          return undefined;
+          return { ran: false, reason: "lock-held" };
         }
       }
 
       if (!acquired) lockBusy();
       try {
-        return await fn();
+        return { ran: true, value: await fn() };
       } finally {
         await releasePg(pg);
       }
@@ -170,13 +189,13 @@ export async function withMigrateLock<T>(
       const v = acquired[0]?.locked;
       if (!(v === 1 || v === true)) lockBusy();
       try {
-        return await fn();
+        return { ran: true, value: await fn() };
       } finally {
         await my.execute(sql`SELECT RELEASE_LOCK(${MYSQL_LOCK_NAME})`);
       }
     }
     case "sqlite":
-      return fn();
+      return { ran: true, value: await fn() };
     default: {
       const _exhaustive: never = dialect;
       throw new Error(`Unsupported dialect: ${String(_exhaustive)}`);

--- a/packages/nextly/src/errors/error-codes.ts
+++ b/packages/nextly/src/errors/error-codes.ts
@@ -53,6 +53,8 @@ export const NEXTLY_ERROR_STATUS = {
   // rather than 409 — a load balancer should take the instance out of rotation
   // and retry it, which is exactly the recovery this refusal wants.
   NEXTLY_BOOT_MIGRATIONS_NOT_RUN: 503,
+  // Still running rather than refused. 503 for the same reason: retry shortly.
+  NEXTLY_BOOT_MIGRATIONS_PENDING: 503,
   NEXTLY_CORE_DESTRUCTIVE_REFUSED: 409,
   NEXTLY_MIGRATION_DRIFT: 409,
   NEXTLY_MIGRATION_APPLY_FAILED: 500,

--- a/packages/nextly/src/errors/error-codes.ts
+++ b/packages/nextly/src/errors/error-codes.ts
@@ -47,6 +47,12 @@ export const NEXTLY_ERROR_STATUS = {
   // Plan C2 — nextly migrate phases.
   NEXTLY_MIGRATE_LOCK_BUSY: 409,
   NEXTLY_BASELINE_LOCK_NOT_HELD: 409,
+  NEXTLY_RESOLVE_LOCK_NOT_HELD: 409,
+  // Boot refused to serve: the migrate lock stayed held past the wait deadline,
+  // so this process never established whether the schema matches the code. 503
+  // rather than 409 — a load balancer should take the instance out of rotation
+  // and retry it, which is exactly the recovery this refusal wants.
+  NEXTLY_BOOT_MIGRATIONS_NOT_RUN: 503,
   NEXTLY_CORE_DESTRUCTIVE_REFUSED: 409,
   NEXTLY_MIGRATION_DRIFT: 409,
   NEXTLY_MIGRATION_APPLY_FAILED: 500,

--- a/packages/nextly/src/init.ts
+++ b/packages/nextly/src/init.ts
@@ -201,6 +201,13 @@ export async function getNextly(options: GetNextlyOptions): Promise<Nextly> {
     return globalForInit.__nextly_initPromise;
   }
 
+  // The public factory's own gate. When services are ALREADY registered, the
+  // block below skips the migration branch entirely — so without this, a
+  // concurrent `getNextly()` builds and returns the API while another surface
+  // is still waiting on the migrate lock. `getCachedNextly()` was gated and
+  // this was not, which is a difference nothing but memory enforced.
+  await awaitBootMigrations();
+
   // Begin first-time initialisation and store the Promise so concurrent calls
   // above return it rather than spawning duplicate DB connections.
   const initPromise = (async (): Promise<Nextly> => {

--- a/packages/nextly/src/init.ts
+++ b/packages/nextly/src/init.ts
@@ -46,6 +46,7 @@ import { getNextly as getDirectAPI } from "./direct-api/nextly";
 import { resolveCollectionTableName } from "./domains/schema/utils/resolve-table-name";
 import { NextlyError } from "./errors/nextly-error";
 import { runBootTimeApplyIfDev } from "./init/boot-apply";
+import { awaitBootMigrations } from "./init/boot-migrations-gate";
 import {
   buildServiceConfig,
   type GetNextlyOptions,
@@ -396,6 +397,14 @@ export async function getNextly(options: GetNextlyOptions): Promise<Nextly> {
  * `getNextly({ config })` directly.
  */
 export async function getCachedNextly(): Promise<Nextly> {
+  // Before ANY return, including the cached one. This is the surface that could
+  // serve during another surface's migration wait: the request-path boot
+  // registers services and then waits for the lock, and everything below keys
+  // off `isServicesRegistered()`, which is true throughout that window. Awaiting
+  // rather than testing means a request racing a normal boot still waits for it,
+  // exactly as before — it only learns the answer once there is one.
+  await awaitBootMigrations();
+
   if (globalForInit.__nextly_cachedInstance) {
     return globalForInit.__nextly_cachedInstance;
   }

--- a/packages/nextly/src/init.ts
+++ b/packages/nextly/src/init.ts
@@ -259,7 +259,12 @@ export async function getNextly(options: GetNextlyOptions): Promise<Nextly> {
 
         // Production sibling of boot-apply: when `db.runMigrationsOnBoot` is on,
         // apply committed migration files (prod only; no-op in dev). Wired at
-        // both init entry points. Failure-safe — it logs but never throws.
+        // both init entry points.
+        //
+        // NOT failure-safe, deliberately, and it used to say it was. Ordinary
+        // failures are still logged and swallowed, but a boot that could not
+        // establish whether migrations ran THROWS: serving a schema nobody
+        // verified is worse than not starting.
         const { runProdMigrationsIfEnabled } = await import(
           "./init/prod-migrations"
         );

--- a/packages/nextly/src/init.ts
+++ b/packages/nextly/src/init.ts
@@ -201,17 +201,22 @@ export async function getNextly(options: GetNextlyOptions): Promise<Nextly> {
     return globalForInit.__nextly_initPromise;
   }
 
-  // The public factory's own gate. When services are ALREADY registered, the
-  // block below skips the migration branch entirely — so without this, a
-  // concurrent `getNextly()` builds and returns the API while another surface
-  // is still waiting on the migrate lock. `getCachedNextly()` was gated and
-  // this was not, which is a difference nothing but memory enforced.
-  await awaitBootMigrations();
-
   // Begin first-time initialisation and store the Promise so concurrent calls
   // above return it rather than spawning duplicate DB connections.
   const initPromise = (async (): Promise<Nextly> => {
     try {
+      // INSIDE the published promise, never before it. An `await` above this
+      // point yields after the `__nextly_initPromise` check but before the
+      // promise is stored, so two simultaneous cold calls both pass that check
+      // and both call `registerServices()` — restoring the duplicate adapter
+      // connections the latch exists to prevent, against databases that
+      // auto-suspend and time out on a connection storm.
+      //
+      // When services are ALREADY registered the branch below is skipped
+      // entirely, so this is also the only place the public factory learns that
+      // another surface is still waiting on the migrate lock.
+      await awaitBootMigrations();
+
       if (!isServicesRegistered()) {
         // Build final config from provided options
         const finalConfig = buildServiceConfig(options);

--- a/packages/nextly/src/init/__tests__/boot-migrations-gate.test.ts
+++ b/packages/nextly/src/init/__tests__/boot-migrations-gate.test.ts
@@ -129,6 +129,25 @@ describe("the boot-migrations gate", () => {
   });
 
   /**
+   * A refusal is FINAL for the process, and a retry must not reopen its way
+   * past one. The refusal path calls `shutdownServices()`, so the next request
+   * re-registers — and re-registration is what opens the gate. Clearing the
+   * refusal on open handed every retry a clean slate and let it migrate as
+   * though nothing had been decided.
+   */
+  it("survives the gate being reopened by a re-registration", async () => {
+    openBootMigrationsGate(true);
+    refuseBootMigrations(refusal());
+
+    // What a retry does: `registerServices` runs again and opens the gate.
+    openBootMigrationsGate(true);
+
+    await expect(awaitBootMigrations()).rejects.toMatchObject({
+      code: "NEXTLY_BOOT_MIGRATIONS_NOT_RUN",
+    });
+  });
+
+  /**
    * The positive control for the case above: an ALLOWED boot must not leave the
    * gate closed behind it, or every later request hangs. Without this, a gate
    * that simply never opened would satisfy the refusal tests.

--- a/packages/nextly/src/init/__tests__/boot-migrations-gate.test.ts
+++ b/packages/nextly/src/init/__tests__/boot-migrations-gate.test.ts
@@ -1,0 +1,106 @@
+/**
+ * The gate exists because `isServicesRegistered()` answers a different
+ * question. The request-path boot registers services and THEN waits for the
+ * migrate lock, so throughout that wait the container is registered while the
+ * schema is unverified — and another surface keying off the registered flag
+ * would serve inside that window whatever the wait eventually decided.
+ */
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { NextlyError } from "../../errors";
+import {
+  _resetBootMigrationsGateForTest,
+  awaitBootMigrations,
+  beginBootMigrations,
+} from "../boot-migrations-gate";
+
+const refusal = (): NextlyError =>
+  new NextlyError({
+    code: "NEXTLY_BOOT_MIGRATIONS_NOT_RUN",
+    publicMessage: "refused",
+  });
+
+/** Whether a promise is still pending, without waiting on it. */
+async function isPending(p: Promise<unknown>): Promise<boolean> {
+  const marker = Symbol("pending");
+  const winner = await Promise.race([
+    p.then(
+      () => "settled",
+      () => "settled"
+    ),
+    Promise.resolve(marker),
+  ]);
+  return winner === marker;
+}
+
+beforeEach(() => {
+  _resetBootMigrationsGateForTest();
+});
+
+describe("the boot-migrations gate", () => {
+  /**
+   * Development, or `runMigrationsOnBoot` off. Every serving surface calls this
+   * unconditionally, so a closed gate here would block the common case.
+   */
+  it("lets everything through when no boot opened it", async () => {
+    await expect(awaitBootMigrations()).resolves.toBeUndefined();
+  });
+
+  /**
+   * The race itself. A consumer arriving mid-boot must WAIT, not decide — and
+   * not fail either: throwing while pending would turn every normal cold-boot
+   * request into a 503.
+   */
+  it("holds a consumer that arrives while migrations are still running", async () => {
+    const gate = beginBootMigrations();
+
+    const consumer = awaitBootMigrations();
+    expect(await isPending(consumer)).toBe(true);
+
+    gate.allow();
+    await expect(consumer).resolves.toBeUndefined();
+  });
+
+  it("rejects the waiting consumer when the boot refuses", async () => {
+    const gate = beginBootMigrations();
+    const consumer = awaitBootMigrations();
+
+    gate.refuse(refusal());
+
+    await expect(consumer).rejects.toMatchObject({
+      code: "NEXTLY_BOOT_MIGRATIONS_NOT_RUN",
+    });
+  });
+
+  /**
+   * The sticky half. A consumer that arrives AFTER the refusal has settled has
+   * no pending promise to wait on, so the refusal has to be recorded as state —
+   * otherwise the second request through any surface finds an empty gate and
+   * serves the schema the process refused.
+   */
+  it("keeps refusing consumers that arrive after it settled", async () => {
+    const gate = beginBootMigrations();
+    gate.refuse(refusal());
+
+    await expect(awaitBootMigrations()).rejects.toMatchObject({
+      code: "NEXTLY_BOOT_MIGRATIONS_NOT_RUN",
+    });
+    // And again — the refusal is not consumed by being read.
+    await expect(awaitBootMigrations()).rejects.toMatchObject({
+      code: "NEXTLY_BOOT_MIGRATIONS_NOT_RUN",
+    });
+  });
+
+  /**
+   * The positive control for the case above: an ALLOWED boot must not leave the
+   * gate closed behind it, or every later request hangs. Without this, a gate
+   * that simply never opened would satisfy the refusal tests.
+   */
+  it("stays open once a boot allowed it", async () => {
+    const gate = beginBootMigrations();
+    gate.allow();
+
+    await expect(awaitBootMigrations()).resolves.toBeUndefined();
+    await expect(awaitBootMigrations()).resolves.toBeUndefined();
+  });
+});

--- a/packages/nextly/src/init/__tests__/boot-migrations-gate.test.ts
+++ b/packages/nextly/src/init/__tests__/boot-migrations-gate.test.ts
@@ -5,13 +5,15 @@
  * schema is unverified — and another surface keying off the registered flag
  * would serve inside that window whatever the wait eventually decided.
  */
-import { beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { NextlyError } from "../../errors";
 import {
   _resetBootMigrationsGateForTest,
+  allowBootMigrations,
   awaitBootMigrations,
-  beginBootMigrations,
+  openBootMigrationsGate,
+  refuseBootMigrations,
 } from "../boot-migrations-gate";
 
 const refusal = (): NextlyError =>
@@ -35,6 +37,14 @@ async function isPending(p: Promise<unknown>): Promise<boolean> {
 
 beforeEach(() => {
   _resetBootMigrationsGateForTest();
+  // The gate only opens for a production boot with migrations configured, which
+  // is exactly the state these cases are about. `stubEnv` rather than direct
+  // assignment so the restore cannot leak a value into a sibling suite.
+  vi.stubEnv("NODE_ENV", "production");
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
 });
 
 describe("the boot-migrations gate", () => {
@@ -47,25 +57,41 @@ describe("the boot-migrations gate", () => {
   });
 
   /**
+   * The gate must not open for a boot that will never settle it. Registration
+   * happens in the CLI and the test harness too, and a gate opened there would
+   * hang every later consumer forever.
+   */
+  it("does not open when this boot will not run migrations", async () => {
+    openBootMigrationsGate(false);
+    await expect(awaitBootMigrations()).resolves.toBeUndefined();
+  });
+
+  it("does not open outside production", async () => {
+    vi.stubEnv("NODE_ENV", "development");
+    openBootMigrationsGate(true);
+    await expect(awaitBootMigrations()).resolves.toBeUndefined();
+  });
+
+  /**
    * The race itself. A consumer arriving mid-boot must WAIT, not decide — and
    * not fail either: throwing while pending would turn every normal cold-boot
    * request into a 503.
    */
   it("holds a consumer that arrives while migrations are still running", async () => {
-    const gate = beginBootMigrations();
+    openBootMigrationsGate(true);
 
     const consumer = awaitBootMigrations();
     expect(await isPending(consumer)).toBe(true);
 
-    gate.allow();
+    allowBootMigrations();
     await expect(consumer).resolves.toBeUndefined();
   });
 
   it("rejects the waiting consumer when the boot refuses", async () => {
-    const gate = beginBootMigrations();
+    openBootMigrationsGate(true);
     const consumer = awaitBootMigrations();
 
-    gate.refuse(refusal());
+    refuseBootMigrations(refusal());
 
     await expect(consumer).rejects.toMatchObject({
       code: "NEXTLY_BOOT_MIGRATIONS_NOT_RUN",
@@ -79,8 +105,8 @@ describe("the boot-migrations gate", () => {
    * serves the schema the process refused.
    */
   it("keeps refusing consumers that arrive after it settled", async () => {
-    const gate = beginBootMigrations();
-    gate.refuse(refusal());
+    openBootMigrationsGate(true);
+    refuseBootMigrations(refusal());
 
     await expect(awaitBootMigrations()).rejects.toMatchObject({
       code: "NEXTLY_BOOT_MIGRATIONS_NOT_RUN",
@@ -97,8 +123,8 @@ describe("the boot-migrations gate", () => {
    * that simply never opened would satisfy the refusal tests.
    */
   it("stays open once a boot allowed it", async () => {
-    const gate = beginBootMigrations();
-    gate.allow();
+    openBootMigrationsGate(true);
+    allowBootMigrations();
 
     await expect(awaitBootMigrations()).resolves.toBeUndefined();
     await expect(awaitBootMigrations()).resolves.toBeUndefined();

--- a/packages/nextly/src/init/__tests__/boot-migrations-gate.test.ts
+++ b/packages/nextly/src/init/__tests__/boot-migrations-gate.test.ts
@@ -22,7 +22,14 @@ const refusal = (): NextlyError =>
     publicMessage: "refused",
   });
 
-/** Whether a promise is still pending, without waiting on it. */
+/**
+ * Whether a promise is still pending, without waiting on it.
+ *
+ * Raced against a MACROTASK, not `Promise.resolve`. A resolved microtask can
+ * win against an already-settled promise, so the earlier version reported
+ * "pending" for a gate that had never opened — the assertion below would then
+ * pass whether or not `openBootMigrationsGate` did anything.
+ */
 async function isPending(p: Promise<unknown>): Promise<boolean> {
   const marker = Symbol("pending");
   const winner = await Promise.race([
@@ -30,7 +37,7 @@ async function isPending(p: Promise<unknown>): Promise<boolean> {
       () => "settled",
       () => "settled"
     ),
-    Promise.resolve(marker),
+    new Promise(resolve => setTimeout(() => resolve(marker), 0)),
   ]);
   return winner === marker;
 }
@@ -64,6 +71,10 @@ describe("the boot-migrations gate", () => {
   it("does not open when this boot will not run migrations", async () => {
     openBootMigrationsGate(false);
     await expect(awaitBootMigrations()).resolves.toBeUndefined();
+    // The control for `isPending` itself: an unopened gate must read as NOT
+    // pending, or the pending assertion below cannot distinguish a gate that
+    // opened from one that never did.
+    expect(await isPending(awaitBootMigrations())).toBe(false);
   });
 
   it("does not open outside production", async () => {

--- a/packages/nextly/src/init/__tests__/boot-migrations-gate.test.ts
+++ b/packages/nextly/src/init/__tests__/boot-migrations-gate.test.ts
@@ -11,6 +11,7 @@ import { NextlyError } from "../../errors";
 import {
   _resetBootMigrationsGateForTest,
   allowBootMigrations,
+  assertBootMigrationsSettled,
   awaitBootMigrations,
   openBootMigrationsGate,
   refuseBootMigrations,
@@ -145,6 +146,41 @@ describe("the boot-migrations gate", () => {
     await expect(awaitBootMigrations()).rejects.toMatchObject({
       code: "NEXTLY_BOOT_MIGRATIONS_NOT_RUN",
     });
+  });
+
+  /**
+   * The synchronous consumer, which cannot wait. `getNextly()` in the Direct API
+   * is exported from the package root and a Server Component can call
+   * `nextly.find()` on it, so its only choices while the gate is pending are to
+   * throw or to query a schema nobody has verified.
+   */
+  it("refuses a synchronous consumer while migrations are still running", () => {
+    openBootMigrationsGate(true);
+
+    expect(() => assertBootMigrationsSettled()).toThrow(
+      expect.objectContaining({ code: "NEXTLY_BOOT_MIGRATIONS_PENDING" })
+    );
+  });
+
+  it("refuses a synchronous consumer after a refusal", () => {
+    openBootMigrationsGate(true);
+    refuseBootMigrations(refusal());
+
+    expect(() => assertBootMigrationsSettled()).toThrow(
+      expect.objectContaining({ code: "NEXTLY_BOOT_MIGRATIONS_NOT_RUN" })
+    );
+  });
+
+  /**
+   * The control for both. Without it they are satisfied by a function that
+   * throws unconditionally — which would break every Direct API call in
+   * development and in any app that does not run boot migrations.
+   */
+  it("lets a synchronous consumer through once the gate has settled", () => {
+    openBootMigrationsGate(true);
+    allowBootMigrations();
+
+    expect(() => assertBootMigrationsSettled()).not.toThrow();
   });
 
   /**

--- a/packages/nextly/src/init/__tests__/build-service-config.test.ts
+++ b/packages/nextly/src/init/__tests__/build-service-config.test.ts
@@ -79,4 +79,33 @@ describe("buildServiceConfig — retention carry-through", () => {
     });
     expect(result.auditRetention).toEqual(explicit);
   });
+
+  /**
+   * `runMigrationsOnBoot` on the SERVICE config is internal wiring, not an
+   * option — it tells `registerServices` whether to open the boot-migrations
+   * gate, and that must match what `runProdMigrationsIfEnabled` will actually
+   * do, which reads the nested `db` block. A caller-supplied value winning here
+   * would open no gate while migrations ran anyway, which is precisely the
+   * unguarded window the gate exists to close.
+   *
+   * The opposite direction is asserted too: a caller cannot manufacture a gate
+   * that nothing will ever settle, which would hang every later consumer.
+   */
+  it("derives the gate flag from the nested config, ignoring a caller override", () => {
+    const enabled = buildServiceConfig({
+      config: {
+        db: { runMigrationsOnBoot: true },
+      } as unknown as SanitizedNextlyConfig,
+      runMigrationsOnBoot: false,
+    } as Parameters<typeof buildServiceConfig>[0]);
+    expect(enabled.runMigrationsOnBoot).toBe(true);
+
+    const disabled = buildServiceConfig({
+      config: {
+        db: { runMigrationsOnBoot: false },
+      } as unknown as SanitizedNextlyConfig,
+      runMigrationsOnBoot: true,
+    } as Parameters<typeof buildServiceConfig>[0]);
+    expect(disabled.runMigrationsOnBoot).toBe(false);
+  });
 });

--- a/packages/nextly/src/init/__tests__/prod-migrations.test.ts
+++ b/packages/nextly/src/init/__tests__/prod-migrations.test.ts
@@ -1,4 +1,5 @@
 import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { NextlyError } from "../../errors";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -44,12 +45,74 @@ function args(over: Record<string, unknown> = {}) {
 }
 
 describe("runProdMigrationsIfEnabled", () => {
+  beforeEach(() => {
+    // Process-global by design — the refusal must outlive a request — so it has
+    // to be cleared between cases or the first refusal fails every test after.
+    delete (globalThis as { __nextly_bootMigrationsRefused?: unknown })
+      .__nextly_bootMigrationsRefused;
+  });
+
   /**
    * The lock timing out tells this process nothing about whether the holder
    * migrated. Serving anyway is the case that put a replica on an unmigrated
    * schema while logging `complete (0 applied)` — `applied` is 0 here and 0 on
    * an up-to-date database, so the count cannot distinguish them.
    */
+  /**
+   * The refusal has to outlive the request that raised it. Both entry points
+   * run migrations inside `if (!isServicesRegistered())`, and DI is already
+   * marked registered by the time this throws — so without stickiness the very
+   * next request skips migrations and serves the schema the process refused.
+   *
+   * Second call passes a migrateCore that would SUCCEED, so this cannot pass by
+   * the failure simply repeating.
+   */
+  it("keeps refusing on later calls, even when migrations would now succeed", async () => {
+    process.env.NODE_ENV = "production";
+    await expect(
+      runProdMigrationsIfEnabled(
+        args({
+          migrateCore: vi.fn(async () => ({
+            applied: 0,
+            coreChanged: false,
+            ran: false,
+          })),
+        }) as never
+      )
+    ).rejects.toMatchObject({ code: "NEXTLY_BOOT_MIGRATIONS_NOT_RUN" });
+
+    const wouldSucceed = vi.fn(async () => ({
+      applied: 3,
+      coreChanged: false,
+      ran: true,
+    }));
+    await expect(
+      runProdMigrationsIfEnabled(args({ migrateCore: wouldSucceed }) as never)
+    ).rejects.toMatchObject({ code: "NEXTLY_BOOT_MIGRATIONS_NOT_RUN" });
+    expect(wouldSucceed).not.toHaveBeenCalled();
+  });
+
+  /**
+   * MySQL reports a busy lock by THROWING `NEXTLY_MIGRATE_LOCK_BUSY` rather
+   * than returning `ran: false`, so a catch that rethrew only the refusal let
+   * MySQL serve the unmigrated schema this change exists to prevent.
+   */
+  it("refuses when the lock was busy on a dialect that throws instead", async () => {
+    process.env.NODE_ENV = "production";
+    const a = args({
+      migrateCore: vi.fn(async () => {
+        throw new NextlyError({
+          code: "NEXTLY_MIGRATE_LOCK_BUSY",
+          publicMessage: "busy",
+        });
+      }),
+    });
+
+    await expect(runProdMigrationsIfEnabled(a as never)).rejects.toMatchObject({
+      code: "NEXTLY_BOOT_MIGRATIONS_NOT_RUN",
+    });
+  });
+
   it("refuses to start when the migrations did not run", async () => {
     process.env.NODE_ENV = "production";
     const a = args({

--- a/packages/nextly/src/init/__tests__/prod-migrations.test.ts
+++ b/packages/nextly/src/init/__tests__/prod-migrations.test.ts
@@ -1,5 +1,6 @@
 import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { NextlyError } from "../../errors";
+import { _resetBootMigrationsGateForTest } from "../boot-migrations-gate";
 
 const shutdownServices = vi.fn();
 vi.mock("../../di", () => ({ shutdownServices: () => shutdownServices() }));
@@ -51,8 +52,7 @@ describe("runProdMigrationsIfEnabled", () => {
   beforeEach(() => {
     // Process-global by design — the refusal must outlive a request — so it has
     // to be cleared between cases or the first refusal fails every test after.
-    delete (globalThis as { __nextly_bootMigrationsRefused?: unknown })
-      .__nextly_bootMigrationsRefused;
+    _resetBootMigrationsGateForTest();
     shutdownServices.mockClear();
   });
 
@@ -160,8 +160,7 @@ describe("runProdMigrationsIfEnabled", () => {
       }
     );
 
-    delete (globalThis as { __nextly_bootMigrationsRefused?: unknown })
-      .__nextly_bootMigrationsRefused;
+    _resetBootMigrationsGateForTest();
 
     const my = args({ migrateCore: vi.fn(async () => notRun()) });
     my.adapter.dialect = "mysql";

--- a/packages/nextly/src/init/__tests__/prod-migrations.test.ts
+++ b/packages/nextly/src/init/__tests__/prod-migrations.test.ts
@@ -34,12 +34,56 @@ function args(over: Record<string, unknown> = {}) {
       executeQuery: async () => undefined,
     },
     logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
-    migrateCore: vi.fn(async () => ({ applied: 1, coreChanged: false })),
+    migrateCore: vi.fn(async () => ({
+      applied: 1,
+      coreChanged: false,
+      ran: true,
+    })),
     ...over,
   };
 }
 
 describe("runProdMigrationsIfEnabled", () => {
+  /**
+   * The lock timing out tells this process nothing about whether the holder
+   * migrated. Serving anyway is the case that put a replica on an unmigrated
+   * schema while logging `complete (0 applied)` — `applied` is 0 here and 0 on
+   * an up-to-date database, so the count cannot distinguish them.
+   */
+  it("refuses to start when the migrations did not run", async () => {
+    process.env.NODE_ENV = "production";
+    const a = args({
+      migrateCore: vi.fn(async () => ({
+        applied: 0,
+        coreChanged: false,
+        ran: false,
+      })),
+    });
+
+    await expect(runProdMigrationsIfEnabled(a as never)).rejects.toMatchObject({
+      code: "NEXTLY_BOOT_MIGRATIONS_NOT_RUN",
+    });
+  });
+
+  /**
+   * The positive control for the refusal, and the boundary of it. Every OTHER
+   * boot-migration failure is still swallowed so the app starts — those leave a
+   * database the app can usefully serve, and `nextly migrate` fixes them. Only
+   * "we do not know what we are serving" is fatal.
+   */
+  it("still starts when boot migrations fail for any other reason", async () => {
+    process.env.NODE_ENV = "production";
+    const a = args({
+      migrateCore: vi.fn(async () => {
+        throw new Error("connection reset");
+      }),
+    });
+
+    await expect(
+      runProdMigrationsIfEnabled(a as never)
+    ).resolves.toBeUndefined();
+  });
+
   it("skips unless NODE_ENV=production", async () => {
     process.env.NODE_ENV = "development";
     const a = args();
@@ -71,7 +115,7 @@ describe("runProdMigrationsIfEnabled", () => {
       migrateCore: vi.fn(async (deps: { logger: Record<string, unknown> }) => {
         // Simulate what runFileMigrations actually does.
         (deps.logger.success as (m: string) => void)("Applied x.sql");
-        return { applied: 1, coreChanged: false };
+        return { applied: 1, coreChanged: false, ran: true };
       }),
     });
     await expect(

--- a/packages/nextly/src/init/__tests__/prod-migrations.test.ts
+++ b/packages/nextly/src/init/__tests__/prod-migrations.test.ts
@@ -1,6 +1,10 @@
 import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { NextlyError } from "../../errors";
-import { _resetBootMigrationsGateForTest } from "../boot-migrations-gate";
+import {
+  _resetBootMigrationsGateForTest,
+  awaitBootMigrations,
+  openBootMigrationsGate,
+} from "../boot-migrations-gate";
 
 const shutdownServices = vi.fn();
 vi.mock("../../di", () => ({ shutdownServices: () => shutdownServices() }));
@@ -167,6 +171,23 @@ describe("runProdMigrationsIfEnabled", () => {
     const err = await runProdMigrationsIfEnabled(my as never).catch(e => e);
     expect(err.publicMessage).not.toContain("--force-unlock");
     expect(err.publicMessage).toContain("released when that connection ends");
+  });
+
+  /**
+   * `registerServices` opens the gate; this helper settles it. If the two ever
+   * disagree about the conditions, a gate opened and never settled hangs every
+   * consumer forever — a worse outage than the one being guarded against. So
+   * the helper closes it on the early exits too, where it was never opened.
+   */
+  it("settles the gate even when it returns early", async () => {
+    process.env.NODE_ENV = "production";
+    const a = args();
+    a.config.db.runMigrationsOnBoot = false;
+
+    openBootMigrationsGate(true);
+    await runProdMigrationsIfEnabled(a as never);
+
+    await expect(awaitBootMigrations()).resolves.toBeUndefined();
   });
 
   it("refuses to start when the migrations did not run", async () => {

--- a/packages/nextly/src/init/__tests__/prod-migrations.test.ts
+++ b/packages/nextly/src/init/__tests__/prod-migrations.test.ts
@@ -1,5 +1,8 @@
 import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { NextlyError } from "../../errors";
+
+const clearServices = vi.fn();
+vi.mock("../../di", () => ({ clearServices: () => clearServices() }));
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -50,6 +53,7 @@ describe("runProdMigrationsIfEnabled", () => {
     // to be cleared between cases or the first refusal fails every test after.
     delete (globalThis as { __nextly_bootMigrationsRefused?: unknown })
       .__nextly_bootMigrationsRefused;
+    clearServices.mockClear();
   });
 
   /**
@@ -67,6 +71,30 @@ describe("runProdMigrationsIfEnabled", () => {
    * Second call passes a migrateCore that would SUCCEED, so this cannot pass by
    * the failure simply repeating.
    */
+  /**
+   * The sticky flag lives inside this helper, and both entry points call it
+   * only inside `if (!isServicesRegistered())` — which `registerServices()` has
+   * already made false by the time the refusal is thrown. Without reopening
+   * that gate the flag is unreachable: the next request skips this helper
+   * entirely, builds the dispatcher, and serves the unverified schema.
+   */
+  it("clears registration so the refusal is reachable on the next request", async () => {
+    process.env.NODE_ENV = "production";
+    const a = args({
+      migrateCore: vi.fn(async () => ({
+        applied: 0,
+        coreChanged: false,
+        ran: false,
+      })),
+    });
+
+    await expect(runProdMigrationsIfEnabled(a as never)).rejects.toMatchObject({
+      code: "NEXTLY_BOOT_MIGRATIONS_NOT_RUN",
+    });
+
+    expect(clearServices).toHaveBeenCalled();
+  });
+
   it("keeps refusing on later calls, even when migrations would now succeed", async () => {
     process.env.NODE_ENV = "production";
     await expect(

--- a/packages/nextly/src/init/__tests__/prod-migrations.test.ts
+++ b/packages/nextly/src/init/__tests__/prod-migrations.test.ts
@@ -1,8 +1,8 @@
 import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { NextlyError } from "../../errors";
 
-const clearServices = vi.fn();
-vi.mock("../../di", () => ({ clearServices: () => clearServices() }));
+const shutdownServices = vi.fn();
+vi.mock("../../di", () => ({ shutdownServices: () => shutdownServices() }));
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -53,7 +53,7 @@ describe("runProdMigrationsIfEnabled", () => {
     // to be cleared between cases or the first refusal fails every test after.
     delete (globalThis as { __nextly_bootMigrationsRefused?: unknown })
       .__nextly_bootMigrationsRefused;
-    clearServices.mockClear();
+    shutdownServices.mockClear();
   });
 
   /**
@@ -78,7 +78,7 @@ describe("runProdMigrationsIfEnabled", () => {
    * that gate the flag is unreachable: the next request skips this helper
    * entirely, builds the dispatcher, and serves the unverified schema.
    */
-  it("clears registration so the refusal is reachable on the next request", async () => {
+  it("tears services down so the refusal is reachable without leaking a pool", async () => {
     process.env.NODE_ENV = "production";
     const a = args({
       migrateCore: vi.fn(async () => ({
@@ -92,7 +92,9 @@ describe("runProdMigrationsIfEnabled", () => {
       code: "NEXTLY_BOOT_MIGRATIONS_NOT_RUN",
     });
 
-    expect(clearServices).toHaveBeenCalled();
+    // `shutdownServices`, not `clearServices`: the latter leaves the adapter
+    // connected, so each retry would build another pool.
+    expect(shutdownServices).toHaveBeenCalled();
   });
 
   it("keeps refusing on later calls, even when migrations would now succeed", async () => {
@@ -139,6 +141,33 @@ describe("runProdMigrationsIfEnabled", () => {
     await expect(runProdMigrationsIfEnabled(a as never)).rejects.toMatchObject({
       code: "NEXTLY_BOOT_MIGRATIONS_NOT_RUN",
     });
+  });
+
+  /**
+   * `forceUnlock` deletes the Postgres lock ROW and returns immediately for
+   * every other dialect, so telling a MySQL operator to run it during an
+   * incident sends them to a no-op. MySQL's lock is session-scoped and dies
+   * with its connection, which makes restarting the holder the real recovery.
+   */
+  it("gives dialect-appropriate recovery guidance", async () => {
+    process.env.NODE_ENV = "production";
+    const notRun = () => ({ applied: 0, coreChanged: false, ran: false });
+
+    const pg = args({ migrateCore: vi.fn(async () => notRun()) });
+    await expect(runProdMigrationsIfEnabled(pg as never)).rejects.toMatchObject(
+      {
+        publicMessage: expect.stringContaining("--force-unlock"),
+      }
+    );
+
+    delete (globalThis as { __nextly_bootMigrationsRefused?: unknown })
+      .__nextly_bootMigrationsRefused;
+
+    const my = args({ migrateCore: vi.fn(async () => notRun()) });
+    my.adapter.dialect = "mysql";
+    const err = await runProdMigrationsIfEnabled(my as never).catch(e => e);
+    expect(err.publicMessage).not.toContain("--force-unlock");
+    expect(err.publicMessage).toContain("released when that connection ends");
   });
 
   it("refuses to start when the migrations did not run", async () => {

--- a/packages/nextly/src/init/boot-migrations-gate.ts
+++ b/packages/nextly/src/init/boot-migrations-gate.ts
@@ -47,6 +47,12 @@ export function openBootMigrationsGate(willRunMigrations: boolean): void {
   if (process.env.NODE_ENV !== "production") return;
   if (!willRunMigrations) return;
   if (globalForGate.__nextly_bootMigrationsPending) return;
+  // A refusal is FINAL for the process, so a retry cannot reopen its way past
+  // one. The refusal path calls `shutdownServices()`, which makes the next
+  // request re-register — and re-registration is what opens the gate, so
+  // clearing the refusal here handed every retry a clean slate and let it
+  // proceed to migrate as though nothing had been decided.
+  if (globalForGate.__nextly_bootMigrationsRefused) return;
 
   let settle: (() => void) | undefined;
   let fail: ((error: unknown) => void) | undefined;
@@ -63,7 +69,6 @@ export function openBootMigrationsGate(willRunMigrations: boolean): void {
   globalForGate.__nextly_bootMigrationsPending = pending;
   globalForGate.__nextly_settle = settle;
   globalForGate.__nextly_fail = fail;
-  delete globalForGate.__nextly_bootMigrationsRefused;
 }
 
 /** Migrations ran, were not required, or failed recoverably: serving is allowed. */

--- a/packages/nextly/src/init/boot-migrations-gate.ts
+++ b/packages/nextly/src/init/boot-migrations-gate.ts
@@ -21,7 +21,7 @@
  * @module init/boot-migrations-gate
  */
 
-import type { NextlyError } from "../errors";
+import { NextlyError } from "../errors";
 
 const globalForGate = globalThis as unknown as {
   __nextly_bootMigrationsPending?: Promise<void>;
@@ -103,6 +103,35 @@ export function refuseBootMigrations(error: NextlyError): void {
 export function assertBootMigrationsNotRefused(): void {
   const refused = globalForGate.__nextly_bootMigrationsRefused;
   if (refused) throw refused;
+}
+
+/**
+ * Throw unless boot migrations have SETTLED and allowed serving.
+ *
+ * For synchronous consumers, which cannot wait. The Direct API's `getNextly()`
+ * is one: it is exported from the package root and a Server Component can call
+ * `nextly.find()` on it, and it decides readiness from `isServicesRegistered()`
+ * alone — which is true throughout a migration wait.
+ *
+ * Refusing while merely PENDING is the deliberate part. An async consumer waits
+ * for the answer; a synchronous one cannot, so its only choices are to throw or
+ * to query a schema nobody has verified. Throwing is recoverable — the caller
+ * retries and the gate has settled — and the alternative is silently reading a
+ * database this build may not match.
+ */
+export function assertBootMigrationsSettled(): void {
+  const refused = globalForGate.__nextly_bootMigrationsRefused;
+  if (refused) throw refused;
+
+  if (globalForGate.__nextly_bootMigrationsPending) {
+    throw new NextlyError({
+      code: "NEXTLY_BOOT_MIGRATIONS_PENDING",
+      publicMessage:
+        "Boot migrations are still running, so the schema this build expects " +
+        "is not yet confirmed. Retry shortly; this resolves once migrations " +
+        "finish.",
+    });
+  }
 }
 
 /**

--- a/packages/nextly/src/init/boot-migrations-gate.ts
+++ b/packages/nextly/src/init/boot-migrations-gate.ts
@@ -1,0 +1,97 @@
+/**
+ * Whether this process may serve, with respect to boot migrations.
+ *
+ * `isServicesRegistered()` is not that question and never was. The request-path
+ * boot registers services and THEN runs migrations, so between those two steps
+ * the container is fully registered while the schema is still unverified — and
+ * `getCachedNextly()` builds and returns an instance on the registered flag
+ * alone. A second surface can therefore serve during the first surface's
+ * migration wait, whatever that wait eventually decides.
+ *
+ * This gate is the missing question, asked in one place. Consumers AWAIT it
+ * rather than test it: a request arriving mid-boot should wait for the boot it
+ * is racing, exactly as it does today, and only then learn whether serving is
+ * allowed. Throwing while pending would turn every normal cold-boot request
+ * into a 503.
+ *
+ * On `globalThis` for the reason the rest of the boot state is: Next.js and
+ * Turbopack can evaluate this module in more than one server graph, and a
+ * refusal recorded in one copy has to be visible from the other.
+ *
+ * @module init/boot-migrations-gate
+ */
+
+import type { NextlyError } from "../errors";
+
+const globalForGate = globalThis as unknown as {
+  __nextly_bootMigrationsPending?: Promise<void>;
+  __nextly_bootMigrationsRefused?: NextlyError;
+};
+
+/** Handle for the boot that owns the gate, returned by {@link beginBootMigrations}. */
+export interface BootMigrationsGate {
+  /** Migrations ran (or were not required): serving is allowed. */
+  allow(): void;
+  /** Migrations did not run: this process must not serve, now or later. */
+  refuse(error: NextlyError): void;
+}
+
+/**
+ * Open the gate for a boot that is about to run migrations.
+ *
+ * Called BEFORE `registerServices()` so the window this closes — registered but
+ * unverified — never exists unguarded. Every consumer that arrives after this
+ * point waits for `allow` or `refuse`.
+ */
+export function beginBootMigrations(): BootMigrationsGate {
+  let settle: (() => void) | undefined;
+  let fail: ((error: unknown) => void) | undefined;
+
+  const pending = new Promise<void>((resolve, reject) => {
+    settle = resolve;
+    fail = reject;
+  });
+  // Consumers attach their own handlers when they await this. Attaching one
+  // here keeps a refusal from surfacing as an unhandled rejection in the window
+  // before the first consumer arrives — which would crash the process for the
+  // wrong reason and hide the refusal behind it.
+  void pending.catch(() => undefined);
+
+  globalForGate.__nextly_bootMigrationsPending = pending;
+  delete globalForGate.__nextly_bootMigrationsRefused;
+
+  return {
+    allow(): void {
+      globalForGate.__nextly_bootMigrationsPending = undefined;
+      settle?.();
+    },
+    refuse(error: NextlyError): void {
+      // Recorded BEFORE rejecting, so a consumer that arrives after the promise
+      // settles still finds the refusal rather than an empty gate.
+      globalForGate.__nextly_bootMigrationsRefused = error;
+      globalForGate.__nextly_bootMigrationsPending = undefined;
+      fail?.(error);
+    },
+  };
+}
+
+/**
+ * Wait until boot migrations have settled, then throw if they refused.
+ *
+ * Resolves immediately when no boot has opened the gate — development, or
+ * `runMigrationsOnBoot` off — so this is safe to call from any serving surface
+ * unconditionally.
+ */
+export async function awaitBootMigrations(): Promise<void> {
+  const refused = globalForGate.__nextly_bootMigrationsRefused;
+  if (refused) throw refused;
+
+  const pending = globalForGate.__nextly_bootMigrationsPending;
+  if (pending) await pending;
+}
+
+/** Test seam: drop all gate state. Never called by product code. */
+export function _resetBootMigrationsGateForTest(): void {
+  globalForGate.__nextly_bootMigrationsPending = undefined;
+  delete globalForGate.__nextly_bootMigrationsRefused;
+}

--- a/packages/nextly/src/init/boot-migrations-gate.ts
+++ b/packages/nextly/src/init/boot-migrations-gate.ts
@@ -26,60 +26,85 @@ import type { NextlyError } from "../errors";
 const globalForGate = globalThis as unknown as {
   __nextly_bootMigrationsPending?: Promise<void>;
   __nextly_bootMigrationsRefused?: NextlyError;
+  __nextly_settle?: () => void;
+  __nextly_fail?: (error: unknown) => void;
 };
 
-/** Handle for the boot that owns the gate, returned by {@link beginBootMigrations}. */
-export interface BootMigrationsGate {
-  /** Migrations ran (or were not required): serving is allowed. */
-  allow(): void;
-  /** Migrations did not run: this process must not serve, now or later. */
-  refuse(error: NextlyError): void;
-}
-
 /**
- * Open the gate for a boot that is about to run migrations.
+ * Open the gate, if this boot will run migrations.
  *
- * Called BEFORE `registerServices()` so the window this closes — registered but
- * unverified — never exists unguarded. Every consumer that arrives after this
- * point waits for `allow` or `refuse`.
+ * Called from `registerServices()` BEFORE it publishes the container, because
+ * that is the only boundary both boot paths cross. Opening it inside the
+ * migration helper was too late: the request path publishes services and only
+ * calls that helper afterwards, leaving a window in which `isServicesRegistered()`
+ * is true, the gate is not yet open, and a concurrent `getNextly()` serves.
+ *
+ * Gated on the conditions under which `runProdMigrationsIfEnabled` will settle
+ * it. Opening it more widely would hang every caller that registers services
+ * without ever running boot migrations — the test harness and the CLI.
  */
-export function beginBootMigrations(): BootMigrationsGate {
+export function openBootMigrationsGate(willRunMigrations: boolean): void {
+  if (process.env.NODE_ENV !== "production") return;
+  if (!willRunMigrations) return;
+  if (globalForGate.__nextly_bootMigrationsPending) return;
+
   let settle: (() => void) | undefined;
   let fail: ((error: unknown) => void) | undefined;
-
   const pending = new Promise<void>((resolve, reject) => {
     settle = resolve;
     fail = reject;
   });
   // Consumers attach their own handlers when they await this. Attaching one
   // here keeps a refusal from surfacing as an unhandled rejection in the window
-  // before the first consumer arrives — which would crash the process for the
+  // before the first consumer arrives, which would crash the process for the
   // wrong reason and hide the refusal behind it.
   void pending.catch(() => undefined);
 
   globalForGate.__nextly_bootMigrationsPending = pending;
+  globalForGate.__nextly_settle = settle;
+  globalForGate.__nextly_fail = fail;
   delete globalForGate.__nextly_bootMigrationsRefused;
+}
 
-  return {
-    allow(): void {
-      globalForGate.__nextly_bootMigrationsPending = undefined;
-      settle?.();
-    },
-    refuse(error: NextlyError): void {
-      // Recorded BEFORE rejecting, so a consumer that arrives after the promise
-      // settles still finds the refusal rather than an empty gate.
-      globalForGate.__nextly_bootMigrationsRefused = error;
-      globalForGate.__nextly_bootMigrationsPending = undefined;
-      fail?.(error);
-    },
-  };
+/** Migrations ran, were not required, or failed recoverably: serving is allowed. */
+export function allowBootMigrations(): void {
+  const settle = globalForGate.__nextly_settle;
+  globalForGate.__nextly_bootMigrationsPending = undefined;
+  globalForGate.__nextly_settle = undefined;
+  globalForGate.__nextly_fail = undefined;
+  settle?.();
+}
+
+/** Migrations did not run: this process must not serve, now or on any retry. */
+export function refuseBootMigrations(error: NextlyError): void {
+  const fail = globalForGate.__nextly_fail;
+  // Recorded BEFORE rejecting, so a consumer arriving after the promise settles
+  // still finds the refusal rather than an empty gate.
+  globalForGate.__nextly_bootMigrationsRefused = error;
+  globalForGate.__nextly_bootMigrationsPending = undefined;
+  globalForGate.__nextly_settle = undefined;
+  globalForGate.__nextly_fail = undefined;
+  fail?.(error);
+}
+
+/**
+ * Throw if a previous boot already refused, WITHOUT waiting on a pending gate.
+ *
+ * For the migration helper itself, which is the code that settles the gate: it
+ * must still honour an earlier refusal, but awaiting a gate it is responsible
+ * for closing deadlocks the boot it was called to perform. Serving surfaces
+ * want {@link awaitBootMigrations} instead.
+ */
+export function assertBootMigrationsNotRefused(): void {
+  const refused = globalForGate.__nextly_bootMigrationsRefused;
+  if (refused) throw refused;
 }
 
 /**
  * Wait until boot migrations have settled, then throw if they refused.
  *
- * Resolves immediately when no boot has opened the gate — development, or
- * `runMigrationsOnBoot` off — so this is safe to call from any serving surface
+ * Resolves immediately when no boot opened the gate — development, or
+ * `runMigrationsOnBoot` off — so every serving surface can call it
  * unconditionally.
  */
 export async function awaitBootMigrations(): Promise<void> {
@@ -93,5 +118,7 @@ export async function awaitBootMigrations(): Promise<void> {
 /** Test seam: drop all gate state. Never called by product code. */
 export function _resetBootMigrationsGateForTest(): void {
   globalForGate.__nextly_bootMigrationsPending = undefined;
+  globalForGate.__nextly_settle = undefined;
+  globalForGate.__nextly_fail = undefined;
   delete globalForGate.__nextly_bootMigrationsRefused;
 }

--- a/packages/nextly/src/init/build-service-config.ts
+++ b/packages/nextly/src/init/build-service-config.ts
@@ -65,6 +65,14 @@ export function buildServiceConfig(
   // Start with provided config or empty object
   const serviceConfig: Partial<NextlyServiceConfig> = {};
 
+  // Carried so `registerServices` can open the boot-migrations gate before it
+  // publishes the container. Set here because this builder is the one both boot
+  // paths go through, which is what stops the flag reaching one and not the
+  // other — the failure this whole change exists to prevent.
+  if (providedConfig?.config?.db?.runMigrationsOnBoot === true) {
+    serviceConfig.runMigrationsOnBoot = true;
+  }
+
   // Copy over service config properties (excluding 'config')
   if (providedConfig) {
     const { config: nextlyConfig, ...rest } = providedConfig;

--- a/packages/nextly/src/init/build-service-config.ts
+++ b/packages/nextly/src/init/build-service-config.ts
@@ -65,18 +65,19 @@ export function buildServiceConfig(
   // Start with provided config or empty object
   const serviceConfig: Partial<NextlyServiceConfig> = {};
 
-  // Carried so `registerServices` can open the boot-migrations gate before it
-  // publishes the container. Set here because this builder is the one both boot
-  // paths go through, which is what stops the flag reaching one and not the
-  // other — the failure this whole change exists to prevent.
-  if (providedConfig?.config?.db?.runMigrationsOnBoot === true) {
-    serviceConfig.runMigrationsOnBoot = true;
-  }
-
   // Copy over service config properties (excluding 'config')
   if (providedConfig) {
     const { config: nextlyConfig, ...rest } = providedConfig;
     Object.assign(serviceConfig, rest);
+
+    // AFTER the caller spread, and derived only from the nested config, so a
+    // caller cannot set it directly. It is internal wiring, not an option: the
+    // gate it opens must match what `runProdMigrationsIfEnabled` will actually
+    // do, and that reads `config.db.runMigrationsOnBoot`. A caller passing a
+    // conflicting top-level value would open no gate while migrations ran
+    // anyway — the exact unguarded window this exists to close.
+    serviceConfig.runMigrationsOnBoot =
+      nextlyConfig?.db?.runMigrationsOnBoot === true;
 
     // If storagePlugins not explicitly provided, use from nextly.config.ts
     if (!serviceConfig.storagePlugins && nextlyConfig?.storage) {

--- a/packages/nextly/src/init/prod-migrations.ts
+++ b/packages/nextly/src/init/prod-migrations.ts
@@ -14,8 +14,9 @@ import { resolveDeclaredSchema } from "../domains/schema/migrate/resolved-schema
 import { NextlyError } from "../errors";
 
 import {
-  awaitBootMigrations,
-  beginBootMigrations,
+  allowBootMigrations,
+  assertBootMigrationsNotRefused,
+  refuseBootMigrations,
 } from "./boot-migrations-gate";
 
 interface AdapterLike {
@@ -128,10 +129,23 @@ export async function runProdMigrationsIfEnabled(
 ): Promise<void> {
   // Before the environment checks, because a process that has already refused
   // must keep refusing regardless of how the next caller reaches this.
-  await awaitBootMigrations();
+  //
+  // The REFUSAL only, not the pending gate: this function is what settles that
+  // gate, so awaiting it here would deadlock the very boot it was called to
+  // perform. Found by a test that hung for ten seconds, not by reading it.
+  assertBootMigrationsNotRefused();
 
-  if (process.env.NODE_ENV !== "production") return;
-  if (args.config.db.runMigrationsOnBoot !== true) return;
+  // Settled on the early exits too: `registerServices` only opens the gate
+  // under exactly these conditions, but a mismatch here would hang every
+  // consumer, so this closes it rather than assuming it was never opened.
+  if (process.env.NODE_ENV !== "production") {
+    allowBootMigrations();
+    return;
+  }
+  if (args.config.db.runMigrationsOnBoot !== true) {
+    allowBootMigrations();
+    return;
+  }
 
   const { adapter, logger } = args;
   const migrationsDir = resolve(process.cwd(), args.config.db.migrationsDir);
@@ -181,11 +195,6 @@ export async function runProdMigrationsIfEnabled(
       return migrateCore(deps as never);
     });
 
-  // Opened before any work, so the window this closes — services registered but
-  // the schema unverified — never exists unguarded. Consumers that arrive from
-  // another surface now wait here instead of serving on the registered flag.
-  const gate = beginBootMigrations();
-
   try {
     logger.info("[Nextly] Running production migrations on boot...");
     const resolvedSchema = await resolveDeclaredSchema({
@@ -224,7 +233,7 @@ export async function runProdMigrationsIfEnabled(
       throw bootMigrationsNotRun(adapter.dialect);
     }
     logger.info(`[Nextly] Boot migrations complete (${applied} applied).`);
-    gate.allow();
+    allowBootMigrations();
   } catch (err) {
     // A refusal is not a failure to swallow. Every other error here is
     // recoverable by running `nextly migrate` against a database the app can
@@ -246,7 +255,7 @@ export async function runProdMigrationsIfEnabled(
           : bootMigrationsNotRun(args.adapter.dialect);
       // Recorded BEFORE rethrowing, so the next request through either entry
       // point refuses too rather than finding services already registered.
-      gate.refuse(fatal);
+      refuseBootMigrations(fatal);
       // Reopen the registration gate, or the sticky flag above is unreachable.
       // Both entry points call this helper only inside
       // `if (!isServicesRegistered())`, and `registerServices()` has already
@@ -277,6 +286,6 @@ export async function runProdMigrationsIfEnabled(
     // The app continues on this path, so the gate must open — a swallowed
     // failure that left it pending would hang every consumer forever, turning a
     // recoverable error into a worse outage than the one being tolerated.
-    gate.allow();
+    allowBootMigrations();
   }
 }

--- a/packages/nextly/src/init/prod-migrations.ts
+++ b/packages/nextly/src/init/prod-migrations.ts
@@ -13,6 +13,11 @@ import { shutdownServices } from "../di";
 import { resolveDeclaredSchema } from "../domains/schema/migrate/resolved-schema";
 import { NextlyError } from "../errors";
 
+import {
+  awaitBootMigrations,
+  beginBootMigrations,
+} from "./boot-migrations-gate";
+
 interface AdapterLike {
   dialect: "postgresql" | "mysql" | "sqlite";
   getDrizzle: () => unknown;
@@ -90,9 +95,6 @@ export interface RunProdMigrationsArgs {
  * is now correct — the migration it would need to observe is the one that did
  * not run. A restart is the recovery, and that is what an orchestrator does.
  */
-const globalForBootMigrations = globalThis as unknown as {
-  __nextly_bootMigrationsRefused?: NextlyError;
-};
 
 /** The refusal, built in one place so its code and wording cannot drift. */
 function bootMigrationsNotRun(dialect: string): NextlyError {
@@ -126,8 +128,7 @@ export async function runProdMigrationsIfEnabled(
 ): Promise<void> {
   // Before the environment checks, because a process that has already refused
   // must keep refusing regardless of how the next caller reaches this.
-  const refused = globalForBootMigrations.__nextly_bootMigrationsRefused;
-  if (refused) throw refused;
+  await awaitBootMigrations();
 
   if (process.env.NODE_ENV !== "production") return;
   if (args.config.db.runMigrationsOnBoot !== true) return;
@@ -180,6 +181,11 @@ export async function runProdMigrationsIfEnabled(
       return migrateCore(deps as never);
     });
 
+  // Opened before any work, so the window this closes — services registered but
+  // the schema unverified — never exists unguarded. Consumers that arrive from
+  // another surface now wait here instead of serving on the registered flag.
+  const gate = beginBootMigrations();
+
   try {
     logger.info("[Nextly] Running production migrations on boot...");
     const resolvedSchema = await resolveDeclaredSchema({
@@ -218,6 +224,7 @@ export async function runProdMigrationsIfEnabled(
       throw bootMigrationsNotRun(adapter.dialect);
     }
     logger.info(`[Nextly] Boot migrations complete (${applied} applied).`);
+    gate.allow();
   } catch (err) {
     // A refusal is not a failure to swallow. Every other error here is
     // recoverable by running `nextly migrate` against a database the app can
@@ -239,7 +246,7 @@ export async function runProdMigrationsIfEnabled(
           : bootMigrationsNotRun(args.adapter.dialect);
       // Recorded BEFORE rethrowing, so the next request through either entry
       // point refuses too rather than finding services already registered.
-      globalForBootMigrations.__nextly_bootMigrationsRefused = fatal;
+      gate.refuse(fatal);
       // Reopen the registration gate, or the sticky flag above is unreachable.
       // Both entry points call this helper only inside
       // `if (!isServicesRegistered())`, and `registerServices()` has already
@@ -267,5 +274,9 @@ export async function runProdMigrationsIfEnabled(
         err instanceof Error ? err.message : String(err)
       }. The app will continue; run \`nextly migrate\` to resolve.`
     );
+    // The app continues on this path, so the gate must open — a swallowed
+    // failure that left it pending would hang every consumer forever, turning a
+    // recoverable error into a worse outage than the one being tolerated.
+    gate.allow();
   }
 }

--- a/packages/nextly/src/init/prod-migrations.ts
+++ b/packages/nextly/src/init/prod-migrations.ts
@@ -9,7 +9,7 @@
 
 import { resolve } from "node:path";
 
-import { clearServices } from "../di";
+import { shutdownServices } from "../di";
 import { resolveDeclaredSchema } from "../domains/schema/migrate/resolved-schema";
 import { NextlyError } from "../errors";
 
@@ -95,15 +95,29 @@ const globalForBootMigrations = globalThis as unknown as {
 };
 
 /** The refusal, built in one place so its code and wording cannot drift. */
-function bootMigrationsNotRun(): NextlyError {
+function bootMigrationsNotRun(dialect: string): NextlyError {
+  // Dialect-specific, because the recovery differs and the wrong advice is
+  // worse than none. `forceUnlock` deletes the Postgres lock ROW; it returns
+  // immediately for every other dialect. MySQL's lock is a session-scoped
+  // `GET_LOCK`, so there IS no stale row to clear — it is held by a live
+  // connection and dies with it, which makes "restart the holder" the only
+  // recovery and `--force-unlock` a no-op that would waste an operator's time
+  // during an incident.
+  const recovery =
+    dialect === "postgresql"
+      ? "This usually resolves on restart once the other instance finishes; " +
+        "if the lock is stale, clear it with `nextly migrate --force-unlock`."
+      : "The lock is held by another live connection and is released when that " +
+        "connection ends, so this usually resolves on restart once the other " +
+        "instance finishes or is stopped.";
+
   return new NextlyError({
     code: "NEXTLY_BOOT_MIGRATIONS_NOT_RUN",
     publicMessage:
       "Boot migrations did not run: the migrate lock was still held after " +
       "waiting. Refusing to start rather than serve against a schema that may " +
-      "not match this build. This usually resolves on restart once the other " +
-      "instance finishes; if the lock is stale, clear it with " +
-      "`nextly migrate --force-unlock`.",
+      "not match this build. " +
+      recovery,
   });
 }
 
@@ -201,7 +215,7 @@ export async function runProdMigrationsIfEnabled(
     // finished. A genuinely stuck lock needs `nextly migrate --force-unlock`,
     // which is the intervention the situation actually calls for.
     if (!ran) {
-      throw bootMigrationsNotRun();
+      throw bootMigrationsNotRun(adapter.dialect);
     }
     logger.info(`[Nextly] Boot migrations complete (${applied} applied).`);
   } catch (err) {
@@ -222,7 +236,7 @@ export async function runProdMigrationsIfEnabled(
       const fatal =
         err.code === "NEXTLY_BOOT_MIGRATIONS_NOT_RUN"
           ? err
-          : bootMigrationsNotRun();
+          : bootMigrationsNotRun(args.adapter.dialect);
       // Recorded BEFORE rethrowing, so the next request through either entry
       // point refuses too rather than finding services already registered.
       globalForBootMigrations.__nextly_bootMigrationsRefused = fatal;
@@ -239,7 +253,12 @@ export async function runProdMigrationsIfEnabled(
       // every request. That is the right trade: the process is refusing to
       // serve and wants restarting, and a wasted registration is cheaper than a
       // request served against a schema nobody verified.
-      clearServices();
+      // `shutdownServices`, not `clearServices`: the latter empties the
+      // container WITHOUT disconnecting the adapter, so re-registering on the
+      // next request would build a second connected pool and leak one per
+      // retry — exhausting connections that healthy replicas need. Tearing
+      // down releases what this boot took before reopening the gate.
+      await shutdownServices();
       logger.error(`[Nextly] ${fatal.publicMessage}`);
       throw fatal;
     }

--- a/packages/nextly/src/init/prod-migrations.ts
+++ b/packages/nextly/src/init/prod-migrations.ts
@@ -79,24 +79,6 @@ export interface RunProdMigrationsArgs {
   migrateCore?: MigrateCoreLike;
 }
 
-/**
- * Set once this process has refused to serve, and never cleared.
- *
- * The refusal has to OUTLIVE the request that raised it. Both production entry
- * points run migrations inside `if (!isServicesRegistered())`, and by the time
- * this throws, `registerServices()` has already marked DI registered — so the
- * next request skips migrations entirely and serves the schema this process was
- * refusing to serve. Throwing once only fails one request.
- *
- * On `globalThis` for the same reason the boot plugin list is: Next.js and
- * Turbopack can evaluate this module in more than one server graph, and a
- * refusal recorded in one copy has to be seen by the other.
- *
- * Never cleared, deliberately. Nothing in the process can establish the schema
- * is now correct — the migration it would need to observe is the one that did
- * not run. A restart is the recovery, and that is what an orchestrator does.
- */
-
 /** The refusal, built in one place so its code and wording cannot drift. */
 function bootMigrationsNotRun(dialect: string): NextlyError {
   // Dialect-specific, because the recovery differs and the wrong advice is

--- a/packages/nextly/src/init/prod-migrations.ts
+++ b/packages/nextly/src/init/prod-migrations.ts
@@ -72,9 +72,48 @@ export interface RunProdMigrationsArgs {
   migrateCore?: MigrateCoreLike;
 }
 
+/**
+ * Set once this process has refused to serve, and never cleared.
+ *
+ * The refusal has to OUTLIVE the request that raised it. Both production entry
+ * points run migrations inside `if (!isServicesRegistered())`, and by the time
+ * this throws, `registerServices()` has already marked DI registered — so the
+ * next request skips migrations entirely and serves the schema this process was
+ * refusing to serve. Throwing once only fails one request.
+ *
+ * On `globalThis` for the same reason the boot plugin list is: Next.js and
+ * Turbopack can evaluate this module in more than one server graph, and a
+ * refusal recorded in one copy has to be seen by the other.
+ *
+ * Never cleared, deliberately. Nothing in the process can establish the schema
+ * is now correct — the migration it would need to observe is the one that did
+ * not run. A restart is the recovery, and that is what an orchestrator does.
+ */
+const globalForBootMigrations = globalThis as unknown as {
+  __nextly_bootMigrationsRefused?: NextlyError;
+};
+
+/** The refusal, built in one place so its code and wording cannot drift. */
+function bootMigrationsNotRun(): NextlyError {
+  return new NextlyError({
+    code: "NEXTLY_BOOT_MIGRATIONS_NOT_RUN",
+    publicMessage:
+      "Boot migrations did not run: the migrate lock was still held after " +
+      "waiting. Refusing to start rather than serve against a schema that may " +
+      "not match this build. This usually resolves on restart once the other " +
+      "instance finishes; if the lock is stale, clear it with " +
+      "`nextly migrate --force-unlock`.",
+  });
+}
+
 export async function runProdMigrationsIfEnabled(
   args: RunProdMigrationsArgs
 ): Promise<void> {
+  // Before the environment checks, because a process that has already refused
+  // must keep refusing regardless of how the next caller reaches this.
+  const refused = globalForBootMigrations.__nextly_bootMigrationsRefused;
+  if (refused) throw refused;
+
   if (process.env.NODE_ENV !== "production") return;
   if (args.config.db.runMigrationsOnBoot !== true) return;
 
@@ -161,15 +200,7 @@ export async function runProdMigrationsIfEnabled(
     // finished. A genuinely stuck lock needs `nextly migrate --force-unlock`,
     // which is the intervention the situation actually calls for.
     if (!ran) {
-      throw new NextlyError({
-        code: "NEXTLY_BOOT_MIGRATIONS_NOT_RUN",
-        publicMessage:
-          "Boot migrations did not run: the migrate lock was still held after " +
-          "waiting. Refusing to start rather than serve against a schema that " +
-          "may not match this build. This usually resolves on restart once the " +
-          "other instance finishes; if the lock is stale, clear it with " +
-          "`nextly migrate --force-unlock`.",
-      });
+      throw bootMigrationsNotRun();
     }
     logger.info(`[Nextly] Boot migrations complete (${applied} applied).`);
   } catch (err) {
@@ -177,12 +208,25 @@ export async function runProdMigrationsIfEnabled(
     // recoverable by running `nextly migrate` against a database the app can
     // still usefully serve; this one means the app does not know what it is
     // serving, which is the case the refusal exists for.
+    // Two fatal shapes, and MySQL is why the second is here: `withMigrateLock`
+    // reports a busy lock as `ran: false` on Postgres but THROWS
+    // `NEXTLY_MIGRATE_LOCK_BUSY` on MySQL when the wait expires mid-flight.
+    // Rethrowing only the first would have left MySQL serving the unmigrated
+    // schema this whole change exists to prevent.
     if (
       err instanceof NextlyError &&
-      err.code === "NEXTLY_BOOT_MIGRATIONS_NOT_RUN"
+      (err.code === "NEXTLY_BOOT_MIGRATIONS_NOT_RUN" ||
+        err.code === "NEXTLY_MIGRATE_LOCK_BUSY")
     ) {
-      logger.error(`[Nextly] ${err.publicMessage}`);
-      throw err;
+      const fatal =
+        err.code === "NEXTLY_BOOT_MIGRATIONS_NOT_RUN"
+          ? err
+          : bootMigrationsNotRun();
+      // Recorded BEFORE rethrowing, so the next request through either entry
+      // point refuses too rather than finding services already registered.
+      globalForBootMigrations.__nextly_bootMigrationsRefused = fatal;
+      logger.error(`[Nextly] ${fatal.publicMessage}`);
+      throw fatal;
     }
     logger.error(
       `[Nextly] Boot migrations failed: ${

--- a/packages/nextly/src/init/prod-migrations.ts
+++ b/packages/nextly/src/init/prod-migrations.ts
@@ -10,6 +10,7 @@
 import { resolve } from "node:path";
 
 import { resolveDeclaredSchema } from "../domains/schema/migrate/resolved-schema";
+import { NextlyError } from "../errors";
 
 interface AdapterLike {
   dialect: "postgresql" | "mysql" | "sqlite";
@@ -37,7 +38,7 @@ interface MigrateCoreLike {
     isSettled?: () => Promise<boolean>;
     ensureLedger?: () => Promise<void>;
     knownJunctions?: ReadonlySet<string>;
-  }): Promise<{ applied: number; coreChanged: boolean }>;
+  }): Promise<{ applied: number; coreChanged: boolean; ran: boolean }>;
 }
 
 export interface RunProdMigrationsArgs {
@@ -132,7 +133,7 @@ export async function runProdMigrationsIfEnabled(
       config: args.config,
       deferredExtends: args.deferredExtends,
     });
-    const { applied } = await core({
+    const { applied, ran } = await core({
       dialect: adapter.dialect,
       db: adapter.getDrizzle(),
       adapter,
@@ -143,8 +144,46 @@ export async function runProdMigrationsIfEnabled(
       knownJunctions: resolvedSchema.knownJunctions,
       ensureLedger,
     });
+    // REFUSES rather than serving. `ran: false` means the migrate lock stayed
+    // held past the wait deadline, so this process never learned whether the
+    // schema it is about to serve matches the code. The tempting reading — "the
+    // holder did the work, carry on" — is an assumption: the holder may have
+    // died, been killed, or still be mid-flight, and a lock timing out says
+    // nothing about whether migrations ran.
+    //
+    // `applied` is 0 here and 0 on an up-to-date database, which is why this
+    // previously logged `complete (0 applied)` and started anyway. On a rolling
+    // deploy that is the second replica serving traffic against a schema it
+    // never migrated.
+    //
+    // Failing startup is recoverable and quiet in an orchestrator: the process
+    // exits, the platform restarts it, and by then the holder has usually
+    // finished. A genuinely stuck lock needs `nextly migrate --force-unlock`,
+    // which is the intervention the situation actually calls for.
+    if (!ran) {
+      throw new NextlyError({
+        code: "NEXTLY_BOOT_MIGRATIONS_NOT_RUN",
+        publicMessage:
+          "Boot migrations did not run: the migrate lock was still held after " +
+          "waiting. Refusing to start rather than serve against a schema that " +
+          "may not match this build. This usually resolves on restart once the " +
+          "other instance finishes; if the lock is stale, clear it with " +
+          "`nextly migrate --force-unlock`.",
+      });
+    }
     logger.info(`[Nextly] Boot migrations complete (${applied} applied).`);
   } catch (err) {
+    // A refusal is not a failure to swallow. Every other error here is
+    // recoverable by running `nextly migrate` against a database the app can
+    // still usefully serve; this one means the app does not know what it is
+    // serving, which is the case the refusal exists for.
+    if (
+      err instanceof NextlyError &&
+      err.code === "NEXTLY_BOOT_MIGRATIONS_NOT_RUN"
+    ) {
+      logger.error(`[Nextly] ${err.publicMessage}`);
+      throw err;
+    }
     logger.error(
       `[Nextly] Boot migrations failed: ${
         err instanceof Error ? err.message : String(err)

--- a/packages/nextly/src/init/prod-migrations.ts
+++ b/packages/nextly/src/init/prod-migrations.ts
@@ -9,6 +9,7 @@
 
 import { resolve } from "node:path";
 
+import { clearServices } from "../di";
 import { resolveDeclaredSchema } from "../domains/schema/migrate/resolved-schema";
 import { NextlyError } from "../errors";
 
@@ -225,6 +226,20 @@ export async function runProdMigrationsIfEnabled(
       // Recorded BEFORE rethrowing, so the next request through either entry
       // point refuses too rather than finding services already registered.
       globalForBootMigrations.__nextly_bootMigrationsRefused = fatal;
+      // Reopen the registration gate, or the sticky flag above is unreachable.
+      // Both entry points call this helper only inside
+      // `if (!isServicesRegistered())`, and `registerServices()` has already
+      // made that false by the time we get here — so a second request would
+      // skip this helper entirely, build the dispatcher, and serve. Clearing
+      // registration is ONE edit at the point of refusal; adding the check to
+      // both caller gates would be the same fix wired into two places, which is
+      // how the original defect survived in the first place.
+      //
+      // It costs a re-registration per request on a process that now fails
+      // every request. That is the right trade: the process is refusing to
+      // serve and wants restarting, and a wasted registration is cheaper than a
+      // request served against a schema nobody verified.
+      clearServices();
       logger.error(`[Nextly] ${fatal.publicMessage}`);
       throw fatal;
     }

--- a/packages/nextly/src/route-handler/auth-handler.ts
+++ b/packages/nextly/src/route-handler/auth-handler.ts
@@ -17,6 +17,7 @@ import {
   shutdownServices,
 } from "../di";
 import type { NextlyServiceConfig } from "../di/register";
+import { awaitBootMigrations } from "../init/boot-migrations-gate";
 import { buildServiceConfig } from "../init/build-service-config";
 import { seedAllPermissions } from "../init/seed-permissions";
 import { ensureHmrListener } from "../runtime/hmr-listener";
@@ -357,6 +358,12 @@ export async function ensureServicesInitialized(): Promise<void> {
   });
   _initInFlight = run;
   await run;
+
+  // After registration, because this is the request path's own gate: a boot on
+  // ANOTHER surface may still be waiting on the migrate lock, and this one must
+  // not start dispatching until that settles. Resolves immediately when no boot
+  // opened the gate.
+  await awaitBootMigrations();
 }
 
 // The in-flight recovery/registration pass concurrent callers await.


### PR DESCRIPTION
A production instance could serve traffic against a database it never migrated, while logging that migrations completed.

Handed over by the lock-schema lane after I found it; they verified it independently first.

## The defect

`withMigrateLock` in `"wait"` mode polls until a deadline, then:

```ts
opts.logger?.warn?.("[Nextly] migrate lock still held after waiting; proceeding without it.");
return undefined;   // returns WITHOUT calling fn()
```

The message says it proceeds. It returns. And `migrateCore` accumulates `applied` by mutation *inside* that callback, so a callback that never ran leaves `applied = 0` — identical to an up-to-date database.

`init/prod-migrations.ts` is the only `"wait"`-mode caller (`db.runMigrationsOnBoot`). It then logged:

```
[Nextly] Boot migrations complete (0 applied).
```

On a rolling deploy or any multi-replica start, that is the second instance serving against an unmigrated schema and reporting success.

## Why it was invisible

The guard already existed — in exactly one caller. `migrate-baseline.ts:603` checks `result === undefined` and throws, with a comment explaining that "an empty result here would mean reporting success for a history that was never started". That reasoning is verbatim what boot needed. It was wired into one call site and the other was never revisited.

The root cause is that `undefined` was doing double duty: *"your function returned undefined"* and *"your function never ran"*. Only a convention distinguished them.

## What changed

**`withMigrateLock` returns a discriminated outcome** — `{ ran: true; value: T } | { ran: false; reason: "lock-held" }` — so the compiler enumerates the call sites instead of a comment. It found every one: `migrate-baseline`, `migrate-resolve`, `migrate-down`, `migrate`, `upgrade` ×2.

**Boot refuses to start** when `ran` is false, throwing `NEXTLY_BOOT_MIGRATIONS_NOT_RUN`. Founder decision, and the reasoning is that the tempting reading — *the holder did the work, carry on* — is an assumption. The holder may have died, been killed, or still be mid-flight; a lock timing out says nothing about whether migrations ran. Failing startup is recoverable and quiet in an orchestrator: the process exits, the platform restarts it, and the holder has usually finished by then. A genuinely stale lock wants `nextly migrate --force-unlock`, which is the intervention the situation actually calls for.

**Every other boot-migration failure is still swallowed**, deliberately. Those leave a database the app can usefully serve and `nextly migrate` fixes them. Only *"we do not know what we are serving"* is fatal.

**The wait-timeout message now says the migrations were SKIPPED.**

## Tests

- `refuses to start when the migrations did not run`
- `still starts when boot migrations fail for any other reason` — the boundary control, so the refusal cannot silently widen into "any failure is fatal"
- `wait mode: settles via isSettled()` now asserts `{ ran: false, reason: "lock-held" }` rather than `undefined`

Break-verified at all three layers independently: disabling the refusal, swallowing it in the `catch`, and making the lock report `ran: true` when it skipped each fail the intended test and only that test.

The test doubles for `withLock` in `migrate-down` and `migrate-core` had to adopt the real discriminated shape — a double looser than production is how this class of thing survives.

## Not in scope

`withMigrateLock` has **no TTL renewal**: nothing extends the lease while `fn()` runs, so a migration exceeding 900s lets a second process acquire and begin applying DDL concurrently. Postgres only — MySQL's `GET_LOCK` is session-scoped and SQLite is a no-op. That is the same hazard the lock-schema lane is fixing on the field-group lock in #777, and its complete answer needs cancellation between steps, for which this codebase has no convention (measured: `AbortSignal` appears in exactly one non-test file). Left deliberately: the skip-reported-as-success is live and silent today, and shipping the honest result first stops the dangerous case being invisible while the rest is designed.

Also unfixed and noted: `maxWaitMs` defaults to `ttlSeconds * 1000`, so `wait` mode gives up at precisely the moment the lock would have become acquirable.

Filed as `tasks/left-tasks/2026-08-14-0600-boot-migrations-report-success-when-the-lock-times-out.md`.

## Verification

Typecheck and lint clean. Failing unit files are the four already-recorded pre-existing ones (`migration-discovery`, `runtime-schema-generator`, `build-from-fields`, `field-column-descriptor`) — no new failures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an option to run database migrations during service startup.
  - Service initialization and request handling now wait for startup migrations to complete.
- **Bug Fixes**
  - Services no longer begin serving when migration locks cannot be acquired within the configured wait period.
  - Migration lock outcomes are handled consistently across supported database engines.
  - Added clearer errors for unavailable migration locks and refused startup.
- **Reliability**
  - Startup refusal remains enforced until migrations can safely complete, preventing requests against an unprepared schema.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->