### PR TITLE
feat(nextly): serve installation metadata from an authenticated route

### DIFF
--- a/.changeset/authenticated-admin-workspace-meta.md
+++ b/.changeset/authenticated-admin-workspace-meta.md
@@ -25,4 +25,4 @@
 "@nextlyhq/module-specifiers": patch
 ---
 
-Serve the admin metadata that describes the installation from an authenticated route, so a plugin-declared permission slug is no longer readable before sign-in.
+Add `GET /api/admin-meta/workspace`, a session-gated route serving the admin metadata that describes the installation: mounted plugins and their contributions, configured locales, custom sidebar groups, and builder availability. `/api/admin-meta` still serves these alongside branding until the admin reads them from the new route, so nothing is withheld from an anonymous caller yet.

--- a/.changeset/authenticated-admin-workspace-meta.md
+++ b/.changeset/authenticated-admin-workspace-meta.md
@@ -1,0 +1,28 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+Serve the admin metadata that describes the installation from an authenticated route, so a plugin-declared permission slug is no longer readable before sign-in.

--- a/packages/nextly/src/__tests__/routeHandler-admin-meta-workspace.test.ts
+++ b/packages/nextly/src/__tests__/routeHandler-admin-meta-workspace.test.ts
@@ -84,6 +84,29 @@ describe("admin-meta split over HTTP", () => {
     expect(await response.text()).not.toContain("Acme");
   });
 
+  it("marks the workspace response as belonging to one session", async () => {
+    const response = await handlers().GET(
+      request("admin-meta/workspace"),
+      ctx(["admin-meta", "workspace"])
+    );
+
+    expect(response.headers.get("cache-control")).toBe("private, no-store");
+    expect(response.headers.get("vary")).toBe("Cookie");
+  });
+
+  it("leaves the public route cacheable", async () => {
+    // The separating half. Setting the headers unconditionally would satisfy
+    // the case above while telling every cache to skip the one response that
+    // is the same for everyone and is fetched before every sign-in.
+    const response = await handlers().GET(
+      request("admin-meta"),
+      ctx(["admin-meta"])
+    );
+
+    expect(response.headers.get("cache-control")).toBeNull();
+    expect(response.headers.get("vary")).toBeNull();
+  });
+
   it("keeps the workspace fields on the public route for now", async () => {
     // The admin still reads these from the public payload. Removing them
     // before it is migrated would blank the sidebar rather than close

--- a/packages/nextly/src/__tests__/routeHandler-admin-meta-workspace.test.ts
+++ b/packages/nextly/src/__tests__/routeHandler-admin-meta-workspace.test.ts
@@ -1,0 +1,99 @@
+/**
+ * The admin-meta split at the HTTP boundary.
+ *
+ * `/api/admin-meta` answers before a session exists, because the sign-in
+ * screen draws with it. `/api/admin-meta/workspace` describes the installation
+ * — mounted plugins and what they contribute, locales, sidebar groups — and
+ * requires a session.
+ *
+ * The property worth pinning is the DISPATCH, not the payload. Both paths
+ * begin `admin-meta`, so a handler that matches on the first segment alone
+ * answers for the second as well: the authenticated URL then returns the
+ * public payload with a 200, which reads exactly like a working route. Only a
+ * real Request through the real handler can see that, so these assert the
+ * wire.
+ *
+ * No database is involved — an unauthenticated request is refused before any
+ * connection is opened, which is itself part of what these lock in.
+ */
+
+import { afterAll, describe, expect, it } from "vitest";
+
+import { createDynamicHandlers } from "../routeHandler";
+import { sanitizeConfig } from "../shared/types/config";
+
+const ORIGINAL_DB_DIALECT = process.env.DB_DIALECT;
+
+// sqlite is the one dialect that needs no connection string.
+process.env.DB_DIALECT = "sqlite";
+
+afterAll(() => {
+  if (ORIGINAL_DB_DIALECT === undefined) delete process.env.DB_DIALECT;
+  else process.env.DB_DIALECT = ORIGINAL_DB_DIALECT;
+});
+
+function handlers() {
+  return createDynamicHandlers({
+    config: sanitizeConfig({
+      collections: [],
+      admin: { branding: { logoText: "Acme" } },
+    }),
+  });
+}
+
+/** Next.js hands route segments in as a promise; mirror that shape. */
+function ctx(params: string[]) {
+  return { params: Promise.resolve({ params }) };
+}
+
+function request(path: string) {
+  return new Request(`http://localhost/api/${path}`, { method: "GET" });
+}
+
+describe("admin-meta split over HTTP", () => {
+  it("serves branding without a session", async () => {
+    const response = await handlers().GET(
+      request("admin-meta"),
+      ctx(["admin-meta"])
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({ logoText: "Acme" });
+  });
+
+  it("refuses the workspace route without a session", async () => {
+    const response = await handlers().GET(
+      request("admin-meta/workspace"),
+      ctx(["admin-meta", "workspace"])
+    );
+
+    expect(response.status).toBe(401);
+  });
+
+  it("does not answer the workspace route from the public handler", async () => {
+    // The separating assertion. A first-segment match would return 200 with
+    // the branding payload, so status alone cannot tell a working gate from a
+    // route that quietly fell through: `logoText` is present in exactly the
+    // response that should never be produced here.
+    const response = await handlers().GET(
+      request("admin-meta/workspace"),
+      ctx(["admin-meta", "workspace"])
+    );
+
+    expect(response.status).not.toBe(200);
+    expect(await response.text()).not.toContain("Acme");
+  });
+
+  it("keeps the workspace fields on the public route for now", async () => {
+    // The admin still reads these from the public payload. Removing them
+    // before it is migrated would blank the sidebar rather than close
+    // anything, so this asserts the duplication is intact and is expected to
+    // be inverted once the client reads the authenticated route.
+    const response = await handlers().GET(
+      request("admin-meta"),
+      ctx(["admin-meta"])
+    );
+
+    expect(await response.json()).toMatchObject({ showBuilder: true });
+  });
+});

--- a/packages/nextly/src/routeHandler.ts
+++ b/packages/nextly/src/routeHandler.ts
@@ -1220,42 +1220,43 @@ async function handleServiceRequest(
 // ============================================================================
 
 /**
- * GET /api/admin-meta
+ * The admin metadata, separated by the audience each half is answerable to.
  *
- * Returns the admin branding configuration to the admin UI.
- * Public — no authentication required.
- * Colors are converted from user-supplied hex to complete CSS colors here on
- * the server so the client only has to inject them as CSS variables. They must
- * be complete colors: the `--nx-*` tokens are consumed directly by the theme,
- * so a bare "H S% L%" triplet would be an invalid value and get dropped.
+ * `branding` is what the sign-in screen draws with, so it has to be readable
+ * before a session exists. `workspace` describes the authenticated admin —
+ * which plugins are mounted, what they contribute, the configured locales and
+ * the sidebar groups — and none of it is needed to render a login form.
+ *
+ * Built together and returned apart so each field has ONE implementation. A
+ * second builder for the authenticated route would agree on the day it was
+ * written and drift afterwards, and the drift is invisible because both halves
+ * look correct alone.
  */
-async function handleAdminMetaRequest(): Promise<Response> {
+async function buildAdminMeta(): Promise<{
+  branding: Record<string, unknown>;
+  workspace: Record<string, unknown>;
+}> {
   const config = getHandlerConfig();
-  const branding = config?.admin?.branding;
+  const configuredBranding = config?.admin?.branding;
 
-  const payload: Record<string, unknown> = {};
+  const branding: Record<string, unknown> = {};
+  const workspace: Record<string, unknown> = {};
 
-  if (branding?.logoUrl) payload.logoUrl = branding.logoUrl;
-  if (branding?.logoUrlLight) payload.logoUrlLight = branding.logoUrlLight;
-  if (branding?.logoUrlDark) payload.logoUrlDark = branding.logoUrlDark;
-  if (branding?.logoText) payload.logoText = branding.logoText;
-  if (branding?.favicon?.trim()) payload.favicon = branding.favicon.trim();
+  if (configuredBranding?.logoUrl)
+    branding.logoUrl = configuredBranding.logoUrl;
+  if (configuredBranding?.logoUrlLight)
+    branding.logoUrlLight = configuredBranding.logoUrlLight;
+  if (configuredBranding?.logoUrlDark)
+    branding.logoUrlDark = configuredBranding.logoUrlDark;
+  if (configuredBranding?.logoText)
+    branding.logoText = configuredBranding.logoText;
+  if (configuredBranding?.favicon?.trim())
+    branding.favicon = configuredBranding.favicon.trim();
 
-  // Same resolver the schema-mutation endpoints enforce with, so what the
-  // admin renders and what the API accepts can never disagree.
-  payload.showBuilder = isBuilderEnabled();
-
-  // Content-localization config for the admin (present only when i18n is enabled).
-  const localization = config?.localization;
-  if (localization) {
-    payload.locales = {
-      defaultLocale: localization.defaultLocale,
-      fallback: localization.fallback,
-      locales: localization.locales,
-    };
-  }
-
-  const colors = branding?.colors;
+  // Colors are resolved to complete CSS colors here rather than in the client,
+  // because the `--nx-*` tokens are consumed directly by the theme: a bare
+  // "H S% L%" triplet is an invalid value and gets dropped.
+  const colors = configuredBranding?.colors;
   if (colors) {
     const resolved: Record<string, string> = {};
 
@@ -1269,8 +1270,22 @@ async function handleAdminMetaRequest(): Promise<Response> {
     }
 
     if (Object.keys(resolved).length > 0) {
-      payload.colors = resolved;
+      branding.colors = resolved;
     }
+  }
+
+  // Same resolver the schema-mutation endpoints enforce with, so what the
+  // admin renders and what the API accepts can never disagree.
+  workspace.showBuilder = isBuilderEnabled();
+
+  // Content-localization config for the admin (present only when i18n is enabled).
+  const localization = config?.localization;
+  if (localization) {
+    workspace.locales = {
+      defaultLocale: localization.defaultLocale,
+      fallback: localization.fallback,
+      locales: localization.locales,
+    };
   }
 
   // Collect plugin metadata from registered plugins with host override
@@ -1278,7 +1293,7 @@ async function handleAdminMetaRequest(): Promise<Response> {
   const pluginOverrides = config?.admin?.pluginOverrides;
   const plugins = buildPluginAdminMeta(config?.plugins ?? [], pluginOverrides);
   if (plugins.length > 0) {
-    payload.plugins = plugins;
+    workspace.plugins = plugins;
   }
 
   // Override config branding with DB values when available
@@ -1288,17 +1303,14 @@ async function handleAdminMetaRequest(): Promise<Response> {
         "generalSettingsService"
       );
       const settings = await svc.getSettings();
-      if (settings.applicationName) payload.logoText = settings.applicationName;
-      if (settings.logoUrl) payload.logoUrl = settings.logoUrl;
+      if (settings.applicationName)
+        branding.logoText = settings.applicationName;
+      if (settings.logoUrl) branding.logoUrl = settings.logoUrl;
 
       // Include custom sidebar groups for admin navigation
       const customGroups = svc.getCustomSidebarGroups(settings);
-      console.log(
-        "[ADMIN-META] customGroups from DB:",
-        JSON.stringify(customGroups)
-      );
       if (customGroups.length > 0) {
-        payload.customGroups = customGroups;
+        workspace.customGroups = customGroups;
       }
 
       // Plugin placement overrides removed — placement is now author-defined
@@ -1310,15 +1322,66 @@ async function handleAdminMetaRequest(): Promise<Response> {
     console.error("[ADMIN-META] Error fetching settings from DB:", err);
   }
 
-  // respondData (bare object). The admin-meta payload is
-  // a non-CRUD read; the admin client already consumes a bare body via the
-  // migrated fetcher. `respondData` requires a Record-shaped argument and
-  // `payload` is built as `Record<string, unknown>` above so the bound is
-  // satisfied without a cast.
+  return { branding, workspace };
+}
+
+/**
+ * Serialize an admin-meta payload.
+ *
+ * `respondData` (bare object): this is a non-CRUD read and the admin client
+ * consumes a bare body via the migrated fetcher. It requires a Record-shaped
+ * argument, which both halves are built as, so the bound is satisfied without
+ * a cast.
+ */
+function respondAdminMeta(payload: Record<string, unknown>): Response {
   const response = respondData(payload);
   // Configuration, not content: see `SKIP_DATE_FORMATTING_HEADER`.
   response.headers.set(SKIP_DATE_FORMATTING_HEADER, "1");
   return response;
+}
+
+/**
+ * GET /api/admin-meta
+ *
+ * Public — no authentication required, because the sign-in screen renders
+ * before a session exists.
+ *
+ * Still carries the workspace half, which `GET /api/admin-meta/workspace`
+ * now also serves. The duplication is deliberate and temporary: the admin
+ * reads these fields from here until it is migrated to the authenticated
+ * route, and removing them before then would blank the sidebar rather than
+ * close anything.
+ */
+async function handleAdminMetaRequest(): Promise<Response> {
+  const { branding, workspace } = await buildAdminMeta();
+  return respondAdminMeta({ ...branding, ...workspace });
+}
+
+/**
+ * GET /api/admin-meta/workspace
+ *
+ * The admin metadata that describes the installation rather than its
+ * appearance: mounted plugins and everything they contribute, the configured
+ * locales, the custom sidebar groups, and whether the builder is available.
+ *
+ * Gated on a SESSION rather than on a permission. Every signed-in role needs
+ * its sidebar and its plugin routes to render, so requiring an administrative
+ * permission here would leave a read-only editor with an empty navigation
+ * rather than a restricted one. What each role may then DO with a contributed
+ * page is decided by that page's own `requiredPermission`.
+ *
+ * Named for the workspace rather than for plugins because it carries three
+ * non-plugin fields; naming it after one of its members is how the next
+ * addition ends up on the public route by default.
+ */
+async function handleAdminMetaWorkspaceRequest(
+  req: Request
+): Promise<Response> {
+  const auth = await requireAuthentication(req);
+  if (isErrorResponse(auth)) return createJsonErrorResponse(auth);
+
+  const { workspace } = await buildAdminMeta();
+  return respondAdminMeta(workspace);
 }
 
 /**
@@ -1381,6 +1444,12 @@ async function handleAdminMetaSidebarGroups(req: Request): Promise<Response> {
 // ============================================================================
 
 async function handleGet(req: Request, params: string[]) {
+  // Matched before the bare `admin-meta` branch, which would otherwise answer
+  // for every path beneath it and serve the public payload from the
+  // authenticated route's URL.
+  if (params[0] === "admin-meta" && params[1] === "workspace") {
+    return handleAdminMetaWorkspaceRequest(req);
+  }
   if (params[0] === "admin-meta") {
     return handleAdminMetaRequest();
   }

--- a/packages/nextly/src/routeHandler.ts
+++ b/packages/nextly/src/routeHandler.ts
@@ -1341,6 +1341,24 @@ function respondAdminMeta(payload: Record<string, unknown>): Response {
 }
 
 /**
+ * Mark a response as belonging to one session.
+ *
+ * A session-gated GET is otherwise an ordinary cacheable response, so a shared
+ * proxy may retain one caller's payload and serve it to the next request
+ * without the authentication check running again. `Vary: Cookie` states what
+ * the response depends on, for any cache that stores it regardless.
+ *
+ * Applied to the REFUSAL as well as the answer. A cached 401 replayed to a
+ * request that does carry a session is the same defect pointing the other way,
+ * and it is the direction that looks like a working gate.
+ */
+function withSessionCacheHeaders(response: Response): Response {
+  response.headers.set("Cache-Control", "private, no-store");
+  response.headers.set("Vary", "Cookie");
+  return response;
+}
+
+/**
  * GET /api/admin-meta
  *
  * Public — no authentication required, because the sign-in screen renders
@@ -1378,10 +1396,20 @@ async function handleAdminMetaWorkspaceRequest(
   req: Request
 ): Promise<Response> {
   const auth = await requireAuthentication(req);
-  if (isErrorResponse(auth)) return createJsonErrorResponse(auth);
+  if (isErrorResponse(auth)) {
+    return withSessionCacheHeaders(createJsonErrorResponse(auth));
+  }
+
+  // After the authentication precondition, never before it. Service
+  // initialisation is lazy, so on the first authenticated request of a process
+  // booted through `createDynamicHandlers` the container is still empty — and
+  // `buildAdminMeta` would then silently skip the persisted sidebar groups and
+  // branding overrides and describe the pre-boot plugin configuration instead
+  // of the running one.
+  await ensureServicesInitialized();
 
   const { workspace } = await buildAdminMeta();
-  return respondAdminMeta(workspace);
+  return withSessionCacheHeaders(respondAdminMeta(workspace));
 }
 
 /**


### PR DESCRIPTION
`/api/admin-meta` is public — the sign-in screen draws with it before a session exists. It also carries every mounted plugin and everything each contributes, **including the `requiredPermission` on every contributed page and widget.**

So a plugin's permission vocabulary is readable by anyone who can reach the app, and those slugs are the input to every subsequent probe against that plugin.

The built-in vocabulary (`read-media`, `read-users`, `read-roles`, `manage-settings`) is already public regardless — `packages/admin/src/constants/navigation.ts` hard-codes it and ships in the admin bundle. The residual exposure is specifically **plugin-declared** slugs, which the bundle does not carry.

## This is step 1 of 3, and it closes nothing yet

Expand → migrate → contract. Deliberately, because the alternative is one change that touches a security boundary, 24 components and the server contract at once.

| | |
|---|---|
| **1. Expand** ← this PR | Add the authenticated route. Public route unchanged. No exposure change, no client change. |
| **2. Migrate** | `usePluginMeta()`; move the 24 readers. Public route still serves the fields, harmlessly duplicated. |
| **3. Contract** | Strip them from the public route. **This is the step that closes the hole**, and by then it is a small diff. |

## What I measured, which changed the plan

The filed task warns the boot sequence is *"the work, not the route definition"*, because the admin fetches plugin metadata with branding before sign-in.

**No pre-auth surface reads `branding.plugins`.** All six auth pages — login, signup, forgot-password, reset-password, accept-invite, setup — read exactly one field:

```ts
const appName = branding.logoText ?? "Nextly";
```

The 24 files reading `branding.plugins` are all behind the dashboard. Branding and workspace already split along the authentication line, so step 2 is a mechanical migration rather than a boot-order redesign.

**Three more fields were public that are not branding:** `showBuilder`, `locales` (the site's whole language configuration) and `customGroups` (admin nav structure). None is needed pre-auth. The decision on file is *"the public route keeps branding only"*, so they move with the plugins.

## Why the route is named `workspace`, not `plugins`

It carries three non-plugin fields. Naming it after one member is how the next addition ends up on the public route by default — which is how this leak happened the first time.

## Why a session, not a permission

The sibling `PATCH /admin-meta/sidebar-groups` gates on `manage settings`. Copying that here would be wrong: **every signed-in role needs its sidebar and plugin routes to render**, so an administrative permission would leave a read-only editor with an empty navigation rather than a restricted one. What a role may then *do* with a contributed page is still decided by that page's own `requiredPermission`.

## Break-verified

The assertion that matters is the dispatch, not the payload. Both paths begin `admin-meta`, so a first-segment match answers for both. Removing the ordering guard:

```
× refuses the workspace route without a session
    AssertionError: expected 200 to be 401
× does not answer the workspace route from the public handler
    AssertionError: expected 200 not to be 200
```

**200 with the public payload** — an authenticated route silently serving public data, which reads exactly like a working route. Status alone cannot separate the two, so the test also asserts the branding value is absent from the body.

## Not done here

`requiredPermission` is **not** deleted from the payload. Two consumers gate on it — `PluginWidgetGrid.tsx:21` and `usePluginPageRegistration.ts:51,65` — and `undefined` fails **open**: every widget renders and plugin routes stop being gated. That trades a disclosure for an access-control defect. It moves behind auth in step 3; it never disappears.

## Incidental

Removed a `console.log` that dumped DB sidebar config to server logs on **every request to a public endpoint**. The `console.error` fallback beside it is left alone.

## Notes

- Changeset generated from `.changeset/config.json` (24 packages, `patch`), verified by `check-changesets.mjs`.
- `pnpm turbo run check-types --filter=nextly --force` and `lint` both clean; 59 tests across the four related suites.
