### PR TITLE
fix(nextly): persist the admin options a collection is allowed to set

### DIFF
--- a/.changeset/persist-collection-admin-options.md
+++ b/.changeset/persist-collection-admin-options.md
@@ -1,0 +1,39 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+fix(nextly): persist the admin options a collection is allowed to set
+
+order and sidebarGroup were accepted by CollectionAdminOptions and dropped by the
+projection that writes the registry, so a code-first collection could set its
+sidebar position, type-check, and still sort by the default. admin.description
+had no column under admin at all; it now resolves to the collection's own
+description, which is the field the admin already renders and the Schema Builder
+already edits.
+
+A compile-time assertion now requires every admin option to be either persisted
+or listed with the reason it is not, so adding one forces the author to classify
+it in the same change. That list is exactly what drifted twice before.

--- a/packages/nextly/src/di/register.ts
+++ b/packages/nextly/src/di/register.ts
@@ -41,6 +41,7 @@ import type { ApiKeyService } from "../domains/auth/services/api-key-service";
 import type { AuthService } from "../domains/auth/services/auth-service";
 import type { PermissionSeedService } from "../domains/auth/services/permission-seed-service";
 import type { RBACAccessControlService } from "../domains/auth/services/rbac-access-control-service";
+import { resolveDescription } from "../domains/collections/services/collection-sync-service";
 import type { ResolvedEmailRetentionConfig } from "../domains/email/retention-config";
 import { emailRetentionAfterTransform } from "../domains/email/retention-config";
 import type { EmailDeliveryService } from "../domains/email/services/email-delivery-service";
@@ -1781,7 +1782,7 @@ async function syncCodeFirstCollections(
         plural: collection.labels?.plural ?? `${collection.slug}s`,
       },
       fields: collection.fields,
-      description: collection.description,
+      description: resolveDescription(collection),
       tableName: collection.dbName,
       timestamps: collection.timestamps,
       admin: collection.admin,

--- a/packages/nextly/src/di/register.ts
+++ b/packages/nextly/src/di/register.ts
@@ -41,7 +41,10 @@ import type { ApiKeyService } from "../domains/auth/services/api-key-service";
 import type { AuthService } from "../domains/auth/services/auth-service";
 import type { PermissionSeedService } from "../domains/auth/services/permission-seed-service";
 import type { RBACAccessControlService } from "../domains/auth/services/rbac-access-control-service";
-import { resolveDescription } from "../domains/collections/services/collection-sync-service";
+import {
+  resolveDescription,
+  toPersistedAdmin,
+} from "../domains/collections/services/collection-sync-service";
 import type { ResolvedEmailRetentionConfig } from "../domains/email/retention-config";
 import { emailRetentionAfterTransform } from "../domains/email/retention-config";
 import type { EmailDeliveryService } from "../domains/email/services/email-delivery-service";
@@ -1785,7 +1788,11 @@ async function syncCodeFirstCollections(
       description: resolveDescription(collection),
       tableName: collection.dbName,
       timestamps: collection.timestamps,
-      admin: collection.admin,
+      // Through the SAME projection the CLI path uses. Forwarding the authored object
+      // instead would store whatever it holds — including a `preview.url` function that
+      // JSON.stringify drops silently, leaving a preview config that cannot work — and would
+      // put the primary write path outside the boundary that decides what `admin` may contain.
+      admin: toPersistedAdmin(collection.admin),
       source: sourceBySlug.get(collection.slug) ?? "code",
       // Forward Draft/Published flag from code-first config so the boot-time
       // sync persists it to dynamic_collections.status.

--- a/packages/nextly/src/domains/collections/services/__tests__/persisted-admin.test.ts
+++ b/packages/nextly/src/domains/collections/services/__tests__/persisted-admin.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it } from "vitest";
 
 import type { CollectionConfig } from "../../../../collections/config/define-collection";
-import { toPersistedAdmin } from "../collection-sync-service";
+import {
+  ADMIN_KEYS_NOT_PERSISTED,
+  resolveDescription,
+  toPersistedAdmin,
+} from "../collection-sync-service";
 
 /**
  * The projection from a collection's authored admin options to the shape stored
@@ -51,5 +55,85 @@ describe("toPersistedAdmin", () => {
 
   it("returns undefined when a collection declares no admin options", () => {
     expect(toPersistedAdmin(undefined)).toBeUndefined();
+  });
+});
+
+/**
+ * Sidebar placement reaches the registry.
+ *
+ * `DynamicCollectionNav` takes its collections from the persisted registry, so a value dropped by
+ * the projection means a code-first collection can set its position, type-check, and still sort
+ * by the default — the same shape as the `defaultColumns` drop, found by auditing the rest of the
+ * key list after fixing that one.
+ */
+describe("sidebar placement", () => {
+  it("carries order and sidebarGroup", () => {
+    const admin: CollectionConfig["admin"] = {
+      order: 2,
+      sidebarGroup: "editorial",
+    };
+
+    const persisted = toPersistedAdmin(admin);
+    // On the VALUES: a present key holding undefined sorts by the default just as an absent one
+    // does, so a presence check would pass on the broken projection.
+    expect(persisted?.order).toBe(2);
+    expect(persisted?.sidebarGroup).toBe("editorial");
+  });
+
+  it("leaves them undefined when the author set neither", () => {
+    // The scaffold must not invent a position. `order` defaulting to 0 here would silently pin
+    // every code-first collection above every other one.
+    const persisted = toPersistedAdmin({ useAsTitle: "title" });
+    expect(persisted?.order).toBeUndefined();
+    expect(persisted?.sidebarGroup).toBeUndefined();
+  });
+});
+
+/**
+ * `admin.description` and the top-level `description` are two spellings of one thing, and only
+ * the second has a column. Resolved in one place so the two sync paths cannot disagree.
+ */
+describe("resolveDescription", () => {
+  it("uses admin.description when the collection sets no top-level one", () => {
+    expect(
+      resolveDescription({ admin: { description: "Blog posts and news" } })
+    ).toBe("Blog posts and news");
+  });
+
+  it("prefers the top-level description when both are set", () => {
+    // The documented home wins: an author setting both is most plausibly migrating off the
+    // `admin` spelling and expects the explicit field to take effect.
+    expect(
+      resolveDescription({
+        description: "explicit",
+        admin: { description: "legacy" },
+      })
+    ).toBe("explicit");
+  });
+
+  it("is undefined when neither is set", () => {
+    expect(resolveDescription({})).toBeUndefined();
+  });
+});
+
+/**
+ * The exclusion list is a claim, not a comment: every key on it is an admin option a caller can
+ * set and this projection deliberately will not store, and the reason is what a later reader has
+ * to weigh before moving it. A blank one would pass the compiler's completeness check while
+ * telling that reader nothing.
+ */
+describe("ADMIN_KEYS_NOT_PERSISTED", () => {
+  it("gives a reason for every excluded key", () => {
+    const entries = Object.entries(ADMIN_KEYS_NOT_PERSISTED);
+    // A control on the assertion below: it holds vacuously over an empty list, and an empty list
+    // is also what a bad refactor would leave behind.
+    expect(entries.length).toBeGreaterThan(0);
+
+    for (const [key, reason] of entries) {
+      expect(reason, `${key} is excluded without a reason`).toBeTruthy();
+      expect(reason.trim().length, `${key}'s reason is blank`).toBeGreaterThan(
+        0
+      );
+    }
   });
 });

--- a/packages/nextly/src/domains/collections/services/__tests__/persisted-admin.test.ts
+++ b/packages/nextly/src/domains/collections/services/__tests__/persisted-admin.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import type { CollectionConfig } from "../../../../collections/config/define-collection";
 import {
   ADMIN_KEYS_NOT_PERSISTED,
+  asAdminOptions,
   resolveDescription,
   toPersistedAdmin,
 } from "../collection-sync-service";
@@ -135,5 +136,36 @@ describe("ADMIN_KEYS_NOT_PERSISTED", () => {
         0
       );
     }
+  });
+});
+
+/**
+ * The seam where a config has lost its type.
+ *
+ * The HMR payload builder reads a module re-imported across a reload and holds `admin` as
+ * `unknown`, so something has to re-establish the type before the projection can run. Keeping
+ * that narrowing in one named place is what lets the projection keep a precise signature — the
+ * alternative, widening it to accept `unknown`, would let every caller hand it anything.
+ */
+describe("asAdminOptions", () => {
+  it("passes an object through so the projection can read it", () => {
+    const narrowed = asAdminOptions({ order: 3, sidebarGroup: "editorial" });
+    // Through the projection, because that is what the caller does with it — asserting the
+    // narrowing alone would not show that the value survives the trip.
+    expect(toPersistedAdmin(narrowed)?.order).toBe(3);
+    expect(toPersistedAdmin(narrowed)?.sidebarGroup).toBe("editorial");
+  });
+
+  it.each([
+    ["undefined", undefined],
+    ["null", null],
+    ["a string", "admin"],
+    ["a number", 7],
+  ])("treats %s as no admin block at all", (_label, value) => {
+    // Not a throw. A malformed value reaching this seam means a reload delivered something
+    // unexpected, and refusing to boot over it would be a worse outcome than a collection
+    // rendering with default admin options.
+    expect(asAdminOptions(value)).toBeUndefined();
+    expect(toPersistedAdmin(asAdminOptions(value))).toBeUndefined();
   });
 });

--- a/packages/nextly/src/domains/collections/services/collection-registry-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-registry-service.ts
@@ -44,6 +44,8 @@ import {
 } from "../../webhooks/recording-policy";
 import { isConfigOwnedSource } from "../../webhooks/recording-provenance";
 
+import { resolveDescription } from "./collection-sync-service";
+
 /** Options for updating a collection. */
 export interface UpdateCollectionOptions {
   /** Source making the update. Used to enforce locking rules. */
@@ -230,7 +232,7 @@ export class CollectionRegistryService extends BaseRegistryService<
       slug: data.slug,
       labels: JSON.stringify(data.labels),
       table_name: tableName,
-      description: data.description,
+      description: data.description ?? undefined,
       fields: fieldsJson,
       timestamps: (data.timestamps ?? true) ? 1 : 0,
       admin: data.admin ? JSON.stringify(data.admin) : null,
@@ -599,7 +601,7 @@ export class CollectionRegistryService extends BaseRegistryService<
             config.slug,
             {
               labels: config.labels,
-              description: config.description,
+              description: resolveDescription(config) ?? null,
               fields: config.fields,
               timestamps: config.timestamps,
               admin: config.admin,
@@ -625,13 +627,23 @@ export class CollectionRegistryService extends BaseRegistryService<
           await this.seedPermissionsForCollection(config.slug);
         } else if (
           this.adminConfigChanged(config.admin, existing.admin) ||
-          this.labelsChanged(config.labels, existing.labels)
+          this.labelsChanged(config.labels, existing.labels) ||
+          resolveDescription(config) !== (existing.description ?? undefined)
         ) {
           await this.updateCollection(
             config.slug,
             {
               labels: config.labels,
-              admin: config.admin,
+              // Resolved, because a collection may spell its description under `admin` — and
+              // compared above for the same reason: without it, editing or removing that
+              // spelling leaves the row stale until some unrelated schema change happens to
+              // trigger a write.
+              description: resolveDescription(config) ?? null,
+              // Explicit null when the config no longer declares an admin block, so
+              // `updateCollection` clears the column instead of reading `undefined` as "leave
+              // unchanged" and stranding a sidebar position the config has dropped. Same
+              // reasoning as `revalidate` and `webhooks` above.
+              admin: config.admin ?? null,
               locked: true,
             },
             { source: config.source ?? "code" }

--- a/packages/nextly/src/domains/collections/services/collection-registry-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-registry-service.ts
@@ -604,7 +604,11 @@ export class CollectionRegistryService extends BaseRegistryService<
               description: resolveDescription(config) ?? null,
               fields: config.fields,
               timestamps: config.timestamps,
-              admin: config.admin,
+              // Explicit null when the config no longer declares an admin block, matching the
+              // metadata-only branch below. Removing `admin` usually accompanies some other
+              // edit, and that edit selects THIS branch — so without it the common case is the
+              // one where stale placement survives.
+              admin: config.admin ?? null,
               configPath: config.configPath,
               schemaHash,
               locked: true,

--- a/packages/nextly/src/domains/collections/services/collection-sync-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-sync-service.ts
@@ -37,7 +37,10 @@ import { dirname, join, resolve } from "node:path";
 
 import type { DrizzleAdapter } from "@nextlyhq/adapter-drizzle";
 
-import type { CollectionConfig } from "../../../collections/config/define-collection";
+import type {
+  CollectionAdminOptions,
+  CollectionConfig,
+} from "../../../collections/config/define-collection";
 import type { SanitizedNextlyConfig } from "../../../collections/config/define-config";
 import type { FieldConfig } from "../../../collections/fields/types";
 import type { DynamicCollectionRecord } from "../../../schemas/dynamic-collections/types";
@@ -236,6 +239,31 @@ export interface CollectionSyncResultWithValidation
  * Exported so the projection can be asserted directly rather than only through
  * a sync that needs a database.
  */
+/**
+ * `admin` keys this projection deliberately does NOT carry, each with the reason it is absent.
+ *
+ * Every key of `CollectionAdminOptions` must appear either in the object `toPersistedAdmin`
+ * returns or here — enforced below, at compile time. That is the point: the list of persisted
+ * keys is precisely what has drifted twice already (both conversion paths once omitted
+ * `defaultColumns`, and only one of them carried `disableCreate`), and a drop is invisible
+ * because the value type-checks at the author's keyboard and simply never arrives.
+ *
+ * Adding an option to `CollectionAdminOptions` now fails the build until it is classified.
+ */
+export const ADMIN_KEYS_NOT_PERSISTED = {
+  /**
+   * Written to the collection's own `description` column instead of into `admin`, so the two
+   * authoring paths describe a collection in one place. See `resolveDescription`.
+   */
+  description: "stored on the collection row rather than under `admin`",
+  /**
+   * Carries `url`, a function of the entry, which no column can hold. Serving it needs the
+   * admin to ASK the server to evaluate it rather than to read it back, which is a change to
+   * how the panel obtains config and is deliberately not folded in here.
+   */
+  preview: "holds a function; needs server-side evaluation rather than storage",
+} as const;
+
 export function toPersistedAdmin(admin: CollectionConfig["admin"]) {
   if (!admin) return undefined;
   return {
@@ -246,6 +274,11 @@ export function toPersistedAdmin(admin: CollectionConfig["admin"]) {
     defaultColumns: admin.defaultColumns,
     isPlugin: admin.isPlugin,
     disableCreate: admin.disableCreate,
+    // Sidebar placement. Both are read by `DynamicCollectionNav`, which takes its collections
+    // from the persisted registry — so omitting them here meant a code-first collection could
+    // set them, type-check, and still sort by the default.
+    order: admin.order,
+    sidebarGroup: admin.sidebarGroup,
     pagination: admin.pagination
       ? {
           defaultLimit: admin.pagination.defaultLimit,
@@ -255,6 +288,42 @@ export function toPersistedAdmin(admin: CollectionConfig["admin"]) {
     // Include custom components for plugins (e.g., custom Edit views)
     components: admin.components,
   };
+}
+
+/**
+ * Every `admin` option is either persisted or explicitly excluded — checked by the compiler.
+ *
+ * A plain assertion the checker EVALUATES, rather than a suppression: when
+ * `CollectionAdminOptions` gains a key that is in neither set, `UnclassifiedAdminKey` stops
+ * being `never` and this line fails with the offending key names in the error text.
+ */
+type UnclassifiedAdminKey = Exclude<
+  keyof CollectionAdminOptions,
+  | keyof NonNullable<ReturnType<typeof toPersistedAdmin>>
+  | keyof typeof ADMIN_KEYS_NOT_PERSISTED
+>;
+const _everyAdminKeyIsClassified: UnclassifiedAdminKey extends never
+  ? true
+  : [
+      "unclassified admin key(s) — persist them or list a reason",
+      UnclassifiedAdminKey,
+    ] = true;
+void _everyAdminKeyIsClassified;
+
+/**
+ * The description a collection is stored with.
+ *
+ * `admin.description` and the top-level `description` are two spellings of one thing — help text
+ * under the collection title — and only the second has a column. Resolved in ONE place so the two
+ * sync paths cannot disagree about which wins.
+ *
+ * The top-level field takes precedence: it is the documented home, so an author who sets both is
+ * most plausibly migrating from the `admin` spelling and expects the explicit field to win.
+ */
+export function resolveDescription(
+  config: Pick<CollectionConfig, "description" | "admin">
+): string | undefined {
+  return config.description ?? config.admin?.description;
 }
 
 /**
@@ -677,7 +746,7 @@ export class CollectionSyncService extends BaseService {
         plural: config.labels?.plural ?? toPluralLabel(config.slug),
       },
       fields: config.fields,
-      description: config.description,
+      description: resolveDescription(config),
       tableName: config.dbName ?? config.slug.replace(/-/g, "_"),
       timestamps: config.timestamps ?? true,
       // Persist Draft/Published, i18n, and the resolved versioning config through
@@ -879,7 +948,7 @@ export class CollectionSyncService extends BaseService {
           plural: config.labels?.plural ?? toPluralLabel(config.slug),
         },
         tableName,
-        description: config.description,
+        description: resolveDescription(config),
         fields: config.fields,
         timestamps: config.timestamps ?? true,
         // Why: status from defineCollection() input if present, otherwise false.

--- a/packages/nextly/src/domains/collections/services/collection-sync-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-sync-service.ts
@@ -267,6 +267,28 @@ export const ADMIN_KEYS_NOT_PERSISTED = {
   preview: "holds a function; needs server-side evaluation rather than storage",
 } as const;
 
+/**
+ * Re-establish the `admin` type on a value that has lost it.
+ *
+ * The HMR payload builder holds its config as `unknown`: it reads a module that has been
+ * re-imported across a reload, so nothing carries the authored type across that boundary. The
+ * projection keeps its precise signature — it is the boundary that decides what may be stored, and
+ * widening it to `unknown` would mean every caller could hand it anything.
+ *
+ * So the narrowing lives here, once, named for what it does. It checks only that the value is an
+ * object: the projection reads individual keys and each is optional, so a malformed one yields a
+ * projection with undefined fields rather than a throw — the same outcome as an absent `admin`.
+ *
+ * No assertion is needed after that narrowing: every option on `CollectionAdminOptions` is
+ * optional, so a non-null object is already assignable to it.
+ */
+export function asAdminOptions(
+  value: unknown
+): CollectionAdminOptions | undefined {
+  if (typeof value !== "object" || value === null) return undefined;
+  return value;
+}
+
 export function toPersistedAdmin(admin: CollectionConfig["admin"]) {
   if (!admin) return undefined;
   return {

--- a/packages/nextly/src/domains/collections/services/collection-sync-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-sync-service.ts
@@ -43,7 +43,10 @@ import type {
 } from "../../../collections/config/define-collection";
 import type { SanitizedNextlyConfig } from "../../../collections/config/define-config";
 import type { FieldConfig } from "../../../collections/fields/types";
-import type { DynamicCollectionRecord } from "../../../schemas/dynamic-collections/types";
+import type {
+  CollectionAdminConfig,
+  DynamicCollectionRecord,
+} from "../../../schemas/dynamic-collections/types";
 import type { Logger } from "../../../services/shared";
 import { BaseService } from "../../../shared/base-service";
 import {
@@ -311,6 +314,32 @@ const _everyAdminKeyIsClassified: UnclassifiedAdminKey extends never
 void _everyAdminKeyIsClassified;
 
 /**
+ * Everything this projection returns is a field the registry actually stores.
+ *
+ * The companion to the check above, and it has to be its own assertion because the two run in
+ * opposite directions. That one is computed from what the projection RETURNS, so it catches a
+ * key the persisted shape declares and the projection drops — which is how `order` and
+ * `sidebarGroup` were being lost. Basing it on `CollectionAdminConfig` instead would certify
+ * those as handled simply because the column type mentions them.
+ *
+ * This one is the reverse: every key the projection emits must exist on `CollectionAdminConfig`.
+ * Assignability alone does not give it, since a structural check permits extra properties — so a
+ * key could be marked "persisted" by the check above merely by being returned, while the column's
+ * type never described it and nothing could read it back with types.
+ */
+type UnstorableProjectedKey = Exclude<
+  keyof NonNullable<ReturnType<typeof toPersistedAdmin>>,
+  keyof CollectionAdminConfig
+>;
+const _everyProjectedKeyIsStorable: UnstorableProjectedKey extends never
+  ? true
+  : [
+      "projected key(s) absent from CollectionAdminConfig — declare them or stop returning them",
+      UnstorableProjectedKey,
+    ] = true;
+void _everyProjectedKeyIsStorable;
+
+/**
  * The description a collection is stored with.
  *
  * `admin.description` and the top-level `description` are two spellings of one thing — help text
@@ -320,10 +349,20 @@ void _everyAdminKeyIsClassified;
  * The top-level field takes precedence: it is the documented home, so an author who sets both is
  * most plausibly migrating from the `admin` spelling and expects the explicit field to win.
  */
-export function resolveDescription(
-  config: Pick<CollectionConfig, "description" | "admin">
-): string | undefined {
-  return config.description ?? config.admin?.description;
+export function resolveDescription(config: {
+  description?: string;
+  admin?: unknown;
+}): string | undefined {
+  if (config.description !== undefined) return config.description;
+
+  // `admin` is narrowed here rather than required as a typed shape, because one of the callers
+  // holds it as `unknown`: the HMR payload builder reads a config that has crossed a module
+  // reload and does not carry its type. Narrowing in the single resolver keeps that seam honest
+  // without a cast at the call site, and without every caller repeating the check.
+  if (typeof config.admin !== "object" || config.admin === null)
+    return undefined;
+  const description = (config.admin as { description?: unknown }).description;
+  return typeof description === "string" ? description : undefined;
 }
 
 /**

--- a/packages/nextly/src/init/reload-config.ts
+++ b/packages/nextly/src/init/reload-config.ts
@@ -27,6 +27,7 @@ import { type SQL } from "drizzle-orm";
 
 import type { CollectionHooks } from "../collections/config/define-collection";
 import { type ResolvedAuditRetentionConfig } from "../domains/audit/retention-config";
+import { resolveDescription } from "../domains/collections/services/collection-sync-service";
 import { withMigrationExcluded } from "../domains/field-groups/migration/sync-guard";
 import { chooseTypeColumns } from "../domains/field-groups/storage/resolve-storage-names";
 import type { I18nTransitionKind } from "../domains/i18n/migration/transition-state";
@@ -316,7 +317,7 @@ function buildCollectionSyncPayload(collections: CollectionDef[]) {
         plural: c.labels?.plural ?? `${c.slug}s`,
       },
       fields: c.fields ?? [],
-      description: c.description,
+      description: resolveDescription(c),
       tableName: c.dbName,
       timestamps: c.timestamps,
       admin: c.admin,

--- a/packages/nextly/src/init/reload-config.ts
+++ b/packages/nextly/src/init/reload-config.ts
@@ -27,7 +27,11 @@ import { type SQL } from "drizzle-orm";
 
 import type { CollectionHooks } from "../collections/config/define-collection";
 import { type ResolvedAuditRetentionConfig } from "../domains/audit/retention-config";
-import { resolveDescription } from "../domains/collections/services/collection-sync-service";
+import {
+  asAdminOptions,
+  resolveDescription,
+  toPersistedAdmin,
+} from "../domains/collections/services/collection-sync-service";
 import { withMigrationExcluded } from "../domains/field-groups/migration/sync-guard";
 import { chooseTypeColumns } from "../domains/field-groups/storage/resolve-storage-names";
 import type { I18nTransitionKind } from "../domains/i18n/migration/transition-state";
@@ -320,7 +324,9 @@ function buildCollectionSyncPayload(collections: CollectionDef[]) {
       description: resolveDescription(c),
       tableName: c.dbName,
       timestamps: c.timestamps,
-      admin: c.admin,
+      // Same projection as boot and the CLI: one decision about what `admin` may contain,
+      // applied wherever a collection reaches the registry.
+      admin: toPersistedAdmin(asAdminOptions(c.admin)),
       // Draft/Published flag + versioning persisted to dynamic_collections so a
       // code-first toggle reaches the registry.
       status: c.status === true,

--- a/packages/nextly/src/schemas/dynamic-collections/types.ts
+++ b/packages/nextly/src/schemas/dynamic-collections/types.ts
@@ -161,6 +161,14 @@ export interface CollectionAdminConfig {
   sidebarGroup?: string;
 
   /**
+   * Which fields the entry list shows as columns, and in what order.
+   *
+   * Field keys. One that no longer exists is ignored rather than erroring, so a rename leaves a
+   * shorter list rather than an unusable screen.
+   */
+  defaultColumns?: string[];
+
+  /**
    * Whether this collection is provided by a plugin.
    */
   isPlugin?: boolean;
@@ -377,7 +385,12 @@ export interface DynamicCollectionInsert {
   tableName: string;
 
   /** Optional description of the collection */
-  description?: string;
+  /**
+   * `null` CLEARS the stored value on update; `undefined` leaves it unchanged. The two are
+   * distinct intents and the update path reads them that way, as it already does for
+   * `revalidate` and `webhooks`.
+   */
+  description?: string | null;
 
   /** Field configurations defining the collection schema */
   fields: FieldConfig[];
@@ -420,7 +433,11 @@ export interface DynamicCollectionInsert {
   localized?: boolean;
 
   /** Admin UI configuration options */
-  admin?: CollectionAdminConfig;
+  /**
+   * `null` CLEARS the stored block on update; `undefined` leaves it unchanged — so a config
+   * that drops its `admin` entirely does not strand a sidebar position it no longer declares.
+   */
+  admin?: CollectionAdminConfig | null;
 
   /** Where the collection was defined */
   source: CollectionSource;


### PR DESCRIPTION
Closes the `defaultColumns` shape #783 fixed once. Auditing the rest of `CollectionAdminOptions` found four more keys that a collection can set, that type-check, and that never arrive.

## The classification, which had to come first

The task this came from said to decide per key before touching the projection, because "add the missing four" is guessing. Comparing what an author can write against the **persisted** `CollectionAdminConfig` splits them cleanly:

| key | in the persisted type? | verdict |
|---|---|---|
| `order` | **yes** | accidental drop — projection omits it |
| `sidebarGroup` | **yes** | accidental drop — same |
| `description` | **no** — the column is on the collection row | wrong home, not a drop |
| `preview` | yes, but only as `urlTemplate` (a string) | carries a **function**; no column can hold it |

`order` and `sidebarGroup` are read by `DynamicCollectionNav`, which takes its collections from the persisted registry — so the drop meant a code-first collection sorted by the default no matter what it declared.

## What this changes

- **`order` + `sidebarGroup`** are carried through.
- **`description`** resolves to the collection's own column via one `resolveDescription`, used by both sync paths. The top-level field wins when both are set: it is the documented home, and an author setting both is most plausibly migrating off the `admin` spelling.
- **`preview` stays unpersisted**, now listed with its reason. Serving a function needs the admin to *ask the server to evaluate it* rather than read it back — a change to how the panel obtains config, and its own piece of work rather than a line here.

## The durable part

A hand-kept list is exactly what drifted twice (both paths once omitted `defaultColumns`; only one carried `disableCreate`), and a drop is invisible because the value type-checks at the author's keyboard and simply never arrives.

So every admin option must now be either in the persisted object or in `ADMIN_KEYS_NOT_PERSISTED`, **checked by the compiler** — an assertion the checker evaluates, not a suppression:

```
error TS2322: Type 'boolean' is not assignable to type
  '["unclassified admin key(s) — persist them or list a reason", "brandNewOption"]'
```

That is the real output from adding an unclassified key, which is how the guard was verified. Adding an option now fails the build until it is classified, in the same change.

The exclusion list is exported and its reasons asserted, so an entry cannot satisfy the compiler while telling a later reader nothing — with a control on the assertion, since it would otherwise hold vacuously over an empty list.

## Verification

Break-verified, each restored:

| break | fails |
|---|---|
| drop `order`/`sidebarGroup` from the projection | `carries order and sidebarGroup` |
| `resolveDescription` ignores the admin spelling | `uses admin.description when …` |
| add an unclassified key to `CollectionAdminOptions` | the build, naming the key |

Assertions are on **values**, not key presence: a key holding `undefined` sorts by the default exactly as an absent one does, so a presence check would pass on the broken projection.

`check-types` and `lint` exit 0. `src/domains/collections` has a **pre-existing** baseline of 11 failures across three files (`collection-hooks`, `collection-access`, `collection-mutation`) — identical with this work stashed. This adds 5 passing tests and no new failures.

@codex please review this PR