### PR TITLE
feat(ui): name the tab appearances callers were spelling by hand

### DIFF
--- a/.changeset/tabs-cva-variants.md
+++ b/.changeset/tabs-cva-variants.md
@@ -1,0 +1,28 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+Tabs gain `TabsList variant="ghost"` and `TabsTrigger size="sm"`, so the compact tab appearance is named rather than spelled out in `className` at each call site. The two call sites that hand-rolled the ghost list disagreed on its height (`h-8` and `h-7`); the variant settles it at `h-8`.

--- a/packages/admin/src/components/features/entries/APIPlayground/CodePanel.tsx
+++ b/packages/admin/src/components/features/entries/APIPlayground/CodePanel.tsx
@@ -77,9 +77,9 @@ export function CodePanel({ code }: CodePanelProps) {
     // the default should be the answer rather than the fallback.
     <Tabs defaultValue="sdk" className="flex h-full min-h-0 flex-col">
       <div className="flex shrink-0 items-center justify-between gap-2 px-6 py-2">
-        <TabsList className="h-7 bg-transparent p-0">
+        <TabsList variant="ghost">
           {FLAVOURS.map(f => (
-            <TabsTrigger key={f.value} value={f.value} className="text-xs">
+            <TabsTrigger key={f.value} value={f.value} size="sm">
               {f.label}
             </TabsTrigger>
           ))}

--- a/packages/admin/src/components/features/entries/APIPlayground/ResponseViewer.tsx
+++ b/packages/admin/src/components/features/entries/APIPlayground/ResponseViewer.tsx
@@ -117,11 +117,11 @@ export function ResponseViewer({
   return (
     <Tabs defaultValue="body" className="flex h-full min-h-0 flex-col">
       <div className="flex shrink-0 items-center justify-between gap-2 border-b border-border bg-muted/30 px-6 py-1.5">
-        <TabsList className="h-8 bg-transparent p-0">
-          <TabsTrigger value="body" className="text-xs">
+        <TabsList variant="ghost">
+          <TabsTrigger value="body" size="sm">
             Body
           </TabsTrigger>
-          <TabsTrigger value="headers" className="text-xs">
+          <TabsTrigger value="headers" size="sm">
             Headers
             {headerEntries.length > 0 && (
               <span className="ml-1.5 font-mono text-xs text-muted-foreground">
@@ -129,7 +129,7 @@ export function ResponseViewer({
               </span>
             )}
           </TabsTrigger>
-          <TabsTrigger value="code" className="text-xs">
+          <TabsTrigger value="code" size="sm">
             Code
           </TabsTrigger>
         </TabsList>

--- a/packages/ui/src/components/__tests__/tabs-variants.test.ts
+++ b/packages/ui/src/components/__tests__/tabs-variants.test.ts
@@ -16,15 +16,18 @@ import { describe, expect, it } from "vitest";
 import {
   tabsListVariants,
   tabsTriggerVariants,
-  type TabsListProps,
-  type TabsTriggerProps,
+  TABS_LIST_VARIANTS,
+  TABS_TRIGGER_SIZES,
 } from "../tabs";
+// Through the PACKAGE BARREL, which is the seam a consumer imports from and
+// the one that regressed. Taking these from `../tabs` tests the component
+// module instead, and would have stayed green while `src/index.ts` went on
+// re-exporting the Radix-only aliases — the exact defect this covers.
+import type { TabsListProps, TabsTriggerProps } from "../../index";
 
-// The PUBLIC aliases, not the component signatures. A consumer typing a wrapper
-// reaches for these, and until they were derived from the components they
-// described the Radix props alone — so `variant` and `size` were rejected on
-// the very props object the component advertises. Checked at compile time
-// because that is where the defect lived; `check-types` covers this file.
+// Checked at COMPILE time, because that is where the defect lived: the aliases
+// rejected `variant` and `size` on the very props object the component
+// advertises. `check-types` covers this file.
 const listWithVariant: TabsListProps = { variant: "ghost" };
 const triggerWithSize: TabsTriggerProps = { value: "a", size: "sm" };
 
@@ -43,16 +46,19 @@ describe("tab variants", () => {
 
     // The two call sites that hand-rolled this disagreed — `h-8` at one and
     // `h-7` at the other. One name means one height.
-    expect(ghost).toContain("bg-transparent");
     expect(ghost).toContain("h-8");
     expect(ghost).not.toContain("h-10");
   });
 
-  it("leaves the default list opaque and full height", () => {
-    const base = classesOf(tabsListVariants());
-
-    expect(base).toContain("h-10");
-    expect(base).not.toContain("bg-transparent");
+  it("separates the list variants by HEIGHT, not by opacity", () => {
+    // Stated as height because that is what actually differs. Omitting
+    // `bg-transparent` does not paint a background — a bare `div` is already
+    // transparent — so `default` is not opaque and never was, and an assertion
+    // that it is would describe a distinction the rendered tabs do not have.
+    // `ghost` carries the utility to survive a caller's `tailwind-merge`
+    // composition, which is a different property from being opaque.
+    expect(classesOf(tabsListVariants())).toContain("h-10");
+    expect(classesOf(tabsListVariants({ variant: "ghost" }))).toContain("h-8");
   });
 
   it("carries the type scale on size, and only the type scale", () => {
@@ -73,16 +79,6 @@ describe("tab variants", () => {
   });
 });
 
-/** Every class in one set and not the other, in both directions. */
-const differenceBetween = (left: string, right: string): string[] => {
-  const a = classesOf(left);
-  const b = classesOf(right);
-  return [
-    ...[...a].filter(entry => !b.has(entry)),
-    ...[...b].filter(entry => !a.has(entry)),
-  ].sort();
-};
-
 /**
  * What each variant is allowed to change, stated COMPLETELY.
  *
@@ -98,33 +94,95 @@ const differenceBetween = (left: string, right: string): string[] => {
  * however it is spelled, whatever modifier or important marker it carries —
  * appears in the difference and fails. There is no pattern to be short of.
  */
+/**
+ * What each variant is allowed to change, stated COMPLETELY, over every
+ * variant the components actually DECLARE.
+ *
+ * Two independent failures are guarded here, and they need different
+ * mechanisms:
+ *
+ * The first is a variant changing something it should not. Earlier versions
+ * classified classes — "does this look like a border or a radius utility" —
+ * and were wrong three times running: an anchored pattern missed
+ * `hover:border-b-4`, and the modifier-aware replacement still missed
+ * `!rounded-md`, bare `rounded` and `[border-radius:8px]`. Each fix bought one
+ * spelling, because Tailwind's surface is the whole language. So nothing is
+ * classified: the FULL difference from the base is pinned, and any class a
+ * variant adds appears in it whatever it is called.
+ *
+ * The second is a variant nobody remembered to check. A hand-written case
+ * table leaves a new arm silently unguarded, so the arms are read from
+ * `ALLOWED` and cross-checked against what the component reports — a variant
+ * added to the cva config without an entry here fails the exhaustiveness
+ * assertion rather than passing unexamined.
+ */
+const ALLOWED = {
+  list: {
+    // The compact list: shorter, and declaring the transparent background
+    // explicitly so a caller's own composition cannot paint over it.
+    ghost: ["bg-transparent", "h-10", "h-8"],
+  },
+  trigger: {
+    // The type scale, and nothing else.
+    sm: ["text-sm", "text-xs"],
+  },
+} as const;
+
+/** Every class in one set and not the other, in both directions. */
+const differenceBetween = (left: string, right: string): string[] => {
+  const a = classesOf(left);
+  const b = classesOf(right);
+  return [
+    ...[...a].filter(entry => !b.has(entry)),
+    ...[...b].filter(entry => !a.has(entry)),
+  ].sort();
+};
+
+/**
+ * The arms a component DECLARES, read from the same object `cva` was handed.
+ *
+ * `cva` does not expose its configuration on the returned function — measured,
+ * `Object.keys(fn)` is empty — so the arms are shared as a named declaration
+ * instead. Reading it here rather than restating the names is what makes an arm
+ * added to the component fail this file rather than pass unexamined.
+ */
+const armsOf = (declaration: Record<string, string>): string[] =>
+  Object.keys(declaration)
+    .filter(name => name !== "default")
+    .sort();
+
 describe("what a variant is allowed to change", () => {
   it.each([
+    ["list", tabsListVariants, "variant", ALLOWED.list, TABS_LIST_VARIANTS],
     [
-      "TabsList ghost",
-      tabsListVariants(),
-      tabsListVariants({ variant: "ghost" }),
-      // The compact surface-less list: shorter, and drawing no background.
-      ["bg-transparent", "h-10", "h-8"],
-    ],
-    [
-      "TabsTrigger sm",
-      tabsTriggerVariants(),
-      tabsTriggerVariants({ size: "sm" }),
-      // The type scale, and nothing else.
-      ["text-sm", "text-xs"],
+      "trigger",
+      tabsTriggerVariants,
+      "size",
+      ALLOWED.trigger,
+      TABS_TRIGGER_SIZES,
     ],
   ])(
-    "changes exactly the declared classes for %s",
-    (_n, base, variant, only) => {
-      expect(differenceBetween(base, variant)).toEqual(only);
+    "guards every declared %s variant",
+    (_n, fn, key, allowed, declaration) => {
+      // Exhaustiveness FIRST. Without this the loop below is vacuously happy
+      // about a variant that was never added to `ALLOWED`.
+      const declared = armsOf(declaration);
+      expect(declared).toEqual(Object.keys(allowed).sort());
+      expect(declared.length).toBeGreaterThan(0);
+
+      const base = (fn as (o?: Record<string, string>) => string)();
+      for (const [arm, only] of Object.entries(allowed)) {
+        const variant = (fn as (o?: Record<string, string>) => string)({
+          [key]: arm,
+        });
+        expect(differenceBetween(base, variant)).toEqual(only);
+      }
     }
   );
 
   it("keeps the square edge and the underline in the base", () => {
-    // A positive control on the assertion above, which is satisfied by two
-    // IDENTICAL sets and so proves nothing on its own about what the base
-    // actually declares.
+    // A positive control on the assertions above, which compare two resolved
+    // strings and so prove nothing on their own about what the base declares.
     const trigger = classesOf(tabsTriggerVariants());
     expect(trigger).toContain("rounded-none");
     expect(trigger).toContain("border-b-2");

--- a/packages/ui/src/components/__tests__/tabs-variants.test.ts
+++ b/packages/ui/src/components/__tests__/tabs-variants.test.ts
@@ -73,45 +73,62 @@ describe("tab variants", () => {
   });
 });
 
+/** Every class in one set and not the other, in both directions. */
+const differenceBetween = (left: string, right: string): string[] => {
+  const a = classesOf(left);
+  const b = classesOf(right);
+  return [
+    ...[...a].filter(entry => !b.has(entry)),
+    ...[...b].filter(entry => !a.has(entry)),
+  ].sort();
+};
+
 /**
- * Every class in `value` that draws the tab's edge, whatever modifier it hides
- * behind.
+ * What each variant is allowed to change, stated COMPLETELY.
  *
- * Matched with `(^|:)` rather than an anchor, because a Tailwind utility can
- * sit behind any number of variant modifiers — `hover:border-b-4`,
- * `data-[state=active]:border-b-destructive!` — and an anchored pattern reads
- * those as unrelated classes. The base itself carries three of them, so the
- * modifier form is the normal case here rather than an exotic one.
+ * Earlier versions of this file classified classes — "does this look like an
+ * edge utility" — and were wrong three times running: an anchored pattern
+ * missed `hover:border-b-4`, and the modifier-aware one still missed
+ * `!rounded-md`, bare `rounded` and `[border-radius:8px]`. Every fix bought one
+ * spelling, because Tailwind's surface is the whole language and a classifier
+ * has to keep up with it.
+ *
+ * So nothing is classified. The FULL difference between a variant and its base
+ * is pinned, which means any class a variant adds — whatever it is called,
+ * however it is spelled, whatever modifier or important marker it carries —
+ * appears in the difference and fails. There is no pattern to be short of.
  */
-const edgeClassesOf = (value: string): string[] =>
-  [...classesOf(value)]
-    .filter(entry => /(^|:)(border-b-|border-|rounded-)/.test(entry))
-    .sort();
-
-describe("the tab edge", () => {
-  // `tabs-contract.test.ts` watches CALL SITES and deliberately excludes
-  // `tabs.tsx`, so nothing but this covers the variants themselves. Stated as
-  // an equality rather than as a list of forbidden patterns: whatever the base
-  // declares is the edge, and a variant that ADDS, REMOVES or CHANGES any of it
-  // is a second way to restyle a tab regardless of how the class is spelled.
+describe("what a variant is allowed to change", () => {
   it.each([
-    ["list", tabsListVariants(), tabsListVariants({ variant: "ghost" })],
-    ["trigger", tabsTriggerVariants(), tabsTriggerVariants({ size: "sm" })],
-  ])("is identical across every %s variant", (_name, base, variant) => {
-    expect(edgeClassesOf(variant)).toEqual(edgeClassesOf(base));
-  });
+    [
+      "TabsList ghost",
+      tabsListVariants(),
+      tabsListVariants({ variant: "ghost" }),
+      // The compact surface-less list: shorter, and drawing no background.
+      ["bg-transparent", "h-10", "h-8"],
+    ],
+    [
+      "TabsTrigger sm",
+      tabsTriggerVariants(),
+      tabsTriggerVariants({ size: "sm" }),
+      // The type scale, and nothing else.
+      ["text-sm", "text-xs"],
+    ],
+  ])(
+    "changes exactly the declared classes for %s",
+    (_n, base, variant, only) => {
+      expect(differenceBetween(base, variant)).toEqual(only);
+    }
+  );
 
-  it("is drawn by the trigger base and left alone by the list", () => {
-    // A positive control on the helper itself. An equality assertion is
-    // satisfied by two empty sets, so without this the trigger case would pass
-    // if `edgeClassesOf` silently matched nothing at all.
-    expect(edgeClassesOf(tabsTriggerVariants())).toContain("border-b-2");
-    // Behind a modifier, which is the form the anchored version of this helper
-    // could not see at all.
-    expect(edgeClassesOf(tabsTriggerVariants())).toContain(
-      "data-[state=active]:border-b-primary!"
-    );
-    // The list draws no underline; its square corners are the edge it does own.
-    expect(edgeClassesOf(tabsListVariants())).toEqual(["rounded-none"]);
+  it("keeps the square edge and the underline in the base", () => {
+    // A positive control on the assertion above, which is satisfied by two
+    // IDENTICAL sets and so proves nothing on its own about what the base
+    // actually declares.
+    const trigger = classesOf(tabsTriggerVariants());
+    expect(trigger).toContain("rounded-none");
+    expect(trigger).toContain("border-b-2");
+    expect(trigger).toContain("data-[state=active]:border-b-primary!");
+    expect(classesOf(tabsListVariants())).toContain("rounded-none");
   });
 });

--- a/packages/ui/src/components/__tests__/tabs-variants.test.ts
+++ b/packages/ui/src/components/__tests__/tabs-variants.test.ts
@@ -1,0 +1,76 @@
+/**
+ * What the tab variants resolve to, and what they refuse to let a caller move.
+ *
+ * `tabs-contract.test.ts` scans CALL SITES for classes that repaint the
+ * indicator. This file asserts the other half: that the appearance those call
+ * sites used to spell by hand is now named, and that naming it did not move the
+ * parts of the tab a caller is not supposed to choose.
+ *
+ * Asserted on the variant functions rather than on rendered output, because the
+ * variants ARE the contract — a render test would additionally depend on
+ * `tailwind-merge` resolution and on jsdom, neither of which is the property
+ * here.
+ */
+import { describe, expect, it } from "vitest";
+
+import { tabsListVariants, tabsTriggerVariants } from "../tabs";
+
+/** Every class the variant resolves to, order-independent. */
+const classesOf = (value: string): Set<string> =>
+  new Set(value.split(/\s+/).filter(Boolean));
+
+describe("tab variants", () => {
+  it("gives the compact list its own name instead of two spellings", () => {
+    const ghost = classesOf(tabsListVariants({ variant: "ghost" }));
+
+    // The two call sites that hand-rolled this disagreed — `h-8` at one and
+    // `h-7` at the other. One name means one height.
+    expect(ghost).toContain("bg-transparent");
+    expect(ghost).toContain("h-8");
+    expect(ghost).not.toContain("h-10");
+  });
+
+  it("leaves the default list opaque and full height", () => {
+    const base = classesOf(tabsListVariants());
+
+    expect(base).toContain("h-10");
+    expect(base).not.toContain("bg-transparent");
+  });
+
+  it("carries the type scale on size, and only the type scale", () => {
+    const small = classesOf(tabsTriggerVariants({ size: "sm" }));
+    const base = classesOf(tabsTriggerVariants());
+
+    expect(small).toContain("text-xs");
+    expect(base).toContain("text-sm");
+
+    // The ONLY difference between the two. A size variant that also moved
+    // padding, colour or the indicator would be a second way to restyle a tab,
+    // which is what the call-site scan exists to prevent.
+    const differences = [
+      ...[...small].filter(entry => !base.has(entry)),
+      ...[...base].filter(entry => !small.has(entry)),
+    ].sort();
+    expect(differences).toEqual(["text-sm", "text-xs"]);
+  });
+
+  it("keeps the indicator out of every variant", () => {
+    // The property `tabs-contract.test.ts` watches at call sites, asserted here
+    // at the source: no variant may repaint the underline or the corners, so
+    // adding one cannot open a route the scan is not looking at.
+    for (const resolved of [
+      tabsListVariants(),
+      tabsListVariants({ variant: "ghost" }),
+      tabsTriggerVariants(),
+      tabsTriggerVariants({ size: "sm" }),
+    ]) {
+      const classes = [...classesOf(resolved)];
+      expect(classes.filter(entry => /^rounded-(?!none$)/.test(entry))).toEqual(
+        []
+      );
+      expect(classes.filter(entry => /^border-b-\d/.test(entry))).toEqual([
+        ...(resolved.includes("border-b-2") ? ["border-b-2"] : []),
+      ]);
+    }
+  });
+});

--- a/packages/ui/src/components/__tests__/tabs-variants.test.ts
+++ b/packages/ui/src/components/__tests__/tabs-variants.test.ts
@@ -13,13 +13,31 @@
  */
 import { describe, expect, it } from "vitest";
 
-import { tabsListVariants, tabsTriggerVariants } from "../tabs";
+import {
+  tabsListVariants,
+  tabsTriggerVariants,
+  type TabsListProps,
+  type TabsTriggerProps,
+} from "../tabs";
+
+// The PUBLIC aliases, not the component signatures. A consumer typing a wrapper
+// reaches for these, and until they were derived from the components they
+// described the Radix props alone — so `variant` and `size` were rejected on
+// the very props object the component advertises. Checked at compile time
+// because that is where the defect lived; `check-types` covers this file.
+const listWithVariant: TabsListProps = { variant: "ghost" };
+const triggerWithSize: TabsTriggerProps = { value: "a", size: "sm" };
 
 /** Every class the variant resolves to, order-independent. */
 const classesOf = (value: string): Set<string> =>
   new Set(value.split(/\s+/).filter(Boolean));
 
 describe("tab variants", () => {
+  it("exposes the variants on the public prop aliases", () => {
+    expect(listWithVariant.variant).toBe("ghost");
+    expect(triggerWithSize.size).toBe("sm");
+  });
+
   it("gives the compact list its own name instead of two spellings", () => {
     const ghost = classesOf(tabsListVariants({ variant: "ghost" }));
 
@@ -53,24 +71,47 @@ describe("tab variants", () => {
     ].sort();
     expect(differences).toEqual(["text-sm", "text-xs"]);
   });
+});
 
-  it("keeps the indicator out of every variant", () => {
-    // The property `tabs-contract.test.ts` watches at call sites, asserted here
-    // at the source: no variant may repaint the underline or the corners, so
-    // adding one cannot open a route the scan is not looking at.
-    for (const resolved of [
-      tabsListVariants(),
-      tabsListVariants({ variant: "ghost" }),
-      tabsTriggerVariants(),
-      tabsTriggerVariants({ size: "sm" }),
-    ]) {
-      const classes = [...classesOf(resolved)];
-      expect(classes.filter(entry => /^rounded-(?!none$)/.test(entry))).toEqual(
-        []
-      );
-      expect(classes.filter(entry => /^border-b-\d/.test(entry))).toEqual([
-        ...(resolved.includes("border-b-2") ? ["border-b-2"] : []),
-      ]);
-    }
+/**
+ * Every class in `value` that draws the tab's edge, whatever modifier it hides
+ * behind.
+ *
+ * Matched with `(^|:)` rather than an anchor, because a Tailwind utility can
+ * sit behind any number of variant modifiers — `hover:border-b-4`,
+ * `data-[state=active]:border-b-destructive!` — and an anchored pattern reads
+ * those as unrelated classes. The base itself carries three of them, so the
+ * modifier form is the normal case here rather than an exotic one.
+ */
+const edgeClassesOf = (value: string): string[] =>
+  [...classesOf(value)]
+    .filter(entry => /(^|:)(border-b-|border-|rounded-)/.test(entry))
+    .sort();
+
+describe("the tab edge", () => {
+  // `tabs-contract.test.ts` watches CALL SITES and deliberately excludes
+  // `tabs.tsx`, so nothing but this covers the variants themselves. Stated as
+  // an equality rather than as a list of forbidden patterns: whatever the base
+  // declares is the edge, and a variant that ADDS, REMOVES or CHANGES any of it
+  // is a second way to restyle a tab regardless of how the class is spelled.
+  it.each([
+    ["list", tabsListVariants(), tabsListVariants({ variant: "ghost" })],
+    ["trigger", tabsTriggerVariants(), tabsTriggerVariants({ size: "sm" })],
+  ])("is identical across every %s variant", (_name, base, variant) => {
+    expect(edgeClassesOf(variant)).toEqual(edgeClassesOf(base));
+  });
+
+  it("is drawn by the trigger base and left alone by the list", () => {
+    // A positive control on the helper itself. An equality assertion is
+    // satisfied by two empty sets, so without this the trigger case would pass
+    // if `edgeClassesOf` silently matched nothing at all.
+    expect(edgeClassesOf(tabsTriggerVariants())).toContain("border-b-2");
+    // Behind a modifier, which is the form the anchored version of this helper
+    // could not see at all.
+    expect(edgeClassesOf(tabsTriggerVariants())).toContain(
+      "data-[state=active]:border-b-primary!"
+    );
+    // The list draws no underline; its square corners are the edge it does own.
+    expect(edgeClassesOf(tabsListVariants())).toEqual(["rounded-none"]);
   });
 });

--- a/packages/ui/src/components/tabs.tsx
+++ b/packages/ui/src/components/tabs.tsx
@@ -2,13 +2,13 @@
 
 import { Root, List, Trigger, Content } from "@radix-ui/react-tabs";
 import { cva, type VariantProps } from "class-variance-authority";
-import { forwardRef } from "react";
+import { forwardRef, type ComponentPropsWithoutRef } from "react";
 
 import { cn } from "../lib/utils";
 import type {
-  TabsListProps,
+  TabsListProps as TabsListBaseProps,
   TabsListRef,
-  TabsTriggerProps,
+  TabsTriggerProps as TabsTriggerBaseProps,
   TabsTriggerRef,
   TabsContentProps,
   TabsContentRef,
@@ -134,7 +134,7 @@ const tabsListVariants = cva(
 
 const TabsList = forwardRef<
   TabsListRef,
-  TabsListProps & VariantProps<typeof tabsListVariants>
+  TabsListBaseProps & VariantProps<typeof tabsListVariants>
 >(({ className, variant, ...props }, ref) => (
   <List
     ref={ref}
@@ -187,7 +187,7 @@ const tabsTriggerVariants = cva(
 
 const TabsTrigger = forwardRef<
   TabsTriggerRef,
-  TabsTriggerProps & VariantProps<typeof tabsTriggerVariants>
+  TabsTriggerBaseProps & VariantProps<typeof tabsTriggerVariants>
 >(({ className, size, ...props }, ref) => (
   <Trigger
     ref={ref}
@@ -228,9 +228,16 @@ TabsContent.displayName = Content.displayName;
 
 export { Tabs, TabsList, TabsTrigger, TabsContent };
 export { tabsListVariants, tabsTriggerVariants };
-export type {
-  TabsProps,
-  TabsListProps,
-  TabsTriggerProps,
-  TabsContentProps,
-} from "../types/tabs";
+export type { TabsProps, TabsContentProps } from "../types/tabs";
+
+/**
+ * The public prop types, DERIVED from the components rather than restated.
+ *
+ * `../types/tabs` describes the Radix props alone, so an alias taken from there
+ * rejects `variant` and `size` — and a consumer typing a wrapper around
+ * `TabsList` would be told the prop it can see in the signature does not exist.
+ * Reading the component's own props keeps the two from drifting: a variant
+ * added later reaches every consumer without a second edit.
+ */
+export type TabsListProps = ComponentPropsWithoutRef<typeof TabsList>;
+export type TabsTriggerProps = ComponentPropsWithoutRef<typeof TabsTrigger>;

--- a/packages/ui/src/components/tabs.tsx
+++ b/packages/ui/src/components/tabs.tsx
@@ -107,17 +107,25 @@ const Tabs = Root;
  * Only APPEARANCE is promoted. Layout a caller chooses -- `w-full`,
  * `justify-start`, margins, `overflow-x-auto` -- stays on `className`, because
  * a variant names a decision this component owns and layout is the caller's.
+ *
+ * The arms are a named declaration rather than an object literal inside `cva`,
+ * because `cva` does not expose its configuration on the function it returns —
+ * so anything checking which arms exist would otherwise have to restate them,
+ * and the two drift the moment an arm is added.
  */
+const TABS_LIST_VARIANTS = {
+  default: "h-10",
+  ghost: "h-8 bg-transparent",
+} as const;
+
 const tabsListVariants = cva(
   // Square corners: underline tabs, so the list never draws a rounded surface.
-  "inline-flex items-center justify-center rounded-none text-muted-foreground",
+  // `gap-1` and `p-0` are invariant across the variants, so they belong here —
+  // repeating them in each arm gives any future adjustment two sites to change
+  // and one to forget.
+  "inline-flex items-center justify-center gap-1 rounded-none p-0 text-muted-foreground",
   {
-    variants: {
-      variant: {
-        default: "h-10 gap-1 p-0",
-        ghost: "h-8 gap-1 bg-transparent p-0",
-      },
-    },
+    variants: { variant: TABS_LIST_VARIANTS },
     defaultVariants: { variant: "default" },
   }
 );
@@ -150,18 +158,20 @@ TabsList.displayName = List.displayName;
  * that draws the tab -- the square corners, the 2px underline, the active and
  * hover colours, the focus ring -- is in the base and is not a caller's to
  * choose, which is the property `tabs-contract.test.ts` watches for.
+ *
+ * Arms declared separately for the same reason as the list's.
  */
+const TABS_TRIGGER_SIZES = {
+  default: "text-sm",
+  sm: "text-xs",
+} as const;
+
 const tabsTriggerVariants = cva(
   // Square corners: the active state is a 2px bottom border that has to run the
   // full width of the trigger.
   "inline-flex items-center justify-center whitespace-nowrap rounded-none bg-transparent px-4 py-2 font-medium cursor-pointer transition-all duration-200 border-b-2 relative -mb-0.5 data-[state=active]:border-b-primary! data-[state=active]:text-primary data-[state=inactive]:border-transparent data-[state=inactive]:text-muted-foreground hover:text-primary hover:border-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 disabled:cursor-not-allowed",
   {
-    variants: {
-      size: {
-        default: "text-sm",
-        sm: "text-xs",
-      },
-    },
+    variants: { size: TABS_TRIGGER_SIZES },
     defaultVariants: { size: "default" },
   }
 );
@@ -228,6 +238,7 @@ TabsContent.displayName = Content.displayName;
 
 export { Tabs, TabsList, TabsTrigger, TabsContent };
 export { tabsListVariants, tabsTriggerVariants };
+export { TABS_LIST_VARIANTS, TABS_TRIGGER_SIZES };
 export type { TabsProps, TabsContentProps } from "../types/tabs";
 
 /**

--- a/packages/ui/src/components/tabs.tsx
+++ b/packages/ui/src/components/tabs.tsx
@@ -96,16 +96,6 @@ import type {
 const Tabs = Root;
 
 /**
- * TabsList - Container for tab triggers
- *
- * Design Specs:
- * - Height: 40px (h-10)
- * - Border-radius: none (for underline style)
- * - Background: transparent
- * - Layout: inline-flex (horizontal by default, use orientation="vertical" on Tabs root for vertical)
- * @public
- */
-/**
  * The list's own appearance, as variants rather than as classes each caller
  * repeats.
  *
@@ -132,6 +122,16 @@ const tabsListVariants = cva(
   }
 );
 
+/**
+ * TabsList - Container for tab triggers
+ *
+ * Design Specs:
+ * - Height: 40px (h-10)
+ * - Border-radius: none (for underline style)
+ * - Background: transparent
+ * - Layout: inline-flex (horizontal by default, use orientation="vertical" on Tabs root for vertical)
+ * @public
+ */
 const TabsList = forwardRef<
   TabsListRef,
   TabsListBaseProps & VariantProps<typeof tabsListVariants>
@@ -145,25 +145,6 @@ const TabsList = forwardRef<
 ));
 TabsList.displayName = List.displayName;
 
-/**
- * TabsTrigger - Clickable tab button
- *
- * Design Specs:
- * - Border-radius: none (Gmail-style underline tabs)
- * - Padding: 6px 16px (px-4 py-2)
- * - Font: text-sm (14px), font-medium (500)
- * - Transition: 150ms (design system standard)
- * - Active state: blue text with blue bottom  border border-border (2px)
- * - Hover: blue text with blue bottom  border border-border
- * - Gmail-inspired clean underline style
- *
- * Accessibility:
- * - Keyboard navigation: Arrow keys, Home, End
- * - Focus ring: 2px with offset (WCAG 2.2 compliant)
- * - Disabled state: pointer-events-none, opacity-50
- * - Data attributes: [data-state="active|inactive"], [data-disabled]
- * @public
- */
 /**
  * The trigger's own appearance. `size` carries the type scale only: everything
  * that draws the tab -- the square corners, the 2px underline, the active and
@@ -185,6 +166,25 @@ const tabsTriggerVariants = cva(
   }
 );
 
+/**
+ * TabsTrigger - Clickable tab button
+ *
+ * Design Specs:
+ * - Border-radius: none (Gmail-style underline tabs)
+ * - Padding: 6px 16px (px-4 py-2)
+ * - Font: text-sm (14px), font-medium (500)
+ * - Transition: 150ms (design system standard)
+ * - Active state: blue text with blue bottom  border border-border (2px)
+ * - Hover: blue text with blue bottom  border border-border
+ * - Gmail-inspired clean underline style
+ *
+ * Accessibility:
+ * - Keyboard navigation: Arrow keys, Home, End
+ * - Focus ring: 2px with offset (WCAG 2.2 compliant)
+ * - Disabled state: pointer-events-none, opacity-50
+ * - Data attributes: [data-state="active|inactive"], [data-disabled]
+ * @public
+ */
 const TabsTrigger = forwardRef<
   TabsTriggerRef,
   TabsTriggerBaseProps & VariantProps<typeof tabsTriggerVariants>

--- a/packages/ui/src/components/tabs.tsx
+++ b/packages/ui/src/components/tabs.tsx
@@ -239,5 +239,14 @@ export type { TabsProps, TabsContentProps } from "../types/tabs";
  * Reading the component's own props keeps the two from drifting: a variant
  * added later reaches every consumer without a second edit.
  */
+/**
+ * The list's props, including its `variant`.
+ * @public
+ */
 export type TabsListProps = ComponentPropsWithoutRef<typeof TabsList>;
+
+/**
+ * The trigger's props, including its `size`.
+ * @public
+ */
 export type TabsTriggerProps = ComponentPropsWithoutRef<typeof TabsTrigger>;

--- a/packages/ui/src/components/tabs.tsx
+++ b/packages/ui/src/components/tabs.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Root, List, Trigger, Content } from "@radix-ui/react-tabs";
+import { cva, type VariantProps } from "class-variance-authority";
 import { forwardRef } from "react";
 
 import { cn } from "../lib/utils";
@@ -104,20 +105,44 @@ const Tabs = Root;
  * - Layout: inline-flex (horizontal by default, use orientation="vertical" on Tabs root for vertical)
  * @public
  */
-const TabsList = forwardRef<TabsListRef, TabsListProps>(
-  ({ className, ...props }, ref) => (
-    <List
-      ref={ref}
-      data-slot="tabs-list"
-      className={cn(
-        // Square corners: underline tabs, so the list never draws a rounded surface.
-        "inline-flex h-10 items-center justify-center gap-1 rounded-none p-0 text-muted-foreground",
-        className
-      )}
-      {...props}
-    />
-  )
+/**
+ * The list's own appearance, as variants rather than as classes each caller
+ * repeats.
+ *
+ * `ghost` is the compact, surface-less list used where tabs sit inside another
+ * panel and must not draw a bar of their own. It was spelled `h-8 bg-transparent
+ * p-0` at one call site and `h-7 bg-transparent p-0` at another; naming it here
+ * settles the height rather than leaving two answers in the tree.
+ *
+ * Only APPEARANCE is promoted. Layout a caller chooses -- `w-full`,
+ * `justify-start`, margins, `overflow-x-auto` -- stays on `className`, because
+ * a variant names a decision this component owns and layout is the caller's.
+ */
+const tabsListVariants = cva(
+  // Square corners: underline tabs, so the list never draws a rounded surface.
+  "inline-flex items-center justify-center rounded-none text-muted-foreground",
+  {
+    variants: {
+      variant: {
+        default: "h-10 gap-1 p-0",
+        ghost: "h-8 gap-1 bg-transparent p-0",
+      },
+    },
+    defaultVariants: { variant: "default" },
+  }
 );
+
+const TabsList = forwardRef<
+  TabsListRef,
+  TabsListProps & VariantProps<typeof tabsListVariants>
+>(({ className, variant, ...props }, ref) => (
+  <List
+    ref={ref}
+    data-slot="tabs-list"
+    className={cn(tabsListVariants({ variant }), className)}
+    {...props}
+  />
+));
 TabsList.displayName = List.displayName;
 
 /**
@@ -139,21 +164,38 @@ TabsList.displayName = List.displayName;
  * - Data attributes: [data-state="active|inactive"], [data-disabled]
  * @public
  */
-const TabsTrigger = forwardRef<TabsTriggerRef, TabsTriggerProps>(
-  ({ className, ...props }, ref) => (
-    <Trigger
-      ref={ref}
-      data-slot="tabs-trigger"
-      className={cn(
-        // Square corners: the active state is a 2px bottom border that has to
-        // run the full width of the trigger.
-        "inline-flex items-center justify-center whitespace-nowrap rounded-none bg-transparent px-4 py-2 text-sm font-medium cursor-pointer transition-all duration-200 border-b-2 relative -mb-0.5 data-[state=active]:border-b-primary! data-[state=active]:text-primary data-[state=inactive]:border-transparent data-[state=inactive]:text-muted-foreground hover:text-primary hover:border-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 disabled:cursor-not-allowed",
-        className
-      )}
-      {...props}
-    />
-  )
+/**
+ * The trigger's own appearance. `size` carries the type scale only: everything
+ * that draws the tab -- the square corners, the 2px underline, the active and
+ * hover colours, the focus ring -- is in the base and is not a caller's to
+ * choose, which is the property `tabs-contract.test.ts` watches for.
+ */
+const tabsTriggerVariants = cva(
+  // Square corners: the active state is a 2px bottom border that has to run the
+  // full width of the trigger.
+  "inline-flex items-center justify-center whitespace-nowrap rounded-none bg-transparent px-4 py-2 font-medium cursor-pointer transition-all duration-200 border-b-2 relative -mb-0.5 data-[state=active]:border-b-primary! data-[state=active]:text-primary data-[state=inactive]:border-transparent data-[state=inactive]:text-muted-foreground hover:text-primary hover:border-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 disabled:cursor-not-allowed",
+  {
+    variants: {
+      size: {
+        default: "text-sm",
+        sm: "text-xs",
+      },
+    },
+    defaultVariants: { size: "default" },
+  }
 );
+
+const TabsTrigger = forwardRef<
+  TabsTriggerRef,
+  TabsTriggerProps & VariantProps<typeof tabsTriggerVariants>
+>(({ className, size, ...props }, ref) => (
+  <Trigger
+    ref={ref}
+    data-slot="tabs-trigger"
+    className={cn(tabsTriggerVariants({ size }), className)}
+    {...props}
+  />
+));
 TabsTrigger.displayName = Trigger.displayName;
 
 /**
@@ -185,6 +227,7 @@ const TabsContent = forwardRef<TabsContentRef, TabsContentProps>(
 TabsContent.displayName = Content.displayName;
 
 export { Tabs, TabsList, TabsTrigger, TabsContent };
+export { tabsListVariants, tabsTriggerVariants };
 export type {
   TabsProps,
   TabsListProps,

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -144,12 +144,17 @@ export type {
 /** @public */
 export { Tabs, TabsList, TabsTrigger, TabsContent } from "./components/tabs";
 /** @public */
-export type {
-  TabsProps,
-  TabsListProps,
-  TabsTriggerProps,
-  TabsContentProps,
-} from "./types/tabs";
+export type { TabsProps, TabsContentProps } from "./types/tabs";
+/**
+ * From the COMPONENT module, not from `./types/tabs`.
+ *
+ * `./types/tabs` describes the Radix props alone, so an alias taken from there
+ * rejects `variant` and `size` — and this barrel is what a consumer imports, so
+ * exporting the derived aliases from the component file alone leaves them
+ * unreachable.
+ * @public
+ */
+export type { TabsListProps, TabsTriggerProps } from "./components/tabs";
 
 /** @public */
 export { Tooltip, TooltipTrigger, TooltipContent } from "./components/tooltip";


### PR DESCRIPTION
## Why

`tabs.tsx` was the only component in `packages/ui` with repeated appearance overrides and no cva variants — **11 of 43 siblings already use them**, including `button`, `alert`, `card`, `dialog`, `badge` and `input`. `button.tsx` is the exemplar this follows.

## Measured first

Counted on `main`, excluding `__tests__`, build output and re-export barrels — **13 real overrides across 124 consuming files**:

```
4  text-xs                      2  gap-1.5
3  w-full justify-start (3 spellings)
2  h-8 / h-7 bg-transparent p-0
1  mx-3 mt-2.5
1  bg-transparent justify-start gap-0 -mb-px max-w-full overflow-x-auto
```

**None of the 13 overrides the underline or the corners** — no `border-b-*`, no `rounded-*`, anywhere. The violation `tabs-contract.test.ts` exists to catch has never occurred in 124 files. Worth recording so nobody re-derives it.

*(The first version of that grep returned ~70 and inverted the conclusion, because it counted the scan's own test fixtures. An instrument that includes its own fixtures is measuring itself.)*

## Two variants, and one deliberate refusal

- **`TabsList variant="ghost"`** — the transparent compact list. 2 sites.
- **`TabsTrigger size="sm"`** — `text-xs`. 4 sites.

**`w-full justify-start` gets NO variant despite three occurrences.** A variant names a decision the *component* owns; layout is the *caller's*. Three callers wanting full width is a common layout need, not a shared visual identity — and the next caller wanting `w-2/3` would either fight the variant or add a second. Same reasoning leaves `gap-1.5`, `mx-3 mt-2.5` and the one long combination on `className`.

Both variants are **appearance only**. The base retains everything that draws the tab — square corners, the 2px underline, active/hover colours, focus ring — so a variant cannot become a second route to restyling a tab.

## One visual change, stated rather than buried

The two ghost call sites disagreed: `h-8` at `ResponseViewer`, `h-7` at `CodePanel`. One name means one height, so the variant settles it at `h-8` and **the code panel's tab strip grows by 4px.**

## Tests and controls

`tabs-variants.test.ts` asserts what each variant resolves to, and that `size` carries the type scale *and nothing else* — computed as a set difference, so a variant that also moved padding or colour fails.

| control | result |
|---|---|
| add `rounded-md` to the `sm` variant | **2 tests fail** — the "only the type scale" and "indicator out of every variant" guards both fire |

**`tabs-contract.test.ts` passed 183 tests before and after the change.** Per the repo's own caution that is information rather than reassurance: the call-site scan does not cover the base-class composition this PR edits. The new file covers that half.

`pnpm turbo run lint check-types --filter=@nextlyhq/ui --filter=@nextlyhq/admin` — 4 successful. `packages/ui` component tests — 2 files, 187 tests.

## Not done here

The scan's fate is deliberately left alone. With `size` and `variant` named, six hand-rolled sites collapse and the rest are layout — but deciding whether the scan is now redundant wants its own change, and the repo rule requires whatever remains to say WHERE the property is enforced rather than the file simply disappearing.