### PR TITLE
fix(create-nextly-app): let the workspace-package pin reinstall under pnpm

### DIFF
--- a/.changeset/scaffold-pin-install.md
+++ b/.changeset/scaffold-pin-install.md
@@ -1,0 +1,39 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+Fix the scaffold job's workspace-package pin, and fail closed on an unreadable
+search-index manifest.
+
+The pin rewrites dependency specifiers after the scaffold has generated its
+lockfile, and pnpm turns frozen-lockfile on by default in CI — so the pnpm blog
+leg aborted with ERR_PNPM_OUTDATED_LOCKFILE before it could build.
+
+An index manifest that exists but cannot be parsed no longer reads as owning
+nothing. writeFileSync is not atomic, so an interrupted build can truncate it,
+and treating that as an empty ownership list left the previous index in place
+while the status flipped to empty — the search page would load and serve
+unpublished results.

--- a/.github/workflows/scaffold-build.yml
+++ b/.github/workflows/scaffold-build.yml
@@ -384,7 +384,18 @@ jobs:
           cd /tmp/scaffold-build/scaffolded-app
           node "$GITHUB_WORKSPACE/scripts/pin-workspace-packages.mjs" \
             /tmp/nextly-workspace-packs "${{ matrix.pm }}"
-          ${{ matrix.pm }} install
+
+          # The pin rewrites dependency specifiers AFTER the scaffold generated its
+          # lockfile, so the two disagree by design at this point. pnpm turns
+          # frozen-lockfile ON by default when CI is set and then refuses the install with
+          # ERR_PNPM_OUTDATED_LOCKFILE — measured, with exactly that code — so the repin
+          # has to say it means it. npm has no equivalent default: `npm install` updates
+          # the lockfile, and it is `npm ci` that would refuse.
+          if [ "${{ matrix.pm }}" = "pnpm" ]; then
+            pnpm install --no-frozen-lockfile
+          else
+            npm install
+          fi
 
           # The assertion this whole step exists for, and it has to compare CONTENT: the
           # install exits 0 either way, and a registry copy carries the same name and version

--- a/templates/blog/scripts/build-search-index.mjs
+++ b/templates/blog/scripts/build-search-index.mjs
@@ -121,14 +121,42 @@ function entriesOf(dir) {
   }
 }
 
-/** The entries a previous run recorded owning, or an empty list. */
+/**
+ * The entries a previous run recorded owning.
+ *
+ * An ABSENT manifest means there is nothing to clean and returns an empty list.
+ * A manifest that exists but cannot be read is a different answer and throws:
+ * `writeFileSync` is not atomic, so an interrupted build can leave a truncated
+ * file, and reading that as "owns nothing" would leave the previous index in
+ * place while the status flips to empty — the search page would then load and
+ * serve unpublished results. Refusing is the safe direction, because the build
+ * stops with a cause instead of shipping stale content.
+ */
 function readOwnedEntries(dir) {
+  const path = join(dir, MANIFEST);
+  let raw;
   try {
-    const parsed = JSON.parse(readFileSync(join(dir, MANIFEST), "utf-8"));
-    return Array.isArray(parsed.entries) ? parsed.entries : [];
-  } catch {
-    return [];
+    raw = readFileSync(path, "utf-8");
+  } catch (err) {
+    if (err.code === "ENOENT") return [];
+    throw err;
   }
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    throw new Error(
+      `${path} exists but is not valid JSON (${err.message}). It records which ` +
+        "files the previous search index created; delete it to rebuild from scratch."
+    );
+  }
+  if (!Array.isArray(parsed.entries)) {
+    throw new Error(
+      `${path} has no "entries" array, so the previous index cannot be identified. ` +
+        "Delete it to rebuild from scratch."
+    );
+  }
+  return parsed.entries;
 }
 
 /**


### PR DESCRIPTION
Two defects Codex reported on #783 **after it merged**, so they are on `main` now. Both reproduced before fixing.

## The blog-visual leg cannot install (P1)

#783 added a step that repoints a scaffold at the workspace packages. It rewrites dependency specifiers *after* the scaffold has generated its lockfile, so the two disagree by design at that point — and **pnpm turns `frozen-lockfile` on by default when `CI` is set**. Reproduced locally with the exact code:

```
ERR_PNPM_OUTDATED_LOCKFILE  Cannot install with "frozen-lockfile" because
pnpm-lock.yaml is not up to date with package.json
Note that in CI environments this setting is true by default.
```

So the `blog-visual` leg aborts before it can build. The deliberate repin now says it means it. npm needs no equivalent: `npm install` updates the lockfile, and it is `npm ci` that would refuse — so the flag is applied only on the pnpm leg rather than to both.

## An unreadable index manifest read as "owns nothing" (P2)

The manifest records which files the search index created, so a later empty build can remove exactly those. `writeFileSync` is not atomic, so an interrupted build can leave it truncated — and parsing that into an empty ownership list meant the cleanup deleted only the manifest and **left `pagefind.js` and its fragments in place while the status flipped to `empty`**. The search page would then load successfully and serve unpublished results, which is the exact outcome the manifest exists to prevent.

An **absent** manifest still means there is nothing to clean. A manifest that exists and cannot be read is now an error: the build stops with a cause instead of shipping stale content.

## Verification

Both directions, on a real scaffold:

```
truncated manifest, empty build  -> exit 1, "exists but is not valid JSON ... delete it to
                                    rebuild from scratch"; the index is left in place rather
                                    than silently disowned
posts -> posts -> no posts       -> manifest owns 15 across the rebuild; index removed
absent manifest, absent dir      -> clean no-op, exit 0
```

Gate: `pnpm install --frozen-lockfile` clean, build plus `check-types --continue --force` at 22/22.

## Note on how these arrived

Codex's verdict landed on the merged head after the merge, and the clean pass that preceded it named `790a93f259` — the pre-rebase head — rather than `cc3bbf680`. The rebase was gate-verified locally before pushing, and #783 itself is content-verified whole (15 markers, all present in the merge commit), so nothing was lost; but the review that accompanied the merge was one commit stale, which is what let these two through.
