### PR TITLE
docs(root): repair an orphaned fragment in the retarget section

### DIFF
--- a/.claude/rules/reading-a-ci-verdict.md
+++ b/.claude/rules/reading-a-ci-verdict.md
@@ -48,7 +48,7 @@ workflows check out `refs/pull/N/merge`, so what was BUILT AND TESTED is your
 branch merged with the base, while the resulting check-runs are attached to the
 PR HEAD. So the head is where to look them up, and "the head tree passed" is
 not what a green check means — it means the merge of head and base passed.
- (Inside a workflow the relationship inverts, but only for `pull_request`:
+(Inside a workflow the relationship inverts, but only for `pull_request`:
 there `github.sha` IS the synthetic merge commit. On `pull_request_target` it is
 the tip of the BASE branch — `main` for an ordinary PR, and the PARENT FEATURE
 BRANCH for a stacked one, so `labeler.yml` and `pr-title.yml` see whichever the
@@ -287,13 +287,13 @@ a remedy that worked:
 
 Either way something must be confirmed to have started. A remedy that is
 believed to have worked is how a stacked PR sits for a day looking retargeted.
- Close-and-reopen
-also starts CI and is the worse remedy, because it leaves the head SHA
-unchanged: the diff expands to include the parent stack while every existing
-review still points at that same SHA, so a coverage check keyed on the head
-happily reuses reviews taken when those commits were not in scope. A rebase
-moves the head and invalidates them, which is the outcome you want. Then gate on
-the run, never on the base having been changed.
+
+**Close-and-reopen carries a cost the other remedies do not**, which is the
+caveat promised above: it leaves the head SHA unchanged, so the diff expands to
+include the parent stack while every existing review still points at that same
+SHA — and a coverage check keyed on the head reuses reviews taken when those
+commits were not in scope. Moving the head is what invalidates them. Gate on the
+run, never on the base having been changed.
 
 **Retargeting changes what a review MEANS, not just what CI runs.** A review is
 evidence about a diff, and the diff is `base..head`; moving the base moves the


### PR DESCRIPTION
Editing artifact from my own #814, found by reading the merged file rather than the diff.

Sequential replacements in the retarget section left a sentence fragment stranded at line 290:

```
Either way something must be confirmed to have started. ...
 Close-and-reopen
also starts CI and is the worse remedy, because it leaves the head SHA
unchanged: ...
```

It begins mid-sentence with a leading space, and it contradicts line 275, which already introduces close-and-reopen and promises "with the caveat below". A reader hits the caveat as a broken duplicate instead.

Rewritten as the caveat it was meant to be, keeping the substance — that close-and-reopen leaves the head unchanged, so existing reviews stay attached to a SHA whose diff has since expanded.

Also removes a stray leading space that had indented the `pull_request_target` parenthetical into a different block.

**Why this happened, since it is the same shape the file is about:** each edit asserted its anchor and applied cleanly, and the result was still wrong — the anchors were correct and their *composition* was not. A per-edit assertion cannot see that, and I verified the commits by marker (which passed, the markers were all present) rather than by reading the assembled prose. Content verification finds absence, not incoherence.

Docs only, no changeset.