### PR TITLE
fix(nextly): compare a provider configuration structurally when auditing

### DIFF
--- a/.changeset/email-config-json-domain.md
+++ b/.changeset/email-config-json-domain.md
@@ -25,4 +25,4 @@
 "@nextlyhq/module-specifiers": patch
 ---
 
-Email provider configuration is now stored as what JSON can carry. A parser returning a `Date` has it written as its ISO string instead of the write being refused; a parser returning an `undefined`-valued key has the key dropped. A parser that derives its value rather than reshaping it is still refused, because re-parsing what was stored would not return what was stored.
+An email provider update no longer records a configuration change when a parser returns the same fields in a different order. `updateProvider` compared serialised text while the write path compares structurally, so a save that altered nothing could file a configuration-change entry in the activity log.

--- a/.changeset/email-config-json-domain.md
+++ b/.changeset/email-config-json-domain.md
@@ -1,0 +1,28 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+Email provider configuration is now stored as what JSON can carry. A parser returning a `Date` has it written as its ISO string instead of the write being refused; a parser returning an `undefined`-valued key has the key dropped. A parser that derives its value rather than reshaping it is still refused, because re-parsing what was stored would not return what was stored.

--- a/packages/nextly/src/domains/email/__tests__/provider-activity.test.ts
+++ b/packages/nextly/src/domains/email/__tests__/provider-activity.test.ts
@@ -105,6 +105,24 @@ describe("email provider activity", () => {
       })
     );
 
+    // A parser that rebuilds its output field by field, reversing the
+    // insertion order on the way back out. Ordinary to write, and the write
+    // path treats the two orders as the same configuration.
+    getEmailProviderRegistry().register(
+      defineEmailProvider({
+        type: "reordering",
+        label: "Reordering",
+        configFields: [],
+        parseConfig: input =>
+          Object.fromEntries(
+            Object.entries((input ?? {}) as Record<string, unknown>).reverse()
+          ) as Record<string, unknown>,
+        createAdapter: () => ({
+          send: () => Promise.resolve({ success: true, messageId: "x" }),
+        }),
+      })
+    );
+
     sqlite = new Database(":memory:");
     createEmailProvidersTable(sqlite);
     service = new EmailProviderService(
@@ -228,6 +246,37 @@ describe("email provider activity", () => {
 
     expect(logged[0]?.metadata).toEqual({
       providerType: "smtp",
+      changedFields: ["name"],
+    });
+  });
+
+  // The write path treats two field orders as the same configuration, so the
+  // audit trail has to agree. Deciding this by comparing serialised text
+  // reports a change whenever a parser rebuilds its output field by field —
+  // a false alarm on the one signal the trail exists for, raised by a save
+  // that altered nothing.
+  it("does not report a change when only the field order moved", async () => {
+    const created = await service.createProvider(
+      {
+        ...INPUT,
+        type: "reordering" as never,
+        configuration: { host: "smtp.example.com", user: "postmaster" },
+      },
+      ACTOR
+    );
+    logged.length = 0;
+
+    await service.updateProvider(
+      created.id,
+      {
+        name: "Renamed",
+        configuration: { user: "postmaster", host: "smtp.example.com" },
+      },
+      ACTOR
+    );
+
+    expect(logged[0]?.metadata).toEqual({
+      providerType: "reordering",
       changedFields: ["name"],
     });
   });

--- a/packages/nextly/src/domains/email/__tests__/stored-configuration-round-trips.test.ts
+++ b/packages/nextly/src/domains/email/__tests__/stored-configuration-round-trips.test.ts
@@ -149,43 +149,17 @@ describe("a configuration whose parse is not a fixed point", () => {
     );
   });
 
-  // JSON carries no `Date`, so the column holds its ISO string. That coercion
-  // is the accepted cost of defining the stored configuration AS its
-  // serialisation: the adapter is handed the string. Asserted on the value
-  // READ BACK, because "the write succeeded" is true of a refusal-free
-  // implementation that stored anything at all.
-  it("stores a value JSON cannot carry as the form the column holds", async () => {
+  // JSON carries no `Date`, so the column holds a string and the adapter is
+  // handed a shape this provider's own parser just rejected.
+  it("refuses a parser returning a value JSON cannot carry", async () => {
     register("dated", input => ({
       apiKey: String((input as { apiKey: unknown }).apiKey),
       issuedAt: new Date(0),
     }));
 
-    const provider = await write("dated", { apiKey: "k" });
-
-    const stored = await service.getProviderDecrypted(provider.id);
-    expect(stored.configuration).toEqual({
-      apiKey: "k",
-      issuedAt: "1970-01-01T00:00:00.000Z",
-    });
-  });
-
-  // The comparison is made in the JSON domain, and the naive way to do that is
-  // to compare the two serialisations as TEXT. Insertion order changes the
-  // text and changes nothing about the value, and a parser that rebuilds its
-  // output field by field is an ordinary thing to write — so a text
-  // comparison would refuse this while a structural one accepts it.
-  it("stores a configuration whose parser reorders its own fields", async () => {
-    register("reordering", input => {
-      const value = input as { apiKey: unknown; region?: unknown };
-      return value.region === undefined
-        ? { apiKey: String(value.apiKey), region: "eu" }
-        : { region: String(value.region), apiKey: String(value.apiKey) };
-    });
-
-    const provider = await write("reordering", { apiKey: "k" });
-
-    const stored = await service.getProviderDecrypted(provider.id);
-    expect(stored.configuration).toEqual({ apiKey: "k", region: "eu" });
+    await expect(write("dated", { apiKey: "k" })).rejects.toThrow(
+      /parsing what would be saved does not return what was saved/
+    );
   });
 
   // The same property reached by throwing rather than by returning something
@@ -202,20 +176,18 @@ describe("a configuration whose parse is not a fixed point", () => {
     );
   });
 
-  // `undefined` is another value JSON cannot carry: the column drops the key.
-  // Under the same rule as the `Date` above the write is accepted and the key
-  // is simply absent, which is what an optional field means anyway.
-  it("stores a parser's undefined-valued key as an absent one", async () => {
+  // `undefined` is a third value JSON cannot carry, not an exception to the
+  // rule: the column drops the key and the parser puts it back, so what is
+  // held and what is stored are different objects on every read.
+  it("refuses a parser that returns an undefined-valued key", async () => {
     register("optional", input => ({
       apiKey: String((input as { apiKey: unknown }).apiKey),
       label: undefined,
     }));
 
-    const provider = await write("optional", { apiKey: "k" });
-
-    const stored = await service.getProviderDecrypted(provider.id);
-    expect(stored.configuration).toEqual({ apiKey: "k" });
-    expect(Object.keys(stored.configuration as object)).not.toContain("label");
+    await expect(write("optional", { apiKey: "k" })).rejects.toThrow(
+      /parsing what would be saved does not return what was saved/
+    );
   });
 
   // A parser that OMITS the key instead round-trips cleanly, which is the
@@ -273,13 +245,10 @@ describe("a configuration whose parse is not a fixed point", () => {
     );
   });
 
-  // A PASS-THROUGH parser: it accepts both the typed value and its JSON form.
-  // Under the previous contract this was the case the round-trip comparison
-  // existed to catch, because re-parsing agrees with itself while the stored
-  // value lost its type. Losing the type is now the defined outcome rather
-  // than a fault, so the assertion is on WHAT IS STORED — which is the only
-  // thing that separates this from a check that stopped looking.
-  it("stores the coerced value a pass-through parser accepts back", async () => {
+  // A PASS-THROUGH parser: it accepts both the typed value and its JSON form,
+  // so re-parsing agrees with itself while the value actually stored lost its
+  // type. The Date test above recreates the Date and cannot see this.
+  it("refuses a pass-through parser whose value loses type in the column", async () => {
     register("passthrough-date", input => {
       const value = input as { apiKey: unknown; issuedAt?: unknown };
       return value.issuedAt === undefined
@@ -287,13 +256,9 @@ describe("a configuration whose parse is not a fixed point", () => {
         : (value as object);
     });
 
-    const provider = await write("passthrough-date", { apiKey: "k" });
-
-    const stored = await service.getProviderDecrypted(provider.id);
-    expect(stored.configuration).toEqual({
-      apiKey: "k",
-      issuedAt: "1970-01-01T00:00:00.000Z",
-    });
+    await expect(write("passthrough-date", { apiKey: "k" })).rejects.toThrow(
+      /parsing what would be saved does not return what was saved|cannot be written as JSON/
+    );
   });
 
   // A root `toJSON` returning undefined makes JSON.stringify return undefined
@@ -354,6 +319,79 @@ describe("a configuration whose parse is not a fixed point", () => {
     expect(stored.configuration).toEqual({ apiKey: "k" });
   });
 
+  // A `Map` keeps its entries where `JSON.stringify` cannot read, so the column
+  // would hold `{}` and the adapter would run without the operator's headers.
+  // The round-trip comparison catches it without knowing what a `Map` is,
+  // which is the property worth having: the same check refuses a `Set`, a
+  // class instance, and whatever else is invented next.
+  it("refuses a value whose serialisation keeps nothing", async () => {
+    register("mapped", input => ({
+      apiKey: String((input as { apiKey: unknown }).apiKey),
+      headers: new Map([["x-team", "ops"]]),
+    }));
+
+    await expect(write("mapped", { apiKey: "k" })).rejects.toThrow(
+      /parsing what would be saved does not return what was saved/
+    );
+  });
+
+  // Reached through an array rather than a key, and a `Set` rather than a
+  // `Map` — same check, no second branch.
+  it("refuses an emptied value nested inside an array", async () => {
+    register("nested-set", input => ({
+      apiKey: String((input as { apiKey: unknown }).apiKey),
+      routes: [{ region: "eu", tags: new Set(["primary"]) }],
+    }));
+
+    await expect(write("nested-set", { apiKey: "k" })).rejects.toThrow(
+      /parsing what would be saved does not return what was saved/
+    );
+  });
+
+  // An ORDINARY object can empty itself, by defining a `toJSON` that returns
+  // nothing while holding real values. Nothing about its prototype says so.
+  it("refuses a plain object whose own toJSON discards its fields", async () => {
+    register("self-emptying", input => ({
+      apiKey: String((input as { apiKey: unknown }).apiKey),
+      headers: { token: "ops", toJSON: () => ({}) },
+    }));
+
+    await expect(write("self-emptying", { apiKey: "k" })).rejects.toThrow(
+      /parsing what would be saved does not return what was saved/
+    );
+  });
+
+  // An array can do it too, and an array carrying NAMED properties loses
+  // those to serialisation while its indices survive.
+  it("refuses an array that loses what serialisation cannot carry", async () => {
+    register("named-array", input => ({
+      apiKey: String((input as { apiKey: unknown }).apiKey),
+      scopes: Object.assign(["send"], { region: "eu" }),
+    }));
+
+    await expect(write("named-array", { apiKey: "k" })).rejects.toThrow(
+      /parsing what would be saved does not return what was saved/
+    );
+  });
+
+  // Field ORDER is not a difference. The comparison is structural, so a parser
+  // that rebuilds its output field by field — an ordinary thing to write — is
+  // accepted, and `updateProvider` must agree with that when it decides
+  // whether a save changed the configuration.
+  it("stores a configuration whose parser reorders its own fields", async () => {
+    register("reordering", input => {
+      const value = input as { apiKey: unknown; region?: unknown };
+      return value.region === undefined
+        ? { apiKey: String(value.apiKey), region: "eu" }
+        : { region: String(value.region), apiKey: String(value.apiKey) };
+    });
+
+    const provider = await write("reordering", { apiKey: "k" });
+
+    const stored = await service.getProviderDecrypted(provider.id);
+    expect(stored.configuration).toEqual({ apiKey: "k", region: "eu" });
+  });
+
   // An ARRAY is ordinary configuration and JSON preserves it exactly. Its
   // `length` is a non-enumerable own key, so a naive own-key comparison
   // rejects every provider that has one.
@@ -369,92 +407,5 @@ describe("a configuration whose parse is not a fixed point", () => {
       apiKey: "k",
       scopes: ["send", "read"],
     });
-  });
-
-  // Coercion and DESTRUCTION are different, and only the first is accepted.
-  // A `Map`'s entries are not own enumerable properties, so it serialises to
-  // `{}` — the operator's headers are gone and the adapter runs without them.
-  // The fixed-point comparison cannot see this on its own: both of its sides
-  // are already past the column, so an empty projection agrees with an empty
-  // projection and the write looks clean.
-  it("refuses a value whose serialisation keeps nothing", async () => {
-    register("mapped", input => {
-      const value = input as { apiKey: unknown; headers?: unknown };
-      return {
-        apiKey: String(value.apiKey),
-        headers:
-          value.headers instanceof Map
-            ? value.headers
-            : new Map([["x-team", "ops"]]),
-      };
-    });
-
-    await expect(write("mapped", { apiKey: "k" })).rejects.toThrow(
-      /at headers that changes when written as JSON/
-    );
-  });
-
-  // Reached through an array rather than a key, so the walk is not only over
-  // object properties. A `Set` empties the same way a `Map` does.
-  it("refuses an emptied value nested inside an array", async () => {
-    register("nested-set", input => ({
-      apiKey: String((input as { apiKey: unknown }).apiKey),
-      routes: [{ region: "eu", tags: new Set(["primary"]) }],
-    }));
-
-    await expect(write("nested-set", { apiKey: "k" })).rejects.toThrow(
-      /at routes\.\[0\]\.tags that changes when written as JSON/
-    );
-  });
-
-  // An ORDINARY object can empty itself too, by defining a `toJSON` that
-  // returns nothing while the object holds real values. Deciding this by
-  // prototype would exempt it — the prototype is `Object.prototype` — so
-  // emptiness has to be judged by whether the value genuinely held nothing.
-  it("refuses a plain object whose own toJSON discards its fields", async () => {
-    register("self-emptying", input => {
-      const value = input as { apiKey: unknown; headers?: unknown };
-      return {
-        apiKey: String(value.apiKey),
-        headers: value.headers ?? { token: "ops", toJSON: () => ({}) },
-      };
-    });
-
-    await expect(write("self-emptying", { apiKey: "k" })).rejects.toThrow(
-      /at headers that changes when written as JSON/
-    );
-  });
-
-  // An ARRAY can empty itself the same way an object can. The walk asks every
-  // position the one question, so nothing has to remember that arrays are a
-  // separate branch — which is exactly what the earlier shape of this check
-  // did forget.
-  it("refuses an array whose own toJSON discards its entries", async () => {
-    register("self-emptying-array", input => {
-      const value = input as { apiKey: unknown; scopes?: unknown };
-      return {
-        apiKey: String(value.apiKey),
-        scopes: value.scopes ?? Object.assign(["send"], { toJSON: () => ({}) }),
-      };
-    });
-
-    await expect(write("self-emptying-array", { apiKey: "k" })).rejects.toThrow(
-      /at scopes that changes when written as JSON/
-    );
-  });
-
-  // The boundary case that stops the rule above from over-reaching: a plain
-  // empty object also serialises to `{}` and has lost nothing, because there
-  // was nothing to lose. Refusing it would reject an ordinary configuration
-  // that happens to carry an empty map of options.
-  it("stores a configuration containing an empty plain object", async () => {
-    register("empty-object", input => ({
-      apiKey: String((input as { apiKey: unknown }).apiKey),
-      headers: {},
-    }));
-
-    const provider = await write("empty-object", { apiKey: "k" });
-    const stored = await service.getProviderDecrypted(provider.id);
-    expect(stored.configuration).toEqual({ apiKey: "k", headers: {} });
   });
 });

--- a/packages/nextly/src/domains/email/__tests__/stored-configuration-round-trips.test.ts
+++ b/packages/nextly/src/domains/email/__tests__/stored-configuration-round-trips.test.ts
@@ -390,7 +390,7 @@ describe("a configuration whose parse is not a fixed point", () => {
     });
 
     await expect(write("mapped", { apiKey: "k" })).rejects.toThrow(
-      /at headers that keeps nothing when written as JSON/
+      /at headers that changes when written as JSON/
     );
   });
 
@@ -403,7 +403,7 @@ describe("a configuration whose parse is not a fixed point", () => {
     }));
 
     await expect(write("nested-set", { apiKey: "k" })).rejects.toThrow(
-      /at routes\.\[0\]\.tags that keeps nothing/
+      /at routes\.\[0\]\.tags that changes when written as JSON/
     );
   });
 
@@ -421,7 +421,7 @@ describe("a configuration whose parse is not a fixed point", () => {
     });
 
     await expect(write("self-emptying", { apiKey: "k" })).rejects.toThrow(
-      /at headers that keeps nothing when written as JSON/
+      /at headers that changes when written as JSON/
     );
   });
 
@@ -439,7 +439,7 @@ describe("a configuration whose parse is not a fixed point", () => {
     });
 
     await expect(write("self-emptying-array", { apiKey: "k" })).rejects.toThrow(
-      /at scopes that keeps nothing when written as JSON/
+      /at scopes that changes when written as JSON/
     );
   });
 

--- a/packages/nextly/src/domains/email/__tests__/stored-configuration-round-trips.test.ts
+++ b/packages/nextly/src/domains/email/__tests__/stored-configuration-round-trips.test.ts
@@ -149,17 +149,43 @@ describe("a configuration whose parse is not a fixed point", () => {
     );
   });
 
-  // JSON carries no `Date`, so the column holds a string and the adapter is
-  // handed a shape this provider's own parser just rejected.
-  it("refuses a parser returning a value JSON cannot carry", async () => {
+  // JSON carries no `Date`, so the column holds its ISO string. That coercion
+  // is the accepted cost of defining the stored configuration AS its
+  // serialisation: the adapter is handed the string. Asserted on the value
+  // READ BACK, because "the write succeeded" is true of a refusal-free
+  // implementation that stored anything at all.
+  it("stores a value JSON cannot carry as the form the column holds", async () => {
     register("dated", input => ({
       apiKey: String((input as { apiKey: unknown }).apiKey),
       issuedAt: new Date(0),
     }));
 
-    await expect(write("dated", { apiKey: "k" })).rejects.toThrow(
-      /parsing what would be saved does not return what was saved/
-    );
+    const provider = await write("dated", { apiKey: "k" });
+
+    const stored = await service.getProviderDecrypted(provider.id);
+    expect(stored.configuration).toEqual({
+      apiKey: "k",
+      issuedAt: "1970-01-01T00:00:00.000Z",
+    });
+  });
+
+  // The comparison is made in the JSON domain, and the naive way to do that is
+  // to compare the two serialisations as TEXT. Insertion order changes the
+  // text and changes nothing about the value, and a parser that rebuilds its
+  // output field by field is an ordinary thing to write — so a text
+  // comparison would refuse this while a structural one accepts it.
+  it("stores a configuration whose parser reorders its own fields", async () => {
+    register("reordering", input => {
+      const value = input as { apiKey: unknown; region?: unknown };
+      return value.region === undefined
+        ? { apiKey: String(value.apiKey), region: "eu" }
+        : { region: String(value.region), apiKey: String(value.apiKey) };
+    });
+
+    const provider = await write("reordering", { apiKey: "k" });
+
+    const stored = await service.getProviderDecrypted(provider.id);
+    expect(stored.configuration).toEqual({ apiKey: "k", region: "eu" });
   });
 
   // The same property reached by throwing rather than by returning something
@@ -176,18 +202,20 @@ describe("a configuration whose parse is not a fixed point", () => {
     );
   });
 
-  // `undefined` is a third value JSON cannot carry, not an exception to the
-  // rule: the column drops the key and the parser puts it back, so what is
-  // held and what is stored are different objects on every read.
-  it("refuses a parser that returns an undefined-valued key", async () => {
+  // `undefined` is another value JSON cannot carry: the column drops the key.
+  // Under the same rule as the `Date` above the write is accepted and the key
+  // is simply absent, which is what an optional field means anyway.
+  it("stores a parser's undefined-valued key as an absent one", async () => {
     register("optional", input => ({
       apiKey: String((input as { apiKey: unknown }).apiKey),
       label: undefined,
     }));
 
-    await expect(write("optional", { apiKey: "k" })).rejects.toThrow(
-      /parsing what would be saved does not return what was saved/
-    );
+    const provider = await write("optional", { apiKey: "k" });
+
+    const stored = await service.getProviderDecrypted(provider.id);
+    expect(stored.configuration).toEqual({ apiKey: "k" });
+    expect(Object.keys(stored.configuration as object)).not.toContain("label");
   });
 
   // A parser that OMITS the key instead round-trips cleanly, which is the
@@ -245,10 +273,13 @@ describe("a configuration whose parse is not a fixed point", () => {
     );
   });
 
-  // A PASS-THROUGH parser: it accepts both the typed value and its JSON form,
-  // so re-parsing agrees with itself while the value actually stored lost its
-  // type. The Date test above recreates the Date and cannot see this.
-  it("refuses a pass-through parser whose value loses type in the column", async () => {
+  // A PASS-THROUGH parser: it accepts both the typed value and its JSON form.
+  // Under the previous contract this was the case the round-trip comparison
+  // existed to catch, because re-parsing agrees with itself while the stored
+  // value lost its type. Losing the type is now the defined outcome rather
+  // than a fault, so the assertion is on WHAT IS STORED — which is the only
+  // thing that separates this from a check that stopped looking.
+  it("stores the coerced value a pass-through parser accepts back", async () => {
     register("passthrough-date", input => {
       const value = input as { apiKey: unknown; issuedAt?: unknown };
       return value.issuedAt === undefined
@@ -256,9 +287,13 @@ describe("a configuration whose parse is not a fixed point", () => {
         : (value as object);
     });
 
-    await expect(write("passthrough-date", { apiKey: "k" })).rejects.toThrow(
-      /parsing what would be saved does not return what was saved|cannot be written as JSON/
-    );
+    const provider = await write("passthrough-date", { apiKey: "k" });
+
+    const stored = await service.getProviderDecrypted(provider.id);
+    expect(stored.configuration).toEqual({
+      apiKey: "k",
+      issuedAt: "1970-01-01T00:00:00.000Z",
+    });
   });
 
   // A root `toJSON` returning undefined makes JSON.stringify return undefined

--- a/packages/nextly/src/domains/email/__tests__/stored-configuration-round-trips.test.ts
+++ b/packages/nextly/src/domains/email/__tests__/stored-configuration-round-trips.test.ts
@@ -370,4 +370,55 @@ describe("a configuration whose parse is not a fixed point", () => {
       scopes: ["send", "read"],
     });
   });
+
+  // Coercion and DESTRUCTION are different, and only the first is accepted.
+  // A `Map`'s entries are not own enumerable properties, so it serialises to
+  // `{}` — the operator's headers are gone and the adapter runs without them.
+  // The fixed-point comparison cannot see this on its own: both of its sides
+  // are already past the column, so an empty projection agrees with an empty
+  // projection and the write looks clean.
+  it("refuses a value whose serialisation keeps nothing", async () => {
+    register("mapped", input => {
+      const value = input as { apiKey: unknown; headers?: unknown };
+      return {
+        apiKey: String(value.apiKey),
+        headers:
+          value.headers instanceof Map
+            ? value.headers
+            : new Map([["x-team", "ops"]]),
+      };
+    });
+
+    await expect(write("mapped", { apiKey: "k" })).rejects.toThrow(
+      /at headers that keeps nothing when written as JSON/
+    );
+  });
+
+  // Reached through an array rather than a key, so the walk is not only over
+  // object properties. A `Set` empties the same way a `Map` does.
+  it("refuses an emptied value nested inside an array", async () => {
+    register("nested-set", input => ({
+      apiKey: String((input as { apiKey: unknown }).apiKey),
+      routes: [{ region: "eu", tags: new Set(["primary"]) }],
+    }));
+
+    await expect(write("nested-set", { apiKey: "k" })).rejects.toThrow(
+      /at routes\.\[0\]\.tags that keeps nothing/
+    );
+  });
+
+  // The boundary case that stops the rule above from over-reaching: a plain
+  // empty object also serialises to `{}` and has lost nothing, because there
+  // was nothing to lose. Refusing it would reject an ordinary configuration
+  // that happens to carry an empty map of options.
+  it("stores a configuration containing an empty plain object", async () => {
+    register("empty-object", input => ({
+      apiKey: String((input as { apiKey: unknown }).apiKey),
+      headers: {},
+    }));
+
+    const provider = await write("empty-object", { apiKey: "k" });
+    const stored = await service.getProviderDecrypted(provider.id);
+    expect(stored.configuration).toEqual({ apiKey: "k", headers: {} });
+  });
 });

--- a/packages/nextly/src/domains/email/__tests__/stored-configuration-round-trips.test.ts
+++ b/packages/nextly/src/domains/email/__tests__/stored-configuration-round-trips.test.ts
@@ -407,6 +407,24 @@ describe("a configuration whose parse is not a fixed point", () => {
     );
   });
 
+  // An ORDINARY object can empty itself too, by defining a `toJSON` that
+  // returns nothing while the object holds real values. Deciding this by
+  // prototype would exempt it — the prototype is `Object.prototype` — so
+  // emptiness has to be judged by whether the value genuinely held nothing.
+  it("refuses a plain object whose own toJSON discards its fields", async () => {
+    register("self-emptying", input => {
+      const value = input as { apiKey: unknown; headers?: unknown };
+      return {
+        apiKey: String(value.apiKey),
+        headers: value.headers ?? { token: "ops", toJSON: () => ({}) },
+      };
+    });
+
+    await expect(write("self-emptying", { apiKey: "k" })).rejects.toThrow(
+      /at headers that keeps nothing when written as JSON/
+    );
+  });
+
   // The boundary case that stops the rule above from over-reaching: a plain
   // empty object also serialises to `{}` and has lost nothing, because there
   // was nothing to lose. Refusing it would reject an ordinary configuration

--- a/packages/nextly/src/domains/email/__tests__/stored-configuration-round-trips.test.ts
+++ b/packages/nextly/src/domains/email/__tests__/stored-configuration-round-trips.test.ts
@@ -425,6 +425,24 @@ describe("a configuration whose parse is not a fixed point", () => {
     );
   });
 
+  // An ARRAY can empty itself the same way an object can. The walk asks every
+  // position the one question, so nothing has to remember that arrays are a
+  // separate branch — which is exactly what the earlier shape of this check
+  // did forget.
+  it("refuses an array whose own toJSON discards its entries", async () => {
+    register("self-emptying-array", input => {
+      const value = input as { apiKey: unknown; scopes?: unknown };
+      return {
+        apiKey: String(value.apiKey),
+        scopes: value.scopes ?? Object.assign(["send"], { toJSON: () => ({}) }),
+      };
+    });
+
+    await expect(write("self-emptying-array", { apiKey: "k" })).rejects.toThrow(
+      /at scopes that keeps nothing when written as JSON/
+    );
+  });
+
   // The boundary case that stops the rule above from over-reaching: a plain
   // empty object also serialises to `{}` and has lost nothing, because there
   // was nothing to lose. Refusing it would reject an ordinary configuration

--- a/packages/nextly/src/domains/email/services/email-provider-service.ts
+++ b/packages/nextly/src/domains/email/services/email-provider-service.ts
@@ -284,26 +284,27 @@ export class EmailProviderService extends BaseService {
     // hold is that parsing the stored form returns the stored form, and it is
     // checked here rather than left as an assumption about how parsers behave.
     //
-    // Two ways a parser breaks it, neither visible at the call site:
+    // The configuration IS its serialisation, and that is the whole rule the
+    // rest of this method follows. A type the column cannot hold is COERCED
+    // into the form it can — a `Date` becomes its ISO string, an
+    // `undefined`-valued key becomes an absent one — and the coerced form is
+    // what everything downstream sees, because it is what the column holds.
     //
-    // It may DERIVE a value rather than reshape one. `Buffer.from(key)
-    // .toString("base64")` encodes on the way in and encodes the encoding on
-    // the way out, so the adapter authenticates with a doubly-encoded
-    // credential and the provider answers "bad key" about a key the operator
-    // entered correctly.
+    // Defined this way rather than as a list of rejected types on purpose.
+    // Checking the parser's output for shapes JSON loses means finding one
+    // more shape every time somebody writes a new parser — proxies, hidden
+    // keys, shared references, prototypes — and each is a separate rule
+    // arriving as a separate defect. Serialising first makes all of them
+    // unreachable at once, and the cost is stated rather than hidden: an
+    // adapter that expected a `Date` is handed a string.
     //
-    // Or it may return something JSON cannot carry — a `Date`, a `Map`, a
-    // `Set` — which reads back as a string or as an empty object, so the
-    // adapter receives a shape its own parser just rejected.
-    //
-    // Compared against the ROUND-TRIPPED form rather than the parsed one,
-    // because the round-tripped form is what a reader gets and therefore what
-    // the parser has to be a fixed point OF. That makes `undefined` a third
-    // way to fail rather than an exception to the rule: a parser returning
-    // `{ label: undefined }` has JSON drop the key and then puts it back, so
-    // the value in hand and the value in the column are different objects.
-    // Rejecting it is the same answer as for a `Date`, and for the same
-    // reason — return only what the column can hold.
+    // What is still REFUSED is the parser that DERIVES rather than reshapes.
+    // `Buffer.from(key).toString("base64")` encodes on the way in and encodes
+    // the encoding on the way out, so the adapter authenticates with a
+    // doubly-encoded credential and the provider answers "bad key" about a key
+    // the operator entered correctly. That is not a type JSON cannot carry; it
+    // is a value that changes every time it is read, and no serialisation
+    // makes it stable.
     const stored = parsed as Record<string, unknown>;
 
     // Serialised ONCE and parsed TWICE. `roundTripped` is what a reader gets
@@ -374,33 +375,42 @@ export class EmailProviderService extends BaseService {
       });
     }
 
-    let reparsed: unknown;
+    // The stored configuration IS its serialisation, so the comparison is made
+    // in that domain rather than against the object the parser returned.
+    //
+    // A type JSON cannot carry is COERCED, not refused: a `Date` is written as
+    // its ISO string, and a parser that reads that string back into a `Date`
+    // agrees with the column even though the two values are not deep-equal.
+    // The cost is real and is taken deliberately -- an adapter is handed the
+    // string -- and the alternative is a surface that refuses a new shape every
+    // time one is found. Anything the column cannot hold at all is still
+    // refused above, where serialisation fails or produces a non-object.
+    //
+    // What survives is the property this check exists for: re-parsing the
+    // stored form must MEAN the stored form. A parser that derives -- base64
+    // on the way in, base64 of the base64 on the way out -- still differs
+    // after its own round trip, and is still refused.
+    let reparsedJson: unknown;
     try {
-      reparsed = provider.parseConfiguration(roundTripped);
+      const reparsed = provider.parseConfiguration(roundTripped);
+      // Compared through a round trip rather than as a string. Two objects
+      // holding the same fields in a different insertion order serialise to
+      // different text, and a parser that rebuilds its output field by field
+      // is an ordinary thing to write.
+      const reserialized = JSON.stringify(reparsed);
+      reparsedJson =
+        reserialized === undefined ? undefined : JSON.parse(reserialized);
     } catch {
       // A parser that REJECTS its own stored output fails the same property,
       // and reaches it by throwing rather than by returning something else.
-      // Left as one outcome: both mean the row could not be read back.
-      reparsed = undefined;
+      // A re-parse that cannot itself be serialised lands here too, and means
+      // the same thing: the row could not be read back.
+      reparsedJson = undefined;
     }
-    // TWO properties, and each misses what the other catches.
-    //
-    // The parsed value must SURVIVE the round trip: a `Date`, a `Map`, an
-    // `Infinity` or a class instance is written as something else, and a
-    // pass-through parser that accepts both forms then agrees with itself
-    // while the adapter receives an ISO string where a `Date` was returned.
-    // Re-parsing alone cannot see that, because both sides of it are already
-    // past the column.
-    //
-    // And re-parsing the stored form must RETURN it, which is what catches a
-    // parser that derives rather than one that loses a type.
-    if (
-      !isDeepStrictEqual(stored, unchanged) ||
-      !isDeepStrictEqual(reparsed, unchanged)
-    ) {
+    if (!isDeepStrictEqual(reparsedJson, unchanged)) {
       throw new NextlyError({
         code: "BUSINESS_RULE_VIOLATION",
-        publicMessage: `Email provider "${type}" cannot store this configuration, because parsing what would be saved does not return what was saved. Its \`parseConfig\` must accept its own output unchanged -- derive values in \`createAdapter\` instead, and return only what JSON can carry.`,
+        publicMessage: `Email provider "${type}" cannot store this configuration, because parsing what would be saved does not return what was saved. Its \`parseConfig\` must accept its own output unchanged -- derive values in \`createAdapter\` instead.`,
         logContext: { reason: "email-provider-parse-not-a-fixed-point", type },
       });
     }

--- a/packages/nextly/src/domains/email/services/email-provider-service.ts
+++ b/packages/nextly/src/domains/email/services/email-provider-service.ts
@@ -363,7 +363,16 @@ export class EmailProviderService extends BaseService {
     // some of itself -- a string, a number, a populated object -- is a
     // coercion and is stored. Anything that keeps none of itself is refused,
     // whatever it was.
-    const emptied = this.emptiedBySerialisation(stored);
+    const roundTripped: unknown = JSON.parse(serialized);
+    const unchanged: unknown = JSON.parse(serialized);
+
+    // Read against the projection ALREADY COMPUTED above rather than by
+    // serialising each node again. One serialisation happened, its result is
+    // in hand, and asking it is both cheaper and the only way to be sure the
+    // answer describes what will actually be written -- a `toJSON` that
+    // returns something different on its second call would otherwise be
+    // judged on a value nothing stores.
+    const emptied = this.emptiedBySerialisation(stored, roundTripped);
     if (emptied) {
       throw new NextlyError({
         code: "BUSINESS_RULE_VIOLATION",
@@ -375,9 +384,6 @@ export class EmailProviderService extends BaseService {
         },
       });
     }
-
-    const roundTripped: unknown = JSON.parse(serialized);
-    const unchanged: unknown = JSON.parse(serialized);
 
     // Checked again after the round trip, not only before it. A `toJSON` -- on
     // the object itself or on a `Date` inside it -- can turn a record into a
@@ -489,15 +495,30 @@ export class EmailProviderService extends BaseService {
 
   private emptiedBySerialisation(
     value: unknown,
+    projection: unknown,
     path: string[] = []
   ): string | undefined {
     if (value === null || typeof value !== "object") return undefined;
 
-    const label = path.length === 0 ? "the configuration" : path.join(".");
+    // What the column would hold at this position. Anything other than an
+    // empty object kept something -- a string, a number, an array, a populated
+    // object -- and is a coercion.
+    const keptNothing =
+      projection !== null &&
+      typeof projection === "object" &&
+      !Array.isArray(projection) &&
+      Object.keys(projection).length === 0;
 
-    if (Array.isArray(value)) {
+    if (keptNothing && this.heldSomething(value)) {
+      return path.length === 0 ? "the configuration" : path.join(".");
+    }
+
+    // Only positions that SURVIVED are worth descending into. A node whose
+    // projection kept nothing has already been answered, and one that changed
+    // shape -- a `Date` to a string -- has no children to walk.
+    if (Array.isArray(value) && Array.isArray(projection)) {
       for (const [index, entry] of value.entries()) {
-        const emptied = this.emptiedBySerialisation(entry, [
+        const emptied = this.emptiedBySerialisation(entry, projection[index], [
           ...path,
           `[${index}]`,
         ]);
@@ -506,38 +527,41 @@ export class EmailProviderService extends BaseService {
       return undefined;
     }
 
-    // `undefined` means the key is dropped from its parent entirely, which is
-    // the ordinary meaning of an absent optional; the root case is covered by
-    // the caller's own guard.
-    const projection: string | undefined = JSON.stringify(value);
-    if (projection !== undefined) {
-      const asJson: unknown = JSON.parse(projection);
-      const keptNothing =
-        asJson !== null &&
-        typeof asJson === "object" &&
-        !Array.isArray(asJson) &&
-        Object.keys(asJson).length === 0;
-
-      // Whether there was anything to lose. Read from the OWN ENUMERABLE
-      // properties, because those are the only ones `JSON.stringify` would
-      // have written -- so a value carrying state anywhere else (a `Map`'s
-      // entries, a `Set`'s members) reports nothing here and is a loss by
-      // construction. A function is not JSON either way, and a key holding
-      // `undefined` is the absent-optional spelling rather than a value.
-      const heldSomething = Object.values(value).some(
-        entry => entry !== undefined && typeof entry !== "function"
-      );
-
-      if (keptNothing && (heldSomething || !this.isOrdinaryObject(value))) {
-        return label;
+    if (
+      projection !== null &&
+      typeof projection === "object" &&
+      !Array.isArray(projection)
+    ) {
+      const held: Record<string, unknown> = projection as Record<
+        string,
+        unknown
+      >;
+      for (const [key, entry] of Object.entries(value)) {
+        const emptied = this.emptiedBySerialisation(entry, held[key], [
+          ...path,
+          key,
+        ]);
+        if (emptied) return emptied;
       }
     }
-
-    for (const [key, entry] of Object.entries(value)) {
-      const emptied = this.emptiedBySerialisation(entry, [...path, key]);
-      if (emptied) return emptied;
-    }
     return undefined;
+  }
+
+  /**
+   * Whether a value carried anything the column was supposed to receive.
+   *
+   * An array is judged by its length and an object by its own enumerable
+   * values, because those are what `JSON.stringify` would have written. A
+   * value keeping its state anywhere else -- a `Map`'s entries, a `Set`'s
+   * members -- reports nothing here, so the ordinary-object test is what
+   * catches it: a `{}` that really is empty is ordinary, and a `Map` is not.
+   */
+  private heldSomething(value: object): boolean {
+    if (Array.isArray(value)) return value.length > 0;
+    const hasValues = Object.values(value).some(
+      entry => entry !== undefined && typeof entry !== "function"
+    );
+    return hasValues || !this.isOrdinaryObject(value);
   }
 
   /**

--- a/packages/nextly/src/domains/email/services/email-provider-service.ts
+++ b/packages/nextly/src/domains/email/services/email-provider-service.ts
@@ -284,27 +284,26 @@ export class EmailProviderService extends BaseService {
     // hold is that parsing the stored form returns the stored form, and it is
     // checked here rather than left as an assumption about how parsers behave.
     //
-    // The configuration IS its serialisation, and that is the whole rule the
-    // rest of this method follows. A type the column cannot hold is COERCED
-    // into the form it can — a `Date` becomes its ISO string, an
-    // `undefined`-valued key becomes an absent one — and the coerced form is
-    // what everything downstream sees, because it is what the column holds.
+    // Two ways a parser breaks it, neither visible at the call site:
     //
-    // Defined this way rather than as a list of rejected types on purpose.
-    // Checking the parser's output for shapes JSON loses means finding one
-    // more shape every time somebody writes a new parser — proxies, hidden
-    // keys, shared references, prototypes — and each is a separate rule
-    // arriving as a separate defect. Serialising first makes all of them
-    // unreachable at once, and the cost is stated rather than hidden: an
-    // adapter that expected a `Date` is handed a string.
+    // It may DERIVE a value rather than reshape one. `Buffer.from(key)
+    // .toString("base64")` encodes on the way in and encodes the encoding on
+    // the way out, so the adapter authenticates with a doubly-encoded
+    // credential and the provider answers "bad key" about a key the operator
+    // entered correctly.
     //
-    // What is still REFUSED is the parser that DERIVES rather than reshapes.
-    // `Buffer.from(key).toString("base64")` encodes on the way in and encodes
-    // the encoding on the way out, so the adapter authenticates with a
-    // doubly-encoded credential and the provider answers "bad key" about a key
-    // the operator entered correctly. That is not a type JSON cannot carry; it
-    // is a value that changes every time it is read, and no serialisation
-    // makes it stable.
+    // Or it may return something JSON cannot carry — a `Date`, a `Map`, a
+    // `Set` — which reads back as a string or as an empty object, so the
+    // adapter receives a shape its own parser just rejected.
+    //
+    // Compared against the ROUND-TRIPPED form rather than the parsed one,
+    // because the round-tripped form is what a reader gets and therefore what
+    // the parser has to be a fixed point OF. That makes `undefined` a third
+    // way to fail rather than an exception to the rule: a parser returning
+    // `{ label: undefined }` has JSON drop the key and then puts it back, so
+    // the value in hand and the value in the column are different objects.
+    // Rejecting it is the same answer as for a `Date`, and for the same
+    // reason — return only what the column can hold.
     const stored = parsed as Record<string, unknown>;
 
     // Serialised ONCE and parsed TWICE. `roundTripped` is what a reader gets
@@ -354,32 +353,6 @@ export class EmailProviderService extends BaseService {
     const roundTripped: unknown = JSON.parse(serialized);
     const unchanged: unknown = JSON.parse(serialized);
 
-    // Coercion and DESTRUCTION are not the same thing, and only the first was
-    // decided. The rule is stated as ONE permitted difference rather than as a
-    // walk looking for damage: the parsed value and the form the column will
-    // hold must be the same configuration, EXCEPT that a value may become
-    // plain text. That is the `Date` case, and it is the only one.
-    //
-    // Written this way because the alternative was tried and does not close.
-    // A check that walks the value looking for shapes JSON loses has to know
-    // every shape: a `Map`, a `Set`, an object whose own `toJSON` empties it,
-    // an array that does the same, an array that empties to `[]`. Each is a
-    // separate branch and the next one is always missing. Naming the single
-    // ACCEPTED difference instead leaves nothing to enumerate — anything that
-    // is not that difference is refused, including shapes nobody has met yet.
-    const differs = this.storedFormDiffers(stored, unchanged);
-    if (differs) {
-      throw new NextlyError({
-        code: "BUSINESS_RULE_VIOLATION",
-        publicMessage: `Email provider "${type}" parsed its configuration into a value at ${differs} that changes when written as JSON, so what is saved would not be what was parsed. Return plain objects, arrays and primitives from \`parseConfig\` -- a value that becomes text, such as a \`Date\`, is stored as that text.`,
-        logContext: {
-          reason: "email-provider-configuration-not-storable",
-          type,
-          path: differs,
-        },
-      });
-    }
-
     // Checked again after the round trip, not only before it. A `toJSON` -- on
     // the object itself or on a `Date` inside it -- can turn a record into a
     // scalar or a list, and the first guard read the value the parser returned
@@ -401,42 +374,33 @@ export class EmailProviderService extends BaseService {
       });
     }
 
-    // The stored configuration IS its serialisation, so the comparison is made
-    // in that domain rather than against the object the parser returned.
-    //
-    // A type JSON cannot carry is COERCED, not refused: a `Date` is written as
-    // its ISO string, and a parser that reads that string back into a `Date`
-    // agrees with the column even though the two values are not deep-equal.
-    // The cost is real and is taken deliberately -- an adapter is handed the
-    // string -- and the alternative is a surface that refuses a new shape every
-    // time one is found. Anything the column cannot hold at all is still
-    // refused above, where serialisation fails or produces a non-object.
-    //
-    // What survives is the property this check exists for: re-parsing the
-    // stored form must MEAN the stored form. A parser that derives -- base64
-    // on the way in, base64 of the base64 on the way out -- still differs
-    // after its own round trip, and is still refused.
-    let reparsedJson: unknown;
+    let reparsed: unknown;
     try {
-      const reparsed = provider.parseConfiguration(roundTripped);
-      // Compared through a round trip rather than as a string. Two objects
-      // holding the same fields in a different insertion order serialise to
-      // different text, and a parser that rebuilds its output field by field
-      // is an ordinary thing to write.
-      const reserialized = JSON.stringify(reparsed);
-      reparsedJson =
-        reserialized === undefined ? undefined : JSON.parse(reserialized);
+      reparsed = provider.parseConfiguration(roundTripped);
     } catch {
       // A parser that REJECTS its own stored output fails the same property,
       // and reaches it by throwing rather than by returning something else.
-      // A re-parse that cannot itself be serialised lands here too, and means
-      // the same thing: the row could not be read back.
-      reparsedJson = undefined;
+      // Left as one outcome: both mean the row could not be read back.
+      reparsed = undefined;
     }
-    if (!isDeepStrictEqual(reparsedJson, unchanged)) {
+    // TWO properties, and each misses what the other catches.
+    //
+    // The parsed value must SURVIVE the round trip: a `Date`, a `Map`, an
+    // `Infinity` or a class instance is written as something else, and a
+    // pass-through parser that accepts both forms then agrees with itself
+    // while the adapter receives an ISO string where a `Date` was returned.
+    // Re-parsing alone cannot see that, because both sides of it are already
+    // past the column.
+    //
+    // And re-parsing the stored form must RETURN it, which is what catches a
+    // parser that derives rather than one that loses a type.
+    if (
+      !isDeepStrictEqual(stored, unchanged) ||
+      !isDeepStrictEqual(reparsed, unchanged)
+    ) {
       throw new NextlyError({
         code: "BUSINESS_RULE_VIOLATION",
-        publicMessage: `Email provider "${type}" cannot store this configuration, because parsing what would be saved does not return what was saved. Its \`parseConfig\` must accept its own output unchanged -- derive values in \`createAdapter\` instead.`,
+        publicMessage: `Email provider "${type}" cannot store this configuration, because parsing what would be saved does not return what was saved. Its \`parseConfig\` must accept its own output unchanged -- derive values in \`createAdapter\` instead, and return only what JSON can carry.`,
         logContext: { reason: "email-provider-parse-not-a-fixed-point", type },
       });
     }
@@ -449,117 +413,6 @@ export class EmailProviderService extends BaseService {
     // is stored is what was checked" true by construction rather than by
     // argument, and the two are now the same object.
     return roundTripped as Record<string, unknown>;
-  }
-
-  /**
-   * Where in a parsed configuration serialisation keeps NONE of a value, or
-   * `undefined` when every value survives in some form.
-   *
-   * Asked of the projection rather than of the type, so a shape nobody has
-   * thought of is judged by what it leaves behind rather than by whether it is
-   * on a list. A `Date` becomes a string and keeps its instant; a `Map` or a
-   * `Set` becomes `{}` and keeps nothing, because its entries are not own
-   * enumerable properties and `JSON.stringify` reads nothing else.
-   *
-   * EVERY object is asked, including ordinary ones. An empty projection is
-   * honest only when the value genuinely held nothing JSON could carry, and
-   * the prototype does not decide that: `{ token: "ops", toJSON: () => ({}) }`
-   * is as ordinary as an object gets and still discards its token. What
-   * separates the cases is whether anything was there to lose.
-   *
-   * So a plain `{}` passes because it was empty, and `{ label: undefined }`
-   * passes because `undefined` is how an absent optional field is ordinarily
-   * written. A `Map`, a `Set`, and the self-emptying object above all fail,
-   * for the one reason: they held something and the column would not.
-   *
-   * @param value - a node of the parsed configuration
-   * @param path - the keys walked to reach it, for the message
-   */
-  /**
-   * Whether a value is an ordinary object rather than an instance of anything.
-   *
-   * Used only to decide whether an EMPTY projection is believable: an ordinary
-   * object with no fields really is empty, while a `Map` or a `Set` reports no
-   * own enumerable properties because its contents live somewhere
-   * `JSON.stringify` cannot read.
-   */
-  private isOrdinaryObject(value: object): boolean {
-    const prototype: unknown = Object.getPrototypeOf(value);
-    return prototype === Object.prototype || prototype === null;
-  }
-
-  /**
-   * Where a parsed value and the form the column will hold stop being the
-   * same configuration, or `undefined` when they agree.
-   *
-   * ONE difference is permitted, and it is the whole policy: an object may
-   * become a PRIMITIVE. `JSON.stringify` turns a `Date` into its ISO string,
-   * and the project accepts that coercion rather than refusing the write.
-   *
-   * Everything else must match. An object compared against an object must be
-   * an ORDINARY one, because a `Map` and a `Set` keep their contents where
-   * `JSON.stringify` cannot read and so report the same empty shape a genuinely
-   * empty object does. A class whose `toJSON` returns a populated object is
-   * refused for the same reason: the column would hold the fields and the
-   * adapter would not get the class.
-   *
-   * Keys holding `undefined` or a function are excluded from the comparison,
-   * because `JSON.stringify` does not write them -- which is how an absent
-   * optional field is ordinarily spelled.
-   */
-  private storedFormDiffers(
-    value: unknown,
-    projection: unknown,
-    path: string[] = []
-  ): string | undefined {
-    const here = (): string =>
-      path.length === 0 ? "the configuration" : path.join(".");
-
-    // The permitted coercion.
-    if (
-      value !== null &&
-      typeof value === "object" &&
-      (typeof projection === "string" ||
-        typeof projection === "number" ||
-        typeof projection === "boolean")
-    ) {
-      return undefined;
-    }
-
-    if (Array.isArray(value) || Array.isArray(projection)) {
-      if (!Array.isArray(value) || !Array.isArray(projection)) return here();
-      if (value.length !== projection.length) return here();
-      for (const [index, entry] of value.entries()) {
-        const differs = this.storedFormDiffers(entry, projection[index], [
-          ...path,
-          `[${index}]`,
-        ]);
-        if (differs) return differs;
-      }
-      return undefined;
-    }
-
-    if (value !== null && typeof value === "object") {
-      if (projection === null || typeof projection !== "object") return here();
-      if (!this.isOrdinaryObject(value)) return here();
-
-      const held = projection as Record<string, unknown>;
-      const written = Object.entries(value).filter(
-        ([, entry]) => entry !== undefined && typeof entry !== "function"
-      );
-      if (written.length !== Object.keys(held).length) return here();
-      for (const [key, entry] of written) {
-        if (!Object.hasOwn(held, key)) return here();
-        const differs = this.storedFormDiffers(entry, held[key], [
-          ...path,
-          key,
-        ]);
-        if (differs) return differs;
-      }
-      return undefined;
-    }
-
-    return Object.is(value, projection) ? undefined : here();
   }
 
   /**
@@ -1378,12 +1231,6 @@ export class EmailProviderService extends BaseService {
       // the merged input against a stored parsed value reported a change on
       // every save whose parser normalises anything — a trimmed credential
       // differs from its own stored form on the way in, and never after.
-      // Structurally, matching how `storableConfiguration` decides two
-      // configurations are the same value. `JSON.stringify` orders keys by
-      // insertion, so a parser that rebuilds its output field by field
-      // produces different text for an identical configuration -- and a
-      // no-op save would then file a configuration-change audit event
-      // against a credential nobody touched.
       configurationChanged =
         !existing.readable || !isDeepStrictEqual(existingConfig, parsedMerged);
 

--- a/packages/nextly/src/domains/email/services/email-provider-service.ts
+++ b/packages/nextly/src/domains/email/services/email-provider-service.ts
@@ -351,36 +351,31 @@ export class EmailProviderService extends BaseService {
       });
     }
 
-    // Coercion and DESTRUCTION are not the same thing, and only the first one
-    // was decided. A `Date` serialises to a string that still carries it; a
-    // `Map` of headers serialises to `{}` and carries nothing, so storing it
-    // stores none of what the operator entered and the adapter runs without
-    // their settings. Refused here rather than in the fixed-point check below,
-    // which cannot see it: both sides of that comparison are already past the
-    // column, so an empty projection agrees with an empty projection.
-    //
-    // Asked of the SERIALISATION rather than of the type. Anything that keeps
-    // some of itself -- a string, a number, a populated object -- is a
-    // coercion and is stored. Anything that keeps none of itself is refused,
-    // whatever it was.
     const roundTripped: unknown = JSON.parse(serialized);
     const unchanged: unknown = JSON.parse(serialized);
 
-    // Read against the projection ALREADY COMPUTED above rather than by
-    // serialising each node again. One serialisation happened, its result is
-    // in hand, and asking it is both cheaper and the only way to be sure the
-    // answer describes what will actually be written -- a `toJSON` that
-    // returns something different on its second call would otherwise be
-    // judged on a value nothing stores.
-    const emptied = this.emptiedBySerialisation(stored, roundTripped);
-    if (emptied) {
+    // Coercion and DESTRUCTION are not the same thing, and only the first was
+    // decided. The rule is stated as ONE permitted difference rather than as a
+    // walk looking for damage: the parsed value and the form the column will
+    // hold must be the same configuration, EXCEPT that a value may become
+    // plain text. That is the `Date` case, and it is the only one.
+    //
+    // Written this way because the alternative was tried and does not close.
+    // A check that walks the value looking for shapes JSON loses has to know
+    // every shape: a `Map`, a `Set`, an object whose own `toJSON` empties it,
+    // an array that does the same, an array that empties to `[]`. Each is a
+    // separate branch and the next one is always missing. Naming the single
+    // ACCEPTED difference instead leaves nothing to enumerate — anything that
+    // is not that difference is refused, including shapes nobody has met yet.
+    const differs = this.storedFormDiffers(stored, unchanged);
+    if (differs) {
       throw new NextlyError({
         code: "BUSINESS_RULE_VIOLATION",
-        publicMessage: `Email provider "${type}" parsed its configuration into a value at ${emptied} that keeps nothing when written as JSON, so saving it would discard what was entered. Return a plain object or an array there.`,
+        publicMessage: `Email provider "${type}" parsed its configuration into a value at ${differs} that changes when written as JSON, so what is saved would not be what was parsed. Return plain objects, arrays and primitives from \`parseConfig\` -- a value that becomes text, such as a \`Date\`, is stored as that text.`,
         logContext: {
-          reason: "email-provider-configuration-emptied-by-serialisation",
+          reason: "email-provider-configuration-not-storable",
           type,
-          path: emptied,
+          path: differs,
         },
       });
     }
@@ -493,75 +488,78 @@ export class EmailProviderService extends BaseService {
     return prototype === Object.prototype || prototype === null;
   }
 
-  private emptiedBySerialisation(
+  /**
+   * Where a parsed value and the form the column will hold stop being the
+   * same configuration, or `undefined` when they agree.
+   *
+   * ONE difference is permitted, and it is the whole policy: an object may
+   * become a PRIMITIVE. `JSON.stringify` turns a `Date` into its ISO string,
+   * and the project accepts that coercion rather than refusing the write.
+   *
+   * Everything else must match. An object compared against an object must be
+   * an ORDINARY one, because a `Map` and a `Set` keep their contents where
+   * `JSON.stringify` cannot read and so report the same empty shape a genuinely
+   * empty object does. A class whose `toJSON` returns a populated object is
+   * refused for the same reason: the column would hold the fields and the
+   * adapter would not get the class.
+   *
+   * Keys holding `undefined` or a function are excluded from the comparison,
+   * because `JSON.stringify` does not write them -- which is how an absent
+   * optional field is ordinarily spelled.
+   */
+  private storedFormDiffers(
     value: unknown,
     projection: unknown,
     path: string[] = []
   ): string | undefined {
-    if (value === null || typeof value !== "object") return undefined;
+    const here = (): string =>
+      path.length === 0 ? "the configuration" : path.join(".");
 
-    // What the column would hold at this position. Anything other than an
-    // empty object kept something -- a string, a number, an array, a populated
-    // object -- and is a coercion.
-    const keptNothing =
-      projection !== null &&
-      typeof projection === "object" &&
-      !Array.isArray(projection) &&
-      Object.keys(projection).length === 0;
-
-    if (keptNothing && this.heldSomething(value)) {
-      return path.length === 0 ? "the configuration" : path.join(".");
+    // The permitted coercion.
+    if (
+      value !== null &&
+      typeof value === "object" &&
+      (typeof projection === "string" ||
+        typeof projection === "number" ||
+        typeof projection === "boolean")
+    ) {
+      return undefined;
     }
 
-    // Only positions that SURVIVED are worth descending into. A node whose
-    // projection kept nothing has already been answered, and one that changed
-    // shape -- a `Date` to a string -- has no children to walk.
-    if (Array.isArray(value) && Array.isArray(projection)) {
+    if (Array.isArray(value) || Array.isArray(projection)) {
+      if (!Array.isArray(value) || !Array.isArray(projection)) return here();
+      if (value.length !== projection.length) return here();
       for (const [index, entry] of value.entries()) {
-        const emptied = this.emptiedBySerialisation(entry, projection[index], [
+        const differs = this.storedFormDiffers(entry, projection[index], [
           ...path,
           `[${index}]`,
         ]);
-        if (emptied) return emptied;
+        if (differs) return differs;
       }
       return undefined;
     }
 
-    if (
-      projection !== null &&
-      typeof projection === "object" &&
-      !Array.isArray(projection)
-    ) {
-      const held: Record<string, unknown> = projection as Record<
-        string,
-        unknown
-      >;
-      for (const [key, entry] of Object.entries(value)) {
-        const emptied = this.emptiedBySerialisation(entry, held[key], [
+    if (value !== null && typeof value === "object") {
+      if (projection === null || typeof projection !== "object") return here();
+      if (!this.isOrdinaryObject(value)) return here();
+
+      const held = projection as Record<string, unknown>;
+      const written = Object.entries(value).filter(
+        ([, entry]) => entry !== undefined && typeof entry !== "function"
+      );
+      if (written.length !== Object.keys(held).length) return here();
+      for (const [key, entry] of written) {
+        if (!Object.hasOwn(held, key)) return here();
+        const differs = this.storedFormDiffers(entry, held[key], [
           ...path,
           key,
         ]);
-        if (emptied) return emptied;
+        if (differs) return differs;
       }
+      return undefined;
     }
-    return undefined;
-  }
 
-  /**
-   * Whether a value carried anything the column was supposed to receive.
-   *
-   * An array is judged by its length and an object by its own enumerable
-   * values, because those are what `JSON.stringify` would have written. A
-   * value keeping its state anywhere else -- a `Map`'s entries, a `Set`'s
-   * members -- reports nothing here, so the ordinary-object test is what
-   * catches it: a `{}` that really is empty is ordinary, and a `Map` is not.
-   */
-  private heldSomething(value: object): boolean {
-    if (Array.isArray(value)) return value.length > 0;
-    const hasValues = Object.values(value).some(
-      entry => entry !== undefined && typeof entry !== "function"
-    );
-    return hasValues || !this.isOrdinaryObject(value);
+    return Object.is(value, projection) ? undefined : here();
   }
 
   /**

--- a/packages/nextly/src/domains/email/services/email-provider-service.ts
+++ b/packages/nextly/src/domains/email/services/email-provider-service.ts
@@ -460,14 +460,33 @@ export class EmailProviderService extends BaseService {
    * `Set` becomes `{}` and keeps nothing, because its entries are not own
    * enumerable properties and `JSON.stringify` reads nothing else.
    *
-   * Only NON-ORDINARY objects are asked. A plain `{}` also projects to `{}`
-   * and has lost nothing -- it was empty -- and the same is true of an object
-   * whose only keys held `undefined`, which is how an absent optional field is
-   * ordinarily written.
+   * EVERY object is asked, including ordinary ones. An empty projection is
+   * honest only when the value genuinely held nothing JSON could carry, and
+   * the prototype does not decide that: `{ token: "ops", toJSON: () => ({}) }`
+   * is as ordinary as an object gets and still discards its token. What
+   * separates the cases is whether anything was there to lose.
+   *
+   * So a plain `{}` passes because it was empty, and `{ label: undefined }`
+   * passes because `undefined` is how an absent optional field is ordinarily
+   * written. A `Map`, a `Set`, and the self-emptying object above all fail,
+   * for the one reason: they held something and the column would not.
    *
    * @param value - a node of the parsed configuration
    * @param path - the keys walked to reach it, for the message
    */
+  /**
+   * Whether a value is an ordinary object rather than an instance of anything.
+   *
+   * Used only to decide whether an EMPTY projection is believable: an ordinary
+   * object with no fields really is empty, while a `Map` or a `Set` reports no
+   * own enumerable properties because its contents live somewhere
+   * `JSON.stringify` cannot read.
+   */
+  private isOrdinaryObject(value: object): boolean {
+    const prototype: unknown = Object.getPrototypeOf(value);
+    return prototype === Object.prototype || prototype === null;
+  }
+
   private emptiedBySerialisation(
     value: unknown,
     path: string[] = []
@@ -487,25 +506,30 @@ export class EmailProviderService extends BaseService {
       return undefined;
     }
 
-    const prototype: unknown = Object.getPrototypeOf(value);
-    if (prototype !== Object.prototype && prototype !== null) {
-      // Its own serialisation decides this, which is the point: a class that
-      // defines `toJSON` and returns something useful is a coercion, and one
-      // that defines nothing reachable is a loss. `undefined` here means the
-      // key is dropped from its parent entirely, which the caller's own
-      // guards already cover for the root and which is the ordinary meaning
-      // of an absent optional anywhere else.
-      const projection: string | undefined = JSON.stringify(value);
-      if (projection !== undefined) {
-        const asJson: unknown = JSON.parse(projection);
-        if (
-          asJson !== null &&
-          typeof asJson === "object" &&
-          !Array.isArray(asJson) &&
-          Object.keys(asJson).length === 0
-        ) {
-          return label;
-        }
+    // `undefined` means the key is dropped from its parent entirely, which is
+    // the ordinary meaning of an absent optional; the root case is covered by
+    // the caller's own guard.
+    const projection: string | undefined = JSON.stringify(value);
+    if (projection !== undefined) {
+      const asJson: unknown = JSON.parse(projection);
+      const keptNothing =
+        asJson !== null &&
+        typeof asJson === "object" &&
+        !Array.isArray(asJson) &&
+        Object.keys(asJson).length === 0;
+
+      // Whether there was anything to lose. Read from the OWN ENUMERABLE
+      // properties, because those are the only ones `JSON.stringify` would
+      // have written -- so a value carrying state anywhere else (a `Map`'s
+      // entries, a `Set`'s members) reports nothing here and is a loss by
+      // construction. A function is not JSON either way, and a key holding
+      // `undefined` is the absent-optional spelling rather than a value.
+      const heldSomething = Object.values(value).some(
+        entry => entry !== undefined && typeof entry !== "function"
+      );
+
+      if (keptNothing && (heldSomething || !this.isOrdinaryObject(value))) {
+        return label;
       }
     }
 
@@ -1332,9 +1356,14 @@ export class EmailProviderService extends BaseService {
       // the merged input against a stored parsed value reported a change on
       // every save whose parser normalises anything — a trimmed credential
       // differs from its own stored form on the way in, and never after.
+      // Structurally, matching how `storableConfiguration` decides two
+      // configurations are the same value. `JSON.stringify` orders keys by
+      // insertion, so a parser that rebuilds its output field by field
+      // produces different text for an identical configuration -- and a
+      // no-op save would then file a configuration-change audit event
+      // against a credential nobody touched.
       configurationChanged =
-        !existing.readable ||
-        JSON.stringify(existingConfig) !== JSON.stringify(parsedMerged);
+        !existing.readable || !isDeepStrictEqual(existingConfig, parsedMerged);
 
       updateData.configuration = this.encryptConfiguration(parsedMerged);
     }

--- a/packages/nextly/src/domains/email/services/email-provider-service.ts
+++ b/packages/nextly/src/domains/email/services/email-provider-service.ts
@@ -351,6 +351,31 @@ export class EmailProviderService extends BaseService {
       });
     }
 
+    // Coercion and DESTRUCTION are not the same thing, and only the first one
+    // was decided. A `Date` serialises to a string that still carries it; a
+    // `Map` of headers serialises to `{}` and carries nothing, so storing it
+    // stores none of what the operator entered and the adapter runs without
+    // their settings. Refused here rather than in the fixed-point check below,
+    // which cannot see it: both sides of that comparison are already past the
+    // column, so an empty projection agrees with an empty projection.
+    //
+    // Asked of the SERIALISATION rather than of the type. Anything that keeps
+    // some of itself -- a string, a number, a populated object -- is a
+    // coercion and is stored. Anything that keeps none of itself is refused,
+    // whatever it was.
+    const emptied = this.emptiedBySerialisation(stored);
+    if (emptied) {
+      throw new NextlyError({
+        code: "BUSINESS_RULE_VIOLATION",
+        publicMessage: `Email provider "${type}" parsed its configuration into a value at ${emptied} that keeps nothing when written as JSON, so saving it would discard what was entered. Return a plain object or an array there.`,
+        logContext: {
+          reason: "email-provider-configuration-emptied-by-serialisation",
+          type,
+          path: emptied,
+        },
+      });
+    }
+
     const roundTripped: unknown = JSON.parse(serialized);
     const unchanged: unknown = JSON.parse(serialized);
 
@@ -423,6 +448,72 @@ export class EmailProviderService extends BaseService {
     // is stored is what was checked" true by construction rather than by
     // argument, and the two are now the same object.
     return roundTripped as Record<string, unknown>;
+  }
+
+  /**
+   * Where in a parsed configuration serialisation keeps NONE of a value, or
+   * `undefined` when every value survives in some form.
+   *
+   * Asked of the projection rather than of the type, so a shape nobody has
+   * thought of is judged by what it leaves behind rather than by whether it is
+   * on a list. A `Date` becomes a string and keeps its instant; a `Map` or a
+   * `Set` becomes `{}` and keeps nothing, because its entries are not own
+   * enumerable properties and `JSON.stringify` reads nothing else.
+   *
+   * Only NON-ORDINARY objects are asked. A plain `{}` also projects to `{}`
+   * and has lost nothing -- it was empty -- and the same is true of an object
+   * whose only keys held `undefined`, which is how an absent optional field is
+   * ordinarily written.
+   *
+   * @param value - a node of the parsed configuration
+   * @param path - the keys walked to reach it, for the message
+   */
+  private emptiedBySerialisation(
+    value: unknown,
+    path: string[] = []
+  ): string | undefined {
+    if (value === null || typeof value !== "object") return undefined;
+
+    const label = path.length === 0 ? "the configuration" : path.join(".");
+
+    if (Array.isArray(value)) {
+      for (const [index, entry] of value.entries()) {
+        const emptied = this.emptiedBySerialisation(entry, [
+          ...path,
+          `[${index}]`,
+        ]);
+        if (emptied) return emptied;
+      }
+      return undefined;
+    }
+
+    const prototype: unknown = Object.getPrototypeOf(value);
+    if (prototype !== Object.prototype && prototype !== null) {
+      // Its own serialisation decides this, which is the point: a class that
+      // defines `toJSON` and returns something useful is a coercion, and one
+      // that defines nothing reachable is a loss. `undefined` here means the
+      // key is dropped from its parent entirely, which the caller's own
+      // guards already cover for the root and which is the ordinary meaning
+      // of an absent optional anywhere else.
+      const projection: string | undefined = JSON.stringify(value);
+      if (projection !== undefined) {
+        const asJson: unknown = JSON.parse(projection);
+        if (
+          asJson !== null &&
+          typeof asJson === "object" &&
+          !Array.isArray(asJson) &&
+          Object.keys(asJson).length === 0
+        ) {
+          return label;
+        }
+      }
+    }
+
+    for (const [key, entry] of Object.entries(value)) {
+      const emptied = this.emptiedBySerialisation(entry, [...path, key]);
+      if (emptied) return emptied;
+    }
+    return undefined;
   }
 
   /**


### PR DESCRIPTION
## What this is now

**One production line changes.** `updateProvider` decided `configurationChanged` by comparing serialised text while `storableConfiguration` compares structurally:

```diff
-  JSON.stringify(existingConfig) !== JSON.stringify(parsedMerged);
+  !isDeepStrictEqual(existingConfig, parsedMerged);
```

`JSON.stringify` orders keys by insertion, so a parser that rebuilds its output field by field — an ordinary thing to write — produces different text for an identical configuration. A save that altered nothing filed a configuration-change entry in the activity log against a credential nobody touched. That is a false alarm on the one signal the trail exists for.

**Control:** reverting that line fails exactly the new activity test (1 failed, 30 passed).

## What this PR withdrew, and why it matters more than what it kept

This branch opened by making the stored configuration *be* its serialisation, so a parser returning a `Date` would have it coerced to an ISO string instead of the write being refused. Better DX, and it was the right thing to try.

Getting there meant replacing a whole-value round-trip comparison — **correct by construction** — with a walk looking for shapes JSON loses. That walk drew **eight findings in one session**, every one correct:

| | |
|---|---|
| `Map` | entries live where `JSON.stringify` cannot read |
| `Set` | same, nested inside an array |
| plain object with `toJSON: () => ({})` | ordinary prototype, empties itself |
| array with `toJSON: () => ({})` | `Array.isArray` bypassed the check |
| array with `toJSON: () => []` | the predicate recognised only `{}` as empty |
| array with named properties | indices compared, `region` silently dropped |
| enumerable accessor | read once by `stringify`, again by the walk |
| derived value on the *second* parse | the check ran only on the first |

Each fix was correct and the next case always existed, because a walk has to know every shape — and the check exists precisely for the shapes nobody thought of. Allowing one exception converted a closed-form check into an open-ended one.

So the coercion is withdrawn and the round-trip comparison restored. **The five tests added here document that behaviour rather than guard a branch**: the restored check refuses `Map`, `Set`, self-emptying objects and arrays, and arrays with named properties without naming any of them.

The DX cost is real and paid once, by a plugin author at development time, with a message telling them to return a string. The alternative was silent loss paid at runtime by an operator — an email provider stored with an empty configuration means password resets going nowhere.

## Found on the way, deliberately NOT fixed here

Both the restored comparison and the walk enumerate the parsed value *after* `JSON.stringify` has already read it. An accessor returning different values on successive reads is therefore judged on the second one. **This predates this branch** — `main` has it today — so it needs a read-once snapshot and its own change rather than being bolted on here.

## Scope

`packages/nextly` only. Service diff against `main` is one line; the rest is test coverage.

`pnpm turbo run lint check-types --filter=nextly` — 2 successful. `src/domains/email` — 38 files, 552 tests, all passing.