### PR TITLE
refactor(admin): give every list one owner for its page state

### DIFF
--- a/.changeset/admin-pagination-hook.md
+++ b/.changeset/admin-pagination-hook.md
@@ -1,0 +1,36 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+Give every admin list one owner for its page state, and one source for its page-size policy.
+
+Twelve list surfaces each held the same two `useState` calls plus their own `handlePageSizeChange` wrapper that set the size and then reset the page. They now use the existing `usePagination` hook, which owns those resets. That removes the drift risk across the copies and, more usefully, removes the wrapper entirely: `onPageSizeChange` is the hook's `setPageSize`, which resets the page in the same update, so a query keyed on both refetches once rather than twice.
+
+The page-size options were a literal `[10, 25, 50]` written out at nine call sites. They are now `PAGINATION.TABLE_PAGE_SIZE_OPTIONS`, beside the existing page-size constants, so the policy can change in one place. The two lists that deliberately differ keep their own: the media grid offers 12/24/48/96 because it lays out thumbnails, and the delivery log offers 20/50/100 because it is read in long scans. `usePagination`'s own defaults now derive from those constants rather than restating 0 and 10.
+
+`Pagination`'s `pageSizeOptions` is typed `readonly number[]`, since the component only maps over it and a mutable type would reject the shared options for no reason a caller could act on.
+
+Two lists stay off the hook and say why where they declare their state. The entries list is 1-indexed because that is what its API takes, and converting at every read and write trades one clear boundary for a class of off-by-one. The relationship picker accumulates results rather than paginating them: its page number only increments, results append, and there is no way back to a previous page.

--- a/packages/admin/src/components/features/api-keys/ApiKeyTable.tsx
+++ b/packages/admin/src/components/features/api-keys/ApiKeyTable.tsx
@@ -30,6 +30,8 @@ import type {
   NextlyColumn,
   RowAction,
 } from "@admin/components/ui/table/data-table";
+import { PAGINATION } from "@admin/constants/pagination";
+import { usePagination } from "@admin/hooks/usePagination";
 import type { ApiKeyMeta } from "@admin/services/apiKeyApi";
 
 // ============================================================
@@ -121,8 +123,7 @@ export const ApiKeyTable: React.FC<ApiKeyTableProps> = ({
 }) => {
   const [search, setSearch] = useState("");
   const [hiddenColumns, setHiddenColumns] = useState<Set<string>>(new Set());
-  const [page, setPage] = useState(0);
-  const [pageSize, setPageSize] = useState(10);
+  const { page, pageSize, setPage, setPageSize, resetPage } = usePagination();
 
   const toggleColumn = (key: string) => {
     setHiddenColumns(prev => {
@@ -132,11 +133,6 @@ export const ApiKeyTable: React.FC<ApiKeyTableProps> = ({
       return next;
     });
   };
-
-  const handlePageSizeChange = useCallback((newPageSize: number) => {
-    setPageSize(newPageSize);
-    setPage(0);
-  }, []);
 
   const allColumns = useMemo((): NextlyColumn<ApiKeyMeta>[] => {
     return [
@@ -269,8 +265,8 @@ export const ApiKeyTable: React.FC<ApiKeyTableProps> = ({
 
   // Reset to the first page whenever the search term changes.
   useEffect(() => {
-    setPage(0);
-  }, [search]);
+    resetPage();
+  }, [search, resetPage]);
 
   const rowActions = useCallback(
     (key: ApiKeyMeta): RowAction<ApiKeyMeta>[] => {
@@ -359,9 +355,9 @@ export const ApiKeyTable: React.FC<ApiKeyTableProps> = ({
               currentPage: page,
               totalPages: Math.max(1, totalPages),
               pageSize,
-              pageSizeOptions: [10, 25, 50],
+              pageSizeOptions: PAGINATION.TABLE_PAGE_SIZE_OPTIONS,
               onPageChange: setPage,
-              onPageSizeChange: handlePageSizeChange,
+              onPageSizeChange: setPageSize,
               totalItems,
               isLoading,
             }}

--- a/packages/admin/src/components/features/entries/EntryForm/EntryFormProvider.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/EntryFormProvider.tsx
@@ -61,7 +61,9 @@ export function EntryFormProvider({
     <FormProvider {...form}>
       <form
         id={formId}
-        onSubmit={(e) => { void onSubmit(e); }}
+        onSubmit={e => {
+          void onSubmit(e);
+        }}
         className={className}
         noValidate // Use Zod validation instead of browser validation
       >

--- a/packages/admin/src/components/features/entries/EntryList/EntryList.tsx
+++ b/packages/admin/src/components/features/entries/EntryList/EntryList.tsx
@@ -235,7 +235,13 @@ export function EntryList({ collectionSlug }: EntryListProps) {
   // State
   // ---------------------------------------------------------------------------
 
-  const [page, setPage] = useState(1); // 1-indexed for API
+  // Held here rather than in `usePagination`, and the reason is the index base
+  // rather than preference: this page number goes to the entries API, which is
+  // 1-indexed, while the hook is 0-indexed like every table surface that reads
+  // its value straight into a slice. Moving this onto the hook would mean
+  // converting at every read and every write, and one missed conversion is an
+  // off-by-one page of content with nothing to catch it.
+  const [page, setPage] = useState(1);
   const [limit, setLimit] = useState(25);
   const [sort, setSort] = useState<string | undefined>("-createdAt"); // Default: newest entries first
   const [search, setSearch] = useState("");

--- a/packages/admin/src/components/features/entries/fields/relational/RelationshipSearch.tsx
+++ b/packages/admin/src/components/features/entries/fields/relational/RelationshipSearch.tsx
@@ -133,6 +133,11 @@ export function RelationshipSearch({
 }: RelationshipSearchProps) {
   const [search, setSearch] = useState("");
   const [selectedCollection, setSelectedCollection] = useState(collections[0]);
+  // Not `usePagination`, because this list does not paginate: it ACCUMULATES.
+  // The page number only ever increments to fetch more, results append to what
+  // is already shown, and there is no page size selector and no way back to a
+  // previous page. The hook models navigation between pages of a fixed set,
+  // which is a different thing that happens to count with the same word.
   const [currentPage, setCurrentPage] = useState(1);
   const [accumulatedResults, setAccumulatedResults] = useState<
     SearchResultItem[]

--- a/packages/admin/src/components/features/media-library/index.tsx
+++ b/packages/admin/src/components/features/media-library/index.tsx
@@ -53,6 +53,7 @@ import {
   useSubfolders,
   useRootFolders,
 } from "@admin/hooks/queries/useMedia";
+import { usePagination } from "@admin/hooks/usePagination";
 import {
   usePersistedState,
   usePersistedStringSet,
@@ -128,8 +129,9 @@ export function MediaLibrary({
   className,
 }: MediaLibraryProps = {}) {
   // State: Pagination
-  const [page, setPage] = React.useState(0);
-  const [pageSize, setPageSize] = React.useState(defaultPageSize);
+  const { page, pageSize, setPage, setPageSize, resetPage } = usePagination({
+    initialPageSize: defaultPageSize,
+  });
   // Hidden list-view columns persist across visits. Functional updates so
   // two quick toggles both land instead of the second reading stale state.
   const [hiddenColumns, updateHiddenColumns] = usePersistedStringSet(
@@ -191,8 +193,8 @@ export function MediaLibrary({
 
   // Reset page when folder changes
   React.useEffect(() => {
-    setPage(0);
-  }, [activeFolderId]);
+    resetPage();
+  }, [activeFolderId, resetPage]);
 
   const [isCreateFolderDialogOpen, setIsCreateFolderDialogOpen] =
     React.useState(false);
@@ -244,11 +246,11 @@ export function MediaLibrary({
   React.useEffect(() => {
     const timer = setTimeout(() => {
       setDebouncedSearch(search);
-      setPage(0); // Reset to page 1 when search changes
+      resetPage(); // Reset to page 1 when search changes
     }, 300);
 
     return () => clearTimeout(timer);
-  }, [search]);
+  }, [search, resetPage]);
 
   // Build query params. Local React state name `pageSize` (admin-
   // internal) maps to canonical wire field `limit`.
@@ -386,50 +388,54 @@ export function MediaLibrary({
   );
 
   // Handlers: Pagination
-  const handlePageChange = React.useCallback((newPage: number) => {
-    setPage(newPage);
-    window.scrollTo({ top: 0, behavior: "smooth" });
-  }, []);
-
-  const handlePageSizeChange = React.useCallback((newPageSize: number) => {
-    setPageSize(newPageSize);
-    setPage(0); // Reset to page 1 when page size changes
-  }, []);
+  const handlePageChange = React.useCallback(
+    (newPage: number) => {
+      setPage(newPage);
+      window.scrollTo({ top: 0, behavior: "smooth" });
+    },
+    [setPage]
+  );
 
   // Handlers: Filters
   const handleSearchChange = React.useCallback((value: string) => {
     setSearch(value);
   }, []);
 
-  const handleTypeFilterChange = React.useCallback((value: string) => {
-    setTypeFilter(value as MediaType | "all");
-    setPage(0); // Reset to page 1 when filter changes
-  }, []);
+  const handleTypeFilterChange = React.useCallback(
+    (value: string) => {
+      setTypeFilter(value as MediaType | "all");
+      resetPage(); // Reset to page 1 when filter changes
+    },
+    [resetPage]
+  );
 
-  const handleSortChange = React.useCallback((value: string) => {
-    // Narrow the "<field>-<order>" select value by comparison; the option
-    // list is closed, so anything else is ignored rather than cast through.
-    const [newSortBy, newSortOrder] = value.split("-");
-    if (
-      (newSortBy === "uploadedAt" ||
-        newSortBy === "filename" ||
-        newSortBy === "size") &&
-      (newSortOrder === "asc" || newSortOrder === "desc")
-    ) {
-      setSortBy(newSortBy);
-      setSortOrder(newSortOrder);
-      setPage(0); // Reset to page 1 when ordering changes
-    }
-  }, []);
+  const handleSortChange = React.useCallback(
+    (value: string) => {
+      // Narrow the "<field>-<order>" select value by comparison; the option
+      // list is closed, so anything else is ignored rather than cast through.
+      const [newSortBy, newSortOrder] = value.split("-");
+      if (
+        (newSortBy === "uploadedAt" ||
+          newSortBy === "filename" ||
+          newSortBy === "size") &&
+        (newSortOrder === "asc" || newSortOrder === "desc")
+      ) {
+        setSortBy(newSortBy);
+        setSortOrder(newSortOrder);
+        resetPage(); // Reset to page 1 when ordering changes
+      }
+    },
+    [resetPage]
+  );
 
   // Handlers: Folders
 
   const handleDeleteFolderSuccess = React.useCallback(() => {
     if (deleteFolderId === activeFolderId) {
       setActiveFolderId(null);
-      setPage(0);
+      resetPage();
     }
-  }, [deleteFolderId, activeFolderId, setActiveFolderId]);
+  }, [deleteFolderId, activeFolderId, setActiveFolderId, resetPage]);
 
   const handleMoveToFolder = React.useCallback(() => {
     if (selectedIds.size === 0) return;
@@ -784,7 +790,7 @@ export function MediaLibrary({
                   pageSizeOptions={[12, 24, 48, 96]}
                   showPageSizeSelector
                   onPageChange={handlePageChange}
-                  onPageSizeChange={handlePageSizeChange}
+                  onPageSizeChange={setPageSize}
                   // This page renders TWO pagers -- one per view -- and they
                   // are identical in every other prop, so the name is the only
                   // thing that tells a screen reader which list it moves.
@@ -822,7 +828,7 @@ export function MediaLibrary({
                         pageSizeOptions: [12, 24, 48, 96],
                         showPageSizeSelector: true,
                         onPageChange: handlePageChange,
-                        onPageSizeChange: handlePageSizeChange,
+                        onPageSizeChange: setPageSize,
                         // The other half of the pair above: same props, other
                         // view, so the name is what tells a screen reader
                         // which list it moves.

--- a/packages/admin/src/components/features/webhooks/WebhookTable.tsx
+++ b/packages/admin/src/components/features/webhooks/WebhookTable.tsx
@@ -18,6 +18,8 @@ import type {
   RowAction,
 } from "@admin/components/ui/table/data-table";
 import { ListShell } from "@admin/components/ui/table/list-shell";
+import { PAGINATION } from "@admin/constants/pagination";
+import { usePagination } from "@admin/hooks/usePagination";
 import type { WebhookEndpointSummary } from "@admin/types/webhooks";
 
 import { EndpointStatusBadge, describeEvents } from "./status";
@@ -51,18 +53,12 @@ export const WebhookTable: React.FC<WebhookTableProps> = ({
   onViewDeliveries,
 }) => {
   const [search, setSearch] = useState("");
-  const [page, setPage] = useState(0);
-  const [pageSize, setPageSize] = useState(10);
-
-  const handlePageSizeChange = useCallback((next: number) => {
-    setPageSize(next);
-    setPage(0);
-  }, []);
+  const { page, pageSize, setPage, setPageSize, resetPage } = usePagination();
 
   // Reset to the first page whenever the search term changes.
   useEffect(() => {
-    setPage(0);
-  }, [search]);
+    resetPage();
+  }, [search, resetPage]);
 
   const columns = useMemo(
     (): NextlyColumn<WebhookEndpointSummary>[] => [
@@ -149,7 +145,7 @@ export const WebhookTable: React.FC<WebhookTableProps> = ({
   useEffect(() => {
     const lastPage = Math.max(0, totalPages - 1);
     if (page > lastPage) setPage(lastPage);
-  }, [page, totalPages]);
+  }, [page, totalPages, setPage]);
 
   const rowActions = useCallback(
     (webhook: WebhookEndpointSummary): RowAction<WebhookEndpointSummary>[] => {
@@ -235,9 +231,9 @@ export const WebhookTable: React.FC<WebhookTableProps> = ({
           currentPage: page,
           totalPages: Math.max(1, totalPages),
           pageSize,
-          pageSizeOptions: [10, 25, 50],
+          pageSizeOptions: PAGINATION.TABLE_PAGE_SIZE_OPTIONS,
           onPageChange: setPage,
-          onPageSizeChange: handlePageSizeChange,
+          onPageSizeChange: setPageSize,
           totalItems,
           isLoading,
         }}

--- a/packages/admin/src/components/shared/pagination/index.tsx
+++ b/packages/admin/src/components/shared/pagination/index.tsx
@@ -8,6 +8,7 @@ import {
   ChevronRight,
   ChevronsRight,
 } from "@admin/components/icons";
+import { PAGINATION } from "@admin/constants/pagination";
 import { cn } from "@admin/lib/utils";
 
 import type { PaginationProps } from "./types";
@@ -44,29 +45,37 @@ import type { PaginationProps } from "./types";
  *
  * ## Usage Examples
  *
- * ### Basic Usage
- * ```tsx
- * import { Pagination } from "@nextly/admin";
+ * ### Basic usage
  *
+ * A table hands its pagination to `DataTableView` as data and never renders
+ * this component itself — the table knows which of its two views is showing,
+ * so it is the only thing that can place a pager correctly:
+ *
+ * ```tsx
  * function UserList() {
- *   const [page, setPage] = useState(0);
- *   const [pageSize, setPageSize] = useState(10);
+ *   const { page, pageSize, setPage, setPageSize } = usePagination();
  *   const { data } = useUsers({ pagination: { page, pageSize } });
  *
  *   return (
- *     <Pagination
- *       currentPage={page}
- *       totalPages={data.meta.totalPages}
- *       pageSize={pageSize}
- *       onPageChange={setPage}
- *       onPageSizeChange={(size) => {
- *         setPageSize(size);
- *         setPage(0); // Reset to first page
+ *     <DataTableView
+ *       columns={columns}
+ *       rows={data.items}
+ *       pagination={{
+ *         currentPage: page,
+ *         totalPages: data.meta.totalPages,
+ *         pageSize,
+ *         onPageChange: setPage,
+ *         onPageSizeChange: setPageSize,
  *       }}
  *     />
  *   );
  * }
  * ```
+ *
+ * `usePagination` owns the first-page resets, so `onPageSizeChange` is its
+ * `setPageSize` rather than a wrapper that also calls `setPage(0)`. Rendering
+ * this component directly is for lists that are NOT tables — a grid, or rows
+ * drawn by something other than `DataTableView`.
  *
  * ### With Custom Page Size Options
  * ```tsx
@@ -122,7 +131,7 @@ export const Pagination = React.forwardRef<HTMLElement, PaginationProps>(
       currentPage,
       totalPages,
       pageSize,
-      pageSizeOptions = [10, 25, 50],
+      pageSizeOptions = PAGINATION.TABLE_PAGE_SIZE_OPTIONS,
       showPageSizeSelector = true,
       maxVisiblePages = 5,
       onPageChange,

--- a/packages/admin/src/components/shared/pagination/types.ts
+++ b/packages/admin/src/components/shared/pagination/types.ts
@@ -9,7 +9,12 @@ export type PaginationProps = {
   /** Current page size (items per page) */
   pageSize: number;
   /** Available page size options for the selector */
-  pageSizeOptions?: number[];
+  /**
+   * Readonly because this component only maps over it. A mutable array type
+   * would reject the shared `as const` options tuple for no reason the caller
+   * could act on, which pushes every call site back to its own literal.
+   */
+  pageSizeOptions?: readonly number[];
   /** Whether to show the page size selector */
   showPageSizeSelector?: boolean;
   /** Maximum number of visible page number buttons */

--- a/packages/admin/src/constants/pagination.ts
+++ b/packages/admin/src/constants/pagination.ts
@@ -25,4 +25,19 @@ export const PAGINATION = {
    * Default starting page (0-indexed).
    */
   DEFAULT_PAGE: 0,
+
+  /**
+   * Page sizes a table's size selector offers.
+   *
+   * One array rather than a literal per list. The same three values were
+   * written out at nine call sites, which is nine chances for a list to offer a
+   * different set than its neighbours for no stated reason -- and no way to
+   * change the policy without finding all nine.
+   *
+   * A list whose rows are unusually large or small states its own instead of
+   * bending this one: the media grid offers 12/24/48/96 because it lays out
+   * thumbnails, and the delivery log offers 20/50/100 because it is read in
+   * long scans. Those are decisions about that surface, not about tables.
+   */
+  TABLE_PAGE_SIZE_OPTIONS: [10, 25, 50],
 } as const;

--- a/packages/admin/src/hooks/usePagination.ts
+++ b/packages/admin/src/hooks/usePagination.ts
@@ -2,6 +2,8 @@
 
 import { useCallback, useState } from "react";
 
+import { PAGINATION } from "@admin/constants/pagination";
+
 /**
  * The page/size state a paginated list runs on, with the resets built in.
  *
@@ -80,18 +82,25 @@ export interface UsePaginationOptions {
 export function usePagination(
   options: UsePaginationOptions = {}
 ): PaginationState {
-  const { initialPage = 0, initialPageSize = 10 } = options;
+  // Defaults come from the pagination constants rather than being written out
+  // again here. Two copies of "a table starts on page 0 showing 10 rows" agree
+  // until one is changed, and the one that gets changed is whichever the next
+  // reader finds first.
+  const {
+    initialPage = PAGINATION.DEFAULT_PAGE,
+    initialPageSize = PAGINATION.TABLE_DEFAULT_PAGE_SIZE,
+  } = options;
 
   const [page, setPage] = useState(initialPage);
   const [pageSize, setPageSizeState] = useState(initialPageSize);
 
   const setPageSize = useCallback((next: number) => {
     setPageSizeState(next);
-    setPage(0);
+    setPage(PAGINATION.DEFAULT_PAGE);
   }, []);
 
   const resetPage = useCallback(() => {
-    setPage(0);
+    setPage(PAGINATION.DEFAULT_PAGE);
   }, []);
 
   return { page, pageSize, setPage, setPageSize, resetPage };

--- a/packages/admin/src/lib/errors/error-types.ts
+++ b/packages/admin/src/lib/errors/error-types.ts
@@ -14,9 +14,7 @@ function isError(error: unknown): error is Error {
 /**
  * Type guard to check if value is an object with a message property
  */
-function isErrorWithMessage(
-  error: unknown
-): error is { message: unknown } {
+function isErrorWithMessage(error: unknown): error is { message: unknown } {
   return (
     typeof error === "object" &&
     error !== null &&

--- a/packages/admin/src/pages/dashboard/collection/components/CollectionTable.tsx
+++ b/packages/admin/src/pages/dashboard/collection/components/CollectionTable.tsx
@@ -37,6 +37,7 @@ import type {
   NextlyColumn,
   RowAction,
 } from "@admin/components/ui/table/data-table";
+import { PAGINATION } from "@admin/constants/pagination";
 import { ROUTES, buildRoute } from "@admin/constants/routes";
 import { UI } from "@admin/constants/ui";
 import {
@@ -45,6 +46,7 @@ import {
   useBulkDeleteCollections,
 } from "@admin/hooks/queries";
 import { useDebouncedValue } from "@admin/hooks/useDebouncedValue";
+import { usePagination } from "@admin/hooks/usePagination";
 import { useRowSelection } from "@admin/hooks/useRowSelection";
 import { formatDateTime } from "@admin/lib/dates/format";
 import { navigateTo } from "@admin/lib/navigation";
@@ -118,16 +120,15 @@ const ALWAYS_VISIBLE = new Set(["label", "createdAt"]);
  * rendering is delegated to the unified DataTableView.
  */
 export default function CollectionTable() {
-  const [page, setPage] = useState(0);
-  const [pageSize, setPageSize] = useState(10);
+  const { page, pageSize, setPage, setPageSize, resetPage } = usePagination();
   const [search, setSearch] = useState("");
   const debouncedSearch = useDebouncedValue(search, UI.SEARCH_DEBOUNCE_MS);
 
   // Reset to the first page when the search term changes so a later page does not
   // request out-of-range results and show a false empty state.
   useEffect(() => {
-    setPage(0);
-  }, [debouncedSearch]);
+    resetPage();
+  }, [debouncedSearch, resetPage]);
 
   const [sourceFilter, setSourceFilter] = useState<CollectionSource | "all">(
     "all"
@@ -398,19 +399,14 @@ export default function CollectionTable() {
     [allColumns]
   );
 
-  const handlePageSizeChange = (newPageSize: number) => {
-    setPageSize(newPageSize);
-    setPage(0);
-  };
-
   const handleSourceFilterChange = (value: string) => {
     setSourceFilter(value as CollectionSource | "all");
-    setPage(0);
+    resetPage();
   };
 
   const handleMigrationFilterChange = (value: string) => {
     setMigrationFilter(value as MigrationStatus | "all");
-    setPage(0);
+    resetPage();
   };
 
   const selection = useMemo<DataTableSelection<ApiCollection>>(
@@ -653,9 +649,9 @@ export default function CollectionTable() {
                     currentPage: page,
                     totalPages: data.meta.totalPages,
                     pageSize,
-                    pageSizeOptions: [10, 25, 50],
+                    pageSizeOptions: PAGINATION.TABLE_PAGE_SIZE_OPTIONS,
                     onPageChange: setPage,
-                    onPageSizeChange: handlePageSizeChange,
+                    onPageSizeChange: setPageSize,
                     isLoading: isFetching,
                     totalItems: data.meta.total,
                   }

--- a/packages/admin/src/pages/dashboard/field-group/components/FieldGroupTable.tsx
+++ b/packages/admin/src/pages/dashboard/field-group/components/FieldGroupTable.tsx
@@ -30,6 +30,7 @@ import type {
   NextlyColumn,
   RowAction,
 } from "@admin/components/ui/table/data-table";
+import { PAGINATION } from "@admin/constants/pagination";
 import { ROUTES, buildRoute } from "@admin/constants/routes";
 import { UI } from "@admin/constants/ui";
 import {
@@ -38,6 +39,7 @@ import {
   useBulkDeleteFieldGroups,
 } from "@admin/hooks/queries";
 import { useDebouncedValue } from "@admin/hooks/useDebouncedValue";
+import { usePagination } from "@admin/hooks/usePagination";
 import { useRowSelection } from "@admin/hooks/useRowSelection";
 import { formatDateTime } from "@admin/lib/dates/format";
 import { navigateTo } from "@admin/lib/navigation";
@@ -99,16 +101,15 @@ const ALWAYS_VISIBLE = new Set(["label", "createdAt"]);
  * rendering is delegated to the unified DataTableView.
  */
 export default function FieldGroupTable() {
-  const [page, setPage] = useState(0);
-  const [pageSize, setPageSize] = useState(10);
+  const { page, pageSize, setPage, setPageSize, resetPage } = usePagination();
   const [search, setSearch] = useState("");
   const debouncedSearch = useDebouncedValue(search, UI.SEARCH_DEBOUNCE_MS);
 
   // Reset to the first page when the search term changes so a later page does not
   // request out-of-range results and show a false empty state.
   useEffect(() => {
-    setPage(0);
-  }, [debouncedSearch]);
+    resetPage();
+  }, [debouncedSearch, resetPage]);
 
   const [sourceFilter, setSourceFilter] = useState<FieldGroupSource | "all">(
     "all"
@@ -377,19 +378,14 @@ export default function FieldGroupTable() {
     [allColumns]
   );
 
-  const handlePageSizeChange = (newPageSize: number) => {
-    setPageSize(newPageSize);
-    setPage(0);
-  };
-
   const handleSourceFilterChange = (value: string) => {
     setSourceFilter(value as FieldGroupSource | "all");
-    setPage(0);
+    resetPage();
   };
 
   const handleMigrationFilterChange = (value: string) => {
     setMigrationFilter(value as FieldGroupMigrationStatus | "all");
-    setPage(0);
+    resetPage();
   };
 
   const selection = useMemo<DataTableSelection<ApiFieldGroup>>(
@@ -615,9 +611,9 @@ export default function FieldGroupTable() {
                     totalPages:
                       data.meta.totalPages > 0 ? data.meta.totalPages : 1,
                     pageSize,
-                    pageSizeOptions: [10, 25, 50],
+                    pageSizeOptions: PAGINATION.TABLE_PAGE_SIZE_OPTIONS,
                     onPageChange: setPage,
-                    onPageSizeChange: handlePageSizeChange,
+                    onPageSizeChange: setPageSize,
                     isLoading: isFetching,
                     totalItems: data.meta.total,
                   }

--- a/packages/admin/src/pages/dashboard/roles/components/RoleTable.tsx
+++ b/packages/admin/src/pages/dashboard/roles/components/RoleTable.tsx
@@ -27,6 +27,7 @@ import type {
   RowAction,
 } from "@admin/components/ui/table/data-table";
 import { ListShell } from "@admin/components/ui/table/list-shell";
+import { PAGINATION } from "@admin/constants/pagination";
 import { ROUTES, buildRoute } from "@admin/constants/routes";
 import {
   useRoles,
@@ -34,6 +35,7 @@ import {
   useBulkDeleteRoles,
 } from "@admin/hooks/queries/useRoles";
 import { useDebouncedValue } from "@admin/hooks/useDebouncedValue";
+import { usePagination } from "@admin/hooks/usePagination";
 import { useRowSelection } from "@admin/hooks/useRowSelection";
 import { navigateTo } from "@admin/lib/navigation";
 import type { Role } from "@admin/types/entities";
@@ -51,8 +53,7 @@ const ALWAYS_VISIBLE = new Set(["roleName"]);
  * delegated to the unified DataTableView.
  */
 export default function RoleTable() {
-  const [page, setPage] = useState(0);
-  const [pageSize, setPageSize] = useState(10);
+  const { page, pageSize, setPage, setPageSize, resetPage } = usePagination();
   const [search, setSearch] = useState("");
   const [hiddenColumns, setHiddenColumns] = useState<Set<string>>(new Set());
 
@@ -78,8 +79,8 @@ export default function RoleTable() {
   // Reset to the first page when the search term changes so a later page does not
   // request out-of-range results and show a false empty state.
   useEffect(() => {
-    setPage(0);
-  }, [debouncedSearch]);
+    resetPage();
+  }, [debouncedSearch, resetPage]);
 
   // Selection is page-scoped: clear it whenever the page or search changes so a
   // bulk action never targets rows that are no longer shown/confirmed.
@@ -286,11 +287,6 @@ export default function RoleTable() {
     });
   }, []);
 
-  const handlePageSizeChange = useCallback((newPageSize: number) => {
-    setPageSize(newPageSize);
-    setPage(0);
-  }, []);
-
   const selection = useMemo<DataTableSelection<Role>>(
     () => ({
       selectedIds,
@@ -411,9 +407,9 @@ export default function RoleTable() {
                   currentPage: page,
                   totalPages: data.meta.totalPages,
                   pageSize,
-                  pageSizeOptions: [10, 25, 50],
+                  pageSizeOptions: PAGINATION.TABLE_PAGE_SIZE_OPTIONS,
                   onPageChange: setPage,
-                  onPageSizeChange: handlePageSizeChange,
+                  onPageSizeChange: setPageSize,
                   isLoading,
                   totalItems: data.meta.total,
                 }

--- a/packages/admin/src/pages/dashboard/settings/email-providers/index.tsx
+++ b/packages/admin/src/pages/dashboard/settings/email-providers/index.tsx
@@ -53,6 +53,7 @@ import type {
   NextlyColumn,
   RowAction,
 } from "@admin/components/ui/table/data-table";
+import { PAGINATION } from "@admin/constants/pagination";
 import { ROUTES, buildRoute } from "@admin/constants/routes";
 import {
   useEmailProviders,
@@ -62,6 +63,7 @@ import {
   useTestProvider,
 } from "@admin/hooks/queries/useEmailProviders";
 import { formatDateWithAdminTimezone } from "@admin/hooks/useAdminDateFormatter";
+import { usePagination } from "@admin/hooks/usePagination";
 import { navigateTo } from "@admin/lib/navigation";
 import type {
   EmailProviderDescriptor,
@@ -308,8 +310,7 @@ function ProviderTestDialog({
 const ALWAYS_VISIBLE = new Set(["name"]);
 
 function EmailProviderTable() {
-  const [page, setPage] = useState(0);
-  const [pageSize, setPageSize] = useState(10);
+  const { page, pageSize, setPage, setPageSize, resetPage } = usePagination();
   const [search, setSearch] = useState("");
   // `undefined` is "no filter". A hardcoded sentinel would have to be a string
   // no provider may register, and no such string exists -- a plugin is entitled
@@ -499,17 +500,12 @@ function EmailProviderTable() {
     [providerToTest, doTest]
   );
 
-  const handlePageSizeChange = useCallback((newPageSize: number) => {
-    setPageSize(newPageSize);
-    setPage(0);
-  }, []);
-
   const handleTypeChange = useCallback(
     (newType: string) => {
       setType(newType === allTypesValue ? undefined : newType);
-      setPage(0);
+      resetPage();
     },
-    [allTypesValue]
+    [allTypesValue, resetPage]
   );
 
   const allColumns = useMemo<NextlyColumn<EmailProviderRecord>[]>(
@@ -826,9 +822,9 @@ function EmailProviderTable() {
                     currentPage: page,
                     totalPages: data.meta.totalPages,
                     pageSize,
-                    pageSizeOptions: [10, 25, 50],
+                    pageSizeOptions: PAGINATION.TABLE_PAGE_SIZE_OPTIONS,
                     onPageChange: setPage,
-                    onPageSizeChange: handlePageSizeChange,
+                    onPageSizeChange: setPageSize,
                     isLoading,
                     totalItems,
                   }

--- a/packages/admin/src/pages/dashboard/settings/email-templates/index.tsx
+++ b/packages/admin/src/pages/dashboard/settings/email-templates/index.tsx
@@ -47,6 +47,7 @@ import type {
   NextlyColumn,
   RowAction,
 } from "@admin/components/ui/table/data-table";
+import { PAGINATION } from "@admin/constants/pagination";
 import { ROUTES, buildRoute } from "@admin/constants/routes";
 import {
   useEmailTemplates,
@@ -54,6 +55,7 @@ import {
   usePreviewEmailTemplate,
 } from "@admin/hooks/queries/useEmailTemplates";
 import { formatDateWithAdminTimezone } from "@admin/hooks/useAdminDateFormatter";
+import { usePagination } from "@admin/hooks/usePagination";
 import { navigateTo } from "@admin/lib/navigation";
 import type { EmailTemplateRecord } from "@admin/services/emailTemplateApi";
 
@@ -239,8 +241,7 @@ function EmailTemplateTable() {
 
   const { mutate: doDelete, isPending: isDeleting } = useDeleteEmailTemplate();
 
-  const [page, setPage] = useState(0);
-  const [pageSize, setPageSize] = useState(10);
+  const { page, pageSize, setPage, setPageSize, resetPage } = usePagination();
   const [search, setSearch] = useState("");
   const [hiddenColumns, setHiddenColumns] = useState<Set<string>>(new Set());
 
@@ -284,8 +285,8 @@ function EmailTemplateTable() {
   );
 
   useEffect(() => {
-    setPage(0);
-  }, [search]);
+    resetPage();
+  }, [search, resetPage]);
 
   const handleEdit = useCallback((template: EmailTemplateRecord) => {
     navigateTo(
@@ -333,11 +334,6 @@ function EmailTemplateTable() {
     navigateTo(
       `${ROUTES.SETTINGS_EMAIL_TEMPLATES_CREATE}?duplicate=${template.id}`
     );
-  }, []);
-
-  const handlePageSizeChange = useCallback((newPageSize: number) => {
-    setPageSize(newPageSize);
-    setPage(0);
   }, []);
 
   const allColumns = useMemo<NextlyColumn<EmailTemplateRecord>[]>(
@@ -540,9 +536,9 @@ function EmailTemplateTable() {
               currentPage: page,
               totalPages: Math.max(1, totalPages),
               pageSize,
-              pageSizeOptions: [10, 25, 50],
+              pageSizeOptions: PAGINATION.TABLE_PAGE_SIZE_OPTIONS,
               onPageChange: setPage,
-              onPageSizeChange: handlePageSizeChange,
+              onPageSizeChange: setPageSize,
               totalItems,
               isLoading,
             }}

--- a/packages/admin/src/pages/dashboard/settings/image-sizes/index.tsx
+++ b/packages/admin/src/pages/dashboard/settings/image-sizes/index.tsx
@@ -36,6 +36,7 @@ import type {
   RowAction,
 } from "@admin/components/ui/table/data-table";
 import { ROUTES, buildRoute } from "@admin/constants/routes";
+import { usePagination } from "@admin/hooks/usePagination";
 import { navigateTo } from "@admin/lib/navigation";
 import {
   deleteImageSize,
@@ -75,8 +76,7 @@ function ImageSizesContent({
 }) {
   const [sizes, setSizes] = React.useState<ImageSize[]>([]);
   const [isLoading, setIsLoading] = React.useState(true);
-  const [page, setPage] = React.useState(0);
-  const [pageSize, setPageSize] = React.useState(10);
+  const { page, pageSize, setPage, setPageSize, resetPage } = usePagination();
   const [hiddenColumns, setHiddenColumns] = React.useState<Set<string>>(
     new Set()
   );
@@ -130,20 +130,8 @@ function ImageSizesContent({
 
   // Handle pagination (reset to first page on search)
   React.useEffect(() => {
-    setPage(0);
-  }, [search]);
-
-  // Changing the page size makes the current page number point somewhere the
-  // list may not reach -- at a larger size the slice below starts past the end
-  // and returns nothing, leaving the empty message on a list that has rows.
-  // Returning to the first page is always in range, and it is what every other
-  // list in the admin does, so the two behave alike. It does NOT keep the rows
-  // that were on screen: row 31 is on page 2 at twenty-five per page, and the
-  // reset moves away from it.
-  const handlePageSizeChange = React.useCallback((size: number) => {
-    setPageSize(size);
-    setPage(0);
-  }, []);
+    resetPage();
+  }, [search, resetPage]);
 
   // Filtered sizes based on search
   const filteredSizes = React.useMemo(() => {
@@ -331,7 +319,7 @@ function ImageSizesContent({
                 totalItems: filteredSizes.length,
                 pageSize,
                 onPageChange: setPage,
-                onPageSizeChange: handlePageSizeChange,
+                onPageSizeChange: setPageSize,
                 isLoading,
               }
             : undefined

--- a/packages/admin/src/pages/dashboard/settings/webhooks/[id]/deliveries/index.tsx
+++ b/packages/admin/src/pages/dashboard/settings/webhooks/[id]/deliveries/index.tsx
@@ -18,9 +18,11 @@ import { PageErrorFallback } from "@admin/components/shared/error-fallbacks";
 import { QueryErrorBoundary } from "@admin/components/shared/query-error-boundary";
 import { toast } from "@admin/components/ui";
 import { Link } from "@admin/components/ui/link";
+import { PAGINATION } from "@admin/constants/pagination";
 import { ROUTES, buildRoute } from "@admin/constants/routes";
 import { useDeliveries, useRunDrain, useWebhook } from "@admin/hooks/queries";
 import { useCan } from "@admin/hooks/useCan";
+import { usePagination } from "@admin/hooks/usePagination";
 import { useRouter } from "@admin/hooks/useRouter";
 import { apiErrorMessage } from "@admin/lib/api/parseApiError";
 import { navigateTo } from "@admin/lib/navigation";
@@ -42,8 +44,9 @@ const DeliveriesContent: React.FC<{ id: string }> = ({ id }) => {
   const canManage = useCan("update-webhooks");
   const canRead = canReadWebhooks || canManage;
 
-  const [page, setPage] = useState(0);
-  const [pageSize, setPageSize] = useState(20);
+  const { page, pageSize, setPage, setPageSize, resetPage } = usePagination({
+    initialPageSize: PAGINATION.DEFAULT_PAGE_SIZE,
+  });
   const [status, setStatus] = useState<WebhookDeliveryStatus | undefined>();
   const [eventType, setEventType] = useState<WebhookEventType | undefined>();
 
@@ -71,23 +74,24 @@ const DeliveriesContent: React.FC<{ id: string }> = ({ id }) => {
     if (!data || isPlaceholderData) return;
     const lastPage = Math.max(0, data.meta.totalPages - 1);
     if (page > lastPage) setPage(lastPage);
-  }, [data, isPlaceholderData, page]);
+  }, [data, isPlaceholderData, page, setPage]);
 
   // Filters and page-size changes reset to the first page so the new query
   // never lands past the end of a shorter result set.
-  const handleStatusChange = useCallback((next?: WebhookDeliveryStatus) => {
-    setStatus(next);
-    setPage(0);
-  }, []);
-  const handleEventTypeChange = useCallback((next?: WebhookEventType) => {
-    setEventType(next);
-    setPage(0);
-  }, []);
-  const handlePageSizeChange = useCallback((next: number) => {
-    setPageSize(next);
-    setPage(0);
-  }, []);
-
+  const handleStatusChange = useCallback(
+    (next?: WebhookDeliveryStatus) => {
+      setStatus(next);
+      resetPage();
+    },
+    [resetPage]
+  );
+  const handleEventTypeChange = useCallback(
+    (next?: WebhookEventType) => {
+      setEventType(next);
+      resetPage();
+    },
+    [resetPage]
+  );
   const handleRowClick = useCallback(
     (delivery: WebhookDeliverySummary) => {
       navigateTo(
@@ -198,7 +202,7 @@ const DeliveriesContent: React.FC<{ id: string }> = ({ id }) => {
           status={status}
           eventType={eventType}
           onPageChange={setPage}
-          onPageSizeChange={handlePageSizeChange}
+          onPageSizeChange={setPageSize}
           onStatusChange={handleStatusChange}
           onEventTypeChange={handleEventTypeChange}
           onRowClick={handleRowClick}

--- a/packages/admin/src/pages/dashboard/singles/components/SinglesTable.tsx
+++ b/packages/admin/src/pages/dashboard/singles/components/SinglesTable.tsx
@@ -35,6 +35,7 @@ import type {
   NextlyColumn,
   RowAction,
 } from "@admin/components/ui/table/data-table";
+import { PAGINATION } from "@admin/constants/pagination";
 import { ROUTES, buildRoute } from "@admin/constants/routes";
 import { UI } from "@admin/constants/ui";
 import {
@@ -43,6 +44,7 @@ import {
   useBulkDeleteSingles,
 } from "@admin/hooks/queries";
 import { useDebouncedValue } from "@admin/hooks/useDebouncedValue";
+import { usePagination } from "@admin/hooks/usePagination";
 import { useRowSelection } from "@admin/hooks/useRowSelection";
 import { formatDateTime } from "@admin/lib/dates/format";
 import { navigateTo } from "@admin/lib/navigation";
@@ -112,16 +114,15 @@ const ALWAYS_VISIBLE = new Set(["label", "createdAt"]);
  * the unified DataTableView.
  */
 export default function SinglesTable({ mode = "builder" }: SinglesTableProps) {
-  const [page, setPage] = useState(0);
-  const [pageSize, setPageSize] = useState(10);
+  const { page, pageSize, setPage, setPageSize, resetPage } = usePagination();
   const [search, setSearch] = useState("");
   const debouncedSearch = useDebouncedValue(search, UI.SEARCH_DEBOUNCE_MS);
 
   // Reset to the first page when the search term changes so a later page does not
   // request out-of-range results and show a false empty state.
   useEffect(() => {
-    setPage(0);
-  }, [debouncedSearch]);
+    resetPage();
+  }, [debouncedSearch, resetPage]);
 
   const [sourceFilter, setSourceFilter] = useState<SingleSource | "all">("all");
   const [migrationFilter, setMigrationFilter] = useState<
@@ -369,20 +370,21 @@ export default function SinglesTable({ mode = "builder" }: SinglesTableProps) {
     [allColumns]
   );
 
-  const handlePageSizeChange = useCallback((newPageSize: number) => {
-    setPageSize(newPageSize);
-    setPage(0);
-  }, []);
+  const handleSourceFilterChange = useCallback(
+    (value: string) => {
+      setSourceFilter(value as SingleSource | "all");
+      resetPage();
+    },
+    [resetPage]
+  );
 
-  const handleSourceFilterChange = useCallback((value: string) => {
-    setSourceFilter(value as SingleSource | "all");
-    setPage(0);
-  }, []);
-
-  const handleMigrationFilterChange = useCallback((value: string) => {
-    setMigrationFilter(value as SingleMigrationStatus | "all");
-    setPage(0);
-  }, []);
+  const handleMigrationFilterChange = useCallback(
+    (value: string) => {
+      setMigrationFilter(value as SingleMigrationStatus | "all");
+      resetPage();
+    },
+    [resetPage]
+  );
 
   const selection = useMemo<DataTableSelection<ApiSingle>>(
     () => ({
@@ -617,9 +619,9 @@ export default function SinglesTable({ mode = "builder" }: SinglesTableProps) {
                     totalPages:
                       data.meta.totalPages > 0 ? data.meta.totalPages : 1,
                     pageSize,
-                    pageSizeOptions: [10, 25, 50],
+                    pageSizeOptions: PAGINATION.TABLE_PAGE_SIZE_OPTIONS,
                     onPageChange: setPage,
-                    onPageSizeChange: handlePageSizeChange,
+                    onPageSizeChange: setPageSize,
                     isLoading,
                     totalItems: data.meta.total,
                   }

--- a/packages/admin/src/pages/dashboard/users/components/UserTable.tsx
+++ b/packages/admin/src/pages/dashboard/users/components/UserTable.tsx
@@ -30,6 +30,7 @@ import type {
   RowAction,
 } from "@admin/components/ui/table/data-table";
 import { ListShell } from "@admin/components/ui/table/list-shell";
+import { PAGINATION } from "@admin/constants/pagination";
 import { ROUTES, buildRoute } from "@admin/constants/routes";
 import { useUserFields } from "@admin/hooks/queries/useUserFields";
 import {
@@ -39,6 +40,7 @@ import {
 } from "@admin/hooks/queries/useUsers";
 import { formatDateWithAdminTimezone } from "@admin/hooks/useAdminDateFormatter";
 import { useDebouncedValue } from "@admin/hooks/useDebouncedValue";
+import { usePagination } from "@admin/hooks/usePagination";
 import { useRowSelection } from "@admin/hooks/useRowSelection";
 import { navigateTo } from "@admin/lib/navigation";
 import type { UserFieldDefinitionRecord } from "@admin/services/userFieldsApi";
@@ -126,8 +128,7 @@ const ALWAYS_VISIBLE = new Set(["name"]);
  * DataTableView.
  */
 export default function UserTable() {
-  const [page, setPage] = useState(0);
-  const [pageSize, setPageSize] = useState(10);
+  const { page, pageSize, setPage, setPageSize, resetPage } = usePagination();
   const [search, setSearch] = useState("");
   const [roleFilter] = useState<string>("all");
   const [hiddenColumns, setHiddenColumns] = useState<Set<string>>(new Set());
@@ -155,8 +156,8 @@ export default function UserTable() {
   // Reset to the first page when the search term changes so a later page does not
   // request out-of-range results and show a false empty state.
   useEffect(() => {
-    setPage(0);
-  }, [debouncedSearch]);
+    resetPage();
+  }, [debouncedSearch, resetPage]);
 
   // Selection is page-scoped: clear it whenever the page or search changes so a
   // bulk action never targets rows that are no longer shown/confirmed.
@@ -384,11 +385,6 @@ export default function UserTable() {
     });
   }, []);
 
-  const handlePageSizeChange = (newPageSize: number) => {
-    setPageSize(newPageSize);
-    setPage(0);
-  };
-
   // Controlled selection wired to the page-level selection hook.
   const selection = useMemo<DataTableSelection<UserApiResponse>>(
     () => ({
@@ -508,9 +504,9 @@ export default function UserTable() {
                   totalPages: data.meta.totalPages,
                   totalItems: data.meta.total,
                   pageSize,
-                  pageSizeOptions: [10, 25, 50],
+                  pageSizeOptions: PAGINATION.TABLE_PAGE_SIZE_OPTIONS,
                   onPageChange: setPage,
-                  onPageSizeChange: handlePageSizeChange,
+                  onPageSizeChange: setPageSize,
                   isLoading,
                 }
               : undefined

--- a/packages/admin/src/pages/dashboard/users/fields/index.tsx
+++ b/packages/admin/src/pages/dashboard/users/fields/index.tsx
@@ -77,6 +77,7 @@ import { QueryErrorBoundary } from "@admin/components/shared/query-error-boundar
 import { SearchBar } from "@admin/components/shared/search-bar";
 import { toast } from "@admin/components/ui";
 import { Link } from "@admin/components/ui/link";
+import { PAGINATION } from "@admin/constants/pagination";
 import { buildRoute, ROUTES } from "@admin/constants/routes";
 import {
   useDeleteUserField,
@@ -84,6 +85,7 @@ import {
   useUserFields,
 } from "@admin/hooks/queries/useUserFields";
 import { formatDateWithAdminTimezone } from "@admin/hooks/useAdminDateFormatter";
+import { usePagination } from "@admin/hooks/usePagination";
 import { navigateTo } from "@admin/lib/navigation";
 import { cn } from "@admin/lib/utils";
 import type {
@@ -491,8 +493,7 @@ function SortableFieldRow({
 
 function UserFieldsTable() {
   // Pagination state
-  const [page, setPage] = useState(0);
-  const [pageSize, setPageSize] = useState(10);
+  const { page, pageSize, setPage, setPageSize, resetPage } = usePagination();
 
   // Search state
   const [search, setSearch] = useState("");
@@ -571,8 +572,8 @@ function UserFieldsTable() {
 
   // Reset page when search changes
   useEffect(() => {
-    setPage(0);
-  }, [search]);
+    resetPage();
+  }, [search, resetPage]);
 
   // Action handlers
   const handleEdit = useCallback((field: UserFieldDefinitionRecord) => {
@@ -640,11 +641,6 @@ function UserFieldsTable() {
     },
     [localFields, doReorder, data]
   );
-
-  const handlePageSizeChange = useCallback((newPageSize: number) => {
-    setPageSize(newPageSize);
-    setPage(0);
-  }, []);
 
   // Error state
   if (isError) {
@@ -810,9 +806,9 @@ function UserFieldsTable() {
             currentPage={page}
             totalPages={Math.max(1, totalPages)}
             pageSize={pageSize}
-            pageSizeOptions={[10, 25, 50]}
+            pageSizeOptions={PAGINATION.TABLE_PAGE_SIZE_OPTIONS}
             onPageChange={setPage}
-            onPageSizeChange={handlePageSizeChange}
+            onPageSizeChange={setPageSize}
             totalItems={totalItems + filteredStaticFields.length}
             // Named rather than left as the default "Pagination". A screen
             // reader announces this control by that name, and the admin renders

--- a/packages/admin/src/services/__tests__/singleApi.locale.test.ts
+++ b/packages/admin/src/services/__tests__/singleApi.locale.test.ts
@@ -49,7 +49,11 @@ describe("singleApi.updateDocument — write locale", () => {
   beforeEach(() => patch.mockClear());
 
   it("appends ?locale= so the save targets the active language", async () => {
-    await singleApi.updateDocument("site-settings", { tagline: "T" }, { locale: "ar" });
+    await singleApi.updateDocument(
+      "site-settings",
+      { tagline: "T" },
+      { locale: "ar" }
+    );
     const url = patch.mock.calls[0][0] as string;
     expect(url).toContain("/singles/site-settings?locale=ar");
   });

--- a/packages/admin/src/types/guards.ts
+++ b/packages/admin/src/types/guards.ts
@@ -37,7 +37,7 @@ export const isUser = (data: unknown): data is User => {
     typeof data === "object" &&
     data !== null &&
     "id" in data &&
-    typeof (data).id === "string" &&
+    typeof data.id === "string" &&
     "email" in data &&
     typeof (data as { email: unknown }).email === "string"
   );
@@ -65,7 +65,7 @@ export const isUserApiResponse = (data: unknown): data is UserApiResponse => {
     typeof data === "object" &&
     data !== null &&
     "id" in data &&
-    typeof (data).id === "number" &&
+    typeof data.id === "number" &&
     "email" in data &&
     typeof (data as { email: unknown }).email === "string"
   );
@@ -94,7 +94,7 @@ export const isRole = (data: unknown): data is Role => {
     typeof data === "object" &&
     data !== null &&
     "id" in data &&
-    typeof (data).id === "string" &&
+    typeof data.id === "string" &&
     "roleName" in data &&
     typeof (data as { roleName: unknown }).roleName === "string"
   );
@@ -125,7 +125,7 @@ export const isPermission = (data: unknown): data is Permission => {
     typeof data === "object" &&
     data !== null &&
     "id" in data &&
-    typeof (data).id === "string" &&
+    typeof data.id === "string" &&
     "name" in data &&
     typeof (data as { name: unknown }).name === "string" &&
     "resource" in data &&


### PR DESCRIPTION
Completes the pagination lane: after #757 gave `DataTableView` a `pagination` prop and #821 fixed how that slot resolves, this gives the *state* behind it one owner.

## What was duplicated

Twelve list surfaces each held the same two `useState` calls and their own `handlePageSizeChange` wrapper — set the size, then reset the page. `usePagination` already existed and already owned those resets; nothing used it except `useServerTable`.

The wrapper is the part worth removing rather than merely deduplicating. `onPageSizeChange` is now the hook's `setPageSize`, which resets the page **in the same update**, so a query keyed on `{ page, pageSize }` refetches once instead of twice.

## The page-size policy had no owner

`[10, 25, 50]` was written out at **nine** call sites. It is now `PAGINATION.TABLE_PAGE_SIZE_OPTIONS`, beside the `DEFAULT_PAGE_SIZE` / `TABLE_DEFAULT_PAGE_SIZE` constants that already existed in that file and that **no call site was using**. `usePagination`'s own defaults now derive from them rather than restating `0` and `10` — three copies of "a table starts on page 0 showing 10 rows" collapse to one.

Two lists keep their own options because their rows differ in kind, and the constant says so: the media grid offers 12/24/48/96 because it lays out thumbnails; the delivery log offers 20/50/100 because it is read in long scans.

`Pagination`'s `pageSizeOptions` is now `readonly number[]` — the component only maps over it, and a mutable type rejects the shared `as const` tuple for no reason a caller could act on, which would push every site back to its own literal.

## Every list keeps the page size it had

This is the failure mode I was most worried about, because adopting the hook already caused one silent regression earlier in this lane — `PluginsTable` went from 25 rows to 10 when it picked up the default. Verified by enumeration rather than by eye:

| site | before | after |
|---|---|---|
| media library | `defaultPageSize` (24) | passed explicitly |
| delivery log | 20 | `PAGINATION.DEFAULT_PAGE_SIZE` (20) |
| plugins | 25 | passed explicitly |
| the other nine | 10 | hook default → `TABLE_DEFAULT_PAGE_SIZE` (10) |

And the old construct is gone: `grep -rn "setPage(0)" packages/admin/src` returns exactly one hit, in a JSDoc example — which this PR rewrites, since a doc teaching the hand-rolled pattern is a DX defect once the hook is the answer.

## Two lists deliberately stay off the hook

Both now say why where they declare their state, rather than looking like sites the migration missed:

- **`EntryList`** is 1-indexed because that is what the entries API takes. The hook is 0-indexed like every table that reads its value into a slice. Converting at every read and write trades one clear boundary for a class of off-by-one with nothing to catch it.
- **`RelationshipSearch`** does not paginate — it **accumulates**. The page number only increments, results append to what is shown, there is no size selector and no way back. The hook models navigation between pages of a fixed set, which is a different thing that happens to count with the same word.

## Verification

- `check-types` clean, `lint` exit 0
- Admin suite **19 failed / 5 files — the exact pre-existing baseline**, same file list (StatsCard, RoleBasicInfo, BasicsTab, SlugInput, DefaultValueField)
- `usePagination`'s own 7 tests pass unchanged, so the reset semantics still have one tested owner
- Changeset generated from `.changeset/config.json`: 24 packages, all `patch`
