### PR TITLE
fix(ci): declare the verdict gate's request layer as review-domain tooling

### DIFF
--- a/scripts/check-comment-convention.mjs
+++ b/scripts/check-comment-convention.mjs
@@ -247,6 +247,12 @@ const EXCLUDED_DIRS = new Set(["node_modules", "dist", ".next", ".turbo", "cover
  */
 const REVIEW_DOMAIN_PATHS = [
   "scripts/ci-verdict",
+  // The gate's request layer, named separately because the match above is at a
+  // path BOUNDARY: "scripts/ci-verdict" covers `ci-verdict.mjs` and anything
+  // under `ci-verdict/`, and deliberately not a sibling whose name merely
+  // starts with it. It reads pull requests and refs, so the vocabulary is what
+  // it operates on rather than narration about a change.
+  "scripts/ci-verdict-evidence",
   "scripts/verify-merge",
   "scripts/release/",
   ".claude/rules/",


### PR DESCRIPTION
**`main` is red on `Comment convention (describes code, not process)`.** This is the fix.

## What happened

`#849` added `scripts/ci-verdict-evidence.mjs`, the verdict gate's request layer. It reads pull requests and refs, so it carries the same vocabulary the gate itself does — but it is not covered by the gate's review-domain exemption, and the check has been failing since it merged.

Measured, not inferred:

```
head e448ffa9e   completed/failure   Comment convention (describes code, not process)
merge 10e58e3b8  completed/failure   Comment convention (describes code, not process)
```

## The cause is the rule working correctly

`REVIEW_DOMAIN_PATHS` matches at a **path boundary**, not as a raw prefix:

```js
path === entry || path.startsWith(`${entry}.`) || path.startsWith(`${entry}/`)
```

So `scripts/ci-verdict` covers `ci-verdict.mjs` and anything under `ci-verdict/`, and stops short of `ci-verdict-evidence.mjs` — which is followed by `-`.

That is deliberate, and the comment beside it says why: a raw prefix would also cover `scripts/verify-merge-anything.ts`, *"a different file nobody exempted"*. A new sibling therefore needs its own entry, **named**. This PR adds it.

## Declared, not allowlisted

The allowlist records what predated the check and may only shrink — adding an entry there would silence two comments. `REVIEW_DOMAIN_PATHS` is a statement about what a file's subject matter **is**, which is the accurate claim here: this module's whole job is reading pull requests.

## Break-verified, on the scan CI runs

`pnpm check:comments` runs the full default-roots scan (`.`, `packages`, `apps`, `e2e`, `templates`, `scripts`), not just `scripts/`.

```
with the entry:     EXIT=0   3948 of 3971 files, 23 read with the pull-request vocabulary allowed
without the entry:  EXIT=1
```

## How this got past me, since it is the more useful half

I ran the gate locally and recorded a pass. I piped it through `tail -1`, and **a pipeline reports the last command's status** — `tail` always succeeds, so the checker's exit code never reached me.

That is the precise trap `.claude/rules/reading-a-ci-verdict.md` documents under `set -o pipefail`, hit while working on the gate that exists to catch this class of thing. The remedy is not more care: it is checking the exit code, which is now what the watcher instructions say to do for this command.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated validation rules to allow review and pull-request terminology in the designated CI verdict evidence path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->