### PR TITLE
fix(blocks-engine): bound validation by the limits the survey enforced

### DIFF
--- a/.changeset/survey-enforced-limits.md
+++ b/.changeset/survey-enforced-limits.md
@@ -1,0 +1,28 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+Bound block-document validation by the limits the survey enforced, so a caller passing a limits object whose values change between reads can no longer make the walk outrun the cap that was checked.

--- a/packages/blocks-engine/src/comment-convention.test.ts
+++ b/packages/blocks-engine/src/comment-convention.test.ts
@@ -26,8 +26,12 @@ import { describe, expect, it } from "vitest";
  * no meaning inside a description of what the code does, so matching them
  * cannot reject a correct comment.
  *
- * There is deliberately no pattern for ordinal narration, and the reason
- * generalises. "The third instance of this shape we have found" is process
+ * ORDINAL PROCESS NARRATION IS NOT ENFORCED HERE, and that is stated rather
+ * than left to be inferred from its absence: "the third instance of this shape
+ * we have found" passes this suite, and no other check in the repository covers
+ * it. The convention still forbids it; nothing mechanical catches it.
+ *
+ * The reason generalises. "The third instance of this shape we have found" is process
  * history; "the third instance in the array owns the separator" describes a
  * parser. The difference is intent, not vocabulary, so no expression over the
  * words can separate them. Pairing the ordinal with a discovery verb does not
@@ -36,6 +40,14 @@ import { describe, expect, it } from "vitest";
  * sentences of exactly that shape which describe runtime behaviour. This file
  * matches structure and leaves intent unenforced, rather than pretending intent
  * is detectable syntax.
+ *
+ * Narrowing to first-person discovery — "we found", "I fixed" — looks like the
+ * reliable version and is not. Measured against this repository, the first
+ * expression of that shape matches `verify-credentials.ts`'s "of whether we
+ * found a user", which describes what a lookup returned. The OBJECT of the verb
+ * separates the two cases, and enumerating objects is the unbounded surface
+ * again. That sample is a negative control below, so the next attempt fails on
+ * it immediately rather than shipping and being silenced.
  */
 const FORBIDDEN: Array<{ pattern: RegExp; why: string }> = [
   {
@@ -169,6 +181,10 @@ describe("code comments describe the code", () => {
       "// the second time the cache missed, refresh the credentials",
       "// the third instance found in the pool is the one that owns the lock",
       "// on the second retry the fixed backoff is replaced by the jittered one",
+      // First-person discovery, taken verbatim from `verify-credentials.ts`. It
+      // describes what a lookup returned, so a pattern keyed on "we found"
+      // rejects working prose.
+      "// of whether we found a user. Without this branch, the miss path returns",
     ];
     for (const sample of allowed) {
       const [comment] = commentText(sample);

--- a/packages/blocks-engine/src/comment-convention.test.ts
+++ b/packages/blocks-engine/src/comment-convention.test.ts
@@ -46,8 +46,8 @@ import { describe, expect, it } from "vitest";
  * expression of that shape matches `verify-credentials.ts`'s "of whether we
  * found a user", which describes what a lookup returned. The OBJECT of the verb
  * separates the two cases, and enumerating objects is the unbounded surface
- * again. That sample is a negative control below, so the next attempt fails on
- * it immediately rather than shipping and being silenced.
+ * again. That sample sits among the negative controls below, so any matcher
+ * keyed on first-person discovery is rejected by this suite.
  */
 const FORBIDDEN: Array<{ pattern: RegExp; why: string }> = [
   {
@@ -182,8 +182,8 @@ describe("code comments describe the code", () => {
       "// the third instance found in the pool is the one that owns the lock",
       "// on the second retry the fixed backoff is replaced by the jittered one",
       // First-person discovery, taken verbatim from `verify-credentials.ts`. It
-      // describes what a lookup returned, so a pattern keyed on "we found"
-      // rejects working prose.
+      // describes what a lookup returned, so a matcher keyed on "we found"
+      // rejects working prose and is refused here.
       "// of whether we found a user. Without this branch, the miss path returns",
     ];
     for (const sample of allowed) {

--- a/packages/blocks-engine/src/comment-convention.test.ts
+++ b/packages/blocks-engine/src/comment-convention.test.ts
@@ -20,6 +20,21 @@ import { describe, expect, it } from "vitest";
  * and a check that gets silenced is worth less than no check. These match the
  * specific shapes that have actually appeared: a count of review iterations, a
  * reference to a reviewer, and a deictic reference to the change itself.
+ *
+ * Every one of them matches a NAME the code cannot own — a review tool, the
+ * pull request, the reviewer. That is what makes them safe: those words carry
+ * no meaning inside a description of what the code does, so matching them
+ * cannot reject a correct comment.
+ *
+ * There is deliberately no pattern for ordinal narration, and the reason
+ * generalises. "The third instance of this shape we have found" is process
+ * history; "the third instance in the array owns the separator" describes a
+ * parser. The difference is intent, not vocabulary. Narrowing such a pattern
+ * toward discovery verbs does not close the gap, because those verbs are
+ * ordinary technical words too — a cache MISSES, a guard CATCHES, a value is
+ * FOUND — so each narrowing admits a new bystander. The negative controls below
+ * keep three of them. This file matches structure and leaves intent
+ * unenforced, rather than pretending intent is detectable syntax.
  */
 const FORBIDDEN: Array<{ pattern: RegExp; why: string }> = [
   {
@@ -41,29 +56,6 @@ const FORBIDDEN: Array<{ pattern: RegExp; why: string }> = [
   {
     pattern: /\breviewer\s+(said|asked|found|flagged)\b/i,
     why: "quotes a conversation",
-  },
-  {
-    // Ordinal process narration: "the third instance ... was found", "the
-    // second time this regressed". A comment counting how often something has
-    // been DISCOVERED describes the history of the work rather than the code,
-    // and that history is not available to whoever reads the file next. It gets
-    // past the patterns above because it narrates without naming a review or a
-    // tool.
-    //
-    // The ordinal alone is not the signal, and two rounds of narrowing say so:
-    // ordinary prose counts things. "The first occurrence sees the `+` that
-    // leaves the first root" describes parsing; "the second time the callback
-    // runs, reuse the cached value" describes runtime. Both are correct
-    // comments and an ordinal-only pattern rejected them. So the ordinal must
-    // sit within a clause of DISCOVERY — found, missed, fixed, regressed — which
-    // is what separates narrating the work from describing the code.
-    //
-    // A check that fires on correct prose gets silenced, and a silenced check is
-    // worth less than none, which is why this errs toward missing violations
-    // rather than toward catching bystanders.
-    pattern:
-      /\bthe\s+(second|third|fourth|fifth)\s+(time|instance)\b[^.]{0,80}\b(found|caught|missed|fixed|discovered|reported|flagged|shipped|regressed|recurr\w*)\b/i,
-    why: "counts how often something was found, which is process history",
   },
 ];
 
@@ -151,8 +143,6 @@ describe("code comments describe the code", () => {
       "/* Codex flagged this */",
       "// the reviewer asked for a guard here",
       "// added in this PR",
-      "// the third instance of this shape we have found",
-      "// broken for the second time this week, fixed again",
     ];
     for (const sample of offending) {
       const [comment] = commentText(sample);
@@ -171,6 +161,14 @@ describe("code comments describe the code", () => {
       "// the first occurrence sees the `+` that leaves the first root",
       "// the second time the callback runs, reuse the cached value",
       "// the third instance in the array owns the separator",
+      // Each of these was refused by a successive narrowing of an ordinal
+      // pattern that no longer exists, and they are kept as the reason it does
+      // not: a discovery verb is also ordinary technical vocabulary, so no
+      // amount of tightening separates counting the work from counting the
+      // data. A pattern reintroduced here fails on one of them.
+      "// the second time the cache missed, refresh the credentials",
+      "// the third instance found in the pool is the one that owns the lock",
+      "// on the second retry the fixed backoff is replaced by the jittered one",
     ];
     for (const sample of allowed) {
       const [comment] = commentText(sample);

--- a/packages/blocks-engine/src/comment-convention.test.ts
+++ b/packages/blocks-engine/src/comment-convention.test.ts
@@ -29,12 +29,13 @@ import { describe, expect, it } from "vitest";
  * There is deliberately no pattern for ordinal narration, and the reason
  * generalises. "The third instance of this shape we have found" is process
  * history; "the third instance in the array owns the separator" describes a
- * parser. The difference is intent, not vocabulary. Narrowing such a pattern
- * toward discovery verbs does not close the gap, because those verbs are
- * ordinary technical words too — a cache MISSES, a guard CATCHES, a value is
- * FOUND — so each narrowing admits a new bystander. The negative controls below
- * keep three of them. This file matches structure and leaves intent
- * unenforced, rather than pretending intent is detectable syntax.
+ * parser. The difference is intent, not vocabulary, so no expression over the
+ * words can separate them. Pairing the ordinal with a discovery verb does not
+ * help either, because those verbs are ordinary technical words: a cache
+ * MISSES, a guard CATCHES, a value is FOUND. The negative controls below hold
+ * sentences of exactly that shape which describe runtime behaviour. This file
+ * matches structure and leaves intent unenforced, rather than pretending intent
+ * is detectable syntax.
  */
 const FORBIDDEN: Array<{ pattern: RegExp; why: string }> = [
   {
@@ -161,11 +162,10 @@ describe("code comments describe the code", () => {
       "// the first occurrence sees the `+` that leaves the first root",
       "// the second time the callback runs, reuse the cached value",
       "// the third instance in the array owns the separator",
-      // Each of these was refused by a successive narrowing of an ordinal
-      // pattern that no longer exists, and they are kept as the reason it does
-      // not: a discovery verb is also ordinary technical vocabulary, so no
-      // amount of tightening separates counting the work from counting the
-      // data. A pattern reintroduced here fails on one of them.
+      // Ordinal counting beside a discovery verb, all three describing runtime
+      // behaviour rather than the work that produced the file. They are what a
+      // pattern keyed on that shape rejects, and are here so that adding one
+      // fails.
       "// the second time the cache missed, refresh the credentials",
       "// the third instance found in the pool is the one that owns the lock",
       "// on the second retry the fixed backoff is replaced by the jittered one",

--- a/packages/blocks-engine/src/measure-bytes.ts
+++ b/packages/blocks-engine/src/measure-bytes.ts
@@ -327,6 +327,11 @@ export interface DocumentSurvey {
    * check and a large one afterwards leaves the caller's walk unbounded while
    * this survey's verdict says the document was refused.
    *
+   * `readonly` on the PROPERTY as well as its members. Freezing the inner
+   * object leaves `survey.limits = {...}` legal, and a walk reading the
+   * replacement would be bounded by numbers this survey never enforced — which
+   * is the whole point of publishing the snapshot.
+   *
    * `Readonly<SurveyLimits>` rather than a second interface of the same three
    * members: the shape a caller passes IN and the shape it reads back OUT are
    * the same three bounds, and two names for them would drift and would ask a
@@ -337,7 +342,7 @@ export interface DocumentSurvey {
    * Primitive numbers, because `bounded` rejects anything else — so a consumer
    * of this field cannot be handed an accessor at one remove.
    */
-  limits: Readonly<SurveyLimits>;
+  readonly limits: Readonly<SurveyLimits>;
   /** Serialized size in bytes; a lower bound once `tooLarge` is set. */
   bytes: number;
   /** The byte cap was passed. */

--- a/packages/blocks-engine/src/measure-bytes.ts
+++ b/packages/blocks-engine/src/measure-bytes.ts
@@ -519,11 +519,10 @@ export function surveyDocument(
   // of them overrides a field.
   //
   // Each verdict is a comparison the walk's own counters already answer, so a
-  // return site that asserted its own verdict would be a second implementation
-  // of the same question: the two agree on the day they are written, and a
-  // break in either leaves the other producing the expected result. That is not
-  // hypothetical here — a single-site break in the byte verdict left the walk
-  // returning the right answer from the other site.
+  // return site asserting its own verdict would be a second implementation of
+  // the same question. Two implementations agree on the day they are written
+  // and a break in either leaves the other producing the expected result, so
+  // the pair is untestable one site at a time.
   //
   // `deepest` and `nodes` are advanced immediately before the check that ends
   // the walk, so reading them here reports the same breach the exit detected

--- a/packages/blocks-engine/src/measure-bytes.ts
+++ b/packages/blocks-engine/src/measure-bytes.ts
@@ -316,13 +316,6 @@ function memberPlacement(
  * The stack is explicit so deep nesting cannot overflow, every bound stops the
  * walk at its first breach, and no branch reads a value it has not guarded.
  */
-/** Bounds a survey was measured against, as primitive numbers. */
-export interface SurveyedLimits {
-  maxBytes: number;
-  maxDepth: number;
-  maxNodes: number;
-}
-
 export interface DocumentSurvey {
   /**
    * The bounds this survey ENFORCED, snapshotted before the walk began.
@@ -334,10 +327,17 @@ export interface DocumentSurvey {
    * check and a large one afterwards leaves the caller's walk unbounded while
    * this survey's verdict says the document was refused.
    *
+   * `Readonly<SurveyLimits>` rather than a second interface of the same three
+   * members: the shape a caller passes IN and the shape it reads back OUT are
+   * the same three bounds, and two names for them would drift and would ask a
+   * reader to work out which is which. `readonly` because the object is frozen,
+   * so a type permitting assignment would describe a runtime `TypeError` as
+   * legal.
+   *
    * Primitive numbers, because `bounded` rejects anything else — so a consumer
    * of this field cannot be handed an accessor at one remove.
    */
-  limits: SurveyedLimits;
+  limits: Readonly<SurveyLimits>;
   /** Serialized size in bytes; a lower bound once `tooLarge` is set. */
   bytes: number;
   /** The byte cap was passed. */
@@ -495,7 +495,7 @@ export function surveyDocument(
   // Built once and shared by every survey this walk returns, so a caller cannot
   // be handed two objects that disagree, and frozen because the bound a caller
   // reads must be the one that was enforced rather than one a later reader set.
-  const enforced: SurveyedLimits = Object.freeze({
+  const enforced: Readonly<SurveyLimits> = Object.freeze<SurveyLimits>({
     maxBytes,
     maxDepth,
     maxNodes,

--- a/packages/blocks-engine/src/measure-bytes.ts
+++ b/packages/blocks-engine/src/measure-bytes.ts
@@ -316,7 +316,28 @@ function memberPlacement(
  * The stack is explicit so deep nesting cannot overflow, every bound stops the
  * walk at its first breach, and no branch reads a value it has not guarded.
  */
+/** Bounds a survey was measured against, as primitive numbers. */
+export interface SurveyedLimits {
+  maxBytes: number;
+  maxDepth: number;
+  maxNodes: number;
+}
+
 export interface DocumentSurvey {
+  /**
+   * The bounds this survey ENFORCED, snapshotted before the walk began.
+   *
+   * Published because a caller that goes on to walk the same document must
+   * bound its own work by the same numbers. Reading them again from the limits
+   * object asks a question that has already been answered, and can be answered
+   * differently the second time: an accessor returning a small bound for the
+   * check and a large one afterwards leaves the caller's walk unbounded while
+   * this survey's verdict says the document was refused.
+   *
+   * Primitive numbers, because `bounded` rejects anything else — so a consumer
+   * of this field cannot be handed an accessor at one remove.
+   */
+  limits: SurveyedLimits;
   /** Serialized size in bytes; a lower bound once `tooLarge` is set. */
   bytes: number;
   /** The byte cap was passed. */
@@ -471,6 +492,14 @@ export function surveyDocument(
   const maxBytes = bounded(limits.maxBytes, "maxBytes");
   const maxDepth = bounded(limits.maxDepth, "maxDepth");
   const maxNodes = bounded(limits.maxNodes, "maxNodes");
+  // Built once and shared by every survey this walk returns, so a caller cannot
+  // be handed two objects that disagree, and frozen because the bound a caller
+  // reads must be the one that was enforced rather than one a later reader set.
+  const enforced: SurveyedLimits = Object.freeze({
+    maxBytes,
+    maxDepth,
+    maxNodes,
+  });
 
   let bytes = 0;
   let unserializable = false;
@@ -500,6 +529,7 @@ export function surveyDocument(
   // the walk, so reading them here reports the same breach the exit detected
   // rather than a stale one.
   const done = (): DocumentSurvey => ({
+    limits: enforced,
     bytes,
     tooLarge: bytes > maxBytes,
     tooDeep: deepest > maxDepth,

--- a/packages/blocks-engine/src/measure-bytes.ts
+++ b/packages/blocks-engine/src/measure-bytes.ts
@@ -486,10 +486,23 @@ export function surveyDocument(
   const onPath = new Set<object>();
   const stack: Frame[] = [{ value: root, kind: "value", depth: 0 }];
 
+  // The ONE place a verdict is decided. Every exit below returns this, and none
+  // of them overrides a field.
+  //
+  // Each verdict is a comparison the walk's own counters already answer, so a
+  // return site that asserted its own verdict would be a second implementation
+  // of the same question: the two agree on the day they are written, and a
+  // break in either leaves the other producing the expected result. That is not
+  // hypothetical here — a single-site break in the byte verdict left the walk
+  // returning the right answer from the other site.
+  //
+  // `deepest` and `nodes` are advanced immediately before the check that ends
+  // the walk, so reading them here reports the same breach the exit detected
+  // rather than a stale one.
   const done = (): DocumentSurvey => ({
     bytes,
     tooLarge: bytes > maxBytes,
-    tooDeep: false,
+    tooDeep: deepest > maxDepth,
     tooManyNodes: nodes > maxNodes,
     unserializable,
     nodes,
@@ -651,9 +664,9 @@ export function surveyDocument(
           nodes += 1;
           if (hiddenPlacement.depth > deepest) deepest = hiddenPlacement.depth;
           if (hiddenPlacement.depth > maxDepth) {
-            return { ...done(), tooDeep: true };
+            return done();
           }
-          if (nodes > maxNodes) return { ...done(), tooManyNodes: true };
+          if (nodes > maxNodes) return done();
         }
 
         // A hidden value is not readable by the writer but IS readable by the
@@ -683,7 +696,7 @@ export function surveyDocument(
         // writes nothing for it — which is why this is the array branch only.
         if (!keyed) {
           bytes += 4;
-          if (bytes > maxBytes) return { ...done(), tooLarge: true };
+          if (bytes > maxBytes) return done();
         }
         continue;
       }
@@ -691,7 +704,7 @@ export function surveyDocument(
       if (keyed) {
         bytes +=
           utf8ByteLength(key, maxBytes) + 3 + (frame.emitted === true ? 1 : 0);
-        if (bytes > maxBytes) return { ...done(), tooLarge: true };
+        if (bytes > maxBytes) return done();
       }
 
       const placement = memberPlacement(
@@ -771,10 +784,10 @@ export function surveyDocument(
           // wrong depth, and disagree with `treeDepth`.
           nodes += 1;
           if (reached.depth > deepest) deepest = reached.depth;
-          if (reached.depth > maxDepth) return { ...done(), tooDeep: true };
-          if (nodes > maxNodes) return { ...done(), tooManyNodes: true };
+          if (reached.depth > maxDepth) return done();
+          if (nodes > maxNodes) return done();
         }
-        if (takeScalar(held)) return { ...done(), tooLarge: true };
+        if (takeScalar(held)) return done();
       }
       continue;
     }
@@ -811,12 +824,12 @@ export function surveyDocument(
     if (kind === "node") {
       nodes += 1;
       if (depth > deepest) deepest = depth;
-      if (depth > maxDepth) return { ...done(), tooDeep: true };
-      if (nodes > maxNodes) return { ...done(), tooManyNodes: true };
+      if (depth > maxDepth) return done();
+      if (nodes > maxNodes) return done();
     }
 
     if (typeof value !== "object" || value === null) {
-      if (takeScalar(value)) return { ...done(), tooLarge: true };
+      if (takeScalar(value)) return done();
       continue;
     }
 
@@ -889,7 +902,7 @@ export function surveyDocument(
       // writes one element per position whether or not that position is
       // present.
       bytes += 2 + Math.max(0, length - 1);
-      if (bytes > maxBytes) return { ...done(), tooLarge: true };
+      if (bytes > maxBytes) return done();
 
       // Every position costs at least one more byte — the shortest thing JSON
       // can write at one is a single digit, and a hole costs four — so an array
@@ -898,7 +911,7 @@ export function surveyDocument(
       // proportional to `length` for an array it was always going to reject.
       if (bytes + length > maxBytes) {
         bytes += length;
-        return { ...done(), tooLarge: true };
+        return done();
       }
 
       stack.push({
@@ -931,7 +944,7 @@ export function surveyDocument(
     }
 
     bytes += 2; // braces
-    if (bytes > maxBytes) return { ...done(), tooLarge: true };
+    if (bytes > maxBytes) return done();
 
     stack.push({
       value,

--- a/packages/blocks-engine/src/validation.test.ts
+++ b/packages/blocks-engine/src/validation.test.ts
@@ -780,11 +780,12 @@ describe("validation never throws on adversarial input", () => {
     // Exactly one, and the message must quote the bound that was ENFORCED
     // rather than whichever value a later read produced.
     expect(reads).toBe(1);
+    // The WHOLE message, not a substring of it. `includes("10")` is satisfied
+    // by "100" and by the getter's own 1000000000, so it passes on exactly the
+    // implementation this asserts against.
     expect(
-      issues.some(
-        i => i.code === "node-count-exceeded" && i.message.includes("10")
-      )
-    ).toBe(true);
+      issues.filter(i => i.code === "node-count-exceeded").map(i => i.message)
+    ).toEqual(["Document exceeds the maximum of 10 nodes."]);
   });
 
   it("bounds the path text unknown class warnings can return", () => {

--- a/packages/blocks-engine/src/validation.test.ts
+++ b/packages/blocks-engine/src/validation.test.ts
@@ -741,6 +741,52 @@ describe("validation never throws on adversarial input", () => {
     expect(asked).toBe(0);
   });
 
+  it("enforces the node cap the survey measured, not a later answer", () => {
+    // A limit that GROWS between reads. Nothing obliges a caller to hand over a
+    // plain object, and an accessor is free to answer differently every time —
+    // so a bound read once for the verdict and again to size the walk is two
+    // different bounds, and the second one is the one that decides how much
+    // work a hostile document gets.
+    //
+    // The walk must be sized by the number the verdict was computed from. The
+    // observable form of that is the read COUNT: one read per limit, at the
+    // point the survey snapshots them. Asserting only that the issue is
+    // reported passes on the broken implementation too, because the verdict was
+    // always right — it was the traversal after it that ran unbounded.
+    let reads = 0;
+    const nodes = Array.from({ length: 200 }, (_, i) => ({
+      id: `n${i}`,
+      type: "core/text",
+      version: 1,
+      props: {},
+    }));
+    const doc = invalidDoc({ formatVersion: 1, kind: "page", nodes });
+    const limits = {
+      maxDepth: 12,
+      maxBytes: 2 * 1024 * 1024,
+      get maxNodes() {
+        reads += 1;
+        return reads === 1 ? 10 : 1_000_000_000;
+      },
+    };
+
+    const issues = validate(doc, {
+      breakpoints: FIXTURE_BREAKPOINTS,
+      mode: "strict",
+      limits,
+    });
+
+    expect(issues.some(i => i.code === "node-count-exceeded")).toBe(true);
+    // Exactly one, and the message must quote the bound that was ENFORCED
+    // rather than whichever value a later read produced.
+    expect(reads).toBe(1);
+    expect(
+      issues.some(
+        i => i.code === "node-count-exceeded" && i.message.includes("10")
+      )
+    ).toBe(true);
+  });
+
   it("bounds the path text unknown class warnings can return", () => {
     // A JSON Pointer repeats every key above it, so a node under a very long
     // slot key copies that key into every warning reported beneath it. Counting

--- a/packages/blocks-engine/src/validation.ts
+++ b/packages/blocks-engine/src/validation.ts
@@ -23,6 +23,7 @@ import { describeValue, pointer } from "./issue-text";
 import { DEFAULT_LIMITS, LIMIT_WARNING_RATIO } from "./limits";
 import type { DocumentLimits } from "./limits";
 import { surveyDocument } from "./measure-bytes";
+import type { DocumentSurvey } from "./measure-bytes";
 import { isPlainRecord } from "./plain-record";
 import type { TokenKind } from "./style/catalog-types";
 import { MAX_NAMED_CLASS_NAME_LENGTH } from "./style/named-class";
@@ -334,7 +335,7 @@ export function validate(
   }
 
   const beforeLimits = issues.length;
-  checkLimits(doc, limits, issues);
+  const survey = checkLimits(doc, limits, issues);
   // Any limit rejection, not the byte one alone. A forest over the node or
   // depth cap is refused BEFORE its bytes are measured, so asking only about
   // size would leave the expensive per-value work running on a document already
@@ -399,12 +400,12 @@ export function validate(
   const queue: Array<{ node: BlockNode; path: string }> = [];
   for (
     let i = 0;
-    i < doc.nodes.length && queue.length <= limits.maxNodes;
+    i < doc.nodes.length && queue.length <= survey.limits.maxNodes;
     i++
   ) {
     queue.push({ node: doc.nodes[i], path: pointer("/nodes", i) });
   }
-  for (let i = 0; i < queue.length && i < limits.maxNodes; i++) {
+  for (let i = 0; i < queue.length && i < survey.limits.maxNodes; i++) {
     const { node, path } = queue[i];
     validateNode(node, path, nodeState);
     if (isPlainRecord(node) && isPlainRecord(node.slots)) {
@@ -413,7 +414,7 @@ export function validate(
           const slotPath = pointer(pointer(path, "slots"), slot);
           for (
             let c = 0;
-            c < children.length && queue.length <= limits.maxNodes;
+            c < children.length && queue.length <= survey.limits.maxNodes;
             c++
           ) {
             queue.push({ node: children[c], path: pointer(slotPath, c) });
@@ -472,7 +473,7 @@ function checkLimits(
   doc: BlockDocument,
   limits: DocumentLimits,
   issues: ValidationIssue[]
-): void {
+): DocumentSurvey {
   // ONE traversal answers all three bounds.
   //
   // Depth, node count and serialized size were measured by two separate walks,
@@ -493,7 +494,7 @@ function checkLimits(
       path: "/nodes",
       code: "depth-exceeded",
       severity: "error",
-      message: `Node tree is nested deeper than the maximum of ${limits.maxDepth}.`,
+      message: `Node tree is nested deeper than the maximum of ${survey.limits.maxDepth}.`,
     });
   }
   if (survey.tooManyNodes) {
@@ -501,14 +502,14 @@ function checkLimits(
       path: "/nodes",
       code: "node-count-exceeded",
       severity: "error",
-      message: `Document exceeds the maximum of ${limits.maxNodes} nodes.`,
+      message: `Document exceeds the maximum of ${survey.limits.maxNodes} nodes.`,
     });
   }
   // A structurally over-cap document is already rejected, and the walk stopped
   // at that breach — so its byte count is a lower bound rather than a
   // measurement, and reporting a size from it would report a number that was
   // never finished.
-  if (survey.tooDeep || survey.tooManyNodes) return;
+  if (survey.tooDeep || survey.tooManyNodes) return survey;
 
   // The CAUSE, not just the refusal. A document over the limit is fixed by
   // removing content; one holding a value JSON cannot write is not made smaller
@@ -526,7 +527,7 @@ function checkLimits(
       path: "",
       code: "document-too-large",
       severity: "error",
-      message: `Document exceeds the maximum of ${limits.maxBytes} bytes.`,
+      message: `Document exceeds the maximum of ${survey.limits.maxBytes} bytes.`,
     });
   } else if (survey.unserializable) {
     issues.push({
@@ -536,16 +537,17 @@ function checkLimits(
       message:
         "Document holds a value JSON cannot write, so it has no stored form.",
     });
-  } else if (bytes > limits.maxBytes * LIMIT_WARNING_RATIO) {
+  } else if (bytes > survey.limits.maxBytes * LIMIT_WARNING_RATIO) {
     issues.push({
       path: "",
       code: "document-size-warning",
       severity: "warning",
       message: `Document is ${bytes} bytes, over ${Math.round(
         LIMIT_WARNING_RATIO * 100
-      )}% of the ${limits.maxBytes}-byte limit.`,
+      )}% of the ${survey.limits.maxBytes}-byte limit.`,
     });
   }
+  return survey;
 }
 
 interface NodeCheckState {


### PR DESCRIPTION
Follow-up to #738, carrying its remaining round-26 threads. Three are fixed here; the fourth turned out to need a design change with a security consequence and is filed rather than rushed.

Every claim was verified against the code before being fixed, and every fix is stub-verified — the numbers below are measurements, not estimates.

---

## 1. Each survey verdict now has ONE decision site (`3780840838`, P1)

**Claim:** `tooManyNodes` is decided both in `done()` and independently at every node-cap return site, so breaking either leaves the other producing the expected result.

**Verified.** `done()` computed `tooManyNodes: nodes > maxNodes`, and thirteen return sites re-tested the identical condition and overrode the field they had just tested. `tooDeep` had the mirror-image problem — `done()` hardcoded `false` and three sites each decided it independently. `tooLarge` had it too: `takeScalar` returns `bytes > maxBytes`, which `done()` already computes.

The override was **redundant rather than additive**, which is what makes it dangerous — a single-site stub-verification passes on a broken implementation. That is not hypothetical: a single-site break in the byte verdict during #738 returned the right answer from the other site and read as a broken test.

`done()` now derives all three, and every exit is a bare `return done()`. Safe because `deepest` and `nodes` are advanced immediately before the check that ends the walk, so reading them in `done()` reports the same breach the exit detected.

**Stub-verified — each verdict broken alone, in the single remaining site:**

| broken | tests failing |
|---|---|
| `tooManyNodes` | 10 |
| `tooDeep` | 2 |
| `tooLarge` | 22 |

Every one of those was survivable before.

## 2. Validation is bounded by the limits the survey ENFORCED (`3780840832`, P1)

**Claim:** the queue loops re-read `limits.maxNodes`, so a growing accessor makes the survey report `node-count-exceeded` correctly while the entire oversized forest is still validated.

**Verified by reading and then by measurement.** `validation.ts` bound `const limits = ctx.limits ?? DEFAULT_LIMITS` — the **object**. `surveyDocument` snapshots its bounds internally, so its verdict is safe, but nothing downstream shared that snapshot: three loop **conditions** re-invoked the accessor once per iteration.

The order that produces is backwards. The cap is meant to stop the work, not annotate it.

`surveyDocument` now publishes the bounds it enforced as a frozen `SurveyedLimits`; `checkLimits` returns the survey; the walk sizes itself from that snapshot. Issue messages quote the enforced bound too, so a report cannot name a limit other than the one applied. The **single** remaining read of the caller's object is the call into `surveyDocument`, which is where the snapshot is taken.

**Measured** with `maxNodes` as a getter returning `10` then `1e9`, over 200 nodes:

```
before   401 reads   (~2N+1, matching the reviewer's 2,002 over 1,000 nodes)
after      1 read
```

New test `enforces the node cap the survey measured, not a later answer` asserts the read COUNT, deliberately. Asserting only that the issue is reported passes on the broken implementation too — the verdict was always right; it was the traversal after it that ran unbounded. Stub-verified: reverting the three loop conditions fails it with `expected 401 to be 1`.

## 3. The ordinal-narration pattern is deleted (`3780840839`, P2)

**Claim accepted in full.** "The second time the cache missed, refresh the credentials" matches, because `missed` is ordinary technical vocabulary.

Every remaining pattern matches a **name the code cannot own** — a review tool, the pull request, the reviewer. That is what makes them safe: those words carry no meaning inside a description of what the code does, so matching them cannot reject a correct comment. Counting is not like that. "The third instance of this shape we have found" is process history; "the third instance in the array owns the separator" describes a parser, and the difference is intent, not vocabulary. Narrowing toward discovery verbs cannot close that gap, because a cache MISSES, a guard CATCHES and a value is FOUND.

Three bystanders are kept as **negative controls**, so reintroducing such a pattern fails. Stub-verified: reinstating the old expression fails on `the second time the cache missed, refresh the credentials`.

---

## 4. Deferred, with the reason measured (`3780840834`, P1)

**The claim is real** — `validateClasses` enumerates `node.classes` before consulting `skipValueParsing`, and every check re-reads the field, so an accessor is invoked roughly twice per member.

**The obvious fix is wrong, and that was measured rather than reasoned.** Returning early when `overLimits` is set breaks `rejects a sparse classes array (holes are not skipped)` — and that test is correct. On `origin/main`, so this predates anything here:

```
document:      { ..., classes: [<hole>, "cls"] }
JSON.stringify {"...","classes":[null,"cls"]}      <- writes perfectly
survey         unserializable=true  bytes=12  tooLarge=false
validate()     ["document-unwritable"]
```

12 bytes, fully measured, written by `JSON.stringify` — and refused with a message reading "Document holds a value JSON cannot write, so it has no stored form."

`surveyDocument` is behaving to contract; `unserializable` is documented to cover an array hole. **The defect is what `validation.ts` does with it.** `overLimits` treats `document-unwritable` as grounds to stop bounded work, but the rationale written into that code is specifically about a document whose *size is unknown* — an accessor reported absent, so its megabytes were never counted. That covers a SUBSET of what sets the flag:

| question | justifies skipping downstream work? | examples |
|---|---|---|
| the walk could not MEASURE this | **yes** — `bytes` is not a measurement, so nothing downstream is bounded | accessor refused by descriptor, `getOwnPropertyNames` threw |
| JSON will not PRESERVE this | **no** — fully measured and bounded | array hole, `-0`, non-index array property |

One flag, two questions. Gating validation on the wider set silently drops real issues on perfectly measurable documents, which is what the sparse-classes test caught.

The fix is to split the field and gate on the narrower one. Getting that wrong re-opens the unbounded-work hole `document-unwritable` was added to close, and the site list must be derived from the walk rather than guessed — so it wants its own review rather than riding along with three unrelated fixes. Filed with the full analysis in `tasks/left-tasks/2026-08-14-1200-unwritable-conflates-two-questions.md`.

The sparse-array false positive is a live product defect on its own: a document JSON writes fine is refused as having no stored form.

---

## Gate

`blocks-engine` 1208 passed, 29 files. `check-types` clean (both configs).

No changeset: no published behaviour changes for any document whose limits are plain numbers, which is every document a caller of the public API can produce.
