### PR TITLE
fix(root): read an approver's permission rather than their association

### DIFF
--- a/scripts/verify-merge.mjs
+++ b/scripts/verify-merge.mjs
@@ -481,17 +481,22 @@ export function pageWrapping(key) {
  * become a blocker through the other surface.
  */
 /**
- * Author associations that carry write access, and so can approve on the
- * project's behalf.
+ * Repository permissions that carry write access.
  *
- * Any account can submit an APPROVED review, including a contributor's own and
- * a bot's, so the state alone does not say the project accepted the change.
+ * Read from the collaborator permission rather than inferred from an author
+ * association: in an ORGANISATION repository `MEMBER` means membership of the
+ * org, which says nothing about access to this repository, so a read-only
+ * member's approval would be counted as the project accepting the change. The
+ * association is a label GitHub applies to the author; the permission is the
+ * fact about what they may do here.
+ *
+ * Named rather than excluded, so a permission this code has not met refuses.
  */
-export const MAINTAINER_ASSOCIATIONS = Object.freeze([
-  "OWNER",
-  "MEMBER",
-  "COLLABORATOR",
-]);
+export const WRITE_PERMISSIONS = Object.freeze(["admin", "maintain", "write"]);
+
+export function hasWriteAccess(permission) {
+  return WRITE_PERMISSIONS.includes(permission);
+}
 
 export const OPTIONAL_STATUS_CONTEXTS = Object.freeze(["CodeRabbit"]);
 
@@ -587,6 +592,27 @@ export const PATH_FILTER_WINDOW = 300;
 
 /** Past this many commits GitHub runs the workflow without evaluating filters. */
 export const PATH_FILTER_COMMIT_LIMIT = 1000;
+
+/**
+ * The paths a workflow's filters are actually evaluated against.
+ *
+ * Two platform limits, and only one of them applies in both modes.
+ *
+ * The 300-file window is a property of filter evaluation itself, so it holds
+ * whichever event produced the run.
+ *
+ * The 1000-commit bypass is a property of the PULL REQUEST's diff. After a
+ * merge the checks come from a `push` of the squash commit — one commit,
+ * whatever the pull request contained — so applying the pull request's count
+ * there answers with a number belonging to an event that is over. It would
+ * empty the path list on any large pull request and require every workflow
+ * regardless of what the push actually triggered.
+ */
+export function pathsForFiltering({ changedPaths, commits, merged }) {
+  if (!Array.isArray(changedPaths)) return [];
+  if (!merged && commits > PATH_FILTER_COMMIT_LIMIT) return [];
+  return changedPaths.slice(0, PATH_FILTER_WINDOW);
+}
 
 export function workflowApplies(pathsIgnore, changedPaths) {
   if (!Array.isArray(pathsIgnore) || pathsIgnore.length === 0) return true;
@@ -823,6 +849,42 @@ function workflowAt(revision, path) {
   });
 }
 
+/**
+ * Approvals from accounts that actually hold write access here.
+ *
+ * One request per distinct approver, cached, because a pull request with many
+ * reviews would otherwise ask about the same account repeatedly. A lookup that
+ * fails is treated as NOT write access: an approval this code could not verify
+ * is not one it may count, and the only consequence is the advisory line
+ * reporting `none`, which is the direction that understates rather than
+ * invents.
+ */
+function countWriteAccessApprovals(reviews) {
+  const seen = new Map();
+  let count = 0;
+  for (const review of reviews) {
+    if (review?.state !== "APPROVED") continue;
+    const login = review?.user?.login;
+    if (typeof login !== "string" || login === "") continue;
+    if (!seen.has(login)) {
+      let permission = null;
+      try {
+        permission = ghText([
+          "api",
+          `repos/${REPO}/collaborators/${login}/permission`,
+          "--jq",
+          ".permission",
+        ]);
+      } catch {
+        permission = null;
+      }
+      seen.set(login, hasWriteAccess(permission));
+    }
+    if (seen.get(login)) count += 1;
+  }
+  return count;
+}
+
 /** Every configured remote as `[name, url]`, for matching against the head repository. */
 function configuredRemotes() {
   const out = execFileSync("git", ["remote", "-v"], { encoding: "utf8" });
@@ -949,10 +1011,11 @@ export function main(argv) {
   // workflow regardless, so deciding from paths there would excuse a check that
   // did run. An empty list makes every workflow applicable, which is the
   // direction that requires evidence.
-  const filterPaths =
-    meta.commits > PATH_FILTER_COMMIT_LIMIT
-      ? []
-      : changedPaths.slice(0, PATH_FILTER_WINDOW);
+  const filterPaths = pathsForFiltering({
+    changedPaths,
+    commits: meta.commits,
+    merged,
+  });
 
   // Read from the workflow, for the trigger whose run produced the checks being
   // judged: `pull_request` before a merge, `push` to the base branch after one.
@@ -1082,9 +1145,7 @@ export function main(argv) {
     eligibility: { state: meta.state, draft: meta.draft, merged },
     codexReviewedSha: reviewedSha,
     coderabbitReviewCount: coderabbit,
-    approvalCount: reviews.filter(
-      r => r?.state === "APPROVED" && MAINTAINER_ASSOCIATIONS.includes(r?.author_association)
-    ).length,
+    approvalCount: countWriteAccessApprovals(reviews),
   });
 
   // Nothing is printed until the freshness read below has decided. Emitting the

--- a/scripts/verify-merge.test.mjs
+++ b/scripts/verify-merge.test.mjs
@@ -27,7 +27,9 @@ import {
   OPTIONAL_STATUS_CONTEXTS,
   missingRequired,
   PATH_FILTER_WINDOW,
-  MAINTAINER_ASSOCIATIONS,
+  WRITE_PERMISSIONS,
+  hasWriteAccess,
+  pathsForFiltering,
   PATH_FILTER_COMMIT_LIMIT,
   pageWrapping,
   pathMatches,
@@ -408,13 +410,53 @@ describe("OPTIONAL_STATUS_CONTEXTS", () => {
   });
 });
 
-describe("maintainer associations", () => {
-  it("counts only associations carrying write access", () => {
-    // Any account can submit an APPROVED review, a contributor's own and a
-    // bot's included, so the state alone does not say the project accepted it.
-    expect(MAINTAINER_ASSOCIATIONS).toEqual(["OWNER", "MEMBER", "COLLABORATOR"]);
-    expect(MAINTAINER_ASSOCIATIONS).not.toContain("CONTRIBUTOR");
-    expect(MAINTAINER_ASSOCIATIONS).not.toContain("NONE");
+describe("hasWriteAccess", () => {
+  it("accepts the permissions that actually carry write", () => {
+    for (const p of WRITE_PERMISSIONS) expect(hasWriteAccess(p)).toBe(true);
+  });
+
+  it("refuses read, none, and anything unrecognised", () => {
+    // The case the association allowlist got wrong: in an ORGANISATION
+    // repository `MEMBER` means membership of the org and says nothing about
+    // access here, so a read-only member's approval was counted as the project
+    // accepting the change. A permission is the fact; an association is a label.
+    expect(hasWriteAccess("read")).toBe(false);
+    expect(hasWriteAccess("none")).toBe(false);
+    expect(hasWriteAccess("triage")).toBe(false);
+    expect(hasWriteAccess(null)).toBe(false);
+    expect(hasWriteAccess("SOMETHING_NEW")).toBe(false);
+  });
+});
+
+describe("pathsForFiltering", () => {
+  const many = Array.from({ length: 400 }, (_, i) => `packages/a/${i}.ts`);
+
+  it("applies the 300-file window in BOTH modes", () => {
+    // A property of filter evaluation itself, so it holds whichever event
+    // produced the run.
+    expect(pathsForFiltering({ changedPaths: many, commits: 3, merged: false }))
+      .toHaveLength(300);
+    expect(pathsForFiltering({ changedPaths: many, commits: 3, merged: true }))
+      .toHaveLength(300);
+  });
+
+  it("applies the 1000-commit bypass only BEFORE a merge", () => {
+    // It is a property of the pull request's diff. After a merge the checks
+    // come from a push of the squash commit — one commit, whatever the pull
+    // request contained — so the pull request's count belongs to an event that
+    // is over, and using it would empty the list on any large pull request and
+    // require every workflow regardless of what the push triggered.
+    expect(
+      pathsForFiltering({ changedPaths: many, commits: 1500, merged: false })
+    ).toEqual([]);
+    expect(
+      pathsForFiltering({ changedPaths: many, commits: 1500, merged: true })
+    ).toHaveLength(300);
+  });
+
+  it("returns nothing readable as nothing", () => {
+    expect(pathsForFiltering({ changedPaths: null, commits: 1, merged: false }))
+      .toEqual([]);
   });
 });
 


### PR DESCRIPTION
Two of the four findings deferred from #798 by the project owner's call. Filed with analysis in `tasks/left-tasks/2026-08-14-1700-verify-merge-followups.md`; the other two are left there deliberately (one may belong in `ci-verdict.mjs` instead).

## 1. An association is not write access

`MAINTAINER_ASSOCIATIONS` accepted `OWNER`, `MEMBER` and `COLLABORATOR`. In an **organisation** repository, `MEMBER` means membership of the *org* — it says nothing about access to *this* repository. A read-only org member's approval was therefore counted as the project having accepted the change.

**An association is a label GitHub applies to the author; a permission is the fact about what they may do here.** That distinction is `.claude/rules/derived-checks.md`'s own rule — identify by structure rather than by someone else's spelling — and this was a name standing in for the thing.

The collaborator permission is now queried directly, once per distinct approver and cached. **A failed lookup counts as no write access**: an approval this code could not verify is not one it may count, and the only consequence is the advisory line reporting `none` — understating rather than inventing.

`WRITE_PERMISSIONS` is a *named* set (`admin`, `maintain`, `write`), so a permission this code has never met refuses rather than passes.

## 2. The 1000-commit bypass belongs to pull-request filtering only

Past 1000 commits GitHub stops evaluating path filters and runs the workflow regardless. That is a property of the **pull request's** diff.

After a merge, the checks come from a `push` of the **squash commit** — one commit, whatever the pull request contained. So applying `.commits` there answers with a number belonging to an event that is over: it emptied the path list on any large pull request and required every workflow regardless of what the push actually triggered.

The 300-file window is different — that is a property of filter evaluation itself, so it holds in both modes. Both now live in `pathsForFiltering`, where a test can hand them inputs rather than the decision sitting inline in `main()`.

## Verification

202 tests. Four mutations, each failing the intended assertion:

| mutation | fails |
|---|---|
| commit bypass applied post-merge too | the mode test |
| commit bypass dropped entirely | the mode test |
| 300-file window dropped | both window tests |
| `read` admitted to `WRITE_PERMISSIONS` | the refusal test |

The `SOMETHING_NEW` case in the permission test is the one that makes it structural: it fails on any implementation that excludes rather than names.

## Note on stacking

This branches from `main`, not from #820. The two touch different functions — #820 is `reviewsCoveringTip`, this is approvals and path filtering — so they should merge in either order without conflict.