### PR TITLE
fix(nextly): claim a legacy lock table by owner instead of skipping it

### DIFF
--- a/.changeset/migration-lock-legacy-owner-claim.md
+++ b/.changeset/migration-lock-legacy-owner-claim.md
@@ -1,0 +1,28 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+A schema sync on a database whose migration-lock table predates its expiry column now holds that lock by owner instead of running without one.

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/helpers/migration-lock-double.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/helpers/migration-lock-double.ts
@@ -142,6 +142,24 @@ const RELEASE = new RegExp(
   String.raw`^UPDATE "${TABLE}" SET "owner" = NULL, "expires_at" = NULL WHERE "id" = \$\d+ AND "owner" = \$(?<owner>\d+)$`
 );
 
+/**
+ * The owner-only statements a legacy lock table takes.
+ *
+ * A table created before `expires_at` existed cannot answer any statement naming that column, so the
+ * session falls back to these three. Modelled here rather than absorbed by a permissive default: a
+ * double that resolved them silently would certify an exclusion nobody took, which is exactly the
+ * claim this fallback exists to make true.
+ */
+const OWNER_READ = new RegExp(
+  String.raw`^SELECT "owner" FROM "${TABLE}" WHERE "id" = \$\d+$`
+);
+const OWNER_CLAIM = new RegExp(
+  String.raw`^UPDATE "${TABLE}" SET "owner" = \$(?<claim>\d+) WHERE "id" = \$\d+ AND "owner" IS NULL$`
+);
+const OWNER_RELEASE = new RegExp(
+  String.raw`^UPDATE "${TABLE}" SET "owner" = NULL WHERE "id" = \$\d+ AND "owner" = \$(?<owner>\d+)$`
+);
+
 type Groups = Record<string, string | undefined> | undefined;
 
 /** The statements this module issues, named. */
@@ -150,7 +168,13 @@ export type LockStatementKind =
   | "state"
   | "claim"
   | "renew"
-  | "release";
+  | "release"
+  // The legacy-table fallback. Named separately from their expiry-aware counterparts because a test
+  // that fails "the state read" must NOT also fail these — they are the path taken precisely when
+  // the state read cannot work.
+  | "owner-read"
+  | "owner-claim"
+  | "owner-release";
 
 /**
  * What a statement IS, separately from what it DOES.
@@ -168,6 +192,9 @@ function matchLockStatement(
     ["claim", CLAIM],
     ["renew", RENEW],
     ["release", RELEASE],
+    ["owner-read", OWNER_READ],
+    ["owner-claim", OWNER_CLAIM],
+    ["owner-release", OWNER_RELEASE],
   ] as const) {
     const match = pattern.exec(flat);
     if (match) return { kind, groups: match.groups };
@@ -243,6 +270,23 @@ export function interpretLockStatement(
           },
         ]
       : [];
+  }
+  if (matched?.kind === "owner-read") {
+    return lock.seeded ? [{ owner: lock.owner }] : [];
+  }
+  if (matched?.kind === "owner-claim") {
+    // Predicated on the row being FREE, exactly as the statement is: a contender that won the race
+    // leaves the row naming them, and the session's read-back is what notices.
+    if (lock.seeded && lock.owner === null) {
+      lock.owner = bound(groups, params, "claim") as string | null;
+    }
+    return [];
+  }
+  if (matched?.kind === "owner-release") {
+    // Owner-scoped. `expires_at` is deliberately untouched: on this table it does not exist, and a
+    // model that cleared it would let a fixture pass that the real database would reject.
+    if (lock.owner === bound(groups, params, "owner")) lock.owner = null;
+    return [];
   }
   if (matched?.kind === "claim") {
     // 🔴 Unconditional, because the real statement is: `acquire` decides under a row lock and then

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/session.test.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/session.test.ts
@@ -1260,6 +1260,74 @@ describe("field-group migration session", () => {
   });
 
   /**
+   * 🔴 The window is between the database COMMITTING the claim and this process being scheduled
+   * again to register its handlers. A signal landing there takes the default termination path with
+   * the row already owned — and this claim has no expiry to lapse.
+   *
+   * Pinned as "the handlers are live BEFORE the claim statement runs", because that is the property
+   * that closes the window; the race itself cannot be exhibited once the fix removes it, and a test
+   * that waits for the gap would be waiting for something that no longer exists.
+   */
+  it("has its interrupt handlers installed before it claims the row", async () => {
+    let listenersAtClaim = 0;
+    const h = createAdapter({
+      heldBy: null,
+      stateReadError: Object.assign(
+        new Error('column "expires_at" does not exist'),
+        { code: "42703" }
+      ),
+      onStatement: kind => {
+        // Sampled AS the claim is interpreted, which is the instant the row becomes owned.
+        if (kind === "owner-claim") {
+          listenersAtClaim = process.listenerCount("SIGINT");
+        }
+      },
+    });
+
+    const before = process.listenerCount("SIGINT");
+    await withMigrationSession(
+      {
+        adapter: h.adapter,
+        dialect: "postgresql",
+        label: "sync-1",
+        requireExistingLock: true,
+        releaseOnInterrupt: true,
+      },
+      async () => undefined
+    );
+
+    // A handler was already listening when the row was claimed, and none leaked afterwards.
+    expect(listenersAtClaim).toBeGreaterThan(before);
+    expect(process.listenerCount("SIGINT")).toBe(before);
+  });
+
+  // Registered before the attempt, so the path that never held anything has to take them off again.
+  // Two process-wide listeners per refused sync is a slow leak in watch mode, which refuses often.
+  it("removes its interrupt handlers when the legacy claim is refused", async () => {
+    const h = createAdapter({
+      heldBy: "field-group-migration#other",
+      stateReadError: Object.assign(
+        new Error('column "expires_at" does not exist'),
+        { code: "42703" }
+      ),
+    });
+
+    const before = process.listenerCount("SIGINT");
+    await withMigrationSession(
+      {
+        adapter: h.adapter,
+        dialect: "postgresql",
+        label: "sync-1",
+        requireExistingLock: true,
+        releaseOnInterrupt: true,
+      },
+      async () => undefined
+    ).catch(() => undefined);
+
+    expect(process.listenerCount("SIGINT")).toBe(before);
+  });
+
+  /**
    * Completing is not the same as having been protected while completing. If an operator clears the
    * row — plausible on this path, since a claim with no expiry is exactly the thing an operator is
    * told to clear by hand — the exclusion this session promised was not held for the whole run.

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/session.test.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/session.test.ts
@@ -1126,6 +1126,7 @@ describe("field-group migration session", () => {
     });
 
     const observed: LockObservation[] = [];
+    let ownerDuringWork: string | null = null;
     await withMigrationSession(
       {
         adapter: h.adapter,
@@ -1138,19 +1139,101 @@ describe("field-group migration session", () => {
       },
       async session => {
         observed.push(session.lock);
+        ownerDuringWork = h.owner();
       }
     );
 
-    // 🔴 The work RAN — the whole point is that a sync is not blocked by a lock it cannot read.
+    // 🔴 The work RAN — a sync must not be blocked by a column its table happens to lack.
     expect(observed).toHaveLength(1);
-    // And it is told plainly that it holds nothing, rather than the default that claims ownership.
-    expect(observed[0]).toEqual({ kind: "not-held" });
-    // 🔴 And the skip is REPORTED. A silent downgrade from excluded to unexcluded is the thing that
-    // would make this dangerous rather than merely tolerant.
+    // 🔴 And it ran HOLDING the lock, by owner alone. Reporting `not-held` here was the earlier
+    // behaviour and it meant the sync proceeded with no exclusion at all, so a migration starting
+    // during it could rename tables underneath work that had already decided what exists.
+    expect(observed[0]).toEqual({ kind: "held", owner: expect.any(String) });
+    // The row actually named this claim while the callback ran — asserted on the DATABASE, because
+    // the reported observation is this session's own claim about itself.
+    expect(ownerDuringWork).toMatch(/^sync-1#/);
+    // And it was cleared afterwards, so the next sync is not blocked by this one.
+    expect(h.owner()).toBeNull();
+    // Still reported: the operator needs to know this database is on the older shape, because the
+    // claim it just took has no expiry and a killed process would leave it behind.
     expect(warn).toHaveBeenCalledTimes(1);
     expect(warn.mock.calls[0]?.[1]).toMatchObject({
       reason: "migration lock table is missing expires_at",
     });
+  });
+
+  /**
+   * 🔴 The property the owner-only claim exists to buy, and the one no assertion above can show.
+   *
+   * A test that only proves the claim is TAKEN passes just as well against a fallback that takes it
+   * unconditionally — which would be worse than skipping, since it would overwrite a live
+   * migration's claim. Exclusion means someone else's claim REFUSES this one.
+   *
+   * Refused rather than waited out, because without `expires_at` there is no basis on which to call
+   * a holder dead: guessing would mean stealing the lock from a run that may still be writing.
+   */
+  it("refuses a legacy lock that another run already holds", async () => {
+    const h = createAdapter({
+      heldBy: "field-group-migration#other",
+      stateReadError: Object.assign(
+        new Error('column "expires_at" does not exist'),
+        { code: "42703" }
+      ),
+    });
+    const ran = vi.fn();
+
+    const refusal = await withMigrationSession(
+      {
+        adapter: h.adapter,
+        dialect: "postgresql",
+        label: "sync-1",
+        requireExistingLock: true,
+      },
+      async () => {
+        ran();
+      }
+    ).catch((error: unknown) => error);
+
+    expect(NextlyError.is(refusal)).toBe(true);
+    if (NextlyError.is(refusal)) {
+      // The REASON, not just the code: a lock this session could not READ and a lock another run
+      // HOLDS are different situations with different remedies, and both surface as unavailable.
+      expect(refusal.logContext?.reason).toBe(
+        "migration lock is held elsewhere"
+      );
+      expect(refusal.logContext?.heldBy).toBe("field-group-migration#other");
+    }
+    // The work never ran, and the other run's claim is untouched.
+    expect(ran).not.toHaveBeenCalled();
+    expect(h.owner()).toBe("field-group-migration#other");
+  });
+
+  // A claim that outlived a failed callback would block every later sync on a table that cannot
+  // expire it, so the release has to be in a `finally` rather than on the happy path.
+  it("clears its legacy claim even when the work throws", async () => {
+    const h = createAdapter({
+      heldBy: null,
+      stateReadError: Object.assign(
+        new Error('column "expires_at" does not exist'),
+        { code: "42703" }
+      ),
+    });
+
+    await expect(
+      withMigrationSession(
+        {
+          adapter: h.adapter,
+          dialect: "postgresql",
+          label: "sync-1",
+          requireExistingLock: true,
+        },
+        async () => {
+          throw new Error("sync failed");
+        }
+      )
+    ).rejects.toThrowError();
+
+    expect(h.owner()).toBeNull();
   });
 
   // A renewal already in flight when the callback finishes outlives `clearInterval`, which only

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/session.test.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/session.test.ts
@@ -1208,6 +1208,98 @@ describe("field-group migration session", () => {
     expect(h.owner()).toBe("field-group-migration#other");
   });
 
+  /**
+   * 🔴 The interrupt matters MORE here than on the expiry-aware path, which is why it is pinned.
+   *
+   * A terminated process never reaches the `finally`, and this claim has NO EXPIRY to lapse. So a
+   * stranded claim does not merely block the next sync — it blocks the migration that would ADD
+   * `expires_at`, making the one action that permanently repairs the database the action the
+   * stranded claim prevents. Watch mode documents Ctrl+C as the way to stop, so this is the ordinary
+   * path rather than an edge case.
+   */
+  it("releases a legacy claim when the process is interrupted", async () => {
+    const h = createAdapter({
+      heldBy: null,
+      stateReadError: Object.assign(
+        new Error('column "expires_at" does not exist'),
+        { code: "42703" }
+      ),
+    });
+    const signals: string[] = [];
+    const kill = vi
+      .spyOn(process, "kill")
+      .mockImplementation((_pid: number, signal?: string | number) => {
+        signals.push(String(signal));
+        return true;
+      });
+    try {
+      let ownerWhileHeld: string | null = null;
+      await withMigrationSession(
+        {
+          adapter: h.adapter,
+          dialect: "postgresql",
+          label: "sync-1",
+          requireExistingLock: true,
+          releaseOnInterrupt: true,
+        },
+        async () => {
+          ownerWhileHeld = h.owner();
+          process.emit("SIGINT");
+          // Let the signal path settle before the callback returns, so this observes the handler
+          // rather than the ordinary release in `finally`.
+          await new Promise(resolve => setImmediate(resolve));
+          expect(h.owner()).toBeNull();
+        }
+      );
+
+      expect(ownerWhileHeld).toMatch(/^sync-1#/);
+      expect(signals).toContain("SIGINT");
+    } finally {
+      kill.mockRestore();
+    }
+  });
+
+  /**
+   * Completing is not the same as having been protected while completing. If an operator clears the
+   * row — plausible on this path, since a claim with no expiry is exactly the thing an operator is
+   * told to clear by hand — the exclusion this session promised was not held for the whole run.
+   *
+   * The expiry-aware path refuses at completion for the same reason, and the answer was already
+   * computed here and thrown away.
+   */
+  it("fails a legacy run whose claim was taken while it worked", async () => {
+    const h = createAdapter({
+      heldBy: null,
+      stateReadError: Object.assign(
+        new Error('column "expires_at" does not exist'),
+        { code: "42703" }
+      ),
+    });
+
+    const failure = await withMigrationSession(
+      {
+        adapter: h.adapter,
+        dialect: "postgresql",
+        label: "sync-1",
+        requireExistingLock: true,
+      },
+      async () => {
+        // Someone else takes the row mid-run, exactly as clearing and re-claiming it would.
+        h.takeOver("someone-else");
+        return "done";
+      }
+    ).catch((error: unknown) => error);
+
+    expect(NextlyError.is(failure)).toBe(true);
+    if (NextlyError.is(failure)) {
+      // The REASON, because "held elsewhere at acquisition" and "lost during the run" are different
+      // events with the same status code and different remedies.
+      expect(failure.logContext?.reason).toBe(
+        "migration lock was not held at completion"
+      );
+    }
+  });
+
   // A claim that outlived a failed callback would block every later sync on a table that cannot
   // expire it, so the release has to be in a `finally` rather than on the happy path.
   it("clears its legacy claim even when the work throws", async () => {

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/session.test.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/session.test.ts
@@ -1301,6 +1301,76 @@ describe("field-group migration session", () => {
     expect(process.listenerCount("SIGINT")).toBe(before);
   });
 
+  /**
+   * The handlers are registered before the claim, so EVERY way out has to remove them — including
+   * the one that is not a refusal. An acquisition that REJECTS (a dropped connection, an UPDATE
+   * permission error) skipped the cleanup entirely, and watch mode retries often enough for two
+   * process-wide listeners per attempt to accumulate.
+   */
+  it("removes its interrupt handlers when the legacy acquisition throws", async () => {
+    const h = createAdapter({
+      heldBy: null,
+      stateReadError: Object.assign(
+        new Error('column "expires_at" does not exist'),
+        { code: "42703" }
+      ),
+      onStatement: kind => {
+        // Fails the claim itself rather than the whole transaction layer, so the session reaches
+        // acquisition and dies there — which is the path the cleanup was missing.
+        if (kind === "owner-claim") throw new Error("connection reset");
+      },
+    });
+
+    const before = process.listenerCount("SIGINT");
+    await withMigrationSession(
+      {
+        adapter: h.adapter,
+        dialect: "postgresql",
+        label: "sync-1",
+        requireExistingLock: true,
+        releaseOnInterrupt: true,
+      },
+      async () => undefined
+    ).catch(() => undefined);
+
+    expect(process.listenerCount("SIGINT")).toBe(before);
+  });
+
+  /**
+   * 🔴 A `finally` that throws REPLACES whatever the callback raised, and this module promises a few
+   * lines above that the caller's own failure stays primary. A connection dropping during cleanup
+   * would otherwise hide the actual sync error behind a cleanup error.
+   */
+  it("keeps the callback's failure when the legacy release also fails", async () => {
+    const h = createAdapter({
+      heldBy: null,
+      stateReadError: Object.assign(
+        new Error('column "expires_at" does not exist'),
+        { code: "42703" }
+      ),
+      onStatement: kind => {
+        if (kind === "owner-release") throw new Error("connection dropped");
+      },
+    });
+
+    const failure = await withMigrationSession(
+      {
+        adapter: h.adapter,
+        dialect: "postgresql",
+        label: "sync-1",
+        requireExistingLock: true,
+      },
+      async () => {
+        throw new Error("the sync itself failed");
+      }
+    ).catch((error: unknown) => error);
+
+    // 🔴 The CALLBACK's message, not the release's. Asserting only that it threw would pass on the
+    // very substitution this exists to prevent, since both paths reject.
+    expect(String(failure)).toContain("the sync itself failed");
+    expect(String(failure)).not.toContain("connection dropped");
+  });
+
   // Registered before the attempt, so the path that never held anything has to take them off again.
   // Two process-wide listeners per refused sync is a slow leak in watch mode, which refuses often.
   it("removes its interrupt handlers when the legacy claim is refused", async () => {

--- a/packages/nextly/src/domains/field-groups/migration/session.ts
+++ b/packages/nextly/src/domains/field-groups/migration/session.ts
@@ -726,66 +726,101 @@ export async function withMigrationSession<T>(
         process.once("SIGTERM", onLegacyTerminate);
       }
 
-      const legacy = await acquireOwnerOnly(adapter, claim);
-      if (!legacy.ok) {
-        // Registered before the attempt, so they have to come off on the path that never held
-        // anything. Left on, they would outlive this call and a later interrupt would run a release
-        // for a claim this process does not own — harmless against the row, which is owner-scoped,
-        // and a leak of two process-wide listeners per refused sync.
-        process.off("SIGINT", onLegacyInterrupt);
-        process.off("SIGTERM", onLegacyTerminate);
-        // Refused for the same reason the expiry-aware path refuses, and it is a REFUSAL rather
-        // than a skip: the row names a holder, and without an expiry there is no basis on which to
-        // call that holder dead. Proceeding would run the sync against storage a migration may be
-        // renaming, which is the outcome this whole module exists to prevent.
-        throw NextlyError.serviceUnavailable({
-          logMessage:
-            "field-group migration lock is held; another run holds a claim on a lock table that predates its expiry column",
-          logContext: {
-            reason: "migration lock is held elsewhere",
-            heldBy: legacy.heldBy,
-            table: MIGRATION_LOCK_TABLE,
-            label,
-          },
-        });
-      }
-
-      // Held for real, so the caller is told so rather than being handed `not-held`. Nothing renews
-      // it, because there is no lease to extend — see `acquireOwnerOnly` for what that gives up.
-      let heldToTheEnd = true;
-      let legacyResult: T;
+      // 🔴 ONE `try` covers the acquisition, the work and the release, and the handlers come off in
+      // its `finally` — not at three separate points.
+      //
+      // Sliding the removal earlier or later just moves the gap: taken off before the release, a
+      // signal in that window strands the claim; done only on the `!ok` branch, an acquisition that
+      // REJECTS (a dropped connection, an UPDATE permission error) skips the cleanup entirely and
+      // leaks two process-wide listeners per attempt, which watch mode repeats. Spanning everything
+      // that can throw is the answer that has no next window.
+      //
+      // Keeping them live THROUGH the release is safe: `releaseOwnerOnly` is owner-scoped and
+      // idempotent, so a signal landing mid-release clears a row that is already being cleared and
+      // then re-raises. Doing it twice costs nothing; not doing it at all strands a claim that has
+      // no expiry to lapse.
       try {
-        legacyResult = await fn({
-          ...session,
-          lock: { kind: "held", owner: claim },
-        });
+        const legacy = await acquireOwnerOnly(adapter, claim);
+        if (!legacy.ok) {
+          // Refused for the same reason the expiry-aware path refuses, and it is a REFUSAL rather
+          // than a skip: the row names a holder, and without an expiry there is no basis on which
+          // to call that holder dead. Proceeding would run the sync against storage a migration may
+          // be renaming, which is the outcome this whole module exists to prevent.
+          throw NextlyError.serviceUnavailable({
+            logMessage:
+              "field-group migration lock is held; another run holds a claim on a lock table that predates its expiry column",
+            logContext: {
+              reason: "migration lock is held elsewhere",
+              heldBy: legacy.heldBy,
+              table: MIGRATION_LOCK_TABLE,
+              label,
+            },
+          });
+        }
+
+        // Held for real, so the caller is told so rather than being handed `not-held`. Nothing
+        // renews it, because there is no lease to extend — see `acquireOwnerOnly` for what that
+        // gives up.
+        let heldToTheEnd = true;
+        // 🔴 Three outcomes, not two. "The row stopped being ours" and "the release could not run"
+        // are different facts with different remedies, and collapsing them into one boolean is the
+        // failure-semantics mistake this codebase keeps finding: the first means another run may
+        // have overlapped this one, the second means the claim is probably still sitting there.
+        let releaseFailure: unknown;
+        let legacyResult: T;
+        try {
+          legacyResult = await fn({
+            ...session,
+            lock: { kind: "held", owner: claim },
+          });
+        } finally {
+          // 🔴 This `finally` must not THROW. A rejection here replaces whatever `fn` raised, so a
+          // connection dropping during cleanup would hide the actual sync failure behind a cleanup
+          // failure — and the caller's own error staying primary is a promise this module makes a
+          // few lines up. The outcome is recorded and judged after the block instead.
+          heldToTheEnd = await releaseOwnerOnly(adapter, claim).then(
+            held => held,
+            error => {
+              releaseFailure = error;
+              return false;
+            }
+          );
+        }
+
+        // Reached only when `fn` RESOLVED; a rejection propagates from the block above with the
+        // caller's failure intact.
+        if (releaseFailure !== undefined) {
+          throw NextlyError.serviceUnavailable({
+            logMessage:
+              "field-group migration finished but could not release its lock; the claim may still be held",
+            logContext: {
+              reason: "migration lock release failed",
+              table: MIGRATION_LOCK_TABLE,
+              label,
+            },
+            cause: releaseFailure instanceof Error ? releaseFailure : undefined,
+          });
+        }
+        // An interrupt is an orderly shutdown that already signalled its outcome, so it is not a
+        // lost claim.
+        if (!heldToTheEnd && !legacyReleasedOnSignal) {
+          throw NextlyError.serviceUnavailable({
+            logMessage:
+              "field-group migration finished without holding its lock; another run may have overlapped it",
+            logContext: {
+              reason: "migration lock was not held at completion",
+              table: MIGRATION_LOCK_TABLE,
+              label,
+            },
+          });
+        }
+        return legacyResult;
       } finally {
-        // Removed before releasing, so a signal arriving during an orderly release cannot start a
-        // second one.
+        // The ONE removal point, reached however this branch ends: a refused claim, a rejected
+        // acquisition, a thrown callback, or an orderly return.
         process.off("SIGINT", onLegacyInterrupt);
         process.off("SIGTERM", onLegacyTerminate);
-        // Owner-scoped, and its ANSWER is kept rather than discarded. Completing is not the same as
-        // having been protected while completing: if an operator or another actor cleared or took
-        // the row mid-run, the exclusion this session promised was not held, and reporting success
-        // would be the same false clean the expiry-aware path refuses at its own completion.
-        heldToTheEnd = await releaseOwnerOnly(adapter, claim);
       }
-
-      // Reached only when `fn` RESOLVED; a rejection propagates from the block above and keeps the
-      // caller's own failure primary. An interrupt is an orderly shutdown that already signalled its
-      // outcome, so it is not a lost claim.
-      if (!heldToTheEnd && !legacyReleasedOnSignal) {
-        throw NextlyError.serviceUnavailable({
-          logMessage:
-            "field-group migration finished without holding its lock; another run may have overlapped it",
-          logContext: {
-            reason: "migration lock was not held at completion",
-            table: MIGRATION_LOCK_TABLE,
-            label,
-          },
-        });
-      }
-      return legacyResult;
     }
   } else {
     await ensureLockRow(adapter, dialect);

--- a/packages/nextly/src/domains/field-groups/migration/session.ts
+++ b/packages/nextly/src/domains/field-groups/migration/session.ts
@@ -1271,6 +1271,13 @@ async function acquireOwnerOnly(
     if (before === undefined) return { ok: false, heldBy: null };
     // Any owner blocks, because without an expiry there is no basis on which to judge a claim dead.
     // Guessing would mean stealing the lock from a migration that may still be writing.
+    //
+    // 🔴 This early return is BELT AND BRACES, not the guard. The `AND "owner" IS NULL` predicate on
+    // the UPDATE below is what actually enforces exclusion, and the read-back is what reports it —
+    // measured, by removing each in turn: dropping this line alone changes no behaviour and no test,
+    // while dropping the predicate lets a held row be overwritten. Said here because the opposite
+    // reading is the dangerous one: someone tidying the statement on the strength of this check
+    // would remove the only thing enforcing the claim.
     if (before.owner !== null) return { ok: false, heldBy: before.owner };
 
     await ctx.runStatement(

--- a/packages/nextly/src/domains/field-groups/migration/session.ts
+++ b/packages/nextly/src/domains/field-groups/migration/session.ts
@@ -667,14 +667,18 @@ export async function withMigrationSession<T>(
 
     // 🔴 A lock table created before `expires_at` existed cannot answer the liveness read, and THIS
     // branch is forbidden from adding it — the upgrade ALTER runs only where DDL is allowed. So the
-    // lock is skipped rather than the caller failed: reported NOT HELD, warned about, and treated
-    // exactly as an absent table is treated four lines above.
+    // lock is taken through the `owner` column alone, which every version of this table has.
     //
-    // Skipping rather than refusing is the deliberate choice. This caller is a schema sync, not the
-    // migration; it was never the thing the exclusion existed to hold back, and refusing would
-    // break every `--no-auto-sync` install that has not yet run a migration under the new release.
-    // The row it would have contended for carries no expiry, so there is no live claim to respect.
-    // The remedy is a single migration run, which adds the column on the branch that may.
+    // Claiming rather than skipping, and rather than refusing outright. Skipping was the earlier
+    // answer and it left the sync running with NO exclusion at all, free to be overtaken by a
+    // migration that started during it. Refusing would break every `--no-auto-sync` install that has
+    // not yet run a migration under this release, which is a certain outage in place of a narrow
+    // risk. An owner-only claim is real exclusion and writes no DDL.
+    //
+    // What it gives up: no expiry means NO TAKEOVER, so an occupied legacy row refuses until an
+    // operator clears it and a killed process leaves a claim behind. That is the contract this lock
+    // had BEFORE `expires_at` existed rather than a new hazard, and the remedy is the same single
+    // migration run, which adds the column on the branch that may.
     if (!(await lockTableUnderstandsExpiry(adapter, dialect))) {
       // Describes the TABLE, which is established, rather than this session's outcome, which is not
       // known until the claim below either succeeds or is refused. Saying "holding it by owner
@@ -689,32 +693,20 @@ export async function withMigrationSession<T>(
         }
       );
 
-      const legacy = await acquireOwnerOnly(adapter, claim);
-      if (!legacy.ok) {
-        // Refused for the same reason the expiry-aware path refuses, and it is a REFUSAL rather
-        // than a skip: the row names a holder, and without an expiry there is no basis on which to
-        // call that holder dead. Proceeding would run the sync against storage a migration may be
-        // renaming, which is the outcome this whole module exists to prevent.
-        throw NextlyError.serviceUnavailable({
-          logMessage:
-            "field-group migration lock is held; another run holds a claim on a lock table that predates its expiry column",
-          logContext: {
-            reason: "migration lock is held elsewhere",
-            heldBy: legacy.heldBy,
-            table: MIGRATION_LOCK_TABLE,
-            label,
-          },
-        });
-      }
-
-      // 🔴 The interrupt handlers matter MORE on this path than on the expiry-aware one, and this is
-      // the branch that would most easily have gone without them.
+      // 🔴 Installed BEFORE the claim is attempted, not after it returns.
       //
-      // A terminated process never reaches the `finally` below, so a Ctrl+C would strand the claim —
-      // and this claim has NO EXPIRY to lapse. That does not merely block the next sync: it blocks
-      // the migration that would add `expires_at`, so the one action that permanently fixes the
-      // database is the action the stranded claim prevents. Watch mode documents Ctrl+C as the way
-      // to stop, so this is the ordinary path rather than an edge case.
+      // The database commits the claim inside `acquireOwnerOnly`; this process then has to be
+      // scheduled again before the next line runs. A signal landing in that gap would take the
+      // default termination path with the row already owned — and this claim has NO EXPIRY to lapse,
+      // so the strand does not merely block the next sync: it blocks the migration that would add
+      // `expires_at`, making the one action that permanently repairs the database the action the
+      // strand prevents. Watch mode documents Ctrl+C as the way to stop, so the window is on the
+      // ordinary path rather than an exotic one.
+      //
+      // Registering early is safe precisely because the release is OWNER-SCOPED: a signal arriving
+      // before the claim was taken clears nothing, because the row does not name this claim. There
+      // is no symmetric hazard to trade against, which is what makes "earlier" strictly better here
+      // rather than a different bet.
       let legacyReleasedOnSignal = false;
       const releaseLegacyOnSignal = (signal: NodeJS.Signals): void => {
         legacyReleasedOnSignal = true;
@@ -732,6 +724,30 @@ export async function withMigrationSession<T>(
       if (args.releaseOnInterrupt === true) {
         process.once("SIGINT", onLegacyInterrupt);
         process.once("SIGTERM", onLegacyTerminate);
+      }
+
+      const legacy = await acquireOwnerOnly(adapter, claim);
+      if (!legacy.ok) {
+        // Registered before the attempt, so they have to come off on the path that never held
+        // anything. Left on, they would outlive this call and a later interrupt would run a release
+        // for a claim this process does not own — harmless against the row, which is owner-scoped,
+        // and a leak of two process-wide listeners per refused sync.
+        process.off("SIGINT", onLegacyInterrupt);
+        process.off("SIGTERM", onLegacyTerminate);
+        // Refused for the same reason the expiry-aware path refuses, and it is a REFUSAL rather
+        // than a skip: the row names a holder, and without an expiry there is no basis on which to
+        // call that holder dead. Proceeding would run the sync against storage a migration may be
+        // renaming, which is the outcome this whole module exists to prevent.
+        throw NextlyError.serviceUnavailable({
+          logMessage:
+            "field-group migration lock is held; another run holds a claim on a lock table that predates its expiry column",
+          logContext: {
+            reason: "migration lock is held elsewhere",
+            heldBy: legacy.heldBy,
+            table: MIGRATION_LOCK_TABLE,
+            label,
+          },
+        });
       }
 
       // Held for real, so the caller is told so rather than being handed `not-held`. Nothing renews

--- a/packages/nextly/src/domains/field-groups/migration/session.ts
+++ b/packages/nextly/src/domains/field-groups/migration/session.ts
@@ -677,14 +677,42 @@ export async function withMigrationSession<T>(
     // The remedy is a single migration run, which adds the column on the branch that may.
     if (!(await lockTableUnderstandsExpiry(adapter, dialect))) {
       args.logger?.warn?.(
-        "field-group migration lock predates its expiry column; continuing without it",
+        "field-group migration lock predates its expiry column; holding it by owner alone",
         {
           reason: "migration lock table is missing expires_at",
           table: MIGRATION_LOCK_TABLE,
           label,
         }
       );
-      return fn({ ...session, lock: { kind: "not-held" } });
+
+      const legacy = await acquireOwnerOnly(adapter, claim);
+      if (!legacy.ok) {
+        // Refused for the same reason the expiry-aware path refuses, and it is a REFUSAL rather
+        // than a skip: the row names a holder, and without an expiry there is no basis on which to
+        // call that holder dead. Proceeding would run the sync against storage a migration may be
+        // renaming, which is the outcome this whole module exists to prevent.
+        throw NextlyError.serviceUnavailable({
+          logMessage:
+            "field-group migration lock is held; another run holds a claim on a lock table that predates its expiry column",
+          logContext: {
+            reason: "migration lock is held elsewhere",
+            heldBy: legacy.heldBy,
+            table: MIGRATION_LOCK_TABLE,
+            label,
+          },
+        });
+      }
+
+      // Held for real, so the caller is told so rather than being handed `not-held`. Nothing renews
+      // it, because there is no lease to extend — see `acquireOwnerOnly` for what that gives up.
+      try {
+        return await fn({ ...session, lock: { kind: "held", owner: claim } });
+      } finally {
+        // Owner-scoped, and awaited so the row is free before this returns. A failure here leaves a
+        // claim an operator clears, which is the same residue an interrupted run leaves and is why
+        // the upgrade path exists.
+        await releaseOwnerOnly(adapter, claim).catch(() => undefined);
+      }
     }
   } else {
     await ensureLockRow(adapter, dialect);
@@ -1203,6 +1231,92 @@ function clearClaimStatement(claim: string): SQL {
           ${sql.identifier("expires_at")} = NULL
       WHERE ${sql.identifier("id")} = ${LOCK_ROW_ID}
         AND ${sql.identifier("owner")} = ${claim}`;
+}
+
+/**
+ * Take the lock on a table that predates `expires_at`, using the `owner` column alone.
+ *
+ * ## Why this exists rather than skipping the lock
+ *
+ * A caller that may not issue DDL cannot add the missing column, and refusing outright would break
+ * every `--no-auto-sync` install that has not yet run a migration under this release. Skipping was
+ * the first answer and it is not safe enough: the sync then runs with NO exclusion at all, so a
+ * migration that starts during it — or one already in its pre-marker phase, which the marker check
+ * cannot see — is free to rename tables underneath work that has already decided what exists.
+ *
+ * The `owner` column is present on every version of this table, so exclusion does not depend on the
+ * new column at all. This claims it, holds it, and clears it, writing no DDL.
+ *
+ * ## What it gives up, stated rather than glossed
+ *
+ * No expiry means NO TAKEOVER. An occupied legacy row blocks until an operator clears it, and a
+ * process killed mid-run leaves a claim behind. That is not a new hazard introduced here — it is
+ * exactly the contract this lock had before `expires_at` existed, and the remedy is the same single
+ * migration run that permanently upgrades the row. Exclusion that occasionally needs an operator is
+ * a better trade than no exclusion at all, which is what the alternative offered.
+ *
+ * Nothing renews: there is no lease to extend, so the claim simply stands for the life of the call.
+ */
+async function acquireOwnerOnly(
+  adapter: DrizzleAdapter,
+  claim: string
+): Promise<Acquisition> {
+  return adapter.transaction(async ctx => {
+    // The same serialisation the expiry-aware path uses: contenders queue here, so the read below
+    // cannot be overtaken between reading and writing.
+    await ctx.lockRow(MIGRATION_LOCK_TABLE, LOCK_ROW_ID);
+
+    const rows = await ctx.queryStatement(ownerOnlyQuery());
+    const before = rows[0] as { owner: string | null } | undefined;
+    if (before === undefined) return { ok: false, heldBy: null };
+    // Any owner blocks, because without an expiry there is no basis on which to judge a claim dead.
+    // Guessing would mean stealing the lock from a migration that may still be writing.
+    if (before.owner !== null) return { ok: false, heldBy: before.owner };
+
+    await ctx.runStatement(
+      sql`UPDATE ${sql.identifier(MIGRATION_LOCK_TABLE)}
+          SET ${sql.identifier("owner")} = ${claim}
+          WHERE ${sql.identifier("id")} = ${LOCK_ROW_ID}
+            AND ${sql.identifier("owner")} IS NULL`
+    );
+
+    // Read back rather than trusting affected-row counts, which the dialects report inconsistently.
+    // Predicating the UPDATE on `owner IS NULL` means a contender that won the race leaves the row
+    // naming them, and this is what notices.
+    const settled = (await ctx.queryStatement(ownerOnlyQuery()))[0] as
+      | { owner: string | null }
+      | undefined;
+    if (settled?.owner === claim) return { ok: true };
+    return { ok: false, heldBy: settled?.owner ?? null };
+  });
+}
+
+/** The owner, read without touching a column this table may not have. */
+function ownerOnlyQuery(): SQL {
+  return sql`SELECT ${sql.identifier("owner")}
+      FROM ${sql.identifier(MIGRATION_LOCK_TABLE)}
+      WHERE ${sql.identifier("id")} = ${LOCK_ROW_ID}`;
+}
+
+/** Clear an owner-only claim, scoped to this claim so a late finaliser cannot free someone else's. */
+async function releaseOwnerOnly(
+  adapter: DrizzleAdapter,
+  claim: string
+): Promise<boolean> {
+  return adapter.transaction(async ctx => {
+    await ctx.lockRow(MIGRATION_LOCK_TABLE, LOCK_ROW_ID);
+    const before = (await ctx.queryStatement(ownerOnlyQuery()))[0] as
+      | { owner: string | null }
+      | undefined;
+    const heldToTheEnd = before?.owner === claim;
+    await ctx.runStatement(
+      sql`UPDATE ${sql.identifier(MIGRATION_LOCK_TABLE)}
+          SET ${sql.identifier("owner")} = NULL
+          WHERE ${sql.identifier("id")} = ${LOCK_ROW_ID}
+            AND ${sql.identifier("owner")} = ${claim}`
+    );
+    return heldToTheEnd;
+  });
 }
 
 /** Release only what we hold, so a late finaliser cannot free someone else's run. */

--- a/packages/nextly/src/domains/field-groups/migration/session.ts
+++ b/packages/nextly/src/domains/field-groups/migration/session.ts
@@ -676,8 +676,12 @@ export async function withMigrationSession<T>(
     // The row it would have contended for carries no expiry, so there is no live claim to respect.
     // The remedy is a single migration run, which adds the column on the branch that may.
     if (!(await lockTableUnderstandsExpiry(adapter, dialect))) {
+      // Describes the TABLE, which is established, rather than this session's outcome, which is not
+      // known until the claim below either succeeds or is refused. Saying "holding it by owner
+      // alone" here told an operator they held a lock and then, on the next line, that someone else
+      // did — and said it just as confidently when acquisition failed on a database error.
       args.logger?.warn?.(
-        "field-group migration lock predates its expiry column; holding it by owner alone",
+        "field-group migration lock predates its expiry column; falling back to an owner-only claim",
         {
           reason: "migration lock table is missing expires_at",
           table: MIGRATION_LOCK_TABLE,
@@ -703,16 +707,69 @@ export async function withMigrationSession<T>(
         });
       }
 
+      // 🔴 The interrupt handlers matter MORE on this path than on the expiry-aware one, and this is
+      // the branch that would most easily have gone without them.
+      //
+      // A terminated process never reaches the `finally` below, so a Ctrl+C would strand the claim —
+      // and this claim has NO EXPIRY to lapse. That does not merely block the next sync: it blocks
+      // the migration that would add `expires_at`, so the one action that permanently fixes the
+      // database is the action the stranded claim prevents. Watch mode documents Ctrl+C as the way
+      // to stop, so this is the ordinary path rather than an edge case.
+      let legacyReleasedOnSignal = false;
+      const releaseLegacyOnSignal = (signal: NodeJS.Signals): void => {
+        legacyReleasedOnSignal = true;
+        // The signal is re-raised whether or not the release succeeded, exactly as the expiry-aware
+        // path does it: a pool torn down by the same interrupt is the likely failure, and an
+        // unobserved rejection would surface instead of letting the process stop.
+        void releaseOwnerOnly(adapter, claim)
+          .catch(() => undefined)
+          .finally(() => {
+            process.kill(process.pid, signal);
+          });
+      };
+      const onLegacyInterrupt = (): void => releaseLegacyOnSignal("SIGINT");
+      const onLegacyTerminate = (): void => releaseLegacyOnSignal("SIGTERM");
+      if (args.releaseOnInterrupt === true) {
+        process.once("SIGINT", onLegacyInterrupt);
+        process.once("SIGTERM", onLegacyTerminate);
+      }
+
       // Held for real, so the caller is told so rather than being handed `not-held`. Nothing renews
       // it, because there is no lease to extend — see `acquireOwnerOnly` for what that gives up.
+      let heldToTheEnd = true;
+      let legacyResult: T;
       try {
-        return await fn({ ...session, lock: { kind: "held", owner: claim } });
+        legacyResult = await fn({
+          ...session,
+          lock: { kind: "held", owner: claim },
+        });
       } finally {
-        // Owner-scoped, and awaited so the row is free before this returns. A failure here leaves a
-        // claim an operator clears, which is the same residue an interrupted run leaves and is why
-        // the upgrade path exists.
-        await releaseOwnerOnly(adapter, claim).catch(() => undefined);
+        // Removed before releasing, so a signal arriving during an orderly release cannot start a
+        // second one.
+        process.off("SIGINT", onLegacyInterrupt);
+        process.off("SIGTERM", onLegacyTerminate);
+        // Owner-scoped, and its ANSWER is kept rather than discarded. Completing is not the same as
+        // having been protected while completing: if an operator or another actor cleared or took
+        // the row mid-run, the exclusion this session promised was not held, and reporting success
+        // would be the same false clean the expiry-aware path refuses at its own completion.
+        heldToTheEnd = await releaseOwnerOnly(adapter, claim);
       }
+
+      // Reached only when `fn` RESOLVED; a rejection propagates from the block above and keeps the
+      // caller's own failure primary. An interrupt is an orderly shutdown that already signalled its
+      // outcome, so it is not a lost claim.
+      if (!heldToTheEnd && !legacyReleasedOnSignal) {
+        throw NextlyError.serviceUnavailable({
+          logMessage:
+            "field-group migration finished without holding its lock; another run may have overlapped it",
+          logContext: {
+            reason: "migration lock was not held at completion",
+            table: MIGRATION_LOCK_TABLE,
+            label,
+          },
+        });
+      }
+      return legacyResult;
     }
   } else {
     await ensureLockRow(adapter, dialect);


### PR DESCRIPTION
Implements the founder's decision on the legacy migration-lock table, replacing the skip that #838 shipped.

## The problem with skipping

A lock table created before `expires_at` existed cannot answer the liveness read, and a caller that may not issue DDL (`db:sync --no-auto-sync`, or a role with DML but no DDL rights) cannot add the column. #838 skipped the lock and warned. Codex pointed out on that PR — correctly — that skipping means the sync then runs with **no exclusion at all**: a migration starting during it, or one already in the pre-marker phase that the marker check cannot see, is free to rename tables underneath work that has already decided what exists.

Refusing outright was the other option and was rejected: it breaks every such install until someone intervenes, turning a narrow risk into a certain outage.

## What this does instead

The `owner` column is present on **every** version of this table, so exclusion never needed the new column. This claims the row by owner alone, holds it for the callback, and clears it afterwards — writing no DDL.

- `acquireOwnerOnly` takes the row under the same `lockRow` serialisation the expiry-aware path uses, predicated on `owner IS NULL`, with a read-back because dialects report affected rows inconsistently.
- `releaseOwnerOnly` is owner-scoped and runs in a `finally`, so a failed sync cannot leave a claim behind.
- The session now reports `{ kind: "held" }` on this path rather than `not-held`, because it genuinely is.
- The warning still fires: the operator needs to know this database is on the older shape.

## What it gives up, stated rather than glossed

**No expiry means no takeover.** An occupied legacy row blocks until an operator clears it, and a killed process leaves a claim behind. That is not a new hazard — it is exactly the contract this lock had before `expires_at` existed, and the remedy is the same single migration run that permanently upgrades the row. Nothing renews, because there is no lease to extend.

Exclusion that occasionally needs an operator is a better trade than no exclusion at all.

## Tests

- the legacy table is now CLAIMED, asserted on the database (`owner` names this claim during the callback, and is null after) rather than on the session's own report of itself;
- **a legacy lock another run already holds is REFUSED**, asserted on the reason rather than the code — "could not read the lock" and "another run holds it" are different situations with different remedies and both surface as unavailable;
- the claim is cleared even when the callback throws.

The shared lock double gained the three owner-only statements, named as their own kinds so a fixture failing "the state read" does not also fail the path taken precisely when that read cannot work.

**Break control worth reporting, because the first one passed.** Removing the early `owner !== null` return changed nothing: the `AND "owner" IS NULL` predicate on the UPDATE is what actually enforces the claim. Removing the predicate as well fails the refusal test (2 failed / 49 passed, from 51). The early return is belt-and-braces and the code now says so — the dangerous misreading is the other way round, where someone tidies the statement believing the check covers it.

## Verification

Bar green by exit code from the worktree root: build, `check-types --force`, lint, drizzle-v1 guard, storage-format literals. Unit run diffed per failing file against a freshly measured `origin/main` baseline — 34 files / 364 tests, identical sets in both directions.

`check-types` was also re-run AFTER committing: the pre-commit fixer rewrote an import on a sibling branch earlier today and broke compilation after a passing check.
