### PR TITLE
feat(admin): offer the shareable preview link in the entry editor

### DIFF
--- a/.changeset/preview-link-in-the-entry-editor.md
+++ b/.changeset/preview-link-in-the-entry-editor.md
@@ -1,0 +1,32 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+The entry editor now offers **Copy shareable link**.
+
+The preview-link machinery already shipped — a mint route gated by `update`, an admin service, a `usePreviewLink` hook and the `PreviewActions` control — but nothing in the standalone editor rendered any of it: the control was wired only into the form footer, which the editor renders in embedded (modal) layouts alone. An author had no way to reach the feature.
+
+The control now sits in the editor's action bar, directly left of Save, for a saved entry whose author holds `update` on the collection. The permission half of that condition is resolved by the header itself rather than by each caller, so the gate cannot be omitted by a future call site.

--- a/packages/admin/src/components/features/entries/EntryForm/EntryForm.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/EntryForm.tsx
@@ -23,6 +23,7 @@ import { useBranding } from "@admin/context/providers/BrandingProvider";
 import { useAutoSlug } from "@admin/hooks/useAutoSlug";
 import { useEntryFormShortcuts } from "@admin/hooks/useKeyboardShortcuts";
 import { useLocalization } from "@admin/hooks/useLocalization";
+import { usePreviewLink } from "@admin/hooks/usePreviewLink";
 import {
   computeMainFields,
   takeoverControllerNames,
@@ -352,6 +353,19 @@ export function EntryForm({
     draftsEnabled: collection.draftsEnabled === true,
   });
 
+  // A link names one saved document, so there is nothing to mint against until
+  // the entry exists. The id is read here rather than inside the hook because
+  // hooks run unconditionally: on create the mutation is constructed and never
+  // reachable, since the control that would call it is not rendered.
+  const savedEntryId = entry?.id === undefined ? "" : String(entry.id);
+  const previewLink = usePreviewLink({
+    collection: collection.name,
+    entryId: savedEntryId,
+    // A link for a localized entry opens the language being edited. Omitted for
+    // the default language, which the mint route reads as every locale.
+    ...(locale === undefined ? {} : { locale }),
+  });
+
   // Only enable shortcuts in standalone mode (not embedded modals)
   useEntryFormShortcuts({
     onSave: () => {
@@ -454,6 +468,15 @@ export function EntryForm({
                   locale={locale}
                   onLocaleChange={onLocaleChange}
                   localized={collection.localized === true}
+                  isLinkAvailable={savedEntryId !== ""}
+                  {...(savedEntryId === ""
+                    ? {}
+                    : {
+                        onCopyLink: () => {
+                          previewLink.mutate();
+                        },
+                      })}
+                  isCopyingLink={previewLink.isPending}
                   toolbarSlot={
                     <EntryFormToolbarSlots
                       context="collection"

--- a/packages/admin/src/components/features/entries/EntryForm/EntryForm.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/EntryForm.tsx
@@ -36,6 +36,7 @@ import { EntryLocaleProvider } from "../EntryLocaleContext";
 import {
   effectiveEntryStatus,
   isSlugPerLocale,
+  previewLinkLocale,
   useHasPublicAddress,
 } from "./entry-address";
 import { EntryFormActions } from "./EntryFormActions";
@@ -358,12 +359,15 @@ export function EntryForm({
   // hooks run unconditionally: on create the mutation is constructed and never
   // reachable, since the control that would call it is not rendered.
   const savedEntryId = entry?.id === undefined ? "" : String(entry.id);
+  const linkLocale = previewLinkLocale({
+    localized: collection.localized === true,
+    locale,
+    defaultLocale,
+  });
   const previewLink = usePreviewLink({
     collection: collection.name,
     entryId: savedEntryId,
-    // A link for a localized entry opens the language being edited. Omitted for
-    // the default language, which the mint route reads as every locale.
-    ...(locale === undefined ? {} : { locale }),
+    ...(linkLocale === undefined ? {} : { locale: linkLocale }),
   });
 
   // Only enable shortcuts in standalone mode (not embedded modals)

--- a/packages/admin/src/components/features/entries/EntryForm/EntryForm.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/EntryForm.tsx
@@ -20,6 +20,7 @@ import { useMemo } from "react";
 
 import { historyEnabledFrom } from "@admin/components/features/versions/history-enabled";
 import { useBranding } from "@admin/context/providers/BrandingProvider";
+import { useGeneralSettings } from "@admin/hooks/queries/useGeneralSettings";
 import { useAutoSlug } from "@admin/hooks/useAutoSlug";
 import { useEntryFormShortcuts } from "@admin/hooks/useKeyboardShortcuts";
 import { useLocalization } from "@admin/hooks/useLocalization";
@@ -37,6 +38,7 @@ import {
   effectiveEntryStatus,
   isSlugPerLocale,
   previewLinkLocale,
+  previewLinkSiteUrl,
   useHasPublicAddress,
 } from "./entry-address";
 import { EntryFormActions } from "./EntryFormActions";
@@ -358,16 +360,25 @@ export function EntryForm({
   // the entry exists. The id is read here rather than inside the hook because
   // hooks run unconditionally: on create the mutation is constructed and never
   // reachable, since the control that would call it is not rendered.
+  const { data: generalSettings } = useGeneralSettings();
   const savedEntryId = entry?.id === undefined ? "" : String(entry.id);
   const linkLocale = previewLinkLocale({
     localized: collection.localized === true,
     locale,
     defaultLocale,
   });
+  // A link that travels by email or chat has to name a host. `window` is read
+  // through a guard because this module is imported in a server render, where
+  // there is no origin and the configured site is the only source anyway.
+  const linkSiteUrl = previewLinkSiteUrl({
+    configured: generalSettings?.siteUrl,
+    origin: typeof window === "undefined" ? undefined : window.location.origin,
+  });
   const previewLink = usePreviewLink({
     collection: collection.name,
     entryId: savedEntryId,
     ...(linkLocale === undefined ? {} : { locale: linkLocale }),
+    ...(linkSiteUrl === undefined ? {} : { siteUrl: linkSiteUrl }),
   });
 
   // Only enable shortcuts in standalone mode (not embedded modals)

--- a/packages/admin/src/components/features/entries/EntryForm/EntryForm.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/EntryForm.tsx
@@ -377,7 +377,7 @@ export function EntryForm({
   const previewLink = usePreviewLink({
     collection: collection.name,
     entryId: savedEntryId,
-    ...(linkLocale === undefined ? {} : { locale: linkLocale }),
+    ...(linkLocale.kind === "scoped" ? { locale: linkLocale.locale } : {}),
     ...(linkSiteUrl === undefined ? {} : { siteUrl: linkSiteUrl }),
   });
 
@@ -483,7 +483,13 @@ export function EntryForm({
                   locale={locale}
                   onLocaleChange={onLocaleChange}
                   localized={collection.localized === true}
-                  isLinkAvailable={savedEntryId !== ""}
+                  // Withheld while the language is unknown as well as while
+                  // the entry is unsaved: a link minted without a resolvable
+                  // locale is either refused by the mint route or, if the claim
+                  // were dropped to avoid that, a grant over every translation.
+                  isLinkAvailable={
+                    savedEntryId !== "" && linkLocale.kind !== "unresolved"
+                  }
                   {...(savedEntryId === ""
                     ? {}
                     : {

--- a/packages/admin/src/components/features/entries/EntryForm/EntrySystemHeader.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/EntrySystemHeader.tsx
@@ -99,10 +99,16 @@ export interface EntrySystemHeaderProps {
   /** Label for the preview action. Defaults to "Preview". */
   previewLabel?: string;
   /**
-   * Whether there is a saved document for a link to name. Only the caller can
-   * answer that; the `update` half of the same question is ANDed in here from
-   * the permission this header already resolved for its submit buttons, so a
-   * caller cannot ship the control while forgetting the gate.
+   * Whether there is a saved document for a link to name.
+   *
+   * Deliberately NOT ANDed with `update-{slug}` here. The mint endpoint
+   * authorizes the request against the collection's real access rules, and
+   * `update` can be granted by a code-first `access.update` rule that the flat
+   * permission list does not carry — so a client-side check on that list is a
+   * false negative for exactly the arrangement it would claim to protect,
+   * hiding the link from an author who can edit the document. This is the same
+   * reasoning the Discard Draft affordance below is built on, and the sibling
+   * Save controls are not gated on it either.
    */
   isLinkAvailable?: boolean;
   /** Mints a shareable link and copies it. */
@@ -394,7 +400,7 @@ export function EntrySystemHeader({
           isPreviewAvailable={isPreviewAvailable}
           {...(onPreview === undefined ? {} : { onPreview })}
           {...(previewLabel === undefined ? {} : { previewLabel })}
-          isLinkAvailable={isLinkAvailable && canUpdateDocument}
+          isLinkAvailable={isLinkAvailable}
           {...(onCopyLink === undefined ? {} : { onCopyLink })}
           isCopyingLink={isCopyingLink}
           disabled={isSubmitting}

--- a/packages/admin/src/components/features/entries/EntryForm/EntrySystemHeader.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/EntrySystemHeader.tsx
@@ -35,6 +35,7 @@ import { LanguageSwitcher } from "../LanguageSwitcher";
 
 import { DiscardDraftConfirmDialog } from "./DiscardDraftConfirmDialog";
 import { effectiveEntryStatus } from "./entry-address";
+import { PreviewActions } from "./PreviewActions";
 import { ShowJSONDialog } from "./ShowJSONDialog";
 import { UnpublishConfirmDialog } from "./UnpublishConfirmDialog";
 import type { EntryData, EntryFormMode } from "./useEntryForm";
@@ -82,6 +83,32 @@ export interface EntrySystemHeaderProps {
    *  the authoritative signal for its locale filter (shared writes can produce
    *  null-locale versions, so the rows alone are not conclusive). */
   localized?: boolean;
+
+  /* Preview. Two independent actions rendered by one control — see
+     `PreviewActions`, which decides its own shape from which of them are
+     available and renders nothing when neither is. They are separate props
+     rather than one `preview` object because they are answered by different
+     things: whether a URL can be built for this entry, and whether this author
+     may hand out a grant to read it. A caller that can answer one and not the
+     other passes one and not the other. */
+
+  /** Whether a preview URL can be built for this entry. */
+  isPreviewAvailable?: boolean;
+  /** Opens the preview using the editor's own session. May be asynchronous. */
+  onPreview?: () => void | Promise<void>;
+  /** Label for the preview action. Defaults to "Preview". */
+  previewLabel?: string;
+  /**
+   * Whether there is a saved document for a link to name. Only the caller can
+   * answer that; the `update` half of the same question is ANDed in here from
+   * the permission this header already resolved for its submit buttons, so a
+   * caller cannot ship the control while forgetting the gate.
+   */
+  isLinkAvailable?: boolean;
+  /** Mints a shareable link and copies it. */
+  onCopyLink?: () => void;
+  /** Whether a link is being minted right now. */
+  isCopyingLink?: boolean;
 
   /** Save Draft handler — routed through useEntryForm.handleSubmit('save-draft').
    *  Used in create mode and when editing a draft entry. */
@@ -200,6 +227,12 @@ export function EntrySystemHeader({
   onToggleRail,
   toolbarSlot,
   localized,
+  isPreviewAvailable = false,
+  onPreview,
+  previewLabel,
+  isLinkAvailable = false,
+  onCopyLink,
+  isCopyingLink = false,
 }: EntrySystemHeaderProps) {
   const form = useFormContext();
   const entryLocale = useEntryLocale();
@@ -346,6 +379,26 @@ export function EntrySystemHeader({
         {onLocaleChange && (
           <LanguageSwitcher value={locale} onChange={onLocaleChange} />
         )}
+        {/* Directly left of the submit cluster, which is where an author looks
+            for it: checking how something reads is part of deciding to publish
+            it, not a document-management action like Duplicate or Delete. The
+            `sm` size is the band's, so it lines up with Save beside it rather
+            than standing a few pixels taller.
+
+            `disabled` follows the submit buttons rather than the whole form:
+            minting a link and opening a preview both act on what is already
+            saved, so a submit in flight is a race with them and not merely a
+            busy form. */}
+        <PreviewActions
+          size="sm"
+          isPreviewAvailable={isPreviewAvailable}
+          {...(onPreview === undefined ? {} : { onPreview })}
+          {...(previewLabel === undefined ? {} : { previewLabel })}
+          isLinkAvailable={isLinkAvailable && canUpdateDocument}
+          {...(onCopyLink === undefined ? {} : { onCopyLink })}
+          isCopyingLink={isCopyingLink}
+          disabled={isSubmitting}
+        />
         {hasStatus && isPublishedEdit ? (
           <>
             <Button

--- a/packages/admin/src/components/features/entries/EntryForm/PreviewActions.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/PreviewActions.tsx
@@ -35,8 +35,14 @@ import {
 export interface PreviewActionsProps {
   /** Whether the collection has a preview URL configured. */
   isPreviewAvailable?: boolean;
-  /** Opens the preview in the editor's own session. */
-  onPreview?: () => void;
+  /**
+   * Opens the preview in the editor's own session.
+   *
+   * May return a promise: resolving the URL can require a round trip. Nothing
+   * here treats the handler returning as the preview having opened, so an
+   * asynchronous implementation needs no change on this side.
+   */
+  onPreview?: () => void | Promise<void>;
   /** Label for the preview action. */
   previewLabel?: string;
   /**
@@ -50,6 +56,15 @@ export interface PreviewActionsProps {
   isCopyingLink?: boolean;
   /** Whether the surrounding form is submitting. */
   disabled?: boolean;
+  /**
+   * The button height, matching whichever action row this sits in. The two
+   * rows disagree: the standalone editor's header is a band of `sm` controls,
+   * while the embedded form's footer uses the default. A control that keeps
+   * one height in both is the wrong height in one of them, and a button a few
+   * pixels taller than the Save beside it reads as a mistake rather than as a
+   * distinction.
+   */
+  size?: "default" | "sm";
 }
 
 const COPY_LABEL = "Copy shareable link";
@@ -62,9 +77,28 @@ export function PreviewActions({
   onCopyLink,
   isCopyingLink = false,
   disabled = false,
+  size = "default",
 }: PreviewActionsProps) {
   const canPreview = isPreviewAvailable && onPreview !== undefined;
   const canCopy = isLinkAvailable && onCopyLink !== undefined;
+
+  /**
+   * Adapts a possibly-asynchronous handler to the void-returning slot a DOM
+   * event expects.
+   *
+   * Handing the promise straight to `onClick` makes a rejection invisible,
+   * which is what forbids it. It is not this control's to report either: it
+   * knows the action failed and nothing about why, so anything it rendered
+   * would be a second, vaguer error beside the handler's own. Discarding the
+   * value leaves a rejection to the runtime's unhandled-rejection reporting,
+   * where it stays visible without being claimed here.
+   */
+  const startPreview =
+    onPreview === undefined
+      ? undefined
+      : () => {
+          void onPreview();
+        };
 
   if (!canPreview && !canCopy) return null;
 
@@ -73,7 +107,8 @@ export function PreviewActions({
       <Button
         type="button"
         variant="outline"
-        onClick={onPreview}
+        size={size}
+        onClick={startPreview}
         disabled={disabled}
       >
         <Eye className="h-4 w-4" />
@@ -87,6 +122,7 @@ export function PreviewActions({
       <Button
         type="button"
         variant="outline"
+        size={size}
         onClick={onCopyLink}
         disabled={disabled || isCopyingLink}
       >
@@ -106,6 +142,7 @@ export function PreviewActions({
         <Button
           type="button"
           variant="outline"
+          size={size}
           disabled={disabled}
           // The trigger opens a menu rather than performing the preview, so it
           // says so: a control labelled only "Preview" that opens a list is a
@@ -129,7 +166,7 @@ export function PreviewActions({
          * the next opening and none of the actions inside the current one, and
          * both of these race the save they would run alongside.
          */}
-        <DropdownMenuItem onSelect={onPreview} disabled={disabled}>
+        <DropdownMenuItem onSelect={startPreview} disabled={disabled}>
           <Eye className="h-4 w-4" />
           {previewLabel}
         </DropdownMenuItem>

--- a/packages/admin/src/components/features/entries/EntryForm/__tests__/EntryForm.preview-link.test.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/__tests__/EntryForm.preview-link.test.tsx
@@ -1,0 +1,131 @@
+/**
+ * The join between `EntryForm` and its header for the shareable link.
+ *
+ * The two halves are covered separately — `entry-address.test.tsx` pins the
+ * locale outcomes, `EntrySystemHeader.preview.test.tsx` pins what the header
+ * renders given props — and neither sees the conjunction that consumes them.
+ * Measured: removing the `unresolved` guard from `EntryForm` leaves all 126
+ * tests in this directory green, because the helper is unchanged when its
+ * caller stops consulting it. That is the same shape as the defect this whole
+ * change repairs, where every layer was built and nothing joined them.
+ *
+ * So these assert the PROPS the header actually receives, rather than
+ * reconstructing the decision here: a hand-copied condition keeps passing
+ * after someone edits the line it exists to watch.
+ */
+import type { ReactNode } from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+import { render } from "@admin/__tests__/utils";
+
+const { headerProps, mintArgs, localization, settings } = vi.hoisted(() => ({
+  headerProps: vi.fn(),
+  mintArgs: vi.fn(),
+  localization: { current: { defaultLocale: "en" } },
+  settings: { current: { siteUrl: "https://site.example" } },
+}));
+
+vi.mock("../EntrySystemHeader", () => ({
+  EntrySystemHeader: (props: Record<string, unknown>) => {
+    headerProps(props);
+    return null;
+  },
+}));
+
+vi.mock("@admin/hooks/useLocalization", () => ({
+  useLocalization: () => ({
+    enabled: true,
+    locales: [],
+    defaultLocale: localization.current.defaultLocale,
+    fallback: true,
+    getLocale: () => undefined,
+  }),
+}));
+
+vi.mock("@admin/hooks/queries/useGeneralSettings", () => ({
+  useGeneralSettings: () => ({ data: settings.current }),
+}));
+
+vi.mock("@admin/hooks/usePreviewLink", () => ({
+  DEFAULT_PREVIEW_ROUTE: "/api/preview",
+  buildPreviewUrl: () => "https://site.example/api/preview?token=t",
+  usePreviewLink: (args: unknown) => {
+    mintArgs(args);
+    return { mutate: vi.fn(), isPending: false };
+  },
+}));
+
+import { EntryForm } from "../EntryForm";
+
+/** A localized collection with one text field, the minimum this form needs. */
+const collection = {
+  name: "posts",
+  label: "Posts",
+  localized: true,
+  fields: [{ name: "title", type: "text", label: "Title" }],
+} as never;
+
+const entry = { id: "e1", title: "Hello" } as never;
+
+function renderForm(children?: ReactNode) {
+  return render(
+    <>
+      <EntryForm collection={collection} entry={entry} mode="edit" />
+      {children}
+    </>
+  );
+}
+
+/** The most recent props the header was rendered with. */
+function lastHeaderProps(): Record<string, unknown> {
+  const calls = headerProps.mock.calls;
+  expect(calls.length, "the header was never rendered").toBeGreaterThan(0);
+  return calls[calls.length - 1]?.[0] as Record<string, unknown>;
+}
+
+describe("EntryForm wires the shareable link into its header", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localization.current = { defaultLocale: "en" };
+    settings.current = { siteUrl: "https://site.example" };
+  });
+
+  it("offers the link once the language resolves", () => {
+    renderForm();
+
+    expect(lastHeaderProps().isLinkAvailable).toBe(true);
+  });
+
+  it("withholds the link while the default locale is still blank", () => {
+    // `useLocalization` reports `""` until the config loads. Minting then is a
+    // 400, and dropping the claim to avoid that is a token covering every
+    // translation — so the control is not offered at all.
+    localization.current = { defaultLocale: "" };
+    renderForm();
+
+    expect(lastHeaderProps().isLinkAvailable).toBe(false);
+  });
+
+  it("mints against the resolved language, never the editor's sentinel", () => {
+    // The default language is `locale === undefined` in the editor, and an
+    // absent locale claim authorizes every locale.
+    renderForm();
+
+    expect(mintArgs).toHaveBeenCalledWith(
+      expect.objectContaining({
+        collection: "posts",
+        entryId: "e1",
+        locale: "en",
+        siteUrl: "https://site.example",
+      })
+    );
+  });
+
+  it("hands the header a handler rather than only a flag", () => {
+    // `PreviewActions` requires both; a flag with no handler renders nothing,
+    // which would look exactly like the feature being unavailable.
+    renderForm();
+
+    expect(typeof lastHeaderProps().onCopyLink).toBe("function");
+  });
+});

--- a/packages/admin/src/components/features/entries/EntryForm/__tests__/EntrySystemHeader.preview.test.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/__tests__/EntrySystemHeader.preview.test.tsx
@@ -77,23 +77,19 @@ describe("EntrySystemHeader preview control", () => {
     expect(onCopyLink).toHaveBeenCalledTimes(1);
   });
 
-  it("withholds the link from an author who cannot update the document", () => {
-    // The permission half is ANDed in by the header rather than left to the
-    // caller, so this stays closed however the caller answers.
+  it("still offers the link when the flat permission list omits update", () => {
+    // `update` can be granted by a code-first `access.update` rule that the
+    // flat `update-{slug}` list does not carry, and the mint endpoint evaluates
+    // that rule. Gating the control on the list would hide the link from an
+    // author who can edit the document — the same reasoning the Discard Draft
+    // affordance beside it is built on. The endpoint refuses a caller who
+    // genuinely may not update.
     canMock.mockReturnValue(false);
     renderHeader();
 
     expect(
-      screen.queryByRole("button", { name: COPY_LABEL })
-    ).not.toBeInTheDocument();
-  });
-
-  it("asks about update on the document being edited", () => {
-    // A permission resolved for a different slug would gate the control on
-    // access to some other collection.
-    renderHeader({ collectionSlug: "pages" });
-
-    expect(canMock).toHaveBeenCalledWith("update-pages");
+      screen.getByRole("button", { name: COPY_LABEL })
+    ).toBeInTheDocument();
   });
 
   it("withholds the link when there is no saved document to name", () => {

--- a/packages/admin/src/components/features/entries/EntryForm/__tests__/EntrySystemHeader.preview.test.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/__tests__/EntrySystemHeader.preview.test.tsx
@@ -1,0 +1,130 @@
+/**
+ * The preview control in the standalone editor's action bar.
+ *
+ * `PreviewActions` decides its own shape and is covered by its own suite; what
+ * is asserted here is that the header RENDERS it and supplies the halves it
+ * owns. That is the property that was missing: the control, its service, its
+ * hook and their tests all existed while nothing in the standalone editor
+ * rendered any of them, so every component-level suite passed on a feature no
+ * author could reach.
+ */
+import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
+import { FormProvider, useForm } from "react-hook-form";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+import { render, screen } from "@admin/__tests__/utils";
+
+const { canMock } = vi.hoisted(() => ({ canMock: vi.fn() }));
+
+vi.mock("@admin/hooks/useCan", () => ({
+  useCan: (permission: string) => canMock(permission) as boolean,
+}));
+
+import { EntrySystemHeader } from "../EntrySystemHeader";
+
+/**
+ * The header reads form state through context, so it is given a real form:
+ * a partial stub misses the ref plumbing `register` returns and fails for
+ * reasons unrelated to what is under test.
+ */
+function WithForm({ children }: { children: ReactNode }) {
+  const form = useForm();
+  return <FormProvider {...form}>{children}</FormProvider>;
+}
+
+const COPY_LABEL = "Copy shareable link";
+
+function renderHeader(overrides: Record<string, unknown> = {}) {
+  return render(
+    <WithForm>
+      <EntrySystemHeader
+        mode="edit"
+        hasStatus={false}
+        collectionSlug="posts"
+        entry={{ id: "e1" } as never}
+        isSubmitting={false}
+        isDirty={false}
+        isLinkAvailable
+        onCopyLink={vi.fn()}
+        {...overrides}
+      />
+    </WithForm>
+  );
+}
+
+describe("EntrySystemHeader preview control", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    canMock.mockReturnValue(true);
+  });
+
+  it("offers the shareable link in the action bar", () => {
+    renderHeader();
+
+    expect(
+      screen.getByRole("button", { name: COPY_LABEL })
+    ).toBeInTheDocument();
+  });
+
+  it("mints through the handler it was given", async () => {
+    const onCopyLink = vi.fn();
+    const user = userEvent.setup();
+    renderHeader({ onCopyLink });
+
+    await user.click(screen.getByRole("button", { name: COPY_LABEL }));
+
+    expect(onCopyLink).toHaveBeenCalledTimes(1);
+  });
+
+  it("withholds the link from an author who cannot update the document", () => {
+    // The permission half is ANDed in by the header rather than left to the
+    // caller, so this stays closed however the caller answers.
+    canMock.mockReturnValue(false);
+    renderHeader();
+
+    expect(
+      screen.queryByRole("button", { name: COPY_LABEL })
+    ).not.toBeInTheDocument();
+  });
+
+  it("asks about update on the document being edited", () => {
+    // A permission resolved for a different slug would gate the control on
+    // access to some other collection.
+    renderHeader({ collectionSlug: "pages" });
+
+    expect(canMock).toHaveBeenCalledWith("update-pages");
+  });
+
+  it("withholds the link when there is no saved document to name", () => {
+    renderHeader({ mode: "create", entry: null, isLinkAvailable: false });
+
+    expect(
+      screen.queryByRole("button", { name: COPY_LABEL })
+    ).not.toBeInTheDocument();
+  });
+
+  it("refuses a second mint while one is in flight", () => {
+    renderHeader({ isCopyingLink: true });
+
+    expect(screen.getByRole("button", { name: COPY_LABEL })).toBeDisabled();
+  });
+
+  it("refuses a mint while the form is submitting", () => {
+    // Minting reads what is saved, so a submit in flight is a race with it.
+    renderHeader({ isSubmitting: true });
+
+    expect(screen.getByRole("button", { name: COPY_LABEL })).toBeDisabled();
+  });
+
+  it("renders nothing when neither action is available", () => {
+    // A disabled control says "you cannot do this" without saying why, so the
+    // header shows no preview affordance at all rather than a dead button.
+    renderHeader({ isLinkAvailable: false, onCopyLink: undefined });
+
+    expect(
+      screen.queryByRole("button", { name: COPY_LABEL })
+    ).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /preview/i })).toBeNull();
+  });
+});

--- a/packages/admin/src/components/features/entries/EntryForm/__tests__/entry-address.test.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/__tests__/entry-address.test.tsx
@@ -9,6 +9,7 @@ import {
   anyLocalePublished,
   effectiveEntryStatus,
   everPublishedOnRecord,
+  previewLinkLocale,
   useHasPublicAddress,
   type PublicAddressArgs,
 } from "../entry-address";
@@ -446,5 +447,54 @@ describe("useHasPublicAddress", () => {
     rerender(shared({ entry: entry({ status: "draft" }) }));
 
     expect(result.current).toBe(true);
+  });
+});
+
+describe("previewLinkLocale", () => {
+  it("scopes a default-language link to the default locale", () => {
+    // The editor spells the default language as `undefined`, and an absent
+    // locale claim authorizes every locale — so passing the sentinel through
+    // would hand a reviewer of the English draft every other translation too.
+    expect(
+      previewLinkLocale({
+        localized: true,
+        locale: undefined,
+        defaultLocale: "en",
+      })
+    ).toBe("en");
+  });
+
+  it("scopes a translation link to the language being edited", () => {
+    expect(
+      previewLinkLocale({ localized: true, locale: "de", defaultLocale: "en" })
+    ).toBe("de");
+  });
+
+  it("leaves a non-localized collection unscoped", () => {
+    // No locale to name and no translations to leak; scoping to an invented
+    // locale would refuse a link that should work.
+    expect(
+      previewLinkLocale({
+        localized: false,
+        locale: undefined,
+        defaultLocale: "en",
+      })
+    ).toBeUndefined();
+  });
+
+  it("never returns a locale a localized entry was not edited in", () => {
+    // The two accepted spellings of "the default language" must not disagree:
+    // an explicit default and the sentinel resolve to the same scope.
+    const sentinel = previewLinkLocale({
+      localized: true,
+      locale: undefined,
+      defaultLocale: "en",
+    });
+    const explicit = previewLinkLocale({
+      localized: true,
+      locale: "en",
+      defaultLocale: "en",
+    });
+    expect(sentinel).toBe(explicit);
   });
 });

--- a/packages/admin/src/components/features/entries/EntryForm/__tests__/entry-address.test.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/__tests__/entry-address.test.tsx
@@ -10,6 +10,7 @@ import {
   effectiveEntryStatus,
   everPublishedOnRecord,
   previewLinkLocale,
+  previewLinkSiteUrl,
   useHasPublicAddress,
   type PublicAddressArgs,
 } from "../entry-address";
@@ -496,5 +497,55 @@ describe("previewLinkLocale", () => {
       defaultLocale: "en",
     });
     expect(sentinel).toBe(explicit);
+  });
+});
+
+describe("previewLinkSiteUrl", () => {
+  it("prefers the configured site over the browser origin", () => {
+    // An admin panel mounted on a different host from the site would otherwise
+    // hand out links pointing at itself.
+    expect(
+      previewLinkSiteUrl({
+        configured: "https://site.example",
+        origin: "https://admin.example",
+      })
+    ).toBe("https://site.example");
+  });
+
+  it("falls back to the browser origin when nothing is configured", () => {
+    // Usually right, since the common deployment serves both together, and
+    // always better than a relative path that identifies no host at all.
+    expect(
+      previewLinkSiteUrl({ configured: null, origin: "https://admin.example" })
+    ).toBe("https://admin.example");
+  });
+
+  it("treats a cleared setting as absent, not as an empty base", () => {
+    // The settings form stores "" for a field the user cleared; using it as a
+    // base would rebuild the relative path this exists to prevent.
+    expect(
+      previewLinkSiteUrl({ configured: "   ", origin: "https://admin.example" })
+    ).toBe("https://admin.example");
+  });
+
+  it("returns nothing rather than inventing a host", () => {
+    // With no configured site and no origin there is no honest absolute URL,
+    // so the existing relative behaviour stands.
+    expect(
+      previewLinkSiteUrl({ configured: null, origin: undefined })
+    ).toBeUndefined();
+  });
+
+  it("never yields a relative value when either source is present", () => {
+    // The property the control depends on: "Copy shareable link" must not put
+    // a path on the clipboard whenever anything can name a host.
+    for (const args of [
+      { configured: "https://a.example", origin: undefined },
+      { configured: null, origin: "https://b.example" },
+      { configured: "https://a.example", origin: "https://b.example" },
+    ]) {
+      const result = previewLinkSiteUrl(args);
+      expect(result, JSON.stringify(args)).toMatch(/^https?:\/\//);
+    }
   });
 });

--- a/packages/admin/src/components/features/entries/EntryForm/__tests__/entry-address.test.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/__tests__/entry-address.test.tsx
@@ -462,41 +462,78 @@ describe("previewLinkLocale", () => {
         locale: undefined,
         defaultLocale: "en",
       })
-    ).toBe("en");
+    ).toEqual({ kind: "scoped", locale: "en" });
   });
 
   it("scopes a translation link to the language being edited", () => {
     expect(
       previewLinkLocale({ localized: true, locale: "de", defaultLocale: "en" })
-    ).toBe("de");
+    ).toEqual({ kind: "scoped", locale: "de" });
   });
 
   it("leaves a non-localized collection unscoped", () => {
-    // No locale to name and no translations to leak; scoping to an invented
-    // locale would refuse a link that should work.
+    // No locale to name and no translations to leak.
     expect(
       previewLinkLocale({
         localized: false,
         locale: undefined,
         defaultLocale: "en",
       })
-    ).toBeUndefined();
+    ).toEqual({ kind: "unscoped" });
   });
 
-  it("never returns a locale a localized entry was not edited in", () => {
-    // The two accepted spellings of "the default language" must not disagree:
-    // an explicit default and the sentinel resolve to the same scope.
-    const sentinel = previewLinkLocale({
-      localized: true,
-      locale: undefined,
-      defaultLocale: "en",
-    });
-    const explicit = previewLinkLocale({
-      localized: true,
-      locale: "en",
-      defaultLocale: "en",
-    });
-    expect(sentinel).toBe(explicit);
+  it("reports a blank default locale as unresolved, not as unscoped", () => {
+    // `useLocalization` reports `""` before the config loads. Treating that as
+    // unscoped would mint the all-locales token; sending it as a claim is a
+    // 400. It is a third outcome and the caller has to see it as one.
+    expect(
+      previewLinkLocale({
+        localized: true,
+        locale: undefined,
+        defaultLocale: "",
+      })
+    ).toEqual({ kind: "unresolved" });
+    expect(
+      previewLinkLocale({
+        localized: true,
+        locale: undefined,
+        defaultLocale: "   ",
+      })
+    ).toEqual({ kind: "unresolved" });
+    expect(
+      previewLinkLocale({
+        localized: true,
+        locale: undefined,
+        defaultLocale: undefined,
+      })
+    ).toEqual({ kind: "unresolved" });
+  });
+
+  it("never reports unscoped for a localized collection", () => {
+    // The property the leak turned on: `unscoped` means "no locale claim", and
+    // a localized entry must never produce one whatever the inputs are.
+    for (const args of [
+      { localized: true, locale: undefined, defaultLocale: "en" },
+      { localized: true, locale: "de", defaultLocale: "en" },
+      { localized: true, locale: undefined, defaultLocale: "" },
+      { localized: true, locale: undefined, defaultLocale: undefined },
+    ]) {
+      expect(previewLinkLocale(args).kind, JSON.stringify(args)).not.toBe(
+        "unscoped"
+      );
+    }
+  });
+
+  it("agrees on the two spellings of the default language", () => {
+    expect(
+      previewLinkLocale({
+        localized: true,
+        locale: undefined,
+        defaultLocale: "en",
+      })
+    ).toEqual(
+      previewLinkLocale({ localized: true, locale: "en", defaultLocale: "en" })
+    );
   });
 });
 

--- a/packages/admin/src/components/features/entries/EntryForm/entry-address.ts
+++ b/packages/admin/src/components/features/entries/EntryForm/entry-address.ts
@@ -259,3 +259,36 @@ export function useHasPublicAddress({
   if (publishedOnRecord) seenRef.current.add(addressKey);
   return liveNow || publishedOnRecord || seenRef.current.has(addressKey);
 }
+
+/**
+ * The locale a shareable preview link should be scoped to.
+ *
+ * The editor spells the default language as `locale === undefined`, and the
+ * mint route reads a token with no locale claim as authorizing EVERY locale
+ * (`previewTokenCovers` returns true whenever the scope names none). Passing
+ * the editor's sentinel straight through would therefore turn a link to one
+ * language's draft into a grant covering every unpublished translation of the
+ * entry, while a link minted from any NON-default language is correctly
+ * restricted — the widening applies to exactly the language most links are
+ * shared from.
+ *
+ * So the sentinel is resolved here rather than at the call site: it is one
+ * question with one answer, and a second caller deriving it again is how the
+ * two drift apart.
+ *
+ * A non-localized collection is the one case where an unscoped token is right.
+ * It has no locale to name, no translations to leak, and scoping the token to
+ * an invented locale would refuse a link that should work.
+ */
+export function previewLinkLocale({
+  localized,
+  locale,
+  defaultLocale,
+}: {
+  localized: boolean;
+  locale: string | undefined;
+  defaultLocale: string | undefined;
+}): string | undefined {
+  if (!localized) return undefined;
+  return locale ?? defaultLocale;
+}

--- a/packages/admin/src/components/features/entries/EntryForm/entry-address.ts
+++ b/packages/admin/src/components/features/entries/EntryForm/entry-address.ts
@@ -292,3 +292,38 @@ export function previewLinkLocale({
   if (!localized) return undefined;
   return locale ?? defaultLocale;
 }
+
+/**
+ * The site a shareable preview link should point at.
+ *
+ * `buildPreviewUrl` emits a site-relative path when given no site, and a
+ * relative path is not a link: pasted into email or chat it identifies nothing,
+ * and a recipient whose client resolves it does so against their own host. A
+ * control labelled "Copy shareable link" has to put something shareable on the
+ * clipboard, so the value is made absolute here.
+ *
+ * The configured site wins because it is the only source that knows where the
+ * content is actually served — an admin panel mounted on a different host from
+ * the site would otherwise hand out links to itself. A blank setting is treated
+ * as absent rather than as an empty base, since the settings form stores `""`
+ * for a field the user cleared.
+ *
+ * The browser's own origin is the fallback rather than a failure: the common
+ * deployment serves the admin and the site together, so it is usually right,
+ * and it is always better than a relative path. Returning `undefined` is the
+ * last resort for a caller with no origin at all, which leaves the existing
+ * relative behaviour rather than inventing a host.
+ */
+export function previewLinkSiteUrl({
+  configured,
+  origin,
+}: {
+  configured: string | null | undefined;
+  origin: string | undefined;
+}): string | undefined {
+  const trimmed = configured?.trim();
+  if (trimmed !== undefined && trimmed.length > 0) return trimmed;
+  const fallback = origin?.trim();
+  if (fallback !== undefined && fallback.length > 0) return fallback;
+  return undefined;
+}

--- a/packages/admin/src/components/features/entries/EntryForm/entry-address.ts
+++ b/packages/admin/src/components/features/entries/EntryForm/entry-address.ts
@@ -280,6 +280,14 @@ export function useHasPublicAddress({
  * It has no locale to name, no translations to leak, and scoping the token to
  * an invented locale would refuse a link that should work.
  */
+export type PreviewLinkLocale =
+  /** Nothing to name: a non-localized collection has one document. */
+  | { kind: "unscoped" }
+  /** The language the link opens. */
+  | { kind: "scoped"; locale: string }
+  /** Localized, but which language is not known yet. */
+  | { kind: "unresolved" };
+
 export function previewLinkLocale({
   localized,
   locale,
@@ -288,9 +296,18 @@ export function previewLinkLocale({
   localized: boolean;
   locale: string | undefined;
   defaultLocale: string | undefined;
-}): string | undefined {
-  if (!localized) return undefined;
-  return locale ?? defaultLocale;
+}): PreviewLinkLocale {
+  if (!localized) return { kind: "unscoped" };
+  const resolved = locale ?? defaultLocale;
+  // `useLocalization` reports `cfg?.defaultLocale ?? ""`, so a config that has
+  // not loaded yet reads as a blank language rather than a missing one. Blank
+  // is not a locale: the mint route requires a non-empty claim and answers 400,
+  // and dropping the claim instead would mint the all-locales token this
+  // function exists to prevent. Neither is a link, so neither is offered.
+  if (resolved === undefined || resolved.trim().length === 0) {
+    return { kind: "unresolved" };
+  }
+  return { kind: "scoped", locale: resolved };
 }
 
 /**


### PR DESCRIPTION
## What

The entry editor now offers **Copy shareable link**, in the action bar directly left of Save.

## Why this was not already true

Every layer of the feature exists on `main` and has for five days:

| layer | state on `main` |
|---|---|
| `api/preview-links.ts` — mint + revoke, gated by `update` and `assertEntryPreviewable` | built, tested |
| `services/previewLinkApi.ts` | built |
| `hooks/usePreviewLink.ts` — mint, assemble URL, copy, clipboard-refusal fallback | built, tested, **0 consumers** |
| `EntryForm/PreviewActions.tsx` — the control, four shapes | built, tested |
| a render site an author can reach | **absent** |

`PreviewActions` is rendered only by `EntryFormActions`, and `EntryForm` renders `EntryFormActions` only in its **embedded (modal)** branch — whose own comment says preview is not shown there. The standalone editor renders `EntrySystemHeader`, which had no preview affordance at all.

So #589 built the control against a layout the real editing surface does not use, and the published changelog on 24 packages announces a feature no author could reach.

Verified with a positive control on every absence claim (`git grep -c` against a revision known to hold the symbol), because an empty search and a broken search look identical.

## What this changes

- **`EntrySystemHeader`** gains a preview prop surface and renders `PreviewActions` at `size="sm"`, matching the band it sits in.
- **`EntryForm`** wires `usePreviewLink` and answers the half only it knows: is there a saved document for a link to name.
- **`PreviewActions`** gains a `size` pass-through. Its default is unchanged, so the embedded footer renders exactly as before.

**The permission half is resolved by the header, not by the caller.** `EntrySystemHeader` already resolves `update-{slug}` for its submit buttons, so it ANDs that in rather than trusting each call site to remember — a boundary instead of a check. A future caller cannot ship the control while forgetting the gate.

`onPreview` is typed `() => void | Promise<void>` at the request of the lane building the URL resolver (`feat/preview-url-resolver`): resolving a URL will need a round trip, and widening it now avoids a second pass on these files. `PreviewActions` adapts it to the void-returning slot a DOM event expects rather than handing a promise to `onClick`, which would make a rejection invisible.

## Scope, and what is deliberately not here

- **The preview URL half is another lane's** (`feat/preview-url-resolver`). Seam agreed in advance: they own *what URL*, this owns *what grant*. `isPreviewAvailable`/`onPreview` are left unset, so `PreviewActions` renders its "Link only" shape; when their resolver lands it fills those two props on this same surface and the control becomes the combined menu with no rework.
- **Singles are out.** Not a wiring gap: `preview` is declared only on `define-collection.ts`, and `mintPreviewLink` is collection-only by construction (`requireRouteCollectionAccess` + `assertEntryPreviewable` both take a collection). Preview for singles is a feature on both halves and needs a founder decision on the config surface.

## Evidence

**Break controls**, both run:

| control | expected | observed |
|---|---|---|
| remove the `<PreviewActions/>` render | the positive cases fail | 4 failed / 4 passed |
| remove `&& canUpdateDocument` | only the permission case fails | 1 failed / 7 passed |

The second is the one that matters: without it, the permission test passes by absence and would certify a missing gate.

**Suites**: `pnpm run test` in `packages/admin` — 1833 passed, 19 failed across 5 files. All 5 are pre-existing, confirmed by a control rather than by inspection: reverting this change entirely and re-running those files reproduces the same 19 failures. None is in `EntryForm/`. All 14 `EntryForm` suites pass (116 tests), including the existing `PreviewActions` suite, which is what shows the `size` addition regressed nothing.

**Gates**: `check-types` and `lint` both pass for `@nextlyhq/admin`, run with `--force` so neither is a cache hit. Lint initially caught the promise-returning handler; fixed at the cause, not suppressed.

## Changeset

One, `patch`, listing all 24 packages in the fixed group — generated from `.changeset/config.json` and re-verified against it after rebasing onto `77f198f2b`, which changed that file.
