### PR TITLE
fix(nextly): advance schema_version when localization moves columns

### DIFF
--- a/.changeset/schema-version-tracks-shape.md
+++ b/.changeset/schema-version-tracks-shape.md
@@ -1,0 +1,28 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+Toggling a field group between localized and not now advances its schema version, so a Schema Builder tab opened before the change is told to reload instead of overwriting it. Previously only a field change advanced the version, and the toggle moves columns between tables.

--- a/packages/nextly/src/domains/field-groups/__tests__/field-group-registry-service.test.ts
+++ b/packages/nextly/src/domains/field-groups/__tests__/field-group-registry-service.test.ts
@@ -311,6 +311,51 @@ describe("FieldGroupRegistryService", () => {
       expect(updateData.schema_hash).toBe("new-hash");
     });
 
+    // 🔴 `schema_version` is an optimistic lock, and toggling localization MOVES every translatable
+    // column between the main table and `comp_<slug>_locales`. Tying the bump to `fields` alone left
+    // that transition invisible to `assertSchemaVersionMatch`: a preview taken beforehand still
+    // matched, and applying it wrote a stale field set over a shape that had already moved.
+    it("increments schema_version when localization is toggled with no field change", async () => {
+      ctx.adapter.selectOne.mockResolvedValue(
+        dbRow({ locked: 0, localized: 0 })
+      );
+      ctx.adapter.update.mockResolvedValue([dbRow({ schema_version: 2 })]);
+
+      await ctx.service.updateComponent("seo", { localized: true });
+
+      const updateData = ctx.adapter.update.mock.calls[0][1] as Record<
+        string,
+        unknown
+      >;
+      expect(updateData.schema_version).toBe(2);
+      // Nothing about the field set changed, so the migration status must not be disturbed.
+      expect(updateData.fields).toBeUndefined();
+      expect(updateData.migration_status).toBeUndefined();
+    });
+
+    // 🔴 The control that keeps the bump from becoming noise. Compared against the STORED value
+    // rather than merely being present: a request resending the current setting changes no storage,
+    // so invalidating every open editor for it would make the lock fire on saves that conflict with
+    // nothing.
+    it("leaves schema_version alone when localized is resent unchanged", async () => {
+      ctx.adapter.selectOne.mockResolvedValue(
+        dbRow({ locked: 0, localized: 1 })
+      );
+      ctx.adapter.update.mockResolvedValue([dbRow()]);
+
+      await ctx.service.updateComponent("seo", {
+        localized: true,
+        label: "Renamed",
+      });
+
+      const updateData = ctx.adapter.update.mock.calls[0][1] as Record<
+        string,
+        unknown
+      >;
+      expect(updateData.schema_version).toBeUndefined();
+      expect(updateData.label).toBe("Renamed");
+    });
+
     it("throws FORBIDDEN when locked and source is not 'code'", async () => {
       ctx.adapter.selectOne.mockResolvedValue(dbRow({ locked: 1 }));
 

--- a/packages/nextly/src/domains/field-groups/services/field-group-registry-service.ts
+++ b/packages/nextly/src/domains/field-groups/services/field-group-registry-service.ts
@@ -336,10 +336,31 @@ export class FieldGroupRegistryService extends BaseRegistryService<
       updateData.description = data.description;
     }
 
+    // 🔴 The version advances when the PHYSICAL SHAPE changes, not when `fields` happens to be
+    // present. `schema_version` is an optimistic lock: `assertSchemaVersionMatch` rejects a save
+    // whose editor was loaded before someone else changed the schema, so anything that moves
+    // storage has to invalidate an in-flight editor.
+    //
+    // Toggling `localized` moves every translatable column between the main table and
+    // `comp_<slug>_locales`. Tying the bump to `fields` alone left that transition invisible to the
+    // guard: a preview taken beforehand still matched, and applying it wrote a stale field set over
+    // a shape that had already moved. `applyComponentSchemaChanges` bumps after the same physical
+    // transition, so this is two paths performing one move and only one of them advancing the lock.
+    //
+    // Compared against the STORED value rather than merely being present, so a request that resends
+    // the current setting does not invalidate every open editor for no reason.
+    const localizationChanged =
+      data.localized !== undefined &&
+      (data.localized === true) !== (existing.localized === true);
+
     if (data.fields) {
       updateData.fields = JSON.stringify(data.fields);
-      updateData.schema_version = existing.schemaVersion + 1;
       updateData.migration_status = data.migrationStatus || "pending";
+    }
+
+    if (data.fields || localizationChanged) {
+      // One increment even when both changed: the row moved to the next version, once.
+      updateData.schema_version = existing.schemaVersion + 1;
     }
 
     if (data.admin !== undefined) {


### PR DESCRIPTION
`schema_version` is an **optimistic lock**. `assertSchemaVersionMatch` rejects a Schema Builder save
whose editor was loaded before someone else changed the schema, so that the second save cannot
silently overwrite the first — last-write-wins on DDL plus metadata is the outcome it exists to
prevent.

It advanced only when `fields` was present. **Toggling `localized` moves every translatable column
between the main table and `comp_<slug>_locales`**, and left the version untouched — so a preview
taken before the toggle still matched, and applying it wrote a stale field set over a shape that had
already moved.

This is the second of five findings Codex raised on #781 that merged with it, so it is a defect on
`main` rather than a review comment.

## Why the registry, not the caller

`applyComponentSchemaChanges` already bumps after performing the same physical transition. Two paths
perform one move and only one advances the lock — so the fix belongs where the rule lives, not in a
second caller. A caller passing a synthetic version would be a second implementation of "when does
the schema version advance", which is the shape this repo has been bitten by repeatedly.

## Compared against the stored value, not merely present

    const localizationChanged =
      data.localized !== undefined &&
      (data.localized === true) !== (existing.localized === true);

A request that resends the current setting changes no storage. Bumping on presence alone would make
the lock fire on saves that conflict with nothing, invalidating every open editor for a no-op — a
guard that cries wolf gets worked around, which costs more than the bug it was added for.

One increment when both `fields` and `localized` change: the row moved to the next version, once.

`migration_status` is deliberately untouched by a localization-only toggle. It records whether DDL is
outstanding, and the companion transition has already been applied by the caller before this write.

## Evidence

Two tests, break-controlled in **both** directions:

| break | fails |
| --- | --- |
| bump only on `fields` (restore the defect) | increments schema_version when localization is toggled with no field change |
| bump on presence rather than change | leaves schema_version alone when localized is resent unchanged |

The second control is what stops the fix from replacing a missed lock with an over-firing one.

- `build`, `check-types --force`, `lint`, `check-drizzle-v1-legacy`, `check:storage-format-literals`
  — all exit 0 from the worktree root
- affected suites measured against the same suites with my two files scope-reverted to `origin/main`:
  **3 failing before, 3 failing after, +2 passing** — exactly the tests added, zero regressions
