### PR TITLE
fix(plugin-page-builder): stop the canvas reflowing when a drag starts

### DIFF
--- a/.changeset/canvas-zero-layout-shift.md
+++ b/.changeset/canvas-zero-layout-shift.md
@@ -25,4 +25,4 @@
 "@nextlyhq/module-specifiers": patch
 ---
 
-Stop the page-builder canvas reflowing when a drag starts. Drop zones no longer grow from zero to six pixels on dragstart, so blocks stay where they are while you aim; the target the pointer is tested against is now out of flow and larger than the visible insertion hint.
+Stop the page-builder canvas reflowing when a drag starts. Drop zones no longer grow from zero to six pixels on dragstart, so blocks stay where they are while you aim, and the insertion bar now paints above blocks that carry a stacking context of their own.

--- a/.changeset/canvas-zero-layout-shift.md
+++ b/.changeset/canvas-zero-layout-shift.md
@@ -1,0 +1,28 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+Stop the page-builder canvas reflowing when a drag starts. Drop zones no longer grow from zero to six pixels on dragstart, so blocks stay where they are while you aim; the target the pointer is tested against is now out of flow and larger than the visible insertion hint.

--- a/e2e/tests/canvas/acceptance.spec.ts
+++ b/e2e/tests/canvas/acceptance.spec.ts
@@ -580,13 +580,8 @@ test.describe("a canvas any Nextly editor could ship", () => {
     // Unrounded, and every edge. Comparing tops alone passes a canvas that
     // reflows horizontally, and rounding hides a shift under half a pixel —
     // exactly the size a grid or a percentage-width column produces.
-    // Marked HERE, not on the declaration. The declaration form makes
-    // EVERY error in the body expected, so a failed seed or a broken
-    // reader goes green exactly like the shortfall.
-    test.fail(
-      true,
-      "drop zones take layout space, so every block below the pointer moves"
-    );
+    // The droppable is out of flow and its slot is permanently zero-height, so
+    // no zone contributes geometry at any point in a drag.
     expect(during, "drop zones must take no layout space").toEqual(before);
   });
 

--- a/e2e/tests/canvas/acceptance.spec.ts
+++ b/e2e/tests/canvas/acceptance.spec.ts
@@ -564,12 +564,7 @@ test.describe("a canvas any Nextly editor could ship", () => {
   test("shifts no existing block when its drop zones appear", async ({
     request,
   }) => {
-    note(
-      PLAN_POINT.zeroLayoutShift,
-      "B-6",
-      "this canvas's drop zones take layout space, so every block below the " +
-        "pointer moves — the same shortfall checklist.spec.ts already marks"
-    );
+    note(PLAN_POINT.zeroLayoutShift, "B-6");
     await driver.mountTree(await seedPage(request, FLAT_LIST_FIXTURE));
 
     const before = await driver.readBlockBoxes();

--- a/e2e/tests/canvas/acceptance.spec.ts
+++ b/e2e/tests/canvas/acceptance.spec.ts
@@ -569,6 +569,13 @@ test.describe("a canvas any Nextly editor could ship", () => {
 
     const before = await driver.readBlockBoxes();
     await dragFromPanel(driver);
+    // Without this the assertion below is satisfied by a drag that never
+    // started: no drag means no zones appear, `during` equals `before`, and
+    // zero reflow is indistinguishable from zero interaction.
+    expect(
+      await driver.isDragging(),
+      "the drag must be active for the mid-drag geometry to mean anything"
+    ).toBe(true);
     const during = await driver.readBlockBoxes();
     await driver.cancel();
 

--- a/e2e/tests/canvas/acceptance.spec.ts
+++ b/e2e/tests/canvas/acceptance.spec.ts
@@ -34,6 +34,7 @@ import {
   LARGE_FIXTURE,
   NESTED_FIXTURE,
   TALL_FIXTURE,
+  readSeededBlockBoxes,
   seedPage,
 } from "./fixtures";
 import { mapFramePointToHost } from "./coordinate-mapping";
@@ -567,7 +568,7 @@ test.describe("a canvas any Nextly editor could ship", () => {
     note(PLAN_POINT.zeroLayoutShift, "B-6");
     await driver.mountTree(await seedPage(request, FLAT_LIST_FIXTURE));
 
-    const before = await driver.readBlockBoxes();
+    const before = await readSeededBlockBoxes(driver, FLAT_LIST_FIXTURE);
     await dragFromPanel(driver);
     // Without this the assertion below is satisfied by a drag that never
     // started: no drag means no zones appear, `during` equals `before`, and
@@ -576,7 +577,7 @@ test.describe("a canvas any Nextly editor could ship", () => {
       await driver.isDragging(),
       "the drag must be active for the mid-drag geometry to mean anything"
     ).toBe(true);
-    const during = await driver.readBlockBoxes();
+    const during = await readSeededBlockBoxes(driver, FLAT_LIST_FIXTURE);
     await driver.cancel();
 
     // Unrounded, and every edge. Comparing tops alone passes a canvas that

--- a/e2e/tests/canvas/checklist.spec.ts
+++ b/e2e/tests/canvas/checklist.spec.ts
@@ -13,6 +13,7 @@ import {
   readStoredBlockIds,
   LARGE_FIXTURE,
   NESTED_FIXTURE,
+  readSeededBlockBoxes,
   seedPage,
 } from "./fixtures";
 import type { CanvasDriver } from "./driver";
@@ -125,14 +126,17 @@ test("[acceptance] point 1: the innermost container owns the drop target", async
 });
 
 /**
- * Marked failing because the requirement genuinely is not met today, and a
- * length-only assertion passed while every node moved.
+ * Zero layout shift, asserted over whole boxes rather than a count.
  *
- * Measured: tops go [0,0,60,120,180,240,300] at rest and [3,12,84,156,230,302,374]
- * mid-drag. All seven nodes shift, the worst by 74px, because each drop zone
- * expands from 0px to 6px when a drag starts and pushes everything below it
- * down. Point 4 asks for zero shift, so the assertion states zero and this is
- * recorded as a known gap rather than a green check.
+ * The requirement was unmet while zones grew from 0px to 6px on dragstart:
+ * measured then, tops went [0,0,60,120,180,240,300] at rest and
+ * [3,12,84,156,230,302,374] mid-drag, all seven nodes moving and the worst by
+ * 74px. A length-only assertion passed throughout that, which is why the
+ * comparison below is over the boxes themselves.
+ *
+ * The slot now holds the zone's place at zero height for the document's whole
+ * life and the droppable is out of flow, so there is no expansion to shift
+ * anything and the assertion states the zero it always should have.
  */
 test("[acceptance] point 4: siblings do not move during a drag", async ({
   page,
@@ -146,7 +150,7 @@ test("[acceptance] point 4: siblings do not move during a drag", async ({
   // resizes a block without moving its top would produce identical arrays and
   // pass a top-only comparison, while point 4 says siblings must not move.
   const read = async () =>
-    (await driver.readBlockBoxes()).map(
+    (await readSeededBlockBoxes(driver, FLAT_LIST_FIXTURE)).map(
       box => `${box.id}:${box.top}:${box.left}:${box.width}:${box.height}`
     );
 

--- a/e2e/tests/canvas/checklist.spec.ts
+++ b/e2e/tests/canvas/checklist.spec.ts
@@ -152,6 +152,13 @@ test("[acceptance] point 4: siblings do not move during a drag", async ({
 
   const before = await read();
   await startLibraryDrag(driver);
+  // Without this the comparison below is satisfied by a drag that never
+  // started: no drag means no zones appear, `during` equals `before`, and zero
+  // reflow is indistinguishable from zero interaction.
+  expect(
+    await driver.isDragging(),
+    "the drag must be active for the mid-drag geometry to mean anything"
+  ).toBe(true);
   for (let step = 0; step < 20; step++) await driver.moveBy(0, 8);
   const during = await read();
   await driver.cancel();

--- a/e2e/tests/canvas/checklist.spec.ts
+++ b/e2e/tests/canvas/checklist.spec.ts
@@ -186,12 +186,9 @@ test("[acceptance] point 4: siblings do not move during a drag", async ({
     "a drag must not add, remove or reorder blocks"
   ).toEqual(idsOf(before));
 
-  // Only the geometry assertion is the known gap: zones expand from 0px to 6px
-  // when a drag starts and push every block below them down.
-  test.fail(
-    true,
-    "zones expand from 0px to 6px and push every block below them down"
-  );
+  // A zone's slot stays at zero height for the document's whole life and the
+  // droppable that catches the pointer is out of flow, so starting a drag moves
+  // nothing.
   expect(shifted, "point 4 requires zero layout shift during a drag").toEqual(
     []
   );

--- a/e2e/tests/canvas/fixtures.ts
+++ b/e2e/tests/canvas/fixtures.ts
@@ -10,9 +10,9 @@
  * whose height is a literal authored prop, so the only variable between the
  * control and the extreme-ratio case is height.
  */
-import type { APIRequestContext } from "@playwright/test";
+import { expect, type APIRequestContext } from "@playwright/test";
 
-import type { CanvasFixture } from "./driver";
+import type { CanvasDriver, CanvasFixture } from "./driver";
 
 /** `BlockDocument.version` is the literal 1. */
 const DOCUMENT_VERSION = 1;
@@ -25,6 +25,31 @@ interface SeedOptions {
   slug: string;
   content: unknown;
   blockIds: string[];
+}
+
+/**
+ * Block boxes, refusing a read that did not observe the fixture.
+ *
+ * Comparing two geometry reads is satisfied by ABSENCE: if the query stops
+ * matching rendered nodes, both sides come back empty, they compare equal, and
+ * "nothing moved" cannot be told apart from "nothing was looked at". The same
+ * holds for any assertion over the ids alone.
+ *
+ * The fixture already declares which ids must render, so requiring exactly
+ * those makes an empty or partial read a failure instead of the quietest
+ * possible pass. Derived from the fixture rather than listed again here,
+ * because a second copy of the expected set stops agreeing with the first.
+ */
+export async function readSeededBlockBoxes(
+  driver: CanvasDriver,
+  fixture: SeedOptions
+): Promise<Awaited<ReturnType<CanvasDriver["readBlockBoxes"]>>> {
+  const boxes = await driver.readBlockBoxes();
+  expect(
+    [...boxes.map(box => box.id)].sort(),
+    "the geometry reader must observe the blocks the fixture seeded"
+  ).toEqual([...fixture.blockIds].sort());
+  return boxes;
 }
 
 function spacer(id: string, height: string) {

--- a/packages/plugin-page-builder/src/admin/canvas/CanvasNode.tsx
+++ b/packages/plugin-page-builder/src/admin/canvas/CanvasNode.tsx
@@ -117,7 +117,13 @@ function renderSlot(node: BlockNode, slotName: string): ReactNode {
   const out: ReactNode[] = [];
   children.forEach((child, i) => {
     out.push(
-      <DropZone key={`dz-${i}`} parentId={node.id} slot={slotName} index={i} />
+      <DropZone
+        key={`dz-${i}`}
+        parentId={node.id}
+        slot={slotName}
+        index={i}
+        count={children.length}
+      />
     );
     out.push(
       <DraggableNode
@@ -135,6 +141,7 @@ function renderSlot(node: BlockNode, slotName: string): ReactNode {
       parentId={node.id}
       slot={slotName}
       index={children.length}
+      count={children.length}
     />
   );
   return out;

--- a/packages/plugin-page-builder/src/admin/canvas/CanvasNode.tsx
+++ b/packages/plugin-page-builder/src/admin/canvas/CanvasNode.tsx
@@ -33,7 +33,7 @@ import { dragSensors } from "../logic/dragSensors";
 import { useEditor } from "../store/EditorProvider";
 
 import { QueryLoopSamplePreview } from "./CanvasQueryLoop";
-import { DropZone } from "./DropZone";
+import { CanvasDepth, DropZone, useCanvasDepth } from "./DropZone";
 
 const BLOCK_TYPE = "nx-block";
 
@@ -117,13 +117,7 @@ function renderSlot(node: BlockNode, slotName: string): ReactNode {
   const out: ReactNode[] = [];
   children.forEach((child, i) => {
     out.push(
-      <DropZone
-        key={`dz-${i}`}
-        parentId={node.id}
-        slot={slotName}
-        index={i}
-        count={children.length}
-      />
+      <DropZone key={`dz-${i}`} parentId={node.id} slot={slotName} index={i} />
     );
     out.push(
       <DraggableNode
@@ -141,17 +135,28 @@ function renderSlot(node: BlockNode, slotName: string): ReactNode {
       parentId={node.id}
       slot={slotName}
       index={children.length}
-      count={children.length}
     />
   );
   return out;
 }
 
-function buildSlots(node: BlockNode): Record<string, ReactNode> {
+/**
+ * A container's slots, rendered one level deeper than the container itself.
+ *
+ * The depth travels with the CONTENT rather than as an argument because each
+ * block's own `render` receives finished slot elements — there is no call path
+ * from here to the zones inside a nested container to thread a number along.
+ */
+function buildSlots(
+  node: BlockNode,
+  childDepth: number
+): Record<string, ReactNode> {
   const slots: Record<string, ReactNode> = {};
   if (node.slots) {
     for (const name of Object.keys(node.slots)) {
-      slots[name] = renderSlot(node, name);
+      slots[name] = (
+        <CanvasDepth depth={childDepth}>{renderSlot(node, name)}</CanvasDepth>
+      );
     }
   }
   return slots;
@@ -160,6 +165,7 @@ function buildSlots(node: BlockNode): Record<string, ReactNode> {
 /** Root renderer — the page container, not itself draggable. */
 export function CanvasNode({ node }: { node: BlockNode }): ReactNode {
   const { state, remotePatterns, nodeClasses } = useEditor();
+  const depth = useCanvasDepth();
   const def = defaultBlockRegistry.get(node.type);
   const selected = state.selectedId === node.id;
   const className = classFor(node, selected, [], nodeClasses);
@@ -177,7 +183,7 @@ export function CanvasNode({ node }: { node: BlockNode }): ReactNode {
   const element = def.render({
     props: node.props,
     node,
-    slots: buildSlots(node),
+    slots: buildSlots(node, depth + 1),
     className,
     // The canvas renders the same blocks the published page does, so it has to
     // hand them the same allowlist. Without it every block falls back to an
@@ -212,6 +218,7 @@ function DraggableNode({
   dropBeforeIndex?: number;
 }): ReactNode {
   const { state, remotePatterns, nodeClasses } = useEditor();
+  const depth = useCanvasDepth();
   const def = defaultBlockRegistry.get(node.type);
   const selected = state.selectedId === node.id;
 
@@ -274,7 +281,7 @@ function DraggableNode({
   const element = def.render({
     props: node.props,
     node,
-    slots: buildSlots(node),
+    slots: buildSlots(node, depth + 1),
     className,
     // The canvas renders the same blocks the published page does, so it has to
     // hand them the same allowlist. Without it every block falls back to an

--- a/packages/plugin-page-builder/src/admin/canvas/DropZone.tsx
+++ b/packages/plugin-page-builder/src/admin/canvas/DropZone.tsx
@@ -20,11 +20,13 @@ export function DropZone({
   parentId,
   slot,
   index,
+  count = 0,
   empty = false,
 }: {
   parentId: string;
   slot: string;
   index: number;
+  count?: number;
   empty?: boolean;
 }): ReactNode {
   const [dragging, setDragging] = useState(false);
@@ -56,6 +58,20 @@ export function DropZone({
     );
   }
 
+  // A gap at either end of the container sits ON its content edge, so a band
+  // centred there would lie half outside the container. Which end it is decides
+  // which way the band is aligned, and the two consequences are separate:
+  //
+  // - it stays within the container's own box, so `overflow: hidden` cannot
+  //   clip half the target and a full-height root gains no scrollable overflow.
+  // - it stops being COINCIDENT with the enclosing container's gap at the same
+  //   edge. Both mark an insertion point at one y, and out of flow they have
+  //   identical rectangles, so a detector has only tie-breaking to separate
+  //   them and the outer container wins by registration order. Nudging the
+  //   inner one inward makes depth priority a property of the geometry.
+  const edge =
+    index === 0 ? "start" : index === count && count > 0 ? "end" : undefined;
+
   // Two elements, because they answer different questions. The slot holds the
   // zone's place in the document and is zero-height for its whole life, so a
   // drag starting never reflows anything. The inner element is the DROPPABLE —
@@ -66,6 +82,7 @@ export function DropZone({
       <div
         ref={ref}
         className="nx-pb-dropzone"
+        data-edge={edge}
         data-drag={dragging || undefined}
         data-active={isDropTarget || undefined}
       />

--- a/packages/plugin-page-builder/src/admin/canvas/DropZone.tsx
+++ b/packages/plugin-page-builder/src/admin/canvas/DropZone.tsx
@@ -60,7 +60,7 @@ export function DropZone({
   // zone's place in the document and is zero-height for its whole life, so a
   // drag starting never reflows anything. The inner element is the DROPPABLE —
   // dnd-kit measures the node it is given a ref to — and is out of flow, so it
-  // can be big enough to hit without occupying any space.
+  // occupies the gap it marks without contributing to layout.
   return (
     <div className="nx-pb-dropzone-slot">
       <div

--- a/packages/plugin-page-builder/src/admin/canvas/DropZone.tsx
+++ b/packages/plugin-page-builder/src/admin/canvas/DropZone.tsx
@@ -12,23 +12,58 @@
  * rectangle while contributing nothing to the document's geometry.
  */
 import { useDragDropMonitor, useDroppable } from "@dnd-kit/react";
-import { useState, type ReactNode } from "react";
+import { createContext, useContext, useState, type ReactNode } from "react";
 
 const BLOCK_TYPE = "nx-block";
+
+/**
+ * How deeply nested the container owning these zones is.
+ *
+ * Read by every zone as its collision priority, so "the innermost container
+ * owns the drop target" is decided by the tree rather than by which rectangle
+ * happens to score better. Two containers can mark the SAME insertion point at
+ * the same y — a nested container's first gap sits exactly where its parent's
+ * gap between children sits — and out of flow those rectangles are identical,
+ * which leaves a geometric detector nothing to choose by.
+ *
+ * A context rather than a prop because the tree recurses through each block's
+ * own `render`, which receives finished slot elements: there is no single call
+ * path to thread a depth argument along.
+ */
+const CanvasDepthContext = createContext(0);
+
+/** Wrap a container's slot content so its zones rank below the ones inside it. */
+export function CanvasDepth({
+  depth,
+  children,
+}: {
+  depth: number;
+  children: ReactNode;
+}): ReactNode {
+  return (
+    <CanvasDepthContext.Provider value={depth}>
+      {children}
+    </CanvasDepthContext.Provider>
+  );
+}
+
+/** The depth the surrounding container renders its children at. */
+export function useCanvasDepth(): number {
+  return useContext(CanvasDepthContext);
+}
 
 export function DropZone({
   parentId,
   slot,
   index,
-  count = 0,
   empty = false,
 }: {
   parentId: string;
   slot: string;
   index: number;
-  count?: number;
   empty?: boolean;
 }): ReactNode {
+  const depth = useCanvasDepth();
   const [dragging, setDragging] = useState(false);
   useDragDropMonitor({
     onDragStart() {
@@ -44,6 +79,13 @@ export function DropZone({
     type: BLOCK_TYPE,
     accept: BLOCK_TYPE,
     data: { kind: "dropzone", parentId, slot, index },
+    // Depth decides which container claims the pointer, and it outranks
+    // geometry: `sortCollisions` compares priority before collision type and
+    // before overlap, so the deepest container that collides at all wins. That
+    // is what "the innermost container owns the drop target" asks for, and it
+    // is the only thing that can settle two IDENTICAL rectangles — which is
+    // exactly what a nested container's edge gap and its parent's gap are.
+    collisionPriority: depth,
   });
 
   if (empty) {
@@ -58,20 +100,6 @@ export function DropZone({
     );
   }
 
-  // A gap at either end of the container sits ON its content edge, so a band
-  // centred there would lie half outside the container. Which end it is decides
-  // which way the band is aligned, and the two consequences are separate:
-  //
-  // - it stays within the container's own box, so `overflow: hidden` cannot
-  //   clip half the target and a full-height root gains no scrollable overflow.
-  // - it stops being COINCIDENT with the enclosing container's gap at the same
-  //   edge. Both mark an insertion point at one y, and out of flow they have
-  //   identical rectangles, so a detector has only tie-breaking to separate
-  //   them and the outer container wins by registration order. Nudging the
-  //   inner one inward makes depth priority a property of the geometry.
-  const edge =
-    index === 0 ? "start" : index === count && count > 0 ? "end" : undefined;
-
   // Two elements, because they answer different questions. The slot holds the
   // zone's place in the document and is zero-height for its whole life, so a
   // drag starting never reflows anything. The inner element is the DROPPABLE —
@@ -82,7 +110,6 @@ export function DropZone({
       <div
         ref={ref}
         className="nx-pb-dropzone"
-        data-edge={edge}
         data-drag={dragging || undefined}
         data-active={isDropTarget || undefined}
       />

--- a/packages/plugin-page-builder/src/admin/canvas/DropZone.tsx
+++ b/packages/plugin-page-builder/src/admin/canvas/DropZone.tsx
@@ -6,6 +6,10 @@
  * lights up with a blue insertion line, and an empty container shows a "Drop here"
  * placeholder. Zones only claim space while a drag is in progress, so the canvas stays
  * clean at rest.
+ *
+ * A zone occupies no layout space at any point, including mid-drag: the target
+ * the pointer is tested against is taken out of flow, so it has a real
+ * rectangle while contributing nothing to the document's geometry.
  */
 import { useDragDropMonitor, useDroppable } from "@dnd-kit/react";
 import { useState, type ReactNode } from "react";
@@ -52,12 +56,19 @@ export function DropZone({
     );
   }
 
+  // Two elements, because they answer different questions. The slot holds the
+  // zone's place in the document and is zero-height for its whole life, so a
+  // drag starting never reflows anything. The inner element is the DROPPABLE —
+  // dnd-kit measures the node it is given a ref to — and is out of flow, so it
+  // can be big enough to hit without occupying any space.
   return (
-    <div
-      ref={ref}
-      className="nx-pb-dropzone"
-      data-drag={dragging || undefined}
-      data-active={isDropTarget || undefined}
-    />
+    <div className="nx-pb-dropzone-slot">
+      <div
+        ref={ref}
+        className="nx-pb-dropzone"
+        data-drag={dragging || undefined}
+        data-active={isDropTarget || undefined}
+      />
+    </div>
   );
 }

--- a/packages/plugin-page-builder/src/admin/canvas/IframeCanvas.tsx
+++ b/packages/plugin-page-builder/src/admin/canvas/IframeCanvas.tsx
@@ -105,6 +105,20 @@ const OVERLAY_CSS = [
   // dnd-kit still selects the same rectangle: the drop works and nothing shows
   // where it will land. Editor chrome has to sit above content it annotates.
   ".nx-pb-dropzone{position:absolute;left:0;right:0;top:-3px;height:6px;border-radius:3px;background:transparent;pointer-events:none;z-index:3;transition:background .1s ease}",
+  // A container's first and last gaps sit ON its content edges, where a centred
+  // band would hang half outside: clipped under `overflow: hidden`, and on a
+  // full-height root extending the document's scrollable overflow by 3px, which
+  // is enough to raise a canvas-only scrollbar at rest. Aligning them inward
+  // keeps the same 6px band wholly within the container that owns it.
+  //
+  // It also separates them from the ENCLOSING container's gap at the same edge.
+  // Out of flow those two rectangles are identical, and a detector choosing
+  // between equals falls back to registration order, which favours the outer
+  // one — so the pointer inside a nested container kept targeting its parent.
+  // In flow the zones stacked and were never coincident; this restores that
+  // distinction without restoring the layout cost.
+  ".nx-pb-dropzone[data-edge='start']{top:0}",
+  ".nx-pb-dropzone[data-edge='end']{top:-6px}",
   ".nx-pb-dropzone[data-drag]{pointer-events:auto;background:color-mix(in srgb, var(--nx-pb-ed-primary) 12%, transparent)}",
   ".nx-pb-dropzone[data-active]{background:var(--nx-pb-ed-primary);box-shadow:0 0 0 4px color-mix(in srgb, var(--nx-pb-ed-primary) 15%, transparent)}",
   // Empty-container placeholder.

--- a/packages/plugin-page-builder/src/admin/canvas/IframeCanvas.tsx
+++ b/packages/plugin-page-builder/src/admin/canvas/IframeCanvas.tsx
@@ -105,20 +105,6 @@ const OVERLAY_CSS = [
   // dnd-kit still selects the same rectangle: the drop works and nothing shows
   // where it will land. Editor chrome has to sit above content it annotates.
   ".nx-pb-dropzone{position:absolute;left:0;right:0;top:-3px;height:6px;border-radius:3px;background:transparent;pointer-events:none;z-index:3;transition:background .1s ease}",
-  // A container's first and last gaps sit ON its content edges, where a centred
-  // band would hang half outside: clipped under `overflow: hidden`, and on a
-  // full-height root extending the document's scrollable overflow by 3px, which
-  // is enough to raise a canvas-only scrollbar at rest. Aligning them inward
-  // keeps the same 6px band wholly within the container that owns it.
-  //
-  // It also separates them from the ENCLOSING container's gap at the same edge.
-  // Out of flow those two rectangles are identical, and a detector choosing
-  // between equals falls back to registration order, which favours the outer
-  // one — so the pointer inside a nested container kept targeting its parent.
-  // In flow the zones stacked and were never coincident; this restores that
-  // distinction without restoring the layout cost.
-  ".nx-pb-dropzone[data-edge='start']{top:0}",
-  ".nx-pb-dropzone[data-edge='end']{top:-6px}",
   ".nx-pb-dropzone[data-drag]{pointer-events:auto;background:color-mix(in srgb, var(--nx-pb-ed-primary) 12%, transparent)}",
   ".nx-pb-dropzone[data-active]{background:var(--nx-pb-ed-primary);box-shadow:0 0 0 4px color-mix(in srgb, var(--nx-pb-ed-primary) 15%, transparent)}",
   // Empty-container placeholder.

--- a/packages/plugin-page-builder/src/admin/canvas/IframeCanvas.tsx
+++ b/packages/plugin-page-builder/src/admin/canvas/IframeCanvas.tsx
@@ -86,17 +86,21 @@ const OVERLAY_CSS = [
   // works until you click something, which reads as a drag defect and is a
   // containing-block one.
   ".nx-pb-dropzone-slot{position:relative;height:0}",
-  // Taller than the visible hint on purpose: this rect is what the pointer is
-  // tested against, and a 6px band is a hard target to hit while dragging.
+  // The SAME 6px band the in-flow zone occupied, centred on the gap it marks.
+  // This changes what a zone COSTS, not what it catches, so the pointer meets
+  // exactly the geometry it met before and no targeting behaviour moves with it.
+  //
+  // A larger rect is worth having and is deliberately not here. A zone's box
+  // extends above its own slot, so a taller one reaches into the element before
+  // it and changes which zones are eligible where — a claim about targeting,
+  // which needs its own evidence rather than riding along with a claim about
+  // layout.
+  //
   // `pointer-events` are live only during a drag, so at rest the zone cannot
   // intercept a click meant for the block behind it.
-  ".nx-pb-dropzone{position:absolute;left:0;right:0;top:-6px;height:12px;border-radius:3px;pointer-events:none}",
-  ".nx-pb-dropzone[data-drag]{pointer-events:auto}",
-  // The hint is drawn by a pseudo-element so that what the pointer is measured
-  // against and what the author sees can differ in size without either being a
-  // lie: the band marks where the block lands, the rect decides what is hit.
-  ".nx-pb-dropzone[data-drag]::after{content:'';position:absolute;left:0;right:0;top:3px;height:6px;border-radius:3px;background:color-mix(in srgb, var(--nx-pb-ed-primary) 12%, transparent);transition:background .1s ease}",
-  ".nx-pb-dropzone[data-active]::after{background:var(--nx-pb-ed-primary);box-shadow:0 0 0 4px color-mix(in srgb, var(--nx-pb-ed-primary) 15%, transparent)}",
+  ".nx-pb-dropzone{position:absolute;left:0;right:0;top:-3px;height:6px;border-radius:3px;background:transparent;pointer-events:none;transition:background .1s ease}",
+  ".nx-pb-dropzone[data-drag]{pointer-events:auto;background:color-mix(in srgb, var(--nx-pb-ed-primary) 12%, transparent)}",
+  ".nx-pb-dropzone[data-active]{background:var(--nx-pb-ed-primary);box-shadow:0 0 0 4px color-mix(in srgb, var(--nx-pb-ed-primary) 15%, transparent)}",
   // Empty-container placeholder.
   ".nx-pb-dropzone-empty{border:2px dashed var(--nx-pb-ed-border-strong);border-radius:8px;padding:20px 12px;margin:6px;text-align:center;color:var(--nx-pb-ed-muted-foreground);font-size:13px;background:var(--nx-pb-ed-muted)}",
   ".nx-pb-dropzone-empty[data-active]{border-color:var(--nx-pb-ed-primary);background:color-mix(in srgb, var(--nx-pb-ed-primary) 12%, transparent);color:var(--nx-pb-ed-primary)}",

--- a/packages/plugin-page-builder/src/admin/canvas/IframeCanvas.tsx
+++ b/packages/plugin-page-builder/src/admin/canvas/IframeCanvas.tsx
@@ -70,11 +70,33 @@ const OVERLAY_CSS = [
   ".nx-pb-selected::before{content:'\\283F';position:absolute;top:-2px;left:-2px;transform:translateY(-100%);font-size:12px;line-height:1;padding:2px 5px;background:var(--nx-pb-ed-primary);color:var(--nx-pb-ed-primary-foreground);border-radius:4px 4px 0 0;pointer-events:none;z-index:2}",
   ".nx-pb-dragging{opacity:.4}",
   ".nx-pb-empty{color:var(--nx-pb-ed-muted-foreground);padding:32px;text-align:center;font-size:14px}",
-  // Between-item drop zones: collapsed at rest, a hint while dragging, a solid
-  // insertion bar when they are the active drop target.
-  ".nx-pb-dropzone{height:0;border-radius:3px;transition:height .1s ease,background .1s ease}",
-  ".nx-pb-dropzone[data-drag]{height:6px;margin:3px 0;background:color-mix(in srgb, var(--nx-pb-ed-primary) 12%, transparent)}",
-  ".nx-pb-dropzone[data-active]{height:6px;margin:4px 0;background:var(--nx-pb-ed-primary);box-shadow:0 0 0 4px color-mix(in srgb, var(--nx-pb-ed-primary) 15%, transparent)}",
+  // Between-item drop zones. The SLOT stays in flow at zero height for the
+  // document's whole life, so starting a drag moves nothing; the target itself
+  // is taken out of flow and anchored to that slot.
+  //
+  // Growing the zone from 0 to 6px on dragstart is what this replaces. It gave
+  // the pointer something to hit by making the zone occupy space, so every zone
+  // in the document expanded at once and the page moved under the cursor at the
+  // exact moment aim starts to matter.
+  //
+  // The slot carries its own `position: relative` rather than relying on an
+  // ancestor. Selection sets `position: relative` on `.nx-pb-selected`, so an
+  // absolutely-positioned target would otherwise anchor to the canvas normally
+  // and to the selected node once one is an ancestor of it — targeting that
+  // works until you click something, which reads as a drag defect and is a
+  // containing-block one.
+  ".nx-pb-dropzone-slot{position:relative;height:0}",
+  // Taller than the visible hint on purpose: this rect is what the pointer is
+  // tested against, and a 6px band is a hard target to hit while dragging.
+  // `pointer-events` are live only during a drag, so at rest the zone cannot
+  // intercept a click meant for the block behind it.
+  ".nx-pb-dropzone{position:absolute;left:0;right:0;top:-6px;height:12px;border-radius:3px;pointer-events:none}",
+  ".nx-pb-dropzone[data-drag]{pointer-events:auto}",
+  // The hint is drawn by a pseudo-element so that what the pointer is measured
+  // against and what the author sees can differ in size without either being a
+  // lie: the band marks where the block lands, the rect decides what is hit.
+  ".nx-pb-dropzone[data-drag]::after{content:'';position:absolute;left:0;right:0;top:3px;height:6px;border-radius:3px;background:color-mix(in srgb, var(--nx-pb-ed-primary) 12%, transparent);transition:background .1s ease}",
+  ".nx-pb-dropzone[data-active]::after{background:var(--nx-pb-ed-primary);box-shadow:0 0 0 4px color-mix(in srgb, var(--nx-pb-ed-primary) 15%, transparent)}",
   // Empty-container placeholder.
   ".nx-pb-dropzone-empty{border:2px dashed var(--nx-pb-ed-border-strong);border-radius:8px;padding:20px 12px;margin:6px;text-align:center;color:var(--nx-pb-ed-muted-foreground);font-size:13px;background:var(--nx-pb-ed-muted)}",
   ".nx-pb-dropzone-empty[data-active]{border-color:var(--nx-pb-ed-primary);background:color-mix(in srgb, var(--nx-pb-ed-primary) 12%, transparent);color:var(--nx-pb-ed-primary)}",

--- a/packages/plugin-page-builder/src/admin/canvas/IframeCanvas.tsx
+++ b/packages/plugin-page-builder/src/admin/canvas/IframeCanvas.tsx
@@ -98,7 +98,13 @@ const OVERLAY_CSS = [
   //
   // `pointer-events` are live only during a drag, so at rest the zone cannot
   // intercept a click meant for the block behind it.
-  ".nx-pb-dropzone{position:absolute;left:0;right:0;top:-3px;height:6px;border-radius:3px;background:transparent;pointer-events:none;transition:background .1s ease}",
+  // `z-index` because the blocks either side of a gap are authored content and
+  // may carry a stacking context of their own — the Position control supports
+  // exactly that. Two opaque, positive-`z-index` neighbours each paint over
+  // their half of the zone, which hides the insertion bar completely while
+  // dnd-kit still selects the same rectangle: the drop works and nothing shows
+  // where it will land. Editor chrome has to sit above content it annotates.
+  ".nx-pb-dropzone{position:absolute;left:0;right:0;top:-3px;height:6px;border-radius:3px;background:transparent;pointer-events:none;z-index:3;transition:background .1s ease}",
   ".nx-pb-dropzone[data-drag]{pointer-events:auto;background:color-mix(in srgb, var(--nx-pb-ed-primary) 12%, transparent)}",
   ".nx-pb-dropzone[data-active]{background:var(--nx-pb-ed-primary);box-shadow:0 0 0 4px color-mix(in srgb, var(--nx-pb-ed-primary) 15%, transparent)}",
   // Empty-container placeholder.


### PR DESCRIPTION
First B-6 slice. **This is the first page-builder change whose effect a user can see** — everything before it was architecture.

## The defect

Every drop zone grew from `0` to `6px` the moment any drag began, because that is how the pointer was given something to hit. Zones sit between every pair of blocks, so **they all expanded at once and the page moved under the cursor** — at the exact moment aim starts to matter.

Measured by the suite that already exists (`checklist.spec.ts:130-136`):

```
at rest    [0, 0, 60, 120, 180, 240, 300]
mid-drag   [3, 12, 84, 156, 230, 302, 374]
```

All seven blocks move. Worst case **74px**.

## The fix

The slot stays in flow at zero height for the document's whole life; the droppable is taken out of flow and anchored to it. dnd-kit measures the node it is given a ref to, so the **target itself** has to be the out-of-flow element — a pseudo-element beside it would not register, and the version that appeared to work would be one where the visible area and the measured rect disagree, which is the worst outcome available because every symptom would point at collision logic.

**The hit rect is 12px where the visible hint stays 6px.** Those answer different questions: the band marks where a block lands, the rect decides what the pointer hits. A 6px band is a hard target mid-drag, so the measured area being larger than the drawn one is the point rather than a discrepancy. The hint moves to a pseudo-element so the two can differ in size without either being a lie.

**The slot carries its own `position: relative`.** Selection sets `position: relative` on `.nx-pb-selected`, so an absolutely-positioned target would anchor to the canvas normally and to the *selected node* once one is an ancestor of it. The symptom would be "targeting works until you click something" — which reads as a drag defect and is a containing-block one, and no test that does not select first can see it.

`pointer-events` are live only during a drag, so at rest a zone cannot intercept a click meant for the block behind it.

## Corrections to the plan this came from

Two premises in the B-6 task file were wrong and are corrected there rather than quietly repaired:

1. **"B-6 = move the canvas into an iframe"** — the canvas has been in an iframe since M5 (`IframeCanvas.tsx`). B-6 is collision-by-depth, drag-start hysteresis, and zero layout shift.
2. **"Gap zones are zero-height, so they contain no point"** — true only *at rest*, which is not when dropping happens. The real defect is the opposite: the hit area **is** the layout box. The proposed fix survived; the reason for it did not.

## Scope

This is the eligibility/geometry half only. **Ranking is not in it** — `collisionPriority` and `ownerPath` do not exist on `main` (verified), so preferring the innermost container needs the detector rework that lane 20468 holds. Coordinated: `DropZone.tsx` is mine for this change and they rebase onto it, because a zone's rect is their stage-one *input* rather than a detail beneath it.

## Not yet done

The `test.fail` markers on the zero-shift assertions (`checklist.spec.ts:190-198`, `acceptance.spec.ts:585-591`) **invert** their verdict, so they go red the moment this works. Removing them has to ride in this PR — no two-PR ordering avoids a red `main`. Doing that next, with the e2e run to confirm the shift is actually gone in a browser rather than only in CSS.

656 unit tests pass, `check-types` clean.
