### PR TITLE
fix(nextly): recover the migration-lock commits stranded by #777

### DIFF
--- a/.changeset/migration-lock-stranded-tail.md
+++ b/.changeset/migration-lock-stranded-tail.md
@@ -1,0 +1,28 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+A schema sync now reports a migration lock it had to skip, and a run whose lock renewal never answers fails instead of hanging.

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/helpers/locking-adapter.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/helpers/locking-adapter.ts
@@ -14,6 +14,7 @@ import type { DrizzleAdapter } from "@nextlyhq/adapter-drizzle";
 import type { SQL } from "drizzle-orm";
 
 import {
+  classifyLockStatement,
   createLockRow,
   interpretLockStatement,
   type LockClock,
@@ -38,6 +39,15 @@ export interface LockingAdapterOptions {
   /** The database's clock, so a suite can let a seeded claim lapse, and that claim's expiry. */
   clock?: LockClock;
   expiresAt?: number | null;
+  /**
+   * Thrown by the liveness read only, leaving every other statement working.
+   *
+   * Models a lock table created before `expires_at` existed: the row is there and seeds fine, and
+   * only the query selecting that column fails. Applied on the transaction path as well as the
+   * adapter one, because a column that is absent is absent for every reader — a fixture failing
+   * just one of them lets acquisition succeed and certifies the outcome the code exists to prevent.
+   */
+  stateReadError?: unknown;
 }
 
 /** The probe {@link createLockingAdapter} has to answer honestly. */
@@ -53,8 +63,15 @@ export function createLockingAdapter(options: LockingAdapterOptions = {}) {
   // The lock's own semantics live in one place, shared with the surface that adds them to other
   // suites' doubles. Two interpreters of the same statements would agree the day they were written
   // and drift silently afterwards, because each looks correct read on its own.
-  const interpret = (statement: SQL): Record<string, unknown>[] =>
-    interpretLockStatement(lock, statement);
+  const interpret = (statement: SQL): Record<string, unknown>[] => {
+    if (
+      options.stateReadError !== undefined &&
+      classifyLockStatement(statement) === "state"
+    ) {
+      throw options.stateReadError;
+    }
+    return interpretLockStatement(lock, statement);
+  };
 
   const adapter = {
     dialect: "postgresql" as const,

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/helpers/locking-adapter.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/helpers/locking-adapter.ts
@@ -14,9 +14,8 @@ import type { DrizzleAdapter } from "@nextlyhq/adapter-drizzle";
 import type { SQL } from "drizzle-orm";
 
 import {
-  classifyLockStatement,
   createLockRow,
-  interpretLockStatement,
+  createLockStatementReader,
   type LockClock,
 } from "./migration-lock-double";
 
@@ -63,15 +62,7 @@ export function createLockingAdapter(options: LockingAdapterOptions = {}) {
   // The lock's own semantics live in one place, shared with the surface that adds them to other
   // suites' doubles. Two interpreters of the same statements would agree the day they were written
   // and drift silently afterwards, because each looks correct read on its own.
-  const interpret = (statement: SQL): Record<string, unknown>[] => {
-    if (
-      options.stateReadError !== undefined &&
-      classifyLockStatement(statement) === "state"
-    ) {
-      throw options.stateReadError;
-    }
-    return interpretLockStatement(lock, statement);
-  };
+  const interpret = createLockStatementReader(lock, options);
 
   const adapter = {
     dialect: "postgresql" as const,

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/helpers/migration-lock-double.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/helpers/migration-lock-double.ts
@@ -279,6 +279,38 @@ export function interpretLockStatement(
 }
 
 /**
+ * One reader per double, used on EVERY path that reads the lock.
+ *
+ * A double serves the same row through several seams — the adapter, the transaction context, and
+ * each of those separately for reads and writes — and a fixture modelling a schema fault has to
+ * appear on all of them. That is not a matter of care: a table without `expires_at` has no such
+ * column for any reader, so a copy of the gate on one seam and not another models a database that
+ * cannot exist, and it lets the code under test succeed at exactly the point the fixture was
+ * written to stop it. Measured here: an earlier version failed only the adapter-level read while
+ * acquisition reads inside a transaction, and the broken code passed.
+ *
+ * Building the reader ONCE and handing it to every seam is what removes that, rather than three
+ * copies of a predicate with a comment asking them to agree.
+ *
+ * `stateReadError` fails the liveness read alone, leaving every other statement working — the shape
+ * of a lock table that predates its expiry column.
+ */
+export function createLockStatementReader(
+  lock: LockRow,
+  options: { stateReadError?: unknown } = {}
+): (statement: SQL) => Record<string, unknown>[] {
+  return statement => {
+    if (
+      options.stateReadError !== undefined &&
+      classifyLockStatement(statement) === "state"
+    ) {
+      throw options.stateReadError;
+    }
+    return interpretLockStatement(lock, statement);
+  };
+}
+
+/**
  * Whether a statement is the renewal a holder issues while it works.
  *
  * Exported so a suite can fail exactly that statement and nothing else. Selecting it by shape,

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/session.test.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/session.test.ts
@@ -77,7 +77,7 @@ function createAdapter(
      * different question. Classified through {@link classifyLockStatement} rather than a regex of
      * this suite's own, so the double cannot disagree with itself about which statement is which.
      */
-    onStatement?: (kind: LockStatementKind | undefined) => void;
+    onStatement?: (kind: LockStatementKind | undefined) => Promise<void> | void;
   } = {}
 ) {
   const clock = createLockClock();
@@ -102,11 +102,11 @@ function createAdapter(
     }),
     runStatement: vi.fn(async (statement: SQL) => {
       interpretLockStatement(lock, statement);
-      options.onStatement?.(classifyLockStatement(statement));
+      await options.onStatement?.(classifyLockStatement(statement));
     }),
     queryStatement: vi.fn(async (statement: SQL) => {
       const rows = interpretLockStatement(lock, statement);
-      options.onStatement?.(classifyLockStatement(statement));
+      await options.onStatement?.(classifyLockStatement(statement));
       return rows;
     }),
   };
@@ -1095,27 +1095,27 @@ describe("field-group migration session", () => {
   });
 
   // A renewal already in flight when the callback finishes outlives `clearInterval`, which only
-  // stops NEW attempts. That attempt is about to read the very row the release is clearing — and a
+  // stops NEW attempts. That attempt is about to read the very row the release is clearing, and a
   // session that reads its own shutdown as a contender's takeover would fail a migration that held
-  // its lock the whole way through and released it itself. The worst kind of false alarm: it fires
-  // on the healthy path.
-  it("does not mistake its own release for a takeover", async () => {
+  // its lock the whole way through and released it itself — a false alarm on the healthy path.
+  //
+  // 🔴 Asserted as ORDERING rather than as the failure. The fix makes the bad interleaving
+  // impossible rather than merely unlikely, so no gate-based construction can exhibit it: any test
+  // that makes the renewal wait for the release deadlocks against the fix itself, measured at a 10s
+  // timeout. What IS observable either way is whether the release waits, so that is what this pins.
+  it("settles an in-flight renewal before releasing the claim", async () => {
     vi.useFakeTimers();
     try {
-      let releaseRenewal: (() => void) | undefined;
-      const renewalGate = new Promise<void>(resolve => {
-        releaseRenewal = resolve;
-      });
-      let renewalsSeen = 0;
-
+      const order: string[] = [];
       const h = createAdapter({
         heldBy: null,
-        onTransaction: async seq => {
-          // 1 is the acquisition. The next transaction is the renewal, which is held open so it is
-          // still outstanding when the callback returns.
-          if (seq === 2) {
-            renewalsSeen += 1;
-            await renewalGate;
+        onStatement: async kind => {
+          if (kind === undefined) return;
+          order.push(kind);
+          // Slow the renewal's READ-BACK specifically, so it is still outstanding when the callback
+          // returns. Self-resolving, so nothing here can deadlock against the code under test.
+          if (kind === "renew") {
+            for (let turn = 0; turn < 20; turn++) await Promise.resolve();
           }
         },
       });
@@ -1123,23 +1123,24 @@ describe("field-group migration session", () => {
       const run = withMigrationSession(
         { adapter: h.adapter, dialect: "postgresql", label: "run-1" },
         async () => {
-          // Start the renewal, then finish the work without waiting for it.
+          // Starts a renewal and returns without waiting for it.
           vi.advanceTimersByTime(LOCK_RENEW_INTERVAL_MS);
           return "migrated";
         }
       );
 
-      // Let the release path reach its wait, then let the queued renewal complete.
       await vi.advanceTimersByTimeAsync(0);
-      releaseRenewal?.();
-
-      // 🔴 The migration SUCCEEDS. Without the in-flight settle it rejects with
-      // SERVICE_UNAVAILABLE, having done nothing wrong.
       await expect(run).resolves.toBe("migrated");
 
-      // Positive controls: the renewal really was started and held (so the interleaving happened),
-      // and the row was released normally rather than left behind.
-      expect(renewalsSeen).toBe(1);
+      // Positive control: the interleaving this is about actually occurred — a renewal was issued
+      // and a release happened. Without it the ordering assertion below is vacuous.
+      expect(order).toContain("renew");
+      expect(order).toContain("release");
+
+      // 🔴 The renewal's read-back completes BEFORE the row is cleared. Reversed, the renewal reads
+      // an owner that is no longer this claim and reports the claim disproved.
+      const lastStateRead = order.lastIndexOf("state");
+      expect(lastStateRead).toBeLessThan(order.indexOf("release"));
       expect(h.owner()).toBeNull();
     } finally {
       vi.useRealTimers();

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/session.test.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/session.test.ts
@@ -1094,6 +1094,58 @@ describe("field-group migration session", () => {
     }
   });
 
+  // A renewal already in flight when the callback finishes outlives `clearInterval`, which only
+  // stops NEW attempts. That attempt is about to read the very row the release is clearing — and a
+  // session that reads its own shutdown as a contender's takeover would fail a migration that held
+  // its lock the whole way through and released it itself. The worst kind of false alarm: it fires
+  // on the healthy path.
+  it("does not mistake its own release for a takeover", async () => {
+    vi.useFakeTimers();
+    try {
+      let releaseRenewal: (() => void) | undefined;
+      const renewalGate = new Promise<void>(resolve => {
+        releaseRenewal = resolve;
+      });
+      let renewalsSeen = 0;
+
+      const h = createAdapter({
+        heldBy: null,
+        onTransaction: async seq => {
+          // 1 is the acquisition. The next transaction is the renewal, which is held open so it is
+          // still outstanding when the callback returns.
+          if (seq === 2) {
+            renewalsSeen += 1;
+            await renewalGate;
+          }
+        },
+      });
+
+      const run = withMigrationSession(
+        { adapter: h.adapter, dialect: "postgresql", label: "run-1" },
+        async () => {
+          // Start the renewal, then finish the work without waiting for it.
+          vi.advanceTimersByTime(LOCK_RENEW_INTERVAL_MS);
+          return "migrated";
+        }
+      );
+
+      // Let the release path reach its wait, then let the queued renewal complete.
+      await vi.advanceTimersByTimeAsync(0);
+      releaseRenewal?.();
+
+      // 🔴 The migration SUCCEEDS. Without the in-flight settle it rejects with
+      // SERVICE_UNAVAILABLE, having done nothing wrong.
+      await expect(run).resolves.toBe("migrated");
+
+      // Positive controls: the renewal really was started and held (so the interleaving happened),
+      // and the row was released normally rather than left behind.
+      expect(renewalsSeen).toBe(1);
+      expect(h.owner()).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   // Declaring the loss tells the CALLER it is unprotected. It does nothing about the callback,
   // which nothing here can stop and which is still writing — so giving up on renewal at that moment
   // guarantees the row lapses under work that never stopped. A loss declared because renewals could

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/session.test.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/session.test.ts
@@ -1216,6 +1216,54 @@ describe("field-group migration session", () => {
     }
   });
 
+  // A renewal blocked on a connection that never comes back does not fail — it never answers at
+  // all. Waiting for it without a bound leaves the caller neither resolved nor rejected, which is
+  // worse than either outcome this session can report: a run that hangs holds its claim, blocks
+  // every contender, and gives an operator nothing to act on.
+  it("gives up on a renewal that never answers, rather than hanging the caller", async () => {
+    vi.useFakeTimers();
+    try {
+      const h = createAdapter({
+        heldBy: null,
+        // The statement reaches the row and the answer never comes back — a driver that has stopped
+        // responding, not one that reports a failure. Never rejects, so nothing here can be mistaken
+        // for the already-covered error path.
+        onStatement: kind =>
+          kind === "renew" ? new Promise<never>(() => undefined) : undefined,
+      });
+
+      const run = withMigrationSession(
+        { adapter: h.adapter, dialect: "postgresql", label: "run-1" },
+        async () => {
+          // Starts a renewal and returns without waiting for it, so the shutdown below meets an
+          // attempt that is still outstanding.
+          vi.advanceTimersByTime(LOCK_RENEW_INTERVAL_MS);
+          return "migrated";
+        }
+      );
+      const settled = run.then(
+        () => "resolved",
+        (error: unknown) => error
+      );
+
+      // 🔴 The whole lease, because the wait is bounded by what remains of it. Without the bound
+      // this advance settles nothing and the test times out, which is the caller's experience.
+      await vi.advanceTimersByTimeAsync(LOCK_LOSS_AFTER_MS);
+
+      expect(await settled).toMatchObject({
+        code: "SERVICE_UNAVAILABLE",
+        logContext: { reason: "migration lock was not held at completion" },
+      });
+
+      // 🔴 And the row was NOT cleared while that attempt is still outstanding. Releasing under a
+      // stalled renewal is the failure the wait exists to prevent: the UPDATE lands afterwards and
+      // re-extends a row nothing is watching any more.
+      expect(h.owner()).toMatch(/^run-1#/);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   // Declaring the loss tells the CALLER it is unprotected. It does nothing about the callback,
   // which nothing here can stop and which is still writing — so giving up on renewal at that moment
   // guarantees the row lapses under work that never stopped. A loss declared because renewals could

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/session.test.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/session.test.ts
@@ -1094,6 +1094,62 @@ describe("field-group migration session", () => {
     }
   });
 
+  // Declaring the loss tells the CALLER it is unprotected. It does nothing about the callback,
+  // which nothing here can stop and which is still writing — so giving up on renewal at that moment
+  // guarantees the row lapses under work that never stopped. A loss declared because renewals could
+  // not REACH the database says nothing about who owns the row, and the UPDATE is owner-scoped, so
+  // continuing to try can only ever re-protect work in flight or no-op against a real takeover.
+  it("keeps renewing a lost claim while the work is still running", async () => {
+    vi.useFakeTimers();
+    try {
+      const h = createAdapter({ heldBy: null });
+      const realRunStatement = h.ctx.runStatement.getMockImplementation();
+      let renewalsFail = true;
+      h.ctx.runStatement.mockImplementation(async (statement: SQL) => {
+        if (renewalsFail && isRenewalStatement(statement)) {
+          throw new Error("connection reset");
+        }
+        await realRunStatement?.(statement);
+      });
+
+      let finishWork: (() => void) | undefined;
+      const working = new Promise<void>(resolve => {
+        finishWork = resolve;
+      });
+
+      const run = withMigrationSession(
+        { adapter: h.adapter, dialect: "postgresql", label: "run-1" },
+        () => working
+      );
+      const settled = run.then(
+        () => undefined,
+        (error: unknown) => error
+      );
+
+      await vi.advanceTimersByTimeAsync(LOCK_LOSS_AFTER_MS);
+      expect(await settled).toMatchObject({ code: "SERVICE_UNAVAILABLE" });
+      const expiryAtLoss = h.expiresAt() as number;
+
+      // The database comes back while the callback is still writing. The clock moves so a fresh
+      // lease is distinguishable from the one already in the row.
+      renewalsFail = false;
+      h.clock.advance(1);
+      await vi.advanceTimersByTimeAsync(LOCK_RENEW_INTERVAL_MS);
+
+      // 🔴 The lease was RE-EXTENDED over work that never stopped — the property this exists for.
+      // Asserted as a MOVEMENT rather than "not null", which the pre-existing expiry satisfies.
+      expect(h.owner()).toMatch(/^run-1#/);
+      expect(h.expiresAt() as number).toBeGreaterThan(expiryAtLoss);
+
+      // And it still stops once the work does, rather than renewing an abandoned row forever.
+      finishWork?.();
+      await vi.advanceTimersByTimeAsync(0);
+      expect(h.owner()).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   // 🔴 THE case a renewal makes worse if the exit path is naive, in BOTH directions. A renewal that
   // failed on a blip leaves the row still owned by this claim, so an owner-scoped release matches
   // and frees it — while `fn`, which nothing here can stop, carries on rewriting tables. Freeing it

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/session.test.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/session.test.ts
@@ -78,6 +78,14 @@ function createAdapter(
      * this suite's own, so the double cannot disagree with itself about which statement is which.
      */
     onStatement?: (kind: LockStatementKind | undefined) => Promise<void> | void;
+    /**
+     * Thrown by the liveness read only, leaving every other statement working.
+     *
+     * Models a lock table created before `expires_at` existed: the row is there and can be seeded,
+     * and only the query that selects that column fails. `lockReadError` is the blunter neighbour —
+     * it fails every adapter-level read, which models a privilege problem rather than a shape one.
+     */
+    stateReadError?: unknown;
   } = {}
 ) {
   const clock = createLockClock();
@@ -122,6 +130,12 @@ function createAdapter(
       // Models a role that may read the marker and registry but not the lock
       // table -- the case `tableExists` cannot distinguish from absence.
       if (options.lockReadError !== undefined) throw options.lockReadError;
+      if (
+        options.stateReadError !== undefined &&
+        classifyLockStatement(statement) === "state"
+      ) {
+        throw options.stateReadError;
+      }
       return interpretLockStatement(lock, statement);
     }),
     tableExists: vi.fn(async () => options.lockTableMissing !== true),
@@ -1092,6 +1106,51 @@ describe("field-group migration session", () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  // A lock table created by the previous release has two columns and no `expires_at`. The no-DDL
+  // callers — `db:sync --no-auto-sync`, a role granted DML but not DDL — cannot add it, because the
+  // upgrade ALTER runs only on the branch that may issue schema changes. Failing them would break
+  // every such install that has not yet run a migration under the new release, for a lock that is
+  // not even theirs: they are schema syncs, never the thing the exclusion holds back.
+  it("skips a lock table that predates its expiry column, and says so", async () => {
+    const warn = vi.fn();
+    // The legacy shape: the row seeds fine and only the liveness read fails, exactly as a table
+    // without `expires_at` behaves. 42703 is undefined_column.
+    const h = createAdapter({
+      heldBy: null,
+      stateReadError: Object.assign(
+        new Error('column "expires_at" does not exist'),
+        { code: "42703" }
+      ),
+    });
+
+    const observed: LockObservation[] = [];
+    await withMigrationSession(
+      {
+        adapter: h.adapter,
+        dialect: "postgresql",
+        label: "sync-1",
+        requireExistingLock: true,
+        logger: { warn } as unknown as Parameters<
+          typeof withMigrationSession
+        >[0]["logger"],
+      },
+      async session => {
+        observed.push(session.lock);
+      }
+    );
+
+    // 🔴 The work RAN — the whole point is that a sync is not blocked by a lock it cannot read.
+    expect(observed).toHaveLength(1);
+    // And it is told plainly that it holds nothing, rather than the default that claims ownership.
+    expect(observed[0]).toEqual({ kind: "not-held" });
+    // 🔴 And the skip is REPORTED. A silent downgrade from excluded to unexcluded is the thing that
+    // would make this dangerous rather than merely tolerant.
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0]?.[1]).toMatchObject({
+      reason: "migration lock table is missing expires_at",
+    });
   });
 
   // A renewal already in flight when the callback finishes outlives `clearInterval`, which only

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/session.test.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/session.test.ts
@@ -113,6 +113,16 @@ function createAdapter(
       await options.onStatement?.(classifyLockStatement(statement));
     }),
     queryStatement: vi.fn(async (statement: SQL) => {
+      // 🔴 The same failure inside a transaction as outside it. A table without `expires_at` has no
+      // such column for ANY reader, so a fixture that only fails the adapter-level read models a
+      // database that does not exist — and lets acquisition succeed, which is precisely the outcome
+      // the code is supposed to make impossible.
+      if (
+        options.stateReadError !== undefined &&
+        classifyLockStatement(statement) === "state"
+      ) {
+        throw options.stateReadError;
+      }
       const rows = interpretLockStatement(lock, statement);
       await options.onStatement?.(classifyLockStatement(statement));
       return rows;

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/session.test.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/session.test.ts
@@ -21,6 +21,7 @@ import {
   classifyLockStatement,
   createLockClock,
   createLockRow,
+  createLockStatementReader,
   interpretLockStatement,
   isRenewalStatement,
   type LockStatementKind,
@@ -95,6 +96,9 @@ function createAdapter(
       options.expiresIn === undefined ? null : clock.now() + options.expiresIn,
   });
   const ddl: string[] = [];
+  // Built once and handed to every seam below, so a schema fault this fixture models cannot be
+  // present on one read path and absent from another.
+  const readLock = createLockStatementReader(lock, options);
   let open = 0;
   let peakOpen = 0;
   let transactions = 0;
@@ -109,21 +113,11 @@ function createAdapter(
       return data;
     }),
     runStatement: vi.fn(async (statement: SQL) => {
-      interpretLockStatement(lock, statement);
+      readLock(statement);
       await options.onStatement?.(classifyLockStatement(statement));
     }),
     queryStatement: vi.fn(async (statement: SQL) => {
-      // 🔴 The same failure inside a transaction as outside it. A table without `expires_at` has no
-      // such column for ANY reader, so a fixture that only fails the adapter-level read models a
-      // database that does not exist — and lets acquisition succeed, which is precisely the outcome
-      // the code is supposed to make impossible.
-      if (
-        options.stateReadError !== undefined &&
-        classifyLockStatement(statement) === "state"
-      ) {
-        throw options.stateReadError;
-      }
-      const rows = interpretLockStatement(lock, statement);
+      const rows = readLock(statement);
       await options.onStatement?.(classifyLockStatement(statement));
       return rows;
     }),
@@ -138,15 +132,11 @@ function createAdapter(
     // adapter rather than the transaction context.
     queryStatement: vi.fn(async (statement: SQL) => {
       // Models a role that may read the marker and registry but not the lock
-      // table -- the case `tableExists` cannot distinguish from absence.
+      // table -- the case `tableExists` cannot distinguish from absence. Asked
+      // before the reader because it denies the whole table rather than one
+      // column, so nothing below it could answer either.
       if (options.lockReadError !== undefined) throw options.lockReadError;
-      if (
-        options.stateReadError !== undefined &&
-        classifyLockStatement(statement) === "state"
-      ) {
-        throw options.stateReadError;
-      }
-      return interpretLockStatement(lock, statement);
+      return readLock(statement);
     }),
     tableExists: vi.fn(async () => options.lockTableMissing !== true),
     transaction: vi.fn(async (work: (c: unknown) => Promise<unknown>) => {

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/sync-guard.test.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/sync-guard.test.ts
@@ -323,6 +323,43 @@ describe("holding the exclusion for the whole sync", () => {
     expect(ownerDuringWork).not.toBeNull();
   });
 
+  // A lock table created by the previous release has no `expires_at`, and a caller that may not
+  // issue DDL cannot add it, so the session skips the lock and runs the sync unexcluded. That is
+  // survivable only while it is REPORTED: the warning is the operator's one signal that this run
+  // held nothing, and it reaches them only if this seam hands its logger down.
+  it("reports a skipped legacy lock through the caller's logger", async () => {
+    // Fresh rather than the shared double, so the assertion cannot be satisfied by another test's
+    // call — the module-level logger is never reset between cases.
+    const warn = vi.fn();
+    // 42703 is undefined_column: the row seeds fine and only the liveness read fails, which is
+    // exactly how a table without the column behaves.
+    const { adapter } = createLockingAdapter({
+      stateReadError: Object.assign(
+        new Error('column "expires_at" does not exist'),
+        { code: "42703" }
+      ),
+    });
+    const work = vi.fn(() => Promise.resolve());
+
+    await withMigrationExcluded(
+      {
+        adapter,
+        logger: { warn } as unknown as Logger,
+        label: "db:sync",
+        mayCreateLock: false,
+        releaseOnInterrupt: true,
+      },
+      work
+    );
+
+    expect(work).toHaveBeenCalledTimes(1);
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0]?.[1]).toMatchObject({
+      reason: "migration lock table is missing expires_at",
+      label: "db:sync",
+    });
+  });
+
   // Holding the lock is necessary and not sufficient. An operator who cleared a
   // dead run's lock row without settling its marker would otherwise be let
   // straight into half-renamed storage.

--- a/packages/nextly/src/domains/field-groups/migration/session.ts
+++ b/packages/nextly/src/domains/field-groups/migration/session.ts
@@ -814,6 +814,13 @@ export async function withMigrationSession<T>(
   // not step: an NTP correction mid-migration would otherwise expire or extend a claim by accident.
   let leaseConfirmedAt = claimStartedAt;
 
+  // How much of the lease is left to run without a fresh confirmation, asked in one place because
+  // two callers need the same answer: the renewal loop, which gives up when it reaches zero, and
+  // the shutdown below, which will not wait past it. Two spellings of one formula would agree today
+  // and drift the first time the margin moves.
+  const leaseRemainingMs = (): number =>
+    LOCK_LOSS_AFTER_MS - (performance.now() - leaseConfirmedAt);
+
   // Only ever one attempt in flight. `setInterval` fires on a schedule, not on completion, so a
   // renewal slower than the interval would otherwise have a second started underneath it — and with
   // a single-connection pool those queue against each other, each making the next later still.
@@ -825,7 +832,7 @@ export async function withMigrationSession<T>(
   const renewal = setInterval(() => {
     // Asked BEFORE attempting, because this is the question the attempt cannot answer: a renewal
     // that never comes back reports nothing at all, and the lease drains while it hangs.
-    if (performance.now() - leaseConfirmedAt >= LOCK_LOSS_AFTER_MS) {
+    if (leaseRemainingMs() <= 0) {
       // Reported, and then the attempt below runs ANYWAY. Declaring the loss tells the CALLER it is
       // no longer protected; it does nothing about the callback, which nothing here can stop and
       // which is still writing. Renewal is owner-scoped, so an attempt after a genuine takeover is
@@ -917,6 +924,44 @@ export async function withMigrationSession<T>(
       if (pending !== undefined) await Promise.allSettled([pending]);
     };
 
+    // 🔴 The same wait, BOUNDED, reporting whether it got its answer. A renewal blocked on a
+    // connection that never comes back does not reject — it simply never settles — so an unbounded
+    // wait here leaves the caller neither resolved nor rejected, which is worse than either outcome
+    // this session can report. The bound is what remains of the lease rather than a timeout invented
+    // for the occasion: while the claim could still be live, waiting may yet confirm it; once it
+    // could not, there is nothing left to confirm and nothing left to protect.
+    const settleWithin = (
+      pending: Promise<unknown>,
+      ms: number
+    ): Promise<boolean> => {
+      if (ms <= 0) return Promise.resolve(false);
+      return new Promise<boolean>(resolve => {
+        const deadline = setTimeout(() => resolve(false), ms);
+        // Never a reason for the process to stay alive, for the same reason the renewal timer is
+        // not: this waits on work that is already finished.
+        deadline.unref?.();
+        void Promise.allSettled([pending]).then(() => {
+          clearTimeout(deadline);
+          resolve(true);
+        });
+      });
+    };
+
+    // Clear the row once nothing this session started can still write to it. Shared by the two ways
+    // of ending without a confirmed claim, because they need the identical ordering: wait for the
+    // callback, since a late extension protects work that is still running; then stop the timer, so
+    // no further attempt begins; then wait for whichever attempt was in flight, read after the stop
+    // so it is the last one; only then release. Detached, because it may outlive the caller by as
+    // long as a blocked renewal takes.
+    const clearWhenQuiet = (): void => {
+      void (async () => {
+        await settle(work);
+        clearInterval(renewal);
+        await settle(outstandingRenewal);
+        await release(adapter, dialect, claim).catch(() => undefined);
+      })();
+    };
+
     if (!claimWasLost) {
       clearInterval(renewal);
       // 🔴 The in-flight attempt is settled BEFORE the release, not after. `clearInterval` stops new
@@ -925,8 +970,22 @@ export async function withMigrationSession<T>(
       // claim disproved, and the completion guard below would then fail a migration that held its
       // lock the whole way through and released it itself. A session must not be able to mistake
       // its OWN shutdown for a contender.
-      await settle(outstandingRenewal);
-      heldToTheEnd = await release(adapter, dialect, claim);
+      //
+      // 🔴 Waiting past the lease would not make the release safer, so it stops there and reports
+      // the claim unconfirmed. Releasing anyway would be the worse choice: the stalled attempt can
+      // still land afterwards and re-extend a row this session no longer watches. So the release is
+      // handed to the quiet-clear below, which waits that attempt out, and the run is failed rather
+      // than told it held a lock it could not confirm.
+      const confirmed = await settleWithin(
+        outstandingRenewal,
+        leaseRemainingMs()
+      );
+      if (confirmed) {
+        heldToTheEnd = await release(adapter, dialect, claim);
+      } else {
+        heldToTheEnd = false;
+        clearWhenQuiet();
+      }
     } else {
       // 🔴 The row is still not freed HERE, for the reason above — but leaving it entirely alone is
       // not enough either. A renewal already in flight when the claim was abandoned still runs its
@@ -952,12 +1011,7 @@ export async function withMigrationSession<T>(
       // THEN wait for whichever attempt was already in flight, read after the stop so it is the
       // last one, because its UPDATE would otherwise land after the release and leave the row
       // extended with nobody working. Only then clear.
-      void (async () => {
-        await settle(work);
-        clearInterval(renewal);
-        await settle(outstandingRenewal);
-        await release(adapter, dialect, claim).catch(() => undefined);
-      })();
+      clearWhenQuiet();
     }
   }
 

--- a/packages/nextly/src/domains/field-groups/migration/session.ts
+++ b/packages/nextly/src/domains/field-groups/migration/session.ts
@@ -831,8 +831,23 @@ export async function withMigrationSession<T>(
     // callback's value stand. Completing is not the same as having been protected while completing:
     // the exclusion promises no other run touched these tables meanwhile, and a claim that lapsed
     // or was taken over means that promise was not kept.
+    // Shared by both exits below: an attempt that is already in flight has to be allowed to finish
+    // before the row is touched, whichever way this session is ending.
+    const settle = async (
+      pending: Promise<unknown> | undefined
+    ): Promise<void> => {
+      if (pending !== undefined) await Promise.allSettled([pending]);
+    };
+
     if (!claimWasLost) {
       clearInterval(renewal);
+      // 🔴 The in-flight attempt is settled BEFORE the release, not after. `clearInterval` stops new
+      // attempts and does nothing about one already running, and that one is about to read the row
+      // this release is clearing — it would see an owner that is no longer this claim, report the
+      // claim disproved, and the completion guard below would then fail a migration that held its
+      // lock the whole way through and released it itself. A session must not be able to mistake
+      // its OWN shutdown for a contender.
+      await settle(outstandingRenewal);
       heldToTheEnd = await release(adapter, dialect, claim);
     } else {
       // 🔴 The row is still not freed HERE, for the reason above — but leaving it entirely alone is
@@ -859,9 +874,6 @@ export async function withMigrationSession<T>(
       // THEN wait for whichever attempt was already in flight, read after the stop so it is the
       // last one, because its UPDATE would otherwise land after the release and leave the row
       // extended with nobody working. Only then clear.
-      const settle = async (pending: Promise<unknown> | undefined) => {
-        if (pending !== undefined) await Promise.allSettled([pending]);
-      };
       void (async () => {
         await settle(work);
         clearInterval(renewal);

--- a/packages/nextly/src/domains/field-groups/migration/session.ts
+++ b/packages/nextly/src/domains/field-groups/migration/session.ts
@@ -34,6 +34,7 @@ import { sql, type SQL } from "drizzle-orm";
 import { safeCode } from "../../../database/errors";
 import { NextlyError } from "../../../errors/nextly-error";
 import { fieldGroupLockColumnTypes } from "../../../schemas/field-group-lock";
+import type { Logger } from "../../../shared/types";
 
 /** Dialects the migration runs on. */
 export type MigrationDialect = "postgresql" | "mysql" | "sqlite";
@@ -273,6 +274,25 @@ async function readLockStateOutsideTransaction(
   return toLockState(rows[0]);
 }
 
+/**
+ * Whether this lock table is new enough to answer a liveness read.
+ *
+ * Issues the REAL state query rather than inspecting a catalogue, so it cannot drift from the
+ * statement acquisition is about to run: if this one succeeds, that one will too.
+ */
+async function lockTableUnderstandsExpiry(
+  adapter: DrizzleAdapter,
+  dialect: MigrationDialect
+): Promise<boolean> {
+  try {
+    await readLockStateOutsideTransaction(adapter, dialect);
+    return true;
+  } catch (error) {
+    if (isMissingColumn(error, dialect)) return false;
+    throw error;
+  }
+}
+
 /** Whether the single lock row is present, read outside any transaction. */
 async function lockRowExists(adapter: DrizzleAdapter): Promise<boolean> {
   const rows = await adapter.queryStatement(
@@ -444,6 +464,40 @@ export function getMigrationLockUpgradeDdl(dialect: MigrationDialect): string {
 }
 
 /**
+ * Whether a statement failed because `expires_at` is not there.
+ *
+ * A lock table created before that column existed answers every liveness read this way. Classified
+ * by the driver's own code at the specificity the claim needs, exactly as {@link isDuplicateColumn}
+ * and {@link isMissingTable} are — a message match would also catch a typo'd column name, which is
+ * a programming error that must NOT be quietly tolerated.
+ */
+function isMissingColumn(error: unknown, dialect: MigrationDialect): boolean {
+  let link: unknown = error;
+  for (
+    let depth = 0;
+    depth < 5 && link !== null && link !== undefined;
+    depth++
+  ) {
+    const code = safeCode(link);
+    const message = link instanceof Error ? link.message : "";
+
+    // 42703 undefined_column.
+    if (dialect === "postgresql" && code === "42703") return true;
+    if (
+      dialect === "mysql" &&
+      (code === "ER_BAD_FIELD_ERROR" || code === "1054" || code === "42S22")
+    ) {
+      return true;
+    }
+    // SQLite has no distinct code, and the text is unambiguous for this case.
+    if (dialect === "sqlite" && /no such column/i.test(message)) return true;
+
+    link = (link as { cause?: unknown }).cause;
+  }
+  return false;
+}
+
+/**
  * Whether a failed ALTER means the column is already there.
  *
  * Classified by the driver's own code where one exists, at the specificity the claim needs — the
@@ -505,6 +559,8 @@ export async function withMigrationSession<T>(
      * DML but not DDL would be refused outright.
      */
     requireExistingLock?: boolean;
+    /** Where a skipped lock is reported. Absent means the skip is silent, which is a caller's choice. */
+    logger?: Logger;
     /**
      * Release the claim if the process is interrupted.
      *
@@ -608,6 +664,28 @@ export async function withMigrationSession<T>(
       return fn({ ...session, lock: { kind: "not-held" } });
     }
     await seedLockRow(adapter);
+
+    // 🔴 A lock table created before `expires_at` existed cannot answer the liveness read, and THIS
+    // branch is forbidden from adding it — the upgrade ALTER runs only where DDL is allowed. So the
+    // lock is skipped rather than the caller failed: reported NOT HELD, warned about, and treated
+    // exactly as an absent table is treated four lines above.
+    //
+    // Skipping rather than refusing is the deliberate choice. This caller is a schema sync, not the
+    // migration; it was never the thing the exclusion existed to hold back, and refusing would
+    // break every `--no-auto-sync` install that has not yet run a migration under the new release.
+    // The row it would have contended for carries no expiry, so there is no live claim to respect.
+    // The remedy is a single migration run, which adds the column on the branch that may.
+    if (!(await lockTableUnderstandsExpiry(adapter, dialect))) {
+      args.logger?.warn?.(
+        "field-group migration lock predates its expiry column; continuing without it",
+        {
+          reason: "migration lock table is missing expires_at",
+          table: MIGRATION_LOCK_TABLE,
+          label,
+        }
+      );
+      return fn({ ...session, lock: { kind: "not-held" } });
+    }
   } else {
     await ensureLockRow(adapter, dialect);
   }

--- a/packages/nextly/src/domains/field-groups/migration/session.ts
+++ b/packages/nextly/src/domains/field-groups/migration/session.ts
@@ -748,8 +748,14 @@ export async function withMigrationSession<T>(
     // Asked BEFORE attempting, because this is the question the attempt cannot answer: a renewal
     // that never comes back reports nothing at all, and the lease drains while it hangs.
     if (performance.now() - leaseConfirmedAt >= LOCK_LOSS_AFTER_MS) {
+      // Reported, and then the attempt below runs ANYWAY. Declaring the loss tells the CALLER it is
+      // no longer protected; it does nothing about the callback, which nothing here can stop and
+      // which is still writing. Renewal is owner-scoped, so an attempt after a genuine takeover is
+      // a no-op that cannot steal the row back — but where the loss came from renewals that could
+      // not reach the database, the row is still ours and a later success re-extends the lease over
+      // work that never stopped. Giving up entirely is the only option that is strictly worse than
+      // both.
       onLost();
-      return;
     }
     if (renewing) return;
     renewing = true;
@@ -811,7 +817,6 @@ export async function withMigrationSession<T>(
     work.catch(() => undefined);
     result = await Promise.race([work, claimLost]);
   } finally {
-    clearInterval(renewal);
     // Removed before releasing, so a signal arriving during an orderly release
     // cannot start a second one.
     process.off("SIGINT", onInterrupt);
@@ -827,6 +832,7 @@ export async function withMigrationSession<T>(
     // the exclusion promises no other run touched these tables meanwhile, and a claim that lapsed
     // or was taken over means that promise was not kept.
     if (!claimWasLost) {
+      clearInterval(renewal);
       heldToTheEnd = await release(adapter, dialect, claim);
     } else {
       // 🔴 The row is still not freed HERE, for the reason above — but leaving it entirely alone is
@@ -843,12 +849,25 @@ export async function withMigrationSession<T>(
       //
       // Detached deliberately: the caller has already been told the claim was lost, and this
       // clean-up may outlive the callback by as long as the blocked renewal takes.
-      const abandoned = [work, outstandingRenewal].filter(
-        (pending): pending is Promise<unknown> => pending !== undefined
-      );
-      void Promise.allSettled(abandoned).then(() =>
-        release(adapter, dialect, claim).catch(() => undefined)
-      );
+      // 🔴 The timer is NOT stopped here. Renewal keeps running for as long as the callback does,
+      // because that is the only thing still able to protect it: the row may well still be ours —
+      // a loss declared from renewals that could not reach the database says nothing about who owns
+      // it — and a later success re-extends the lease over work that never stopped.
+      //
+      // Ordering matters in three steps. Wait for the callback, because until it stops, extending
+      // is protection rather than a leak. THEN stop the timer, so no further attempt can start.
+      // THEN wait for whichever attempt was already in flight, read after the stop so it is the
+      // last one, because its UPDATE would otherwise land after the release and leave the row
+      // extended with nobody working. Only then clear.
+      const settle = async (pending: Promise<unknown> | undefined) => {
+        if (pending !== undefined) await Promise.allSettled([pending]);
+      };
+      void (async () => {
+        await settle(work);
+        clearInterval(renewal);
+        await settle(outstandingRenewal);
+        await release(adapter, dialect, claim).catch(() => undefined);
+      })();
     }
   }
 

--- a/packages/nextly/src/domains/field-groups/migration/sync-guard.ts
+++ b/packages/nextly/src/domains/field-groups/migration/sync-guard.ts
@@ -138,6 +138,10 @@ export async function withMigrationExcluded<T>(
       label: args.label,
       requireExistingLock: !args.mayCreateLock,
       releaseOnInterrupt: args.releaseOnInterrupt,
+      // Without this the session has nowhere to report a lock it had to skip, and a downgrade from
+      // excluded to unexcluded happens in silence — which is the one outcome that makes skipping
+      // dangerous rather than merely tolerant. Every caller here already has a logger.
+      logger: args.logger,
     },
     async () => {
       await assertNoMigrationInFlight({


### PR DESCRIPTION
Recovers five commits that were stranded when #777 merged.

#777 merged at `9a291fe3c` against `headRefOid = 9b70a7377`, but the branch tip was `fae1f7d2b`. Five commits pushed after that snapshot never reached `main`. Nothing was force-pushed, so the branch still held them and this is a straight cherry-pick — all five applied cleanly.

**Verified by CONTENT before opening this, with a positive control:**

| marker | on `main` | here |
| --- | --- | --- |
| `lockTableUnderstandsExpiry` | 0 | present |
| `isMissingColumn` | 0 | present |
| `stateReadError` | 0 | present |
| `UTC_TIMESTAMP` (control — did merge) | present | present |

The control matters: it proves the search can find things, so the three zeroes are absence rather than a broken query.

## Why this is not cosmetic

`main` currently has the expiry-aware acquisition **without** the guard that makes it safe on existing installations:

- **`skip a lock table that predates its expiry column`** — a lock table created before this release has no `expires_at`, and the liveness read selects it. Every `db:sync --no-auto-sync` install in that state fails with `column "expires_at" does not exist` **before its sync work starts**. The upgrade `ALTER` only runs on the branch permitted to issue DDL, which is not the one those callers take. Behaviour is skip the lock, warn, treat as absent — a maintainer decision, on the grounds that a schema sync was never the thing the exclusion held back and refusing would make the state harder to escape.
- **`settle an in-flight renewal before releasing the claim`** — without it a session reads its OWN release as a takeover, declares the claim lost, and **fails a migration that succeeded and released cleanly**. A false alarm on the healthy path.
- **`keep renewing a lost claim while its work runs`** — after loss is declared the callback keeps running unpreemptibly; stopping renewal at that moment lets the row lapse under work that is still writing. Renewal is owner-scoped, so continuing either re-protects live work or no-ops against a real takeover.
- Two test commits that make the above load-bearing, including one that fixes a fixture which had only half-modelled a missing column (adapter reads failed, transaction reads did not) and so let the broken code pass.

## Verification

Full bar green by exit code: `pnpm build`, `pnpm check-types --force`, `pnpm lint`, `check-drizzle-v1-legacy`, `check:storage-format-literals`, and 646 tests across the migration and schema suites (43 files).

## The cause, so it does not recur

`gh pr view --json headRefOid` LAGS a push — measured twice independently during that session (the API reported `9b70a7377` while `git ls-remote` reported `3ca26f79e`). The merge was taken against the stale value.

The remedy is already written in `.claude/rules/verifying-merged-work.md`: resolve the head from `git ls-remote`, and pass that exact SHA to `gh pr merge --match-head-commit`, which makes the server refuse when the head has moved. Worth doing on every merge, not just this lane's.

No changeset: these commits carry #777's, which already merged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved migration lock compatibility when existing lock tables lack expiry information.
  * Migration work can continue with a logged warning when lock upgrades are unavailable.
  * Improved lock renewal, shutdown, and cleanup behavior during temporary or permanent connection issues.
  * Prevented lock release while active work is still running after a lease loss.

* **Tests**
  * Added coverage for legacy lock tables, renewal failures, cleanup, and skipped-lock reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->