### PR TITLE
fix(nextly): stop serving declared plugin permissions to anonymous callers

### DIFF
--- a/.changeset/public-admin-meta-permissions.md
+++ b/.changeset/public-admin-meta-permissions.md
@@ -1,0 +1,32 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+Stop serving the declared permission vocabulary on the public `/api/admin-meta`
+payload. That endpoint answers without authentication, so every plugin action
+and resource name was readable by anyone who could reach the app. The admin
+plugin page now takes permissions from the authenticated permissions endpoint,
+which reports the rows that actually exist rather than the declarations.

--- a/.changeset/public-admin-meta-permissions.md
+++ b/.changeset/public-admin-meta-permissions.md
@@ -25,8 +25,11 @@
 "@nextlyhq/module-specifiers": patch
 ---
 
-Stop serving the declared permission vocabulary on the public `/api/admin-meta`
-payload. That endpoint answers without authentication, so every plugin action
-and resource name was readable by anyone who could reach the app. The admin
-plugin page now takes permissions from the authenticated permissions endpoint,
-which reports the rows that actually exist rather than the declarations.
+Stop serving plugins' declared custom permissions on the public
+`/api/admin-meta` payload. That endpoint answers without authentication, so
+every plugin action and resource name it carried was readable by anyone who
+could reach the app.
+
+The plugin detail page no longer lists a plugin's permissions. Reading them
+from an authenticated endpoint is a separate change and is not in this
+release.

--- a/packages/admin/src/pages/dashboard/plugins/[slug].tsx
+++ b/packages/admin/src/pages/dashboard/plugins/[slug].tsx
@@ -16,7 +16,6 @@ import {
   Package,
   Route,
   Settings as SettingsIcon,
-  Shield,
 } from "@admin/components/icons";
 import { PageContainer } from "@admin/components/layout/page-container";
 import { Breadcrumbs } from "@admin/components/shared";
@@ -421,15 +420,6 @@ function Contributions({ plugin }: { plugin: PluginMetadata }) {
       label: "Field types",
       icon: SettingsIcon,
       items: (plugin.fieldTypes ?? []).map(ft => ({ primary: ft.type })),
-    },
-    {
-      key: "permissions",
-      label: "Permissions",
-      icon: Shield,
-      items: (plugin.permissions ?? []).map(p => ({
-        primary: p.label ?? `${p.action}-${p.resource}`,
-        secondary: p.danger ? "danger" : undefined,
-      })),
     },
     {
       key: "routes",

--- a/packages/admin/src/pages/dashboard/plugins/plugin-detail.test.tsx
+++ b/packages/admin/src/pages/dashboard/plugins/plugin-detail.test.tsx
@@ -92,9 +92,7 @@ describe("PluginDetailPage layout", () => {
 
     // NOT in the rail: what the plugin contributes. The separating assertion —
     // without it, moving the whole page inside the aside would pass.
-    expect(within(aside).queryByText("Permissions")).toBeNull();
     expect(within(aside).queryByText("API routes")).toBeNull();
-    expect(screen.getByText("Permissions")).toBeInTheDocument();
     expect(screen.getByText("API routes")).toBeInTheDocument();
   });
 
@@ -150,9 +148,9 @@ describe("PluginDetailPage", () => {
     );
     expect(screen.getByText("form-submissions")).toBeInTheDocument();
     expect(screen.getByText("form-settings")).toBeInTheDocument();
-    // Permission shows its label and danger marker.
-    expect(screen.getByText("Export Submissions")).toBeInTheDocument();
-    expect(screen.getByText("danger")).toBeInTheDocument();
+    // Permissions are deliberately absent: the public payload no longer
+    // carries them, so nothing here can render one.
+    expect(screen.queryByText("Export Submissions")).toBeNull();
     // Route summary includes the namespaced final URL.
     expect(
       screen.getByText("GET /admin/api/plugins/@acme/forms/submissions/export")
@@ -256,22 +254,15 @@ describe("PluginDetailPage dormant disclosure", () => {
 });
 
 /**
- * A disabled plugin's permissions are seeded and granted like any other's, so
- * the page must show them. Its routes are not mounted, so those must not be
- * shown as current. These pin both halves of that split on one plugin.
+ * A disabled plugin keeps its schema and its grants; only its routes stop
+ * being mounted. These pin that split.
+ *
+ * The rendering half of the permissions case is gone with the public
+ * payload's permission fields: the page receives none, so there is nothing
+ * left to assert renders. What the page still SAYS about grants surviving a
+ * disable is covered below, and that sentence is what the split needs.
  */
 describe("PluginDetailPage disabled plugin permissions", () => {
-  it("lists a disabled plugin's permissions as things it has", () => {
-    render(<PluginDetailPage params={{ slug: "acme-disabled" }} />);
-
-    const contributions = screen
-      .getByText("What this plugin adds")
-      .closest("section");
-    expect(
-      within(contributions!).getByText("Purge Archive")
-    ).toBeInTheDocument();
-  });
-
   /**
    * The separating assertion. If the enabled flag simply stopped mattering,
    * routes would show here too — they must not, because they are not mounted.

--- a/packages/admin/src/types/branding.ts
+++ b/packages/admin/src/types/branding.ts
@@ -83,14 +83,6 @@ export interface PluginMetadata {
   singles?: string[];
   /** Slugs of contributed field groups, for the detail page's contributions view. */
   fieldGroups?: string[];
-  /** Declared custom permissions (identity + display fields only; enabled plugins). */
-  permissions?: Array<{
-    action: string;
-    resource: string;
-    label?: string;
-    description?: string;
-    danger?: boolean;
-  }>;
   /** Declared HTTP routes as method + path (enabled plugins only). */
   /**
    * Declared HTTP routes. `fullPath` is the namespace the dispatcher mounts

--- a/packages/nextly/src/plugins/admin-meta.test.ts
+++ b/packages/nextly/src/plugins/admin-meta.test.ts
@@ -1,13 +1,11 @@
 import { describe, expect, it } from "vitest";
 
-import type { CollectedPermission } from "./permissions/collect-permissions";
 import type { PluginDefinition } from "./plugin-context";
 
 import { NEXTLY_ERROR_STATUS } from "../errors/error-codes";
 import { NextlyError } from "../errors/nextly-error";
 
-import { adminMetaPermissions, buildPluginAdminMeta } from "./admin-meta";
-import { isPermissionCollision } from "./permission-error";
+import { buildPluginAdminMeta } from "./admin-meta";
 
 const base = {
   name: "@acme/p",
@@ -17,26 +15,6 @@ const base = {
 
 function asPlugins(defs: unknown[]): PluginDefinition[] {
   return defs as PluginDefinition[];
-}
-
-/**
- * One entry of the collected set, as `collectCustomPermissions` produces it.
- * Defaults to a plugin-owned permission belonging to `base`, since that is what
- * most cases here are about.
- */
-function collectedPermission(
-  overrides: Partial<CollectedPermission> &
-    Pick<CollectedPermission, "action" | "resource">
-): CollectedPermission {
-  return {
-    slug: `${overrides.action}-${overrides.resource}`,
-    name: `${overrides.action} ${overrides.resource}`,
-    owner: base.name,
-    source: "plugin",
-    group: "General",
-    danger: false,
-    ...overrides,
-  };
 }
 
 describe("buildPluginAdminMeta", () => {
@@ -57,8 +35,7 @@ describe("buildPluginAdminMeta", () => {
           },
         },
       ]),
-      undefined,
-      []
+      undefined
     );
     expect(meta[0].fieldTypes?.[0]).toMatchObject({
       type: "page-builder",
@@ -88,8 +65,7 @@ describe("buildPluginAdminMeta", () => {
           },
         },
       ]),
-      undefined,
-      []
+      undefined
     );
     expect(meta[0].fieldTypes?.[0]).toEqual({
       type: "rating",
@@ -115,8 +91,7 @@ describe("buildPluginAdminMeta", () => {
           },
         },
       ]),
-      undefined,
-      []
+      undefined
     );
     expect(meta[0].fieldTypes?.[0]).toEqual({
       type: "rating",
@@ -135,8 +110,7 @@ describe("buildPluginAdminMeta", () => {
           contributes: { admin: { schemaBuilderSlot: "@acme/p/admin#Toggle" } },
         },
       ]),
-      undefined,
-      []
+      undefined
     );
     expect(enabled[0].schemaBuilderSlot).toBe("@acme/p/admin#Toggle");
 
@@ -148,8 +122,7 @@ describe("buildPluginAdminMeta", () => {
           contributes: { admin: { schemaBuilderSlot: "@acme/p/admin#Toggle" } },
         },
       ]),
-      undefined,
-      []
+      undefined
     );
     expect(disabled[0].schemaBuilderSlot).toBeUndefined();
   });
@@ -162,8 +135,7 @@ describe("buildPluginAdminMeta", () => {
           contributes: { admin: { entryFormToolbarSlot: "@acme/p/admin#Bar" } },
         },
       ]),
-      undefined,
-      []
+      undefined
     );
     expect(enabled[0].entryFormToolbarSlot).toBe("@acme/p/admin#Bar");
 
@@ -175,8 +147,7 @@ describe("buildPluginAdminMeta", () => {
           contributes: { admin: { entryFormToolbarSlot: "@acme/p/admin#Bar" } },
         },
       ]),
-      undefined,
-      []
+      undefined
     );
     expect(disabled[0].entryFormToolbarSlot).toBeUndefined();
   });
@@ -208,8 +179,7 @@ describe("buildPluginAdminMeta", () => {
           },
         },
       ]),
-      undefined,
-      []
+      undefined
     );
 
     expect(meta[0].menu).toEqual([
@@ -248,8 +218,7 @@ describe("buildPluginAdminMeta", () => {
           },
         },
       ]),
-      undefined,
-      []
+      undefined
     );
     expect(meta[0].headerSlot).toBe("@acme/p/admin#HeaderBadge");
     expect(meta[0].widgets?.[0]).toMatchObject({
@@ -276,8 +245,7 @@ describe("buildPluginAdminMeta", () => {
           },
         },
       ]),
-      undefined,
-      []
+      undefined
     );
     expect(meta[0].header).toEqual({
       slot: "@acme/p/admin#Publish",
@@ -296,8 +264,7 @@ describe("buildPluginAdminMeta", () => {
           contributes: { admin: { headerSlot: "@acme/p/admin#Badge" } },
         },
       ]),
-      undefined,
-      []
+      undefined
     );
     expect(meta[0].header?.slot).toBe("@acme/p/admin#Badge");
     expect(meta[0].headerSlot).toBe("@acme/p/admin#Badge");
@@ -316,8 +283,7 @@ describe("buildPluginAdminMeta", () => {
           },
         },
       ]),
-      undefined,
-      []
+      undefined
     );
     expect(meta[0].header).toBeUndefined();
     expect(meta[0].headerSlot).toBeUndefined();
@@ -337,8 +303,7 @@ describe("buildPluginAdminMeta", () => {
           },
         },
       ]),
-      undefined,
-      []
+      undefined
     );
     expect(meta[0].headerSlot).toBeUndefined();
     expect(meta[0].widgets).toBeUndefined();
@@ -350,8 +315,7 @@ describe("buildPluginAdminMeta", () => {
     ];
     const enabled = buildPluginAdminMeta(
       asPlugins([{ ...base, contributes: { fieldTypes } }]),
-      undefined,
-      []
+      undefined
     );
     expect(enabled[0].fieldTypes).toEqual([
       { type: "rating", component: "@acme/p/admin#Rating", storage: "number" },
@@ -361,8 +325,7 @@ describe("buildPluginAdminMeta", () => {
     // can still render fields of retained collections.
     const disabled = buildPluginAdminMeta(
       asPlugins([{ ...base, enabled: false, contributes: { fieldTypes } }]),
-      undefined,
-      []
+      undefined
     );
     expect(disabled[0].fieldTypes).toEqual([
       { type: "rating", component: "@acme/p/admin#Rating", storage: "number" },
@@ -380,8 +343,7 @@ describe("buildPluginAdminMeta", () => {
           },
         },
       ]),
-      undefined,
-      []
+      undefined
     );
     // The plugin entry still exists (its schema still applies), but its
     // behavioral admin UI (menu/pages/settings) is skipped per D49.
@@ -404,8 +366,7 @@ describe("buildPluginAdminMeta", () => {
           contributes: { collections: [{ slug: "forms" }] },
         },
       ]),
-      { "acme-p": { order: 5, appearance: { badge: "Beta" } } },
-      []
+      { "acme-p": { order: 5, appearance: { badge: "Beta" } } }
     );
 
     expect(meta[0].placement).toBe("users");
@@ -419,7 +380,7 @@ describe("buildPluginAdminMeta", () => {
   });
 
   it("defaults placement to 'plugins' and has no admin keys when none declared", () => {
-    const meta = buildPluginAdminMeta(asPlugins([{ ...base }]), undefined, []);
+    const meta = buildPluginAdminMeta(asPlugins([{ ...base }]), undefined);
     expect(meta[0].placement).toBe("plugins");
     expect(meta[0].menu).toBeUndefined();
     expect(meta[0].pages).toBeUndefined();
@@ -440,8 +401,7 @@ describe("buildPluginAdminMeta", () => {
           tags: ["forms", "email"],
         },
       ]),
-      undefined,
-      []
+      undefined
     );
     expect(meta[0]).toMatchObject({
       author: "Acme Inc.",
@@ -459,21 +419,19 @@ describe("buildPluginAdminMeta", () => {
       asPlugins([
         { ...base, enabled: false, author: "Acme Inc.", license: "MIT" },
       ]),
-      undefined,
-      []
+      undefined
     );
     expect(meta[0].author).toBe("Acme Inc.");
     expect(meta[0].license).toBe("MIT");
   });
 
   it("serializes the enabled state explicitly", () => {
-    const on = buildPluginAdminMeta(asPlugins([{ ...base }]), undefined, []);
+    const on = buildPluginAdminMeta(asPlugins([{ ...base }]), undefined);
     expect(on[0].enabled).toBe(true);
 
     const off = buildPluginAdminMeta(
       asPlugins([{ ...base, enabled: false }]),
-      undefined,
-      []
+      undefined
     );
     expect(off[0].enabled).toBe(false);
   });
@@ -481,19 +439,24 @@ describe("buildPluginAdminMeta", () => {
   it("serializes dependsOn ranges for the detail page", () => {
     const meta = buildPluginAdminMeta(
       asPlugins([{ ...base, dependsOn: { "@acme/core": "^1.2.0" } }]),
-      undefined,
-      []
+      undefined
     );
     expect(meta[0].dependsOn).toEqual({ "@acme/core": "^1.2.0" });
   });
 
   /**
-   * Whatever the enabled state, because the ROWS exist whatever the enabled
-   * state: the permission fold covers disabled plugins (D49), the seeder
-   * creates them, and new ones are granted to super_admin. Reporting them only
-   * while enabled made this payload disagree with the database.
+   * The admin-meta endpoint answers WITHOUT authentication, so anything on this
+   * payload is readable by anyone who can reach the app. A permission
+   * vocabulary is a map of what the installation can do and how each capability
+   * is spelled, which is reconnaissance rather than content, so it is not
+   * served here at all.
+   *
+   * Asserted against a plugin that DECLARES one, so the absence is the
+   * serializer declining to carry it rather than a fixture with nothing to
+   * carry. The admin reads the seeded rows from the authenticated permissions
+   * endpoint instead, which is also the set that actually exists.
    */
-  it("summarizes declared permissions whether or not the plugin is enabled", () => {
+  it("never serializes declared permissions onto the public payload", () => {
     const contributes = {
       permissions: [
         {
@@ -504,99 +467,20 @@ describe("buildPluginAdminMeta", () => {
         },
       ],
     };
-    const collected = [
-      collectedPermission({
-        action: "export",
-        resource: "submissions",
-        name: "Export submissions",
-        danger: true,
-      }),
-    ];
     const enabled = buildPluginAdminMeta(
       asPlugins([{ ...base, contributes }]),
-      undefined,
-      collected
+      undefined
     );
-    expect(enabled[0].permissions).toEqual([
-      {
-        action: "export",
-        resource: "submissions",
-        label: "Export submissions",
-        danger: true,
-      },
-    ]);
+    expect(enabled[0]).not.toHaveProperty("permissions");
+    // The plugin itself was serialized: without this the assertion above would
+    // pass just as well for a fixture the builder dropped entirely.
+    expect(enabled[0].name).toBe(base.name);
 
     const disabled = buildPluginAdminMeta(
       asPlugins([{ ...base, enabled: false, contributes }]),
-      undefined,
-      collected
+      undefined
     );
-    // Identical to the enabled case. The separating assertion for the split is
-    // below: routes DO disappear when disabled, so this is not simply "the
-    // enabled flag changes nothing".
-    expect(disabled[0].permissions).toEqual(enabled[0].permissions);
-    expect(disabled[0].permissions).toHaveLength(1);
-  });
-
-  /**
-   * The separating property for taking the collected set rather than
-   * recomputing one. `collectCustomPermissions` DROPS a `publish` declaration
-   * whose resource is a configured collection, because the seeder emits that
-   * slug itself and keeps the row ownerless — so the collected set here holds
-   * only `export`, while the plugin's own `contributes.permissions` still holds
-   * both. Serializing the declaration would put this plugin's label and danger
-   * flag on a permission the roles data does not attribute to it.
-   *
-   * `export` is the positive control: it is present in both, so the assertion
-   * cannot pass by the whole list having been dropped.
-   */
-  it("serializes the collected set, not the plugin's own declaration", () => {
-    const meta = buildPluginAdminMeta(
-      asPlugins([
-        {
-          ...base,
-          contributes: {
-            permissions: [
-              { action: "publish", resource: "posts", label: "Publish posts" },
-              { action: "export", resource: "submissions" },
-            ],
-          },
-        },
-      ]),
-      undefined,
-      [collectedPermission({ action: "export", resource: "submissions" })]
-    );
-
-    expect(meta[0].permissions).toEqual([
-      {
-        action: "export",
-        resource: "submissions",
-        label: "export submissions",
-      },
-    ]);
-  });
-
-  /**
-   * The host's sentinel owner is the literal string `"app"`, so a plugin
-   * legitimately named `app` shares it. Grouping by `owner` alone would file
-   * every host-declared permission under that plugin and report the
-   * application's own permissions as the plugin's contributions.
-   */
-  it("does not attribute host-declared permissions to a plugin named app", () => {
-    const meta = buildPluginAdminMeta(
-      asPlugins([{ ...base, name: "app" }]),
-      undefined,
-      [
-        collectedPermission({
-          action: "purge",
-          resource: "cache",
-          owner: "app",
-          source: "app",
-        }),
-      ]
-    );
-
-    expect(meta[0].permissions).toBeUndefined();
+    expect(disabled[0]).not.toHaveProperty("permissions");
   });
 
   it("summarizes declared routes (method + path only) for enabled plugins only", () => {
@@ -612,8 +496,7 @@ describe("buildPluginAdminMeta", () => {
     };
     const enabled = buildPluginAdminMeta(
       asPlugins([{ ...base, contributes }]),
-      undefined,
-      []
+      undefined
     );
     // `fullPath` travels too: it is the namespace the dispatcher mounts the
     // route at, derived from the raw package name, and the admin renders it
@@ -628,8 +511,7 @@ describe("buildPluginAdminMeta", () => {
 
     const disabled = buildPluginAdminMeta(
       asPlugins([{ ...base, enabled: false, contributes }]),
-      undefined,
-      []
+      undefined
     );
     expect(disabled[0].routes).toBeUndefined();
   });
@@ -646,8 +528,7 @@ describe("buildPluginAdminMeta", () => {
           },
         },
       ]),
-      undefined,
-      []
+      undefined
     );
     expect(meta[0].collections).toEqual(["forms"]);
     expect(meta[0].singles).toEqual(["form-settings"]);
@@ -667,8 +548,7 @@ describe("buildPluginAdminMeta — clientConfig", () => {
       withConfig({
         remotePatterns: [{ protocol: "https", hostname: "a.example" }],
       }),
-      undefined,
-      []
+      undefined
     );
     expect(meta[0]?.clientConfig).toEqual({
       remotePatterns: [{ protocol: "https", hostname: "a.example" }],
@@ -691,8 +571,7 @@ describe("buildPluginAdminMeta — clientConfig", () => {
           },
         },
       ]),
-      undefined,
-      []
+      undefined
     );
     expect(meta[0]?.enabled).toBe(false);
     expect(meta[0]?.clientConfig).toEqual({ a: 1 });
@@ -717,7 +596,7 @@ describe("buildPluginAdminMeta — clientConfig", () => {
       // live in the log context, which is where a boot failure is read.
       let thrown: unknown;
       try {
-        buildPluginAdminMeta(withConfig(bad), undefined, []);
+        buildPluginAdminMeta(withConfig(bad), undefined);
       } catch (error) {
         thrown = error;
       }
@@ -738,7 +617,7 @@ describe("buildPluginAdminMeta — clientConfig", () => {
     // client receives is missing a key the plugin wrote. That is a silent
     // shape change, not a harmless omission.
     expect(() =>
-      buildPluginAdminMeta(withConfig({ a: 1, gone: undefined }), undefined, [])
+      buildPluginAdminMeta(withConfig({ a: 1, gone: undefined }), undefined)
     ).toThrow(NextlyError);
   });
 
@@ -751,16 +630,16 @@ describe("buildPluginAdminMeta — clientConfig", () => {
       arr: [1, "two", { three: 3 }],
       nested: { deep: { deeper: [true] } },
     };
-    const meta = buildPluginAdminMeta(withConfig(config), undefined, []);
+    const meta = buildPluginAdminMeta(withConfig(config), undefined);
     expect(meta[0]?.clientConfig).toEqual(config);
   });
 
   it("survives a cycle by refusing rather than by hanging", () => {
     const cyclic: Record<string, unknown> = { a: 1 };
     cyclic.self = cyclic;
-    expect(() =>
-      buildPluginAdminMeta(withConfig(cyclic), undefined, [])
-    ).toThrow(NextlyError);
+    expect(() => buildPluginAdminMeta(withConfig(cyclic), undefined)).toThrow(
+      NextlyError
+    );
   });
 });
 
@@ -776,7 +655,7 @@ describe("buildPluginAdminMeta — clientConfig runtime shapes", () => {
     // it — and every reader downstream assumes an object it can destructure.
     for (const bad of [null, [1, 2], "a string", 42, true]) {
       expect(
-        () => buildPluginAdminMeta(withConfig(bad), undefined, []),
+        () => buildPluginAdminMeta(withConfig(bad), undefined),
         JSON.stringify(bad)
       ).toThrow(NextlyError);
     }
@@ -786,7 +665,7 @@ describe("buildPluginAdminMeta — clientConfig runtime shapes", () => {
     // Observable in the browser as `1 / value`, so it is a mangled copy like
     // any other rather than a rounding detail.
     expect(() =>
-      buildPluginAdminMeta(withConfig({ n: -0 }), undefined, [])
+      buildPluginAdminMeta(withConfig({ n: -0 }), undefined)
     ).toThrow(NextlyError);
   });
 
@@ -802,7 +681,7 @@ describe("buildPluginAdminMeta — clientConfig runtime shapes", () => {
     };
     let thrown: unknown;
     try {
-      buildPluginAdminMeta(withConfig(config), undefined, []);
+      buildPluginAdminMeta(withConfig(config), undefined);
     } catch (error) {
       thrown = error;
     }
@@ -815,7 +694,7 @@ describe("buildPluginAdminMeta — clientConfig runtime shapes", () => {
   it("resolves its status from the canonical table, not an inline literal", () => {
     let thrown: unknown;
     try {
-      buildPluginAdminMeta(withConfig({ when: new Date() }), undefined, []);
+      buildPluginAdminMeta(withConfig({ when: new Date() }), undefined);
     } catch (error) {
       thrown = error;
     }
@@ -847,8 +726,7 @@ describe("dormant routes", () => {
   it("reports a disabled plugin's routes as dormant, not active", () => {
     const [meta] = buildPluginAdminMeta(
       [{ ...declaring, enabled: false } as PluginDefinition],
-      undefined,
-      []
+      undefined
     );
 
     expect(meta.whenEnabled?.routes).toEqual([
@@ -866,8 +744,7 @@ describe("dormant routes", () => {
   it("never presents permissions as pending on being enabled", () => {
     const [meta] = buildPluginAdminMeta(
       [{ ...declaring, enabled: false } as PluginDefinition],
-      undefined,
-      []
+      undefined
     );
 
     expect(Object.keys(meta.whenEnabled ?? {})).toEqual(["routes"]);
@@ -876,8 +753,7 @@ describe("dormant routes", () => {
   it("reports an enabled plugin's routes as active, not dormant", () => {
     const [meta] = buildPluginAdminMeta(
       [{ ...declaring, enabled: true } as PluginDefinition],
-      undefined,
-      []
+      undefined
     );
 
     expect(meta.routes).toEqual([
@@ -891,8 +767,7 @@ describe("dormant routes", () => {
     enabled => {
       const [meta] = buildPluginAdminMeta(
         [{ ...declaring, enabled } as PluginDefinition],
-        undefined,
-        []
+        undefined
       );
 
       const active = Boolean(meta.routes);
@@ -918,8 +793,7 @@ describe("dormant routes", () => {
           contributes: { routes: [{ method: "GET", path: "export" }] },
         } as unknown as PluginDefinition,
       ],
-      undefined,
-      []
+      undefined
     );
 
     expect(meta.whenEnabled).toBeUndefined();
@@ -946,8 +820,7 @@ describe("dormant routes", () => {
           },
         } as unknown as PluginDefinition,
       ],
-      undefined,
-      []
+      undefined
     );
 
     expect(meta.whenEnabled).toBeUndefined();
@@ -962,8 +835,7 @@ describe("dormant routes", () => {
           enabled: false,
         } as PluginDefinition,
       ],
-      undefined,
-      []
+      undefined
     );
 
     expect(meta.whenEnabled).toBeUndefined();
@@ -994,8 +866,7 @@ describe("dormant routes against the enabled set", () => {
     // Both resolve to /plugins/foo/bar/x.
     const metas = buildPluginAdminMeta(
       [enabledOwner, disabledClaimant],
-      undefined,
-      []
+      undefined
     );
     const claimant = metas.find(m => m.name === "foo/bar");
 
@@ -1008,7 +879,7 @@ describe("dormant routes against the enabled set", () => {
    * than about a route that was never valid.
    */
   it("keeps it when no enabled plugin holds that path", () => {
-    const metas = buildPluginAdminMeta([disabledClaimant], undefined, []);
+    const metas = buildPluginAdminMeta([disabledClaimant], undefined);
     const claimant = metas.find(m => m.name === "foo/bar");
 
     expect(claimant?.whenEnabled?.routes).toEqual([
@@ -1019,187 +890,11 @@ describe("dormant routes against the enabled set", () => {
   it("leaves the enabled owner's own route reported", () => {
     const metas = buildPluginAdminMeta(
       [enabledOwner, disabledClaimant],
-      undefined,
-      []
+      undefined
     );
 
     expect(metas.find(m => m.name === "foo")?.routes).toEqual([
       { method: "GET", path: "/bar/x", fullPath: "/plugins/foo/bar/x" },
     ]);
-  });
-});
-
-/**
- * The public admin-meta payload is served WITHOUT initializing services, so the
- * config it folds is the one the route module stored — before any plugin
- * `setup` transformer has run.
- */
-describe("adminMetaPermissions", () => {
-  const colliding = asPlugins([
-    {
-      name: "@acme/a",
-      version: "1.0.0",
-      contributes: { permissions: [{ action: "purge", resource: "cache" }] },
-    },
-    {
-      name: "@acme/b",
-      version: "1.0.0",
-      contributes: { permissions: [{ action: "purge", resource: "cache" }] },
-    },
-  ]);
-
-  /**
-   * A transformer may legitimately resolve this collision, so the raw list can
-   * hold one boot never sees. Throwing here would blank the whole endpoint —
-   * branding included — for an app that boots perfectly well.
-   */
-  it("describes no permissions when the raw declarations collide", () => {
-    expect(adminMetaPermissions({ plugins: colliding })).toEqual([]);
-  });
-
-  /**
-   * The positive control. Without it the assertion above is satisfied by a
-   * function that returns `[]` for every input, which would be the endpoint
-   * silently describing nothing rather than degrading only on a collision.
-   */
-  it("returns the collected set when the declarations are valid", () => {
-    const [a] = colliding;
-    expect(adminMetaPermissions({ plugins: [a] }).map(p => p.slug)).toEqual([
-      "purge-cache",
-    ]);
-  });
-
-  /**
-   * Boot merges a plugin's contributed entities into the config before asking
-   * whether a `publish` declaration names one; this endpoint reads a config
-   * where they are still absent. Without widening, a plugin publishing to a
-   * collection IT contributes is reported as owning a permission the seeder
-   * takes over and keeps ownerless.
-   *
-   * `export` is the positive control: a genuine custom permission on the same
-   * plugin, which must survive the widening.
-   */
-  it("counts a contributed collection boot merged as an entity", () => {
-    const collected = adminMetaPermissions({
-      // As the booted config arrives: `registerServices` folds
-      // `contributes.collections` into `collections` before publishing, so the
-      // contribution is already here. This fold reads that rather than
-      // re-deriving entity slugs from the declarations, which would be a second
-      // answer to which entities exist.
-      collections: [{ slug: "submissions" }],
-      plugins: asPlugins([
-        {
-          name: "@acme/forms",
-          version: "1.0.0",
-          contributes: {
-            collections: [{ slug: "submissions" }],
-            permissions: [
-              { action: "publish", resource: "submissions" },
-              { action: "export", resource: "submissions" },
-            ],
-          },
-        },
-      ]),
-    });
-
-    expect(collected.map(p => p.slug)).toEqual(["export-submissions"]);
-  });
-
-  /**
-   * The separating case for reading the merged config rather than the
-   * declarations. Boot's schema fold runs over the PRE-transform plugin list,
-   * so a plugin a `setup` transformer added has its contributions skipped — its
-   * collection is absent from the booted `collections`. Re-deriving here would
-   * classify `reports` as an entity and drop the declaration as adopted, while
-   * the seeder writes it as a plugin-owned custom permission.
-   */
-  it("does not invent an entity boot never merged", () => {
-    const collected = adminMetaPermissions({
-      collections: [],
-      plugins: asPlugins([
-        {
-          name: "@acme/added-by-setup",
-          version: "1.0.0",
-          contributes: {
-            collections: [{ slug: "reports" }],
-            permissions: [{ action: "publish", resource: "reports" }],
-          },
-        },
-      ]),
-    });
-
-    expect(collected.map(p => p.slug)).toEqual(["publish-reports"]);
-  });
-
-  /**
-   * A reserved system resource is a different REASON but the same rejection,
-   * and it is judged against the same pre-transform list — a transformer can
-   * drop the offending plugin just as it can resolve a duplicate. Boot still
-   * refuses if the declaration survives, which is where the operator sees it;
-   * blanking the admin as well reports it twice and helps nobody.
-   */
-  it("degrades on a reserved system resource too", () => {
-    expect(
-      adminMetaPermissions({
-        plugins: asPlugins([
-          {
-            name: "@acme/a",
-            version: "1.0.0",
-            contributes: {
-              permissions: [{ action: "read", resource: "users" }],
-            },
-          },
-        ]),
-      })
-    ).toEqual([]);
-  });
-
-  /**
-   * What the degradation must NOT absorb, asserted at the CALL SITE. Without
-   * this the `catch` can be widened to swallow everything and the suite stays
-   * green — measured, so it is the case this exists for. The plugin throws on
-   * the property the fold reads, standing in for any unexpected failure inside
-   * it; a defect there must reach the caller rather than be reported as an app
-   * with no custom permissions.
-   */
-  it("rethrows a failure that is not a rejected declaration", () => {
-    const exploding = new Proxy({} as PluginDefinition, {
-      get(target, prop) {
-        if (prop === "contributes") throw new TypeError("boom");
-        return Reflect.get(target, prop);
-      },
-    });
-
-    expect(() => adminMetaPermissions({ plugins: [exploding] })).toThrow(
-      TypeError
-    );
-  });
-
-  /**
-   * The guard itself, so a widened code match is caught as well as a widened
-   * catch.
-   */
-  it("discriminates a collision from any other NextlyError", () => {
-    expect(
-      isPermissionCollision(
-        new NextlyError({
-          code: "NEXTLY_PERMISSION_COLLISION",
-          statusCode: 409,
-          publicMessage: "x",
-          logMessage: "x",
-        })
-      )
-    ).toBe(true);
-    expect(
-      isPermissionCollision(
-        new NextlyError({
-          code: "NEXTLY_ROUTE_COLLISION",
-          statusCode: 409,
-          publicMessage: "x",
-          logMessage: "x",
-        })
-      )
-    ).toBe(false);
-    expect(isPermissionCollision(new Error("boom"))).toBe(false);
   });
 });

--- a/packages/nextly/src/plugins/admin-meta.ts
+++ b/packages/nextly/src/plugins/admin-meta.ts
@@ -19,12 +19,6 @@ import type {
   PluginMenuItem,
 } from "./admin-contributions";
 import type { FieldSurface } from "./contributions";
-import { isPermissionCollision } from "./permission-error";
-import {
-  type CollectedPermission,
-  collectCustomPermissions,
-  type PermissionConfigSource,
-} from "./permissions/collect-permissions";
 import { pluginCollectionSlugs } from "./plugin-admin-meta";
 import type {
   PluginAdminAppearance,
@@ -81,22 +75,6 @@ export interface PluginAdminMeta {
    * JSON-only; see `PluginAdminContributions.clientConfig`.
    */
   clientConfig?: Record<string, unknown>;
-  /**
-   * Declared custom permissions (identity + display fields only).
-   *
-   * Present whatever the enabled state, unlike the rest of the behavioral
-   * surface, because these rows exist whatever the enabled state: the
-   * permission fold covers disabled plugins too, the seeder creates them, and
-   * new ones are granted to super_admin. A disabled plugin's permission is
-   * held and assignable; what it protects is simply not mounted.
-   */
-  permissions?: Array<{
-    action: string;
-    resource: string;
-    label?: string;
-    description?: string;
-    danger?: boolean;
-  }>;
   /**
    * Declared HTTP routes, summarized as method + path. Handlers and
    * middleware are code and never serialize; the admin only names what the
@@ -252,96 +230,10 @@ function mountableRoutes(
     : undefined;
 }
 
-/**
- * The custom permissions to describe on the PUBLIC admin-meta payload.
- *
- * That endpoint is served WITHOUT initializing services, so the config it reads
- * is whatever the route module stored — before any plugin `setup` transformer
- * has run. A transformer may legitimately resolve a collision between two
- * declarations, so the raw list can hold one that boot never sees, and
- * `collectCustomPermissions` throws on it. Letting that escape would take the
- * whole endpoint down — branding included — over a configuration that boots.
- *
- * Degrades to describing NO custom permissions rather than to describing the
- * raw declarations: a set that cannot be folded is a set this cannot attribute,
- * and attributing it wrongly is the thing the fold exists to prevent.
- *
- * Deliberately a different failure semantic from `collectPluginInfo`, which
- * folds the same declarations for the CLI and lets the collision throw — there
- * an invalid config should be reported, here it should not blank the admin.
- *
- * Only the collision is absorbed. Anything else is a defect, and rethrows.
- *
- * The entity slugs are widened with each plugin's CONTRIBUTED collections and
- * singles before folding, taken from `resolvePluginSelf` so they are the slugs
- * the entities RESOLVE to. A host may remap one with the public
- * `plugin.rename({ forms: "contact-forms" })` API and the schema fold seeds
- * against the renamed slug, so widening with the declared name instead would
- * leave a `publish:contact-forms` declaration looking plugin-owned while boot
- * drops it as an adopted lifecycle permission. Whether a `publish` declaration is the plugin's own
- * or one the seeder owns is decided by whether its resource names an entity —
- * and boot merges contributed entities into the config before that question is
- * asked, while this endpoint reads a config where they are still absent. Folded
- * against the narrow view, a plugin declaring `publish` for a collection it
- * contributes itself would be reported as owning a permission the seeder takes
- * over.
- *
- * This closes the CONFIG half of that gap and not the database half: a Schema
- * Builder collection lives in `dynamic_collections` and is unknowable here, so
- * a declaration naming one is still collected as plugin-owned. That limit is
- * the collector's own and predates this function — see the Builder-entity case
- * in `seed-system-permissions.integration.test.ts`.
- */
-export function adminMetaPermissions(
-  config: PermissionConfigSource & { plugins?: PluginDefinition[] }
-): CollectedPermission[] {
-  const plugins = config.plugins ?? [];
-
-  try {
-    // The config AS GIVEN. No widening from plugin declarations: the booted
-    // config's `collections` and `singles` are already contribution-merged —
-    // `registerServices` folds `contributes.{collections,singles}` in before it
-    // publishes — and boot's own `collectCustomPermissions` call reads exactly
-    // this shape. Re-deriving entity slugs here would be a second answer to
-    // "which entities exist", and it would be the WRONG one: it classifies a
-    // contribution from a plugin the schema fold never merged, so a lifecycle
-    // declaration on it reads as adopted here while the seeder makes it a
-    // plugin-owned custom permission.
-    return collectCustomPermissions(config, plugins);
-  } catch (error) {
-    if (isPermissionCollision(error)) return [];
-    throw error;
-  }
-}
-
 export function buildPluginAdminMeta(
   plugins: PluginDefinition[],
-  pluginOverrides: Record<string, PluginOverride> | undefined,
-  permissions: readonly CollectedPermission[]
+  pluginOverrides: Record<string, PluginOverride> | undefined
 ): PluginAdminMeta[] {
-  // The permissions that actually become rows, indexed by the plugin that owns
-  // them.
-  //
-  // TAKEN rather than folded here. A declaration and a seeded permission are
-  // not the same set — `collectCustomPermissions` drops a `publish`/`unpublish`
-  // declaration whose resource is a collection or single, since the seeder
-  // emits that slug itself and keeps the row ownerless — so this must read the
-  // collected set rather than `contributes.permissions`. But collecting it here
-  // as well as at the caller would compute one authoritative answer twice and
-  // leave two projections of it free to drift; `collectPluginInfo` already
-  // collects the same set for the CLI's slug summary.
-  //
-  // `source` rather than `owner` decides what belongs to a plugin: the host's
-  // sentinel owner is the literal `"app"`, and a plugin may legally be named
-  // that, which would file every host-declared permission under it.
-  const ownedPermissions = new Map<string, CollectedPermission[]>();
-  for (const permission of permissions) {
-    if (permission.source !== "plugin") continue;
-    const owned = ownedPermissions.get(permission.owner);
-    if (owned) owned.push(permission);
-    else ownedPermissions.set(permission.owner, [permission]);
-  }
-
   // Here, and not only at boot, because this is the one place a plugin list
   // becomes ADDRESSES: the slug below is the admin's URL for the plugin and
   // the key its host override is read by. Two boot paths do not reach it —
@@ -440,33 +332,10 @@ export function buildPluginAdminMeta(
         meta.entryFormToolbarSlot = admin.entryFormToolbarSlot;
     }
 
-    // Permissions are serialized whatever the enabled state, because they
-    // EXIST whatever the enabled state: `collectCustomPermissions` folds over
-    // every plugin including disabled ones (D49), the post-init seeder creates
-    // the rows, and new ones are assigned to super_admin. Withholding them
-    // here made the page disagree with the database — an operator could hold a
-    // plugin's permission, see it in the roles UI, and find nothing on the
-    // owning plugin's page to explain where it came from.
-    //
-    // Routes are the genuinely absent half: `collectPluginRoutes` skips
-    // disabled plugins, so a disabled plugin serves none. Those move to
-    // `whenEnabled`, and the `if/else` is what stops a route being reported as
-    // both served and pending.
-    const permissions = ownedPermissions.get(plugin.name);
-    if (permissions && permissions.length > 0) {
-      meta.permissions = permissions.map(p => ({
-        action: p.action,
-        resource: p.resource,
-        // The name the row carries, which the collector already resolved from
-        // the declared label or composed from the action and resource. Sending
-        // it under `label` keeps this page and the roles UI naming the same
-        // permission the same way.
-        label: p.name,
-        ...(p.description ? { description: p.description } : {}),
-        ...(p.danger ? { danger: p.danger } : {}),
-      }));
-    }
-
+    // Routes move to `whenEnabled` when the plugin is disabled, because
+    // `collectPluginRoutes` skips disabled plugins and so a disabled plugin
+    // serves none. The `if/else` is what stops a route being reported as both
+    // served and pending.
     const declaredRoutes = mountableRoutes(plugin, plugins);
     if (isEnabled) {
       if (declaredRoutes) meta.routes = declaredRoutes;

--- a/packages/nextly/src/plugins/plugin-introspection.ts
+++ b/packages/nextly/src/plugins/plugin-introspection.ts
@@ -89,9 +89,7 @@ export function collectPluginInfo(
   // Admin menu/page/settings (host overrides only affect placement/appearance,
   // not these counts, so we fold with no overrides).
   const adminMetaByName = new Map(
-    buildPluginAdminMeta(resolved, undefined, collectedPermissions).map(
-      meta => [meta.name, meta]
-    )
+    buildPluginAdminMeta(resolved, undefined).map(meta => [meta.name, meta])
   );
 
   return resolved.map(plugin => {

--- a/packages/nextly/src/routeHandler.ts
+++ b/packages/nextly/src/routeHandler.ts
@@ -92,10 +92,7 @@ import { withTimezoneFormatting } from "./lib/date-formatting";
 import { createCorsMiddleware } from "./middleware/cors";
 import { createRateLimiter } from "./middleware/rate-limit";
 import { createSecurityHeadersMiddleware } from "./middleware/security-headers";
-import {
-  adminMetaPermissions,
-  buildPluginAdminMeta,
-} from "./plugins/admin-meta";
+import { buildPluginAdminMeta } from "./plugins/admin-meta";
 import { runPluginRoute } from "./plugins/routes/dispatch";
 import { getPluginRouteRegistry } from "./plugins/routes/route-registry";
 import { assertClientConfigs } from "./plugins/validate-client-config";
@@ -1279,11 +1276,7 @@ async function handleAdminMetaRequest(): Promise<Response> {
   // Collect plugin metadata from registered plugins with host override
   // resolution + contributes.admin menu/pages/settings folding (D20/D21/D49).
   const pluginOverrides = config?.admin?.pluginOverrides;
-  const plugins = buildPluginAdminMeta(
-    config?.plugins ?? [],
-    pluginOverrides,
-    adminMetaPermissions(config ?? {})
-  );
+  const plugins = buildPluginAdminMeta(config?.plugins ?? [], pluginOverrides);
   if (plugins.length > 0) {
     payload.plugins = plugins;
   }


### PR DESCRIPTION
`GET /api/admin-meta` answers **without authentication** — `handleGet` routes it to `handleAdminMetaRequest()` before `handleServiceRequest`, which is where auth lives. Every plugin's declared custom permissions were serialized onto that payload, so any unauthenticated caller could read them: action, resource, label, description and the `danger` flag.

## What this removes, and what it does NOT

Removed: the top-level `permissions` array and the machinery that filled it.

**Not removed: `requiredPermission` on contributed menu items, pages and widgets.** Those still carry plugin-declared slugs to anonymous callers. Raised by review, verified, and deliberately left — see below. **This PR does not claim the permission vocabulary is fully withheld.** It removes the enumeration.

## Why the rest is not in here

Those slugs are load-bearing on the client:

- `PluginWidgetGrid.tsx:21` filters widgets by `hasPermission(w.requiredPermission)`
- `usePluginPageRegistration.ts:51,65` gates plugin routes on it

Redacting the field removes the input two gating paths run on. Doing it properly means splitting this endpoint — public branding, which the login page needs before a session exists, from authenticated plugin metadata — which is an admin-bootstrapping change, not a serialization one. Bundling it would hold a live disclosure fix behind a redesign.

Severity context that cuts against this PR: the BUILT-IN vocabulary is already public regardless. `packages/admin/src/constants/navigation.ts` hard-codes `read-media`, `read-users`, `read-roles` and `manage-settings`, and ships in the admin bundle. The residual exposure is specifically plugin-declared slugs.

## Changes

- `PluginAdminMeta.permissions` and the block that filled it — deleted.
- `adminMetaPermissions()` — deleted; it existed only to feed this payload.
- `buildPluginAdminMeta()` loses its `permissions` parameter and the owner-indexed map.
- `AdminBranding.permissions` and the detail page's Permissions group — deleted.

## Callers

- `routeHandler.ts` — the public endpoint. This is the fix.
- `plugin-introspection.ts` — the local CLI path. Builds its own `permissionsByOwner` and never read `meta.permissions`, so it reports permissions exactly as before. Found by the build, not by my grep: I searched for `adminMetaPermissions` and not for callers of `buildPluginAdminMeta`.

## Verification

- `admin-meta.test.ts` 43 pass. Three tests asserting the payload CARRIES permissions were obsolete and are replaced by one asserting it never does — run against a plugin that DECLARES a permission, plus an assertion that the plugin was serialized at all, so it cannot pass by the fixture being dropped.
- Break-verified: re-serializing `contributes.permissions` reddens exactly that test, 42 green.
- `plugin-detail.test.tsx` 15 pass. It was RED at 3/16 when this PR was opened and I did not catch it — I ran nextly's suites and never asked which tests assert on the UI I deleted.
- `src/plugins/` + `src/route-handler/` 506 pass. Two failures in `schema/caching.test.ts` are pre-existing, measured at the base with the change stashed.
- Build and eslint clean on a built tree.

## Follow-up

The endpoint split, and wiring the detail page to the authenticated permissions endpoint. The changeset says the page simply stops listing permissions, rather than promising the wiring.