### PR TITLE
feat(blocks-engine): publish the survey a validation judged with

### DIFF
--- a/packages/blocks-engine/src/index.ts
+++ b/packages/blocks-engine/src/index.ts
@@ -104,6 +104,7 @@ export type {
   BlockTypeLookup,
   ClassLookup,
   IssueCode,
+  ValidationResult,
   IssueSeverity,
   TokenLookup,
   ValidationContext,

--- a/packages/blocks-engine/src/validation.ts
+++ b/packages/blocks-engine/src/validation.ts
@@ -271,12 +271,57 @@ const ENGINE_NODE_TYPES = new Set<string>([COMPONENT_INSTANCE_TYPE]);
  * renderer can still show what it can. Structural corruption (missing ids,
  * malformed shapes, exceeded limits) is always an error.
  */
+/**
+ * What one validation produced: the issues, and the survey they were derived
+ * from.
+ *
+ * The survey is published because a caller that goes on to walk the same
+ * document needs to know whether the engine measured it in FULL, and issue
+ * codes are the wrong channel for that question. A code says what is wrong with
+ * the document; `complete` says whether these numbers can be trusted, and the
+ * two do not line up — a document JSON merely rewrites is fully measured and
+ * safe to walk, while one holding an accessor is neither, and both are errors.
+ *
+ * Reconstructing the second answer from the first means keeping a list of codes
+ * in the consumer, which is a copy of a fact the engine already established and
+ * goes stale in silence when a verdict is added.
+ */
+export interface ValidationResult {
+  issues: ValidationIssue[];
+  survey: DocumentSurvey;
+}
+
+/**
+ * Issues only — the narrow view, DERIVED from {@link validateDocument} rather
+ * than computed beside it.
+ *
+ * Most callers want exactly this and should keep using it. Reach for the richer
+ * function when the answer decides whether to do more work on the same
+ * document.
+ */
 export function validate(
   doc: BlockDocument,
   ctx: ValidationContext
 ): ValidationIssue[] {
+  return validateDocument(doc, ctx).issues;
+}
+
+export function validateDocument(
+  doc: BlockDocument,
+  ctx: ValidationContext
+): ValidationResult {
   const issues: ValidationIssue[] = [];
   const limits = ctx.limits ?? DEFAULT_LIMITS;
+  // Taken before ANY return, so every path can hand back the measurement it
+  // judged the document with. The walk accepts arbitrary input by design, so a
+  // malformed document surveys as readily as a well-formed one — and a caller
+  // that gets issues without a survey would have to guess whether the absence
+  // means "not measured" or "nothing to measure".
+  const survey = surveyDocument(doc, {
+    maxBytes: limits.maxBytes,
+    maxDepth: limits.maxDepth,
+    maxNodes: limits.maxNodes,
+  });
   const unknownSeverity: IssueSeverity =
     ctx.mode === "strict" ? "error" : "warning";
 
@@ -292,7 +337,7 @@ export function validate(
       severity: "error",
       message: "The document must be an object.",
     });
-    return issues;
+    return { issues, survey };
   }
 
   const knownBreakpoints = collectBreakpointIds(ctx.breakpoints, issues);
@@ -331,11 +376,11 @@ export function validate(
       message: "The document nodes field must be an array.",
     });
     // Nothing further to check without a node forest.
-    return issues;
+    return { issues, survey };
   }
 
   const beforeLimits = issues.length;
-  const survey = checkLimits(doc, limits, issues);
+  checkLimits(survey, issues);
   // Any limit rejection, not the byte one alone. A forest over the node or
   // depth cap is refused BEFORE its bytes are measured, so asking only about
   // size would leave the expensive per-value work running on a document already
@@ -424,7 +469,7 @@ export function validate(
     }
   }
 
-  return issues;
+  return { issues, survey };
 }
 
 /**
@@ -469,12 +514,9 @@ function collectBreakpointIds(
   return ids;
 }
 
-function checkLimits(
-  doc: BlockDocument,
-  limits: DocumentLimits,
-  issues: ValidationIssue[]
-): DocumentSurvey {
-  // ONE traversal answers all three bounds.
+function checkLimits(survey: DocumentSurvey, issues: ValidationIssue[]): void {
+  // ONE traversal answers all three bounds, taken by the caller and handed
+  // here.
   //
   // Depth, node count and serialized size were measured by two separate walks,
   // and the second of them had to decide what counts as a node and how deep it
@@ -483,12 +525,6 @@ function checkLimits(
   // keep them agreeing — and a document sits between them only when they
   // disagree, which is exactly when nobody is looking. Every accepted document
   // also paid for the tree twice.
-  const survey = surveyDocument(doc, {
-    maxBytes: limits.maxBytes,
-    maxDepth: limits.maxDepth,
-    maxNodes: limits.maxNodes,
-  });
-
   if (survey.tooDeep) {
     issues.push({
       path: "/nodes",
@@ -509,7 +545,7 @@ function checkLimits(
   // at that breach — so its byte count is a lower bound rather than a
   // measurement, and reporting a size from it would report a number that was
   // never finished.
-  if (survey.tooDeep || survey.tooManyNodes) return survey;
+  if (survey.tooDeep || survey.tooManyNodes) return;
 
   // The CAUSE, not just the refusal. A document over the limit is fixed by
   // removing content; one holding a value JSON cannot write is not made smaller
@@ -547,7 +583,6 @@ function checkLimits(
       )}% of the ${survey.limits.maxBytes}-byte limit.`,
     });
   }
-  return survey;
 }
 
 interface NodeCheckState {


### PR DESCRIPTION
Re-lands a commit that #797 stranded. **Nothing here is new work** — `fc6988b2b` cherry-picked onto `main`, unchanged.

## Why this one is urgent

**#799 imports `validateDocument` and `main` does not have it.** The stranded half is the API the founder chose; the half that landed (`readonly limits`) is the cosmetic one.

```
#797 merged ec9b4c799 from headRefOid edb2ed3e8, branch tip fc6988b2b
git log edb2ed3e8..fc6988b2b -> fc6988b2b   "publish the survey a validation judged with"
```

| | `export function validateDocument` |
|---|---|
| branch tip `fc6988b2b` | **1 hit** |
| merge commit `ec9b4c799` | 0 — ABSENT |
| control: `export function validate` in the merged file | 1 hit, so the search reaches it |

## What it restores

A consumer that walks a document after validating it needs to know whether the engine measured it **in full**, and issue codes are the wrong channel: a code says what is wrong with the document, `complete` says whether the numbers can be trusted, and the two do not line up — a document JSON merely rewrites is fully measured and safe to walk, one holding an accessor is neither, and both are errors.

`validateDocument` returns `{ issues, survey }`. **`validate` keeps its exact signature** and becomes the narrow view derived from it, so no existing caller changes and there is still one implementation.

The survey is taken before *any* return, so every path hands back the measurement it judged the document with — including the two early returns for a non-object document and non-array nodes. `checkLimits` consumes that survey rather than taking its own, which also removes a second traversal on the malformed paths.

1208 pass, `check-types` clean.

## Fourth stranded tail on my PRs today

#796, #802, #804 and now #797 — same mechanism each time: the merge snapshots a head, and a push after that snapshot is outside the merge entirely, so the PR reads complete with green checks and resolved threads. `gh`'s `headRefOid` **is** the merged head, so nothing inside the PR can show it.

Three of the four lost the half that mattered while the harmless half landed, which is the property that makes this hard to notice: the suite stays green.

The gate that prevents rather than detects it is `gh pr merge --squash --match-head-commit <the revision you verified>`, which makes the check and the merge one atomic operation on GitHub's side.
