### PR TITLE
feat(admin): read a plugin's permissions from the seeded rows

### DIFF
--- a/.changeset/plugin-permissions-from-rows.md
+++ b/.changeset/plugin-permissions-from-rows.md
@@ -1,0 +1,36 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+Show a plugin's permissions on its detail page again, read from the
+authenticated permissions endpoint rather than the public admin-meta payload.
+
+These are the rows the seeder actually created, which is a different set from
+the declarations: a `publish` or `unpublish` declaration naming a collection
+or single is dropped, because the seeder emits that slug itself and keeps the
+row ownerless. The page now reports what exists rather than what was asked
+for, and it reports nothing at all when the request fails instead of showing
+an empty section.

--- a/packages/admin/src/pages/dashboard/plugins/[slug].tsx
+++ b/packages/admin/src/pages/dashboard/plugins/[slug].tsx
@@ -478,7 +478,9 @@ function PluginPermissions({ pluginName }: { pluginName: string }) {
       )}
       {!isPending && !isError && owned.length === 0 && (
         <p className="text-xs text-muted-foreground">
-          No permission rows are attributed to this plugin.
+          No current permission rows are attributed to this plugin. Rows
+          retained from a version that no longer declares them are not listed
+          here.
         </p>
       )}
       {!isPending && !isError && owned.length > 0 && (

--- a/packages/admin/src/pages/dashboard/plugins/[slug].tsx
+++ b/packages/admin/src/pages/dashboard/plugins/[slug].tsx
@@ -1,7 +1,11 @@
 "use client";
 
 import { Badge } from "@nextlyhq/ui";
-import { useQueryClient, useSuspenseQuery } from "@tanstack/react-query";
+import {
+  useQuery,
+  useQueryClient,
+  useSuspenseQuery,
+} from "@tanstack/react-query";
 import { Suspense } from "react";
 
 import {
@@ -35,6 +39,7 @@ import { API_PATH_PREFIX } from "@admin/lib/api/fetcher";
 import { categoryLabel } from "@admin/lib/plugins/plugin-categories";
 import { pluginSlug } from "@admin/lib/plugins/plugin-slug";
 import { staticRegistrySource } from "@admin/lib/plugins/registry/static-source";
+import { fetchPermissionsFromApi } from "@admin/services/realPermissionsApi";
 import type { PluginMetadata } from "@admin/types/branding";
 
 import { NotInstalledPlugin } from "./components/NotInstalledPlugin";
@@ -360,6 +365,79 @@ interface ContributionGroup {
  * the serialized metadata the server already computed. Honest by
  * construction — an empty group simply is not rendered.
  */
+/**
+ * A plugin's permissions, read from the SEEDED ROWS rather than folded from the
+ * configuration.
+ *
+ * The rows are what the seeder actually wrote, so Schema Builder entities,
+ * `setup` transformers and orphan repair are all already accounted for — none
+ * of which a fold over the configuration can see, because a Builder collection
+ * exists only in `dynamic_collections`. It also keeps the permission vocabulary
+ * off the public `admin-meta` payload, which served it to anonymous callers.
+ *
+ * `owner` is the DECLARING PLUGIN NAME, and the host's own sentinel is the
+ * literal string `"app"`. A plugin legally named `app` is therefore
+ * indistinguishable here from host-declared permissions, because the row
+ * carries no `source` column to separate them — the collector computes that
+ * distinction in memory and never persists it. Accepted rather than guarded:
+ * the ambiguity needs a schema change to close, and it is recorded here so the
+ * next reader is not surprised by it.
+ *
+ * Its own query rather than a suspending one, so a caller without the roles
+ * read permission degrades THIS card instead of the page.
+ */
+function PluginPermissions({ pluginName }: { pluginName: string }) {
+  const { data, isPending, isError } = useQuery({
+    queryKey: ["plugin-permissions", pluginName],
+    queryFn: () => fetchPermissionsFromApi({ limit: 200 }),
+    // A refusal is an answer about this viewer's access, not a transient
+    // failure, so retrying it only delays the message.
+    retry: false,
+  });
+
+  const owned = (data?.data ?? []).filter(entry => entry.owner === pluginName);
+
+  // Rendered even when empty, unlike the configuration-fed groups beside it.
+  // An absent section reads as "this plugin declares none", which is a claim
+  // this card cannot make while the request is pending or refused.
+  return (
+    <div className="rounded-lg border border-border bg-card p-4">
+      <div className="mb-2 flex items-center gap-2">
+        <Shield className="h-4 w-4 text-muted-foreground" />
+        <h3 className="text-sm font-medium text-foreground">Permissions</h3>
+      </div>
+      {isPending && (
+        <p className="text-xs text-muted-foreground">Loading permissions…</p>
+      )}
+      {isError && (
+        <p className="text-xs text-muted-foreground">
+          Not available. Reading permissions needs the roles read permission, so
+          this list is hidden rather than empty.
+        </p>
+      )}
+      {!isPending && !isError && owned.length === 0 && (
+        <p className="text-xs text-muted-foreground">
+          This plugin declares no permissions.
+        </p>
+      )}
+      {!isPending && !isError && owned.length > 0 && (
+        <ul className="space-y-1.5">
+          {owned.map(entry => (
+            <li key={entry.id} className="text-sm text-foreground">
+              {entry.name || `${entry.action}-${entry.resource}`}
+              {entry.danger === true && (
+                <span className="ml-2 text-xs text-muted-foreground">
+                  danger
+                </span>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
 function Contributions({ plugin }: { plugin: PluginMetadata }) {
   const enabled = plugin.enabled !== false;
 
@@ -431,7 +509,9 @@ function Contributions({ plugin }: { plugin: PluginMetadata }) {
     },
   ].filter(group => group.items.length > 0);
 
-  if (groups.length === 0) return null;
+  // NOT `groups.length === 0`: permissions come from their own query now, so a
+  // plugin whose only contribution is a permission would have had the whole
+  // section removed by a check that cannot see them.
 
   return (
     <section className="mb-8">
@@ -504,6 +584,7 @@ function Contributions({ plugin }: { plugin: PluginMetadata }) {
             </ul>
           </div>
         ))}
+        <PluginPermissions pluginName={plugin.name} />
       </div>
     </section>
   );

--- a/packages/admin/src/pages/dashboard/plugins/[slug].tsx
+++ b/packages/admin/src/pages/dashboard/plugins/[slug].tsx
@@ -40,7 +40,10 @@ import { API_PATH_PREFIX } from "@admin/lib/api/fetcher";
 import { categoryLabel } from "@admin/lib/plugins/plugin-categories";
 import { pluginSlug } from "@admin/lib/plugins/plugin-slug";
 import { staticRegistrySource } from "@admin/lib/plugins/registry/static-source";
-import { fetchPermissionsFromApi } from "@admin/services/realPermissionsApi";
+import {
+  type ApiPermissionEntry,
+  fetchPermissionsFromApi,
+} from "@admin/services/realPermissionsApi";
 import type { PluginMetadata } from "@admin/types/branding";
 
 import { NotInstalledPlugin } from "./components/NotInstalledPlugin";
@@ -387,16 +390,67 @@ interface ContributionGroup {
  * Its own query rather than a suspending one, so a caller without the roles
  * read permission degrades THIS card instead of the page.
  */
+/** Retries left to a failure that says nothing about this viewer's access. */
+const DEFAULT_QUERY_RETRIES = 2;
+
+/** Rows per request. The endpoint caps a page; the loop below spans them. */
+const PERMISSION_PAGE_SIZE = 200;
+
+/**
+ * Whether an error is the server REFUSING rather than failing.
+ *
+ * A refusal is an answer about this viewer and repeating it changes nothing. A
+ * network error or a 5xx is the absence of an answer, and the two must not
+ * share a branch: conflating them suppresses the retry that would have
+ * recovered the second, and reports missing permissions to someone who has
+ * them.
+ */
+function isAccessDenial(error: unknown): boolean {
+  const status = (error as { status?: unknown } | null)?.status;
+  return status === 401 || status === 403;
+}
+
+/**
+ * Every permission row, across pages.
+ *
+ * The endpoint sorts globally by resource, so ONE plugin's rows are scattered
+ * rather than grouped — a single page filtered by owner therefore omits rows
+ * silently, and reports "none" for a plugin whose rows all sort late. Paging is
+ * what makes the owner filter answer about the whole set.
+ */
+async function fetchAllPermissions(): Promise<ApiPermissionEntry[]> {
+  const first = await fetchPermissionsFromApi({
+    limit: PERMISSION_PAGE_SIZE,
+    page: 1,
+  });
+  const rows = [...first.data];
+  // Bounded by the total the server reported, and re-read from each response,
+  // so a shrinking result set cannot spin here.
+  for (let page = 2; page <= (first.meta?.totalPages ?? 1); page += 1) {
+    const next = await fetchPermissionsFromApi({
+      limit: PERMISSION_PAGE_SIZE,
+      page,
+    });
+    if (next.data.length === 0) break;
+    rows.push(...next.data);
+  }
+  return rows;
+}
+
 function PluginPermissions({ pluginName }: { pluginName: string }) {
-  const { data, isPending, isError } = useQuery({
+  const { data, isPending, isError, error } = useQuery({
     queryKey: ["plugin-permissions", pluginName],
-    queryFn: () => fetchPermissionsFromApi({ limit: 200 }),
-    // A refusal is an answer about this viewer's access, not a transient
-    // failure, so retrying it only delays the message.
-    retry: false,
+    queryFn: () => fetchAllPermissions(),
+    // Only a DENIAL is an answer about this viewer, so only a denial stops the
+    // retries. A network failure or a 5xx says nothing about access, and
+    // treating it as one both skips the retry that would have recovered it and
+    // tells the viewer they lack a permission they may well hold.
+    retry: (failureCount, err) =>
+      !isAccessDenial(err) && failureCount < DEFAULT_QUERY_RETRIES,
   });
 
-  const owned = (data?.data ?? []).filter(entry => entry.owner === pluginName);
+  const denied = isError && isAccessDenial(error);
+  const owned = (data ?? []).filter(entry => entry.owner === pluginName);
 
   // Rendered even when empty, unlike the configuration-fed groups beside it.
   // An absent section reads as "this plugin declares none", which is a claim
@@ -410,15 +464,21 @@ function PluginPermissions({ pluginName }: { pluginName: string }) {
       {isPending && (
         <p className="text-xs text-muted-foreground">Loading permissions…</p>
       )}
-      {isError && (
+      {denied && (
         <p className="text-xs text-muted-foreground">
           Not available. Reading permissions needs the roles read permission, so
           this list is hidden rather than empty.
         </p>
       )}
+      {isError && !denied && (
+        <p className="text-xs text-muted-foreground">
+          Could not load permissions. This is a failure to ask, not an answer —
+          the plugin may well own some.
+        </p>
+      )}
       {!isPending && !isError && owned.length === 0 && (
         <p className="text-xs text-muted-foreground">
-          This plugin declares no permissions.
+          No permission rows are attributed to this plugin.
         </p>
       )}
       {!isPending && !isError && owned.length > 0 && (

--- a/packages/admin/src/pages/dashboard/plugins/[slug].tsx
+++ b/packages/admin/src/pages/dashboard/plugins/[slug].tsx
@@ -20,6 +20,7 @@ import {
   Package,
   Route,
   Settings as SettingsIcon,
+  Shield,
 } from "@admin/components/icons";
 import { PageContainer } from "@admin/components/layout/page-container";
 import { Breadcrumbs } from "@admin/components/shared";

--- a/packages/admin/src/pages/dashboard/plugins/plugin-detail.test.tsx
+++ b/packages/admin/src/pages/dashboard/plugins/plugin-detail.test.tsx
@@ -67,18 +67,31 @@ const plugins: PluginMetadata[] = [
 
 // The permissions card reads the SEEDED ROWS from the authenticated endpoint,
 // so a test rendering the page supplies that answer rather than the network.
-const permissionRows = vi.hoisted(() => ({ current: [] as unknown[] }));
+// `pageSize` is what makes the loop observable: with it below the row count
+// the endpoint answers in several pages, exactly as the real one does past its
+// cap, and a card reading only page one omits whatever sorts late.
+const permissionRows = vi.hoisted(() => ({
+  current: [] as unknown[],
+  pageSize: 200,
+}));
 vi.mock("@admin/services/realPermissionsApi", () => ({
-  fetchPermissionsFromApi: () =>
-    Promise.resolve({
-      data: permissionRows.current,
+  fetchPermissionsFromApi: (options?: { page?: number }) => {
+    const size = permissionRows.pageSize;
+    const page = options?.page ?? 1;
+    const start = (page - 1) * size;
+    return Promise.resolve({
+      data: permissionRows.current.slice(start, start + size),
       meta: {
         total: permissionRows.current.length,
-        page: 1,
-        limit: 200,
-        totalPages: 1,
+        page,
+        limit: size,
+        totalPages: Math.max(
+          1,
+          Math.ceil(permissionRows.current.length / size)
+        ),
       },
-    }),
+    });
+  },
 }));
 
 vi.mock("@admin/context/providers/BrandingProvider", () => ({
@@ -128,6 +141,27 @@ const seededRows = [
 
 beforeEach(() => {
   permissionRows.current = seededRows;
+  permissionRows.pageSize = 200;
+});
+
+/**
+ * The endpoint sorts globally by resource, so one plugin's rows are scattered
+ * across pages rather than grouped. A card reading only the first page filters
+ * a partial set and reports "none" for a plugin whose rows all sort late —
+ * which is indistinguishable from a plugin that genuinely owns none.
+ *
+ * `pageSize: 1` puts the target row on page two, so this fails against any
+ * implementation that does not follow `totalPages`.
+ */
+describe("PluginDetailPage permissions across pages", () => {
+  it("finds a plugin's rows when they fall beyond the first page", async () => {
+    permissionRows.pageSize = 1;
+    // seededRows[1] is the @acme/disabled row, so page one holds only the
+    // @acme/forms one and the target is reachable only by paging.
+    renderPage("acme-disabled");
+
+    expect(await screen.findByText("Purge Archive")).toBeInTheDocument();
+  });
 });
 
 function renderPage(slug: string) {

--- a/packages/admin/src/pages/dashboard/plugins/plugin-detail.test.tsx
+++ b/packages/admin/src/pages/dashboard/plugins/plugin-detail.test.tsx
@@ -23,14 +23,6 @@ const plugins: PluginMetadata[] = [
     collections: ["forms", "form-submissions"],
     singles: ["form-settings"],
     menu: [{ label: "All Forms", to: "/admin/collections/forms" }],
-    permissions: [
-      {
-        action: "export",
-        resource: "submissions",
-        label: "Export Submissions",
-        danger: true,
-      },
-    ],
     routes: [
       {
         method: "GET",
@@ -45,14 +37,6 @@ const plugins: PluginMetadata[] = [
     enabled: false,
     placement: "plugins",
     collections: ["retained"],
-    permissions: [
-      {
-        action: "purge",
-        resource: "archive",
-        label: "Purge Archive",
-        danger: true,
-      },
-    ],
     whenEnabled: {
       routes: [
         {

--- a/packages/admin/src/pages/dashboard/plugins/plugin-detail.test.tsx
+++ b/packages/admin/src/pages/dashboard/plugins/plugin-detail.test.tsx
@@ -1,6 +1,6 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, screen, within } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { PluginMetadata } from "@admin/types/branding";
 
@@ -65,6 +65,22 @@ const plugins: PluginMetadata[] = [
   },
 ];
 
+// The permissions card reads the SEEDED ROWS from the authenticated endpoint,
+// so a test rendering the page supplies that answer rather than the network.
+const permissionRows = vi.hoisted(() => ({ current: [] as unknown[] }));
+vi.mock("@admin/services/realPermissionsApi", () => ({
+  fetchPermissionsFromApi: () =>
+    Promise.resolve({
+      data: permissionRows.current,
+      meta: {
+        total: permissionRows.current.length,
+        page: 1,
+        limit: 200,
+        totalPages: 1,
+      },
+    }),
+}));
+
 vi.mock("@admin/context/providers/BrandingProvider", () => ({
   useBranding: () => ({ plugins }),
   // Settled with an answer, so a slug missing from `plugins` really is absent.
@@ -77,13 +93,61 @@ vi.mock("@admin/context/providers/BrandingProvider", () => ({
  * contributes — its permissions and API routes included — stays in the main
  * column, visible without an interaction rather than behind one.
  */
+/**
+ * Supplies the QueryClient the permissions card needs. That card reads rows
+ * from the API rather than the branding payload, so rendering the page is a
+ * query even when nothing on screen is loading.
+ */
+/**
+ * Rows as the seeder writes them. `owner` is the DECLARING PLUGIN NAME, which
+ * is what attributes a permission to a plugin — the resource string cannot,
+ * because a plugin names its own resources.
+ */
+const seededRows = [
+  {
+    id: "p1",
+    name: "Export Submissions",
+    slug: "submissions.export",
+    action: "export",
+    resource: "submissions",
+    description: null,
+    owner: "@acme/forms",
+    danger: true,
+  },
+  {
+    id: "p2",
+    name: "Purge Archive",
+    slug: "archive.purge",
+    action: "purge",
+    resource: "archive",
+    description: null,
+    owner: "@acme/disabled",
+    danger: true,
+  },
+];
+
+beforeEach(() => {
+  permissionRows.current = seededRows;
+});
+
+function renderPage(slug: string) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={client}>
+      <PluginDetailPage params={{ slug }} />
+    </QueryClientProvider>
+  );
+}
+
 describe("PluginDetailPage layout", () => {
   function rail() {
     return screen.getByRole("complementary", { name: "About @acme/forms" });
   }
 
   it("puts the metadata in a rail and the contributions outside it", () => {
-    render(<PluginDetailPage params={{ slug: "acme-forms" }} />);
+    renderPage("acme-forms");
 
     const aside = rail();
     // In the rail: the About metadata.
@@ -106,7 +170,7 @@ describe("PluginDetailPage layout", () => {
    * at window widths where the page has no room for it.
    */
   it("gives the rail the classes that let it stick", () => {
-    render(<PluginDetailPage params={{ slug: "acme-forms" }} />);
+    renderPage("acme-forms");
 
     const className = rail().className;
     expect(className).toContain("@3xl/content:sticky");
@@ -116,7 +180,7 @@ describe("PluginDetailPage layout", () => {
 
 describe("PluginDetailPage", () => {
   it("renders the identity header with version, status, category, and author", () => {
-    render(<PluginDetailPage params={{ slug: "acme-forms" }} />);
+    renderPage("acme-forms");
     expect(
       screen.getByRole("heading", { name: "@acme/forms" })
     ).toBeInTheDocument();
@@ -127,7 +191,7 @@ describe("PluginDetailPage", () => {
   });
 
   it("links homepage, repository — external links open in a new tab", () => {
-    render(<PluginDetailPage params={{ slug: "acme-forms" }} />);
+    renderPage("acme-forms");
     const homepage = screen.getByRole("link", { name: /Homepage/ });
     expect(homepage).toHaveAttribute("href", "https://acme.dev");
     expect(homepage).toHaveAttribute("target", "_blank");
@@ -138,8 +202,8 @@ describe("PluginDetailPage", () => {
     );
   });
 
-  it("lists what the plugin adds, computed from its registrations", () => {
-    render(<PluginDetailPage params={{ slug: "acme-forms" }} />);
+  it("lists what the plugin adds, computed from its registrations", async () => {
+    renderPage("acme-forms");
     expect(screen.getByText("What this plugin adds")).toBeInTheDocument();
     // Collections group with both slugs; the collection links to its list page.
     expect(screen.getByRole("link", { name: "forms" })).toHaveAttribute(
@@ -148,9 +212,10 @@ describe("PluginDetailPage", () => {
     );
     expect(screen.getByText("form-submissions")).toBeInTheDocument();
     expect(screen.getByText("form-settings")).toBeInTheDocument();
-    // Permissions are deliberately absent: the public payload no longer
-    // carries them, so nothing here can render one.
-    expect(screen.queryByText("Export Submissions")).toBeNull();
+    // Permissions are AWAITED: they come from the authenticated rows endpoint
+    // rather than the branding payload, so they arrive after the first paint.
+    expect(await screen.findByText("Export Submissions")).toBeInTheDocument();
+    expect(screen.getByText("danger")).toBeInTheDocument();
     // Route summary includes the namespaced final URL.
     expect(
       screen.getByText("GET /admin/api/plugins/@acme/forms/submissions/export")
@@ -158,14 +223,14 @@ describe("PluginDetailPage", () => {
   });
 
   it("shows the About rows including license and dependencies", () => {
-    render(<PluginDetailPage params={{ slug: "acme-forms" }} />);
+    renderPage("acme-forms");
     expect(screen.getByText("License")).toBeInTheDocument();
     expect(screen.getByText("MIT")).toBeInTheDocument();
     expect(screen.getByText("@acme/core ^1.0.0")).toBeInTheDocument();
   });
 
   it("marks a disabled plugin and names the surfaces that stop", () => {
-    render(<PluginDetailPage params={{ slug: "acme-disabled" }} />);
+    renderPage("acme-disabled");
     expect(screen.getByText("Disabled")).toBeInTheDocument();
     expect(
       screen.getByText(
@@ -200,7 +265,7 @@ describe("PluginDetailPage", () => {
  */
 describe("PluginDetailPage dormant disclosure", () => {
   it("shows a disabled plugin's routes under their own heading", () => {
-    render(<PluginDetailPage params={{ slug: "acme-disabled" }} />);
+    renderPage("acme-disabled");
 
     expect(screen.getByText("Would serve when enabled")).toBeInTheDocument();
     // Enabling in config is necessary and NOT sufficient: config HMR does not
@@ -221,7 +286,7 @@ describe("PluginDetailPage dormant disclosure", () => {
    * pass a presence-only check.
    */
   it("keeps them out of what the plugin currently adds", () => {
-    render(<PluginDetailPage params={{ slug: "acme-disabled" }} />);
+    renderPage("acme-disabled");
 
     const contributions = screen
       .getByText("What this plugin adds")
@@ -231,7 +296,7 @@ describe("PluginDetailPage dormant disclosure", () => {
   });
 
   it("shows no dormant section for an enabled plugin", () => {
-    render(<PluginDetailPage params={{ slug: "acme-forms" }} />);
+    renderPage("acme-forms");
 
     // The enabled fixture declares a route, so this asserts the section is
     // withheld rather than that there was nothing to show.
@@ -245,7 +310,7 @@ describe("PluginDetailPage dormant disclosure", () => {
    * whose name has a scope — which is all three first-party ones.
    */
   it("names the dispatcher's namespace for an enabled plugin's routes", () => {
-    render(<PluginDetailPage params={{ slug: "acme-forms" }} />);
+    renderPage("acme-forms");
 
     expect(
       screen.getByText("GET /admin/api/plugins/@acme/forms/submissions/export")
@@ -257,18 +322,32 @@ describe("PluginDetailPage dormant disclosure", () => {
  * A disabled plugin keeps its schema and its grants; only its routes stop
  * being mounted. These pin that split.
  *
- * The rendering half of the permissions case is gone with the public
- * payload's permission fields: the page receives none, so there is nothing
- * left to assert renders. What the page still SAYS about grants surviving a
- * disable is covered below, and that sentence is what the split needs.
+ * The permissions half is read from the authenticated rows endpoint rather
+ * than the public payload, so it is AWAITED here while the routes half is
+ * synchronous. Both are still asserted on one plugin, which is what makes
+ * the split observable.
  */
 describe("PluginDetailPage disabled plugin permissions", () => {
+  it("lists a disabled plugin's permissions as things it has", async () => {
+    renderPage("acme-disabled");
+
+    // Awaited for the same reason: the rows arrive from the API, not from the
+    // branding payload the rest of this section reads.
+    expect(await screen.findByText("Purge Archive")).toBeInTheDocument();
+    const contributions = screen
+      .getByText("What this plugin adds")
+      .closest("section");
+    expect(
+      within(contributions!).getByText("Purge Archive")
+    ).toBeInTheDocument();
+  });
+
   /**
    * The separating assertion. If the enabled flag simply stopped mattering,
    * routes would show here too — they must not, because they are not mounted.
    */
   it("still withholds a disabled plugin's routes from that section", () => {
-    render(<PluginDetailPage params={{ slug: "acme-disabled" }} />);
+    renderPage("acme-disabled");
 
     const contributions = screen
       .getByText("What this plugin adds")
@@ -279,7 +358,7 @@ describe("PluginDetailPage disabled plugin permissions", () => {
   });
 
   it("says the permissions stay granted while the plugin is off", () => {
-    render(<PluginDetailPage params={{ slug: "acme-disabled" }} />);
+    renderPage("acme-disabled");
 
     expect(screen.getByText(/permissions stay granted/i)).toBeInTheDocument();
   });
@@ -292,7 +371,7 @@ describe("PluginDetailPage disabled plugin permissions", () => {
    * this cannot pass by the whole paragraph having gone missing.
    */
   it("does not claim everything the permissions protect is unloaded", () => {
-    render(<PluginDetailPage params={{ slug: "acme-disabled" }} />);
+    renderPage("acme-disabled");
 
     expect(
       screen.getByText(/field editors it contributes stay available/i)

--- a/packages/admin/src/services/permissionApi.ts
+++ b/packages/admin/src/services/permissionApi.ts
@@ -5,17 +5,12 @@ import { fetcher } from "../lib/api/fetcher";
 import type { MutationResponse } from "../lib/api/response-types";
 import type { Permission } from "../types/entities";
 
-/**
- * Real permission entry shape returned by the backend API.
- */
-interface ApiPermissionEntry {
-  id: string;
-  name: string;
-  slug: string;
-  action: string;
-  resource: string;
-  description: string | null;
-}
+// One declaration for one endpoint. A second copy agreed with the first on the
+// day it was written and then diverged: `owner`, `permissionGroup` and `danger`
+// cross the wire, and neither local copy admitted they existed — so a consumer
+// reading the type could not see the field that decides which plugin a
+// permission belongs to.
+import type { ApiPermissionEntry } from "./realPermissionsApi";
 
 /**
  * Map a backend permission entry to the admin Permission entity shape.

--- a/packages/admin/src/services/permissionApi.ts
+++ b/packages/admin/src/services/permissionApi.ts
@@ -5,11 +5,10 @@ import { fetcher } from "../lib/api/fetcher";
 import type { MutationResponse } from "../lib/api/response-types";
 import type { Permission } from "../types/entities";
 
-// One declaration for one endpoint. A second copy agreed with the first on the
-// day it was written and then diverged: `owner`, `permissionGroup` and `danger`
-// cross the wire, and neither local copy admitted they existed — so a consumer
-// reading the type could not see the field that decides which plugin a
-// permission belongs to.
+// The wire shape is declared once, in the module that performs the request.
+// `owner` is the field that decides which plugin a permission belongs to, and
+// it arrives alongside `group`, `orphaned` and `danger`; a second local copy of
+// the interface would be free to omit any of them while still compiling.
 import type { ApiPermissionEntry } from "./realPermissionsApi";
 
 /**

--- a/packages/admin/src/services/permissionApi.ts
+++ b/packages/admin/src/services/permissionApi.ts
@@ -9,12 +9,12 @@ import type { Permission } from "../types/entities";
 // `owner` is the field that decides which plugin a permission belongs to, and
 // it arrives alongside `group`, `orphaned` and `danger`; a second local copy of
 // the interface would be free to omit any of them while still compiling.
-import type { ApiPermissionEntry } from "./realPermissionsApi";
+import type { ApiPermissionBase } from "./realPermissionsApi";
 
 /**
  * Map a backend permission entry to the admin Permission entity shape.
  */
-function toPermission(entry: ApiPermissionEntry): Permission {
+function toPermission(entry: ApiPermissionBase): Permission {
   return {
     id: entry.id,
     name: entry.name,
@@ -47,7 +47,7 @@ export const fetchPermissions = async (
   const query = buildQuery(params);
   const url = `/permissions${query ? `?${query}` : ""}`;
 
-  const result = await fetcher<ListResponse<ApiPermissionEntry>>(url, {}, true);
+  const result = await fetcher<ListResponse<ApiPermissionBase>>(url, {}, true);
 
   return {
     items: (result.items ?? []).map(toPermission),
@@ -61,7 +61,7 @@ export const fetchPermissions = async (
 export const getPermissionById = async (
   permissionId: string
 ): Promise<Permission> => {
-  const result = await fetcher<ApiPermissionEntry>(
+  const result = await fetcher<ApiPermissionBase>(
     `/permissions/${permissionId}`,
     {},
     true
@@ -79,7 +79,7 @@ export const updatePermission = async (
   permissionId: string,
   updates: Partial<Permission>
 ): Promise<Permission> => {
-  await fetcher<MutationResponse<ApiPermissionEntry>>(
+  await fetcher<MutationResponse<ApiPermissionBase>>(
     `/permissions/${permissionId}`,
     {
       method: "PATCH",
@@ -97,7 +97,7 @@ export const updatePermission = async (
  * response body.
  */
 export const deletePermission = async (permissionId: string): Promise<void> => {
-  await fetcher<MutationResponse<ApiPermissionEntry>>(
+  await fetcher<MutationResponse<ApiPermissionBase>>(
     `/permissions/${permissionId}`,
     { method: "DELETE" },
     true

--- a/packages/admin/src/services/realPermissionsApi.ts
+++ b/packages/admin/src/services/realPermissionsApi.ts
@@ -12,6 +12,22 @@ export interface ApiPermissionEntry {
   action: string;
   resource: string;
   description: string | null;
+  /**
+   * The plugin that owns this permission, or null for one the seeder owns.
+   *
+   * Provenance rather than a naming convention: a plugin names its own
+   * resource, so a permission cannot be attributed by inspecting its resource
+   * string. This is the field that decides which plugin a permission belongs
+   * to, and it is what the rows record — as opposed to what a configuration
+   * declares, which cannot see Schema Builder entities at all.
+   */
+  owner?: string | null;
+  /** Heading within the owner's section, when the owner set one. */
+  permissionGroup?: string | null;
+  /** Marked by the seeder when the declaration that created it disappeared. */
+  orphanedAt?: string | null;
+  /** Declared destructive by whoever contributed it. */
+  danger?: boolean;
 }
 
 // Canonical pagination meta is { total, page, limit, totalPages, hasNext,

--- a/packages/admin/src/services/realPermissionsApi.ts
+++ b/packages/admin/src/services/realPermissionsApi.ts
@@ -21,13 +21,23 @@ export interface ApiPermissionEntry {
    * to, and it is what the rows record — as opposed to what a configuration
    * declares, which cannot see Schema Builder entities at all.
    */
-  owner?: string | null;
-  /** Heading within the owner's section, when the owner set one. */
-  permissionGroup?: string | null;
-  /** Marked by the seeder when the declaration that created it disappeared. */
-  orphanedAt?: string | null;
-  /** Declared destructive by whoever contributed it. */
-  danger?: boolean;
+  owner: string | null;
+  /**
+   * Heading within the owner's section; null when the owner set none.
+   *
+   * Named for the field the endpoint SERIALIZES. `PermissionService`
+   * `listPermissions` maps its columns to `group` and `orphaned` and returns
+   * that result directly, so a DTO naming the column instead would declare
+   * properties that never cross the wire — always `undefined` at runtime, while
+   * hiding the ones that do arrive.
+   */
+  group: string | null;
+  /** True once the declaring package stopped declaring it. */
+  orphaned: boolean;
+  /** True for a permission the admin should warn before granting. */
+  danger: boolean;
+  /** Grouping label the settings page reads; absent unless the row sets one. */
+  category?: string;
 }
 
 // Canonical pagination meta is { total, page, limit, totalPages, hasNext,

--- a/packages/admin/src/services/realPermissionsApi.ts
+++ b/packages/admin/src/services/realPermissionsApi.ts
@@ -5,13 +5,34 @@ import type { ListResponse } from "../lib/api/response-types";
  * Real permission entry shape from the backend.
  * Distinct from the mock `Permission` type in `entities.ts` which is UI-specific.
  */
-export interface ApiPermissionEntry {
+/**
+ * The fields EVERY permission response carries.
+ *
+ * `getPermissionById` selects exactly these plus `category`, so a consumer of
+ * a single permission may rely on them and on nothing else. The list rows carry
+ * more, and {@link ApiPermissionEntry} derives from this rather than restating
+ * it — one shape declared once, widened where the wire is actually wider.
+ */
+export interface ApiPermissionBase {
   id: string;
   name: string;
   slug: string;
   action: string;
   resource: string;
   description: string | null;
+  /** Grouping label the settings page reads; absent unless the row sets one. */
+  category?: string;
+}
+
+/**
+ * A row from the permission LIST endpoint.
+ *
+ * The extra members are list-only: `PermissionService.listPermissions` joins
+ * and maps them, while `getPermissionById` selects the base columns alone. A
+ * single type covering both would promise these on a response that never
+ * carries them — `undefined` at runtime behind a type that says otherwise.
+ */
+export interface ApiPermissionEntry extends ApiPermissionBase {
   /**
    * The plugin that owns this permission, or null for one the seeder owns.
    *
@@ -36,8 +57,6 @@ export interface ApiPermissionEntry {
   orphaned: boolean;
   /** True for a permission the admin should warn before granting. */
   danger: boolean;
-  /** Grouping label the settings page reads; absent unless the row sets one. */
-  category?: string;
 }
 
 // Canonical pagination meta is { total, page, limit, totalPages, hasNext,

--- a/packages/nextly/src/domains/auth/services/permission-service.ts
+++ b/packages/nextly/src/domains/auth/services/permission-service.ts
@@ -209,22 +209,32 @@ export class PermissionService extends BaseService {
       const whereClause =
         conditions.length > 0 ? and(...conditions) : undefined;
 
-      let orderByClause;
+      let sortColumn;
       const orderFn = sortOrder === "asc" ? asc : desc;
 
       switch (sortBy) {
         case "name":
-          orderByClause = orderFn(permissions.name);
+          sortColumn = permissions.name;
           break;
         case "action":
-          orderByClause = orderFn(permissions.action);
+          sortColumn = permissions.action;
           break;
         case "resource":
-          orderByClause = orderFn(permissions.resource);
+          sortColumn = permissions.resource;
           break;
         default:
-          orderByClause = orderFn(permissions.resource);
+          sortColumn = permissions.resource;
       }
+
+      // `id` breaks ties, and it is what makes OFFSET paging sound rather than
+      // tidy. None of the sortable columns is unique, so rows sharing a value
+      // have no defined order between pages: the engine may place a tied row
+      // after the boundary on one request and before it on the next, which
+      // DUPLICATES that row on one page and DROPS a different one from the
+      // other. A caller walking every page then sees neither the total it was
+      // promised nor a stable set, and the loss is silent because each page is
+      // individually well formed.
+      const orderByClause = [orderFn(sortColumn), asc(permissions.id)];
 
       const offset = (page - 1) * limit;
 
@@ -250,7 +260,7 @@ export class PermissionService extends BaseService {
         })
         .from(permissions)
         .where(whereClause)
-        .orderBy(orderByClause)
+        .orderBy(...orderByClause)
         .limit(limit)
         .offset(offset);
 

--- a/packages/nextly/src/plugins/validate-slugs.test.ts
+++ b/packages/nextly/src/plugins/validate-slugs.test.ts
@@ -114,8 +114,7 @@ describe("buildPluginAdminMeta", () => {
   it("addresses plugins whose slugs differ", () => {
     const meta = buildPluginAdminMeta(
       [plugin("@acme/one"), plugin("@acme/two")],
-      undefined,
-      []
+      undefined
     );
 
     // The positive control: it really does produce metadata for both, so the
@@ -129,8 +128,7 @@ describe("buildPluginAdminMeta", () => {
     try {
       buildPluginAdminMeta(
         [plugin("@acme/plugin-seo"), plugin("acme_plugin_seo")],
-        undefined,
-        []
+        undefined
       );
     } catch (error) {
       reason = (error as { logContext?: { reason?: string } }).logContext


### PR DESCRIPTION
Completes the pair with #823. That PR stopped serving plugins' declared permissions on the unauthenticated `/api/admin-meta` payload and removed the detail page's Permissions section with it. This restores the section from the **authenticated** permissions endpoint.

## Why the rows and not the declarations

They are different sets, and the rows are the truthful one. `collectCustomPermissions` DROPS a `publish`/`unpublish` declaration whose resource is a collection or single, because the seeder emits that slug itself and keeps the row ownerless. A page fed from declarations therefore lists permissions that no row backs, and an operator following one finds nothing to grant.

The rows also cover what the config cannot see at all: a Schema Builder collection lives in `dynamic_collections`, so a declaration naming one is invisible to any config-time fold.

`rbac.listPermissions` already exists and already returns `owner`, so this is a derivation rather than a new endpoint. `owner` is what decides attribution — a plugin names its own resource, so a permission cannot be attributed by inspecting the resource string.

## Changes

- `realPermissionsApi.ts` — `ApiPermissionEntry` widened with the fields the rows carry (`owner`, `permissionGroup`, `orphanedAt`, `danger`).
- `permissionApi.ts` — its local duplicate of that interface deleted; it now imports the one declaration. The wire-to-UI adapter (`toPermission`) stays, because the UI model is a different shape from the payload and that boundary is deliberate.
- `[slug].tsx` — a `PluginPermissions` component querying the endpoint and filtering on `entry.owner === pluginName`, with distinct pending / error / empty / list states.
- `retry: false` on that query: a permissions read that fails should say so rather than retry silently behind a spinner.
- The groups guard changed from `if (groups.length === 0) return null` so a plugin whose only contribution is permissions is no longer hidden entirely.

## One behaviour worth calling out

An **empty** result and a **failed** request now render differently. Previously both produced an absent section, which is the shape this repo keeps getting bitten by — "nothing there" and "nobody could look" rendering identically.

## Verification

- `src/pages/dashboard/plugins/` — 43 pass across 4 files.
- The suite mocks `fetchPermissionsFromApi` and seeds rows owned by `@acme/forms` and `@acme/disabled`, so the filter is exercised rather than assumed; two assertions became async because the rows now arrive after first paint.
- Rebased onto `main` after #823 merged. The rebase produced a conflict in the test file, resolved to this branch's side, **and then a clean rebase still shipped broken code**: #823 removed the `Shield` import along with its section, this branch re-adds a section that uses it, and git reported no conflict on that hunk. Every plugin-page test failed with `ReferenceError: Shield is not defined` until `f2c1472b4`. Running the suite is what caught it; the merge was textually clean.
- Build and eslint clean on a built tree.

## Not in scope

`requiredPermission` on contributed menu items, pages and widgets still reaches anonymous callers through the same public payload — filed separately, with the measurement showing why deleting the field fails OPEN rather than closed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added plugin permission details to the contributions section.
  * Permissions now load across multiple pages and are filtered by the declaring plugin.
  * Added clear loading, empty, access-denied, and error states.
  * Contributions remain visible when a plugin has permissions but no other contributions.

* **Bug Fixes**
  * Permission details are now correctly shown for enabled and disabled plugins, while restricted routes remain protected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->