### PR TITLE
ci: compare a pull request against its merge base, not the branch tip

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,25 @@ jobs:
             fail_open "base $BASE_SHA is not present; running everything."
           fi
 
+          # On a pull request, compare against the MERGE BASE rather than the
+          # base branch's current tip. `pull_request.base.sha` moves as `main`
+          # advances, so diffing from it reports every commit `main` gained
+          # since the branch point as though this pull request had made it.
+          # Measured here: a change touching one `.claude/` file read as six
+          # files and ran the full matrix. The error is in the safe direction —
+          # it can only ever run MORE — but in a repository with several
+          # branches active it fires on nearly every pull request, which is the
+          # whole cost this job exists to remove.
+          #
+          # A push already carries the right value in `before`: the previous tip
+          # of that branch, which is the merge base by construction.
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            MERGE_BASE=$(git merge-base "$BASE_SHA" "$HEAD_SHA" 2>/dev/null) || \
+              fail_open "no merge base for $BASE_SHA..$HEAD_SHA; running everything."
+            [ -n "$MERGE_BASE" ] || fail_open "empty merge base; running everything."
+            BASE_SHA="$MERGE_BASE"
+          fi
+
           CHANGED=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA" 2>/dev/null) || \
             fail_open "could not diff $BASE_SHA..$HEAD_SHA; running everything."
 


### PR DESCRIPTION
## Why

#780 added a `changes` job that skips build/test/e2e when every changed file is provably inert. **It was doing almost nothing.**

Measured on its first live run, PR #774 — a change to exactly one file under `.claude/`:

```
git diff base.sha..head        -> 6 files   (5 of them main's own commits)
git diff merge-base..head      -> 1 file    .claude/rules/verifying-merged-work.md
```

It read six files, decided `inert=false`, and ran the full 45-minute matrix on a documentation-only change.

## Cause

`pull_request.base.sha` is the base branch's **current tip**, not the branch point. It advances as `main` does, so diffing from it attributes every commit `main` gained to this PR.

## Why it survived review and its own controls

The error is in the **safe** direction — it can only ever run *more* — so nothing failed, no test caught it, and the job's own summary reported a correct decision. That is the harder shape to notice: the mechanism works, the verdict is right, and the cost it exists to remove is still being paid in full. With several branches active it fires on nearly every PR.

## Fix

Use the merge base on `pull_request`. A `push` needs no equivalent: `github.event.before` is the previous tip of that branch, which is the merge base by construction.

Failure to compute a merge base falls open like every other uncertainty in this job.

## Verification

Simulated against #774's real SHAs:

```
merge-base 7ea3567c5 0c5f6e357 -> dd3eafdc2
files: 1
  .claude/rules/verifying-merged-work.md
-> inert=true (CI SKIPPED)
```

YAML parses; job graph unchanged (`changes`, `ci`, `e2e`, `scaffold-smoke`, `dev-script-smoke`).

CI-only: no changeset.