### PR TITLE
test(root): place the canvas pointer at a known depth inside a zone

### DIFF
--- a/e2e/tests/canvas/driver.ts
+++ b/e2e/tests/canvas/driver.ts
@@ -554,6 +554,123 @@ export function dwellAllowanceOf(driver: Partial<CanvasDriver>): number {
  * Returns the containing zone's ordinal, or -1 if none was reached — a value the
  * CALLER must assert on, for the same reason `dragUntilTarget` says so.
  */
+/**
+ * What placing the pointer at a known depth needs, which is less than a whole
+ * canvas.
+ *
+ * `pointer()` is what makes the result a MEASUREMENT rather than an intention:
+ * the inset is reported in pixels of pointer movement, which is the only unit
+ * an assertion about a hysteresis band can be written in. A collision score
+ * cannot serve — `Collision.value` is pointer distance for one collision type
+ * and overlap area for another, so the same number means different things per
+ * candidate kind.
+ */
+type ZoneInsetDriver = Pick<
+  CanvasDriver,
+  "moveBy" | "zoneContainingPointer" | "pointer"
+>;
+
+/** Where {@link dragToInsetInZone} left the pointer, and how it knows. */
+export interface ZoneInset {
+  /** The zone the pointer ended inside, or -1 when none was reached. */
+  readonly zone: number;
+  /**
+   * Pixels of pointer movement PAST the boundary, measured rather than assumed.
+   *
+   * Pointer positions and DOM geometry are fractional and the coarse approach
+   * overshoots, so the achieved depth is not the requested one and a caller
+   * asserting on a band width has to know which it got.
+   */
+  readonly insetPx: number;
+  /**
+   * Why a request could not be met, absent when it was.
+   *
+   * `too-narrow` is a fact about the FIXTURE rather than about the canvas: a
+   * zone shallower than the requested depth cannot answer the question at all,
+   * and returning the closest depth achieved would silently measure something
+   * the caller did not ask for.
+   */
+  readonly refused?: "never-entered" | "too-narrow";
+}
+
+/** Pixels per step while closing on the boundary, once the zone has been found. */
+const INSET_PROBE_PX = 1;
+
+/**
+ * Carry the drag to EXACTLY `wantInsetPx` inside the zone it first enters.
+ *
+ * {@link dragUntilInsideZone} stops at the first coarse step that lands inside
+ * a zone, so where it leaves the pointer is an accident of the step size and no
+ * caller can say how deep it is. That is fine for a containment question and
+ * useless for a hysteresis one: a canvas whose hysteresis is a distance margin
+ * has correctly NOT switched a few pixels past a boundary, because that is
+ * inside its margin and holding the previous target there is what the
+ * requirement asks for. Waiting cannot rescue it — waiting does not move a
+ * pointer, and a distance-based resolver does not change its mind with time.
+ * The only way to ask such a canvas a question is to stand at a KNOWN depth.
+ *
+ * Three phases, and the middle one is what makes the answer exact:
+ *
+ * 1. coarse steps until some zone contains the pointer, so the walk starts from
+ *    a live zone rather than dead space;
+ * 2. one-pixel steps BACK until the zone is left, then one forward — the
+ *    boundary is now bracketed to within a pixel and its position is read from
+ *    the driver rather than inferred from a step count;
+ * 3. forward to the requested depth, re-reading containment so a zone too
+ *    shallow to hold it is reported rather than approximated.
+ *
+ * Vertical, matching the axis every zone boundary in this suite is crossed on.
+ */
+export async function dragToInsetInZone(
+  driver: ZoneInsetDriver,
+  wantInsetPx: number,
+  maxSteps = 40
+): Promise<ZoneInset> {
+  let zone = await driver.zoneContainingPointer();
+  for (let step = 0; step < maxSteps && zone < 0; step += 1) {
+    await driver.moveBy(0, 4);
+    zone = await driver.zoneContainingPointer();
+  }
+  if (zone < 0) return { zone: -1, insetPx: 0, refused: "never-entered" };
+
+  // Back out a pixel at a time until the zone is left. Bounded by the coarse
+  // distance already travelled plus a step, because that is the furthest inside
+  // the zone the approach can have put us.
+  const retreatLimit = maxSteps * 4 + 4;
+  let left = false;
+  for (let step = 0; step < retreatLimit; step += 1) {
+    await driver.moveBy(0, -INSET_PROBE_PX);
+    if ((await driver.zoneContainingPointer()) !== zone) {
+      left = true;
+      break;
+    }
+  }
+  if (!left) return { zone, insetPx: 0, refused: "never-entered" };
+
+  // One step back in: the pointer is now within a pixel of the boundary, and
+  // this position — not a step count — is what the depth is measured from.
+  await driver.moveBy(0, INSET_PROBE_PX);
+  if ((await driver.zoneContainingPointer()) !== zone) {
+    return { zone, insetPx: 0, refused: "never-entered" };
+  }
+  const boundaryY = driver.pointer().y;
+
+  for (let moved = 0; moved < wantInsetPx; moved += INSET_PROBE_PX) {
+    await driver.moveBy(0, INSET_PROBE_PX);
+    if ((await driver.zoneContainingPointer()) !== zone) {
+      // Reported rather than approximated: the fixture cannot answer at this
+      // depth, and a shallower reading would be a different measurement wearing
+      // the requested one's name.
+      return {
+        zone,
+        insetPx: driver.pointer().y - boundaryY,
+        refused: "too-narrow",
+      };
+    }
+  }
+  return { zone, insetPx: driver.pointer().y - boundaryY };
+}
+
 export async function dragUntilInsideZone(
   driver: CanvasDriver,
   maxSteps = 40

--- a/e2e/tests/canvas/driver.ts
+++ b/e2e/tests/canvas/driver.ts
@@ -773,13 +773,31 @@ async function bracketZoneEdge(
  * The pointer is left INSIDE the reported zone in every outcome but
  * `never-entered`, and is restored to where it started when no boundary can be
  * found — a probe that fails is not entitled to leave the drag somewhere else.
+ * `edge-moving` is the one refusal that does NOT rewind: the last bracket left
+ * the pointer just inside the zone, and putting it back where that bracket
+ * began would return it to a position the edge has since travelled past. The
+ * zone reported there is read from the pointer's actual containment rather than
+ * assumed, so the result describes where the drag really is.
  *
  * Vertical, matching the axis every zone boundary in this suite is crossed on.
  */
 export async function dragToInsetInZone(
   driver: ZoneInsetDriver,
   wantInsetPx: number,
-  maxSteps = 40
+  maxSteps = 40,
+  /**
+   * How this waits between edge measurements.
+   *
+   * Injected so a FIXTURE can move its edge at the one moment the probe is
+   * known to be between brackets, rather than after a duration it has to guess.
+   * A fixture keyed to the clock races the process it is testing: pause the
+   * runner for longer than the wait and the edge has already moved before the
+   * first measurement, so the walk lands in the settled band and the test
+   * passes without ever exercising the re-entry it exists to cover.
+   *
+   * The default is the real wait, so nothing about a live canvas changes.
+   */
+  settle: (ms: number) => Promise<void> = settleMs
 ): Promise<ZoneInset> {
   const refuse = (
     zone: number,
@@ -833,25 +851,29 @@ export async function dragToInsetInZone(
   // would put wall-clock dependence into the one control a band assertion
   // rests on, and would still be a guess about a duration the canvas owns.
   let boundaryY: number | null = null;
-  let settledMoved = 0;
   for (let attempt = 0; attempt < EDGE_SETTLE_ATTEMPTS; attempt += 1) {
     const found = await bracketZoneEdge(driver, zone, retreatLimit);
     if (!found) return refuse(zone, "boundary-not-found");
-    if (boundaryY === found.boundaryY) {
-      settledMoved = found.movedPx;
-      break;
-    }
+    if (boundaryY === found.boundaryY) break;
     boundaryY = found.boundaryY;
-    settledMoved = found.movedPx;
     // Across the transition rather than adjacent to it. Two brackets taken back
     // to back land inside the same animation frame and can agree on a whole
     // pixel the edge is still travelling through.
-    await settleMs(EDGE_SETTLE_MS);
+    await settle(EDGE_SETTLE_MS);
     if (attempt === EDGE_SETTLE_ATTEMPTS - 1) {
       // Still moving. Reported rather than measured through: a depth taken from
       // an edge that is in motion is a number with no referent.
-      await driver.moveBy(0, -settledMoved);
-      return refuse(zone, "edge-moving");
+      //
+      // The pointer is LEFT where the last bracket put it, which that bracket
+      // confirmed was inside the zone as its final act. Undoing its movement
+      // would return the pointer to where this attempt began — a position the
+      // edge has since travelled past, and outside the very zone the result
+      // names. A refusal is still a description of where the pointer is, so it
+      // may not put the pointer somewhere its own `zone` does not cover.
+      //
+      // Read back rather than assumed, because "the bracket said so a moment
+      // ago" is exactly the claim a moving edge invalidates.
+      return refuse(await driver.zoneContainingPointer(), "edge-moving");
     }
   }
   if (boundaryY === null) return refuse(zone, "boundary-not-found");

--- a/e2e/tests/canvas/driver.ts
+++ b/e2e/tests/canvas/driver.ts
@@ -856,10 +856,11 @@ export async function dragToInsetInZone(
     if (!found) return refuse(zone, "boundary-not-found");
     if (boundaryY === found.boundaryY) break;
     boundaryY = found.boundaryY;
-    // Across the transition rather than adjacent to it. Two brackets taken back
-    // to back land inside the same animation frame and can agree on a whole
-    // pixel the edge is still travelling through.
-    await settle(EDGE_SETTLE_MS);
+    // Exhaustion is decided BEFORE waiting, because the wait is only ever there
+    // to separate one bracket from the NEXT one. After the last bracket there
+    // is no next one, and waiting anyway gives the edge one more interval to
+    // travel — invalidating the containment that bracket just confirmed, so the
+    // refusal reads back `-1` and reports being in no zone at all.
     if (attempt === EDGE_SETTLE_ATTEMPTS - 1) {
       // Still moving. Reported rather than measured through: a depth taken from
       // an edge that is in motion is a number with no referent.
@@ -875,6 +876,10 @@ export async function dragToInsetInZone(
       // ago" is exactly the claim a moving edge invalidates.
       return refuse(await driver.zoneContainingPointer(), "edge-moving");
     }
+    // Across the transition rather than adjacent to it. Two brackets taken back
+    // to back land inside the same animation frame and can agree on a whole
+    // pixel the edge is still travelling through.
+    await settle(EDGE_SETTLE_MS);
   }
   if (boundaryY === null) return refuse(zone, "boundary-not-found");
 

--- a/e2e/tests/canvas/driver.ts
+++ b/e2e/tests/canvas/driver.ts
@@ -611,11 +611,13 @@ export interface ZoneInset {
   /**
    * Pixels of pointer movement PAST the boundary, measured rather than assumed.
    *
-   * The pointer is INSIDE `zone` at this depth in every outcome, including the
-   * refusals — a reported depth the pointer is not standing at would be a
-   * different measurement wearing this one's name.
+   * Present only when a boundary was actually found: the pointer is INSIDE
+   * `zone` at this depth, including under `too-narrow`. ABSENT for the refusals
+   * that never located an edge, because there is no boundary for a depth to be
+   * measured from and a `0` there would read as "at the boundary" — a position
+   * the pointer is not standing at.
    */
-  readonly insetPx: number;
+  readonly insetPx?: number;
   /**
    * How precisely the boundary itself is known, in pixels.
    *
@@ -660,6 +662,22 @@ const INSET_APPROACH_PX = 4;
 const EDGE_SETTLE_ATTEMPTS = 3;
 
 /**
+ * The longest a zone edge may still be moving after the pointer enters it.
+ *
+ * The canvas animates a drop zone's height and margin over 100ms when it becomes
+ * the active target, and an animation is CONTINUOUS: two brackets taken back to
+ * back can quantize to the same whole pixel while the edge is still travelling
+ * inside it. Agreement between adjacent samples is therefore necessary and not
+ * sufficient, and no purely positional method can close that — "has an animation
+ * finished" is a question about an interval.
+ *
+ * So this is a clock, deliberately, and it is the canvas's own transition
+ * duration rather than a guess. Paired with the agreement check: the wait covers
+ * the animation, the agreement confirms it is over.
+ */
+const EDGE_SETTLE_MS = 120;
+
+/**
  * The first pointer position INSIDE `zone`, found by retreating out and stepping back in.
  *
  * Returns `null` when the zone's edge is not within `retreatLimit` — the pointer
@@ -669,6 +687,11 @@ const EDGE_SETTLE_ATTEMPTS = 3;
  * Leaves the pointer where it found the boundary, and reports how far it
  * retreated so a caller that must abandon the measurement can put the drag back.
  */
+/** One wait, named for what it is, so no caller invents its own. */
+function settleMs(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
 async function bracketZoneEdge(
   driver: ZoneInsetDriver,
   zone: number,
@@ -735,12 +758,7 @@ export async function dragToInsetInZone(
   const refuse = (
     zone: number,
     reason: NonNullable<ZoneInset["refused"]>
-  ): ZoneInset => ({
-    zone,
-    insetPx: 0,
-    resolutionPx: INSET_PROBE_PX,
-    refused: reason,
-  });
+  ): ZoneInset => ({ zone, resolutionPx: INSET_PROBE_PX, refused: reason });
 
   // A request this probe cannot represent is a CALLER fault, not a fact about
   // the canvas — so it throws rather than joining the refusals, which a caller
@@ -751,6 +769,16 @@ export async function dragToInsetInZone(
   if (!Number.isInteger(wantInsetPx) || wantInsetPx < 0) {
     throw new Error(
       `dragToInsetInZone needs a whole, non-negative depth in pixels; got ${wantInsetPx}`
+    );
+  }
+  // The same treatment for the budget, and each bad value fails differently:
+  // `Infinity` never terminates and hangs the run until Playwright's outer
+  // timeout — defeating the runaway guard this parameter IS — while `NaN` and a
+  // negative skip the approach entirely and report `never-entered` about a
+  // canvas that was never asked.
+  if (!Number.isInteger(maxSteps) || maxSteps < 0) {
+    throw new Error(
+      `dragToInsetInZone needs a whole, non-negative step budget; got ${maxSteps}`
     );
   }
 
@@ -789,6 +817,10 @@ export async function dragToInsetInZone(
     }
     boundaryY = found.boundaryY;
     settledRetreat = found.retreatedPx;
+    // Across the transition rather than adjacent to it. Two brackets taken back
+    // to back land inside the same animation frame and can agree on a whole
+    // pixel the edge is still travelling through.
+    await settleMs(EDGE_SETTLE_MS);
     if (attempt === EDGE_SETTLE_ATTEMPTS - 1) {
       // Still moving. Reported rather than measured through: a depth taken from
       // an edge that is in motion is a number with no referent.

--- a/e2e/tests/canvas/driver.ts
+++ b/e2e/tests/canvas/driver.ts
@@ -597,8 +597,13 @@ async function approachZone(
 ): Promise<ZoneApproach> {
   const startedAt = driver.pointer().y;
   let zone = await driver.zoneContainingPointer();
-  for (let step = 0; step < maxSteps && zone < 0; step += 1) {
-    await driver.moveBy(0, INSET_APPROACH_PX);
+  // Bounded in PIXELS and stepped at the probe resolution. The budget a caller
+  // expressed in coarse steps reaches exactly as far as before; what changed is
+  // that every pixel along the way is sampled, so a zone thinner than a coarse
+  // step is entered rather than jumped over.
+  const budgetPx = maxSteps * INSET_APPROACH_PX;
+  for (let moved = 0; moved < budgetPx && zone < 0; moved += INSET_PROBE_PX) {
+    await driver.moveBy(0, INSET_PROBE_PX);
     zone = await driver.zoneContainingPointer();
   }
   return { zone, travelledPx: driver.pointer().y - startedAt };
@@ -655,7 +660,19 @@ export interface ZoneInset {
 /** Pixels per step while closing on the boundary, once the zone has been found. */
 const INSET_PROBE_PX = 1;
 
-/** Pixels per step while approaching, before any zone has been reached. */
+/**
+ * How far one unit of a caller's step budget carries the approach, in pixels.
+ *
+ * A BUDGET SCALE, not a step size. The approach walks at {@link INSET_PROBE_PX}
+ * so it cannot stride over a zone: a drop zone is 6 CSS pixels tall, which at
+ * the 0.5 canvas scale this suite supports is 3 host pixels, and a 4px step
+ * starting at a fractional offset can place the entire span between two
+ * commands — the walk then reports the zone below it, or none at all, and the
+ * helper can never say the first zone was `too-narrow` because it never saw it.
+ *
+ * Kept as the multiplier so a `maxSteps` a caller already passes reaches the
+ * same distance it always did; only the sampling in between got finer.
+ */
 const INSET_APPROACH_PX = 4;
 
 /** How many times the boundary may be re-measured before its motion is a verdict. */

--- a/e2e/tests/canvas/driver.ts
+++ b/e2e/tests/canvas/driver.ts
@@ -158,6 +158,22 @@ export interface CanvasDriver {
   dwellAllowanceMs?: number;
 
   /**
+   * How long this canvas may still be moving a zone's edge after the pointer
+   * enters it, in milliseconds.
+   *
+   * Declared per driver for the same reason `dwellAllowanceMs` is: the duration
+   * belongs to the canvas — the PoC animates a drop zone's geometry over 100ms
+   * in its own stylesheet — so no constant written into a probe is correct for
+   * every canvas. A probe carrying its own copy re-brackets while the edge is
+   * still travelling once that duration grows, agrees with itself on a whole
+   * pixel, and returns a stale depth with nothing reporting it was rushed.
+   *
+   * Optional: a driver that omits it gets the probe's default. A canvas whose
+   * zone geometry never animates declares 0.
+   */
+  geometrySettleMs?: number;
+
+  /**
    * Ordinal of the active drop zone among ALL drop zones in document order, or
    * -1 when none is active. Ordinal rather than id because the droppable id is
    * not present in the DOM.
@@ -568,7 +584,8 @@ export function dwellAllowanceOf(driver: Partial<CanvasDriver>): number {
 type ZoneInsetDriver = Pick<
   CanvasDriver,
   "moveBy" | "zoneContainingPointer" | "pointer"
->;
+> &
+  Partial<Pick<CanvasDriver, "geometrySettleMs">>;
 
 /** What the coarse approach observed, which is more than the zone it reached. */
 interface ZoneApproach {
@@ -692,7 +709,24 @@ const EDGE_SETTLE_ATTEMPTS = 3;
  * duration rather than a guess. Paired with the agreement check: the wait covers
  * the animation, the agreement confirms it is over.
  */
-const EDGE_SETTLE_MS = 120;
+const DEFAULT_GEOMETRY_SETTLE_MS = 120;
+
+/**
+ * How long this canvas may still be moving a zone's edge after the pointer
+ * enters it, in milliseconds.
+ *
+ * Declared per driver for the same reason {@link CanvasDriver.dwellAllowanceMs}
+ * is: the duration belongs to the canvas, so no constant written here is
+ * correct for every canvas. A probe carrying its own number is a second copy of
+ * a fact the canvas owns — lengthen the transition and the probe re-brackets
+ * while the edge is still travelling, agrees with itself on a whole pixel, and
+ * returns a stale depth with nothing reporting that anything was rushed.
+ *
+ * Optional: a driver that omits it gets {@link DEFAULT_GEOMETRY_SETTLE_MS}.
+ * Understating it is self-punishing rather than self-serving — measurements
+ * come back stale and the assertions built on them fail — which is what makes
+ * it safe to trust a driver's own answer.
+ */
 
 /** One wait, named for what it is, so no caller invents its own. */
 function settleMs(ms: number): Promise<void> {
@@ -900,7 +934,7 @@ export async function dragToInsetInZone(
     // Across the transition rather than adjacent to it. Two brackets taken back
     // to back land inside the same animation frame and can agree on a whole
     // pixel the edge is still travelling through.
-    await settle(EDGE_SETTLE_MS);
+    await settle(driver.geometrySettleMs ?? DEFAULT_GEOMETRY_SETTLE_MS);
   }
   if (boundaryY === null) return refuse(zone, "boundary-not-found");
 

--- a/e2e/tests/canvas/driver.ts
+++ b/e2e/tests/canvas/driver.ts
@@ -577,24 +577,44 @@ export interface ZoneInset {
   /**
    * Pixels of pointer movement PAST the boundary, measured rather than assumed.
    *
-   * Pointer positions and DOM geometry are fractional and the coarse approach
-   * overshoots, so the achieved depth is not the requested one and a caller
-   * asserting on a band width has to know which it got.
+   * The pointer is INSIDE `zone` at this depth in every outcome, including the
+   * refusals — a reported depth the pointer is not standing at would be a
+   * different measurement wearing this one's name.
    */
   readonly insetPx: number;
   /**
+   * How precisely the boundary itself is known, in pixels.
+   *
+   * A zone edge comes from `getBoundingClientRect()` and is fractional; the
+   * pointer is commanded in whole probe steps. So the boundary this measures
+   * from is the first COMMANDED position inside the zone, which can sit up to
+   * one step past the real edge, and `insetPx` carries that error.
+   *
+   * Reported rather than hidden, because a caller comparing a measured band
+   * against a required range has to widen its bounds by exactly this much. The
+   * alternative — resolving the fractional edge — is not available to a probe
+   * that can only command whole pixels.
+   */
+  readonly resolutionPx: number;
+  /**
    * Why a request could not be met, absent when it was.
    *
-   * `too-narrow` is a fact about the FIXTURE rather than about the canvas: a
-   * zone shallower than the requested depth cannot answer the question at all,
-   * and returning the closest depth achieved would silently measure something
-   * the caller did not ask for.
+   * Three distinct facts, because a caller reports them differently:
+   * `never-entered` is about the canvas drawing no zone in reach;
+   * `too-narrow` is about the FIXTURE, and comes with the deepest depth the
+   * zone does hold, so a caller can say what it would need; and
+   * `boundary-not-found` is about this probe, which cannot locate an edge it
+   * did not cross — a drag already deep inside a tall zone has no boundary in
+   * retreat range, and saying "no zone" there would be false.
    */
-  readonly refused?: "never-entered" | "too-narrow";
+  readonly refused?: "never-entered" | "too-narrow" | "boundary-not-found";
 }
 
 /** Pixels per step while closing on the boundary, once the zone has been found. */
 const INSET_PROBE_PX = 1;
+
+/** Pixels per step while approaching, before any zone has been reached. */
+const INSET_APPROACH_PX = 4;
 
 /**
  * Carry the drag to EXACTLY `wantInsetPx` inside the zone it first enters.
@@ -611,13 +631,18 @@ const INSET_PROBE_PX = 1;
  *
  * Three phases, and the middle one is what makes the answer exact:
  *
- * 1. coarse steps until some zone contains the pointer, so the walk starts from
- *    a live zone rather than dead space;
+ * 1. coarse steps until some zone contains the pointer, REMEMBERING how far it
+ *    travelled — that distance bounds where the boundary can be, so the retreat
+ *    below is derived from observed geometry rather than from a fixed budget;
  * 2. one-pixel steps BACK until the zone is left, then one forward — the
- *    boundary is now bracketed to within a pixel and its position is read from
+ *    boundary is now bracketed to within a step and its position is read from
  *    the driver rather than inferred from a step count;
  * 3. forward to the requested depth, re-reading containment so a zone too
- *    shallow to hold it is reported rather than approximated.
+ *    shallow to hold it is reported from the deepest point it does hold.
+ *
+ * The pointer is left INSIDE the reported zone in every outcome but
+ * `never-entered`, and is restored to where it started when no boundary can be
+ * found — a probe that fails is not entitled to leave the drag somewhere else.
  *
  * Vertical, matching the axis every zone boundary in this suite is crossed on.
  */
@@ -626,51 +651,101 @@ export async function dragToInsetInZone(
   wantInsetPx: number,
   maxSteps = 40
 ): Promise<ZoneInset> {
+  const startedAt = driver.pointer().y;
+  const refuse = (
+    zone: number,
+    reason: NonNullable<ZoneInset["refused"]>
+  ): ZoneInset => ({
+    zone,
+    insetPx: 0,
+    resolutionPx: INSET_PROBE_PX,
+    refused: reason,
+  });
+
   let zone = await driver.zoneContainingPointer();
+  const enteredInside = zone >= 0;
   for (let step = 0; step < maxSteps && zone < 0; step += 1) {
-    await driver.moveBy(0, 4);
+    await driver.moveBy(0, INSET_APPROACH_PX);
     zone = await driver.zoneContainingPointer();
   }
-  if (zone < 0) return { zone: -1, insetPx: 0, refused: "never-entered" };
+  if (zone < 0) return refuse(-1, "never-entered");
 
-  // Back out a pixel at a time until the zone is left. Bounded by the coarse
-  // distance already travelled plus a step, because that is the furthest inside
-  // the zone the approach can have put us.
-  const retreatLimit = maxSteps * 4 + 4;
+  // How far back the boundary can possibly be. Having WALKED into the zone, it
+  // is the distance travelled plus the step that crossed it. Having started
+  // inside, nothing observed bounds it, so the approach budget stands in — and
+  // running out is reported as its own fact rather than as "no zone".
+  const travelled = driver.pointer().y - startedAt;
+  const retreatLimit = enteredInside
+    ? maxSteps * INSET_APPROACH_PX
+    : travelled + INSET_APPROACH_PX;
+
   let left = false;
-  for (let step = 0; step < retreatLimit; step += 1) {
+  let retreated = 0;
+  while (retreated < retreatLimit) {
     await driver.moveBy(0, -INSET_PROBE_PX);
+    retreated += INSET_PROBE_PX;
     if ((await driver.zoneContainingPointer()) !== zone) {
       left = true;
       break;
     }
   }
-  if (!left) return { zone, insetPx: 0, refused: "never-entered" };
+  if (!left) {
+    // Put the drag back where it was found. A measurement that could not be
+    // taken must not also move the pointer, or the caller's next reading is
+    // about a position this probe chose.
+    await driver.moveBy(0, retreated);
+    return refuse(zone, "boundary-not-found");
+  }
 
-  // One step back in: the pointer is now within a pixel of the boundary, and
-  // this position — not a step count — is what the depth is measured from.
+  // One step back in: the pointer is within a step of the boundary, and this
+  // position — not a step count — is what the depth is measured from.
   await driver.moveBy(0, INSET_PROBE_PX);
   if ((await driver.zoneContainingPointer()) !== zone) {
-    return { zone, insetPx: 0, refused: "never-entered" };
+    await driver.moveBy(0, retreated - INSET_PROBE_PX);
+    return refuse(zone, "boundary-not-found");
   }
   const boundaryY = driver.pointer().y;
 
   for (let moved = 0; moved < wantInsetPx; moved += INSET_PROBE_PX) {
     await driver.moveBy(0, INSET_PROBE_PX);
     if ((await driver.zoneContainingPointer()) !== zone) {
-      // Reported rather than approximated: the fixture cannot answer at this
-      // depth, and a shallower reading would be a different measurement wearing
-      // the requested one's name.
+      // Back to the last contained point, so the reported depth is one the
+      // pointer is actually standing at. Reporting the overshooting step would
+      // overstate the zone's capacity by exactly the step that left it.
+      await driver.moveBy(0, -INSET_PROBE_PX);
       return {
         zone,
         insetPx: driver.pointer().y - boundaryY,
+        resolutionPx: INSET_PROBE_PX,
         refused: "too-narrow",
       };
     }
   }
-  return { zone, insetPx: driver.pointer().y - boundaryY };
+  return {
+    zone,
+    insetPx: driver.pointer().y - boundaryY,
+    resolutionPx: INSET_PROBE_PX,
+  };
 }
 
+/**
+ * Carry the drag until the pointer is INSIDE a zone, not merely until one is
+ * active.
+ *
+ * `dragUntilTarget` stops as soon as a target resolves, and
+ * `@dnd-kit/collision` resolves one by the dragged shape's OVERLAP when no zone
+ * contains the pointer. So "a target is active" and "the pointer is inside that
+ * target" are different states, and every exact claim about mapping — is the
+ * indicator where the pointer is, do two drags resolve the same way — is only
+ * decidable in the second.
+ *
+ * The distinction is not academic: it is where a stale-scroll or unscaled
+ * transform hides. Those implementations select a NEIGHBOURING zone, which any
+ * assertion tolerant of the overlap case accepts.
+ *
+ * Returns the containing zone's ordinal, or -1 if none was reached — a value the
+ * CALLER must assert on, for the same reason `dragUntilTarget` says so.
+ */
 export async function dragUntilInsideZone(
   driver: CanvasDriver,
   maxSteps = 40

--- a/e2e/tests/canvas/driver.ts
+++ b/e2e/tests/canvas/driver.ts
@@ -677,47 +677,73 @@ const EDGE_SETTLE_ATTEMPTS = 3;
  */
 const EDGE_SETTLE_MS = 120;
 
-/**
- * The first pointer position INSIDE `zone`, found by retreating out and stepping back in.
- *
- * Returns `null` when the zone's edge is not within `retreatLimit` — the pointer
- * is inside a zone whose boundary this walk never crossed, which is a different
- * fact from there being no zone.
- *
- * Leaves the pointer where it found the boundary, and reports how far it
- * retreated so a caller that must abandon the measurement can put the drag back.
- */
 /** One wait, named for what it is, so no caller invents its own. */
 function settleMs(ms: number): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
 
+/**
+ * The first pointer position INSIDE `zone`, and the NET distance this moved to find it.
+ *
+ * Two directions, because a zone edge moves both ways. The pointer may start
+ * inside — the ordinary case, where the edge is somewhere above — or OUTSIDE,
+ * which is what the canvas produces when a drop zone takes its 4px active margin
+ * in place of the 3px drag one: the top edge travels DOWN, and a pointer resting
+ * on the old boundary is left above the new one. Retreating from there only ever
+ * moves further away, so a walk that assumed "inside" would report an edge it
+ * was standing a pixel short of as unfindable.
+ *
+ * Returns `null` when no edge is within `limitPx` in either direction, and
+ * restores the pointer before doing so: a measurement that could not be taken
+ * must not also move the drag.
+ *
+ * `movedPx` is signed and NET — positive is downward — so one caller can undo
+ * the whole excursion without tracking its parts.
+ */
 async function bracketZoneEdge(
   driver: ZoneInsetDriver,
   zone: number,
-  retreatLimit: number
-): Promise<{ boundaryY: number; retreatedPx: number } | null> {
+  limitPx: number
+): Promise<{ boundaryY: number; movedPx: number } | null> {
+  let moved = 0;
+  const restore = async (): Promise<null> => {
+    await driver.moveBy(0, -moved);
+    return null;
+  };
+
+  // Forward until the zone is re-entered, for the case where its edge moved out
+  // from under the pointer.
+  let advanced = 0;
+  while (
+    (await driver.zoneContainingPointer()) !== zone &&
+    advanced < limitPx
+  ) {
+    await driver.moveBy(0, INSET_PROBE_PX);
+    moved += INSET_PROBE_PX;
+    advanced += INSET_PROBE_PX;
+  }
+  if ((await driver.zoneContainingPointer()) !== zone) return restore();
+
+  // Back out a pixel at a time until the zone is left.
   let retreated = 0;
   let left = false;
-  while (retreated < retreatLimit) {
+  while (retreated < limitPx) {
     await driver.moveBy(0, -INSET_PROBE_PX);
+    moved -= INSET_PROBE_PX;
     retreated += INSET_PROBE_PX;
     if ((await driver.zoneContainingPointer()) !== zone) {
       left = true;
       break;
     }
   }
-  if (!left) {
-    await driver.moveBy(0, retreated);
-    return null;
-  }
+  if (!left) return restore();
 
+  // One step back in: the pointer is within a step of the boundary, and this
+  // position — not a step count — is what the depth is measured from.
   await driver.moveBy(0, INSET_PROBE_PX);
-  if ((await driver.zoneContainingPointer()) !== zone) {
-    await driver.moveBy(0, retreated - INSET_PROBE_PX);
-    return null;
-  }
-  return { boundaryY: driver.pointer().y, retreatedPx: retreated };
+  moved += INSET_PROBE_PX;
+  if ((await driver.zoneContainingPointer()) !== zone) return restore();
+  return { boundaryY: driver.pointer().y, movedPx: moved };
 }
 
 /**
@@ -807,16 +833,16 @@ export async function dragToInsetInZone(
   // would put wall-clock dependence into the one control a band assertion
   // rests on, and would still be a guess about a duration the canvas owns.
   let boundaryY: number | null = null;
-  let settledRetreat = 0;
+  let settledMoved = 0;
   for (let attempt = 0; attempt < EDGE_SETTLE_ATTEMPTS; attempt += 1) {
     const found = await bracketZoneEdge(driver, zone, retreatLimit);
     if (!found) return refuse(zone, "boundary-not-found");
     if (boundaryY === found.boundaryY) {
-      settledRetreat = found.retreatedPx;
+      settledMoved = found.movedPx;
       break;
     }
     boundaryY = found.boundaryY;
-    settledRetreat = found.retreatedPx;
+    settledMoved = found.movedPx;
     // Across the transition rather than adjacent to it. Two brackets taken back
     // to back land inside the same animation frame and can agree on a whole
     // pixel the edge is still travelling through.
@@ -824,7 +850,7 @@ export async function dragToInsetInZone(
     if (attempt === EDGE_SETTLE_ATTEMPTS - 1) {
       // Still moving. Reported rather than measured through: a depth taken from
       // an edge that is in motion is a number with no referent.
-      await driver.moveBy(0, settledRetreat);
+      await driver.moveBy(0, -settledMoved);
       return refuse(zone, "edge-moving");
     }
   }

--- a/e2e/tests/canvas/driver.ts
+++ b/e2e/tests/canvas/driver.ts
@@ -570,6 +570,40 @@ type ZoneInsetDriver = Pick<
   "moveBy" | "zoneContainingPointer" | "pointer"
 >;
 
+/** What the coarse approach observed, which is more than the zone it reached. */
+interface ZoneApproach {
+  /** The zone containing the pointer, or -1 when none was reached. */
+  readonly zone: number;
+  /** Pixels travelled to reach it — 0 when the pointer was already inside. */
+  readonly travelledPx: number;
+}
+
+/**
+ * Step until some zone contains the pointer, reporting how far that took.
+ *
+ * The one coarse walk, because two of them drift: the step size and the
+ * termination rule are the same question asked by `dragUntilInsideZone` and by
+ * the exact-depth probe, and a change to either in one place would silently
+ * make the two disagree while both still returned a number.
+ *
+ * `travelledPx` is what the second caller needs and the first ignores. It bounds
+ * where the boundary can be — having walked in, the edge is at most this far
+ * back — which is how a retreat gets a limit derived from observation rather
+ * than from a constant.
+ */
+async function approachZone(
+  driver: Pick<CanvasDriver, "moveBy" | "zoneContainingPointer" | "pointer">,
+  maxSteps: number
+): Promise<ZoneApproach> {
+  const startedAt = driver.pointer().y;
+  let zone = await driver.zoneContainingPointer();
+  for (let step = 0; step < maxSteps && zone < 0; step += 1) {
+    await driver.moveBy(0, INSET_APPROACH_PX);
+    zone = await driver.zoneContainingPointer();
+  }
+  return { zone, travelledPx: driver.pointer().y - startedAt };
+}
+
 /** Where {@link dragToInsetInZone} left the pointer, and how it knows. */
 export interface ZoneInset {
   /** The zone the pointer ended inside, or -1 when none was reached. */
@@ -605,9 +639,15 @@ export interface ZoneInset {
    * zone does hold, so a caller can say what it would need; and
    * `boundary-not-found` is about this probe, which cannot locate an edge it
    * did not cross — a drag already deep inside a tall zone has no boundary in
-   * retreat range, and saying "no zone" there would be false.
+   * retreat range, and saying "no zone" there would be false; and `edge-moving`
+   * is about the canvas relaying out underneath the measurement, where a depth
+   * would be a number with no referent.
    */
-  readonly refused?: "never-entered" | "too-narrow" | "boundary-not-found";
+  readonly refused?:
+    | "never-entered"
+    | "too-narrow"
+    | "boundary-not-found"
+    | "edge-moving";
 }
 
 /** Pixels per step while closing on the boundary, once the zone has been found. */
@@ -615,6 +655,47 @@ const INSET_PROBE_PX = 1;
 
 /** Pixels per step while approaching, before any zone has been reached. */
 const INSET_APPROACH_PX = 4;
+
+/** How many times the boundary may be re-measured before its motion is a verdict. */
+const EDGE_SETTLE_ATTEMPTS = 3;
+
+/**
+ * The first pointer position INSIDE `zone`, found by retreating out and stepping back in.
+ *
+ * Returns `null` when the zone's edge is not within `retreatLimit` — the pointer
+ * is inside a zone whose boundary this walk never crossed, which is a different
+ * fact from there being no zone.
+ *
+ * Leaves the pointer where it found the boundary, and reports how far it
+ * retreated so a caller that must abandon the measurement can put the drag back.
+ */
+async function bracketZoneEdge(
+  driver: ZoneInsetDriver,
+  zone: number,
+  retreatLimit: number
+): Promise<{ boundaryY: number; retreatedPx: number } | null> {
+  let retreated = 0;
+  let left = false;
+  while (retreated < retreatLimit) {
+    await driver.moveBy(0, -INSET_PROBE_PX);
+    retreated += INSET_PROBE_PX;
+    if ((await driver.zoneContainingPointer()) !== zone) {
+      left = true;
+      break;
+    }
+  }
+  if (!left) {
+    await driver.moveBy(0, retreated);
+    return null;
+  }
+
+  await driver.moveBy(0, INSET_PROBE_PX);
+  if ((await driver.zoneContainingPointer()) !== zone) {
+    await driver.moveBy(0, retreated - INSET_PROBE_PX);
+    return null;
+  }
+  return { boundaryY: driver.pointer().y, retreatedPx: retreated };
+}
 
 /**
  * Carry the drag to EXACTLY `wantInsetPx` inside the zone it first enters.
@@ -651,7 +732,6 @@ export async function dragToInsetInZone(
   wantInsetPx: number,
   maxSteps = 40
 ): Promise<ZoneInset> {
-  const startedAt = driver.pointer().y;
   const refuse = (
     zone: number,
     reason: NonNullable<ZoneInset["refused"]>
@@ -662,49 +742,61 @@ export async function dragToInsetInZone(
     refused: reason,
   });
 
-  let zone = await driver.zoneContainingPointer();
-  const enteredInside = zone >= 0;
-  for (let step = 0; step < maxSteps && zone < 0; step += 1) {
-    await driver.moveBy(0, INSET_APPROACH_PX);
-    zone = await driver.zoneContainingPointer();
+  // A request this probe cannot represent is a CALLER fault, not a fact about
+  // the canvas — so it throws rather than joining the refusals, which a caller
+  // is meant to read as findings. A fractional depth would silently round up to
+  // the next whole step; a negative or NaN one would skip the walk entirely and
+  // report depth 0 as a success, which is a false measurement rather than a
+  // failed one.
+  if (!Number.isInteger(wantInsetPx) || wantInsetPx < 0) {
+    throw new Error(
+      `dragToInsetInZone needs a whole, non-negative depth in pixels; got ${wantInsetPx}`
+    );
   }
+
+  const { zone, travelledPx } = await approachZone(driver, maxSteps);
   if (zone < 0) return refuse(-1, "never-entered");
 
   // How far back the boundary can possibly be. Having WALKED into the zone, it
   // is the distance travelled plus the step that crossed it. Having started
-  // inside, nothing observed bounds it, so the approach budget stands in — and
-  // running out is reported as its own fact rather than as "no zone".
-  const travelled = driver.pointer().y - startedAt;
-  const retreatLimit = enteredInside
-    ? maxSteps * INSET_APPROACH_PX
-    : travelled + INSET_APPROACH_PX;
+  // inside, travelled is 0 and nothing observed bounds it, so the approach
+  // budget stands in — and running out is reported as its own fact rather than
+  // as "no zone".
+  const retreatLimit =
+    travelledPx > 0
+      ? travelledPx + INSET_APPROACH_PX
+      : maxSteps * INSET_APPROACH_PX;
 
-  let left = false;
-  let retreated = 0;
-  while (retreated < retreatLimit) {
-    await driver.moveBy(0, -INSET_PROBE_PX);
-    retreated += INSET_PROBE_PX;
-    if ((await driver.zoneContainingPointer()) !== zone) {
-      left = true;
+  // The edge is measured until two consecutive measurements AGREE, because
+  // arriving in a zone changes its geometry: the canvas gives a drop zone a
+  // 6px height and a 3px margin while a drag is in flight, and a 4px margin
+  // once it is the active target — so entering one moves its own edge and
+  // every edge below it. A single reading taken across that transition is
+  // stale by the time the depth is walked, and the returned depth would be
+  // measured from a boundary that has since moved.
+  //
+  // Measured rather than waited out. A sleep sized to the 100ms transition
+  // would put wall-clock dependence into the one control a band assertion
+  // rests on, and would still be a guess about a duration the canvas owns.
+  let boundaryY: number | null = null;
+  let settledRetreat = 0;
+  for (let attempt = 0; attempt < EDGE_SETTLE_ATTEMPTS; attempt += 1) {
+    const found = await bracketZoneEdge(driver, zone, retreatLimit);
+    if (!found) return refuse(zone, "boundary-not-found");
+    if (boundaryY === found.boundaryY) {
+      settledRetreat = found.retreatedPx;
       break;
     }
+    boundaryY = found.boundaryY;
+    settledRetreat = found.retreatedPx;
+    if (attempt === EDGE_SETTLE_ATTEMPTS - 1) {
+      // Still moving. Reported rather than measured through: a depth taken from
+      // an edge that is in motion is a number with no referent.
+      await driver.moveBy(0, settledRetreat);
+      return refuse(zone, "edge-moving");
+    }
   }
-  if (!left) {
-    // Put the drag back where it was found. A measurement that could not be
-    // taken must not also move the pointer, or the caller's next reading is
-    // about a position this probe chose.
-    await driver.moveBy(0, retreated);
-    return refuse(zone, "boundary-not-found");
-  }
-
-  // One step back in: the pointer is within a step of the boundary, and this
-  // position — not a step count — is what the depth is measured from.
-  await driver.moveBy(0, INSET_PROBE_PX);
-  if ((await driver.zoneContainingPointer()) !== zone) {
-    await driver.moveBy(0, retreated - INSET_PROBE_PX);
-    return refuse(zone, "boundary-not-found");
-  }
-  const boundaryY = driver.pointer().y;
+  if (boundaryY === null) return refuse(zone, "boundary-not-found");
 
   for (let moved = 0; moved < wantInsetPx; moved += INSET_PROBE_PX) {
     await driver.moveBy(0, INSET_PROBE_PX);
@@ -750,12 +842,7 @@ export async function dragUntilInsideZone(
   driver: CanvasDriver,
   maxSteps = 40
 ): Promise<number> {
-  let containing = await driver.zoneContainingPointer();
-  for (let step = 0; step < maxSteps && containing < 0; step += 1) {
-    await driver.moveBy(0, 4);
-    containing = await driver.zoneContainingPointer();
-  }
-  return containing;
+  return (await approachZone(driver, maxSteps)).zone;
 }
 
 /** The two readings that together say "the shell survived the gesture". */

--- a/e2e/tests/canvas/driver.ts
+++ b/e2e/tests/canvas/driver.ts
@@ -856,13 +856,17 @@ export async function dragToInsetInZone(
       ? travelledPx + INSET_APPROACH_PX
       : maxSteps * INSET_APPROACH_PX;
 
-  // The edge is measured until two consecutive measurements AGREE, because
-  // arriving in a zone changes its geometry: the canvas gives a drop zone a
-  // 6px height and a 3px margin while a drag is in flight, and a 4px margin
-  // once it is the active target — so entering one moves its own edge and
-  // every edge below it. A single reading taken across that transition is
-  // stale by the time the depth is walked, and the returned depth would be
-  // measured from a boundary that has since moved.
+  // The edge is measured until two consecutive measurements AGREE, because a
+  // canvas may RESTYLE a zone at the moment it becomes the active target, and
+  // restyling it moves its own edge and every edge below it. A single reading
+  // taken across that transition is stale by the time the depth is walked, and
+  // the returned depth would be measured from a boundary that has since moved.
+  //
+  // Stated as the property rather than as the rule that currently produces it.
+  // This driver is a vocabulary several canvases implement, so the specific
+  // styling is one canvas's business and is free to change — a canvas that
+  // makes its zones geometrically constant simply settles on the first two
+  // measurements and pays nothing for this loop.
   //
   // Measured rather than waited out. A sleep sized to the 100ms transition
   // would put wall-clock dependence into the one control a band assertion

--- a/e2e/tests/canvas/geometry-settle-matches-the-canvas.test.ts
+++ b/e2e/tests/canvas/geometry-settle-matches-the-canvas.test.ts
@@ -1,0 +1,58 @@
+/**
+ * The probe's settle allowance must still cover what the canvas actually animates.
+ *
+ * `geometrySettleMs` is a number the driver states and the canvas owns, and nothing in either file
+ * refers to the other — the exact shape `.claude/rules/derived-checks.md` calls out, where two
+ * copies agree on the day they are written and drift silently afterwards. The drift is invisible in
+ * the direction that matters: lengthen the CSS transition and every inset measurement quietly
+ * starts coming back stale, with no test naming the timing.
+ *
+ * Deriving the driver's value from the stylesheet at runtime is not available — the rule lives in a
+ * template string compiled into the iframe, and a zone only exists mid-drag. So the duplication
+ * stays and is CHECKED instead, which is the weaker remedy the rule permits when one answer cannot
+ * be shared.
+ */
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { expect, test } from "@playwright/test";
+
+import { POC_GEOMETRY_SETTLE_MS } from "./poc-driver";
+
+const CANVAS_CSS = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  "../../../packages/plugin-page-builder/src/admin/canvas/IframeCanvas.tsx"
+);
+
+/** Every `transition` duration the drop-zone rules declare, in milliseconds. */
+function zoneTransitionDurationsMs(source: string): number[] {
+  const found: number[] = [];
+  for (const rule of source.split("\n")) {
+    if (!rule.includes("nx-pb-dropzone") || !rule.includes("transition"))
+      continue;
+    for (const [, value, unit] of rule.matchAll(/([\d.]+)(ms|s)\b/g)) {
+      found.push(unit === "s" ? Number(value) * 1000 : Number(value));
+    }
+  }
+  return found;
+}
+
+test("the PoC driver's settle allowance covers the zone transition it animates", () => {
+  const source = readFileSync(CANVAS_CSS, "utf8");
+  const durations = zoneTransitionDurationsMs(source);
+
+  // The positive control, and it is the whole reason this file is not vacuous: a parser that
+  // matched nothing would satisfy every assertion below by having no values to check.
+  expect(durations.length).toBeGreaterThan(0);
+
+  // Imported rather than restated, so this cannot pass against a number the driver does not
+  // actually use — a guard holding its own copy compares a constant with itself.
+  const declared = POC_GEOMETRY_SETTLE_MS;
+  for (const duration of durations) {
+    expect(
+      duration,
+      `a drop-zone transition of ${String(duration)}ms is not covered by the driver's ${String(declared)}ms geometrySettleMs — raise geometrySettleMs in poc-driver.ts`
+    ).toBeLessThanOrEqual(declared);
+  }
+});

--- a/e2e/tests/canvas/poc-driver.ts
+++ b/e2e/tests/canvas/poc-driver.ts
@@ -47,6 +47,15 @@ interface RecordedTransition {
 const DROP_ZONES = ".nx-pb-dropzone, .nx-pb-dropzone-empty";
 
 /**
+ * How long this canvas may still be moving a zone's edge after entry, in milliseconds.
+ *
+ * Exported so the guard that compares it against the stylesheet reads the SAME value the driver
+ * uses. A guard restating the number checks a constant against itself and passes while the driver
+ * carries something else entirely.
+ */
+export const POC_GEOMETRY_SETTLE_MS = 120;
+
+/**
  * Block-level insertion targets. A grid registers insert-before and append
  * droppables on the block element itself and signals them with these classes
  * rather than with `data-active` on a separate zone element, so they are a
@@ -166,6 +175,18 @@ export function createPocDriver(page: Page): CanvasDriver {
     // dwell it does not have would spend a wait per reading for lag that never
     // happens, and would let a real hysteresis defect hide inside the wait.
     dwellAllowanceMs: 0,
+
+    // The zone geometry this canvas animates, plus headroom. `IframeCanvas`
+    // transitions a drop zone's height over 100ms; a probe that re-measures
+    // inside that window can read the same whole pixel twice while the edge is
+    // still travelling through it, and return a depth measured from a boundary
+    // that has already moved.
+    //
+    // Stated here rather than inside the probe because the duration belongs to
+    // this canvas. `geometry-settle-matches-the-canvas.test.ts` parses the
+    // stylesheet and fails if the transition ever outgrows this number, so the
+    // two cannot drift silently.
+    geometrySettleMs: POC_GEOMETRY_SETTLE_MS,
 
     async mountTree(fixture: CanvasFixture) {
       await gotoAdmin(page, `/collections/pages/${fixture.entryId}`);

--- a/e2e/tests/canvas/zone-inset.test.ts
+++ b/e2e/tests/canvas/zone-inset.test.ts
@@ -135,6 +135,9 @@ test("reports a boundary it never crossed as its own failure, and puts the point
   expect(result.refused).toBe("boundary-not-found");
   expect(result.zone).toBe(3);
   expect(canvas.pointer().y).toBe(5_000);
+  // No depth, because no boundary was found to measure one from. A `0` here
+  // would read as "at the boundary", which is a position the pointer is not at.
+  expect(result.insetPx).toBeUndefined();
 });
 
 test("reports never reaching a zone as a refusal, not as a depth of zero", async () => {
@@ -241,6 +244,7 @@ test("refuses rather than measuring from an edge that keeps moving", async () =>
 
   expect(result.refused).toBe("edge-moving");
   expect(result.zone).toBe(4);
+  expect(result.insetPx).toBeUndefined();
 });
 
 test("refuses a depth it cannot represent, rather than rounding to one it can", async () => {
@@ -258,5 +262,23 @@ test("refuses a depth it cannot represent, rather than rounding to one it can", 
   );
   await expect(dragToInsetInZone(canvas(), Number.NaN)).rejects.toThrow(
     /whole, non-negative depth/
+  );
+});
+
+test("refuses a step budget it cannot honour, rather than running forever", async () => {
+  // `Infinity` is the dangerous one: the approach never terminates and the run
+  // hangs until Playwright's outer timeout, defeating the runaway guard this
+  // parameter exists to be. `NaN` and a negative skip the approach entirely and
+  // would report `never-entered` about a canvas that was never asked.
+  const outside = () => bandedCanvas([{ zone: 0, from: 9_000, to: 9_010 }]);
+
+  await expect(
+    dragToInsetInZone(outside(), 4, Number.POSITIVE_INFINITY)
+  ).rejects.toThrow(/whole, non-negative step budget/);
+  await expect(dragToInsetInZone(outside(), 4, -1)).rejects.toThrow(
+    /whole, non-negative step budget/
+  );
+  await expect(dragToInsetInZone(outside(), 4, Number.NaN)).rejects.toThrow(
+    /whole, non-negative step budget/
   );
 });

--- a/e2e/tests/canvas/zone-inset.test.ts
+++ b/e2e/tests/canvas/zone-inset.test.ts
@@ -299,6 +299,21 @@ test("keeps an edge-moving refusal inside the zone it reports, going DOWN", asyn
   expect(await canvas.zoneContainingPointer()).toBe(result.zone);
 });
 
+test("enters a zone thinner than one unit of the approach budget", async () => {
+  // Every other band in this file is at least 8px tall, so none of them can be stepped over and
+  // none could have caught this. A 3px band is what a 6 CSS-pixel drop zone becomes at the 0.5
+  // canvas scale the suite supports, and it starts at 51 so it does not begin on a multiple of the
+  // old 4px stride — the arrangement that put an entire zone between two commands.
+  const canvas = bandedCanvas([{ zone: 2, from: 51, to: 54 }]);
+
+  const result = await dragToInsetInZone(canvas, 0);
+
+  // The zone is REACHED. Reporting it as `too-narrow` for a depth it cannot hold would also be a
+  // correct answer; skipping it and reporting a later zone, or none, is not.
+  expect(result.zone).toBe(2);
+  expect(result.insetPx).toBe(0);
+});
+
 test("refuses a depth it cannot represent, rather than rounding to one it can", async () => {
   // A caller deriving a depth from fractional or scaled DOM geometry would
   // otherwise get 13px of movement for a 12.5px request and a success saying 13

--- a/e2e/tests/canvas/zone-inset.test.ts
+++ b/e2e/tests/canvas/zone-inset.test.ts
@@ -1,0 +1,143 @@
+/**
+ * The exact-depth control, against a canvas whose geometry is known.
+ *
+ * A hysteresis expressed as a distance MARGIN can only be questioned from a
+ * known depth: a compliant canvas holds its previous target a few pixels past a
+ * boundary, so a probe that stops "somewhere inside" cannot tell a correct
+ * margin from a missing one. `dragToInsetInZone` exists to stand at a stated
+ * depth; these tests exist because a control that reports the wrong depth would
+ * make every band measurement built on it wrong in a way nothing downstream
+ * could notice.
+ *
+ * The simulated canvas has bands at known pixel positions, so the answer is
+ * arithmetic rather than a second opinion — which is the only way to check an
+ * instrument that is itself the measuring device.
+ *
+ * No browser, matching `settle.test.ts` and `dwelling-canvas.test.ts`.
+ */
+import { expect, test } from "@playwright/test";
+
+import { dragToInsetInZone } from "./driver";
+
+interface Band {
+  readonly zone: number;
+  readonly from: number;
+  readonly to: number;
+}
+
+/**
+ * A canvas whose zones are half-open vertical bands, with dead space between.
+ *
+ * Half-open (`from <= y < to`) so a boundary belongs to exactly one band and
+ * "the first y inside zone K" is a single well-defined number the assertions
+ * can be written against.
+ */
+function bandedCanvas(bands: Band[], startY = 0) {
+  let y = startY;
+  const moves: number[] = [];
+  return {
+    moves,
+    pointer: () => ({ x: 0, y }),
+    moveBy: async (_dx: number, dy: number) => {
+      y += dy;
+      moves.push(dy);
+    },
+    zoneContainingPointer: async () => {
+      const hit = bands.find(b => y >= b.from && y < b.to);
+      return hit ? hit.zone : -1;
+    },
+  };
+}
+
+const ONE_BAND: Band[] = [{ zone: 2, from: 50, to: 90 }];
+
+test("stands at exactly the depth it was asked for", async () => {
+  // The whole point. The band starts at y=50, so a depth of 12 means y=62 — and
+  // the reported depth has to be the measured one rather than the requested one
+  // echoed back.
+  const canvas = bandedCanvas(ONE_BAND);
+
+  const result = await dragToInsetInZone(canvas, 12);
+
+  expect(result.zone).toBe(2);
+  expect(result.insetPx).toBe(12);
+  expect(result.refused).toBeUndefined();
+  expect(canvas.pointer().y).toBe(62);
+});
+
+test("lands on the same depth from a coarse approach that overshoots", async () => {
+  // The defect this replaces: a 4px scan enters the band anywhere from 0 to 3px
+  // past its edge, so where it stops is an accident of the start position. Every
+  // start inside one step has to produce the same depth.
+  for (const startY of [0, 1, 2, 3]) {
+    const canvas = bandedCanvas(ONE_BAND, startY);
+    const result = await dragToInsetInZone(canvas, 10);
+    expect(result.insetPx).toBe(10);
+    expect(canvas.pointer().y).toBe(60);
+  }
+});
+
+test("reports a band too shallow to hold the depth, rather than the depth it managed", async () => {
+  // A fact about the FIXTURE, not the canvas. Returning the closest depth
+  // reached would answer a question the caller did not ask while carrying the
+  // name of the one they did.
+  const canvas = bandedCanvas([{ zone: 1, from: 20, to: 28 }]);
+
+  const result = await dragToInsetInZone(canvas, 25);
+
+  expect(result.refused).toBe("too-narrow");
+  expect(result.zone).toBe(1);
+  // And it still says how far it got, so a caller can report the fixture's real
+  // capacity instead of guessing at it.
+  expect(result.insetPx).toBeLessThan(25);
+});
+
+test("reports never reaching a zone as a refusal, not as a depth of zero", async () => {
+  // Depth 0 is a legitimate reading at a boundary; "no zone was ever entered" is
+  // not a reading at all, and collapsing the two would let a canvas drawing no
+  // zones pass as one whose bands begin where the pointer already is.
+  const canvas = bandedCanvas([{ zone: 0, from: 10_000, to: 10_010 }]);
+
+  const result = await dragToInsetInZone(canvas, 5);
+
+  expect(result.refused).toBe("never-entered");
+  expect(result.zone).toBe(-1);
+});
+
+test("measures from the band it entered, not from where the walk began", async () => {
+  // Dead space between bands is the case a step-count would get wrong: the
+  // pointer crosses a gap, and a depth counted from the start position or from
+  // the previous band is larger than the depth inside THIS one.
+  const canvas = bandedCanvas([
+    { zone: 0, from: 4, to: 12 },
+    { zone: 1, from: 40, to: 80 },
+  ]);
+  // Start already past the first band and inside the gap, so the first band is
+  // never entered and zone 1 is the one measured from.
+  const inGap = bandedCanvas(
+    [
+      { zone: 0, from: 4, to: 12 },
+      { zone: 1, from: 40, to: 80 },
+    ],
+    20
+  );
+  expect(await canvas.zoneContainingPointer()).toBe(-1);
+
+  const result = await dragToInsetInZone(inGap, 9);
+
+  expect(result.zone).toBe(1);
+  expect(result.insetPx).toBe(9);
+  expect(inGap.pointer().y).toBe(49);
+});
+
+test("a depth of zero puts the pointer on the first row inside the band", async () => {
+  // The boundary itself is a legitimate request — a band assertion needs both
+  // ends — and it must not be confused with the refusals above.
+  const canvas = bandedCanvas(ONE_BAND);
+
+  const result = await dragToInsetInZone(canvas, 0);
+
+  expect(result.refused).toBeUndefined();
+  expect(result.insetPx).toBe(0);
+  expect(canvas.pointer().y).toBe(50);
+});

--- a/e2e/tests/canvas/zone-inset.test.ts
+++ b/e2e/tests/canvas/zone-inset.test.ts
@@ -101,9 +101,40 @@ test("reports a band too shallow to hold the depth, rather than the depth it man
 
   expect(result.refused).toBe("too-narrow");
   expect(result.zone).toBe(1);
-  // And it still says how far it got, so a caller can report the fixture's real
-  // capacity instead of guessing at it.
-  expect(result.insetPx).toBeLessThan(25);
+  // The EXACT capacity, not merely "less than asked". The band spans y=20..27,
+  // so the deepest contained depth is 7 — and a looser bound would accept a
+  // result that overstated it by the step that left the zone.
+  expect(result.insetPx).toBe(7);
+  // And the pointer is standing at the depth reported, inside the zone it
+  // names. A reported depth the pointer is not at is a different measurement.
+  expect(canvas.pointer().y).toBe(27);
+  expect(await canvas.zoneContainingPointer()).toBe(1);
+});
+
+test("says how precisely it knows the boundary", async () => {
+  // A zone edge is fractional and the pointer is commanded in whole steps, so
+  // the boundary this measures from can sit a step past the real one. A caller
+  // comparing a measured band against a required range has to widen its bounds
+  // by exactly this, which it can only do if the probe says what it is.
+  const canvas = bandedCanvas(ONE_BAND);
+
+  const result = await dragToInsetInZone(canvas, 5);
+
+  expect(result.resolutionPx).toBe(1);
+});
+
+test("reports a boundary it never crossed as its own failure, and puts the pointer back", async () => {
+  // A drag already deep inside a tall zone has no boundary within reach. Saying
+  // "never entered a zone" there would be false — the pointer is in one — and
+  // leaving it moved by the whole retreat would make the caller's next reading
+  // about a position this probe chose rather than the one they set up.
+  const canvas = bandedCanvas([{ zone: 3, from: 0, to: 10_000 }], 5_000);
+
+  const result = await dragToInsetInZone(canvas, 5);
+
+  expect(result.refused).toBe("boundary-not-found");
+  expect(result.zone).toBe(3);
+  expect(canvas.pointer().y).toBe(5_000);
 });
 
 test("reports never reaching a zone as a refusal, not as a depth of zero", async () => {

--- a/e2e/tests/canvas/zone-inset.test.ts
+++ b/e2e/tests/canvas/zone-inset.test.ts
@@ -34,13 +34,10 @@ interface Band {
  */
 function bandedCanvas(bands: Band[], startY = 0) {
   let y = startY;
-  const moves: number[] = [];
   return {
-    moves,
     pointer: () => ({ x: 0, y }),
     moveBy: async (_dx: number, dy: number) => {
       y += dy;
-      moves.push(dy);
     },
     zoneContainingPointer: async () => {
       const hit = bands.find(b => y >= b.from && y < b.to);
@@ -50,6 +47,19 @@ function bandedCanvas(bands: Band[], startY = 0) {
 }
 
 const ONE_BAND: Band[] = [{ zone: 2, from: 50, to: 90 }];
+
+/**
+ * The depth the pointer ACTUALLY sits at, computed from the band's known edge.
+ *
+ * The separating assertion, and it has to be stated separately from the
+ * returned value: a control that measured from wherever its coarse approach
+ * landed reports a self-consistent depth that is simply not the depth from the
+ * boundary. Comparing the report against this catches that; comparing it
+ * against the request cannot.
+ */
+function trueDepth(band: Band, y: number): number {
+  return y - band.from;
+}
 
 test("stands at exactly the depth it was asked for", async () => {
   // The whole point. The band starts at y=50, so a depth of 12 means y=62 — and
@@ -63,6 +73,9 @@ test("stands at exactly the depth it was asked for", async () => {
   expect(result.insetPx).toBe(12);
   expect(result.refused).toBeUndefined();
   expect(canvas.pointer().y).toBe(62);
+  // The reported depth is the REAL one, measured from the band's edge rather
+  // than from wherever the approach happened to stop.
+  expect(trueDepth(ONE_BAND[0], canvas.pointer().y)).toBe(result.insetPx);
 });
 
 test("lands on the same depth from a coarse approach that overshoots", async () => {
@@ -74,6 +87,7 @@ test("lands on the same depth from a coarse approach that overshoots", async () 
     const result = await dragToInsetInZone(canvas, 10);
     expect(result.insetPx).toBe(10);
     expect(canvas.pointer().y).toBe(60);
+    expect(trueDepth(ONE_BAND[0], canvas.pointer().y)).toBe(result.insetPx);
   }
 });
 
@@ -108,26 +122,21 @@ test("measures from the band it entered, not from where the walk began", async (
   // Dead space between bands is the case a step-count would get wrong: the
   // pointer crosses a gap, and a depth counted from the start position or from
   // the previous band is larger than the depth inside THIS one.
-  const canvas = bandedCanvas([
+  const bands: Band[] = [
     { zone: 0, from: 4, to: 12 },
     { zone: 1, from: 40, to: 80 },
-  ]);
-  // Start already past the first band and inside the gap, so the first band is
-  // never entered and zone 1 is the one measured from.
-  const inGap = bandedCanvas(
-    [
-      { zone: 0, from: 4, to: 12 },
-      { zone: 1, from: 40, to: 80 },
-    ],
-    20
-  );
+  ];
+  // Started past the first band and inside the gap, so the first band is never
+  // entered and zone 1 is the one the depth is measured from.
+  const canvas = bandedCanvas(bands, 20);
   expect(await canvas.zoneContainingPointer()).toBe(-1);
 
-  const result = await dragToInsetInZone(inGap, 9);
+  const result = await dragToInsetInZone(canvas, 9);
 
   expect(result.zone).toBe(1);
   expect(result.insetPx).toBe(9);
-  expect(inGap.pointer().y).toBe(49);
+  expect(canvas.pointer().y).toBe(49);
+  expect(trueDepth(bands[1], canvas.pointer().y)).toBe(result.insetPx);
 });
 
 test("a depth of zero puts the pointer on the first row inside the band", async () => {
@@ -140,4 +149,5 @@ test("a depth of zero puts the pointer on the first row inside the band", async 
   expect(result.refused).toBeUndefined();
   expect(result.insetPx).toBe(0);
   expect(canvas.pointer().y).toBe(50);
+  expect(trueDepth(ONE_BAND[0], canvas.pointer().y)).toBe(result.insetPx);
 });

--- a/e2e/tests/canvas/zone-inset.test.ts
+++ b/e2e/tests/canvas/zone-inset.test.ts
@@ -189,11 +189,14 @@ test("a depth of zero puts the pointer on the first row inside the band", async 
 /**
  * A canvas whose zone edge MOVES the first `shifts` times it is entered.
  *
- * The real one does this: a drop zone is 6px tall with a 3px margin while a
- * drag is in flight and takes a 4px margin once it is the ACTIVE target, so
- * arriving in a zone moves its own edge and every edge below it. A depth
- * measured across that transition is measured from a boundary that has since
- * moved.
+ * A real canvas does this whenever becoming the active target changes a zone's
+ * box: the edge moves, and so does every edge below it, so a depth measured
+ * across that transition is measured from a boundary that has since moved.
+ *
+ * The fixture asserts the PROBE's behaviour, not any canvas's styling. A canvas
+ * whose zones never move is a canvas this case cannot arise on, which makes the
+ * fixture useless as a description of that canvas and still correct as a
+ * description of what the probe must do when it does arise.
  */
 function shiftingEdgeCanvas(
   band: Band,
@@ -302,9 +305,13 @@ test("keeps an edge-moving refusal inside the zone it reports, going DOWN", asyn
 test("enters a zone thinner than one unit of the approach budget", async () => {
   // Every other band in this file is at least 8px tall, so none of them can be stepped over and
   // none could have caught this. A 3px band is what a 6 CSS-pixel drop zone becomes at the 0.5
-  // canvas scale the suite supports, and it starts at 51 so it does not begin on a multiple of the
-  // old 4px stride — the arrangement that put an entire zone between two commands.
-  const canvas = bandedCanvas([{ zone: 2, from: 51, to: 54 }]);
+  // canvas scale the suite supports.
+  //
+  // The BOUNDS are the experiment, not the width. Walking from 0 in 4px strides samples 52 and 56
+  // and nothing between, so `[53, 56)` falls entirely into that gap while a band merely 3px wide
+  // — `[51, 54)`, say — still contains 52 and is found by the coarse walk anyway. A control at
+  // those bounds passes with and without the fix, which is how this one was first written.
+  const canvas = bandedCanvas([{ zone: 2, from: 53, to: 56 }]);
 
   const result = await dragToInsetInZone(canvas, 0);
 

--- a/e2e/tests/canvas/zone-inset.test.ts
+++ b/e2e/tests/canvas/zone-inset.test.ts
@@ -195,7 +195,12 @@ test("a depth of zero puts the pointer on the first row inside the band", async 
  * measured across that transition is measured from a boundary that has since
  * moved.
  */
-function shiftingEdgeCanvas(band: Band, shifts: number, startY = 0) {
+function shiftingEdgeCanvas(
+  band: Band,
+  shifts: number,
+  startY = 0,
+  direction: -1 | 1 = -1
+) {
   let y = startY;
   let from = band.from;
   let entries = 0;
@@ -213,7 +218,7 @@ function shiftingEdgeCanvas(band: Band, shifts: number, startY = 0) {
       // (`boundary-not-found`) and would not exercise this one.
       if (inside && !wasInside && entries < shifts) {
         entries += 1;
-        from -= 1;
+        from += direction;
       }
       wasInside = inside;
       return inside ? band.zone : -1;
@@ -281,4 +286,20 @@ test("refuses a step budget it cannot honour, rather than running forever", asyn
   await expect(dragToInsetInZone(outside(), 4, Number.NaN)).rejects.toThrow(
     /whole, non-negative step budget/
   );
+});
+
+test("re-enters a zone whose edge moved DOWN out from under the pointer", async () => {
+  // The direction the real canvas produces: a drop zone swaps its 3px drag margin for a 4px
+  // active one, so the top edge travels DOWN and a pointer resting on the old boundary is left
+  // just above the new one. A bracket that only ever retreats moves further away, and reports an
+  // edge it is standing one pixel short of as unfindable.
+  const canvas = shiftingEdgeCanvas({ zone: 5, from: 50, to: 90 }, 1, 0, 1);
+
+  const result = await dragToInsetInZone(canvas, 6);
+
+  expect(result.refused).toBeUndefined();
+  expect(result.zone).toBe(5);
+  expect(result.insetPx).toBe(6);
+  // Measured from the edge where it SETTLED, not where it started.
+  expect(canvas.pointer().y).toBe(57);
 });

--- a/e2e/tests/canvas/zone-inset.test.ts
+++ b/e2e/tests/canvas/zone-inset.test.ts
@@ -288,18 +288,46 @@ test("refuses a step budget it cannot honour, rather than running forever", asyn
   );
 });
 
+/**
+ * A canvas whose zone edge moves once, at a WALL-CLOCK moment after construction.
+ *
+ * Time rather than an entry count, because the thing being modelled is a CSS transition and the
+ * moment that matters is DURING the probe's settle wait — after one bracket has succeeded and
+ * before the next begins. An entry-counted fixture cannot express that: the approach consumes the
+ * first entry, so the edge has already finished moving before any bracket runs, and the test
+ * passes with or without the code it exists to check.
+ */
+function edgeMovesAtCanvas(band: Band, afterMs: number, byPx: number) {
+  const bornAt = Date.now();
+  let y = 0;
+  return {
+    pointer: () => ({ x: 0, y }),
+    moveBy: async (_dx: number, dy: number) => {
+      y += dy;
+    },
+    zoneContainingPointer: async () => {
+      const from =
+        Date.now() - bornAt >= afterMs ? band.from + byPx : band.from;
+      return y >= from && y < band.to ? band.zone : -1;
+    },
+  };
+}
+
 test("re-enters a zone whose edge moved DOWN out from under the pointer", async () => {
   // The direction the real canvas produces: a drop zone swaps its 3px drag margin for a 4px
   // active one, so the top edge travels DOWN and a pointer resting on the old boundary is left
   // just above the new one. A bracket that only ever retreats moves further away, and reports an
   // edge it is standing one pixel short of as unfindable.
-  const canvas = shiftingEdgeCanvas({ zone: 5, from: 50, to: 90 }, 1, 0, 1);
+  //
+  // 60ms lands inside the probe's settle wait, which is 120ms — so the first bracket succeeds
+  // against the original edge and the second meets the moved one.
+  const canvas = edgeMovesAtCanvas({ zone: 5, from: 50, to: 90 }, 60, 4);
 
   const result = await dragToInsetInZone(canvas, 6);
 
   expect(result.refused).toBeUndefined();
   expect(result.zone).toBe(5);
   expect(result.insetPx).toBe(6);
-  // Measured from the edge where it SETTLED, not where it started.
-  expect(canvas.pointer().y).toBe(57);
+  // Measured from where the edge SETTLED (54), not where it started (50).
+  expect(canvas.pointer().y).toBe(60);
 });

--- a/e2e/tests/canvas/zone-inset.test.ts
+++ b/e2e/tests/canvas/zone-inset.test.ts
@@ -250,6 +250,49 @@ test("refuses rather than measuring from an edge that keeps moving", async () =>
   expect(result.refused).toBe("edge-moving");
   expect(result.zone).toBe(4);
   expect(result.insetPx).toBeUndefined();
+  // A refusal still describes WHERE the drag is. `zone` is the one field it
+  // reports, so the pointer has to be in it: a caller that continues the drag
+  // from here would otherwise be starting somewhere the result denies.
+  expect(await canvas.zoneContainingPointer()).toBe(result.zone);
+});
+
+/**
+ * A canvas whose edge moves DOWN between every pair of measurements, never settling.
+ *
+ * Shifted on the SETTLE rather than on entry, which is what separates this from
+ * `shiftingEdgeCanvas`: an edge that moves each time it is entered simply outruns the probe and is
+ * reported as `boundary-not-found`, a different fact. Moving only between brackets lets each
+ * bracket succeed and disagree with the last, which is the state `edge-moving` names.
+ */
+function edgeAlwaysMovingDownCanvas(band: Band, byPx: number) {
+  let y = 0;
+  let from = band.from;
+  return {
+    pointer: () => ({ x: 0, y }),
+    moveBy: async (_dx: number, dy: number) => {
+      y += dy;
+    },
+    zoneContainingPointer: async () =>
+      y >= from && y < band.to ? band.zone : -1,
+    settle: async () => {
+      from += byPx;
+    },
+  };
+}
+
+test("keeps an edge-moving refusal inside the zone it reports, going DOWN", async () => {
+  // The direction the upward control cannot reach, and the one where a rewind is actively wrong.
+  // With the boundary travelling DOWN, each bracket ends by walking FORWARD to catch it, so the
+  // last one's net movement is POSITIVE — and undoing that movement carries the pointer back UP,
+  // above a boundary the edge has already passed. The refusal would then name a zone the pointer
+  // is standing outside of, and a caller continuing the drag would resume from the wrong place.
+  const canvas = edgeAlwaysMovingDownCanvas({ zone: 4, from: 50, to: 900 }, 4);
+
+  const result = await dragToInsetInZone(canvas, 6, 40, canvas.settle);
+
+  expect(result.refused).toBe("edge-moving");
+  expect(result.insetPx).toBeUndefined();
+  expect(await canvas.zoneContainingPointer()).toBe(result.zone);
 });
 
 test("refuses a depth it cannot represent, rather than rounding to one it can", async () => {
@@ -297,18 +340,31 @@ test("refuses a step budget it cannot honour, rather than running forever", asyn
  * first entry, so the edge has already finished moving before any bracket runs, and the test
  * passes with or without the code it exists to check.
  */
-function edgeMovesAtCanvas(band: Band, afterMs: number, byPx: number) {
-  const bornAt = Date.now();
+/**
+ * A canvas whose zone edge moves DOWN once, at the moment the probe waits between measurements.
+ *
+ * The shift is driven by the probe's own settle wait rather than by the clock, and that is the
+ * whole point of the fixture. A time-based version races the runner: pause the process for longer
+ * than the wait and the edge has already moved before the first measurement, so the coarse walk
+ * enters the settled band directly and the test finishes at the same coordinate with the re-entry
+ * logic removed. Keyed to the wait, the first bracket is guaranteed to measure the ORIGINAL edge
+ * and the second to meet the moved one, on a loaded runner and an idle one alike.
+ */
+function edgeMovesOnSettleCanvas(band: Band, byPx: number) {
   let y = 0;
+  let moved = false;
   return {
     pointer: () => ({ x: 0, y }),
     moveBy: async (_dx: number, dy: number) => {
       y += dy;
     },
     zoneContainingPointer: async () => {
-      const from =
-        Date.now() - bornAt >= afterMs ? band.from + byPx : band.from;
+      const from = moved ? band.from + byPx : band.from;
       return y >= from && y < band.to ? band.zone : -1;
+    },
+    /** Stands in for the probe's wait, and is the observable event the shift hangs on. */
+    settle: async () => {
+      moved = true;
     },
   };
 }
@@ -318,12 +374,9 @@ test("re-enters a zone whose edge moved DOWN out from under the pointer", async 
   // active one, so the top edge travels DOWN and a pointer resting on the old boundary is left
   // just above the new one. A bracket that only ever retreats moves further away, and reports an
   // edge it is standing one pixel short of as unfindable.
-  //
-  // 60ms lands inside the probe's settle wait, which is 120ms — so the first bracket succeeds
-  // against the original edge and the second meets the moved one.
-  const canvas = edgeMovesAtCanvas({ zone: 5, from: 50, to: 90 }, 60, 4);
+  const canvas = edgeMovesOnSettleCanvas({ zone: 5, from: 50, to: 90 }, 4);
 
-  const result = await dragToInsetInZone(canvas, 6);
+  const result = await dragToInsetInZone(canvas, 6, 40, canvas.settle);
 
   expect(result.refused).toBeUndefined();
   expect(result.zone).toBe(5);

--- a/e2e/tests/canvas/zone-inset.test.ts
+++ b/e2e/tests/canvas/zone-inset.test.ts
@@ -182,3 +182,81 @@ test("a depth of zero puts the pointer on the first row inside the band", async 
   expect(canvas.pointer().y).toBe(50);
   expect(trueDepth(ONE_BAND[0], canvas.pointer().y)).toBe(result.insetPx);
 });
+
+/**
+ * A canvas whose zone edge MOVES the first `shifts` times it is entered.
+ *
+ * The real one does this: a drop zone is 6px tall with a 3px margin while a
+ * drag is in flight and takes a 4px margin once it is the ACTIVE target, so
+ * arriving in a zone moves its own edge and every edge below it. A depth
+ * measured across that transition is measured from a boundary that has since
+ * moved.
+ */
+function shiftingEdgeCanvas(band: Band, shifts: number, startY = 0) {
+  let y = startY;
+  let from = band.from;
+  let entries = 0;
+  let wasInside = false;
+  return {
+    pointer: () => ({ x: 0, y }),
+    moveBy: async (_dx: number, dy: number) => {
+      y += dy;
+    },
+    zoneContainingPointer: async () => {
+      const inside = y >= from && y < band.to;
+      // Shifted on ENTRY only. The real transition fires when a zone becomes the
+      // active target, not on every read — and an edge that receded on every
+      // read would simply outrun the probe, which is a different fact
+      // (`boundary-not-found`) and would not exercise this one.
+      if (inside && !wasInside && entries < shifts) {
+        entries += 1;
+        from -= 1;
+      }
+      wasInside = inside;
+      return inside ? band.zone : -1;
+    },
+  };
+}
+
+test("settles a moving edge by measuring it twice, not by waiting", async () => {
+  // One shift is what the real transition produces: the zone grows once, when it
+  // becomes the active target. A second agreeing measurement is what proves the
+  // edge has stopped, and it costs no wall-clock time.
+  const canvas = shiftingEdgeCanvas({ zone: 4, from: 50, to: 90 }, 1);
+
+  const result = await dragToInsetInZone(canvas, 6);
+
+  expect(result.refused).toBeUndefined();
+  expect(result.zone).toBe(4);
+  expect(result.insetPx).toBe(6);
+});
+
+test("refuses rather than measuring from an edge that keeps moving", async () => {
+  // A depth taken from an edge in motion is a number with no referent, and
+  // reporting one would be worse than reporting nothing — every band assertion
+  // built on it would be wrong with no symptom pointing here.
+  const canvas = shiftingEdgeCanvas({ zone: 4, from: 50, to: 900 }, 99);
+
+  const result = await dragToInsetInZone(canvas, 6);
+
+  expect(result.refused).toBe("edge-moving");
+  expect(result.zone).toBe(4);
+});
+
+test("refuses a depth it cannot represent, rather than rounding to one it can", async () => {
+  // A caller deriving a depth from fractional or scaled DOM geometry would
+  // otherwise get 13px of movement for a 12.5px request and a success saying 13
+  // — a false measurement rather than a failed one. Negative and NaN are worse:
+  // the walk never runs and depth 0 comes back as a success.
+  const canvas = () => bandedCanvas(ONE_BAND);
+
+  await expect(dragToInsetInZone(canvas(), 12.5)).rejects.toThrow(
+    /whole, non-negative depth/
+  );
+  await expect(dragToInsetInZone(canvas(), -4)).rejects.toThrow(
+    /whole, non-negative depth/
+  );
+  await expect(dragToInsetInZone(canvas(), Number.NaN)).rejects.toThrow(
+    /whole, non-negative depth/
+  );
+});

--- a/e2e/tests/canvas/zone-inset.test.ts
+++ b/e2e/tests/canvas/zone-inset.test.ts
@@ -292,6 +292,10 @@ test("keeps an edge-moving refusal inside the zone it reports, going DOWN", asyn
 
   expect(result.refused).toBe("edge-moving");
   expect(result.insetPx).toBeUndefined();
+  // A REAL zone first. `zone` and the read-back are compared below, and two
+  // absent zones compare equal — so without this the assertion is satisfied by
+  // the pointer being nowhere, which is the outcome it exists to rule out.
+  expect(result.zone).toBeGreaterThanOrEqual(0);
   expect(await canvas.zoneContainingPointer()).toBe(result.zone);
 });
 


### PR DESCRIPTION
Unblocks the B-7 hysteresis lane. Filed as §6 of `tasks/left-tasks/2026-08-14-0030-canvas-harness-dwell-follow-ups.md`, deferred from #763.

## Why the existing control cannot answer a margin question

The requirement permits target-switch hysteresis as an 8-12px distance margin **or** a >100ms dwell. #763 addressed the dwell form thoroughly — waiting, settling, declared allowances. It addressed the margin form not at all, and one place makes that concrete.

`dragUntilInsideZone` stops at the first 4px step that puts the pointer inside a zone. A canvas whose hysteresis is a distance margin has **correctly not switched** there: that position is inside its margin, and holding the previous target is exactly what the requirement asks for. So the containment comparisons reject a compliant canvas.

`settledTarget` cannot rescue it. **Waiting does not move a pointer**, and a distance-based resolver does not change its mind with time. No amount of settling turns "somewhere inside" into "far enough inside".

The B-7 lane has chosen the margin form, so this is a live dependency rather than a hypothetical one.

## What this adds

```ts
dragToInsetInZone(driver, wantInsetPx, maxSteps?): Promise<ZoneInset>
// { zone, insetPx, refused?: "never-entered" | "too-narrow" }
```

Three phases, and the middle one is what makes the answer exact:

1. coarse steps until a zone contains the pointer;
2. one-pixel steps **back** until the zone is left, then one forward — the boundary is now bracketed to within a pixel, and its position is read from `driver.pointer()` rather than inferred from a step count;
3. forward to the requested depth, re-reading containment so a zone too shallow reports that.

Three properties the consumer asked for, and each is a test:

- **The depth is MEASURED, not echoed.** `insetPx` is what was achieved. Pointer positions and DOM geometry are fractional and a 4px scan overshoots, so the achieved depth is not always the requested one and a caller asserting on a band width has to know which it got.
- **A zone too shallow REFUSES.** Returning the closest depth managed would silently measure a number the caller did not ask for — and would pass.
- **No settling.** For a margin implementation there is nothing to wait for, and mixing a dwell wait in would put wall-clock dependence into the one control a width assertion rests on.

`ZoneInsetDriver` is declared as the capability (`moveBy`, `zoneContainingPointer`, `pointer`) rather than the whole `CanvasDriver`, matching `EdgeSearchDriver` and `JitterDriver`, so it runs against a simulated canvas as well as a real one.

## Why the unit is pixels of pointer movement

`Collision.value` is not in consistent units — pointer distance for one collision type, overlap area for another — so a band expressed as a raw collision score means different things per candidate kind. `pointer()` is what makes the result assertable in the only unit a band width can honestly be stated in.

## Evidence

Six tests against a simulated canvas with bands at **known pixel positions**, so the expected answer is arithmetic rather than a second opinion. That matters more than usual here: this control is itself the measuring device for every band assertion built on it, so it cannot be checked against another instrument.

The separating assertion is `trueDepth(band, pointer().y) === insetPx` — the reported depth compared against the band's real edge. Removing only the boundary bracketing (phase 2), which is exactly what `dragUntilInsideZone` does today, fails 3 of 6: the control then reports a self-consistent depth measured from wherever its coarse approach happened to land. Comparing the report against the *request* would not catch that; comparing it against the real edge does.

Also covered: the same depth from four different start offsets within one coarse step; a band too shallow refusing rather than approximating; never entering a zone reported as a refusal rather than as depth 0; a depth measured from the band entered rather than from a band crossed earlier; and depth 0 as a legitimate request, since a band assertion needs both ends.

No browser, matching `settle.test.ts` and `dwelling-canvas.test.ts`.

## Not in scope

The suite still does not assert hysteresis **width** — §1 of the follow-up, and the reason it matters: the existing ±2px jitter probe is satisfied by a 3px margin, so it would accept an implementation the requirement forbids. The B-7 lane is writing that assertion in a file of their own, in pixels of pointer movement, mutation-checked. This is the control it needs.

`dragUntilInsideZone` is left in place and unchanged — its callers ask a containment question it answers correctly, and changing where it stops would change what the whole suite measures.

Test-only, so no changeset.
