### PR TITLE
fix(release): build changelog entries from git, not the GitHub API

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@3.0.0/schema.json",
   "changelog": [
-    "@changesets/changelog-github",
+    "../scripts/release/changelog.cjs",
     {
       "repo": "nextlyhq/nextly"
     }

--- a/scripts/release/changelog.cjs
+++ b/scripts/release/changelog.cjs
@@ -21,8 +21,26 @@
 
 const { execFileSync } = require("node:child_process");
 
-/** `feat(scope): subject (#1234)` - the shape a squash merge writes. */
-const PULL_REQUEST_IN_SUBJECT = /\(#(\d+)\)\s*$/;
+/**
+ * The two subject shapes that name a pull request unambiguously.
+ *
+ * A squash merge writes `feat(scope): subject (#1234)`; a merge commit writes
+ * `Merge pull request #1234 from owner/branch`. Both identify the pull request in the commit
+ * itself, so neither can attribute an entry to the wrong one.
+ *
+ * A commit arriving by neither route gets a commit link and no pull-request link. That is a
+ * deliberate miss: 118 of 560 changeset-adding commits in this history carry no reference at all,
+ * in the subject or the body, and the only way to reach one is to walk forward to an enclosing
+ * merge. Measured on three of them, that walk answers correctly once, lands on a
+ * `Merge remote-tracking branch` sync commit once, and finds nothing once - so it would sometimes
+ * name a pull request the change did not come from. A wrong link is worse than an absent one, for
+ * the same reason the author is dropped rather than guessed from a git identity.
+ */
+const PULL_REQUEST_PATTERNS = [
+  // Anchored to the END: `(#12)` mid-sentence is prose about an issue, not this merge's number.
+  /\(#(\d+)\)\s*$/,
+  /^Merge pull request #(\d+)\b/,
+];
 
 /**
  * Read every commit once, rather than per changeset.
@@ -66,8 +84,11 @@ function pullRequestFor(commit, subjects = commitSubjects()) {
   if (!commit) return null;
   const subject = subjects.get(commit);
   if (!subject) return null;
-  const match = PULL_REQUEST_IN_SUBJECT.exec(subject);
-  return match ? match[1] : null;
+  for (const pattern of PULL_REQUEST_PATTERNS) {
+    const match = pattern.exec(subject);
+    if (match) return match[1];
+  }
+  return null;
 }
 
 /** One release line. Exported so its formatting is testable without running a release. */
@@ -97,15 +118,27 @@ const changelogFunctions = {
     if (dependenciesUpdated.length === 0) return "";
     const repo = options?.repo ?? "nextlyhq/nextly";
     const subjects = commitSubjects();
-    const updatedBy = changesets.map(changeset => {
-      if (!changeset.commit) return "- Updated dependencies";
-      const short = changeset.commit.slice(0, 7);
-      const pull = pullRequestFor(changeset.commit, subjects);
-      const link = `[\`${short}\`](https://github.com/${repo}/commit/${changeset.commit})`;
-      return `- Updated dependencies ${link}${pull ? ` [#${pull}](https://github.com/${repo}/pull/${pull})` : ""}`;
-    });
+    // ONE bullet, with the commits inline and the packages nested under it.
+    //
+    // A bullet per changeset followed by a single package list reads correctly in source and
+    // renders wrongly: Markdown attaches the nested list to the LAST bullet, so every earlier
+    // changeset becomes an empty `Updated dependencies` line and the package versions appear to
+    // belong to whichever commit happened to sort last. With a lockstep release group every
+    // changeset touches every package, so that is not a corner case - it is the normal shape, and
+    // at this repository's backlog it produces dozens of empty bullets per package.
+    const links = changesets
+      .filter(changeset => changeset.commit)
+      .map(changeset => {
+        const short = changeset.commit.slice(0, 7);
+        const pull = pullRequestFor(changeset.commit, subjects);
+        const commitLink = `[\`${short}\`](https://github.com/${repo}/commit/${changeset.commit})`;
+        return pull
+          ? `${commitLink} [#${pull}](https://github.com/${repo}/pull/${pull})`
+          : commitLink;
+      });
+    const heading = links.length > 0 ? `- Updated dependencies ${links.join(", ")}` : "- Updated dependencies";
     const packages = dependenciesUpdated.map(one => `  - ${one.name}@${one.newVersion}`);
-    return [...updatedBy, ...packages].join("\n");
+    return [heading, ...packages].join("\n");
   },
 };
 

--- a/scripts/release/changelog.cjs
+++ b/scripts/release/changelog.cjs
@@ -1,0 +1,121 @@
+/**
+ * Changelog entries built from LOCAL git, with no GitHub API call.
+ *
+ * `@changesets/changelog-github` asks GitHub for the pull request and author behind every
+ * changeset. Its `get-github-info` loader batches with no `maxBatchSize`, so one query carries an
+ * aliased `object(expression: <commit>)` per changeset, each with a nested
+ * `associatedPullRequests(first: 50)`. Past a few hundred pending changesets GitHub stops
+ * VALIDATING the document - `{"message": "Timeout on validation of query"}` - and the release
+ * fails before writing anything. Validation is refused rather than the work being slow, so
+ * retries and backoff do not reach it; the query has to stop being built.
+ *
+ * Everything those entries need is already in the repository. The squash subject a merge writes
+ * carries its pull-request number, `changeset.commit` carries the revision, and both URLs are
+ * constructed from the repo name. One `git log` pass over the whole history builds the map, so
+ * the cost does not grow with the number of changesets and no network is involved.
+ *
+ * The trade against `@changesets/changelog-github` is author attribution: a git author is not a
+ * GitHub login, and guessing one from a name or an email would be a fabricated link. Attribution
+ * is dropped rather than approximated.
+ */
+
+const { execFileSync } = require("node:child_process");
+
+/** `feat(scope): subject (#1234)` - the shape a squash merge writes. */
+const PULL_REQUEST_IN_SUBJECT = /\(#(\d+)\)\s*$/;
+
+/**
+ * Read every commit once, rather than per changeset.
+ *
+ * A lookup per entry would be several hundred subprocesses on a backlog this size. This is one,
+ * and its result is reused for every line in the run.
+ *
+ * Resolved lazily so that importing this module cannot fail: `changeset version` runs in trees
+ * where git may be absent or the history shallow, and a changelog is not worth aborting a release
+ * over. A failed read yields an empty map, which degrades every entry to its summary alone.
+ */
+let subjectsByCommit;
+
+function commitSubjects() {
+  if (subjectsByCommit) return subjectsByCommit;
+  subjectsByCommit = new Map();
+  try {
+    const log = execFileSync("git", ["log", "--format=%H%x09%s"], {
+      encoding: "utf8",
+      maxBuffer: 256 * 1024 * 1024,
+    });
+    for (const line of log.split("\n")) {
+      const tab = line.indexOf("\t");
+      if (tab === -1) continue;
+      subjectsByCommit.set(line.slice(0, tab), line.slice(tab + 1));
+    }
+  } catch {
+    // Left empty on purpose. The caller cannot tell "no such commit" from "no git", and both
+    // resolve the same way: emit the summary without links rather than fail the release.
+  }
+  return subjectsByCommit;
+}
+
+/**
+ * The pull request a commit landed through, or null when the subject does not name one.
+ *
+ * Null is the correct answer for a direct push and for a commit this checkout does not have. It is
+ * not an error: an entry without a link is still a correct changelog entry.
+ */
+function pullRequestFor(commit, subjects = commitSubjects()) {
+  if (!commit) return null;
+  const subject = subjects.get(commit);
+  if (!subject) return null;
+  const match = PULL_REQUEST_IN_SUBJECT.exec(subject);
+  return match ? match[1] : null;
+}
+
+/** One release line. Exported so its formatting is testable without running a release. */
+function releaseLine(changeset, repo, subjects = commitSubjects()) {
+  const [first, ...rest] = changeset.summary.split("\n").map(line => line.trimEnd());
+
+  const links = [];
+  if (changeset.commit) {
+    const short = changeset.commit.slice(0, 7);
+    links.push(`[\`${short}\`](https://github.com/${repo}/commit/${changeset.commit})`);
+    const pull = pullRequestFor(changeset.commit, subjects);
+    if (pull) links.push(`[#${pull}](https://github.com/${repo}/pull/${pull})`);
+  }
+
+  const prefix = links.length > 0 ? `${links.join(" ")} - ` : "";
+  let line = `- ${prefix}${first}`;
+  // A multi-line summary keeps its shape, indented under the bullet, as changelog-git does.
+  if (rest.length > 0) line += `\n${rest.map(one => `  ${one}`).join("\n")}`;
+  return line;
+}
+
+const changelogFunctions = {
+  getReleaseLine: async (changeset, _type, options) =>
+    releaseLine(changeset, options?.repo ?? "nextlyhq/nextly"),
+
+  getDependencyReleaseLine: async (changesets, dependenciesUpdated, options) => {
+    if (dependenciesUpdated.length === 0) return "";
+    const repo = options?.repo ?? "nextlyhq/nextly";
+    const subjects = commitSubjects();
+    const updatedBy = changesets.map(changeset => {
+      if (!changeset.commit) return "- Updated dependencies";
+      const short = changeset.commit.slice(0, 7);
+      const pull = pullRequestFor(changeset.commit, subjects);
+      const link = `[\`${short}\`](https://github.com/${repo}/commit/${changeset.commit})`;
+      return `- Updated dependencies ${link}${pull ? ` [#${pull}](https://github.com/${repo}/pull/${pull})` : ""}`;
+    });
+    const packages = dependenciesUpdated.map(one => `  - ${one.name}@${one.newVersion}`);
+    return [...updatedBy, ...packages].join("\n");
+  },
+};
+
+// CommonJS on purpose. `apply-release-plan` loads this with `require()`, which cannot read an
+// ESM `.mjs` on Node 20 - a version this repository still supports - so the module format is
+// decided by the consumer rather than by the surrounding convention.
+//
+// `default` as well as the bare shape: the loader accepts either, and pinning both means a change
+// to its interop cannot silently fall through to an undefined function.
+module.exports = changelogFunctions;
+module.exports.default = changelogFunctions;
+module.exports.pullRequestFor = pullRequestFor;
+module.exports.releaseLine = releaseLine;

--- a/scripts/release/changelog.test.mjs
+++ b/scripts/release/changelog.test.mjs
@@ -12,6 +12,7 @@ const COMMIT = "a0e2817a2f1c4d5e6b7a8c9d0e1f2a3b4c5d6e7f";
 const subjects = new Map([
   [COMMIT, "fix(ui): make one control size name mean one control height (#833)"],
   ["b".repeat(40), "chore: a commit that arrived without a pull request"],
+  ["d".repeat(40), "Merge pull request #783 from nextlyhq/fix/blog-template-builds"],
 ]);
 
 describe("pullRequestFor", () => {
@@ -27,6 +28,13 @@ describe("pullRequestFor", () => {
   it("returns null for a commit this checkout does not have", () => {
     // A shallow clone reaches here. Degrading to no link is correct; failing is not.
     expect(pullRequestFor("c".repeat(40), subjects)).toBe(null);
+  });
+
+  it("reads the number a merge commit names", () => {
+    // The other shape that identifies a pull request in the commit ITSELF. 118 of 560
+    // changeset-adding commits in this history carry no `(#N)` suffix, and a merge commit is the
+    // one remaining case where the answer is present rather than inferred.
+    expect(pullRequestFor("d".repeat(40), subjects)).toBe("783");
   });
 
   it("does not read a number from the middle of a subject", () => {
@@ -89,6 +97,28 @@ describe("the changelog contract", () => {
     );
     expect(out).toContain("Updated dependencies");
     expect(out).toContain("  - @nextlyhq/ui@0.0.2-alpha.42");
+  });
+
+  it("emits ONE bullet with the packages nested under it", async () => {
+    // Markdown attaches a nested list to the LAST bullet, so a bullet per changeset leaves every
+    // earlier one empty. With a lockstep group that is the normal shape, not a corner case.
+    const out = await changelogFunctions.getDependencyReleaseLine(
+      [{ commit: COMMIT }, { commit: "b".repeat(40) }],
+      [{ name: "@nextlyhq/ui", newVersion: "0.0.2-alpha.42" }],
+      { repo: REPO }
+    );
+    expect(out.split("\n").filter(line => line.startsWith("- "))).toHaveLength(1);
+    expect(out).toContain("  - @nextlyhq/ui@0.0.2-alpha.42");
+  });
+
+  it("names every contributing commit in that one bullet", async () => {
+    const out = await changelogFunctions.getDependencyReleaseLine(
+      [{ commit: COMMIT }, { commit: "b".repeat(40) }],
+      [{ name: "@nextlyhq/ui", newVersion: "0.0.2-alpha.42" }],
+      { repo: REPO }
+    );
+    expect(out).toContain(COMMIT.slice(0, 7));
+    expect(out).toContain("b".repeat(7));
   });
 
   it("makes NO network call", async () => {

--- a/scripts/release/changelog.test.mjs
+++ b/scripts/release/changelog.test.mjs
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest";
+
+import changelog from "./changelog.cjs";
+
+const { pullRequestFor, releaseLine } = changelog;
+const changelogFunctions = changelog;
+
+const REPO = "nextlyhq/nextly";
+const COMMIT = "a0e2817a2f1c4d5e6b7a8c9d0e1f2a3b4c5d6e7f";
+
+/** A stand-in for the real `git log` map, so these assert formatting rather than this checkout. */
+const subjects = new Map([
+  [COMMIT, "fix(ui): make one control size name mean one control height (#833)"],
+  ["b".repeat(40), "chore: a commit that arrived without a pull request"],
+]);
+
+describe("pullRequestFor", () => {
+  it("reads the number a squash subject ends with", () => {
+    expect(pullRequestFor(COMMIT, subjects)).toBe("833");
+  });
+
+  it("returns null for a subject that names no pull request", () => {
+    // A direct push is not an error and must still produce a changelog entry.
+    expect(pullRequestFor("b".repeat(40), subjects)).toBe(null);
+  });
+
+  it("returns null for a commit this checkout does not have", () => {
+    // A shallow clone reaches here. Degrading to no link is correct; failing is not.
+    expect(pullRequestFor("c".repeat(40), subjects)).toBe(null);
+  });
+
+  it("does not read a number from the middle of a subject", () => {
+    // `(#12)` mid-sentence is prose about an issue, not the merge's own number. Anchoring to the
+    // end is what separates them, and without this the link would point somewhere arbitrary.
+    const middle = new Map([[COMMIT, "fix: handle (#12) in the parser correctly"]]);
+    expect(pullRequestFor(COMMIT, middle)).toBe(null);
+  });
+});
+
+describe("releaseLine", () => {
+  it("links the commit and the pull request", () => {
+    const line = releaseLine({ summary: "do the thing", commit: COMMIT }, REPO, subjects);
+    expect(line).toBe(
+      `- [\`a0e2817\`](https://github.com/${REPO}/commit/${COMMIT})` +
+        ` [#833](https://github.com/${REPO}/pull/833) - do the thing`
+    );
+  });
+
+  it("links only the commit when no pull request is named", () => {
+    const line = releaseLine({ summary: "do the thing", commit: "b".repeat(40) }, REPO, subjects);
+    expect(line).toContain("/commit/");
+    expect(line).not.toContain("/pull/");
+    expect(line).toContain("- do the thing");
+  });
+
+  it("emits the summary alone when there is no commit", () => {
+    // What a changeset added but not yet committed looks like, and what a failed git read
+    // degrades every entry to.
+    expect(releaseLine({ summary: "do the thing" }, REPO, subjects)).toBe("- do the thing");
+  });
+
+  it("keeps a multi-line summary indented under the bullet", () => {
+    const line = releaseLine({ summary: "first line\nsecond line", commit: undefined }, REPO, subjects);
+    expect(line).toBe("- first line\n  second line");
+  });
+
+  it("trims trailing whitespace from every line", () => {
+    expect(releaseLine({ summary: "first  \nsecond\t" }, REPO, subjects)).toBe("- first\n  second");
+  });
+});
+
+describe("the changelog contract", () => {
+  it("exports the two functions changesets calls", () => {
+    // Named exactly as `changeset version` looks them up. A rename here fails the release at the
+    // point of use rather than at import, so it is pinned.
+    expect(typeof changelogFunctions.getReleaseLine).toBe("function");
+    expect(typeof changelogFunctions.getDependencyReleaseLine).toBe("function");
+  });
+
+  it("returns an empty string when nothing was updated", async () => {
+    expect(await changelogFunctions.getDependencyReleaseLine([], [], { repo: REPO })).toBe("");
+  });
+
+  it("lists each updated dependency under the commits that moved it", async () => {
+    const out = await changelogFunctions.getDependencyReleaseLine(
+      [{ commit: COMMIT }],
+      [{ name: "@nextlyhq/ui", newVersion: "0.0.2-alpha.42" }],
+      { repo: REPO }
+    );
+    expect(out).toContain("Updated dependencies");
+    expect(out).toContain("  - @nextlyhq/ui@0.0.2-alpha.42");
+  });
+
+  it("makes NO network call", async () => {
+    // The property this module exists for. `changelog-github` reaches api.github.com here, and at
+    // this repository's changeset count GitHub refuses to validate the query it builds.
+    const original = globalThis.fetch;
+    globalThis.fetch = () => {
+      throw new Error("changelog generation must not perform network requests");
+    };
+    try {
+      await expect(
+        changelogFunctions.getReleaseLine({ summary: "s", commit: COMMIT }, "patch", { repo: REPO })
+      ).resolves.toContain("- ");
+    } finally {
+      globalThis.fetch = original;
+    }
+  });
+});


### PR DESCRIPTION
`Version & Publish` has been failing on `main` — **14 of the last 20 runs** — so Version PR #744 is stale and nothing publishes.

## Mechanism, confirmed from source rather than inferred

`@changesets/changelog-github` asks GitHub for the pull request behind every changeset. Its `get-github-info` loader is a `DataLoader` with **no `maxBatchSize`**, so `makeQuery` emits one aliased `object(expression: <commit>)` per changeset, each carrying a nested `associatedPullRequests(first: 50)`.

`main` currently has **472 pending changesets**. GitHub stops *validating* the document:

```
Error: An error occurred when fetching data from GitHub
  { "message": "Timeout on validation of query" }
```

That is validation being refused, not the work being slow — so retries and backoff cannot reach it. The three successes among the last 20 are the query sitting right at the boundary. It fails safe (`no files should have been affected`), so nothing is corrupted; nothing releases either.

## The fix

Everything those entries need is already in the repository. The squash subject carries its pull-request number, the changeset carries the revision, and both URLs are constructed from the repo name. **One `git log` pass** builds the map, so cost does not grow with the changeset count and no network is involved.

Output keeps its shape:

```
- [`8a7e734`](https://github.com/nextlyhq/nextly/commit/8a7e734…) [#720](https://github.com/nextlyhq/nextly/pull/720) - Take the reference palette's light-mode values…
```

**Attribution is dropped rather than approximated.** A git author is not a GitHub login, and guessing one from a name or email would be a fabricated link. That is the one thing this loses against `changelog-github`, and it is deliberate.

## Verification

End to end, not just unit level: `changeset version` over all **472** changesets with `GITHUB_TOKEN` and `GH_TOKEN` **unset** completes with exit 0 and emits entries carrying both links. The same command fails against the previous configuration.

13 tests cover the formatting and the degradations that matter — a commit with no pull request, a commit this checkout does not have (a shallow clone), a `(#12)` mid-subject that must NOT be read as the merge's number, and an explicit assertion that generation performs **no network call**.

Two constraints found while building it, both worth knowing:
- `apply-release-plan` resolves the path with `resolveFrom(changesetPath, …)`, so it is relative to `.changeset/`, not the repo root.
- It loads via `require()`, which cannot read `.mjs` on Node 20 — a version this repo still supports — so the module is CommonJS by necessity rather than by convention.

## Scope

This does not touch release strategy. The 472 changesets stay, prerelease mode stays, and the Version PR picks up from where it is.

No changeset: this is CI/release tooling and ships nothing.