### PR TITLE
feat(admin): disclose a plugin's retired permissions

### DIFF
--- a/.changeset/orphaned-permission-disclosure.md
+++ b/.changeset/orphaned-permission-disclosure.md
@@ -1,0 +1,36 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+Disclose a plugin's retired permissions on its detail page instead of omitting
+them.
+
+The permission list endpoint now forwards `includeOrphaned`, so a caller that
+reports what a plugin owns can ask for rows nothing declares any more. They are
+shown marked rather than hidden: the row still exists and still carries its
+grants, so leaving it out understated what a plugin left behind. Lists that
+OFFER permissions are unchanged, because the option is off unless asked for, so
+the role permission matrix still shows only permissions that enforce something.

--- a/packages/admin/src/pages/dashboard/plugins/[slug].tsx
+++ b/packages/admin/src/pages/dashboard/plugins/[slug].tsx
@@ -390,11 +390,17 @@ function isAccessDenial(error: unknown): boolean {
  * rather than grouped — a single page filtered by owner therefore omits rows
  * silently, and reports "none" for a plugin whose rows all sort late. Paging is
  * what makes the owner filter answer about the whole set.
+ *
+ * Orphans are requested because this card DISCLOSES what a plugin owns rather
+ * than offering permissions to grant. A row the plugin no longer declares is
+ * still attributed to it and still carries whatever grants it was given, so
+ * omitting it would understate what the plugin left behind.
  */
 async function fetchAllPermissions(): Promise<ApiPermissionEntry[]> {
   const first = await fetchPermissionsFromApi({
     limit: PERMISSION_PAGE_SIZE,
     page: 1,
+    includeOrphaned: true,
   });
   const rows = [...first.data];
   // Bounded by the total the server reported, and re-read from each response,
@@ -403,6 +409,7 @@ async function fetchAllPermissions(): Promise<ApiPermissionEntry[]> {
     const next = await fetchPermissionsFromApi({
       limit: PERMISSION_PAGE_SIZE,
       page,
+      includeOrphaned: true,
     });
     if (next.data.length === 0) break;
     rows.push(...next.data);
@@ -451,9 +458,7 @@ function PluginPermissions({ pluginName }: { pluginName: string }) {
       )}
       {!isPending && !isError && owned.length === 0 && (
         <p className="text-xs text-muted-foreground">
-          No current permission rows are attributed to this plugin. Rows
-          retained from a version that no longer declares them are not listed
-          here.
+          No permission rows are attributed to this plugin.
         </p>
       )}
       {!isPending && !isError && owned.length > 0 && (
@@ -464,6 +469,15 @@ function PluginPermissions({ pluginName }: { pluginName: string }) {
               {entry.danger === true && (
                 <span className="ml-2 text-xs text-muted-foreground">
                   danger
+                </span>
+              )}
+              {/* Marked rather than omitted: the row still exists and still
+                  carries its grants, so hiding it would understate what this
+                  plugin left behind. It enforces nothing until the plugin
+                  declares it again. */}
+              {entry.orphaned === true && (
+                <span className="ml-2 text-xs text-muted-foreground">
+                  no longer declared
                 </span>
               )}
             </li>

--- a/packages/admin/src/pages/dashboard/plugins/plugin-detail.test.tsx
+++ b/packages/admin/src/pages/dashboard/plugins/plugin-detail.test.tsx
@@ -58,21 +58,44 @@ const permissionRows = vi.hoisted(() => ({
   current: [] as unknown[],
   pageSize: 200,
 }));
+/**
+ * Whether a row is one nothing declares any more.
+ *
+ * Reads the property off an untyped row, because the rows here are written as
+ * the seeder writes them rather than as the response DTO: a row that sets no
+ * `orphaned` column is a current one.
+ */
+function isOrphanedRow(row: unknown): boolean {
+  return (
+    typeof row === "object" &&
+    row !== null &&
+    "orphaned" in row &&
+    row.orphaned === true
+  );
+}
+
 vi.mock("@admin/services/realPermissionsApi", () => ({
-  fetchPermissionsFromApi: (options?: { page?: number }) => {
+  fetchPermissionsFromApi: (options?: {
+    page?: number;
+    includeOrphaned?: boolean;
+  }) => {
     const size = permissionRows.pageSize;
     const page = options?.page ?? 1;
     const start = (page - 1) * size;
+    // The server hides orphans in the WHERE clause unless asked, so they are
+    // absent from the page AND from the total. Serving them regardless would
+    // let a card that never requests them still render one, which is the
+    // assertion this file makes.
+    const visible = options?.includeOrphaned
+      ? permissionRows.current
+      : permissionRows.current.filter(row => !isOrphanedRow(row));
     return Promise.resolve({
-      data: permissionRows.current.slice(start, start + size),
+      data: visible.slice(start, start + size),
       meta: {
-        total: permissionRows.current.length,
+        total: visible.length,
         page,
         limit: size,
-        totalPages: Math.max(
-          1,
-          Math.ceil(permissionRows.current.length / size)
-        ),
+        totalPages: Math.max(1, Math.ceil(visible.length / size)),
       },
     });
   },
@@ -133,6 +156,20 @@ const seededRows = [
     owner: "@acme/disabled",
     danger: true,
   },
+  // Retained from a version that declared it. The row still exists and still
+  // carries its grants, so the card owes the reader its presence and its
+  // state, not its omission.
+  {
+    id: "p3",
+    name: "Import Submissions",
+    slug: "submissions.import",
+    action: "import",
+    resource: "submissions",
+    description: null,
+    owner: "@acme/forms",
+    danger: false,
+    orphaned: true,
+  },
 ];
 
 beforeEach(() => {
@@ -157,6 +194,33 @@ describe("PluginDetailPage permissions across pages", () => {
     renderPage("acme-disabled");
 
     expect(await screen.findByText("Purge Archive")).toBeInTheDocument();
+  });
+});
+
+/**
+ * A permission the plugin stopped declaring is DISCLOSED, marked, rather than
+ * hidden. The row survives in the table with its grants intact, so a card that
+ * omits it understates what the plugin left behind, and the reader has no way
+ * to tell that from a plugin that never declared it.
+ *
+ * The double applies the server's default, so this fails against a card that
+ * renders the marker without having asked for orphans.
+ */
+describe("PluginDetailPage orphaned permissions", () => {
+  it("lists a no-longer-declared permission and marks it", async () => {
+    renderPage("acme-forms");
+
+    expect(await screen.findByText("Import Submissions")).toBeInTheDocument();
+    expect(screen.getByText("no longer declared")).toBeInTheDocument();
+  });
+
+  it("leaves a current permission unmarked", async () => {
+    renderPage("acme-forms");
+
+    expect(await screen.findByText("Export Submissions")).toBeInTheDocument();
+    // One marker for the one orphaned row, so the marker tracks the row's
+    // state rather than being rendered for every entry.
+    expect(screen.getAllByText("no longer declared")).toHaveLength(1);
   });
 });
 

--- a/packages/admin/src/services/realPermissionsApi.ts
+++ b/packages/admin/src/services/realPermissionsApi.ts
@@ -86,12 +86,23 @@ export const fetchPermissionsFromApi = async (options?: {
   action?: string;
   limit?: number;
   page?: number;
+  /**
+   * Ask for permissions nothing declares any more, so they can be shown MARKED
+   * rather than silently omitted.
+   *
+   * Off unless requested, and the parameter is omitted entirely rather than
+   * sent as `false`: the server hides them by default, so a caller offering
+   * permissions as choices needs to do nothing to keep offering only the ones
+   * that still enforce something.
+   */
+  includeOrphaned?: boolean;
 }): Promise<PermissionListResult> => {
   const params = new URLSearchParams();
 
   if (options?.search) params.set("search", options.search);
   if (options?.resource) params.set("resource", options.resource);
   if (options?.action) params.set("action", options.action);
+  if (options?.includeOrphaned) params.set("includeOrphaned", "true");
   params.set("limit", String(options?.limit ?? 200));
   params.set("page", String(options?.page ?? 1));
   params.set("sortBy", "resource");

--- a/packages/nextly/src/dispatcher/handlers/__tests__/auth-dispatcher-shapes.test.ts
+++ b/packages/nextly/src/dispatcher/handlers/__tests__/auth-dispatcher-shapes.test.ts
@@ -144,6 +144,57 @@ describe("dispatchRbac — paginated lists (respondList)", () => {
       },
     });
   });
+
+  // Observed on the service call rather than reconstructed here: the response
+  // body is identical whichever way the option went, so asserting the shape
+  // again would pass on a dispatcher that dropped the parameter entirely.
+  it.each([
+    ["true", true],
+    ["false", false],
+  ])(
+    "forwards includeOrphaned=%s to the service as %s",
+    async (query, expected) => {
+      const listPermissions = vi.fn().mockResolvedValue({
+        data: [],
+        meta: { total: 0, page: 1, limit: 10, totalPages: 0 },
+      });
+      const container = {
+        permissions: { listPermissions },
+        roles: {},
+      } as unknown as ServiceContainer;
+
+      await dispatchRbac(
+        container,
+        "listPermissions",
+        { includeOrphaned: query },
+        undefined
+      );
+
+      expect(listPermissions).toHaveBeenCalledWith(
+        expect.objectContaining({ includeOrphaned: expected })
+      );
+    }
+  );
+
+  // Omission has to reach the service as `undefined` rather than as `false`,
+  // so the service's own default decides. A dispatcher substituting a literal
+  // here would pin the policy in two places.
+  it("leaves includeOrphaned undefined when the query omits it", async () => {
+    const listPermissions = vi.fn().mockResolvedValue({
+      data: [],
+      meta: { total: 0, page: 1, limit: 10, totalPages: 0 },
+    });
+    const container = {
+      permissions: { listPermissions },
+      roles: {},
+    } as unknown as ServiceContainer;
+
+    await dispatchRbac(container, "listPermissions", { page: "1" }, undefined);
+
+    expect(listPermissions).toHaveBeenCalledWith(
+      expect.objectContaining({ includeOrphaned: undefined })
+    );
+  });
 });
 
 describe("dispatchRbac — non-paginated lists (respondData)", () => {

--- a/packages/nextly/src/dispatcher/handlers/auth-dispatcher.ts
+++ b/packages/nextly/src/dispatcher/handlers/auth-dispatcher.ts
@@ -240,6 +240,11 @@ const RBAC_METHODS: Record<string, MethodHandler<RbacContainer>> = {
         resource: p.resource,
         sortBy: p.sortBy as "action" | "resource" | "name" | undefined,
         sortOrder: p.sortOrder as "asc" | "desc" | undefined,
+        // Forwarded so a caller that DISCLOSES orphaned rows can ask for them.
+        // Absent, the service applies its own default and hides them, which is
+        // what the permission matrix needs: a permission nothing declares any
+        // more enforces nothing, so it must not be offered as a choice.
+        includeOrphaned: toBoolean(p.includeOrphaned),
       });
       return respondList(result.data, toPaginationMeta(result.meta));
     },


### PR DESCRIPTION
## What

A permission a plugin stopped declaring keeps its row and keeps its grants. The
plugin detail card omitted those rows, so it understated what a plugin left
behind and read identically to a plugin that never declared one.

They are now listed and marked `no longer declared`.

## Why the change spans two packages

`PermissionService.listPermissions` has accepted `includeOrphaned` all along.
Nothing in the route layer forwarded it, so asking for orphans over the API had
no effect at all: a client-only change compiles and does nothing. Measured
before writing anything, on `main`:

- query parameters DO reach the dispatcher, merged into `routeParams` at
  `route-parser.ts:2198`
- `auth-dispatcher.ts` built its options object without the key

So the dispatcher forwards it, and the card asks.

## What is deliberately unchanged

Surfaces that OFFER permissions as choices. The option is off unless requested
and the parameter is omitted rather than sent as `false`, so the service's own
default still decides for every existing caller. The role permission matrix and
the permissions overview page keep showing only permissions that enforce
something, which is the point of hiding orphans there: granting one does
nothing.

## Evidence

Each property was broken and observed to fail for its own reason, from the
committed SHA:

| broken | result |
| --- | --- |
| dispatcher stops forwarding | 3 dispatcher tests fail on the service call arguments |
| card stops asking | the orphaned row is ABSENT, both card tests fail |
| marker span removed | row still renders, marker assertions fail |

The second is the one that matters: the admin test double now applies the
server's default and filters orphans unless asked. Before, it served them
regardless, so the card could have rendered a marker without ever requesting
the rows and the test would still have passed.

Assertions observe the arguments the service actually receives rather than
reconstructing the call, so an edit to the forwarding line cannot leave them
green.

## Checks

- `auth-dispatcher-shapes.test.ts` 14 passed
- `plugin-detail.test.tsx` 19 passed
- `turbo check-types lint --filter=@nextlyhq/admin --filter=nextly --force`
  4 successful, 0 cached
- `check-comment-convention.mjs` exit 0

## Follow-up, not in scope

The permissions overview page (`settings/permissions`) is also a browse surface
rather than an offer surface, so it may want the same disclosure. It needs its
own copy decision and is left alone here.
