### PR TITLE
test(root): run the verdict gate as a program, not as imports

### DIFF
--- a/scripts/ci-verdict.cli.test.mjs
+++ b/scripts/ci-verdict.cli.test.mjs
@@ -24,6 +24,7 @@ import {
   chmodSync,
   mkdirSync,
   mkdtempSync,
+  readFileSync,
   rmSync,
   symlinkSync,
   writeFileSync,
@@ -53,9 +54,14 @@ let chain;
  * fixture into a passing test.
  */
 const STUB = `#!/usr/bin/env node
-import { readFileSync } from "node:fs";
+import { appendFileSync, readFileSync } from "node:fs";
 const argv = process.argv.slice(2);
 const fixture = JSON.parse(readFileSync(process.env.GH_STUB_FIXTURE, "utf8"));
+// Every invocation is recorded, so a case can assert that a request was MADE
+// rather than only that its answer was accepted. Validating each call
+// independently cannot see a request the command skipped: the remaining calls
+// return the same fixture data either way.
+appendFileSync(process.env.GH_STUB_CALLS, JSON.stringify(argv) + "\\n");
 const tokens = [];
 for (let i = 0; i < argv.length; i += 1) {
   // Inserted on every api request by the caller, so it does not identify one.
@@ -87,6 +93,11 @@ beforeAll(() => {
   git(["init", "-q", "-b", "feature/x", "."]);
   git(["config", "user.email", "test@example.com"]);
   git(["config", "user.name", "test"]);
+  // A developer with `commit.gpgSign=true` in their user configuration has no
+  // signing key for this synthetic identity, so the fixture would fail to
+  // build before any case ran. Set in the throwaway repository rather than
+  // passed per commit, so it also covers any commit added here later.
+  git(["config", "commit.gpgSign", "false"]);
   chain = [];
   for (let i = 0; i < 5; i += 1) {
     writeFileSync(join(origin, "f.txt"), `${i}\n`);
@@ -120,6 +131,19 @@ const shallowClone = name => {
 };
 
 /**
+ * A clone whose local `HEAD` sits at `sha` while the remote branch stays put.
+ *
+ * Full rather than shallow, because the commit being checked out is behind the
+ * boundary a `--depth 1` clone would draw.
+ */
+const detachedClone = (name, sha) => {
+  const path = join(root, name);
+  execFileSync("git", ["clone", "-q", `file://${origin}`, path]);
+  execFileSync("git", ["checkout", "-q", "--detach", sha], { cwd: path });
+  return path;
+};
+
+/**
  * The routes every lifecycle needs, so a case states only what it varies.
  *
  * `--slurp` hands back one array per page, which the command flattens; the
@@ -135,9 +159,17 @@ const baseRoutes = ({
 }) => [
   { when: ["auth", "setup-git"] },
   {
+    // The PR number and `--repo` value are REQUIRED here, not decoration.
+    // `gh pr view` with no argument resolves the current branch's pull
+    // request and `--repo` selects the repository, so a route matching on the
+    // command words alone accepts a call that reads lifecycle and head
+    // metadata from a different pull request than the API requests use.
     when: [
       "pr",
       "view",
+      "1",
+      "--repo",
+      "nextlyhq/nextly",
       "headRefName,isCrossRepository,headRepositoryOwner,headRepository,state,headRefOid,baseRefOid",
     ],
     stdout: {
@@ -151,7 +183,14 @@ const baseRoutes = ({
     },
   },
   {
-    when: ["pr", "view", "state,headRefOid,baseRefOid"],
+    when: [
+      "pr",
+      "view",
+      "1",
+      "--repo",
+      "nextlyhq/nextly",
+      "state,headRefOid,baseRefOid",
+    ],
     stdout: { state, headRefOid, baseRefOid: "base000" },
   },
   { when: ["repos/nextlyhq/nextly/pulls/1/reviews"], stdout: [reviews] },
@@ -240,13 +279,16 @@ const cliEnv = ({ nodeOptions } = {}) => {
  */
 const runCli = ({ cwd, routes, entry = ENTRY, nodeOptions, args = ["1"] }) => {
   const fixture = join(root, "fixture.json");
+  const calls = join(root, "calls.log");
   writeFileSync(fixture, JSON.stringify({ routes }));
+  writeFileSync(calls, "");
   const result = spawnSync(process.execPath, [entry, ...args], {
     cwd,
     encoding: "utf8",
     env: {
       ...cliEnv({ nodeOptions }),
       GH_STUB_FIXTURE: fixture,
+      GH_STUB_CALLS: calls,
     },
   });
   let report;
@@ -260,8 +302,17 @@ const runCli = ({ cwd, routes, entry = ENTRY, nodeOptions, args = ["1"] }) => {
     stdout: result.stdout,
     stderr: result.stderr,
     report,
+    /** Every `gh` invocation, in order, as its argv array. */
+    calls: readFileSync(calls, "utf8")
+      .split("\n")
+      .filter(Boolean)
+      .map(line => JSON.parse(line)),
   };
 };
+
+/** How many recorded invocations carry every one of `tokens`. */
+const callsMatching = (calls, tokens) =>
+  calls.filter(argv => tokens.every(token => argv.includes(token))).length;
 
 // Each case spawns a clone, the command, and the several `gh` and `git`
 // subprocesses it makes — measured near 4.3s against a 5s default, which is a
@@ -307,8 +358,14 @@ describe("ci-verdict as a command", { timeout: 60_000 }, () => {
 
   it("clears an open pull request reviewed at its current head", () => {
     const tip = chain[4];
+    // The checkout's local HEAD is moved OFF the branch tip while the remote
+    // ref stays where it is. Every clone otherwise leaves the two equal, so
+    // `git rev-parse HEAD` would answer identically and the case could not
+    // tell the local checkout from the configured repository's branch — which
+    // is the whole thing the command has to get right, since it may run from
+    // a stale or unrelated working copy.
     const run = runCli({
-      cwd: shallowClone("clean"),
+      cwd: detachedClone("clean", chain[0]),
       routes: baseRoutes({
         state: "OPEN",
         headRefOid: tip,
@@ -317,7 +374,16 @@ describe("ci-verdict as a command", { timeout: 60_000 }, () => {
       }),
     });
     expect(run.report?.verdict).toBe("CLEAN");
+    expect(run.report?.head).toBe(tip);
     expect(run.status).toBe(0);
+    // The verdict is computed BETWEEN two identical observations, so the
+    // evidence cannot have moved while it was being decided. Every route
+    // answers the same data whichever way that goes, so only counting the
+    // requests can see the closing observation happen: asserting on the
+    // report alone leaves the recheck removable with the suite green.
+    expect(
+      callsMatching(run.calls, ["pr", "view", "state,headRefOid,baseRefOid"])
+    ).toBeGreaterThanOrEqual(2);
     // An advisory reviewer's absence is REPORTED but does not hold the merge,
     // so a gap stays visible without a reviewer outside the blocking set being
     // able to block on quota it never spent.
@@ -355,6 +421,9 @@ describe("ci-verdict as a command", { timeout: 60_000 }, () => {
           when: [
             "pr",
             "view",
+            "1",
+            "--repo",
+            "nextlyhq/nextly",
             "headRefName,isCrossRepository,headRepositoryOwner,headRepository,state,headRefOid,baseRefOid",
           ],
           stdout: {
@@ -367,7 +436,10 @@ describe("ci-verdict as a command", { timeout: 60_000 }, () => {
             baseRefOid: "base000",
           },
         },
-        { when: ["pr", "view", "state"], stdout: { state: "CLOSED" } },
+        {
+          when: ["pr", "view", "1", "--repo", "nextlyhq/nextly", "state"],
+          stdout: { state: "CLOSED" },
+        },
       ],
     });
     expect(run.report?.verdict).toBe("CLOSED WITHOUT MERGING");

--- a/scripts/ci-verdict.cli.test.mjs
+++ b/scripts/ci-verdict.cli.test.mjs
@@ -194,29 +194,59 @@ const review = (login, commitId) => ({
 });
 
 /**
+ * The environment the command runs under, with every variable it READS pinned.
+ *
+ * Inheriting the runner's environment is not neutral here. `GH_HOST` is an
+ * ordinary Enterprise setting, and the command derives its request host and its
+ * git remote from it — so an inherited value sends the subprocess at a host the
+ * `insteadOf` rewrite below does not intercept, and the cases either fail or
+ * reach the network. `CI_VERDICT_BLOCKING` and `CI_VERDICT_ADVISORY` rename the
+ * reviewers the verdict is computed from, which changes the expected answer
+ * without changing the fixture.
+ *
+ * `NODE_OPTIONS` is pinned for the same reason in the opposite direction: the
+ * symlink case SETS it, so leaving it inherited elsewhere would let a runner
+ * supply the flag to every other case and quietly remove the contrast that one
+ * is demonstrating.
+ */
+const cliEnv = ({ nodeOptions } = {}) => {
+  const env = {
+    ...process.env,
+    PATH: `${join(root, "bin")}:${process.env.PATH}`,
+    GH_REPO: "nextlyhq/nextly",
+    NODE_OPTIONS: nodeOptions ?? "",
+    // Real git, aimed at the throwaway repository. Supplied through the
+    // environment so no config file anywhere is written or read.
+    GIT_CONFIG_COUNT: "1",
+    GIT_CONFIG_KEY_0: `url.${origin}.insteadOf`,
+    GIT_CONFIG_VALUE_0: "https://github.com/nextlyhq/nextly.git",
+  };
+  // Deleted rather than blanked: the command falls back to its own default
+  // when these are absent, and an empty string is a configured value that
+  // would override it.
+  delete env.GH_HOST;
+  delete env.CI_VERDICT_BLOCKING;
+  delete env.CI_VERDICT_ADVISORY;
+  delete env.GH_STUB_FIXTURE;
+  return env;
+};
+
+/**
  * Start the command and return its status and parsed report.
  *
  * `stdout` is returned unparsed as well, because a case that exits without
  * emitting has to be able to assert on the absence rather than on a parse
  * failure that would look identical to malformed output.
  */
-const runCli = ({ cwd, routes, entry = ENTRY, nodeOptions }) => {
+const runCli = ({ cwd, routes, entry = ENTRY, nodeOptions, args = ["1"] }) => {
   const fixture = join(root, "fixture.json");
   writeFileSync(fixture, JSON.stringify({ routes }));
-  const result = spawnSync(process.execPath, [entry, "1"], {
+  const result = spawnSync(process.execPath, [entry, ...args], {
     cwd,
     encoding: "utf8",
     env: {
-      ...process.env,
-      PATH: `${join(root, "bin")}:${process.env.PATH}`,
+      ...cliEnv({ nodeOptions }),
       GH_STUB_FIXTURE: fixture,
-      GH_REPO: "nextlyhq/nextly",
-      ...(nodeOptions ? { NODE_OPTIONS: nodeOptions } : {}),
-      // Real git, aimed at the throwaway repository. Supplied through the
-      // environment so no config file anywhere is written or read.
-      GIT_CONFIG_COUNT: "1",
-      GIT_CONFIG_KEY_0: `url.${origin}.insteadOf`,
-      GIT_CONFIG_VALUE_0: "https://github.com/nextlyhq/nextly.git",
     },
   });
   let report;
@@ -233,7 +263,11 @@ const runCli = ({ cwd, routes, entry = ENTRY, nodeOptions }) => {
   };
 };
 
-describe("ci-verdict as a command", () => {
+// Each case spawns a clone, the command, and the several `gh` and `git`
+// subprocesses it makes — measured near 4.3s against a 5s default, which is a
+// margin a loaded runner erases. Raised so a slow machine reports slowness
+// rather than a failure of the behaviour under test.
+describe("ci-verdict as a command", { timeout: 60_000 }, () => {
   it("counts the whole tail from a shallow clone", () => {
     // The branch carries three commits the merge does not. A shallow checkout
     // stops `rev-list` at its own boundary and answers 1 — the reassuring
@@ -307,6 +341,12 @@ describe("ci-verdict as a command", () => {
   it("answers for a pull request closed without merging", () => {
     // Its branch is commonly deleted straight after, so resolving the ref
     // first turned this conclusive lifecycle into a failure to answer.
+    //
+    // `headRefName` names a ref the throwaway origin does NOT have, which is
+    // what makes this case able to fail. Pointing it at the existing branch
+    // lets an early `ls-remote` succeed and produce the same verdict, so the
+    // fixture would never reach the mechanism and the case would pass on the
+    // broken ordering it exists to reject.
     const run = runCli({
       cwd: shallowClone("closed"),
       routes: [
@@ -318,7 +358,7 @@ describe("ci-verdict as a command", () => {
             "headRefName,isCrossRepository,headRepositoryOwner,headRepository,state,headRefOid,baseRefOid",
           ],
           stdout: {
-            headRefName: "feature/x",
+            headRefName: "feature/deleted-after-closing",
             isCrossRepository: false,
             headRepositoryOwner: { login: "nextlyhq" },
             headRepository: { name: "nextly" },
@@ -451,11 +491,17 @@ describe("ci-verdict as a command", () => {
   });
 
   it("rejects a pull request argument that would rewrite the request path", () => {
-    const run = spawnSync(process.execPath, [ENTRY, "1/../2"], {
+    // Asserted on the USAGE message rather than on the status. Exit 2 is also
+    // what every later failure produces, so a weakened validation that let the
+    // value through would reach `gh` and still exit 2 with empty stdout — the
+    // case would stay green with the request-path protection gone. The usage
+    // line is emitted only by the argument check.
+    const run = runCli({
       cwd: root,
-      encoding: "utf8",
-      env: { ...process.env, PATH: `${join(root, "bin")}:${process.env.PATH}` },
+      args: ["1/../2"],
+      routes: [{ when: ["auth", "setup-git"] }],
     });
+    expect(run.stderr).toMatch(/^usage: /);
     expect(run.status).toBe(2);
     expect(run.stdout).toBe("");
   });

--- a/scripts/ci-verdict.cli.test.mjs
+++ b/scripts/ci-verdict.cli.test.mjs
@@ -376,6 +376,19 @@ describe("ci-verdict as a command", { timeout: 60_000 }, () => {
     expect(run.report?.verdict).toBe("CLEAN");
     expect(run.report?.head).toBe(tip);
     expect(run.status).toBe(0);
+    // Listing a route does not require the command to CALL it — the stub
+    // permits unused routes, so an omitted request is invisible in the
+    // verdict. `git` does not read `GH_TOKEN`, and the workflow checks out
+    // without persisted credentials, so dropping this leaves `ls-remote`
+    // unable to authenticate against a private repository.
+    expect(
+      callsMatching(run.calls, [
+        "auth",
+        "setup-git",
+        "--hostname",
+        "github.com",
+      ])
+    ).toBeGreaterThanOrEqual(1);
     // The verdict is computed BETWEEN two identical observations, so the
     // evidence cannot have moved while it was being decided. Every route
     // answers the same data whichever way that goes, so only counting the
@@ -449,6 +462,49 @@ describe("ci-verdict as a command", { timeout: 60_000 }, () => {
     // "nothing outstanding".
     expect(run.report?.unresolved_threads).toBe("unavailable");
     expect(run.report?.missing_reviews).toBe("unavailable");
+    // Supplying the recheck's response does not prove it was consumed. This
+    // path takes no other remote observation, so without the re-read the
+    // verdict rests on a lifecycle sampled earlier in the run.
+    expect(
+      callsMatching(run.calls, ["pr", "view", "1", "state"])
+    ).toBeGreaterThanOrEqual(1);
+  });
+
+  it("refuses when a closed pull request was reopened mid-run", () => {
+    // The positive control for the re-read above: the second lifecycle
+    // response DIFFERS, and only a command that consumes it can notice.
+    // Reopening is precisely the transition that makes the shortcut wrong.
+    const routes = [
+      { when: ["auth", "setup-git"] },
+      {
+        when: [
+          "pr",
+          "view",
+          "1",
+          "--repo",
+          "nextlyhq/nextly",
+          "headRefName,isCrossRepository,headRepositoryOwner,headRepository,state,headRefOid,baseRefOid",
+        ],
+        stdout: {
+          headRefName: "feature/deleted-after-closing",
+          isCrossRepository: false,
+          headRepositoryOwner: { login: "nextlyhq" },
+          headRepository: { name: "nextly" },
+          state: "CLOSED",
+          headRefOid: chain[4],
+          baseRefOid: "base000",
+        },
+      },
+      {
+        when: ["pr", "view", "1", "--repo", "nextlyhq/nextly", "state"],
+        stdout: { state: "OPEN" },
+      },
+    ];
+    const run = runCli({ cwd: shallowClone("reopened"), routes });
+
+    expect(run.status).toBe(2);
+    expect(run.stdout).toBe("");
+    expect(run.stderr).toContain("lifecycle changed");
   });
 
   it("runs when invoked through a symlink that the runtime does not resolve", () => {
@@ -460,19 +516,29 @@ describe("ci-verdict as a command", { timeout: 60_000 }, () => {
     const link = join(root, "linked-ci-verdict.mjs");
     rmSync(link, { force: true });
     symlinkSync(ENTRY, link);
-    const run = runCli({
-      cwd: shallowClone("symlink"),
-      entry: link,
-      nodeOptions: "--preserve-symlinks-main",
-      routes: baseRoutes({
-        state: "OPEN",
-        headRefOid: chain[4],
-        reviews: [review(CODEX, chain[4])],
-        commits: [chain[4]],
-      }),
+    const routes = baseRoutes({
+      state: "OPEN",
+      headRefOid: chain[4],
+      reviews: [review(CODEX, chain[4])],
+      commits: [chain[4]],
     });
-    expect(run.report?.verdict).toBe("CLEAN");
-    expect(run.status).toBe(0);
+
+    // BOTH modes, through the same link. The guard accepts the raw entry and
+    // its resolved form, and each covers one of these: with the flag,
+    // `import.meta.url` keeps the link while `realpathSync` resolves it away;
+    // without it, the runtime resolves `import.meta.url` while `process.argv[1]`
+    // still holds the link. Exercising one mode leaves the other's half of the
+    // guard removable with the case green.
+    for (const nodeOptions of ["--preserve-symlinks-main", ""]) {
+      const run = runCli({
+        cwd: shallowClone(`symlink-${nodeOptions === "" ? "resolved" : "raw"}`),
+        entry: link,
+        nodeOptions,
+        routes,
+      });
+      expect(run.report?.verdict).toBe("CLEAN");
+      expect(run.status).toBe(0);
+    }
   });
 
   it("refuses to answer when a request fails", () => {

--- a/scripts/ci-verdict.cli.test.mjs
+++ b/scripts/ci-verdict.cli.test.mjs
@@ -1,0 +1,462 @@
+// Runs `scripts/ci-verdict.mjs` AS A PROGRAM.
+//
+// The sibling suite imports the decision helpers and calls them. That covers
+// what those functions compute, and nothing about whether the command around
+// them executes: the entry guard, the request sequence, the git commands and
+// the process exit are all reachable only by starting the process. A suite
+// that only imports has been fully green while the command crashed on its
+// first line, because no test ever ran it.
+//
+// So every case here spawns the real file. Two substitutions make that
+// possible without a network:
+//
+//   `gh`  is a stub on PATH, answering from a recorded fixture. Its requests
+//         are reads with stable shapes, so a recording is as good as the
+//         service and it runs anywhere, including CI.
+//
+//   `git` is REAL, pointed at a throwaway repository by `url.<path>.insteadOf`
+//         supplied through `GIT_CONFIG_COUNT`. It is deliberately NOT stubbed:
+//         the counting defect this file pins comes from how a genuine shallow
+//         clone answers `rev-list`, and a stub would only reproduce whatever
+//         belief was written into it.
+import { execFileSync, spawnSync } from "node:child_process";
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const ENTRY = join(HERE, "ci-verdict.mjs");
+const CODEX = "chatgpt-codex-connector[bot]";
+const RABBIT = "coderabbitai[bot]";
+
+let root;
+let origin;
+/** The five-commit chain, oldest first, as SHAs. */
+let chain;
+
+/**
+ * A `gh` that answers from a fixture instead of the network.
+ *
+ * Routes are matched on argv ELEMENTS rather than on a joined string, because
+ * `pulls/1` is a prefix of `pulls/1/reviews` and a substring match would let
+ * one route answer both. An ambiguous or unmatched request exits non-zero
+ * rather than guessing: a stub that silently picks a route turns a missing
+ * fixture into a passing test.
+ */
+const STUB = `#!/usr/bin/env node
+import { readFileSync } from "node:fs";
+const argv = process.argv.slice(2);
+const fixture = JSON.parse(readFileSync(process.env.GH_STUB_FIXTURE, "utf8"));
+const tokens = [];
+for (let i = 0; i < argv.length; i += 1) {
+  // Inserted on every api request by the caller, so it does not identify one.
+  if (argv[i] === "--hostname") { i += 1; continue; }
+  tokens.push(argv[i]);
+}
+const hits = fixture.routes.filter(
+  r =>
+    r.when.every(t => tokens.includes(t)) &&
+    !(r.unless ?? []).some(t => tokens.includes(t))
+);
+if (hits.length !== 1) {
+  process.stderr.write("gh-stub: " + hits.length + " routes match " + JSON.stringify(tokens) + "\\n");
+  process.exit(64);
+}
+const [route] = hits;
+if (route.stderr) process.stderr.write(route.stderr);
+if (route.stdout !== undefined) process.stdout.write(JSON.stringify(route.stdout));
+process.exit(route.exitCode ?? 0);
+`;
+
+beforeAll(() => {
+  root = mkdtempSync(join(tmpdir(), "ci-verdict-cli-"));
+  origin = join(root, "origin");
+  mkdirSync(origin, { recursive: true });
+
+  const git = args =>
+    execFileSync("git", args, { cwd: origin, encoding: "utf8" });
+  git(["init", "-q", "-b", "feature/x", "."]);
+  git(["config", "user.email", "test@example.com"]);
+  git(["config", "user.name", "test"]);
+  chain = [];
+  for (let i = 0; i < 5; i += 1) {
+    writeFileSync(join(origin, "f.txt"), `${i}\n`);
+    git(["add", "f.txt"]);
+    git(["commit", "-qm", `c${i}`]);
+    chain.push(git(["rev-parse", "HEAD"]).trim());
+  }
+
+  const bin = join(root, "bin");
+  mkdirSync(bin, { recursive: true });
+  writeFileSync(join(bin, "gh"), STUB);
+  chmodSync(join(bin, "gh"), 0o755);
+});
+
+afterAll(() => {
+  if (root) rmSync(root, { recursive: true, force: true });
+});
+
+/** A fresh shallow clone, which is what a CI checkout gives the command. */
+const shallowClone = name => {
+  const path = join(root, name);
+  execFileSync("git", [
+    "clone",
+    "-q",
+    "--depth",
+    "1",
+    `file://${origin}`,
+    path,
+  ]);
+  return path;
+};
+
+/**
+ * The routes every lifecycle needs, so a case states only what it varies.
+ *
+ * `--slurp` hands back one array per page, which the command flattens; the
+ * nesting here is that page structure rather than an accident.
+ */
+const baseRoutes = ({
+  state,
+  headRefOid,
+  reviews = [],
+  threads = [],
+  timeline = [],
+  commits,
+}) => [
+  { when: ["auth", "setup-git"] },
+  {
+    when: [
+      "pr",
+      "view",
+      "headRefName,isCrossRepository,headRepositoryOwner,headRepository,state,headRefOid,baseRefOid",
+    ],
+    stdout: {
+      headRefName: "feature/x",
+      isCrossRepository: false,
+      headRepositoryOwner: { login: "nextlyhq" },
+      headRepository: { name: "nextly" },
+      state,
+      headRefOid,
+      baseRefOid: "base000",
+    },
+  },
+  {
+    when: ["pr", "view", "state,headRefOid,baseRefOid"],
+    stdout: { state, headRefOid, baseRefOid: "base000" },
+  },
+  { when: ["repos/nextlyhq/nextly/pulls/1/reviews"], stdout: [reviews] },
+  {
+    when: ["repos/nextlyhq/nextly/pulls/1"],
+    stdout: { commits: commits.length },
+  },
+  {
+    when: ["repos/nextlyhq/nextly/pulls/1/commits"],
+    stdout: [commits.map(sha => ({ sha, parents: [{ sha: "p" }] }))],
+  },
+  { when: ["repos/nextlyhq/nextly/issues/1/comments"], stdout: [[]] },
+  {
+    when: ["graphql"],
+    stdout: {
+      data: {
+        repository: {
+          pullRequest: {
+            reviewThreads: {
+              nodes: threads,
+              pageInfo: { hasNextPage: false, endCursor: null },
+            },
+          },
+        },
+      },
+    },
+  },
+  {
+    when: ["repos/nextlyhq/nextly/issues/1/timeline?per_page=100"],
+    stdout: [timeline],
+  },
+];
+
+const review = (login, commitId) => ({
+  id: `${login}-${commitId}`,
+  user: { login },
+  commit_id: commitId,
+  state: "APPROVED",
+  submitted_at: "2026-08-15T10:00:00Z",
+});
+
+/**
+ * Start the command and return its status and parsed report.
+ *
+ * `stdout` is returned unparsed as well, because a case that exits without
+ * emitting has to be able to assert on the absence rather than on a parse
+ * failure that would look identical to malformed output.
+ */
+const runCli = ({ cwd, routes, entry = ENTRY, nodeOptions }) => {
+  const fixture = join(root, "fixture.json");
+  writeFileSync(fixture, JSON.stringify({ routes }));
+  const result = spawnSync(process.execPath, [entry, "1"], {
+    cwd,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      PATH: `${join(root, "bin")}:${process.env.PATH}`,
+      GH_STUB_FIXTURE: fixture,
+      GH_REPO: "nextlyhq/nextly",
+      ...(nodeOptions ? { NODE_OPTIONS: nodeOptions } : {}),
+      // Real git, aimed at the throwaway repository. Supplied through the
+      // environment so no config file anywhere is written or read.
+      GIT_CONFIG_COUNT: "1",
+      GIT_CONFIG_KEY_0: `url.${origin}.insteadOf`,
+      GIT_CONFIG_VALUE_0: "https://github.com/nextlyhq/nextly.git",
+    },
+  });
+  let report;
+  try {
+    report = JSON.parse(result.stdout);
+  } catch {
+    report = undefined;
+  }
+  return {
+    status: result.status,
+    stdout: result.stdout,
+    stderr: result.stderr,
+    report,
+  };
+};
+
+describe("ci-verdict as a command", () => {
+  it("counts the whole tail from a shallow clone", () => {
+    // The branch carries three commits the merge does not. A shallow checkout
+    // stops `rev-list` at its own boundary and answers 1 — the reassuring
+    // direction, since a short count reads as a clean tail. The exit status is
+    // 10 either way, so the COUNT is what this asserts: a case pinned on the
+    // status alone passes straight through the defect.
+    const merged = chain[1];
+    const tip = chain[4];
+    const run = runCli({
+      cwd: shallowClone("tail"),
+      routes: baseRoutes({
+        state: "MERGED",
+        headRefOid: merged,
+        reviews: [review(CODEX, tip)],
+        commits: [tip],
+      }),
+    });
+    expect(run.report?.verdict).toBe("MERGED WITH UNMERGED CANDIDATES");
+    expect(run.report?.detail?.unmergedCandidates).toBe(3);
+    expect(run.status).toBe(10);
+  });
+
+  it("reports a merged pull request whose branch never moved as settled", () => {
+    const tip = chain[4];
+    const run = runCli({
+      cwd: shallowClone("settled"),
+      routes: baseRoutes({
+        state: "MERGED",
+        headRefOid: tip,
+        reviews: [review(CODEX, tip)],
+        commits: [tip],
+      }),
+    });
+    expect(run.report?.verdict).toBe("ALREADY MERGED");
+    expect(run.status).toBe(0);
+  });
+
+  it("clears an open pull request reviewed at its current head", () => {
+    const tip = chain[4];
+    const run = runCli({
+      cwd: shallowClone("clean"),
+      routes: baseRoutes({
+        state: "OPEN",
+        headRefOid: tip,
+        reviews: [review(CODEX, tip)],
+        commits: [tip],
+      }),
+    });
+    expect(run.report?.verdict).toBe("CLEAN");
+    expect(run.status).toBe(0);
+    // An advisory reviewer's absence is REPORTED but does not hold the merge,
+    // so a gap stays visible without a reviewer outside the blocking set being
+    // able to block on quota it never spent.
+    expect(run.report?.missing_reviews).toContain(RABBIT);
+  });
+
+  it("refuses an open pull request whose review names an earlier revision", () => {
+    const run = runCli({
+      cwd: shallowClone("stale"),
+      routes: baseRoutes({
+        state: "OPEN",
+        headRefOid: chain[4],
+        reviews: [review(CODEX, chain[2])],
+        commits: [chain[4]],
+      }),
+    });
+    expect(run.report?.verdict).toBe("MISSING REVIEW AT HEAD");
+    expect(run.status).toBe(10);
+  });
+
+  it("answers for a pull request closed without merging", () => {
+    // Its branch is commonly deleted straight after, so resolving the ref
+    // first turned this conclusive lifecycle into a failure to answer.
+    const run = runCli({
+      cwd: shallowClone("closed"),
+      routes: [
+        { when: ["auth", "setup-git"] },
+        {
+          when: [
+            "pr",
+            "view",
+            "headRefName,isCrossRepository,headRepositoryOwner,headRepository,state,headRefOid,baseRefOid",
+          ],
+          stdout: {
+            headRefName: "feature/x",
+            isCrossRepository: false,
+            headRepositoryOwner: { login: "nextlyhq" },
+            headRepository: { name: "nextly" },
+            state: "CLOSED",
+            headRefOid: chain[4],
+            baseRefOid: "base000",
+          },
+        },
+        { when: ["pr", "view", "state"], stdout: { state: "CLOSED" } },
+      ],
+    });
+    expect(run.report?.verdict).toBe("CLOSED WITHOUT MERGING");
+    expect(run.status).toBe(10);
+    // The review evidence was never requested on this path, so it is serialized
+    // as unavailable rather than as an empty result a caller could read as
+    // "nothing outstanding".
+    expect(run.report?.unresolved_threads).toBe("unavailable");
+    expect(run.report?.missing_reviews).toBe("unavailable");
+  });
+
+  it("runs when invoked through a symlink that the runtime does not resolve", () => {
+    // `--preserve-symlinks-main` leaves the link in `import.meta.url` while
+    // `realpathSync` resolves it away, so an entry check comparing only the
+    // resolved form matches nothing and the process exits 0 having executed
+    // no code at all. Asserting a verdict rather than a status alone, because
+    // "exited 0 having done nothing" and "passed" are the same status.
+    const link = join(root, "linked-ci-verdict.mjs");
+    rmSync(link, { force: true });
+    symlinkSync(ENTRY, link);
+    const run = runCli({
+      cwd: shallowClone("symlink"),
+      entry: link,
+      nodeOptions: "--preserve-symlinks-main",
+      routes: baseRoutes({
+        state: "OPEN",
+        headRefOid: chain[4],
+        reviews: [review(CODEX, chain[4])],
+        commits: [chain[4]],
+      }),
+    });
+    expect(run.report?.verdict).toBe("CLEAN");
+    expect(run.status).toBe(0);
+  });
+
+  it("refuses to answer when a request fails", () => {
+    // A failed request must not reach the decision half as empty evidence:
+    // "nobody has reviewed this" and "the reviews could not be read" produce
+    // the same empty array, and only one of them is a verdict.
+    const routes = baseRoutes({
+      state: "OPEN",
+      headRefOid: chain[4],
+      reviews: [review(CODEX, chain[4])],
+      commits: [chain[4]],
+    }).map(route =>
+      route.when.includes("repos/nextlyhq/nextly/pulls/1/reviews")
+        ? {
+            ...route,
+            stdout: undefined,
+            stderr: "gh: server error\n",
+            exitCode: 1,
+          }
+        : route
+    );
+    const run = runCli({ cwd: shallowClone("failing"), routes });
+    expect(run.status).toBe(2);
+    expect(run.stdout).toBe("");
+  });
+
+  it("counts an unresolved thread that only appears on a later page", () => {
+    // The command asks for 100 at a time. A repository with more than that
+    // returns a full first page of resolved threads, and reading it alone
+    // reports a clean verdict over an open one.
+    const tip = chain[4];
+    const routes = baseRoutes({
+      state: "OPEN",
+      headRefOid: tip,
+      reviews: [review(CODEX, tip)],
+      commits: [tip],
+    }).filter(route => !route.when.includes("graphql"));
+    routes.push(
+      {
+        // Discriminated by the ABSENCE of the cursor rather than by repeating
+        // the query text, which would break this case on any edit to the query
+        // and report it as an unmatched request.
+        when: ["graphql"],
+        unless: ["cursor=PAGE2"],
+        stdout: {
+          data: {
+            repository: {
+              pullRequest: {
+                reviewThreads: {
+                  nodes: [
+                    {
+                      isResolved: true,
+                      comments: { nodes: [{ author: { login: CODEX } }] },
+                    },
+                  ],
+                  pageInfo: { hasNextPage: true, endCursor: "PAGE2" },
+                },
+              },
+            },
+          },
+        },
+      },
+      {
+        when: ["graphql", "cursor=PAGE2"],
+        stdout: {
+          data: {
+            repository: {
+              pullRequest: {
+                reviewThreads: {
+                  nodes: [
+                    {
+                      isResolved: false,
+                      comments: { nodes: [{ author: { login: CODEX } }] },
+                    },
+                  ],
+                  pageInfo: { hasNextPage: false, endCursor: null },
+                },
+              },
+            },
+          },
+        },
+      }
+    );
+    const run = runCli({ cwd: shallowClone("paged"), routes });
+    expect(run.report?.verdict).toBe("UNRESOLVED THREADS");
+    expect(run.report?.unresolved_threads).toBe(1);
+    expect(run.status).toBe(10);
+  });
+
+  it("rejects a pull request argument that would rewrite the request path", () => {
+    const run = spawnSync(process.execPath, [ENTRY, "1/../2"], {
+      cwd: root,
+      encoding: "utf8",
+      env: { ...process.env, PATH: `${join(root, "bin")}:${process.env.PATH}` },
+    });
+    expect(run.status).toBe(2);
+    expect(run.stdout).toBe("");
+  });
+});

--- a/scripts/ci-verdict.mjs
+++ b/scripts/ci-verdict.mjs
@@ -960,95 +960,109 @@ async function main(argv) {
   // the first, so the whole computation — the lifecycle checks, the stranded
   // count and `report()` — sits between two identical readings of everything
   // it consumed.
+  // The bracket is a FUNCTION rather than a sequence, so the ordering is
+  // structural instead of a convention. `decide` runs between the two
+  // observations because it is called between them; there is no arrangement of
+  // statements elsewhere that moves the computation outside the window while
+  // leaving this helper intact.
+  //
+  // Written this way after the ordering turned out to be untestable from
+  // outside: the verdict is identical whether it is computed inside the window
+  // or after it, so no assertion over the output can tell the two apart.
+  const bracketed = decide => {
+    const observed = snapshot();
+    const outcome = decide(observed);
+    return stamp(observed) === stamp(snapshot()) ? outcome : undefined;
+  };
+
   let accepted;
   for (
     let attempt = 0;
     attempt < STABILITY_ATTEMPTS && !accepted;
     attempt += 1
   ) {
-    const observed = snapshot();
+    let refusal;
+    accepted = bracketed(observed => {
+      if (
+        observed.head !== head ||
+        observed.state !== meta.state ||
+        observed.base !== meta.baseRefOid
+      ) {
+        refusal =
+          "ci-verdict: head, base or lifecycle moved since the first read; re-run\n";
+        return undefined;
+      }
+      // ANY rewrite event disqualifies the tail check, so this compares against
+      // zero rather than against a baseline taken earlier in the same run — a
+      // baseline could only say "it did not move while I looked", which is the
+      // weaker claim and the one an empty range already defeats.
+      if (meta.state === "MERGED" && observed.rewrites > 0) {
+        refusal = `ci-verdict: ${observed.rewrites} history-rewrite event(s); tail NOT CHECKABLE\n`;
+        return undefined;
+      }
 
-    if (
-      observed.head !== head ||
-      observed.state !== meta.state ||
-      observed.base !== meta.baseRefOid
-    ) {
-      process.stderr.write(
-        "ci-verdict: head, base or lifecycle moved since the first read; re-run\n"
-      );
-      return 2;
-    }
-    // ANY rewrite event disqualifies the tail check, so this compares against
-    // zero rather than against a baseline taken earlier in the same run — a
-    // baseline could only say "it did not move while I looked", which is the
-    // weaker claim and the one an empty range already defeats.
-    if (meta.state === "MERGED" && observed.rewrites > 0) {
-      process.stderr.write(
-        `ci-verdict: ${observed.rewrites} history-rewrite event(s); tail NOT CHECKABLE\n`
-      );
-      return 2;
-    }
+      // A merged pull request keeps a branch that can still be pushed to while
+      // GitHub freezes `headRefOid` at the revision that merged, so commits after
+      // that point are in neither and would otherwise go unnoticed.
+      let stranded = 0;
+      if (
+        meta.state === "MERGED" &&
+        observed.mergedHead &&
+        observed.mergedHead !== head
+      ) {
+        // Both ends fetched from the remote that HAS them: the workflow checks
+        // out shallow, and after a squash the merged head is commonly absent.
+        // A shallow checkout keeps its boundary in `.git/shallow`, and fetching
+        // two more objects does not remove it — so `rev-list` stops at the
+        // boundary and reports a SHORT count rather than failing. That is the
+        // reassuring direction: a truncated range reads as a clean tail, which is
+        // exactly what this count exists to disprove.
+        //
+        // Deepened only when the repository is actually shallow, because
+        // `--unshallow` errors on a complete one.
+        const isShallow =
+          execFileSync("git", ["rev-parse", "--is-shallow-repository"], {
+            encoding: "utf8",
+          }).trim() === "true";
+        execFileSync(
+          "git",
+          [
+            "fetch",
+            ...(isShallow ? ["--unshallow"] : []),
+            headRemote,
+            head,
+            observed.mergedHead,
+          ],
+          { stdio: "ignore" }
+        );
+        stranded =
+          Number(
+            execFileSync(
+              "git",
+              ["rev-list", "--count", `${observed.mergedHead}..${head}`],
+              { encoding: "utf8" }
+            ).trim()
+          ) || 0;
+      }
 
-    // A merged pull request keeps a branch that can still be pushed to while
-    // GitHub freezes `headRefOid` at the revision that merged, so commits after
-    // that point are in neither and would otherwise go unnoticed.
-    let stranded = 0;
-    if (
-      meta.state === "MERGED" &&
-      observed.mergedHead &&
-      observed.mergedHead !== head
-    ) {
-      // Both ends fetched from the remote that HAS them: the workflow checks
-      // out shallow, and after a squash the merged head is commonly absent.
-      // A shallow checkout keeps its boundary in `.git/shallow`, and fetching
-      // two more objects does not remove it — so `rev-list` stops at the
-      // boundary and reports a SHORT count rather than failing. That is the
-      // reassuring direction: a truncated range reads as a clean tail, which is
-      // exactly what this count exists to disprove.
-      //
-      // Deepened only when the repository is actually shallow, because
-      // `--unshallow` errors on a complete one.
-      const isShallow =
-        execFileSync("git", ["rev-parse", "--is-shallow-repository"], {
-          encoding: "utf8",
-        }).trim() === "true";
-      execFileSync(
-        "git",
-        [
-          "fetch",
-          ...(isShallow ? ["--unshallow"] : []),
-          headRemote,
-          head,
-          observed.mergedHead,
-        ],
-        { stdio: "ignore" }
-      );
-      stranded =
-        Number(
-          execFileSync(
-            "git",
-            ["rev-list", "--count", `${observed.mergedHead}..${head}`],
-            { encoding: "utf8" }
-          ).trim()
-        ) || 0;
-    }
-
-    const candidate = report({
-      head,
-      coverageSince: observed.baseChangedAt,
-      revisionOrder,
-      revisionOrderComplete,
-      reviews: observed.reviews,
-      threads: observed.threads,
-      issueComments: observed.issueComments,
-      blocking,
-      advisory,
-      state: meta.state,
-      stranded,
+      return report({
+        head,
+        coverageSince: observed.baseChangedAt,
+        revisionOrder,
+        revisionOrderComplete,
+        reviews: observed.reviews,
+        threads: observed.threads,
+        issueComments: observed.issueComments,
+        blocking,
+        advisory,
+        state: meta.state,
+        stranded,
+      });
     });
-
-    // The closing observation. Only an unchanged world licenses the candidate.
-    if (stamp(observed) === stamp(snapshot())) accepted = candidate;
+    if (refusal !== undefined) {
+      process.stderr.write(refusal);
+      return 2;
+    }
   }
 
   if (!accepted) {


### PR DESCRIPTION
`scripts/ci-verdict.test.mjs` imports the decision helpers and calls them. It **never starts the command**, so the entry guard, the request sequence, the git commands and the process exit have no coverage at all.

That is not theoretical. Every defect below shipped past a fully green suite and was found by a person reading the code:

- the entry guard failed to match under `--preserve-symlinks-main`, so the process **exited 0 having executed nothing**;
- one block move left three dangling references; the command crashed on startup while the suite stayed green;
- the merged-PR path could not produce a verdict at all, because every manual run had been against an OPEN pull request;
- a shallow checkout let `rev-list` stop at its boundary and report a SHORT tail count — "nothing lost" when something was, which is the exact claim this gate exists to disprove.

## What this adds

Nine cases that **spawn the real file**. No change to `ci-verdict.mjs`.

Two substitutions make that work without a network:

| | |
|---|---|
| `gh` | a stub on PATH answering from a recorded fixture. Its requests are reads with stable shapes, so a recording is as good as the service, and the suite runs in CI. |
| `git` | **REAL**, aimed at a throwaway repository via `url.<path>.insteadOf` through `GIT_CONFIG_COUNT`. |

git is deliberately **not** stubbed. The tail count depends on how a genuine shallow clone answers `rev-list`; a stub would only reproduce whatever belief was written into it.

## Break-verified, not assumed

Each property was confirmed by breaking the code and watching the case fail for the intended reason.

**Shallow tail count** — removing `--unshallow` from the fetch makes a five-commit chain report `unmergedCandidates: 1` instead of `3`.

The exit status is `10` **in both cases**. A test pinned on the status alone passes straight through the defect, so the assertion is on the count. That is why this case asserts what it does.

**Entry guard** — reducing the guard to the resolved form only, then invoking through a symlink under `--preserve-symlinks-main`:

```
current script:  EXIT=10, one verdict emitted
broken guard:    EXIT=0,  0 bytes of output
```

Exit 0 with no output is the worst way for a gate to fail, and it is what the current two-form comparison prevents.

## Coverage

MERGED with a moved branch · MERGED settled · OPEN clean · OPEN reviewed at an earlier revision · CLOSED without merging · symlinked entry under `--preserve-symlinks-main` · a failing `gh` (must exit 2, never a clean verdict) · an unresolved thread on page **two** of `reviewThreads` · a `pr` argument that would rewrite the request path.

The dangling-reference class needs no dedicated case: it fails **all nine**, because all nine start the process.

## Why tests first, restructure second

The filed task is to split the I/O seam into its own module. This PR deliberately does **not** do that.

The same file has broken twice from block moves whose damage the suite could not see, and both times a manual run was the only thing that caught it. Landing the harness first means the restructure lands with a net — and a reviewer can see these cases pass against **unchanged** code, which is what proves they pin current behaviour rather than encoding the new structure's.

The split follows as its own PR.

## Notes

- Test-only, so no changeset.
- `pnpm test:scripts` already runs `--dir scripts` in CI, so this is picked up with no workflow change.
- Runtime ~4s.
