### PR TITLE
fix(root): accept both entry URL forms, and date the absent-check finding

### DIFF
--- a/.claude/rules/derived-checks.md
+++ b/.claude/rules/derived-checks.md
@@ -234,6 +234,13 @@ The second shape is the commoner one, so do not reach for the first tell alone:
 entirely, which would tell someone their `default`-arm bug is not an instance of
 this rule when it is the cleanest kind.
 
+**A rule is itself a generalisation from instances, so it is subject to the
+failure it describes.** The paragraph above was first written with the narrower
+tell, by someone holding only the flag case — the rule's own failure mode,
+committed while writing the rule. So before shipping a tell, test it against an
+instance you did NOT derive it from; one that fits every case you had in mind is
+evidence of nothing, because those are the cases it was fitted to.
+
 ## A gate's OUTPUT is an interface, with no compiler enforcing its use
 
 A return type has a checker; a printed verdict has a person under time pressure

--- a/.claude/rules/derived-checks.md
+++ b/.claude/rules/derived-checks.md
@@ -198,6 +198,60 @@ structure rather than by someone else's spelling, at the granularity your claim
 actually needs — which is the separating-property test applied to the identifier
 itself.
 
+## A fix that produces the OPPOSITE failure narrowed the symptom
+
+When a repair is followed by the same defect pointing the other way, the second
+attempt was a different assumption rather than the removal of one. Only the
+third makes the wrong state unrepresentable, so go there directly.
+
+**The tell is that the fix addressed the DIRECTION of the failure rather than
+what produced both directions.** Ask what single thing made the first failure
+possible; if the second attempt leaves it standing, the third failure is already
+written.
+
+Two shapes, and the remedy differs:
+
+- **the cause is something the code cannot observe** — a runtime flag, an
+  environment shape, a value another system spells. Removal is forced, because
+  no amount of assuming correctly is stable. An entry guard here compared
+  `import.meta.url` against `pathToFileURL(process.argv[1])`, which never matches
+  under a symlinked prefix; resolving with `realpathSync` fixed that and broke
+  the opposite case, because `--preserve-symlinks-main` is settable through
+  `NODE_OPTIONS` and turns the resolution off. Accepting BOTH forms depends on
+  neither. Failure mode throughout: the module declined to run and the process
+  **exited 0 having verified nothing**.
+- **the cause is one construct serving two questions** — nothing is hidden, and
+  fixing either direction necessarily exposes the other. A `switch` with a
+  `default` arm silently absorbed a new union member: the union was fully
+  visible, the arm simply declined to look: an exhaustive `Record` makes the
+  compiler demand each case. A sentinel comparison repaired a gain/loss case
+  and immediately produced a false rename pair, because one map answered both
+  "which fields changed value" and "which fields add or drop a column". Split
+  the construct.
+
+The second shape is the commoner one, so do not reach for the first tell alone:
+"something unobservable" fits the flag case and misses the conflation case
+entirely, which would tell someone their `default`-arm bug is not an instance of
+this rule when it is the cleanest kind.
+
+## A gate's OUTPUT is an interface, with no compiler enforcing its use
+
+A return type has a checker; a printed verdict has a person under time pressure
+who will `grep`, `head` or skim it. Both failures below were consumers
+misreading a gate correctly doing its job, and both were cheaper to fix in the
+output than in every caller:
+
+- a refusal printed below the twelfth line was cut off by `head -12`, and the
+  run read as clean. Remedy: the verdict and exit status come FIRST.
+- a finding worded "never reported — no build or test coverage for this
+  revision" was quoted as a durable property of a merged commit. The check-run
+  had not registered yet and subsequently passed. Remedy: a point-in-time
+  reading says so — "AS OF this reading" — and names the causes it cannot
+  separate, because their remedies differ.
+
+Same move as preferring a boundary to a check: make the output accommodate the
+caller it actually has, rather than the one who reads it all.
+
 ## The THIRD finding of one shape is a prompt to TEST the check
 
 Two findings that rhyme are a coincidence. The third is worth a minute spent on

--- a/scripts/verify-merge.mjs
+++ b/scripts/verify-merge.mjs
@@ -254,7 +254,7 @@ export function gateVerdict({
     for (const name of missingRequired(checkRuns, changedPaths, required)) {
       blockers.push({
         kind: "required-check-absent",
-        detail: `${name} never reported — no build or test coverage for this revision`,
+        detail: `${name} has no check-run AS OF this reading — either it never triggered, or it has not registered yet`,
       });
     }
     for (const job of blockingJobs(checkRuns)) {
@@ -1167,20 +1167,33 @@ export function main(argv) {
  * returns; that is the only reason it is a parameter.
  */
 /**
- * `process.argv[1]` as the URL `import.meta.url` would report for it.
+ * Every URL form `import.meta.url` might report for `process.argv[1]`.
  *
- * `import.meta.url` is percent-encoded AND resolved through symlinks, while
- * `argv[1]` is neither, so comparing them directly fails whenever the path
- * contains a character needing encoding or sits under a symlinked prefix — on
- * macOS `/tmp` resolves to `/private/tmp`, so an ordinary invocation there
- * silently declines to run and exits reporting nothing.
+ * BOTH forms, because symlink resolution is a runtime option rather than a
+ * fixed behaviour. By default `import.meta.url` is resolved through symlinks
+ * while `argv[1]` is not — on macOS `/tmp` is `/private/tmp`, so comparing the
+ * unresolved form there never matches. Under `--preserve-symlinks-main`, which
+ * `NODE_OPTIONS` can set from outside the command line, it is the opposite: the
+ * resolved form never matches.
+ *
+ * Committing to either one makes the guard depend on a flag this code cannot
+ * see, and its failure is silent in the worst way — the module declines to run
+ * and the process exits 0 having verified nothing, which is indistinguishable
+ * from a clean pass.
  */
-function entryHref(argvPath) {
+function entryHrefs(argvPath) {
+  const forms = [];
   try {
-    return pathToFileURL(realpathSync(argvPath)).href;
+    forms.push(pathToFileURL(argvPath).href);
   } catch {
-    return "";
+    // An unconvertible path contributes nothing rather than failing the guard.
   }
+  try {
+    forms.push(pathToFileURL(realpathSync(argvPath)).href);
+  } catch {
+    // Unresolvable is not fatal either: the plain form above may still match.
+  }
+  return forms;
 }
 
 export function runCli(argv, run = main) {
@@ -1197,7 +1210,7 @@ export function runCli(argv, run = main) {
 
 if (
   process.argv[1] &&
-  import.meta.url === entryHref(process.argv[1])
+  entryHrefs(process.argv[1]).includes(import.meta.url)
 ) {
   // `process.exitCode`, not `process.exit()`. Exiting terminates Node before a
   // redirected stdout finishes flushing, truncating exactly the blocker names a


### PR DESCRIPTION
Two reports from the schema lane, one of which turned out to be a live silent-no-op.

## 1. The entry guard depended on a flag it cannot see

Symlink resolution is a **runtime option**, not fixed behaviour:

- **by default** `import.meta.url` is resolved through symlinks, `argv[1]` is not
- **under `--preserve-symlinks-main`** it is the opposite

`NODE_OPTIONS` can set that from outside the command line, so committing to either form makes the guard depend on something this code cannot observe. And the failure is silent in the worst possible way: the module declines to run and the process **exits 0 having verified nothing**, which is indistinguishable from a clean pass.

Measured through a symlinked directory, old form versus new:

```
--- default ---
OLD FORM: executed
NEW FORM: executed
--- --preserve-symlinks-main ---
OLD FORM: DECLINED TO RUN (silent no-op)
NEW FORM: executed
```

My earlier fix for the `/tmp` → `/private/tmp` case created the opposite hole. Accepting **both** forms is the version that does not depend on the flag.

## 2. `required-check-absent` asserted a durable property from a moment

The text read *"never reported — no build or test coverage for this revision"*. A check-run that has not registered **yet** reads identically to one that never will, and the remedies differ — a dropped trigger needs a push or a path-filter check; a slow registration needs waiting.

The schema lane relayed that wording to their founder as a statement about a merged revision, and had to correct it: the job was pending, and subsequently passed. The reading was accurate as an observation and wrong as the claim it licensed.

Now: *"has no check-run AS OF this reading — either it never triggered, or it has not registered yet"*, which names both causes and carries its own expiry.

## What I did NOT change, and why

Their report also said the gate **collapses** a queued row into `required-check-absent`. **It does not**, and I checked before acting:

```
queued row present -> missingRequired: []          <- not absent
no row at all      -> missingRequired: ["CI"]
blockingJobs on queued row -> [{name:"CI",status:"queued",conclusion:null}]
```

`missingRequired` filters on **name presence** only, so a queued job already surfaces as `job-not-green: CI (queued/-)`. The two states were already separate findings with distinct remedies. What they saw was a genuine absence at that moment — the row appeared later — so the defect was the wording, not the classification.

## Verification

202 tests. The entry-guard change is verified by the control above rather than by a unit test: it is an I/O-boundary behaviour under a Node flag, and the honest evidence is running it both ways through a symlink.