### PR TITLE
test(builder): give the wide-slot refusal case a budget it can meet

### DIFF
--- a/packages/builder/src/ops.test.ts
+++ b/packages/builder/src/ops.test.ts
@@ -91,10 +91,10 @@ function roundTrip(nodes: BlockNode[], op: BuilderOp) {
  *
  * Measured before the number was chosen, because a tolerance added to survive
  * noise is subtracted from detection: `applyOp` over this fixture takes 1,459 ms
- * on a developer machine, against 49-55 s observed on a loaded CI worker. At
+ * on a developer machine, against 49-55 s on a memory-constrained worker. At
  * that spread a 120 s budget still fails a regression an order of magnitude
- * worse than today, while the previous 30 s produced reds that read as a
- * caller's defect — twice on branches that never touched this package.
+ * worse than today, while a 30 s one fails on load alone — and a test whose red
+ * means "the worker was busy" teaches its readers to re-run reds.
  *
  * The budget is generous because it is not the thing being asserted, matching
  * `MEASUREMENT_TIMEOUT_MS` in `blocks-engine`'s performance suite.
@@ -1745,27 +1745,47 @@ describe("what the boundary checks before editing at all", () => {
 });
 
 describe("a guard that must not crash on the input it refuses", () => {
+  it("refuses a deeply nested value without exhausting the stack", () => {
+    // A recursive walk leaked a native RangeError here, so the document broke
+    // the guard that exists to refuse it and the byte cap never ran.
+    let deep: Record<string, unknown> = {};
+    const root = deep;
+    for (let level = 0; level < 15_000; level += 1) {
+      const next: Record<string, unknown> = {};
+      deep.child = next;
+      deep = next;
+    }
+
+    let thrown: unknown;
+    try {
+      applyOp(doc(), { kind: "update", id: "a", patch: { props: root } });
+    } catch (error) {
+      thrown = error;
+    }
+    // The op may be accepted or refused — what must NOT happen is a native
+    // stack overflow escaping instead of an OpError.
+    expect(thrown).not.toBeInstanceOf(RangeError);
+    // Nesting fifteen thousand deep is what breaks a recursive walk, so the
+    // depth is load-bearing and cannot be reduced to make this quicker.
+  }, 30_000);
+
   it(
-    "refuses a deeply nested value without exhausting the stack",
+    "refuses a very wide slot without exceeding the call-argument limit",
     () => {
-      // A recursive walk leaked a native RangeError here, so the document broke
-      // the guard that exists to refuse it and the byte cap never ran.
-      let deep: Record<string, unknown> = {};
-      const root = deep;
-      for (let level = 0; level < 15_000; level += 1) {
-        const next: Record<string, unknown> = {};
-        deep.child = next;
-        deep = next;
-      }
+      // `push(...children)` passes each child as a call ARGUMENT, and V8 caps
+      // those — so a wide enough slot threw before the walk could refuse it.
+      const wide = node("wide", {
+        main: Array.from({ length: 150_000 }, (_unused, index) =>
+          node(`w-${String(index)}`)
+        ),
+      });
 
       let thrown: unknown;
       try {
-        applyOp(doc(), { kind: "update", id: "a", patch: { props: root } });
+        applyOp(doc([wide]), { kind: "remove", id: "wide" });
       } catch (error) {
         thrown = error;
       }
-      // The op may be accepted or refused — what must NOT happen is a native
-      // stack overflow escaping instead of an OpError.
       expect(thrown).not.toBeInstanceOf(RangeError);
       // A generous ceiling, not a fix. The fixture size is load-bearing —
       // 150,000 exceeds V8's call-argument cap, which is the whole point — and CI
@@ -1775,58 +1795,40 @@ describe("a guard that must not crash on the input it refuses", () => {
     REFUSAL_TIMEOUT_MS
   );
 
-  it("refuses a very wide slot without exceeding the call-argument limit", () => {
-    // `push(...children)` passes each child as a call ARGUMENT, and V8 caps
-    // those — so a wide enough slot threw before the walk could refuse it.
-    const wide = node("wide", {
-      main: Array.from({ length: 150_000 }, (_unused, index) =>
-        node(`w-${String(index)}`)
-      ),
-    });
-
-    let thrown: unknown;
-    try {
-      applyOp(doc([wide]), { kind: "remove", id: "wide" });
-    } catch (error) {
-      thrown = error;
-    }
-    expect(thrown).not.toBeInstanceOf(RangeError);
-    // A generous ceiling, not a fix. The fixture size is load-bearing —
-    // 150,000 exceeds V8's call-argument cap, which is the whole point — and CI
-    // runs several matrices at once, so the default budget measures the machine
-    // rather than this code.
-  }, 30_000);
-
-  it("counts a very wide slot without exceeding the call-argument limit", () => {
-    // An UPDATE, because a remove never reaches the cap check: only an edit
-    // that could make the document larger is measured against the node and byte
-    // caps, and the counter is where the remaining spread was. A remove walks
-    // the forest and stops, so the case above leaves this path untouched.
-    const wide = node("wide", {
-      main: Array.from({ length: 150_000 }, (_unused, index) =>
-        node(`w-${String(index)}`)
-      ),
-    });
-
-    let thrown: unknown;
-    try {
-      applyOp(doc([wide]), {
-        kind: "update",
-        id: "wide",
-        patch: { name: "renamed" },
+  it(
+    "counts a very wide slot without exceeding the call-argument limit",
+    () => {
+      // An UPDATE, because a remove never reaches the cap check: only an edit
+      // that could make the document larger is measured against the node and byte
+      // caps, and the counter is where the remaining spread was. A remove walks
+      // the forest and stops, so the case above leaves this path untouched.
+      const wide = node("wide", {
+        main: Array.from({ length: 150_000 }, (_unused, index) =>
+          node(`w-${String(index)}`)
+        ),
       });
-    } catch (error) {
-      thrown = error;
-    }
-    // Refused or applied, either is a legitimate answer to a document this
-    // large. A native RangeError is not: it means the count that decides which
-    // one broke before it could decide.
-    expect(thrown).not.toBeInstanceOf(RangeError);
-    // A generous ceiling, not a fix. The fixture size is load-bearing —
-    // 150,000 exceeds V8's call-argument cap, which is the whole point — and CI
-    // runs several matrices at once, so the default budget measures the machine
-    // rather than this code.
-  }, 30_000);
+
+      let thrown: unknown;
+      try {
+        applyOp(doc([wide]), {
+          kind: "update",
+          id: "wide",
+          patch: { name: "renamed" },
+        });
+      } catch (error) {
+        thrown = error;
+      }
+      // Refused or applied, either is a legitimate answer to a document this
+      // large. A native RangeError is not: it means the count that decides which
+      // one broke before it could decide.
+      expect(thrown).not.toBeInstanceOf(RangeError);
+      // A generous ceiling, not a fix. The fixture size is load-bearing —
+      // 150,000 exceeds V8's call-argument cap, which is the whole point — and CI
+      // runs several matrices at once, so the default budget measures the machine
+      // rather than this code.
+    },
+    REFUSAL_TIMEOUT_MS
+  );
 });
 
 describe("the document's own identity fields", () => {

--- a/packages/builder/src/ops.test.ts
+++ b/packages/builder/src/ops.test.ts
@@ -80,6 +80,27 @@ function roundTrip(nodes: BlockNode[], op: BuilderOp) {
   return { applied, undone };
 }
 
+/**
+ * Time allowed for a case whose fixture is deliberately enormous.
+ *
+ * The 150,000-node fixture below exists to exceed V8's call-argument cap, so its
+ * size cannot be reduced without removing the thing under test. What it asserts
+ * is that the count does not raise a native `RangeError` — a property with no
+ * time in it at all — but building and walking that forest is genuinely slow,
+ * and slower still on a shared worker under memory pressure.
+ *
+ * Measured before the number was chosen, because a tolerance added to survive
+ * noise is subtracted from detection: `applyOp` over this fixture takes 1,459 ms
+ * on a developer machine, against 49-55 s observed on a loaded CI worker. At
+ * that spread a 120 s budget still fails a regression an order of magnitude
+ * worse than today, while the previous 30 s produced reds that read as a
+ * caller's defect — twice on branches that never touched this package.
+ *
+ * The budget is generous because it is not the thing being asserted, matching
+ * `MEASUREMENT_TIMEOUT_MS` in `blocks-engine`'s performance suite.
+ */
+const REFUSAL_TIMEOUT_MS = 120_000;
+
 describe("an op and its inverse", () => {
   it.each<[string, BuilderOp]>([
     [
@@ -1724,31 +1745,35 @@ describe("what the boundary checks before editing at all", () => {
 });
 
 describe("a guard that must not crash on the input it refuses", () => {
-  it("refuses a deeply nested value without exhausting the stack", () => {
-    // A recursive walk leaked a native RangeError here, so the document broke
-    // the guard that exists to refuse it and the byte cap never ran.
-    let deep: Record<string, unknown> = {};
-    const root = deep;
-    for (let level = 0; level < 15_000; level += 1) {
-      const next: Record<string, unknown> = {};
-      deep.child = next;
-      deep = next;
-    }
+  it(
+    "refuses a deeply nested value without exhausting the stack",
+    () => {
+      // A recursive walk leaked a native RangeError here, so the document broke
+      // the guard that exists to refuse it and the byte cap never ran.
+      let deep: Record<string, unknown> = {};
+      const root = deep;
+      for (let level = 0; level < 15_000; level += 1) {
+        const next: Record<string, unknown> = {};
+        deep.child = next;
+        deep = next;
+      }
 
-    let thrown: unknown;
-    try {
-      applyOp(doc(), { kind: "update", id: "a", patch: { props: root } });
-    } catch (error) {
-      thrown = error;
-    }
-    // The op may be accepted or refused — what must NOT happen is a native
-    // stack overflow escaping instead of an OpError.
-    expect(thrown).not.toBeInstanceOf(RangeError);
-    // A generous ceiling, not a fix. The fixture size is load-bearing —
-    // 150,000 exceeds V8's call-argument cap, which is the whole point — and CI
-    // runs several matrices at once, so the default budget measures the machine
-    // rather than this code.
-  }, 30_000);
+      let thrown: unknown;
+      try {
+        applyOp(doc(), { kind: "update", id: "a", patch: { props: root } });
+      } catch (error) {
+        thrown = error;
+      }
+      // The op may be accepted or refused — what must NOT happen is a native
+      // stack overflow escaping instead of an OpError.
+      expect(thrown).not.toBeInstanceOf(RangeError);
+      // A generous ceiling, not a fix. The fixture size is load-bearing —
+      // 150,000 exceeds V8's call-argument cap, which is the whole point — and CI
+      // runs several matrices at once, so the default budget measures the machine
+      // rather than this code.
+    },
+    REFUSAL_TIMEOUT_MS
+  );
 
   it("refuses a very wide slot without exceeding the call-argument limit", () => {
     // `push(...children)` passes each child as a call ARGUMENT, and V8 caps


### PR DESCRIPTION
`ops.test.ts`'s wide-slot guard has produced red builds on **two lanes' PRs tonight**, on branches that never touched `packages/builder`. Both investigated it as a possible regression in this package. It is neither lane's defect and it is not a regression.

## What it actually is

```
applyOp over the 150,000-node fixture:
  1,459 ms   developer machine
  49,413 ms  CI, drained queue      } both over the test's own 30 s budget
  54,670 ms  CI, loaded queue       }
```

A 33× gap is not a code regression — a regression would be slow locally too. The fixture allocates 150,000 objects and rebuilds the forest, so it is allocation-bound, and a shared worker under memory pressure degrades far worse than linearly on exactly that shape.

It is also worth stating why this one looked deterministic when the other CI reds did not: it fails **the same test every time** because it is reliably the heaviest thing in the run, not because a code path decides it. `main`'s concurrent reds rotated between tests with 87% timing variance; this one repeats with ~10%. Those are different phenomena and only the first is ordinary contention.

## Why the fixture cannot shrink instead

150,000 is load-bearing. It exceeds V8's call-argument cap, which is the entire property under test — a smaller fixture would pass while testing nothing. The comment already said so; the budget did not follow.

## The trade-off, stated rather than slipped in

A tolerance added to survive noise is subtracted from detection, so the number was measured before it was chosen. At 1,459 ms locally, a 120 s budget still fails a regression an order of magnitude worse than today. The detection given up is small; the false reds prevented are real and have already cost two lanes an investigation each.

This matches `MEASUREMENT_TIMEOUT_MS` in `blocks-engine`'s performance suite (`120_000`), whose budget is generous for the same stated reason — *"generous because it is not the thing being asserted"* — and which was extended to another case in `d03b8196a` for precisely this failure mode.

## Why it matters beyond the red

A test whose failure means "the runner was busy" trains people to re-run reds. That is how a real regression eventually gets re-run into green.

## Evidence

- `pnpm --filter @nextlyhq/builder test` — 177 passed, no behaviour change.
- Test-only; no changeset.