### PR TITLE
fix(nextly): refuse field updates needing main-table ddl

### DIFF
--- a/.changeset/field-group-update-refuses-ddl.md
+++ b/.changeset/field-group-update-refuses-ddl.md
@@ -1,0 +1,28 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+Updating a field group now refuses a field change that would need a column on its main table, pointing the caller at the schema preview and apply flow. Previously the request succeeded, recorded the new fields, and left the table without the columns it claimed to have.

--- a/packages/nextly/src/domains/field-groups/services/__tests__/field-group-metadata-apply-contract.test.ts
+++ b/packages/nextly/src/domains/field-groups/services/__tests__/field-group-metadata-apply-contract.test.ts
@@ -866,6 +866,63 @@ describe("a field-group update refuses what it cannot deliver", () => {
     expect(registry.updateComponent).not.toHaveBeenCalled();
   });
 
+  // 🔴 The cost of recording columnless fields in the companion map, corrected. Swapping one
+  // `component` field for a differently named one is one add and one drop BY KEY, which reads as a
+  // rename pair — while neither materialises a companion column and the reconciler emits nothing
+  // for either. Refusing it would reject a safe metadata-only edit.
+  it("allows swapping one columnless localized field for another", async () => {
+    const registry = registryWithGroup({
+      localized: true,
+      fields: [{ name: "body", type: "component", localized: true }] as never,
+    });
+    const adapter = adapterDouble(async () => true);
+    const service = serviceOver(
+      registry as unknown as ReturnType<typeof registryDouble>,
+      adapter
+    );
+
+    await expect(
+      service.updateFieldGroup({
+        slug: "hero",
+        fields: [
+          { name: "aside", type: "component", localized: true },
+        ] as never,
+      })
+    ).resolves.toMatchObject({
+      record: expect.objectContaining({ slug: "hero" }),
+    });
+  });
+
+  // The control that keeps the narrowing from swallowing the rename it was carved out of: two
+  // fields that DO render columns, swapped, is still the destructive pair.
+  it("still refuses a rename between two column-backed localized fields", async () => {
+    const registry = registryWithGroup({
+      localized: true,
+      fields: [{ name: "body", type: "text", localized: true }] as never,
+    });
+    const adapter = adapterDouble(async () => true);
+    const service = serviceOver(
+      registry as unknown as ReturnType<typeof registryDouble>,
+      adapter
+    );
+
+    const refusal = await service
+      .updateFieldGroup({
+        slug: "hero",
+        fields: [{ name: "aside", type: "text", localized: true }] as never,
+      })
+      .catch((error: unknown) => error);
+
+    expect(refusal).toMatchObject({
+      code: "VALIDATION_ERROR",
+      publicData: {
+        errors: expect.arrayContaining([
+          expect.objectContaining({ code: "requires_schema_change" }),
+        ]),
+      },
+    });
+  });
+
   // A layout-only field has no column anywhere, so adding one cannot need DDL on any table.
   it("allows a field that produces no column at all", async () => {
     const registry = registryWithGroup({

--- a/packages/nextly/src/domains/field-groups/services/__tests__/field-group-metadata-apply-contract.test.ts
+++ b/packages/nextly/src/domains/field-groups/services/__tests__/field-group-metadata-apply-contract.test.ts
@@ -85,9 +85,15 @@ function registryDouble() {
  * failure these tests inject; routing it into the exclusion's probe as well would refuse the create
  * before it started, and every assertion below would be describing a different path.
  */
-function adapterDouble(tableExists: () => Promise<boolean>) {
+function adapterDouble(
+  tableExists: () => Promise<boolean>,
+  // The dialect the service reads its column shapes for. Parameterised because whether a change
+  // needs DDL is a per-dialect question: the same `maxLength` edit alters a MySQL VARCHAR and
+  // leaves a SQLite TEXT untouched, and a guard tested on one dialect says nothing about the other.
+  dialect: "postgresql" | "mysql" | "sqlite" = "postgresql"
+) {
   return withMigrationLockSurface({
-    getCapabilities: () => ({ dialect: "postgresql" as const }),
+    getCapabilities: () => ({ dialect }),
     // The parameter is declared even though nothing here reads it: `entityStatements` reads the
     // recorded calls, and a mock with no declared parameters records them as an empty tuple.
     executeQuery: vi.fn(async (_sql: string) => []),
@@ -465,6 +471,105 @@ describe("a field-group update refuses what it cannot deliver", () => {
       .updateFieldGroup({
         slug: "hero",
         fields: [{ name: "score", type: "number", dbType: "decimal" }] as never,
+      })
+      .catch((error: unknown) => error);
+
+    expect(refusal).toMatchObject({
+      code: "VALIDATION_ERROR",
+      publicData: {
+        errors: [
+          expect.objectContaining({
+            path: "fields.score",
+            code: "requires_schema_change",
+          }),
+        ],
+      },
+    });
+    expect(registry.updateComponent).not.toHaveBeenCalled();
+  });
+
+  // 🔴 THE case a column comparison cannot see. `unique` creates `uq_<table>_<column>` and leaves
+  // the column itself byte-identical, so a check that reads only the column shape accepts the edit
+  // and the constraint is never created — duplicates stay physically permitted while the registry
+  // records the field as unique.
+  it("refuses a uniqueness change, which alters an index and not the column", async () => {
+    const registry = registryWithGroup({
+      fields: [{ name: "code", type: "text" }],
+    });
+    const adapter = adapterDouble(async () => true);
+    const service = serviceOver(
+      registry as unknown as ReturnType<typeof registryDouble>,
+      adapter
+    );
+
+    const refusal = await service
+      .updateFieldGroup({
+        slug: "hero",
+        fields: [{ name: "code", type: "text", unique: true }] as never,
+      })
+      .catch((error: unknown) => error);
+
+    expect(refusal).toMatchObject({
+      code: "VALIDATION_ERROR",
+      publicData: {
+        errors: [
+          expect.objectContaining({
+            path: "fields.code",
+            code: "requires_schema_change",
+          }),
+        ],
+      },
+    });
+    expect(registry.updateComponent).not.toHaveBeenCalled();
+  });
+
+  // 🔴 THE control against over-refusing. SQLite has one string type, so a `maxLength` edit renders
+  // to the same TEXT column and needs no DDL at all. Refusing it would send a caller to an apply
+  // flow for a database change that does not exist — and the Direct API has no apply flow to send
+  // them to.
+  it("allows a bound change that renders to the same column on this dialect", async () => {
+    const registry = registryWithGroup({
+      fields: [{ name: "heading", type: "text", maxLength: 100 }] as never,
+    });
+    const adapter = adapterDouble(async () => true, "sqlite");
+    const service = serviceOver(
+      registry as unknown as ReturnType<typeof registryDouble>,
+      adapter
+    );
+
+    await expect(
+      service.updateFieldGroup({
+        slug: "hero",
+        fields: [{ name: "heading", type: "text", maxLength: 255 }] as never,
+      })
+    ).resolves.toMatchObject({
+      record: expect.objectContaining({ slug: "hero" }),
+    });
+  });
+
+  // 🔴 THE case the main table cannot see, because the column is not on it. A localized field's
+  // column lives in `comp_<slug>_locales`, and the companion reconciler diffs that table by NAME
+  // only — so a same-named field whose storage changes emits no ALTER there either, and the group
+  // would advance describing a column shape the companion does not have.
+  it("refuses a storage change to a field whose column lives in the companion", async () => {
+    const registry = registryWithGroup({
+      localized: true,
+      fields: [
+        { name: "score", type: "number", dbType: "integer", localized: true },
+      ] as never,
+    });
+    const adapter = adapterDouble(async () => true);
+    const service = serviceOver(
+      registry as unknown as ReturnType<typeof registryDouble>,
+      adapter
+    );
+
+    const refusal = await service
+      .updateFieldGroup({
+        slug: "hero",
+        fields: [
+          { name: "score", type: "number", dbType: "decimal", localized: true },
+        ] as never,
       })
       .catch((error: unknown) => error);
 

--- a/packages/nextly/src/domains/field-groups/services/__tests__/field-group-metadata-apply-contract.test.ts
+++ b/packages/nextly/src/domains/field-groups/services/__tests__/field-group-metadata-apply-contract.test.ts
@@ -28,6 +28,10 @@ vi.mock("../field-group-table-provisioning", () => ({
     bound.push(tableName);
   }),
   reconcileComponentCompanion: vi.fn(async () => {}),
+  // The update path probes which discriminator column the existing table carries before it moves
+  // anything. Stubbed to the current spelling: these tests are about which field CHANGES are
+  // accepted, and a real probe would make every one of them a test of the catalog instead.
+  resolveComponentTypeColumn: vi.fn(async () => "type"),
 }));
 
 import type { DrizzleAdapter } from "@nextlyhq/adapter-drizzle";
@@ -327,5 +331,126 @@ describe("a create whose generated names would not fit is refused", () => {
     });
 
     expect(migrationStatus).toBe("applied");
+  });
+});
+
+/**
+ * A registry that returns a stored field group, so an UPDATE can be driven through the service.
+ *
+ * `getComponent` is what the update re-reads inside the exclusion to re-establish its preconditions,
+ * so it decides both the old field set the diff is taken against and whether the group is localized.
+ */
+function registryWithGroup(args: {
+  fields: { name: string; type: string; localized?: boolean }[];
+  localized?: boolean;
+}) {
+  const record = {
+    slug: "hero",
+    tableName: "comp_hero",
+    fields: args.fields,
+    localized: args.localized ?? false,
+    locked: false,
+    schemaVersion: 1,
+  };
+  return {
+    getAllComponents: vi.fn().mockResolvedValue([]),
+    registerComponent: vi.fn(async (row: unknown) => row),
+    getComponent: vi.fn().mockResolvedValue(record),
+    updateComponent: vi.fn(async () => record),
+  };
+}
+
+describe("a field-group update refuses what it cannot deliver", () => {
+  // 🔴 THE defect this guards. This path alters the COMPANION table only, so a field whose column
+  // lives on the main table needs DDL it never emits — and before the guard the request answered
+  // SUCCESS while writing a schema hash for columns that were never created.
+  it("refuses a field that needs a column on the main table", async () => {
+    const registry = registryWithGroup({
+      fields: [{ name: "heading", type: "text" }],
+    });
+    const adapter = adapterDouble(async () => true);
+    const service = serviceOver(
+      registry as unknown as ReturnType<typeof registryDouble>,
+      adapter
+    );
+
+    const refusal = await service
+      .updateFieldGroup({
+        slug: "hero",
+        fields: [
+          { name: "heading", type: "text" },
+          { name: "subheading", type: "text" },
+        ] as never,
+      })
+      .catch((error: unknown) => error);
+
+    // Asserted on the REASON, not the code: this method raises VALIDATION_ERROR for a malformed
+    // plugin option too, so the code alone cannot tell the two apart.
+    expect(refusal).toMatchObject({
+      code: "VALIDATION_ERROR",
+      publicData: {
+        errors: [
+          expect.objectContaining({
+            path: "fields.subheading",
+            code: "requires_schema_change",
+          }),
+        ],
+      },
+    });
+    // Nothing was written: a refusal has to happen before the row moves, not after.
+    expect(registry.updateComponent).not.toHaveBeenCalled();
+  });
+
+  // 🔴 THE control that stops the guard from breaking the one path that works. A translatable field
+  // on a LOCALIZED group lives in `comp_<slug>_locales`, which `reconcileCompanion` does apply — so
+  // refusing it would take away working behaviour in the name of fixing a defect.
+  it("allows a translatable field on a localized group, which the companion applies", async () => {
+    const registry = registryWithGroup({
+      localized: true,
+      fields: [{ name: "heading", type: "text", localized: true }],
+    });
+    const adapter = adapterDouble(async () => true);
+    const service = serviceOver(
+      registry as unknown as ReturnType<typeof registryDouble>,
+      adapter
+    );
+
+    await expect(
+      service.updateFieldGroup({
+        slug: "hero",
+        fields: [
+          { name: "heading", type: "text", localized: true },
+          { name: "subheading", type: "text", localized: true },
+        ] as never,
+      })
+    ).resolves.toMatchObject({
+      record: expect.objectContaining({ slug: "hero" }),
+    });
+
+    expect(registry.updateComponent).toHaveBeenCalled();
+  });
+
+  // A layout-only field has no column anywhere, so adding one cannot need DDL on any table.
+  it("allows a field that produces no column at all", async () => {
+    const registry = registryWithGroup({
+      fields: [{ name: "heading", type: "text" }],
+    });
+    const adapter = adapterDouble(async () => true);
+    const service = serviceOver(
+      registry as unknown as ReturnType<typeof registryDouble>,
+      adapter
+    );
+
+    await expect(
+      service.updateFieldGroup({
+        slug: "hero",
+        fields: [
+          { name: "heading", type: "text" },
+          { name: "layout", type: "component" },
+        ] as never,
+      })
+    ).resolves.toMatchObject({
+      record: expect.objectContaining({ slug: "hero" }),
+    });
   });
 });

--- a/packages/nextly/src/domains/field-groups/services/__tests__/field-group-metadata-apply-contract.test.ts
+++ b/packages/nextly/src/domains/field-groups/services/__tests__/field-group-metadata-apply-contract.test.ts
@@ -799,6 +799,73 @@ describe("a field-group update refuses what it cannot deliver", () => {
     });
   });
 
+  // 🔴 THE transition a column-shape comparison cannot see, because one side HAS no column. A
+  // localized `component` field stores its data in its own table and materialises nothing in the
+  // companion; changing it to `text` under the same name needs an ADD COLUMN that the reconciler
+  // never emits — it diffs raw localized NAMES, and the name was already there. The registry and
+  // the runtime would advance to a companion column nothing created.
+  it("refuses a localized field that gains a companion column under the same name", async () => {
+    const registry = registryWithGroup({
+      localized: true,
+      fields: [{ name: "body", type: "component", localized: true }] as never,
+    });
+    const adapter = adapterDouble(async () => true);
+    const service = serviceOver(
+      registry as unknown as ReturnType<typeof registryDouble>,
+      adapter
+    );
+
+    const refusal = await service
+      .updateFieldGroup({
+        slug: "hero",
+        fields: [{ name: "body", type: "text", localized: true }] as never,
+      })
+      .catch((error: unknown) => error);
+
+    expect(refusal).toMatchObject({
+      code: "VALIDATION_ERROR",
+      publicData: {
+        errors: expect.arrayContaining([
+          expect.objectContaining({
+            path: "fields.body",
+            code: "requires_schema_change",
+          }),
+        ]),
+      },
+    });
+    expect(registry.updateComponent).not.toHaveBeenCalled();
+  });
+
+  // The reverse, which strands the old column instead of missing a new one.
+  it("refuses a localized field that loses its companion column", async () => {
+    const registry = registryWithGroup({
+      localized: true,
+      fields: [{ name: "body", type: "text", localized: true }] as never,
+    });
+    const adapter = adapterDouble(async () => true);
+    const service = serviceOver(
+      registry as unknown as ReturnType<typeof registryDouble>,
+      adapter
+    );
+
+    const refusal = await service
+      .updateFieldGroup({
+        slug: "hero",
+        fields: [{ name: "body", type: "component", localized: true }] as never,
+      })
+      .catch((error: unknown) => error);
+
+    expect(refusal).toMatchObject({
+      code: "VALIDATION_ERROR",
+      publicData: {
+        errors: expect.arrayContaining([
+          expect.objectContaining({ code: "requires_schema_change" }),
+        ]),
+      },
+    });
+    expect(registry.updateComponent).not.toHaveBeenCalled();
+  });
+
   // A layout-only field has no column anywhere, so adding one cannot need DDL on any table.
   it("allows a field that produces no column at all", async () => {
     const registry = registryWithGroup({

--- a/packages/nextly/src/domains/field-groups/services/__tests__/field-group-metadata-apply-contract.test.ts
+++ b/packages/nextly/src/domains/field-groups/services/__tests__/field-group-metadata-apply-contract.test.ts
@@ -34,6 +34,14 @@ vi.mock("../field-group-table-provisioning", () => ({
   resolveComponentTypeColumn: vi.fn(async () => "type"),
 }));
 
+// Enabling localization is gated on the app declaring a `localization` block, and that gate runs
+// BEFORE the schema check these tests are about. Left real, a fixture that turns localization on
+// is refused for a missing config and never reaches the guard — a test passing on the wrong
+// rejection. Its own behaviour is covered where it lives.
+vi.mock("../../../i18n/config/require-app-config", () => ({
+  assertLocalizationConfigured: vi.fn(),
+}));
+
 import type { DrizzleAdapter } from "@nextlyhq/adapter-drizzle";
 
 import { NextlyError } from "../../../../errors";
@@ -579,6 +587,119 @@ describe("a field-group update refuses what it cannot deliver", () => {
         errors: [
           expect.objectContaining({
             path: "fields.score",
+            code: "requires_schema_change",
+          }),
+        ],
+      },
+    });
+    expect(registry.updateComponent).not.toHaveBeenCalled();
+  });
+
+  // 🔴 THE case that DESTROYS content rather than leaving a stale shape. `heading` -> `title` on an
+  // already-localized group is invisible to a name-keyed comparison, and the companion reconciler
+  // reads it as ADD `title`, DROP `heading` — every stored translation goes with the drop, with no
+  // rename resolution because a PATCH has nowhere to ask the question.
+  it("refuses a rename on a localized group, which the companion would apply as a drop", async () => {
+    const registry = registryWithGroup({
+      localized: true,
+      fields: [{ name: "heading", type: "text", localized: true }],
+    });
+    const adapter = adapterDouble(async () => true);
+    const service = serviceOver(
+      registry as unknown as ReturnType<typeof registryDouble>,
+      adapter
+    );
+
+    const refusal = await service
+      .updateFieldGroup({
+        slug: "hero",
+        fields: [{ name: "title", type: "text", localized: true }] as never,
+      })
+      .catch((error: unknown) => error);
+
+    expect(refusal).toMatchObject({
+      code: "VALIDATION_ERROR",
+      publicData: {
+        errors: expect.arrayContaining([
+          expect.objectContaining({
+            path: "fields.title",
+            code: "requires_schema_change",
+          }),
+          expect.objectContaining({
+            path: "fields.heading",
+            code: "requires_schema_change",
+          }),
+        ]),
+      },
+    });
+    expect(registry.updateComponent).not.toHaveBeenCalled();
+  });
+
+  // 🔴 The same ambiguity through the OTHER companion path. Enabling localization while renaming
+  // hides the change twice over: both names are translatable under the requested state, so neither
+  // appears on the main table, and the enable planner seeds only new columns whose name already
+  // exists on main — so `title` is seeded from nothing and `heading` is left behind on main.
+  it("refuses a rename that arrives with localization being enabled", async () => {
+    const registry = registryWithGroup({
+      localized: false,
+      fields: [{ name: "heading", type: "text", localized: true }],
+    });
+    const adapter = adapterDouble(async () => true);
+    const service = serviceOver(
+      registry as unknown as ReturnType<typeof registryDouble>,
+      adapter
+    );
+
+    const refusal = await service
+      .updateFieldGroup({
+        slug: "hero",
+        localized: true,
+        fields: [{ name: "title", type: "text", localized: true }] as never,
+      })
+      .catch((error: unknown) => error);
+
+    expect(refusal).toMatchObject({
+      code: "VALIDATION_ERROR",
+      publicData: {
+        errors: expect.arrayContaining([
+          expect.objectContaining({ code: "requires_schema_change" }),
+        ]),
+      },
+    });
+    expect(registry.updateComponent).not.toHaveBeenCalled();
+  });
+
+  // 🔴 THE property the desired-table builder drops on purpose. It carries no DEFAULT for a user
+  // column, because the diff engine compares it against a live database whose reported defaults
+  // would otherwise churn — but the field group's CREATOR does emit a checkbox default, so a
+  // `defaultValue` edit changes the column while leaving the desired table byte-identical.
+  it("refuses a checkbox default change, which the desired table does not carry", async () => {
+    const registry = registryWithGroup({
+      fields: [
+        { name: "featured", type: "checkbox", defaultValue: false },
+      ] as never,
+    });
+    const adapter = adapterDouble(async () => true);
+    const service = serviceOver(
+      registry as unknown as ReturnType<typeof registryDouble>,
+      adapter
+    );
+
+    const refusal = await service
+      .updateFieldGroup({
+        slug: "hero",
+        fields: [
+          { name: "featured", type: "checkbox", defaultValue: true },
+        ] as never,
+      })
+      .catch((error: unknown) => error);
+
+    expect(refusal).toMatchObject({
+      code: "VALIDATION_ERROR",
+      publicData: {
+        errors: [
+          expect.objectContaining({
+            path: "fields.featured",
             code: "requires_schema_change",
           }),
         ],

--- a/packages/nextly/src/domains/field-groups/services/__tests__/field-group-metadata-apply-contract.test.ts
+++ b/packages/nextly/src/domains/field-groups/services/__tests__/field-group-metadata-apply-contract.test.ts
@@ -427,7 +427,59 @@ describe("a field-group update refuses what it cannot deliver", () => {
       record: expect.objectContaining({ slug: "hero" }),
     });
 
+    // 🔴 Asserted on the COMPANION CALL, not on the registry write. Checking only that the row was
+    // updated leaves the control green if `reconcileCompanion` were removed or bypassed — the
+    // promise still resolves and `updateComponent` is still reached, while `subheading` is never
+    // added to `comp_hero_locales`. The claim is "the companion applies it", so the companion call
+    // is what has to be observed.
+    const { reconcileComponentCompanion } = await import(
+      "../field-group-table-provisioning"
+    );
+    expect(reconcileComponentCompanion).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tableName: "comp_hero",
+        localized: true,
+        newFields: expect.arrayContaining([
+          expect.objectContaining({ name: "subheading" }),
+        ]),
+      })
+    );
     expect(registry.updateComponent).toHaveBeenCalled();
+  });
+
+  // 🔴 THE case a definition-level diff cannot see. The field keeps its name and its `type`, so a
+  // predicate comparing field definitions reports no change — while `integer` -> `decimal` alters
+  // the column on every dialect. Comparing what the DDL generator would BUILD catches it; comparing
+  // what the author wrote does not.
+  it("refuses a storage change that leaves the field definition looking the same", async () => {
+    const registry = registryWithGroup({
+      fields: [{ name: "score", type: "number", dbType: "integer" }] as never,
+    });
+    const adapter = adapterDouble(async () => true);
+    const service = serviceOver(
+      registry as unknown as ReturnType<typeof registryDouble>,
+      adapter
+    );
+
+    const refusal = await service
+      .updateFieldGroup({
+        slug: "hero",
+        fields: [{ name: "score", type: "number", dbType: "decimal" }] as never,
+      })
+      .catch((error: unknown) => error);
+
+    expect(refusal).toMatchObject({
+      code: "VALIDATION_ERROR",
+      publicData: {
+        errors: [
+          expect.objectContaining({
+            path: "fields.score",
+            code: "requires_schema_change",
+          }),
+        ],
+      },
+    });
+    expect(registry.updateComponent).not.toHaveBeenCalled();
   });
 
   // A layout-only field has no column anywhere, so adding one cannot need DDL on any table.

--- a/packages/nextly/src/domains/field-groups/services/__tests__/field-group-metadata-apply-contract.test.ts
+++ b/packages/nextly/src/domains/field-groups/services/__tests__/field-group-metadata-apply-contract.test.ts
@@ -708,6 +708,68 @@ describe("a field-group update refuses what it cannot deliver", () => {
     expect(registry.updateComponent).not.toHaveBeenCalled();
   });
 
+  // 🔴 THE one-sided case the PAIR rule cannot see. Enabling localization while REMOVING a
+  // translatable field: the removal has no matching add, so the rename check passes it, both main
+  // snapshots omit the field because it is translatable under the requested state, and the enable
+  // planner derives its companion from the NEW fields alone — so nothing drops the column that is
+  // still physically on the main table. The registry would stop describing a field whose data is
+  // sitting on a column nothing will read again.
+  it("refuses removing a translatable field while localization is being enabled", async () => {
+    const registry = registryWithGroup({
+      localized: false,
+      fields: [
+        { name: "heading", type: "text", localized: true },
+        { name: "body", type: "text", localized: true },
+      ] as never,
+    });
+    const adapter = adapterDouble(async () => true);
+    const service = serviceOver(
+      registry as unknown as ReturnType<typeof registryDouble>,
+      adapter
+    );
+
+    const refusal = await service
+      .updateFieldGroup({
+        slug: "hero",
+        localized: true,
+        fields: [{ name: "heading", type: "text", localized: true }] as never,
+      })
+      .catch((error: unknown) => error);
+
+    expect(refusal).toMatchObject({
+      code: "VALIDATION_ERROR",
+      publicData: {
+        errors: expect.arrayContaining([
+          expect.objectContaining({
+            path: "fields.body",
+            code: "requires_schema_change",
+          }),
+        ]),
+      },
+    });
+    expect(registry.updateComponent).not.toHaveBeenCalled();
+  });
+
+  // The control that keeps the enable path usable: a plain enable, dropping nothing, still works.
+  // Without it a rule that refused every enable would satisfy the case above.
+  it("allows a plain enable that removes no translatable field", async () => {
+    const registry = registryWithGroup({
+      localized: false,
+      fields: [{ name: "heading", type: "text", localized: true }] as never,
+    });
+    const adapter = adapterDouble(async () => true);
+    const service = serviceOver(
+      registry as unknown as ReturnType<typeof registryDouble>,
+      adapter
+    );
+
+    await expect(
+      service.updateFieldGroup({ slug: "hero", localized: true })
+    ).resolves.toMatchObject({
+      record: expect.objectContaining({ slug: "hero" }),
+    });
+  });
+
   // A layout-only field has no column anywhere, so adding one cannot need DDL on any table.
   it("allows a field that produces no column at all", async () => {
     const registry = registryWithGroup({

--- a/packages/nextly/src/domains/field-groups/services/__tests__/field-group-metadata-apply-contract.test.ts
+++ b/packages/nextly/src/domains/field-groups/services/__tests__/field-group-metadata-apply-contract.test.ts
@@ -770,6 +770,35 @@ describe("a field-group update refuses what it cannot deliver", () => {
     });
   });
 
+  // 🔴 The control that scopes the rule above to ENABLEMENT. On a group that is ALREADY localized
+  // the companion exists, so `buildCompanionReconcileStatements` emits a real DROP COLUMN for a
+  // removed translatable field — that is appliable, and refusing it would take working behaviour
+  // away. Without this, a rule that read the localization state wrongly and refused every drop
+  // would still satisfy the enablement case.
+  it("allows removing a translatable field from an already-localized group", async () => {
+    const registry = registryWithGroup({
+      localized: true,
+      fields: [
+        { name: "heading", type: "text", localized: true },
+        { name: "body", type: "text", localized: true },
+      ] as never,
+    });
+    const adapter = adapterDouble(async () => true);
+    const service = serviceOver(
+      registry as unknown as ReturnType<typeof registryDouble>,
+      adapter
+    );
+
+    await expect(
+      service.updateFieldGroup({
+        slug: "hero",
+        fields: [{ name: "heading", type: "text", localized: true }] as never,
+      })
+    ).resolves.toMatchObject({
+      record: expect.objectContaining({ slug: "hero" }),
+    });
+  });
+
   // A layout-only field has no column anywhere, so adding one cannot need DDL on any table.
   it("allows a field that produces no column at all", async () => {
     const registry = registryWithGroup({

--- a/packages/nextly/src/domains/field-groups/services/field-group-metadata-service.ts
+++ b/packages/nextly/src/domains/field-groups/services/field-group-metadata-service.ts
@@ -591,7 +591,8 @@ export class FieldGroupMetadataService {
     // stops describing the field while its data sits on a column nothing will ever read again.
     //
     // The pair rule above cannot catch it, because a removal on its own has no matching add.
-    if (!args.wasLocalized && args.localized && companionDropped.length > 0) {
+    const isEnabling = args.existing.localized !== true && args.localized;
+    if (isEnabling && companionDropped.length > 0) {
       for (const name of companionDropped) changed.add(name);
     }
 

--- a/packages/nextly/src/domains/field-groups/services/field-group-metadata-service.ts
+++ b/packages/nextly/src/domains/field-groups/services/field-group-metadata-service.ts
@@ -538,13 +538,30 @@ export class FieldGroupMetadataService {
     // than the spec object, because that string IS the column the reconciler would write: on SQLite
     // a `maxLength` change moves the spec and renders to the same TEXT, which needs no statement and
     // must not be refused.
+    // Not a valid rendering of any column, so it can never equal one.
+    const NO_COMPANION_COLUMN = "\u0000none";
     const companionOf = (fields: FieldDefinition[]): Map<string, string> => {
       const out = new Map<string, string>();
       for (const field of fields) {
         if (!isFieldLocalized(field, args.localized)) continue;
         const column = fieldToLocalizedColumnSpec(field, dialect, "fieldGroup");
-        if (column)
-          out.set(field.name, `${column.name} ${ddlType(column, dialect)}`);
+        // 🔴 Recorded even when it materialises NO column, rather than skipped.
+        //
+        // Skipping made a field that gains or loses its column invisible: a `component` or
+        // many-to-many field stores its data elsewhere and produces none, so changing it to `text`
+        // under the same name left this map without a "before" entry and the change without a
+        // common name to compare. `buildCompanionReconcileStatements` then diffs the raw localized
+        // NAMES, sees the name already present, and emits no ADD — so the registry and the runtime
+        // advance to a companion column nothing created. The reverse leaves the old one behind.
+        //
+        // A sentinel keeps the name in the map with a value that cannot collide with a rendered
+        // column, so the transition reads as what it is: a change on a name present in both.
+        out.set(
+          field.name,
+          column
+            ? `${column.name} ${ddlType(column, dialect)}`
+            : NO_COMPANION_COLUMN
+        );
       }
       return out;
     };

--- a/packages/nextly/src/domains/field-groups/services/field-group-metadata-service.ts
+++ b/packages/nextly/src/domains/field-groups/services/field-group-metadata-service.ts
@@ -505,7 +505,13 @@ export class FieldGroupMetadataService {
     const creatorLines = (fields: FieldDefinition[]): Map<string, string> => {
       const sql = new FieldGroupSchemaService(dialect).generateMigrationSQL(
         args.existing.tableName,
-        fields,
+        // The stored field list and the config field list are two representations of one thing, and
+        // this service already crosses between them where it writes the registry row and where it
+        // reconciles the companion. Crossed here for the same reason: the creator is declared
+        // against the config shape, and it is the creator's answer this needs.
+        fields as unknown as Parameters<
+          InstanceType<typeof FieldGroupSchemaService>["generateMigrationSQL"]
+        >[1],
         { localized: args.localized }
       );
       const out = new Map<string, string>();

--- a/packages/nextly/src/domains/field-groups/services/field-group-metadata-service.ts
+++ b/packages/nextly/src/domains/field-groups/services/field-group-metadata-service.ts
@@ -587,11 +587,25 @@ export class FieldGroupMetadataService {
     // detector asks which of the two a caller meant, and a PATCH has no way to ask. So this refuses
     // only the PAIR: a pure add is a new translatable field and a pure drop is a removed one, and
     // the reconciler applies both correctly.
+    // 🔴 Only fields that actually RENDER a column, which is narrower than the map's keys.
+    //
+    // The map deliberately records every localized field, sentinel included, so that a field
+    // GAINING or LOSING its column shows up as a change on a common name. That is the right domain
+    // for the value comparison above and the wrong one here: two columnless fields swapped for each
+    // other — a `component` removed and a differently named `component` added — are one add and one
+    // drop by key, which reads as a rename pair, while neither materialises a companion column and
+    // `buildCompanionReconcileStatements` emits nothing for either. Refusing that would reject a
+    // safe metadata-only edit.
+    //
+    // The same narrowing is correct for the enablement rule below: a columnless field removed during
+    // an enable leaves no column behind on the main table, so there is nothing stranded to refuse.
+    const rendersColumn = (map: Map<string, string>, name: string): boolean =>
+      map.get(name) !== NO_COMPANION_COLUMN;
     const companionAdded = [...companionAfter.keys()].filter(
-      name => !companionBefore.has(name)
+      name => !companionBefore.has(name) && rendersColumn(companionAfter, name)
     );
     const companionDropped = [...companionBefore.keys()].filter(
-      name => !companionAfter.has(name)
+      name => !companionAfter.has(name) && rendersColumn(companionBefore, name)
     );
     if (companionAdded.length > 0 && companionDropped.length > 0) {
       for (const name of [...companionAdded, ...companionDropped])

--- a/packages/nextly/src/domains/field-groups/services/field-group-metadata-service.ts
+++ b/packages/nextly/src/domains/field-groups/services/field-group-metadata-service.ts
@@ -487,6 +487,47 @@ export class FieldGroupMetadataService {
       for (const column of index.columns) changed.add(attribute(column));
     }
 
+    // What the CREATOR would write for the main table, line by line.
+    //
+    // 🔴 The desired-table builder answers "which columns and indexes exist", which is what the diff
+    // engine compares against introspection — and it deliberately carries no DEFAULT for a user
+    // column, because a live database reports defaults in a form that would make every reconcile
+    // propose changing them. `FieldGroupSchemaService` is the thing that actually creates a field
+    // group's table, and it DOES emit a checkbox's `DEFAULT`. So a `defaultValue` edit changes the
+    // column the creator writes while leaving the desired table identical, and rows inserted without
+    // the field would keep taking the old default.
+    //
+    // Each user column is one line beginning with its quoted name, so a changed line still names the
+    // field it belongs to.
+    const { FieldGroupSchemaService } = await import(
+      "../../../services/field-groups/field-group-schema-service"
+    );
+    const creatorLines = (fields: FieldDefinition[]): Map<string, string> => {
+      const sql = new FieldGroupSchemaService(dialect).generateMigrationSQL(
+        args.existing.tableName,
+        fields,
+        { localized: args.localized }
+      );
+      const out = new Map<string, string>();
+      for (const line of sql.split("\n")) {
+        // A column definition, and nothing else: INDENTED and QUOTED, which the statements are
+        // not. Matching an unquoted leading word instead picked up `CREATE TABLE ...` and reported
+        // a field called "CREATE". The index statements are excluded on purpose — they are already
+        // compared, by name and uniqueness, from the desired table above.
+        const column = /^\s+["`]([A-Za-z0-9_]+)["`]\s+\S/.exec(line);
+        if (column) out.set(column[1], line.trim());
+      }
+      return out;
+    };
+    const creatorBefore = creatorLines(oldFields);
+    const creatorAfter = creatorLines(args.fields);
+    for (const [column, line] of creatorAfter) {
+      if (creatorBefore.get(column) !== line) changed.add(attribute(column));
+    }
+    for (const column of creatorBefore.keys()) {
+      if (!creatorAfter.has(column)) changed.add(attribute(column));
+    }
+
     // The companion, for a field localized on both sides. Compared as the rendered DDL type rather
     // than the spec object, because that string IS the column the reconciler would write: on SQLite
     // a `maxLength` change moves the spec and renders to the same TEXT, which needs no statement and
@@ -507,6 +548,31 @@ export class FieldGroupMetadataService {
       // Only a field present on BOTH sides: an add or a drop is the delta the reconciler applies.
       const was = companionBefore.get(name);
       if (was !== undefined && was !== column) changed.add(name);
+    }
+
+    // 🔴 A companion that both GAINS and LOSES a column in one edit is a rename the reconciler
+    // cannot see, and the consequence is destroyed content rather than a stale shape.
+    //
+    // Neither companion path resolves it. While the group STAYS localized,
+    // `buildCompanionReconcileStatements` diffs by name alone, so a rename becomes ADD the new
+    // column, DROP the old — and every stored translation goes with the drop. While localization is
+    // being ENABLED, `buildCompanionTransitionStatements` seeds only the new columns whose name
+    // already exists on main, so a renamed field is seeded from nothing and its old column is left
+    // behind on the main table.
+    //
+    // A drop-and-add pair is the ambiguity the apply pipeline exists to resolve — its rename
+    // detector asks which of the two a caller meant, and a PATCH has no way to ask. So this refuses
+    // only the PAIR: a pure add is a new translatable field and a pure drop is a removed one, and
+    // the reconciler applies both correctly.
+    const companionAdded = [...companionAfter.keys()].filter(
+      name => !companionBefore.has(name)
+    );
+    const companionDropped = [...companionBefore.keys()].filter(
+      name => !companionAfter.has(name)
+    );
+    if (companionAdded.length > 0 && companionDropped.length > 0) {
+      for (const name of [...companionAdded, ...companionDropped])
+        changed.add(name);
     }
 
     if (changed.size === 0) return;

--- a/packages/nextly/src/domains/field-groups/services/field-group-metadata-service.ts
+++ b/packages/nextly/src/domains/field-groups/services/field-group-metadata-service.ts
@@ -316,7 +316,24 @@ export class FieldGroupMetadataService {
       assertLocalizationConfigured("component", input.slug);
     }
 
-    // 1. MOVE the physical schema, when this edit implies one. A `localized` toggle alone does:
+    // 1. REFUSE a field set this path cannot deliver.
+    //
+    // 🔴 This method changes the COMPANION table and nothing else. A field whose column lives on the
+    // main table therefore needs DDL that only `applySchemaChanges` emits — and without this guard
+    // the request SUCCEEDED, wrote the new fields and a matching `schema_hash`, and left the table
+    // without the columns the registry now claims it has. The registry marks
+    // `migration_status: "pending"` and a preview still introspects the truth, so the drift is
+    // recorded rather than silent; it is still a success answered to a caller whose change did not
+    // happen.
+    //
+    // Refusing rather than applying the pipeline here is deliberate. `applySchemaChanges` carries a
+    // version guard, rename detection and an interactive resolution step — a rename is ambiguous
+    // (rename versus drop-and-add) and a PATCH has no way to ask. Duplicating that inside a metadata
+    // edit would be a second implementation of "apply a schema change"; refusing keeps one, and
+    // turns a silent wrong result into an actionable error.
+    await this.assertNoMainTableSchemaChange({ existing, fields, localized });
+
+    // 2. MOVE the physical schema, when this edit implies one. A `localized` toggle alone does:
     // enabling seeds the companion from the main table and drops those columns, disabling restores
     // and archives them. A save that skipped that would persist the flag while the content stayed
     // where the runtime no longer looks for it.
@@ -329,7 +346,7 @@ export class FieldGroupMetadataService {
       });
     }
 
-    // 2. RECORD, after the physical change succeeded.
+    // 3. RECORD, after the physical change succeeded.
     const record = await this.registry.updateComponent(
       input.slug,
       {
@@ -353,6 +370,71 @@ export class FieldGroupMetadataService {
     );
 
     return { record };
+  }
+
+  /**
+   * Refuse a field change that would need a column on the MAIN table.
+   *
+   * 🔴 Every question here is answered by the code that already owns it, so this guard cannot
+   * disagree with what actually emits DDL:
+   *
+   * - `computeFieldDiff` is the diff the PREVIEW endpoint itself computes;
+   * - `fieldProducesColumn` is documented at its definition as "the single answer" to whether a
+   *   field has a column, with the DDL generator and the field classifier both deferring to it —
+   *   it already excludes layout-only types, components (own `comp_` table) and many-to-many
+   *   (junction table);
+   * - `isFieldLocalized` is the predicate `reconcileCompanion` itself filters on to decide what the
+   *   companion carries, and it folds in the entity flag, so it is uniformly false for a
+   *   non-localized field group and no separate branch is needed for that case.
+   *
+   * A fourth opinion about where a column lives is exactly how the three transports came to disagree
+   * in the first place.
+   */
+  private async assertNoMainTableSchemaChange(args: {
+    existing: DynamicFieldGroupRecord;
+    fields: FieldDefinition[];
+    localized: boolean;
+  }): Promise<void> {
+    const { computeFieldDiff } = await import(
+      "../../schema/services/field-diff"
+    );
+    const { fieldProducesColumn } = await import(
+      "../../schema/services/field-column-descriptor"
+    );
+    const { isFieldLocalized } = await import("../../i18n/classify-fields");
+
+    const diff = computeFieldDiff(
+      args.existing.fields as unknown as FieldDefinition[],
+      args.fields
+    );
+    // A CHANGED entry carries only the field's name, so the definition is taken from whichever side
+    // still has it — the new one for added and changed, the old one for removed.
+    const touched: FieldDefinition[] = [
+      ...diff.added,
+      ...diff.removed,
+      ...diff.changed
+        .map(c => args.fields.find(f => f.name === c.name))
+        .filter((f): f is FieldDefinition => f !== undefined),
+    ];
+
+    const needsMainTable = touched.filter(
+      field =>
+        fieldProducesColumn(field) && !isFieldLocalized(field, args.localized)
+    );
+    if (needsMainTable.length === 0) return;
+
+    throw NextlyError.validation({
+      errors: needsMainTable.map(field => ({
+        path: `fields.${field.name}`,
+        code: "requires_schema_change",
+        message: `Changing "${field.name}" alters the field group's table. Use the schema preview and apply flow, which reviews the change and resolves renames, rather than updating the field group directly.`,
+      })),
+      logContext: {
+        reason: "field update requires main-table ddl",
+        slug: args.existing.slug,
+        fields: needsMainTable.map(f => f.name),
+      },
+    });
   }
 
   /** The stored hash for a field set, from the one implementation the whole pipeline uses. */

--- a/packages/nextly/src/domains/field-groups/services/field-group-metadata-service.ts
+++ b/packages/nextly/src/domains/field-groups/services/field-group-metadata-service.ts
@@ -378,11 +378,10 @@ export class FieldGroupMetadataService {
    * 🔴 Every question here is answered by the code that already owns it, so this guard cannot
    * disagree with what actually emits DDL:
    *
-   * - `computeFieldDiff` is the diff the PREVIEW endpoint itself computes;
-   * - `fieldProducesColumn` is documented at its definition as "the single answer" to whether a
-   *   field has a column, with the DDL generator and the field classifier both deferring to it —
-   *   it already excludes layout-only types, components (own `comp_` table) and many-to-many
-   *   (junction table);
+   * - `getColumnDescriptor` is what the DDL GENERATOR builds each column from, so comparing the
+   *   descriptors two field sets produce is comparing what would actually be emitted — it returns
+   *   null for layout-only types, components (own `comp_` table) and many-to-many (junction table),
+   *   via the same `fieldProducesColumn` documented at its definition as "the single answer";
    * - `isFieldLocalized` is the predicate `reconcileCompanion` itself filters on to decide what the
    *   companion carries, and it folds in the entity flag, so it is uniformly false for a
    *   non-localized field group and no separate branch is needed for that case.
@@ -395,44 +394,72 @@ export class FieldGroupMetadataService {
     fields: FieldDefinition[];
     localized: boolean;
   }): Promise<void> {
-    const { computeFieldDiff } = await import(
-      "../../schema/services/field-diff"
-    );
-    const { fieldProducesColumn } = await import(
+    const { getColumnDescriptor } = await import(
       "../../schema/services/field-column-descriptor"
     );
     const { isFieldLocalized } = await import("../../i18n/classify-fields");
 
-    const diff = computeFieldDiff(
-      args.existing.fields as unknown as FieldDefinition[],
-      args.fields
-    );
-    // A CHANGED entry carries only the field's name, so the definition is taken from whichever side
-    // still has it — the new one for added and changed, the old one for removed.
-    const touched: FieldDefinition[] = [
-      ...diff.added,
-      ...diff.removed,
-      ...diff.changed
-        .map(c => args.fields.find(f => f.name === c.name))
-        .filter((f): f is FieldDefinition => f !== undefined),
-    ];
+    const oldFields = args.existing.fields as unknown as FieldDefinition[];
 
-    const needsMainTable = touched.filter(
-      field =>
-        fieldProducesColumn(field) && !isFieldLocalized(field, args.localized)
-    );
-    if (needsMainTable.length === 0) return;
+    /**
+     * The column a field would occupy on the MAIN table, or null when it would occupy none.
+     *
+     * 🔴 The DESCRIPTOR, not the field definition. Comparing definitions answers "did the author
+     * change anything", which is a wider and differently-shaped question than "does the column need
+     * altering" — a `dbType` moving from integer to decimal, or a changed `precision`, `scale`,
+     * `length` or `index`, all alter the column while leaving a definition-level diff reporting no
+     * change at all. This is the same function the DDL generator builds from, so what it says about
+     * two field sets is what the generator would emit for them.
+     *
+     * A localized field returns null because its column lives in `comp_<slug>_locales`, which
+     * `reconcileCompanion` does apply — the predicate is the one that reconciler itself filters on.
+     */
+    const mainTableColumn = (
+      field: FieldDefinition
+    ): Record<string, unknown> | null => {
+      if (isFieldLocalized(field, args.localized)) return null;
+      return getColumnDescriptor(
+        field,
+        this.dialect,
+        "fieldGroup"
+      ) as unknown as Record<string, unknown> | null;
+    };
 
+    const describe = (fields: FieldDefinition[]): Map<string, string> => {
+      const out = new Map<string, string>();
+      for (const field of fields) {
+        const descriptor = mainTableColumn(field);
+        if (descriptor === null) continue;
+        // Serialised for comparison rather than compared field by field: a descriptor gaining a
+        // property would otherwise be silently excluded from the check that exists to notice it.
+        out.set(field.name, JSON.stringify(descriptor));
+      }
+      return out;
+    };
+
+    const before = describe(oldFields);
+    const after = describe(args.fields);
+
+    const changed = new Set<string>();
+    for (const [name, spec] of after) {
+      if (before.get(name) !== spec) changed.add(name);
+    }
+    for (const name of before.keys()) {
+      if (!after.has(name)) changed.add(name);
+    }
+    if (changed.size === 0) return;
+
+    const names = [...changed];
     throw NextlyError.validation({
-      errors: needsMainTable.map(field => ({
-        path: `fields.${field.name}`,
+      errors: names.map(name => ({
+        path: `fields.${name}`,
         code: "requires_schema_change",
-        message: `Changing "${field.name}" alters the field group's table. Use the schema preview and apply flow, which reviews the change and resolves renames, rather than updating the field group directly.`,
+        message: `Changing "${name}" alters the field group's table. Use the schema preview and apply flow, which reviews the change and resolves renames, rather than updating the field group directly.`,
       })),
       logContext: {
         reason: "field update requires main-table ddl",
         slug: args.existing.slug,
-        fields: needsMainTable.map(f => f.name),
+        fields: names,
       },
     });
   }

--- a/packages/nextly/src/domains/field-groups/services/field-group-metadata-service.ts
+++ b/packages/nextly/src/domains/field-groups/services/field-group-metadata-service.ts
@@ -581,6 +581,20 @@ export class FieldGroupMetadataService {
         changed.add(name);
     }
 
+    // 🔴 A DROP is only appliable when the companion already exists, which an ENABLE means it does
+    // not.
+    //
+    // Both main-table snapshots are built at the requested state, so a field that is translatable
+    // under it never appears on either — including one this edit REMOVES, whose column is still
+    // physically on the main table because the group is not localized yet. The enable planner then
+    // derives its companion from the NEW fields alone, so nothing drops that column: the registry
+    // stops describing the field while its data sits on a column nothing will ever read again.
+    //
+    // The pair rule above cannot catch it, because a removal on its own has no matching add.
+    if (!args.wasLocalized && args.localized && companionDropped.length > 0) {
+      for (const name of companionDropped) changed.add(name);
+    }
+
     if (changed.size === 0) return;
 
     const names = [...changed];

--- a/packages/nextly/src/domains/field-groups/services/field-group-metadata-service.ts
+++ b/packages/nextly/src/domains/field-groups/services/field-group-metadata-service.ts
@@ -331,7 +331,7 @@ export class FieldGroupMetadataService {
     // (rename versus drop-and-add) and a PATCH has no way to ask. Duplicating that inside a metadata
     // edit would be a second implementation of "apply a schema change"; refusing keeps one, and
     // turns a silent wrong result into an actionable error.
-    await this.assertNoMainTableSchemaChange({ existing, fields, localized });
+    await this.assertNoUnappliableSchemaChange({ existing, fields, localized });
 
     // 2. MOVE the physical schema, when this edit implies one. A `localized` toggle alone does:
     // enabling seeds the companion from the main table and drops those columns, disabling restores
@@ -373,80 +373,142 @@ export class FieldGroupMetadataService {
   }
 
   /**
-   * Refuse a field change that would need a column on the MAIN table.
+   * Refuse a field change whose physical consequence this path cannot carry out.
    *
-   * 🔴 Every question here is answered by the code that already owns it, so this guard cannot
-   * disagree with what actually emits DDL:
+   * 🔴 Two tables, and exactly one of them can be moved from here:
    *
-   * - `getColumnDescriptor` is what the DDL GENERATOR builds each column from, so comparing the
-   *   descriptors two field sets produce is comparing what would actually be emitted — it returns
-   *   null for layout-only types, components (own `comp_` table) and many-to-many (junction table),
-   *   via the same `fieldProducesColumn` documented at its definition as "the single answer";
-   * - `isFieldLocalized` is the predicate `reconcileCompanion` itself filters on to decide what the
-   *   companion carries, and it folds in the entity flag, so it is uniformly false for a
-   *   non-localized field group and no separate branch is needed for that case.
+   * - the MAIN `comp_<slug>` table receives no DDL at all on this path, so ANY difference in the
+   *   table it should have — a column added, dropped or reshaped, an index created or removed — is
+   *   unappliable and has to be refused;
+   * - the companion `comp_<slug>_locales` IS reconciled, but only by ADDING and DROPPING columns by
+   *   NAME. A localized field that keeps its name while its column changes shape emits no statement
+   *   there either, so that case is refused too.
    *
-   * A fourth opinion about where a column lives is exactly how the three transports came to disagree
-   * in the first place.
+   * Every question is answered by the code that already owns it, so this guard cannot disagree with
+   * what actually emits DDL:
+   *
+   * - `buildDesiredTableFromComponentFields` is the desired-state builder the diff engine runs for a
+   *   field group. It renders each column for the dialect, injects the same system columns both
+   *   sides get, carries the `idx_`/`uq_` indexes the schema service creates, and omits translatable
+   *   columns when the group is localized. Comparing the table it describes for the old fields
+   *   against the one it describes for the new is comparing what the generator would build;
+   * - `fieldToLocalizedColumnSpec` and `ddlType` are what the companion reconciler renders its
+   *   `ADD COLUMN` from, so the text they produce is the companion column itself;
+   * - `isFieldLocalized` is the predicate `reconcileCompanion` filters on, and it folds in the
+   *   entity flag, so a non-localized field group needs no separate branch.
+   *
+   * Both sides are built at the SAME localization state, deliberately. A `localized` toggle moves
+   * columns between the two tables and `reconcileCompanion` performs exactly that move, so holding
+   * the flag constant asks the question this guard is for — does the FIELD SET edit need DDL — and
+   * leaves the transition to the code that applies it.
+   *
+   * A fourth opinion about where a column lives, or about what shape it takes, is exactly how the
+   * three transports came to disagree in the first place.
    */
-  private async assertNoMainTableSchemaChange(args: {
+  private async assertNoUnappliableSchemaChange(args: {
     existing: DynamicFieldGroupRecord;
     fields: FieldDefinition[];
     localized: boolean;
   }): Promise<void> {
+    const { buildDesiredTableFromComponentFields } = await import(
+      "../../schema/pipeline/diff/build-from-fields"
+    );
     const { getColumnDescriptor } = await import(
       "../../schema/services/field-column-descriptor"
     );
     const { isFieldLocalized } = await import("../../i18n/classify-fields");
+    const { fieldToLocalizedColumnSpec } = await import(
+      "../../i18n/migration/field-to-column-spec"
+    );
+    const { ddlType } = await import("../../i18n/migration/ddl-types");
 
     const oldFields = args.existing.fields as unknown as FieldDefinition[];
+    const dialect = this.dialect;
+
+    const desiredTable = (fields: FieldDefinition[]) =>
+      buildDesiredTableFromComponentFields(
+        args.existing.tableName,
+        fields,
+        dialect,
+        { localized: args.localized, builtBy: "fieldGroup" }
+      );
+
+    const before = desiredTable(oldFields);
+    const after = desiredTable(args.fields);
 
     /**
-     * The column a field would occupy on the MAIN table, or null when it would occupy none.
+     * Which field a column belongs to, for the error path only.
      *
-     * 🔴 The DESCRIPTOR, not the field definition. Comparing definitions answers "did the author
-     * change anything", which is a wider and differently-shaped question than "does the column need
-     * altering" — a `dbType` moving from integer to decimal, or a changed `precision`, `scale`,
-     * `length` or `index`, all alter the column while leaving a definition-level diff reporting no
-     * change at all. This is the same function the DDL generator builds from, so what it says about
-     * two field sets is what the generator would emit for them.
-     *
-     * A localized field returns null because its column lives in `comp_<slug>_locales`, which
-     * `reconcileCompanion` does apply — the predicate is the one that reconciler itself filters on.
+     * The comparison above has already decided; this just names the field so the caller is told
+     * WHICH one to take through the apply flow. It reads the same `getColumnDescriptor(...).name`
+     * the builder resolves its own column names with, and falls back to the raw column name when a
+     * column belongs to no field — the system columns, which are identical on both sides and so
+     * never appear here.
      */
-    const mainTableColumn = (
-      field: FieldDefinition
-    ): Record<string, unknown> | null => {
-      if (isFieldLocalized(field, args.localized)) return null;
-      return getColumnDescriptor(
-        field,
-        this.dialect,
-        "fieldGroup"
-      ) as unknown as Record<string, unknown> | null;
-    };
+    const fieldNameByColumn = new Map<string, string>();
+    for (const field of [...oldFields, ...args.fields]) {
+      const column = getColumnDescriptor(field, dialect, "fieldGroup");
+      if (column) fieldNameByColumn.set(column.name, field.name);
+    }
+    const attribute = (column: string): string =>
+      fieldNameByColumn.get(column) ?? column;
 
-    const describe = (fields: FieldDefinition[]): Map<string, string> => {
+    const changed = new Set<string>();
+
+    // Columns, by name: a serialised ColumnSpec so a spec gaining a property is not silently
+    // excluded from the check that exists to notice it.
+    const columnsOf = (table: typeof before): Map<string, string> =>
+      new Map(
+        table.columns.map(column => [column.name, JSON.stringify(column)])
+      );
+    const columnsBefore = columnsOf(before);
+    const columnsAfter = columnsOf(after);
+    for (const [name, spec] of columnsAfter) {
+      if (columnsBefore.get(name) !== spec) changed.add(attribute(name));
+    }
+    for (const name of columnsBefore.keys()) {
+      if (!columnsAfter.has(name)) changed.add(attribute(name));
+    }
+
+    // Indexes, by name. A field toggling `unique` or `index` leaves its COLUMN identical and moves
+    // only this list, which is why the column comparison alone let it through. An index is
+    // attributed to every field it covers, so a composite one names all of them.
+    const indexesOf = (table: typeof before) =>
+      new Map((table.indexes ?? []).map(index => [index.name, index]));
+    const indexesBefore = indexesOf(before);
+    const indexesAfter = indexesOf(after);
+    for (const [name, index] of indexesAfter) {
+      const was = indexesBefore.get(name);
+      if (was && JSON.stringify(was) === JSON.stringify(index)) continue;
+      for (const column of index.columns) changed.add(attribute(column));
+    }
+    for (const [name, index] of indexesBefore) {
+      if (indexesAfter.has(name)) continue;
+      for (const column of index.columns) changed.add(attribute(column));
+    }
+
+    // The companion, for a field localized on both sides. Compared as the rendered DDL type rather
+    // than the spec object, because that string IS the column the reconciler would write: on SQLite
+    // a `maxLength` change moves the spec and renders to the same TEXT, which needs no statement and
+    // must not be refused.
+    const companionOf = (fields: FieldDefinition[]): Map<string, string> => {
       const out = new Map<string, string>();
       for (const field of fields) {
-        const descriptor = mainTableColumn(field);
-        if (descriptor === null) continue;
-        // Serialised for comparison rather than compared field by field: a descriptor gaining a
-        // property would otherwise be silently excluded from the check that exists to notice it.
-        out.set(field.name, JSON.stringify(descriptor));
+        if (!isFieldLocalized(field, args.localized)) continue;
+        const column = fieldToLocalizedColumnSpec(field, dialect, "fieldGroup");
+        if (column)
+          out.set(field.name, `${column.name} ${ddlType(column, dialect)}`);
       }
       return out;
     };
-
-    const before = describe(oldFields);
-    const after = describe(args.fields);
-
-    const changed = new Set<string>();
-    for (const [name, spec] of after) {
-      if (before.get(name) !== spec) changed.add(name);
+    const companionBefore = companionOf(oldFields);
+    const companionAfter = companionOf(args.fields);
+    for (const [name, column] of companionAfter) {
+      // Only a field present on BOTH sides: an add or a drop is the delta the reconciler applies.
+      const was = companionBefore.get(name);
+      if (was !== undefined && was !== column) changed.add(name);
     }
-    for (const name of before.keys()) {
-      if (!after.has(name)) changed.add(name);
-    }
+
     if (changed.size === 0) return;
 
     const names = [...changed];
@@ -457,7 +519,7 @@ export class FieldGroupMetadataService {
         message: `Changing "${name}" alters the field group's table. Use the schema preview and apply flow, which reviews the change and resolves renames, rather than updating the field group directly.`,
       })),
       logContext: {
-        reason: "field update requires main-table ddl",
+        reason: "field update requires ddl this path does not emit",
         slug: args.existing.slug,
         fields: names,
       },


### PR DESCRIPTION
Updating a field group's fields **succeeded while doing nothing to the table**. The request stored
the new field set and a matching `schema_hash`, and left the table without the columns the registry
now claimed it had.

This is one of five findings Codex raised on #781 that merged with it, so it is a defect on `main`
rather than a review comment.

## Why it happened

`updateFieldGroup` alters the **companion** table and nothing else — `reconcileComponentCompanion`
returns immediately for a group that is and stays non-localized. A field whose column lives on the
**main** table needs DDL that only `applySchemaChanges` emits, and nothing refused it.

The damage was bounded, and I checked both bounds rather than assuming them: the registry marks
`migration_status: "pending"` when fields change, and `previewComponentSchemaChanges` introspects
the LIVE database rather than reading the stored hash, so the drift is recorded and still visible.
It was still a success answered to a caller whose change did not happen.

**Pre-existing rather than introduced by #781** — the dispatcher never ran the main-table pipeline
on this path either. What #781 changed is REACH: that safety lived in the admin UI's convention of
calling preview first, and two more transports now arrive at the same service without it.

## Why refuse rather than apply

`applySchemaChanges` carries a version guard, rename detection and an interactive resolution step.
A rename is genuinely ambiguous — rename versus drop-and-add — and a PATCH has no way to ask.
Duplicating 215 lines of that inside a method whose contract is a metadata edit would be a second
implementation of "apply a schema change", which is the exact shape this repo has been bitten by
five times. Refusing keeps one implementation and turns a silent wrong result into an actionable
error.

## The rule adds no new opinion

Every question is answered by the code that already owns it, so the guard cannot disagree with what
actually emits DDL:

| question | existing answer |
| --- | --- |
| what changed? | `computeFieldDiff` — the diff the preview endpoint itself computes |
| does this field have a column? | `fieldProducesColumn` — documented at its definition as **"the single answer"**, with the DDL generator and field classifier both deferring to it |
| does that column live in the companion? | `isFieldLocalized` — the predicate `reconcileCompanion` itself filters on |

`isFieldLocalized` folds in the entity flag, so it is uniformly false for a non-localized group and
no separate branch is needed. `fieldProducesColumn` already excludes layout-only types, components
(own `comp_` table) and many-to-many (junction table).

Refuse when a diffed field **produces a column** AND is **not localized**. Three helpers, one line.

## Evidence

Three tests, break-controlled in BOTH directions — the second matters as much as the first, because
over-refusing would take away behaviour that works today:

| break | fails |
| --- | --- |
| remove the guard | refuses a field that needs a column on the main table |
| ignore localization when deciding | allows a translatable field on a localized group |

A third test covers a field that produces no column at all (`component`), which cannot need DDL
anywhere.

**One process note worth recording:** my first run of both break-controls produced NO output and I
nearly logged them as passing. The test path was wrong for the filter's working directory, so the
file never matched and nothing ran. A break-control that prints nothing is not a break-control that
passed.

- `build`, `check-types --force`, `lint`, `check-drizzle-v1-legacy`, `check:storage-format-literals`
  — all exit 0 from the worktree root
- affected suites measured against the same suites with my two files scope-reverted to `origin/main`:
  **11 failing before, 11 failing after, +3 passing** — exactly the tests added, zero regressions
