### PR TITLE
docs(nextly): record the accepted authorize-then-write window at its site

### DIFF
--- a/packages/nextly/src/domains/collections/__tests__/collection-mutation.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/collection-mutation.test.ts
@@ -98,9 +98,16 @@ vi.mock("@nextly/hooks/context-builder", () => ({
   buildContext: vi.fn((opts: Record<string, unknown>) => opts),
 }));
 
+// Hoisted so every instance shares one spy. A per-instance `vi.fn()` is unreachable from a test,
+// which would leave this seam unobservable — and an unobservable seam is exactly where hook
+// dispatch could move ahead of the access check without any assertion noticing.
+const storedHookExecute = vi.hoisted(() =>
+  vi.fn().mockResolvedValue({ data: undefined, errors: [] })
+);
+
 vi.mock("@nextly/hooks/stored-hook-executor", () => {
   class MockStoredHookExecutor {
-    execute = vi.fn().mockResolvedValue({ data: undefined, errors: [] });
+    execute = storedHookExecute;
   }
   return { StoredHookExecutor: MockStoredHookExecutor };
 });
@@ -486,13 +493,19 @@ describe("CollectionEntryService — Mutation Contracts", () => {
         { title: "Updated" }
       );
 
+      // EVERY dispatch seam, not the one that happened to be handy. Asserting only
+      // `executeBeforeOperation` leaves `execute` — which carries `beforeUpdate` — and the stored
+      // hook executor free to move above the gate with this test still green.
       expect(mockHookRegistry.executeBeforeOperation).not.toHaveBeenCalled();
+      expect(mockHookRegistry.execute).not.toHaveBeenCalled();
+      expect(storedHookExecute).not.toHaveBeenCalled();
     });
 
-    it("runs that same hook for a caller it allows", async () => {
-      // The positive control the assertion above needs. Without it a registry that never
-      // dispatches anything — a renamed seam, a mock that stopped being wired — satisfies
-      // `not.toHaveBeenCalled()`, and the ordering rule reads as enforced while nothing checks it.
+    it("runs those same hooks for a caller it allows", async () => {
+      // The positive control the assertions above need, and it has to cover the same seams: one
+      // that never dispatches — a renamed method, a mock that stopped being wired — satisfies
+      // `not.toHaveBeenCalled()`, and the ordering rule then reads as enforced while nothing
+      // checks it.
       selectData.rows = [createSampleEntry()];
 
       await service.updateEntry(
@@ -501,6 +514,7 @@ describe("CollectionEntryService — Mutation Contracts", () => {
       );
 
       expect(mockHookRegistry.executeBeforeOperation).toHaveBeenCalled();
+      expect(mockHookRegistry.execute).toHaveBeenCalled();
     });
 
     it("should execute beforeOperation hooks", async () => {

--- a/packages/nextly/src/domains/collections/__tests__/collection-mutation.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/collection-mutation.test.ts
@@ -11,7 +11,12 @@
  * - deleteEntry: 404, hooks, access control, success response.
  */
 
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+import {
+  clearFieldFunctions,
+  registerFieldFunctions,
+} from "../../../shared/lib/field-level-registry";
 
 import { NextlyError } from "../../../errors/nextly-error";
 import { CollectionEntryService } from "../../../services/collections/collection-entry-service";
@@ -138,6 +143,12 @@ vi.mock("../../../lib/field-transform", () => ({
 // the documented contract, which keeps this observable without changing any outcome.
 const titleValidate = vi.fn().mockReturnValue(true);
 
+// A field-level `access.update` callback is configuration-supplied code that also resolves the
+// caller's grants, so running it for a caller about to be refused both executes application code
+// and performs a lookup on their behalf. It reaches the service through the function registry
+// rather than through the collection, so it is a separate door from the validator above.
+const titleFieldAccess = vi.fn().mockResolvedValue(true);
+
 // `updateEntry` reads `schemaDefinition.fields` in preference to `fields`, so both lists carry
 // the validator: attaching it to only one leaves the assertion watching a list nothing reads.
 function withTitleValidator<T extends { name: string }>(
@@ -178,6 +189,12 @@ describe("CollectionEntryService — Mutation Contracts", () => {
   let mockComponentDataService: ReturnType<
     typeof createMockComponentDataService
   >;
+
+  afterEach(() => {
+    // The function registry is module-global, so a registration left behind would apply to every
+    // later test in the file.
+    clearFieldFunctions();
+  });
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -530,6 +547,9 @@ describe("CollectionEntryService — Mutation Contracts", () => {
       mockCollectionService.getCollection.mockResolvedValue(
         collectionWithTitleValidator()
       );
+      registerFieldFunctions("collection", "posts", [
+        { name: "title", type: "text", access: { update: titleFieldAccess } },
+      ]);
       mockAccessControlService.evaluateAccess.mockResolvedValueOnce({
         allowed: false,
         reason: "Not authorized to update",
@@ -548,6 +568,7 @@ describe("CollectionEntryService — Mutation Contracts", () => {
       expect(runFieldHooksSpy).not.toHaveBeenCalled();
       expect(storedHookExecute).not.toHaveBeenCalled();
       expect(titleValidate).not.toHaveBeenCalled();
+      expect(titleFieldAccess).not.toHaveBeenCalled();
     });
 
     it("runs those same hooks for a caller it allows", async () => {
@@ -559,6 +580,9 @@ describe("CollectionEntryService — Mutation Contracts", () => {
       mockCollectionService.getCollection.mockResolvedValue(
         collectionWithTitleValidator()
       );
+      registerFieldFunctions("collection", "posts", [
+        { name: "title", type: "text", access: { update: titleFieldAccess } },
+      ]);
 
       await service.updateEntry(
         { collectionName: "posts", entryId: "entry-1", user: { id: "user-1" } },
@@ -570,6 +594,7 @@ describe("CollectionEntryService — Mutation Contracts", () => {
       expect(runFieldHooksSpy).toHaveBeenCalled();
       expect(storedHookExecute).toHaveBeenCalled();
       expect(titleValidate).toHaveBeenCalled();
+      expect(titleFieldAccess).toHaveBeenCalled();
     });
 
     it("should execute beforeOperation hooks", async () => {

--- a/packages/nextly/src/domains/collections/__tests__/collection-mutation.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/collection-mutation.test.ts
@@ -105,6 +105,16 @@ const storedHookExecute = vi.hoisted(() =>
   vi.fn().mockResolvedValue({ data: undefined, errors: [] })
 );
 
+// Field hooks are an independently movable dispatcher: `updateEntry` calls `runFieldHooks`
+// directly, so it is a fourth door the ordering assertions have to watch. Spied rather than
+// stubbed wholesale, so the rest of the registry keeps its real behaviour.
+const runFieldHooksSpy = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+
+vi.mock("../../../shared/lib/field-level-registry", async importActual => {
+  const actual = await importActual<Record<string, unknown>>();
+  return { ...actual, runFieldHooks: runFieldHooksSpy };
+});
+
 vi.mock("@nextly/hooks/stored-hook-executor", () => {
   class MockStoredHookExecutor {
     execute = storedHookExecute;
@@ -499,6 +509,7 @@ describe("CollectionEntryService — Mutation Contracts", () => {
       expect(mockHookRegistry.executeBeforeOperation).not.toHaveBeenCalled();
       expect(mockHookRegistry.execute).not.toHaveBeenCalled();
       expect(storedHookExecute).not.toHaveBeenCalled();
+      expect(runFieldHooksSpy).not.toHaveBeenCalled();
     });
 
     it("runs those same hooks for a caller it allows", async () => {
@@ -515,6 +526,7 @@ describe("CollectionEntryService — Mutation Contracts", () => {
 
       expect(mockHookRegistry.executeBeforeOperation).toHaveBeenCalled();
       expect(mockHookRegistry.execute).toHaveBeenCalled();
+      expect(runFieldHooksSpy).toHaveBeenCalled();
     });
 
     it("should execute beforeOperation hooks", async () => {

--- a/packages/nextly/src/domains/collections/__tests__/collection-mutation.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/collection-mutation.test.ts
@@ -22,6 +22,7 @@ import {
   createMockAdapter,
   silentLogger,
   createMockFileManager,
+  createMockCollection,
   createMockCollectionService,
   createMockRelationshipService,
   createMockHookRegistry,
@@ -131,6 +132,33 @@ vi.mock("../../../hooks/stored-hook-executor", () => {
 vi.mock("../../../lib/field-transform", () => ({
   transformRichTextFields: vi.fn((entry: unknown) => entry),
 }));
+
+// A schema-supplied `validate` callback is application code that runs on the caller's data, so
+// it belongs behind the access gate for the same reason hooks do. Returning a non-string passes
+// the documented contract, which keeps this observable without changing any outcome.
+const titleValidate = vi.fn().mockReturnValue(true);
+
+// `updateEntry` reads `schemaDefinition.fields` in preference to `fields`, so both lists carry
+// the validator: attaching it to only one leaves the assertion watching a list nothing reads.
+function withTitleValidator<T extends { name: string }>(
+  fields: T[]
+): (T & { validate?: typeof titleValidate })[] {
+  return fields.map(field =>
+    field.name === "title" ? { ...field, validate: titleValidate } : field
+  );
+}
+
+function collectionWithTitleValidator() {
+  const base = createMockCollection();
+  return {
+    ...base,
+    schemaDefinition: {
+      ...base.schemaDefinition,
+      fields: withTitleValidator(base.schemaDefinition.fields),
+    },
+    fields: withTitleValidator(base.fields),
+  };
+}
 
 // ── Test suite ────────────────────────────────────────────────────────────
 
@@ -499,6 +527,9 @@ describe("CollectionEntryService — Mutation Contracts", () => {
       // The 403 assertion above cannot see this — a hook fired before the check leaves the status
       // unchanged — and moving hook dispatch above the access check still compiles.
       selectData.rows = [createSampleEntry()];
+      mockCollectionService.getCollection.mockResolvedValue(
+        collectionWithTitleValidator()
+      );
       mockAccessControlService.evaluateAccess.mockResolvedValueOnce({
         allowed: false,
         reason: "Not authorized to update",
@@ -516,6 +547,7 @@ describe("CollectionEntryService — Mutation Contracts", () => {
       expect(mockHookRegistry.execute).not.toHaveBeenCalled();
       expect(runFieldHooksSpy).not.toHaveBeenCalled();
       expect(storedHookExecute).not.toHaveBeenCalled();
+      expect(titleValidate).not.toHaveBeenCalled();
     });
 
     it("runs those same hooks for a caller it allows", async () => {
@@ -524,6 +556,9 @@ describe("CollectionEntryService — Mutation Contracts", () => {
       // `not.toHaveBeenCalled()`, and the ordering rule then reads as enforced while nothing
       // checks it.
       selectData.rows = [createSampleEntry()];
+      mockCollectionService.getCollection.mockResolvedValue(
+        collectionWithTitleValidator()
+      );
 
       await service.updateEntry(
         { collectionName: "posts", entryId: "entry-1", user: { id: "user-1" } },
@@ -534,6 +569,7 @@ describe("CollectionEntryService — Mutation Contracts", () => {
       expect(mockHookRegistry.execute).toHaveBeenCalled();
       expect(runFieldHooksSpy).toHaveBeenCalled();
       expect(storedHookExecute).toHaveBeenCalled();
+      expect(titleValidate).toHaveBeenCalled();
     });
 
     it("should execute beforeOperation hooks", async () => {

--- a/packages/nextly/src/domains/collections/__tests__/collection-mutation.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/collection-mutation.test.ts
@@ -116,6 +116,26 @@ const storedHookExecute = vi.hoisted(() =>
 // stubbed wholesale, so the rest of the registry keeps its real behaviour.
 const runFieldHooksSpy = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
 
+// Relationship normalisation mutates the caller's data before the write. It is a seventh door:
+// `shapeWriteParts` calls it directly, so it can move above the gate independently of every hook
+// and validator. Spied rather than stubbed, so the rest of the module keeps its real behaviour.
+const normalizeRelationshipFieldsSpy = vi.hoisted(() => vi.fn());
+
+vi.mock("../../../shared/lib/field-transform", async importActual => {
+  const actual = await importActual<Record<string, unknown>>();
+  return {
+    ...actual,
+    normalizeRelationshipFields: vi.fn(
+      (...args: Parameters<typeof normalizeRelationshipFieldsSpy>) => {
+        normalizeRelationshipFieldsSpy(...args);
+        return (
+          actual.normalizeRelationshipFields as (...inner: unknown[]) => unknown
+        )(...args);
+      }
+    ),
+  };
+});
+
 vi.mock("../../../shared/lib/field-level-registry", async importActual => {
   const actual = await importActual<Record<string, unknown>>();
   return { ...actual, runFieldHooks: runFieldHooksSpy };
@@ -557,7 +577,9 @@ describe("CollectionEntryService — Mutation Contracts", () => {
 
       await service.updateEntry(
         { collectionName: "posts", entryId: "entry-1", user: { id: "user-1" } },
-        { title: "Updated" }
+        // A relationship value shaped as the admin sends it: an object carrying display
+        // properties, which normalisation reduces to its id.
+        { title: "Updated", author: { id: "user-9", name: "Ada" } }
       );
 
       // EVERY dispatch seam, not the one that happened to be handy. Asserting only
@@ -569,6 +591,7 @@ describe("CollectionEntryService — Mutation Contracts", () => {
       expect(storedHookExecute).not.toHaveBeenCalled();
       expect(titleValidate).not.toHaveBeenCalled();
       expect(titleFieldAccess).not.toHaveBeenCalled();
+      expect(normalizeRelationshipFieldsSpy).not.toHaveBeenCalled();
     });
 
     it("runs those same hooks for a caller it allows", async () => {
@@ -586,7 +609,9 @@ describe("CollectionEntryService — Mutation Contracts", () => {
 
       await service.updateEntry(
         { collectionName: "posts", entryId: "entry-1", user: { id: "user-1" } },
-        { title: "Updated" }
+        // A relationship value shaped as the admin sends it: an object carrying display
+        // properties, which normalisation reduces to its id.
+        { title: "Updated", author: { id: "user-9", name: "Ada" } }
       );
 
       expect(mockHookRegistry.executeBeforeOperation).toHaveBeenCalled();
@@ -595,6 +620,7 @@ describe("CollectionEntryService — Mutation Contracts", () => {
       expect(storedHookExecute).toHaveBeenCalled();
       expect(titleValidate).toHaveBeenCalled();
       expect(titleFieldAccess).toHaveBeenCalled();
+      expect(normalizeRelationshipFieldsSpy).toHaveBeenCalled();
     });
 
     it("should execute beforeOperation hooks", async () => {

--- a/packages/nextly/src/domains/collections/__tests__/collection-mutation.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/collection-mutation.test.ts
@@ -509,10 +509,12 @@ describe("CollectionEntryService — Mutation Contracts", () => {
       expect(mockHookRegistry.executeBeforeOperation).not.toHaveBeenCalled();
       expect(mockHookRegistry.execute).not.toHaveBeenCalled();
       expect(runFieldHooksSpy).not.toHaveBeenCalled();
-      // The stored-hook executor is NOT asserted here. This fixture registers no stored hook, so
-      // it never reaches that seam on the allowed path either - an assertion would be satisfied by
-      // absence and would read as coverage it does not have. Covering it needs a collection
-      // configured with a stored hook, which this fixture does not build.
+      // The stored-hook executor is NOT asserted here, and the reason is a WIRING gap rather than
+      // an unreachable seam: updateEntry calls it unconditionally, but through
+      // `this.hookService.storedHookExecutor` - an injected instance - while the mock above
+      // replaces the exported CLASS. The spy therefore observes nothing the service actually
+      // calls, so an assertion either way would report on the mock rather than on the ordering.
+      // Covering it means giving the fixture a hookService whose storedHookExecutor IS the spy.
     });
 
     it("runs those same hooks for a caller it allows", async () => {

--- a/packages/nextly/src/domains/collections/__tests__/collection-mutation.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/collection-mutation.test.ts
@@ -94,7 +94,7 @@ vi.mock("../../../services/collections/geo-utils", () => ({
   sortByDistance: vi.fn(),
 }));
 
-vi.mock("@nextly/hooks/context-builder", () => ({
+vi.mock("../../../hooks/context-builder", () => ({
   buildContext: vi.fn((opts: Record<string, unknown>) => opts),
 }));
 
@@ -115,14 +115,20 @@ vi.mock("../../../shared/lib/field-level-registry", async importActual => {
   return { ...actual, runFieldHooks: runFieldHooksSpy };
 });
 
-vi.mock("@nextly/hooks/stored-hook-executor", () => {
+// Mocked by relative path, not by the `@nextly/hooks/stored-hook-executor` alias the source
+// imports: `vi.mock` does not resolve the tsconfig-path aliases that `vite-tsconfig-paths`
+// applies to real imports, so the alias form registers a mock against a specifier nothing
+// resolves to and the real class is constructed instead. That failure is silent — the factory
+// simply never runs — so the spy stays untouched and every `not.toHaveBeenCalled()` assertion
+// against it passes without observing anything.
+vi.mock("../../../hooks/stored-hook-executor", () => {
   class MockStoredHookExecutor {
     execute = storedHookExecute;
   }
   return { StoredHookExecutor: MockStoredHookExecutor };
 });
 
-vi.mock("@nextly/lib/field-transform", () => ({
+vi.mock("../../../lib/field-transform", () => ({
   transformRichTextFields: vi.fn((entry: unknown) => entry),
 }));
 
@@ -509,12 +515,7 @@ describe("CollectionEntryService — Mutation Contracts", () => {
       expect(mockHookRegistry.executeBeforeOperation).not.toHaveBeenCalled();
       expect(mockHookRegistry.execute).not.toHaveBeenCalled();
       expect(runFieldHooksSpy).not.toHaveBeenCalled();
-      // The stored-hook executor is NOT asserted here, and the reason is a WIRING gap rather than
-      // an unreachable seam: updateEntry calls it unconditionally, but through
-      // `this.hookService.storedHookExecutor` - an injected instance - while the mock above
-      // replaces the exported CLASS. The spy therefore observes nothing the service actually
-      // calls, so an assertion either way would report on the mock rather than on the ordering.
-      // Covering it means giving the fixture a hookService whose storedHookExecutor IS the spy.
+      expect(storedHookExecute).not.toHaveBeenCalled();
     });
 
     it("runs those same hooks for a caller it allows", async () => {
@@ -532,6 +533,7 @@ describe("CollectionEntryService — Mutation Contracts", () => {
       expect(mockHookRegistry.executeBeforeOperation).toHaveBeenCalled();
       expect(mockHookRegistry.execute).toHaveBeenCalled();
       expect(runFieldHooksSpy).toHaveBeenCalled();
+      expect(storedHookExecute).toHaveBeenCalled();
     });
 
     it("should execute beforeOperation hooks", async () => {

--- a/packages/nextly/src/domains/collections/__tests__/collection-mutation.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/collection-mutation.test.ts
@@ -468,6 +468,41 @@ describe("CollectionEntryService — Mutation Contracts", () => {
       expect(result.statusCode).toBe(403);
     });
 
+    it("runs no hook for a caller it refuses", async () => {
+      // Authorization is a precondition, so nothing may run on behalf of a caller about to be
+      // refused. Hooks are the sharp case: they reach outside this process, so one dispatched
+      // before the gate is an effect a refused request still caused.
+      //
+      // The 403 assertion above cannot see this — a hook fired before the check leaves the status
+      // unchanged — and moving hook dispatch above the access check still compiles.
+      selectData.rows = [createSampleEntry()];
+      mockAccessControlService.evaluateAccess.mockResolvedValueOnce({
+        allowed: false,
+        reason: "Not authorized to update",
+      });
+
+      await service.updateEntry(
+        { collectionName: "posts", entryId: "entry-1", user: { id: "user-1" } },
+        { title: "Updated" }
+      );
+
+      expect(mockHookRegistry.executeBeforeOperation).not.toHaveBeenCalled();
+    });
+
+    it("runs that same hook for a caller it allows", async () => {
+      // The positive control the assertion above needs. Without it a registry that never
+      // dispatches anything — a renamed seam, a mock that stopped being wired — satisfies
+      // `not.toHaveBeenCalled()`, and the ordering rule reads as enforced while nothing checks it.
+      selectData.rows = [createSampleEntry()];
+
+      await service.updateEntry(
+        { collectionName: "posts", entryId: "entry-1", user: { id: "user-1" } },
+        { title: "Updated" }
+      );
+
+      expect(mockHookRegistry.executeBeforeOperation).toHaveBeenCalled();
+    });
+
     it("should execute beforeOperation hooks", async () => {
       selectData.rows = [createSampleEntry()];
 

--- a/packages/nextly/src/domains/collections/__tests__/collection-mutation.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/collection-mutation.test.ts
@@ -508,8 +508,11 @@ describe("CollectionEntryService — Mutation Contracts", () => {
       // hook executor free to move above the gate with this test still green.
       expect(mockHookRegistry.executeBeforeOperation).not.toHaveBeenCalled();
       expect(mockHookRegistry.execute).not.toHaveBeenCalled();
-      expect(storedHookExecute).not.toHaveBeenCalled();
       expect(runFieldHooksSpy).not.toHaveBeenCalled();
+      // The stored-hook executor is NOT asserted here. This fixture registers no stored hook, so
+      // it never reaches that seam on the allowed path either - an assertion would be satisfied by
+      // absence and would read as coverage it does not have. Covering it needs a collection
+      // configured with a stored hook, which this fixture does not build.
     });
 
     it("runs those same hooks for a caller it allows", async () => {

--- a/packages/nextly/src/domains/collections/__tests__/collection-mutation.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/collection-mutation.test.ts
@@ -179,15 +179,29 @@ function withTitleValidator<T extends { name: string }>(
   );
 }
 
+// The shared fixture declares `author` as `type: "relation"`, but `normalizeRelationshipFields`
+// dispatches on `type === "relationship"`. A value under the shared spelling therefore reaches the
+// normaliser and is skipped, so an ordering assertion on the spy passes while the mechanism it
+// names never runs. Corrected here rather than in the shared helper, which other suites rely on.
+function asRelationshipFields<T extends { name: string; type?: string }>(
+  fields: T[]
+): T[] {
+  return fields.map(field =>
+    field.type === "relation" ? { ...field, type: "relationship" } : field
+  );
+}
+
 function collectionWithTitleValidator() {
   const base = createMockCollection();
+  const shape = <T extends { name: string; type?: string }>(fields: T[]) =>
+    asRelationshipFields(withTitleValidator(fields));
   return {
     ...base,
     schemaDefinition: {
       ...base.schemaDefinition,
-      fields: withTitleValidator(base.schemaDefinition.fields),
+      fields: shape(base.schemaDefinition.fields),
     },
-    fields: withTitleValidator(base.fields),
+    fields: shape(base.fields),
   };
 }
 
@@ -621,6 +635,12 @@ describe("CollectionEntryService — Mutation Contracts", () => {
       expect(titleValidate).toHaveBeenCalled();
       expect(titleFieldAccess).toHaveBeenCalled();
       expect(normalizeRelationshipFieldsSpy).toHaveBeenCalled();
+      // The mechanism, not just the entry point: normalisation reduces the admin's object to its
+      // id, and the data object is mutated in place, so this reads what the call actually did.
+      const normalised = normalizeRelationshipFieldsSpy.mock.calls[0]?.[0] as
+        | Record<string, unknown>
+        | undefined;
+      expect(normalised?.author).toBe("user-9");
     });
 
     it("should execute beforeOperation hooks", async () => {

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -4532,15 +4532,23 @@ export class CollectionMutationService extends BaseService {
       // verdict that has stopped being true. Exploiting it requires an actor who
       // held legitimate access moments earlier.
       //
-      // Narrowing it is cheaper than it looks, and closing it is not.
-      // `checkCollectionAccess` accepts a transaction-bound `executor` so its
-      // RBAC and metadata reads run on the transaction's connection, and
-      // `updateEntryInTransaction` already calls it that way — so routing this
-      // path through that shape is ordinary work. It would close the stale
-      // DOCUMENT case only: that path locks the content row, while the role,
-      // permission and collection-metadata rows the verdict also depends on are
-      // read without locks and the transaction is not serializable. A grant
-      // revoked concurrently still races.
+      // Two facts about closing it, and no proposed remedy, because the last
+      // three attempts at one here were each wrong in a different direction.
+      //
+      // The evaluator can already read inside a transaction:
+      // `checkCollectionAccess` takes a transaction-bound `executor` so its RBAC
+      // and metadata reads run on that connection. So the missing piece is not
+      // the evaluator.
+      //
+      // And a transaction alone would not close the window anyway. Locking the
+      // content row leaves the role, permission and collection-metadata rows the
+      // verdict also depends on unlocked, and the transaction is not
+      // serializable, so a grant revoked concurrently still races.
+      //
+      // `updateEntryInTransaction` is NOT the path to delegate to: it accepts
+      // none of `locale`, `context`, `sourceVersionNo` or `authenticatedScope`,
+      // and it performs neither the localized companion writes nor the
+      // working-draft promotion this method owns.
       //
       // One rule for anyone editing this method: do NOT move validation,
       // relationship resolution or hook dispatch ahead of this check to shorten

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -4532,8 +4532,9 @@ export class CollectionMutationService extends BaseService {
       // verdict that has stopped being true. Exploiting it requires an actor who
       // held legitimate access moments earlier.
       //
-      // Two facts about closing it, and no proposed remedy, because the last
-      // three attempts at one here were each wrong in a different direction.
+      // Two facts about closing it, and no remedy: a remedy stated here would
+      // have to name a path, and every path this method could take differs from
+      // it in ways the next two paragraphs make concrete.
       //
       // The evaluator can already read inside a transaction:
       // `checkCollectionAccess` takes a transaction-bound `executor` so its RBAC

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -4564,7 +4564,15 @@ export class CollectionMutationService extends BaseService {
       // `assertLocalizedFieldGroupsWritable` warms its verdicts beforehand
       // because resolving inside would issue a query that aborts the whole
       // transaction on PostgreSQL. Work that uses a pooled helper stays where
-      // it is; only work that already takes an executor can move.
+      // it is. Accepting an executor is necessary for work to move but not
+      // sufficient: the transaction runs inside `withVersionConflictRetry`,
+      // which re-runs its closure up to three attempts, so only work whose
+      // repetition is harmless belongs there. Database writes qualify, because
+      // a rolled-back attempt leaves nothing behind. Hook dispatch does not,
+      // whatever its signature accepts: `CollectionHookService.runBeforeChange`
+      // takes an executor and still runs handlers that reach outside this
+      // process, so a retried attempt re-fires effects no rollback can
+      // withdraw. External dispatch stays outside the retrying closure.
       //
       // A rule that must be judged against the row as locked belongs in the
       // under-lock re-check the publish path already uses, not here.

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -4523,6 +4523,25 @@ export class CollectionMutationService extends BaseService {
       }
 
       // 1. Check collection-level access FIRST (with document for owner checks)
+      //
+      // This verdict is NOT atomic with the write it guards, and that is a known
+      // property rather than an oversight. The transaction opens several hundred
+      // lines below, after schema loads, hook dispatch and relationship
+      // resolution, so a change to this document's ownership or to the
+      // collection's access rules in between leaves the write proceeding on a
+      // verdict that has stopped being true. Exploiting it requires an actor who
+      // held legitimate access moments earlier.
+      //
+      // Closing it properly means authorizing inside the transaction with the
+      // row locked, which every access evaluator would have to accept an
+      // executor to do: they currently read through the pooled adapter, and
+      // mixing pooled reads with an open transaction is what stalls the pool.
+      //
+      // Two things follow for anyone editing this method. Work added between
+      // here and the transaction widens the window, so prefer to add it before
+      // this check or inside the transaction. And a rule that must be judged
+      // against the row as locked belongs in the under-lock re-check the publish
+      // path already uses, not here.
       const accessDenied = await this.accessService.checkCollectionAccess(
         params.collectionName,
         "update",

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -4532,16 +4532,23 @@ export class CollectionMutationService extends BaseService {
       // verdict that has stopped being true. Exploiting it requires an actor who
       // held legitimate access moments earlier.
       //
-      // Closing it properly means authorizing inside the transaction with the
-      // row locked, which every access evaluator would have to accept an
-      // executor to do: they currently read through the pooled adapter, and
-      // mixing pooled reads with an open transaction is what stalls the pool.
+      // Closing it means authorizing against the row as locked, and the parts
+      // that would take are already here rather than absent:
+      // `checkCollectionAccess` accepts a transaction-bound `executor` so its
+      // RBAC and metadata reads run on the transaction's own connection instead
+      // of taking a second pooled one, and `updateEntryInTransaction` already
+      // calls it that way. What remains is routing this path through the same
+      // shape, which is work rather than a blocker.
       //
-      // Two things follow for anyone editing this method. Work added between
-      // here and the transaction widens the window, so prefer to add it before
-      // this check or inside the transaction. And a rule that must be judged
-      // against the row as locked belongs in the under-lock re-check the publish
-      // path already uses, not here.
+      // Two things follow for anyone editing this method, and the first is a
+      // rule rather than a preference: do NOT move validation, relationship
+      // resolution or hook dispatch ahead of this check to shorten the gap.
+      // Authorization is a precondition, so work placed before it runs for
+      // callers who are about to be refused, and hooks in particular have
+      // effects outside this process. Add such work INSIDE the transaction.
+      //
+      // Second, a rule that must be judged against the row as locked belongs in
+      // the under-lock re-check the publish path already uses, not here.
       const accessDenied = await this.accessService.checkCollectionAccess(
         params.collectionName,
         "update",

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -4532,23 +4532,33 @@ export class CollectionMutationService extends BaseService {
       // verdict that has stopped being true. Exploiting it requires an actor who
       // held legitimate access moments earlier.
       //
-      // Closing it means authorizing against the row as locked, and the parts
-      // that would take are already here rather than absent:
+      // Narrowing it is cheaper than it looks, and closing it is not.
       // `checkCollectionAccess` accepts a transaction-bound `executor` so its
-      // RBAC and metadata reads run on the transaction's own connection instead
-      // of taking a second pooled one, and `updateEntryInTransaction` already
-      // calls it that way. What remains is routing this path through the same
-      // shape, which is work rather than a blocker.
+      // RBAC and metadata reads run on the transaction's connection, and
+      // `updateEntryInTransaction` already calls it that way — so routing this
+      // path through that shape is ordinary work. It would close the stale
+      // DOCUMENT case only: that path locks the content row, while the role,
+      // permission and collection-metadata rows the verdict also depends on are
+      // read without locks and the transaction is not serializable. A grant
+      // revoked concurrently still races.
       //
-      // Two things follow for anyone editing this method, and the first is a
-      // rule rather than a preference: do NOT move validation, relationship
-      // resolution or hook dispatch ahead of this check to shorten the gap.
-      // Authorization is a precondition, so work placed before it runs for
-      // callers who are about to be refused, and hooks in particular have
-      // effects outside this process. Add such work INSIDE the transaction.
+      // One rule for anyone editing this method: do NOT move validation,
+      // relationship resolution or hook dispatch ahead of this check to shorten
+      // the gap. Authorization is a precondition, so work placed before it runs
+      // for callers about to be refused, and hooks reach outside this process.
+      // `collection-mutation.test.ts` holds that ordering for hooks, with an
+      // authorized positive control so it cannot pass by nothing dispatching.
       //
-      // Second, a rule that must be judged against the row as locked belongs in
-      // the under-lock re-check the publish path already uses, not here.
+      // Moving such work INTO the transaction is not the general answer either,
+      // and this method is already evidence: component-registry and
+      // webhook-field resolution are deliberately resolved outside it, and
+      // `assertLocalizedFieldGroupsWritable` warms its verdicts beforehand
+      // because resolving inside would issue a query that aborts the whole
+      // transaction on PostgreSQL. Work that uses a pooled helper stays where
+      // it is; only work that already takes an executor can move.
+      //
+      // A rule that must be judged against the row as locked belongs in the
+      // under-lock re-check the publish path already uses, not here.
       const accessDenied = await this.accessService.checkCollectionAccess(
         params.collectionName,
         "update",


### PR DESCRIPTION
Task 039 item 3, decided rather than built.

`updateEntry` evaluates access and then does **575 lines** of work — schema loads, hook dispatch, relationship resolution — before opening its transaction. A change to the document's ownership or the collection's access rules in that gap leaves the write proceeding on a verdict that is no longer true. Exploiting it needs an actor who held legitimate access moments earlier.

**Decision: accept it, explicitly.** No change to the authorization flow. Closing it properly means authorizing inside the transaction with the row locked, which every access evaluator would need to accept an executor to do — they currently read through the pooled adapter, and mixing pooled reads with an open transaction is what stalls the pool.

**Why the comment is in the code and not only in `tasks/`:** that directory is not version-controlled, so a decision recorded only there is invisible to anyone reading the method — and an accepted risk that looks like an oversight gets re-reported or 'fixed' by the next person to find it.

**Re-measured before deciding, and it had moved.** The window was recorded as 400+ lines in July; it is 575 today (check at 4526, transaction at 5101). `deleteEntry` is much narrower at 135. That growth is why the comment also tells anyone editing the method to add work before the check or inside the transaction — otherwise it widens on its own and nobody widening it notices.

Verified this introduces no new comment-convention offence in the file.

Docs-only, so no changeset.

@codex please review this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added clarification around collection update authorization timing and validation behavior.

* **Tests**
  * Expanded update authorization coverage.
  * Verified denied updates do not trigger hooks.
  * Verified authorized updates trigger all applicable hooks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->