### PR TITLE
test(root): recover the settle-guard commit stranded by #825

### DIFF
--- a/e2e/tests/canvas/geometry-settle-matches-the-canvas.test.ts
+++ b/e2e/tests/canvas/geometry-settle-matches-the-canvas.test.ts
@@ -951,6 +951,13 @@ test.describe("the drop-zone geometry the probe waits on", () => {
     // never settling; this one settles instantly, and the two must not be confused — `0 * Infinity`
     // is `NaN`, which the caller reports as an unparseable time and sends someone hunting a
     // malformed value that does not exist.
+    //
+    // The DELAY is nonzero deliberately, and it is what makes this a test rather than a
+    // demonstration. With a zero delay the expected span is zero, which an implementation that
+    // simply returned on `duration === 0` would also produce — so the control could not tell the
+    // delay accounting from its absence. At 400ms the three candidate implementations separate:
+    // charging the delay reports 400, dropping it reports 0, and multiplying by `Infinity` first
+    // refuses on a `NaN` that no malformed value produced.
     const injected = await frame.evaluate(() => {
       const sheet = (
         document.getElementById("nx-pb-style") as HTMLStyleElement | null
@@ -960,23 +967,28 @@ test.describe("the drop-zone geometry the probe waits on", () => {
         sheet.cssRules.length
       );
       sheet?.insertRule(
-        ".nx-pb-dropzone { animation: nx-instant 0s infinite }",
+        ".nx-pb-dropzone { animation: nx-instant 0s .4s infinite }",
         sheet.cssRules.length
       );
       const zone = document.querySelector(".nx-pb-dropzone");
       if (!zone) return null;
       const style = getComputedStyle(zone as HTMLElement);
-      // The population: the rule must have applied AND still be endless, or this measures an
-      // ordinary finite animation and says nothing about the multiplication.
+      // The population: the rule must have applied, still be endless, AND carry the delay this
+      // test is about. A browser that normalised any of the three would leave the assertion below
+      // measuring something else entirely.
       return {
         duration: style.animationDuration,
+        delay: style.animationDelay,
         iterations: style.animationIterationCount,
       };
     });
     expect(injected?.duration).toBe("0s");
+    expect(injected?.delay).toBe("0.4s");
     expect(injected?.iterations).toBe("infinite");
 
-    expect(await geometrySpanMs(frame, "data-drag data-active")).toBe(0);
+    // The DELAY, not zero: under the default fill mode an instantaneous animation still applies its
+    // end state when the delay elapses, so the edge is settled at 400ms rather than at 0.
+    expect(await geometrySpanMs(frame, "data-drag data-active")).toBe(400);
   });
 
   test("an effect on a pseudo-element this loop never reads is refused", async ({

--- a/e2e/tests/canvas/geometry-settle-matches-the-canvas.test.ts
+++ b/e2e/tests/canvas/geometry-settle-matches-the-canvas.test.ts
@@ -294,10 +294,19 @@ async function geometrySpanMs(
               // begins.
               const count = cycled(counts, i);
               if (count === 0) return;
-              longest = Math.max(
-                longest,
-                cycled(durations, i) * count + cycled(delays, i)
-              );
+              // A zero-DURATION entry settles before the iteration count is even consulted, and it
+              // has to be handled first: `0 * Infinity` is `NaN`, which the caller refuses as an
+              // unparseable time. `animation: grow 0s infinite` is valid CSS whose edge never
+              // travels, so refusing it would name the wrong cause and send someone looking for a
+              // malformed value that is not there. Its DELAY still counts, because a delayed
+              // instantaneous animation applies its end state at the end of the delay under the
+              // default fill mode.
+              const duration = cycled(durations, i);
+              if (duration === 0) {
+                longest = Math.max(longest, cycled(delays, i));
+                return;
+              }
+              longest = Math.max(longest, duration * count + cycled(delays, i));
             });
           }
 
@@ -924,6 +933,44 @@ test.describe("the drop-zone geometry the probe waits on", () => {
     // between-item zone. A rule keyed on `[data-drag]` for an empty zone can never fire, so
     // measuring it would pin a span for movement the canvas cannot produce.
     expect(await geometrySpanMs(frame, "data-drag")).toBe(0);
+  });
+
+  test("an ENDLESS animation of zero duration settles rather than refusing", async ({
+    page,
+    request,
+  }) => {
+    const frame = await canvas(page, request);
+
+    // Valid CSS whose edge never travels. The endless neighbour a few tests up is refused for
+    // never settling; this one settles instantly, and the two must not be confused — `0 * Infinity`
+    // is `NaN`, which the caller reports as an unparseable time and sends someone hunting a
+    // malformed value that does not exist.
+    const injected = await frame.evaluate(() => {
+      const sheet = (
+        document.getElementById("nx-pb-style") as HTMLStyleElement | null
+      )?.sheet;
+      sheet?.insertRule(
+        "@keyframes nx-instant { from { height: 0 } to { height: 6px } }",
+        sheet.cssRules.length
+      );
+      sheet?.insertRule(
+        ".nx-pb-dropzone { animation: nx-instant 0s infinite }",
+        sheet.cssRules.length
+      );
+      const zone = document.querySelector(".nx-pb-dropzone");
+      if (!zone) return null;
+      const style = getComputedStyle(zone as HTMLElement);
+      // The population: the rule must have applied AND still be endless, or this measures an
+      // ordinary finite animation and says nothing about the multiplication.
+      return {
+        duration: style.animationDuration,
+        iterations: style.animationIterationCount,
+      };
+    });
+    expect(injected?.duration).toBe("0s");
+    expect(injected?.iterations).toBe("infinite");
+
+    expect(await geometrySpanMs(frame, "data-drag data-active")).toBe(0);
   });
 
   test("an effect on a pseudo-element this loop never reads is refused", async ({

--- a/e2e/tests/canvas/poc-driver.ts
+++ b/e2e/tests/canvas/poc-driver.ts
@@ -49,9 +49,9 @@ const DROP_ZONES = ".nx-pb-dropzone, .nx-pb-dropzone-empty";
 /**
  * How long this canvas may still be moving a zone's edge after entry, in milliseconds.
  *
- * Exported so the guard that compares it against the stylesheet reads the SAME value the driver
- * uses. A guard restating the number checks a constant against itself and passes while the driver
- * carries something else entirely.
+ * Exported so the guard that checks it against the canvas's MEASURED spans reads the SAME value
+ * the driver uses. A guard restating the number checks a constant against itself and passes while
+ * the driver carries something else entirely.
  */
 export const POC_GEOMETRY_SETTLE_MS = 120;
 
@@ -163,16 +163,25 @@ export function createPocDriver(page: Page): CanvasDriver {
     // happens, and would let a real hysteresis defect hide inside the wait.
     dwellAllowanceMs: 0,
 
-    // The zone geometry this canvas animates, plus headroom. `IframeCanvas`
-    // transitions a drop zone's height over 100ms; a probe that re-measures
-    // inside that window can read the same whole pixel twice while the edge is
-    // still travelling through it, and return a depth measured from a boundary
-    // that has already moved.
+    // How long this canvas may still be moving a zone's EDGE after entry. A
+    // probe that re-measures inside that window can read the same whole pixel
+    // twice while the edge is still travelling through it, and return a depth
+    // measured from a boundary that has already moved.
     //
-    // Stated here rather than inside the probe because the duration belongs to
-    // this canvas. `geometry-settle-matches-the-canvas.test.ts` parses the
-    // stylesheet and fails if the transition ever outgrows this number, so the
-    // two cannot drift silently.
+    // Every geometry span this canvas currently produces is ZERO. The
+    // between-item zone is `position: absolute` at a fixed `height: 6px` and
+    // transitions only `background`, which moves no edge; the empty placeholder
+    // is in flow at an auto height and declares no transition at all. So this
+    // number is not covering a known animation — it is headroom against one
+    // arriving, and against two brackets landing inside a single animation
+    // frame.
+    //
+    // Stated here rather than inside the probe because the timing belongs to
+    // this canvas. `geometry-settle-matches-the-canvas.test.ts` MEASURES the
+    // real elements through `getComputedStyle` rather than reading any
+    // stylesheet, pins each state's span, and fails if a span ever outgrows
+    // this number — so the two cannot drift silently, and a lowered allowance
+    // is checked against movement rather than against declarations.
     geometrySettleMs: POC_GEOMETRY_SETTLE_MS,
 
     async mountTree(fixture: CanvasFixture) {


### PR DESCRIPTION
## Recovering a stranded tail from #825

#825 merged at `63538b75c` while a further commit was being pushed to its branch, so `b8a38e2e1` never landed. This carries it.

**Confirmed by content, not by ancestry** — a squash merge makes every ancestry check unsound:

```
$ git log --oneline 63538b75c..b8a38e2e1
b8a38e2e1 test(root): settle a zero-duration endless animation instead of refusing

$ git grep -F -e "if (duration === 0) {" 7a4e3213c -- e2e/.../geometry-settle-matches-the-canvas.test.ts
(no output — ABSENT from the merge commit)

$ git grep -F -e "if (duration === 0) {" b8a38e2e1 -- e2e/.../geometry-settle-matches-the-canvas.test.ts
(present — so the search is capable, and the absence above is real)
```

`node scripts/verify-merge.mjs 825` independently names the same candidate.

## What was lost

Two review findings answered on #825 whose fixes did not reach `main`:

**1. `0 * Infinity` is `NaN` (comment `3789090146`).** `animation: grow 0s infinite` is valid CSS whose edge never travels, and the probe refused it as "a duration that is not a time this test could parse" — the wrong cause, sending a reader to hunt a malformed value that does not exist. Zero duration is now handled before the multiplication, and the DELAY still counts because a delayed instantaneous animation applies its end state when the delay elapses.

**2. `poc-driver.ts` carried an obsolete rationale (P1, comment `3789090147`).** It said `IframeCanvas` transitions a drop zone's height over 100ms and that the guard parses the stylesheet. Both false: the between-item zone is `position: absolute` at a fixed `height: 6px` transitioning only `background`, the empty placeholder declares no transition at all, and the guard has measured through `getComputedStyle` since #825 replaced the regex reader.

That second one is why this is worth recovering promptly rather than folding into later work: the next change to this file lowers `POC_GEOMETRY_SETTLE_MS`, and the stale text names a 100ms animation as the reason for the current value — the exact false floor that would justify leaving it alone.

## Evidence

24/24 green on this base. The zero-duration control asserts the population first (`animationDuration === "0s"` AND `animationIterationCount === "infinite"`), because a rule that failed to apply or a count the browser normalised would leave it measuring an ordinary animation. With the guard removed it fails with the wrong-cause message above.

## Known red, and not mine to fix here

`@nextlyhq/e2e#check-types` fails on `main` with `TS2339: Property 'animationTimeline' does not exist on type 'CSSStyleDeclaration'`, from #825. Turbo cached the task so it reported success without ever running; I reproduced it with `--force` on a clean worktree off `main`.

It is my defect. The fix is already in **#832** using `getPropertyValue("animation-timeline")`, which is the correct CSSOM accessor rather than a cast, so this PR does not duplicate it and will rebase once that lands. Filed separately: a cached check reporting success without running is a CI-integrity gap that `AGENTS.md` documents for humans and nothing enforces.

No changeset: `e2e/` only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed animation timing calculations for zero-duration animations, including those with infinite iterations.
  * Corrected geometry settling to account for animation delays without producing invalid measurements.

* **Tests**
  * Added coverage verifying accurate canvas geometry settling for delayed, zero-duration animations.
  * Improved validation using measured element spans and timing allowances.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->