### PR TITLE
refactor(root): give both gates one review-state vocabulary

### DIFF
--- a/.claude/rules/reading-a-ci-verdict.md
+++ b/.claude/rules/reading-a-ci-verdict.md
@@ -56,11 +56,51 @@ PR targets rather than the PR's own revision. On `push` it is the pushed commit.
 Do not carry a variable named `SHA` between contexts, and qualify the claim by
 event AND by base before relying on it.)
 
-**`set -o pipefail` is load-bearing, not tidiness.** Without it the exit status
-is `sort`'s, so an authentication failure, a rate limit or a transient 5xx from
-`gh` yields an empty list AND a success status — the precise false-clean this
-file exists to prevent, reproduced by the command recommending against it. An
-unavailable answer must never read as a passing one.
+**A pipeline reports the LAST command's status, so any check read through one
+is UNREAD.** Above, without `pipefail` the status is `sort`'s, so an
+authentication failure, a rate limit or a transient 5xx from `gh` yields an
+empty list AND a success status — the precise false-clean this file exists to
+prevent, reproduced by the command recommending against it.
+
+That is one instance of a property with three now, across three mechanisms, so
+it is worth stating as the property rather than as a note about one command:
+
+- **status lost to the pipe.** A test run piped for readability reported
+  "42 passed" from a run that had exited 1.
+- **status lost to the pipe, and merged.** A comment-convention run read through
+  `tail -1` printed a summary line while exiting 1. The pass was recorded, the
+  pull request merged, and `main` was red on that check until someone else's
+  pull request inherited the failure and reported it.
+- **OUTPUT lost to the pipe.** A refusal printed below the twelfth line was cut
+  off by `head -12` and the run read as clean. That one is in
+  `derived-checks.md`, from the output side rather than the status side.
+
+Both halves have to reach the reader, and a pipe can lose either.
+
+**`set -o pipefail` is the obvious remedy and it has a scoping trap**, identical
+to the one `whole-file-writes.md` documents for `set -o noclobber`. The option
+applies to the shell that executes it. Where each command runs in a FRESH shell —
+which is every tool invocation for an agent — setting it in one call and running
+the pipeline in the next protects nothing, because the option is back at its
+default. Measured: `set -o pipefail; false | true` reports 1; a `false | true`
+in the next invocation reports 0.
+
+So it has to be in the SAME invocation as the pipeline:
+
+```sh
+set -o pipefail; gh api ... | sort      # ONE command, both parts
+```
+
+**Prefer not piping at all when what you want is a verdict.** Redirect, capture
+the status on its own line, then read the file. It has no scoping subtlety to
+get wrong and it keeps the whole output:
+
+```sh
+node scripts/check-comment-convention.mjs > out.log 2>&1; echo "EXIT=$?"
+```
+
+An unavailable answer must never read as a passing one, and neither must an
+answer whose status you did not look at.
 
 **Requiring `success` from a FIXED list is the obvious form and it is wrong
 here**, because some skips are the pipeline working. `ci.yml`'s first job

--- a/scripts/ci-verdict.mjs
+++ b/scripts/ci-verdict.mjs
@@ -72,8 +72,24 @@ export const RATE_LIMIT_MARKER = /Review limit reached/;
  *
  * `PENDING` is an unsubmitted draft and `DISMISSED` has been explicitly
  * withdrawn, so neither is anybody saying anything about the revision.
+ *
+ * NAMED rather than excluded, which is the direction that fails closed.
+ * Excluding one state grants coverage to every other — including `DISMISSED`,
+ * which opens no thread, so a gate counting it reads clean on a revision whose
+ * only review was withdrawn — and to any state added later that nobody here
+ * has met.
+ *
+ * Exported because the merge-verification gate asks the same question, and two
+ * lists of three strings agree until one of them is edited.
  */
-const SUBMITTED = new Set(["APPROVED", "CHANGES_REQUESTED", "COMMENTED"]);
+export const SUBMITTED_REVIEW_STATES = Object.freeze([
+  "APPROVED",
+  "CHANGES_REQUESTED",
+  "COMMENTED",
+]);
+
+/** Membership form of {@link SUBMITTED_REVIEW_STATES}, for the hot path. */
+const SUBMITTED = new Set(SUBMITTED_REVIEW_STATES);
 
 /**
  * Exit code for a verdict that REFUSES, as distinct from a failure to answer.

--- a/scripts/verify-merge.mjs
+++ b/scripts/verify-merge.mjs
@@ -720,24 +720,29 @@ export function reviewsCoveringTip(reviews, tip, login) {
 }
 
 /**
- * Review states that constitute coverage, named rather than excluded.
+ * Review states that constitute coverage, re-exported from the verdict gate.
  *
- * A NAMED set is the direction that fails closed. Excluding one state — say
- * `PENDING` — grants coverage to every other, including `DISMISSED`, which is a
- * review GitHub explicitly invalidated and which opens no thread, so a gate
- * counting it reads clean on a revision whose only review was withdrawn. It
- * also grants coverage to any state added later, which nobody here has met.
+ * One list, not two. Both gates ask the same question of the same API, and two
+ * frozen arrays of three strings agree until somebody edits one — silently,
+ * because each reads correctly on its own.
  *
- * The filter lives INSIDE this function rather than at its callers because two
- * callers each applying their own left them disagreeing: one excluded drafts
- * and the other filtered nothing, four lines apart, so the same review was
- * coverage for one reviewer and not the other.
+ * Resolved through this file's REAL path. A bare relative specifier is resolved
+ * against what the runtime holds for the main module, and under
+ * `--preserve-symlinks-main` that is the SYMLINK, so the sibling is looked for
+ * beside the link and the process dies before running. The entry guard below
+ * accepts two URL forms for the same reason; this is its import-time half.
+ *
+ * The filter stays INSIDE `reviewsCoveringTip` rather than at its callers,
+ * because two callers each applying their own left them disagreeing: one
+ * excluded drafts and the other filtered nothing, four lines apart, so the same
+ * review was coverage for one reviewer and not the other.
  */
-export const SUBMITTED_REVIEW_STATES = Object.freeze([
-  "APPROVED",
-  "CHANGES_REQUESTED",
-  "COMMENTED",
-]);
+const verdict = await import(
+  pathToFileURL(
+    join(dirname(realpathSync(fileURLToPath(import.meta.url))), "ci-verdict.mjs")
+  ).href
+);
+export const SUBMITTED_REVIEW_STATES = verdict.SUBMITTED_REVIEW_STATES;
 
 /**
  * Whether the merge took everything the branch had.
@@ -775,7 +780,8 @@ export function landedWhole({ checkable, reason, candidates }) {
 
 import { execFileSync } from "node:child_process";
 import { realpathSync } from "node:fs";
-import { pathToFileURL } from "node:url";
+import { dirname, join } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 const REPO = "nextlyhq/nextly";
 


### PR DESCRIPTION
Two changes, both about one question having one answer.

## One review-state vocabulary

`SUBMITTED_REVIEW_STATES` (`verify-merge.mjs`, frozen array) and `SUBMITTED` (`ci-verdict.mjs`, `Set`) held the **same three strings**. Both gates ask the same question of the same API, and two lists agree until somebody edits one — silently, because each reads correctly on its own.

The verdict gate now exports the named set and derives its own membership form from it; the merge-verification gate re-exports it.

**Break-verified as one list, not two.** Adding `DISMISSED` to the verdict gate's array:

```
verify-merge sees: DISMISSED,APPROVED,CHANGES_REQUESTED,COMMENTED
```

Before this change that edit would have left `verify-merge` reporting the old three — which is the drift, demonstrated.

`DISMISSED` is the right probe, incidentally: it is a review GitHub explicitly invalidated, it opens no thread, and a gate counting it reads clean on a revision whose only review was withdrawn.

## The import is resolved through the real path, deliberately

`verify-merge.mjs` had **no relative imports** before this. Adding one introduces the hazard that broke `#849`: a bare relative specifier resolves against what the runtime holds for the main module, and under `--preserve-symlinks-main` that is the **symlink**, so the sibling is looked for beside the link and the process dies before running.

The entry guard already accepts two URL forms for exactly this reason. This is its import-time half.

**The command suite added in `#852` is what makes this safe, and it earns its place immediately.** Reverting to a bare specifier:

```
× runs when invoked through a symlink the runtime does not resolve
```

Both modes also confirmed directly, through one symlink:

```
default:                   EXIT=2  usage: node scripts/verify-merge.mjs <pr-number>
--preserve-symlinks-main:  EXIT=2  usage: node scripts/verify-merge.mjs <pr-number>
```

## The rule behind a red `main`

`.claude/rules/reading-a-ci-verdict.md` documented `set -o pipefail` for one specific `gh api | sort` invocation. The property is wider: **a pipeline reports the LAST command's status, so any check read through one is unread.**

Three instances, three mechanisms:

| lost | instance |
|---|---|
| status | a suite reporting `42 passed` from a run that exited 1 |
| status | a comment-convention summary read through `tail -1`; the pass was recorded, the PR merged, and `main` was red on that check until another lane's PR inherited it |
| **output** | a refusal printed below the twelfth line, cut off by `head -12` (already in `derived-checks.md`) |

**`set -o pipefail` is the obvious remedy and it has a scoping trap** — the same one `whole-file-writes.md` documents for `set -o noclobber`. It applies to the shell that executes it, and every agent tool invocation is a fresh shell. Measured:

```sh
set -o pipefail; false | true   # 1
false | true                    # 0   (next invocation, option back at default)
```

So it has to be in the same invocation as the pipeline — or, better, do not pipe a verdict at all: redirect, capture `$?` on its own line, read the file. No scoping subtlety, and the whole output survives.

## Verification

- 403 tests across the root `scripts/` suites; the two CLI suites (14 cases) green.
- Comment gate checked **by exit code**: `EXIT=0` on the full default-roots scan.
- No changeset — `scripts/` and `.claude/` sit in no workspace package.
