### PR TITLE
fix(nextly): paginate users by user rather than by role-joined row

### DIFF
--- a/.changeset/users-find-distinct-pagination.md
+++ b/.changeset/users-find-distinct-pagination.md
@@ -1,0 +1,40 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+fix(nextly): paginate users by user rather than by role-joined row
+
+listUsers applied LIMIT/OFFSET to a query that left-joined user_roles and roles
+and grouped afterwards, so a user holding three roles consumed three rows of the
+page. A page of N therefore returned fewer than N users, and OFFSET advanced
+over joined rows rather than users — which skipped users entirely rather than
+merely short-filling the page. Measured on nine users with two holding three
+roles each: walking every page visited six of them.
+
+The page query now selects one row per user and roles are fetched for exactly
+the users that page selected, so total keeps counting the same thing it always
+did and a page of N contains N distinct users. Role order per user is now
+deterministic; the join left it to the planner.

--- a/packages/nextly/src/direct-api/namespaces/users.ts
+++ b/packages/nextly/src/direct-api/namespaces/users.ts
@@ -65,7 +65,10 @@ export function createUsersNamespace(ctx: NextlyContext): UsersNamespace {
         createRequestContext(args)
       );
 
-      return toListResult(result, limit, page);
+      // The limit the service ACTUALLY paginated by, not the one requested. It bounds the page
+      // size it will honour, and deriving `totalPages` from the request instead would report a
+      // page count for a page size that was never used.
+      return toListResult(result, result.pagination.limit, page);
     },
 
     async findOne(args: FindOneUserArgs = {}): Promise<User | null> {

--- a/packages/nextly/src/domains/users/__tests__/list-users-pagination.integration.test.ts
+++ b/packages/nextly/src/domains/users/__tests__/list-users-pagination.integration.test.ts
@@ -227,6 +227,21 @@ describe("listUsers pagination over users with several roles (real SQLite)", () 
     expect(single.roles).toHaveLength(1);
   });
 
+  it("bounds the page size a caller can ask for", async () => {
+    // `user-dispatcher.ts` forwards `toNumber(p.limit)` with nothing bounding it, and this method
+    // is reachable directly as well — `ListUsersSchema`'s `max(100)` is not applied on either
+    // path. Roles are fetched with `inArray` over the page's ids, one bound parameter per user,
+    // so an unbounded page would exceed SQLite's default SQLITE_MAX_VARIABLE_NUMBER of 32766 and
+    // fail AFTER the page query had already succeeded.
+    const page = await query.listUsers({ page: 1, limit: 1_000_000 });
+
+    // Clamped to the shared PAGINATION_DEFAULTS.maxLimit, not to the requested value.
+    expect(page.meta.limit).toBe(500);
+    // The fixture holds fewer users than the clamp, so every user still comes back — the bound
+    // caps the request without truncating a legitimate result.
+    expect(page.data).toHaveLength(USER_COUNT);
+  }, 30_000);
+
   it("reports a total counting users rather than joined rows", async () => {
     const page = await query.listUsers({ page: 1, limit: PAGE_SIZE });
 

--- a/packages/nextly/src/domains/users/__tests__/list-users-pagination.integration.test.ts
+++ b/packages/nextly/src/domains/users/__tests__/list-users-pagination.integration.test.ts
@@ -43,6 +43,7 @@ import {
 } from "../../../schemas/users/sqlite";
 import { splitStatements } from "../../schema/pipeline/sql-statement-utils";
 import { UserQueryService } from "../services/user-query-service";
+import { UserService } from "../services/user-service";
 
 const TEST_DB_DIR = join(
   tmpdir(),
@@ -240,6 +241,40 @@ describe("listUsers pagination over users with several roles (real SQLite)", () 
     // The fixture holds fewer users than the clamp, so every user still comes back — the bound
     // caps the request without truncating a legitimate result.
     expect(page.data).toHaveLength(USER_COUNT);
+  }, 30_000);
+
+  it("propagates the clamped page size through the facade, not the request", async () => {
+    // The clamp inside the query service is only half an answer: `UserService.listUsers`
+    // recomputed `offset`/`hasMore` from the REQUESTED limit, and the Direct API derived
+    // `totalPages` from it too. A page-2 request for 1000 users then described a 1000-item page
+    // while the rows came from offset 500 — data and envelope disagreeing about the same page.
+    //
+    // Asserted through the FACADE rather than the query service, because the query service
+    // already had the clamp; a test at that level passes with the defect present.
+    const service = new UserService(
+      query,
+      {} as never,
+      {} as never,
+      undefined,
+      silentLogger as never
+    );
+
+    const page1 = await service.listUsers(
+      { pagination: { page: 1, limit: 1_000_000 } },
+      {} as never
+    );
+    expect(page1.pagination.limit).toBe(500);
+    expect(page1.pagination.offset).toBe(0);
+    expect(page1.data).toHaveLength(USER_COUNT);
+
+    const page2 = await service.listUsers(
+      { pagination: { page: 2, limit: 1_000_000 } },
+      {} as never
+    );
+    // Offset derived from the CLAMPED size. From the request it would be 1,000,000.
+    expect(page2.pagination.offset).toBe(500);
+    expect(page2.data).toHaveLength(0);
+    expect(page2.pagination.hasMore).toBe(false);
   }, 30_000);
 
   it("reports a total counting users rather than joined rows", async () => {

--- a/packages/nextly/src/domains/users/__tests__/list-users-pagination.integration.test.ts
+++ b/packages/nextly/src/domains/users/__tests__/list-users-pagination.integration.test.ts
@@ -1,0 +1,236 @@
+/**
+ * A page of `limit` users contains `limit` USERS, whatever roles they hold.
+ *
+ * `listUsers` used to apply LIMIT/OFFSET to a query that left-joined `user_roles`
+ * and `roles`, then grouped the rows by user. A user holding three roles
+ * therefore consumed three rows of the page, which has two consequences and the
+ * second is the serious one:
+ *
+ * - the page returns FEWER than `limit` users, with nothing saying it did; and
+ * - OFFSET advances over JOINED ROWS rather than users, so page 2 starts partway
+ *   through the joined result and users are SKIPPED entirely. A caller walking
+ *   pages to find an account can conclude it does not exist.
+ *
+ * Meanwhile `total` counts base users, so `totalPages` looks right the whole
+ * time and nothing in the response indicates the gap.
+ *
+ * This is an integration test rather than a unit test on purpose: the defect is
+ * row multiplication performed by the DATABASE. Against a mocked query builder
+ * the canned rows are whatever the fixture says, so a mock cannot tell the two
+ * implementations apart — `user-query-service.test.ts` passes under both.
+ *
+ * THE SEPARATING PROPERTY is a multi-role user positioned so the inflation
+ * crosses a page boundary. A fixture where everyone holds exactly one role
+ * returns identical results from the broken and the fixed code, so it would pass
+ * either way and prove nothing.
+ */
+
+import { existsSync, mkdirSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+import { createSqliteAdapter } from "@nextlyhq/adapter-sqlite";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { getSQLiteDrizzleKit } from "../../../database/drizzle-kit-lazy";
+import {
+  roles as rolesSqlite,
+  userRoles as userRolesSqlite,
+} from "../../../schemas/rbac/sqlite";
+import {
+  accounts as accountsSqlite,
+  users as usersSqlite,
+} from "../../../schemas/users/sqlite";
+import { splitStatements } from "../../schema/pipeline/sql-statement-utils";
+import { UserQueryService } from "../services/user-query-service";
+
+const TEST_DB_DIR = join(
+  tmpdir(),
+  `nextly-list-users-pagination-${process.pid}-${Date.now()}`
+);
+const TEST_DB_PATH = join(TEST_DB_DIR, "test.db");
+const TEST_DB_URL = `file:${TEST_DB_PATH}`;
+
+process.env.DB_DIALECT = "sqlite";
+process.env.DATABASE_URL = TEST_DB_URL;
+
+async function ddl(): Promise<string[]> {
+  const kit = await getSQLiteDrizzleKit();
+  const statements = await kit.generateMigration(
+    await kit.generateDrizzleJson({}),
+    await kit.generateDrizzleJson({
+      users: usersSqlite,
+      accounts: accountsSqlite,
+      roles: rolesSqlite,
+      userRoles: userRolesSqlite,
+    })
+  );
+  return splitStatements(statements);
+}
+
+const silentLogger = {
+  debug: () => {},
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+};
+
+/**
+ * Nine users, named so that ordering by name is the same as this array's order:
+ * `user-00` … `user-08`. Sorting is by name ascending throughout, so which user
+ * lands on which page is fixed rather than left to the planner.
+ */
+const USER_COUNT = 9;
+const PAGE_SIZE = 3;
+const ROLE_NAMES = ["admin", "editor", "viewer"] as const;
+
+/**
+ * Users given every role. Both sit INSIDE a page rather than at its end, so the
+ * extra joined rows spill across the boundary that follows — which is what makes
+ * pages 2 and 3 wrong under the old implementation rather than merely short.
+ */
+const MULTI_ROLE_USERS = ["user-01", "user-04"];
+
+describe("listUsers pagination over users with several roles (real SQLite)", () => {
+  let adapter: ReturnType<typeof createSqliteAdapter>;
+  let query: UserQueryService;
+
+  beforeAll(async () => {
+    if (!existsSync(TEST_DB_DIR)) mkdirSync(TEST_DB_DIR, { recursive: true });
+    adapter = createSqliteAdapter({ url: TEST_DB_URL });
+    await adapter.connect();
+    for (const stmt of await ddl()) {
+      await adapter.executeQuery(stmt);
+    }
+
+    const nowEpoch = Math.floor(Date.now() / 1000);
+
+    for (const roleName of ROLE_NAMES) {
+      await adapter.executeQuery(
+        `INSERT INTO roles (id, name, slug, level, is_system, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?)`,
+        [`role-${roleName}`, roleName, roleName, 0, 0, nowEpoch, nowEpoch]
+      );
+    }
+
+    for (let i = 0; i < USER_COUNT; i++) {
+      const id = `user-0${i}`;
+      await adapter.executeQuery(
+        `INSERT INTO users (id, email, name, is_active, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?)`,
+        [id, `${id}@test.local`, id, 1, nowEpoch, nowEpoch]
+      );
+
+      // Everyone gets one role; the chosen few get all three. Giving every user
+      // at least one role matters: it means the fixed and broken versions return
+      // the same COUNT of joined rows for the single-role users, so any
+      // difference the test finds comes from the multi-role ones.
+      const assigned = MULTI_ROLE_USERS.includes(id)
+        ? ROLE_NAMES
+        : [ROLE_NAMES[i % ROLE_NAMES.length]];
+      for (const roleName of assigned) {
+        await adapter.executeQuery(
+          `INSERT INTO user_roles (user_id, role_id, created_at) VALUES (?, ?, ?)`,
+          [id, `role-${roleName}`, nowEpoch]
+        );
+      }
+    }
+
+    query = new UserQueryService(adapter, silentLogger as never);
+  });
+
+  afterAll(async () => {
+    try {
+      await adapter?.disconnect?.();
+    } catch {
+      // ignore teardown close errors
+    }
+    rmSync(TEST_DB_DIR, { recursive: true, force: true });
+  });
+
+  // A control on the fixture, before anything is concluded from the pages. If
+  // the multi-role assignment silently failed — a bad id, a swallowed insert —
+  // every user would hold one role, the mechanism would never engage, and each
+  // assertion below would pass against the BROKEN implementation too.
+  it("the fixture actually contains multi-role users", async () => {
+    const rows = await adapter.executeQuery<{ user_id: string; n: number }>(
+      `SELECT user_id, COUNT(*) AS n FROM user_roles GROUP BY user_id HAVING COUNT(*) > 1`
+    );
+    expect(rows.map(r => r.user_id).sort()).toEqual(
+      [...MULTI_ROLE_USERS].sort()
+    );
+    for (const row of rows) {
+      expect(Number(row.n)).toBe(ROLE_NAMES.length);
+    }
+  });
+
+  it("returns a full page of distinct users when one of them holds several roles", async () => {
+    const page = await query.listUsers({
+      page: 1,
+      limit: PAGE_SIZE,
+      sortBy: "name",
+      sortOrder: "asc",
+    });
+
+    expect(page.data).toHaveLength(PAGE_SIZE);
+    expect(new Set(page.data!.map(u => String(u.id))).size).toBe(PAGE_SIZE);
+    expect(page.data!.map(u => String(u.id))).toEqual([
+      "user-00",
+      "user-01",
+      "user-02",
+    ]);
+  });
+
+  it("walking every page visits each user exactly once", async () => {
+    const seen: string[] = [];
+    for (let page = 1; page <= Math.ceil(USER_COUNT / PAGE_SIZE); page++) {
+      const result = await query.listUsers({
+        page,
+        limit: PAGE_SIZE,
+        sortBy: "name",
+        sortOrder: "asc",
+      });
+      seen.push(...result.data!.map(u => String(u.id)));
+    }
+
+    // No user skipped and none returned twice — the property a caller walking
+    // pages to find an account actually depends on.
+    expect(seen).toHaveLength(USER_COUNT);
+    expect(new Set(seen).size).toBe(USER_COUNT);
+    expect([...seen].sort()).toEqual(
+      Array.from({ length: USER_COUNT }, (_, i) => `user-0${i}`)
+    );
+  });
+
+  it("still attaches every role a user holds", async () => {
+    const page = await query.listUsers({
+      page: 1,
+      limit: PAGE_SIZE,
+      sortBy: "name",
+      sortOrder: "asc",
+    });
+
+    const multi = page.data!.find(
+      u => String(u.id) === "user-01"
+    ) as unknown as {
+      roles: Array<{ id: string; name: string }>;
+    };
+    // Fixing the page count must not cost the roles themselves — the obvious
+    // wrong fix is to drop the join and return users with no roles at all.
+    expect(multi.roles.map(r => r.name)).toEqual([...ROLE_NAMES].sort());
+
+    const single = page.data!.find(
+      u => String(u.id) === "user-00"
+    ) as unknown as {
+      roles: Array<{ id: string; name: string }>;
+    };
+    expect(single.roles).toHaveLength(1);
+  });
+
+  it("reports a total counting users rather than joined rows", async () => {
+    const page = await query.listUsers({ page: 1, limit: PAGE_SIZE });
+
+    expect(page.meta.total).toBe(USER_COUNT);
+    expect(page.meta.totalPages).toBe(Math.ceil(USER_COUNT / PAGE_SIZE));
+  });
+});

--- a/packages/nextly/src/domains/users/__tests__/user-query-service.test.ts
+++ b/packages/nextly/src/domains/users/__tests__/user-query-service.test.ts
@@ -60,6 +60,14 @@ vi.mock("../../../services/index", () => ({
 /** Stored resolve data per query — tests set this before calling the service */
 let selectResolveData: Record<string, unknown>[] = [];
 let countResolveData: { value: number }[] = [{ value: 0 }];
+/**
+ * Rows the role lookup returns, as `{ userId, roleId, roleName }`.
+ *
+ * Separate from `selectResolveData` because roles are no longer joined into the
+ * page query: LIMIT/OFFSET apply to that query, so one row per user is what
+ * makes a page of `limit` contain `limit` users.
+ */
+let roleResolveData: Record<string, unknown>[] = [];
 
 /** Creates a chainable mock that mimics Drizzle's fluent API (select/from/where/...) */
 function createChainableMock(resolveData: () => Record<string, unknown>[]) {
@@ -74,6 +82,7 @@ function createChainableMock(resolveData: () => Record<string, unknown>[]) {
     "select",
     "from",
     "leftJoin",
+    "innerJoin",
     "where",
     "orderBy",
     "limit",
@@ -146,19 +155,25 @@ function createMockDb() {
   const countChain = createChainableMock(
     () => countResolveData as unknown as Record<string, unknown>[]
   );
+  const roleChain = createChainableMock(() => roleResolveData);
 
-  // db.select() either returns the count chain or the main chain
-  // We detect by inspecting the select argument
-  let callCount = 0;
-  const selectFn = vi.fn().mockImplementation(() => {
-    callCount++;
-    // In listUsers, the first select() is the count query, the second is the main query
-    // We detect the count chain by checking the call order
-    if (callCount % 2 === 1) {
-      return countChain;
-    }
-    return mainChain;
-  });
+  /**
+   * Route each `select()` by WHAT it projects, not by when it is called.
+   *
+   * The previous version alternated on call parity, which encoded the exact
+   * number and order of queries the implementation happened to make — so
+   * splitting one query into two silently handed a later query the count
+   * chain's rows. Projection is a property of the query itself, so this keeps
+   * answering correctly however many statements the service issues.
+   */
+  const selectFn = vi
+    .fn()
+    .mockImplementation((columns?: Record<string, unknown>) => {
+      const keys = Object.keys(columns ?? {});
+      if (keys.includes("value")) return countChain;
+      if (keys.includes("roleId")) return roleChain;
+      return mainChain;
+    });
 
   return {
     select: selectFn,
@@ -174,9 +189,7 @@ function createMockDb() {
     },
     _mainChain: mainChain,
     _countChain: countChain,
-    _resetCallCount: () => {
-      callCount = 0;
-    },
+    _roleChain: roleChain,
   };
 }
 
@@ -221,6 +234,7 @@ describe("UserQueryService", () => {
     vi.clearAllMocks();
     selectResolveData = [];
     countResolveData = [{ value: 0 }];
+    roleResolveData = [];
     mockAdapter = createMockAdapter();
     service = new UserQueryService(mockAdapter as never, silentLogger as never);
   });
@@ -231,7 +245,6 @@ describe("UserQueryService", () => {
     it("should return paginated result with default pagination", async () => {
       countResolveData = [{ value: 0 }];
       selectResolveData = [];
-      mockDb._resetCallCount();
 
       // Post-migration (PR 4): no `success`/`statusCode`/`message` envelope.
       const result = await service.listUsers();
@@ -247,6 +260,8 @@ describe("UserQueryService", () => {
 
     it("should return users with roles grouped correctly", async () => {
       countResolveData = [{ value: 2 }];
+      // ONE row per user. The page query no longer joins roles, so a
+      // multi-role user occupies a single row of the page.
       selectResolveData = [
         {
           userId: "user-1",
@@ -257,20 +272,6 @@ describe("UserQueryService", () => {
           isActive: true,
           createdAt: new Date("2026-01-01"),
           updatedAt: new Date("2026-01-01"),
-          roleId: "role-1",
-          roleName: "admin",
-        },
-        {
-          userId: "user-1",
-          email: "alice@example.com",
-          emailVerified: new Date("2026-01-01"),
-          name: "Alice",
-          image: null,
-          isActive: true,
-          createdAt: new Date("2026-01-01"),
-          updatedAt: new Date("2026-01-01"),
-          roleId: "role-2",
-          roleName: "editor",
         },
         {
           userId: "user-2",
@@ -281,11 +282,14 @@ describe("UserQueryService", () => {
           isActive: true,
           createdAt: new Date("2026-01-02"),
           updatedAt: new Date("2026-01-02"),
-          roleId: null,
-          roleName: null,
         },
       ];
-      mockDb._resetCallCount();
+      // Alice holds two roles; Bob holds none, so he contributes no row at all
+      // (the lookup inner-joins, rather than left-joining from users).
+      roleResolveData = [
+        { userId: "user-1", roleId: "role-1", roleName: "admin" },
+        { userId: "user-1", roleId: "role-2", roleName: "editor" },
+      ];
 
       const result = await service.listUsers({ page: 1, limit: 10 });
 
@@ -309,7 +313,6 @@ describe("UserQueryService", () => {
     it("should use custom page and limit", async () => {
       countResolveData = [{ value: 25 }];
       selectResolveData = [];
-      mockDb._resetCallCount();
 
       const options: ListUsersOptions = { page: 3, limit: 5 };
       const result = await service.listUsers(options);
@@ -323,7 +326,6 @@ describe("UserQueryService", () => {
     it("should handle page beyond total pages gracefully", async () => {
       countResolveData = [{ value: 5 }];
       selectResolveData = [];
-      mockDb._resetCallCount();
 
       const result = await service.listUsers({ page: 100, limit: 10 });
 
@@ -348,7 +350,6 @@ describe("UserQueryService", () => {
           roleName: null,
         },
       ];
-      mockDb._resetCallCount();
 
       const result = await service.listUsers({ search: "alice" });
 
@@ -372,7 +373,6 @@ describe("UserQueryService", () => {
           roleName: null,
         },
       ];
-      mockDb._resetCallCount();
 
       const result = await service.listUsers({ emailVerified: true });
 
@@ -395,7 +395,6 @@ describe("UserQueryService", () => {
           roleName: null,
         },
       ];
-      mockDb._resetCallCount();
 
       const result = await service.listUsers({ hasPassword: true });
 
@@ -430,7 +429,6 @@ describe("UserQueryService", () => {
           roleName: null,
         },
       ];
-      mockDb._resetCallCount();
 
       const result = await service.listUsers({
         sortBy: "name",
@@ -447,7 +445,6 @@ describe("UserQueryService", () => {
     it("should default sortBy to email and sortOrder to asc", async () => {
       countResolveData = [{ value: 0 }];
       selectResolveData = [];
-      mockDb._resetCallCount();
 
       const result = await service.listUsers({});
 
@@ -471,7 +468,6 @@ describe("UserQueryService", () => {
           roleName: null,
         },
       ];
-      mockDb._resetCallCount();
 
       const result = await service.listUsers({
         sortBy: "createdAt",
@@ -484,7 +480,6 @@ describe("UserQueryService", () => {
     it("should calculate totalPages correctly", async () => {
       countResolveData = [{ value: 23 }];
       selectResolveData = [];
-      mockDb._resetCallCount();
 
       const result = await service.listUsers({ page: 1, limit: 5 });
 
@@ -509,7 +504,6 @@ describe("UserQueryService", () => {
           roleName: null,
         },
       ];
-      mockDb._resetCallCount();
 
       const result = await service.listUsers({
         search: "alice",
@@ -535,7 +529,6 @@ describe("UserQueryService", () => {
           roleName: null,
         },
       ];
-      mockDb._resetCallCount();
 
       const result = await service.listUsers();
 

--- a/packages/nextly/src/domains/users/services/user-query-service.ts
+++ b/packages/nextly/src/domains/users/services/user-query-service.ts
@@ -478,6 +478,14 @@ export class UserQueryService extends BaseService {
     // Build select columns — custom field columns are intentionally excluded
     // here; they are fetched via a dedicated query below to avoid Drizzle ORM
     // issues when a runtime-generated table is combined with multiple JOINs.
+    //
+    // Role columns are excluded for a different reason: this query is what LIMIT
+    // and OFFSET apply to, so it must produce exactly one row per user. Joining
+    // roles here would make a user with three roles consume three rows of the
+    // page, so a page of `limit` returns fewer than `limit` users and OFFSET
+    // advances over joined rows rather than users — which skips users entirely
+    // rather than merely short-filling the page. Roles are fetched below, for
+    // the users this page actually selected.
     const selectColumns: Record<string, unknown> = {
       userId: users.id,
       email: users.email,
@@ -487,8 +495,6 @@ export class UserQueryService extends BaseService {
       isActive: users.isActive,
       createdAt: users.createdAt,
       updatedAt: users.updatedAt,
-      roleId: roles.id,
-      roleName: roles.name,
     };
 
     // Required by Drizzle ORM — runtime-generated tables need untyped db access
@@ -496,20 +502,19 @@ export class UserQueryService extends BaseService {
       .select(selectColumns)
       .from(users);
 
+    // `user_ext` is one row per user, so joining it cannot inflate the page the
+    // way the role tables would.
     if (needsExtJoinForSort && userExtTable) {
       query = query.leftJoin(userExtTable, eq(users.id, userExtTable.user_id));
     }
 
-    // LEFT JOIN roles
     query = query
-      .leftJoin(userRoles, eq(users.id, userRoles.userId))
-      .leftJoin(roles, eq(userRoles.roleId, roles.id))
       .where(whereClause)
       .orderBy(orderByClause)
       .limit(limit)
       .offset(offset);
 
-    const userListWithRoles: Record<string, unknown>[] = await query;
+    const pageOfUsers: Record<string, unknown>[] = await query;
 
     const totalPages = Math.ceil(total / limit);
 
@@ -530,23 +535,47 @@ export class UserQueryService extends BaseService {
       }
     >();
 
-    for (const row of userListWithRoles) {
+    // Insertion order is the page's order, and `Map` preserves it — so the
+    // result keeps whatever `orderByClause` asked for without a second sort.
+    for (const row of pageOfUsers) {
       const userId = row.userId as string;
-      if (!usersMap.has(userId)) {
-        usersMap.set(userId, {
-          id: userId,
-          email: row.email as string,
-          emailVerified: (row.emailVerified as Date | null) ?? null,
-          name: (row.name as string | null) ?? null,
-          image: (row.image as string | null) ?? null,
-          isActive: (row.isActive as boolean | undefined) ?? undefined,
-          createdAt: (row.createdAt as Date | null | undefined) ?? undefined,
-          updatedAt: (row.updatedAt as Date | null | undefined) ?? undefined,
-          roles: [],
-        });
-      }
-      // Add role if it exists (LEFT JOIN may return null for users without roles)
-      if (row.roleId && row.roleName) {
+      usersMap.set(userId, {
+        id: userId,
+        email: row.email as string,
+        emailVerified: (row.emailVerified as Date | null) ?? null,
+        name: (row.name as string | null) ?? null,
+        image: (row.image as string | null) ?? null,
+        isActive: (row.isActive as boolean | undefined) ?? undefined,
+        createdAt: (row.createdAt as Date | null | undefined) ?? undefined,
+        updatedAt: (row.updatedAt as Date | null | undefined) ?? undefined,
+        roles: [],
+      });
+    }
+
+    // Roles for exactly the users on this page. One query rather than one per
+    // user, and scoped by id rather than by re-running the filter — re-running
+    // it could select a different set if a concurrent write changed a user's
+    // filterable state between the two statements.
+    if (usersMap.size > 0) {
+      const pageUserIds = Array.from(usersMap.keys());
+      const roleRows: Record<string, unknown>[] = await (
+        this.db as unknown as DrizzleChain
+      )
+        .select({
+          userId: userRoles.userId,
+          roleId: roles.id,
+          roleName: roles.name,
+        })
+        .from(userRoles)
+        .innerJoin(roles, eq(userRoles.roleId, roles.id))
+        .where(inArray(userRoles.userId, pageUserIds))
+        // Deterministic role order per user. The previous join left it to the
+        // planner, so two identical requests could differ.
+        .orderBy(asc(roles.name));
+
+      for (const row of roleRows) {
+        const entry = usersMap.get(String(row.userId));
+        if (!entry || !row.roleId || !row.roleName) continue;
         // Type-narrow row.roleId before stringification — avoids
         // Object#toString fallthrough on unknown driver values.
         const rawRoleId = row.roleId;
@@ -554,10 +583,7 @@ export class UserQueryService extends BaseService {
           typeof rawRoleId === "string" || typeof rawRoleId === "number"
             ? String(rawRoleId)
             : "";
-        usersMap.get(userId)!.roles.push({
-          id: roleId,
-          name: row.roleName as string,
-        });
+        entry.roles.push({ id: roleId, name: row.roleName as string });
       }
     }
 

--- a/packages/nextly/src/domains/users/services/user-query-service.ts
+++ b/packages/nextly/src/domains/users/services/user-query-service.ts
@@ -29,6 +29,7 @@ import { and, eq, ne, or, asc, desc, count, sql, inArray } from "drizzle-orm";
 import { GetUserByIdSchema } from "@nextly/schemas/_zod/user";
 import { EmailSchema } from "@nextly/schemas/_zod/validation";
 import type { MinimalUser } from "@nextly/types/auth";
+import { clampLimit } from "@nextly/types/pagination";
 
 import { toDbError } from "../../../database/errors";
 import { container } from "../../../di/container";
@@ -360,13 +361,23 @@ export class UserQueryService extends BaseService {
   ): Promise<ListUsersResponse> {
     const {
       page = 1,
-      limit = 10,
+      limit: requestedLimit = 10,
       search,
       emailVerified,
       hasPassword,
       sortBy = "email",
       sortOrder = "asc",
     } = options || {};
+
+    // The dispatcher forwards whatever numeric `limit` arrived on the request, and this method is
+    // also reachable directly, so nothing upstream bounds it. An unbounded page is a problem in
+    // its own right, and it became a hard failure once roles were fetched with `inArray` over the
+    // page's ids: one bound parameter per user, against a SQLite default
+    // `SQLITE_MAX_VARIABLE_NUMBER` of 32766.
+    //
+    // Clamped rather than chunked, because the bound is what the API already advertises — the
+    // shared helper, so this cannot drift from every other paginated list.
+    const limit = clampLimit(requestedLimit);
 
     const { users, userRoles, roles } = this.tables;
 

--- a/packages/nextly/src/domains/users/services/user-service.ts
+++ b/packages/nextly/src/domains/users/services/user-service.ts
@@ -304,13 +304,19 @@ export class UserService {
 
     const users = result.data.map(u => this.mapToUser(u));
     const total = result.meta.total;
-    const offset = (page - 1) * limit;
+
+    // The EFFECTIVE page size, read back from the query rather than from what was asked for.
+    // `listUsers` bounds the limit it will honour, so recomputing the offset from the request
+    // would describe a different page than the one returned — a page-2 request for 1000 users
+    // would report a 1000-item page while the rows came from offset 500.
+    const effectiveLimit = result.meta.limit;
+    const offset = (page - 1) * effectiveLimit;
 
     return {
       data: users,
       pagination: {
         total,
-        limit,
+        limit: effectiveLimit,
         offset,
         hasMore: offset + users.length < total,
       },


### PR DESCRIPTION
## The defect

`listUsers` applied `LIMIT`/`OFFSET` to a query that left-joined `user_roles` and `roles`, then grouped the rows by user. A user holding three roles consumed **three rows of the page**.

Two consequences, and the second is the serious one:

- a page of N returns fewer than N users, with nothing saying it did;
- `OFFSET` advances over **joined rows** rather than users, so page 2 starts partway through the joined result and **users are skipped entirely**.

Meanwhile `total` counts base users, so `totalPages` looks right the whole time and nothing in the response indicates the gap. This reaches the **admin Users page** through `dispatcher/handlers/user-dispatcher.ts`.

Measured against nine users, two of them holding three roles each, pages of three:

| | old | new |
|---|---|---|
| page 1 size | 2 | 3 |
| users seen walking every page | **6 of 9** | 9 of 9 |
| roles on the multi-role user | `[admin, editor]` | `[admin, editor, viewer]` |

The third row is worth noting: the join truncated a user's own role list when the third joined row fell past the page limit.

## The fix

The page query projects one row per user; roles are fetched in a second query scoped to exactly the ids that page selected. `total` keeps counting what it always counted.

Scoping the second query **by id** rather than by re-running the filter is deliberate: re-running it could select a different set if a concurrent write changed a user's filterable state between the two statements.

Role order per user is now deterministic (`ORDER BY roles.name`). The join left it to the planner, so two identical requests could differ.

## Why the coverage is an integration test

The defect is row multiplication performed by the **database**. Against a mocked query builder the rows are whatever the fixture says, so a mock cannot separate the two implementations — `user-query-service.test.ts` passes under both, which is why it is not the evidence here.

`list-users-pagination.integration.test.ts` runs against real SQLite with:

- **the separating property** — multi-role users positioned *inside* a page so the inflation crosses the boundary that follows. A fixture where everyone holds one role returns identical results from broken and fixed code;
- **a fixture control** asserting the multi-role assignment actually landed. Without it, a silently failed insert would leave every user single-role, the mechanism would never engage, and every assertion would pass against the broken implementation;
- **a guard against the obvious wrong fix** — dropping the join and returning users with no roles at all.

Break-verified: against the original implementation, 3 of the 5 cases fail with exactly the numbers in the table.

## Notes

- **`describe.skip("listUsers()")` in `services/users.test.ts` was left alone, deliberately.** I un-skipped it first as planned. That whole file already fails 24 tests on unmodified `main` — `adapter.getCapabilities is not a function` in `beforeEach`, so nothing in it runs, including tests that were never skipped. The skip comment blames missing `isActive`/`createdAt`/`updatedAt` columns, which is no longer the reason. Un-skipping would have added 15 failures to a known baseline; the fixture rot is its own task.
- The service's unit suite routed `select()` by call parity, which encoded the exact number and order of queries the implementation made. It now routes by what each query projects, so splitting a query no longer hands a later one the count chain's rows.
- No new failures against the baseline: 6 of 7 files in `domains/users` pass, and `services/users.test.ts` fails exactly its pre-existing 24.

@codex please review this PR