### PR TITLE
fix(create-nextly-app): stop generating a script for a CLI command that does not exist

### DIFF
--- a/.changeset/scaffold-real-cli-scripts.md
+++ b/.changeset/scaffold-real-cli-scripts.md
@@ -1,0 +1,30 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+Stop generating a `db:migrate:reset` script that names a command the CLI does not
+register. Every scaffolded project shipped an `npm run db:migrate:reset` that
+failed; `db:migrate:fresh` already drops all tables and re-runs the migrations.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -627,6 +627,22 @@ jobs:
           # avoids the multi-minute pnpm install during the smoke check.
           npm exec --yes --package="$tarball" -- create-nextly-app smoke-app --template blank --skip-install --yes
           test -f smoke-app/package.json && echo "scaffold ok"
+
+      # The generated scripts and the CLI's command set live in two different
+      # packages, and nothing compared them: every project shipped a
+      # `db:migrate:reset` calling a command `nextly` has never registered, which
+      # failed the first time a user ran it while every build stayed green.
+      #
+      # It runs HERE rather than in `scaffold-build.yml` because this job is
+      # reached by a change to EITHER side. That workflow triggers on the
+      # scaffolder and the templates, so a pull request that removes or renames a
+      # CLI command — the other half of the contract — would never run it.
+      - name: Check the generated scripts name real CLI commands
+        shell: bash
+        run: |
+          node scripts/check-scaffold-cli-scripts.mjs \
+            /tmp/scaffold-test/smoke-app \
+            packages/nextly/dist/cli/nextly.mjs
   # The `dev` script of `packages/ui` starts TWO watchers, and the shape it used
   # before — `a --watch & b --watch & wait` — is POSIX. `cmd.exe` treats `&` as a
   # SEQUENTIAL separator and has no `wait`, so on Windows the first watcher held

--- a/.github/workflows/scaffold-build.yml
+++ b/.github/workflows/scaffold-build.yml
@@ -415,56 +415,6 @@ jobs:
           fi
           echo "installed nextly matches the packed workspace build"
 
-      # Every `nextly <command>` the generator writes into package.json must be a command
-      # the CLI actually registers. A generated script naming a command that does not exist
-      # fails only when a user runs it, which no build step reaches — measured: every
-      # scaffold shipped `db:migrate:reset` calling `nextly migrate:reset`, which the CLI
-      # has never registered, and a unit test pinned it as expected output.
-      #
-      # Asserted against the INSTALLED CLI rather than a list in this file or in the
-      # generator's tests. The scripts and the command set live in two different packages,
-      # so only the installed project can tell whether they agree.
-      - name: Check the generated scripts name real CLI commands
-        shell: bash
-        run: |
-          cd /tmp/scaffold-build/scaffolded-app
-          mapfile -t cmds < <(node -e '
-            const s = require("./package.json").scripts || {};
-            const seen = new Set();
-            for (const v of Object.values(s)) {
-              // Take the subcommand after each `nextly` invocation, ignoring flags and
-              // anything chained after && so `nextly migrate && next build` is covered.
-              for (const part of String(v).split("&&")) {
-                const m = part.trim().match(/^nextly\s+([a-z][a-z0-9:-]*)/);
-                if (m) seen.add(m[1]);
-              }
-            }
-            for (const c of seen) console.log(c);
-          ')
-
-          # A positive control on that extraction. Reporting "every command is valid" after
-          # scanning nothing is the failure this check would otherwise hide.
-          echo "nextly subcommands referenced by the generated scripts: ${#cmds[@]}"
-          [ "${#cmds[@]}" -gt 0 ] || { echo "scanned no nextly commands at all"; exit 1; }
-
-          # `nextly help <cmd>` rather than `nextly <cmd> --help`. Measured: the second
-          # exits 0 for an UNKNOWN command — it falls back to printing the root help — so a
-          # check built on it passes for exactly the commands it exists to catch. `help`
-          # exits 1 when the command is not registered and 0 when it is.
-          failed=""
-          for c in "${cmds[@]}"; do
-            if npx nextly help "$c" > /dev/null 2>&1; then
-              echo "  ok   nextly $c"
-            else
-              echo "  MISSING   nextly $c"
-              failed="$failed $c"
-            fi
-          done
-          [ -z "$failed" ] || {
-            echo "generated scripts name commands the CLI does not register:$failed"
-            exit 1
-          }
-
       - name: Build the scaffolded project
         shell: bash
         run: |

--- a/.github/workflows/scaffold-build.yml
+++ b/.github/workflows/scaffold-build.yml
@@ -415,6 +415,56 @@ jobs:
           fi
           echo "installed nextly matches the packed workspace build"
 
+      # Every `nextly <command>` the generator writes into package.json must be a command
+      # the CLI actually registers. A generated script naming a command that does not exist
+      # fails only when a user runs it, which no build step reaches — measured: every
+      # scaffold shipped `db:migrate:reset` calling `nextly migrate:reset`, which the CLI
+      # has never registered, and a unit test pinned it as expected output.
+      #
+      # Asserted against the INSTALLED CLI rather than a list in this file or in the
+      # generator's tests. The scripts and the command set live in two different packages,
+      # so only the installed project can tell whether they agree.
+      - name: Check the generated scripts name real CLI commands
+        shell: bash
+        run: |
+          cd /tmp/scaffold-build/scaffolded-app
+          mapfile -t cmds < <(node -e '
+            const s = require("./package.json").scripts || {};
+            const seen = new Set();
+            for (const v of Object.values(s)) {
+              // Take the subcommand after each `nextly` invocation, ignoring flags and
+              // anything chained after && so `nextly migrate && next build` is covered.
+              for (const part of String(v).split("&&")) {
+                const m = part.trim().match(/^nextly\s+([a-z][a-z0-9:-]*)/);
+                if (m) seen.add(m[1]);
+              }
+            }
+            for (const c of seen) console.log(c);
+          ')
+
+          # A positive control on that extraction. Reporting "every command is valid" after
+          # scanning nothing is the failure this check would otherwise hide.
+          echo "nextly subcommands referenced by the generated scripts: ${#cmds[@]}"
+          [ "${#cmds[@]}" -gt 0 ] || { echo "scanned no nextly commands at all"; exit 1; }
+
+          # `nextly help <cmd>` rather than `nextly <cmd> --help`. Measured: the second
+          # exits 0 for an UNKNOWN command — it falls back to printing the root help — so a
+          # check built on it passes for exactly the commands it exists to catch. `help`
+          # exits 1 when the command is not registered and 0 when it is.
+          failed=""
+          for c in "${cmds[@]}"; do
+            if npx nextly help "$c" > /dev/null 2>&1; then
+              echo "  ok   nextly $c"
+            else
+              echo "  MISSING   nextly $c"
+              failed="$failed $c"
+            fi
+          done
+          [ -z "$failed" ] || {
+            echo "generated scripts name commands the CLI does not register:$failed"
+            exit 1
+          }
+
       - name: Build the scaffolded project
         shell: bash
         run: |

--- a/packages/create-nextly-app/src/__tests__/template.test.ts
+++ b/packages/create-nextly-app/src/__tests__/template.test.ts
@@ -172,7 +172,10 @@ describe("generatePackageJson", () => {
     expect(result.scripts["db:migrate"]).toBe("nextly migrate");
     expect(result.scripts["db:migrate:status"]).toBe("nextly migrate:status");
     expect(result.scripts["db:migrate:fresh"]).toBe("nextly migrate:fresh");
-    expect(result.scripts["db:migrate:reset"]).toBe("nextly migrate:reset");
+    // Asserted ABSENT: `nextly migrate:reset` is not a registered command, so
+    // generating this script shipped every project a `npm run db:migrate:reset`
+    // that fails. The test previously pinned it as expected output.
+    expect(result.scripts["db:migrate:reset"]).toBeUndefined();
     expect(result.scripts["types:generate"]).toBe("nextly generate:types");
   });
 

--- a/packages/create-nextly-app/src/utils/template.ts
+++ b/packages/create-nextly-app/src/utils/template.ts
@@ -649,8 +649,11 @@ export async function generatePackageJson(
       "db:setup": "nextly db:sync",
       "db:migrate": "nextly migrate",
       "db:migrate:status": "nextly migrate:status",
+      // No `db:migrate:reset`: `nextly migrate:reset` is not a command the CLI
+      // registers, so the script it generated failed for every scaffolded
+      // project. `migrate:fresh` is the one that drops all tables and re-runs
+      // the migrations, and it is already exposed above.
       "db:migrate:fresh": "nextly migrate:fresh",
-      "db:migrate:reset": "nextly migrate:reset",
       "types:generate": "nextly generate:types",
     },
     dependencies,

--- a/scripts/check-scaffold-cli-scripts.mjs
+++ b/scripts/check-scaffold-cli-scripts.mjs
@@ -1,0 +1,124 @@
+#!/usr/bin/env node
+
+/**
+ * Every `nextly <command>` a scaffolded project's scripts name must be a command
+ * the CLI registers.
+ *
+ * The two sides live in different packages — `create-nextly-app` writes the
+ * scripts, `nextly` registers the commands — and nothing compared them. Measured:
+ * every project generated until now shipped `db:migrate:reset` calling `nextly
+ * migrate:reset`, which the CLI has never registered, so the script failed the
+ * first time a user ran it. A unit test in the generator pinned it as expected
+ * output, because that test could only see one side.
+ *
+ * Both sides are DERIVED rather than restated: the commands come from the
+ * scaffolded `package.json`, and the verdict comes from asking the real CLI.
+ *
+ * Usage:
+ *   node scripts/check-scaffold-cli-scripts.mjs <scaffolded-dir> <path-to-cli.mjs>
+ */
+
+import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+const [projectArg, cliArg] = process.argv.slice(2);
+
+if (!projectArg || !cliArg) {
+  console.error(
+    "usage: check-scaffold-cli-scripts.mjs <scaffolded-dir> <path-to-cli.mjs>"
+  );
+  process.exit(1);
+}
+
+const projectDir = resolve(projectArg);
+const cliPath = resolve(cliArg);
+
+/** Subcommands named by `nextly ...` anywhere in the generated scripts. */
+function referencedCommands(scripts) {
+  const found = new Set();
+  for (const value of Object.values(scripts ?? {})) {
+    // Split on `&&` so a chained script like `nextly migrate && next build`
+    // contributes its `nextly` half rather than being skipped.
+    for (const part of String(value).split("&&")) {
+      const match = part.trim().match(/^nextly\s+([a-z][a-z0-9:-]*)/);
+      if (match) found.add(match[1]);
+    }
+  }
+  return [...found];
+}
+
+const manifestPath = join(projectDir, "package.json");
+let manifest;
+try {
+  manifest = JSON.parse(readFileSync(manifestPath, "utf-8"));
+} catch (err) {
+  console.error(`Cannot read ${manifestPath}: ${err.message}`);
+  process.exit(1);
+}
+
+const referenced = referencedCommands(manifest.scripts);
+
+// A positive control on the extraction. Reporting "every command is valid" after
+// finding none is the failure this check would otherwise hide, and a broken
+// pattern is likelier than a genuinely script-free scaffold.
+if (referenced.length === 0) {
+  console.error(
+    `No 'nextly <command>' scripts found in ${manifestPath}. A scaffolded ` +
+      "project has several, so this is a broken extraction rather than a pass."
+  );
+  process.exit(1);
+}
+
+/**
+ * Whether the CLI registers this command.
+ *
+ * `help <cmd>` rather than `<cmd> --help`. Measured: the second exits 0 for an
+ * UNKNOWN command, because it falls back to printing the root help — so a check
+ * built on it passes for exactly the commands it exists to catch. `help` exits
+ * non-zero when the command is not registered.
+ */
+function isRegistered(command) {
+  const result = spawnSync(process.execPath, [cliPath, "help", command], {
+    stdio: "ignore",
+    // The CLI is only being asked to describe itself, so keep it away from any
+    // ambient database configuration that could make it do more than that.
+    env: { ...process.env, DATABASE_URL: "", DB_DIALECT: "" },
+  });
+  return result.status === 0;
+}
+
+// A control on the PROBE itself, before its verdicts are worth reading. A CLI
+// path that does not run, or a `help` that always fails, would otherwise report
+// every command as missing and read as a real finding.
+if (!isRegistered("migrate")) {
+  console.error(
+    `The probe cannot confirm a command that certainly exists ('migrate') via ` +
+      `${cliPath}. Build \`nextly\` first; a broken probe must not report ` +
+      "missing commands."
+  );
+  process.exit(1);
+}
+
+const missing = referenced.filter(command => !isRegistered(command));
+
+console.log(`scripts reference ${referenced.length} nextly command(s):`);
+for (const command of referenced) {
+  console.log(
+    `  ${missing.includes(command) ? "MISSING" : "ok  "} nextly ${command}`
+  );
+}
+
+if (missing.length > 0) {
+  console.error(
+    `\nThe generated scripts name ${missing.length} command(s) the CLI does not ` +
+      `register: ${missing.join(", ")}`
+  );
+  console.error(
+    "Either register them, or stop generating the script. A script naming a " +
+      "command that does not exist fails only when a user runs it."
+  );
+  process.exit(1);
+}
+
+console.log(`\nAll ${referenced.length} commands are registered by the CLI.`);


### PR DESCRIPTION
Roadmap item 11 ("Templates refactoring"), first slice. Small, but it fixes something every scaffolded project has shipped broken.

## The defect

Every project generated by `create-nextly-app` carries:

```json
"db:migrate:reset": "nextly migrate:reset"
```

`migrate:reset` is **not a command the CLI registers**. The registered set is `migrate`, `migrate:baseline`, `migrate:check`, `migrate:create`, `migrate:down`, `migrate:fresh`, `migrate:resolve`, `migrate:status` — no `migrate:reset`. So the script fails the first time a user runs it, and it has always failed.

`migrate:fresh` is the command that does what the name promises — *"Drop all tables and re-run all migrations"* — and `db:migrate:fresh` already exposes it. So the script is removed rather than repointed; there is nothing it offers that is not already there.

The roadmap called this script "stale". It is worse than stale: it is a command that never existed.

## The suite agreed with the defect

`template.test.ts` asserted the broken script as **expected output**:

```js
expect(result.scripts["db:migrate:reset"]).toBe("nextly migrate:reset");
```

So the generator and its test agreed with each other, and neither agreed with the CLI. The test now pins the script's absence, break-verified: reinstating the script fails it with `expected 'nextly migrate:reset' to be undefined`.

## The guard, which is the point of the PR

Fixing this instance is a line. The class is that **generated scripts and the CLI's command set live in two different packages and nothing compared them**. The scaffold job now does, against the CLI the project actually installed:

- extract every `nextly <subcommand>` from the generated `package.json` (splitting on `&&`, so `nextly migrate && next build` is covered);
- assert each one resolves;
- a positive control that the extraction found a non-zero number of commands, because "all commands valid" after scanning nothing is the failure this would otherwise hide.

**The probe is `nextly help <cmd>`, and that detail is load-bearing.** My first version used `nextly <cmd> --help` — measured, it exits **0 for an unknown command**, because it falls back to printing the root help. A guard built on it passes for exactly the commands it exists to catch. `nextly help <cmd>` exits 1 when the command is not registered and 0 when it is.

Verified both directions on a real scaffold:

```
nextly help migrate:reset  -> exit 1   (the defect is caught)
nextly help migrate:fresh  -> exit 0   (no false alarm)
sweep over a real scaffold's scripts: 5 ok, 1 MISSING (migrate:reset)
```

## Not in this PR

The larger half of item 11 — generated `AGENTS.md`/`CLAUDE.md` per scaffolded project, which the roadmap calls the single highest-impact AI item — needs a managed-block design so regeneration cannot clobber a user's edits. There is no prior art for that pattern in this repo, so it gets its own change rather than being appended here.
