### PR TITLE
fix(root): grant review coverage from a named set of states

### DIFF
--- a/scripts/verify-merge.mjs
+++ b/scripts/verify-merge.mjs
@@ -679,8 +679,33 @@ export function reviewsCoveringTip(reviews, tip, login) {
     throw new TypeError("reviewsCoveringTip needs an array of reviews");
   }
   if (typeof tip !== "string" || tip.length < FULL_SHA_LENGTH) return [];
-  return reviews.filter(r => r?.user?.login === login && r?.commit_id === tip);
+  return reviews.filter(
+    r =>
+      r?.user?.login === login &&
+      r?.commit_id === tip &&
+      SUBMITTED_REVIEW_STATES.includes(r?.state)
+  );
 }
+
+/**
+ * Review states that constitute coverage, named rather than excluded.
+ *
+ * A NAMED set is the direction that fails closed. Excluding one state — say
+ * `PENDING` — grants coverage to every other, including `DISMISSED`, which is a
+ * review GitHub explicitly invalidated and which opens no thread, so a gate
+ * counting it reads clean on a revision whose only review was withdrawn. It
+ * also grants coverage to any state added later, which nobody here has met.
+ *
+ * The filter lives INSIDE this function rather than at its callers because two
+ * callers each applying their own left them disagreeing: one excluded drafts
+ * and the other filtered nothing, four lines apart, so the same review was
+ * coverage for one reviewer and not the other.
+ */
+export const SUBMITTED_REVIEW_STATES = Object.freeze([
+  "APPROVED",
+  "CHANGES_REQUESTED",
+  "COMMENTED",
+]);
 
 /**
  * Whether the merge took everything the branch had.
@@ -1021,8 +1046,10 @@ export function main(argv) {
   // instead assumes reviews complete in the order they were requested, and an
   // older-head review finishing after a current-head one then hides a verdict
   // that does cover this revision behind one that does not.
-  const submitted = reviews.filter(r => r?.state !== "PENDING");
-  const reviewedSha = reviewsCoveringTip(submitted, tip, CODEX).length
+  const submitted = reviews.filter(r =>
+    SUBMITTED_REVIEW_STATES.includes(r?.state)
+  );
+  const reviewedSha = reviewsCoveringTip(reviews, tip, CODEX).length
     ? tip
     : submitted
         .filter(r => r?.user?.login === CODEX && r?.commit_id)

--- a/scripts/verify-merge.test.mjs
+++ b/scripts/verify-merge.test.mjs
@@ -35,6 +35,7 @@ import {
   repoFromRemoteUrl,
   requiredChecks,
   reviewCoverage,
+  SUBMITTED_REVIEW_STATES,
   reviewsCoveringTip,
   runCli,
   staleVerification,
@@ -253,6 +254,18 @@ describe("verdictCoversTip", () => {
   it("rejects a missing verdict rather than treating absence as agreement", () => {
     expect(verdictCoversTip("", FULL_TIP)).toBe(false);
     expect(verdictCoversTip(undefined, FULL_TIP)).toBe(false);
+  });
+});
+
+describe("SUBMITTED_REVIEW_STATES", () => {
+  it("names the states that ARE coverage rather than excluding one", () => {
+    expect(SUBMITTED_REVIEW_STATES).toEqual([
+      "APPROVED",
+      "CHANGES_REQUESTED",
+      "COMMENTED",
+    ]);
+    expect(SUBMITTED_REVIEW_STATES).not.toContain("DISMISSED");
+    expect(SUBMITTED_REVIEW_STATES).not.toContain("PENDING");
   });
 });
 
@@ -618,14 +631,43 @@ describe("reviewsCoveringTip", () => {
   it("ignores a review written against an EARLIER revision", () => {
     // Counting it reports a reviewer as having covered a commit it never saw.
     const reviews = [
-      { user: { login: "coderabbitai[bot]" }, commit_id: other },
+      { user: { login: "coderabbitai[bot]" }, commit_id: other, state: "COMMENTED" },
+    ];
+
+    expect(reviewsCoveringTip(reviews, tip, "coderabbitai[bot]")).toEqual([]);
+  });
+
+  it("does NOT count a DISMISSED review, which GitHub invalidated", () => {
+    // A dismissed review says nothing and opens no thread, so counting it makes
+    // the gate read clean on a revision whose only review was withdrawn — with
+    // the unresolved thread count at zero for the same reason.
+    const reviews = [
+      { user: { login: "coderabbitai[bot]" }, commit_id: tip, state: "DISMISSED" },
+    ];
+
+    expect(reviewsCoveringTip(reviews, tip, "coderabbitai[bot]")).toEqual([]);
+  });
+
+  it("does NOT count an unsubmitted PENDING draft", () => {
+    const reviews = [
+      { user: { login: "coderabbitai[bot]" }, commit_id: tip, state: "PENDING" },
+    ];
+
+    expect(reviewsCoveringTip(reviews, tip, "coderabbitai[bot]")).toEqual([]);
+  });
+
+  it("does NOT count a state this code has never met", () => {
+    // The property that makes a NAMED set the right shape: excluding one state
+    // grants coverage to every other, including any added later.
+    const reviews = [
+      { user: { login: "coderabbitai[bot]" }, commit_id: tip, state: "SOMETHING_NEW" },
     ];
 
     expect(reviewsCoveringTip(reviews, tip, "coderabbitai[bot]")).toEqual([]);
   });
 
   it("counts a review whose commit_id IS the tip", () => {
-    const reviews = [{ user: { login: "coderabbitai[bot]" }, commit_id: tip }];
+    const reviews = [{ user: { login: "coderabbitai[bot]" }, commit_id: tip, state: "COMMENTED" }];
 
     expect(reviewsCoveringTip(reviews, tip, "coderabbitai[bot]")).toHaveLength(
       1
@@ -634,7 +676,7 @@ describe("reviewsCoveringTip", () => {
 
   it("ignores another reviewer's review of the same revision", () => {
     const reviews = [
-      { user: { login: "chatgpt-codex-connector[bot]" }, commit_id: tip },
+      { user: { login: "chatgpt-codex-connector[bot]" }, commit_id: tip, state: "COMMENTED" },
     ];
 
     expect(reviewsCoveringTip(reviews, tip, "coderabbitai[bot]")).toEqual([]);
@@ -648,7 +690,7 @@ describe("reviewsCoveringTip", () => {
     // truncating both sides identifies no particular commit.
     const short = tip.slice(0, 9);
     const reviews = [
-      { user: { login: "coderabbitai[bot]" }, commit_id: short },
+      { user: { login: "coderabbitai[bot]" }, commit_id: short, state: "COMMENTED" },
     ];
 
     expect(reviewsCoveringTip(reviews, short, "coderabbitai[bot]")).toEqual([]);


### PR DESCRIPTION
## Two live defects on `main`, found by the verdict-gate lane

Both fail toward "clean", which is the direction this file exists to refuse.

**1. `DISMISSED` counted as coverage.** `reviewsCoveringTip` applied no state filter, and its Codex caller filtered by *exclusion* (`state !== "PENDING"`) — so every other state passed, including `DISMISSED`: a review GitHub explicitly **invalidated**.

That one compounds. A dismissed review opens no thread, so the unresolved count is zero for the same reason — the gate reads clean on a revision whose only review was withdrawn, with two independent signals both satisfied and nothing having reviewed it.

**2. The two callers disagreed with each other.** Four lines apart in the same function:

```js
const submitted = reviews.filter(r => r?.state !== "PENDING");   // Codex path
const reviewedSha = reviewsCoveringTip(submitted, tip, CODEX)...

const coderabbit = reviewsCoveringTip(reviews, tip, "coderabbitai[bot]").length;
//                                    ^^^^^^^ unfiltered
```

So an unsubmitted **draft** counted as `secondReviewer: "reviewed"`. That signal exists specifically to distinguish "nobody looked" from "looked and found nothing" — and it could report the first as the second.

## The fix removes the possibility, rather than patching two sites

The state filter moves **inside** `reviewsCoveringTip`, so the callers cannot diverge again. Patching both call sites would have left the third one free to be wrong.

And coverage is granted from a **named set** rather than withheld from one state:

```js
export const SUBMITTED_REVIEW_STATES = Object.freeze([
  "APPROVED", "CHANGES_REQUESTED", "COMMENTED",
]);
```

Exclusion admits everything unlisted, including any state added later that nobody here has met. A named set refuses it. That direction is `.claude/rules/reading-a-ci-verdict.md`'s own guidance, which was on `main` disagreeing with this script.

## Verification

202 tests. Three mutations, each failing the intended assertion:

| mutation | fails |
|---|---|
| back to `state !== "PENDING"` | the `DISMISSED` case and the unknown-state case |
| no state filter in the helper | both, plus the draft case |
| `DISMISSED` added to the named set | the named-set pin and the `DISMISSED` case |

The unknown-state test is the one that makes this structural rather than a patch: it fails on *any* exclusion-based implementation, not just the one that was there.

## Credit

Found and measured by the verdict-gate lane, who ran both gates against the same fixtures rather than reasoning about them. Their `tasks/left-tasks/2026-08-14-1930-two-gates-answer-the-review-coverage-question.md` has the break-verification and the longer-term consolidation plan.