### PR TITLE
test(blocks-engine): give the node-ceiling case the file's own measurement budget

### DIFF
--- a/packages/blocks-engine/src/performance.test.ts
+++ b/packages/blocks-engine/src/performance.test.ts
@@ -294,15 +294,26 @@ describe("validation scales linearly with document size", () => {
     MEASUREMENT_TIMEOUT_MS
   );
 
-  it("handles a document at the node ceiling", () => {
-    const doc = fiveThousandNodePage();
-    const issues = validate(doc, ctx);
-    // At exactly the cap the document is legal, so the size itself is not an
-    // issue; this asserts the engine completes rather than that it is silent.
-    expect(
-      issues.filter(issue => issue.code === "node-count-exceeded")
-    ).toEqual([]);
-  });
+  it(
+    "handles a document at the node ceiling",
+    () => {
+      const doc = fiveThousandNodePage();
+      const issues = validate(doc, ctx);
+      // At exactly the cap the document is legal, so the size itself is not an
+      // issue; this asserts the engine completes rather than that it is silent.
+      expect(
+        issues.filter(issue => issue.code === "node-count-exceeded")
+      ).toEqual([]);
+    },
+    // Given the same budget as the measurements above, for the reason stated
+    // there: what is asserted is COMPLETION, not speed, so the implicit 5 s
+    // default was a wall-clock threshold this test never chose. Building and
+    // validating five thousand nodes is fast — 26.8 ms locally, fastest of
+    // three — but a saturated worker runs this file more than twenty times
+    // slower, and a budget that survives an idle runner and fails a loaded one
+    // measures the machine rather than the engine.
+    MEASUREMENT_TIMEOUT_MS
+  );
 });
 
 describe("migration scales linearly with document size", () => {


### PR DESCRIPTION
## The defect

`performance.test.ts > handles a document at the node ceiling` fails on `main`, and has done since `fb1d2baf0` — **8 of the last 10 `main` runs**. While it stands, no PR in the repository can meet a "CI fully green" merge gate. Reported by the lane holding #785, whose diff is `packages/nextly` only and cannot reach this package.

The failure is `Error: Test timed out in 5000ms` — not an assertion.

## Why the budget was wrong

The test asserts that validation **completes** and reports no `node-count-exceeded` for a document at exactly the cap. It carries no explicit timeout, so it inherited vitest's 5 s default: a wall-clock threshold it never chose and does not assert.

The file already knows this and says so, at `MEASUREMENT_TIMEOUT_MS`:

> Vitest's default 5 s would then fail on a worker several times slower than a laptop, reintroducing the runner-dependent failure this file is arranged to avoid. The budget is generous because it is not the thing being asserted.

Three tests in the file already take that constant. This one was missed. So this is applying the file's own established convention rather than inventing a tolerance.

## Measured before touching the threshold

A tolerance added to survive noise is subtracted from detection, so the question is whether a real regression is being masked. It is not:

| | |
|---|---|
| `validate()` on 5,000 nodes, fastest of 3 after a warm pass | **26.8 ms** |
| whole `performance.test.ts` file, locally | **2.44 s**, 13 passed |
| same file on a saturated CI runner | **56 s** |
| sibling measurement case on CI, **passing** | **36,097 ms** — it has the longer budget |

26.8 ms against a 5,000 ms limit is not a performance problem. A limit that survives an idle runner and fails a loaded one is measuring the machine, and the runners have been saturated all night.

## Why not raise it further, or lower the fixture

Neither is needed. The sibling tests that genuinely measure speed assert **ratios** (`perRound / passes < CATASTROPHE_CEILING_MS`), which are load-tolerant by construction. This test is not one of them; it is a completeness check that happened to inherit a clock.

## Scope

One test, one file. Test-only, so no changeset.
