### PR TITLE
fix(plugin-page-builder): rank every canvas droppable on one scale

### DIFF
--- a/.changeset/canvas-one-priority-scale.md
+++ b/.changeset/canvas-one-priority-scale.md
@@ -1,5 +1,28 @@
 ---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
 "@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
 ---
 
 Rank every canvas drop target on one collision scale, so which target claims the pointer no longer depends on how deeply the page nests.

--- a/.changeset/canvas-one-priority-scale.md
+++ b/.changeset/canvas-one-priority-scale.md
@@ -1,0 +1,5 @@
+---
+"@nextlyhq/plugin-page-builder": patch
+---
+
+Rank every canvas drop target on one collision scale, so which target claims the pointer no longer depends on how deeply the page nests.

--- a/packages/plugin-page-builder/package.json
+++ b/packages/plugin-page-builder/package.json
@@ -74,6 +74,7 @@
     "react-hook-form": ">=7.0.0"
   },
   "devDependencies": {
+    "@dnd-kit/abstract": "0.5.0",
     "@nextlyhq/admin": "workspace:*",
     "@nextlyhq/plugin-sdk": "workspace:*",
     "@nextlyhq/tsconfig": "workspace:*",

--- a/packages/plugin-page-builder/src/admin/canvas/CanvasNode.tsx
+++ b/packages/plugin-page-builder/src/admin/canvas/CanvasNode.tsx
@@ -33,7 +33,12 @@ import { dragSensors } from "../logic/dragSensors";
 import { useEditor } from "../store/EditorProvider";
 
 import { QueryLoopSamplePreview } from "./CanvasQueryLoop";
-import { CanvasDepth, DropZone, useCanvasDepth } from "./DropZone";
+import {
+  CanvasDepth,
+  DropZone,
+  canvasPriority,
+  useCanvasDepth,
+} from "./DropZone";
 
 const BLOCK_TYPE = "nx-block";
 
@@ -236,6 +241,9 @@ function DraggableNode({
     accept: BLOCK_TYPE,
     disabled: dropBeforeIndex == null,
     data: { kind: "dropzone", parentId, slot, index: dropBeforeIndex ?? 0 },
+    // This node's OWN depth: it marks a position among its siblings, so it
+    // competes with the gap zones beside it and must rank alongside them.
+    collisionPriority: canvasPriority(depth),
   });
 
   // Grid itself: "append" target for its own default slot.
@@ -252,6 +260,11 @@ function DraggableNode({
       slot: "default",
       index: appendIndex,
     },
+    // One level IN, unlike `before:` above: this targets a position among the
+    // grid's own children rather than among its siblings, so it ranks with the
+    // zones inside it. Without that a drag over a grid nested in a container
+    // would be claimed by the container holding the grid.
+    collisionPriority: canvasPriority(depth + 1),
   });
 
   const className = classFor(

--- a/packages/plugin-page-builder/src/admin/canvas/DropZone.tsx
+++ b/packages/plugin-page-builder/src/admin/canvas/DropZone.tsx
@@ -52,6 +52,35 @@ export function useCanvasDepth(): number {
   return useContext(CanvasDepthContext);
 }
 
+/**
+ * Above every priority the collision detector assigns on its own.
+ *
+ * `collisionPriority` OVERRIDES the detector's value rather than supplying one
+ * where none exists — `@dnd-kit/abstract` applies it after the detector has
+ * already decided — and the detector's own scale is `High` (3) when the pointer
+ * is inside the element and `Normal` (2) otherwise. Depths counted from zero
+ * therefore share numbers with it, so a droppable that MISSED its priority
+ * would tie with, or beat, a correctly ranked one, and which happened would
+ * depend on how deeply the document happened to nest.
+ *
+ * Basing the canvas scale above that range makes the two kinds
+ * non-overlapping: an omission then loses to every ranked droppable at any
+ * depth, which is a loud and constant failure rather than a plausible one.
+ */
+const CANVAS_PRIORITY_BASE = 10;
+
+/**
+ * The collision priority for a droppable at `depth`.
+ *
+ * Every droppable the canvas registers takes its priority from HERE. The
+ * numbers are only comparable if one place produces them: two scales in one
+ * canvas make "which target claims the pointer" depend on nesting depth, which
+ * is not a question anyone means to ask.
+ */
+export function canvasPriority(depth: number): number {
+  return CANVAS_PRIORITY_BASE + depth;
+}
+
 export function DropZone({
   parentId,
   slot,
@@ -85,7 +114,7 @@ export function DropZone({
     // is what "the innermost container owns the drop target" asks for, and it
     // is the only thing that can settle two IDENTICAL rectangles — which is
     // exactly what a nested container's edge gap and its parent's gap are.
-    collisionPriority: depth,
+    collisionPriority: canvasPriority(depth),
   });
 
   if (empty) {

--- a/packages/plugin-page-builder/src/admin/canvas/canvas-priority.test.ts
+++ b/packages/plugin-page-builder/src/admin/canvas/canvas-priority.test.ts
@@ -1,0 +1,52 @@
+import { CollisionPriority } from "@dnd-kit/abstract";
+import { describe, expect, it } from "vitest";
+
+import { canvasPriority } from "./DropZone";
+
+/**
+ * The canvas ranks every droppable it registers on ONE scale, and that scale
+ * must not overlap the collision detector's own.
+ *
+ * `collisionPriority` OVERRIDES what the detector decided rather than filling a
+ * gap, so a droppable that never sets it still carries a priority — `High` when
+ * the pointer is inside it, `Normal` otherwise. Two scales sharing numbers make
+ * "which target claims the pointer" depend on how deeply the document nests,
+ * and that is not a question the canvas means to ask.
+ *
+ * Read from `CollisionPriority` rather than written as 2 and 3: the numbers are
+ * the library's to choose, and a copy here would keep passing after it changed
+ * them.
+ */
+describe("the canvas collision scale", () => {
+  const DETECTOR_ASSIGNS = [
+    CollisionPriority.Lowest,
+    CollisionPriority.Low,
+    CollisionPriority.Normal,
+    CollisionPriority.High,
+    CollisionPriority.Highest,
+  ];
+
+  it("puts the shallowest canvas droppable above every detector priority", () => {
+    // Depth 0 is the root's own level, so this is the whole scale's floor: if
+    // it clears the detector, every deeper droppable does too.
+    for (const assigned of DETECTOR_ASSIGNS) {
+      expect(canvasPriority(0)).toBeGreaterThan(assigned);
+    }
+  });
+
+  it("ranks a deeper droppable above a shallower one", () => {
+    // What makes the innermost container win. Asserted across a span rather
+    // than one pair, because a scale that inverted or saturated somewhere
+    // further down would satisfy a single comparison.
+    for (let depth = 0; depth < 12; depth++) {
+      expect(canvasPriority(depth + 1)).toBeGreaterThan(canvasPriority(depth));
+    }
+  });
+
+  it("gives one depth exactly one priority", () => {
+    // Two droppables at the same depth must tie, so that geometry decides
+    // between siblings. A scale that varied per call would make sibling
+    // ordering depend on registration order instead.
+    expect(canvasPriority(3)).toBe(canvasPriority(3));
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1335,6 +1335,9 @@ importers:
         specifier: ^4.0.4
         version: 4.0.5
     devDependencies:
+      '@dnd-kit/abstract':
+        specifier: 0.5.0
+        version: 0.5.0
       '@nextlyhq/admin':
         specifier: workspace:*
         version: link:../admin


### PR DESCRIPTION
`collisionPriority` **overrides** the detector's own value rather than filling a gap. `@dnd-kit/abstract` applies it after the detector has already decided:

```js
// @dnd-kit/abstract/index.js:429
if (entry.collisionPriority != null) { collision.priority = entry.collisionPriority; }
```

and the detector assigns `High` (3) when the pointer is inside an element, `Normal` (2) otherwise. **There is no default of zero.**

So #813 giving gap zones a depth starting at 1, while leaving the grid's `before:` and `append:` droppables unset, did not leave those neutral — it left them on the detector's scale, sharing numbers with shallow depths. Which kind won then depended on how deeply the document nested: grid targets outranked gap zones near the root and lost to them further down. Nobody intended that.

## What changes

Every canvas droppable takes its priority from `canvasPriority(depth)`:

- `before:` ranks at its node's **own** depth — it marks a position among siblings, so it competes with the gap zones beside it.
- `append:` ranks **one level in** — it targets a position among the grid's own children.

The scale is based above the detector's range, so a droppable that ever misses its priority loses to every ranked one at any depth. That is a loud, constant failure instead of a plausible one that varies with nesting.

## On the evidence

**Nothing failed before this.** Grids carry no interleaved gap zones, so the two kinds only meet where a grid sits beside ordinary block flow, and no fixture nests one deep enough for the scales to cross. That is a fixture gap rather than evidence of correctness, so it is stated rather than left to read as coverage.

The new test asserts the scale against `CollisionPriority` **itself**, read from `@dnd-kit/abstract` — now declared as a devDependency — rather than copied as the literals 2 and 3, which would keep passing after the library changed them.

## Verification

- 659 plugin unit tests, 68/68 canvas e2e specs, typecheck and lint clean.
- Stub-verified: setting the base to 0 fails the floor assertion alone, then restored and proven identical by diff.

Found by lane 20468 reading `@dnd-kit/abstract` source, correcting a warning I had given them backwards. Filed at `tasks/left-tasks/2026-08-15-0100-two-priority-scales-in-the-canvas.md`.

Once this lands, the tie #829 documents as a stated limit stops being reachable at all.