### PR TITLE
docs(root): read a full object name rather than reconstructing one

### DIFF
--- a/.claude/rules/verifying-merged-work.md
+++ b/.claude/rules/verifying-merged-work.md
@@ -431,6 +431,29 @@ is what makes it safe, because it is the server that refuses. Both take
 a merge precondition naming the wrong revision either refuses a correct merge or,
 worse, permits the one it was added to stop.
 
+**Read the full object name; never reconstruct one from an abbreviation.** The
+flag needs all forty characters, every printed form of a SHA is abbreviated, and
+the two failures are not symmetric. A fabricated value that happens to prefix
+the real head still refuses — which is the flag working. A fabricated value is
+never accidentally CORRECT, so the danger is not this command; it is every other
+place a hand-assembled SHA is used where nothing checks it.
+
+Measured while merging the pull request that added `scripts/verify-merge.mjs`: a
+ten-character prefix was padded out to full length and passed here, and GitHub
+answered `Head branch was modified`. That message names a race, and no race had
+occurred — the head was untouched and the SHA was invented. Reading the error at
+face value would have sent the next step chasing a phantom push.
+
+So take it from `git ls-remote origin "refs/heads/$BR"` in the same command that
+uses it, and read `Head branch was modified` as EITHER a moved head or a wrong
+value. The two are indistinguishable from the message, and one of them is a
+typing error rather than an event.
+
+This is the case that argues for the flag most directly, and it is not the race
+this section otherwise describes. A race is narrow and needs bad timing. A
+mistyped revision needs only a person, and care does not prevent it, because the
+wrong value looks exactly like the right one.
+
 Re-reading `ls-remote` immediately before merging is better than not, and it is
 still two operations: a push arriving between the read and the merge is exactly
 the window being closed, and narrowing a race is not closing one. `--match-head-commit`

--- a/.claude/rules/verifying-merged-work.md
+++ b/.claude/rules/verifying-merged-work.md
@@ -431,9 +431,13 @@ is what makes it safe, because it is the server that refuses. Both take
 a merge precondition naming the wrong revision either refuses a correct merge or,
 worse, permits the one it was added to stop.
 
-**Read the full object name; never reconstruct one from an abbreviation.** The
-flag needs all forty characters, every printed form of a SHA is abbreviated, and
-the two failures are not symmetric. A fabricated value that happens to prefix
+**Copy a full object name; never extend an abbreviated one.** The flag needs all
+forty characters, and both forms are in circulation: `git rev-parse HEAD`,
+`git log --format=%H` and the `ls-remote | cut -f1` above print the object name
+in full, while `--oneline`, `%h` and most of what `gh` displays print a prefix.
+So the rule is not "distrust printed SHAs" — it is to know which of the two you
+are looking at, and to take the full form when one is available rather than
+lengthening a short one. The two failures are not symmetric. A fabricated value that happens to prefix
 the real head still refuses — which is the flag working. A fabricated value is
 never accidentally CORRECT, so the danger is not this command; it is every other
 place a hand-assembled SHA is used where nothing checks it.

--- a/.claude/rules/verifying-merged-work.md
+++ b/.claude/rules/verifying-merged-work.md
@@ -444,10 +444,22 @@ answered `Head branch was modified`. That message names a race, and no race had
 occurred — the head was untouched and the SHA was invented. Reading the error at
 face value would have sent the next step chasing a phantom push.
 
-So take it from `git ls-remote origin "refs/heads/$BR"` in the same command that
-uses it, and read `Head branch was modified` as EITHER a moved head or a wrong
-value. The two are indistinguishable from the message, and one of them is a
-typing error rather than an event.
+So capture it in full when you VERIFY, from the ref rather than from any
+printed abbreviation, and carry that value into `$VERIFIED`. Not at merge time:
+re-reading the tip here binds the flag to whatever is newest, which after a push
+is the unverified revision this precondition exists to reject — the rubber stamp
+this section warns about three paragraphs above. The point is to avoid
+retyping a SHA, never to refresh one.
+
+Derive the remote the same way the tail check above does, from
+`isCrossRepository`: `origin` is the BASE repository, so for a fork it does not
+own `refs/heads/$BR` and returns nothing — or, where the base has a branch of the
+same name, an unrelated revision. That derivation already exists in this file;
+reuse it rather than writing a second one.
+
+Then read `Head branch was modified` as EITHER a moved head or a wrong value.
+The two are indistinguishable from the message, and one of them is a typing
+error rather than an event.
 
 This is the case that argues for the flag most directly, and it is not the race
 this section otherwise describes. A race is narrow and needs bad timing. A


### PR DESCRIPTION
## What happened

While merging #798 I passed `--match-head-commit` a SHA I had **fabricated** — a ten-character prefix padded out to full length rather than read from the ref. GitHub answered:

```
GraphQL: Head branch was modified. Review and try the merge again.
```

That message names a race. **No race had occurred.** The head was untouched; the value was invented. Taken at face value it would have sent the next step looking for a push that never happened.

## Why this is worth a paragraph in the rule

The file currently argues for `--match-head-commit` on the grounds that it closes a push race between the verification read and the merge. True, and it is the weaker of the two arguments:

- a **race** needs bad timing to occur;
- a **mistyped revision** needs only a person, and care does not prevent it, because the wrong value looks exactly like the right one.

The flag caught the second, which is the one that will happen again.

## What the rule now says

- Read the full object name from `git ls-remote origin "refs/heads/$BR"` in the same command that uses it. Every printed form of a SHA is abbreviated, so any hand-assembled one is a guess.
- Read `Head branch was modified` as **either** a moved head **or** a wrong value — the two are indistinguishable from the message, and one of them is a typing error rather than an event.
- Notes the asymmetry that makes this specific command safe: a fabricated value is never accidentally correct, so the danger is not here — it is every other place a hand-assembled SHA is used where nothing checks it.

## Scope

Documentation only. One file, one section, no code. No changeset (docs-only).

Suggested by the api-freeze lane, who pointed out the file argues the race and not this.