### PR TITLE
refactor(root): give the verdict gate's requests an injectable runner

### DIFF
--- a/scripts/ci-verdict-evidence.mjs
+++ b/scripts/ci-verdict-evidence.mjs
@@ -1,0 +1,147 @@
+// The request layer the verdict gate reads its evidence through.
+//
+// Separated from the command because these are where the two halves of the
+// program disagree about the WORLD rather than about a value: a request that
+// failed, a ref that answered nothing, a fork whose branch is not on `origin`.
+// None of that is reachable by importing a decision function, and running the
+// whole command to reach it means every case needs a process.
+//
+// So the process runner is a PARAMETER. A caller supplies `execFileSync`; a
+// test supplies whatever failure it wants to describe. The distinction that
+// matters is between a command that failed and a command that succeeded while
+// reporting nothing useful — the first announces itself, and the second is the
+// one that reaches a verdict as empty evidence.
+
+/**
+ * A `gh` invocation that returns parsed JSON, or throws.
+ *
+ * Every query is its own process and its failure is its own exception. A
+ * rejected request must reach the caller as a refusal rather than as empty
+ * data: "nobody has reviewed this" and "the reviews could not be read" produce
+ * the same empty array, and only one of them is a verdict.
+ *
+ * `--hostname` is inserted on every api call. Parsing the host out of the
+ * configuration and then letting the requests default sends them to public
+ * GitHub while the report claims to describe an Enterprise repository.
+ */
+export function createGh({ exec, host }) {
+  return args =>
+    JSON.parse(
+      exec(
+        "gh",
+        args[0] === "api"
+          ? ["api", "--hostname", host, ...args.slice(1)]
+          : args,
+        { encoding: "utf8", maxBuffer: 64e6 }
+      )
+    );
+}
+
+/**
+ * Point git at the credentials `gh` is using, and carry on if it cannot.
+ *
+ * `git` does not read `GH_TOKEN`, and the workflow checks out with
+ * `persist-credentials: false`, so `ls-remote` against a private repository
+ * would fail after the API lookups had already succeeded.
+ *
+ * Deliberately swallows its failure: unauthenticated public access still
+ * works, and a private repository fails later at `ls-remote` with a message
+ * naming the ref it could not read. Returns whether it succeeded so a caller
+ * can say so rather than having to guess.
+ */
+export function setupGitCredentials({ exec, host }) {
+  try {
+    exec("gh", ["auth", "setup-git", "--hostname", host], { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * The remote that HAS the pull request's branch.
+ *
+ * A fork's branch is not on `origin`, so reading the ref from there returns
+ * nothing — or, where the base repository has a branch of the same name, an
+ * unrelated revision belonging to somebody else.
+ *
+ * Both forms are derived from the CONFIGURED repository rather than from the
+ * checkout. `origin` is whatever this working copy happens to point at, which
+ * need not be the repository the configuration selected: the API data would
+ * then describe one repository while the SHA came from another.
+ */
+export function headRemoteFor(meta, { host, repo }) {
+  return meta?.isCrossRepository
+    ? `https://${host}/${meta.headRepositoryOwner.login}/${meta.headRepository.name}.git`
+    : `https://${host}/${repo}.git`;
+}
+
+/**
+ * The branch tip, from the REF rather than from the pull request object.
+ *
+ * `headRefOid` lags a push — measured a full commit behind while `ls-remote`
+ * was already correct — so a gate reading it certifies a revision that is no
+ * longer the head, which is the class of defect this program exists to stop.
+ *
+ * Throws on an empty answer. `ls-remote` exits 0 for a ref that does not
+ * exist, so the success status says only that the question was asked; taking
+ * the first field of an empty line yields `undefined`, and a comparison
+ * against `undefined` reports a moved head rather than a missing one.
+ */
+export function readHeadSha({ exec, headRemote, headRefName }) {
+  const line = exec(
+    "git",
+    ["ls-remote", headRemote, `refs/heads/${headRefName}`],
+    {
+      encoding: "utf8",
+    }
+  ).trim();
+  const sha = line.split(/\s+/)[0];
+  if (!sha) {
+    throw new Error(`no such ref on ${headRemote}: refs/heads/${headRefName}`);
+  }
+  return sha;
+}
+
+/**
+ * How many commits the branch carries that the merge does not.
+ *
+ * A merged pull request keeps a branch that can still be pushed to while the
+ * merged head is frozen, so commits after that point are in neither and would
+ * otherwise go unnoticed.
+ *
+ * Both ends are fetched from the remote that HAS them: the workflow checks out
+ * shallow, and after a squash the merged head is commonly absent. A shallow
+ * checkout keeps its boundary in `.git/shallow`, and fetching two more objects
+ * does not remove it — so `rev-list` stops at the boundary and reports a SHORT
+ * count rather than failing. That is the reassuring direction: a truncated
+ * range reads as a clean tail, which is exactly what this count exists to
+ * disprove.
+ *
+ * Deepened only when the repository is actually shallow, because `--unshallow`
+ * errors on a complete one.
+ */
+export function countStranded({ exec, headRemote, mergedHead, head }) {
+  const isShallow =
+    exec("git", ["rev-parse", "--is-shallow-repository"], {
+      encoding: "utf8",
+    }).trim() === "true";
+  exec(
+    "git",
+    [
+      "fetch",
+      ...(isShallow ? ["--unshallow"] : []),
+      headRemote,
+      head,
+      mergedHead,
+    ],
+    { stdio: "ignore" }
+  );
+  return (
+    Number(
+      exec("git", ["rev-list", "--count", `${mergedHead}..${head}`], {
+        encoding: "utf8",
+      }).trim()
+    ) || 0
+  );
+}

--- a/scripts/ci-verdict-evidence.test.mjs
+++ b/scripts/ci-verdict-evidence.test.mjs
@@ -1,0 +1,201 @@
+// The request layer, with the process runner supplied by the test.
+//
+// These cover the failures where the TRANSPORT's report and the OPERATION's
+// outcome disagree. Both directions exist and they need opposite handling: a
+// command that fails announces itself, while a command that SUCCEEDS having
+// answered nothing is the dangerous one — its empty result reaches a decision
+// function as evidence, and "nobody reviewed this" is indistinguishable from
+// "the reviews could not be read".
+//
+// None of this is reachable by importing a decision function, and reaching it
+// through the command means a process per case.
+
+import { describe, expect, it } from "vitest";
+
+import {
+  countStranded,
+  createGh,
+  headRemoteFor,
+  readHeadSha,
+  setupGitCredentials,
+} from "./ci-verdict-evidence.mjs";
+
+/** A runner that records its calls and answers from a queue. */
+function runner(answers) {
+  const calls = [];
+  const exec = (file, args) => {
+    calls.push([file, ...args]);
+    const answer = answers.shift();
+    if (typeof answer === "function") return answer();
+    return answer ?? "";
+  };
+  return { exec, calls };
+}
+
+describe("createGh", () => {
+  it("inserts the hostname on an api request", () => {
+    const { exec, calls } = runner(['{"ok":true}']);
+    const gh = createGh({ exec, host: "ghe.example.com" });
+
+    expect(gh(["api", "repos/a/b/pulls/1"])).toEqual({ ok: true });
+    expect(calls[0]).toEqual([
+      "gh",
+      "api",
+      "--hostname",
+      "ghe.example.com",
+      "repos/a/b/pulls/1",
+    ]);
+  });
+
+  it("leaves a non-api invocation alone", () => {
+    // `gh pr view` takes `--repo`, not `--hostname`; inserting one there makes
+    // the command fail rather than sending it somewhere else.
+    const { exec, calls } = runner(['{"state":"OPEN"}']);
+    const gh = createGh({ exec, host: "ghe.example.com" });
+
+    gh(["pr", "view", "1", "--repo", "a/b"]);
+    expect(calls[0]).toEqual(["gh", "pr", "view", "1", "--repo", "a/b"]);
+  });
+
+  it("throws when the request fails rather than answering empty", () => {
+    // The dangerous direction. A rejected request returning `[]` reaches the
+    // decision half as "no reviews", which is a verdict rather than a failure
+    // to ask — and it is the reassuring one.
+    const { exec } = runner([
+      () => {
+        throw new Error("gh: HTTP 502");
+      },
+    ]);
+    const gh = createGh({ exec, host: "github.com" });
+
+    expect(() => gh(["api", "repos/a/b/pulls/1/reviews"])).toThrow(/502/);
+  });
+
+  it("throws when the request succeeds with output it cannot parse", () => {
+    // Exit 0 says the command ran, never that it answered. A truncated or
+    // warning-prefixed body is a successful process and unusable evidence.
+    const { exec } = runner(["not json"]);
+    const gh = createGh({ exec, host: "github.com" });
+
+    expect(() => gh(["api", "repos/a/b/pulls/1"])).toThrow();
+  });
+});
+
+describe("setupGitCredentials", () => {
+  it("reports success when the helper is configured", () => {
+    const { exec } = runner([""]);
+    expect(setupGitCredentials({ exec, host: "github.com" })).toBe(true);
+  });
+
+  it("degrades rather than throwing when it cannot be", () => {
+    // Deliberately fail-open: unauthenticated public access still works, and a
+    // private repository fails later at the ref read with a message naming what
+    // it could not reach. Refusing here would block every public run.
+    const { exec } = runner([
+      () => {
+        throw new Error("not logged in");
+      },
+    ]);
+    expect(setupGitCredentials({ exec, host: "github.com" })).toBe(false);
+  });
+});
+
+describe("headRemoteFor", () => {
+  it("uses the base repository for a same-repo pull request", () => {
+    expect(
+      headRemoteFor(
+        { isCrossRepository: false },
+        {
+          host: "github.com",
+          repo: "nextlyhq/nextly",
+        }
+      )
+    ).toBe("https://github.com/nextlyhq/nextly.git");
+  });
+
+  it("uses the FORK for a cross-repository pull request", () => {
+    // The base repository does not own a contributor's head ref, so reading it
+    // from there returns nothing — or an unrelated branch of the same name,
+    // and the gate then judges a revision belonging to somebody else.
+    expect(
+      headRemoteFor(
+        {
+          isCrossRepository: true,
+          headRepositoryOwner: { login: "contributor" },
+          headRepository: { name: "nextly" },
+        },
+        { host: "github.com", repo: "nextlyhq/nextly" }
+      )
+    ).toBe("https://github.com/contributor/nextly.git");
+  });
+
+  it("keeps a fork lookup on the configured host", () => {
+    // Hard-coding github.com sends an Enterprise fork lookup to the public
+    // host, where it either fails or finds an unrelated repository.
+    expect(
+      headRemoteFor(
+        {
+          isCrossRepository: true,
+          headRepositoryOwner: { login: "contributor" },
+          headRepository: { name: "site" },
+        },
+        { host: "ghe.example.com", repo: "acme/site" }
+      )
+    ).toBe("https://ghe.example.com/contributor/site.git");
+  });
+});
+
+describe("readHeadSha", () => {
+  it("takes the object name from the ref line", () => {
+    const { exec, calls } = runner(["abc123\trefs/heads/feature/x\n"]);
+
+    expect(
+      readHeadSha({ exec, headRemote: "R", headRefName: "feature/x" })
+    ).toBe("abc123");
+    expect(calls[0]).toEqual(["git", "ls-remote", "R", "refs/heads/feature/x"]);
+  });
+
+  it("throws when the ref does not exist", () => {
+    // `ls-remote` exits 0 for a ref that is not there, so the success status
+    // says only that the question was asked. Taking the first field of an empty
+    // line yields `undefined`, and comparing that against the head reports a
+    // MOVED head rather than a missing ref — a different verdict, from the same
+    // silence.
+    const { exec } = runner([""]);
+
+    expect(() =>
+      readHeadSha({ exec, headRemote: "R", headRefName: "gone" })
+    ).toThrow(/no such ref/);
+  });
+});
+
+describe("countStranded", () => {
+  it("deepens a shallow checkout before counting", () => {
+    // A shallow clone keeps its boundary in `.git/shallow`, and fetching two
+    // more objects does not remove it — `rev-list` then stops at the boundary
+    // and reports a SHORT count, which reads as a clean tail.
+    const { exec, calls } = runner(["true\n", "", "3\n"]);
+
+    expect(
+      countStranded({ exec, headRemote: "R", mergedHead: "A", head: "B" })
+    ).toBe(3);
+    expect(calls[1]).toContain("--unshallow");
+  });
+
+  it("does not pass --unshallow to a complete repository", () => {
+    // `--unshallow` errors on a repository that is not shallow, so passing it
+    // unconditionally turns a correct count into a failure to answer.
+    const { exec, calls } = runner(["false\n", "", "0\n"]);
+
+    countStranded({ exec, headRemote: "R", mergedHead: "A", head: "B" });
+    expect(calls[1]).not.toContain("--unshallow");
+  });
+
+  it("reads a non-numeric answer as zero rather than NaN", () => {
+    const { exec } = runner(["false\n", "", "\n"]);
+
+    expect(
+      countStranded({ exec, headRemote: "R", mergedHead: "A", head: "B" })
+    ).toBe(0);
+  });
+});

--- a/scripts/ci-verdict.mjs
+++ b/scripts/ci-verdict.mjs
@@ -35,7 +35,34 @@
 // imports can be green while the program does not run at all.
 
 import { realpathSync } from "node:fs";
-import { pathToFileURL } from "node:url";
+import { dirname, join } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+/**
+ * The request layer, resolved through this file's REAL path.
+ *
+ * A bare `./ci-verdict-evidence.mjs` would be resolved relative to the
+ * specifier the runtime holds for this module — and under
+ * `--preserve-symlinks-main` that is the SYMLINK, so the sibling is looked
+ * for beside the link rather than beside this file and the process dies
+ * before running. The same flag is why the entry check below accepts two
+ * forms; this is its import-time half.
+ */
+const evidence = await import(
+  pathToFileURL(
+    join(
+      dirname(realpathSync(fileURLToPath(import.meta.url))),
+      "ci-verdict-evidence.mjs"
+    )
+  ).href
+);
+const {
+  countStranded,
+  createGh,
+  headRemoteFor,
+  readHeadSha,
+  setupGitCredentials,
+} = evidence;
 
 /** Reviewers whose verdict blocks a merge, and the marker text of a refusal. */
 export const RATE_LIMIT_MARKER = /Review limit reached/;
@@ -607,33 +634,8 @@ async function main(argv) {
   }
   const { owner, name, host, repo, repoArg } = target;
   const { execFileSync } = await import("node:child_process");
-  // `git` does not read GH_TOKEN, and the workflow checks out with
-  // `persist-credentials: false`, so `ls-remote` against a private repository
-  // would fail after the API lookups had already succeeded. This points git at
-  // the same credentials `gh` is using.
-  try {
-    execFileSync("gh", ["auth", "setup-git", "--hostname", host], {
-      stdio: "ignore",
-    });
-  } catch {
-    // Unauthenticated public access still works; a private repository fails
-    // later at `ls-remote`, with a message naming the ref it could not read.
-  }
-  // Each query is its own process and its failure is its own exception: a
-  // rejected request must reach the caller as a refusal, never as empty data.
-  // `--hostname` on every API call, and a host-qualified `--repo`. Parsing the
-  // host out of GH_REPO and then letting the requests default sends them to
-  // public GitHub while claiming to describe an Enterprise repository.
-  const gh = args =>
-    JSON.parse(
-      execFileSync(
-        "gh",
-        args[0] === "api"
-          ? ["api", "--hostname", host, ...args.slice(1)]
-          : args,
-        { encoding: "utf8", maxBuffer: 64e6 }
-      )
-    );
+  setupGitCredentials({ exec: execFileSync, host });
+  const gh = createGh({ exec: execFileSync, host });
 
   // The head comes from the REF, not from the pull request object. GitHub's
   // `headRefOid` lags a push — measured a full commit behind while `ls-remote`
@@ -660,24 +662,14 @@ async function main(argv) {
   // the checkout. `origin` is whatever this working copy happens to point at,
   // which need not be the repository GH_REPO selected — the API data would then
   // describe one repository while the SHA came from another.
-  const headRemote = meta.isCrossRepository
-    ? `https://${host}/${meta.headRepositoryOwner.login}/${meta.headRepository.name}.git`
-    : `https://${host}/${repo}.git`;
+  const headRemote = headRemoteFor(meta, { host, repo });
 
-  const headOf = () => {
-    const line = execFileSync(
-      "git",
-      ["ls-remote", headRemote, `refs/heads/${meta.headRefName}`],
-      { encoding: "utf8" }
-    ).trim();
-    const sha = line.split(/\s+/)[0];
-    if (!sha) {
-      throw new Error(
-        `no such ref on ${headRemote}: refs/heads/${meta.headRefName}`
-      );
-    }
-    return sha;
-  };
+  const headOf = () =>
+    readHeadSha({
+      exec: execFileSync,
+      headRemote,
+      headRefName: meta.headRefName,
+    });
   // A pull request CLOSED WITHOUT MERGING is settled by its lifecycle alone,
   // and its branch is commonly deleted straight afterwards — so resolving the
   // ref first turned a conclusive answer into `exit 2` for a missing ref.
@@ -1051,39 +1043,15 @@ async function main(argv) {
         observed.mergedHead &&
         observed.mergedHead !== head
       ) {
-        // Both ends fetched from the remote that HAS them: the workflow checks
-        // out shallow, and after a squash the merged head is commonly absent.
-        // A shallow checkout keeps its boundary in `.git/shallow`, and fetching
-        // two more objects does not remove it — so `rev-list` stops at the
-        // boundary and reports a SHORT count rather than failing. That is the
-        // reassuring direction: a truncated range reads as a clean tail, which is
-        // exactly what this count exists to disprove.
-        //
-        // Deepened only when the repository is actually shallow, because
-        // `--unshallow` errors on a complete one.
-        const isShallow =
-          execFileSync("git", ["rev-parse", "--is-shallow-repository"], {
-            encoding: "utf8",
-          }).trim() === "true";
-        execFileSync(
-          "git",
-          [
-            "fetch",
-            ...(isShallow ? ["--unshallow"] : []),
-            headRemote,
-            head,
-            observed.mergedHead,
-          ],
-          { stdio: "ignore" }
-        );
-        stranded =
-          Number(
-            execFileSync(
-              "git",
-              ["rev-list", "--count", `${observed.mergedHead}..${head}`],
-              { encoding: "utf8" }
-            ).trim()
-          ) || 0;
+        // Both ends fetched from the remote that HAS them, and the checkout
+        // deepened first where it is shallow — a truncated range reads as a
+        // clean tail, which is what this count exists to disprove.
+        stranded = countStranded({
+          exec: execFileSync,
+          headRemote,
+          mergedHead: observed.mergedHead,
+          head,
+        });
       }
 
       return report({


### PR DESCRIPTION
Step 2 of 2. The first step made the target resolution testable; this one does the same for the requests themselves, which is where the program is wrong about the **world** rather than about a value.

## What this makes reachable

`headOf`, the `gh` wrapper, the fork remote and the stranded count were only exercisable by running the whole command — a process per case, and several of these failures need a *specific* one. The process runner is now a parameter: the command supplies `execFileSync`, a test supplies whatever failure it is describing.

**Fourteen cases, covering both directions of the distinction that matters.** A command that *fails* announces itself. A command that *succeeds having answered nothing* is the dangerous one: its empty result reaches a decision function as evidence, where "nobody reviewed this" and "the reviews could not be read" are the same empty array.

## The sharpest case, and it had no coverage

`ls-remote` **exits 0 for a ref that does not exist.** The success status says only that the question was asked. Taking the first field of an empty line yields `undefined`, and comparing that against the head reports a **moved head** rather than a missing ref — a different verdict, from the same silence.

```
BREAK: remove the empty-answer guard
  × throws when the ref does not exist
```

Also break-verified: `--unshallow` passed unconditionally (it errors on a complete repository, turning a correct count into a failure to answer).

## The regression the CLI suite caught

Adding a sibling module broke invocation through a symlink, and **the suite added in #837 is what found it** — this is the first time that net has caught something.

A bare `./ci-verdict-evidence.mjs` is resolved against the specifier the runtime holds for the main module. Under `--preserve-symlinks-main` that is the **symlink**, so the module is looked for beside the link:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find module '…/lnk/ci-verdict-evidence.mjs'
                              imported from '…/lnk/cv.mjs'
```

The sibling is now resolved through this file's real path. That is the import-time half of the same flag the entry guard already accepts two forms for, and reverting it fails the symlink case.

## One implementation, not two

`countStranded` moved rather than being copied — `is-shallow-repository` now appears **zero** times in `ci-verdict.mjs`. Exporting it while leaving the inline block would have been two answers to one question, which is the thing this repository has a rule about.

## Verification

- 91 tests across three suites (14 new).
- Three break-verifications above, each failing for its intended reason.
- Comment gate clean; no changeset (`scripts/` is in no workspace package).

## Note on the pre-push hook

It failed first with 361 `@nextlyhq/ui` `no-unresolved` errors in `packages/admin` — the documented unbuilt-`dist` case in a fresh worktree, not this change, which touches only `scripts/`. `pnpm build` then a clean push, rather than `--no-verify`.
