### PR TITLE
chore(nextly): tighten the bare-error ratchet after cleaning a throw

### DIFF
--- a/packages/nextly/eslint-bare-error-allowlist.json
+++ b/packages/nextly/eslint-bare-error-allowlist.json
@@ -20,7 +20,7 @@
   "src/dispatcher/dispatcher.ts": 4,
   "src/dispatcher/handlers/auth-dispatcher.ts": 18,
   "src/dispatcher/handlers/collection-dispatcher.ts": 28,
-  "src/dispatcher/handlers/component-dispatcher.ts": 14,
+  "src/dispatcher/handlers/component-dispatcher.ts": 13,
   "src/dispatcher/handlers/email-dispatcher.ts": 4,
   "src/dispatcher/handlers/form-dispatcher.ts": 1,
   "src/dispatcher/handlers/single-dispatcher.ts": 22,


### PR DESCRIPTION
`main` fails `Lint / Typecheck / Test / Build` for **every open PR**, and main's own run does not report it.

## What happened

#781 removed a bare `throw new Error` from `dispatcher/handlers/component-dispatcher.ts` and did not lower the allowlist entry protecting it. Measured on `origin/main`:

| | |
| --- | --- |
| `eslint-bare-error-allowlist.json` | `component-dispatcher.ts: 14` |
| actual bare throws in that file | **13** |

The guard fails on the LOWER count, which is the direction nobody expects a cleanup to break anything in. Its own message says exactly this: *"A LOWER count means they were cleaned — lower the number, or remove the entry entirely at zero, so the guard starts protecting them."*

## Why it reached main

I had already fixed this on the branch as `978cbb949`, **after** GitHub computed the merge. `gh pr view 781 --json headRefOid` reports `ac29f25f3`; the merge `cec9cc391` was built from that snapshot, so the fix was stranded on the branch and never landed. This commit is a cherry-pick of it.

## Why nobody caught it

`main`'s own `Lint / Typecheck / Test / Build` is **skipped**, so the break is invisible on main and surfaces only on PRs — where it reads as the PR's fault. Confirmed on an unrelated PR whose diff touches neither `src/dispatcher/**` nor the allowlist. The tell is that the failing file is one your diff never touched.

## Verification

`bare-error-allowlist.test.ts` 5 passed against main + this change. Break-controlled on the original branch: restoring `14` fails the guard again.

Test-only allowlist data, no published code changes, so no changeset.