### PR TITLE
feat(root): make the merge-verification decisions testable code

### DIFF
--- a/.claude/rules/verifying-merged-work.md
+++ b/.claude/rules/verifying-merged-work.md
@@ -27,6 +27,14 @@ plus the change rather than the tree CI ran on, and the two disagree. Measured
 on one merged pull request here, the branch head reported the CI job and one
 integration leg as `success` while the merge commit had them queued.
 
+**Know its range before trusting it.** The script's module header lists what it
+does not cover, and the four worth carrying in your head are: it snapshots
+threads and checks once rather than holding them still; `REQUIRED_CHECKS` is a
+floor listing workflows whose absence is known to mean no coverage, not every
+workflow; `refs/pull/N/merge` is resolved rather than pinned; and the
+landed-whole range screens without certifying. The project runs this advisory,
+so those windows are closed by the merge precondition below, not by the script.
+
 **Exit status distinguishes three outcomes, and the third is not a softer
 second.** `0` passed, `1` blocked, `2` did not get to answer — a rewritten
 history, or a candidate list from the landed-whole screen that nobody has

--- a/.claude/rules/verifying-merged-work.md
+++ b/.claude/rules/verifying-merged-work.md
@@ -318,6 +318,15 @@ They are easy to run together and none substitutes for another:
    answers the same way whether or not the commit landed. Match it as a FIXED
    string: a marker containing `.`, `[` or `*` is otherwise a pattern, and can
    match text it was never taken from.
+
+   **The marker must fit on ONE line.** `git grep` matches per line, so a marker
+   spanning a wrapped comment or a formatted call finds nothing in a merge
+   commit that contains it — which reads exactly like a lost tail, in the
+   alarming direction. Measured here while verifying a merge by content: the
+   control is what separated the two, because the same marker was absent from
+   the BRANCH HEAD as well, and content the branch does not have cannot have
+   been lost by the merge. Pick a marker from a single line, and when the search
+   comes back empty run it against the head before believing it.
    - it ADDED content → `git grep -F -e "$marker" <mergeCommit> -- <path>`;
      expect a hit. The `-e` is not optional: a marker beginning with `-`, which
      a Markdown list item usually does, is otherwise parsed as an option and

--- a/.claude/rules/verifying-merged-work.md
+++ b/.claude/rules/verifying-merged-work.md
@@ -8,6 +8,19 @@ of the merged work has been opened.
 
 ## The decisions in this file are also code
 
+**Run it, do not retype it:**
+
+```sh
+node scripts/verify-merge.mjs <pr-number>
+```
+
+It reads the tip from `git ls-remote` rather than the API's cached head, refuses
+when the branch cannot answer, names every blocking job rather than counting
+them, and reports a second reviewer that never ran as distinct from one that
+found nothing. Exit status is the verdict. A gate typed out again by hand is a
+second implementation of the same question, which this repository has a rule
+about.
+
 `scripts/verify-merge.mjs` implements the judgements below as pure functions —
 whether a branch can answer the question at all, whether a job counts as
 passing, whether a review verdict belongs to the revision being merged, and

--- a/.claude/rules/verifying-merged-work.md
+++ b/.claude/rules/verifying-merged-work.md
@@ -6,6 +6,23 @@ an act rather than a file type, and the checks below are needed before any file
 of the merged work has been opened.
 -->
 
+## The decisions in this file are also code
+
+`scripts/verify-merge.mjs` implements the judgements below as pure functions —
+whether a branch can answer the question at all, whether a job counts as
+passing, whether a review verdict belongs to the revision being merged, and
+whether a second reviewer looked. `scripts/verify-merge.test.mjs` runs them
+against the inputs that produced this repository's actual false cleans, and
+`pnpm test:scripts` runs it in CI.
+
+Prefer them to re-deriving the logic in shell. The snippets here stay because
+the reasoning is worth reading, but a snippet is not a control: every one of
+them was wrong at least once — a count computed and never read, an exit status
+swallowed by the pipeline that consumed it, a comparison against a base that
+moves — and each was found by a person executing it mentally rather than by
+anything running it. When a rule and the script disagree, the script is the one
+with tests.
+
 ## A squash merge makes every ancestry check unsound
 
 Merging squashes the branch into one new commit, so the branch head is **never**

--- a/.claude/rules/verifying-merged-work.md
+++ b/.claude/rules/verifying-merged-work.md
@@ -17,13 +17,26 @@ node scripts/verify-merge.mjs <pr-number>
 It reads the tip from `git ls-remote` rather than the API's cached head, refuses
 when the branch cannot answer, names every blocking job rather than counting
 them, and reports a second reviewer that never ran as distinct from one that
-found nothing. Exit status is the verdict. A gate typed out again by hand is a
-second implementation of the same question, which this repository has a rule
-about.
+found nothing. A gate typed out again by hand is a second implementation of the
+same question, which this repository has a rule about.
+
+**It answers a different question before and after the merge**, because the two
+questions have different subjects. Open, it judges the branch tip — the thing
+being proposed. Merged, it judges `merge_commit_sha`: a squash commit is `main`
+plus the change rather than the tree CI ran on, and the two disagree. Measured
+on one merged pull request here, the branch head reported the CI job and one
+integration leg as `success` while the merge commit had them queued.
+
+**Exit status distinguishes three outcomes, and the third is not a softer
+second.** `0` passed, `1` blocked, `2` did not get to answer — a rewritten
+history, or a candidate list from the landed-whole screen that nobody has
+settled by content yet. A caller may retry or escalate a `2`; it must never read
+one as a pass.
 
 `scripts/verify-merge.mjs` implements the judgements below as pure functions —
 whether a branch can answer the question at all, whether a job counts as
-passing, whether a review verdict belongs to the revision being merged, and
+passing, whether a check was ever DUE to report given the paths the pull request
+touches, whether a review verdict belongs to the revision being merged, and
 whether a second reviewer looked. `scripts/verify-merge.test.mjs` runs them
 against the inputs that produced this repository's actual false cleans, and
 `pnpm test:scripts` runs it in CI.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -303,7 +303,7 @@ jobs:
       # `turbo run test` never reaches it. Its own suite runs here: a defect in
       # the release-notes builder only surfaces during a real publish, after the
       # packages are already on npm. Needs no build, runs in milliseconds.
-      - name: Release script tests
+      - name: Script tests
         run: pnpm test:scripts
 
       # The published packages version in lockstep, so a changeset that names

--- a/scripts/verify-merge.mjs
+++ b/scripts/verify-merge.mjs
@@ -335,16 +335,17 @@ export function remoteForRepo(repoFullName, remotes) {
  * Deliberately reports staleness only: adopting the new values would rubber
  * stamp exactly the unverified state this detects.
  */
-export function staleVerification({
-  mergedAtStart,
-  mergedNow,
-  tipAtStart,
-  tipNow,
-}) {
-  if (mergedAtStart !== mergedNow) {
-    return mergedNow ? "merged-during-verification" : "unmerged-during-verification";
+export function staleVerification(before, after) {
+  // Compares the WHOLE snapshot rather than naming fields. Enumerating them has
+  // now missed one twice: the merged flag after the tip, and eligibility after
+  // the merged flag — each time the field added last round was the only one
+  // being watched. Anything mutable that reaches a blocker belongs in the
+  // snapshot, and comparing every key means adding one cannot be forgotten here.
+  if (!before || !after) return "eligibility-unreadable";
+  const keys = new Set([...Object.keys(before), ...Object.keys(after)]);
+  for (const key of keys) {
+    if (before[key] !== after[key]) return `${key}-changed-during-verification`;
   }
-  if (tipAtStart !== tipNow) return "head-moved";
   return null;
 }
 
@@ -385,6 +386,24 @@ export function flatPages(pages, label, isReadablePage = Array.isArray) {
     }
   }
   return pages;
+}
+
+/**
+ * Refuses a changed-file list the API truncated.
+ *
+ * Silence is the failure here: a capped response carries no marker saying so,
+ * and the shorter list is exactly the input that makes a source change look
+ * like a documentation-only one.
+ */
+export function assertCompleteFileList(retrieved, reported) {
+  if (!Number.isInteger(reported)) {
+    throw new TypeError("changed files: the pull request reported no count");
+  }
+  if (retrieved < reported) {
+    throw new TypeError(
+      `changed files: read ${retrieved} of ${reported}; the list is truncated`
+    );
+  }
 }
 
 /** A paginated page that wraps its array under `key`, as the checks endpoints do. */
@@ -706,8 +725,18 @@ function ghLog(merged, tip) {
  * fall back to whatever the working tree happens to hold.
  */
 function workflowAt(revision, path) {
-  run(["fetch", "origin", revision, "--quiet"]);
-  return execFileSync("git", ["show", `${revision}:${path}`], {
+  // REMOTE_FOR_FETCH, never a literal "origin". From a fork checkout `origin`
+  // is the fork, so a hardcoded fetch aborts on a revision it does not have and
+  // the gate exits 2 for an entirely healthy pull request. `remoteForRepo` has
+  // already answered this question; asking it again differently is how the two
+  // answers diverge.
+  run(["fetch", REMOTE_FOR_FETCH, revision, "--quiet"]);
+  // Read through FETCH_HEAD rather than by the name fetched. `git fetch <remote>
+  // refs/pull/N/merge` does not create a local ref of that name, so naming it in
+  // `git show` fails with `invalid object name` — for a plain sha it happens to
+  // work, which is what let this pass everywhere except the one revision the
+  // pre-merge path actually uses.
+  return execFileSync("git", ["show", `FETCH_HEAD:${path}`], {
     encoding: "utf8",
   });
 }
@@ -746,7 +775,7 @@ export function main(argv) {
     "api",
     `repos/${REPO}/pulls/${pr}`,
     "--jq",
-    "{cross:.head.repo.full_name!=.base.repo.full_name,repo:.head.repo.full_name,branch:.head.ref,merged:.merged,mergeSha:.merge_commit_sha,head:.head.sha,state:.state,draft:.draft}",
+    "{cross:.head.repo.full_name!=.base.repo.full_name,repo:.head.repo.full_name,branch:.head.ref,merged:.merged,mergeSha:.merge_commit_sha,head:.head.sha,state:.state,draft:.draft,changedFiles:.changed_files}",
   ]);
   REMOTE_FOR_FETCH = remoteForRepo(meta.repo, configuredRemotes());
   const tip = lsRemoteTip(REMOTE_FOR_FETCH, meta.branch);
@@ -815,6 +844,13 @@ export function main(argv) {
     .map(file => file?.filename)
     .filter(name => typeof name === "string");
 
+  // The endpoint stops at 3000 files however it is paginated, and a truncated
+  // list is indistinguishable from a complete one. If the part returned happens
+  // to be documentation while a source file falls past the cap, every
+  // integration check is excused. Compared against the count the pull request
+  // itself reports.
+  assertCompleteFileList(changedPaths.length, meta.changedFiles);
+
   // Read from the workflow, for the trigger whose run produced the checks being
   // judged: `pull_request` before a merge, `push` to the base branch after one.
   // The two blocks are edited independently, so answering from the wrong one
@@ -824,8 +860,14 @@ export function main(argv) {
   // outside the pull request's worktree: a later commit adding a path to
   // `paths-ignore` would otherwise excuse checks that an older merge was
   // genuinely due to create.
+  // Pre-merge the workflow runs from `refs/pull/N/merge` — the branch combined
+  // with the CURRENT base — not from the branch tip. A base that has since
+  // stopped ignoring a path would otherwise be judged with the head's older
+  // filter, excusing integration runs that were genuinely due. Post-merge the
+  // squash commit IS the revision the push workflow ran on.
+  const filterRevision = merged ? subject : `refs/pull/${pr}/merge`;
   const integrationIgnore = workflowPathsIgnore(
-    workflowAt(subject, ".github/workflows/integration.yml"),
+    workflowAt(filterRevision, ".github/workflows/integration.yml"),
     merged ? "push" : "pull_request"
   );
   const required = requiredChecks(integrationIgnore, { merged });
@@ -946,13 +988,14 @@ export function main(argv) {
   // taken in the pre-merge mode, judging the branch head with the landed-whole
   // question never asked. The mode is as much a part of what was verified as
   // the revision is.
-  const stale = staleVerification({
-    mergedAtStart: merged,
-    mergedNow:
-      ghText(["api", `repos/${REPO}/pulls/${pr}`, "--jq", ".merged"]) === "true",
-    tipAtStart: tip,
-    tipNow: lsRemoteTip(REMOTE_FOR_FETCH, meta.branch),
-  });
+  // Every mutable fact a blocker depends on, read once at the start and once at
+  // the end. Anything added to this projection is compared automatically.
+  const MUTABLE = "{merged:.merged,state:.state,draft:.draft}";
+  const after = ghJson(["api", `repos/${REPO}/pulls/${pr}`, "--jq", MUTABLE]);
+  const stale = staleVerification(
+    { merged, state: meta.state, draft: meta.draft, tip },
+    { ...after, tip: lsRemoteTip(REMOTE_FOR_FETCH, meta.branch) }
+  );
   if (stale) {
     process.stdout.write(
       `  ${stale}: this verdict describes ${tip.slice(0, 9)} as it stood when ` +
@@ -995,5 +1038,8 @@ if (
   process.argv[1] &&
   import.meta.url === pathToFileURL(process.argv[1]).href
 ) {
-  process.exit(runCli(process.argv.slice(2)));
+  // `process.exitCode`, not `process.exit()`. Exiting terminates Node before a
+  // redirected stdout finishes flushing, truncating exactly the blocker names a
+  // caller needs — and the truncation is silent, so the output looks complete.
+  process.exitCode = runCli(process.argv.slice(2));
 }

--- a/scripts/verify-merge.mjs
+++ b/scripts/verify-merge.mjs
@@ -217,6 +217,7 @@ export function gateVerdict({
   eligibility,
   codexReviewedSha,
   coderabbitReviewCount,
+  approvalCount = 0,
 }) {
   const blockers = [];
 
@@ -288,6 +289,12 @@ export function gateVerdict({
     // Reported, never a blocker. The project's decision is to run with one
     // reviewer and know it, rather than to treat its silence as coverage.
     secondReviewer: reviewCoverage(coderabbitReviewCount),
+    // Also reported rather than enforced. CONTRIBUTING.md asks for one
+    // maintainer approval before merge, and no merge in this repository
+    // currently carries one — so blocking on it would refuse every pull request
+    // rather than raise the bar for any. Surfacing it states the gap instead of
+    // hiding it behind a green verdict or making the gate unusable.
+    maintainerApproval: approvalCount > 0 ? "approved" : "none",
   };
 }
 
@@ -300,6 +307,11 @@ export function formatVerdict(verdict) {
   if (verdict.secondReviewer !== "reviewed") {
     lines.push(
       `  ! second reviewer: ${verdict.secondReviewer} (not a blocker; not coverage either)`
+    );
+  }
+  if (verdict.maintainerApproval === "none") {
+    lines.push(
+      "  ! maintainer approval: none (CONTRIBUTING asks for one; not enforced here)"
     );
   }
   return lines.join("\n");
@@ -1022,6 +1034,7 @@ export function main(argv) {
     eligibility: { state: meta.state, draft: meta.draft, merged },
     codexReviewedSha: reviewedSha,
     coderabbitReviewCount: coderabbit,
+    approvalCount: reviews.filter(r => r?.state === "APPROVED").length,
   });
 
   // Nothing is printed until the freshness read below has decided. Emitting the

--- a/scripts/verify-merge.mjs
+++ b/scripts/verify-merge.mjs
@@ -931,6 +931,13 @@ export function main(argv) {
     );
     threads += page.n;
     if (!page.more) break;
+    // A cursor that does not advance would loop for ever, re-reading one page
+    // and adding its count each time. Both failures are silent in opposite
+    // directions — the process hangs, or an inflated count blocks a clean pull
+    // request — so an absent or repeated cursor stops the read instead.
+    if (!page.cur || page.cur === cursor) {
+      throw new Error("review threads: pagination cursor did not advance");
+    }
     cursor = page.cur;
   }
 

--- a/scripts/verify-merge.mjs
+++ b/scripts/verify-merge.mjs
@@ -2,16 +2,15 @@
  * Decides whether a pull request may merge, and whether a merged one landed
  * whole.
  *
- * `.claude/rules/verifying-merged-work.md` describes this procedure in prose
- * with runnable shell in it. Prose does not run, so nothing checked the shell
- * and it was wrong in three separate ways that all looked like a pass: a count
- * computed and never read, an exit status swallowed by the pipeline that
- * consumed it, and a comparison against a base that moves. Each was found by a
- * reader executing the snippet mentally, one at a time.
+ * `.claude/rules/verifying-merged-work.md` describes the same procedure in
+ * prose with runnable shell in it. Shell embedded in a document has nothing
+ * executing it, and every way it can be wrong here looks like a pass: a count
+ * computed and never read, an exit status swallowed by a pipeline, a comparison
+ * against a base that moves. A gate whose failure mode is a false clean has to
+ * be the kind of thing a test can hold inputs against.
  *
- * The decisions live here as pure functions so they can be given inputs whose
- * answers are known. Every I/O call stays in the caller: a function that
- * fetches cannot be handed the case it must get right.
+ * So the decisions live here as pure functions, and every I/O call stays in the
+ * caller: a function that fetches cannot be handed the case it must get right.
  */
 
 /**
@@ -176,6 +175,7 @@ export function gateVerdict({
   tip,
   unresolvedThreads,
   checkRuns,
+  changedPaths,
   codexReviewedSha,
   coderabbitReviewCount,
 }) {
@@ -211,7 +211,7 @@ export function gateVerdict({
       detail: "no check-runs reported for this revision",
     });
   } else {
-    for (const name of missingRequired(checkRuns)) {
+    for (const name of missingRequired(checkRuns, changedPaths)) {
       blockers.push({
         kind: "required-check-absent",
         detail: `${name} never reported — no build or test coverage for this revision`,
@@ -256,6 +256,23 @@ export function formatVerdict(verdict) {
 }
 
 /**
+ * The process exit status, as a decision rather than as control flow.
+ *
+ * Kept here with the other decisions because the caller's `return` statements
+ * are the one part of a gate nothing can hand inputs to, and this gate's
+ * failures are all false cleans — the exact thing an untested branch produces.
+ *
+ * 0 passed, 1 blocked, 2 unsettled. The third is not a softer version of the
+ * second: a caller may reasonably retry or escalate an unsettled result, and
+ * must never treat it as a pass.
+ */
+export function exitCode({ checkable, landedVerdict, mergeable }) {
+  if (!checkable) return 2;
+  if (landedVerdict === "candidates") return 2;
+  return mergeable ? 0 : 1;
+}
+
+/**
  * A commit STATUS, expressed as a check-run so one rule judges both.
  *
  * GitHub has two independent surfaces and a gate that reads one sees a partial
@@ -284,28 +301,107 @@ export function statusAsRun(status) {
  * and no tests. Absence of the expected name is the only thing that separates
  * them, and absence is invisible to any filter over what IS present.
  */
-export function missingRequired(checkRuns, required = REQUIRED_CHECKS) {
+export function missingRequired(
+  checkRuns,
+  changedPaths,
+  required = REQUIRED_CHECKS
+) {
   if (!Array.isArray(checkRuns)) {
     throw new TypeError("missingRequired needs an array of check-runs");
   }
   const present = new Set(checkRuns.map(run => run?.name));
-  return required.filter(name => !present.has(name));
+  return required
+    .filter(check => workflowApplies(check.pathsIgnore, changedPaths))
+    .map(check => check.name)
+    .filter(name => !present.has(name));
 }
 
 /**
- * The job every other job in `ci.yml` depends on through `needs: [ci]`.
+ * One segment of a workflow path filter, as a regular expression source.
  *
- * If it never reported, the browser, scaffold and dev-script jobs did not run
- * either — so its absence means the revision has no build or test coverage at
- * all, however many unrelated workflows went green.
+ * `**` spans directory separators and `*` stops at one, which is what makes
+ * `**​/*.md` and `*.md` different patterns rather than spellings of each other.
+ */
+function globSegmentSource(glob) {
+  let source = "";
+  for (let i = 0; i < glob.length; i += 1) {
+    const char = glob[i];
+    if (char === "*") {
+      if (glob[i + 1] === "*") {
+        source += ".*";
+        i += 1;
+      } else {
+        source += "[^/]*";
+      }
+    } else if (char === "?") {
+      source += "[^/]";
+    } else {
+      source += char.replace(/[.+^${}()|[\]\\]/g, "\\$&");
+    }
+  }
+  return source;
+}
+
+/** Whether one changed file is covered by one workflow path filter. */
+export function pathMatches(glob, path) {
+  if (typeof glob !== "string" || typeof path !== "string") return false;
+  return new RegExp(`^${globSegmentSource(glob)}$`).test(path);
+}
+
+/**
+ * Whether a workflow filtered by `paths-ignore` runs for this change set.
+ *
+ * GitHub skips such a workflow only when EVERY changed file matches a pattern,
+ * so one unmatched file is enough to make it run — and therefore enough to make
+ * its absence from the check-runs a finding rather than an expected quiet.
+ *
+ * Unreadable input answers `true`. The whole purpose of the caller is to notice
+ * a check that never reported, so an unknown change set must require the check
+ * and be argued with, rather than excuse it and be believed.
+ */
+export function workflowApplies(pathsIgnore, changedPaths) {
+  if (!Array.isArray(pathsIgnore) || pathsIgnore.length === 0) return true;
+  if (!Array.isArray(changedPaths) || changedPaths.length === 0) return true;
+  return changedPaths.some(
+    path => !pathsIgnore.some(glob => pathMatches(glob, path))
+  );
+}
+
+/**
+ * `integration.yml`'s `paths-ignore`, which decides whether it runs at all.
+ *
+ * It filters at the TRIGGER, so on a change set it ignores the workflow creates
+ * no check-runs whatsoever. That is the opposite of `ci.yml`, which runs always
+ * and decides inertness in a job — leaving a `skipped` check-run behind, which
+ * is a report. Absence and skipped look the same to a reader and only one of
+ * them is evidence.
+ *
+ * Mirrored rather than parsed, and pinned by a test that reads the workflow, so
+ * that editing the workflow fails CI here instead of silently widening what
+ * this gate will pass.
+ */
+export const INTEGRATION_PATHS_IGNORE = Object.freeze(["docs/**", "**/*.md"]);
+
+/**
+ * Checks whose absence means the revision has no coverage, not that it is
+ * clean, each with the filter deciding whether it was due to report.
  */
 export const REQUIRED_CHECKS = Object.freeze([
-  "Lint / Typecheck / Test / Build",
-  // Its own workflow, on every pull request, and the repository calls it the
-  // enforcement gate. Listing only the CI job meant a run where `secret-scan`
-  // created no check-run passed on the strength of an unrelated workflow being
-  // green — the same absence-is-invisible defect, one workflow along.
-  "gitleaks",
+  // Every other job in `ci.yml` hangs off this one through `needs: [ci]`, so if
+  // it never reported then the browser, scaffold and dev-script jobs did not
+  // run either, however many unrelated workflows went green.
+  { name: "Lint / Typecheck / Test / Build", pathsIgnore: [] },
+  // Its own workflow, unfiltered, on every pull request, and the repository
+  // calls it the enforcement gate.
+  { name: "gitleaks", pathsIgnore: [] },
+  // The only coverage any dialect-specific behaviour has: the unit suites mock
+  // the drivers and the browser tests run on sqlite alone. Listing the CI job
+  // and gitleaks while omitting these meant a run where `integration.yml`
+  // created no check-runs passed on the strength of the other two being green,
+  // which is the same absence-is-invisible defect one workflow along.
+  { name: "Integration (postgres)", pathsIgnore: INTEGRATION_PATHS_IGNORE },
+  { name: "Integration (mysql)", pathsIgnore: INTEGRATION_PATHS_IGNORE },
+  { name: "Integration (sqlite)", pathsIgnore: INTEGRATION_PATHS_IGNORE },
 ]);
 
 /**
@@ -454,44 +550,65 @@ export function main(argv) {
     "api",
     `repos/${REPO}/pulls/${pr}`,
     "--jq",
-    "{cross:.head.repo.full_name!=.base.repo.full_name,repo:.head.repo.full_name,branch:.head.ref}",
+    "{cross:.head.repo.full_name!=.base.repo.full_name,repo:.head.repo.full_name,branch:.head.ref,merged:.merged,mergeSha:.merge_commit_sha,head:.head.sha}",
   ]);
   REMOTE_FOR_FETCH = meta.cross
     ? `https://github.com/${meta.repo}.git`
     : "origin";
   const tip = lsRemoteTip(REMOTE_FOR_FETCH, meta.branch);
 
+  // `.merged`, never the presence of `.merge_commit_sha`. GitHub populates that
+  // field on OPEN pull requests too, with the throwaway commit from its
+  // mergeability test — so keying off it would send every open PR down the
+  // post-merge path and judge it on a commit that is not in anyone's history.
+  const merged = meta.merged === true;
+
+  // Which revision the checks belong to is the whole difference between the two
+  // questions this script answers.
+  //
+  // Before merging, the branch tip is the thing being proposed and the thing CI
+  // ran on. After merging, the squash commit is a DIFFERENT TREE — `main` plus
+  // this change — and it is the one that decides whether `main` is green. A
+  // head can be green while the merge commit is red, so reading the head after
+  // the merge reports on a tree nobody has.
+  const subject = merged ? meta.mergeSha : tip;
+
   const rewrites = countRewriteEvents(timelinePages(pr));
   const reach = checkability({ tip, rewriteEvents: rewrites });
 
-  // Perform the check rather than only reporting whether it could be done.
-  // The previous version computed reachability, printed "available", and never
-  // compared anything — a module named for a check that did not run it. The
-  // merged head is `headRefOid`; anything the ref has beyond it never reached
-  // `main`.
+  // Only after a merge is there a merge to have lost anything. Run before one,
+  // this compares the API's cached head against the ref and reports ordinary
+  // in-flight pushes as candidates.
   let candidates = [];
-  if (reach.checkable) {
-    const merged = ghText([
-      "api",
-      `repos/${REPO}/pulls/${pr}`,
-      "--jq",
-      ".head.sha",
-    ]);
-    if (merged && merged !== tip) {
-      run(["fetch", REMOTE_FOR_FETCH, tip, "--quiet"]);
-      candidates = ghLog(merged, tip);
-    }
+  if (merged && reach.checkable && meta.head && meta.head !== tip) {
+    run(["fetch", REMOTE_FOR_FETCH, tip, "--quiet"]);
+    candidates = ghLog(meta.head, tip);
   }
-  const landed = landedWhole({ ...reach, candidates });
+  const landed = merged
+    ? landedWhole({ ...reach, candidates })
+    : { verdict: "n/a", reason: "not merged", candidates: [] };
 
-  const checkRuns = tip
+  const checkRuns = subject
     ? ghJson([
         "api",
-        `repos/${REPO}/commits/${tip}/check-runs?per_page=100`,
+        `repos/${REPO}/commits/${subject}/check-runs?per_page=100`,
         "--jq",
         ".check_runs",
       ])
     : [];
+
+  // Every file the pull request touches, so a check that was never due to run
+  // is not reported as one that failed to. Paginated: a change set larger than
+  // one page would otherwise look small enough to have skipped a workflow.
+  const changedPaths = ghJson([
+    "api",
+    "--paginate",
+    "--slurp",
+    `repos/${REPO}/pulls/${pr}/files?per_page=100`,
+  ])
+    .flat()
+    .map(file => file?.filename)
+    .filter(name => typeof name === "string");
   // Paginated. A pull request with more than 100 review threads would
   // otherwise have everything past the first page counted as resolved, which
   // is the reassuring direction.
@@ -545,10 +662,14 @@ export function main(argv) {
   // produced `commits//status`, which throws before the script can print
   // NOT CHECKABLE or return its exit code — so the documented refusal became
   // a stack trace.
-  const statuses = tip
+  // Keyed off `subject` for the same reason the check-runs are: statuses are
+  // per-commit exactly as check-runs are, so leaving this one on the tip would
+  // judge a merged pull request half on the merge commit and half on the branch
+  // — and the half still reading the branch is the half that reports green.
+  const statuses = subject
     ? ghJson([
         "api",
-        `repos/${REPO}/commits/${tip}/status`,
+        `repos/${REPO}/commits/${subject}/status`,
         "--jq",
         ".statuses",
       ])
@@ -556,14 +677,22 @@ export function main(argv) {
   const allChecks = [...checkRuns, ...statuses.map(statusAsRun)];
 
   const verdict = gateVerdict({
+    // Deliberately the TIP even after a merge, unlike the checks above. A review
+    // is written against the branch revision the reviewer read; no bot ever
+    // reviews a squash commit, so comparing a verdict to `subject` post-merge
+    // would report every merged pull request as unreviewed.
     tip,
     unresolvedThreads: threads,
     checkRuns: allChecks,
+    changedPaths,
     codexReviewedSha: reviewedSha,
     coderabbitReviewCount: coderabbit,
   });
 
-  process.stdout.write(`PR #${pr} @ ${tip.slice(0, 9) || "(no ref)"}\n`);
+  process.stdout.write(
+    `PR #${pr} @ ${(subject || "").slice(0, 9) || "(no ref)"}` +
+      `${merged ? ` (merge commit; branch ${tip.slice(0, 9)})` : ""}\n`
+  );
   process.stdout.write(
     `  landed-whole: ${landed.verdict} (${landed.reason})\n`
   );
@@ -571,11 +700,11 @@ export function main(argv) {
     process.stdout.write(`    candidate, confirm by content: ${line}\n`);
   }
   process.stdout.write(`${formatVerdict(verdict)}\n`);
-  // Not checkable is not clean. Returning 0 here would let automation treat
-  // the history-rewrite case as a pass — the one state this file exists to
-  // distinguish from a pass.
-  if (!reach.checkable) return 2;
-  return verdict.mergeable ? 0 : 1;
+  return exitCode({
+    checkable: reach.checkable,
+    landedVerdict: landed.verdict,
+    mergeable: verdict.mergeable,
+  });
 }
 
 if (

--- a/scripts/verify-merge.mjs
+++ b/scripts/verify-merge.mjs
@@ -266,8 +266,14 @@ export function formatVerdict(verdict) {
  * second: a caller may reasonably retry or escalate an unsettled result, and
  * must never treat it as a pass.
  */
-export function exitCode({ checkable, landedVerdict, mergeable }) {
-  if (!checkable) return 2;
+export function exitCode({ landedVerdict, mergeable }) {
+  // Read from the landed-whole verdict alone rather than from reachability as
+  // well. Reachability answers whether a BRANCH could be compared against a
+  // merge, which is not a question an open pull request has: taking it directly
+  // made every open branch with a force-push in its history exit 2, hiding a
+  // perfectly good BLOCKED verdict behind "could not answer". `landedWhole`
+  // already folds reachability in, and reports `n/a` before there is a merge.
+  if (landedVerdict === "not-checkable") return 2;
   if (landedVerdict === "candidates") return 2;
   return mergeable ? 0 : 1;
 }
@@ -701,7 +707,6 @@ export function main(argv) {
   }
   process.stdout.write(`${formatVerdict(verdict)}\n`);
   return exitCode({
-    checkable: reach.checkable,
     landedVerdict: landed.verdict,
     mergeable: verdict.mergeable,
   });

--- a/scripts/verify-merge.mjs
+++ b/scripts/verify-merge.mjs
@@ -1,0 +1,228 @@
+/**
+ * Decides whether a pull request may merge, and whether a merged one landed
+ * whole.
+ *
+ * `.claude/rules/verifying-merged-work.md` describes this procedure in prose
+ * with runnable shell in it. Prose does not run, so nothing checked the shell
+ * and it was wrong in three separate ways that all looked like a pass: a count
+ * computed and never read, an exit status swallowed by the pipeline that
+ * consumed it, and a comparison against a base that moves. Each was found by a
+ * reader executing the snippet mentally, one at a time.
+ *
+ * The decisions live here as pure functions so they can be given inputs whose
+ * answers are known. Every I/O call stays in the caller: a function that
+ * fetches cannot be handed the case it must get right.
+ */
+
+/**
+ * Timeline events that replace a branch's history.
+ *
+ * A force-push, a deletion, and a deletion followed by recreation all leave the
+ * branch reading as ordinary while the commits that were on it are gone. The
+ * range check then compares a head against itself and reports nothing missing,
+ * which is indistinguishable from a branch that never had a tail.
+ *
+ * The list is a FLOOR rather than a proof. A mutable remote ref observed over
+ * several round trips cannot support "no commit ever existed here outside the
+ * merge", so this exists to disqualify the cases we know of, not to certify the
+ * rest.
+ */
+export const HISTORY_REWRITE_EVENTS = Object.freeze([
+  "head_ref_force_pushed",
+  "head_ref_deleted",
+  "head_ref_restored",
+]);
+
+/**
+ * Total history-rewrite events across every page of a timeline.
+ *
+ * Takes the pages rather than fetching them, and takes them as already-parsed
+ * arrays: the GitHub timeline is paged at 100 and long pull requests here reach
+ * three pages, so a caller that reads only the first gets zero — the
+ * reassuring answer — for a branch whose history was rewritten on page two.
+ */
+export function countRewriteEvents(pages) {
+  if (!Array.isArray(pages)) {
+    throw new TypeError("countRewriteEvents needs an array of timeline pages");
+  }
+  return pages
+    .flat()
+    .filter(event => HISTORY_REWRITE_EVENTS.includes(event?.event)).length;
+}
+
+/**
+ * Whether the branch can answer "did every commit land" at all.
+ *
+ * Returns a REASON rather than a boolean, because every caller so far has
+ * wanted to print why. Collapsing it to a boolean is how "I could not look"
+ * becomes "nothing to see", which is the failure this whole file exists to
+ * separate.
+ */
+export function checkability({ tip, rewriteEvents }) {
+  if (typeof tip !== "string" || tip.length === 0) {
+    // An absent tip has three causes and only one is genuinely unanswerable:
+    // the branch was deleted, the pull request came from a fork whose branch
+    // was never on this remote, or the name given did not resolve. A name typed
+    // from memory produces this as readily as a deletion, and did.
+    return { checkable: false, reason: "no-ref" };
+  }
+  if (!Number.isInteger(rewriteEvents) || rewriteEvents < 0) {
+    // Unreadable is not zero. A failed timeline query that degrades to 0 turns
+    // the guard off exactly when it cannot see.
+    return { checkable: false, reason: "rewrite-count-unknown" };
+  }
+  if (rewriteEvents > 0) {
+    return { checkable: false, reason: "history-rewritten" };
+  }
+  return { checkable: true, reason: "ok" };
+}
+
+/**
+ * A check-run's conclusion, reduced to whether it may be counted as passing.
+ *
+ * `skipped` passes because a job skipped by a condition is how this repository
+ * expresses "this commit cannot affect me", and branch protection accepts it.
+ * Everything else that is not `success` does NOT pass — including `queued` and
+ * `in_progress`, which are the ones that get miscounted: filtering for
+ * `conclusion === "failure"` and finding none reads as green while nothing has
+ * run. One merge commit here had four required jobs queued for hours and two
+ * unrelated ones completed, and answered zero failures throughout.
+ */
+export function jobPasses(run) {
+  return run?.conclusion === "success" || run?.conclusion === "skipped";
+}
+
+/**
+ * The jobs standing between a revision and a merge, named rather than counted.
+ *
+ * A count cannot be acted on. "3 not green" sends the reader to the web UI;
+ * a name tells them whether it is theirs, which is the difference between
+ * attributing a red and inheriting one.
+ */
+export function blockingJobs(checkRuns) {
+  if (!Array.isArray(checkRuns)) {
+    throw new TypeError("blockingJobs needs an array of check-runs");
+  }
+  return checkRuns
+    .filter(run => !jobPasses(run))
+    .map(run => ({
+      name: run?.name ?? "(unnamed)",
+      status: run?.status ?? "unknown",
+      conclusion: run?.conclusion ?? null,
+    }));
+}
+
+/**
+ * Whether a review verdict belongs to the revision being merged.
+ *
+ * A verdict describes the tree it read. Carried forward to a later push it is
+ * an opinion about a revision nobody is merging, and it reads exactly like an
+ * opinion about this one. Compared by prefix because the bots report a short
+ * sha and the ref reports a full one.
+ */
+export function verdictCoversTip(reviewedSha, tip) {
+  if (typeof reviewedSha !== "string" || reviewedSha.length === 0) return false;
+  if (typeof tip !== "string" || tip.length === 0) return false;
+  const shorter = Math.min(reviewedSha.length, tip.length);
+  // A prefix comparison is only meaningful at a length that can identify a
+  // commit. Seven is git's own floor for an abbreviated sha.
+  if (shorter < 7) return false;
+  return reviewedSha.slice(0, shorter) === tip.slice(0, shorter);
+}
+
+/**
+ * Whether a reviewer looked at all, kept separate from what it found.
+ *
+ * Zero findings and zero reviews render identically in every count-based gate,
+ * and one of them means nothing was checked. This repository's second reviewer
+ * runs on a per-developer quota shared by every concurrent session, so it
+ * silently stops reviewing under exactly the conditions that produce the most
+ * pull requests.
+ */
+export function reviewCoverage(reviewCount) {
+  if (!Number.isInteger(reviewCount) || reviewCount < 0) return "unknown";
+  return reviewCount === 0 ? "not-reviewed" : "reviewed";
+}
+
+/**
+ * The merge gate: every blocker, or an empty list.
+ *
+ * Returns them all rather than the first, so one round of fixing clears the
+ * gate instead of revealing the next reason a merge was never going to happen.
+ */
+export function gateVerdict({
+  tip,
+  unresolvedThreads,
+  checkRuns,
+  codexReviewedSha,
+  coderabbitReviewCount,
+}) {
+  const blockers = [];
+
+  if (typeof tip !== "string" || tip.length === 0) {
+    blockers.push({ kind: "no-tip", detail: "no head revision to merge" });
+  }
+
+  if (!Number.isInteger(unresolvedThreads)) {
+    // Unknown is not zero, for the same reason everywhere else in this file.
+    blockers.push({
+      kind: "threads-unknown",
+      detail: "could not read review threads",
+    });
+  } else if (unresolvedThreads > 0) {
+    blockers.push({
+      kind: "unresolved-threads",
+      detail: `${unresolvedThreads} unresolved review thread(s)`,
+    });
+  }
+
+  if (!Array.isArray(checkRuns)) {
+    blockers.push({
+      kind: "checks-unknown",
+      detail: "could not read check-runs",
+    });
+  } else if (checkRuns.length === 0) {
+    // No jobs at all is not a pass. It is the shape of a run that never
+    // started, and a pull request has merged here in exactly that state.
+    blockers.push({
+      kind: "no-checks",
+      detail: "no check-runs reported for this revision",
+    });
+  } else {
+    for (const job of blockingJobs(checkRuns)) {
+      blockers.push({
+        kind: "job-not-green",
+        detail: `${job.name} (${job.status}/${job.conclusion ?? "-"})`,
+      });
+    }
+  }
+
+  if (!verdictCoversTip(codexReviewedSha, tip)) {
+    blockers.push({
+      kind: "verdict-stale",
+      detail: `no review verdict for ${typeof tip === "string" ? tip.slice(0, 9) : "(unknown)"}`,
+    });
+  }
+
+  return {
+    mergeable: blockers.length === 0,
+    blockers,
+    // Reported, never a blocker. The project's decision is to run with one
+    // reviewer and know it, rather than to treat its silence as coverage.
+    secondReviewer: reviewCoverage(coderabbitReviewCount),
+  };
+}
+
+/** Human-readable gate result, for a caller that prints rather than branches. */
+export function formatVerdict(verdict) {
+  const lines = [];
+  lines.push(verdict.mergeable ? "GATE PASSED" : "GATE BLOCKED");
+  for (const blocker of verdict.blockers)
+    lines.push(`  - ${blocker.kind}: ${blocker.detail}`);
+  if (verdict.secondReviewer !== "reviewed") {
+    lines.push(
+      `  ! second reviewer: ${verdict.secondReviewer} (not a blocker; not coverage either)`
+    );
+  }
+  return lines.join("\n");
+}

--- a/scripts/verify-merge.mjs
+++ b/scripts/verify-merge.mjs
@@ -336,11 +336,11 @@ export function remoteForRepo(repoFullName, remotes) {
  * stamp exactly the unverified state this detects.
  */
 export function staleVerification(before, after) {
-  // Compares the WHOLE snapshot rather than naming fields. Enumerating them has
-  // now missed one twice: the merged flag after the tip, and eligibility after
-  // the merged flag — each time the field added last round was the only one
-  // being watched. Anything mutable that reaches a blocker belongs in the
-  // snapshot, and comparing every key means adding one cannot be forgotten here.
+  // Compares every key rather than naming fields. A named comparison covers
+  // exactly the fields someone thought of, so extending the snapshot silently
+  // leaves the new one unwatched; comparing the whole object makes the snapshot
+  // itself the single place that decides what freshness means. Anything mutable
+  // that reaches a blocker belongs in it.
   if (!before || !after) return "eligibility-unreadable";
   const keys = new Set([...Object.keys(before), ...Object.keys(after)]);
   for (const key of keys) {
@@ -657,6 +657,15 @@ const REPO = "nextlyhq/nextly";
 let REMOTE_FOR_FETCH = "origin";
 
 /**
+ * Where the BASE repository's objects live.
+ *
+ * `refs/pull/N/merge` and a squash commit belong to the base repository even
+ * when the branch does not, so they are fetched from here rather than from the
+ * head remote, which for a fork holds neither.
+ */
+const BASE_REMOTE = "origin";
+
+/**
  * `gh api`, raw. Throws on failure rather than degrading to an empty result.
  *
  * `--jq` prints the filter's output verbatim, NOT as JSON: a string comes back
@@ -688,11 +697,11 @@ function ghJson(args) {
  */
 function timelinePages(pr) {
   // `--slurp` returns ONE array of pages, so the pages stay separate without
-  // this code parsing JSON itself. The previous version counted brackets to
-  // split `--paginate`'s concatenated arrays, which a `[` inside any review
-  // body broke: the depth never returned to zero, the function returned no
-  // pages, and a force-push counted as zero — the false clean this verifier
-  // exists to refuse, introduced by the verifier.
+  // this code parsing JSON itself. Splitting `--paginate`'s concatenated arrays
+  // by counting brackets does not work here: a `[` inside any review body
+  // leaves the depth never returning to zero, which yields no pages at all and
+  // therefore counts zero force-pushes — a false clean produced by the check
+  // that exists to refuse them.
   return JSON.parse(
     execFileSync(
       "gh",
@@ -725,12 +734,12 @@ function ghLog(merged, tip) {
  * fall back to whatever the working tree happens to hold.
  */
 function workflowAt(revision, path) {
-  // REMOTE_FOR_FETCH, never a literal "origin". From a fork checkout `origin`
-  // is the fork, so a hardcoded fetch aborts on a revision it does not have and
-  // the gate exits 2 for an entirely healthy pull request. `remoteForRepo` has
-  // already answered this question; asking it again differently is how the two
-  // answers diverge.
-  run(["fetch", REMOTE_FOR_FETCH, revision, "--quiet"]);
+  // Base repository, not the head one. `refs/pull/N/merge` and the squash commit
+  // are objects of the BASE repository; a fork holds neither, so fetching them
+  // from the head remote fails on every cross-repository pull request. The head
+  // remote answers a different question — where the branch lives — and the two
+  // coincide only when the pull request is not from a fork.
+  run(["fetch", BASE_REMOTE, revision, "--quiet"]);
   // Read through FETCH_HEAD rather than by the name fetched. `git fetch <remote>
   // refs/pull/N/merge` does not create a local ref of that name, so naming it in
   // `git show` fails with `invalid object name` — for a plain sha it happens to
@@ -957,39 +966,23 @@ export function main(argv) {
     coderabbitReviewCount: coderabbit,
   });
 
-  process.stdout.write(
+  // Nothing is printed until the freshness read below has decided. Emitting the
+  // verdict first meant a run that turned out to be stale had already written
+  // GATE PASSED to stdout, contradicted only by a later line and the exit code —
+  // which misleads a human and actively misinforms any caller that reads the
+  // documented text rather than the status.
+  const report =
     `PR #${pr} @ ${(subject || "").slice(0, 9) || "(no ref)"}` +
-      `${merged ? ` (merge commit; branch ${tip.slice(0, 9)})` : ""}\n`
-  );
-  process.stdout.write(
-    `  landed-whole: ${landed.verdict} (${landed.reason})\n`
-  );
-  for (const line of landed.candidates) {
-    process.stdout.write(`    candidate, confirm by content: ${line}\n`);
-  }
-  process.stdout.write(`${formatVerdict(verdict)}\n`);
-  // Everything above was read across many round trips, all keyed to the `tip`
-  // read at the start. A push landing during them leaves every answer describing
-  // a revision the branch no longer has, and the gate would report a pass for a
-  // commit nothing checked or reviewed.
-  //
-  // This REFUSES on a difference; it must never re-key the verdict to the new
-  // head. That distinction is the whole point, and the opposite mistake is easy
-  // to make here: adopting the fresh head would rubber-stamp exactly the
-  // unverified revision this is detecting. The verdict stays with the revision
-  // that was actually examined, and the caller is told it is now stale.
-  //
-  // It narrows the window rather than closing it — the read and the merge are
-  // still separate operations. `gh pr merge --match-head-commit <tip>` is what
-  // closes it, because there the server refuses.
-  // The merged STATE is re-read alongside the tip, not only the tip. A pull
-  // request that merges during the intervening calls usually leaves its branch
-  // untouched, so a tip comparison alone passes — while every answer above was
-  // taken in the pre-merge mode, judging the branch head with the landed-whole
-  // question never asked. The mode is as much a part of what was verified as
-  // the revision is.
-  // Every mutable fact a blocker depends on, read once at the start and once at
-  // the end. Anything added to this projection is compared automatically.
+    `${merged ? ` (merge commit; branch ${tip.slice(0, 9)})` : ""}\n` +
+    `  landed-whole: ${landed.verdict} (${landed.reason})\n` +
+    landed.candidates
+      .map(line => `    candidate, confirm by content: ${line}\n`)
+      .join("") +
+    `${formatVerdict(verdict)}\n`;
+
+  // Every mutable fact a blocker depends on, read once at the start and once
+  // here. The whole snapshot is compared, so a fact added to the projection is
+  // covered without editing the comparison.
   const MUTABLE = "{merged:.merged,state:.state,draft:.draft}";
   const after = ghJson(["api", `repos/${REPO}/pulls/${pr}`, "--jq", MUTABLE]);
   const stale = staleVerification(
@@ -998,11 +991,14 @@ export function main(argv) {
   );
   if (stale) {
     process.stdout.write(
-      `  ${stale}: this verdict describes ${tip.slice(0, 9)} as it stood when ` +
-        "the check began, and is no longer current\n"
+      `PR #${pr}: ${stale}\n` +
+        `  no verdict issued: the answers describe ${tip.slice(0, 9)} as it\n` +
+        "  stood when the check began, and that is no longer current\n"
     );
     return 2;
   }
+
+  process.stdout.write(report);
 
   return exitCode({
     landedVerdict: landed.verdict,

--- a/scripts/verify-merge.mjs
+++ b/scripts/verify-merge.mjs
@@ -349,7 +349,12 @@ export function repoFromRemoteUrl(url) {
 export function remoteForRepo(repoFullName, remotes) {
   if (typeof repoFullName !== "string" || repoFullName === "") return null;
   const wanted = repoFullName.toLowerCase();
-  for (const [name, url] of remotes ?? []) {
+  for (const [name, url, kind] of remotes ?? []) {
+    // FETCH records only. A remote may push and fetch different repositories,
+    // and every read here is a fetch — matching a push URL selects a remote that
+    // does not hold the objects, which then fails on the operation rather than
+    // on the selection and reads as a broken revision.
+    if (kind !== undefined && kind !== "(fetch)") continue;
     if (repoFromRemoteUrl(url)?.toLowerCase() === wanted) return name;
   }
   return `https://github.com/${repoFullName}.git`;
@@ -544,6 +549,9 @@ export function pathMatches(glob, path) {
  * a check that never reported, so an unknown change set must require the check
  * and be argued with, rather than excuse it and be believed.
  */
+/** How many files GitHub's own path filtering looks at, and no more. */
+export const PATH_FILTER_WINDOW = 300;
+
 export function workflowApplies(pathsIgnore, changedPaths) {
   if (!Array.isArray(pathsIgnore) || pathsIgnore.length === 0) return true;
   if (!Array.isArray(changedPaths) || changedPaths.length === 0) return true;
@@ -783,7 +791,7 @@ function configuredRemotes() {
     .split("\n")
     .filter(Boolean)
     .map(line => line.split(/\s+/))
-    .map(([name, url]) => [name, url]);
+    .map(([name, url, kind]) => [name, url, kind]);
 }
 
 /** The branch's real tip, from the ref rather than from the API's cached head. */
@@ -888,6 +896,13 @@ export function main(argv) {
   // itself reports.
   assertCompleteFileList(changedPaths.length, meta.changedFiles);
 
+  // GitHub evaluates path filters over the FIRST 300 files of its generated
+  // diff and no further. Judging every path would diverge from the decision the
+  // platform actually made: where the first 300 are all ignored, the workflow is
+  // skipped and creates no check-runs, so requiring one on the strength of file
+  // 301 demands a check that can never arrive.
+  const filterPaths = changedPaths.slice(0, PATH_FILTER_WINDOW);
+
   // Read from the workflow, for the trigger whose run produced the checks being
   // judged: `pull_request` before a merge, `push` to the base branch after one.
   // The two blocks are edited independently, so answering from the wrong one
@@ -937,11 +952,11 @@ export function main(argv) {
     cursor = page.cur;
   }
 
-  // From the review RECORD's own `commit_id`, not from a comment body. An
-  // issue comment is not evidence a review covered a commit: the previous
-  // version matched any backticked hex in the latest bot comment, which
-  // accepts progress text that happens to name the sha and misses a real
-  // review whose sha never appears in prose.
+  // From the review RECORD's own `commit_id`, never from a comment body. An
+  // issue comment is not evidence that a review covered a commit: prose naming
+  // a sha may be progress text rather than a verdict, and a real review whose
+  // sha never appears in its body carries none. Only the record states which
+  // tree was read.
   // `--slurp` returns an array of PAGES and cannot be combined with `--jq`,
   // so the flattening happens here rather than in the query.
   const reviews = ghJson([
@@ -1000,7 +1015,7 @@ export function main(argv) {
     tip,
     unresolvedThreads: threads,
     checkRuns: allChecks,
-    changedPaths,
+    changedPaths: filterPaths,
     required,
     eligibility: { state: meta.state, draft: meta.draft, merged },
     codexReviewedSha: reviewedSha,

--- a/scripts/verify-merge.mjs
+++ b/scripts/verify-merge.mjs
@@ -11,6 +11,38 @@
  *
  * So the decisions live here as pure functions, and every I/O call stays in the
  * caller: a function that fetches cannot be handed the case it must get right.
+ *
+ * ## What this does NOT cover
+ *
+ * Stated because a gate's worst failure is being trusted past its range, and a
+ * reader who knows only what it checks will assume the rest.
+ *
+ * - **It is a point-in-time snapshot, not a lock.** Threads, check-runs and
+ *   statuses are read once. A thread reopened, or a check rerun, after its query
+ *   and before the exit is not seen: the freshness comparison at the end covers
+ *   the revision and the pull request's own mutable fields, not every input a
+ *   blocker was derived from. `gh pr merge --match-head-commit <tip>` is what
+ *   makes the merge itself refuse a moved head; nothing here can hold the rest
+ *   of GitHub still.
+ *
+ * - **`REQUIRED_CHECKS` is a floor, not a proof.** It names the workflows whose
+ *   absence is known to mean no coverage. Others in `.github/workflows` are
+ *   path-triggered and are judged only when they report, so a workflow that
+ *   fails to create its check-runs is invisible here unless it is listed. Adding
+ *   one is deliberate work; the list does not derive itself.
+ *
+ * - **`refs/pull/N/merge` is resolved, not pinned.** A base branch advancing
+ *   mid-run can change which revision that ref names, and the filter would then
+ *   be read from a revision other than the one the checks ran on.
+ *
+ * - **"Landed whole" screens; it cannot certify.** A mutable remote ref cannot
+ *   answer "no commit ever existed here outside the merge", so an empty
+ *   candidate list means this look found nothing, never that nothing was lost.
+ *
+ * The project runs this ADVISORY: a session invokes it, and merging is still a
+ * human decision. That is why the limits above are acceptable rather than
+ * defects — each narrows a window that a merge precondition, not this script,
+ * is what closes.
  */
 
 /**

--- a/scripts/verify-merge.mjs
+++ b/scripts/verify-merge.mjs
@@ -177,6 +177,7 @@ export function gateVerdict({
   checkRuns,
   changedPaths,
   required,
+  eligibility,
   codexReviewedSha,
   coderabbitReviewCount,
 }) {
@@ -224,6 +225,17 @@ export function gateVerdict({
         detail: `${job.name} (${job.status}/${job.conclusion ?? "-"})`,
       });
     }
+  }
+
+  // GitHub will not merge either of these, so a gate that reports the revision
+  // as mergeable is describing something that cannot happen. Neither is visible
+  // in checks or threads: a closed pull request keeps its green head checks, and
+  // a draft never loses them.
+  if (eligibility?.draft === true) {
+    blockers.push({ kind: "draft", detail: "pull request is a draft" });
+  }
+  if (eligibility?.state === "closed" && eligibility?.merged !== true) {
+    blockers.push({ kind: "closed", detail: "pull request is closed unmerged" });
   }
 
   if (!verdictCoversTip(codexReviewedSha, tip)) {
@@ -357,16 +369,27 @@ export function exitCode({ landedVerdict, mergeable }) {
  * SHORTER list that looks complete: fewer changed files can turn a source change
  * into a documentation-only one and excuse every integration check.
  */
-export function flatPages(pages, label) {
+export function flatPages(pages, label, isReadablePage = Array.isArray) {
   if (!Array.isArray(pages)) {
     throw new TypeError(`${label}: expected an array of pages`);
   }
   for (const page of pages) {
-    if (page === null || typeof page !== "object") {
+    // The predicate is per-ENDPOINT because the shapes differ: files paginate
+    // as bare arrays, check-runs and statuses as objects wrapping one. A single
+    // "is it a non-null object" test spans both and therefore accepts neither
+    // properly — an API error body like `{ message: "Bad credentials" }` passes
+    // it, and is then dropped by the `?? []` downstream, so an unread page
+    // carrying blockers becomes a passing gate.
+    if (!isReadablePage(page)) {
       throw new TypeError(`${label}: a page could not be read`);
     }
   }
   return pages;
+}
+
+/** A paginated page that wraps its array under `key`, as the checks endpoints do. */
+export function pageWrapping(key) {
+  return page => Array.isArray(page?.[key]);
 }
 
 /**
@@ -530,7 +553,7 @@ export function workflowPathsIgnore(workflowText, trigger) {
  * Checks whose absence means the revision has no coverage, not that it is
  * clean, each with the filter deciding whether it was due to report.
  */
-export function requiredChecks(integrationPathsIgnore) {
+export function requiredChecks(integrationPathsIgnore, { merged = false } = {}) {
   return [
     // Every other job in `ci.yml` hangs off this one through `needs: [ci]`, so
     // if it never reported then the browser, scaffold and dev-script jobs did
@@ -544,6 +567,14 @@ export function requiredChecks(integrationPathsIgnore) {
     { name: "Integration (postgres)", pathsIgnore: integrationPathsIgnore },
     { name: "Integration (mysql)", pathsIgnore: integrationPathsIgnore },
     { name: "Integration (sqlite)", pathsIgnore: integrationPathsIgnore },
+    // Reports through the STATUSES surface from its own workflow, and only on a
+    // pull request — a push to the base branch has no title to validate, so
+    // requiring it post-merge would demand a status that is never written.
+    // Judged only when present, a run that never started left the title
+    // unvalidated and the gate green.
+    ...(merged
+      ? []
+      : [{ name: "Validate PR title follows Conventional Commits", pathsIgnore: [] }]),
   ];
 }
 
@@ -715,7 +746,7 @@ export function main(argv) {
     "api",
     `repos/${REPO}/pulls/${pr}`,
     "--jq",
-    "{cross:.head.repo.full_name!=.base.repo.full_name,repo:.head.repo.full_name,branch:.head.ref,merged:.merged,mergeSha:.merge_commit_sha,head:.head.sha}",
+    "{cross:.head.repo.full_name!=.base.repo.full_name,repo:.head.repo.full_name,branch:.head.ref,merged:.merged,mergeSha:.merge_commit_sha,head:.head.sha,state:.state,draft:.draft}",
   ]);
   REMOTE_FOR_FETCH = remoteForRepo(meta.repo, configuredRemotes());
   const tip = lsRemoteTip(REMOTE_FOR_FETCH, meta.branch);
@@ -763,7 +794,8 @@ export function main(argv) {
           "--slurp",
           `repos/${REPO}/commits/${subject}/check-runs?per_page=100`,
         ]),
-        "check-runs"
+        "check-runs",
+        pageWrapping("check_runs")
       ).flatMap(page => page.check_runs ?? [])
     : [];
 
@@ -796,7 +828,7 @@ export function main(argv) {
     workflowAt(subject, ".github/workflows/integration.yml"),
     merged ? "push" : "pull_request"
   );
-  const required = requiredChecks(integrationIgnore);
+  const required = requiredChecks(integrationIgnore, { merged });
   // Paginated. A pull request with more than 100 review threads would
   // otherwise have everything past the first page counted as resolved, which
   // is the reassuring direction.
@@ -862,7 +894,8 @@ export function main(argv) {
           "--slurp",
           `repos/${REPO}/commits/${subject}/status?per_page=100`,
         ]),
-        "statuses"
+        "statuses",
+        pageWrapping("statuses")
       ).flatMap(page => page.statuses ?? [])
     : [];
   const allChecks = [...checkRuns, ...statuses.map(statusAsRun)];
@@ -877,6 +910,7 @@ export function main(argv) {
     checkRuns: allChecks,
     changedPaths,
     required,
+    eligibility: { state: meta.state, draft: meta.draft, merged },
     codexReviewedSha: reviewedSha,
     coderabbitReviewCount: coderabbit,
   });

--- a/scripts/verify-merge.mjs
+++ b/scripts/verify-merge.mjs
@@ -266,6 +266,45 @@ export function formatVerdict(verdict) {
  * second: a caller may reasonably retry or escalate an unsettled result, and
  * must never treat it as a pass.
  */
+/**
+ * A git remote URL reduced to `owner/repo`, or null when it names no repository.
+ *
+ * Compared structurally rather than by string equality because one repository
+ * has several spellings — `https://`, `git@`, `ssh://`, with or without `.git`,
+ * with or without a trailing slash — and a check that misses a spelling falls
+ * back to a remote that may be a different repository entirely.
+ */
+export function repoFromRemoteUrl(url) {
+  if (typeof url !== "string") return null;
+  const match =
+    /^(?:https?:\/\/|ssh:\/\/)?(?:[^@/]+@)?github\.com[:/]+([^/]+)\/(.+?)(?:\.git)?\/?$/i.exec(
+      url.trim()
+    );
+  return match ? `${match[1]}/${match[2]}` : null;
+}
+
+/**
+ * The remote to read a pull request's head from.
+ *
+ * The head repository comes from the pull request, never from an assumption
+ * about `origin`. Running from a fork checkout, `origin` is the fork, so a pull
+ * request whose head lives in the upstream repository would resolve against a
+ * same-named branch on the fork — a real, unrelated revision, whose checks and
+ * reviews this gate would then report as the pull request's.
+ *
+ * A local remote is preferred only when it IS that repository, so configured
+ * credentials and transports keep working; otherwise the canonical URL, which
+ * is correct everywhere and needs no local setup.
+ */
+export function remoteForRepo(repoFullName, remotes) {
+  if (typeof repoFullName !== "string" || repoFullName === "") return null;
+  const wanted = repoFullName.toLowerCase();
+  for (const [name, url] of remotes ?? []) {
+    if (repoFromRemoteUrl(url)?.toLowerCase() === wanted) return name;
+  }
+  return `https://github.com/${repoFullName}.git`;
+}
+
 export function exitCode({ landedVerdict, mergeable }) {
   // Read from the landed-whole verdict alone rather than from reachability as
   // well. Reachability answers whether a BRANCH could be compared against a
@@ -532,6 +571,16 @@ function ghLog(merged, tip) {
   return out ? out.split("\n") : [];
 }
 
+/** Every configured remote as `[name, url]`, for matching against the head repository. */
+function configuredRemotes() {
+  const out = execFileSync("git", ["remote", "-v"], { encoding: "utf8" });
+  return out
+    .split("\n")
+    .filter(Boolean)
+    .map(line => line.split(/\s+/))
+    .map(([name, url]) => [name, url]);
+}
+
 /** The branch's real tip, from the ref rather than from the API's cached head. */
 function lsRemoteTip(remote, branch) {
   const out = execFileSync(
@@ -558,9 +607,7 @@ export function main(argv) {
     "--jq",
     "{cross:.head.repo.full_name!=.base.repo.full_name,repo:.head.repo.full_name,branch:.head.ref,merged:.merged,mergeSha:.merge_commit_sha,head:.head.sha}",
   ]);
-  REMOTE_FOR_FETCH = meta.cross
-    ? `https://github.com/${meta.repo}.git`
-    : "origin";
+  REMOTE_FOR_FETCH = remoteForRepo(meta.repo, configuredRemotes());
   const tip = lsRemoteTip(REMOTE_FOR_FETCH, meta.branch);
 
   // `.merged`, never the presence of `.merge_commit_sha`. GitHub populates that
@@ -706,15 +753,62 @@ export function main(argv) {
     process.stdout.write(`    candidate, confirm by content: ${line}\n`);
   }
   process.stdout.write(`${formatVerdict(verdict)}\n`);
+  // Everything above was read across many round trips, all keyed to the `tip`
+  // read at the start. A push landing during them leaves every answer describing
+  // a revision the branch no longer has, and the gate would report a pass for a
+  // commit nothing checked or reviewed.
+  //
+  // This REFUSES on a difference; it must never re-key the verdict to the new
+  // head. That distinction is the whole point, and the opposite mistake is easy
+  // to make here: adopting the fresh head would rubber-stamp exactly the
+  // unverified revision this is detecting. The verdict stays with the revision
+  // that was actually examined, and the caller is told it is now stale.
+  //
+  // It narrows the window rather than closing it — the read and the merge are
+  // still separate operations. `gh pr merge --match-head-commit <tip>` is what
+  // closes it, because there the server refuses.
+  const tipNow = lsRemoteTip(REMOTE_FOR_FETCH, meta.branch);
+  if (tipNow !== tip) {
+    process.stdout.write(
+      `  head moved ${tip.slice(0, 9)} -> ${(tipNow || "(gone)").slice(0, 9)} ` +
+        `during verification; this verdict describes ${tip.slice(0, 9)}\n`
+    );
+    return 2;
+  }
+
   return exitCode({
     landedVerdict: landed.verdict,
     mergeable: verdict.mergeable,
   });
 }
 
+/**
+ * The executable boundary, where a failure to look becomes exit 2.
+ *
+ * Every helper below the pure section throws rather than degrading, which is
+ * right — but an uncaught throw exits 1, and 1 is the code meaning this gate
+ * examined the revision and rejected it. An expired token, an unreachable API,
+ * a malformed response or a failed fetch would therefore be indistinguishable
+ * from a verdict, and a caller would stop rather than retry.
+ *
+ * `run` is injectable so this decision can be given a failure and asked what it
+ * returns; that is the only reason it is a parameter.
+ */
+export function runCli(argv, run = main) {
+  try {
+    return run(argv);
+  } catch (error) {
+    process.stderr.write(
+      `verify-merge: could not complete the check — ${error?.message ?? error}\n` +
+        "This is exit 2 (unanswered), not a rejection. Retry, or check auth.\n"
+    );
+    return 2;
+  }
+}
+
 if (
   process.argv[1] &&
   import.meta.url === pathToFileURL(process.argv[1]).href
 ) {
-  process.exit(main(process.argv.slice(2)));
+  process.exit(runCli(process.argv.slice(2)));
 }

--- a/scripts/verify-merge.mjs
+++ b/scripts/verify-merge.mjs
@@ -693,9 +693,11 @@ let REMOTE_FOR_FETCH = "origin";
  *
  * `refs/pull/N/merge` and a squash commit belong to the base repository even
  * when the branch does not, so they are fetched from here rather than from the
- * head remote, which for a fork holds neither. Resolved through the same
- * function as the head remote: from a fork checkout `origin` is the fork, so a
- * literal here is the defect this variable exists to fix, one step along.
+ * head remote, which for a fork holds neither.
+ *
+ * Resolved rather than assumed, through the same function as the head remote.
+ * `origin` names the base repository only in a checkout of that repository; in
+ * a fork's checkout it is the fork, which holds neither of these objects.
  */
 let BASE_REMOTE = "origin";
 

--- a/scripts/verify-merge.mjs
+++ b/scripts/verify-merge.mjs
@@ -301,6 +301,11 @@ export function missingRequired(checkRuns, required = REQUIRED_CHECKS) {
  */
 export const REQUIRED_CHECKS = Object.freeze([
   "Lint / Typecheck / Test / Build",
+  // Its own workflow, on every pull request, and the repository calls it the
+  // enforcement gate. Listing only the CI job meant a run where `secret-scan`
+  // created no check-run passed on the strength of an unrelated workflow being
+  // green — the same absence-is-invisible defect, one workflow along.
+  "gitleaks",
 ]);
 
 /**
@@ -319,6 +324,30 @@ export function reviewsCoveringTip(reviews, tip, login) {
   return reviews.filter(r => r?.user?.login === login && r?.commit_id === tip);
 }
 
+/**
+ * Whether the merge took everything the branch had.
+ *
+ * Takes the candidate commits rather than running git, so the interesting
+ * cases can be handed to it. `checkable` comes from {@link checkability}: a
+ * branch whose history was rewritten, or whose ref does not resolve, cannot
+ * answer this at all — and an empty candidate list from an unanswerable branch
+ * is not evidence of anything.
+ */
+export function landedWhole({ checkable, reason, candidates }) {
+  if (!checkable) return { verdict: "not-checkable", reason, candidates: [] };
+  if (!Array.isArray(candidates)) {
+    throw new TypeError("landedWhole needs an array of candidate commits");
+  }
+  if (candidates.length === 0) {
+    return { verdict: "no-candidates", reason: "ok", candidates: [] };
+  }
+  // Deliberately NOT "lost". The range says only "absent from the merged
+  // head", and a surviving branch also collects force-pushes, rebases and
+  // follow-up work. Each named commit is worth confirming by content against
+  // the merge commit; the screen produces the list, never the verdict.
+  return { verdict: "candidates", reason: "absent-from-merge", candidates };
+}
+
 // ---------------------------------------------------------------------------
 // The I/O shell.
 //
@@ -333,6 +362,9 @@ import { execFileSync } from "node:child_process";
 import { pathToFileURL } from "node:url";
 
 const REPO = "nextlyhq/nextly";
+
+/** Set by `main` once the head repository is known; a fork keeps its own. */
+let REMOTE_FOR_FETCH = "origin";
 
 /**
  * `gh api`, raw. Throws on failure rather than degrading to an empty result.
@@ -385,6 +417,19 @@ function timelinePages(pr) {
   );
 }
 
+/** `git`, for the two places this shell needs it. */
+function run(args) {
+  return execFileSync("git", args, { encoding: "utf8" }).trim();
+}
+
+/** Commits the ref has that the merged head does not. */
+function ghLog(merged, tip) {
+  const out = execFileSync("git", ["log", "--oneline", `${merged}..${tip}`], {
+    encoding: "utf8",
+  }).trim();
+  return out ? out.split("\n") : [];
+}
+
 /** The branch's real tip, from the ref rather than from the API's cached head. */
 function lsRemoteTip(remote, branch) {
   const out = execFileSync(
@@ -411,11 +456,33 @@ export function main(argv) {
     "--jq",
     "{cross:.head.repo.full_name!=.base.repo.full_name,repo:.head.repo.full_name,branch:.head.ref}",
   ]);
-  const remote = meta.cross ? `https://github.com/${meta.repo}.git` : "origin";
-  const tip = lsRemoteTip(remote, meta.branch);
+  REMOTE_FOR_FETCH = meta.cross
+    ? `https://github.com/${meta.repo}.git`
+    : "origin";
+  const tip = lsRemoteTip(REMOTE_FOR_FETCH, meta.branch);
 
   const rewrites = countRewriteEvents(timelinePages(pr));
   const reach = checkability({ tip, rewriteEvents: rewrites });
+
+  // Perform the check rather than only reporting whether it could be done.
+  // The previous version computed reachability, printed "available", and never
+  // compared anything — a module named for a check that did not run it. The
+  // merged head is `headRefOid`; anything the ref has beyond it never reached
+  // `main`.
+  let candidates = [];
+  if (reach.checkable) {
+    const merged = ghText([
+      "api",
+      `repos/${REPO}/pulls/${pr}`,
+      "--jq",
+      ".head.sha",
+    ]);
+    if (merged && merged !== tip) {
+      run(["fetch", REMOTE_FOR_FETCH, tip, "--quiet"]);
+      candidates = ghLog(merged, tip);
+    }
+  }
+  const landed = landedWhole({ ...reach, candidates });
 
   const checkRuns = tip
     ? ghJson([
@@ -474,12 +541,18 @@ export function main(argv) {
 
   // Commit STATUSES are a separate surface from check-runs, and this
   // repository's title check and CodeRabbit both report through it.
-  const statuses = ghJson([
-    "api",
-    `repos/${REPO}/commits/${tip}/status`,
-    "--jq",
-    ".statuses",
-  ]);
+  // Guarded like the check-runs lookup above. Unguarded, an empty `tip`
+  // produced `commits//status`, which throws before the script can print
+  // NOT CHECKABLE or return its exit code — so the documented refusal became
+  // a stack trace.
+  const statuses = tip
+    ? ghJson([
+        "api",
+        `repos/${REPO}/commits/${tip}/status`,
+        "--jq",
+        ".statuses",
+      ])
+    : [];
   const allChecks = [...checkRuns, ...statuses.map(statusAsRun)];
 
   const verdict = gateVerdict({
@@ -492,8 +565,11 @@ export function main(argv) {
 
   process.stdout.write(`PR #${pr} @ ${tip.slice(0, 9) || "(no ref)"}\n`);
   process.stdout.write(
-    `  landed-whole check: ${reach.checkable ? "available" : `NOT CHECKABLE (${reach.reason})`}\n`
+    `  landed-whole: ${landed.verdict} (${landed.reason})\n`
   );
+  for (const line of landed.candidates) {
+    process.stdout.write(`    candidate, confirm by content: ${line}\n`);
+  }
   process.stdout.write(`${formatVerdict(verdict)}\n`);
   // Not checkable is not clean. Returning 0 here would let automation treat
   // the history-rewrite case as a pass — the one state this file exists to

--- a/scripts/verify-merge.mjs
+++ b/scripts/verify-merge.mjs
@@ -424,8 +424,18 @@ function globSegmentSource(glob) {
     const char = glob[i];
     if (char === "*") {
       if (glob[i + 1] === "*") {
-        source += ".*";
-        i += 1;
+        // `**/` spans zero OR MORE directories, so `**/*.md` matches a root
+        // README as well as a nested one. Requiring the separator made the gate
+        // demand integration checks the workflow deliberately never created,
+        // which does not merely over-require: those checks can never appear, so
+        // a documentation-only pull request could never pass at all.
+        if (glob[i + 2] === "/") {
+          source += "(?:.*/)?";
+          i += 2;
+        } else {
+          source += ".*";
+          i += 1;
+        }
       } else {
         source += "[^/]*";
       }
@@ -589,7 +599,6 @@ export function landedWhole({ checkable, reason, candidates }) {
 // ---------------------------------------------------------------------------
 
 import { execFileSync } from "node:child_process";
-import { readFileSync } from "node:fs";
 import { pathToFileURL } from "node:url";
 
 const REPO = "nextlyhq/nextly";
@@ -659,6 +668,17 @@ function ghLog(merged, tip) {
     encoding: "utf8",
   }).trim();
   return out ? out.split("\n") : [];
+}
+
+/**
+ * A file as it stood at one revision, fetched first so the read cannot silently
+ * fall back to whatever the working tree happens to hold.
+ */
+function workflowAt(revision, path) {
+  run(["fetch", "origin", revision, "--quiet"]);
+  return execFileSync("git", ["show", `${revision}:${path}`], {
+    encoding: "utf8",
+  });
 }
 
 /** Every configured remote as `[name, url]`, for matching against the head repository. */
@@ -767,11 +787,13 @@ export function main(argv) {
   // judged: `pull_request` before a merge, `push` to the base branch after one.
   // The two blocks are edited independently, so answering from the wrong one
   // waits for a check that will never report or excuses one that should have.
+  // From the revision being judged, not from the working tree. The two differ
+  // whenever the checkout has moved on, and this command is expected to run
+  // outside the pull request's worktree: a later commit adding a path to
+  // `paths-ignore` would otherwise excuse checks that an older merge was
+  // genuinely due to create.
   const integrationIgnore = workflowPathsIgnore(
-    readFileSync(
-      new URL("../.github/workflows/integration.yml", import.meta.url),
-      "utf8"
-    ),
+    workflowAt(subject, ".github/workflows/integration.yml"),
     merged ? "push" : "pull_request"
   );
   const required = requiredChecks(integrationIgnore);
@@ -833,12 +855,15 @@ export function main(argv) {
   // judge a merged pull request half on the merge commit and half on the branch
   // — and the half still reading the branch is the half that reports green.
   const statuses = subject
-    ? ghJson([
-        "api",
-        `repos/${REPO}/commits/${subject}/status`,
-        "--jq",
-        ".statuses",
-      ])
+    ? flatPages(
+        ghJson([
+          "api",
+          "--paginate",
+          "--slurp",
+          `repos/${REPO}/commits/${subject}/status?per_page=100`,
+        ]),
+        "statuses"
+      ).flatMap(page => page.statuses ?? [])
     : [];
   const allChecks = [...checkRuns, ...statuses.map(statusAsRun)];
 

--- a/scripts/verify-merge.mjs
+++ b/scripts/verify-merge.mjs
@@ -211,6 +211,12 @@ export function gateVerdict({
       detail: "no check-runs reported for this revision",
     });
   } else {
+    for (const name of missingRequired(checkRuns)) {
+      blockers.push({
+        kind: "required-check-absent",
+        detail: `${name} never reported — no build or test coverage for this revision`,
+      });
+    }
     for (const job of blockingJobs(checkRuns)) {
       blockers.push({
         kind: "job-not-green",
@@ -247,6 +253,70 @@ export function formatVerdict(verdict) {
     );
   }
   return lines.join("\n");
+}
+
+/**
+ * A commit STATUS, expressed as a check-run so one rule judges both.
+ *
+ * GitHub has two independent surfaces and a gate that reads one sees a partial
+ * picture: `amannn/action-semantic-pull-request` and CodeRabbit both report
+ * through the statuses API, so a check-runs-only query calls a revision green
+ * while the title check is failing. Normalising here means `jobPasses` stays
+ * the single definition of passing rather than growing a second one.
+ */
+export function statusAsRun(status) {
+  const state = status?.state;
+  return {
+    name: status?.context ?? "(unnamed status)",
+    status: state === "pending" ? "in_progress" : "completed",
+    // Only `success` maps to a passing conclusion; `pending`, `failure` and
+    // `error` all keep a value `jobPasses` refuses.
+    conclusion: state === "success" ? "success" : (state ?? null),
+  };
+}
+
+/**
+ * Checks that were expected and never reported at all.
+ *
+ * A non-empty list of check-runs is not evidence that CI ran. The workflows
+ * here are independent, so a run where `ci.yml` never created its jobs while
+ * `secret-scan.yml` succeeded produces a green-looking set containing no build
+ * and no tests. Absence of the expected name is the only thing that separates
+ * them, and absence is invisible to any filter over what IS present.
+ */
+export function missingRequired(checkRuns, required = REQUIRED_CHECKS) {
+  if (!Array.isArray(checkRuns)) {
+    throw new TypeError("missingRequired needs an array of check-runs");
+  }
+  const present = new Set(checkRuns.map(run => run?.name));
+  return required.filter(name => !present.has(name));
+}
+
+/**
+ * The job every other job in `ci.yml` depends on through `needs: [ci]`.
+ *
+ * If it never reported, the browser, scaffold and dev-script jobs did not run
+ * either — so its absence means the revision has no build or test coverage at
+ * all, however many unrelated workflows went green.
+ */
+export const REQUIRED_CHECKS = Object.freeze([
+  "Lint / Typecheck / Test / Build",
+]);
+
+/**
+ * Reviews that examined THIS revision, by the record's own `commit_id`.
+ *
+ * A review describes the tree it read. Counting one written against an earlier
+ * revision reports a reviewer as having covered a commit it never saw — the
+ * same staleness the verdict check refuses, applied to coverage rather than to
+ * findings.
+ */
+export function reviewsCoveringTip(reviews, tip, login) {
+  if (!Array.isArray(reviews)) {
+    throw new TypeError("reviewsCoveringTip needs an array of reviews");
+  }
+  if (typeof tip !== "string" || tip.length < FULL_SHA_LENGTH) return [];
+  return reviews.filter(r => r?.user?.login === login && r?.commit_id === tip);
 }
 
 // ---------------------------------------------------------------------------
@@ -295,30 +365,24 @@ function ghJson(args) {
  * cannot read, and flattening first would throw that distinction away.
  */
 function timelinePages(pr) {
-  const raw = execFileSync(
-    "gh",
-    ["api", "--paginate", `repos/${REPO}/issues/${pr}/timeline?per_page=100`],
-    { encoding: "utf8", maxBuffer: 32 * 1024 * 1024 }
+  // `--slurp` returns ONE array of pages, so the pages stay separate without
+  // this code parsing JSON itself. The previous version counted brackets to
+  // split `--paginate`'s concatenated arrays, which a `[` inside any review
+  // body broke: the depth never returned to zero, the function returned no
+  // pages, and a force-push counted as zero — the false clean this verifier
+  // exists to refuse, introduced by the verifier.
+  return JSON.parse(
+    execFileSync(
+      "gh",
+      [
+        "api",
+        "--paginate",
+        "--slurp",
+        `repos/${REPO}/issues/${pr}/timeline?per_page=100`,
+      ],
+      { encoding: "utf8", maxBuffer: 32 * 1024 * 1024 }
+    )
   );
-  // `gh --paginate` emits one JSON array per page, concatenated. A single
-  // `JSON.parse` sees only the first.
-  const pages = [];
-  let depth = 0;
-  let start = -1;
-  for (let i = 0; i < raw.length; i += 1) {
-    const ch = raw[i];
-    if (ch === "[") {
-      if (depth === 0) start = i;
-      depth += 1;
-    } else if (ch === "]") {
-      depth -= 1;
-      if (depth === 0 && start >= 0) {
-        pages.push(JSON.parse(raw.slice(start, i + 1)));
-        start = -1;
-      }
-    }
-  }
-  return pages;
 }
 
 /** The branch's real tip, from the ref rather than from the API's cached head. */
@@ -361,38 +425,67 @@ export function main(argv) {
         ".check_runs",
       ])
     : [];
-  const threads = Number(
-    ghText([
-      "api",
-      "graphql",
-      "-f",
-      `query=query { repository(owner:"nextlyhq",name:"nextly"){ pullRequest(number:${pr}){ reviewThreads(first:100){ nodes { isResolved } } } } }`,
-      "--jq",
-      "[.data.repository.pullRequest.reviewThreads.nodes[]|select(.isResolved==false)]|length",
-    ])
-  );
-  const codexBody = ghText([
+  // Paginated. A pull request with more than 100 review threads would
+  // otherwise have everything past the first page counted as resolved, which
+  // is the reassuring direction.
+  let threads = 0;
+  let cursor = null;
+  for (;;) {
+    const after = cursor ? `, after: "${cursor}"` : "";
+    const page = JSON.parse(
+      ghText([
+        "api",
+        "graphql",
+        "-f",
+        `query=query { repository(owner:"nextlyhq",name:"nextly"){ pullRequest(number:${pr}){ reviewThreads(first:100${after}){ pageInfo { hasNextPage endCursor } nodes { isResolved } } } } }`,
+        "--jq",
+        "{n:[.data.repository.pullRequest.reviewThreads.nodes[]|select(.isResolved==false)]|length, more:.data.repository.pullRequest.reviewThreads.pageInfo.hasNextPage, cur:.data.repository.pullRequest.reviewThreads.pageInfo.endCursor}",
+      ])
+    );
+    threads += page.n;
+    if (!page.more) break;
+    cursor = page.cur;
+  }
+
+  // From the review RECORD's own `commit_id`, not from a comment body. An
+  // issue comment is not evidence a review covered a commit: the previous
+  // version matched any backticked hex in the latest bot comment, which
+  // accepts progress text that happens to name the sha and misses a real
+  // review whose sha never appears in prose.
+  // `--slurp` returns an array of PAGES and cannot be combined with `--jq`,
+  // so the flattening happens here rather than in the query.
+  const reviews = ghJson([
     "api",
-    `repos/${REPO}/issues/${pr}/comments?per_page=100`,
-    "--jq",
-    '[.[]|select(.user.login=="chatgpt-codex-connector[bot]")|.body]|last // ""',
-  ]);
-  const reviewedSha = (String(codexBody).match(/`([0-9a-f]{7,40})`/g) ?? [])
-    .map(match => match.replaceAll("`", ""))
+    "--paginate",
+    "--slurp",
+    `repos/${REPO}/pulls/${pr}/reviews?per_page=100`,
+  ]).flat();
+  const CODEX = "chatgpt-codex-connector[bot]";
+  const reviewedSha = reviews
+    .filter(r => r?.user?.login === CODEX && r?.commit_id)
+    .map(r => r.commit_id)
     .pop();
-  const coderabbit = Number(
-    ghText([
-      "api",
-      `repos/${REPO}/pulls/${pr}/reviews?per_page=100`,
-      "--jq",
-      '[.[]|select(.user.login=="coderabbitai[bot]")]|length',
-    ])
-  );
+  // Scoped to THIS revision: a review of an earlier one is not coverage of it.
+  const coderabbit = reviewsCoveringTip(
+    reviews,
+    tip,
+    "coderabbitai[bot]"
+  ).length;
+
+  // Commit STATUSES are a separate surface from check-runs, and this
+  // repository's title check and CodeRabbit both report through it.
+  const statuses = ghJson([
+    "api",
+    `repos/${REPO}/commits/${tip}/status`,
+    "--jq",
+    ".statuses",
+  ]);
+  const allChecks = [...checkRuns, ...statuses.map(statusAsRun)];
 
   const verdict = gateVerdict({
     tip,
     unresolvedThreads: threads,
-    checkRuns,
+    checkRuns: allChecks,
     codexReviewedSha: reviewedSha,
     coderabbitReviewCount: coderabbit,
   });
@@ -402,6 +495,10 @@ export function main(argv) {
     `  landed-whole check: ${reach.checkable ? "available" : `NOT CHECKABLE (${reach.reason})`}\n`
   );
   process.stdout.write(`${formatVerdict(verdict)}\n`);
+  // Not checkable is not clean. Returning 0 here would let automation treat
+  // the history-rewrite case as a pass — the one state this file exists to
+  // distinguish from a pass.
+  if (!reach.checkable) return 2;
   return verdict.mergeable ? 0 : 1;
 }
 

--- a/scripts/verify-merge.mjs
+++ b/scripts/verify-merge.mjs
@@ -176,6 +176,7 @@ export function gateVerdict({
   unresolvedThreads,
   checkRuns,
   changedPaths,
+  required,
   codexReviewedSha,
   coderabbitReviewCount,
 }) {
@@ -211,7 +212,7 @@ export function gateVerdict({
       detail: "no check-runs reported for this revision",
     });
   } else {
-    for (const name of missingRequired(checkRuns, changedPaths)) {
+    for (const name of missingRequired(checkRuns, changedPaths, required)) {
       blockers.push({
         kind: "required-check-absent",
         detail: `${name} never reported — no build or test coverage for this revision`,
@@ -305,6 +306,36 @@ export function remoteForRepo(repoFullName, remotes) {
   return `https://github.com/${repoFullName}.git`;
 }
 
+/**
+ * Whether the verdict still describes the pull request that was examined.
+ *
+ * Everything the gate reads is taken across many round trips and keyed to the
+ * revision AND the mode observed at the start. Two things can move underneath
+ * that, and only one of them is a revision:
+ *
+ * - the branch gains a commit, so the answers describe a revision it no longer
+ *   has;
+ * - the pull request MERGES, which usually leaves the tip untouched — so a tip
+ *   comparison alone passes while every answer was taken in the pre-merge mode,
+ *   judging the branch head with the landed-whole question never asked.
+ *
+ * Returns a reason rather than a boolean so the caller can say which moved.
+ * Deliberately reports staleness only: adopting the new values would rubber
+ * stamp exactly the unverified state this detects.
+ */
+export function staleVerification({
+  mergedAtStart,
+  mergedNow,
+  tipAtStart,
+  tipNow,
+}) {
+  if (mergedAtStart !== mergedNow) {
+    return mergedNow ? "merged-during-verification" : "unmerged-during-verification";
+  }
+  if (tipAtStart !== tipNow) return "head-moved";
+  return null;
+}
+
 export function exitCode({ landedVerdict, mergeable }) {
   // Read from the landed-whole verdict alone rather than from reachability as
   // well. Reachability answers whether a BRANCH could be compared against a
@@ -315,6 +346,27 @@ export function exitCode({ landedVerdict, mergeable }) {
   if (landedVerdict === "not-checkable") return 2;
   if (landedVerdict === "candidates") return 2;
   return mergeable ? 0 : 1;
+}
+
+/**
+ * Slurped pages, refused unless every one of them was actually read.
+ *
+ * `--paginate --slurp` yields an array of pages, and a page that failed arrives
+ * as `null` rather than as an error. `flat()` carries that through and the
+ * optional access downstream discards it, so a partly-unread response becomes a
+ * SHORTER list that looks complete: fewer changed files can turn a source change
+ * into a documentation-only one and excuse every integration check.
+ */
+export function flatPages(pages, label) {
+  if (!Array.isArray(pages)) {
+    throw new TypeError(`${label}: expected an array of pages`);
+  }
+  for (const page of pages) {
+    if (page === null || typeof page !== "object") {
+      throw new TypeError(`${label}: a page could not be read`);
+    }
+  }
+  return pages;
 }
 
 /**
@@ -346,11 +398,10 @@ export function statusAsRun(status) {
  * and no tests. Absence of the expected name is the only thing that separates
  * them, and absence is invisible to any filter over what IS present.
  */
-export function missingRequired(
-  checkRuns,
-  changedPaths,
-  required = REQUIRED_CHECKS
-) {
+export function missingRequired(checkRuns, changedPaths, required) {
+  if (!Array.isArray(required)) {
+    throw new TypeError("missingRequired needs the required-check list");
+  }
   if (!Array.isArray(checkRuns)) {
     throw new TypeError("missingRequired needs an array of check-runs");
   }
@@ -425,29 +476,67 @@ export function workflowApplies(pathsIgnore, changedPaths) {
  * that editing the workflow fails CI here instead of silently widening what
  * this gate will pass.
  */
-export const INTEGRATION_PATHS_IGNORE = Object.freeze(["docs/**", "**/*.md"]);
+/**
+ * The `paths-ignore` globs a workflow declares under one trigger.
+ *
+ * The gate reads the workflow itself rather than holding a copy of its filter.
+ * A copy is a second implementation of the same question: it agrees on the day
+ * it is written, and afterwards the workflow can be edited while the copy keeps
+ * looking correct, at which point the gate waits for a check that will never
+ * report or excuses one that should have.
+ *
+ * The TRIGGER matters and is not interchangeable. Before a merge the checks come
+ * from the `pull_request` run; after one they come from `push` to the base
+ * branch, and the two blocks are edited independently. Reading whichever is
+ * nearest would answer about the wrong run.
+ */
+export function workflowPathsIgnore(workflowText, trigger) {
+  if (typeof workflowText !== "string" || typeof trigger !== "string") {
+    throw new TypeError("workflowPathsIgnore needs the workflow text and a trigger");
+  }
+  const lines = workflowText.split("\n");
+  const start = lines.findIndex(line => line.trimEnd() === `  ${trigger}:`);
+  if (start === -1) return [];
+
+  const globs = [];
+  let collecting = false;
+  for (const line of lines.slice(start + 1)) {
+    // Any line at the trigger's own indent or shallower ends the block, so a
+    // filter belonging to the NEXT trigger is never read as this one's.
+    if (/^ {0,2}\S/.test(line)) break;
+    if (line.trim() === "paths-ignore:") {
+      collecting = true;
+      continue;
+    }
+    if (!collecting) continue;
+    const entry = /^\s*-\s*["']?([^"'\s]+)["']?\s*$/.exec(line);
+    if (!entry) break;
+    globs.push(entry[1]);
+  }
+  return globs;
+}
 
 /**
  * Checks whose absence means the revision has no coverage, not that it is
  * clean, each with the filter deciding whether it was due to report.
  */
-export const REQUIRED_CHECKS = Object.freeze([
-  // Every other job in `ci.yml` hangs off this one through `needs: [ci]`, so if
-  // it never reported then the browser, scaffold and dev-script jobs did not
-  // run either, however many unrelated workflows went green.
-  { name: "Lint / Typecheck / Test / Build", pathsIgnore: [] },
-  // Its own workflow, unfiltered, on every pull request, and the repository
-  // calls it the enforcement gate.
-  { name: "gitleaks", pathsIgnore: [] },
-  // The only coverage any dialect-specific behaviour has: the unit suites mock
-  // the drivers and the browser tests run on sqlite alone. Listing the CI job
-  // and gitleaks while omitting these meant a run where `integration.yml`
-  // created no check-runs passed on the strength of the other two being green,
-  // which is the same absence-is-invisible defect one workflow along.
-  { name: "Integration (postgres)", pathsIgnore: INTEGRATION_PATHS_IGNORE },
-  { name: "Integration (mysql)", pathsIgnore: INTEGRATION_PATHS_IGNORE },
-  { name: "Integration (sqlite)", pathsIgnore: INTEGRATION_PATHS_IGNORE },
-]);
+export function requiredChecks(integrationPathsIgnore) {
+  return [
+    // Every other job in `ci.yml` hangs off this one through `needs: [ci]`, so
+    // if it never reported then the browser, scaffold and dev-script jobs did
+    // not run either, however many unrelated workflows went green. `ci.yml`
+    // filters in a job rather than at the trigger, so it always reports.
+    { name: "Lint / Typecheck / Test / Build", pathsIgnore: [] },
+    // Its own workflow, unfiltered, on every pull request.
+    { name: "gitleaks", pathsIgnore: [] },
+    // The only coverage any dialect-specific behaviour has: the unit suites
+    // mock the drivers and the browser tests run on sqlite alone.
+    { name: "Integration (postgres)", pathsIgnore: integrationPathsIgnore },
+    { name: "Integration (mysql)", pathsIgnore: integrationPathsIgnore },
+    { name: "Integration (sqlite)", pathsIgnore: integrationPathsIgnore },
+  ];
+}
+
 
 /**
  * Reviews that examined THIS revision, by the record's own `commit_id`.
@@ -500,6 +589,7 @@ export function landedWhole({ checkable, reason, candidates }) {
 // ---------------------------------------------------------------------------
 
 import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
 import { pathToFileURL } from "node:url";
 
 const REPO = "nextlyhq/nextly";
@@ -641,27 +731,50 @@ export function main(argv) {
     ? landedWhole({ ...reach, candidates })
     : { verdict: "n/a", reason: "not merged", candidates: [] };
 
+  // Paginated. `per_page=100` alone caps the response at one page, so a
+  // revision with more than 100 runs hid every later one from `blockingJobs` —
+  // a queued or failed job on page two simply not existing as far as the gate
+  // was concerned.
   const checkRuns = subject
-    ? ghJson([
-        "api",
-        `repos/${REPO}/commits/${subject}/check-runs?per_page=100`,
-        "--jq",
-        ".check_runs",
-      ])
+    ? flatPages(
+        ghJson([
+          "api",
+          "--paginate",
+          "--slurp",
+          `repos/${REPO}/commits/${subject}/check-runs?per_page=100`,
+        ]),
+        "check-runs"
+      ).flatMap(page => page.check_runs ?? [])
     : [];
 
   // Every file the pull request touches, so a check that was never due to run
   // is not reported as one that failed to. Paginated: a change set larger than
   // one page would otherwise look small enough to have skipped a workflow.
-  const changedPaths = ghJson([
-    "api",
-    "--paginate",
-    "--slurp",
-    `repos/${REPO}/pulls/${pr}/files?per_page=100`,
-  ])
+  const changedPaths = flatPages(
+    ghJson([
+      "api",
+      "--paginate",
+      "--slurp",
+      `repos/${REPO}/pulls/${pr}/files?per_page=100`,
+    ]),
+    "changed files"
+  )
     .flat()
     .map(file => file?.filename)
     .filter(name => typeof name === "string");
+
+  // Read from the workflow, for the trigger whose run produced the checks being
+  // judged: `pull_request` before a merge, `push` to the base branch after one.
+  // The two blocks are edited independently, so answering from the wrong one
+  // waits for a check that will never report or excuses one that should have.
+  const integrationIgnore = workflowPathsIgnore(
+    readFileSync(
+      new URL("../.github/workflows/integration.yml", import.meta.url),
+      "utf8"
+    ),
+    merged ? "push" : "pull_request"
+  );
+  const required = requiredChecks(integrationIgnore);
   // Paginated. A pull request with more than 100 review threads would
   // otherwise have everything past the first page counted as resolved, which
   // is the reassuring direction.
@@ -738,6 +851,7 @@ export function main(argv) {
     unresolvedThreads: threads,
     checkRuns: allChecks,
     changedPaths,
+    required,
     codexReviewedSha: reviewedSha,
     coderabbitReviewCount: coderabbit,
   });
@@ -767,11 +881,23 @@ export function main(argv) {
   // It narrows the window rather than closing it — the read and the merge are
   // still separate operations. `gh pr merge --match-head-commit <tip>` is what
   // closes it, because there the server refuses.
-  const tipNow = lsRemoteTip(REMOTE_FOR_FETCH, meta.branch);
-  if (tipNow !== tip) {
+  // The merged STATE is re-read alongside the tip, not only the tip. A pull
+  // request that merges during the intervening calls usually leaves its branch
+  // untouched, so a tip comparison alone passes — while every answer above was
+  // taken in the pre-merge mode, judging the branch head with the landed-whole
+  // question never asked. The mode is as much a part of what was verified as
+  // the revision is.
+  const stale = staleVerification({
+    mergedAtStart: merged,
+    mergedNow:
+      ghText(["api", `repos/${REPO}/pulls/${pr}`, "--jq", ".merged"]) === "true",
+    tipAtStart: tip,
+    tipNow: lsRemoteTip(REMOTE_FOR_FETCH, meta.branch),
+  });
+  if (stale) {
     process.stdout.write(
-      `  head moved ${tip.slice(0, 9)} -> ${(tipNow || "(gone)").slice(0, 9)} ` +
-        `during verification; this verdict describes ${tip.slice(0, 9)}\n`
+      `  ${stale}: this verdict describes ${tip.slice(0, 9)} as it stood when ` +
+        "the check began, and is no longer current\n"
     );
     return 2;
   }

--- a/scripts/verify-merge.mjs
+++ b/scripts/verify-merge.mjs
@@ -474,6 +474,14 @@ export function pageWrapping(key) {
  * while the title check is failing. Normalising here means `jobPasses` stays
  * the single definition of passing rather than growing a second one.
  */
+/**
+ * Status contexts published by reviewers the gate reports rather than requires.
+ *
+ * Their verdict is deliberately advisory, so the status carrying it must not
+ * become a blocker through the other surface.
+ */
+export const OPTIONAL_STATUS_CONTEXTS = Object.freeze(["CodeRabbit"]);
+
 export function statusAsRun(status) {
   const state = status?.state;
   return {
@@ -984,9 +992,10 @@ export function main(argv) {
   // instead assumes reviews complete in the order they were requested, and an
   // older-head review finishing after a current-head one then hides a verdict
   // that does cover this revision behind one that does not.
-  const reviewedSha = reviewsCoveringTip(reviews, tip, CODEX).length
+  const submitted = reviews.filter(r => r?.state !== "PENDING");
+  const reviewedSha = reviewsCoveringTip(submitted, tip, CODEX).length
     ? tip
-    : reviews
+    : submitted
         .filter(r => r?.user?.login === CODEX && r?.commit_id)
         .map(r => r.commit_id)
         .pop();
@@ -1019,7 +1028,17 @@ export function main(argv) {
         pageWrapping("statuses")
       ).flatMap(page => page.statuses ?? [])
     : [];
-  const allChecks = [...checkRuns, ...statuses.map(statusAsRun)];
+  // An optional reviewer's own status is excluded from the blocking set. Its
+  // review is reported and never blocks, so letting the status it publishes
+  // reach `blockingJobs` would enforce through one surface what the verdict
+  // explicitly declines to enforce through the other — and a quota exhaustion,
+  // which is the common cause, would then block every pull request at once.
+  const allChecks = [
+    ...checkRuns,
+    ...statuses
+      .filter(s => !OPTIONAL_STATUS_CONTEXTS.includes(s?.context))
+      .map(statusAsRun),
+  ];
 
   const verdict = gateVerdict({
     // Deliberately the TIP even after a merge, unlike the checks above. A review

--- a/scripts/verify-merge.mjs
+++ b/scripts/verify-merge.mjs
@@ -480,6 +480,19 @@ export function pageWrapping(key) {
  * Their verdict is deliberately advisory, so the status carrying it must not
  * become a blocker through the other surface.
  */
+/**
+ * Author associations that carry write access, and so can approve on the
+ * project's behalf.
+ *
+ * Any account can submit an APPROVED review, including a contributor's own and
+ * a bot's, so the state alone does not say the project accepted the change.
+ */
+export const MAINTAINER_ASSOCIATIONS = Object.freeze([
+  "OWNER",
+  "MEMBER",
+  "COLLABORATOR",
+]);
+
 export const OPTIONAL_STATUS_CONTEXTS = Object.freeze(["CodeRabbit"]);
 
 export function statusAsRun(status) {
@@ -571,6 +584,9 @@ export function pathMatches(glob, path) {
  */
 /** How many files GitHub's own path filtering looks at, and no more. */
 export const PATH_FILTER_WINDOW = 300;
+
+/** Past this many commits GitHub runs the workflow without evaluating filters. */
+export const PATH_FILTER_COMMIT_LIMIT = 1000;
 
 export function workflowApplies(pathsIgnore, changedPaths) {
   if (!Array.isArray(pathsIgnore) || pathsIgnore.length === 0) return true;
@@ -701,6 +717,7 @@ export function landedWhole({ checkable, reason, candidates }) {
 // ---------------------------------------------------------------------------
 
 import { execFileSync } from "node:child_process";
+import { realpathSync } from "node:fs";
 import { pathToFileURL } from "node:url";
 
 const REPO = "nextlyhq/nextly";
@@ -840,7 +857,7 @@ export function main(argv) {
     "api",
     `repos/${REPO}/pulls/${pr}`,
     "--jq",
-    "{cross:.head.repo.full_name!=.base.repo.full_name,repo:.head.repo.full_name,branch:.head.ref,merged:.merged,mergeSha:.merge_commit_sha,head:.head.sha,state:.state,draft:.draft,changedFiles:.changed_files,baseRepo:.base.repo.full_name}",
+    "{cross:.head.repo.full_name!=.base.repo.full_name,repo:.head.repo.full_name,branch:.head.ref,merged:.merged,mergeSha:.merge_commit_sha,head:.head.sha,state:.state,draft:.draft,changedFiles:.changed_files,baseRepo:.base.repo.full_name,commits:.commits}",
   ]);
   const remotes = configuredRemotes();
   REMOTE_FOR_FETCH = remoteForRepo(meta.repo, remotes);
@@ -863,8 +880,13 @@ export function main(argv) {
   // the merge reports on a tree nobody has.
   const subject = merged ? meta.mergeSha : tip;
 
-  const rewrites = countRewriteEvents(timelinePages(pr));
-  const reach = checkability({ tip, rewriteEvents: rewrites });
+  // Only read before it is needed. Rewrite reachability answers whether a merge
+  // took the whole branch, which an open pull request has not yet asked — so
+  // querying it there lets an unrelated endpoint failure refuse a verdict the
+  // gate could otherwise give.
+  const reach = merged
+    ? checkability({ tip, rewriteEvents: countRewriteEvents(timelinePages(pr)) })
+    : { checkable: true, reason: "not-merged" };
 
   // Only after a merge is there a merge to have lost anything. Run before one,
   // this compares the API's cached head against the ref and reports ordinary
@@ -923,7 +945,14 @@ export function main(argv) {
   // platform actually made: where the first 300 are all ignored, the workflow is
   // skipped and creates no check-runs, so requiring one on the strength of file
   // 301 demands a check that can never arrive.
-  const filterPaths = changedPaths.slice(0, PATH_FILTER_WINDOW);
+  // Past 1000 commits GitHub stops evaluating path filters and runs the
+  // workflow regardless, so deciding from paths there would excuse a check that
+  // did run. An empty list makes every workflow applicable, which is the
+  // direction that requires evidence.
+  const filterPaths =
+    meta.commits > PATH_FILTER_COMMIT_LIMIT
+      ? []
+      : changedPaths.slice(0, PATH_FILTER_WINDOW);
 
   // Read from the workflow, for the trigger whose run produced the checks being
   // judged: `pull_request` before a merge, `push` to the base branch after one.
@@ -1053,7 +1082,9 @@ export function main(argv) {
     eligibility: { state: meta.state, draft: meta.draft, merged },
     codexReviewedSha: reviewedSha,
     coderabbitReviewCount: coderabbit,
-    approvalCount: reviews.filter(r => r?.state === "APPROVED").length,
+    approvalCount: reviews.filter(
+      r => r?.state === "APPROVED" && MAINTAINER_ASSOCIATIONS.includes(r?.author_association)
+    ).length,
   });
 
   // Nothing is printed until the freshness read below has decided. Emitting the
@@ -1108,6 +1139,23 @@ export function main(argv) {
  * `run` is injectable so this decision can be given a failure and asked what it
  * returns; that is the only reason it is a parameter.
  */
+/**
+ * `process.argv[1]` as the URL `import.meta.url` would report for it.
+ *
+ * `import.meta.url` is percent-encoded AND resolved through symlinks, while
+ * `argv[1]` is neither, so comparing them directly fails whenever the path
+ * contains a character needing encoding or sits under a symlinked prefix — on
+ * macOS `/tmp` resolves to `/private/tmp`, so an ordinary invocation there
+ * silently declines to run and exits reporting nothing.
+ */
+function entryHref(argvPath) {
+  try {
+    return pathToFileURL(realpathSync(argvPath)).href;
+  } catch {
+    return "";
+  }
+}
+
 export function runCli(argv, run = main) {
   try {
     return run(argv);
@@ -1122,7 +1170,7 @@ export function runCli(argv, run = main) {
 
 if (
   process.argv[1] &&
-  import.meta.url === pathToFileURL(process.argv[1]).href
+  import.meta.url === entryHref(process.argv[1])
 ) {
   // `process.exitCode`, not `process.exit()`. Exiting terminates Node before a
   // redirected stdout finishes flushing, truncating exactly the blocker names a

--- a/scripts/verify-merge.mjs
+++ b/scripts/verify-merge.mjs
@@ -31,6 +31,11 @@
  *   fails to create its check-runs is invisible here unless it is listed. Adding
  *   one is deliberate work; the list does not derive itself.
  *
+ * - **A retained commit status is accepted as current.** The title check runs on
+ *   `edited` as well as on a push, and GitHub keeps the previous successful
+ *   status until the rerun replaces it — so a title edited without moving the
+ *   head can be judged on the status of the title it replaced.
+ *
  * - **`refs/pull/N/merge` is resolved, not pinned.** A base branch advancing
  *   mid-run can change which revision that ref names, and the filter would then
  *   be read from a revision other than the one the checks ran on.
@@ -548,19 +553,6 @@ export function workflowApplies(pathsIgnore, changedPaths) {
 }
 
 /**
- * `integration.yml`'s `paths-ignore`, which decides whether it runs at all.
- *
- * It filters at the TRIGGER, so on a change set it ignores the workflow creates
- * no check-runs whatsoever. That is the opposite of `ci.yml`, which runs always
- * and decides inertness in a job — leaving a `skipped` check-run behind, which
- * is a report. Absence and skipped look the same to a reader and only one of
- * them is evidence.
- *
- * Mirrored rather than parsed, and pinned by a test that reads the workflow, so
- * that editing the workflow fails CI here instead of silently widening what
- * this gate will pass.
- */
-/**
  * The `paths-ignore` globs a workflow declares under one trigger.
  *
  * The gate reads the workflow itself rather than holding a copy of its filter.
@@ -693,9 +685,11 @@ let REMOTE_FOR_FETCH = "origin";
  *
  * `refs/pull/N/merge` and a squash commit belong to the base repository even
  * when the branch does not, so they are fetched from here rather than from the
- * head remote, which for a fork holds neither.
+ * head remote, which for a fork holds neither. Resolved through the same
+ * function as the head remote: from a fork checkout `origin` is the fork, so a
+ * literal here is the defect this variable exists to fix, one step along.
  */
-const BASE_REMOTE = "origin";
+let BASE_REMOTE = "origin";
 
 /**
  * `gh api`, raw. Throws on failure rather than degrading to an empty result.
@@ -816,9 +810,11 @@ export function main(argv) {
     "api",
     `repos/${REPO}/pulls/${pr}`,
     "--jq",
-    "{cross:.head.repo.full_name!=.base.repo.full_name,repo:.head.repo.full_name,branch:.head.ref,merged:.merged,mergeSha:.merge_commit_sha,head:.head.sha,state:.state,draft:.draft,changedFiles:.changed_files}",
+    "{cross:.head.repo.full_name!=.base.repo.full_name,repo:.head.repo.full_name,branch:.head.ref,merged:.merged,mergeSha:.merge_commit_sha,head:.head.sha,state:.state,draft:.draft,changedFiles:.changed_files,baseRepo:.base.repo.full_name}",
   ]);
-  REMOTE_FOR_FETCH = remoteForRepo(meta.repo, configuredRemotes());
+  const remotes = configuredRemotes();
+  REMOTE_FOR_FETCH = remoteForRepo(meta.repo, remotes);
+  BASE_REMOTE = remoteForRepo(meta.baseRepo, remotes);
   const tip = lsRemoteTip(REMOTE_FOR_FETCH, meta.branch);
 
   // `.merged`, never the presence of `.merge_commit_sha`. GitHub populates that
@@ -955,10 +951,16 @@ export function main(argv) {
     `repos/${REPO}/pulls/${pr}/reviews?per_page=100`,
   ]).flat();
   const CODEX = "chatgpt-codex-connector[bot]";
-  const reviewedSha = reviews
-    .filter(r => r?.user?.login === CODEX && r?.commit_id)
-    .map(r => r.commit_id)
-    .pop();
+  // Through the same helper the second reviewer uses. Taking the LAST record
+  // instead assumes reviews complete in the order they were requested, and an
+  // older-head review finishing after a current-head one then hides a verdict
+  // that does cover this revision behind one that does not.
+  const reviewedSha = reviewsCoveringTip(reviews, tip, CODEX).length
+    ? tip
+    : reviews
+        .filter(r => r?.user?.login === CODEX && r?.commit_id)
+        .map(r => r.commit_id)
+        .pop();
   // Scoped to THIS revision: a review of an earlier one is not coverage of it.
   const coderabbit = reviewsCoveringTip(
     reviews,

--- a/scripts/verify-merge.mjs
+++ b/scripts/verify-merge.mjs
@@ -27,6 +27,9 @@
  * merge", so this exists to disqualify the cases we know of, not to certify the
  * rest.
  */
+/** A git object name in full. Anything shorter is an abbreviation. */
+export const FULL_SHA_LENGTH = 40;
+
 export const HISTORY_REWRITE_EVENTS = Object.freeze([
   "head_ref_force_pushed",
   "head_ref_deleted",
@@ -44,6 +47,16 @@ export const HISTORY_REWRITE_EVENTS = Object.freeze([
 export function countRewriteEvents(pages) {
   if (!Array.isArray(pages)) {
     throw new TypeError("countRewriteEvents needs an array of timeline pages");
+  }
+  // A page that is not an array is a page that was not read. `[events, null]`
+  // survives the check above, `flat()` carries the bad value through, and the
+  // optional access then ignores it — so a partly unreadable timeline counts
+  // zero rewrites and reports the branch as checkable. That is the exact
+  // direction this module exists to refuse.
+  for (const page of pages) {
+    if (!Array.isArray(page)) {
+      throw new TypeError("countRewriteEvents needs every page to be an array");
+    }
   }
   return pages
     .flat()
@@ -81,15 +94,20 @@ export function checkability({ tip, rewriteEvents }) {
  * A check-run's conclusion, reduced to whether it may be counted as passing.
  *
  * `skipped` passes because a job skipped by a condition is how this repository
- * expresses "this commit cannot affect me", and branch protection accepts it.
+ * expresses "this commit cannot affect me". `neutral` passes for the same
+ * reason: GitHub accepts both for a required status check, so refusing them
+ * would make this gate stricter than the protection it claims to model and
+ * block a revision the platform considers mergeable.
  * Everything else that is not `success` does NOT pass — including `queued` and
  * `in_progress`, which are the ones that get miscounted: filtering for
  * `conclusion === "failure"` and finding none reads as green while nothing has
  * run. One merge commit here had four required jobs queued for hours and two
  * unrelated ones completed, and answered zero failures throughout.
  */
+const PASSING_CONCLUSIONS = Object.freeze(["success", "skipped", "neutral"]);
+
 export function jobPasses(run) {
-  return run?.conclusion === "success" || run?.conclusion === "skipped";
+  return PASSING_CONCLUSIONS.includes(run?.conclusion);
 }
 
 /**
@@ -123,11 +141,15 @@ export function blockingJobs(checkRuns) {
 export function verdictCoversTip(reviewedSha, tip) {
   if (typeof reviewedSha !== "string" || reviewedSha.length === 0) return false;
   if (typeof tip !== "string" || tip.length === 0) return false;
-  const shorter = Math.min(reviewedSha.length, tip.length);
-  // A prefix comparison is only meaningful at a length that can identify a
-  // commit. Seven is git's own floor for an abbreviated sha.
-  if (shorter < 7) return false;
-  return reviewedSha.slice(0, shorter) === tip.slice(0, shorter);
+  // Deliberately ASYMMETRIC. The bot reports an abbreviated sha and the ref
+  // reports a full one, so only the VERDICT may be short. A symmetric
+  // comparison accepts a TRUNCATED tip whenever it prefixes a full reviewed
+  // sha, which would let the gate pass without ever identifying the head
+  // revision — the one thing it exists to pin.
+  if (tip.length < FULL_SHA_LENGTH) return false;
+  // Seven is git's own floor for an abbreviation that identifies a commit.
+  if (reviewedSha.length < 7 || reviewedSha.length > tip.length) return false;
+  return tip.startsWith(reviewedSha);
 }
 
 /**
@@ -163,7 +185,7 @@ export function gateVerdict({
     blockers.push({ kind: "no-tip", detail: "no head revision to merge" });
   }
 
-  if (!Number.isInteger(unresolvedThreads)) {
+  if (!Number.isInteger(unresolvedThreads) || unresolvedThreads < 0) {
     // Unknown is not zero, for the same reason everywhere else in this file.
     blockers.push({
       kind: "threads-unknown",
@@ -225,4 +247,167 @@ export function formatVerdict(verdict) {
     );
   }
   return lines.join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// The I/O shell.
+//
+// Everything above is pure so it can be handed the inputs whose answers are
+// known. This part does the fetching, and is deliberately thin: it reads, it
+// hands the values to the functions above, and it prints. No decision is taken
+// here, because a decision taken here is one no test can reach — which is the
+// arrangement this whole file exists to end.
+// ---------------------------------------------------------------------------
+
+import { execFileSync } from "node:child_process";
+import { pathToFileURL } from "node:url";
+
+const REPO = "nextlyhq/nextly";
+
+/**
+ * `gh api`, raw. Throws on failure rather than degrading to an empty result.
+ *
+ * `--jq` prints the filter's output verbatim, NOT as JSON: a string comes back
+ * unquoted and an absent value comes back as an empty line. Parsing everything
+ * as JSON therefore fails on exactly the case that matters — a pull request
+ * with no review verdict yet.
+ */
+function ghText(args) {
+  return execFileSync("gh", args, {
+    encoding: "utf8",
+    maxBuffer: 32 * 1024 * 1024,
+  }).trim();
+}
+
+/** `gh api` where the result really is JSON. Empty output is a failure, not an empty value. */
+function ghJson(args) {
+  const text = ghText(args);
+  if (text === "")
+    throw new Error(`gh returned nothing for: ${args.join(" ")}`);
+  return JSON.parse(text);
+}
+
+/**
+ * Every page of the timeline, each page kept SEPARATE.
+ *
+ * `--paginate` concatenates the pages' arrays into one stream of JSON values,
+ * so they are split back apart here: `countRewriteEvents` refuses a page it
+ * cannot read, and flattening first would throw that distinction away.
+ */
+function timelinePages(pr) {
+  const raw = execFileSync(
+    "gh",
+    ["api", "--paginate", `repos/${REPO}/issues/${pr}/timeline?per_page=100`],
+    { encoding: "utf8", maxBuffer: 32 * 1024 * 1024 }
+  );
+  // `gh --paginate` emits one JSON array per page, concatenated. A single
+  // `JSON.parse` sees only the first.
+  const pages = [];
+  let depth = 0;
+  let start = -1;
+  for (let i = 0; i < raw.length; i += 1) {
+    const ch = raw[i];
+    if (ch === "[") {
+      if (depth === 0) start = i;
+      depth += 1;
+    } else if (ch === "]") {
+      depth -= 1;
+      if (depth === 0 && start >= 0) {
+        pages.push(JSON.parse(raw.slice(start, i + 1)));
+        start = -1;
+      }
+    }
+  }
+  return pages;
+}
+
+/** The branch's real tip, from the ref rather than from the API's cached head. */
+function lsRemoteTip(remote, branch) {
+  const out = execFileSync(
+    "git",
+    ["ls-remote", remote, `refs/heads/${branch}`],
+    {
+      encoding: "utf8",
+    }
+  );
+  return out.split("\t")[0] ?? "";
+}
+
+/** Runs the gate for one pull request and prints why, exiting non-zero when blocked. */
+export function main(argv) {
+  const pr = argv[0];
+  if (!pr || !/^\d+$/.test(pr)) {
+    process.stderr.write("usage: node scripts/verify-merge.mjs <pr-number>\n");
+    return 2;
+  }
+
+  const meta = ghJson([
+    "api",
+    `repos/${REPO}/pulls/${pr}`,
+    "--jq",
+    "{cross:.head.repo.full_name!=.base.repo.full_name,repo:.head.repo.full_name,branch:.head.ref}",
+  ]);
+  const remote = meta.cross ? `https://github.com/${meta.repo}.git` : "origin";
+  const tip = lsRemoteTip(remote, meta.branch);
+
+  const rewrites = countRewriteEvents(timelinePages(pr));
+  const reach = checkability({ tip, rewriteEvents: rewrites });
+
+  const checkRuns = tip
+    ? ghJson([
+        "api",
+        `repos/${REPO}/commits/${tip}/check-runs?per_page=100`,
+        "--jq",
+        ".check_runs",
+      ])
+    : [];
+  const threads = Number(
+    ghText([
+      "api",
+      "graphql",
+      "-f",
+      `query=query { repository(owner:"nextlyhq",name:"nextly"){ pullRequest(number:${pr}){ reviewThreads(first:100){ nodes { isResolved } } } } }`,
+      "--jq",
+      "[.data.repository.pullRequest.reviewThreads.nodes[]|select(.isResolved==false)]|length",
+    ])
+  );
+  const codexBody = ghText([
+    "api",
+    `repos/${REPO}/issues/${pr}/comments?per_page=100`,
+    "--jq",
+    '[.[]|select(.user.login=="chatgpt-codex-connector[bot]")|.body]|last // ""',
+  ]);
+  const reviewedSha = (String(codexBody).match(/`([0-9a-f]{7,40})`/g) ?? [])
+    .map(match => match.replaceAll("`", ""))
+    .pop();
+  const coderabbit = Number(
+    ghText([
+      "api",
+      `repos/${REPO}/pulls/${pr}/reviews?per_page=100`,
+      "--jq",
+      '[.[]|select(.user.login=="coderabbitai[bot]")]|length',
+    ])
+  );
+
+  const verdict = gateVerdict({
+    tip,
+    unresolvedThreads: threads,
+    checkRuns,
+    codexReviewedSha: reviewedSha,
+    coderabbitReviewCount: coderabbit,
+  });
+
+  process.stdout.write(`PR #${pr} @ ${tip.slice(0, 9) || "(no ref)"}\n`);
+  process.stdout.write(
+    `  landed-whole check: ${reach.checkable ? "available" : `NOT CHECKABLE (${reach.reason})`}\n`
+  );
+  process.stdout.write(`${formatVerdict(verdict)}\n`);
+  return verdict.mergeable ? 0 : 1;
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  process.exit(main(process.argv.slice(2)));
 }

--- a/scripts/verify-merge.test.mjs
+++ b/scripts/verify-merge.test.mjs
@@ -25,6 +25,7 @@ import {
   jobPasses,
   landedWhole,
   missingRequired,
+  PATH_FILTER_WINDOW,
   pageWrapping,
   pathMatches,
   remoteForRepo,
@@ -524,6 +525,26 @@ describe("pathMatches", () => {
   });
 });
 
+describe("PATH_FILTER_WINDOW", () => {
+  it("matches the window GitHub's own path filtering uses", () => {
+    // Judging more files than the platform does diverges from the decision it
+    // actually made: where the first 300 are all ignored the workflow is
+    // skipped and creates no check-runs, so requiring one on the strength of a
+    // later file demands a check that can never arrive.
+    expect(PATH_FILTER_WINDOW).toBe(300);
+  });
+
+  it("treats a change set as ignored when every file IN THE WINDOW matches", () => {
+    const docs = Array.from({ length: PATH_FILTER_WINDOW }, (_, i) => `docs/${i}.md`);
+
+    expect(workflowApplies(PR_IGNORE, docs)).toBe(false);
+    // ...and a source file inside the window still makes it apply.
+    expect(
+      workflowApplies(PR_IGNORE, [...docs.slice(1), "packages/nextly/src/a.ts"])
+    ).toBe(true);
+  });
+});
+
 describe("workflowApplies", () => {
   it("runs the workflow when ONE file escapes the filter", () => {
     // GitHub skips only when every changed file matches, so a pull request
@@ -871,6 +892,22 @@ describe("remoteForRepo", () => {
     ];
 
     expect(remoteForRepo("nextlyhq/nextly", remotes)).toBe("upstream");
+  });
+
+  it("ignores a PUSH record, which may name a different repository", () => {
+    // `git remote -v` lists fetch and push separately and they can differ.
+    // Every read here is a fetch, so matching the push URL selects a remote
+    // without the objects — failing on the operation rather than the selection,
+    // which reads as a broken revision instead of a misconfigured lookup.
+    const remotes = [
+      ["origin", "git@github.com:contributor/nextly.git", "(fetch)"],
+      ["origin", "git@github.com:nextlyhq/nextly.git", "(push)"],
+    ];
+
+    expect(remoteForRepo("nextlyhq/nextly", remotes)).toBe(
+      "https://github.com/nextlyhq/nextly.git"
+    );
+    expect(remoteForRepo("contributor/nextly", remotes)).toBe("origin");
   });
 
   it("prefers a local remote that IS the repository", () => {

--- a/scripts/verify-merge.test.mjs
+++ b/scripts/verify-merge.test.mjs
@@ -705,20 +705,23 @@ describe("exitCode", () => {
     // content. Printing that list while exiting 0 lets automation read a
     // possibly-lost tail as verified — the candidates were computed and never
     // reached the decision.
-    expect(
-      exitCode({ checkable: true, landedVerdict: "candidates", mergeable: true })
-    ).toBe(2);
+    expect(exitCode({ landedVerdict: "candidates", mergeable: true })).toBe(2);
+  });
+
+  it("does not let an open branch's rewritten history mask its verdict", () => {
+    // Before a merge there is nothing to have landed, so reachability answers a
+    // question that has not been asked. Taking it directly made every open pull
+    // request with a force-push in its history exit 2 — reporting "could not
+    // answer" over a gate that had answered, in both directions.
+    expect(exitCode({ landedVerdict: "n/a", mergeable: false })).toBe(1);
+    expect(exitCode({ landedVerdict: "n/a", mergeable: true })).toBe(0);
   });
 
   it("passes when the branch had nothing the merge did not take", () => {
     // The positive control for the case above: without it, an implementation
     // that never returns 0 satisfies it.
     expect(
-      exitCode({
-        checkable: true,
-        landedVerdict: "no-candidates",
-        mergeable: true,
-      })
+      exitCode({ landedVerdict: "no-candidates", mergeable: true })
     ).toBe(0);
   });
 
@@ -726,17 +729,13 @@ describe("exitCode", () => {
     // 2 rather than 1, so a caller can tell "the gate says no" from "the gate
     // did not get to answer" and escalate the second rather than retrying it.
     expect(
-      exitCode({
-        checkable: false,
-        landedVerdict: "not-checkable",
-        mergeable: true,
-      })
+      exitCode({ landedVerdict: "not-checkable", mergeable: true })
     ).toBe(2);
   });
 
   it("blocks on the ordinary gate when everything else is settled", () => {
     expect(
-      exitCode({ checkable: true, landedVerdict: "n/a", mergeable: false })
+      exitCode({ landedVerdict: "no-candidates", mergeable: false })
     ).toBe(1);
   });
 });

--- a/scripts/verify-merge.test.mjs
+++ b/scripts/verify-merge.test.mjs
@@ -14,6 +14,7 @@ import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 
 import {
+  assertCompleteFileList,
   flatPages,
   blockingJobs,
   checkability,
@@ -916,43 +917,67 @@ describe("runCli", () => {
 describe("staleVerification", () => {
   const A = "a".repeat(40);
   const B = "b".repeat(40);
+  const OPEN = { merged: false, state: "open", draft: false, tip: A };
 
   it("catches a merge that happened DURING the check, tip unchanged", () => {
     // The case a tip comparison cannot see: merging usually leaves the branch
     // untouched, so the revision matches while every answer above it was taken
-    // in the pre-merge mode — head checks, landed-whole never asked.
-    expect(
-      staleVerification({
-        mergedAtStart: false,
-        mergedNow: true,
-        tipAtStart: A,
-        tipNow: A,
-      })
-    ).toBe("merged-during-verification");
+    // in the pre-merge mode.
+    expect(staleVerification(OPEN, { ...OPEN, merged: true })).toBe(
+      "merged-changed-during-verification"
+    );
   });
 
   it("catches a push during the check", () => {
-    expect(
-      staleVerification({
-        mergedAtStart: false,
-        mergedNow: false,
-        tipAtStart: A,
-        tipNow: B,
-      })
-    ).toBe("head-moved");
+    expect(staleVerification(OPEN, { ...OPEN, tip: B })).toBe(
+      "tip-changed-during-verification"
+    );
   });
 
-  it("reports nothing when neither moved", () => {
-    // The control. Without it, a function returning a reason unconditionally
-    // satisfies both cases above and the gate could never pass.
+  it("catches a pull request CLOSED or drafted mid-check", () => {
+    // Neither moves the tip nor the merged flag, so the two named comparisons
+    // this replaced both passed while GitHub had stopped permitting the merge.
+    expect(staleVerification(OPEN, { ...OPEN, state: "closed" })).toBe(
+      "state-changed-during-verification"
+    );
+    expect(staleVerification(OPEN, { ...OPEN, draft: true })).toBe(
+      "draft-changed-during-verification"
+    );
+  });
+
+  it("compares a field neither case above names", () => {
+    // The property that makes this structural rather than a third enumeration:
+    // a key added to the snapshot is compared without this function being
+    // edited. Enumerating fields missed one twice, each time the newest.
     expect(
-      staleVerification({
-        mergedAtStart: true,
-        mergedNow: true,
-        tipAtStart: A,
-        tipNow: A,
-      })
-    ).toBe(null);
+      staleVerification({ ...OPEN, future: 1 }, { ...OPEN, future: 2 })
+    ).toBe("future-changed-during-verification");
+  });
+
+  it("reports nothing when nothing moved", () => {
+    // The control. Without it a function returning a reason unconditionally
+    // satisfies every case above and the gate could never pass.
+    expect(staleVerification(OPEN, { ...OPEN })).toBe(null);
+  });
+
+  it("refuses an unreadable snapshot rather than reporting fresh", () => {
+    expect(staleVerification(OPEN, null)).toBe("eligibility-unreadable");
+  });
+});
+
+describe("assertCompleteFileList", () => {
+  it("refuses a list the API truncated at its cap", () => {
+    // A capped response carries no marker saying so, and the shorter list is
+    // exactly the input that makes a source change look documentation-only.
+    expect(() => assertCompleteFileList(3000, 3412)).toThrow(TypeError);
+  });
+
+  it("refuses when the pull request reported no count", () => {
+    expect(() => assertCompleteFileList(10, undefined)).toThrow(TypeError);
+  });
+
+  it("accepts a complete list", () => {
+    expect(() => assertCompleteFileList(12, 12)).not.toThrow();
   });
 });
 

--- a/scripts/verify-merge.test.mjs
+++ b/scripts/verify-merge.test.mjs
@@ -26,8 +26,11 @@ import {
   landedWhole,
   missingRequired,
   pathMatches,
+  remoteForRepo,
+  repoFromRemoteUrl,
   reviewCoverage,
   reviewsCoveringTip,
+  runCli,
   statusAsRun,
   verdictCoversTip,
   workflowApplies,
@@ -695,6 +698,88 @@ describe("INTEGRATION_PATHS_IGNORE against the workflow it mirrors", () => {
     expect(declaredIgnores("pull_request")).toEqual([
       ...INTEGRATION_PATHS_IGNORE,
     ]);
+  });
+});
+
+describe("repoFromRemoteUrl", () => {
+  it("reduces every spelling of one repository to the same name", () => {
+    // A string comparison against a single spelling misses the others and falls
+    // through to a remote that may be a different repository entirely.
+    for (const url of [
+      "https://github.com/nextlyhq/nextly.git",
+      "https://github.com/nextlyhq/nextly",
+      "git@github.com:nextlyhq/nextly.git",
+      "ssh://git@github.com/nextlyhq/nextly.git",
+      "https://github.com/nextlyhq/nextly/",
+    ]) {
+      expect(repoFromRemoteUrl(url)).toBe("nextlyhq/nextly");
+    }
+  });
+
+  it("does not read a DIFFERENT repository as the same one", () => {
+    // The control that gives the case above meaning: without it, a function
+    // returning a constant would satisfy every assertion there.
+    expect(repoFromRemoteUrl("git@github.com:someone/nextly.git")).toBe(
+      "someone/nextly"
+    );
+    expect(repoFromRemoteUrl("https://gitlab.com/nextlyhq/nextly.git")).toBe(
+      null
+    );
+    expect(repoFromRemoteUrl("")).toBe(null);
+  });
+});
+
+describe("remoteForRepo", () => {
+  it("does NOT use origin when origin is a different repository", () => {
+    // Running from a fork checkout, a pull request whose head lives upstream
+    // would otherwise resolve against a same-named branch on the fork — a real,
+    // unrelated revision whose checks and reviews the gate would then report as
+    // this pull request's.
+    const remotes = [
+      ["origin", "git@github.com:contributor/nextly.git"],
+      ["upstream", "https://github.com/nextlyhq/nextly.git"],
+    ];
+
+    expect(remoteForRepo("nextlyhq/nextly", remotes)).toBe("upstream");
+  });
+
+  it("prefers a local remote that IS the repository", () => {
+    // So configured credentials and transports keep working in the ordinary
+    // case rather than every invocation reaching for an anonymous URL.
+    expect(
+      remoteForRepo("nextlyhq/nextly", [
+        ["origin", "git@github.com:nextlyhq/nextly.git"],
+      ])
+    ).toBe("origin");
+  });
+
+  it("falls back to the canonical URL when no remote matches", () => {
+    expect(remoteForRepo("nextlyhq/nextly", [["origin", "/tmp/somewhere"]])).toBe(
+      "https://github.com/nextlyhq/nextly.git"
+    );
+    expect(remoteForRepo("nextlyhq/nextly", [])).toBe(
+      "https://github.com/nextlyhq/nextly.git"
+    );
+  });
+});
+
+describe("runCli", () => {
+  it("reports a failure to LOOK as 2, not as a rejection", () => {
+    // Helpers throw rather than degrading, which is right, but an uncaught
+    // throw exits 1 — the code meaning the gate examined the revision and
+    // rejected it. An expired token would be indistinguishable from a verdict
+    // and a caller would stop rather than retry.
+    expect(
+      runCli(["798"], () => {
+        throw new Error("gh: authentication failed");
+      })
+    ).toBe(2);
+  });
+
+  it("passes a real verdict through untouched", () => {
+    // The control: without it, a wrapper returning 2 unconditionally passes.
+    expect(runCli(["798"], () => 0)).toBe(0);
+    expect(runCli(["798"], () => 1)).toBe(1);
   });
 });
 

--- a/scripts/verify-merge.test.mjs
+++ b/scripts/verify-merge.test.mjs
@@ -24,6 +24,7 @@ import {
   gateVerdict,
   jobPasses,
   landedWhole,
+  OPTIONAL_STATUS_CONTEXTS,
   missingRequired,
   PATH_FILTER_WINDOW,
   pageWrapping,
@@ -385,6 +386,23 @@ describe("formatVerdict", () => {
 
     expect(text).toContain("GATE PASSED");
     expect(text).toContain("not-reviewed");
+  });
+});
+
+describe("OPTIONAL_STATUS_CONTEXTS", () => {
+  it("names the reviewer whose verdict is reported rather than required", () => {
+    // Its review never blocks, so the status carrying that review must not
+    // block either — enforcing through one surface what the verdict declines to
+    // enforce through the other. Quota exhaustion is the common cause, and it
+    // would block every pull request at once.
+    expect(OPTIONAL_STATUS_CONTEXTS).toContain("CodeRabbit");
+  });
+
+  it("does not exempt a required context", () => {
+    // The control: an over-broad list would silence real blockers.
+    expect(OPTIONAL_STATUS_CONTEXTS).not.toContain(
+      "action-semantic-pull-request"
+    );
   });
 });
 

--- a/scripts/verify-merge.test.mjs
+++ b/scripts/verify-merge.test.mjs
@@ -710,10 +710,8 @@ describe("REQUIRED_CHECKS", () => {
 });
 
 describe("workflowPathsIgnore", () => {
-  // Replaces a pair of tests that pinned a hand-copied constant against the
-  // workflow. The constant is gone: the gate reads the workflow directly, so
-  // there is no copy left to drift and nothing to pin. What remains to cover is
-  // the parser itself, which is now the only implementation of the filter.
+  // The parser is the only implementation of the integration filter, so these
+  // cover it directly rather than comparing it against a second copy.
   it("reads the filter the workflow declares for a trigger", () => {
     const globs = workflowPathsIgnore(INTEGRATION_YML, "pull_request");
 
@@ -775,6 +773,46 @@ describe("requiredChecks by mode", () => {
     expect(requiredChecks([], { merged: true }).map(c => c.name)).not.toContain(
       TITLE
     );
+  });
+});
+
+describe("maintainer approval", () => {
+  it("reports an unapproved pull request WITHOUT blocking it", () => {
+    // CONTRIBUTING asks for one maintainer approval before merge, and no merge
+    // in this repository carries one. Blocking would refuse every pull request
+    // rather than raise the bar for any, so the gap is surfaced instead.
+    const verdict = gateVerdict({
+      tip: FULL_TIP,
+      unresolvedThreads: 0,
+      checkRuns: allGreen(),
+      changedPaths: CODE_CHANGE,
+      required: REQUIRED,
+      codexReviewedSha: FULL_TIP.slice(0, 10),
+      coderabbitReviewCount: 1,
+      approvalCount: 0,
+    });
+
+    expect(verdict.mergeable).toBe(true);
+    expect(verdict.maintainerApproval).toBe("none");
+    expect(formatVerdict(verdict)).toContain("maintainer approval: none");
+  });
+
+  it("reports an approved one as approved", () => {
+    // The control: without it, a field hardcoded to "none" satisfies the case
+    // above and would report every pull request as unapproved.
+    const verdict = gateVerdict({
+      tip: FULL_TIP,
+      unresolvedThreads: 0,
+      checkRuns: allGreen(),
+      changedPaths: CODE_CHANGE,
+      required: REQUIRED,
+      codexReviewedSha: FULL_TIP.slice(0, 10),
+      coderabbitReviewCount: 1,
+      approvalCount: 2,
+    });
+
+    expect(verdict.maintainerApproval).toBe("approved");
+    expect(formatVerdict(verdict)).not.toContain("maintainer approval");
   });
 });
 

--- a/scripts/verify-merge.test.mjs
+++ b/scripts/verify-merge.test.mjs
@@ -25,6 +25,8 @@ const forcePush = { event: "head_ref_force_pushed" };
 const commented = { event: "commented" };
 const green = name => ({ name, status: "completed", conclusion: "success" });
 const queued = name => ({ name, status: "queued", conclusion: null });
+/** A real 40-character object name; the gate refuses anything shorter as a tip. */
+const FULL_TIP = "91fd9500285dcf264e3609a916b7518b591b51f3";
 
 describe("countRewriteEvents", () => {
   it("counts events beyond the FIRST page", () => {
@@ -58,6 +60,17 @@ describe("countRewriteEvents", () => {
 
   it("refuses a non-array rather than treating it as empty", () => {
     expect(() => countRewriteEvents(undefined)).toThrow(TypeError);
+  });
+
+  it("refuses a page that is not an array, rather than counting it as zero", () => {
+    // A failed or unparsed page arrives as `null` or an error object. The
+    // outer check passes it, `flat()` carries it through, and optional access
+    // ignores it — so a partly unread timeline would report no rewrites and
+    // the branch as checkable.
+    expect(() => countRewriteEvents([[commented], null])).toThrow(TypeError);
+    expect(() =>
+      countRewriteEvents([[commented], { message: "Bad credentials" }])
+    ).toThrow(TypeError);
   });
 });
 
@@ -126,6 +139,19 @@ describe("jobPasses", () => {
     ).toBe(true);
   });
 
+  it("passes a NEUTRAL job", () => {
+    // GitHub accepts `neutral` for a required status check alongside `success`
+    // and `skipped`. Refusing it would make this gate stricter than the
+    // protection it models and block a revision the platform calls mergeable.
+    expect(
+      jobPasses({
+        name: "advisory",
+        status: "completed",
+        conclusion: "neutral",
+      })
+    ).toBe(true);
+  });
+
   it("passes a successful job", () => {
     expect(jobPasses(green("CI"))).toBe(true);
   });
@@ -164,15 +190,22 @@ describe("verdictCoversTip", () => {
     ).toBe(true);
   });
 
-  it("rejects a prefix too short to identify a commit", () => {
+  it("rejects a verdict too short to identify a commit", () => {
     // "a" prefixes an enormous number of commits. Accepting it would make the
     // comparison pass on almost anything.
-    expect(verdictCoversTip("a", "abc1234def")).toBe(false);
+    expect(verdictCoversTip("a", FULL_TIP)).toBe(false);
+  });
+
+  it("rejects a TRUNCATED tip even when the verdict agrees with it", () => {
+    // The comparison is asymmetric on purpose: the bot abbreviates, the ref
+    // does not. Symmetric, this returns true — and the gate would then pass
+    // without ever identifying the head revision it exists to pin.
+    expect(verdictCoversTip(FULL_TIP, FULL_TIP.slice(0, 7))).toBe(false);
   });
 
   it("rejects a missing verdict rather than treating absence as agreement", () => {
-    expect(verdictCoversTip("", "abc1234def")).toBe(false);
-    expect(verdictCoversTip(undefined, "abc1234def")).toBe(false);
+    expect(verdictCoversTip("", FULL_TIP)).toBe(false);
+    expect(verdictCoversTip(undefined, FULL_TIP)).toBe(false);
   });
 });
 
@@ -231,6 +264,15 @@ describe("gateVerdict", () => {
     expect(verdict.blockers.map(b => b.kind)).toContain("threads-unknown");
   });
 
+  it("blocks on a NEGATIVE thread count, which is a sentinel and not a count", () => {
+    // An I/O wrapper that reports -1 for "could not read" would otherwise pass
+    // the integer check and add no blocker — unknown becoming zero by another
+    // route, which the neighbouring validators already refuse.
+    const verdict = gateVerdict({ ...passing, unresolvedThreads: -1 });
+
+    expect(verdict.blockers.map(b => b.kind)).toContain("threads-unknown");
+  });
+
   it("blocks when the review verdict belongs to an earlier revision", () => {
     const verdict = gateVerdict({ ...passing, codexReviewedSha: "0dbcb9470" });
 
@@ -268,10 +310,10 @@ describe("formatVerdict", () => {
   it("says BLOCKED and names each reason", () => {
     const text = formatVerdict(
       gateVerdict({
-        tip: "abc1234def",
+        tip: FULL_TIP,
         unresolvedThreads: 1,
         checkRuns: [green("CI")],
-        codexReviewedSha: "abc1234def",
+        codexReviewedSha: FULL_TIP.slice(0, 10),
         coderabbitReviewCount: 1,
       })
     );
@@ -283,10 +325,10 @@ describe("formatVerdict", () => {
   it("flags an unreviewed second reviewer on an otherwise passing gate", () => {
     const text = formatVerdict(
       gateVerdict({
-        tip: "abc1234def",
+        tip: FULL_TIP,
         unresolvedThreads: 0,
         checkRuns: [green("CI")],
-        codexReviewedSha: "abc1234def",
+        codexReviewedSha: FULL_TIP.slice(0, 10),
         coderabbitReviewCount: 0,
       })
     );

--- a/scripts/verify-merge.test.mjs
+++ b/scripts/verify-merge.test.mjs
@@ -584,10 +584,9 @@ describe("reviewsCoveringTip", () => {
   it("refuses an abbreviated tip even when a record matches it exactly", () => {
     // Both sides abbreviated is the ONLY shape where the length guard decides
     // anything: against a full `commit_id` the comparison already fails, so a
-    // test using one passes whether or not the guard exists — which is what
-    // the first version of this test did. Coverage must be established against
-    // a full object name; a match obtained by truncating both sides identifies
-    // no particular commit.
+    // case built on one passes whether or not the guard exists. Coverage must be
+    // established against a full object name, because a match obtained by
+    // truncating both sides identifies no particular commit.
     const short = tip.slice(0, 9);
     const reviews = [
       { user: { login: "coderabbitai[bot]" }, commit_id: short },

--- a/scripts/verify-merge.test.mjs
+++ b/scripts/verify-merge.test.mjs
@@ -1,29 +1,36 @@
 /**
- * Every case here is a defect this repository actually shipped, written as the
- * input that produced it.
+ * Every case here is a false clean this gate can produce, written as the input
+ * that produces it.
  *
- * The procedure these functions replace lived as shell inside a Markdown rule.
- * It was wrong in several ways at once and each one was found by a reviewer
- * executing it mentally rather than by anything running it — so the tests are
- * organised by the WRONG ANSWER each function used to give, not by its
- * signature.
+ * The cases are grouped by the WRONG ANSWER rather than by function signature,
+ * because the answers are what overlap: several unrelated functions here fail
+ * by reporting "nothing to see" for an input they could not read, and grouping
+ * by that shape keeps the next instance next to its siblings instead of filed
+ * under whichever function happened to grow it.
  */
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
 import { describe, expect, it } from "vitest";
 
 import {
+  INTEGRATION_PATHS_IGNORE,
   REQUIRED_CHECKS,
   blockingJobs,
   checkability,
   countRewriteEvents,
+  exitCode,
   formatVerdict,
   gateVerdict,
   jobPasses,
   landedWhole,
   missingRequired,
+  pathMatches,
   reviewCoverage,
   reviewsCoveringTip,
   statusAsRun,
   verdictCoversTip,
+  workflowApplies,
 } from "./verify-merge.mjs";
 
 const forcePush = { event: "head_ref_force_pushed" };
@@ -34,6 +41,18 @@ const queued = name => ({ name, status: "queued", conclusion: null });
 const CI = "Lint / Typecheck / Test / Build";
 /** A real 40-character object name; the gate refuses anything shorter as a tip. */
 const FULL_TIP = "91fd9500285dcf264e3609a916b7518b591b51f3";
+/** A change set every workflow in the repository runs for. */
+const CODE_CHANGE = ["packages/nextly/src/index.ts"];
+/** A change set `integration.yml` ignores at the trigger, so it never runs. */
+const DOCS_CHANGE = ["docs/guide.md", "docs/api/reference.md"];
+/** Every required check present and green, which is what a pass needs. */
+const allGreen = () => [
+  green(CI),
+  green("gitleaks"),
+  green("Integration (postgres)"),
+  green("Integration (mysql)"),
+  green("Integration (sqlite)"),
+];
 
 describe("countRewriteEvents", () => {
   it("counts events beyond the FIRST page", () => {
@@ -231,9 +250,10 @@ describe("reviewCoverage", () => {
 
 describe("gateVerdict", () => {
   const passing = {
-    tip: "91fd9500285dcf264e3609a916b7518b591b51f3",
+    tip: FULL_TIP,
     unresolvedThreads: 0,
-    checkRuns: [green(CI), green("gitleaks")],
+    checkRuns: allGreen(),
+    changedPaths: CODE_CHANGE,
     codexReviewedSha: "91fd950028",
     coderabbitReviewCount: 3,
   };
@@ -301,7 +321,7 @@ describe("gateVerdict", () => {
     const verdict = gateVerdict({
       ...passing,
       unresolvedThreads: 2,
-      checkRuns: [queued(CI), green("gitleaks")],
+      checkRuns: allGreen().map(run => (run.name === CI ? queued(CI) : run)),
       codexReviewedSha: "0dbcb9470",
     });
 
@@ -319,7 +339,8 @@ describe("formatVerdict", () => {
       gateVerdict({
         tip: FULL_TIP,
         unresolvedThreads: 1,
-        checkRuns: [green(CI), green("gitleaks")],
+        checkRuns: allGreen(),
+        changedPaths: CODE_CHANGE,
         codexReviewedSha: FULL_TIP.slice(0, 10),
         coderabbitReviewCount: 1,
       })
@@ -334,7 +355,8 @@ describe("formatVerdict", () => {
       gateVerdict({
         tip: FULL_TIP,
         unresolvedThreads: 0,
-        checkRuns: [green(CI), green("gitleaks")],
+        checkRuns: allGreen(),
+        changedPaths: CODE_CHANGE,
         codexReviewedSha: FULL_TIP.slice(0, 10),
         coderabbitReviewCount: 0,
       })
@@ -376,29 +398,121 @@ describe("missingRequired", () => {
     // its jobs while `secret-scan.yml` succeeded yields a non-empty,
     // all-green set containing no build and no tests. Absence is invisible to
     // any filter over what is present.
-    expect(missingRequired([green("gitleaks")])).toEqual([
-      "Lint / Typecheck / Test / Build",
-    ]);
+    expect(missingRequired([green("gitleaks")], CODE_CHANGE)).toContain(
+      "Lint / Typecheck / Test / Build"
+    );
   });
 
   it("reports nothing when the required check reported, even failing", () => {
     // Presence, not success — `blockingJobs` judges the outcome. Conflating
     // them would report a failing required job twice and an absent one never.
+    const runs = allGreen();
+    runs[0] = queued("Lint / Typecheck / Test / Build");
+
+    expect(missingRequired(runs, CODE_CHANGE)).toEqual([]);
+  });
+
+  it("reports the integration legs a code change was due to run", () => {
+    // The unit suites mock the drivers and the browser tests run on sqlite
+    // alone, so these are the only coverage a Postgres- or MySQL-specific
+    // regression has. Listing the CI job and gitleaks while omitting them let a
+    // run where `integration.yml` created no check-runs pass on the other two
+    // being green.
     expect(
-      missingRequired([
-        queued("Lint / Typecheck / Test / Build"),
-        green("gitleaks"),
-      ])
+      missingRequired(
+        [green("Lint / Typecheck / Test / Build"), green("gitleaks")],
+        CODE_CHANGE
+      )
+    ).toEqual([
+      "Integration (postgres)",
+      "Integration (mysql)",
+      "Integration (sqlite)",
+    ]);
+  });
+
+  it("does NOT report the integration legs the workflow filtered out", () => {
+    // The positive control for the case above. Without it, requiring the
+    // integration checks unconditionally would block every documentation pull
+    // request forever, and the test above would pass on that implementation.
+    expect(
+      missingRequired(
+        [green("Lint / Typecheck / Test / Build"), green("gitleaks")],
+        DOCS_CHANGE
+      )
     ).toEqual([]);
   });
 
+  it("requires every check when the change set could not be read", () => {
+    // An unknown change set must not excuse a check. The failure this whole
+    // file guards is a gate reporting clean because it could not see, so the
+    // unreadable case resolves toward demanding evidence.
+    expect(missingRequired([green("gitleaks")], undefined)).toEqual([
+      "Lint / Typecheck / Test / Build",
+      "Integration (postgres)",
+      "Integration (mysql)",
+      "Integration (sqlite)",
+    ]);
+  });
+
   it("names the checks whose ABSENCE means no coverage", () => {
-    // Both run on every pull request from independent workflows, so either
-    // failing to report leaves a green-looking set with a gate missing.
-    expect(REQUIRED_CHECKS).toEqual([
+    expect(REQUIRED_CHECKS.map(c => c.name)).toEqual([
       "Lint / Typecheck / Test / Build",
       "gitleaks",
+      "Integration (postgres)",
+      "Integration (mysql)",
+      "Integration (sqlite)",
     ]);
+  });
+});
+
+describe("pathMatches", () => {
+  it("lets ** span directory separators and * stop at one", () => {
+    expect(pathMatches("docs/**", "docs/api/reference.md")).toBe(true);
+    expect(pathMatches("*.md", "docs/guide.md")).toBe(false);
+  });
+
+  it("does not treat a dot in the pattern as a wildcard", () => {
+    // `.` unescaped matches any character, so `**/*.md` would accept
+    // `srcXmd` — a filter admitting source files as documentation.
+    expect(pathMatches("**/*.md", "packages/nextly/srcXmd")).toBe(false);
+  });
+
+  it("reads **/ as requiring a directory, which errs toward requiring", () => {
+    // A root-level `README.md` does not match `**/*.md` on the literal reading
+    // of the filter, so a pull request touching only that file is treated as
+    // one `integration.yml` runs for. That direction is deliberate: over-
+    // requiring a check produces an argument, under-requiring one produces a
+    // silent gap, which is the failure this file exists to refuse.
+    expect(pathMatches("**/*.md", "README.md")).toBe(false);
+    expect(pathMatches("**/*.md", "docs/guide.md")).toBe(true);
+  });
+});
+
+describe("workflowApplies", () => {
+  it("runs the workflow when ONE file escapes the filter", () => {
+    // GitHub skips only when every changed file matches, so a pull request
+    // that edits documentation and one source file still runs it. Treating
+    // "mostly documentation" as ignored is how a code change loses its
+    // database coverage.
+    expect(
+      workflowApplies(INTEGRATION_PATHS_IGNORE, [
+        "docs/guide.md",
+        "packages/nextly/src/index.ts",
+      ])
+    ).toBe(true);
+  });
+
+  it("skips the workflow when every file matches", () => {
+    expect(workflowApplies(INTEGRATION_PATHS_IGNORE, DOCS_CHANGE)).toBe(false);
+  });
+
+  it("applies when the change set is unknown or empty", () => {
+    expect(workflowApplies(INTEGRATION_PATHS_IGNORE, undefined)).toBe(true);
+    expect(workflowApplies(INTEGRATION_PATHS_IGNORE, [])).toBe(true);
+  });
+
+  it("applies when the workflow declares no filter at all", () => {
+    expect(workflowApplies([], DOCS_CHANGE)).toBe(true);
   });
 });
 
@@ -530,9 +644,99 @@ describe("REQUIRED_CHECKS", () => {
     // the enforcement gate. With only the CI job listed, a run where that
     // workflow created no check-run passed on an unrelated workflow being
     // green — absence being invisible, one workflow along.
-    expect(REQUIRED_CHECKS).toContain("gitleaks");
-    expect(missingRequired([green("Lint / Typecheck / Test / Build")])).toEqual(
-      ["gitleaks"]
-    );
+    expect(REQUIRED_CHECKS.map(c => c.name)).toContain("gitleaks");
+
+    const withoutScan = allGreen().filter(run => run.name !== "gitleaks");
+    expect(missingRequired(withoutScan, CODE_CHANGE)).toEqual(["gitleaks"]);
+  });
+});
+
+describe("INTEGRATION_PATHS_IGNORE against the workflow it mirrors", () => {
+  // The constant is a copy of a filter that lives in `integration.yml`, and two
+  // spellings of one rule drift silently — the copy keeps looking correct while
+  // the workflow moves underneath it, and the gate then excuses a check the
+  // workflow was due to create.
+  const workflow = readFileSync(
+    fileURLToPath(new URL("../.github/workflows/integration.yml", import.meta.url)),
+    "utf8"
+  );
+
+  /** The `paths-ignore` globs declared under one trigger in a workflow file. */
+  const declaredIgnores = trigger => {
+    const lines = workflow.split("\n");
+    const start = lines.findIndex(l => l.trimEnd() === `  ${trigger}:`);
+    if (start === -1) return [];
+    const globs = [];
+    let collecting = false;
+    for (const line of lines.slice(start + 1)) {
+      // Any line at the trigger's own indent or shallower ends the block, so a
+      // filter belonging to the NEXT trigger is never read as this one's.
+      if (/^ {0,2}\S/.test(line)) break;
+      if (line.trim() === "paths-ignore:") {
+        collecting = true;
+        continue;
+      }
+      if (!collecting) continue;
+      const entry = /^\s*-\s*["']?([^"'\s]+)["']?\s*$/.exec(line);
+      if (!entry) break;
+      globs.push(entry[1]);
+    }
+    return globs;
+  };
+
+  it("finds a filter at all, so a failed parse cannot read as agreement", () => {
+    // Without this, restructuring the workflow makes the extractor return
+    // nothing, and an empty list compares equal to an empty list — the parse
+    // failing would certify the mirror rather than fail the build.
+    expect(declaredIgnores("pull_request").length).toBeGreaterThan(0);
+  });
+
+  it("matches what the workflow actually declares", () => {
+    expect(declaredIgnores("pull_request")).toEqual([
+      ...INTEGRATION_PATHS_IGNORE,
+    ]);
+  });
+});
+
+describe("exitCode", () => {
+  it("refuses success while landed-whole candidates are unsettled", () => {
+    // `landedWhole` names commits the merge does not contain and stops short of
+    // calling them lost, because the verdict comes from confirming each by
+    // content. Printing that list while exiting 0 lets automation read a
+    // possibly-lost tail as verified — the candidates were computed and never
+    // reached the decision.
+    expect(
+      exitCode({ checkable: true, landedVerdict: "candidates", mergeable: true })
+    ).toBe(2);
+  });
+
+  it("passes when the branch had nothing the merge did not take", () => {
+    // The positive control for the case above: without it, an implementation
+    // that never returns 0 satisfies it.
+    expect(
+      exitCode({
+        checkable: true,
+        landedVerdict: "no-candidates",
+        mergeable: true,
+      })
+    ).toBe(0);
+  });
+
+  it("reports an unanswerable branch as unsettled, not as blocked", () => {
+    // 2 rather than 1, so a caller can tell "the gate says no" from "the gate
+    // did not get to answer" and escalate the second rather than retrying it.
+    expect(
+      exitCode({
+        checkable: false,
+        landedVerdict: "not-checkable",
+        mergeable: true,
+      })
+    ).toBe(2);
+  });
+
+  it("blocks on the ordinary gate when everything else is settled", () => {
+    expect(
+      exitCode({ checkable: true, landedVerdict: "n/a", mergeable: false })
+    ).toBe(1);
   });
 });

--- a/scripts/verify-merge.test.mjs
+++ b/scripts/verify-merge.test.mjs
@@ -495,14 +495,25 @@ describe("pathMatches", () => {
     expect(pathMatches("**/*.md", "packages/nextly/srcXmd")).toBe(false);
   });
 
-  it("reads **/ as requiring a directory, which errs toward requiring", () => {
-    // A root-level `README.md` does not match `**/*.md` on the literal reading
-    // of the filter, so a pull request touching only that file is treated as
-    // one `integration.yml` runs for. That direction is deliberate: over-
-    // requiring a check produces an argument, under-requiring one produces a
-    // silent gap, which is the failure this file exists to refuse.
-    expect(pathMatches("**/*.md", "README.md")).toBe(false);
+  it("matches a ROOT file with **/, as the workflow matcher does", () => {
+    // `**/` spans zero or more directories. Requiring the separator made the
+    // gate demand integration checks the workflow deliberately never creates —
+    // and those can never appear, so a documentation-only pull request could
+    // not pass at all rather than merely being held to a stricter bar.
+    expect(pathMatches("**/*.md", "README.md")).toBe(true);
     expect(pathMatches("**/*.md", "docs/guide.md")).toBe(true);
+    expect(pathMatches("**/*.md", "docs/a/b/guide.md")).toBe(true);
+  });
+
+  it("still refuses a non-matching extension under **/", () => {
+    // The control: without it, a translation collapsing to `.*` passes every
+    // assertion above while matching files the filter never covered.
+    expect(pathMatches("**/*.md", "packages/nextly/src/index.ts")).toBe(false);
+  });
+
+  it("keeps the docs prefix anchored", () => {
+    expect(pathMatches("docs/**", "docs/a/reference.md")).toBe(true);
+    expect(pathMatches("docs/**", "packages/docs/a.md")).toBe(false);
   });
 });
 

--- a/scripts/verify-merge.test.mjs
+++ b/scripts/verify-merge.test.mjs
@@ -27,6 +27,8 @@ import {
   OPTIONAL_STATUS_CONTEXTS,
   missingRequired,
   PATH_FILTER_WINDOW,
+  MAINTAINER_ASSOCIATIONS,
+  PATH_FILTER_COMMIT_LIMIT,
   pageWrapping,
   pathMatches,
   remoteForRepo,
@@ -403,6 +405,24 @@ describe("OPTIONAL_STATUS_CONTEXTS", () => {
     expect(OPTIONAL_STATUS_CONTEXTS).not.toContain(
       "action-semantic-pull-request"
     );
+  });
+});
+
+describe("maintainer associations", () => {
+  it("counts only associations carrying write access", () => {
+    // Any account can submit an APPROVED review, a contributor's own and a
+    // bot's included, so the state alone does not say the project accepted it.
+    expect(MAINTAINER_ASSOCIATIONS).toEqual(["OWNER", "MEMBER", "COLLABORATOR"]);
+    expect(MAINTAINER_ASSOCIATIONS).not.toContain("CONTRIBUTOR");
+    expect(MAINTAINER_ASSOCIATIONS).not.toContain("NONE");
+  });
+});
+
+describe("PATH_FILTER_COMMIT_LIMIT", () => {
+  it("matches the point GitHub stops evaluating path filters", () => {
+    // Past it the workflow runs regardless, so deciding from paths would excuse
+    // a check that did run.
+    expect(PATH_FILTER_COMMIT_LIMIT).toBe(1000);
   });
 });
 
@@ -1027,8 +1047,9 @@ describe("staleVerification", () => {
   });
 
   it("catches a pull request CLOSED or drafted mid-check", () => {
-    // Neither moves the tip nor the merged flag, so the two named comparisons
-    // this replaced both passed while GitHub had stopped permitting the merge.
+    // Neither moves the tip nor the merged flag, so a comparison naming only
+    // those two reports the verification as fresh while GitHub has already
+    // stopped permitting the merge.
     expect(staleVerification(OPEN, { ...OPEN, state: "closed" })).toBe(
       "state-changed-during-verification"
     );

--- a/scripts/verify-merge.test.mjs
+++ b/scripts/verify-merge.test.mjs
@@ -18,6 +18,7 @@ import {
   formatVerdict,
   gateVerdict,
   jobPasses,
+  landedWhole,
   missingRequired,
   reviewCoverage,
   reviewsCoveringTip,
@@ -300,7 +301,7 @@ describe("gateVerdict", () => {
     const verdict = gateVerdict({
       ...passing,
       unresolvedThreads: 2,
-      checkRuns: [queued(CI)],
+      checkRuns: [queued(CI), green("gitleaks")],
       codexReviewedSha: "0dbcb9470",
     });
 
@@ -318,7 +319,7 @@ describe("formatVerdict", () => {
       gateVerdict({
         tip: FULL_TIP,
         unresolvedThreads: 1,
-        checkRuns: [green(CI)],
+        checkRuns: [green(CI), green("gitleaks")],
         codexReviewedSha: FULL_TIP.slice(0, 10),
         coderabbitReviewCount: 1,
       })
@@ -333,7 +334,7 @@ describe("formatVerdict", () => {
       gateVerdict({
         tip: FULL_TIP,
         unresolvedThreads: 0,
-        checkRuns: [green(CI)],
+        checkRuns: [green(CI), green("gitleaks")],
         codexReviewedSha: FULL_TIP.slice(0, 10),
         coderabbitReviewCount: 0,
       })
@@ -384,12 +385,20 @@ describe("missingRequired", () => {
     // Presence, not success — `blockingJobs` judges the outcome. Conflating
     // them would report a failing required job twice and an absent one never.
     expect(
-      missingRequired([queued("Lint / Typecheck / Test / Build")])
+      missingRequired([
+        queued("Lint / Typecheck / Test / Build"),
+        green("gitleaks"),
+      ])
     ).toEqual([]);
   });
 
-  it("names exactly one required check, so its absence is decisive", () => {
-    expect(REQUIRED_CHECKS).toEqual(["Lint / Typecheck / Test / Build"]);
+  it("names the checks whose ABSENCE means no coverage", () => {
+    // Both run on every pull request from independent workflows, so either
+    // failing to report leaves a green-looking set with a gate missing.
+    expect(REQUIRED_CHECKS).toEqual([
+      "Lint / Typecheck / Test / Build",
+      "gitleaks",
+    ]);
   });
 });
 
@@ -453,6 +462,77 @@ describe("gateVerdict + required checks", () => {
     expect(verdict.mergeable).toBe(false);
     expect(verdict.blockers.map(b => b.kind)).toContain(
       "required-check-absent"
+    );
+  });
+});
+
+describe("landedWhole", () => {
+  it("refuses to answer for a branch whose history was rewritten", () => {
+    // An empty candidate list from an unanswerable branch is not evidence.
+    // A force-push resetting a stranded commit away leaves the range empty and
+    // indistinguishable from a branch that never had one.
+    expect(
+      landedWhole({
+        checkable: false,
+        reason: "history-rewritten",
+        candidates: [],
+      })
+    ).toEqual({
+      verdict: "not-checkable",
+      reason: "history-rewritten",
+      candidates: [],
+    });
+  });
+
+  it("refuses for a ref that does not resolve, rather than reporting clean", () => {
+    expect(
+      landedWhole({ checkable: false, reason: "no-ref", candidates: [] })
+        .verdict
+    ).toBe("not-checkable");
+  });
+
+  it("reports CANDIDATES, never a loss", () => {
+    // The range says only "absent from the merged head". A surviving branch
+    // also collects force-pushes, rebases and follow-up work, so naming this
+    // "lost" would raise a false alarm in a procedure whose whole value is
+    // that its alarms mean something.
+    const result = landedWhole({
+      checkable: true,
+      reason: "ok",
+      candidates: [
+        "f4d798078 test(blocks-react): pair the oversized array again",
+      ],
+    });
+
+    expect(result.verdict).toBe("candidates");
+    expect(result.candidates).toHaveLength(1);
+  });
+
+  it("distinguishes an empty answer from no answer", () => {
+    // The positive control for the two refusals above: without it they pass on
+    // a function that refuses unconditionally, and the whole point is that
+    // "checked, found nothing" and "could not check" are different results.
+    expect(
+      landedWhole({ checkable: true, reason: "ok", candidates: [] }).verdict
+    ).toBe("no-candidates");
+  });
+
+  it("refuses a non-array rather than treating it as empty", () => {
+    expect(() =>
+      landedWhole({ checkable: true, reason: "ok", candidates: null })
+    ).toThrow(TypeError);
+  });
+});
+
+describe("REQUIRED_CHECKS", () => {
+  it("includes the secret scan, which is its own workflow", () => {
+    // `secret-scan.yml` runs on every pull request and the repository calls it
+    // the enforcement gate. With only the CI job listed, a run where that
+    // workflow created no check-run passed on an unrelated workflow being
+    // green — absence being invisible, one workflow along.
+    expect(REQUIRED_CHECKS).toContain("gitleaks");
+    expect(missingRequired([green("Lint / Typecheck / Test / Build")])).toEqual(
+      ["gitleaks"]
     );
   });
 });

--- a/scripts/verify-merge.test.mjs
+++ b/scripts/verify-merge.test.mjs
@@ -24,6 +24,7 @@ import {
   jobPasses,
   landedWhole,
   missingRequired,
+  pageWrapping,
   pathMatches,
   remoteForRepo,
   repoFromRemoteUrl,
@@ -56,12 +57,14 @@ const INTEGRATION_YML = readFileSync(
   "utf8"
 );
 const PR_IGNORE = workflowPathsIgnore(INTEGRATION_YML, "pull_request");
-const REQUIRED = requiredChecks(PR_IGNORE);
+const REQUIRED = requiredChecks(PR_IGNORE, { merged: false });
 
 /** Every required check present and green, which is what a pass needs. */
+const TITLE = "Validate PR title follows Conventional Commits";
 const allGreen = () => [
   green(CI),
   green("gitleaks"),
+  green(TITLE),
   green("Integration (postgres)"),
   green("Integration (mysql)"),
   green("Integration (sqlite)"),
@@ -444,6 +447,7 @@ describe("missingRequired", () => {
       "Integration (postgres)",
       "Integration (mysql)",
       "Integration (sqlite)",
+      TITLE,
     ]);
   });
 
@@ -457,7 +461,7 @@ describe("missingRequired", () => {
         DOCS_CHANGE,
         REQUIRED
       )
-    ).toEqual([]);
+    ).toEqual([TITLE]);
   });
 
   it("requires every check when the change set could not be read", () => {
@@ -469,6 +473,7 @@ describe("missingRequired", () => {
       "Integration (postgres)",
       "Integration (mysql)",
       "Integration (sqlite)",
+      TITLE,
     ]);
   });
 
@@ -479,6 +484,7 @@ describe("missingRequired", () => {
       "Integration (postgres)",
       "Integration (mysql)",
       "Integration (sqlite)",
+      TITLE,
     ]);
   });
 });
@@ -736,6 +742,59 @@ describe("workflowPathsIgnore", () => {
   });
 });
 
+describe("requiredChecks by mode", () => {
+  it("requires the PR-title status before a merge and not after", () => {
+    // It reports through the statuses surface from its own workflow, and only
+    // on a pull request. Judged only when present, a run that never started
+    // left the title unvalidated and the gate green; required after a merge, it
+    // would demand a status a push never writes.
+    expect(requiredChecks([], { merged: false }).map(c => c.name)).toContain(
+      TITLE
+    );
+    expect(requiredChecks([], { merged: true }).map(c => c.name)).not.toContain(
+      TITLE
+    );
+  });
+});
+
+describe("gateVerdict eligibility", () => {
+  const base = {
+    tip: FULL_TIP,
+    unresolvedThreads: 0,
+    checkRuns: allGreen(),
+    changedPaths: CODE_CHANGE,
+    required: REQUIRED,
+    codexReviewedSha: FULL_TIP.slice(0, 10),
+    coderabbitReviewCount: 1,
+  };
+
+  it("blocks a draft, whose checks are green and which cannot merge", () => {
+    const verdict = gateVerdict({ ...base, eligibility: { draft: true } });
+
+    expect(verdict.blockers.map(b => b.kind)).toContain("draft");
+  });
+
+  it("blocks a closed unmerged pull request, which keeps its green checks", () => {
+    const verdict = gateVerdict({
+      ...base,
+      eligibility: { state: "closed", merged: false },
+    });
+
+    expect(verdict.blockers.map(b => b.kind)).toContain("closed");
+  });
+
+  it("does not block a MERGED pull request for being closed", () => {
+    // The control that keeps the case above from blocking every merged pull
+    // request the post-merge mode exists to check: merged ones are closed too.
+    const verdict = gateVerdict({
+      ...base,
+      eligibility: { state: "closed", merged: true },
+    });
+
+    expect(verdict.blockers.map(b => b.kind)).not.toContain("closed");
+  });
+});
+
 describe("flatPages", () => {
   it("refuses a page that could not be read", () => {
     // `--paginate --slurp` returns a failed page as null. Flattening past it
@@ -746,6 +805,23 @@ describe("flatPages", () => {
       TypeError
     );
     expect(() => flatPages(null, "files")).toThrow(TypeError);
+  });
+
+  it("refuses an API error body, which is an object but not a page", () => {
+    // The shape a failed request actually returns. A validator asking only for
+    // a non-null object accepts it, and the `?? []` downstream then drops it —
+    // so an unread page carrying blockers becomes a passing gate.
+    expect(() =>
+      flatPages([{ message: "Bad credentials" }], "check-runs", pageWrapping("check_runs"))
+    ).toThrow(TypeError);
+  });
+
+  it("accepts the wrapped shape the checks endpoints return", () => {
+    const pages = [{ check_runs: [green("a")] }];
+
+    expect(flatPages(pages, "check-runs", pageWrapping("check_runs"))).toEqual(
+      pages
+    );
   });
 
   it("passes pages that were all read", () => {

--- a/scripts/verify-merge.test.mjs
+++ b/scripts/verify-merge.test.mjs
@@ -11,13 +11,17 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  REQUIRED_CHECKS,
   blockingJobs,
   checkability,
   countRewriteEvents,
   formatVerdict,
   gateVerdict,
   jobPasses,
+  missingRequired,
   reviewCoverage,
+  reviewsCoveringTip,
+  statusAsRun,
   verdictCoversTip,
 } from "./verify-merge.mjs";
 
@@ -25,6 +29,8 @@ const forcePush = { event: "head_ref_force_pushed" };
 const commented = { event: "commented" };
 const green = name => ({ name, status: "completed", conclusion: "success" });
 const queued = name => ({ name, status: "queued", conclusion: null });
+/** The one check whose ABSENCE means no build ran. Fixtures must name it. */
+const CI = "Lint / Typecheck / Test / Build";
 /** A real 40-character object name; the gate refuses anything shorter as a tip. */
 const FULL_TIP = "91fd9500285dcf264e3609a916b7518b591b51f3";
 
@@ -226,7 +232,7 @@ describe("gateVerdict", () => {
   const passing = {
     tip: "91fd9500285dcf264e3609a916b7518b591b51f3",
     unresolvedThreads: 0,
-    checkRuns: [green("CI"), green("gitleaks")],
+    checkRuns: [green(CI), green("gitleaks")],
     codexReviewedSha: "91fd950028",
     coderabbitReviewCount: 3,
   };
@@ -294,7 +300,7 @@ describe("gateVerdict", () => {
     const verdict = gateVerdict({
       ...passing,
       unresolvedThreads: 2,
-      checkRuns: [queued("CI")],
+      checkRuns: [queued(CI)],
       codexReviewedSha: "0dbcb9470",
     });
 
@@ -312,7 +318,7 @@ describe("formatVerdict", () => {
       gateVerdict({
         tip: FULL_TIP,
         unresolvedThreads: 1,
-        checkRuns: [green("CI")],
+        checkRuns: [green(CI)],
         codexReviewedSha: FULL_TIP.slice(0, 10),
         coderabbitReviewCount: 1,
       })
@@ -327,7 +333,7 @@ describe("formatVerdict", () => {
       gateVerdict({
         tip: FULL_TIP,
         unresolvedThreads: 0,
-        checkRuns: [green("CI")],
+        checkRuns: [green(CI)],
         codexReviewedSha: FULL_TIP.slice(0, 10),
         coderabbitReviewCount: 0,
       })
@@ -335,5 +341,118 @@ describe("formatVerdict", () => {
 
     expect(text).toContain("GATE PASSED");
     expect(text).toContain("not-reviewed");
+  });
+});
+
+describe("statusAsRun", () => {
+  it("treats a pending status as NOT passing", () => {
+    // The title check reports through the statuses API, not check-runs. A
+    // gate that reads only check-runs calls the revision green while the
+    // title check is still pending.
+    expect(
+      jobPasses(statusAsRun({ context: "PR title", state: "pending" }))
+    ).toBe(false);
+  });
+
+  it("treats a failing status as NOT passing", () => {
+    expect(
+      jobPasses(statusAsRun({ context: "CodeRabbit", state: "failure" }))
+    ).toBe(false);
+  });
+
+  it("treats a successful status as passing", () => {
+    // The positive control: without it, both cases above pass on a normaliser
+    // that refuses everything.
+    expect(
+      jobPasses(statusAsRun({ context: "CodeRabbit", state: "success" }))
+    ).toBe(true);
+  });
+});
+
+describe("missingRequired", () => {
+  it("reports the CI job when only unrelated workflows reported", () => {
+    // The workflows are independent, so a run where `ci.yml` never created
+    // its jobs while `secret-scan.yml` succeeded yields a non-empty,
+    // all-green set containing no build and no tests. Absence is invisible to
+    // any filter over what is present.
+    expect(missingRequired([green("gitleaks")])).toEqual([
+      "Lint / Typecheck / Test / Build",
+    ]);
+  });
+
+  it("reports nothing when the required check reported, even failing", () => {
+    // Presence, not success — `blockingJobs` judges the outcome. Conflating
+    // them would report a failing required job twice and an absent one never.
+    expect(
+      missingRequired([queued("Lint / Typecheck / Test / Build")])
+    ).toEqual([]);
+  });
+
+  it("names exactly one required check, so its absence is decisive", () => {
+    expect(REQUIRED_CHECKS).toEqual(["Lint / Typecheck / Test / Build"]);
+  });
+});
+
+describe("reviewsCoveringTip", () => {
+  const other = "0".repeat(40);
+  const tip = "9".repeat(40);
+
+  it("ignores a review written against an EARLIER revision", () => {
+    // Counting it reports a reviewer as having covered a commit it never saw.
+    const reviews = [
+      { user: { login: "coderabbitai[bot]" }, commit_id: other },
+    ];
+
+    expect(reviewsCoveringTip(reviews, tip, "coderabbitai[bot]")).toEqual([]);
+  });
+
+  it("counts a review whose commit_id IS the tip", () => {
+    const reviews = [{ user: { login: "coderabbitai[bot]" }, commit_id: tip }];
+
+    expect(reviewsCoveringTip(reviews, tip, "coderabbitai[bot]")).toHaveLength(
+      1
+    );
+  });
+
+  it("ignores another reviewer's review of the same revision", () => {
+    const reviews = [
+      { user: { login: "chatgpt-codex-connector[bot]" }, commit_id: tip },
+    ];
+
+    expect(reviewsCoveringTip(reviews, tip, "coderabbitai[bot]")).toEqual([]);
+  });
+
+  it("refuses an abbreviated tip even when a record matches it exactly", () => {
+    // Both sides abbreviated is the ONLY shape where the length guard decides
+    // anything: against a full `commit_id` the comparison already fails, so a
+    // test using one passes whether or not the guard exists — which is what
+    // the first version of this test did. Coverage must be established against
+    // a full object name; a match obtained by truncating both sides identifies
+    // no particular commit.
+    const short = tip.slice(0, 9);
+    const reviews = [
+      { user: { login: "coderabbitai[bot]" }, commit_id: short },
+    ];
+
+    expect(reviewsCoveringTip(reviews, short, "coderabbitai[bot]")).toEqual([]);
+  });
+});
+
+describe("gateVerdict + required checks", () => {
+  it("blocks when the required check never reported, though every run is green", () => {
+    // The dangerous shape: nothing failed, nothing is pending, and the build
+    // never ran.
+    const verdict = gateVerdict({
+      tip: "91fd9500285dcf264e3609a916b7518b591b51f3",
+      unresolvedThreads: 0,
+      checkRuns: [green("gitleaks")],
+      codexReviewedSha: "91fd950028",
+      coderabbitReviewCount: 1,
+    });
+
+    expect(verdict.mergeable).toBe(false);
+    expect(verdict.blockers.map(b => b.kind)).toContain(
+      "required-check-absent"
+    );
   });
 });

--- a/scripts/verify-merge.test.mjs
+++ b/scripts/verify-merge.test.mjs
@@ -14,8 +14,7 @@ import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 
 import {
-  INTEGRATION_PATHS_IGNORE,
-  REQUIRED_CHECKS,
+  flatPages,
   blockingJobs,
   checkability,
   countRewriteEvents,
@@ -28,12 +27,15 @@ import {
   pathMatches,
   remoteForRepo,
   repoFromRemoteUrl,
+  requiredChecks,
   reviewCoverage,
   reviewsCoveringTip,
   runCli,
+  staleVerification,
   statusAsRun,
   verdictCoversTip,
   workflowApplies,
+  workflowPathsIgnore,
 } from "./verify-merge.mjs";
 
 const forcePush = { event: "head_ref_force_pushed" };
@@ -48,6 +50,14 @@ const FULL_TIP = "91fd9500285dcf264e3609a916b7518b591b51f3";
 const CODE_CHANGE = ["packages/nextly/src/index.ts"];
 /** A change set `integration.yml` ignores at the trigger, so it never runs. */
 const DOCS_CHANGE = ["docs/guide.md", "docs/api/reference.md"];
+/** The integration filter, read from the workflow exactly as the gate reads it. */
+const INTEGRATION_YML = readFileSync(
+  fileURLToPath(new URL("../.github/workflows/integration.yml", import.meta.url)),
+  "utf8"
+);
+const PR_IGNORE = workflowPathsIgnore(INTEGRATION_YML, "pull_request");
+const REQUIRED = requiredChecks(PR_IGNORE);
+
 /** Every required check present and green, which is what a pass needs. */
 const allGreen = () => [
   green(CI),
@@ -257,6 +267,7 @@ describe("gateVerdict", () => {
     unresolvedThreads: 0,
     checkRuns: allGreen(),
     changedPaths: CODE_CHANGE,
+    required: REQUIRED,
     codexReviewedSha: "91fd950028",
     coderabbitReviewCount: 3,
   };
@@ -344,6 +355,7 @@ describe("formatVerdict", () => {
         unresolvedThreads: 1,
         checkRuns: allGreen(),
         changedPaths: CODE_CHANGE,
+        required: REQUIRED,
         codexReviewedSha: FULL_TIP.slice(0, 10),
         coderabbitReviewCount: 1,
       })
@@ -360,6 +372,7 @@ describe("formatVerdict", () => {
         unresolvedThreads: 0,
         checkRuns: allGreen(),
         changedPaths: CODE_CHANGE,
+        required: REQUIRED,
         codexReviewedSha: FULL_TIP.slice(0, 10),
         coderabbitReviewCount: 0,
       })
@@ -401,7 +414,7 @@ describe("missingRequired", () => {
     // its jobs while `secret-scan.yml` succeeded yields a non-empty,
     // all-green set containing no build and no tests. Absence is invisible to
     // any filter over what is present.
-    expect(missingRequired([green("gitleaks")], CODE_CHANGE)).toContain(
+    expect(missingRequired([green("gitleaks")], CODE_CHANGE, REQUIRED)).toContain(
       "Lint / Typecheck / Test / Build"
     );
   });
@@ -412,7 +425,7 @@ describe("missingRequired", () => {
     const runs = allGreen();
     runs[0] = queued("Lint / Typecheck / Test / Build");
 
-    expect(missingRequired(runs, CODE_CHANGE)).toEqual([]);
+    expect(missingRequired(runs, CODE_CHANGE, REQUIRED)).toEqual([]);
   });
 
   it("reports the integration legs a code change was due to run", () => {
@@ -424,7 +437,8 @@ describe("missingRequired", () => {
     expect(
       missingRequired(
         [green("Lint / Typecheck / Test / Build"), green("gitleaks")],
-        CODE_CHANGE
+        CODE_CHANGE,
+        REQUIRED
       )
     ).toEqual([
       "Integration (postgres)",
@@ -440,7 +454,8 @@ describe("missingRequired", () => {
     expect(
       missingRequired(
         [green("Lint / Typecheck / Test / Build"), green("gitleaks")],
-        DOCS_CHANGE
+        DOCS_CHANGE,
+        REQUIRED
       )
     ).toEqual([]);
   });
@@ -449,7 +464,7 @@ describe("missingRequired", () => {
     // An unknown change set must not excuse a check. The failure this whole
     // file guards is a gate reporting clean because it could not see, so the
     // unreadable case resolves toward demanding evidence.
-    expect(missingRequired([green("gitleaks")], undefined)).toEqual([
+    expect(missingRequired([green("gitleaks")], undefined, REQUIRED)).toEqual([
       "Lint / Typecheck / Test / Build",
       "Integration (postgres)",
       "Integration (mysql)",
@@ -458,7 +473,7 @@ describe("missingRequired", () => {
   });
 
   it("names the checks whose ABSENCE means no coverage", () => {
-    expect(REQUIRED_CHECKS.map(c => c.name)).toEqual([
+    expect(REQUIRED.map(c => c.name)).toEqual([
       "Lint / Typecheck / Test / Build",
       "gitleaks",
       "Integration (postgres)",
@@ -498,7 +513,7 @@ describe("workflowApplies", () => {
     // "mostly documentation" as ignored is how a code change loses its
     // database coverage.
     expect(
-      workflowApplies(INTEGRATION_PATHS_IGNORE, [
+      workflowApplies(PR_IGNORE, [
         "docs/guide.md",
         "packages/nextly/src/index.ts",
       ])
@@ -506,12 +521,12 @@ describe("workflowApplies", () => {
   });
 
   it("skips the workflow when every file matches", () => {
-    expect(workflowApplies(INTEGRATION_PATHS_IGNORE, DOCS_CHANGE)).toBe(false);
+    expect(workflowApplies(PR_IGNORE, DOCS_CHANGE)).toBe(false);
   });
 
   it("applies when the change set is unknown or empty", () => {
-    expect(workflowApplies(INTEGRATION_PATHS_IGNORE, undefined)).toBe(true);
-    expect(workflowApplies(INTEGRATION_PATHS_IGNORE, [])).toBe(true);
+    expect(workflowApplies(PR_IGNORE, undefined)).toBe(true);
+    expect(workflowApplies(PR_IGNORE, [])).toBe(true);
   });
 
   it("applies when the workflow declares no filter at all", () => {
@@ -572,6 +587,8 @@ describe("gateVerdict + required checks", () => {
       tip: "91fd9500285dcf264e3609a916b7518b591b51f3",
       unresolvedThreads: 0,
       checkRuns: [green("gitleaks")],
+      changedPaths: CODE_CHANGE,
+      required: REQUIRED,
       codexReviewedSha: "91fd950028",
       coderabbitReviewCount: 1,
     });
@@ -647,57 +664,83 @@ describe("REQUIRED_CHECKS", () => {
     // the enforcement gate. With only the CI job listed, a run where that
     // workflow created no check-run passed on an unrelated workflow being
     // green — absence being invisible, one workflow along.
-    expect(REQUIRED_CHECKS.map(c => c.name)).toContain("gitleaks");
+    expect(REQUIRED.map(c => c.name)).toContain("gitleaks");
 
     const withoutScan = allGreen().filter(run => run.name !== "gitleaks");
-    expect(missingRequired(withoutScan, CODE_CHANGE)).toEqual(["gitleaks"]);
+    expect(missingRequired(withoutScan, CODE_CHANGE, REQUIRED)).toEqual(["gitleaks"]);
   });
 });
 
-describe("INTEGRATION_PATHS_IGNORE against the workflow it mirrors", () => {
-  // The constant is a copy of a filter that lives in `integration.yml`, and two
-  // spellings of one rule drift silently — the copy keeps looking correct while
-  // the workflow moves underneath it, and the gate then excuses a check the
-  // workflow was due to create.
-  const workflow = readFileSync(
-    fileURLToPath(new URL("../.github/workflows/integration.yml", import.meta.url)),
-    "utf8"
-  );
+describe("workflowPathsIgnore", () => {
+  // Replaces a pair of tests that pinned a hand-copied constant against the
+  // workflow. The constant is gone: the gate reads the workflow directly, so
+  // there is no copy left to drift and nothing to pin. What remains to cover is
+  // the parser itself, which is now the only implementation of the filter.
+  it("reads the filter the workflow declares for a trigger", () => {
+    const globs = workflowPathsIgnore(INTEGRATION_YML, "pull_request");
 
-  /** The `paths-ignore` globs declared under one trigger in a workflow file. */
-  const declaredIgnores = trigger => {
-    const lines = workflow.split("\n");
-    const start = lines.findIndex(l => l.trimEnd() === `  ${trigger}:`);
-    if (start === -1) return [];
-    const globs = [];
-    let collecting = false;
-    for (const line of lines.slice(start + 1)) {
-      // Any line at the trigger's own indent or shallower ends the block, so a
-      // filter belonging to the NEXT trigger is never read as this one's.
-      if (/^ {0,2}\S/.test(line)) break;
-      if (line.trim() === "paths-ignore:") {
-        collecting = true;
-        continue;
-      }
-      if (!collecting) continue;
-      const entry = /^\s*-\s*["']?([^"'\s]+)["']?\s*$/.exec(line);
-      if (!entry) break;
-      globs.push(entry[1]);
-    }
-    return globs;
-  };
-
-  it("finds a filter at all, so a failed parse cannot read as agreement", () => {
-    // Without this, restructuring the workflow makes the extractor return
-    // nothing, and an empty list compares equal to an empty list — the parse
-    // failing would certify the mirror rather than fail the build.
-    expect(declaredIgnores("pull_request").length).toBeGreaterThan(0);
+    // Non-empty first: a parser that silently found nothing would satisfy any
+    // comparison against another empty list, so the failure to read would
+    // certify itself.
+    expect(globs.length).toBeGreaterThan(0);
+    expect(globs).toContain("docs/**");
   });
 
-  it("matches what the workflow actually declares", () => {
-    expect(declaredIgnores("pull_request")).toEqual([
-      ...INTEGRATION_PATHS_IGNORE,
-    ]);
+  it("reads the PUSH trigger too, which decides the post-merge run", () => {
+    // The checks judged after a merge come from `push` to the base branch, not
+    // from `pull_request`. The two blocks are edited independently, so a parser
+    // exercised on only one of them can be correct there and wrong for every
+    // merged pull request the gate looks at.
+    const globs = workflowPathsIgnore(INTEGRATION_YML, "push");
+
+    expect(globs.length).toBeGreaterThan(0);
+  });
+
+  it("stops at the end of the trigger's own block", () => {
+    // Without the dedent guard, a filter belonging to the NEXT trigger is read
+    // as this one's, so a workflow filtered on push and not on pull_request
+    // would excuse checks that were due to report.
+    const yaml = [
+      "on:",
+      "  pull_request:",
+      "    branches: [main]",
+      "  push:",
+      "    paths-ignore:",
+      '      - "docs/**"',
+    ].join("\n");
+
+    expect(workflowPathsIgnore(yaml, "pull_request")).toEqual([]);
+    expect(workflowPathsIgnore(yaml, "push")).toEqual(["docs/**"]);
+  });
+
+  it("returns nothing for a trigger the workflow does not declare", () => {
+    // Empty means "no filter", which `workflowApplies` treats as always
+    // applicable — the direction that requires the check rather than excusing
+    // it.
+    expect(workflowPathsIgnore(INTEGRATION_YML, "schedule")).toEqual([]);
+  });
+
+  it("refuses input it cannot read rather than reporting no filter", () => {
+    expect(() => workflowPathsIgnore(undefined, "push")).toThrow(TypeError);
+  });
+});
+
+describe("flatPages", () => {
+  it("refuses a page that could not be read", () => {
+    // `--paginate --slurp` returns a failed page as null. Flattening past it
+    // yields a SHORTER list that looks complete, and a shorter changed-file
+    // list can turn a source change into a documentation-only one and excuse
+    // every integration check.
+    expect(() => flatPages([[{ filename: "a.ts" }], null], "files")).toThrow(
+      TypeError
+    );
+    expect(() => flatPages(null, "files")).toThrow(TypeError);
+  });
+
+  it("passes pages that were all read", () => {
+    const pages = [[{ filename: "a.ts" }], [{ filename: "b.ts" }]];
+
+    expect(flatPages(pages, "files")).toEqual(pages);
   });
 });
 
@@ -780,6 +823,49 @@ describe("runCli", () => {
     // The control: without it, a wrapper returning 2 unconditionally passes.
     expect(runCli(["798"], () => 0)).toBe(0);
     expect(runCli(["798"], () => 1)).toBe(1);
+  });
+});
+
+describe("staleVerification", () => {
+  const A = "a".repeat(40);
+  const B = "b".repeat(40);
+
+  it("catches a merge that happened DURING the check, tip unchanged", () => {
+    // The case a tip comparison cannot see: merging usually leaves the branch
+    // untouched, so the revision matches while every answer above it was taken
+    // in the pre-merge mode — head checks, landed-whole never asked.
+    expect(
+      staleVerification({
+        mergedAtStart: false,
+        mergedNow: true,
+        tipAtStart: A,
+        tipNow: A,
+      })
+    ).toBe("merged-during-verification");
+  });
+
+  it("catches a push during the check", () => {
+    expect(
+      staleVerification({
+        mergedAtStart: false,
+        mergedNow: false,
+        tipAtStart: A,
+        tipNow: B,
+      })
+    ).toBe("head-moved");
+  });
+
+  it("reports nothing when neither moved", () => {
+    // The control. Without it, a function returning a reason unconditionally
+    // satisfies both cases above and the gate could never pass.
+    expect(
+      staleVerification({
+        mergedAtStart: true,
+        mergedNow: true,
+        tipAtStart: A,
+        tipNow: A,
+      })
+    ).toBe(null);
   });
 });
 

--- a/scripts/verify-merge.test.mjs
+++ b/scripts/verify-merge.test.mjs
@@ -1,0 +1,297 @@
+/**
+ * Every case here is a defect this repository actually shipped, written as the
+ * input that produced it.
+ *
+ * The procedure these functions replace lived as shell inside a Markdown rule.
+ * It was wrong in several ways at once and each one was found by a reviewer
+ * executing it mentally rather than by anything running it — so the tests are
+ * organised by the WRONG ANSWER each function used to give, not by its
+ * signature.
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  blockingJobs,
+  checkability,
+  countRewriteEvents,
+  formatVerdict,
+  gateVerdict,
+  jobPasses,
+  reviewCoverage,
+  verdictCoversTip,
+} from "./verify-merge.mjs";
+
+const forcePush = { event: "head_ref_force_pushed" };
+const commented = { event: "commented" };
+const green = name => ({ name, status: "completed", conclusion: "success" });
+const queued = name => ({ name, status: "queued", conclusion: null });
+
+describe("countRewriteEvents", () => {
+  it("counts events beyond the FIRST page", () => {
+    // The original read one page. The timeline is paged at 100 and pull
+    // requests here reach three pages, so a rewrite on page two counted as
+    // zero — which is the answer that lets the check proceed.
+    const pages = [[commented], [forcePush], [commented, forcePush]];
+
+    expect(countRewriteEvents(pages)).toBe(2);
+  });
+
+  it("counts a deletion and a recreation, not only a force-push", () => {
+    // Deleting a branch and recreating it at the merged head erases a tail
+    // exactly as a force-push does, and the recreated ref reads as ordinary.
+    const pages = [
+      [{ event: "head_ref_deleted" }, { event: "head_ref_restored" }],
+    ];
+
+    expect(countRewriteEvents(pages)).toBe(2);
+  });
+
+  it("ignores unrelated timeline events", () => {
+    // The control for the two above: if this returned non-zero, the cases
+    // above would pass whether or not the event names were matched at all.
+    expect(
+      countRewriteEvents([
+        [commented, { event: "labeled" }, { event: "merged" }],
+      ])
+    ).toBe(0);
+  });
+
+  it("refuses a non-array rather than treating it as empty", () => {
+    expect(() => countRewriteEvents(undefined)).toThrow(TypeError);
+  });
+});
+
+describe("checkability", () => {
+  it("refuses when the ref does not resolve", () => {
+    // Measured cause of a real false clean: a branch name typed from memory,
+    // one word off the real head ref. The empty result was read as "the branch
+    // was auto-deleted, nothing to check" on a pull request that HAD stranded a
+    // commit.
+    expect(checkability({ tip: "", rewriteEvents: 0 })).toEqual({
+      checkable: false,
+      reason: "no-ref",
+    });
+  });
+
+  it("refuses when the rewrite count could not be read", () => {
+    // The query that produces this count was piped into `awk`, and a pipeline
+    // reports the LAST command's status — so an authentication error reached
+    // `awk` as no input, which printed 0 and exited successfully.
+    expect(checkability({ tip: "abc1234", rewriteEvents: null }).reason).toBe(
+      "rewrite-count-unknown"
+    );
+  });
+
+  it("refuses when history was rewritten", () => {
+    expect(checkability({ tip: "abc1234", rewriteEvents: 1 }).reason).toBe(
+      "history-rewritten"
+    );
+  });
+
+  it("permits a present ref with no rewrites", () => {
+    // The positive control. Without it every case above passes on a function
+    // that refuses unconditionally.
+    expect(checkability({ tip: "abc1234", rewriteEvents: 0 })).toEqual({
+      checkable: true,
+      reason: "ok",
+    });
+  });
+});
+
+describe("jobPasses", () => {
+  it("does NOT pass a queued job", () => {
+    // The defect this exists for. Filtering for `conclusion === "failure"` and
+    // finding none reads as green; one merge commit here had four required
+    // jobs queued for hours and answered zero failures the whole time.
+    expect(jobPasses(queued("Lint / Typecheck / Test / Build"))).toBe(false);
+  });
+
+  it("does NOT pass a cancelled job", () => {
+    // A concurrency group superseding a run reports `cancelled`, which is
+    // indistinguishable from a failure to a gate that only looks for failures.
+    expect(
+      jobPasses({ name: "CI", status: "completed", conclusion: "cancelled" })
+    ).toBe(false);
+  });
+
+  it("passes a job skipped by a condition", () => {
+    // How this repository says "this commit cannot affect me". Branch
+    // protection accepts it, so the gate must too.
+    expect(
+      jobPasses({
+        name: "Browser tests",
+        status: "completed",
+        conclusion: "skipped",
+      })
+    ).toBe(true);
+  });
+
+  it("passes a successful job", () => {
+    expect(jobPasses(green("CI"))).toBe(true);
+  });
+});
+
+describe("blockingJobs", () => {
+  it("names the jobs rather than counting them", () => {
+    // A count sends the reader to the web UI. A name tells them whether the red
+    // is theirs — which is what separates attributing a failure from
+    // inheriting one, and four of tonight's reds were inherited.
+    const runs = [green("gitleaks"), queued("Browser tests")];
+
+    expect(blockingJobs(runs)).toEqual([
+      { name: "Browser tests", status: "queued", conclusion: null },
+    ]);
+  });
+
+  it("returns nothing when every job passes", () => {
+    expect(blockingJobs([green("a"), green("b")])).toEqual([]);
+  });
+});
+
+describe("verdictCoversTip", () => {
+  it("rejects a verdict from an earlier revision", () => {
+    // The incident behind all of this: a merge computed from a head that had
+    // moved. A verdict describes the tree it read, and carried forward it is an
+    // opinion about a revision nobody is merging.
+    expect(
+      verdictCoversTip("0dbcb9470", "ec025e8a80b262e426f780479d8346ac1a9788ae")
+    ).toBe(false);
+  });
+
+  it("accepts a short sha that prefixes the tip", () => {
+    expect(
+      verdictCoversTip("91fd950028", "91fd9500285dcf264e3609a916b7518b591b51f3")
+    ).toBe(true);
+  });
+
+  it("rejects a prefix too short to identify a commit", () => {
+    // "a" prefixes an enormous number of commits. Accepting it would make the
+    // comparison pass on almost anything.
+    expect(verdictCoversTip("a", "abc1234def")).toBe(false);
+  });
+
+  it("rejects a missing verdict rather than treating absence as agreement", () => {
+    expect(verdictCoversTip("", "abc1234def")).toBe(false);
+    expect(verdictCoversTip(undefined, "abc1234def")).toBe(false);
+  });
+});
+
+describe("reviewCoverage", () => {
+  it("separates never-looked from looked-and-found-nothing", () => {
+    // These render identically in every count-based gate. Two CI-wide changes
+    // merged here with a reviewer that never ran, showing zero findings.
+    expect(reviewCoverage(0)).toBe("not-reviewed");
+    expect(reviewCoverage(3)).toBe("reviewed");
+  });
+
+  it("reports an unreadable count as unknown, not as reviewed", () => {
+    expect(reviewCoverage(null)).toBe("unknown");
+  });
+});
+
+describe("gateVerdict", () => {
+  const passing = {
+    tip: "91fd9500285dcf264e3609a916b7518b591b51f3",
+    unresolvedThreads: 0,
+    checkRuns: [green("CI"), green("gitleaks")],
+    codexReviewedSha: "91fd950028",
+    coderabbitReviewCount: 3,
+  };
+
+  it("passes a revision that meets every condition", () => {
+    // The positive control for every case below. Without it they all pass on a
+    // gate that blocks unconditionally.
+    const verdict = gateVerdict(passing);
+
+    expect(verdict.mergeable).toBe(true);
+    expect(verdict.blockers).toEqual([]);
+  });
+
+  it("blocks when jobs are merely QUEUED", () => {
+    const verdict = gateVerdict({
+      ...passing,
+      checkRuns: [green("CI"), queued("Browser tests")],
+    });
+
+    expect(verdict.mergeable).toBe(false);
+    expect(verdict.blockers.map(b => b.kind)).toContain("job-not-green");
+  });
+
+  it("blocks when NO jobs reported at all", () => {
+    // Not a pass. It is the shape of a run that never started, and a pull
+    // request merged here in exactly that state.
+    const verdict = gateVerdict({ ...passing, checkRuns: [] });
+
+    expect(verdict.blockers.map(b => b.kind)).toContain("no-checks");
+  });
+
+  it("blocks on an unreadable thread count rather than assuming zero", () => {
+    const verdict = gateVerdict({ ...passing, unresolvedThreads: null });
+
+    expect(verdict.blockers.map(b => b.kind)).toContain("threads-unknown");
+  });
+
+  it("blocks when the review verdict belongs to an earlier revision", () => {
+    const verdict = gateVerdict({ ...passing, codexReviewedSha: "0dbcb9470" });
+
+    expect(verdict.blockers.map(b => b.kind)).toContain("verdict-stale");
+  });
+
+  it("reports an unreviewed second reviewer WITHOUT blocking on it", () => {
+    // The project runs with one reviewer deliberately. The requirement is that
+    // its silence is never read as coverage, not that it gates.
+    const verdict = gateVerdict({ ...passing, coderabbitReviewCount: 0 });
+
+    expect(verdict.mergeable).toBe(true);
+    expect(verdict.secondReviewer).toBe("not-reviewed");
+  });
+
+  it("reports EVERY blocker, not the first", () => {
+    // One round of fixing should clear the gate rather than reveal the next
+    // reason the merge was never going to happen.
+    const verdict = gateVerdict({
+      ...passing,
+      unresolvedThreads: 2,
+      checkRuns: [queued("CI")],
+      codexReviewedSha: "0dbcb9470",
+    });
+
+    expect(verdict.blockers.map(b => b.kind).sort()).toEqual([
+      "job-not-green",
+      "unresolved-threads",
+      "verdict-stale",
+    ]);
+  });
+});
+
+describe("formatVerdict", () => {
+  it("says BLOCKED and names each reason", () => {
+    const text = formatVerdict(
+      gateVerdict({
+        tip: "abc1234def",
+        unresolvedThreads: 1,
+        checkRuns: [green("CI")],
+        codexReviewedSha: "abc1234def",
+        coderabbitReviewCount: 1,
+      })
+    );
+
+    expect(text).toContain("GATE BLOCKED");
+    expect(text).toContain("unresolved-threads");
+  });
+
+  it("flags an unreviewed second reviewer on an otherwise passing gate", () => {
+    const text = formatVerdict(
+      gateVerdict({
+        tip: "abc1234def",
+        unresolvedThreads: 0,
+        checkRuns: [green("CI")],
+        codexReviewedSha: "abc1234def",
+        coderabbitReviewCount: 0,
+      })
+    );
+
+    expect(text).toContain("GATE PASSED");
+    expect(text).toContain("not-reviewed");
+  });
+});


### PR DESCRIPTION
## Why

`.claude/rules/verifying-merged-work.md` carried the merge-verification procedure as **runnable shell inside Markdown**. Nothing executes it, so nothing checked it — and it was wrong in three separate ways that each read as a pass:

- a rewrite count **computed and never read**, so the guard existed only in the prose beside it
- an **exit status swallowed** by the `awk` that consumed the query's output, so a failed API call counted as zero force-pushes
- a diff taken against `pull_request.base.sha`, which **advances with `main`**, so a one-file PR read as six

Each was found by a reviewer executing the snippet mentally, one at a time. That PR took 20 review findings, almost all execution-level.

## What this does

Moves the *decisions* into `scripts/verify-merge.mjs` as pure functions, leaving every I/O call to the caller — a function that fetches cannot be handed the case it must get right.

Follows the existing prior art exactly: `scripts/release/check-changesets.mjs` and its `.test.mjs` neighbour, run by `pnpm test:scripts`, already wired into CI. `scripts/` is lint-exempt repo-wide, so the test suite *is* the control there.

| function | the wrong answer it used to give |
| --- | --- |
| `countRewriteEvents` | read page one only; a rewrite on page two counted as zero |
| `checkability` | an unresolvable ref and an unreadable count both read as "clean" |
| `jobPasses` | `queued` counted as not-failing, therefore as green |
| `blockingJobs` | a count, which cannot tell you whether the red is yours |
| `verdictCoversTip` | a verdict from an earlier revision accepted for this one |
| `reviewCoverage` | "never looked" and "looked, found nothing" rendered identically |
| `gateVerdict` | first blocker only, so fixing one revealed the next |

## Tests are the cases we actually shipped

Organised by the wrong answer rather than by signature. Every one is a real incident: a timeline rewrite on the second page, a branch name one word off the real head ref, four required jobs queued for hours answering "zero failures", a review verdict belonging to a head that had moved, and two CI-wide changes merged with a reviewer that never ran.

**Every guarded behaviour was mutation-verified** — reverted, and the tests that name it confirmed to fail:

```
A: queued counts as passing        -> 5 failed
B: only the first timeline page    -> 1 failed
C: any verdict covers any tip      -> 3 failed
D: unreadable rewrite count = zero -> 1 failed
E: zero reviews = reviewed         -> 3 failed
restored                           -> 122 passed
```

Positive controls included throughout, because every case that asserts a refusal passes on a function that refuses unconditionally.

## The rule now cites the script

The snippets stay — the reasoning is worth reading — but the rule states plainly that **when the two disagree, the script is the one with tests**.

## Also

The CI step was named `Release script tests` while running `--dir scripts`. It now covers a non-release script, so the name would have sent someone looking for this file to the wrong place. Renamed to `Script tests`.

`pnpm test:scripts`: **122 passed, 4 files**. CI-and-tooling only: no changeset.
