### PR TITLE
refactor(root): make the verdict gate's target resolution testable

### DIFF
--- a/scripts/ci-verdict.mjs
+++ b/scripts/ci-verdict.mjs
@@ -520,6 +520,71 @@ const fingerprint = (rv, th, ic) =>
   ]);
 
 /**
+ * Which repository, on which host, from the environment.
+ *
+ * Pure, and exported so the parsing can be exercised without a request. It
+ * decides where every later query is SENT, so getting it wrong describes one
+ * repository while reading another — and until now the only way to run it was
+ * to run the whole command.
+ *
+ * Returns `{ error }` rather than throwing or exiting, so the caller owns the
+ * exit status and this stays callable from a test.
+ */
+export function resolveTarget(env = {}) {
+  // `gh` defines GH_REPO as `[HOST/]OWNER/REPO`, so the owner is the
+  // second-to-last segment rather than the first.
+  const configured = env.GH_REPO ?? "nextlyhq/nextly";
+  const segments = configured.split("/").filter(Boolean);
+  if (segments.length < 2 || segments.length > 3) {
+    return { error: "ci-verdict: GH_REPO must be [HOST/]OWNER/REPO\n" };
+  }
+  const [name] = segments.slice(-1);
+  const [owner] = segments.slice(-2, -1);
+  // `GH_HOST` supplies the hostname when GH_REPO does not carry one, which is
+  // the ordinary Enterprise configuration. Defaulting straight to github.com
+  // would override that selection with the explicit `--hostname` passed later.
+  const host =
+    segments.length === 3 ? segments[0] : (env.GH_HOST ?? "github.com");
+  const repo = `${owner}/${name}`;
+  return {
+    owner,
+    name,
+    host,
+    repo,
+    // `--repo` is host-qualified off github.com, because a bare `owner/name`
+    // there resolves against the public host whatever the API calls do.
+    repoArg: host === "github.com" ? repo : `${host}/${repo}`,
+  };
+}
+
+/**
+ * The reviewer logins whose verdict blocks, and those merely reported.
+ *
+ * Trimmed: a list written with spaces after the commas yields entries that
+ * match no login, and an unmatched blocking reviewer is silently dropped — the
+ * gate then reports clean without that reviewer's coverage.
+ *
+ * An empty blocking set is returned as an error rather than as an empty array,
+ * because "nobody blocks" makes every verdict clean and is far more likely to
+ * be a mistyped variable than a decision.
+ */
+export function resolveReviewers(env = {}) {
+  const logins = value =>
+    value
+      .split(",")
+      .map(entry => entry.trim())
+      .filter(Boolean);
+  const blocking = logins(
+    env.CI_VERDICT_BLOCKING ?? "chatgpt-codex-connector[bot]"
+  );
+  const advisory = logins(env.CI_VERDICT_ADVISORY ?? "coderabbitai[bot]");
+  if (blocking.length === 0) {
+    return { error: "ci-verdict: no blocking reviewer configured\n" };
+  }
+  return { blocking, advisory };
+}
+
+/**
  * Command line entry: `node scripts/ci-verdict.mjs <pr>`.
  *
  * Kept behind the module-vs-main check so importing the decisions never
@@ -535,23 +600,12 @@ async function main(argv) {
     process.stderr.write("usage: node scripts/ci-verdict.mjs <pr-number>\n");
     return 2;
   }
-  // `gh` defines GH_REPO as `[HOST/]OWNER/REPO`, so the owner is the
-  // second-to-last segment rather than the first.
-  const configured = process.env.GH_REPO ?? "nextlyhq/nextly";
-  const segments = configured.split("/").filter(Boolean);
-  if (segments.length < 2 || segments.length > 3) {
-    process.stderr.write(`ci-verdict: GH_REPO must be [HOST/]OWNER/REPO\n`);
+  const target = resolveTarget(process.env);
+  if (target.error) {
+    process.stderr.write(target.error);
     return 2;
   }
-  const [name] = segments.slice(-1);
-  const [owner] = segments.slice(-2, -1);
-  // `GH_HOST` supplies the hostname when GH_REPO does not carry one, which is
-  // the ordinary Enterprise configuration. Defaulting straight to github.com
-  // would override that selection with the explicit `--hostname` below.
-  const host =
-    segments.length === 3 ? segments[0] : (process.env.GH_HOST ?? "github.com");
-
-  const repo = `${owner}/${name}`;
+  const { owner, name, host, repo, repoArg } = target;
   const { execFileSync } = await import("node:child_process");
   // `git` does not read GH_TOKEN, and the workflow checks out with
   // `persist-credentials: false`, so `ls-remote` against a private repository
@@ -580,7 +634,6 @@ async function main(argv) {
         { encoding: "utf8", maxBuffer: 64e6 }
       )
     );
-  const repoArg = host === "github.com" ? repo : `${host}/${repo}`;
 
   // The head comes from the REF, not from the pull request object. GitHub's
   // `headRefOid` lags a push — measured a full commit behind while `ls-remote`
@@ -634,24 +687,12 @@ async function main(argv) {
   // consumer reading `head` or `missing_reviews` a different object exactly
   // where it is least expecting one. Kept for the reader who assumes `report`
   // reviews and threads that cannot change this outcome.
-  // Trimmed: a list written with spaces after the commas yields entries that
-  // match no login, and an unmatched blocking reviewer is silently dropped —
-  // the gate then reports clean without that reviewer's coverage.
-  const logins = value =>
-    value
-      .split(",")
-      .map(entry => entry.trim())
-      .filter(Boolean);
-  const blocking = logins(
-    process.env.CI_VERDICT_BLOCKING ?? "chatgpt-codex-connector[bot]"
-  );
-  const advisory = logins(
-    process.env.CI_VERDICT_ADVISORY ?? "coderabbitai[bot]"
-  );
-  if (blocking.length === 0) {
-    process.stderr.write("ci-verdict: no blocking reviewer configured\n");
+  const reviewers = resolveReviewers(process.env);
+  if (reviewers.error) {
+    process.stderr.write(reviewers.error);
     return 2;
   }
+  const { blocking, advisory } = reviewers;
 
   if (meta.state !== "OPEN" && meta.state !== "MERGED") {
     // Re-read immediately before emitting. This path takes no other remote

--- a/scripts/ci-verdict.test.mjs
+++ b/scripts/ci-verdict.test.mjs
@@ -6,6 +6,8 @@ import {
   missingReviewers,
   rateLimited,
   report,
+  resolveReviewers,
+  resolveTarget,
   reviewersAtHead,
   unresolvedThreads,
   verdictFor,
@@ -831,5 +833,105 @@ describe("report", () => {
     const r = report({ ...base, reviews: [review(CODEX, OLD)] });
     expect(r.verdict).toBe("MISSING REVIEW AT HEAD");
     expect(r.exitCode).toBe(EXIT_NOT_CLEAN);
+  });
+});
+
+
+/**
+ * Where the queries are SENT.
+ *
+ * Every later request derives from this, so a wrong answer here describes one
+ * repository while reading another — and the whole parsing was previously
+ * reachable only by running the command.
+ */
+describe("resolveTarget", () => {
+  it("defaults to the public host when nothing is configured", () => {
+    expect(resolveTarget({})).toMatchObject({
+      owner: "nextlyhq",
+      name: "nextly",
+      host: "github.com",
+      repo: "nextlyhq/nextly",
+      // Bare on github.com: host-qualifying it there is accepted but says
+      // nothing, and the two forms should not both be in circulation.
+      repoArg: "nextlyhq/nextly",
+    });
+  });
+
+  it("reads the owner as the second-to-last segment", () => {
+    // `gh` defines GH_REPO as `[HOST/]OWNER/REPO`, so taking the FIRST segment
+    // as the owner is correct only for the two-segment form and silently wrong
+    // for the Enterprise one.
+    expect(resolveTarget({ GH_REPO: "ghe.example.com/acme/site" })).toMatchObject(
+      {
+        owner: "acme",
+        name: "site",
+        host: "ghe.example.com",
+        repoArg: "ghe.example.com/acme/site",
+      }
+    );
+  });
+
+  it("takes the host from GH_HOST when GH_REPO carries none", () => {
+    expect(
+      resolveTarget({ GH_REPO: "acme/site", GH_HOST: "ghe.example.com" })
+    ).toMatchObject({ host: "ghe.example.com" });
+  });
+
+  it("lets an explicit host in GH_REPO win over GH_HOST", () => {
+    // Both are set and they disagree. Preferring GH_HOST would send the
+    // requests somewhere other than the repository that was named.
+    expect(
+      resolveTarget({
+        GH_REPO: "ghe.example.com/acme/site",
+        GH_HOST: "other.example.com",
+      })
+    ).toMatchObject({ host: "ghe.example.com" });
+  });
+
+  it("refuses a value that is not [HOST/]OWNER/REPO", () => {
+    expect(resolveTarget({ GH_REPO: "nextly" }).error).toMatch(/GH_REPO/);
+    expect(resolveTarget({ GH_REPO: "a/b/c/d" }).error).toMatch(/GH_REPO/);
+  });
+
+  it("ignores empty segments from a trailing or doubled slash", () => {
+    expect(resolveTarget({ GH_REPO: "acme/site/" })).toMatchObject({
+      owner: "acme",
+      name: "site",
+      host: "github.com",
+    });
+  });
+});
+
+describe("resolveReviewers", () => {
+  it("defaults to the configured blocking and advisory reviewers", () => {
+    expect(resolveReviewers({})).toEqual({
+      blocking: [CODEX],
+      advisory: [RABBIT],
+    });
+  });
+
+  it("trims a list written with spaces after the commas", () => {
+    // An untrimmed entry matches no login, so the reviewer is silently dropped
+    // and the gate reports clean without that reviewer's coverage.
+    expect(
+      resolveReviewers({ CI_VERDICT_BLOCKING: `${CODEX}, ${RABBIT}` })
+    ).toMatchObject({ blocking: [CODEX, RABBIT] });
+  });
+
+  it("refuses when the blocking set is empty", () => {
+    // Nobody blocking makes every verdict clean, which is far more likely to be
+    // a mistyped variable than a decision — so it refuses rather than passing.
+    expect(resolveReviewers({ CI_VERDICT_BLOCKING: " , " }).error).toMatch(
+      /no blocking reviewer/
+    );
+  });
+
+  it("accepts an empty advisory set", () => {
+    // Advisory reviewers cannot hold a merge, so having none is a valid
+    // configuration rather than the misconfiguration above.
+    expect(resolveReviewers({ CI_VERDICT_ADVISORY: "" })).toEqual({
+      blocking: [CODEX],
+      advisory: [],
+    });
   });
 });


### PR DESCRIPTION
First of two steps toward moving the verdict gate's I/O behind a testable interface. This one extracts the part that needs no injection at all.

## What had no coverage

Where every query is **sent** was decided inline in `main`. `GH_REPO` parsing has three branches and a wrong answer describes one repository while reading another — and the only way to exercise any of it was to run the whole command.

`resolveTarget` and `resolveReviewers` are now pure and exported. They return `{ error }` rather than writing to stderr and exiting, so the caller keeps the exit status and a test can call them. `main` reads both, so there is **one** implementation rather than a second copy behind an export.

## Ten cases, three break-verified

**The owner is the second-to-last segment.** `gh` defines `GH_REPO` as `[HOST/]OWNER/REPO`, so taking the first segment is correct for the two-segment form and silently wrong for the Enterprise one:

```
BREAK: const [owner] = segments;
  × reads the owner as the second-to-last segment
      expected { owner: 'ghe.example.com', … } to match { owner: 'acme', name: 'site', … }
```

**An explicit host in `GH_REPO` wins over `GH_HOST`.** Both can be set and disagree; preferring `GH_HOST` sends requests somewhere other than the repository that was named:

```
BREAK: env.GH_HOST ?? (segments.length === 3 ? segments[0] : "github.com")
  × lets an explicit host in GH_REPO win over GH_HOST
      expected { … } to match object { host: 'ghe.example.com' }
```

**Reviewer entries are trimmed.** An untrimmed entry matches no login, so that reviewer is dropped and the gate reports clean without their coverage:

```
BREAK: remove .map(entry => entry.trim())
  × trims a list written with spaces after the commas
  × refuses when the blocking set is empty
```

The second failure there is the useful one: without trimming, `" , "` parses as two non-empty entries, so the empty-blocking refusal stops firing too. An empty blocking set makes **every** verdict clean, which is far likelier to be a mistyped variable than a decision.

Also covered: the default, `GH_HOST` as fallback, malformed values (1 and 4 segments), empty segments from a trailing slash, and `repoArg` staying bare on `github.com` so the two forms are not both in circulation.

## What is deliberately not here

The rest of the seam — `headOf`, `readThreads`, `baseChangedAt`, `rewriteEvents`, `snapshot`, the stranded count — needs an injectable process runner to be testable, which is a larger move. Splitting it out separately because this file has broken twice from block moves whose damage the suite could not see.

That risk is much lower now: the CLI suite added in #837 spawns the real program, and it is what caught nothing here because nothing broke — 77 tests green, including all 10 of its cases.

## Notes

- No changeset: `scripts/` sits in no workspace package.
- `pnpm test:scripts` covers both suites in CI.
