### PR TITLE
fix(admin): render a custom footer beside the pager, not instead of it

### DIFF
--- a/.changeset/table-footer-and-pager-compose.md
+++ b/.changeset/table-footer-and-pager-compose.md
@@ -1,0 +1,32 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+Render a table's custom footer beside its pager rather than instead of it.
+
+`DataTableView` resolved its footer slot as `pagination ? pager : footer`, on the reasoning that two pagers in one slot is not a composition anyone wants. But `footer` takes an arbitrary node rather than a pager: a caller using it for a selection summary or bulk actions and then adopting `pagination` lost that content, with both props public, both permitted by the type, and nothing reporting the loss. Both render now, footer first, since a summary describes the rows above it and the pager moves between them.
+
+Also removes a comment in the media library that explained the grid pager's accessible label by what a source-level placement guard needed. That guard was deleted in the same release, so the comment described nothing; the screen-reader reason is the real one and is kept.

--- a/packages/admin/src/components/features/media-library/index.tsx
+++ b/packages/admin/src/components/features/media-library/index.tsx
@@ -786,10 +786,11 @@ export function MediaLibrary({
                   onPageChange={handlePageChange}
                   onPageSizeChange={handlePageSizeChange}
                   // This page renders TWO pagers -- one per view -- and they
-                  // are identical in every other prop. Distinct names are what
-                  // a screen reader announces, and what lets the placement
-                  // guard exempt the grid's pager without also excusing the
-                  // list's, which belongs in the table footer below.
+                  // are identical in every other prop, so the name is the only
+                  // thing that tells a screen reader which list it moves.
+                  // Rendered directly rather than handed to a table because a
+                  // grid has no row-versus-card view to place one for; the list
+                  // view's pager goes to the table below.
                   ariaLabel="Media grid pagination"
                 />
               )}

--- a/packages/admin/src/components/ui/table/data-table/DataTableView.footer.test.tsx
+++ b/packages/admin/src/components/ui/table/data-table/DataTableView.footer.test.tsx
@@ -197,9 +197,11 @@ describe("DataTableView footer", () => {
     expect(tokensOf(pager.parentElement)).toContain("@md/table:border");
   });
 
-  // The two directions React and JavaScript disagree about. Kept together
-  // because fixing either one alone reintroduces the other, which is how this
-  // expression collected three rounds of findings.
+  // The two directions React and JavaScript disagree about, asserted together
+  // because they pull opposite ways: a slot that keeps every non-nullish value
+  // draws a surface for these, and a slot that keeps only truthy values drops
+  // the `0` asserted below. Either predicate alone satisfies one case and
+  // breaks the other, so a control for one is not evidence about the other.
   it.each([
     ["false", false],
     ["true", true],

--- a/packages/admin/src/components/ui/table/data-table/DataTableView.footer.test.tsx
+++ b/packages/admin/src/components/ui/table/data-table/DataTableView.footer.test.tsx
@@ -197,23 +197,34 @@ describe("DataTableView footer", () => {
     expect(tokensOf(pager.parentElement)).toContain("@md/table:border");
   });
 
-  it("prefers pagination over a footer rather than rendering both", () => {
-    // Two pagers in one slot is not a composition anyone wants, and stacking
-    // them would answer a caller's mistake with a layout instead of letting it
-    // be seen. Asserted so the precedence is a decision rather than whichever
-    // order the JSX happened to be written in.
+  it("renders a custom footer alongside the pager, not instead of it", () => {
+    // `footer` is an arbitrary node rather than a pager, so a caller using it
+    // for a selection summary or bulk actions and then adopting `pagination`
+    // must not lose it. Both props are public and both are permitted by the
+    // type, so dropping one silently is content loss with nothing reporting it.
     render(
       <DataTableView<Row>
         columns={[{ name: "name", header: "Name" }]}
         rows={ROWS}
-        footer={<div data-testid="footer">custom</div>}
+        footer={<div data-testid="footer">3 selected</div>}
         pagination={PAGER}
       />
     );
 
-    expect(
-      screen.getByRole("navigation", { name: "Test pagination" })
-    ).toBeInTheDocument();
-    expect(screen.queryByTestId("footer")).toBeNull();
+    const custom = screen.getByTestId("footer");
+    const pager = screen.getByRole("navigation", { name: "Test pagination" });
+    expect(custom).toBeInTheDocument();
+    expect(pager).toBeInTheDocument();
+
+    // Both inside the one surface, since the placement guarantee is what this
+    // file exists for and it has to hold for the composed case too.
+    expect(tokensOf(custom.parentElement)).toContain("@md/table:border");
+    expect(custom.parentElement).toBe(pager.parentElement);
+
+    // Footer first: a summary describes the rows above it, and the pager moves
+    // between pages, so the reading order is summary then controls.
+    expect(custom.compareDocumentPosition(pager)).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING
+    );
   });
 });

--- a/packages/admin/src/components/ui/table/data-table/DataTableView.footer.test.tsx
+++ b/packages/admin/src/components/ui/table/data-table/DataTableView.footer.test.tsx
@@ -197,6 +197,33 @@ describe("DataTableView footer", () => {
     expect(tokensOf(pager.parentElement)).toContain("@md/table:border");
   });
 
+  // The two directions React and JavaScript disagree about. Kept together
+  // because fixing either one alone reintroduces the other, which is how this
+  // expression collected three rounds of findings.
+  it.each([
+    ["false", false],
+    ["true", true],
+    ["an empty string", ""],
+    ["null", null],
+  ])(
+    "draws no footer surface for %s, which React renders as nothing",
+    (_l, value) => {
+      const { container } = render(
+        <DataTableView<Row>
+          columns={[{ name: "name", header: "Name" }]}
+          rows={[]}
+          error="Request failed"
+          footer={value}
+        />
+      );
+      // The error path is where it shows: a surface built for a footer that
+      // renders nothing is an empty bordered box under the alert.
+      expect(container.querySelectorAll(".\\@md\\/table\\:border").length).toBe(
+        0
+      );
+    }
+  );
+
   it("keeps a zero-valued footer, which React renders", () => {
     // `footer` is a ReactNode and `0` is a valid one -- a caller passing
     // `selectedIds.length` with nothing selected renders "0". A truthiness test

--- a/packages/admin/src/components/ui/table/data-table/DataTableView.footer.test.tsx
+++ b/packages/admin/src/components/ui/table/data-table/DataTableView.footer.test.tsx
@@ -197,6 +197,20 @@ describe("DataTableView footer", () => {
     expect(tokensOf(pager.parentElement)).toContain("@md/table:border");
   });
 
+  it("keeps a zero-valued footer, which React renders", () => {
+    // `footer` is a ReactNode and `0` is a valid one -- a caller passing
+    // `selectedIds.length` with nothing selected renders "0". A truthiness test
+    // on the slot drops it, which is content loss wearing a falsy value.
+    render(
+      <DataTableView<Row>
+        columns={[{ name: "name", header: "Name" }]}
+        rows={ROWS}
+        footer={0}
+      />
+    );
+    expect(screen.getByText("0")).toBeInTheDocument();
+  });
+
   it("renders a custom footer alongside the pager, not instead of it", () => {
     // `footer` is an arbitrary node rather than a pager, so a caller using it
     // for a selection summary or bulk actions and then adopting `pagination`

--- a/packages/admin/src/components/ui/table/data-table/DataTableView.tsx
+++ b/packages/admin/src/components/ui/table/data-table/DataTableView.tsx
@@ -337,13 +337,31 @@ export function DataTableView<Row extends object>({
   // `pagination` lost that content silently, with both props public, both
   // permitted by the type, and nothing reporting the loss. A summary above its
   // pager is a real arrangement, so it is the one this renders.
-  // Nullish rather than truthy. `footer` is a ReactNode, and `0` is a valid one
-  // that React renders as "0" -- a caller passing `selectedIds.length` with
-  // nothing selected has it disappear under a truthiness test. That is the same
-  // silent content loss this resolution exists to remove, one type narrower.
-  const hasFooter = footer !== undefined && footer !== null;
+  // Whether the caller's footer will put anything on screen, decided by REACT's
+  // rule rather than by JavaScript's. The two disagree in both directions and
+  // each disagreement is a real defect:
+  //
+  //   truthiness  drops `0`, which React renders as "0" -- so a caller passing
+  //               `selectedIds.length` with nothing selected loses its footer;
+  //   nullishness keeps `false`, which React renders as nothing -- so the
+  //               ubiquitous `footer={show && <Summary />}` draws an empty
+  //               bordered surface under the table when `show` is false.
+  //
+  // React renders nothing for `null`, `undefined` and booleans, and renders
+  // numbers and strings. That set is closed and defined by React, which is what
+  // separates listing it here from guessing at values.
+  const footerRendersNothing =
+    footer === null ||
+    footer === undefined ||
+    typeof footer === "boolean" ||
+    footer === "";
+
+  // The limit worth stating rather than hiding: a component that RETURNS null
+  // still counts as content here, because no inspection of the node can know
+  // what it renders without rendering it. That case draws an empty surface, and
+  // the fix for it belongs at the caller, which knows.
   const footerContent =
-    hasFooter || pagination !== undefined ? (
+    !footerRendersNothing || pagination !== undefined ? (
       <>
         {footer}
         {pagination !== undefined && <Pagination {...pagination} />}

--- a/packages/admin/src/components/ui/table/data-table/DataTableView.tsx
+++ b/packages/admin/src/components/ui/table/data-table/DataTableView.tsx
@@ -337,11 +337,16 @@ export function DataTableView<Row extends object>({
   // `pagination` lost that content silently, with both props public, both
   // permitted by the type, and nothing reporting the loss. A summary above its
   // pager is a real arrangement, so it is the one this renders.
+  // Nullish rather than truthy. `footer` is a ReactNode, and `0` is a valid one
+  // that React renders as "0" -- a caller passing `selectedIds.length` with
+  // nothing selected has it disappear under a truthiness test. That is the same
+  // silent content loss this resolution exists to remove, one type narrower.
+  const hasFooter = footer !== undefined && footer !== null;
   const footerContent =
-    footer || pagination ? (
+    hasFooter || pagination !== undefined ? (
       <>
         {footer}
-        {pagination && <Pagination {...pagination} />}
+        {pagination !== undefined && <Pagination {...pagination} />}
       </>
     ) : undefined;
 

--- a/packages/admin/src/components/ui/table/data-table/DataTableView.tsx
+++ b/packages/admin/src/components/ui/table/data-table/DataTableView.tsx
@@ -330,13 +330,13 @@ export function DataTableView<Row extends object>({
   // it separately per branch is how the error path lost the surface: two
   // answers to one question, agreeing until one of them was edited.
   //
-  // Both render, footer first. An earlier version let `pagination` win and
-  // dropped `footer`, on the reasoning that two pagers in one slot is not a
-  // composition anyone wants -- but `footer` is an arbitrary node, not a pager.
-  // A caller using it for a selection summary or bulk actions and then adopting
-  // `pagination` lost that content silently, with both props public, both
-  // permitted by the type, and nothing reporting the loss. A summary above its
-  // pager is a real arrangement, so it is the one this renders.
+  // Both render, footer first, rather than one displacing the other. `footer`
+  // takes an arbitrary node and not a pager, so a caller can legitimately hold a
+  // selection summary or bulk actions there while paginating -- a summary above
+  // its pager is a real arrangement. Letting `pagination` win would drop that
+  // content with both props public, both permitted by the type, and nothing
+  // reporting the loss. Footer first because a summary describes the rows above
+  // it and the pager moves between them.
   // Whether the caller's footer will put anything on screen, decided by REACT's
   // rule rather than by JavaScript's. The two disagree in both directions and
   // each disagreement is a real defect:

--- a/packages/admin/src/components/ui/table/data-table/DataTableView.tsx
+++ b/packages/admin/src/components/ui/table/data-table/DataTableView.tsx
@@ -330,10 +330,20 @@ export function DataTableView<Row extends object>({
   // it separately per branch is how the error path lost the surface: two
   // answers to one question, agreeing until one of them was edited.
   //
-  // `pagination` wins over `footer` rather than rendering beside it. Two pagers
-  // in one slot is not a composition anyone wants, and silently stacking them
-  // would answer a mistake with a layout instead of a type error.
-  const footerContent = pagination ? <Pagination {...pagination} /> : footer;
+  // Both render, footer first. An earlier version let `pagination` win and
+  // dropped `footer`, on the reasoning that two pagers in one slot is not a
+  // composition anyone wants -- but `footer` is an arbitrary node, not a pager.
+  // A caller using it for a selection summary or bulk actions and then adopting
+  // `pagination` lost that content silently, with both props public, both
+  // permitted by the type, and nothing reporting the loss. A summary above its
+  // pager is a real arrangement, so it is the one this renders.
+  const footerContent =
+    footer || pagination ? (
+      <>
+        {footer}
+        {pagination && <Pagination {...pagination} />}
+      </>
+    ) : undefined;
 
   const surfaceClassName = cn(
     // Clipping is NOT part of the card. The table view rounds its own


### PR DESCRIPTION
Follow-up to #757, carrying the two findings deferred at merge.

## A custom footer was silently dropped

`DataTableView` resolved its footer slot as `pagination ? pager : footer`. My reasoning for that was "two pagers in one slot is not a composition anyone wants" — and it was wrong about what `footer` holds. It takes an arbitrary `ReactNode`, not a pager. A caller using it for a selection summary or bulk actions and then adopting `pagination` lost that content, with **both props public, both permitted by the type, and nothing reporting the loss**.

Both render now, footer first: a summary describes the rows above it, the pager moves between them, so that is the reading order.

The alternative was making the two mutually exclusive in the type. I did not take it because a summary bar *and* a pager is a real arrangement — several admin tables want exactly that — so forbidding the combination would trade one wrong answer for another.

Stub-verified: restoring `pagination ? pager : footer` fails the new test with `Unable to find an element by: [data-testid="footer"]`, which is the content loss itself rather than a proxy for it.

## A comment described a guard that no longer exists

`media-library/index.tsx` explained the grid pager's `ariaLabel` by what the source-level placement guard needed to tell the two media pagers apart. #757 deleted that guard, so the comment described nothing — and AGENTS.md requires comments to describe the code.

The screen-reader rationale is the real reason for the label and is kept.

Worth naming the shape, because it is the third instance this week: the identical stale clause existed in `users/fields/index.tsx`, I rewrote that one, and left its twin. Fixed one call site, missed its neighbour. This time I checked the population rather than the instance — `grep -rni "placement guard\|NOT_A_TABLE_PAGER\|pagination-placement"` across `packages/*/src`, `.claude` and `AGENTS.md` now returns zero.

## Verification

- `check-types` clean, `lint` exit 0
- `DataTableView.footer.test.tsx`: 11 passed
- The new test asserts both nodes present, both inside the same surface (placement is what this file exists for, and it has to hold for the composed case), and the order
