### PR TITLE
docs(root): name the check that cannot tell the defect from the fix

### DIFF
--- a/.claude/rules/derived-checks.md
+++ b/.claude/rules/derived-checks.md
@@ -656,3 +656,50 @@ the unit to audit is the call site. The live risk for a well-documented shared
 helper is gaining a second caller with the opposite polarity, where the
 comment above it still reads correctly and nothing at the definition looks
 wrong.
+
+## An observable the DEFECT and the FIX both satisfy
+
+Distinct from the category error above, and easy to confuse with it. There the
+measurement was correct but answered a NARROWER question than the claim. Here
+the measurement is correctly scoped, correctly taken, and about exactly the
+right thing — and it returns the same value whether the code is broken or
+fixed. Re-running it, widening it, or taking it more carefully cannot help,
+because the two states are not distinguishable in that observable at all.
+
+It is worth separating because the remedy is different. A narrow measurement is
+repaired by measuring the wider thing. A non-discriminating one is repaired by
+measuring a DIFFERENT PROPERTY, and until someone names that property the check
+is decoration however rigorously it is run.
+
+Three instances, two of them found on the same day in one subsystem:
+
+- **Ordering, standing in for a switch margin.** A drop-target ranking was
+  asserted by checking that the nearer target ranks higher. Every candidate
+  metric orders correctly — that is what makes them candidates — so the
+  assertion stayed green across two successive metrics whose margin WIDTH was
+  wrong, one of them turning a 10px requirement into roughly 36px once the
+  pointer sat 100px off-centre. Order was never the property under test; width
+  was, and nothing measured it.
+- **A bracketed edge, standing in for a compliant resolver.** An end-to-end
+  probe reported `bracketed: false` when it could not locate a target-switch
+  boundary to within a pixel, and its own comment said this distinguished a
+  resolver "sticky in one direction only" from a working one. A correct
+  BIDIRECTIONAL margin puts the two crossings a full margin apart, so it emits
+  the identical signal. The guard could not separate the defect it was written
+  for from the fix.
+- **An unresolved-thread count, standing in for a clean review.** Findings that
+  cannot be anchored to a line are written into a review SUMMARY, which opens no
+  thread. A stated P1 therefore leaves the count at zero, which is
+  byte-identical to a review that found nothing.
+
+**The tell is a question, and it is cheap: what would this check report if the
+bug were present?** Not "does it pass now" — run it, in your head, against the
+broken state you are worried about. If the answer is the same as the passing
+state, you have not tested the property yet. The B-7 margin work reached its
+third wrong implementation before anyone asked it.
+
+**Then make the failing case real before trusting the repair.** Break the code
+deliberately, confirm the NEW assertion fails, and restore. A width assertion
+added after a wrong metric shipped is only evidence once it has been seen to
+reject that metric; assuming it would have is the same act of faith that let the
+ordering assertion stand.


### PR DESCRIPTION
## Why a new entry rather than extending an existing one

`derived-checks.md` already has **"A measurement standing in for a CATEGORY clears more than it checked"**. That one is about a measurement answering a *narrower* question than the claim built on it, and the repair is to measure the wider thing.

These are different, and conflating them sends you to the wrong repair. The measurement is **correctly scoped and correctly taken** — and returns the **same value whether the code is broken or fixed**. Re-running it, widening it, or taking it more carefully cannot help, because the two states are not distinguishable in that observable at all. The repair is to name a *different property*.

## The three instances

Two turned up in one subsystem on one day, which is what made it worth naming rather than filing as three war stories.

| observable | what it was taken to prove | why it cannot |
|---|---|---|
| the nearer target ranks higher | the switch margin is correct | every candidate metric orders correctly; only the WIDTH separates them |
| `bracketed: false` | the resolver is sticky in one direction | a correct bidirectional margin puts the two crossings a full margin apart and emits the identical signal |
| unresolved threads == 0 | the review is clean | a finding written into a review SUMMARY opens no thread, so a stated P1 leaves it at zero |

The first cost two successive wrong metrics on #829 — an ordering assertion stayed green while a 10px requirement became roughly 36px once the pointer sat 100px off a zone's horizontal centre. The second is a live guard in `e2e/tests/canvas/driver.ts` whose own doc comment claims it separates those two cases. The third is an open finding against the merge gate.

## What the entry adds

A tell that is a question rather than a checklist item — **"what would this check report if the bug were present?"** — run against the broken state you are worried about, not against the code in front of you.

And a second step that the #829 round is the argument for: **make the failing case real before trusting the repair.** A width assertion added after a wrong metric shipped is only evidence once it has been *seen* to reject that metric. I confirmed the new one fails when the metric is reverted to the hypotenuse rather than assuming it would, which is the only reason I believe it.

## Provenance

Suggested by the page-builder lane after the same shape appeared a third time; the instances come from two lanes and three separate PRs, so it is a repository pattern rather than one person's mistake.

Documentation only — no changeset, no code paths touched.