### PR TITLE
refactor(admin): declare the session-free routes once

### DIFF
--- a/.changeset/one-public-route-declaration.md
+++ b/.changeset/one-public-route-declaration.md
@@ -1,0 +1,40 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+Declare the admin's session-free routes once.
+
+Which routes are reachable without a session was answered in three places: the
+page registry, a hand-kept set in the refresh interceptor, and the
+`pages/(auth)/` directory. A page added to the registry but missed in the
+interceptor still rendered, but its expected 401 redirected to login and
+discarded the URL, which is how an invite token was once lost.
+
+`PUBLIC_ROUTE_PATHS` in `constants/routes.ts` is now the declaration. The
+registry keys its public pages by that type, so the two cannot disagree without
+failing the build, and the interceptor derives its set from the same array. A
+test reads the `(auth)` directory, which no type can reach, and fails on a page
+nobody declared. No behaviour changes.

--- a/packages/admin/src/constants/__tests__/public-routes.test.ts
+++ b/packages/admin/src/constants/__tests__/public-routes.test.ts
@@ -1,0 +1,76 @@
+import { readdirSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+import { PUBLIC_ROUTE_PATHS, ROUTES } from "../routes";
+
+/**
+ * Three things answer "which routes are reachable without a session", and only
+ * two of them can be tied together by the compiler.
+ *
+ * `PUBLIC_ROUTE_PATHS` is the declaration. The registry keys its public pages
+ * by `PublicRoutePath`, so those two cannot disagree without a build failure,
+ * and the refresh interceptor builds its set from the same array. The third is
+ * the `pages/(auth)/` directory, which is a filesystem convention no type can
+ * reach — a page added there is a URL a visitor can open whether or not
+ * anything declared it public.
+ *
+ * So this reads the directory. It is the only one of the three that can catch a
+ * page nobody declared, and the failure it prevents is specific: an undeclared
+ * auth page still renders, but the interceptor redirects its expected 401 to
+ * login and discards the URL. An invite token was lost exactly that way.
+ */
+const AUTH_PAGES_DIR = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "..",
+  "pages",
+  "(auth)"
+);
+
+/**
+ * Page files, by the convention the registry follows: `login.tsx` answers
+ * `/admin/login`. Only top-level `.tsx` is read, so a future subdirectory of
+ * shared parts is not mistaken for a route.
+ */
+function authPageFiles(): string[] {
+  return readdirSync(AUTH_PAGES_DIR, { withFileTypes: true })
+    .filter(entry => entry.isFile() && entry.name.endsWith(".tsx"))
+    .map(entry => entry.name.replace(/\.tsx$/, ""))
+    .sort();
+}
+
+describe("public route declaration", () => {
+  // Guards the guard: every assertion below is satisfied by an empty directory,
+  // so a wrong path, a rename or a glob that stops matching would let the rest
+  // of this file pass without reading anything.
+  it("reads the auth pages directory", () => {
+    expect(authPageFiles().length).toBeGreaterThan(0);
+    expect(authPageFiles()).toContain("login");
+  });
+
+  it("declares every page under (auth) as public", () => {
+    const declared = new Set<string>(PUBLIC_ROUTE_PATHS);
+    const missing = authPageFiles()
+      .map(name => `/admin/${name}`)
+      .filter(path => !declared.has(path));
+
+    expect(missing).toEqual([]);
+  });
+
+  it("declares no path without a page behind it", () => {
+    const pages = new Set(authPageFiles().map(name => `/admin/${name}`));
+    const orphaned = PUBLIC_ROUTE_PATHS.filter(path => !pages.has(path));
+
+    expect(orphaned).toEqual([]);
+  });
+
+  it("names paths from ROUTES rather than spelling them again", () => {
+    const known = new Set<string>(Object.values(ROUTES));
+    const unknown = PUBLIC_ROUTE_PATHS.filter(path => !known.has(path));
+
+    expect(unknown).toEqual([]);
+  });
+});

--- a/packages/admin/src/constants/routes.ts
+++ b/packages/admin/src/constants/routes.ts
@@ -124,6 +124,42 @@ export const ROUTES = {
 export type RouteValue = (typeof ROUTES)[keyof typeof ROUTES];
 
 /**
+ * Routes reachable without a session.
+ *
+ * Declared once here because three places need this answer and they cannot all
+ * ask the router:
+ *
+ * - the page registry pairs each path with its component and marks it public,
+ *   which is what wraps the page in `PublicRoute`;
+ * - the refresh interceptor suppresses its redirect to login on these paths,
+ *   because a 401 from a background query is expected while nobody is signed
+ *   in, and redirecting produces a loop;
+ * - the pages themselves live under `pages/(auth)/`.
+ *
+ * The interceptor cannot import the registry to find out. The registry imports
+ * every page, each page reaches `lib/api/fetcher`, and `fetcher` imports the
+ * interceptor, so that dependency closes a cycle. This module imports nothing,
+ * so both sides can depend on it.
+ *
+ * Adding a route here is not enough to make it reachable, and that is
+ * deliberate: the registry owns which component answers, and its public entries
+ * are keyed by {@link PublicRoutePath}, so a path added here without a page
+ * fails to compile rather than becoming a silently unguarded URL.
+ */
+export const PUBLIC_ROUTE_PATHS = [
+  ROUTES.SETUP,
+  ROUTES.LOGIN,
+  ROUTES.REGISTER,
+  ROUTES.FORGOT_PASSWORD,
+  ROUTES.RESET_PASSWORD,
+  ROUTES.VERIFY_EMAIL,
+  ROUTES.ACCEPT_INVITE,
+] as const;
+
+/** A route from {@link PUBLIC_ROUTE_PATHS}. */
+export type PublicRoutePath = (typeof PUBLIC_ROUTE_PATHS)[number];
+
+/**
  * Helper to build dynamic routes with parameters
  *
  * @example

--- a/packages/admin/src/lib/api/refreshInterceptor.ts
+++ b/packages/admin/src/lib/api/refreshInterceptor.ts
@@ -1,3 +1,5 @@
+import { PUBLIC_ROUTE_PATHS } from "@admin/constants/routes";
+
 import { BASE_URL } from "./fetcher";
 
 interface AuthErrorBody {
@@ -64,19 +66,16 @@ export function setLoginRedirectPath(path: string): void {
  *   2. authFetch sees the code → redirectToLogin() → /admin/login.
  *   3. /admin/login mounts → PublicRoute checks setup-status,
  *      sees no users → navigateTo("/admin/setup"). Bounce.
+ *
+ * DERIVED from the one declaration rather than listed again here. The set that
+ * must not redirect is exactly the set reachable without a session, and a
+ * second hand-kept copy of it drifts silently: a page added to the registry and
+ * missed here bounces the visitor to login, discarding whatever the URL
+ * carried, which is how an invite token was once lost.
  */
-export const NO_REDIRECT_PUBLIC_PATHS = new Set([
-  "/admin/login",
-  "/admin/setup",
-  "/admin/register",
-  "/admin/forgot-password",
-  "/admin/reset-password",
-  "/admin/verify-email",
-  // An invited user reaching this page has no session yet, so a protected
-  // background query answers 401 exactly as it does on the others. Its absence
-  // bounced them to login and lost the invite token in the URL.
-  "/admin/accept-invite",
-]);
+export const NO_REDIRECT_PUBLIC_PATHS: ReadonlySet<string> = new Set<string>(
+  PUBLIC_ROUTE_PATHS
+);
 
 /**
  * Navigate the browser to the configured login path unless we're already

--- a/packages/admin/src/pages/registry.ts
+++ b/packages/admin/src/pages/registry.ts
@@ -1,6 +1,6 @@
 import { lazy } from "react";
 
-import { ROUTES } from "../constants/routes";
+import { type PublicRoutePath, ROUTES } from "../constants/routes";
 import type { PageProps } from "../lib/routing";
 
 import AcceptInvitePage from "./(auth)/accept-invite";
@@ -96,15 +96,39 @@ export interface RouteConfig {
   requiresBuilder?: boolean;
 }
 
+/**
+ * The page that answers each public route.
+ *
+ * Keyed by `PublicRoutePath` rather than by `string`, so the compiler requires
+ * exactly the paths `PUBLIC_ROUTE_PATHS` declares: a path added there without a
+ * page fails to build, and a page here for a path not declared public is
+ * rejected. That is what keeps the two in step, since the interceptor derives
+ * its own copy from the same declaration and cannot import this module.
+ */
+const PUBLIC_PAGES: Record<PublicRoutePath, React.ComponentType<PageProps>> = {
+  [ROUTES.SETUP]: SetupPage,
+  [ROUTES.LOGIN]: LoginPage,
+  [ROUTES.REGISTER]: RegisterPage,
+  [ROUTES.FORGOT_PASSWORD]: ForgotPasswordPage,
+  [ROUTES.RESET_PASSWORD]: ResetPasswordPage,
+  [ROUTES.VERIFY_EMAIL]: VerifyEmailPage,
+  [ROUTES.ACCEPT_INVITE]: AcceptInvitePage,
+};
+
+/**
+ * `PUBLIC_PAGES` as registry entries. Every one is `type: "public"` by
+ * construction, so no entry can be declared public in one place and private in
+ * the other.
+ */
+const publicRouteConfig: Record<string, RouteConfig> = Object.fromEntries(
+  Object.entries(PUBLIC_PAGES).map(([path, component]) => [
+    path,
+    { component, type: "public" },
+  ])
+);
+
 export const routeConfig: Record<string, RouteConfig> = {
-  // Public routes
-  [ROUTES.SETUP]: { component: SetupPage, type: "public" },
-  [ROUTES.LOGIN]: { component: LoginPage, type: "public" },
-  [ROUTES.REGISTER]: { component: RegisterPage, type: "public" },
-  [ROUTES.FORGOT_PASSWORD]: { component: ForgotPasswordPage, type: "public" },
-  [ROUTES.RESET_PASSWORD]: { component: ResetPasswordPage, type: "public" },
-  [ROUTES.VERIFY_EMAIL]: { component: VerifyEmailPage, type: "public" },
-  [ROUTES.ACCEPT_INVITE]: { component: AcceptInvitePage, type: "public" },
+  ...publicRouteConfig,
 
   // Dashboard route (homepage)
   [ROUTES.DASHBOARD]: { component: DashboardPage, type: "private" },


### PR DESCRIPTION
## What

"Which routes are reachable without a session" was answered in three places.
It is now declared once, in `constants/routes.ts`, and the other two derive
from it. No behaviour changes.

## Why it mattered

The three answers were the page registry, a hand-typed `Set` in the refresh
interceptor, and the `pages/(auth)/` directory. They drift silently, because a
page missing from the interceptor still renders correctly — it only misbehaves
once a background query answers 401, and then the redirect to login discards
whatever the URL carried. That is how an invite token was lost previously.

## Why the declaration lives in `constants/routes.ts`

The interceptor cannot import the registry to find out. Measured, not assumed:
`lib/api/fetcher.ts:2` imports `authFetch` from `refreshInterceptor`, so
`registry → pages → fetcher → interceptor` closes a real cycle. `routes.ts`
imports nothing, so both sides can depend on it.

## What is enforced, and by what

| answer | tied to the declaration by |
| --- | --- |
| registry's public pages | the compiler — `Record<PublicRoutePath, …>` |
| interceptor's set | construction — built from the same array |
| `pages/(auth)/` directory | a test, because no type can reach a filesystem convention |

The registry's `PUBLIC_PAGES` is keyed by `PublicRoutePath` rather than
`string`, so a declared path with no page and a page for an undeclared path are
both build failures.

## Evidence

Each property broken from the committed SHA and observed to fail for its own
reason:

| broken | result |
| --- | --- |
| drop `ACCEPT_INVITE` from the declaration | `check-types` exits 2, `TS2353` naming `[ROUTES.ACCEPT_INVITE]`; the directory test also fails |
| add an undeclared `(auth)/magic-link.tsx` | `expected [ '/admin/magic-link' ] to deeply equal []` |
| point the test at a real directory with no pages | the positive control fails |

That third break is why the control exists: with an empty directory the
"declares every page" assertion passes **vacuously**, satisfied by absence. The
control is what distinguishes that from a real pass.

## Checks

- new suite 4 passed
- `turbo check-types lint --filter=@nextlyhq/admin --force` 2 successful, 0 cached
- `check-comment-convention.mjs` exit 0
- full admin suite measured against `main` as one base:
  **main 1853 passed / 19 failed (5 files); this branch 1857 passed / 19 failed
  (5 files)** — identical failing set, +4 being this PR's new tests.

A first run of the branch suite showed 2 extra failures in
`not-installed-detail.test.tsx`. They are not this change: the file passes 16/16
in isolation, the second full run reproduced `main`'s baseline exactly, and the
test imports `PluginDetailPage` directly while mocking `BrandingProvider` — it
references neither `routeConfig`, the registry, the interceptor, nor
`constants/routes`, so this diff cannot reach it. The unreachability is the
exoneration; the passing re-run alone would not be.
