### PR TITLE
ci(root): derive the packed workspace set instead of listing it

### DIFF
--- a/.github/workflows/scaffold-build.yml
+++ b/.github/workflows/scaffold-build.yml
@@ -296,11 +296,36 @@ jobs:
           echo "packed tarballs: $count (expected $expected)"
           [ "$count" -eq "$expected" ] || { echo "expected $expected tarballs, got $count"; exit 1; }
 
-          for tgz in /tmp/nextly-workspace-packs/*.tgz; do
-            files=$(tar -tzf "$tgz" | grep -c '^package/dist/' || true)
-            echo "$(basename "$tgz"): $files dist entries"
-            [ "$files" -gt 0 ] || {
-              echo "$(basename "$tgz") contains no dist/ — it was packed unbuilt"
+          # Each tarball is opened and required to contain the FIRST path its own manifest
+          # declares under `files`. `pnpm pack` exits 0 for an unbuilt package too, so a
+          # count alone would be satisfied by tarballs of metadata with no code — the pin
+          # would then replace working registry packages with empty ones and the leg would
+          # fail to resolve an entry point, blaming the template.
+          #
+          # Read from the manifest rather than assuming `dist`. Not every publishable
+          # package builds: `@nextlyhq/admin-css` has no build script and publishes `src`
+          # and `bin`, so a hardcoded `dist` assertion fails it forever — which is the same
+          # mistake as the hardcoded package list this step just stopped making, one level
+          # down. Negation entries (`!dist/metafile-*.json`) are skipped: they subtract from
+          # a set rather than naming something that must be present.
+          for dir in $PKGS; do
+            NAME=$(node -p "require('./packages/$dir/package.json').name")
+            WANT=$(node -p "
+              (require('./packages/$dir/package.json').files || [])
+                .filter(entry => !entry.startsWith('!'))[0] || ''
+            ")
+            [ -n "$WANT" ] || { echo "$NAME declares no files[] — cannot verify its tarball"; exit 1; }
+
+            TGZ=$(ls /tmp/nextly-workspace-packs/*.tgz | while read -r f; do
+              tar -xzOf "$f" package/package.json 2>/dev/null \
+                | node -e "let d='';process.stdin.on('data',c=>d+=c).on('end',()=>{try{if(JSON.parse(d).name===process.argv[1])console.log(process.argv[2])}catch{}})" "$NAME" "$f"
+            done | head -1)
+            [ -n "$TGZ" ] || { echo "no tarball found for $NAME"; exit 1; }
+
+            entries=$(tar -tzf "$TGZ" | grep -c "^package/$WANT" || true)
+            echo "$(basename "$TGZ"): $entries entries under $WANT"
+            [ "$entries" -gt 0 ] || {
+              echo "$(basename "$TGZ") contains nothing under $WANT — it was packed unbuilt"
               exit 1
             }
           done

--- a/.github/workflows/scaffold-build.yml
+++ b/.github/workflows/scaffold-build.yml
@@ -237,33 +237,64 @@ jobs:
         run: |
           mkdir -p /tmp/nextly-workspace-packs
 
-          # The earlier build step covers `create-nextly-app` and `nextly` (and, through the
-          # dependency graph, the adapters). It does NOT cover admin, ui, plugin-form-builder
-          # or plugin-sdk — and these packages publish only `dist`, so packing one unbuilt
-          # SUCCEEDS and yields a tarball of metadata with no code. The pin would then replace
-          # working registry packages with empty ones and the leg would fail to resolve an
-          # entry point, blaming the template.
+          # The set is DERIVED from the workspace, not listed here. A list was listed here,
+          # and it went stale: `nextly` and `plugin-sdk` both depend on
+          # `@nextlyhq/blocks-engine`, which was never packed — so `pnpm pack` rewrote that
+          # `workspace:*` to a concrete version and the install resolved it FROM THE REGISTRY.
+          # These legs were therefore testing the PUBLISHED blocks-engine while reporting on
+          # the workspace, and on a release PR — where the bumped version does not exist yet —
+          # the same gap fails outright with ETARGET.
           #
-          # The trailing `...` includes each package itself as well as its dependencies.
-          pnpm turbo build --filter=nextly... --filter=@nextlyhq/admin... \
-            --filter=@nextlyhq/ui... --filter=@nextlyhq/adapter-drizzle... \
-            --filter=@nextlyhq/adapter-sqlite... --filter=@nextlyhq/adapter-postgres... \
-            --filter=@nextlyhq/adapter-mysql... --filter=@nextlyhq/plugin-form-builder... \
-            --filter=@nextlyhq/plugin-sdk...
+          # `create-nextly-app` is excluded because it is the scaffolder rather than a
+          # dependency of what it scaffolds; its own pack step covers it.
+          #
+          # This is the rule `pin-workspace-packages.mjs` already states about ITSELF — the
+          # names are a question the manifests answer, and a second answer agrees only until
+          # someone adds a package. That is exactly what happened, one layer up.
+          PKGS=$(node -e '
+            const fs = require("node:fs");
+            const names = fs.readdirSync("packages").filter(dir => {
+              try {
+                const manifest = JSON.parse(
+                  fs.readFileSync(`packages/${dir}/package.json`, "utf8")
+                );
+                return manifest.private !== true && manifest.name &&
+                  manifest.name !== "create-nextly-app";
+              } catch { return false; }
+            });
+            if (names.length === 0) { throw new Error("no publishable packages found"); }
+            console.log(names.join(" "));
+          ')
+          echo "packing: $PKGS"
 
-          for dir in packages/nextly packages/admin packages/ui \
-                     packages/adapter-drizzle packages/adapter-sqlite \
-                     packages/adapter-postgres packages/adapter-mysql \
-                     packages/plugin-form-builder packages/plugin-sdk; do
-            (cd "$dir" && pnpm pack --pack-destination /tmp/nextly-workspace-packs)
+          # Built with the same list. These packages publish only `dist`, so packing one
+          # unbuilt SUCCEEDS and yields a tarball of metadata with no code — the pin would
+          # then replace working registry packages with empty ones and the leg would fail to
+          # resolve an entry point, blaming the template. The trailing `...` includes each
+          # package itself as well as its dependencies.
+          FILTERS=""
+          for dir in $PKGS; do
+            NAME=$(node -p "require('./packages/$dir/package.json').name")
+            FILTERS="$FILTERS --filter=$NAME..."
+          done
+          # shellcheck disable=SC2086
+          pnpm turbo build $FILTERS
+
+          for dir in $PKGS; do
+            (cd "packages/$dir" && pnpm pack --pack-destination /tmp/nextly-workspace-packs)
           done
 
           # Controls on that loop. Counting files is not enough: `pnpm pack` exits 0 for an
-          # unbuilt package too, so the count would be nine while the tarballs held no code.
+          # unbuilt package too, so the count would match while the tarballs held no code.
           # Each one is opened and required to contain a `dist` entry.
-          count=$(ls /tmp/nextly-workspace-packs/*.tgz 2>/dev/null | wc -l)
-          echo "packed tarballs: $count"
-          [ "$count" -ge 9 ] || { echo "expected at least 9 tarballs, got $count"; exit 1; }
+          #
+          # The expected count is DERIVED from the same list rather than a fixed number. A
+          # literal was what let the previous gap hide: nine tarballs satisfied `-ge 9` while
+          # the tenth package the scaffold needed was never packed at all.
+          expected=$(echo "$PKGS" | wc -w | tr -d ' ')
+          count=$(ls /tmp/nextly-workspace-packs/*.tgz 2>/dev/null | wc -l | tr -d ' ')
+          echo "packed tarballs: $count (expected $expected)"
+          [ "$count" -eq "$expected" ] || { echo "expected $expected tarballs, got $count"; exit 1; }
 
           for tgz in /tmp/nextly-workspace-packs/*.tgz; do
             files=$(tar -tzf "$tgz" | grep -c '^package/dist/' || true)


### PR DESCRIPTION
## What was wrong

The scaffold's `core: workspace` legs packed a **hand-written list of nine packages**. `nextly` and `plugin-sdk` both depend on `@nextlyhq/blocks-engine`, which was not on it — so `pnpm pack` rewrote that `workspace:*` to a concrete version and the install resolved it **from the registry**.

**Nine packages were missing, not one:** `blocks-engine`, `blocks-react`, `builder`, `plugin-page-builder`, `plugin-seo`, `admin-css`, and all three `storage-*`.

## The failure a reviewer can reproduce today

Workspace `nextly` installs beside **registry** `@nextlyhq/blocks-engine@0.0.2-alpha.42`, and `nextly` imports a subpath that copy does not export:

```
packages/nextly/src/plugins/codegen/block-document.ts:56
  } from "@nextlyhq/blocks-engine/format";
```

`main` is self-consistent — the import and the export both arrived in `2f3bb5767` (#738). Only the packed/registry **skew** breaks it.

## Why most of the matrix stayed green — the separating property

**Only the two blog legs declare `core: workspace`.** The four `blank` legs never mix registry and workspace packages at all, so a green `blank` proves nothing about this class of defect. That is why a nine-package list drifted for as long as it did while the matrix looked healthy.

## The second, release-only symptom

On the Changesets Version PR the bumped version does not exist yet, so the same gap fails outright:

```
npm error code ETARGET
npm error notarget No matching version found for @nextlyhq/blocks-engine@0.0.2-alpha.58.
```

That is a check that **can never pass on a release**, on every release, forever — while the repository's merge policy is "CI fully green". It is currently sitting on **#744**, whose merge drains the changeset backlog. This removes that particular red; I am **not** claiming it is the only one on #744.

## The fix

The packed set is derived from the workspace: every non-private package under `packages/`, minus `create-nextly-app`, which is the scaffolder rather than a dependency of what it scaffolds. The same derived list drives the turbo build filter, the pack loop, and the count control.

**`pin-workspace-packages.mjs` already states this rule about its own names:**

> The package names are read from the tarballs rather than listed here. A list in this file would be a second answer to a question the manifests already answer, and the two agree only until someone adds a package.

The workflow was breaking that rule one layer up.

## Two literals removed, not one

The count control was `[ "$count" -ge 9 ]` — **that literal is what let the gap hide**, since nine tarballs satisfied it while the tenth was never packed. It is now derived and asserts equality.

The content control asserted `package/dist/` on every tarball. `@nextlyhq/admin-css` has no build script and publishes `src` and `bin`, so that assertion failed it forever — **the same mistake one level down**, caught by Codex and by this PR's own matrix within one round. The expectation is now read from each manifest's `files[]`; negation entries (`ui`'s `!dist/metafile-*.json`) are skipped, and a package declaring no `files[]` refuses rather than passing unverified.

## Verification

| check | result |
|---|---|
| derivation against the real workspace | 18 packages, `blocks-engine` included |
| old list vs derived | **9 omitted** |
| `nextly` / `plugin-sdk` depend on `blocks-engine` | confirmed from their manifests |
| `nextly` imports `@nextlyhq/blocks-engine/format` | confirmed, `block-document.ts:56` |
| derivation with no packages present | **exits 1** — refuses rather than returning empty |
| `admin-css` tarball vs derived `package/src` | **5 entries** |
| `admin-css` tarball vs old `package/dist/` | **0 entries** — the predicted failure |

The refusal control was re-run **without a pipe**: `tail` had been reporting its own exit status, which is the false-clean shape `.claude/rules/reading-a-ci-verdict.md` warns about.

**This PR is self-testing** — it edits `scaffold-build.yml`, which is in that workflow's own `paths` trigger, so the matrix runs against the change that alters it.

## Corroboration

The `blocks-engine` skew was diagnosed **independently by another session** from a different failing leg, on run `31865420109`, reaching the same cause by a different route. The separating property above is theirs.

## A SECOND, independent cause — measured after merge, corrected

`Scaffold blog-visual` (pnpm) still fails while `blog-code-first` (npm) now passes. That split is the evidence: **this PR fixed cause 1; cause 2 is independent of it.**

```
Error: Module not found: Can't resolve '@nextlyhq/plugin-sdk/admin'   (x6)
```

**The mechanism first recorded here was wrong and is corrected rather than quietly edited.** This section originally said the pin script's `overrides` "may not reach peer ranges". The opposite is true, and it was settled by running it (run `31866038617`) rather than by reading the diff:

> **The override DOES reach peer ranges, and reaching them is the defect.** `pnpm.overrides` maps each packed name to `file:/tmp/....tgz`, pnpm applies overrides to `peerDependencies` too, and no resolved semver version can satisfy a `file:` specifier.

The install log is the line neither theory could be talked into:

```
✕ unmet peer nextly@file:/tmp/.../nextly-0.0.2-alpha.57.tgz: found 0.0.2-alpha.57
```

The package is present at the exact version and the peer is still unmet. Under the original theory that line cannot occur. **Both theories predicted the same failing import, so only execution separated them.**

`pin-workspace-packages.mjs` never mentions `peerDependencies` and does not need to — writing the override is enough. The follow-up therefore lives there (and possibly in the scaffolded manifest's `peerDependencyRules`), not in this workflow. Diagnosed and owned by another session; full write-up at `tasks/left-tasks/2026-08-15-1500-blog-scaffold-broken-by-a-hand-listed-pack-set.md`.

Publishing is unaffected: `npm view @nextlyhq/plugin-form-builder peerDependencies` shows a correctly rewritten `0.0.2-alpha.42`. Harness defect, not shipped.

## Scope

CI-only, so **no changeset** per the repo rule.