### PR TITLE
fix(release): memoise and serialise the changelog's GitHub lookups

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "@aws-sdk/lib-storage": "^3.1090.0",
     "@changesets/changelog-github": "^0.5.1",
     "@changesets/cli": "^2.27.10",
+    "@changesets/get-github-info": "^0.7.0",
     "@changesets/parse": "^0.4.3",
     "@commitlint/cli": "^20.1.0",
     "@commitlint/config-conventional": "^20.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,6 +75,9 @@ importers:
       '@changesets/cli':
         specifier: ^2.27.10
         version: 2.30.0(@types/node@24.10.0)
+      '@changesets/get-github-info':
+        specifier: ^0.7.0
+        version: 0.7.0
       '@changesets/parse':
         specifier: ^0.4.3
         version: 0.4.3

--- a/scripts/release/changelog.cjs
+++ b/scripts/release/changelog.cjs
@@ -1,154 +1,95 @@
 /**
- * Changelog entries built from LOCAL git, with no GitHub API call.
+ * `@changesets/changelog-github`, with its GitHub lookups memoised and issued one at a time.
  *
- * `@changesets/changelog-github` asks GitHub for the pull request and author behind every
- * changeset. Its `get-github-info` loader batches with no `maxBatchSize`, so one query carries an
- * aliased `object(expression: <commit>)` per changeset, each with a nested
- * `associatedPullRequests(first: 50)`. Past a few hundred pending changesets GitHub stops
- * VALIDATING the document - `{"message": "Timeout on validation of query"}` - and the release
- * fails before writing anything. Validation is refused rather than the work being slow, so
- * retries and backoff do not reach it; the query has to stop being built.
+ * Every entry is produced by the upstream generator, which this module delegates to rather than
+ * reimplements, so the pull-request link and the `Thanks [@user]` attribution are unchanged. Only
+ * HOW the lookups reach GitHub is different.
  *
- * Everything those entries need is already in the repository. The squash subject a merge writes
- * carries its pull-request number, `changeset.commit` carries the revision, and both URLs are
- * constructed from the repo name. One `git log` pass over the whole history builds the map, so
- * the cost does not grow with the number of changesets and no network is involved.
+ * Two properties of the release path combine into the failure this avoids:
  *
- * The trade against `@changesets/changelog-github` is author attribution: a git author is not a
- * GitHub login, and guessing one from a name or an email would be a fabricated link. Attribution
- * is dropped rather than approximated.
+ * - `apply-release-plan` calls `getReleaseLine` for every changeset of every package in one
+ *   synchronous loop. This repository releases as a fixed lockstep group, so every changeset
+ *   touches every package and the loop is packages x changesets - over a thousand lookups, all
+ *   started in the same tick.
+ * - `get-github-info` batches with a `DataLoader` that declares no `maxBatchSize`, so that whole
+ *   set becomes ONE GraphQL document with an aliased `object(expression: <commit>)` per lookup,
+ *   each carrying a nested `associatedPullRequests(first: 50)`. GitHub stops VALIDATING it -
+ *   `{"message": "Timeout on validation of query"}` - and the release fails before writing
+ *   anything. Validation is refused rather than the work being slow, so retries never reach it.
+ *
+ * `DataLoader` would normally collapse the repeats, and here it cannot: `load()` is handed a
+ * freshly built object every call, so the cache key is never `===` to a previous one. Measured,
+ * four identical `getInfo` calls each cost a full round trip (730ms, 517ms, 553ms, 531ms) - there
+ * is no second-call discount to rely on.
+ *
+ * So this wraps `getInfo` with a cache of its own, keyed by repo and commit, and lets one lookup
+ * run at a time. The thousand-odd calls collapse to one per distinct commit, and each is alone in
+ * its tick, so every batch holds a single alias. The wrap works because the generator reaches its
+ * dependency through a namespace property at CALL time rather than capturing the function at
+ * import, so replacing the property is enough and no patching of internals is involved.
  */
 
-const { execFileSync } = require("node:child_process");
+const getGithubInfo = require("@changesets/get-github-info");
+const changelogGithub = require("@changesets/changelog-github").default;
 
 /**
- * The two subject shapes that name a pull request unambiguously.
+ * One in-flight lookup at a time.
  *
- * A squash merge writes `feat(scope): subject (#1234)`; a merge commit writes
- * `Merge pull request #1234 from owner/branch`. Both identify the pull request in the commit
- * itself, so neither can attribute an entry to the wrong one.
+ * A promise chain rather than a concurrency limiter, because the property needed is not "few at
+ * once" but "alone in its tick" - that is what makes a `DataLoader` batch hold a single key.
  *
- * A commit arriving by neither route gets a commit link and no pull-request link. That is a
- * deliberate miss: 118 of 560 changeset-adding commits in this history carry no reference at all,
- * in the subject or the body, and the only way to reach one is to walk forward to an enclosing
- * merge. Measured on three of them, that walk answers correctly once, lands on a
- * `Merge remote-tracking branch` sync commit once, and finds nothing once - so it would sometimes
- * name a pull request the change did not come from. A wrong link is worse than an absent one, for
- * the same reason the author is dropped rather than guessed from a git identity.
+ * The chain absorbs rejections so one failed lookup cannot strand every later one. The rejection
+ * still reaches the caller through the returned promise; only the CHAIN is protected.
  */
-const PULL_REQUEST_PATTERNS = [
-  // Anchored to the END: `(#12)` mid-sentence is prose about an issue, not this merge's number.
-  /\(#(\d+)\)\s*$/,
-  /^Merge pull request #(\d+)\b/,
-];
+let chain = Promise.resolve();
 
-/**
- * Read every commit once, rather than per changeset.
- *
- * A lookup per entry would be several hundred subprocesses on a backlog this size. This is one,
- * and its result is reused for every line in the run.
- *
- * Resolved lazily so that importing this module cannot fail: `changeset version` runs in trees
- * where git may be absent or the history shallow, and a changelog is not worth aborting a release
- * over. A failed read yields an empty map, which degrades every entry to its summary alone.
- */
-let subjectsByCommit;
-
-function commitSubjects() {
-  if (subjectsByCommit) return subjectsByCommit;
-  subjectsByCommit = new Map();
-  try {
-    const log = execFileSync("git", ["log", "--format=%H%x09%s"], {
-      encoding: "utf8",
-      maxBuffer: 256 * 1024 * 1024,
-    });
-    for (const line of log.split("\n")) {
-      const tab = line.indexOf("\t");
-      if (tab === -1) continue;
-      subjectsByCommit.set(line.slice(0, tab), line.slice(tab + 1));
-    }
-  } catch {
-    // Left empty on purpose. The caller cannot tell "no such commit" from "no git", and both
-    // resolve the same way: emit the summary without links rather than fail the release.
-  }
-  return subjectsByCommit;
+function oneAtATime(work) {
+  const result = chain.then(work, work);
+  chain = result.then(
+    () => undefined,
+    () => undefined
+  );
+  return result;
 }
 
 /**
- * The pull request a commit landed through, or null when the subject does not name one.
+ * Results by repo and commit.
  *
- * Null is the correct answer for a direct push and for a commit this checkout does not have. It is
- * not an error: an entry without a link is still a correct changelog entry.
+ * The PROMISE is stored rather than the resolved value, so concurrent callers asking for the same
+ * commit share one lookup instead of queueing a second behind it.
+ *
+ * A rejection is evicted. Caching one would turn a single transient failure into a permanent hole
+ * in the changelog for that commit, for the rest of the run.
  */
-function pullRequestFor(commit, subjects = commitSubjects()) {
-  if (!commit) return null;
-  const subject = subjects.get(commit);
-  if (!subject) return null;
-  for (const pattern of PULL_REQUEST_PATTERNS) {
-    const match = pattern.exec(subject);
-    if (match) return match[1];
-  }
-  return null;
+const byCommit = new Map();
+
+function cachedGetInfo(request) {
+  const key = `${request.repo}\u0000${request.commit}`;
+  const existing = byCommit.get(key);
+  if (existing) return existing;
+
+  const pending = oneAtATime(() => original(request)).catch(error => {
+    byCommit.delete(key);
+    throw error;
+  });
+  byCommit.set(key, pending);
+  return pending;
 }
 
-/** One release line. Exported so its formatting is testable without running a release. */
-function releaseLine(changeset, repo, subjects = commitSubjects()) {
-  const [first, ...rest] = changeset.summary.split("\n").map(line => line.trimEnd());
-
-  const links = [];
-  if (changeset.commit) {
-    const short = changeset.commit.slice(0, 7);
-    links.push(`[\`${short}\`](https://github.com/${repo}/commit/${changeset.commit})`);
-    const pull = pullRequestFor(changeset.commit, subjects);
-    if (pull) links.push(`[#${pull}](https://github.com/${repo}/pull/${pull})`);
-  }
-
-  const prefix = links.length > 0 ? `${links.join(" ")} - ` : "";
-  let line = `- ${prefix}${first}`;
-  // A multi-line summary keeps its shape, indented under the bullet, as changelog-git does.
-  if (rest.length > 0) line += `\n${rest.map(one => `  ${one}`).join("\n")}`;
-  return line;
-}
+// Captured before the property is replaced, so the wrapper calls the real implementation rather
+// than itself. Assigning the wrapper first and reading the property inside it would recurse.
+const original = getGithubInfo.getInfo;
+getGithubInfo.getInfo = cachedGetInfo;
 
 const changelogFunctions = {
-  getReleaseLine: async (changeset, _type, options) =>
-    releaseLine(changeset, options?.repo ?? "nextlyhq/nextly"),
-
-  getDependencyReleaseLine: async (changesets, dependenciesUpdated, options) => {
-    if (dependenciesUpdated.length === 0) return "";
-    const repo = options?.repo ?? "nextlyhq/nextly";
-    const subjects = commitSubjects();
-    // ONE bullet, with the commits inline and the packages nested under it.
-    //
-    // A bullet per changeset followed by a single package list reads correctly in source and
-    // renders wrongly: Markdown attaches the nested list to the LAST bullet, so every earlier
-    // changeset becomes an empty `Updated dependencies` line and the package versions appear to
-    // belong to whichever commit happened to sort last. With a lockstep release group every
-    // changeset touches every package, so that is not a corner case - it is the normal shape, and
-    // at this repository's backlog it produces dozens of empty bullets per package.
-    const links = changesets
-      .filter(changeset => changeset.commit)
-      .map(changeset => {
-        const short = changeset.commit.slice(0, 7);
-        const pull = pullRequestFor(changeset.commit, subjects);
-        const commitLink = `[\`${short}\`](https://github.com/${repo}/commit/${changeset.commit})`;
-        return pull
-          ? `${commitLink} [#${pull}](https://github.com/${repo}/pull/${pull})`
-          : commitLink;
-      });
-    const heading = links.length > 0 ? `- Updated dependencies ${links.join(", ")}` : "- Updated dependencies";
-    const packages = dependenciesUpdated.map(one => `  - ${one.name}@${one.newVersion}`);
-    return [heading, ...packages].join("\n");
-  },
+  getReleaseLine: (changeset, type, options) =>
+    changelogGithub.getReleaseLine(changeset, type, options),
+  getDependencyReleaseLine: (changesets, dependenciesUpdated, options) =>
+    changelogGithub.getDependencyReleaseLine(changesets, dependenciesUpdated, options),
 };
 
-// CommonJS on purpose. `apply-release-plan` loads this with `require()`, which cannot read an
-// ESM `.mjs` on Node 20 - a version this repository still supports - so the module format is
-// decided by the consumer rather than by the surrounding convention.
-//
-// `default` as well as the bare shape: the loader accepts either, and pinning both means a change
-// to its interop cannot silently fall through to an undefined function.
 module.exports = changelogFunctions;
 module.exports.default = changelogFunctions;
-module.exports.pullRequestFor = pullRequestFor;
-module.exports.releaseLine = releaseLine;
+module.exports.oneAtATime = oneAtATime;
+module.exports.cachedGetInfo = cachedGetInfo;
+module.exports.byCommit = byCommit;

--- a/scripts/release/changelog.cjs
+++ b/scripts/release/changelog.cjs
@@ -62,24 +62,56 @@ function oneAtATime(work) {
  * in the changelog for that commit, for the rest of the run.
  */
 const byCommit = new Map();
+const byPullRequest = new Map();
 
-function cachedGetInfo(request) {
-  const key = `${request.repo}\u0000${request.commit}`;
-  const existing = byCommit.get(key);
-  if (existing) return existing;
+/**
+ * The real implementations, captured before the properties are replaced.
+ *
+ * Held in one object so a test can substitute them without a live GitHub request. Assigning the
+ * wrapper first and reading the property back inside it would recurse instead.
+ */
+const upstream = {
+  getInfo: getGithubInfo.getInfo,
+  getInfoFromPullRequest: getGithubInfo.getInfoFromPullRequest,
+};
 
-  const pending = oneAtATime(() => original(request)).catch(error => {
-    byCommit.delete(key);
-    throw error;
-  });
-  byCommit.set(key, pending);
-  return pending;
+function memoise(cache, keyOf, call) {
+  return request => {
+    const key = keyOf(request);
+    const existing = cache.get(key);
+    if (existing) return existing;
+
+    const pending = oneAtATime(() => call(request)).catch(error => {
+      cache.delete(key);
+      throw error;
+    });
+    cache.set(key, pending);
+    return pending;
+  };
 }
 
-// Captured before the property is replaced, so the wrapper calls the real implementation rather
-// than itself. Assigning the wrapper first and reading the property inside it would recurse.
-const original = getGithubInfo.getInfo;
+const cachedGetInfo = memoise(
+  byCommit,
+  request => `${request.repo}\u0000${request.commit}`,
+  request => upstream.getInfo(request)
+);
+
+/**
+ * The other door into the same API.
+ *
+ * A changeset summary may carry `pr: #123`, and the generator then calls
+ * `getInfoFromPullRequest` instead of `getInfo`. Wrapping only one leaves those lookups
+ * unbatched and unmemoised, which is the same oversized document arriving by a route nobody
+ * looked at.
+ */
+const cachedGetInfoFromPullRequest = memoise(
+  byPullRequest,
+  request => `${request.repo}\u0000${request.pull}`,
+  request => upstream.getInfoFromPullRequest(request)
+);
+
 getGithubInfo.getInfo = cachedGetInfo;
+getGithubInfo.getInfoFromPullRequest = cachedGetInfoFromPullRequest;
 
 const changelogFunctions = {
   getReleaseLine: (changeset, type, options) =>
@@ -92,4 +124,7 @@ module.exports = changelogFunctions;
 module.exports.default = changelogFunctions;
 module.exports.oneAtATime = oneAtATime;
 module.exports.cachedGetInfo = cachedGetInfo;
+module.exports.cachedGetInfoFromPullRequest = cachedGetInfoFromPullRequest;
 module.exports.byCommit = byCommit;
+module.exports.byPullRequest = byPullRequest;
+module.exports.upstream = upstream;

--- a/scripts/release/changelog.cjs
+++ b/scripts/release/changelog.cjs
@@ -97,12 +97,12 @@ const cachedGetInfo = memoise(
 );
 
 /**
- * The other door into the same API.
+ * The second entry point into the same API.
  *
  * A changeset summary may carry `pr: #123`, and the generator then calls
- * `getInfoFromPullRequest` instead of `getInfo`. Wrapping only one leaves those lookups
- * unbatched and unmemoised, which is the same oversized document arriving by a route nobody
- * looked at.
+ * `getInfoFromPullRequest` instead of `getInfo`. Either entry point can build the oversized
+ * document on its own, so both need wrapping: one left unwrapped keeps its lookups unbatched and
+ * unmemoised, and the release fails exactly as it would with neither wrapped.
  */
 const cachedGetInfoFromPullRequest = memoise(
   byPullRequest,

--- a/scripts/release/changelog.test.mjs
+++ b/scripts/release/changelog.test.mjs
@@ -28,13 +28,42 @@ describe("the lookup cache", () => {
     }
   }
 
-  it("replaces BOTH of the dependency's exported lookups", () => {
-    // A changeset summary carrying `pr: #123` routes through `getInfoFromPullRequest` instead of
-    // `getInfo`. Wrapping one door leaves the other unbatched, which is the same oversized
-    // document arriving by a route nobody looked at.
-    const live = createRequire(import.meta.url)("@changesets/get-github-info");
-    expect(live.getInfo).toBe(cachedGetInfo);
-    expect(live.getInfoFromPullRequest).toBe(cachedGetInfoFromPullRequest);
+  it("routes the DELEGATED changelog call through the wrapper", async () => {
+    // Asserted by invoking `getReleaseLine`, not by comparing the dependency's exported property.
+    // A property comparison passes even if the generator captured the function during its own
+    // initialisation, or resolves a separate copy of the dependency under pnpm's isolated layout -
+    // and in both of those cases the delegated call bypasses the cache and rebuilds the oversized
+    // batch. Only reaching the stub through the real path rules that out.
+    byCommit.clear();
+    let calls = 0;
+    const line = await withStub(
+      "getInfo",
+      async () => ((calls += 1), { links: { commit: "[`abc`](c)", pull: "[#1](p)", user: "[@u](x)" } }),
+      () =>
+        changelog.getReleaseLine(
+          { summary: "a change", commit: "abcdefabcdefabcdefabcdefabcdefabcdefabcd" },
+          "patch",
+          { repo: "owner/repo" }
+        )
+    );
+    expect(calls).toBe(1);
+    expect(line).toContain("a change");
+  });
+
+  it("routes a pull-request summary through the other wrapper", async () => {
+    // `pr: #123` in the summary selects `getInfoFromPullRequest`, so this is the second entry
+    // point reached through the same delegated call.
+    byPullRequest.clear();
+    let calls = 0;
+    await withStub(
+      "getInfoFromPullRequest",
+      async () => ((calls += 1), { links: { commit: "[`abc`](c)", pull: "[#123](p)", user: "[@u](x)" } }),
+      () =>
+        changelog.getReleaseLine({ summary: "pr: #123\na change" }, "patch", {
+          repo: "owner/repo",
+        })
+    );
+    expect(calls).toBe(1);
   });
 
   it("asks the real lookup once for a repeated commit", async () => {
@@ -74,9 +103,9 @@ describe("the lookup cache", () => {
   });
 
   it("evicts a rejection so a retry can succeed", async () => {
-    // Driven THROUGH the wrapper, because the point is that the eviction RUNS. Seeding a rejected
-    // promise into the map and clearing it by hand passes whether or not the eviction exists,
-    // which is what the previous version of this test did.
+    // Driven THROUGH the wrapper, because the eviction is what has to run. Manipulating the map
+    // directly would assert the setup rather than the code: seeding a rejected entry and removing
+    // it by hand passes identically whether or not the eviction at the catch exists.
     byCommit.clear();
     let calls = 0;
     await withStub(

--- a/scripts/release/changelog.test.mjs
+++ b/scripts/release/changelog.test.mjs
@@ -1,139 +1,125 @@
 import { describe, expect, it } from "vitest";
 
-import changelog from "./changelog.cjs";
+import { createRequire } from "node:module";
 
-const { pullRequestFor, releaseLine } = changelog;
-const changelogFunctions = changelog;
+// Loaded with `require`, because that is how `apply-release-plan` reads it. An ESM import goes
+// through the runner's CJS interop, which unwraps `default` differently from Node's - so a test
+// written against the import would be asserting the test runner's behaviour rather than the shape
+// the release actually sees.
+const changelog = createRequire(import.meta.url)("./changelog.cjs");
 
-const REPO = "nextlyhq/nextly";
-const COMMIT = "a0e2817a2f1c4d5e6b7a8c9d0e1f2a3b4c5d6e7f";
+const { oneAtATime, cachedGetInfo, byCommit } = changelog;
 
-/** A stand-in for the real `git log` map, so these assert formatting rather than this checkout. */
-const subjects = new Map([
-  [COMMIT, "fix(ui): make one control size name mean one control height (#833)"],
-  ["b".repeat(40), "chore: a commit that arrived without a pull request"],
-  ["d".repeat(40), "Merge pull request #783 from nextlyhq/fix/blog-template-builds"],
-]);
-
-describe("pullRequestFor", () => {
-  it("reads the number a squash subject ends with", () => {
-    expect(pullRequestFor(COMMIT, subjects)).toBe("833");
+describe("the getInfo cache", () => {
+  it("replaces the dependency's exported lookup", async () => {
+    // The wrap works because `changelog-github` reaches its dependency through a namespace
+    // property at CALL time rather than capturing the function at import. If that ever changes,
+    // every lookup goes back to the unbatched original and the release fails the way it used to -
+    // so the replacement itself is pinned.
+    const live = createRequire(import.meta.url)("@changesets/get-github-info");
+    expect(live.getInfo).toBe(cachedGetInfo);
   });
 
-  it("returns null for a subject that names no pull request", () => {
-    // A direct push is not an error and must still produce a changelog entry.
-    expect(pullRequestFor("b".repeat(40), subjects)).toBe(null);
+  it("returns the SAME promise for a repeated commit", async () => {
+    // What memoisation means here, asserted without a network call: a second ask reuses the first
+    // lookup rather than starting another. `DataLoader` cannot collapse these itself - it is
+    // handed a freshly built object every call, so its cache key is never `===` to a previous
+    // one, and four identical lookups each cost a full round trip when measured.
+    //
+    // The key is read back from the map rather than spelled again here. Writing it out twice is
+    // the same duplication this repository has a rule about, and the separator is a control
+    // character that does not survive being retyped.
+    byCommit.clear();
+    const seeded = Promise.resolve({ links: { commit: "x" } });
+    const first = cachedGetInfo({ repo: "owner/repo", commit: "abc" });
+    const key = [...byCommit.keys()][0];
+    byCommit.set(key, seeded);
+
+    expect(cachedGetInfo({ repo: "owner/repo", commit: "abc" })).toBe(seeded);
+    expect(byCommit.size).toBe(1);
+    await first.catch(() => undefined);
   });
 
-  it("returns null for a commit this checkout does not have", () => {
-    // A shallow clone reaches here. Degrading to no link is correct; failing is not.
-    expect(pullRequestFor("c".repeat(40), subjects)).toBe(null);
+  it("keys on the repo as well as the commit", () => {
+    // Two repositories can carry the same commit id, and their links differ.
+    byCommit.clear();
+    cachedGetInfo({ repo: "owner/repo", commit: "abc" }).catch(() => undefined);
+    cachedGetInfo({ repo: "other/repo", commit: "abc" }).catch(() => undefined);
+    expect(byCommit.size).toBe(2);
   });
 
-  it("reads the number a merge commit names", () => {
-    // The other shape that identifies a pull request in the commit ITSELF. 118 of 560
-    // changeset-adding commits in this history carry no `(#N)` suffix, and a merge commit is the
-    // one remaining case where the answer is present rather than inferred.
-    expect(pullRequestFor("d".repeat(40), subjects)).toBe("783");
-  });
-
-  it("does not read a number from the middle of a subject", () => {
-    // `(#12)` mid-sentence is prose about an issue, not the merge's own number. Anchoring to the
-    // end is what separates them, and without this the link would point somewhere arbitrary.
-    const middle = new Map([[COMMIT, "fix: handle (#12) in the parser correctly"]]);
-    expect(pullRequestFor(COMMIT, middle)).toBe(null);
+  it("does not cache a rejection", async () => {
+    // A cached failure would be a permanent hole in the changelog for that commit, for the rest
+    // of the run, from one transient error.
+    byCommit.clear();
+    byCommit.set("owner/repo bad", Promise.reject(new Error("boom")));
+    await expect(byCommit.get("owner/repo bad")).rejects.toThrow("boom");
+    byCommit.clear();
+    expect(byCommit.size).toBe(0);
   });
 });
 
-describe("releaseLine", () => {
-  it("links the commit and the pull request", () => {
-    const line = releaseLine({ summary: "do the thing", commit: COMMIT }, REPO, subjects);
-    expect(line).toBe(
-      `- [\`a0e2817\`](https://github.com/${REPO}/commit/${COMMIT})` +
-        ` [#833](https://github.com/${REPO}/pull/833) - do the thing`
-    );
+describe("oneAtATime", () => {
+  it("never runs two pieces of work concurrently", async () => {
+    // THE property this module exists for. `apply-release-plan` starts every lookup in one
+    // synchronous loop, so without this they share a tick and `DataLoader` batches them into a
+    // single GraphQL document - the one GitHub refuses to validate. Overlap here means the
+    // batching is back, whatever the rest of the file says.
+    let running = 0;
+    let peak = 0;
+    const work = () =>
+      oneAtATime(async () => {
+        running += 1;
+        peak = Math.max(peak, running);
+        await new Promise(resolve => setTimeout(resolve, 5));
+        running -= 1;
+      });
+
+    await Promise.all([work(), work(), work(), work()]);
+
+    expect(peak).toBe(1);
   });
 
-  it("links only the commit when no pull request is named", () => {
-    const line = releaseLine({ summary: "do the thing", commit: "b".repeat(40) }, REPO, subjects);
-    expect(line).toContain("/commit/");
-    expect(line).not.toContain("/pull/");
-    expect(line).toContain("- do the thing");
+  it("preserves the order it was asked in", async () => {
+    const seen = [];
+    await Promise.all(["a", "b", "c"].map(id => oneAtATime(async () => void seen.push(id))));
+    expect(seen).toEqual(["a", "b", "c"]);
   });
 
-  it("emits the summary alone when there is no commit", () => {
-    // What a changeset added but not yet committed looks like, and what a failed git read
-    // degrades every entry to.
-    expect(releaseLine({ summary: "do the thing" }, REPO, subjects)).toBe("- do the thing");
+  it("does not let one failure strand the work behind it", async () => {
+    // A single unreachable commit must not leave every later lookup hanging or rejecting.
+    // Without the chain absorbing rejections, one failure poisons every continuation on it.
+    await expect(
+      oneAtATime(async () => {
+        throw new Error("lookup failed");
+      })
+    ).rejects.toThrow("lookup failed");
+
+    await expect(oneAtATime(async () => "after")).resolves.toBe("after");
   });
 
-  it("keeps a multi-line summary indented under the bullet", () => {
-    const line = releaseLine({ summary: "first line\nsecond line", commit: undefined }, REPO, subjects);
-    expect(line).toBe("- first line\n  second line");
-  });
-
-  it("trims trailing whitespace from every line", () => {
-    expect(releaseLine({ summary: "first  \nsecond\t" }, REPO, subjects)).toBe("- first\n  second");
+  it("reports the failure to ITS caller rather than swallowing it", async () => {
+    // The chain is protected; the returned promise is not. A caller that needs to know still does.
+    await expect(
+      oneAtATime(async () => {
+        throw new Error("visible");
+      })
+    ).rejects.toThrow("visible");
   });
 });
 
 describe("the changelog contract", () => {
   it("exports the two functions changesets calls", () => {
-    // Named exactly as `changeset version` looks them up. A rename here fails the release at the
-    // point of use rather than at import, so it is pinned.
-    expect(typeof changelogFunctions.getReleaseLine).toBe("function");
-    expect(typeof changelogFunctions.getDependencyReleaseLine).toBe("function");
+    // Looked up by name at release time, so a rename fails at the point of use rather than at
+    // import. Pinned here instead.
+    expect(typeof changelog.getReleaseLine).toBe("function");
+    expect(typeof changelog.getDependencyReleaseLine).toBe("function");
   });
 
-  it("returns an empty string when nothing was updated", async () => {
-    expect(await changelogFunctions.getDependencyReleaseLine([], [], { repo: REPO })).toBe("");
-  });
-
-  it("lists each updated dependency under the commits that moved it", async () => {
-    const out = await changelogFunctions.getDependencyReleaseLine(
-      [{ commit: COMMIT }],
-      [{ name: "@nextlyhq/ui", newVersion: "0.0.2-alpha.42" }],
-      { repo: REPO }
-    );
-    expect(out).toContain("Updated dependencies");
-    expect(out).toContain("  - @nextlyhq/ui@0.0.2-alpha.42");
-  });
-
-  it("emits ONE bullet with the packages nested under it", async () => {
-    // Markdown attaches a nested list to the LAST bullet, so a bullet per changeset leaves every
-    // earlier one empty. With a lockstep group that is the normal shape, not a corner case.
-    const out = await changelogFunctions.getDependencyReleaseLine(
-      [{ commit: COMMIT }, { commit: "b".repeat(40) }],
-      [{ name: "@nextlyhq/ui", newVersion: "0.0.2-alpha.42" }],
-      { repo: REPO }
-    );
-    expect(out.split("\n").filter(line => line.startsWith("- "))).toHaveLength(1);
-    expect(out).toContain("  - @nextlyhq/ui@0.0.2-alpha.42");
-  });
-
-  it("names every contributing commit in that one bullet", async () => {
-    const out = await changelogFunctions.getDependencyReleaseLine(
-      [{ commit: COMMIT }, { commit: "b".repeat(40) }],
-      [{ name: "@nextlyhq/ui", newVersion: "0.0.2-alpha.42" }],
-      { repo: REPO }
-    );
-    expect(out).toContain(COMMIT.slice(0, 7));
-    expect(out).toContain("b".repeat(7));
-  });
-
-  it("makes NO network call", async () => {
-    // The property this module exists for. `changelog-github` reaches api.github.com here, and at
-    // this repository's changeset count GitHub refuses to validate the query it builds.
-    const original = globalThis.fetch;
-    globalThis.fetch = () => {
-      throw new Error("changelog generation must not perform network requests");
-    };
-    try {
-      await expect(
-        changelogFunctions.getReleaseLine({ summary: "s", commit: COMMIT }, "patch", { repo: REPO })
-      ).resolves.toContain("- ");
-    } finally {
-      globalThis.fetch = original;
-    }
+  it("carries a default that is the module itself", () => {
+    // `apply-release-plan` accepts either shape from its interop, so both are pinned; a change to
+    // that interop cannot silently fall through to an undefined function.
+    expect(changelog.default).toBe(changelog);
+    expect(typeof changelog.default.getReleaseLine).toBe("function");
   });
 });

--- a/scripts/release/changelog.test.mjs
+++ b/scripts/release/changelog.test.mjs
@@ -8,54 +8,95 @@ import { createRequire } from "node:module";
 // the release actually sees.
 const changelog = createRequire(import.meta.url)("./changelog.cjs");
 
-const { oneAtATime, cachedGetInfo, byCommit } = changelog;
+const { oneAtATime, cachedGetInfo, cachedGetInfoFromPullRequest, byCommit, byPullRequest, upstream } = changelog;
 
-describe("the getInfo cache", () => {
-  it("replaces the dependency's exported lookup", async () => {
-    // The wrap works because `changelog-github` reaches its dependency through a namespace
-    // property at CALL time rather than capturing the function at import. If that ever changes,
-    // every lookup goes back to the unbatched original and the release fails the way it used to -
-    // so the replacement itself is pinned.
+describe("the lookup cache", () => {
+  /**
+   * Swap the real network call for a stub, and put it back.
+   *
+   * `async`, and it AWAITS: a synchronous `finally` restores the real function the moment `run`
+   * returns its promise, so the awaited work would run against the real lookup and the suite
+   * would become network-dependent - the state this helper exists to prevent.
+   */
+  async function withStub(name, impl, run) {
+    const real = upstream[name];
+    upstream[name] = impl;
+    try {
+      return await run();
+    } finally {
+      upstream[name] = real;
+    }
+  }
+
+  it("replaces BOTH of the dependency's exported lookups", () => {
+    // A changeset summary carrying `pr: #123` routes through `getInfoFromPullRequest` instead of
+    // `getInfo`. Wrapping one door leaves the other unbatched, which is the same oversized
+    // document arriving by a route nobody looked at.
     const live = createRequire(import.meta.url)("@changesets/get-github-info");
     expect(live.getInfo).toBe(cachedGetInfo);
+    expect(live.getInfoFromPullRequest).toBe(cachedGetInfoFromPullRequest);
   });
 
-  it("returns the SAME promise for a repeated commit", async () => {
-    // What memoisation means here, asserted without a network call: a second ask reuses the first
-    // lookup rather than starting another. `DataLoader` cannot collapse these itself - it is
-    // handed a freshly built object every call, so its cache key is never `===` to a previous
-    // one, and four identical lookups each cost a full round trip when measured.
-    //
-    // The key is read back from the map rather than spelled again here. Writing it out twice is
-    // the same duplication this repository has a rule about, and the separator is a control
-    // character that does not survive being retyped.
+  it("asks the real lookup once for a repeated commit", async () => {
+    // Counted THROUGH the wrapper, so memoisation is what is observed. `DataLoader` cannot
+    // collapse these itself - it is handed a freshly built object every call, so its key is never
+    // `===` to a previous one.
     byCommit.clear();
-    const seeded = Promise.resolve({ links: { commit: "x" } });
-    const first = cachedGetInfo({ repo: "owner/repo", commit: "abc" });
-    const key = [...byCommit.keys()][0];
-    byCommit.set(key, seeded);
-
-    expect(cachedGetInfo({ repo: "owner/repo", commit: "abc" })).toBe(seeded);
-    expect(byCommit.size).toBe(1);
-    await first.catch(() => undefined);
+    let calls = 0;
+    await withStub("getInfo", async () => ((calls += 1), { links: { commit: "x" } }), async () => {
+      await cachedGetInfo({ repo: "owner/repo", commit: "abc" });
+      await cachedGetInfo({ repo: "owner/repo", commit: "abc" });
+      await cachedGetInfo({ repo: "owner/repo", commit: "abc" });
+    });
+    expect(calls).toBe(1);
   });
 
-  it("keys on the repo as well as the commit", () => {
+  it("keys on the repo as well as the commit", async () => {
     // Two repositories can carry the same commit id, and their links differ.
     byCommit.clear();
-    cachedGetInfo({ repo: "owner/repo", commit: "abc" }).catch(() => undefined);
-    cachedGetInfo({ repo: "other/repo", commit: "abc" }).catch(() => undefined);
-    expect(byCommit.size).toBe(2);
+    let calls = 0;
+    await withStub("getInfo", async () => ((calls += 1), { links: {} }), async () => {
+      await cachedGetInfo({ repo: "owner/repo", commit: "abc" });
+      await cachedGetInfo({ repo: "other/repo", commit: "abc" });
+    });
+    expect(calls).toBe(2);
   });
 
-  it("does not cache a rejection", async () => {
-    // A cached failure would be a permanent hole in the changelog for that commit, for the rest
-    // of the run, from one transient error.
+  it("memoises pull-request lookups on their own key", async () => {
+    byPullRequest.clear();
+    let calls = 0;
+    await withStub("getInfoFromPullRequest", async () => ((calls += 1), { links: {} }), async () => {
+      await cachedGetInfoFromPullRequest({ repo: "owner/repo", pull: 12 });
+      await cachedGetInfoFromPullRequest({ repo: "owner/repo", pull: 12 });
+      await cachedGetInfoFromPullRequest({ repo: "owner/repo", pull: 13 });
+    });
+    expect(calls).toBe(2);
+  });
+
+  it("evicts a rejection so a retry can succeed", async () => {
+    // Driven THROUGH the wrapper, because the point is that the eviction RUNS. Seeding a rejected
+    // promise into the map and clearing it by hand passes whether or not the eviction exists,
+    // which is what the previous version of this test did.
     byCommit.clear();
-    byCommit.set("owner/repo bad", Promise.reject(new Error("boom")));
-    await expect(byCommit.get("owner/repo bad")).rejects.toThrow("boom");
-    byCommit.clear();
-    expect(byCommit.size).toBe(0);
+    let calls = 0;
+    await withStub(
+      "getInfo",
+      async () => {
+        calls += 1;
+        if (calls === 1) throw new Error("transient");
+        return { links: { commit: "second" } };
+      },
+      async () => {
+        await expect(cachedGetInfo({ repo: "owner/repo", commit: "abc" })).rejects.toThrow(
+          "transient"
+        );
+        // A cached failure would be a permanent hole in the changelog for that commit.
+        await expect(cachedGetInfo({ repo: "owner/repo", commit: "abc" })).resolves.toEqual({
+          links: { commit: "second" },
+        });
+      }
+    );
+    expect(calls).toBe(2);
   });
 });
 

--- a/scripts/release/changelog.test.mjs
+++ b/scripts/release/changelog.test.mjs
@@ -129,6 +129,89 @@ describe("the lookup cache", () => {
   });
 });
 
+describe("the delegated output", () => {
+  // Stubbed links, so these assert the SHAPE this module emits rather than GitHub's availability.
+  const links = {
+    commit: "[`abc1234`](https://github.com/owner/repo/commit/abc1234)",
+    pull: "[#123](https://github.com/owner/repo/pull/123)",
+    user: "[@someone](https://github.com/someone)",
+  };
+
+  async function withInfo(run, override = links) {
+    const real = upstream.getInfo;
+    upstream.getInfo = async () => ({ links: override });
+    byCommit.clear();
+    try {
+      return await run();
+    } finally {
+      upstream.getInfo = real;
+    }
+  }
+
+  const releaseLine = (changeset, override) =>
+    withInfo(
+      () => changelog.getReleaseLine(changeset, "patch", { repo: "owner/repo" }),
+      override
+    );
+
+  it("carries the pull-request link, the commit link and the attribution", async () => {
+    // The three things this module exists to preserve. A regression that silently drops any of
+    // them produces a changelog that still looks plausible.
+    const line = await releaseLine({
+      summary: "a change",
+      commit: "abc1234abc1234abc1234abc1234abc1234abc1",
+    });
+    expect(line).toContain("[#123]");
+    expect(line).toContain("[`abc1234`]");
+    expect(line).toContain("Thanks [@someone]");
+    expect(line).toContain("a change");
+  });
+
+  it("omits the attribution when the lookup reports no user", async () => {
+    // The negative half: the assertion above must be satisfied by the user actually being there,
+    // not by the phrase appearing whatever the lookup returned.
+    const line = await releaseLine(
+      { summary: "a change", commit: "abc1234abc1234abc1234abc1234abc1234abc1" },
+      { commit: links.commit, pull: links.pull, user: null }
+    );
+    expect(line).not.toContain("Thanks");
+    expect(line).toContain("[#123]");
+  });
+
+  it("still produces a line when the changeset has no commit", async () => {
+    // A changeset added but not yet committed. It must still appear, without links.
+    const line = await releaseLine({ summary: "uncommitted" });
+    expect(line).toContain("uncommitted");
+  });
+
+  it("keeps a multiline summary's shape", async () => {
+    const line = await releaseLine({ summary: "first line\nsecond line" });
+    expect(line).toContain("first line");
+    expect(line).toContain("second line");
+  });
+
+  it("nests the updated packages under one dependency bullet", async () => {
+    // Markdown attaches a nested list to the preceding bullet, so the package versions must sit
+    // under a single `Updated dependencies` entry rather than trailing a run of empty ones.
+    const out = await withInfo(() =>
+      changelog.getDependencyReleaseLine(
+        [{ commit: "abc1234abc1234abc1234abc1234abc1234abc1" }],
+        [{ name: "@nextlyhq/ui", newVersion: "0.0.2-alpha.58" }],
+        { repo: "owner/repo" }
+      )
+    );
+    expect(out.split("\n").filter(line => line.startsWith("- "))).toHaveLength(1);
+    expect(out).toContain("  - @nextlyhq/ui@0.0.2-alpha.58");
+  });
+
+  it("returns nothing when no dependency moved", async () => {
+    const out = await withInfo(() =>
+      changelog.getDependencyReleaseLine([], [], { repo: "owner/repo" })
+    );
+    expect(out).toBe("");
+  });
+});
+
 describe("oneAtATime", () => {
   it("never runs two pieces of work concurrently", async () => {
     // THE property this module exists for. `apply-release-plan` starts every lookup in one


### PR DESCRIPTION
Follow-up to #836, which fixed `Version & Publish` by dropping the GitHub API — and with it the `Thanks [@user]` attribution. The founder asked for that back: *"I don't want to lose the history + I want the way it was working before."*

This keeps `@changesets/changelog-github`, so **every entry is byte-identical to what you had before**. Only how the lookups reach GitHub changes.

## Two things combine into the failure

**`apply-release-plan` calls `getReleaseLine` for every changeset of every package in one synchronous loop.** This repo releases as a fixed lockstep group, so that loop is packages × changesets — **over a thousand lookups started in the same tick**, not the ~57 I first assumed.

**`get-github-info` batches with a `DataLoader` declaring no `maxBatchSize`**, so the whole set becomes ONE GraphQL document with an aliased `object(expression: <commit>)` per lookup, each with a nested `associatedPullRequests(first: 50)`. GitHub stops *validating* it — and validation being refused is why retries and backoff never reach it.

## Why `DataLoader`'s own cache does not save this

`load()` is handed a freshly built object every call, so its key is never `===` to a previous one. **Measured** — four identical `getInfo` calls: 730ms, 517ms, 553ms, 531ms. There is no second-call discount to build on, which is what ruled out a simpler pre-warming design I tried first.

## The fix

`getInfo` is wrapped with a cache keyed by repo and commit, and one lookup runs at a time. The thousand-odd calls collapse to one per distinct commit, each alone in its tick, so every batch holds a single alias.

The wrap is not a patch of internals: the generator reaches its dependency through a **namespace property at call time** rather than capturing the function at import, so replacing the property is enough. That property is pinned by a test, because if it ever changes every lookup silently goes back to being unbatched.

After wrapping: 793ms, then **0ms, 0ms, 0ms**, and 20 concurrent asks for one commit cost 0ms.

## Verification

End to end with a real token: `changeset version` completes **exit 0**, and the output carries **508 `Thanks [@…]` lines**. Sample:

```
- [#720](https://github.com/nextlyhq/nextly/pull/720) [`8a7e734`](…/commit/8a7e734…) Thanks [@mobeenabdullah](…)! - …
```

Tests cover the properties rather than the plumbing: no two lookups overlap, order is preserved, one failure does not strand the work behind it, the rejection still reaches its own caller, a rejection is never cached, and the dependency's exported lookup really is the wrapper.

`@changesets/get-github-info` is declared as a direct devDependency because this file imports it — under pnpm a transitive package is not resolvable from the root.

## Correction carried over from #836

I claimed 472 pending changesets. Measured: 473 on disk, **416 already consumed**, **57 unreleased**. Prerelease mode retains the files by design; I read a directory listing as a queue. The real driver is the packages × changesets fan-out above.

No changeset: release tooling, ships nothing.