### PR TITLE
fix(root): reject an empty persistent-task set in the dev concurrency gate

### DIFF
--- a/scripts/check-dev-concurrency.mjs
+++ b/scripts/check-dev-concurrency.mjs
@@ -127,6 +127,21 @@ for (const [name, command] of wholeWorkspace) {
 // A check that inspects nothing passes, and this one selects scripts by
 // pattern, so an edit that renames or restructures them would leave it
 // examining an empty set and reporting success.
+// The other half of the same question, and it was missing while the launcher
+// half was present. An enumeration that returns nothing — a workspace glob that
+// stopped matching, a directory that moved — makes every limit trivially
+// sufficient, so the gate certifies a `pnpm dev` that starts nothing. A count
+// this check DERIVES has to have a positive control, or it is only ever
+// comparing a number against zero.
+if (tasks.length === 0) {
+  console.error(
+    "check-dev-concurrency: found no package declaring a `dev` script. Either " +
+      "the workspace layout changed and this check needs teaching, or the " +
+      "enumeration is returning nothing and every limit passes against zero."
+  );
+  process.exit(2);
+}
+
 if (wholeWorkspace.length === 0) {
   console.error(
     "check-dev-concurrency: no root script runs every package's `dev` task. " +


### PR DESCRIPTION
Re-lands a commit that #804 stranded. **Nothing here is new work** — `5803da4f1` cherry-picked onto `main`, unchanged.

## What happened

#804 merged as `a88d6c5f0` from `headRefOid` `cfde909f9`, while the branch tip was `5803da4f1`. The commit answering the review finding never left the branch.

Content-verified, with a control proving the search reaches the file:

| | marker present? |
|---|---|
| branch tip `5803da4f1` | **1 hit** |
| merge commit `a88d6c5f0` | 0 — ABSENT |
| `origin/main` | 0 — ABSENT |
| control: `check-dev-concurrency` in the merged file | 4 hits, so the search works |

## What the commit restores

The gate rejected an empty **launcher** set but not an empty **task** set — the same omission on the other input, in a script whose whole purpose is deriving both.

An enumeration returning nothing (a workspace glob that stopped matching, a directory that moved) makes every limit trivially sufficient, so the check reports `ok — 0 persistent dev tasks` and certifies a `pnpm dev` that starts nothing. A count the script derives needs a positive control, or it is only ever comparing a number against zero.

It now exits 2 with a message separating "the workspace layout changed" from "the enumeration is returning nothing".

**Stub-verified:** suppressing the manifest scan exits 2 rather than passing; the stale-limit and missing-flag cases still exit 1; healthy exits 0.

## This is the second strand on my own PRs today

Same mechanism as #802, a few hours apart, and both times the surviving half was the one that made the suite look fine.

The window is push-a-fix-then-merge: the merge snapshots a head, and a push after that snapshot is outside the merge entirely — so a PR reads as complete with green checks and resolved threads while its last commit is only on the branch. `gh`'s `headRefOid` reports the **merged** head, so nothing inside the PR can show it.

Worth noting for anyone auditing worktrees on "no unpushed commits": a stranded commit **was** pushed, so that count reads 0 while its content never reached `main`.

The gate that prevents this rather than detecting it is `gh pr merge --match-head-commit <the revision you verified>`, which makes the check and the merge one atomic operation on GitHub's side.
