### PR TITLE
test(nextly): pin where a collection's permissions are seeded

### DIFF
--- a/packages/nextly/src/init/boot-permission-seeding.integration.test.ts
+++ b/packages/nextly/src/init/boot-permission-seeding.integration.test.ts
@@ -8,18 +8,22 @@
  * pending migrations. Reading those two sequences side by side suggests a
  * request-triggered cold start seeds against a database that is not ready.
  *
- * It does not, and the reason is that `seedAllPermissions` is not what seeds a
- * collection. `CollectionRegistryService` seeds a collection's permissions when
- * the collection is REGISTERED, and registration happens inside
- * `registerServices` — step one on both paths, ahead of either seeding call.
- * `seedAllPermissions` is a sweep over `dynamic_collections` that covers rows
- * which arrived by some other route.
+ * It does not, and the reason is that nothing a pending migration produces is
+ * an input to seeding. TWO mechanisms put a collection's permissions in place,
+ * and both run ahead of any migration step on either path:
  *
- * Both halves are pinned here because each is load-bearing on its own: the
- * first is what makes the request path correct despite its ordering, and the
- * second is what the first would silently become if the per-registration
- * seeding were ever moved into the post-init step where it looks like it
- * belongs.
+ * `CollectionRegistryService` seeds them when the collection is REGISTERED,
+ * which happens inside `registerServices`. And `seedAllPermissions` sweeps
+ * `dynamic_collections`, which `registerServices` has already written to.
+ *
+ * So the property worth holding is the OUTCOME, and it is asserted here as one
+ * sequence rather than as two separate mechanisms. Pinning either mechanism on
+ * its own would fail an implementation that dropped it and kept the other,
+ * which is a correct implementation — the route serves requests with the
+ * permissions in place either way.
+ *
+ * The second test covers what only the sweep can do, which is a row that
+ * reached `dynamic_collections` without going through registration.
  */
 import { afterEach, describe, expect, it } from "vitest";
 
@@ -78,12 +82,14 @@ async function permissionSlugsFor(
 }
 
 describe("permission seeding across the two boot paths", () => {
-  it("seeds a code-first collection during registerServices, before either path seeds", async () => {
+  it("leaves a code-first collection seeded once the request path has initialised", async () => {
     const handle = await bootRegisterServicesOnly();
 
-    // Read before `seedAllPermissions` is called at all. If this were empty,
-    // the request path would be seeding a collection whose rows depend on a
-    // step that has not run yet — which is the defect the ordering suggests.
+    // The request path's own sequence, in its own order: register services,
+    // then sweep. Nothing between them applies a migration, which is the
+    // ordering the audit questioned.
+    await seedAllPermissions();
+
     expect(await permissionSlugsFor(handle, "articles")).toEqual(
       CRUD_AND_LIFECYCLE
     );

--- a/packages/nextly/src/init/boot-permission-seeding.integration.test.ts
+++ b/packages/nextly/src/init/boot-permission-seeding.integration.test.ts
@@ -44,14 +44,25 @@ import { createTestNextly, type TestNextly } from "../plugins/test-nextly";
 
 import { seedAllPermissions } from "./seed-permissions";
 
-const CRUD_AND_LIFECYCLE = [
-  "create-articles",
-  "delete-articles",
-  "publish-articles",
-  "read-articles",
-  "unpublish-articles",
-  "update-articles",
+/**
+ * The actions collection seeding produces, named once.
+ *
+ * Written per resource in each test, the two lists agree on the day they are
+ * typed and drift the first time the action set moves — and a suite whose two
+ * halves disagree about what seeding should produce reports whichever one was
+ * remembered.
+ */
+const COLLECTION_ACTIONS = [
+  "create",
+  "delete",
+  "publish",
+  "read",
+  "unpublish",
+  "update",
 ];
+
+const slugsFor = (resource: string): string[] =>
+  COLLECTION_ACTIONS.map(action => `${action}-${resource}`).sort();
 
 let current: TestNextly | undefined;
 
@@ -103,7 +114,7 @@ describe("permission seeding across the two boot paths", () => {
     await seedAllPermissions();
 
     expect(await permissionSlugsFor(handle, "articles")).toEqual(
-      CRUD_AND_LIFECYCLE
+      slugsFor("articles")
     );
   });
 
@@ -125,13 +136,8 @@ describe("permission seeding across the two boot paths", () => {
     );
 
     await seedAllPermissions();
-    expect(await permissionSlugsFor(handle, "reports")).toEqual([
-      "create-reports",
-      "delete-reports",
-      "publish-reports",
-      "read-reports",
-      "unpublish-reports",
-      "update-reports",
-    ]);
+    expect(await permissionSlugsFor(handle, "reports")).toEqual(
+      slugsFor("reports")
+    );
   });
 });

--- a/packages/nextly/src/init/boot-permission-seeding.integration.test.ts
+++ b/packages/nextly/src/init/boot-permission-seeding.integration.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Where a collection's permissions actually come from, and why the two boot
+ * paths can disagree about ordering without disagreeing about outcome.
+ *
+ * Nextly boots from two places. `init.ts` migrates, then runs post-init tasks
+ * (which call `seedAllPermissions`) in the background. The route handler's
+ * `initializeServicesOnce` calls `seedAllPermissions` BEFORE it applies
+ * pending migrations. Reading those two sequences side by side suggests a
+ * request-triggered cold start seeds against a database that is not ready.
+ *
+ * It does not, and the reason is that `seedAllPermissions` is not what seeds a
+ * collection. `CollectionRegistryService` seeds a collection's permissions when
+ * the collection is REGISTERED, and registration happens inside
+ * `registerServices` — step one on both paths, ahead of either seeding call.
+ * `seedAllPermissions` is a sweep over `dynamic_collections` that covers rows
+ * which arrived by some other route.
+ *
+ * Both halves are pinned here because each is load-bearing on its own: the
+ * first is what makes the request path correct despite its ordering, and the
+ * second is what the first would silently become if the per-registration
+ * seeding were ever moved into the post-init step where it looks like it
+ * belongs.
+ */
+import { afterEach, describe, expect, it } from "vitest";
+
+import { generateSqliteCoreTableStatements } from "../database/sqlite-core-tables";
+import { createTestNextly, type TestNextly } from "../plugins/test-nextly";
+
+import { seedAllPermissions } from "./seed-permissions";
+
+const CRUD_AND_LIFECYCLE = [
+  "create-articles",
+  "delete-articles",
+  "publish-articles",
+  "read-articles",
+  "unpublish-articles",
+  "update-articles",
+];
+
+let current: TestNextly | undefined;
+
+afterEach(async () => {
+  await current?.destroy();
+  current = undefined;
+});
+
+/**
+ * Boot with one code-first collection and nothing else.
+ *
+ * This is deliberately `registerServices` and no more: no post-init tasks, no
+ * `seedAllPermissions`, no migration step. It is the state the route handler
+ * is in at the moment it reaches its own seeding call.
+ */
+async function bootRegisterServicesOnly(): Promise<TestNextly> {
+  const handle = await createTestNextly({
+    collections: [
+      { slug: "articles", fields: [{ name: "title", type: "text" }] },
+    ],
+  });
+  current = handle;
+  // The core RBAC tables are not part of the code-first collection sync, so the
+  // harness supplies them from the production DDL helper. Already-present
+  // tables are left as they are.
+  for (const statement of generateSqliteCoreTableStatements()) {
+    await handle.adapter.executeQuery(statement).catch(() => undefined);
+  }
+  return handle;
+}
+
+async function permissionSlugsFor(
+  handle: TestNextly,
+  resource: string
+): Promise<string[]> {
+  const rows = (await handle.adapter.executeQuery(
+    `SELECT slug FROM permissions WHERE resource = '${resource}'`
+  )) as unknown as Array<{ slug: string }>;
+  return rows.map(row => String(row.slug)).sort();
+}
+
+describe("permission seeding across the two boot paths", () => {
+  it("seeds a code-first collection during registerServices, before either path seeds", async () => {
+    const handle = await bootRegisterServicesOnly();
+
+    // Read before `seedAllPermissions` is called at all. If this were empty,
+    // the request path would be seeding a collection whose rows depend on a
+    // step that has not run yet — which is the defect the ordering suggests.
+    expect(await permissionSlugsFor(handle, "articles")).toEqual(
+      CRUD_AND_LIFECYCLE
+    );
+  });
+
+  it("sweeps dynamic_collections for rows registration never saw", async () => {
+    const handle = await bootRegisterServicesOnly();
+
+    // A slug that is in no config, so registration cannot have seeded it. This
+    // stands for a collection that reaches the table from migration metadata.
+    expect(await permissionSlugsFor(handle, "reports")).toEqual([]);
+
+    await seedAllPermissions();
+    expect(await permissionSlugsFor(handle, "reports")).toEqual([]);
+
+    await handle.adapter.executeQuery(
+      `INSERT INTO dynamic_collections
+         (slug, labels, table_name, fields, schema_hash, created_at, updated_at)
+       VALUES ('reports', '{}', 'dc_reports', '[]', 'h', '2026-01-01', '2026-01-01')`
+    );
+
+    await seedAllPermissions();
+    expect(await permissionSlugsFor(handle, "reports")).toEqual([
+      "create-reports",
+      "delete-reports",
+      "publish-reports",
+      "read-reports",
+      "unpublish-reports",
+      "update-reports",
+    ]);
+  });
+});

--- a/packages/nextly/src/init/boot-permission-seeding.integration.test.ts
+++ b/packages/nextly/src/init/boot-permission-seeding.integration.test.ts
@@ -9,21 +9,33 @@
  * request-triggered cold start seeds against a database that is not ready.
  *
  * It does not, and the reason is that nothing a pending migration produces is
- * an input to seeding. TWO mechanisms put a collection's permissions in place,
- * and both run ahead of any migration step on either path:
+ * an input to seeding. THREE mechanisms put a collection's permissions in
+ * place, each covering rows the others cannot reach:
  *
- * `CollectionRegistryService` seeds them when the collection is REGISTERED,
- * which happens inside `registerServices`. And `seedAllPermissions` sweeps
- * `dynamic_collections`, which `registerServices` has already written to.
+ * 1. `CollectionRegistryService` seeds them when a collection is REGISTERED,
+ *    which for a code-first collection happens inside `registerServices`.
+ * 2. `seedAllPermissions` sweeps `dynamic_collections`, which
+ *    `registerServices` has already written to. Both boot paths call it.
+ * 3. `boot-apply.ts` calls `seedPermissionsForMigrationCollections` directly
+ *    after `registerFromMigrations` inserts metadata rows, so a collection
+ *    that exists only in a migration is seeded in the same pass.
  *
- * So the property worth holding is the OUTCOME, and it is asserted here as one
- * sequence rather than as two separate mechanisms. Pinning either mechanism on
- * its own would fail an implementation that dropped it and kept the other,
- * which is a correct implementation — the route serves requests with the
- * permissions in place either way.
+ * The first two run before either path applies a migration; the third runs as
+ * part of applying one. So the ordering difference cannot cost a collection
+ * its permissions, whichever route the collection arrived by.
  *
- * The second test covers what only the sweep can do, which is a row that
- * reached `dynamic_collections` without going through registration.
+ * WHAT IS ASSERTED, and what is deliberately not. The first test drives (1)
+ * and (2) as one sequence, in the order the request path runs them, and
+ * asserts the OUTCOME. Pinning either on its own would fail an implementation
+ * that dropped it and kept the other, which serves requests correctly.
+ *
+ * The second test covers what only the sweep reaches — a row that never went
+ * through registration. It calls the sweep DIRECTLY, so it is a test of the
+ * sweep and NOT of (3): removing `seedPermissionsForMigrationCollections`
+ * would leave it green. Covering that call means driving
+ * `registerFromMigrations` against a migrations directory, which is a fixture
+ * this file does not build. Stated rather than implied, so the green here is
+ * not read as coverage it does not have.
  */
 import { afterEach, describe, expect, it } from "vitest";
 
@@ -98,8 +110,9 @@ describe("permission seeding across the two boot paths", () => {
   it("sweeps dynamic_collections for rows registration never saw", async () => {
     const handle = await bootRegisterServicesOnly();
 
-    // A slug that is in no config, so registration cannot have seeded it. This
-    // stands for a collection that reaches the table from migration metadata.
+    // A slug that is in no config, so registration cannot have seeded it. It
+    // exercises the sweep's own reach and is NOT a stand-in for the migration
+    // path, which has its own seeding call that this test never runs.
     expect(await permissionSlugsFor(handle, "reports")).toEqual([]);
 
     await seedAllPermissions();


### PR DESCRIPTION
## What this settles

The two boot paths order seeding and schema work differently:

```
boot    (init.ts):      migrations -> (background) templates, seed, roles
request (auth-handler): registerServices -> templates -> seedAllPermissions
                        -> userExtSchema -> boot-apply -> prod migrations
```

Read side by side, that says a request-triggered cold start runs `seedAllPermissions()` against a database whose pending migrations have not been applied. **It does not, and this PR pins the reason.**

## Measured, by execution

Nothing a pending migration produces is an input to seeding. **Three** mechanisms put a collection's permissions in place, each covering rows the others cannot reach:

1. `CollectionRegistryService` seeds them when a collection is **registered** — inside `registerServices` for a code-first collection
2. `seedAllPermissions` sweeps `dynamic_collections`, which `registerServices` has already written to; both paths call it
3. `boot-apply.ts:269` calls `seedPermissionsForMigrationCollections` directly after `registerFromMigrations` inserts metadata rows

The first two run before either path applies a migration; the third runs as part of applying one. Booting `createTestNextly` with one code-first collection and reading `permissions` before `seedAllPermissions` is ever called returns all six rows; disabling per-registration seeding and running the sweep also returns all six.

So the ordering difference is real and its consequence is not.

## What is asserted, and what deliberately is not

The first revision asserted the state *between* mechanisms (1) and (2), which pinned a redundant internal call — an implementation that dropped either and kept the other still serves requests correctly. Fixed in `4dc5dd6ac`.

The tests now assert the **outcome**:

1. `registerServices` then `seedAllPermissions` as one sequence, in the request path's order.
2. The sweep reaches a row that never went through registration.

**Mechanism (3) is not covered here, and the file says so** rather than letting a passing run imply it. The second test calls the sweep directly, so removing `seedPermissionsForMigrationCollections` would leave it green. Covering that means driving `registerFromMigrations` against a migrations directory — a bigger fixture, better reviewed on its own.

**Controls, all run:**

| control | result |
|---|---|
| per-registration seeding disabled, sweep intact | 2 passed — correct, the outcome holds |
| both mechanisms disabled | 2 failed, `expected [] to deeply equal [ 'create-articles', …(5) ]` |
| sweep given no `dynamic_collections` row | no permissions created |

## Observation, deliberately not acted on

Mechanisms (1) and (2) are two implementations of one question, which `.claude/rules/derived-checks.md` argues against. Collapsing them is a behaviour change rather than a test fix.

## Scope

Test-only. No production change, and no changeset per the repo rule.

`pnpm turbo run lint check-types --filter=nextly` — 2 successful. `src/init` + `src/domains/auth` integration suites — 9 files, 56 tests, all passing.