### PR TITLE
fix(admin): drop the plugin fixtures that outlived the permissions payload

### DIFF
--- a/packages/admin/src/pages/dashboard/plugins/plugin-detail.test.tsx
+++ b/packages/admin/src/pages/dashboard/plugins/plugin-detail.test.tsx
@@ -23,14 +23,6 @@ const plugins: PluginMetadata[] = [
     collections: ["forms", "form-submissions"],
     singles: ["form-settings"],
     menu: [{ label: "All Forms", to: "/admin/collections/forms" }],
-    permissions: [
-      {
-        action: "export",
-        resource: "submissions",
-        label: "Export Submissions",
-        danger: true,
-      },
-    ],
     routes: [
       {
         method: "GET",
@@ -45,14 +37,6 @@ const plugins: PluginMetadata[] = [
     enabled: false,
     placement: "plugins",
     collections: ["retained"],
-    permissions: [
-      {
-        action: "purge",
-        resource: "archive",
-        label: "Purge Archive",
-        danger: true,
-      },
-    ],
     whenEnabled: {
       routes: [
         {

--- a/packages/admin/src/pages/dashboard/plugins/plugin-detail.test.tsx
+++ b/packages/admin/src/pages/dashboard/plugins/plugin-detail.test.tsx
@@ -58,8 +58,14 @@ vi.mock("@admin/context/providers/BrandingProvider", () => ({
 /**
  * The page is two columns with a sticky metadata rail. What these pin is where
  * each half lives: the metadata sits in the rail, and what the plugin
- * contributes — its permissions and API routes included — stays in the main
- * column, visible without an interaction rather than behind one.
+ * contributes stays in the main column, visible without an interaction rather
+ * than behind one.
+ *
+ * Permissions are not among what this suite pins. They are no longer on the
+ * payload these fixtures supply, so an assertion here would pass on absence
+ * rather than on the page's behaviour; that the serializer withholds them is
+ * covered in `packages/nextly/src/plugins/admin-meta.test.ts`, against a
+ * plugin that DECLARES one.
  */
 describe("PluginDetailPage layout", () => {
   function rail() {
@@ -132,9 +138,6 @@ describe("PluginDetailPage", () => {
     );
     expect(screen.getByText("form-submissions")).toBeInTheDocument();
     expect(screen.getByText("form-settings")).toBeInTheDocument();
-    // Permissions are deliberately absent: the public payload no longer
-    // carries them, so nothing here can render one.
-    expect(screen.queryByText("Export Submissions")).toBeNull();
     // Route summary includes the namespaced final URL.
     expect(
       screen.getByText("GET /admin/api/plugins/@acme/forms/submissions/export")

--- a/packages/nextly/src/plugins/validate-slugs.test.ts
+++ b/packages/nextly/src/plugins/validate-slugs.test.ts
@@ -114,8 +114,7 @@ describe("buildPluginAdminMeta", () => {
   it("addresses plugins whose slugs differ", () => {
     const meta = buildPluginAdminMeta(
       [plugin("@acme/one"), plugin("@acme/two")],
-      undefined,
-      []
+      undefined
     );
 
     // The positive control: it really does produce metadata for both, so the
@@ -129,8 +128,7 @@ describe("buildPluginAdminMeta", () => {
     try {
       buildPluginAdminMeta(
         [plugin("@acme/plugin-seo"), plugin("acme_plugin_seo")],
-        undefined,
-        []
+        undefined
       );
     } catch (error) {
       reason = (error as { logContext?: { reason?: string } }).logContext


### PR DESCRIPTION
**`main` is red.** `check-types` fails at `524493402` (#823), which fails `Lint / Typecheck / Test / Build` and reds every PR that rebases onto it. Three dependents — `Browser tests`, `Scaffold smoke`, `Dev script` — declare `needs: [ci]` and are skipping unevaluated, so their first real execution is this push.

#823 removed `permissions` from `PluginMetadata` and dropped the third parameter of `buildPluginAdminMeta`. Two test files still used both:

```
plugin-detail.test.tsx(26,5) and (48,5)
  TS2353: 'permissions' does not exist in type 'PluginMetadata'
validate-slugs.test.ts(118,7) and (133,9)
  TS2554: Expected 2 arguments, but got 3
```

Fixed by removing the stale fixture blocks and the removed argument. No production code changes.

## How this got through, which is the useful half

I verified #823 with `pnpm build`, `vitest` and `eslint`, and **never ran `check-types`**. None of those three sees it:

- `vitest` does not typecheck — the suites passed before and after.
- the `build` I ran was `--filter @nextlyhq/admin...`, and `tsup` does not fail on a type error in a test file.
- `eslint` reported clean on every changed file.

The failing files are TESTS, and test files are typechecked only by the second config — `nextly` runs `tsc --noEmit && tsc --noEmit -p tsconfig.tests.json`. So the one gate that covers them is exactly the one I skipped. Running the package script rather than a hand-picked subset is what would have caught it, and that is already a documented rule in this repo that I did not follow.

The deeper miss: I removed a type member and checked the CALLERS I could grep for. A fixture that CONSTRUCTS the type is not a caller and does not grep the same way — the same shape as the `plugin-introspection.ts` caller in #823 that the build found rather than my search, and the `Shield` import in #826 that a clean rebase still broke. Three instances of "the search I ran does not cover the thing that breaks", in one lane, today.

## Verification

- `pnpm turbo run check-types --filter=@nextlyhq/admin --filter=nextly --force` — 2 of 2 successful. Run with `--force` so the result is of work that actually ran rather than a cache hit.
- `src/pages/dashboard/plugins/` 42 pass; `validate-slugs.test.ts` 11 pass.
- Built with dependencies first, so the typecheck is not reading a stale `dist`.