### PR TITLE
test: stop two timeouts that measure the runner rather than the code

### DIFF
--- a/packages/blocks-engine/vitest.config.ts
+++ b/packages/blocks-engine/vitest.config.ts
@@ -7,5 +7,23 @@ export default defineConfig({
     globals: false,
     environment: "node",
     include: ["src/**/*.test.ts"],
+    // Set for the PACKAGE rather than per test, because this package's suites
+    // are CPU-bound walks over deliberately large synthetic documents and
+    // vitest's 5 s default is a budget none of them was written against.
+    //
+    // Annotating one test at a time is the approach this replaces. It requires
+    // predicting which case is expensive, and each wrong prediction costs a red
+    // gate for the whole repository before anyone finds out — three separate
+    // cases have now had to be discovered that way.
+    //
+    // Sized from a measured environment factor rather than guessed. A CI runner
+    // executing several matrix legs at once was ~50x slower per unit of work
+    // than a developer machine here, measured across tests that PASSED, and the
+    // slowest case in this package outside `performance.test.ts` runs in about
+    // 160 ms locally — so roughly 8 s under load. Thirty seconds leaves headroom
+    // over that while staying far below the point where a genuine hang would go
+    // unnoticed for long. `performance.test.ts` keeps its own larger explicit
+    // budget, which is about the size of the documents it builds.
+    testTimeout: 30_000,
   },
 });

--- a/packages/blocks-react/src/blocks/root-inline-styles.test.tsx
+++ b/packages/blocks-react/src/blocks/root-inline-styles.test.tsx
@@ -411,23 +411,52 @@ function outOfRangeValuesFor(entry: Record<string, unknown>): unknown[] {
  * a member of the wrong type is a different state, and the one `core/list`
  * coerces per item — `stored.slice(...).map(item => text(item))` exists for it.
  *
- * The renderer's own `MAX_ITEMS` truncation is a branch of the same kind, and
- * the oversized array below reaches it at the smallest input that does.
+ * A member of the wrong TYPE is a value alternative like any other, so these
+ * belong in the cross product. An oversized array is not — see
+ * `oversizedArrayVariants`.
  */
 function malformedMemberArraysFor(entry: Record<string, unknown>): unknown[] {
   if (entry.type !== "array") return [];
-  return [
-    [42],
-    [null],
-    [{}],
-    ["ok", 42],
-    // Past the renderer's own truncation. `core/list` slices at a thousand
-    // before it maps, and that slice is a branch like any other: a stored array
-    // can be any length, and nothing in the schema says otherwise. Sized just
-    // over the cap rather than far past it, so the branch is reached at the
-    // smallest input that reaches it.
-    Array.from({ length: 1001 }, (_, index) => `i${index}`),
-  ];
+  return [[42], [null], [{}], ["ok", 42]];
+}
+
+/**
+ * One prop set per array prop, sized past the renderer's own truncation.
+ *
+ * `core/list` slices at a thousand before it maps, and that slice is a branch
+ * like any other: a stored array can be any length, and nothing in the schema
+ * says otherwise. Sized just over the cap rather than far past it, so the branch
+ * is reached at the smallest input that reaches it.
+ *
+ * Held OUTSIDE `alternativesFor`, which is what keeps this affordable, and the
+ * distinction is about what the value probes rather than about its cost. The
+ * alternatives are crossed with each other — layered into conjunctions, then
+ * fanned out through the omitted and sole passes — because a branch can be
+ * keyed on two props at once. Length is not a value another prop can be keyed
+ * on: the truncation runs before any other prop is read, so pairing an
+ * oversized array with each `kind` and `start` alternative re-renders a thousand
+ * items to reach a branch the first render already reached.
+ *
+ * The clamp in `layeredVariants` is what turns that from a duplicate into many:
+ * a prop with fewer alternatives than the widest one repeats its LAST value into
+ * every later layer, so an oversized array sitting at the end of the list is
+ * pinned into each of them and then fanned out again. One prop set per array
+ * prop reaches the same branch.
+ *
+ * Still crossed with every host state and policy, which is the part that must
+ * not be traded away: a block whose truncated output branches on the host is a
+ * block this file would otherwise pass over.
+ */
+function oversizedArrayVariants(
+  base: Record<string, unknown>,
+  schema: Record<string, unknown>
+): unknown[] {
+  return Object.entries(schema)
+    .filter(([, entry]) => (entry as { type?: unknown }).type === "array")
+    .map(([name]) => ({
+      ...base,
+      [name]: Array.from({ length: 1001 }, (_, index) => `i${index}`),
+    }));
 }
 
 function alternativesFor(
@@ -544,6 +573,7 @@ function propVariants(block: AnyBlockDefinition): unknown[] {
     ...soleVariants(base, schema),
     ...layered.flatMap(layer => soleVariants(layer, schema)),
     ...malformedVariants(base, schema),
+    ...oversizedArrayVariants(base, schema),
   ];
 }
 


### PR DESCRIPTION
`blocks-react > a core block's root element > core/list carries no inline style, and was actually reached` has been timing out at the 60s per-block budget in CI, blocking the merge gate repo-wide. It passes locally in ~1.5s.

## It is load, and two lanes including mine concluded otherwise

I previously recorded this as a hang, on the strength of a re-run with the runner queue at **zero** that failed identically. Lane 19396 independently instrumented it on #739 and reached the same conclusion from the other side: `core/list` 63.4s, its siblings in the same file 96ms–5.1s, and the error a vitest timeout rather than an assertion, so the test never concluded.

Both readings were wrong, and the zero-queue result is why. **It rules out queue contention, not a runner that is intrinsically slower per render.** The correction is in the sibling numbers that lane already had:

| | local | CI | ratio |
|---|---|---|---|
| slowest passing sibling (`core/heading`) | 90ms | 5.1s | ~57x |
| fastest passing sibling | 2ms | 96ms | ~48x |
| `core/list` | 1565ms | died at 63.4s | — |

A consistent ~50x environment factor, measured on tests that **completed**. Applied to `core/list`: 1565ms x 50 = 78s against a 60s ceiling, so it is killed at 63.4s. That is how long it took to die, and it is also what the load model predicts. Nothing here needs a hang to explain it.

Recording this because "63.4s is close to the 60s ceiling, therefore vitest gave up, therefore it is a wait that never resolves" is a reasonable-sounding inference that the passing siblings refute.

## Nor is it the size of the matrix

The next hypothesis was that `core/list` simply has the most variants. It does not:

| block | renders | local | **ms per render** |
|---|---|---|---|
| `core/heading` | 5,356 | 90ms | 0.017 |
| `core/button` | 5,304 | 85ms | 0.016 |
| **`core/list`** | **5,148** | **1382ms** | **0.268** |

`core/heading` does *more* renders in 90ms. `core/list` costs ~16x more **per render**.

## The mechanism

`malformedMemberArraysFor` returns a **1001-element array** for any `array`-typed prop, sized to reach `core/list`'s `MAX_ITEMS` slice. `core/list` is the only block with an `array` prop, which is why it is the only one affected.

It was returned as the **last** alternative, so it entered the value cross product. `layeredVariants` clamps with `values[Math.min(i, values.length - 1)]` — a prop with fewer alternatives than the widest one repeats its last value into every later layer. `items` declares 7 alternatives and `start` declares 9, so layers 6, 7 and 8 all pinned `items` to the oversized array, and `omittedVariants` and `soleVariants` then fanned those out again.

One fixture became **13 prop sets**, each rendered under all 13 host states and 4 host policies — 676 renders of a 1001-item list.

Measured on `main`: those 13 prop sets account for **1309ms of 1386ms**. The remaining 86 take 77ms, in line with every sibling.

## The change

Length is not a value another prop can be keyed on. The truncation runs before any other prop is read, so pairing an oversized array with each `kind` and `start` alternative re-renders a thousand items to reach a branch the first render already reached. The oversized array moves out of `alternativesFor` into `oversizedArrayVariants`, which yields one prop set per array prop.

**Still crossed with every host state and policy**, which is the part deliberately not traded away: a block whose truncated output branches on the host is a block this file would otherwise pass over. That costs 52 renders, not 676.

Explicitly **not** raising the timeout. 60s is a deliberate per-block budget, and raising it converts a reproducible failure into an intermittent one.

## Measured, paired, on `main`

```
baseline  1565ms  1728ms
fixed      224ms   202ms
```

`core/list` is no longer an outlier — `core/collection-loop` is 187ms. At the ~50x CI factor that is ~10s against the 60s budget.

## Coverage is preserved, and that was checked rather than assumed

The fixture exists to reach the `MAX_ITEMS` branch, so the branch has to still be reached. Positive control: throwing inside `renderList`'s truncation branch fails **this case and no other** (1 failed, 16 passed), confirming both that the branch is reached after the change and that only `core/list` reaches it.

No changeset: the change is confined to a test file.

---

## Second commit: the same phenomenon, one package over

`blocks-engine`'s `counts the comma between every pair of properties` then timed out at vitest's **5000 ms** default in CI while running in **155 ms** locally. Unrelated to this PR's first commit, and blocking the gate the same way.

The ~50x factor above predicts it exactly: 155 ms x 50 = ~7.8 s against a 5 s ceiling.

**This is the third case in that package found this way**, after #790's node-ceiling test. Annotating one test at a time requires predicting which case is expensive, and the prediction has now been wrong three times — each discovery costing a red gate for the whole repository. So the budget moves to the **package**, where a new expensive suite inherits it instead of waiting to be found.

30 s, sized from the same measured factor: the slowest case in that package outside `performance.test.ts` is ~160 ms locally, so ~8 s under load. `performance.test.ts` keeps its own larger explicit budget, which is about the size of the documents it builds.

Verified the key is honoured rather than assumed: setting it to 50 ms fails the expensive cases with `Test timed out in 50ms`.