### PR TITLE
fix(root): count a transition's delay toward the settle allowance

### DIFF
--- a/e2e/tests/canvas/fixtures.ts
+++ b/e2e/tests/canvas/fixtures.ts
@@ -86,11 +86,6 @@ export const FLAT_LIST_FIXTURE: SeedOptions = {
 };
 
 /**
- * Alternating 400px and 24px siblings, a ratio of about 16:1. dnd-kit #2088
- * reports the jitter as proportional to the ratio between the dragged element
- * and the one it moves over, so this is the condition under test.
- */
-/**
  * A flat list PLUS an empty container, so both drop-zone shapes are on the page at once.
  *
  * `.nx-pb-dropzone` and `.nx-pb-dropzone-empty` are different elements with different markup and
@@ -126,6 +121,11 @@ export const BOTH_ZONE_SHAPES_FIXTURE: SeedOptions = {
   blockIds: ["nx-both-root", "nx-both-0", "nx-both-1", "nx-both-empty"],
 };
 
+/**
+ * Alternating 400px and 24px siblings, a ratio of about 16:1. dnd-kit #2088
+ * reports the jitter as proportional to the ratio between the dragged element
+ * and the one it moves over, so this is the condition under test.
+ */
 export const EXTREME_RATIO_FIXTURE: SeedOptions = {
   title: "spike extreme ratio",
   slug: "spike-extreme-ratio",

--- a/e2e/tests/canvas/fixtures.ts
+++ b/e2e/tests/canvas/fixtures.ts
@@ -90,6 +90,42 @@ export const FLAT_LIST_FIXTURE: SeedOptions = {
  * reports the jitter as proportional to the ratio between the dragged element
  * and the one it moves over, so this is the condition under test.
  */
+/**
+ * A flat list PLUS an empty container, so both drop-zone shapes are on the page at once.
+ *
+ * `.nx-pb-dropzone` and `.nx-pb-dropzone-empty` are different elements with different markup and
+ * different states — the empty placeholder carries `data-active` alone — and the driver waits on
+ * both. A fixture with only one of them lets a guard read as covering the canvas while measuring
+ * half of it.
+ */
+export const BOTH_ZONE_SHAPES_FIXTURE: SeedOptions = {
+  title: "spike both zone shapes",
+  slug: "spike-both-zone-shapes",
+  content: {
+    version: DOCUMENT_VERSION,
+    kind: "page",
+    root: {
+      id: "nx-both-root",
+      type: "core/container",
+      props: { as: "div" },
+      slots: {
+        [DEFAULT_SLOT]: [
+          spacer("nx-both-0", "60px"),
+          spacer("nx-both-1", "60px"),
+          // No children, so its slot renders the empty placeholder rather than gap zones.
+          {
+            id: "nx-both-empty",
+            type: "core/container",
+            props: { as: "div" },
+            slots: { [DEFAULT_SLOT]: [] },
+          },
+        ],
+      },
+    },
+  },
+  blockIds: ["nx-both-root", "nx-both-0", "nx-both-1", "nx-both-empty"],
+};
+
 export const EXTREME_RATIO_FIXTURE: SeedOptions = {
   title: "spike extreme ratio",
   slug: "spike-extreme-ratio",

--- a/e2e/tests/canvas/geometry-settle-matches-the-canvas.test.ts
+++ b/e2e/tests/canvas/geometry-settle-matches-the-canvas.test.ts
@@ -2,31 +2,32 @@
  * The drop-zone timing the probe's settle allowance is chosen against.
  *
  * `poc-driver` declares `geometrySettleMs` — how long the canvas may still be moving a zone edge
- * after the pointer enters it — while the canvas animates that geometry in its own stylesheet.
- * Two statements of one fact, in files that do not refer to each other, so this holds them
- * together.
+ * after the pointer enters it — while the canvas decides that timing in its own stylesheets. Two
+ * statements of one fact, in files that do not refer to each other, so this holds them together.
  *
- * It asserts two things, and needs both:
+ * It asserts two things and needs both:
  *
- * - the stylesheet declaration is UNCHANGED, so a timing edit cannot pass unnoticed;
- * - the driver's allowance still covers the span that declaration produces.
+ * - each drop-zone state still moves for as long as {@link PINNED_SPANS_MS} records;
+ * - the driver's allowance still covers every one of those spans.
  *
- * Either alone is satisfiable while the pair is wrong. Pinning only the text passes when the
- * allowance is lowered underneath it; checking only the allowance passes when the transition is
- * lengthened.
+ * Either alone is satisfiable while the pair is wrong. Pinning only the spans passes when the
+ * allowance is lowered underneath them; checking only the allowance passes when a transition is
+ * lengthened and the pin is updated without anyone re-deriving the wait.
  *
- * ## Why the declaration is PINNED rather than parsed
+ * ## Why this MEASURES rather than reads CSS
  *
- * Computing a span from CSS source means representing CSS: comma-separated entries whose commas
- * may belong to a timing function, times that may be signed or written as `calc()` or resolved
- * through a variable, properties that may appear last or be implicit, longhand declarations that
- * override the shorthand, and only some properties moving the edge this probe measures. A regex
- * cannot represent that, and each spelling handled reveals another.
+ * Deciding from CSS means representing CSS, and then representing the cascade around it: rules
+ * split across sheets, `@media` and `@supports` groups, ancestry selectors, inline styles, a
+ * delay declared apart from its duration, a later rule overriding an earlier one, and `animation`
+ * as an alternative to `transition` entirely. Each spelling handled reveals another, because the
+ * surface is the whole cascade.
  *
- * Pinning makes no semantic claim, which is what makes it complete: every one of those spellings
- * changes the text, so every one trips this, and none requires the test to understand what it
- * changed to. The cost is that a cosmetic edit trips it as well — which is the direction to want,
- * because whoever edits that line is who should re-derive the allowance.
+ * `getComputedStyle` of a real drop zone has already resolved all of it. So this reads the
+ * element that will actually move, and nothing here interprets CSS syntax.
+ *
+ * The pin is therefore a SPAN, not a declaration. Two stylesheets can differ in every character
+ * and animate identically, and one character can change the timing — pinning the measurement
+ * makes a cosmetic edit free and a timing edit visible, which is the direction to want.
  */
 import {
   expect,
@@ -155,8 +156,21 @@ async function geometrySpanMs(
         if (computed.animationName !== "none") {
           const durations = ms(computed.animationDuration);
           const delays = ms(computed.animationDelay);
-          durations.forEach((d, i) => {
-            longest = Math.max(longest, d + cycled(delays, i));
+          // Each cycle moves the edge again, so the span is duration x ITERATIONS, not one pass.
+          // `infinite` parses as `Infinity`, which is the honest answer: an edge that never
+          // settles cannot be covered by any allowance, and the caller refuses on it below.
+          const counts = computed.animationIterationCount
+            .split(",")
+            .map(v =>
+              v.trim() === "infinite"
+                ? Infinity
+                : Number.parseFloat(v.trim()) || 1
+            );
+          durations.forEach((duration, i) => {
+            longest = Math.max(
+              longest,
+              duration * cycled(counts, i) + cycled(delays, i)
+            );
           });
         }
 
@@ -203,6 +217,12 @@ async function geometrySpanMs(
     throw new Error(
       `no elements matched "${DROP_ZONES}" in the canvas frame, so nothing was measured. A zero ` +
         "span here would be indistinguishable from a canvas whose zones do not move."
+    );
+  }
+  if (!Number.isFinite(result.ms)) {
+    throw new Error(
+      "a drop zone runs an animation that never ends, so its edge never settles and no allowance " +
+        "can cover it. Reporting a number here would certify a wait that cannot be long enough."
     );
   }
   if (result.unclassified.length > 0) {
@@ -353,6 +373,60 @@ test.describe("the drop-zone geometry the probe waits on", () => {
     expect(injected).toBe(true);
 
     expect(await geometrySpanMs(frame, null)).toBe(300);
+  });
+
+  test("a REPEATED animation is charged for every iteration", async ({
+    page,
+    request,
+  }) => {
+    const frame = await canvas(page, request);
+
+    // One pass is 100ms; three passes move the edge for 300ms. Counting a single pass would pin
+    // 100, and the allowance would then cover a third of the movement.
+    const injected = await frame.evaluate(() => {
+      const sheet = (
+        document.getElementById("nx-pb-style") as HTMLStyleElement | null
+      )?.sheet;
+      sheet?.insertRule(
+        "@keyframes nx-test-rep { from { height: 0 } to { height: 12px } }",
+        sheet.cssRules.length
+      );
+      sheet?.insertRule(
+        ".nx-pb-dropzone { animation: nx-test-rep .1s 3 }",
+        sheet.cssRules.length
+      );
+      return Boolean(sheet);
+    });
+    expect(injected).toBe(true);
+
+    expect(await geometrySpanMs(frame, null)).toBe(300);
+  });
+
+  test("an ENDLESS animation is refused, not certified finite", async ({
+    page,
+    request,
+  }) => {
+    const frame = await canvas(page, request);
+
+    // An edge that never settles cannot be covered by any allowance. Reporting its per-pass
+    // duration would pin a number and certify a wait that can never be long enough.
+    const injected = await frame.evaluate(() => {
+      const sheet = (
+        document.getElementById("nx-pb-style") as HTMLStyleElement | null
+      )?.sheet;
+      sheet?.insertRule(
+        "@keyframes nx-test-inf { from { height: 0 } to { height: 12px } }",
+        sheet.cssRules.length
+      );
+      sheet?.insertRule(
+        ".nx-pb-dropzone { animation: nx-test-inf .1s infinite }",
+        sheet.cssRules.length
+      );
+      return Boolean(sheet);
+    });
+    expect(injected).toBe(true);
+
+    await expect(geometrySpanMs(frame, null)).rejects.toThrow(/never ends/);
   });
 
   test("it refuses rather than reporting a zero it cannot stand behind", async ({

--- a/e2e/tests/canvas/geometry-settle-matches-the-canvas.test.ts
+++ b/e2e/tests/canvas/geometry-settle-matches-the-canvas.test.ts
@@ -53,7 +53,7 @@ const CANVAS_CSS = resolve(
  * notification that the geometry timing moved.
  */
 const PINNED_DECLARATION =
-  '".nx-pb-dropzone{height:0;border-radius:3px;transition:height .1s ease,background .1s ease}",';
+  ".nx-pb-dropzone{position:absolute;left:0;right:0;top:-3px;height:6px;border-radius:3px;background:transparent;pointer-events:none;z-index:3;transition:background .1s ease}";
 
 /**
  * Properties whose transition moves the vertical edge this probe measures, so its timing counts.
@@ -157,7 +157,9 @@ const PROBE_CLASSES = DROP_ZONES.split(",").map(part =>
  * So an unresolved reference is refused rather than measured, and this is where the definition
  * goes to make it measurable. Empty because the pinned rule reads no variable today.
  */
-const PROBE_CUSTOM_PROPERTIES: Record<string, string> = {};
+const PROBE_CUSTOM_PROPERTIES: Record<string, string> = canvasCustomProperties(
+  readFileSync(CANVAS_CSS, "utf8")
+);
 
 /**
  * How long the geometry in a rule keeps moving, computed BY THE BROWSER.
@@ -174,9 +176,9 @@ async function geometrySpanMs(
   page: Page,
   declaration: string
 ): Promise<number> {
-  // The pinned literal is a quoted, comma-suffixed line of a TypeScript array; the rule inside it
-  // is what a browser can accept.
-  const rule = declaration.trim().replace(/^"/, "").replace(/",?$/, "");
+  // Already a rule as the browser receives it: the reader joins the array and splits on `}`, so
+  // nothing here has to undo TypeScript's quoting.
+  const rule = declaration.trim();
   const result = await page.evaluate(
     ([css, safe, states, geometry, classes, customProps]) => {
       const props = customProps as Record<string, string>;
@@ -371,18 +373,123 @@ async function geometrySpanMs(
   return result.ms;
 }
 
-/** Every drop-zone line declaring a transition, trimmed, in file order. */
-function transitionLines(source: string): string[] {
-  return source
-    .split("\n")
-    .map(line => line.trim())
+/**
+ * The canvas overlay stylesheet as the BROWSER receives it: every entry of the array, joined.
+ *
+ * Read from the joined text rather than line by line, because the array is `.join("")`ed and a
+ * rule is free to straddle two entries — `".nx-pb-dropzone[data-active]{"` in one and
+ * `"transition:margin .2s}"` in the next. No SOURCE LINE then contains both the selector and the
+ * declaration, so a line filter reports the remaining rules, matches the pin, and stays green
+ * while the stylesheet the canvas actually applies carries a transition nobody measured.
+ *
+ * This is the same mismatch the header describes one level up: the instrument has to read what
+ * the browser reads, and the browser never sees the line breaks.
+ */
+function overlayCss(source: string): string {
+  const start = source.indexOf("const OVERLAY_CSS = [");
+  const end = source.indexOf('].join("");', start);
+  if (start === -1 || end === -1) {
+    throw new Error(
+      "could not find OVERLAY_CSS in the canvas source. This test reads that array to learn what " +
+        "the browser is given; if it was renamed or restructured, update this reader — an empty " +
+        "read here would certify a stylesheet nobody looked at."
+    );
+  }
+  // Each entry is a double-quoted literal. Escapes are preserved as authored, which is what the
+  // browser is handed: `\\283F` in the source is the four characters CSS then reads.
+  const entries = [
+    ...source.slice(start, end).matchAll(/"((?:[^"\\]|\\.)*)"/g),
+  ].map(m => m[1]);
+  return entries.join("");
+}
+
+/**
+ * Every drop-zone rule declaring a transition, taken from the joined stylesheet.
+ *
+ * Split on `}` rather than parsed: a rule body here contains no nested braces, and what this
+ * needs is the rule TEXT to pin, not an understanding of it.
+ */
+function transitionRules(source: string): string[] {
+  return overlayCss(source)
+    .split("}")
+    .map(part => `${part.trim()}}`)
     .filter(
-      line => line.includes("nx-pb-dropzone") && line.includes("transition")
+      rule => rule.includes("nx-pb-dropzone") && rule.includes("transition")
     );
 }
 
+/**
+ * Custom properties the canvas stylesheet defines, so a rule reading one can be measured.
+ *
+ * DERIVED from the canvas rather than hand-listed beside it. A second copy of these values is a
+ * second source of truth: the canvas moving `--zone-duration` from `.1s` to `.2s` leaves a
+ * hand-kept table saying `.1s`, the pinned rule text is unchanged so nothing trips, and the probe
+ * measures a duration the canvas stopped using.
+ *
+ * Properties defined OUTSIDE this stylesheet — the admin theme's `--nx-pb-ed-*` tokens — are not
+ * here and cannot be. Those still refuse, naming themselves, which is the honest outcome: this
+ * test cannot see the theme, and a value invented for it would be the same second source of truth
+ * one layer further away.
+ */
+function canvasCustomProperties(source: string): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [, name, value] of overlayCss(source).matchAll(
+    /(--[A-Za-z0-9_-]+)\s*:\s*([^;}]+)/g
+  )) {
+    out[name] = value.trim();
+  }
+  return out;
+}
+
+test("the stylesheet reader sees rules a line filter cannot", () => {
+  // A rule straddling two array entries. Joined, it is one ordinary rule; read line by line,
+  // NO line contains both the selector and the declaration, so a line filter reports nothing and
+  // the pin stays green while the canvas applies a transition nobody measured.
+  const split = [
+    "const OVERLAY_CSS = [",
+    '  ".nx-pb-dropzone[data-active]{",',
+    '  "transition:margin .2s}",',
+    '].join("");',
+  ].join("\n");
+
+  // The positive control on the READER, asserted by naming what it must return rather than by
+  // "not nothing" — an unrelated rule in the same source would satisfy a length check.
+  expect(transitionRules(split)).toEqual([
+    ".nx-pb-dropzone[data-active]{transition:margin .2s}",
+  ]);
+
+  // And the line filter this replaced, on the same input, to show the difference is real rather
+  // than asserted: no single line carries both halves.
+  const byLine = split
+    .split("\n")
+    .map(line => line.trim())
+    .filter(l => l.includes("nx-pb-dropzone") && l.includes("transition"));
+  expect(byLine).toEqual([]);
+});
+
+test("custom properties come from the canvas, not from a second list", () => {
+  const source = [
+    "const OVERLAY_CSS = [",
+    '  ".nx-pb-canvas{--zone-duration:.25s}",',
+    '  ".nx-pb-dropzone{transition:height var(--zone-duration)}",',
+    '].join("");',
+  ].join("\n");
+
+  // The VALUE, so a reader that found the name and dropped the value cannot pass.
+  expect(canvasCustomProperties(source)).toEqual({ "--zone-duration": ".25s" });
+});
+
+test("the stylesheet reader REFUSES a canvas it cannot find the array in", () => {
+  // Its silence would otherwise certify a stylesheet it never read: an empty result reads exactly
+  // like "no transitions here", and the pin test's own population guard would be the only thing
+  // between that and a green run.
+  expect(() => transitionRules("const SOMETHING_ELSE = 1;")).toThrow(
+    /could not find OVERLAY_CSS/
+  );
+});
+
 test("the drop-zone geometry timing has not changed under the probe", () => {
-  const found = transitionLines(readFileSync(CANVAS_CSS, "utf8"));
+  const found = transitionRules(readFileSync(CANVAS_CSS, "utf8"));
 
   // A selector that matched nothing would satisfy an equality against an empty expectation and
   // certify a file it never read.
@@ -421,7 +528,7 @@ test("the span derivation reads geometry and ignores the rest", async ({
   // resolves the syntax; what is asserted here is that the RIGHT properties are counted and that a
   // delay is included.
   const span = (rule: string) =>
-    geometrySpanMs(page, `".nx-pb-dropzone{${rule}}",`);
+    geometrySpanMs(page, `.nx-pb-dropzone{${rule}}`);
 
   expect(await span("transition:height .1s ease")).toBe(100);
   expect(await span("transition:height .1s ease .05s")).toBe(150);
@@ -481,7 +588,7 @@ test("the span derivation refuses what it cannot answer", async ({ page }) => {
   // The other half of the controls above: what the derivation does when it CANNOT decide. Each of
   // these previously produced a confident zero, which is the answer that passes any allowance.
   const span = (rule: string) =>
-    geometrySpanMs(page, `".nx-pb-dropzone{${rule}}",`);
+    geometrySpanMs(page, `.nx-pb-dropzone{${rule}}`);
 
   // A property on neither list. `font-size` does move a box, but the point is not which list it
   // belongs on — it is that an unrecognised name stops the test and names itself instead of being
@@ -496,7 +603,7 @@ test("the span derivation refuses what it cannot answer", async ({ page }) => {
   await expect(
     geometrySpanMs(
       page,
-      '".nx-pb-dropzone[data-nonexistent]{transition:height .2s}",'
+      ".nx-pb-dropzone[data-nonexistent]{transition:height .2s}"
     )
   ).rejects.toThrow(/matches no drop-zone probe element/);
 
@@ -505,7 +612,7 @@ test("the span derivation refuses what it cannot answer", async ({ page }) => {
   expect(
     await geometrySpanMs(
       page,
-      '".nx-pb-dropzone[data-drag]{transition:height .2s}",'
+      ".nx-pb-dropzone[data-drag]{transition:height .2s}"
     )
   ).toBe(200);
 
@@ -513,10 +620,7 @@ test("the span derivation refuses what it cannot answer", async ({ page }) => {
   // probe wearing only that class could never measure a transition added here. Its allowance is
   // waited on exactly as the between-item zone's is.
   expect(
-    await geometrySpanMs(
-      page,
-      '".nx-pb-dropzone-empty{transition:height .2s}",'
-    )
+    await geometrySpanMs(page, ".nx-pb-dropzone-empty{transition:height .2s}")
   ).toBe(200);
 
   // A rule reading a custom property nothing defines is REFUSED, not measured. The browser
@@ -525,7 +629,7 @@ test("the span derivation refuses what it cannot answer", async ({ page }) => {
   await expect(
     geometrySpanMs(
       page,
-      '".nx-pb-dropzone{transition:height var(--zone-duration)}",'
+      ".nx-pb-dropzone{transition:height var(--zone-duration)}"
     )
   ).rejects.toThrow(/--zone-duration/);
 
@@ -534,7 +638,7 @@ test("the span derivation refuses what it cannot answer", async ({ page }) => {
   // cannot see this — the parsed declaration being empty is what separates it from a rule that
   // legitimately declares a zero-length transition.
   await expect(
-    geometrySpanMs(page, '".nx-pb-dropzone{transition:height notatime}",')
+    geometrySpanMs(page, ".nx-pb-dropzone{transition:height notatime}")
   ).rejects.toThrow(/DROPPED/);
 });
 
@@ -550,7 +654,7 @@ test("a variable-backed duration resolves once the fixture defines it", async ({
     expect(
       await geometrySpanMs(
         page,
-        '".nx-pb-dropzone{transition:height var(--zone-duration)}",'
+        ".nx-pb-dropzone{transition:height var(--zone-duration)}"
       )
     ).toBe(200);
   } finally {

--- a/e2e/tests/canvas/geometry-settle-matches-the-canvas.test.ts
+++ b/e2e/tests/canvas/geometry-settle-matches-the-canvas.test.ts
@@ -25,22 +25,41 @@ const CANVAS_CSS = resolve(
   "../../../packages/plugin-page-builder/src/admin/canvas/IframeCanvas.tsx"
 );
 
-/** Every `transition` duration the drop-zone rules declare, in milliseconds. */
-function zoneTransitionDurationsMs(source: string): number[] {
-  const found: number[] = [];
-  for (const rule of source.split("\n")) {
-    if (!rule.includes("nx-pb-dropzone") || !rule.includes("transition"))
+/**
+ * How long each `transition` entry can still be moving geometry, in milliseconds.
+ *
+ * Duration PLUS delay, per entry, because the shorthand carries both and the settle allowance has
+ * to cover the moment the last one stops. `height .1s ease .05s` is 150ms of possible movement;
+ * reading the two numbers separately reports 100 and 50, and each passes a 120ms allowance while
+ * the edge keeps travelling past it — the guard green for the same reason the probe is wrong.
+ *
+ * A `transition` shorthand takes at most two times, and the FIRST is the duration and the second
+ * the delay, whatever order the other keywords appear in. Anything past the second is a keyword,
+ * so summing every number in the entry would inflate the total instead.
+ */
+function zoneTransitionSpansMs(source: string): number[] {
+  const spans: number[] = [];
+  for (const line of source.split("\n")) {
+    if (!line.includes("nx-pb-dropzone") || !line.includes("transition"))
       continue;
-    for (const [, value, unit] of rule.matchAll(/([\d.]+)(ms|s)\b/g)) {
-      found.push(unit === "s" ? Number(value) * 1000 : Number(value));
+    const declaration = /transition\s*:\s*([^;"']+)/.exec(line);
+    if (!declaration) continue;
+    // Comma-separated entries, each its own property with its own timings.
+    for (const entry of declaration[1].split(",")) {
+      const times = [...entry.matchAll(/([\d.]+)(ms|s)\b/g)].map(
+        ([, value, unit]) =>
+          unit === "s" ? Number(value) * 1000 : Number(value)
+      );
+      if (times.length === 0) continue;
+      spans.push(times[0] + (times[1] ?? 0));
     }
   }
-  return found;
+  return spans;
 }
 
 test("the PoC driver's settle allowance covers the zone transition it animates", () => {
   const source = readFileSync(CANVAS_CSS, "utf8");
-  const durations = zoneTransitionDurationsMs(source);
+  const durations = zoneTransitionSpansMs(source);
 
   // The positive control, and it is the whole reason this file is not vacuous: a parser that
   // matched nothing would satisfy every assertion below by having no values to check.
@@ -52,7 +71,7 @@ test("the PoC driver's settle allowance covers the zone transition it animates",
   for (const duration of durations) {
     expect(
       duration,
-      `a drop-zone transition of ${String(duration)}ms is not covered by the driver's ${String(declared)}ms geometrySettleMs — raise geometrySettleMs in poc-driver.ts`
+      `a drop-zone transition lasting ${String(duration)}ms is not covered by the driver's ${String(declared)}ms geometrySettleMs — raise geometrySettleMs in poc-driver.ts`
     ).toBeLessThanOrEqual(declared);
   }
 });

--- a/e2e/tests/canvas/geometry-settle-matches-the-canvas.test.ts
+++ b/e2e/tests/canvas/geometry-settle-matches-the-canvas.test.ts
@@ -34,7 +34,7 @@ import { fileURLToPath } from "node:url";
 
 import { expect, test, type Page } from "@playwright/test";
 
-import { POC_GEOMETRY_SETTLE_MS } from "./poc-driver";
+import { DROP_ZONES, POC_GEOMETRY_SETTLE_MS } from "./poc-driver";
 
 const CANVAS_CSS = resolve(
   dirname(fileURLToPath(import.meta.url)),
@@ -131,6 +131,35 @@ const NON_GEOMETRY_PROPERTIES = new Set([
 const PROBE_STATES = [null, "data-drag", "data-active"];
 
 /**
+ * Every class the driver measures, DERIVED from the driver's own selector.
+ *
+ * `nx-pb-dropzone-empty` does not carry `nx-pb-dropzone` — they are two classes, not a class and
+ * a modifier — and the driver waits on both. A probe that only ever wore the first could not
+ * measure a transition added to the empty placeholder, so the allowance for a target the driver
+ * really does wait on would have no maintenance path at all.
+ *
+ * Split from `DROP_ZONES` rather than restated here, so a third zone shape added to the driver is
+ * measurable by this test without anyone remembering to come back.
+ */
+const PROBE_CLASSES = DROP_ZONES.split(",").map(part =>
+  part.trim().replace(/^\./, "")
+);
+
+/**
+ * Custom properties the fixture defines, for a rule that reads one.
+ *
+ * The probe injects the pinned rule into a bare document rather than into the canvas, so a
+ * `var()` naming something defined elsewhere — a theme token, another canvas rule — resolves to
+ * nothing here. CSS then treats the declaration as invalid at computed-value time and
+ * `getComputedStyle` reports the INITIAL `0s`, which is the dangerous direction: a zone moving
+ * for 200ms measures as instant and any allowance covers it.
+ *
+ * So an unresolved reference is refused rather than measured, and this is where the definition
+ * goes to make it measurable. Empty because the pinned rule reads no variable today.
+ */
+const PROBE_CUSTOM_PROPERTIES: Record<string, string> = {};
+
+/**
  * How long the geometry in a rule keeps moving, computed BY THE BROWSER.
  *
  * The rule is injected into a real document and the resulting `transition-*` longhands are read
@@ -149,38 +178,79 @@ async function geometrySpanMs(
   // is what a browser can accept.
   const rule = declaration.trim().replace(/^"/, "").replace(/",?$/, "");
   const result = await page.evaluate(
-    ([css, safe, states, geometry]) => {
+    ([css, safe, states, geometry, classes, customProps]) => {
+      const props = customProps as Record<string, string>;
+      const vars = document.createElement("style");
+      vars.textContent = `:root{${Object.entries(props)
+        .map(([name, value]) => `${name}:${value}`)
+        .join(";")}}`;
+      document.head.append(vars);
+
       const style = document.createElement("style");
       style.textContent = css as string;
       document.head.append(style);
       const el = document.createElement("div");
-      el.className = "nx-pb-dropzone";
       document.body.append(el);
+      const cleanup = () => {
+        el.remove();
+        style.remove();
+        vars.remove();
+      };
 
       // The rule must actually apply to the probe, or every timing read below is the browser's
       // initial value and the span comes out zero — indistinguishable from a transition that was
       // deliberately removed. The selector is taken as text and handed to `matches`, so nothing
-      // here interprets it; the states are tried in turn because a qualified rule is a normal
-      // edit rather than a strange one.
-      const selector = (css as string).slice(0, (css as string).indexOf("{"));
-      let applied: string | null | undefined;
-      for (const state of states as (string | null)[]) {
-        for (const attr of states as (string | null)[]) {
-          if (attr) el.removeAttribute(attr);
+      // here interprets it; class and state are tried in turn because a rule on the empty
+      // placeholder, or qualified by a state, is an ordinary edit rather than a strange one.
+      const selector = (css as string)
+        .slice(0, (css as string).indexOf("{"))
+        .trim();
+      let matched = false;
+      for (const cls of classes as string[]) {
+        for (const state of states as (string | null)[]) {
+          el.className = cls;
+          for (const attr of states as (string | null)[]) {
+            if (attr) el.removeAttribute(attr);
+          }
+          if (state) el.setAttribute(state, "");
+          if (el.matches(selector)) {
+            matched = true;
+            break;
+          }
         }
-        if (state) el.setAttribute(state, "");
-        if (el.matches(selector.trim())) {
-          applied = state;
-          break;
-        }
+        if (matched) break;
       }
-      if (applied === undefined) {
-        el.remove();
-        style.remove();
-        return { matched: false, ms: 0, unclassified: [] as string[] };
+      if (!matched) {
+        cleanup();
+        return {
+          matched: false,
+          ms: 0,
+          unclassified: [] as string[],
+          unresolvedVars: [] as string[],
+        };
       }
 
       const computed = getComputedStyle(el);
+
+      // A custom property that resolves to nothing makes the whole declaration invalid at
+      // computed-value time, and the browser then reports the INITIAL transition rather than an
+      // error. Checked directly against the element instead of inferred from a zero duration,
+      // which a legitimately instant transition also produces.
+      const referenced = [
+        ...new Set(
+          [...(css as string).matchAll(/var\(\s*(--[A-Za-z0-9_-]+)/g)].map(
+            m => m[1]
+          )
+        ),
+      ];
+      const unresolvedVars = referenced.filter(
+        name => computed.getPropertyValue(name).trim() === ""
+      );
+      if (unresolvedVars.length > 0) {
+        cleanup();
+        return { matched: true, ms: 0, unclassified: [], unresolvedVars };
+      }
+
       const seconds = (value: string) =>
         value.split(",").map(v => Number.parseFloat(v.trim()) * 1000);
       const properties = computed.transitionProperty
@@ -193,21 +263,22 @@ async function geometrySpanMs(
       // zero would read those as instant and report a geometry transition as taking no time.
       const cycled = (list: number[], i: number) =>
         list.length === 0 ? 0 : list[i % list.length];
+      const spanAt = (i: number) => cycled(durations, i) + cycled(delays, i);
 
-      // The LAST entry naming a property is the one CSS uses, so a name repeated with different
-      // timings resolves to its final tuple rather than its longest. Taking the maximum instead
-      // reports `transition-property:height,height;transition-duration:.3s,.1s` as 300ms when the
-      // height transition really runs for 100 — which sends whoever reads the failure off to
-      // lengthen every wait in the probe for a transition that had already finished.
-      const lastEntry = new Map<string, number>();
-      properties.forEach((property, i) => lastEntry.set(property, i));
+      // `all` MATCHES every property, so it is a competing entry for each named one rather than a
+      // separate row: with `height,all`, CSS gives height the `all` entry's timing because it
+      // comes later. Comparing only identical strings keeps the two apart and reports height's
+      // own earlier entry, which over-states the span.
+      const lastAll = properties.lastIndexOf("all");
+      const named = [
+        ...new Set(properties.filter(p => p !== "all" && p !== "none")),
+      ];
 
       const unclassified: string[] = [];
-      let longest = 0;
-      for (const [property, i] of lastEntry) {
-        // `none` is the browser's way of saying there is no transition at all, which is a real
-        // answer of zero rather than a property it could not place.
-        if (property === "none") continue;
+      // `all` covers the geometry properties nothing else names, so its own entry counts whatever
+      // the named ones say.
+      let longest = lastAll === -1 ? 0 : spanAt(lastAll);
+      for (const property of named) {
         if ((safe as string[]).includes(property)) continue;
         if (!(geometry as string[]).includes(property)) {
           // On neither list: it may move the edge and this cannot tell. Collected rather than
@@ -215,17 +286,21 @@ async function geometrySpanMs(
           unclassified.push(property);
           continue;
         }
-        longest = Math.max(longest, cycled(durations, i) + cycled(delays, i));
+        // The LAST entry naming this property wins, and `all` is one of the things that can name
+        // it — so the effective entry is whichever of the two comes later.
+        const effective = Math.max(properties.lastIndexOf(property), lastAll);
+        longest = Math.max(longest, spanAt(effective));
       }
-      el.remove();
-      style.remove();
-      return { matched: true, ms: longest, unclassified };
+      cleanup();
+      return { matched: true, ms: longest, unclassified, unresolvedVars };
     },
     [
       rule,
       [...NON_GEOMETRY_PROPERTIES],
       PROBE_STATES,
       [...GEOMETRY_PROPERTIES],
+      PROBE_CLASSES,
+      PROBE_CUSTOM_PROPERTIES,
     ] as const
   );
 
@@ -234,6 +309,13 @@ async function geometrySpanMs(
       `the pinned rule "${rule}" matches no drop-zone probe element, so its timing cannot be ` +
         `read and a zero span here would be indistinguishable from a removed transition. Add the ` +
         `state it is qualified by to PROBE_STATES.`
+    );
+  }
+  if (result.unresolvedVars.length > 0) {
+    throw new Error(
+      `the pinned rule reads ${result.unresolvedVars.join(", ")}, which resolve to nothing in this ` +
+        `fixture — so the browser discards the declaration and reports the initial 0s, which any ` +
+        `allowance covers. Add each to PROBE_CUSTOM_PROPERTIES with the value the canvas gives it.`
     );
   }
   if (result.unclassified.length > 0) {
@@ -337,6 +419,20 @@ test("the span derivation reads geometry and ignores the rest", async ({
   // A rule that deliberately disables movement is a real answer of zero, not a failed derivation.
   // The allowance covers it, and asserting it away would fail a correct canvas.
   expect(await span("transition:height 0s")).toBe(0);
+
+  // `all` is a competing entry for `height`, not a separate row: it comes later, so CSS gives
+  // height ITS timing. Keeping the two apart reports height's own earlier 300 and over-states the
+  // span, which fails the allowance and sends the reader off to lengthen every wait.
+  expect(
+    await span("transition-property:height,all;transition-duration:.3s,.1s")
+  ).toBe(100);
+
+  // The same pair the other way round, which is what separates "resolve against all" from "always
+  // take the last entry". Here `all` is EARLIER, so height keeps its own 100 — while `all` still
+  // governs every geometry property height does not name, and 300 is the honest answer.
+  expect(
+    await span("transition-property:all,height;transition-duration:.3s,.1s")
+  ).toBe(300);
 });
 
 test("the span derivation refuses what it cannot answer", async ({ page }) => {
@@ -370,4 +466,44 @@ test("the span derivation refuses what it cannot answer", async ({ page }) => {
       '".nx-pb-dropzone[data-drag]{transition:height .2s}",'
     )
   ).toBe(200);
+
+  // The EMPTY placeholder is the driver's other target and does not carry `nx-pb-dropzone`, so a
+  // probe wearing only that class could never measure a transition added here. Its allowance is
+  // waited on exactly as the between-item zone's is.
+  expect(
+    await geometrySpanMs(
+      page,
+      '".nx-pb-dropzone-empty{transition:height .2s}",'
+    )
+  ).toBe(200);
+
+  // A rule reading a custom property nothing defines is REFUSED, not measured. The browser
+  // discards the declaration and reports the initial 0s, which any allowance covers — so this is
+  // the shape that passes while a zone is still moving.
+  await expect(
+    geometrySpanMs(
+      page,
+      '".nx-pb-dropzone{transition:height var(--zone-duration)}",'
+    )
+  ).rejects.toThrow(/--zone-duration/);
+});
+
+test("a variable-backed duration resolves once the fixture defines it", async ({
+  page,
+}) => {
+  // The positive control on the refusal above: it must be a missing DEFINITION that refuses, not
+  // the presence of `var()`. Without this, a derivation that rejected every variable would pass
+  // the rejection case and leave the documented remedy — add it to PROBE_CUSTOM_PROPERTIES —
+  // broken, which is the maintenance path the refusal message promises.
+  PROBE_CUSTOM_PROPERTIES["--zone-duration"] = ".2s";
+  try {
+    expect(
+      await geometrySpanMs(
+        page,
+        '".nx-pb-dropzone{transition:height var(--zone-duration)}",'
+      )
+    ).toBe(200);
+  } finally {
+    delete PROBE_CUSTOM_PROPERTIES["--zone-duration"];
+  }
 });

--- a/e2e/tests/canvas/geometry-settle-matches-the-canvas.test.ts
+++ b/e2e/tests/canvas/geometry-settle-matches-the-canvas.test.ts
@@ -767,8 +767,9 @@ test.describe("the drop-zone geometry the probe waits on", () => {
   }) => {
     const frame = await canvas(page, request);
 
-    // Iterations were applied to the element and not to its pseudo-elements, so a 100ms
-    // animation repeated three times reported 100ms - and an endless one read as finite.
+    // A pseudo-element's span is charged for every iteration, exactly as the element's is: each
+    // cycle moves the edge again, so a 100ms animation repeated three times keeps it travelling
+    // for 300ms, and an endless one never settles at all.
     const injected = await frame.evaluate(() => {
       const sheet = (
         document.getElementById("nx-pb-style") as HTMLStyleElement | null

--- a/e2e/tests/canvas/geometry-settle-matches-the-canvas.test.ts
+++ b/e2e/tests/canvas/geometry-settle-matches-the-canvas.test.ts
@@ -42,16 +42,15 @@ const CANVAS_CSS = resolve(
 );
 
 /**
- * The drop-zone geometry, as ONE statement: the declaration exactly as the canvas writes it, and
- * how long the geometry in it keeps moving.
+ * The drop-zone rule carrying the transition, exactly as the canvas writes it.
  *
- * Kept in a single structure so the two cannot be updated apart. They were separate constants, and
- * separate constants invite the half-edit: paste the new declaration, leave the number, and both
- * assertions below pass while the probe tolerates less than the canvas takes. Editing this literal
- * puts the span under the reader's cursor at the moment they change the text.
+ * The only thing here maintained by hand, and deliberately so: an exact-text comparison is what
+ * makes a timing edit VISIBLE rather than silently absorbed. How long that timing lasts is not
+ * written down — {@link geometrySpanMs} computes it in a browser — so there is no second value to
+ * keep in step.
  *
- * `spanMs` is read off `declaration` by a person. It cannot go stale on its own — the only thing
- * that changes it is an edit to that text, which the first assertion refuses.
+ * Do not edit this to clear a failure without reading what changed. The failure is the
+ * notification that the geometry timing moved.
  */
 const PINNED_DECLARATION =
   '".nx-pb-dropzone{height:0;border-radius:3px;transition:height .1s ease,background .1s ease}",';
@@ -109,10 +108,15 @@ async function geometrySpanMs(
         .map(v => v.trim());
       const durations = seconds(computed.transitionDuration);
       const delays = seconds(computed.transitionDelay);
+      // CSS CYCLES a timing list that is shorter than `transition-property`: with three
+      // properties and one duration, all three take that duration. Treating a missing index as
+      // zero would read those as instant and report a geometry transition as taking no time.
+      const cycled = (list: number[], i: number) =>
+        list.length === 0 ? 0 : list[i % list.length];
       let longest = 0;
       properties.forEach((property, i) => {
         if (!(geometry as string[]).includes(property)) return;
-        longest = Math.max(longest, (durations[i] ?? 0) + (delays[i] ?? 0));
+        longest = Math.max(longest, cycled(durations, i) + cycled(delays, i));
       });
       el.remove();
       style.remove();
@@ -179,4 +183,12 @@ test("the span derivation reads geometry and ignores the rest", async ({
   );
   // The browser evaluates what a regex could not.
   expect(await span("transition:height calc(.04s + .03s) ease")).toBe(70);
+  // A timing list SHORTER than the property list is cycled by CSS, not padded with zeros: one
+  // duration across three properties applies to all three. Read as missing, the geometry entry
+  // here would report 0 and pass any allowance.
+  expect(
+    await span(
+      "transition-property:color,background,height;transition-duration:.15s"
+    )
+  ).toBe(150);
 });

--- a/e2e/tests/canvas/geometry-settle-matches-the-canvas.test.ts
+++ b/e2e/tests/canvas/geometry-settle-matches-the-canvas.test.ts
@@ -567,16 +567,32 @@ test.describe("the drop-zone geometry the probe waits on", () => {
     expect(await geometrySpanMs(frame, null)).toBe(100);
   });
 
-  test("the probe leaves no state behind on a real zone", async ({
+  test("the probe leaves no state behind, even on the refusing path", async ({
     page,
     request,
   }) => {
     const frame = await canvas(page, request);
 
-    await geometrySpanMs(frame, "data-drag data-active");
+    // A Web Animations effect, which is the ONE path that returns before the normal cleanup.
+    // Without it this test never reaches the branch it exists for: the ordinary path cleans up
+    // anyway, so the assertion passes whether or not the early return restores anything.
+    const started = await frame.evaluate(() => {
+      const zone = document.querySelector(".nx-pb-dropzone");
+      if (!zone) return false;
+      (zone as HTMLElement).animate([{ height: "0px" }, { height: "12px" }], {
+        duration: 300,
+        iterations: 1,
+      });
+      return true;
+    });
+    expect(started).toBe(true);
 
-    // The probe writes onto REAL canvas elements, so a missed cleanup is not a test detail: every
-    // later read in the run, and the author's canvas, would see a state the probe invented.
+    // It must refuse - that is the branch under test.
+    await expect(
+      geometrySpanMs(frame, "data-drag data-active")
+    ).rejects.toThrow(/Web Animations API/);
+
+    // And it must not have left the attributes it set on a real canvas element.
     const leftBehind = await frame.evaluate(
       () =>
         [...document.querySelectorAll(".nx-pb-dropzone")].filter(

--- a/e2e/tests/canvas/geometry-settle-matches-the-canvas.test.ts
+++ b/e2e/tests/canvas/geometry-settle-matches-the-canvas.test.ts
@@ -37,7 +37,7 @@ import {
   type Page,
 } from "@playwright/test";
 
-import { FLAT_LIST_FIXTURE, seedPage } from "./fixtures";
+import { BOTH_ZONE_SHAPES_FIXTURE, seedPage } from "./fixtures";
 import {
   canvasFrameOf,
   createPocDriver,
@@ -354,10 +354,32 @@ test.describe("the drop-zone geometry the probe waits on", () => {
     request: APIRequestContext
   ): Promise<Frame> {
     await createPocDriver(page).mountTree(
-      await seedPage(request, FLAT_LIST_FIXTURE)
+      await seedPage(request, BOTH_ZONE_SHAPES_FIXTURE)
     );
     return canvasFrameOf(page);
   }
+
+  test("the fixture renders BOTH zone shapes, so the guards cover both", async ({
+    page,
+    request,
+  }) => {
+    const frame = await canvas(page, request);
+
+    // The population the pin and allowance guards below actually measure. Asserted by MEMBERSHIP
+    // rather than by a count: a fixture rendering only between-item zones lets those guards read
+    // as covering the canvas while measuring half of it, and that is invisible from their result.
+    const shapes = await frame.evaluate(() => ({
+      between: document.querySelectorAll(".nx-pb-dropzone").length,
+      empty: document.querySelectorAll(".nx-pb-dropzone-empty").length,
+    }));
+
+    expect(shapes.between).toBeGreaterThan(0);
+    expect(
+      shapes.empty,
+      "no empty placeholder rendered, so every guard in this file measures only the between-item " +
+        "zone while the driver waits on both shapes"
+    ).toBeGreaterThan(0);
+  });
 
   test("every drop-zone state still moves for as long as it did", async ({
     page,

--- a/e2e/tests/canvas/geometry-settle-matches-the-canvas.test.ts
+++ b/e2e/tests/canvas/geometry-settle-matches-the-canvas.test.ts
@@ -22,8 +22,16 @@
  * as an alternative to `transition` entirely. Each spelling handled reveals another, because the
  * surface is the whole cascade.
  *
- * `getComputedStyle` of a real drop zone has already resolved all of it. So this reads the
- * element that will actually move, and nothing here interprets CSS syntax.
+ * `getComputedStyle` of a real drop zone has already resolved all of it, so this reads the element
+ * that will actually move.
+ *
+ * What that does and does not buy is worth being exact about, because the two are easy to run
+ * together. The BROWSER resolves the cascade — which rule wins, what a shorthand expands to, what
+ * a `var()` evaluates to, whether an `@media` block applies. This helper still parses the COMPUTED
+ * VALUE it gets back: splitting comma-separated lists, reading serialized times, and recognising
+ * keywords like `none`, `infinite`, `auto` and `all`. So the edge cases it owns are those of the
+ * computed-value grammar, which is small and stable, rather than those of the cascade, which is
+ * not.
  *
  * The pin is therefore a SPAN, not a declaration. Two stylesheets can differ in every character
  * and animate identically, and one character can change the timing — pinning the measurement
@@ -195,11 +203,16 @@ async function geometrySpanMs(
         // `subtree: true` is what makes 1 and 3 visible. It is required for 1 regardless, since
         // this function charges `::before` and `::after` CSS timing a few lines below and a
         // narrower population would refuse on the element while waving the pseudo-element through.
+        // The surfaces whose longhands are actually read below. A pseudo-element's effect reports
+        // the ORIGINATING element as its target, so a target test alone accepts EVERY pseudo —
+        // including `::marker`, `::first-letter` and `::backdrop`, which this loop never reads and
+        // which can change a line box inside an auto-sized zone. `pseudoElement` is what
+        // distinguishes them, and anything outside this set is refused rather than read as zero.
+        const READ_SURFACES = new Set([null, "::before", "::after"]);
         const own = (a: Animation) => {
-          const target = (a.effect as KeyframeEffect | null)?.target;
-          // A pseudo-element's effect reports the ORIGINATING element as its target, so this keeps
-          // `::before` and `::after` on the readable side — their longhands are read below.
-          return target === el;
+          const effect = a.effect as KeyframeEffect | null;
+          if (!effect || effect.target !== el) return false;
+          return READ_SURFACES.has(effect.pseudoElement ?? null);
         };
         const unreadable = el
           .getAnimations({ subtree: true })
@@ -911,6 +924,58 @@ test.describe("the drop-zone geometry the probe waits on", () => {
     // between-item zone. A rule keyed on `[data-drag]` for an empty zone can never fire, so
     // measuring it would pin a span for movement the canvas cannot produce.
     expect(await geometrySpanMs(frame, "data-drag")).toBe(0);
+  });
+
+  test("an effect on a pseudo-element this loop never reads is refused", async ({
+    page,
+    request,
+  }) => {
+    const frame = await canvas(page, request);
+
+    // `::marker` is a real, layout-bearing pseudo-element whose effect reports the ORIGINATING
+    // element as its target — so a target test alone calls it readable while this loop reads only
+    // the element, `::before` and `::after`. That combination reports zero for movement inside an
+    // auto-sized zone's line box.
+    const planted = await frame.evaluate(() => {
+      const sheet = (
+        document.getElementById("nx-pb-style") as HTMLStyleElement | null
+      )?.sheet;
+      sheet?.insertRule(
+        "@keyframes nx-marker-grow { from { font-size: 8px } to { font-size: 40px } }",
+        sheet.cssRules.length
+      );
+      sheet?.insertRule(
+        ".nx-pb-dropzone-empty { display: list-item }",
+        sheet.cssRules.length
+      );
+      sheet?.insertRule(
+        ".nx-pb-dropzone-empty::marker { animation: nx-marker-grow .3s 100 }",
+        sheet.cssRules.length
+      );
+      const zone = document.querySelector(".nx-pb-dropzone-empty");
+      if (!zone) return null;
+      const effects = zone.getAnimations({ subtree: true });
+      return {
+        count: effects.length,
+        // The population that makes this test about `pseudoElement` rather than about `target`:
+        // the effect must belong to the ZONE and name a pseudo outside the read set.
+        onUnreadPseudo: effects.some(a => {
+          const effect = a.effect as KeyframeEffect | null;
+          return (
+            effect?.target === zone &&
+            effect.pseudoElement != null &&
+            !["::before", "::after"].includes(effect.pseudoElement)
+          );
+        }),
+      };
+    });
+    expect(planted).not.toBeNull();
+    expect(planted?.count).toBeGreaterThan(0);
+    expect(planted?.onUnreadPseudo).toBe(true);
+
+    await expect(geometrySpanMs(frame, "data-active")).rejects.toThrow(
+      /timing is not in any computed longhand this reads/
+    );
   });
 
   test("a DESCENDANT's declarative animation is refused, not reported as zero", async ({

--- a/e2e/tests/canvas/geometry-settle-matches-the-canvas.test.ts
+++ b/e2e/tests/canvas/geometry-settle-matches-the-canvas.test.ts
@@ -230,6 +230,29 @@ async function geometrySpanMs(
         };
       }
 
+      // The browser DROPS a declaration it cannot parse and leaves the rule standing, so the
+      // computed style falls back to the initial `all 0s` — a silent zero that any allowance
+      // covers. Asked of the parsed rule rather than of the computed value, because the computed
+      // value is identical for "no transition declared" and "transition of zero length".
+      const parsed = (style.sheet?.cssRules[0] as CSSStyleRule | undefined)
+        ?.style;
+      const declaresTransition = Boolean(
+        parsed &&
+          (parsed.transition ||
+            parsed.transitionProperty ||
+            parsed.transitionDuration)
+      );
+      if (!declaresTransition) {
+        cleanup();
+        return {
+          matched: true,
+          ms: 0,
+          unclassified: [] as string[],
+          unresolvedVars: [] as string[],
+          dropped: true,
+        };
+      }
+
       const computed = getComputedStyle(el);
 
       // A custom property that resolves to nothing makes the whole declaration invalid at
@@ -248,7 +271,13 @@ async function geometrySpanMs(
       );
       if (unresolvedVars.length > 0) {
         cleanup();
-        return { matched: true, ms: 0, unclassified: [], unresolvedVars };
+        return {
+          matched: true,
+          ms: 0,
+          unclassified: [],
+          unresolvedVars,
+          dropped: false,
+        };
       }
 
       const seconds = (value: string) =>
@@ -292,7 +321,13 @@ async function geometrySpanMs(
         longest = Math.max(longest, spanAt(effective));
       }
       cleanup();
-      return { matched: true, ms: longest, unclassified, unresolvedVars };
+      return {
+        matched: true,
+        ms: longest,
+        unclassified,
+        unresolvedVars,
+        dropped: false,
+      };
     },
     [
       rule,
@@ -309,6 +344,13 @@ async function geometrySpanMs(
       `the pinned rule "${rule}" matches no drop-zone probe element, so its timing cannot be ` +
         `read and a zero span here would be indistinguishable from a removed transition. Add the ` +
         `state it is qualified by to PROBE_STATES.`
+    );
+  }
+  if (result.dropped) {
+    throw new Error(
+      `the browser parsed the pinned rule but DROPPED its transition declaration, so the computed ` +
+        `style is the initial 0s — a zero that covers any allowance. The declaration is malformed ` +
+        `for this browser; fix the rule rather than re-pinning it.`
     );
   }
   if (result.unresolvedVars.length > 0) {
@@ -486,6 +528,14 @@ test("the span derivation refuses what it cannot answer", async ({ page }) => {
       '".nx-pb-dropzone{transition:height var(--zone-duration)}",'
     )
   ).rejects.toThrow(/--zone-duration/);
+
+  // A value this browser cannot parse is DROPPED, leaving the rule standing and the computed
+  // style at the initial `all 0s`. Measured: the sheet still reports one rule, so counting rules
+  // cannot see this — the parsed declaration being empty is what separates it from a rule that
+  // legitimately declares a zero-length transition.
+  await expect(
+    geometrySpanMs(page, '".nx-pb-dropzone{transition:height notatime}",')
+  ).rejects.toThrow(/DROPPED/);
 });
 
 test("a variable-backed duration resolves once the fixture defines it", async ({

--- a/e2e/tests/canvas/geometry-settle-matches-the-canvas.test.ts
+++ b/e2e/tests/canvas/geometry-settle-matches-the-canvas.test.ts
@@ -28,18 +28,21 @@
  * changed to. The cost is that a cosmetic edit trips it as well — which is the direction to want,
  * because whoever edits that line is who should re-derive the allowance.
  */
-import { readFileSync } from "node:fs";
-import { dirname, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
+import {
+  expect,
+  test,
+  type APIRequestContext,
+  type Frame,
+  type Page,
+} from "@playwright/test";
 
-import { expect, test, type Page } from "@playwright/test";
-
-import { DROP_ZONES, POC_GEOMETRY_SETTLE_MS } from "./poc-driver";
-
-const CANVAS_CSS = resolve(
-  dirname(fileURLToPath(import.meta.url)),
-  "../../../packages/plugin-page-builder/src/admin/canvas/IframeCanvas.tsx"
-);
+import { FLAT_LIST_FIXTURE, seedPage } from "./fixtures";
+import {
+  canvasFrameOf,
+  createPocDriver,
+  DROP_ZONES,
+  POC_GEOMETRY_SETTLE_MS,
+} from "./poc-driver";
 
 /**
  * The drop-zone rule carrying the transition, exactly as the canvas writes it.
@@ -52,8 +55,9 @@ const CANVAS_CSS = resolve(
  * Do not edit this to clear a failure without reading what changed. The failure is the
  * notification that the geometry timing moved.
  */
-const PINNED_DECLARATION =
-  ".nx-pb-dropzone{position:absolute;left:0;right:0;top:-3px;height:6px;border-radius:3px;background:transparent;pointer-events:none;z-index:3;transition:background .1s ease}";
+const PINNED_RULES: readonly string[] = [
+  ".nx-pb-dropzone { position: absolute; left: 0px; right: 0px; top: -3px; height: 6px; border-radius: 3px; background: transparent; pointer-events: none; z-index: 3; transition: background 0.1s; }",
+];
 
 /**
  * Properties whose transition moves the vertical edge this probe measures, so its timing counts.
@@ -146,48 +150,19 @@ const PROBE_CLASSES = DROP_ZONES.split(",").map(part =>
 );
 
 /**
- * Custom properties the fixture defines, for a rule that reads one.
+ * How long the geometry in a rule keeps moving, measured INSIDE THE CANVAS.
  *
- * The probe injects the pinned rule into a bare document rather than into the canvas, so a
- * `var()` naming something defined elsewhere — a theme token, another canvas rule — resolves to
- * nothing here. CSS then treats the declaration as invalid at computed-value time and
- * `getComputedStyle` reports the INITIAL `0s`, which is the dangerous direction: a zone moving
- * for 200ms measures as instant and any allowance covers it.
+ * The rule is injected into the canvas frame and the resulting `transition-*` longhands are read
+ * off a matching element there. Everything that decides those values is already correct in that
+ * document: the cascade, the selector scope, the theme tokens the canvas inherits, and `var()`
+ * with or without a fallback. Nothing here interprets CSS or TypeScript syntax.
  *
- * So an unresolved reference is refused rather than measured, and this is where the definition
- * goes to make it measurable. Empty because the pinned rule reads no variable today.
+ * Measuring anywhere else means REBUILDING that context, and the context is not reconstructible —
+ * a custom property's value is decided by the cascade rather than by any one declaration.
  */
-const PROBE_CUSTOM_PROPERTIES: Record<string, string> = canvasCustomProperties(
-  readFileSync(CANVAS_CSS, "utf8")
-);
-
-/**
- * How long the geometry in a rule keeps moving, computed BY THE BROWSER.
- *
- * The rule is injected into a real document and the resulting `transition-*` longhands are read
- * back off a matching element. Those are already resolved: the shorthand is expanded, each
- * property paired with its own duration and delay, times normalised to seconds, and `calc()`,
- * `var()` and signed values evaluated. Nothing here interprets CSS syntax.
- *
- * That is the point. Computing this span from source text means reimplementing CSS, and the only
- * implementation guaranteed to agree with the canvas is the one the canvas runs in.
- */
-async function geometrySpanMs(
-  page: Page,
-  declaration: string
-): Promise<number> {
-  // Already a rule as the browser receives it: the reader joins the array and splits on `}`, so
-  // nothing here has to undo TypeScript's quoting.
-  const rule = declaration.trim();
-  const result = await page.evaluate(
-    ([css, safe, states, geometry, classes, customProps]) => {
-      const props = customProps as Record<string, string>;
-      const vars = document.createElement("style");
-      vars.textContent = `:root{${Object.entries(props)
-        .map(([name, value]) => `${name}:${value}`)
-        .join(";")}}`;
-      document.head.append(vars);
-
+async function geometrySpanMs(frame: Frame, rule: string): Promise<number> {
+  const result = await frame.evaluate(
+    ([css, safe, states, geometry, classes]) => {
       const style = document.createElement("style");
       style.textContent = css as string;
       document.head.append(style);
@@ -196,14 +171,13 @@ async function geometrySpanMs(
       const cleanup = () => {
         el.remove();
         style.remove();
-        vars.remove();
       };
 
       // The rule must actually apply to the probe, or every timing read below is the browser's
       // initial value and the span comes out zero — indistinguishable from a transition that was
-      // deliberately removed. The selector is taken as text and handed to `matches`, so nothing
-      // here interprets it; class and state are tried in turn because a rule on the empty
-      // placeholder, or qualified by a state, is an ordinary edit rather than a strange one.
+      // deliberately removed. The selector is handed to `matches` as text, so nothing here
+      // interprets it; class and state are tried in turn because a rule on the empty placeholder,
+      // or qualified by a drag state, is an ordinary edit rather than a strange one.
       const selector = (css as string)
         .slice(0, (css as string).indexOf("{"))
         .trim();
@@ -228,108 +202,76 @@ async function geometrySpanMs(
           matched: false,
           ms: 0,
           unclassified: [] as string[],
-          unresolvedVars: [] as string[],
+          discarded: false,
         };
       }
 
-      // The browser DROPS a declaration it cannot parse and leaves the rule standing, so the
-      // computed style falls back to the initial `all 0s` — a silent zero that any allowance
-      // covers. Asked of the parsed rule rather than of the computed value, because the computed
-      // value is identical for "no transition declared" and "transition of zero length".
+      // Whether the declaration survived PARSING. A value the browser cannot parse is dropped and
+      // the rule stands, leaving the computed style at the initial `all 0s` — a silent zero that
+      // covers any allowance.
       const parsed = (style.sheet?.cssRules[0] as CSSStyleRule | undefined)
         ?.style;
-      const declaresTransition = Boolean(
-        parsed &&
-          (parsed.transition ||
-            parsed.transitionProperty ||
-            parsed.transitionDuration)
-      );
-      if (!declaresTransition) {
-        cleanup();
-        return {
-          matched: true,
-          ms: 0,
-          unclassified: [] as string[],
-          unresolvedVars: [] as string[],
-          dropped: true,
-        };
-      }
+      const declared = parsed
+        ? parsed.transition ||
+          parsed.transitionProperty ||
+          parsed.transitionDuration
+        : "";
 
       const computed = getComputedStyle(el);
-
-      // A custom property that resolves to nothing makes the whole declaration invalid at
-      // computed-value time, and the browser then reports the INITIAL transition rather than an
-      // error. Checked directly against the element instead of inferred from a zero duration,
-      // which a legitimately instant transition also produces.
-      const referenced = [
-        ...new Set(
-          [...(css as string).matchAll(/var\(\s*(--[A-Za-z0-9_-]+)/g)].map(
-            m => m[1]
-          )
-        ),
-      ];
-      const unresolvedVars = referenced.filter(
-        name => computed.getPropertyValue(name).trim() === ""
-      );
-      if (unresolvedVars.length > 0) {
-        cleanup();
-        return {
-          matched: true,
-          ms: 0,
-          unclassified: [],
-          unresolvedVars,
-          dropped: false,
-        };
-      }
-
-      const seconds = (value: string) =>
-        value.split(",").map(v => Number.parseFloat(v.trim()) * 1000);
       const properties = computed.transitionProperty
         .split(",")
         .map(v => v.trim());
-      const durations = seconds(computed.transitionDuration);
-      const delays = seconds(computed.transitionDelay);
-      // CSS CYCLES a timing list that is shorter than `transition-property`: with three
-      // properties and one duration, all three take that duration. Treating a missing index as
-      // zero would read those as instant and report a geometry transition as taking no time.
+      const durations = computed.transitionDuration
+        .split(",")
+        .map(v => Number.parseFloat(v.trim()) * 1000);
+      const delays = computed.transitionDelay
+        .split(",")
+        .map(v => Number.parseFloat(v.trim()) * 1000);
+
+      // Declared something, computed the INITIAL value: the declaration was discarded after
+      // parsing — an unresolved `var()` with no fallback is the way that happens. Asked as
+      // "declared but not applied" rather than by scanning the text for `var(`, because a
+      // fallback makes an undefined property perfectly valid and a name scan cannot see that.
+      const isInitial =
+        properties.length === 1 &&
+        properties[0] === "all" &&
+        durations.every(d => d === 0);
+      const discarded =
+        Boolean(declared) && isInitial && !declared.includes("all");
+      if (!declared || discarded) {
+        cleanup();
+        return { matched: true, ms: 0, unclassified: [], discarded: true };
+      }
+
+      // CSS CYCLES a timing list shorter than `transition-property`: with three properties and one
+      // duration, all three take that duration. Reading a missing index as zero would report a
+      // geometry transition as instant.
       const cycled = (list: number[], i: number) =>
         list.length === 0 ? 0 : list[i % list.length];
       const spanAt = (i: number) => cycled(durations, i) + cycled(delays, i);
 
-      // `all` MATCHES every property, so it is a competing entry for each named one rather than a
-      // separate row: with `height,all`, CSS gives height the `all` entry's timing because it
-      // comes later. Comparing only identical strings keeps the two apart and reports height's
-      // own earlier entry, which over-states the span.
+      // `all` MATCHES every property, so it competes with each named entry rather than sitting
+      // beside it: with `height,all`, CSS gives height the `all` entry's timing because it comes
+      // later. Its own entry still counts, for the geometry properties nothing else names.
       const lastAll = properties.lastIndexOf("all");
       const named = [
         ...new Set(properties.filter(p => p !== "all" && p !== "none")),
       ];
-
       const unclassified: string[] = [];
-      // `all` covers the geometry properties nothing else names, so its own entry counts whatever
-      // the named ones say.
       let longest = lastAll === -1 ? 0 : spanAt(lastAll);
       for (const property of named) {
         if ((safe as string[]).includes(property)) continue;
         if (!(geometry as string[]).includes(property)) {
-          // On neither list: it may move the edge and this cannot tell. Collected rather than
-          // skipped, so it refuses below instead of being charged as zero.
           unclassified.push(property);
           continue;
         }
-        // The LAST entry naming this property wins, and `all` is one of the things that can name
-        // it — so the effective entry is whichever of the two comes later.
-        const effective = Math.max(properties.lastIndexOf(property), lastAll);
-        longest = Math.max(longest, spanAt(effective));
+        longest = Math.max(
+          longest,
+          spanAt(Math.max(properties.lastIndexOf(property), lastAll))
+        );
       }
       cleanup();
-      return {
-        matched: true,
-        ms: longest,
-        unclassified,
-        unresolvedVars,
-        dropped: false,
-      };
+      return { matched: true, ms: longest, unclassified, discarded: false };
     },
     [
       rule,
@@ -337,29 +279,21 @@ async function geometrySpanMs(
       PROBE_STATES,
       [...GEOMETRY_PROPERTIES],
       PROBE_CLASSES,
-      PROBE_CUSTOM_PROPERTIES,
     ] as const
   );
 
   if (!result.matched) {
     throw new Error(
-      `the pinned rule "${rule}" matches no drop-zone probe element, so its timing cannot be ` +
-        `read and a zero span here would be indistinguishable from a removed transition. Add the ` +
-        `state it is qualified by to PROBE_STATES.`
+      `the rule "${rule}" matches no drop-zone probe element, so its timing cannot be read and a ` +
+        `zero span would be indistinguishable from a removed transition. Add the state it is ` +
+        `qualified by to PROBE_STATES.`
     );
   }
-  if (result.dropped) {
+  if (result.discarded) {
     throw new Error(
-      `the browser parsed the pinned rule but DROPPED its transition declaration, so the computed ` +
-        `style is the initial 0s — a zero that covers any allowance. The declaration is malformed ` +
-        `for this browser; fix the rule rather than re-pinning it.`
-    );
-  }
-  if (result.unresolvedVars.length > 0) {
-    throw new Error(
-      `the pinned rule reads ${result.unresolvedVars.join(", ")}, which resolve to nothing in this ` +
-        `fixture — so the browser discards the declaration and reports the initial 0s, which any ` +
-        `allowance covers. Add each to PROBE_CUSTOM_PROPERTIES with the value the canvas gives it.`
+      `the browser did not apply the transition in "${rule}" — it parsed to nothing, or was ` +
+        `discarded at computed-value time. Either way the computed style is the initial 0s, which ` +
+        `covers any allowance, so this refuses rather than reporting zero.`
     );
   }
   if (result.unclassified.length > 0) {
@@ -374,290 +308,231 @@ async function geometrySpanMs(
 }
 
 /**
- * The canvas overlay stylesheet as the BROWSER receives it: every entry of the array, joined.
+ * The drop-zone rules carrying a transition, read from the RUNNING canvas.
  *
- * Read from the joined text rather than line by line, because the array is `.join("")`ed and a
- * rule is free to straddle two entries — `".nx-pb-dropzone[data-active]{"` in one and
- * `"transition:margin .2s}"` in the next. No SOURCE LINE then contains both the selector and the
- * declaration, so a line filter reports the remaining rules, matches the pin, and stays green
- * while the stylesheet the canvas actually applies carries a transition nobody measured.
+ * Taken from the stylesheet the browser PARSED — `<style id="nx-pb-overlay">` in the canvas frame
+ * — rather than from `IframeCanvas.tsx`. That is the difference between an instrument that can
+ * answer this question and one that cannot: a reader of the SOURCE has to represent TypeScript,
+ * where an array entry may be an identifier, a template literal or a call, and it cannot represent
+ * the cascade at all. Four review rounds found four such spellings, each fix correct and each
+ * followed by another, because the surface being modelled is two whole languages.
  *
- * This is the same mismatch the header describes one level up: the instrument has to read what
- * the browser reads, and the browser never sees the line breaks.
+ * By the time the browser has parsed this sheet every one of those questions is already answered.
  */
-function overlayCss(source: string): string {
-  const start = source.indexOf("const OVERLAY_CSS = [");
-  const end = source.indexOf('].join("");', start);
-  if (start === -1 || end === -1) {
+async function transitionRules(frame: Frame): Promise<string[]> {
+  const rules = await frame.evaluate(() => {
+    const overlay = document.getElementById(
+      "nx-pb-overlay"
+    ) as HTMLStyleElement | null;
+    if (!overlay?.sheet) return null;
+    return [...overlay.sheet.cssRules].map(rule => rule.cssText);
+  });
+  // An absent sheet would read as "no transitions here", which is the reassuring direction and
+  // would certify a canvas nobody looked at.
+  if (rules === null) {
     throw new Error(
-      "could not find OVERLAY_CSS in the canvas source. This test reads that array to learn what " +
-        "the browser is given; if it was renamed or restructured, update this reader — an empty " +
-        "read here would certify a stylesheet nobody looked at."
+      "the canvas has no parsed #nx-pb-overlay stylesheet, so this test cannot see what the " +
+        "browser was given. It refuses rather than reporting an empty rule list."
     );
   }
-  // Each entry is a double-quoted literal. Escapes are preserved as authored, which is what the
-  // browser is handed: `\\283F` in the source is the four characters CSS then reads.
-  const entries = [
-    ...source.slice(start, end).matchAll(/"((?:[^"\\]|\\.)*)"/g),
-  ].map(m => m[1]);
-  return entries.join("");
+  return rules.filter(
+    rule => rule.includes("nx-pb-dropzone") && rule.includes("transition")
+  );
 }
 
-/**
- * Every drop-zone rule declaring a transition, taken from the joined stylesheet.
- *
- * Split on `}` rather than parsed: a rule body here contains no nested braces, and what this
- * needs is the rule TEXT to pin, not an understanding of it.
- */
-function transitionRules(source: string): string[] {
-  return overlayCss(source)
-    .split("}")
-    .map(part => `${part.trim()}}`)
-    .filter(
-      rule => rule.includes("nx-pb-dropzone") && rule.includes("transition")
+// The canvas iframe is only rendered above a certain width: the editor's rail, block library and
+// inspector claim the row first, and below roughly 1280px the preview is dropped rather than
+// squeezed. At the default viewport `mountTree` therefore waits out its full timeout on an iframe
+// that is present but never sized, which reads as a broken canvas rather than a narrow window.
+// The same width `acceptance.spec.ts` uses, so every canvas spec measures the same layout.
+test.use({ viewport: { width: 2560, height: 1400 } });
+
+// Booting the editor once per test is minutes of work across this file, and the default 30s
+// budget is a per-test timeout rather than a per-action one.
+test.describe.configure({ timeout: 240_000 });
+
+test.describe("the drop-zone geometry the probe waits on", () => {
+  /** Boots the canvas and hands back its frame, which is where every read below happens. */
+  async function canvas(
+    page: Page,
+    request: APIRequestContext
+  ): Promise<Frame> {
+    await createPocDriver(page).mountTree(
+      await seedPage(request, FLAT_LIST_FIXTURE)
     );
-}
-
-/**
- * Custom properties the canvas stylesheet defines, so a rule reading one can be measured.
- *
- * DERIVED from the canvas rather than hand-listed beside it. A second copy of these values is a
- * second source of truth: the canvas moving `--zone-duration` from `.1s` to `.2s` leaves a
- * hand-kept table saying `.1s`, the pinned rule text is unchanged so nothing trips, and the probe
- * measures a duration the canvas stopped using.
- *
- * Properties defined OUTSIDE this stylesheet — the admin theme's `--nx-pb-ed-*` tokens — are not
- * here and cannot be. Those still refuse, naming themselves, which is the honest outcome: this
- * test cannot see the theme, and a value invented for it would be the same second source of truth
- * one layer further away.
- */
-function canvasCustomProperties(source: string): Record<string, string> {
-  const out: Record<string, string> = {};
-  for (const [, name, value] of overlayCss(source).matchAll(
-    /(--[A-Za-z0-9_-]+)\s*:\s*([^;}]+)/g
-  )) {
-    out[name] = value.trim();
+    return canvasFrameOf(page);
   }
-  return out;
-}
 
-test("the stylesheet reader sees rules a line filter cannot", () => {
-  // A rule straddling two array entries. Joined, it is one ordinary rule; read line by line,
-  // NO line contains both the selector and the declaration, so a line filter reports nothing and
-  // the pin stays green while the canvas applies a transition nobody measured.
-  const split = [
-    "const OVERLAY_CSS = [",
-    '  ".nx-pb-dropzone[data-active]{",',
-    '  "transition:margin .2s}",',
-    '].join("");',
-  ].join("\n");
+  test("the pinned rules are what the canvas still applies", async ({
+    page,
+    request,
+  }) => {
+    const frame = await canvas(page, request);
+    const found = await transitionRules(frame);
 
-  // The positive control on the READER, asserted by naming what it must return rather than by
-  // "not nothing" — an unrelated rule in the same source would satisfy a length check.
-  expect(transitionRules(split)).toEqual([
-    ".nx-pb-dropzone[data-active]{transition:margin .2s}",
-  ]);
+    // A read that found nothing would satisfy an equality against an empty expectation and
+    // certify a stylesheet it never saw.
+    expect(found.length).toBeGreaterThan(0);
 
-  // And the line filter this replaced, on the same input, to show the difference is real rather
-  // than asserted: no single line carries both halves.
-  const byLine = split
-    .split("\n")
-    .map(line => line.trim())
-    .filter(l => l.includes("nx-pb-dropzone") && l.includes("transition"));
-  expect(byLine).toEqual([]);
-});
+    expect(
+      found,
+      "the canvas drop-zone transition rules changed. Update PINNED_RULES here; each rule's span " +
+        "is computed by the browser, so nothing else needs recalculating — but raise " +
+        "POC_GEOMETRY_SETTLE_MS in poc-driver.ts if the new spans exceed it."
+    ).toEqual([...PINNED_RULES]);
+  });
 
-test("custom properties come from the canvas, not from a second list", () => {
-  const source = [
-    "const OVERLAY_CSS = [",
-    '  ".nx-pb-canvas{--zone-duration:.25s}",',
-    '  ".nx-pb-dropzone{transition:height var(--zone-duration)}",',
-    '].join("");',
-  ].join("\n");
+  test("the driver's settle allowance covers every pinned rule", async ({
+    page,
+    request,
+  }) => {
+    const frame = await canvas(page, request);
+    // EVERY rule, not just the first. A second drop-zone rule declaring a transition is a normal
+    // edit, and pinning one rule while measuring one span would leave the other unmeasured while
+    // the driver waits on both shapes.
+    for (const rule of PINNED_RULES) {
+      const spanMs = await geometrySpanMs(frame, rule);
 
-  // The VALUE, so a reader that found the name and dropped the value cannot pass.
-  expect(canvasCustomProperties(source)).toEqual({ "--zone-duration": ".25s" });
-});
+      // No `spanMs > 0` guard, deliberately. An unmatched selector, a discarded declaration and an
+      // unclassifiable property all THROW, so the only way to reach here with 0 is a rule that
+      // genuinely moves no geometry — which is exactly what the canvas declares today, since the
+      // zone is out of flow at a fixed height and only `background` transitions. Asserting a
+      // positive span would fail a correct canvas.
+      expect(
+        POC_GEOMETRY_SETTLE_MS,
+        `geometrySettleMs is ${String(POC_GEOMETRY_SETTLE_MS)}ms and "${rule}" moves geometry for ` +
+          `${String(spanMs)}ms, so the probe can re-measure an edge that is still travelling. ` +
+          "Raise it in poc-driver.ts."
+      ).toBeGreaterThanOrEqual(spanMs);
+    }
+  });
 
-test("the stylesheet reader REFUSES a canvas it cannot find the array in", () => {
-  // Its silence would otherwise certify a stylesheet it never read: an empty result reads exactly
-  // like "no transitions here", and the pin test's own population guard would be the only thing
-  // between that and a green run.
-  expect(() => transitionRules("const SOMETHING_ELSE = 1;")).toThrow(
-    /could not find OVERLAY_CSS/
-  );
-});
+  test("the span derivation reads geometry and ignores the rest", async ({
+    page,
+    request,
+  }) => {
+    const frame = await canvas(page, request);
+    const span = (rule: string) =>
+      geometrySpanMs(frame, `.nx-pb-dropzone{${rule}}`);
 
-test("the drop-zone geometry timing has not changed under the probe", () => {
-  const found = transitionRules(readFileSync(CANVAS_CSS, "utf8"));
+    expect(await span("transition:height .1s ease")).toBe(100);
+    expect(await span("transition:height .1s ease .05s")).toBe(150);
+    // A colour moves no edge this probe measures, so its longer timing is not charged.
+    expect(await span("transition:height .1s ease,background .3s ease")).toBe(
+      100
+    );
+    // The browser evaluates what a regex could not.
+    expect(await span("transition:height calc(.04s + .03s) ease")).toBe(70);
+    // A timing list SHORTER than the property list is cycled by CSS, not padded with zeros.
+    expect(
+      await span(
+        "transition-property:color,background,height;transition-duration:.15s"
+      )
+    ).toBe(150);
+    // An individual transform property moves the box: skipped, it reads as 0.
+    expect(await span("transition:translate .2s ease")).toBe(200);
+    // CSS resolves a repeated property to its LAST entry, not its longest.
+    expect(
+      await span(
+        "transition-property:height,height;transition-duration:.3s,.1s"
+      )
+    ).toBe(100);
+    // The same rule reversed, which separates "reads the last" from "reads the first".
+    expect(
+      await span(
+        "transition-property:height,height;transition-duration:.1s,.3s"
+      )
+    ).toBe(300);
+    // `all` competes with a named entry rather than sitting beside it.
+    expect(
+      await span("transition-property:height,all;transition-duration:.3s,.1s")
+    ).toBe(100);
+    // And with `all` EARLIER, height keeps its own timing while `all` still governs the rest.
+    expect(
+      await span("transition-property:all,height;transition-duration:.3s,.1s")
+    ).toBe(300);
+    // A rule that deliberately disables movement is a real answer of zero.
+    expect(await span("transition:height 0s")).toBe(0);
+  });
 
-  // A selector that matched nothing would satisfy an equality against an empty expectation and
-  // certify a file it never read.
-  expect(found.length).toBeGreaterThan(0);
+  test("the span derivation refuses what it cannot answer", async ({
+    page,
+    request,
+  }) => {
+    const frame = await canvas(page, request);
+    const span = (rule: string) =>
+      geometrySpanMs(frame, `.nx-pb-dropzone{${rule}}`);
 
-  expect(
-    found,
-    "the canvas drop-zone transition changed. Update PINNED_DECLARATION here; the span it " +
-      "produces is computed by the browser, so nothing else needs recalculating — but raise " +
-      "POC_GEOMETRY_SETTLE_MS in poc-driver.ts if the new span exceeds it."
-  ).toEqual([PINNED_DECLARATION]);
-});
+    // A property on neither list stops the test and names itself rather than being charged as 0.
+    await expect(span("transition:font-size .2s ease")).rejects.toThrow(
+      /cannot place/
+    );
 
-test("the driver's settle allowance covers that geometry", async ({ page }) => {
-  // No `spanMs > 0` guard here, and its absence is deliberate. It was standing in for "the
-  // derivation actually worked", which is now answered where it can be answered properly: an
-  // unmatched selector and an unclassifiable property both THROW, so the only way to reach this
-  // line with 0 is a rule that genuinely disables movement — `transition: height 0s`, or a delay
-  // cancelling its duration. That is a legitimate result the allowance covers, and asserting it
-  // away would fail a correct canvas. The derivation's positive controls live in the test below,
-  // where they pin known nonzero values instead of merely asking for "not nothing".
-  const spanMs = await geometrySpanMs(page, PINNED_DECLARATION);
+    // A rule the probe never matches.
+    await expect(
+      geometrySpanMs(
+        frame,
+        ".nx-pb-dropzone[data-nonexistent]{transition:height .2s}"
+      )
+    ).rejects.toThrow(/matches no drop-zone probe element/);
 
-  expect(
-    POC_GEOMETRY_SETTLE_MS,
-    `geometrySettleMs is ${String(POC_GEOMETRY_SETTLE_MS)}ms and the drop-zone geometry moves for ` +
-      `${String(spanMs)}ms, so the probe can re-measure an edge that is still travelling. Raise it ` +
-      "in poc-driver.ts."
-  ).toBeGreaterThanOrEqual(spanMs);
-});
+    // A value the browser cannot parse is DROPPED, leaving the initial 0s.
+    await expect(
+      geometrySpanMs(frame, ".nx-pb-dropzone{transition:height notatime}")
+    ).rejects.toThrow(/did not apply/);
 
-test("the span derivation reads geometry and ignores the rest", async ({
-  page,
-}) => {
-  // Controls on the derivation itself, since the pinned rule exercises only one shape. The browser
-  // resolves the syntax; what is asserted here is that the RIGHT properties are counted and that a
-  // delay is included.
-  const span = (rule: string) =>
-    geometrySpanMs(page, `.nx-pb-dropzone{${rule}}`);
+    // An undefined property with NO fallback discards the declaration at computed-value time.
+    await expect(
+      geometrySpanMs(
+        frame,
+        ".nx-pb-dropzone{transition:height var(--nx-nope-undefined)}"
+      )
+    ).rejects.toThrow(/did not apply/);
+  });
 
-  expect(await span("transition:height .1s ease")).toBe(100);
-  expect(await span("transition:height .1s ease .05s")).toBe(150);
-  // A colour moves no edge this probe measures, so its longer timing is not charged.
-  expect(await span("transition:height .1s ease,background .3s ease")).toBe(
-    100
-  );
-  // The browser evaluates what a regex could not.
-  expect(await span("transition:height calc(.04s + .03s) ease")).toBe(70);
-  // A timing list SHORTER than the property list is cycled by CSS, not padded with zeros: one
-  // duration across three properties applies to all three. Read as missing, the geometry entry
-  // here would report 0 and pass any allowance.
-  expect(
-    await span(
-      "transition-property:color,background,height;transition-duration:.15s"
-    )
-  ).toBe(150);
+  test("the span derivation measures what the canvas context supplies", async ({
+    page,
+    request,
+  }) => {
+    const frame = await canvas(page, request);
+    // The positive controls that keep the refusals above from being blanket rejections.
 
-  // An individual transform property moves the box, and it is the case that showed an allowlist
-  // cannot be trusted to be complete: skipped, this reads as 0 and the allowance passes over a
-  // zone still travelling.
-  expect(await span("transition:translate .2s ease")).toBe(200);
-
-  // CSS resolves a repeated property to its LAST entry, not its longest. Taking the maximum
-  // reports 300 here and sends whoever reads the failure off to lengthen every wait in the probe
-  // for a transition that finished 200ms earlier.
-  expect(
-    await span("transition-property:height,height;transition-duration:.3s,.1s")
-  ).toBe(100);
-
-  // The same rule with the entries swapped, which is what separates "reads the last" from "reads
-  // the first" — a fixed pick of either index satisfies one of these two and not both.
-  expect(
-    await span("transition-property:height,height;transition-duration:.1s,.3s")
-  ).toBe(300);
-
-  // A rule that deliberately disables movement is a real answer of zero, not a failed derivation.
-  // The allowance covers it, and asserting it away would fail a correct canvas.
-  expect(await span("transition:height 0s")).toBe(0);
-
-  // `all` is a competing entry for `height`, not a separate row: it comes later, so CSS gives
-  // height ITS timing. Keeping the two apart reports height's own earlier 300 and over-states the
-  // span, which fails the allowance and sends the reader off to lengthen every wait.
-  expect(
-    await span("transition-property:height,all;transition-duration:.3s,.1s")
-  ).toBe(100);
-
-  // The same pair the other way round, which is what separates "resolve against all" from "always
-  // take the last entry". Here `all` is EARLIER, so height keeps its own 100 — while `all` still
-  // governs every geometry property height does not name, and 300 is the honest answer.
-  expect(
-    await span("transition-property:all,height;transition-duration:.3s,.1s")
-  ).toBe(300);
-});
-
-test("the span derivation refuses what it cannot answer", async ({ page }) => {
-  // The other half of the controls above: what the derivation does when it CANNOT decide. Each of
-  // these previously produced a confident zero, which is the answer that passes any allowance.
-  const span = (rule: string) =>
-    geometrySpanMs(page, `.nx-pb-dropzone{${rule}}`);
-
-  // A property on neither list. `font-size` does move a box, but the point is not which list it
-  // belongs on — it is that an unrecognised name stops the test and names itself instead of being
-  // charged as zero.
-  await expect(span("transition:font-size .2s ease")).rejects.toThrow(
-    /cannot place/
-  );
-
-  // A rule the probe element does not match. The canvas already declares `[data-drag]` and
-  // `[data-active]` rules, so a transition moved onto a state is an ordinary edit — and one the
-  // fixture must either measure or refuse, never silently report as zero.
-  await expect(
-    geometrySpanMs(
-      page,
-      ".nx-pb-dropzone[data-nonexistent]{transition:height .2s}"
-    )
-  ).rejects.toThrow(/matches no drop-zone probe element/);
-
-  // The state the canvas really uses IS measured rather than refused, which is what keeps the
-  // refusal above from being a blanket "anything qualified fails".
-  expect(
-    await geometrySpanMs(
-      page,
-      ".nx-pb-dropzone[data-drag]{transition:height .2s}"
-    )
-  ).toBe(200);
-
-  // The EMPTY placeholder is the driver's other target and does not carry `nx-pb-dropzone`, so a
-  // probe wearing only that class could never measure a transition added here. Its allowance is
-  // waited on exactly as the between-item zone's is.
-  expect(
-    await geometrySpanMs(page, ".nx-pb-dropzone-empty{transition:height .2s}")
-  ).toBe(200);
-
-  // A rule reading a custom property nothing defines is REFUSED, not measured. The browser
-  // discards the declaration and reports the initial 0s, which any allowance covers — so this is
-  // the shape that passes while a zone is still moving.
-  await expect(
-    geometrySpanMs(
-      page,
-      ".nx-pb-dropzone{transition:height var(--zone-duration)}"
-    )
-  ).rejects.toThrow(/--zone-duration/);
-
-  // A value this browser cannot parse is DROPPED, leaving the rule standing and the computed
-  // style at the initial `all 0s`. Measured: the sheet still reports one rule, so counting rules
-  // cannot see this — the parsed declaration being empty is what separates it from a rule that
-  // legitimately declares a zero-length transition.
-  await expect(
-    geometrySpanMs(page, ".nx-pb-dropzone{transition:height notatime}")
-  ).rejects.toThrow(/DROPPED/);
-});
-
-test("a variable-backed duration resolves once the fixture defines it", async ({
-  page,
-}) => {
-  // The positive control on the refusal above: it must be a missing DEFINITION that refuses, not
-  // the presence of `var()`. Without this, a derivation that rejected every variable would pass
-  // the rejection case and leave the documented remedy — add it to PROBE_CUSTOM_PROPERTIES —
-  // broken, which is the maintenance path the refusal message promises.
-  PROBE_CUSTOM_PROPERTIES["--zone-duration"] = ".2s";
-  try {
+    // A state the canvas really declares IS measured.
     expect(
       await geometrySpanMs(
-        page,
-        ".nx-pb-dropzone{transition:height var(--zone-duration)}"
+        frame,
+        ".nx-pb-dropzone[data-drag]{transition:height .2s}"
       )
     ).toBe(200);
-  } finally {
-    delete PROBE_CUSTOM_PROPERTIES["--zone-duration"];
-  }
+
+    // The EMPTY placeholder, the driver's other target, which carries no `nx-pb-dropzone` class.
+    expect(
+      await geometrySpanMs(
+        frame,
+        ".nx-pb-dropzone-empty{transition:height .2s}"
+      )
+    ).toBe(200);
+
+    // A `var()` FALLBACK is valid CSS and must be measured, not refused. This is what a name-scan
+    // for `var(` could never get right: the property is undefined and the rule is still correct.
+    expect(
+      await geometrySpanMs(
+        frame,
+        ".nx-pb-dropzone{transition:height var(--nx-nope-undefined,.15s)}"
+      )
+    ).toBe(150);
+
+    // A theme token the CANVAS inherits resolves here because this runs in the canvas document.
+    // Reading the source could never do this: the value is not in that file.
+    const themed = await frame.evaluate(() =>
+      getComputedStyle(document.documentElement)
+        .getPropertyValue("--nx-pb-ed-primary")
+        .trim()
+    );
+    expect(
+      themed,
+      "the canvas frame should carry the admin theme tokens; if this is empty the probe is not " +
+        "running in the canvas document and every measurement above is of the wrong context"
+    ).not.toBe("");
+  });
 });

--- a/e2e/tests/canvas/geometry-settle-matches-the-canvas.test.ts
+++ b/e2e/tests/canvas/geometry-settle-matches-the-canvas.test.ts
@@ -133,7 +133,12 @@ async function geometrySpanMs(
     ([zoneSelector, geometry, safe, appliedState]) => {
       const zones = [...document.querySelectorAll(zoneSelector as string)];
       if (zones.length === 0)
-        return { zones: 0, ms: 0, unclassified: [] as string[] };
+        return {
+          zones: 0,
+          ms: 0,
+          unclassified: [] as string[],
+          nonDocumentTimelines: [] as string[],
+        };
 
       // A value that is not a time cannot be measured, and `|| 0` would report it as instant —
       // the silent zero this file exists to remove. `NaN` is preserved and refused by the caller.
@@ -143,6 +148,7 @@ async function geometrySpanMs(
         list.length === 0 ? 0 : list[i % list.length];
 
       const unclassified: string[] = [];
+      const nonDocumentTimelines: string[] = [];
       let longest = 0;
 
       for (const zone of zones) {
@@ -196,7 +202,12 @@ async function geometrySpanMs(
           // attributes on a real canvas element, so every later read in this run — and the
           // author's own canvas — sees a state the probe invented.
           for (const a of attrs) if (!had.includes(a)) el.removeAttribute(a);
-          return { zones: -1, ms: 0, unclassified: [] as string[] };
+          return {
+            zones: -1,
+            ms: 0,
+            unclassified: [] as string[],
+            nonDocumentTimelines: [] as string[],
+          };
         }
 
         // The element and BOTH pseudo-elements, through one reader. A pseudo that animates or
@@ -227,10 +238,31 @@ async function geometrySpanMs(
               const parsed = Number.parseFloat(text);
               return Number.isNaN(parsed) ? 1 : parsed;
             });
+            // Which CLOCK each animation runs on. `auto` is the document timeline, where a
+            // duration is the wall-clock time this probe assumes. A scroll or view timeline drives
+            // progress from scroll position instead, so a perfectly ordinary `.1s` describes no
+            // elapsed time at all and the edge keeps moving on the next scroll — the declared
+            // number is not wrong, it is about something else. Refused rather than charged.
+            //
+            // Read through `??` because a browser without timeline support exposes no such
+            // longhand; there the value is correctly `auto`, since nothing can be driven by a
+            // timeline the engine does not implement.
+            const timelines = (surface.animationTimeline ?? "auto").split(",");
             names.forEach((name, i) => {
               // `none` occupies a position in every timing list but starts no animation, so its
               // tuple would charge movement that never happens.
               if (name.trim() === "none") return;
+              const timeline =
+                timelines.length === 0
+                  ? ""
+                  : timelines[i % timelines.length].trim();
+              // An empty entry is not treated as `auto`: it means the longhand could not be read,
+              // and defaulting an unreadable clock to the one this probe can measure is the silent
+              // pass the file exists to remove.
+              if (timeline !== "auto") {
+                nonDocumentTimelines.push(timeline || "(unreadable)");
+                return;
+              }
               // Nor does a zero-iteration entry, and its DELAY is equally irrelevant: under the
               // default fill mode nothing is applied before the first iteration, and there is no
               // first iteration. Charging the delay would report a wait for movement that never
@@ -279,7 +311,12 @@ async function geometrySpanMs(
 
         for (const a of attrs) if (!had.includes(a)) el.removeAttribute(a);
       }
-      return { zones: zones.length, ms: longest, unclassified };
+      return {
+        zones: zones.length,
+        ms: longest,
+        unclassified,
+        nonDocumentTimelines,
+      };
     },
     [
       DROP_ZONES,
@@ -296,6 +333,15 @@ async function geometrySpanMs(
       "a drop zone declares an animation or transition whose duration is not a time this test " +
         "could parse, so its span is unknown. Reporting a number would certify an allowance " +
         "against a movement nobody measured."
+    );
+  }
+  if (result.nonDocumentTimelines.length > 0) {
+    throw new Error(
+      "a drop-zone animation runs on a non-document timeline (" +
+        [...new Set(result.nonDocumentTimelines)].join(", ") +
+        "). Its progress is driven by scroll position rather than by elapsed time, so its " +
+        "duration is not a wall-clock span and a later scroll moves the edge again. Charging " +
+        "that duration would pin a number this probe cannot stand behind."
     );
   }
   if (result.zones === -1) {
@@ -852,6 +898,44 @@ test.describe("the drop-zone geometry the probe waits on", () => {
     // between-item zone. A rule keyed on `[data-drag]` for an empty zone can never fire, so
     // measuring it would pin a span for movement the canvas cannot produce.
     expect(await geometrySpanMs(frame, "data-drag")).toBe(0);
+  });
+
+  test("an animation on a SCROLL timeline is refused, not read as its duration", async ({
+    page,
+    request,
+  }) => {
+    const frame = await canvas(page, request);
+
+    // A perfectly ordinary `.2s` that describes no elapsed time: `scroll()` drives progress from
+    // scroll position, so the edge moves again on the next scroll and no allowance covers it.
+    // 200ms is chosen deliberately — it EXCEEDS the driver's allowance, so a probe that read it as
+    // wall-clock would produce a span, not a refusal, and this test's rejection can only come from
+    // the timeline being recognised.
+    const injected = await frame.evaluate(() => {
+      const sheet = (
+        document.getElementById("nx-pb-style") as HTMLStyleElement | null
+      )?.sheet;
+      sheet?.insertRule(
+        "@keyframes nx-scrolled { from { height: 0 } to { height: 6px } }",
+        sheet.cssRules.length
+      );
+      sheet?.insertRule(
+        ".nx-pb-dropzone { animation: nx-scrolled .2s; animation-timeline: scroll() }",
+        sheet.cssRules.length
+      );
+      const zone = document.querySelector(".nx-pb-dropzone");
+      return zone
+        ? getComputedStyle(zone as HTMLElement).animationTimeline
+        : null;
+    });
+    // The population, before the verdict. A browser without scroll-timeline support resolves this
+    // to `auto`, and the refusal below would then be firing for some other reason — or the rule
+    // never applied at all. Neither is this test passing.
+    expect(injected).toContain("scroll");
+
+    await expect(
+      geometrySpanMs(frame, "data-drag data-active")
+    ).rejects.toThrow(/non-document timeline/);
   });
 
   test("a DECLARED animation that was slowed through the API is refused", async ({

--- a/e2e/tests/canvas/geometry-settle-matches-the-canvas.test.ts
+++ b/e2e/tests/canvas/geometry-settle-matches-the-canvas.test.ts
@@ -26,27 +26,54 @@ const CANVAS_CSS = resolve(
 );
 
 /**
+ * The comma-separated entries of a `transition` shorthand, splitting only at TOP LEVEL.
+ *
+ * A timing function carries its own commas — `cubic-bezier(.1,.7,1,.1)` has three — so an
+ * unconditional split tears one entry into pieces and separates a delay from the duration it
+ * belongs to. The two then pass an allowance check independently while the transition they
+ * describe runs for their sum.
+ */
+function topLevelEntries(declaration: string): string[] {
+  const entries: string[] = [];
+  let depth = 0;
+  let current = "";
+  for (const ch of declaration) {
+    if (ch === "(") depth += 1;
+    else if (ch === ")") depth -= 1;
+    if (ch === "," && depth === 0) {
+      entries.push(current);
+      current = "";
+      continue;
+    }
+    current += ch;
+  }
+  entries.push(current);
+  return entries;
+}
+
+/**
  * How long each `transition` entry can still be moving geometry, in milliseconds.
  *
- * Duration PLUS delay, per entry, because the shorthand carries both and the settle allowance has
- * to cover the moment the last one stops. `height .1s ease .05s` is 150ms of possible movement;
- * reading the two numbers separately reports 100 and 50, and each passes a 120ms allowance while
- * the edge keeps travelling past it — the guard green for the same reason the probe is wrong.
+ * Duration PLUS delay, and the delay is SIGNED. A negative delay is valid CSS and means the
+ * transition starts partway through, so it finishes EARLIER: `height .1s ease -.05s` ends 50ms
+ * after the style change, not 150ms. Reading the magnitude would reject a transition the
+ * allowance already covers — a false failure, which is the direction that gets a guard disabled.
  *
  * A `transition` shorthand takes at most two times, and the FIRST is the duration and the second
  * the delay, whatever order the other keywords appear in. Anything past the second is a keyword,
  * so summing every number in the entry would inflate the total instead.
  */
-function zoneTransitionSpansMs(source: string): number[] {
+export function zoneTransitionSpansMs(source: string): number[] {
   const spans: number[] = [];
   for (const line of source.split("\n")) {
     if (!line.includes("nx-pb-dropzone") || !line.includes("transition"))
       continue;
     const declaration = /transition\s*:\s*([^;"']+)/.exec(line);
     if (!declaration) continue;
-    // Comma-separated entries, each its own property with its own timings.
-    for (const entry of declaration[1].split(",")) {
-      const times = [...entry.matchAll(/([\d.]+)(ms|s)\b/g)].map(
+    for (const entry of topLevelEntries(declaration[1])) {
+      // The sign is part of the token. `[\d.]+` alone reads `-.05s` as `.05s`, which is the
+      // magnitude of a value whose whole meaning is its direction.
+      const times = [...entry.matchAll(/(-?[\d.]+)(ms|s)\b/g)].map(
         ([, value, unit]) =>
           unit === "s" ? Number(value) * 1000 : Number(value)
       );
@@ -74,4 +101,38 @@ test("the PoC driver's settle allowance covers the zone transition it animates",
       `a drop-zone transition lasting ${String(duration)}ms is not covered by the driver's ${String(declared)}ms geometrySettleMs — raise geometrySettleMs in poc-driver.ts`
     ).toBeLessThanOrEqual(declared);
   }
+});
+
+/**
+ * The parser, exercised on inputs whose answer is known.
+ *
+ * Reading it off the real stylesheet cannot cover these: the shapes that broke it are ones the
+ * canvas does not currently use, and a guard is worth having precisely for the day it does. This
+ * parser has now been wrong in four distinct ways — a hardcoded allowance, an unsummed delay,
+ * commas inside a timing function, and an unsigned delay — so the controls exercise the SHAPES
+ * rather than the current CSS.
+ */
+test("the span parser reads each transition shape correctly", () => {
+  const spans = (css: string) =>
+    zoneTransitionSpansMs(`  ".nx-pb-dropzone{transition:${css}}",`);
+
+  // Duration alone.
+  expect(spans("height .1s ease")).toEqual([100]);
+
+  // Duration plus delay: the sum is what the allowance must cover.
+  expect(spans("height .1s ease .05s")).toEqual([150]);
+
+  // A timing function's own commas are NOT entry separators. Split naively this reports two
+  // spans of 100 and 50, each of which clears a 120ms allowance while the transition runs 150ms.
+  expect(spans("height .1s cubic-bezier(.1,.7,1,.1) .05s")).toEqual([150]);
+
+  // A NEGATIVE delay starts the transition partway through, so it ends EARLIER. Read as a
+  // magnitude this is 150 and would reject a transition the allowance already covers.
+  expect(spans("height .1s ease -.05s")).toEqual([50]);
+
+  // Several properties, each its own entry with its own timings.
+  expect(spans("height .1s ease .05s,background .2s ease")).toEqual([150, 200]);
+
+  // Milliseconds as well as seconds.
+  expect(spans("height 120ms ease 30ms")).toEqual([150]);
 });

--- a/e2e/tests/canvas/geometry-settle-matches-the-canvas.test.ts
+++ b/e2e/tests/canvas/geometry-settle-matches-the-canvas.test.ts
@@ -1,32 +1,32 @@
 /**
- * The drop-zone timing the probe's settle allowance was chosen against.
+ * The drop-zone timing the probe's settle allowance is chosen against.
  *
  * `poc-driver` declares `geometrySettleMs` — how long the canvas may still be moving a zone edge
- * after the pointer enters it — and the canvas animates that geometry in its own stylesheet. Two
- * statements of one fact, and nothing in either file refers to the other.
+ * after the pointer enters it — while the canvas animates that geometry in its own stylesheet.
+ * Two statements of one fact, in files that do not refer to each other, so this holds them
+ * together.
  *
- * ## Why this PINS the declaration instead of reading it
+ * It asserts two things, and needs both:
  *
- * The first version parsed the `transition` shorthand out of `IframeCanvas.tsx` and compared the
- * computed span against the allowance. That reader was wrong FOURTEEN times, and the list is worth
- * keeping because it is the argument: a hardcoded copy of the value it was checking; every time
- * token read separately so a delay was never summed; commas inside `cubic-bezier()` treated as
- * entry separators; an unsigned delay read as its magnitude; a unit-bearing identifier
- * (`var(--ease-50ms)`) mined for a duration; a second declaration on one line never seen;
- * `calc(.04s + .03s)` summed as separate numbers; a colour's timing charged to the geometry
- * budget; a property-last shorthand (`.2s ease margin`) misread; an implicit-`all` shorthand
- * skipped; a non-exhaustive geometry allowlist silently dropping `max-height` and `block-size`;
- * longhand `transition-duration` overrides ignored; and a leading `+` rejected.
+ * - the stylesheet declaration is UNCHANGED, so a timing edit cannot pass unnoticed;
+ * - the driver's allowance still covers the span that declaration produces.
  *
- * Each fix was correct and each earned the next finding, because a regex over CSS source does not
- * DETERMINE the answer being asked of it — `.claude/rules/derived-checks.md` calls that an
- * abstraction mismatch, where patching by example has no end.
+ * Either alone is satisfiable while the pair is wrong. Pinning only the text passes when the
+ * allowance is lowered underneath it; checking only the allowance passes when the transition is
+ * lengthened.
  *
- * So this makes no semantic claim about CSS. It asserts the declaration is UNCHANGED. That is
- * complete by construction: every one of the fourteen cases changes the text, so every one trips
- * it, and none requires the test to understand what it changed to. The cost is that a cosmetic
- * edit also trips it — which is the right direction, because the person editing that line is
- * exactly the person who should re-check the allowance.
+ * ## Why the declaration is PINNED rather than parsed
+ *
+ * Computing a span from CSS source means representing CSS: comma-separated entries whose commas
+ * may belong to a timing function, times that may be signed or written as `calc()` or resolved
+ * through a variable, properties that may appear last or be implicit, longhand declarations that
+ * override the shorthand, and only some properties moving the edge this probe measures. A regex
+ * cannot represent that, and each spelling handled reveals another.
+ *
+ * Pinning makes no semantic claim, which is what makes it complete: every one of those spellings
+ * changes the text, so every one trips this, and none requires the test to understand what it
+ * changed to. The cost is that a cosmetic edit trips it as well — which is the direction to want,
+ * because whoever edits that line is who should re-derive the allowance.
  */
 import { readFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
@@ -44,12 +44,22 @@ const CANVAS_CSS = resolve(
 /**
  * The drop-zone rules carrying a `transition`, exactly as the canvas writes them.
  *
- * Regenerate by running the selector below against the file; do not hand-edit to make a failure
- * go away, because the failure IS the notification that the geometry timing moved.
+ * Do not hand-edit to clear a failure: the failure is the notification that the geometry timing
+ * moved, and clearing it without re-deriving {@link PINNED_GEOMETRY_SPAN_MS} silently widens what
+ * the probe tolerates.
  */
 const PINNED = [
   '".nx-pb-dropzone{height:0;border-radius:3px;transition:height .1s ease,background .1s ease}",',
 ];
+
+/**
+ * How long the geometry above keeps moving, in milliseconds.
+ *
+ * Read off {@link PINNED} by a person rather than computed, and it travels with it: the only way
+ * this value goes stale is an edit to that declaration, which the assertion below refuses. `height`
+ * transitions over `.1s` with no delay; `background` moves no edge this probe measures.
+ */
+const PINNED_GEOMETRY_SPAN_MS = 100;
 
 /** Every drop-zone line declaring a transition, trimmed, in file order. */
 function transitionLines(source: string): string[] {
@@ -64,15 +74,25 @@ function transitionLines(source: string): string[] {
 test("the drop-zone geometry timing has not changed under the probe", () => {
   const found = transitionLines(readFileSync(CANVAS_CSS, "utf8"));
 
-  // The positive control, and it is not decoration: a selector that matched nothing would satisfy
-  // an equality against an empty PINNED and certify a file it never read.
+  // A selector that matched nothing would satisfy an equality against an empty expectation and
+  // certify a file it never read.
   expect(found.length).toBeGreaterThan(0);
 
   expect(
     found,
-    `the canvas drop-zone transition changed. Re-derive how long geometry can still be moving and ` +
-      `update POC_GEOMETRY_SETTLE_MS in poc-driver.ts (currently ${String(POC_GEOMETRY_SETTLE_MS)}ms), ` +
-      `then update PINNED here. This test deliberately does not parse CSS: doing so was wrong ` +
-      `fourteen times, so it reports that the timing moved rather than guessing by how much.`
+    "the canvas drop-zone transition changed. Re-derive how long its geometry keeps moving, " +
+      "update PINNED_GEOMETRY_SPAN_MS and PINNED here, and raise POC_GEOMETRY_SETTLE_MS in " +
+      "poc-driver.ts if the span now exceeds it."
   ).toEqual(PINNED);
+});
+
+test("the driver's settle allowance covers that geometry", () => {
+  // The other half. Pinning the text alone passes while someone lowers the allowance underneath
+  // it, which lets the probe resume measuring an edge that is still travelling.
+  expect(
+    POC_GEOMETRY_SETTLE_MS,
+    `geometrySettleMs is ${String(POC_GEOMETRY_SETTLE_MS)}ms and the drop-zone geometry moves for ` +
+      `${String(PINNED_GEOMETRY_SPAN_MS)}ms, so the probe can re-measure an edge that is still ` +
+      "travelling. Raise it in poc-driver.ts."
+  ).toBeGreaterThanOrEqual(PINNED_GEOMETRY_SPAN_MS);
 });

--- a/e2e/tests/canvas/geometry-settle-matches-the-canvas.test.ts
+++ b/e2e/tests/canvas/geometry-settle-matches-the-canvas.test.ts
@@ -308,25 +308,70 @@ async function geometrySpanMs(frame: Frame, rule: string): Promise<number> {
 }
 
 /**
- * The drop-zone rules carrying a transition, read from the RUNNING canvas.
+ * The rules that give a drop zone a transition, read from the RUNNING canvas.
  *
- * Taken from the stylesheet the browser PARSED — `<style id="nx-pb-overlay">` in the canvas frame
- * — rather than from `IframeCanvas.tsx`. That is the difference between an instrument that can
- * answer this question and one that cannot: a reader of the SOURCE has to represent TypeScript,
+ * Two questions, and both are answered structurally rather than by matching text.
+ *
+ * WHICH RULES APPLY: each rule's selector is tested against the probe elements with `matches`,
+ * not searched for the substring `nx-pb-dropzone`. A rule can reach a drop zone without naming
+ * its class — `[data-active]{transition:height .2s}` applies to one and contains no such text —
+ * and a text filter drops it while the base rule keeps the pin equal, so the allowance passes
+ * over a zone that moves for 200ms.
+ *
+ * WHICH DECLARE A TRANSITION: asked of the parsed declaration rather than of the rule's text, so
+ * a shorthand, a longhand and a `var()` all answer the same way.
+ *
+ * Read from the stylesheet the browser parsed — `<style id="nx-pb-overlay">` in the canvas frame —
+ * rather than from `IframeCanvas.tsx`. Reading the source would mean representing TypeScript,
  * where an array entry may be an identifier, a template literal or a call, and it cannot represent
- * the cascade at all. Four review rounds found four such spellings, each fix correct and each
- * followed by another, because the surface being modelled is two whole languages.
- *
- * By the time the browser has parsed this sheet every one of those questions is already answered.
+ * the cascade at all, which is where a custom property's value is decided.
  */
 async function transitionRules(frame: Frame): Promise<string[]> {
-  const rules = await frame.evaluate(() => {
-    const overlay = document.getElementById(
-      "nx-pb-overlay"
-    ) as HTMLStyleElement | null;
-    if (!overlay?.sheet) return null;
-    return [...overlay.sheet.cssRules].map(rule => rule.cssText);
-  });
+  const rules = await frame.evaluate(
+    ([classes, states]) => {
+      const overlay = document.getElementById(
+        "nx-pb-overlay"
+      ) as HTMLStyleElement | null;
+      if (!overlay?.sheet) return null;
+
+      const probe = document.createElement("div");
+      document.body.append(probe);
+      const applies = (selector: string) => {
+        for (const cls of classes as string[]) {
+          for (const state of states as (string | null)[]) {
+            probe.className = cls;
+            for (const attr of states as (string | null)[]) {
+              if (attr) probe.removeAttribute(attr);
+            }
+            if (state) probe.setAttribute(state, "");
+            try {
+              if (probe.matches(selector)) return true;
+            } catch {
+              // A selector this browser cannot parse matches nothing here, and the rule it came
+              // from cannot be measured either; the pin below reports it as a change.
+              return false;
+            }
+          }
+        }
+        return false;
+      };
+
+      const found = [...overlay.sheet.cssRules]
+        .filter((rule): rule is CSSStyleRule => "selectorText" in rule)
+        .filter(
+          rule =>
+            Boolean(
+              rule.style.transition ||
+                rule.style.transitionProperty ||
+                rule.style.transitionDuration
+            ) && applies(rule.selectorText)
+        )
+        .map(rule => rule.cssText);
+      probe.remove();
+      return found;
+    },
+    [PROBE_CLASSES, PROBE_STATES] as const
+  );
   // An absent sheet would read as "no transitions here", which is the reassuring direction and
   // would certify a canvas nobody looked at.
   if (rules === null) {
@@ -335,9 +380,7 @@ async function transitionRules(frame: Frame): Promise<string[]> {
         "browser was given. It refuses rather than reporting an empty rule list."
     );
   }
-  return rules.filter(
-    rule => rule.includes("nx-pb-dropzone") && rule.includes("transition")
-  );
+  return rules;
 }
 
 // The canvas iframe is only rendered above a certain width: the editor's rail, block library and
@@ -380,6 +423,31 @@ test.describe("the drop-zone geometry the probe waits on", () => {
         "is computed by the browser, so nothing else needs recalculating — but raise " +
         "POC_GEOMETRY_SETTLE_MS in poc-driver.ts if the new spans exceed it."
     ).toEqual([...PINNED_RULES]);
+  });
+
+  test("a rule reaching a zone without naming its class is still found", async ({
+    page,
+    request,
+  }) => {
+    const frame = await canvas(page, request);
+
+    // `[data-active]` applies to a drop zone and contains none of its class text, which is the
+    // shape a substring filter drops. Appended to the canvas's OWN sheet so the reader meets it
+    // exactly as it would meet a future canvas edit, rather than through a second fixture.
+    const added = await frame.evaluate(() => {
+      const overlay = document.getElementById(
+        "nx-pb-overlay"
+      ) as HTMLStyleElement | null;
+      const rule = "[data-active]{transition:height .2s}";
+      overlay?.sheet?.insertRule(rule, overlay.sheet.cssRules.length);
+      return Boolean(overlay?.sheet);
+    });
+    // The injection itself has to be observable: without this the assertion below is satisfied by
+    // a sheet that was never touched.
+    expect(added).toBe(true);
+
+    const found = await transitionRules(frame);
+    expect(found.some(rule => rule.includes("data-active"))).toBe(true);
   });
 
   test("the driver's settle allowance covers every pinned rule", async ({

--- a/e2e/tests/canvas/geometry-settle-matches-the-canvas.test.ts
+++ b/e2e/tests/canvas/geometry-settle-matches-the-canvas.test.ts
@@ -42,24 +42,23 @@ const CANVAS_CSS = resolve(
 );
 
 /**
- * The drop-zone rules carrying a `transition`, exactly as the canvas writes them.
+ * The drop-zone geometry, as ONE statement: the declaration exactly as the canvas writes it, and
+ * how long the geometry in it keeps moving.
  *
- * Do not hand-edit to clear a failure: the failure is the notification that the geometry timing
- * moved, and clearing it without re-deriving {@link PINNED_GEOMETRY_SPAN_MS} silently widens what
- * the probe tolerates.
- */
-const PINNED = [
-  '".nx-pb-dropzone{height:0;border-radius:3px;transition:height .1s ease,background .1s ease}",',
-];
-
-/**
- * How long the geometry above keeps moving, in milliseconds.
+ * Kept in a single structure so the two cannot be updated apart. They were separate constants, and
+ * separate constants invite the half-edit: paste the new declaration, leave the number, and both
+ * assertions below pass while the probe tolerates less than the canvas takes. Editing this literal
+ * puts the span under the reader's cursor at the moment they change the text.
  *
- * Read off {@link PINNED} by a person rather than computed, and it travels with it: the only way
- * this value goes stale is an edit to that declaration, which the assertion below refuses. `height`
- * transitions over `.1s` with no delay; `background` moves no edge this probe measures.
+ * `spanMs` is read off `declaration` by a person. It cannot go stale on its own — the only thing
+ * that changes it is an edit to that text, which the first assertion refuses.
  */
-const PINNED_GEOMETRY_SPAN_MS = 100;
+const PINNED_GEOMETRY = {
+  declaration:
+    '".nx-pb-dropzone{height:0;border-radius:3px;transition:height .1s ease,background .1s ease}",',
+  // `height` transitions over `.1s` with no delay. `background` moves no edge this probe measures.
+  spanMs: 100,
+} as const;
 
 /** Every drop-zone line declaring a transition, trimmed, in file order. */
 function transitionLines(source: string): string[] {
@@ -81,9 +80,9 @@ test("the drop-zone geometry timing has not changed under the probe", () => {
   expect(
     found,
     "the canvas drop-zone transition changed. Re-derive how long its geometry keeps moving, " +
-      "update PINNED_GEOMETRY_SPAN_MS and PINNED here, and raise POC_GEOMETRY_SETTLE_MS in " +
+      "update PINNED_GEOMETRY here — both its declaration AND its spanMs, and raise POC_GEOMETRY_SETTLE_MS in " +
       "poc-driver.ts if the span now exceeds it."
-  ).toEqual(PINNED);
+  ).toEqual([PINNED_GEOMETRY.declaration]);
 });
 
 test("the driver's settle allowance covers that geometry", () => {
@@ -92,7 +91,7 @@ test("the driver's settle allowance covers that geometry", () => {
   expect(
     POC_GEOMETRY_SETTLE_MS,
     `geometrySettleMs is ${String(POC_GEOMETRY_SETTLE_MS)}ms and the drop-zone geometry moves for ` +
-      `${String(PINNED_GEOMETRY_SPAN_MS)}ms, so the probe can re-measure an edge that is still ` +
+      `${String(PINNED_GEOMETRY.spanMs)}ms, so the probe can re-measure an edge that is still ` +
       "travelling. Raise it in poc-driver.ts."
-  ).toBeGreaterThanOrEqual(PINNED_GEOMETRY_SPAN_MS);
+  ).toBeGreaterThanOrEqual(PINNED_GEOMETRY.spanMs);
 });

--- a/e2e/tests/canvas/geometry-settle-matches-the-canvas.test.ts
+++ b/e2e/tests/canvas/geometry-settle-matches-the-canvas.test.ts
@@ -775,10 +775,10 @@ test.describe("the drop-zone geometry the probe waits on", () => {
   }) => {
     const frame = await canvas(page, request);
 
-    // `DropZone`'s empty branch renders `data-active` only; `data-drag` appears on the
-    // between-item zone. A rule keyed on `[data-drag]` for an empty zone can never fire, so
-    // measuring it would pin a span for movement the canvas cannot produce.
-    const injected = await frame.evaluate(() => {
+    // This fixture renders no empty zones - measured: 7 `.nx-pb-dropzone`, 0
+    // `.nx-pb-dropzone-empty` - so one is created here. Without it the assertion below passes
+    // because its subject does not exist, which is coverage that is not there.
+    const present = await frame.evaluate(() => {
       const sheet = (
         document.getElementById("nx-pb-style") as HTMLStyleElement | null
       )?.sheet;
@@ -786,10 +786,17 @@ test.describe("the drop-zone geometry the probe waits on", () => {
         ".nx-pb-dropzone-empty[data-drag] { transition: height .3s }",
         sheet.cssRules.length
       );
-      return Boolean(sheet);
+      const el = document.createElement("div");
+      el.className = "nx-pb-dropzone-empty";
+      document.body.append(el);
+      return document.querySelectorAll(".nx-pb-dropzone-empty").length;
     });
-    expect(injected).toBe(true);
+    // The population, asserted before the verdict: zero here means the test measured nothing.
+    expect(present).toBeGreaterThan(0);
 
+    // `DropZone`'s empty branch renders `data-active` only; `data-drag` belongs to the
+    // between-item zone. A rule keyed on `[data-drag]` for an empty zone can never fire, so
+    // measuring it would pin a span for movement the canvas cannot produce.
     expect(await geometrySpanMs(frame, "data-drag")).toBe(0);
   });
 

--- a/e2e/tests/canvas/geometry-settle-matches-the-canvas.test.ts
+++ b/e2e/tests/canvas/geometry-settle-matches-the-canvas.test.ts
@@ -597,9 +597,12 @@ test.describe("the drop-zone geometry the probe waits on", () => {
     const started = await frame.evaluate(() => {
       const zone = document.querySelector(".nx-pb-dropzone");
       if (!zone) return false;
+      // Endless, so it cannot finish during the round trip before `getAnimations()` is asked. A
+      // finite one makes this control pass on a fast worker and quietly stop testing anything on
+      // a loaded one - coverage that evaporates exactly when CI needs it most.
       (zone as HTMLElement).animate([{ height: "0px" }, { height: "12px" }], {
         duration: 300,
-        iterations: 1,
+        iterations: Infinity,
       });
       return true;
     });

--- a/e2e/tests/canvas/geometry-settle-matches-the-canvas.test.ts
+++ b/e2e/tests/canvas/geometry-settle-matches-the-canvas.test.ts
@@ -26,12 +26,33 @@ const CANVAS_CSS = resolve(
 );
 
 /**
+ * Properties whose transition moves a zone EDGE.
+ *
+ * A `background` transition changes nothing the probe measures, so its timing must not be charged
+ * to the settle allowance — the stylesheet already carries one, and a visual timing change would
+ * otherwise either fail CI or make every geometry probe wait for a colour.
+ */
+const GEOMETRY_PROPERTIES = [
+  "height",
+  "width",
+  "margin",
+  "padding",
+  "inset",
+  "top",
+  "bottom",
+  "transform",
+  "all",
+];
+
+/** Syntax this reader cannot evaluate, and must not guess at. */
+const UNREPRESENTABLE = /\bcalc\(|\bvar\(|\bclamp\(|\bmin\(|\bmax\(/;
+
+/**
  * The comma-separated entries of a `transition` shorthand, splitting only at TOP LEVEL.
  *
  * A timing function carries its own commas — `cubic-bezier(.1,.7,1,.1)` has three — so an
  * unconditional split tears one entry into pieces and separates a delay from the duration it
- * belongs to. The two then pass an allowance check independently while the transition they
- * describe runs for their sum.
+ * belongs to.
  */
 function topLevelEntries(declaration: string): string[] {
   const entries: string[] = [];
@@ -51,88 +72,120 @@ function topLevelEntries(declaration: string): string[] {
   return entries;
 }
 
-/**
- * How long each `transition` entry can still be moving geometry, in milliseconds.
- *
- * Duration PLUS delay, and the delay is SIGNED. A negative delay is valid CSS and means the
- * transition starts partway through, so it finishes EARLIER: `height .1s ease -.05s` ends 50ms
- * after the style change, not 150ms. Reading the magnitude would reject a transition the
- * allowance already covers — a false failure, which is the direction that gets a guard disabled.
- *
- * A `transition` shorthand takes at most two times, and the FIRST is the duration and the second
- * the delay, whatever order the other keywords appear in. Anything past the second is a keyword,
- * so summing every number in the entry would inflate the total instead.
- */
-export function zoneTransitionSpansMs(source: string): number[] {
-  const spans: number[] = [];
-  for (const line of source.split("\n")) {
-    if (!line.includes("nx-pb-dropzone") || !line.includes("transition"))
-      continue;
-    const declaration = /transition\s*:\s*([^;"']+)/.exec(line);
-    if (!declaration) continue;
-    for (const entry of topLevelEntries(declaration[1])) {
-      // The sign is part of the token. `[\d.]+` alone reads `-.05s` as `.05s`, which is the
-      // magnitude of a value whose whole meaning is its direction.
-      const times = [...entry.matchAll(/(-?[\d.]+)(ms|s)\b/g)].map(
-        ([, value, unit]) =>
-          unit === "s" ? Number(value) * 1000 : Number(value)
-      );
-      if (times.length === 0) continue;
-      spans.push(times[0] + (times[1] ?? 0));
-    }
-  }
-  return spans;
+/** What this reader could not judge, so a caller can refuse rather than under-report. */
+export interface TransitionScan {
+  /** Geometry spans it DID evaluate, in milliseconds. */
+  readonly spansMs: number[];
+  /** Declarations it declined to evaluate, verbatim. */
+  readonly unreadable: string[];
 }
 
-test("the PoC driver's settle allowance covers the zone transition it animates", () => {
+/**
+ * Every geometry `transition` on the drop-zone rules, and everything this reader refused.
+ *
+ * **It reports what it cannot represent instead of guessing.** That is the whole design, and it
+ * is a correction: this reader has been wrong nine times, and every one was a silent WRONG NUMBER
+ * rather than a refusal — a hardcoded allowance, an unsummed delay, commas inside a timing
+ * function, an unsigned delay, a unit-bearing identifier read as a time, a second declaration on
+ * one line never seen, `calc()` summed as separate numbers, and a colour's timing charged to the
+ * geometry budget. A regex cannot represent CSS, so the honest move is not another case: it is to
+ * say so when the input leaves what it can represent.
+ *
+ * Refusing is safe HERE specifically because a refusal fails the test. The caller turns anything
+ * in `unreadable` into a failure naming the declaration, so an unjudgeable transition stops CI
+ * rather than passing quietly — the opposite of the direction every previous defect failed in.
+ *
+ * The end state is to delete this entirely: if the canvas derived its transition from an exported
+ * constant, the driver would import that constant and there would be nothing to parse. Filed as
+ * `tasks/left-tasks/2026-08-14-2200-delete-the-transition-parser.md`.
+ */
+export function scanZoneTransitions(source: string): TransitionScan {
+  const spansMs: number[] = [];
+  const unreadable: string[] = [];
+  for (const line of source.split("\n")) {
+    if (!line.includes("nx-pb-dropzone")) continue;
+    // EVERY declaration on the line, not the first. CSS applies the last of a duplicate pair, so
+    // stopping at one records a value the browser does not use.
+    for (const [, body] of line.matchAll(/transition\s*:\s*([^;"']+)/g)) {
+      for (const entry of topLevelEntries(body)) {
+        if (UNREPRESENTABLE.test(entry)) {
+          unreadable.push(entry.trim());
+          continue;
+        }
+        const property = entry.trim().split(/\s+/)[0];
+        if (!GEOMETRY_PROPERTIES.includes(property)) continue;
+        // Times only where a NUMBER precedes the unit, so `var(--ease-50ms)` — already refused
+        // above — and any identifier carrying a unit cannot be read as a duration.
+        const times = [...entry.matchAll(/(?:^|\s)(-?[\d.]+)(ms|s)\b/g)].map(
+          ([, value, unit]) =>
+            unit === "s" ? Number(value) * 1000 : Number(value)
+        );
+        if (times.length === 0) continue;
+        spansMs.push(times[0] + (times[1] ?? 0));
+      }
+    }
+  }
+  return { spansMs, unreadable };
+}
+
+test("the PoC driver's settle allowance covers the zone geometry it animates", () => {
   const source = readFileSync(CANVAS_CSS, "utf8");
-  const durations = zoneTransitionSpansMs(source);
+  const { spansMs, unreadable } = scanZoneTransitions(source);
 
-  // The positive control, and it is the whole reason this file is not vacuous: a parser that
-  // matched nothing would satisfy every assertion below by having no values to check.
-  expect(durations.length).toBeGreaterThan(0);
+  // Refusals are FAILURES, not skips. An unjudgeable declaration is exactly when this guard has
+  // nothing to say, and saying nothing is how the previous nine defects passed.
+  expect(
+    unreadable,
+    `this reader cannot evaluate ${unreadable.join(" | ")} — compute the span another way or delete the parser (see tasks/left-tasks/2026-08-14-2200-delete-the-transition-parser.md)`
+  ).toEqual([]);
 
-  // Imported rather than restated, so this cannot pass against a number the driver does not
-  // actually use — a guard holding its own copy compares a constant with itself.
-  const declared = POC_GEOMETRY_SETTLE_MS;
-  for (const duration of durations) {
+  // The positive control, and the whole reason this file is not vacuous: a reader that matched
+  // nothing would satisfy the comparison below by having nothing to compare.
+  expect(spansMs.length).toBeGreaterThan(0);
+
+  for (const span of spansMs) {
     expect(
-      duration,
-      `a drop-zone transition lasting ${String(duration)}ms is not covered by the driver's ${String(declared)}ms geometrySettleMs — raise geometrySettleMs in poc-driver.ts`
-    ).toBeLessThanOrEqual(declared);
+      span,
+      `a drop-zone geometry transition lasting ${String(span)}ms is not covered by the driver's ${String(POC_GEOMETRY_SETTLE_MS)}ms geometrySettleMs — raise geometrySettleMs in poc-driver.ts`
+    ).toBeLessThanOrEqual(POC_GEOMETRY_SETTLE_MS);
   }
 });
 
-/**
- * The parser, exercised on inputs whose answer is known.
- *
- * Reading it off the real stylesheet cannot cover these: the shapes that broke it are ones the
- * canvas does not currently use, and a guard is worth having precisely for the day it does. This
- * parser has now been wrong in four distinct ways — a hardcoded allowance, an unsummed delay,
- * commas inside a timing function, and an unsigned delay — so the controls exercise the SHAPES
- * rather than the current CSS.
- */
-test("the span parser reads each transition shape correctly", () => {
-  const spans = (css: string) =>
-    zoneTransitionSpansMs(`  ".nx-pb-dropzone{transition:${css}}",`);
+test("the reader judges what it can and refuses what it cannot", () => {
+  const scan = (css: string) =>
+    scanZoneTransitions(`  ".nx-pb-dropzone{transition:${css}}",`);
 
-  // Duration alone.
-  expect(spans("height .1s ease")).toEqual([100]);
+  // Duration alone, and duration plus delay.
+  expect(scan("height .1s ease").spansMs).toEqual([100]);
+  expect(scan("height .1s ease .05s").spansMs).toEqual([150]);
 
-  // Duration plus delay: the sum is what the allowance must cover.
-  expect(spans("height .1s ease .05s")).toEqual([150]);
+  // A timing function's own commas are not entry separators.
+  expect(scan("height .1s cubic-bezier(.1,.7,1,.1) .05s").spansMs).toEqual([
+    150,
+  ]);
 
-  // A timing function's own commas are NOT entry separators. Split naively this reports two
-  // spans of 100 and 50, each of which clears a 120ms allowance while the transition runs 150ms.
-  expect(spans("height .1s cubic-bezier(.1,.7,1,.1) .05s")).toEqual([150]);
+  // A NEGATIVE delay starts the transition partway through, so it ends EARLIER.
+  expect(scan("height .1s ease -.05s").spansMs).toEqual([50]);
 
-  // A NEGATIVE delay starts the transition partway through, so it ends EARLIER. Read as a
-  // magnitude this is 150 and would reject a transition the allowance already covers.
-  expect(spans("height .1s ease -.05s")).toEqual([50]);
+  // A non-geometry property moves no edge, so its timing is not the probe's concern.
+  expect(scan("height .1s ease, background .1s ease .2s").spansMs).toEqual([
+    100,
+  ]);
 
-  // Several properties, each its own entry with its own timings.
-  expect(spans("height .1s ease .05s,background .2s ease")).toEqual([150, 200]);
+  // A unit-bearing IDENTIFIER is not a time. This one is refused outright as a `var()`, which is
+  // the honest answer — the reader cannot know what the variable resolves to.
+  expect(scan("height .1s var(--ease-50ms)").unreadable).toHaveLength(1);
+  expect(scan("height .1s var(--ease-50ms)").spansMs).toEqual([]);
 
-  // Milliseconds as well as seconds.
-  expect(spans("height 120ms ease 30ms")).toEqual([150]);
+  // A computed time is refused rather than summed wrongly.
+  expect(scan("height .06s ease calc(.04s + .03s)").unreadable).toHaveLength(1);
+
+  // Milliseconds, and BOTH declarations when a line carries two — CSS applies the later one, so
+  // recording only the first hides the value the browser actually uses.
+  expect(scan("height 120ms ease 30ms").spansMs).toEqual([150]);
+  expect(
+    scanZoneTransitions(
+      `  ".nx-pb-dropzone{transition:height .1s;transition:height .15s}",`
+    ).spansMs
+  ).toEqual([100, 150]);
 });

--- a/e2e/tests/canvas/geometry-settle-matches-the-canvas.test.ts
+++ b/e2e/tests/canvas/geometry-settle-matches-the-canvas.test.ts
@@ -158,15 +158,6 @@ async function geometrySpanMs(
         // The element and its pseudo-elements. A `::before` that animates height inside an
         // auto-sized zone moves the zone's own bottom edge, and its timing appears in no computed
         // longhand of the element itself.
-        const surfaces = [
-          getComputedStyle(el),
-          getComputedStyle(el, "::before"),
-          getComputedStyle(el, "::after"),
-        ];
-        const computed = surfaces[0];
-
-        // A running animation moves the edge for its whole duration whatever it animates, because
-        // the keyframes are not inspectable from here. Charged in full rather than skipped.
         // A JS-driven animation carries its timing in the Web Animations API and appears in no
         // computed longhand, so the measurement below cannot see it. Refused rather than ignored:
         // this file measures DECLARED CSS timing, and an effect it cannot read moves the edge
@@ -184,70 +175,75 @@ async function geometrySpanMs(
           return { zones: -1, ms: 0, unclassified: [] as string[] };
         }
 
-        if (computed.animationName !== "none") {
-          // Driven by the NAME list, because that decides how many animations run. CSS cycles a
-          // shorter timing list across every name, so iterating durations would stop at the first
-          // and miss the rest.
-          const names = computed.animationName.split(",");
-          const durations = ms(computed.animationDuration);
-          const delays = ms(computed.animationDelay);
-          // Each cycle moves the edge again, so the span is duration x ITERATIONS, not one pass.
-          // `infinite` parses as `Infinity`: an edge that never settles cannot be covered by any
-          // allowance, and the caller refuses on it.
-          //
-          // A count of ZERO is legitimate and means the animation never runs, so it is preserved
-          // rather than defaulted — `|| 1` would turn "does not move" into a full pass.
-          const counts = computed.animationIterationCount.split(",").map(v => {
-            const text = v.trim();
-            if (text === "infinite") return Infinity;
-            const parsed = Number.parseFloat(text);
-            return Number.isNaN(parsed) ? 1 : parsed;
-          });
-          names.forEach((name, i) => {
-            // `none` occupies a position in every timing list but starts no animation, so its
-            // tuple would charge movement that never happens.
-            if (name.trim() === "none") return;
-            longest = Math.max(
-              longest,
-              cycled(durations, i) * cycled(counts, i) + cycled(delays, i)
-            );
-          });
-        }
-
-        for (const pseudo of surfaces.slice(1)) {
-          if (pseudo.animationName !== "none") {
-            const pd = ms(pseudo.animationDuration);
-            const pdelay = ms(pseudo.animationDelay);
-            pseudo.animationName.split(",").forEach((name, i) => {
+        // The element and BOTH pseudo-elements, through one reader. A pseudo that animates or
+        // transitions an in-flow dimension moves an auto-sized zone's own edge, and its timing is
+        // in no computed longhand of the element. Asking the same function of each is what stops
+        // the pseudo path drifting from the element path — a second, shorter copy of this
+        // accounting is how iterations and transitions went missing from it.
+        for (const surface of [
+          getComputedStyle(el),
+          getComputedStyle(el, "::before"),
+          getComputedStyle(el, "::after"),
+        ]) {
+          if (surface.animationName !== "none") {
+            // Driven by the NAME list, because that decides how many animations run. CSS cycles a
+            // shorter timing list across every name, so iterating durations would stop at the
+            // first and miss the rest.
+            const names = surface.animationName.split(",");
+            const durations = ms(surface.animationDuration);
+            const delays = ms(surface.animationDelay);
+            // Each cycle moves the edge again, so the span is duration x ITERATIONS, not one
+            // pass. `infinite` parses as `Infinity`: an edge that never settles cannot be covered
+            // by any allowance, and the caller refuses on it. A count of ZERO is legitimate and
+            // means the animation never runs, so it survives rather than defaulting to a pass.
+            const counts = surface.animationIterationCount.split(",").map(v => {
+              const text = v.trim();
+              if (text === "infinite") return Infinity;
+              const parsed = Number.parseFloat(text);
+              return Number.isNaN(parsed) ? 1 : parsed;
+            });
+            names.forEach((name, i) => {
+              // `none` occupies a position in every timing list but starts no animation, so its
+              // tuple would charge movement that never happens.
               if (name.trim() === "none") return;
-              longest = Math.max(longest, cycled(pd, i) + cycled(pdelay, i));
+              longest = Math.max(
+                longest,
+                cycled(durations, i) * cycled(counts, i) + cycled(delays, i)
+              );
             });
           }
-        }
 
-        const properties = computed.transitionProperty
-          .split(",")
-          .map(v => v.trim());
-        const durations = ms(computed.transitionDuration);
-        const delays = ms(computed.transitionDelay);
-        const lastAll = properties.lastIndexOf("all");
-        const named = [
-          ...new Set(properties.filter(p => p !== "all" && p !== "none")),
-        ];
-        if (lastAll !== -1) {
-          longest = Math.max(
-            longest,
-            cycled(durations, lastAll) + cycled(delays, lastAll)
-          );
-        }
-        for (const property of named) {
-          if ((safe as string[]).includes(property)) continue;
-          if (!(geometry as string[]).includes(property)) {
-            unclassified.push(property);
-            continue;
+          const properties = surface.transitionProperty
+            .split(",")
+            .map(v => v.trim());
+          const durations = ms(surface.transitionDuration);
+          const delays = ms(surface.transitionDelay);
+          // `all` MATCHES every property, so it competes with each named entry rather than
+          // sitting beside it: with `height,all`, CSS gives height the `all` entry's timing
+          // because it comes later. Its own entry still counts, for the geometry properties
+          // nothing else names.
+          const lastAll = properties.lastIndexOf("all");
+          const named = [
+            ...new Set(properties.filter(p => p !== "all" && p !== "none")),
+          ];
+          if (lastAll !== -1) {
+            longest = Math.max(
+              longest,
+              cycled(durations, lastAll) + cycled(delays, lastAll)
+            );
           }
-          const i = Math.max(properties.lastIndexOf(property), lastAll);
-          longest = Math.max(longest, cycled(durations, i) + cycled(delays, i));
+          for (const property of named) {
+            if ((safe as string[]).includes(property)) continue;
+            if (!(geometry as string[]).includes(property)) {
+              unclassified.push(property);
+              continue;
+            }
+            const i = Math.max(properties.lastIndexOf(property), lastAll);
+            longest = Math.max(
+              longest,
+              cycled(durations, i) + cycled(delays, i)
+            );
+          }
         }
 
         for (const a of attrs) if (!had.includes(a)) el.removeAttribute(a);
@@ -673,6 +669,56 @@ test.describe("the drop-zone geometry the probe waits on", () => {
     expect(injected).toBe(true);
 
     expect(await geometrySpanMs(frame, null)).toBe(400);
+  });
+
+  test("a pseudo-element TRANSITION is charged like the element's own", async ({
+    page,
+    request,
+  }) => {
+    const frame = await canvas(page, request);
+
+    // The pseudo path used to handle animations only. A transition on ::before moves an
+    // auto-sized zone's edge exactly as an animation does.
+    const injected = await frame.evaluate(() => {
+      const sheet = (
+        document.getElementById("nx-pb-style") as HTMLStyleElement | null
+      )?.sheet;
+      sheet?.insertRule(
+        '.nx-pb-dropzone::after { content: ""; transition: height .35s }',
+        sheet.cssRules.length
+      );
+      return Boolean(sheet);
+    });
+    expect(injected).toBe(true);
+
+    expect(await geometrySpanMs(frame, null)).toBe(350);
+  });
+
+  test("a REPEATED pseudo-element animation is charged for every iteration", async ({
+    page,
+    request,
+  }) => {
+    const frame = await canvas(page, request);
+
+    // Iterations were applied to the element and not to its pseudo-elements, so a 100ms
+    // animation repeated three times reported 100ms - and an endless one read as finite.
+    const injected = await frame.evaluate(() => {
+      const sheet = (
+        document.getElementById("nx-pb-style") as HTMLStyleElement | null
+      )?.sheet;
+      sheet?.insertRule(
+        "@keyframes nx-ps-rep { from { height: 0 } to { height: 6px } }",
+        sheet.cssRules.length
+      );
+      sheet?.insertRule(
+        '.nx-pb-dropzone::before { content: ""; animation: nx-ps-rep .1s 3 }',
+        sheet.cssRules.length
+      );
+      return Boolean(sheet);
+    });
+    expect(injected).toBe(true);
+
+    expect(await geometrySpanMs(frame, null)).toBe(300);
   });
 
   test("it refuses rather than reporting a zero it cannot stand behind", async ({

--- a/e2e/tests/canvas/geometry-settle-matches-the-canvas.test.ts
+++ b/e2e/tests/canvas/geometry-settle-matches-the-canvas.test.ts
@@ -797,10 +797,12 @@ test.describe("the drop-zone geometry the probe waits on", () => {
   }) => {
     const frame = await canvas(page, request);
 
-    // This fixture renders no empty zones - measured: 7 `.nx-pb-dropzone`, 0
-    // `.nx-pb-dropzone-empty` - so one is created here. Without it the assertion below passes
-    // because its subject does not exist, which is coverage that is not there.
-    const present = await frame.evaluate(() => {
+    // Measured on the zone the canvas itself rendered, not on an element built here. A
+    // hand-made `div` carries the class and nothing else that decides the answer - the markup
+    // `DropZone`'s empty branch emits, its place in the tree, and the rules the cascade brings
+    // with that place - so it can only ever confirm the probe against the probe's own idea of an
+    // empty zone.
+    const probe = await frame.evaluate(() => {
       const sheet = (
         document.getElementById("nx-pb-style") as HTMLStyleElement | null
       )?.sheet;
@@ -808,13 +810,17 @@ test.describe("the drop-zone geometry the probe waits on", () => {
         ".nx-pb-dropzone-empty[data-drag] { transition: height .3s }",
         sheet.cssRules.length
       );
-      const el = document.createElement("div");
-      el.className = "nx-pb-dropzone-empty";
-      document.body.append(el);
-      return document.querySelectorAll(".nx-pb-dropzone-empty").length;
+      return {
+        injected: Boolean(sheet),
+        empty: document.querySelectorAll(".nx-pb-dropzone-empty").length,
+      };
     });
-    // The population, asserted before the verdict: zero here means the test measured nothing.
-    expect(present).toBeGreaterThan(0);
+    // Both asserted before the verdict, because each failure is silent in the passing
+    // direction: with no rule there is nothing to measure, and with no empty zone there is
+    // nothing to measure it on. Either way the assertion below reports 0 having looked at
+    // nothing.
+    expect(probe.injected).toBe(true);
+    expect(probe.empty).toBeGreaterThan(0);
 
     // `DropZone`'s empty branch renders `data-active` only; `data-drag` belongs to the
     // between-item zone. A rule keyed on `[data-drag]` for an empty zone can never fire, so

--- a/e2e/tests/canvas/geometry-settle-matches-the-canvas.test.ts
+++ b/e2e/tests/canvas/geometry-settle-matches-the-canvas.test.ts
@@ -145,31 +145,51 @@ async function geometrySpanMs(
 
       for (const zone of zones) {
         const el = zone as HTMLElement;
-        const had = appliedState
-          ? el.hasAttribute(appliedState as string)
-          : false;
-        if (appliedState) el.setAttribute(appliedState as string, "");
+        // A state may be a SET of attributes: the canvas can carry data-drag and data-active at
+        // once, and a rule keyed on both is invisible to either alone.
+        const attrs = appliedState ? (appliedState as string).split(" ") : [];
+        const had = attrs.filter(a => el.hasAttribute(a));
+        for (const a of attrs) el.setAttribute(a, "");
         const computed = getComputedStyle(el);
 
         // A running animation moves the edge for its whole duration whatever it animates, because
         // the keyframes are not inspectable from here. Charged in full rather than skipped.
+        // A JS-driven animation carries its timing in the Web Animations API and appears in no
+        // computed longhand, so the measurement below cannot see it. Refused rather than ignored:
+        // this file measures DECLARED CSS timing, and an effect it cannot read moves the edge
+        // just as surely.
+        const scripted = el
+          .getAnimations()
+          .filter(
+            a => !(a instanceof CSSAnimation) && !(a instanceof CSSTransition)
+          );
+        if (scripted.length > 0) {
+          return { zones: -1, ms: 0, unclassified: [] as string[] };
+        }
+
         if (computed.animationName !== "none") {
+          // Driven by the NAME list, because that decides how many animations run. CSS cycles a
+          // shorter timing list across every name, so iterating durations would stop at the first
+          // and miss the rest.
+          const names = computed.animationName.split(",");
           const durations = ms(computed.animationDuration);
           const delays = ms(computed.animationDelay);
           // Each cycle moves the edge again, so the span is duration x ITERATIONS, not one pass.
-          // `infinite` parses as `Infinity`, which is the honest answer: an edge that never
-          // settles cannot be covered by any allowance, and the caller refuses on it below.
-          const counts = computed.animationIterationCount
-            .split(",")
-            .map(v =>
-              v.trim() === "infinite"
-                ? Infinity
-                : Number.parseFloat(v.trim()) || 1
-            );
-          durations.forEach((duration, i) => {
+          // `infinite` parses as `Infinity`: an edge that never settles cannot be covered by any
+          // allowance, and the caller refuses on it.
+          //
+          // A count of ZERO is legitimate and means the animation never runs, so it is preserved
+          // rather than defaulted — `|| 1` would turn "does not move" into a full pass.
+          const counts = computed.animationIterationCount.split(",").map(v => {
+            const text = v.trim();
+            if (text === "infinite") return Infinity;
+            const parsed = Number.parseFloat(text);
+            return Number.isNaN(parsed) ? 1 : parsed;
+          });
+          names.forEach((_name, i) => {
             longest = Math.max(
               longest,
-              duration * cycled(counts, i) + cycled(delays, i)
+              cycled(durations, i) * cycled(counts, i) + cycled(delays, i)
             );
           });
         }
@@ -199,7 +219,7 @@ async function geometrySpanMs(
           longest = Math.max(longest, cycled(durations, i) + cycled(delays, i));
         }
 
-        if (appliedState && !had) el.removeAttribute(appliedState as string);
+        for (const a of attrs) if (!had.includes(a)) el.removeAttribute(a);
       }
       return { zones: zones.length, ms: longest, unclassified };
     },
@@ -213,6 +233,13 @@ async function geometrySpanMs(
 
   // No zones means this is not the canvas, or the document rendered none — and a zero span from
   // an empty query reads exactly like a canvas that animates nothing.
+  if (result.zones === -1) {
+    throw new Error(
+      "a drop zone is running an animation driven by the Web Animations API rather than declared " +
+        "in CSS. Its timing is in no computed longhand, so this measurement cannot see it and " +
+        "refuses instead of reporting a span that ignores it."
+    );
+  }
   if (result.zones === 0) {
     throw new Error(
       `no elements matched "${DROP_ZONES}" in the canvas frame, so nothing was measured. A zero ` +
@@ -244,8 +271,8 @@ async function geometrySpanMs(
  * the timing. Pinning the measurement makes a cosmetic edit free and a timing edit visible, which
  * is the direction that matters.
  *
- * All zero because #813 took the geometry out of flow at a fixed height, leaving only a
- * `background` transition. Do not edit these to clear a failure without reading what changed:
+ * All zero because the zone sits out of flow at a fixed height and only its `background`
+ * transitions. Do not edit these to clear a failure without reading what changed:
  * a nonzero value here is the canvas moving an edge the probe is about to measure.
  */
 // The canvas iframe is only rendered above a certain width: the editor's rail, block library and
@@ -263,6 +290,10 @@ const PINNED_SPANS_MS: Record<string, number> = {
   rest: 0,
   "data-drag": 0,
   "data-active": 0,
+  // Both at once. `DropZone` sets `data-drag` for the whole drag and `data-active` on top when the
+  // zone is the target, so the combined state is what an author sees as a drop lands — and a rule
+  // keyed on both is invisible to either alone.
+  "data-drag data-active": 0,
 };
 
 test.describe("the drop-zone geometry the probe waits on", () => {
@@ -427,6 +458,68 @@ test.describe("the drop-zone geometry the probe waits on", () => {
     expect(injected).toBe(true);
 
     await expect(geometrySpanMs(frame, null)).rejects.toThrow(/never ends/);
+  });
+
+  test("an animation set to run ZERO times moves nothing", async ({
+    page,
+    request,
+  }) => {
+    const frame = await canvas(page, request);
+
+    // `iteration-count: 0` is valid CSS and means the animation never runs. Defaulting a falsy
+    // parse to 1 would charge a full pass for an edge that never moves - over-reporting, which
+    // reads as safe and is how a wrong pin gets written down.
+    const injected = await frame.evaluate(() => {
+      const sheet = (
+        document.getElementById("nx-pb-style") as HTMLStyleElement | null
+      )?.sheet;
+      sheet?.insertRule(
+        "@keyframes nx-test-zero { from { height: 0 } to { height: 12px } }",
+        sheet.cssRules.length
+      );
+      sheet?.insertRule(
+        ".nx-pb-dropzone { animation: nx-test-zero .2s 0 }",
+        sheet.cssRules.length
+      );
+      return Boolean(sheet);
+    });
+    expect(injected).toBe(true);
+
+    expect(await geometrySpanMs(frame, null)).toBe(0);
+  });
+
+  test("a SECOND animation name is charged when the timing list is shorter", async ({
+    page,
+    request,
+  }) => {
+    const frame = await canvas(page, request);
+
+    // Two names, one duration: CSS cycles the duration across both. Iterating the DURATION list
+    // stops after one entry and never reaches the second animation.
+    const injected = await frame.evaluate(() => {
+      const sheet = (
+        document.getElementById("nx-pb-style") as HTMLStyleElement | null
+      )?.sheet;
+      sheet?.insertRule(
+        "@keyframes nx-a { from { height: 0 } to { height: 4px } }",
+        sheet.cssRules.length
+      );
+      sheet?.insertRule(
+        "@keyframes nx-b { from { height: 0 } to { height: 8px } }",
+        sheet.cssRules.length
+      );
+      // One duration, one delay list of two: the SECOND name carries the longer delay, so it is
+      // only reachable by walking the names.
+      sheet?.insertRule(
+        ".nx-pb-dropzone { animation-name: nx-a, nx-b; animation-duration: .1s; animation-delay: 0s, .4s }",
+        sheet.cssRules.length
+      );
+      return Boolean(sheet);
+    });
+    expect(injected).toBe(true);
+
+    // 100ms cycled onto the second name, plus its own 400ms delay.
+    expect(await geometrySpanMs(frame, null)).toBe(500);
   });
 
   test("it refuses rather than reporting a zero it cannot stand behind", async ({

--- a/e2e/tests/canvas/geometry-settle-matches-the-canvas.test.ts
+++ b/e2e/tests/canvas/geometry-settle-matches-the-canvas.test.ts
@@ -310,30 +310,27 @@ async function geometrySpanMs(frame: Frame, rule: string): Promise<number> {
 /**
  * The rules that give a drop zone a transition, read from the RUNNING canvas.
  *
- * Two questions, and both are answered structurally rather than by matching text.
+ * EVERY stylesheet the canvas document carries, not one named sheet. The frame holds at least
+ * three — the admin-token mirror, the overlay, and the compiled document CSS — and the last is
+ * appended AFTER the overlay, so at equal specificity it wins the cascade. Reading only the
+ * overlay would miss a transition declared anywhere else while the pin stayed equal, which is the
+ * shape that lets the allowance pass over a zone that is still moving.
+ *
+ * Three questions, each answered structurally rather than by matching text:
+ *
+ * WHICH SHEETS: all of `document.styleSheets`, so a sheet added later is included without this
+ * reader being told about it.
  *
  * WHICH RULES APPLY: each rule's selector is tested against the probe elements with `matches`,
  * not searched for the substring `nx-pb-dropzone`. A rule can reach a drop zone without naming
- * its class — `[data-active]{transition:height .2s}` applies to one and contains no such text —
- * and a text filter drops it while the base rule keeps the pin equal, so the allowance passes
- * over a zone that moves for 200ms.
+ * its class — `[data-active]{transition:height .2s}` applies to one and contains no such text.
  *
- * WHICH DECLARE A TRANSITION: asked of the parsed declaration rather than of the rule's text, so
- * a shorthand, a longhand and a `var()` all answer the same way.
- *
- * Read from the stylesheet the browser parsed — `<style id="nx-pb-overlay">` in the canvas frame —
- * rather than from `IframeCanvas.tsx`. Reading the source would mean representing TypeScript,
- * where an array entry may be an identifier, a template literal or a call, and it cannot represent
- * the cascade at all, which is where a custom property's value is decided.
+ * WHICH DECLARE A TRANSITION: asked of the parsed declaration, so a shorthand, a longhand and a
+ * `var()` all answer alike.
  */
 async function transitionRules(frame: Frame): Promise<string[]> {
-  const rules = await frame.evaluate(
+  const result = await frame.evaluate(
     ([classes, states]) => {
-      const overlay = document.getElementById(
-        "nx-pb-overlay"
-      ) as HTMLStyleElement | null;
-      if (!overlay?.sheet) return null;
-
       const probe = document.createElement("div");
       document.body.append(probe);
       const applies = (selector: string) => {
@@ -347,8 +344,6 @@ async function transitionRules(frame: Frame): Promise<string[]> {
             try {
               if (probe.matches(selector)) return true;
             } catch {
-              // A selector this browser cannot parse matches nothing here, and the rule it came
-              // from cannot be measured either; the pin below reports it as a change.
               return false;
             }
           }
@@ -356,31 +351,54 @@ async function transitionRules(frame: Frame): Promise<string[]> {
         return false;
       };
 
-      const found = [...overlay.sheet.cssRules]
-        .filter((rule): rule is CSSStyleRule => "selectorText" in rule)
-        .filter(
-          rule =>
-            Boolean(
-              rule.style.transition ||
-                rule.style.transitionProperty ||
-                rule.style.transitionDuration
-            ) && applies(rule.selectorText)
-        )
-        .map(rule => rule.cssText);
+      const found: string[] = [];
+      const unreadable: string[] = [];
+      for (const sheet of [...document.styleSheets]) {
+        let rules: CSSRule[];
+        try {
+          rules = [...sheet.cssRules];
+        } catch {
+          // Collected, never skipped. A sheet this context may not read is "I could not look",
+          // and skipping it would report the same empty answer as a sheet with no transitions.
+          unreadable.push(sheet.href ?? "(inline)");
+          continue;
+        }
+        for (const rule of rules) {
+          if (!("selectorText" in rule)) continue;
+          const styleRule = rule as CSSStyleRule;
+          const declares = Boolean(
+            styleRule.style.transition ||
+              styleRule.style.transitionProperty ||
+              styleRule.style.transitionDuration
+          );
+          if (declares && applies(styleRule.selectorText)) {
+            found.push(styleRule.cssText);
+          }
+        }
+      }
       probe.remove();
-      return found;
+      return { found, unreadable, sheets: document.styleSheets.length };
     },
     [PROBE_CLASSES, PROBE_STATES] as const
   );
-  // An absent sheet would read as "no transitions here", which is the reassuring direction and
-  // would certify a canvas nobody looked at.
-  if (rules === null) {
+
+  // The canvas always injects at least the overlay. Zero sheets means this is not the canvas
+  // document, and an empty rule list from the wrong document reads exactly like a canvas with no
+  // transitions.
+  if (result.sheets === 0) {
     throw new Error(
-      "the canvas has no parsed #nx-pb-overlay stylesheet, so this test cannot see what the " +
-        "browser was given. It refuses rather than reporting an empty rule list."
+      "the canvas frame carries no stylesheets, so this test is not reading the canvas document. " +
+        "It refuses rather than reporting an empty rule list."
     );
   }
-  return rules;
+  if (result.unreadable.length > 0) {
+    throw new Error(
+      `these stylesheets in the canvas frame could not be read: ${result.unreadable.join(", ")}. ` +
+        "A transition declared in one would be invisible here, and an unreadable sheet reports " +
+        "the same nothing as a sheet with no transitions, so this refuses rather than guessing."
+    );
+  }
+  return result.found;
 }
 
 // The canvas iframe is only rendered above a certain width: the editor's rail, block library and
@@ -448,6 +466,33 @@ test.describe("the drop-zone geometry the probe waits on", () => {
 
     const found = await transitionRules(frame);
     expect(found.some(rule => rule.includes("data-active"))).toBe(true);
+  });
+
+  test("a transition in a DIFFERENT canvas sheet is still found", async ({
+    page,
+    request,
+  }) => {
+    const frame = await canvas(page, request);
+
+    // `#nx-pb-style` carries the compiled document CSS and is appended AFTER the overlay, so at
+    // equal specificity it wins the cascade. A reader scoped to the overlay would miss a
+    // transition declared here while the pin stayed equal — the allowance then covers a zone that
+    // is still moving.
+    const injected = await frame.evaluate(() => {
+      const page = document.getElementById(
+        "nx-pb-style"
+      ) as HTMLStyleElement | null;
+      page?.sheet?.insertRule(
+        ".nx-pb-dropzone{transition:height .25s}",
+        page.sheet.cssRules.length
+      );
+      return Boolean(page?.sheet);
+    });
+    // Observable, so the assertion below cannot pass against a sheet nobody touched.
+    expect(injected).toBe(true);
+
+    const found = await transitionRules(frame);
+    expect(found.some(rule => rule.includes("0.25s"))).toBe(true);
   });
 
   test("the driver's settle allowance covers every pinned rule", async ({

--- a/e2e/tests/canvas/geometry-settle-matches-the-canvas.test.ts
+++ b/e2e/tests/canvas/geometry-settle-matches-the-canvas.test.ts
@@ -175,27 +175,39 @@ async function geometrySpanMs(
         // The element and its pseudo-elements. A `::before` that animates height inside an
         // auto-sized zone moves the zone's own bottom edge, and its timing appears in no computed
         // longhand of the element itself.
-        // Two ways an effect's real timing is not in any computed longhand, and both are REFUSED
-        // rather than ignored: this file measures DECLARED CSS timing, and an effect it cannot
-        // read moves the edge just as surely.
+        // Three ways an effect's real timing is not in any computed longhand read below, and all
+        // three are REFUSED rather than ignored: this file measures DECLARED CSS timing on the
+        // zone and its pseudo-elements, and an effect it cannot read moves the edge just as surely.
         //
         // 1. A JS-driven animation carries its timing in the Web Animations API alone.
         // 2. A DECLARATIVE animation whose playback rate has been changed through that same API is
         //    still a `CSSAnimation`, so a class test accepts it, while `animationDuration` keeps
         //    reporting the declared time. At rate 0.5 the edge moves for twice as long; at rate 0
         //    it never finishes. The declaration has stopped being a statement about the edge.
+        // 3. A declarative effect on a DESCENDANT. An in-flow child that animates its own height
+        //    or margin moves an auto-sized zone's bottom edge, and its timing is in no longhand of
+        //    the zone — so accepting it here while reading timing only from the zone reports zero
+        //    for movement that is happening. Refused rather than measured because the two are
+        //    different questions: what a descendant contributes to its ancestor's box depends on
+        //    layout, and an animation's keyframes are not inspectable from here at all, so there
+        //    is no honest number to charge.
         //
-        // `subtree: true` because this function charges `::before` and `::after` CSS timing a few
-        // lines below: reading their scripted timing off a narrower population would refuse on the
-        // element and wave the pseudo-element through. It admits descendants too, which is the
-        // conservative direction — a child cannot move the fixed-height between-item zone's edge,
-        // but it can move an auto-height empty placeholder's.
+        // `subtree: true` is what makes 1 and 3 visible. It is required for 1 regardless, since
+        // this function charges `::before` and `::after` CSS timing a few lines below and a
+        // narrower population would refuse on the element while waving the pseudo-element through.
+        const own = (a: Animation) => {
+          const target = (a.effect as KeyframeEffect | null)?.target;
+          // A pseudo-element's effect reports the ORIGINATING element as its target, so this keeps
+          // `::before` and `::after` on the readable side — their longhands are read below.
+          return target === el;
+        };
         const unreadable = el
           .getAnimations({ subtree: true })
           .filter(
             a =>
               (!(a instanceof CSSAnimation) && !(a instanceof CSSTransition)) ||
-              a.playbackRate !== 1
+              a.playbackRate !== 1 ||
+              !own(a)
           );
         if (unreadable.length > 0) {
           // Restored BEFORE returning. An early return that skips cleanup leaves the probe's
@@ -346,11 +358,12 @@ async function geometrySpanMs(
   }
   if (result.zones === -1) {
     throw new Error(
-      "a drop zone is running an effect whose real timing is not in any computed longhand: either " +
-        "an animation driven by the Web Animations API rather than declared in CSS, or a declared " +
-        "one whose playback rate was changed through that API, which leaves the declared duration " +
-        "describing something other than how long the edge moves. This measurement cannot see " +
-        "either, so it refuses instead of reporting a span that ignores it."
+      "a drop zone is running an effect whose real timing is not in any computed longhand this " +
+        "reads: an animation driven by the Web Animations API rather than declared in CSS, a " +
+        "declared one whose playback rate was changed through that API, or a declarative effect " +
+        "on a DESCENDANT — whose in-flow movement changes an auto-sized zone's own edge while its " +
+        "timing appears in no longhand of the zone. This measurement cannot see any of them, so " +
+        "it refuses instead of reporting a span that ignores one."
     );
   }
   if (result.zones === 0) {
@@ -898,6 +911,53 @@ test.describe("the drop-zone geometry the probe waits on", () => {
     // between-item zone. A rule keyed on `[data-drag]` for an empty zone can never fire, so
     // measuring it would pin a span for movement the canvas cannot produce.
     expect(await geometrySpanMs(frame, "data-drag")).toBe(0);
+  });
+
+  test("a DESCENDANT's declarative animation is refused, not reported as zero", async ({
+    page,
+    request,
+  }) => {
+    const frame = await canvas(page, request);
+
+    // The empty placeholder is in flow at an auto height, so a child growing its own height moves
+    // the zone's bottom edge. Nothing about that appears in the zone's own longhands, which is why
+    // reading only the zone reports zero while the edge is travelling.
+    const planted = await frame.evaluate(() => {
+      const sheet = (
+        document.getElementById("nx-pb-style") as HTMLStyleElement | null
+      )?.sheet;
+      sheet?.insertRule(
+        "@keyframes nx-child-grow { from { height: 0 } to { height: 40px } }",
+        sheet.cssRules.length
+      );
+      sheet?.insertRule(
+        ".nx-pb-child-probe { animation: nx-child-grow .3s 100 }",
+        sheet.cssRules.length
+      );
+      const zone = document.querySelector(".nx-pb-dropzone-empty");
+      if (!zone) return null;
+      const child = document.createElement("div");
+      child.className = "nx-pb-child-probe";
+      zone.append(child);
+      // The effect must exist and must belong to the CHILD, not to the zone — the whole point of
+      // the refusal is the target being someone else.
+      const animations = zone.getAnimations({ subtree: true });
+      return {
+        count: animations.length,
+        onChild: animations.some(
+          a => (a.effect as KeyframeEffect | null)?.target === child
+        ),
+      };
+    });
+    // Population before verdict: no empty zone, no rule, or an effect that never started would
+    // each leave the refusal below firing for some other reason, or not at all.
+    expect(planted).not.toBeNull();
+    expect(planted?.count).toBeGreaterThan(0);
+    expect(planted?.onChild).toBe(true);
+
+    await expect(geometrySpanMs(frame, "data-active")).rejects.toThrow(
+      /DESCENDANT/
+    );
   });
 
   test("an animation on a SCROLL timeline is refused, not read as its duration", async ({

--- a/e2e/tests/canvas/geometry-settle-matches-the-canvas.test.ts
+++ b/e2e/tests/canvas/geometry-settle-matches-the-canvas.test.ts
@@ -870,8 +870,13 @@ test.describe("the drop-zone geometry the probe waits on", () => {
         "@keyframes nx-slowed { from { height: 0 } to { height: 6px } }",
         sheet.cssRules.length
       );
+      // FINITE, and long enough to still be running when the probe reads it. `infinite` would be
+      // the obvious choice for the second property and it destroys the first: an endless animation
+      // is already refused for being endless, so this control would pass with the playback-rate
+      // clause removed and prove nothing about it. At 100 iterations the span is a measurable
+      // 20000ms, so without that clause the probe RETURNS a number instead of refusing.
       sheet?.insertRule(
-        ".nx-pb-dropzone { animation: nx-slowed .2s infinite }",
+        ".nx-pb-dropzone { animation: nx-slowed .2s 100 }",
         sheet.cssRules.length
       );
       const zone = document.querySelector(".nx-pb-dropzone");

--- a/e2e/tests/canvas/geometry-settle-matches-the-canvas.test.ts
+++ b/e2e/tests/canvas/geometry-settle-matches-the-canvas.test.ts
@@ -32,7 +32,7 @@ import { readFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { expect, test } from "@playwright/test";
+import { expect, test, type Page } from "@playwright/test";
 
 import { POC_GEOMETRY_SETTLE_MS } from "./poc-driver";
 
@@ -53,12 +53,74 @@ const CANVAS_CSS = resolve(
  * `spanMs` is read off `declaration` by a person. It cannot go stale on its own — the only thing
  * that changes it is an edit to that text, which the first assertion refuses.
  */
-const PINNED_GEOMETRY = {
-  declaration:
-    '".nx-pb-dropzone{height:0;border-radius:3px;transition:height .1s ease,background .1s ease}",',
-  // `height` transitions over `.1s` with no delay. `background` moves no edge this probe measures.
-  spanMs: 100,
-} as const;
+const PINNED_DECLARATION =
+  '".nx-pb-dropzone{height:0;border-radius:3px;transition:height .1s ease,background .1s ease}",';
+
+/** Properties whose transition moves the vertical edge this probe measures. */
+const GEOMETRY_PROPERTIES = new Set([
+  "height",
+  "min-height",
+  "max-height",
+  "block-size",
+  "margin",
+  "margin-top",
+  "margin-bottom",
+  "padding",
+  "padding-top",
+  "padding-bottom",
+  "top",
+  "bottom",
+  "inset",
+  "transform",
+  "all",
+]);
+
+/**
+ * How long the geometry in a rule keeps moving, computed BY THE BROWSER.
+ *
+ * The rule is injected into a real document and the resulting `transition-*` longhands are read
+ * back off a matching element. Those are already resolved: the shorthand is expanded, each
+ * property paired with its own duration and delay, times normalised to seconds, and `calc()`,
+ * `var()` and signed values evaluated. Nothing here interprets CSS syntax.
+ *
+ * That is the point. Computing this span from source text means reimplementing CSS, and the only
+ * implementation guaranteed to agree with the canvas is the one the canvas runs in.
+ */
+async function geometrySpanMs(
+  page: Page,
+  declaration: string
+): Promise<number> {
+  // The pinned literal is a quoted, comma-suffixed line of a TypeScript array; the rule inside it
+  // is what a browser can accept.
+  const rule = declaration.trim().replace(/^"/, "").replace(/",?$/, "");
+  return page.evaluate(
+    ([css, geometry]) => {
+      const style = document.createElement("style");
+      style.textContent = css as string;
+      document.head.append(style);
+      const el = document.createElement("div");
+      el.className = "nx-pb-dropzone";
+      document.body.append(el);
+      const computed = getComputedStyle(el);
+      const seconds = (value: string) =>
+        value.split(",").map(v => Number.parseFloat(v.trim()) * 1000);
+      const properties = computed.transitionProperty
+        .split(",")
+        .map(v => v.trim());
+      const durations = seconds(computed.transitionDuration);
+      const delays = seconds(computed.transitionDelay);
+      let longest = 0;
+      properties.forEach((property, i) => {
+        if (!(geometry as string[]).includes(property)) return;
+        longest = Math.max(longest, (durations[i] ?? 0) + (delays[i] ?? 0));
+      });
+      el.remove();
+      style.remove();
+      return longest;
+    },
+    [rule, [...GEOMETRY_PROPERTIES]] as const
+  );
+}
 
 /** Every drop-zone line declaring a transition, trimmed, in file order. */
 function transitionLines(source: string): string[] {
@@ -79,19 +141,42 @@ test("the drop-zone geometry timing has not changed under the probe", () => {
 
   expect(
     found,
-    "the canvas drop-zone transition changed. Re-derive how long its geometry keeps moving, " +
-      "update PINNED_GEOMETRY here — both its declaration AND its spanMs, and raise POC_GEOMETRY_SETTLE_MS in " +
-      "poc-driver.ts if the span now exceeds it."
-  ).toEqual([PINNED_GEOMETRY.declaration]);
+    "the canvas drop-zone transition changed. Update PINNED_DECLARATION here; the span it " +
+      "produces is computed by the browser, so nothing else needs recalculating — but raise " +
+      "POC_GEOMETRY_SETTLE_MS in poc-driver.ts if the new span exceeds it."
+  ).toEqual([PINNED_DECLARATION]);
 });
 
-test("the driver's settle allowance covers that geometry", () => {
-  // The other half. Pinning the text alone passes while someone lowers the allowance underneath
-  // it, which lets the probe resume measuring an edge that is still travelling.
+test("the driver's settle allowance covers that geometry", async ({ page }) => {
+  const spanMs = await geometrySpanMs(page, PINNED_DECLARATION);
+
+  // A computation that returned 0 for every input would satisfy the comparison below by being
+  // smaller than any allowance, so the derivation is required to have found something.
+  expect(spanMs).toBeGreaterThan(0);
+
   expect(
     POC_GEOMETRY_SETTLE_MS,
     `geometrySettleMs is ${String(POC_GEOMETRY_SETTLE_MS)}ms and the drop-zone geometry moves for ` +
-      `${String(PINNED_GEOMETRY.spanMs)}ms, so the probe can re-measure an edge that is still ` +
-      "travelling. Raise it in poc-driver.ts."
-  ).toBeGreaterThanOrEqual(PINNED_GEOMETRY.spanMs);
+      `${String(spanMs)}ms, so the probe can re-measure an edge that is still travelling. Raise it ` +
+      "in poc-driver.ts."
+  ).toBeGreaterThanOrEqual(spanMs);
+});
+
+test("the span derivation reads geometry and ignores the rest", async ({
+  page,
+}) => {
+  // Controls on the derivation itself, since the pinned rule exercises only one shape. The browser
+  // resolves the syntax; what is asserted here is that the RIGHT properties are counted and that a
+  // delay is included.
+  const span = (rule: string) =>
+    geometrySpanMs(page, `".nx-pb-dropzone{${rule}}",`);
+
+  expect(await span("transition:height .1s ease")).toBe(100);
+  expect(await span("transition:height .1s ease .05s")).toBe(150);
+  // A colour moves no edge this probe measures, so its longer timing is not charged.
+  expect(await span("transition:height .1s ease,background .3s ease")).toBe(
+    100
+  );
+  // The browser evaluates what a regex could not.
+  expect(await span("transition:height calc(.04s + .03s) ease")).toBe(70);
 });

--- a/e2e/tests/canvas/geometry-settle-matches-the-canvas.test.ts
+++ b/e2e/tests/canvas/geometry-settle-matches-the-canvas.test.ts
@@ -169,16 +169,29 @@ async function geometrySpanMs(
         // The element and its pseudo-elements. A `::before` that animates height inside an
         // auto-sized zone moves the zone's own bottom edge, and its timing appears in no computed
         // longhand of the element itself.
-        // A JS-driven animation carries its timing in the Web Animations API and appears in no
-        // computed longhand, so the measurement below cannot see it. Refused rather than ignored:
-        // this file measures DECLARED CSS timing, and an effect it cannot read moves the edge
-        // just as surely.
-        const scripted = el
-          .getAnimations()
+        // Two ways an effect's real timing is not in any computed longhand, and both are REFUSED
+        // rather than ignored: this file measures DECLARED CSS timing, and an effect it cannot
+        // read moves the edge just as surely.
+        //
+        // 1. A JS-driven animation carries its timing in the Web Animations API alone.
+        // 2. A DECLARATIVE animation whose playback rate has been changed through that same API is
+        //    still a `CSSAnimation`, so a class test accepts it, while `animationDuration` keeps
+        //    reporting the declared time. At rate 0.5 the edge moves for twice as long; at rate 0
+        //    it never finishes. The declaration has stopped being a statement about the edge.
+        //
+        // `subtree: true` because this function charges `::before` and `::after` CSS timing a few
+        // lines below: reading their scripted timing off a narrower population would refuse on the
+        // element and wave the pseudo-element through. It admits descendants too, which is the
+        // conservative direction — a child cannot move the fixed-height between-item zone's edge,
+        // but it can move an auto-height empty placeholder's.
+        const unreadable = el
+          .getAnimations({ subtree: true })
           .filter(
-            a => !(a instanceof CSSAnimation) && !(a instanceof CSSTransition)
+            a =>
+              (!(a instanceof CSSAnimation) && !(a instanceof CSSTransition)) ||
+              a.playbackRate !== 1
           );
-        if (scripted.length > 0) {
+        if (unreadable.length > 0) {
           // Restored BEFORE returning. An early return that skips cleanup leaves the probe's
           // attributes on a real canvas element, so every later read in this run — and the
           // author's own canvas — sees a state the probe invented.
@@ -188,9 +201,10 @@ async function geometrySpanMs(
 
         // The element and BOTH pseudo-elements, through one reader. A pseudo that animates or
         // transitions an in-flow dimension moves an auto-sized zone's own edge, and its timing is
-        // in no computed longhand of the element. Asking the same function of each is what stops
-        // the pseudo path drifting from the element path — a second, shorter copy of this
-        // accounting is how iterations and transitions went missing from it.
+        // in no computed longhand of the element. One loop over all three rather than a separate
+        // pseudo path: every mechanism charged here — iteration counts, delays, transitions —
+        // applies identically to a pseudo-element, so a second accounting could only be a shorter
+        // copy of this one.
         for (const surface of [
           getComputedStyle(el),
           getComputedStyle(el, "::before"),
@@ -286,9 +300,11 @@ async function geometrySpanMs(
   }
   if (result.zones === -1) {
     throw new Error(
-      "a drop zone is running an animation driven by the Web Animations API rather than declared " +
-        "in CSS. Its timing is in no computed longhand, so this measurement cannot see it and " +
-        "refuses instead of reporting a span that ignores it."
+      "a drop zone is running an effect whose real timing is not in any computed longhand: either " +
+        "an animation driven by the Web Animations API rather than declared in CSS, or a declared " +
+        "one whose playback rate was changed through that API, which leaves the declared duration " +
+        "describing something other than how long the edge moves. This measurement cannot see " +
+        "either, so it refuses instead of reporting a span that ignores it."
     );
   }
   if (result.zones === 0) {
@@ -322,9 +338,18 @@ async function geometrySpanMs(
  * the timing. Pinning the measurement makes a cosmetic edit free and a timing edit visible, which
  * is the direction that matters.
  *
- * All zero because the zone sits out of flow at a fixed height and only its `background`
- * transitions. Do not edit these to clear a failure without reading what changed:
- * a nonzero value here is the canvas moving an edge the probe is about to measure.
+ * All zero, and the two zone shapes are zero for DIFFERENT reasons — which is why one sentence
+ * cannot stand for both, and why the shape that is easier to disturb is worth naming:
+ *
+ * - `.nx-pb-dropzone` is `position: absolute` at a fixed `height: 6px`, and the only property it
+ *   transitions is `background`. Out of flow and fixed, so nothing it animates can move an edge.
+ * - `.nx-pb-dropzone-empty` is IN FLOW at an auto height, sized by its own padding and border. It
+ *   is zero only because it declares no transition at all and its `[data-active]` rule changes
+ *   `border-color`, `background` and `color` — paint alone. A transition added to its padding,
+ *   border-width or margin WOULD move its edge, and this pin is what would report that.
+ *
+ * Do not edit these to clear a failure without reading what changed: a nonzero value here is the
+ * canvas moving an edge the probe is about to measure.
  */
 // The canvas iframe is only rendered above a certain width: the editor's rail, block library and
 // inspector claim the row first, and below roughly 1280px the preview is dropped rather than
@@ -719,8 +744,8 @@ test.describe("the drop-zone geometry the probe waits on", () => {
   }) => {
     const frame = await canvas(page, request);
 
-    // The pseudo path used to handle animations only. A transition on ::before moves an
-    // auto-sized zone's edge exactly as an animation does.
+    // A transition on a pseudo-element moves an auto-sized zone's edge exactly as an animation
+    // does, so both mechanisms are charged on both pseudo-elements.
     const injected = await frame.evaluate(() => {
       const sheet = (
         document.getElementById("nx-pb-style") as HTMLStyleElement | null
@@ -826,6 +851,51 @@ test.describe("the drop-zone geometry the probe waits on", () => {
     // between-item zone. A rule keyed on `[data-drag]` for an empty zone can never fire, so
     // measuring it would pin a span for movement the canvas cannot produce.
     expect(await geometrySpanMs(frame, "data-drag")).toBe(0);
+  });
+
+  test("a DECLARED animation that was slowed through the API is refused", async ({
+    page,
+    request,
+  }) => {
+    const frame = await canvas(page, request);
+
+    // The case a class test cannot see: still a `CSSAnimation`, so it is not "scripted", while its
+    // declared 200ms now describes 400ms of movement. Charging the declaration would UNDER-report,
+    // which is the direction that lets the allowance pass over an edge still travelling.
+    const applied = await frame.evaluate(async () => {
+      const sheet = (
+        document.getElementById("nx-pb-style") as HTMLStyleElement | null
+      )?.sheet;
+      sheet?.insertRule(
+        "@keyframes nx-slowed { from { height: 0 } to { height: 6px } }",
+        sheet.cssRules.length
+      );
+      sheet?.insertRule(
+        ".nx-pb-dropzone { animation: nx-slowed .2s infinite }",
+        sheet.cssRules.length
+      );
+      const zone = document.querySelector(".nx-pb-dropzone");
+      if (!zone) return null;
+      const animation = zone
+        .getAnimations()
+        .find(a => a instanceof CSSAnimation);
+      if (!animation) return null;
+      // `updatePlaybackRate` sets a PENDING rate that lands when the animation is next ready, so
+      // reading it back immediately would report the old one — and this control would then be
+      // measuring an animation still running at rate 1.
+      animation.updatePlaybackRate(0.5);
+      await animation.ready;
+      return { isCssAnimation: true, rate: animation.playbackRate };
+    });
+    // The population, before the verdict: no rule, no animation, or a rate that never applied all
+    // leave the refusal below firing for some other reason, or not firing at all.
+    expect(applied).not.toBeNull();
+    expect(applied?.isCssAnimation).toBe(true);
+    expect(applied?.rate).toBe(0.5);
+
+    await expect(
+      geometrySpanMs(frame, "data-drag data-active")
+    ).rejects.toThrow(/playback rate/);
   });
 
   test("it refuses rather than reporting a zero it cannot stand behind", async ({

--- a/e2e/tests/canvas/geometry-settle-matches-the-canvas.test.ts
+++ b/e2e/tests/canvas/geometry-settle-matches-the-canvas.test.ts
@@ -55,7 +55,14 @@ const CANVAS_CSS = resolve(
 const PINNED_DECLARATION =
   '".nx-pb-dropzone{height:0;border-radius:3px;transition:height .1s ease,background .1s ease}",';
 
-/** Properties whose transition moves the vertical edge this probe measures. */
+/**
+ * Properties whose transition moves the vertical edge this probe measures, so its timing counts.
+ *
+ * Paired with {@link NON_GEOMETRY_PROPERTIES}, and the pairing is the point: a property on
+ * neither list is REFUSED. Two lists rather than one because the third state — "this test does
+ * not know" — has nowhere to go in a single allowlist, where it collapses into "skip" and is
+ * charged as zero.
+ */
 const GEOMETRY_PROPERTIES = new Set([
   "height",
   "min-height",
@@ -71,8 +78,57 @@ const GEOMETRY_PROPERTIES = new Set([
   "bottom",
   "inset",
   "transform",
+  "translate",
+  "scale",
+  "rotate",
   "all",
 ]);
+
+/**
+ * Properties whose transition CANNOT move that edge, so its timing is not charged.
+ *
+ * The reason this list exists rather than "everything not in the geometry list" is the failure
+ * direction. A lone allowlist silently SKIPS what it has not heard of, so the first property
+ * nobody thought of is charged as zero and the allowance passes over an edge that is still
+ * travelling — `translate` is the ready example, an individual transform property that moves the
+ * box and would not have been on a list written before it existed.
+ *
+ * With both lists, an unrecognised property is neither counted nor ignored: it stops the test and
+ * names itself, and someone decides which list it belongs on. Both lists may be incomplete, and
+ * being incomplete now costs a refusal rather than a false pass.
+ *
+ * Membership means "changes no box geometry": a paint-only property. `border-color` qualifies and
+ * `border-width` does not, which is why the colour longhands are named individually rather than a
+ * `border` prefix being matched.
+ */
+const NON_GEOMETRY_PROPERTIES = new Set([
+  "background",
+  "background-color",
+  "background-position",
+  "border-color",
+  "border-top-color",
+  "border-right-color",
+  "border-bottom-color",
+  "border-left-color",
+  "box-shadow",
+  "color",
+  "fill",
+  "outline-color",
+  "opacity",
+  "stroke",
+  "text-shadow",
+  "visibility",
+]);
+
+/**
+ * States a drop zone is drawn in, so a rule qualified by one is still measurable.
+ *
+ * The canvas carries its geometry on the unqualified rule today and declares `[data-drag]` and
+ * `[data-active]` beside it, so a transition moved onto one of those is an ordinary edit rather
+ * than an exotic one. A probe element that only ever wears the class would match nothing, compute
+ * a zero span, and report that the geometry had stopped moving.
+ */
+const PROBE_STATES = [null, "data-drag", "data-active"];
 
 /**
  * How long the geometry in a rule keeps moving, computed BY THE BROWSER.
@@ -92,14 +148,38 @@ async function geometrySpanMs(
   // The pinned literal is a quoted, comma-suffixed line of a TypeScript array; the rule inside it
   // is what a browser can accept.
   const rule = declaration.trim().replace(/^"/, "").replace(/",?$/, "");
-  return page.evaluate(
-    ([css, geometry]) => {
+  const result = await page.evaluate(
+    ([css, safe, states, geometry]) => {
       const style = document.createElement("style");
       style.textContent = css as string;
       document.head.append(style);
       const el = document.createElement("div");
       el.className = "nx-pb-dropzone";
       document.body.append(el);
+
+      // The rule must actually apply to the probe, or every timing read below is the browser's
+      // initial value and the span comes out zero — indistinguishable from a transition that was
+      // deliberately removed. The selector is taken as text and handed to `matches`, so nothing
+      // here interprets it; the states are tried in turn because a qualified rule is a normal
+      // edit rather than a strange one.
+      const selector = (css as string).slice(0, (css as string).indexOf("{"));
+      let applied: string | null | undefined;
+      for (const state of states as (string | null)[]) {
+        for (const attr of states as (string | null)[]) {
+          if (attr) el.removeAttribute(attr);
+        }
+        if (state) el.setAttribute(state, "");
+        if (el.matches(selector.trim())) {
+          applied = state;
+          break;
+        }
+      }
+      if (applied === undefined) {
+        el.remove();
+        style.remove();
+        return { matched: false, ms: 0, unclassified: [] as string[] };
+      }
+
       const computed = getComputedStyle(el);
       const seconds = (value: string) =>
         value.split(",").map(v => Number.parseFloat(v.trim()) * 1000);
@@ -113,17 +193,58 @@ async function geometrySpanMs(
       // zero would read those as instant and report a geometry transition as taking no time.
       const cycled = (list: number[], i: number) =>
         list.length === 0 ? 0 : list[i % list.length];
+
+      // The LAST entry naming a property is the one CSS uses, so a name repeated with different
+      // timings resolves to its final tuple rather than its longest. Taking the maximum instead
+      // reports `transition-property:height,height;transition-duration:.3s,.1s` as 300ms when the
+      // height transition really runs for 100 — which sends whoever reads the failure off to
+      // lengthen every wait in the probe for a transition that had already finished.
+      const lastEntry = new Map<string, number>();
+      properties.forEach((property, i) => lastEntry.set(property, i));
+
+      const unclassified: string[] = [];
       let longest = 0;
-      properties.forEach((property, i) => {
-        if (!(geometry as string[]).includes(property)) return;
+      for (const [property, i] of lastEntry) {
+        // `none` is the browser's way of saying there is no transition at all, which is a real
+        // answer of zero rather than a property it could not place.
+        if (property === "none") continue;
+        if ((safe as string[]).includes(property)) continue;
+        if (!(geometry as string[]).includes(property)) {
+          // On neither list: it may move the edge and this cannot tell. Collected rather than
+          // skipped, so it refuses below instead of being charged as zero.
+          unclassified.push(property);
+          continue;
+        }
         longest = Math.max(longest, cycled(durations, i) + cycled(delays, i));
-      });
+      }
       el.remove();
       style.remove();
-      return longest;
+      return { matched: true, ms: longest, unclassified };
     },
-    [rule, [...GEOMETRY_PROPERTIES]] as const
+    [
+      rule,
+      [...NON_GEOMETRY_PROPERTIES],
+      PROBE_STATES,
+      [...GEOMETRY_PROPERTIES],
+    ] as const
   );
+
+  if (!result.matched) {
+    throw new Error(
+      `the pinned rule "${rule}" matches no drop-zone probe element, so its timing cannot be ` +
+        `read and a zero span here would be indistinguishable from a removed transition. Add the ` +
+        `state it is qualified by to PROBE_STATES.`
+    );
+  }
+  if (result.unclassified.length > 0) {
+    throw new Error(
+      `the transition names ${result.unclassified.join(", ")}, which this test cannot place. Add ` +
+        `each to GEOMETRY_PROPERTIES if it can move the zone's vertical edge, or to ` +
+        `NON_GEOMETRY_PROPERTIES if it changes only paint. It is refused rather than skipped ` +
+        `because skipping charges it as zero and passes the allowance over an edge still moving.`
+    );
+  }
+  return result.ms;
 }
 
 /** Every drop-zone line declaring a transition, trimmed, in file order. */
@@ -152,11 +273,14 @@ test("the drop-zone geometry timing has not changed under the probe", () => {
 });
 
 test("the driver's settle allowance covers that geometry", async ({ page }) => {
+  // No `spanMs > 0` guard here, and its absence is deliberate. It was standing in for "the
+  // derivation actually worked", which is now answered where it can be answered properly: an
+  // unmatched selector and an unclassifiable property both THROW, so the only way to reach this
+  // line with 0 is a rule that genuinely disables movement — `transition: height 0s`, or a delay
+  // cancelling its duration. That is a legitimate result the allowance covers, and asserting it
+  // away would fail a correct canvas. The derivation's positive controls live in the test below,
+  // where they pin known nonzero values instead of merely asking for "not nothing".
   const spanMs = await geometrySpanMs(page, PINNED_DECLARATION);
-
-  // A computation that returned 0 for every input would satisfy the comparison below by being
-  // smaller than any allowance, so the derivation is required to have found something.
-  expect(spanMs).toBeGreaterThan(0);
 
   expect(
     POC_GEOMETRY_SETTLE_MS,
@@ -191,4 +315,59 @@ test("the span derivation reads geometry and ignores the rest", async ({
       "transition-property:color,background,height;transition-duration:.15s"
     )
   ).toBe(150);
+
+  // An individual transform property moves the box, and it is the case that showed an allowlist
+  // cannot be trusted to be complete: skipped, this reads as 0 and the allowance passes over a
+  // zone still travelling.
+  expect(await span("transition:translate .2s ease")).toBe(200);
+
+  // CSS resolves a repeated property to its LAST entry, not its longest. Taking the maximum
+  // reports 300 here and sends whoever reads the failure off to lengthen every wait in the probe
+  // for a transition that finished 200ms earlier.
+  expect(
+    await span("transition-property:height,height;transition-duration:.3s,.1s")
+  ).toBe(100);
+
+  // The same rule with the entries swapped, which is what separates "reads the last" from "reads
+  // the first" — a fixed pick of either index satisfies one of these two and not both.
+  expect(
+    await span("transition-property:height,height;transition-duration:.1s,.3s")
+  ).toBe(300);
+
+  // A rule that deliberately disables movement is a real answer of zero, not a failed derivation.
+  // The allowance covers it, and asserting it away would fail a correct canvas.
+  expect(await span("transition:height 0s")).toBe(0);
+});
+
+test("the span derivation refuses what it cannot answer", async ({ page }) => {
+  // The other half of the controls above: what the derivation does when it CANNOT decide. Each of
+  // these previously produced a confident zero, which is the answer that passes any allowance.
+  const span = (rule: string) =>
+    geometrySpanMs(page, `".nx-pb-dropzone{${rule}}",`);
+
+  // A property on neither list. `font-size` does move a box, but the point is not which list it
+  // belongs on — it is that an unrecognised name stops the test and names itself instead of being
+  // charged as zero.
+  await expect(span("transition:font-size .2s ease")).rejects.toThrow(
+    /cannot place/
+  );
+
+  // A rule the probe element does not match. The canvas already declares `[data-drag]` and
+  // `[data-active]` rules, so a transition moved onto a state is an ordinary edit — and one the
+  // fixture must either measure or refuse, never silently report as zero.
+  await expect(
+    geometrySpanMs(
+      page,
+      '".nx-pb-dropzone[data-nonexistent]{transition:height .2s}",'
+    )
+  ).rejects.toThrow(/matches no drop-zone probe element/);
+
+  // The state the canvas really uses IS measured rather than refused, which is what keeps the
+  // refusal above from being a blanket "anything qualified fails".
+  expect(
+    await geometrySpanMs(
+      page,
+      '".nx-pb-dropzone[data-drag]{transition:height .2s}",'
+    )
+  ).toBe(200);
 });

--- a/e2e/tests/canvas/geometry-settle-matches-the-canvas.test.ts
+++ b/e2e/tests/canvas/geometry-settle-matches-the-canvas.test.ts
@@ -151,8 +151,19 @@ async function geometrySpanMs(
         // once, and a rule keyed on both is invisible to either alone.
         const attrs = appliedState ? (appliedState as string).split(" ") : [];
         const had = attrs.filter(a => el.hasAttribute(a));
-        for (const a of attrs) el.setAttribute(a, "");
-        const computed = getComputedStyle(el);
+        // The VALUE React renders, not an empty string. `DropZone` passes
+        // `data-active={isDropTarget || undefined}`, so the real DOM carries `data-active="true"`
+        // and a rule keyed on that value would not match a probe that set `""`.
+        for (const a of attrs) el.setAttribute(a, "true");
+        // The element and its pseudo-elements. A `::before` that animates height inside an
+        // auto-sized zone moves the zone's own bottom edge, and its timing appears in no computed
+        // longhand of the element itself.
+        const surfaces = [
+          getComputedStyle(el),
+          getComputedStyle(el, "::before"),
+          getComputedStyle(el, "::after"),
+        ];
+        const computed = surfaces[0];
 
         // A running animation moves the edge for its whole duration whatever it animates, because
         // the keyframes are not inspectable from here. Charged in full rather than skipped.
@@ -201,6 +212,17 @@ async function geometrySpanMs(
               cycled(durations, i) * cycled(counts, i) + cycled(delays, i)
             );
           });
+        }
+
+        for (const pseudo of surfaces.slice(1)) {
+          if (pseudo.animationName !== "none") {
+            const pd = ms(pseudo.animationDuration);
+            const pdelay = ms(pseudo.animationDelay);
+            pseudo.animationName.split(",").forEach((name, i) => {
+              if (name.trim() === "none") return;
+              longest = Math.max(longest, cycled(pd, i) + cycled(pdelay, i));
+            });
+          }
         }
 
         const properties = computed.transitionProperty
@@ -600,6 +622,57 @@ test.describe("the drop-zone geometry the probe waits on", () => {
         ).length
     );
     expect(leftBehind).toBe(0);
+  });
+
+  test("a rule keyed on the attribute VALUE React renders is matched", async ({
+    page,
+    request,
+  }) => {
+    const frame = await canvas(page, request);
+
+    // `DropZone` passes `data-active={isDropTarget || undefined}`, so React renders the string
+    // "true". A probe setting `""` matches `[data-active]` but not `[data-active="true"]`, and
+    // the miss is silent - the zone reports no movement at all.
+    const injected = await frame.evaluate(() => {
+      const sheet = (
+        document.getElementById("nx-pb-style") as HTMLStyleElement | null
+      )?.sheet;
+      sheet?.insertRule(
+        '.nx-pb-dropzone[data-active="true"] { transition: height .2s }',
+        sheet.cssRules.length
+      );
+      return Boolean(sheet);
+    });
+    expect(injected).toBe(true);
+
+    expect(await geometrySpanMs(frame, "data-active")).toBe(200);
+  });
+
+  test("an animation on a zone PSEUDO-element is charged", async ({
+    page,
+    request,
+  }) => {
+    const frame = await canvas(page, request);
+
+    // A ::before animating height inside an auto-sized zone moves the zone's own bottom edge,
+    // and its timing is in no computed longhand of the element itself.
+    const injected = await frame.evaluate(() => {
+      const sheet = (
+        document.getElementById("nx-pb-style") as HTMLStyleElement | null
+      )?.sheet;
+      sheet?.insertRule(
+        "@keyframes nx-pseudo { from { height: 0 } to { height: 6px } }",
+        sheet.cssRules.length
+      );
+      sheet?.insertRule(
+        '.nx-pb-dropzone::before { content: ""; animation: nx-pseudo .4s }',
+        sheet.cssRules.length
+      );
+      return Boolean(sheet);
+    });
+    expect(injected).toBe(true);
+
+    expect(await geometrySpanMs(frame, null)).toBe(400);
   });
 
   test("it refuses rather than reporting a zero it cannot stand behind", async ({

--- a/e2e/tests/canvas/geometry-settle-matches-the-canvas.test.ts
+++ b/e2e/tests/canvas/geometry-settle-matches-the-canvas.test.ts
@@ -135,8 +135,10 @@ async function geometrySpanMs(
       if (zones.length === 0)
         return { zones: 0, ms: 0, unclassified: [] as string[] };
 
+      // A value that is not a time cannot be measured, and `|| 0` would report it as instant —
+      // the silent zero this file exists to remove. `NaN` is preserved and refused by the caller.
       const ms = (value: string) =>
-        value.split(",").map(v => Number.parseFloat(v.trim()) * 1000 || 0);
+        value.split(",").map(v => Number.parseFloat(v.trim()) * 1000);
       const cycled = (list: number[], i: number) =>
         list.length === 0 ? 0 : list[i % list.length];
 
@@ -164,6 +166,10 @@ async function geometrySpanMs(
             a => !(a instanceof CSSAnimation) && !(a instanceof CSSTransition)
           );
         if (scripted.length > 0) {
+          // Restored BEFORE returning. An early return that skips cleanup leaves the probe's
+          // attributes on a real canvas element, so every later read in this run — and the
+          // author's own canvas — sees a state the probe invented.
+          for (const a of attrs) if (!had.includes(a)) el.removeAttribute(a);
           return { zones: -1, ms: 0, unclassified: [] as string[] };
         }
 
@@ -186,7 +192,10 @@ async function geometrySpanMs(
             const parsed = Number.parseFloat(text);
             return Number.isNaN(parsed) ? 1 : parsed;
           });
-          names.forEach((_name, i) => {
+          names.forEach((name, i) => {
+            // `none` occupies a position in every timing list but starts no animation, so its
+            // tuple would charge movement that never happens.
+            if (name.trim() === "none") return;
             longest = Math.max(
               longest,
               cycled(durations, i) * cycled(counts, i) + cycled(delays, i)
@@ -233,6 +242,13 @@ async function geometrySpanMs(
 
   // No zones means this is not the canvas, or the document rendered none — and a zero span from
   // an empty query reads exactly like a canvas that animates nothing.
+  if (Number.isNaN(result.ms)) {
+    throw new Error(
+      "a drop zone declares an animation or transition whose duration is not a time this test " +
+        "could parse, so its span is unknown. Reporting a number would certify an allowance " +
+        "against a movement nobody measured."
+    );
+  }
   if (result.zones === -1) {
     throw new Error(
       "a drop zone is running an animation driven by the Web Animations API rather than declared " +
@@ -520,6 +536,54 @@ test.describe("the drop-zone geometry the probe waits on", () => {
 
     // 100ms cycled onto the second name, plus its own 400ms delay.
     expect(await geometrySpanMs(frame, null)).toBe(500);
+  });
+
+  test("`none` among animation names charges nothing for that slot", async ({
+    page,
+    request,
+  }) => {
+    const frame = await canvas(page, request);
+
+    // `none` holds a position in every timing list but starts no animation. Charging its tuple
+    // would report movement that never happens - conservative, but wrong, and a wrong number here
+    // gets pinned and then trusted.
+    const injected = await frame.evaluate(() => {
+      const sheet = (
+        document.getElementById("nx-pb-style") as HTMLStyleElement | null
+      )?.sheet;
+      sheet?.insertRule(
+        "@keyframes nx-real { from { height: 0 } to { height: 4px } }",
+        sheet.cssRules.length
+      );
+      sheet?.insertRule(
+        ".nx-pb-dropzone { animation-name: none, nx-real; animation-duration: .9s, .1s }",
+        sheet.cssRules.length
+      );
+      return Boolean(sheet);
+    });
+    expect(injected).toBe(true);
+
+    // Only the real animation is charged; the 900ms belonging to `none` is not movement.
+    expect(await geometrySpanMs(frame, null)).toBe(100);
+  });
+
+  test("the probe leaves no state behind on a real zone", async ({
+    page,
+    request,
+  }) => {
+    const frame = await canvas(page, request);
+
+    await geometrySpanMs(frame, "data-drag data-active");
+
+    // The probe writes onto REAL canvas elements, so a missed cleanup is not a test detail: every
+    // later read in the run, and the author's canvas, would see a state the probe invented.
+    const leftBehind = await frame.evaluate(
+      () =>
+        [...document.querySelectorAll(".nx-pb-dropzone")].filter(
+          el => el.hasAttribute("data-drag") || el.hasAttribute("data-active")
+        ).length
+    );
+    expect(leftBehind).toBe(0);
   });
 
   test("it refuses rather than reporting a zero it cannot stand behind", async ({

--- a/e2e/tests/canvas/geometry-settle-matches-the-canvas.test.ts
+++ b/e2e/tests/canvas/geometry-settle-matches-the-canvas.test.ts
@@ -45,21 +45,6 @@ import {
 } from "./poc-driver";
 
 /**
- * The drop-zone rule carrying the transition, exactly as the canvas writes it.
- *
- * The only thing here maintained by hand, and deliberately so: an exact-text comparison is what
- * makes a timing edit VISIBLE rather than silently absorbed. How long that timing lasts is not
- * written down — {@link geometrySpanMs} computes it in a browser — so there is no second value to
- * keep in step.
- *
- * Do not edit this to clear a failure without reading what changed. The failure is the
- * notification that the geometry timing moved.
- */
-const PINNED_RULES: readonly string[] = [
-  ".nx-pb-dropzone { position: absolute; left: 0px; right: 0px; top: -3px; height: 6px; border-radius: 3px; background: transparent; pointer-events: none; z-index: 3; transition: background 0.1s; }",
-];
-
-/**
  * Properties whose transition moves the vertical edge this probe measures, so its timing counts.
  *
  * Paired with {@link NON_GEOMETRY_PROPERTIES}, and the pairing is the point: a property on
@@ -125,292 +110,140 @@ const NON_GEOMETRY_PROPERTIES = new Set([
 ]);
 
 /**
- * States a drop zone is drawn in, so a rule qualified by one is still measurable.
+ * How long a REAL drop zone's geometry keeps moving, read off the element itself.
  *
- * The canvas carries its geometry on the unqualified rule today and declares `[data-drag]` and
- * `[data-active]` beside it, so a transition moved onto one of those is an ordinary edit rather
- * than an exotic one. A probe element that only ever wears the class would match nothing, compute
- * a zero span, and report that the geometry had stopped moving.
+ * This asks the browser for the resolved answer rather than reconstructing it. Everything that
+ * decides whether a zone animates — which sheet a rule lives in, its position in the cascade, an
+ * `@media` or `@supports` wrapper, an ancestry selector, a `transition-delay` declared separately
+ * from its duration, an inline `style` prop, or an `animation` instead of a `transition` — is
+ * already resolved in `getComputedStyle` of the element that will actually move.
+ *
+ * Enumerating RULES cannot be made complete: each spelling handled reveals another, and the list
+ * is the whole cascade. Reading the computed style of the real element has no such list.
+ *
+ * Both `transition` and `animation` are read, because either can move an edge and the probe waits
+ * on the edge rather than on a mechanism.
  */
-const PROBE_STATES = [null, "data-drag", "data-active"];
-
-/**
- * Every class the driver measures, DERIVED from the driver's own selector.
- *
- * `nx-pb-dropzone-empty` does not carry `nx-pb-dropzone` — they are two classes, not a class and
- * a modifier — and the driver waits on both. A probe that only ever wore the first could not
- * measure a transition added to the empty placeholder, so the allowance for a target the driver
- * really does wait on would have no maintenance path at all.
- *
- * Split from `DROP_ZONES` rather than restated here, so a third zone shape added to the driver is
- * measurable by this test without anyone remembering to come back.
- */
-const PROBE_CLASSES = DROP_ZONES.split(",").map(part =>
-  part.trim().replace(/^\./, "")
-);
-
-/**
- * How long the geometry in a rule keeps moving, measured INSIDE THE CANVAS.
- *
- * The rule is injected into the canvas frame and the resulting `transition-*` longhands are read
- * off a matching element there. Everything that decides those values is already correct in that
- * document: the cascade, the selector scope, the theme tokens the canvas inherits, and `var()`
- * with or without a fallback. Nothing here interprets CSS or TypeScript syntax.
- *
- * Measuring anywhere else means REBUILDING that context, and the context is not reconstructible —
- * a custom property's value is decided by the cascade rather than by any one declaration.
- */
-async function geometrySpanMs(frame: Frame, rule: string): Promise<number> {
+async function geometrySpanMs(
+  frame: Frame,
+  state: string | null
+): Promise<number> {
   const result = await frame.evaluate(
-    ([css, safe, states, geometry, classes]) => {
-      const style = document.createElement("style");
-      style.textContent = css as string;
-      document.head.append(style);
-      const el = document.createElement("div");
-      document.body.append(el);
-      const cleanup = () => {
-        el.remove();
-        style.remove();
-      };
+    ([zoneSelector, geometry, safe, appliedState]) => {
+      const zones = [...document.querySelectorAll(zoneSelector as string)];
+      if (zones.length === 0)
+        return { zones: 0, ms: 0, unclassified: [] as string[] };
 
-      // The rule must actually apply to the probe, or every timing read below is the browser's
-      // initial value and the span comes out zero — indistinguishable from a transition that was
-      // deliberately removed. The selector is handed to `matches` as text, so nothing here
-      // interprets it; class and state are tried in turn because a rule on the empty placeholder,
-      // or qualified by a drag state, is an ordinary edit rather than a strange one.
-      const selector = (css as string)
-        .slice(0, (css as string).indexOf("{"))
-        .trim();
-      let matched = false;
-      for (const cls of classes as string[]) {
-        for (const state of states as (string | null)[]) {
-          el.className = cls;
-          for (const attr of states as (string | null)[]) {
-            if (attr) el.removeAttribute(attr);
-          }
-          if (state) el.setAttribute(state, "");
-          if (el.matches(selector)) {
-            matched = true;
-            break;
-          }
-        }
-        if (matched) break;
-      }
-      if (!matched) {
-        cleanup();
-        return {
-          matched: false,
-          ms: 0,
-          unclassified: [] as string[],
-          discarded: false,
-        };
-      }
-
-      // Whether the declaration survived PARSING. A value the browser cannot parse is dropped and
-      // the rule stands, leaving the computed style at the initial `all 0s` — a silent zero that
-      // covers any allowance.
-      const parsed = (style.sheet?.cssRules[0] as CSSStyleRule | undefined)
-        ?.style;
-      const declared = parsed
-        ? parsed.transition ||
-          parsed.transitionProperty ||
-          parsed.transitionDuration
-        : "";
-
-      const computed = getComputedStyle(el);
-      const properties = computed.transitionProperty
-        .split(",")
-        .map(v => v.trim());
-      const durations = computed.transitionDuration
-        .split(",")
-        .map(v => Number.parseFloat(v.trim()) * 1000);
-      const delays = computed.transitionDelay
-        .split(",")
-        .map(v => Number.parseFloat(v.trim()) * 1000);
-
-      // Declared something, computed the INITIAL value: the declaration was discarded after
-      // parsing — an unresolved `var()` with no fallback is the way that happens. Asked as
-      // "declared but not applied" rather than by scanning the text for `var(`, because a
-      // fallback makes an undefined property perfectly valid and a name scan cannot see that.
-      const isInitial =
-        properties.length === 1 &&
-        properties[0] === "all" &&
-        durations.every(d => d === 0);
-      const discarded =
-        Boolean(declared) && isInitial && !declared.includes("all");
-      if (!declared || discarded) {
-        cleanup();
-        return { matched: true, ms: 0, unclassified: [], discarded: true };
-      }
-
-      // CSS CYCLES a timing list shorter than `transition-property`: with three properties and one
-      // duration, all three take that duration. Reading a missing index as zero would report a
-      // geometry transition as instant.
+      const ms = (value: string) =>
+        value.split(",").map(v => Number.parseFloat(v.trim()) * 1000 || 0);
       const cycled = (list: number[], i: number) =>
         list.length === 0 ? 0 : list[i % list.length];
-      const spanAt = (i: number) => cycled(durations, i) + cycled(delays, i);
 
-      // `all` MATCHES every property, so it competes with each named entry rather than sitting
-      // beside it: with `height,all`, CSS gives height the `all` entry's timing because it comes
-      // later. Its own entry still counts, for the geometry properties nothing else names.
-      const lastAll = properties.lastIndexOf("all");
-      const named = [
-        ...new Set(properties.filter(p => p !== "all" && p !== "none")),
-      ];
       const unclassified: string[] = [];
-      let longest = lastAll === -1 ? 0 : spanAt(lastAll);
-      for (const property of named) {
-        if ((safe as string[]).includes(property)) continue;
-        if (!(geometry as string[]).includes(property)) {
-          unclassified.push(property);
-          continue;
+      let longest = 0;
+
+      for (const zone of zones) {
+        const el = zone as HTMLElement;
+        const had = appliedState
+          ? el.hasAttribute(appliedState as string)
+          : false;
+        if (appliedState) el.setAttribute(appliedState as string, "");
+        const computed = getComputedStyle(el);
+
+        // A running animation moves the edge for its whole duration whatever it animates, because
+        // the keyframes are not inspectable from here. Charged in full rather than skipped.
+        if (computed.animationName !== "none") {
+          const durations = ms(computed.animationDuration);
+          const delays = ms(computed.animationDelay);
+          durations.forEach((d, i) => {
+            longest = Math.max(longest, d + cycled(delays, i));
+          });
         }
-        longest = Math.max(
-          longest,
-          spanAt(Math.max(properties.lastIndexOf(property), lastAll))
-        );
+
+        const properties = computed.transitionProperty
+          .split(",")
+          .map(v => v.trim());
+        const durations = ms(computed.transitionDuration);
+        const delays = ms(computed.transitionDelay);
+        const lastAll = properties.lastIndexOf("all");
+        const named = [
+          ...new Set(properties.filter(p => p !== "all" && p !== "none")),
+        ];
+        if (lastAll !== -1) {
+          longest = Math.max(
+            longest,
+            cycled(durations, lastAll) + cycled(delays, lastAll)
+          );
+        }
+        for (const property of named) {
+          if ((safe as string[]).includes(property)) continue;
+          if (!(geometry as string[]).includes(property)) {
+            unclassified.push(property);
+            continue;
+          }
+          const i = Math.max(properties.lastIndexOf(property), lastAll);
+          longest = Math.max(longest, cycled(durations, i) + cycled(delays, i));
+        }
+
+        if (appliedState && !had) el.removeAttribute(appliedState as string);
       }
-      cleanup();
-      return { matched: true, ms: longest, unclassified, discarded: false };
+      return { zones: zones.length, ms: longest, unclassified };
     },
     [
-      rule,
-      [...NON_GEOMETRY_PROPERTIES],
-      PROBE_STATES,
+      DROP_ZONES,
       [...GEOMETRY_PROPERTIES],
-      PROBE_CLASSES,
+      [...NON_GEOMETRY_PROPERTIES],
+      state,
     ] as const
   );
 
-  if (!result.matched) {
+  // No zones means this is not the canvas, or the document rendered none — and a zero span from
+  // an empty query reads exactly like a canvas that animates nothing.
+  if (result.zones === 0) {
     throw new Error(
-      `the rule "${rule}" matches no drop-zone probe element, so its timing cannot be read and a ` +
-        `zero span would be indistinguishable from a removed transition. Add the state it is ` +
-        `qualified by to PROBE_STATES.`
-    );
-  }
-  if (result.discarded) {
-    throw new Error(
-      `the browser did not apply the transition in "${rule}" — it parsed to nothing, or was ` +
-        `discarded at computed-value time. Either way the computed style is the initial 0s, which ` +
-        `covers any allowance, so this refuses rather than reporting zero.`
+      `no elements matched "${DROP_ZONES}" in the canvas frame, so nothing was measured. A zero ` +
+        "span here would be indistinguishable from a canvas whose zones do not move."
     );
   }
   if (result.unclassified.length > 0) {
     throw new Error(
-      `the transition names ${result.unclassified.join(", ")}, which this test cannot place. Add ` +
-        `each to GEOMETRY_PROPERTIES if it can move the zone's vertical edge, or to ` +
-        `NON_GEOMETRY_PROPERTIES if it changes only paint. It is refused rather than skipped ` +
-        `because skipping charges it as zero and passes the allowance over an edge still moving.`
+      `a drop zone transitions ${result.unclassified.join(", ")}, which this test cannot place. ` +
+        "Add each to GEOMETRY_PROPERTIES if it can move the zone's vertical edge, or to " +
+        "NON_GEOMETRY_PROPERTIES if it changes only paint. Refused rather than skipped, because " +
+        "skipping charges it as zero and passes the allowance over an edge still moving."
     );
   }
   return result.ms;
 }
 
 /**
- * The rules that give a drop zone a transition, read from the RUNNING canvas.
+ * How long each drop-zone state keeps its geometry moving, in ms, as the canvas behaves TODAY.
  *
- * EVERY stylesheet the canvas document carries, not one named sheet. The frame holds at least
- * three — the admin-token mirror, the overlay, and the compiled document CSS — and the last is
- * appended AFTER the overlay, so at equal specificity it wins the cascade. Reading only the
- * overlay would miss a transition declared anywhere else while the pin stayed equal, which is the
- * shape that lets the allowance pass over a zone that is still moving.
+ * The value rather than the CSS text, because the value is the fact the probe depends on: two
+ * stylesheets can differ in every character and animate identically, and one character can change
+ * the timing. Pinning the measurement makes a cosmetic edit free and a timing edit visible, which
+ * is the direction that matters.
  *
- * Three questions, each answered structurally rather than by matching text:
- *
- * WHICH SHEETS: all of `document.styleSheets`, so a sheet added later is included without this
- * reader being told about it.
- *
- * WHICH RULES APPLY: each rule's selector is tested against the probe elements with `matches`,
- * not searched for the substring `nx-pb-dropzone`. A rule can reach a drop zone without naming
- * its class — `[data-active]{transition:height .2s}` applies to one and contains no such text.
- *
- * WHICH DECLARE A TRANSITION: asked of the parsed declaration, so a shorthand, a longhand and a
- * `var()` all answer alike.
+ * All zero because #813 took the geometry out of flow at a fixed height, leaving only a
+ * `background` transition. Do not edit these to clear a failure without reading what changed:
+ * a nonzero value here is the canvas moving an edge the probe is about to measure.
  */
-async function transitionRules(frame: Frame): Promise<string[]> {
-  const result = await frame.evaluate(
-    ([classes, states]) => {
-      const probe = document.createElement("div");
-      document.body.append(probe);
-      const applies = (selector: string) => {
-        for (const cls of classes as string[]) {
-          for (const state of states as (string | null)[]) {
-            probe.className = cls;
-            for (const attr of states as (string | null)[]) {
-              if (attr) probe.removeAttribute(attr);
-            }
-            if (state) probe.setAttribute(state, "");
-            try {
-              if (probe.matches(selector)) return true;
-            } catch {
-              return false;
-            }
-          }
-        }
-        return false;
-      };
-
-      const found: string[] = [];
-      const unreadable: string[] = [];
-      for (const sheet of [...document.styleSheets]) {
-        let rules: CSSRule[];
-        try {
-          rules = [...sheet.cssRules];
-        } catch {
-          // Collected, never skipped. A sheet this context may not read is "I could not look",
-          // and skipping it would report the same empty answer as a sheet with no transitions.
-          unreadable.push(sheet.href ?? "(inline)");
-          continue;
-        }
-        for (const rule of rules) {
-          if (!("selectorText" in rule)) continue;
-          const styleRule = rule as CSSStyleRule;
-          const declares = Boolean(
-            styleRule.style.transition ||
-              styleRule.style.transitionProperty ||
-              styleRule.style.transitionDuration
-          );
-          if (declares && applies(styleRule.selectorText)) {
-            found.push(styleRule.cssText);
-          }
-        }
-      }
-      probe.remove();
-      return { found, unreadable, sheets: document.styleSheets.length };
-    },
-    [PROBE_CLASSES, PROBE_STATES] as const
-  );
-
-  // The canvas always injects at least the overlay. Zero sheets means this is not the canvas
-  // document, and an empty rule list from the wrong document reads exactly like a canvas with no
-  // transitions.
-  if (result.sheets === 0) {
-    throw new Error(
-      "the canvas frame carries no stylesheets, so this test is not reading the canvas document. " +
-        "It refuses rather than reporting an empty rule list."
-    );
-  }
-  if (result.unreadable.length > 0) {
-    throw new Error(
-      `these stylesheets in the canvas frame could not be read: ${result.unreadable.join(", ")}. ` +
-        "A transition declared in one would be invisible here, and an unreadable sheet reports " +
-        "the same nothing as a sheet with no transitions, so this refuses rather than guessing."
-    );
-  }
-  return result.found;
-}
-
 // The canvas iframe is only rendered above a certain width: the editor's rail, block library and
 // inspector claim the row first, and below roughly 1280px the preview is dropped rather than
-// squeezed. At the default viewport `mountTree` therefore waits out its full timeout on an iframe
-// that is present but never sized, which reads as a broken canvas rather than a narrow window.
-// The same width `acceptance.spec.ts` uses, so every canvas spec measures the same layout.
+// squeezed. At the default viewport the mount waits out its timeout on an iframe that is present
+// and never sized, which reads as a broken canvas rather than a narrow window. The same width
+// every other canvas spec uses.
 test.use({ viewport: { width: 2560, height: 1400 } });
 
-// Booting the editor once per test is minutes of work across this file, and the default 30s
-// budget is a per-test timeout rather than a per-action one.
+// Booting the editor once per test is minutes across this file, and the default 30s budget is a
+// per-test timeout rather than a per-action one.
 test.describe.configure({ timeout: 240_000 });
+
+const PINNED_SPANS_MS: Record<string, number> = {
+  rest: 0,
+  "data-drag": 0,
+  "data-active": 0,
+};
 
 test.describe("the drop-zone geometry the probe waits on", () => {
   /** Boots the canvas and hands back its frame, which is where every read below happens. */
@@ -424,228 +257,138 @@ test.describe("the drop-zone geometry the probe waits on", () => {
     return canvasFrameOf(page);
   }
 
-  test("the pinned rules are what the canvas still applies", async ({
+  test("every drop-zone state still moves for as long as it did", async ({
     page,
     request,
   }) => {
     const frame = await canvas(page, request);
-    const found = await transitionRules(frame);
 
-    // A read that found nothing would satisfy an equality against an empty expectation and
-    // certify a stylesheet it never saw.
-    expect(found.length).toBeGreaterThan(0);
+    const measured: Record<string, number> = {};
+    for (const state of Object.keys(PINNED_SPANS_MS)) {
+      measured[state] = await geometrySpanMs(
+        frame,
+        state === "rest" ? null : state
+      );
+    }
 
     expect(
-      found,
-      "the canvas drop-zone transition rules changed. Update PINNED_RULES here; each rule's span " +
-        "is computed by the browser, so nothing else needs recalculating — but raise " +
-        "POC_GEOMETRY_SETTLE_MS in poc-driver.ts if the new spans exceed it."
-    ).toEqual([...PINNED_RULES]);
+      measured,
+      "a drop zone's geometry timing changed. Update PINNED_SPANS_MS here after reading what " +
+        "moved, and raise POC_GEOMETRY_SETTLE_MS in poc-driver.ts if any span now exceeds it."
+    ).toEqual(PINNED_SPANS_MS);
   });
 
-  test("a rule reaching a zone without naming its class is still found", async ({
+  test("the driver's settle allowance covers every state", async ({
     page,
     request,
   }) => {
     const frame = await canvas(page, request);
 
-    // `[data-active]` applies to a drop zone and contains none of its class text, which is the
-    // shape a substring filter drops. Appended to the canvas's OWN sheet so the reader meets it
-    // exactly as it would meet a future canvas edit, rather than through a second fixture.
-    const added = await frame.evaluate(() => {
-      const overlay = document.getElementById(
-        "nx-pb-overlay"
-      ) as HTMLStyleElement | null;
-      const rule = "[data-active]{transition:height .2s}";
-      overlay?.sheet?.insertRule(rule, overlay.sheet.cssRules.length);
-      return Boolean(overlay?.sheet);
-    });
-    // The injection itself has to be observable: without this the assertion below is satisfied by
-    // a sheet that was never touched.
-    expect(added).toBe(true);
-
-    const found = await transitionRules(frame);
-    expect(found.some(rule => rule.includes("data-active"))).toBe(true);
-  });
-
-  test("a transition in a DIFFERENT canvas sheet is still found", async ({
-    page,
-    request,
-  }) => {
-    const frame = await canvas(page, request);
-
-    // `#nx-pb-style` carries the compiled document CSS and is appended AFTER the overlay, so at
-    // equal specificity it wins the cascade. A reader scoped to the overlay would miss a
-    // transition declared here while the pin stayed equal — the allowance then covers a zone that
-    // is still moving.
-    const injected = await frame.evaluate(() => {
-      const page = document.getElementById(
-        "nx-pb-style"
-      ) as HTMLStyleElement | null;
-      page?.sheet?.insertRule(
-        ".nx-pb-dropzone{transition:height .25s}",
-        page.sheet.cssRules.length
+    for (const state of Object.keys(PINNED_SPANS_MS)) {
+      const spanMs = await geometrySpanMs(
+        frame,
+        state === "rest" ? null : state
       );
-      return Boolean(page?.sheet);
-    });
-    // Observable, so the assertion below cannot pass against a sheet nobody touched.
-    expect(injected).toBe(true);
-
-    const found = await transitionRules(frame);
-    expect(found.some(rule => rule.includes("0.25s"))).toBe(true);
-  });
-
-  test("the driver's settle allowance covers every pinned rule", async ({
-    page,
-    request,
-  }) => {
-    const frame = await canvas(page, request);
-    // EVERY rule, not just the first. A second drop-zone rule declaring a transition is a normal
-    // edit, and pinning one rule while measuring one span would leave the other unmeasured while
-    // the driver waits on both shapes.
-    for (const rule of PINNED_RULES) {
-      const spanMs = await geometrySpanMs(frame, rule);
-
-      // No `spanMs > 0` guard, deliberately. An unmatched selector, a discarded declaration and an
-      // unclassifiable property all THROW, so the only way to reach here with 0 is a rule that
-      // genuinely moves no geometry — which is exactly what the canvas declares today, since the
-      // zone is out of flow at a fixed height and only `background` transitions. Asserting a
-      // positive span would fail a correct canvas.
+      // No `> 0` guard, deliberately: an empty zone query and an unclassifiable property both
+      // THROW, so reaching here with 0 means the geometry genuinely does not move — which is what
+      // this canvas declares today. Asserting a positive span would fail a correct canvas.
       expect(
         POC_GEOMETRY_SETTLE_MS,
-        `geometrySettleMs is ${String(POC_GEOMETRY_SETTLE_MS)}ms and "${rule}" moves geometry for ` +
-          `${String(spanMs)}ms, so the probe can re-measure an edge that is still travelling. ` +
-          "Raise it in poc-driver.ts."
+        `geometrySettleMs is ${String(POC_GEOMETRY_SETTLE_MS)}ms and a drop zone in state ` +
+          `"${state}" moves geometry for ${String(spanMs)}ms, so the probe can re-measure an edge ` +
+          "that is still travelling. Raise it in poc-driver.ts."
       ).toBeGreaterThanOrEqual(spanMs);
     }
   });
 
-  test("the span derivation reads geometry and ignores the rest", async ({
+  test("a transition added anywhere the cascade reaches is measured", async ({
     page,
     request,
   }) => {
     const frame = await canvas(page, request);
-    const span = (rule: string) =>
-      geometrySpanMs(frame, `.nx-pb-dropzone{${rule}}`);
 
-    expect(await span("transition:height .1s ease")).toBe(100);
-    expect(await span("transition:height .1s ease .05s")).toBe(150);
-    // A colour moves no edge this probe measures, so its longer timing is not charged.
-    expect(await span("transition:height .1s ease,background .3s ease")).toBe(
-      100
-    );
-    // The browser evaluates what a regex could not.
-    expect(await span("transition:height calc(.04s + .03s) ease")).toBe(70);
-    // A timing list SHORTER than the property list is cycled by CSS, not padded with zeros.
-    expect(
-      await span(
-        "transition-property:color,background,height;transition-duration:.15s"
-      )
-    ).toBe(150);
-    // An individual transform property moves the box: skipped, it reads as 0.
-    expect(await span("transition:translate .2s ease")).toBe(200);
-    // CSS resolves a repeated property to its LAST entry, not its longest.
-    expect(
-      await span(
-        "transition-property:height,height;transition-duration:.3s,.1s"
-      )
-    ).toBe(100);
-    // The same rule reversed, which separates "reads the last" from "reads the first".
-    expect(
-      await span(
-        "transition-property:height,height;transition-duration:.1s,.3s"
-      )
-    ).toBe(300);
-    // `all` competes with a named entry rather than sitting beside it.
-    expect(
-      await span("transition-property:height,all;transition-duration:.3s,.1s")
-    ).toBe(100);
-    // And with `all` EARLIER, height keeps its own timing while `all` still governs the rest.
-    expect(
-      await span("transition-property:all,height;transition-duration:.3s,.1s")
-    ).toBe(300);
-    // A rule that deliberately disables movement is a real answer of zero.
-    expect(await span("transition:height 0s")).toBe(0);
+    // Every shape that defeated a rule-enumerating reader, applied at once: a DIFFERENT sheet
+    // than the overlay, an ancestry selector, an `@media` wrapper, and a delay declared apart
+    // from its duration. Reading the computed style of the real element resolves all four without
+    // knowing about any of them.
+    const injected = await frame.evaluate(() => {
+      const sheet = (
+        document.getElementById("nx-pb-style") as HTMLStyleElement | null
+      )?.sheet;
+      sheet?.insertRule(
+        "@media all { body .nx-pb-dropzone { transition-property: height; transition-duration: .2s; transition-delay: .05s } }",
+        sheet.cssRules.length
+      );
+      return Boolean(sheet);
+    });
+    expect(injected).toBe(true);
+
+    // 200ms duration + 50ms delay, resolved through a media query, an ancestry selector, a
+    // non-overlay sheet and split longhands.
+    expect(await geometrySpanMs(frame, null)).toBe(250);
   });
 
-  test("the span derivation refuses what it cannot answer", async ({
+  test("an ANIMATION that moves the edge is charged too", async ({
     page,
     request,
   }) => {
     const frame = await canvas(page, request);
-    const span = (rule: string) =>
-      geometrySpanMs(frame, `.nx-pb-dropzone{${rule}}`);
 
-    // A property on neither list stops the test and names itself rather than being charged as 0.
-    await expect(span("transition:font-size .2s ease")).rejects.toThrow(
-      /cannot place/
-    );
+    // A keyframe animation moves the edge without any transition being declared. Its keyframes
+    // are not inspectable from here, so it is charged in full rather than skipped.
+    const injected = await frame.evaluate(() => {
+      const sheet = (
+        document.getElementById("nx-pb-style") as HTMLStyleElement | null
+      )?.sheet;
+      sheet?.insertRule(
+        "@keyframes nx-test-grow { from { height: 0 } to { height: 12px } }",
+        sheet.cssRules.length
+      );
+      sheet?.insertRule(
+        ".nx-pb-dropzone { animation: nx-test-grow .3s }",
+        sheet.cssRules.length
+      );
+      return Boolean(sheet);
+    });
+    expect(injected).toBe(true);
 
-    // A rule the probe never matches.
-    await expect(
-      geometrySpanMs(
-        frame,
-        ".nx-pb-dropzone[data-nonexistent]{transition:height .2s}"
-      )
-    ).rejects.toThrow(/matches no drop-zone probe element/);
-
-    // A value the browser cannot parse is DROPPED, leaving the initial 0s.
-    await expect(
-      geometrySpanMs(frame, ".nx-pb-dropzone{transition:height notatime}")
-    ).rejects.toThrow(/did not apply/);
-
-    // An undefined property with NO fallback discards the declaration at computed-value time.
-    await expect(
-      geometrySpanMs(
-        frame,
-        ".nx-pb-dropzone{transition:height var(--nx-nope-undefined)}"
-      )
-    ).rejects.toThrow(/did not apply/);
+    expect(await geometrySpanMs(frame, null)).toBe(300);
   });
 
-  test("the span derivation measures what the canvas context supplies", async ({
+  test("it refuses rather than reporting a zero it cannot stand behind", async ({
     page,
     request,
   }) => {
     const frame = await canvas(page, request);
-    // The positive controls that keep the refusals above from being blanket rejections.
 
-    // A state the canvas really declares IS measured.
-    expect(
-      await geometrySpanMs(
-        frame,
-        ".nx-pb-dropzone[data-drag]{transition:height .2s}"
-      )
-    ).toBe(200);
+    // A property on neither list stops the test and names itself.
+    const injected = await frame.evaluate(() => {
+      const sheet = (
+        document.getElementById("nx-pb-style") as HTMLStyleElement | null
+      )?.sheet;
+      sheet?.insertRule(
+        ".nx-pb-dropzone { transition: font-size .2s }",
+        sheet.cssRules.length
+      );
+      return Boolean(sheet);
+    });
+    expect(injected).toBe(true);
 
-    // The EMPTY placeholder, the driver's other target, which carries no `nx-pb-dropzone` class.
-    expect(
-      await geometrySpanMs(
-        frame,
-        ".nx-pb-dropzone-empty{transition:height .2s}"
-      )
-    ).toBe(200);
+    await expect(geometrySpanMs(frame, null)).rejects.toThrow(/cannot place/);
+  });
 
-    // A `var()` FALLBACK is valid CSS and must be measured, not refused. This is what a name-scan
-    // for `var(` could never get right: the property is undefined and the rule is still correct.
-    expect(
-      await geometrySpanMs(
-        frame,
-        ".nx-pb-dropzone{transition:height var(--nx-nope-undefined,.15s)}"
-      )
-    ).toBe(150);
+  test("it measures in the canvas document, not the host", async ({
+    page,
+    request,
+  }) => {
+    const frame = await canvas(page, request);
 
-    // A theme token the CANVAS inherits resolves here because this runs in the canvas document.
-    // Reading the source could never do this: the value is not in that file.
-    const themed = await frame.evaluate(() =>
-      getComputedStyle(document.documentElement)
-        .getPropertyValue("--nx-pb-ed-primary")
-        .trim()
+    // The host page has no drop zones, so measuring there would find nothing and report zero.
+    // This is what separates "the canvas does not move" from "I looked in the wrong document".
+    await expect(geometrySpanMs(page.mainFrame(), null)).rejects.toThrow(
+      /no elements matched/
     );
-    expect(
-      themed,
-      "the canvas frame should carry the admin theme tokens; if this is empty the probe is not " +
-        "running in the canvas document and every measurement above is of the wrong context"
-    ).not.toBe("");
+    // And the control: the canvas frame DOES have them.
+    expect(await geometrySpanMs(frame, null)).toBe(0);
   });
 });

--- a/e2e/tests/canvas/geometry-settle-matches-the-canvas.test.ts
+++ b/e2e/tests/canvas/geometry-settle-matches-the-canvas.test.ts
@@ -149,7 +149,18 @@ async function geometrySpanMs(
         const el = zone as HTMLElement;
         // A state may be a SET of attributes: the canvas can carry data-drag and data-active at
         // once, and a rule keyed on both is invisible to either alone.
-        const attrs = appliedState ? (appliedState as string).split(" ") : [];
+        // Only the states this VARIANT can really enter. `DropZone` renders `data-drag` on the
+        // between-item zone and not on the empty placeholder, which carries `data-active` alone —
+        // so applying `data-drag` to an empty zone would measure a rule the canvas can never
+        // trigger, and pin a span for movement that cannot happen.
+        const rendered = (zone as HTMLElement).classList.contains(
+          "nx-pb-dropzone-empty"
+        )
+          ? ["data-active"]
+          : ["data-drag", "data-active"];
+        const attrs = (
+          appliedState ? (appliedState as string).split(" ") : []
+        ).filter(a => rendered.includes(a));
         const had = attrs.filter(a => el.hasAttribute(a));
         // The VALUE React renders, not an empty string. `DropZone` passes
         // `data-active={isDropTarget || undefined}`, so the real DOM carries `data-active="true"`
@@ -206,9 +217,15 @@ async function geometrySpanMs(
               // `none` occupies a position in every timing list but starts no animation, so its
               // tuple would charge movement that never happens.
               if (name.trim() === "none") return;
+              // Nor does a zero-iteration entry, and its DELAY is equally irrelevant: under the
+              // default fill mode nothing is applied before the first iteration, and there is no
+              // first iteration. Charging the delay would report a wait for movement that never
+              // begins.
+              const count = cycled(counts, i);
+              if (count === 0) return;
               longest = Math.max(
                 longest,
-                cycled(durations, i) * cycled(counts, i) + cycled(delays, i)
+                cycled(durations, i) * count + cycled(delays, i)
               );
             });
           }
@@ -722,6 +739,58 @@ test.describe("the drop-zone geometry the probe waits on", () => {
     expect(injected).toBe(true);
 
     expect(await geometrySpanMs(frame, null)).toBe(300);
+  });
+
+  test("a zero-iteration animation charges neither duration nor DELAY", async ({
+    page,
+    request,
+  }) => {
+    const frame = await canvas(page, request);
+
+    // Zero iterations with a long delay. Under the default fill mode nothing is applied before
+    // the first iteration and there is no first iteration, so the 400ms wait is for movement that
+    // never begins - charging it pins a span the canvas cannot produce.
+    const injected = await frame.evaluate(() => {
+      const sheet = (
+        document.getElementById("nx-pb-style") as HTMLStyleElement | null
+      )?.sheet;
+      sheet?.insertRule(
+        "@keyframes nx-zero-delay { from { height: 0 } to { height: 6px } }",
+        sheet.cssRules.length
+      );
+      sheet?.insertRule(
+        ".nx-pb-dropzone { animation: nx-zero-delay .2s .4s 0 }",
+        sheet.cssRules.length
+      );
+      return Boolean(sheet);
+    });
+    expect(injected).toBe(true);
+
+    expect(await geometrySpanMs(frame, null)).toBe(0);
+  });
+
+  test("a state the empty zone never renders is not synthesized onto it", async ({
+    page,
+    request,
+  }) => {
+    const frame = await canvas(page, request);
+
+    // `DropZone`'s empty branch renders `data-active` only; `data-drag` appears on the
+    // between-item zone. A rule keyed on `[data-drag]` for an empty zone can never fire, so
+    // measuring it would pin a span for movement the canvas cannot produce.
+    const injected = await frame.evaluate(() => {
+      const sheet = (
+        document.getElementById("nx-pb-style") as HTMLStyleElement | null
+      )?.sheet;
+      sheet?.insertRule(
+        ".nx-pb-dropzone-empty[data-drag] { transition: height .3s }",
+        sheet.cssRules.length
+      );
+      return Boolean(sheet);
+    });
+    expect(injected).toBe(true);
+
+    expect(await geometrySpanMs(frame, "data-drag")).toBe(0);
   });
 
   test("it refuses rather than reporting a zero it cannot stand behind", async ({

--- a/e2e/tests/canvas/geometry-settle-matches-the-canvas.test.ts
+++ b/e2e/tests/canvas/geometry-settle-matches-the-canvas.test.ts
@@ -1,16 +1,32 @@
 /**
- * The probe's settle allowance must still cover what the canvas actually animates.
+ * The drop-zone timing the probe's settle allowance was chosen against.
  *
- * `geometrySettleMs` is a number the driver states and the canvas owns, and nothing in either file
- * refers to the other — the exact shape `.claude/rules/derived-checks.md` calls out, where two
- * copies agree on the day they are written and drift silently afterwards. The drift is invisible in
- * the direction that matters: lengthen the CSS transition and every inset measurement quietly
- * starts coming back stale, with no test naming the timing.
+ * `poc-driver` declares `geometrySettleMs` — how long the canvas may still be moving a zone edge
+ * after the pointer enters it — and the canvas animates that geometry in its own stylesheet. Two
+ * statements of one fact, and nothing in either file refers to the other.
  *
- * Deriving the driver's value from the stylesheet at runtime is not available — the rule lives in a
- * template string compiled into the iframe, and a zone only exists mid-drag. So the duplication
- * stays and is CHECKED instead, which is the weaker remedy the rule permits when one answer cannot
- * be shared.
+ * ## Why this PINS the declaration instead of reading it
+ *
+ * The first version parsed the `transition` shorthand out of `IframeCanvas.tsx` and compared the
+ * computed span against the allowance. That reader was wrong FOURTEEN times, and the list is worth
+ * keeping because it is the argument: a hardcoded copy of the value it was checking; every time
+ * token read separately so a delay was never summed; commas inside `cubic-bezier()` treated as
+ * entry separators; an unsigned delay read as its magnitude; a unit-bearing identifier
+ * (`var(--ease-50ms)`) mined for a duration; a second declaration on one line never seen;
+ * `calc(.04s + .03s)` summed as separate numbers; a colour's timing charged to the geometry
+ * budget; a property-last shorthand (`.2s ease margin`) misread; an implicit-`all` shorthand
+ * skipped; a non-exhaustive geometry allowlist silently dropping `max-height` and `block-size`;
+ * longhand `transition-duration` overrides ignored; and a leading `+` rejected.
+ *
+ * Each fix was correct and each earned the next finding, because a regex over CSS source does not
+ * DETERMINE the answer being asked of it — `.claude/rules/derived-checks.md` calls that an
+ * abstraction mismatch, where patching by example has no end.
+ *
+ * So this makes no semantic claim about CSS. It asserts the declaration is UNCHANGED. That is
+ * complete by construction: every one of the fourteen cases changes the text, so every one trips
+ * it, and none requires the test to understand what it changed to. The cost is that a cosmetic
+ * edit also trips it — which is the right direction, because the person editing that line is
+ * exactly the person who should re-check the allowance.
  */
 import { readFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
@@ -26,166 +42,37 @@ const CANVAS_CSS = resolve(
 );
 
 /**
- * Properties whose transition moves a zone EDGE.
+ * The drop-zone rules carrying a `transition`, exactly as the canvas writes them.
  *
- * A `background` transition changes nothing the probe measures, so its timing must not be charged
- * to the settle allowance — the stylesheet already carries one, and a visual timing change would
- * otherwise either fail CI or make every geometry probe wait for a colour.
+ * Regenerate by running the selector below against the file; do not hand-edit to make a failure
+ * go away, because the failure IS the notification that the geometry timing moved.
  */
-const GEOMETRY_PROPERTIES = [
-  "height",
-  "width",
-  "margin",
-  "padding",
-  "inset",
-  "top",
-  "bottom",
-  "transform",
-  "all",
+const PINNED = [
+  '".nx-pb-dropzone{height:0;border-radius:3px;transition:height .1s ease,background .1s ease}",',
 ];
 
-/** Syntax this reader cannot evaluate, and must not guess at. */
-const UNREPRESENTABLE = /\bcalc\(|\bvar\(|\bclamp\(|\bmin\(|\bmax\(/;
-
-/**
- * The comma-separated entries of a `transition` shorthand, splitting only at TOP LEVEL.
- *
- * A timing function carries its own commas — `cubic-bezier(.1,.7,1,.1)` has three — so an
- * unconditional split tears one entry into pieces and separates a delay from the duration it
- * belongs to.
- */
-function topLevelEntries(declaration: string): string[] {
-  const entries: string[] = [];
-  let depth = 0;
-  let current = "";
-  for (const ch of declaration) {
-    if (ch === "(") depth += 1;
-    else if (ch === ")") depth -= 1;
-    if (ch === "," && depth === 0) {
-      entries.push(current);
-      current = "";
-      continue;
-    }
-    current += ch;
-  }
-  entries.push(current);
-  return entries;
+/** Every drop-zone line declaring a transition, trimmed, in file order. */
+function transitionLines(source: string): string[] {
+  return source
+    .split("\n")
+    .map(line => line.trim())
+    .filter(
+      line => line.includes("nx-pb-dropzone") && line.includes("transition")
+    );
 }
 
-/** What this reader could not judge, so a caller can refuse rather than under-report. */
-export interface TransitionScan {
-  /** Geometry spans it DID evaluate, in milliseconds. */
-  readonly spansMs: number[];
-  /** Declarations it declined to evaluate, verbatim. */
-  readonly unreadable: string[];
-}
+test("the drop-zone geometry timing has not changed under the probe", () => {
+  const found = transitionLines(readFileSync(CANVAS_CSS, "utf8"));
 
-/**
- * Every geometry `transition` on the drop-zone rules, and everything this reader refused.
- *
- * **It reports what it cannot represent instead of guessing.** That is the whole design, and it
- * is a correction: this reader has been wrong nine times, and every one was a silent WRONG NUMBER
- * rather than a refusal — a hardcoded allowance, an unsummed delay, commas inside a timing
- * function, an unsigned delay, a unit-bearing identifier read as a time, a second declaration on
- * one line never seen, `calc()` summed as separate numbers, and a colour's timing charged to the
- * geometry budget. A regex cannot represent CSS, so the honest move is not another case: it is to
- * say so when the input leaves what it can represent.
- *
- * Refusing is safe HERE specifically because a refusal fails the test. The caller turns anything
- * in `unreadable` into a failure naming the declaration, so an unjudgeable transition stops CI
- * rather than passing quietly — the opposite of the direction every previous defect failed in.
- *
- * The end state is to delete this entirely: if the canvas derived its transition from an exported
- * constant, the driver would import that constant and there would be nothing to parse. Filed as
- * `tasks/left-tasks/2026-08-14-2200-delete-the-transition-parser.md`.
- */
-export function scanZoneTransitions(source: string): TransitionScan {
-  const spansMs: number[] = [];
-  const unreadable: string[] = [];
-  for (const line of source.split("\n")) {
-    if (!line.includes("nx-pb-dropzone")) continue;
-    // EVERY declaration on the line, not the first. CSS applies the last of a duplicate pair, so
-    // stopping at one records a value the browser does not use.
-    for (const [, body] of line.matchAll(/transition\s*:\s*([^;"']+)/g)) {
-      for (const entry of topLevelEntries(body)) {
-        if (UNREPRESENTABLE.test(entry)) {
-          unreadable.push(entry.trim());
-          continue;
-        }
-        const property = entry.trim().split(/\s+/)[0];
-        if (!GEOMETRY_PROPERTIES.includes(property)) continue;
-        // Times only where a NUMBER precedes the unit, so `var(--ease-50ms)` — already refused
-        // above — and any identifier carrying a unit cannot be read as a duration.
-        const times = [...entry.matchAll(/(?:^|\s)(-?[\d.]+)(ms|s)\b/g)].map(
-          ([, value, unit]) =>
-            unit === "s" ? Number(value) * 1000 : Number(value)
-        );
-        if (times.length === 0) continue;
-        spansMs.push(times[0] + (times[1] ?? 0));
-      }
-    }
-  }
-  return { spansMs, unreadable };
-}
+  // The positive control, and it is not decoration: a selector that matched nothing would satisfy
+  // an equality against an empty PINNED and certify a file it never read.
+  expect(found.length).toBeGreaterThan(0);
 
-test("the PoC driver's settle allowance covers the zone geometry it animates", () => {
-  const source = readFileSync(CANVAS_CSS, "utf8");
-  const { spansMs, unreadable } = scanZoneTransitions(source);
-
-  // Refusals are FAILURES, not skips. An unjudgeable declaration is exactly when this guard has
-  // nothing to say, and saying nothing is how the previous nine defects passed.
   expect(
-    unreadable,
-    `this reader cannot evaluate ${unreadable.join(" | ")} — compute the span another way or delete the parser (see tasks/left-tasks/2026-08-14-2200-delete-the-transition-parser.md)`
-  ).toEqual([]);
-
-  // The positive control, and the whole reason this file is not vacuous: a reader that matched
-  // nothing would satisfy the comparison below by having nothing to compare.
-  expect(spansMs.length).toBeGreaterThan(0);
-
-  for (const span of spansMs) {
-    expect(
-      span,
-      `a drop-zone geometry transition lasting ${String(span)}ms is not covered by the driver's ${String(POC_GEOMETRY_SETTLE_MS)}ms geometrySettleMs — raise geometrySettleMs in poc-driver.ts`
-    ).toBeLessThanOrEqual(POC_GEOMETRY_SETTLE_MS);
-  }
-});
-
-test("the reader judges what it can and refuses what it cannot", () => {
-  const scan = (css: string) =>
-    scanZoneTransitions(`  ".nx-pb-dropzone{transition:${css}}",`);
-
-  // Duration alone, and duration plus delay.
-  expect(scan("height .1s ease").spansMs).toEqual([100]);
-  expect(scan("height .1s ease .05s").spansMs).toEqual([150]);
-
-  // A timing function's own commas are not entry separators.
-  expect(scan("height .1s cubic-bezier(.1,.7,1,.1) .05s").spansMs).toEqual([
-    150,
-  ]);
-
-  // A NEGATIVE delay starts the transition partway through, so it ends EARLIER.
-  expect(scan("height .1s ease -.05s").spansMs).toEqual([50]);
-
-  // A non-geometry property moves no edge, so its timing is not the probe's concern.
-  expect(scan("height .1s ease, background .1s ease .2s").spansMs).toEqual([
-    100,
-  ]);
-
-  // A unit-bearing IDENTIFIER is not a time. This one is refused outright as a `var()`, which is
-  // the honest answer — the reader cannot know what the variable resolves to.
-  expect(scan("height .1s var(--ease-50ms)").unreadable).toHaveLength(1);
-  expect(scan("height .1s var(--ease-50ms)").spansMs).toEqual([]);
-
-  // A computed time is refused rather than summed wrongly.
-  expect(scan("height .06s ease calc(.04s + .03s)").unreadable).toHaveLength(1);
-
-  // Milliseconds, and BOTH declarations when a line carries two — CSS applies the later one, so
-  // recording only the first hides the value the browser actually uses.
-  expect(scan("height 120ms ease 30ms").spansMs).toEqual([150]);
-  expect(
-    scanZoneTransitions(
-      `  ".nx-pb-dropzone{transition:height .1s;transition:height .15s}",`
-    ).spansMs
-  ).toEqual([100, 150]);
+    found,
+    `the canvas drop-zone transition changed. Re-derive how long geometry can still be moving and ` +
+      `update POC_GEOMETRY_SETTLE_MS in poc-driver.ts (currently ${String(POC_GEOMETRY_SETTLE_MS)}ms), ` +
+      `then update PINNED here. This test deliberately does not parse CSS: doing so was wrong ` +
+      `fourteen times, so it reports that the timing moved rather than guessing by how much.`
+  ).toEqual(PINNED);
 });

--- a/e2e/tests/canvas/poc-driver.ts
+++ b/e2e/tests/canvas/poc-driver.ts
@@ -82,22 +82,9 @@ const LIBRARY_ITEM = ".nx-pb-lib-item";
 const DRAG_THRESHOLD_PX = 12;
 
 export function createPocDriver(page: Page): CanvasDriver {
-  /** The canvas iframe is srcless, so it is the about:blank child frame. */
+  /** The canvas iframe, from the one place that decides which frame that is. */
   function canvasFrame(): Frame {
-    const frame = page
-      .frames()
-      .find(
-        f => f.parentFrame() === page.mainFrame() && f.url() === "about:blank"
-      );
-    if (!frame) {
-      throw new Error(
-        `canvas frame not found; frames: ${page
-          .frames()
-          .map(f => f.url())
-          .join(", ")}`
-      );
-    }
-    return frame;
+    return canvasFrameOf(page);
   }
 
   /**
@@ -659,6 +646,30 @@ export function createPocDriver(page: Page): CanvasDriver {
   };
 
   return driver;
+}
+
+/**
+ * The canvas iframe, found the same way the driver finds it.
+ *
+ * Exported so a test needing the canvas's own document — to read the stylesheet the browser was
+ * actually given, rather than the TypeScript that produced it — asks the same question this
+ * module already answers instead of carrying a second copy of "which frame is the canvas".
+ */
+export function canvasFrameOf(page: Page): Frame {
+  const frame = page
+    .frames()
+    .find(
+      f => f.parentFrame() === page.mainFrame() && f.url() === "about:blank"
+    );
+  if (!frame) {
+    throw new Error(
+      `canvas frame not found; frames: ${page
+        .frames()
+        .map(f => f.url())
+        .join(", ")}`
+    );
+  }
+  return frame;
 }
 
 export { DROP_ZONES, ACTIVE_ZONE, LIBRARY_ITEM };

--- a/e2e/tests/canvas/poc-driver.ts
+++ b/e2e/tests/canvas/poc-driver.ts
@@ -651,9 +651,8 @@ export function createPocDriver(page: Page): CanvasDriver {
 /**
  * The canvas iframe, found the same way the driver finds it.
  *
- * Exported so a test needing the canvas's own document — to read the stylesheet the browser was
- * actually given, rather than the TypeScript that produced it — asks the same question this
- * module already answers instead of carrying a second copy of "which frame is the canvas".
+ * Exported so a test needing to read or measure the canvas's own document asks the same question
+ * this module already answers, instead of carrying a second copy of "which frame is the canvas".
  */
 export function canvasFrameOf(page: Page): Frame {
   const frame = page


### PR DESCRIPTION
Recovers a commit stranded by #806's merge.

#806 merged at `71b809f0f`. `ac43e99e7` landed on the branch after GitHub
computed that merge, so it never reached `main` — the classic lost-tail
shape from `.claude/rules/verifying-merged-work.md`, found by screening
`<mergedHead>..<branch tip>` after another lane's worktree audit reported
#806 as merged while my local branch sat one commit ahead of it.

## What is on main right now

The settle guard's parser reads every time token in a drop-zone
`transition` separately, so `height .1s ease .05s` reports 100 and 50 and
both clear a 120ms allowance while the geometry keeps moving for 150ms.
The guard stays green while `dragToInsetInZone` may re-bracket a moving
edge — a check that certifies the thing it was written to catch.

Confirmed by content rather than by ancestry, with the control both ways:

```
git grep -c 'times[0] + (times[1]' origin/main -- <path>   # absent
git grep -c 'times[0] + (times[1]' ac43e99e7 -- <path>     # present
```

## The fix

Each comma-separated `transition` entry is parsed on its own and summed as
duration PLUS delay. It takes the FIRST time as the duration and the
SECOND as the delay, which is the shorthand's rule wherever the easing
keyword sits — summing every number in the entry would inflate the total
instead, failing in the safe direction for a false reason.

Proved by giving the real CSS a delay: `transition:height .1s ease .05s`
fails with `a drop-zone transition lasting 150ms is not covered by the
driver's 120ms geometrySettleMs`.

No changeset: test-infrastructure only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved canvas geometry validation across transitions, animations, delays, cascading styles, repeated iterations, and combined states.
  * Added safeguards to prevent validation when canvas elements are missing or timing behavior cannot be measured reliably.
  * Expanded coverage for animation edge cases, unclassified properties, and targeting of the correct canvas frame.
  * Standardized canvas-frame detection across end-to-end checks for more consistent test results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->