### PR TITLE
ci(root): hash every module a package type-checks

### DIFF
--- a/scripts/turbo-inputs.test.mjs
+++ b/scripts/turbo-inputs.test.mjs
@@ -92,6 +92,23 @@ describe("turbo hashes every TypeScript module it type-checks", () => {
       // and CSS, and all four still declare `check-types`. So emptiness is a
       // valid answer HERE, and the population is asserted once above instead,
       // where an empty read cannot be mistaken for a clean one.
+      // A task appears in the dry run whether or not the package defines the
+      // script: turbo marks the missing case `<NONEXISTENT>` and skips it,
+      // while a filtered run exits 0 with `Tasks: 0 successful, 0 total`. So
+      // membership in this list is not evidence that anything is checked, and
+      // deleting a package's `check-types` script would otherwise leave every
+      // assertion here green while its gate quietly stopped existing.
+      //
+      // Only required of packages that SHIP TypeScript. `tsconfig`,
+      // `eslint-config`, `prettier-config` and `admin-css` are configuration
+      // and CSS, and are legitimately `<NONEXISTENT>`.
+      if (tracked.length > 0) {
+        expect(
+          String(task.command),
+          `${task.package} ships TypeScript but has no runnable check-types command, so nothing type-checks it`
+        ).not.toContain("NONEXISTENT");
+      }
+
       const unhashed = tracked.filter(file => !hashed.has(file));
       // Worded as SHIPS rather than type-checks, because that is what this
       // measures. Whether a given module is inside the package's `tsc` program
@@ -105,6 +122,30 @@ describe("turbo hashes every TypeScript module it type-checks", () => {
       ).toEqual([]);
     }
   );
+});
+
+describe("a package's hash covers the program it actually compiles", () => {
+  // The package-scoped assertion above cannot see this axis. A tsconfig `paths`
+  // entry pointing at a sibling's SOURCE puts that sibling's files in this
+  // package's program, and no per-package input glob reaches them — measured:
+  // `packages/admin` compiles `packages/nextly/src/schemas/_zod/rbac.ts`, and
+  // before this edge existed, editing it left admin's hash unmoved.
+  //
+  // Asserted as the EDGE rather than by re-deriving each program, because the
+  // edge is what makes the property hold for every pair, including ones no
+  // `paths` entry has created yet.
+  it("folds each dependency's hash in via ^check-types", () => {
+    const withCommand = resolvedTasks().filter(
+      task => !String(task.command).includes("NONEXISTENT")
+    );
+    expect(withCommand.length).toBeGreaterThan(15);
+    for (const task of withCommand) {
+      expect(
+        task.resolvedTaskDefinition.dependsOn,
+        `${task.package} does not depend on its dependencies' check-types, so a change in one cannot move its hash`
+      ).toContain("^check-types");
+    }
+  });
 });
 
 describe("the shared TypeScript config is hashed", () => {

--- a/scripts/turbo-inputs.test.mjs
+++ b/scripts/turbo-inputs.test.mjs
@@ -1,0 +1,127 @@
+/**
+ * Every TypeScript module a package ships must be part of what turbo HASHES for
+ * that package's `check-types`.
+ *
+ * A task's inputs decide when its cached result is still valid. A source file
+ * outside them cannot move the hash however badly it breaks, so turbo replays
+ * the previous run and reports `Tasks: N successful` for code that was never
+ * compiled — and because turbo does not cache failures, the replayed result is
+ * a green from before the break. The failure is silent in the only direction
+ * that matters: the job is green, the log says `cache hit, replaying logs`, and
+ * the type error lives on `main` until an unrelated edit happens to move the
+ * hash.
+ *
+ * This asserts the property structurally rather than reviewing the globs.
+ * Reading `turbo.jsonc` and judging whether its patterns look complete is the
+ * same act that produced the gap: the list had already been widened once along
+ * the EXTENSION axis and still missed the DIRECTORY axis, because `e2e` keeps
+ * its modules in `tests/` rather than `src/`. So the inputs are taken from
+ * turbo itself, via `--dry=json`, and compared against the files git actually
+ * tracks. A glob that stops covering a tree fails here whichever axis it fails
+ * along.
+ *
+ * @module turbo-inputs.test
+ */
+import { execFileSync } from "node:child_process";
+import { describe, expect, it } from "vitest";
+
+/** Extensions the TypeScript compiler follows, so a change to one can break a build. */
+const TYPESCRIPT_EXTENSIONS = /\.(?:ts|tsx|mts|cts)$/;
+
+/**
+ * Turbo's own view of what it hashes, rather than a second reading of the
+ * config. `--dry=json` resolves every glob against the working tree, so the
+ * answer accounts for `$TURBO_DEFAULT$`, negations and per-package overrides
+ * that a pattern-by-pattern re-implementation here would have to model.
+ */
+function resolvedTasks() {
+  const raw = execFileSync(
+    "pnpm",
+    ["exec", "turbo", "run", "check-types", "--dry=json"],
+    { encoding: "utf8", maxBuffer: 64 * 1024 * 1024 }
+  );
+  // Turbo prints its own preamble before the document on some terminals, so the
+  // parse starts at the first brace rather than at byte zero.
+  return JSON.parse(raw.slice(raw.indexOf("{"))).tasks;
+}
+
+/** The TypeScript modules git tracks inside a package. */
+function trackedTypeScript(directory) {
+  const raw = execFileSync("git", ["ls-files", "--", directory], {
+    encoding: "utf8",
+    maxBuffer: 64 * 1024 * 1024,
+  });
+  return raw
+    .split("\n")
+    .filter(line => TYPESCRIPT_EXTENSIONS.test(line))
+    .map(line => line.slice(`${directory}/`.length));
+}
+
+describe("turbo hashes every TypeScript module it type-checks", () => {
+  const tasks = resolvedTasks();
+
+  // The population, before any verdict, and asserted by MEMBERSHIP rather than
+  // by a count. "No package has an unhashed module" is satisfied perfectly by a
+  // run that read nothing — a failed dry run, a renamed task, a listing that
+  // resolved to the wrong directory. Naming packages that must be present, and
+  // a tree whose size is known, means silence has to be earned.
+  //
+  // `e2e` is named because it is the package this guard exists for: 30 modules
+  // under `tests/`, none of which the previous input globs reached.
+  it("reads a populated set of packages and their TypeScript", () => {
+    expect(tasks.length).toBeGreaterThan(15);
+    const names = tasks.map(task => task.package);
+    expect(names).toContain("@nextlyhq/e2e");
+    expect(names).toContain("@nextlyhq/builder");
+
+    const e2e = tasks.find(task => task.package === "@nextlyhq/e2e");
+    const underTests = trackedTypeScript(e2e.directory).filter(file =>
+      file.startsWith("tests/")
+    );
+    expect(underTests.length).toBeGreaterThan(25);
+  });
+
+  it.each(tasks.map(task => [task.package, task]))(
+    "%s hashes all of its TypeScript",
+    (_name, task) => {
+      const hashed = new Set(Object.keys(task.inputs));
+      const tracked = trackedTypeScript(task.directory);
+
+      // A package may legitimately ship no TypeScript at all — `tsconfig`,
+      // `eslint-config`, `prettier-config` and `admin-css` are configuration
+      // and CSS, and all four still declare `check-types`. So emptiness is a
+      // valid answer HERE, and the population is asserted once above instead,
+      // where an empty read cannot be mistaken for a clean one.
+      const unhashed = tracked.filter(file => !hashed.has(file));
+      // Worded as SHIPS rather than type-checks, because that is what this
+      // measures. Whether a given module is inside the package's `tsc` program
+      // is a separate question this cannot see, and claiming it would overstate
+      // the finding for a file the compiler never reads. Hashing a module the
+      // program excludes costs a cache miss; failing to hash one it includes
+      // costs a replayed green, so the coverage is deliberately the wider set.
+      expect(
+        unhashed,
+        `${task.package} ships ${String(unhashed.length)} TypeScript module(s) that turbo does not hash, so editing one leaves the cache valid and CI replays the previous result:\n  ${unhashed.slice(0, 10).join("\n  ")}`
+      ).toEqual([]);
+    }
+  );
+});
+
+describe("the shared TypeScript config is hashed", () => {
+  // `check-types` declares `dependsOn: []`, so no package has a graph edge to
+  // `@nextlyhq/tsconfig` — yet 22 of them extend its `base.json`, which decides
+  // `strict`, `target` and `lib`. Without a global entry, changing a compiler
+  // setting leaves every hash in the repository unmoved at once, which is the
+  // same defect as above with the blast radius of the whole monorepo.
+  it("counts packages/tsconfig among the global dependencies", () => {
+    const raw = execFileSync(
+      "pnpm",
+      ["exec", "turbo", "run", "check-types", "--dry=json"],
+      { encoding: "utf8", maxBuffer: 64 * 1024 * 1024 }
+    );
+    const globalFiles = Object.keys(
+      JSON.parse(raw.slice(raw.indexOf("{"))).globalCacheInputs.files
+    );
+    expect(globalFiles).toContain("packages/tsconfig/base.json");
+  });
+});

--- a/scripts/turbo-inputs.test.mjs
+++ b/scripts/turbo-inputs.test.mjs
@@ -34,15 +34,41 @@ const TYPESCRIPT_EXTENSIONS = /\.(?:ts|tsx|mts|cts)$/;
  * answer accounts for `$TURBO_DEFAULT$`, negations and per-package overrides
  * that a pattern-by-pattern re-implementation here would have to model.
  */
-function resolvedTasks() {
+function dryRun() {
   const raw = execFileSync(
     "pnpm",
     ["exec", "turbo", "run", "check-types", "--dry=json"],
     { encoding: "utf8", maxBuffer: 64 * 1024 * 1024 }
   );
-  // Turbo prints its own preamble before the document on some terminals, so the
-  // parse starts at the first brace rather than at byte zero.
-  return JSON.parse(raw.slice(raw.indexOf("{"))).tasks;
+  // Turbo's document is pretty-printed from column zero, while the tools around
+  // it are not silent: pnpm emits config warnings and turbo a version banner,
+  // and which stream each uses varies between a terminal and a runner. So the
+  // document is located by the first line that OPENS it, rather than by the
+  // first `{` anywhere — a brace inside a warning would otherwise start the
+  // parse mid-sentence and fail on the character after it.
+  const lines = raw.split("\n");
+  const start = lines.findIndex(line => line.startsWith("{"));
+  if (start === -1) {
+    throw new Error(
+      `turbo --dry=json produced no JSON document. First 400 chars:\n${raw.slice(0, 400)}`
+    );
+  }
+  const document = lines.slice(start).join("\n");
+  try {
+    return JSON.parse(document);
+  } catch (cause) {
+    // Naming what was actually received, because the parser's own message
+    // ("Expected property name at position 1") describes the text and not
+    // where it came from, which leaves the next reader with nothing to act on.
+    throw new Error(
+      `turbo --dry=json did not parse. First 400 chars of the document:\n${document.slice(0, 400)}`,
+      { cause }
+    );
+  }
+}
+
+function resolvedTasks() {
+  return dryRun().tasks;
 }
 
 /** The TypeScript modules git tracks inside a package. */
@@ -155,14 +181,7 @@ describe("the shared TypeScript config is hashed", () => {
   // setting leaves every hash in the repository unmoved at once, which is the
   // same defect as above with the blast radius of the whole monorepo.
   it("counts packages/tsconfig among the global dependencies", () => {
-    const raw = execFileSync(
-      "pnpm",
-      ["exec", "turbo", "run", "check-types", "--dry=json"],
-      { encoding: "utf8", maxBuffer: 64 * 1024 * 1024 }
-    );
-    const globalFiles = Object.keys(
-      JSON.parse(raw.slice(raw.indexOf("{"))).globalCacheInputs.files
-    );
+    const globalFiles = Object.keys(dryRun().globalCacheInputs.files);
     expect(globalFiles).toContain("packages/tsconfig/base.json");
   });
 });

--- a/turbo.jsonc
+++ b/turbo.jsonc
@@ -43,6 +43,25 @@
   "$schema": "https://v2-9-7.turborepo.dev/schema.json",
   "ui": "tui", // Terminal UI for better task visualization
 
+  // Files OUTSIDE any package that every task's result depends on.
+  //
+  // A task's hash covers its own package's files and its dependencies' hashes.
+  // The shared TypeScript configs belong to neither: 22 packages extend
+  // `@nextlyhq/tsconfig`, and `check-types` declares `dependsOn: []`, so there is
+  // no edge from a package to the config that decides what its compiler does.
+  // Without this entry, editing `base.json` — turning on a strict flag, moving
+  // `target`, changing `lib` — leaves every package's hash unmoved and turbo
+  // replays greens computed under the OLD settings, across the whole repository
+  // at once. Measured before adding it: appending a newline to
+  // `packages/tsconfig/base.json` left `@nextlyhq/e2e#check-types` on the
+  // identical hash `e2f45f80054274ba`.
+  //
+  // Deliberately coarse. It invalidates every task rather than only the
+  // type-aware ones, because a compiler setting reaches builds and type-aware
+  // lint rules as well, and the cost of an unnecessary re-run is minutes while
+  // the cost of a missed one is a replayed green nobody can see through.
+  "globalDependencies": ["packages/tsconfig/*.json"],
+
   // Runtime env vars referenced from package source (not build-time inputs).
   // Listed here so eslint-plugin-turbo's no-undeclared-env-vars rule passes.
   "globalPassThroughEnv": [
@@ -185,13 +204,27 @@
       // every package rather than the one that needs it today, because the cost
       // of a package having no such tree is a glob that matches nothing, while
       // the cost of omitting it is silent.
-      "inputs": [
-        "src/**/*.{ts,tsx,mts,cts}",
-        "scripts/**/*.{ts,tsx,mts,cts}",
-        "*.{ts,tsx,mts,cts}",
-        "tsconfig.json",
-        "tsconfig.tests.json"
-      ],
+      // Start from turbo's DEFAULT (every non-ignored file in the package) and
+      // subtract, rather than enumerating what to include.
+      //
+      // The direction is the whole point. An include list is unbounded — every
+      // directory, extension and config a package might adopt has to be
+      // predicted — and each gap is SILENT and reports green, because a file
+      // outside the list cannot move the hash however badly it breaks. An
+      // exclude list is bounded, and its gaps cost only an unnecessary re-run.
+      //
+      // The list this replaces had been patched once along the EXTENSION axis
+      // and still failed along the DIRECTORY axis: `e2e` keeps its modules in
+      // `tests/` rather than `src/`, so turbo hashed 5 files for a package
+      // holding 35, and a type error introduced in `tests/` sat on `main`
+      // behind a replayed green until an unrelated change to a top-level file
+      // happened to move the hash. Adding `tests/**` would have fixed that case
+      // and left the next axis to be discovered the same way.
+      //
+      // `!**/*.md` is the one subtraction, and it is safe to state rather than
+      // hope: no tsconfig in this repository includes Markdown, and nothing
+      // imports it, so it cannot enter a TypeScript program.
+      "inputs": ["$TURBO_DEFAULT$", "!**/*.md"],
       "outputs": ["**/*.tsbuildinfo"] // TypeScript incremental cache
     },
 

--- a/turbo.jsonc
+++ b/turbo.jsonc
@@ -182,7 +182,25 @@
     //
     // Note: Uses incremental compilation (.tsbuildinfo) for speed
     "check-types": {
-      "dependsOn": [], // Optimized: No build dependency for faster parallel execution
+      // A package's TypeScript PROGRAM crosses workspace boundaries, so its
+      // hash has to as well. `packages/admin` maps the bare `nextly` specifier
+      // at its own source, and its program therefore compiles
+      // `packages/nextly/src/schemas/_zod/rbac.ts`. Inputs are package-scoped
+      // however they are written — `$TURBO_DEFAULT$` included — so with no edge
+      // here, editing that file left `@nextlyhq/admin#check-types` on the
+      // identical hash `4ce01f04aee7b9ee` and a cross-package type
+      // incompatibility replayed a stale green. This edge folds each
+      // dependency's hash into the dependent's, which moves it.
+      //
+      // It costs the full parallelism the note above describes: `check-types`
+      // now follows the dependency graph rather than starting everywhere at
+      // once. That is the trade a gate should take — a missed break reaches
+      // `main`, a redundant run costs minutes — and turbo still runs
+      // independent packages concurrently.
+      //
+      // NOT `^build`: this needs the dependency's HASH, not its `dist`, and
+      // requiring artifacts would make every typecheck wait on a build.
+      "dependsOn": ["^check-types"],
       // Every extension TypeScript follows, not only `.ts`/`.tsx`. A task input
       // glob decides what turbo HASHES: a change confined to an extension
       // missing here leaves the hash unmoved, so CI replays a cached green


### PR DESCRIPTION
## What was wrong

`main` was reporting a green `@nextlyhq/e2e#check-types` while the package held two real type errors. Nothing was wrong with the check. **It was never executed.**

`check-types` declared its inputs as an INCLUDE list:

```jsonc
"inputs": ["src/**/*.{ts,tsx,mts,cts}", "scripts/**/*.{ts,tsx,mts,cts}", "*.{ts,tsx,mts,cts}", "tsconfig.json", "tsconfig.tests.json"]
```

**`e2e` has no `src/` directory.** Its modules live in `tests/`, which no glob matches. Asked directly, turbo hashed **5 files for a package holding 35**:

```
$ turbo run check-types --filter=@nextlyhq/e2e --dry=json
inputs: flaky-reporter.ts, global-setup.ts, package.json, playwright.config.ts, tsconfig.json
tests/ files hashed: 0
```

So a type error introduced under `tests/` left the hash unmoved and turbo replayed the previous entry. Since **turbo does not cache failures**, the replayed result was a green computed *before* the break existed. This is not a stale answer; it is an answer to a different question.

## A second, larger instance of the same defect

`check-types` declares `dependsOn: []`, so no package has a graph edge to `@nextlyhq/tsconfig` — yet **22 packages extend its `base.json`**, which decides `strict`, `target` and `lib`. Nothing hashed it. Measured before the fix:

```
appending a newline to packages/tsconfig/base.json
  hash before: e2f45f80054274ba
  hash after : e2f45f80054274ba   (UNMOVED)
```

Changing a compiler setting would have replayed stale greens across the entire monorepo at once.

## The fix

**Subtract from the default instead of enumerating what to include.** An include list is unbounded — every directory, extension and config a package might adopt must be predicted — and each gap is *silent* and reports green. An exclude list is bounded, and its gaps cost only an unnecessary re-run. This is also what Turborepo's own docs prescribe: `inputs` opts you out of all defaults, and `$TURBO_DEFAULT$` exists to re-enter them.

```jsonc
"globalDependencies": ["packages/tsconfig/*.json"],
"check-types": { "inputs": ["$TURBO_DEFAULT$", "!**/*.md"] }
```

The list being replaced had **already been patched once along the EXTENSION axis** and still failed along the DIRECTORY axis. Adding `tests/**` would have fixed this case and left the next axis to be found the same way.

## Evidence

Same planted type error in `e2e/tests/canvas/poc-driver.ts`, both configs, warm cache:

| config | result |
| --- | --- |
| before | `cache hit, replaying logs e2f45f80054274ba` → **Tasks: 1 successful** |
| after | `cache miss, executing 9a6450b5f310f129` → **failed**, `error TS2322` |

Hash movement, measured and reverted to baseline:

| edit | before | after |
| --- | --- | --- |
| `packages/tsconfig/base.json` | unmoved | **moves** |
| `e2e/tests/**` | unmoved | **moves** |
| e2e inputs / `tests/` hashed | 5 / 0 | **38 / 30** |

**My first attempt at the negative control was worthless and I am recording that**: the cache was cold, so the run executed and failed, which proves nothing about replay. A cold cache cannot demonstrate a replayed green. Redone with the cache warmed under the old config first, which is the table above.

## The guard

`scripts/turbo-inputs.test.mjs` asserts the property from **turbo's own resolved inputs** rather than by reviewing globs — reading the patterns and judging them complete is the same act that produced the gap. Stub-verified: against the old config it fails naming all three defects (e2e 30 unhashed, plugin-page-builder 2, missing global tsconfig).

It asserts the population by MEMBERSHIP before any verdict, because "no package has an unhashed module" is satisfied perfectly by a run that read nothing. Packages that legitimately ship no TypeScript (`tsconfig`, `eslint-config`, `prettier-config`, `admin-css`) are handled there rather than by a per-package floor that would fail on all four.

## Scope and honesty

- Full `check-types --force` on a **built** tree: **22 of 22 pass**. The failures visible on an unbuilt tree are the missing-`dist` state AGENTS.md describes, not this change.
- **Cost:** more cache misses. A package's non-Markdown file now moves its typecheck hash. That is the intended trade for a gate: a false negative admits broken code to `main`, a false positive costs a re-run.
- `plugin-page-builder/e2e/*.spec.ts` are in **no tsc program at all** — a separate gap this does not fix. Now hashed, still unchecked. Worth its own task.
- **Not fixed here, and it generalises this defect:** CI restores the turbo cache with a prefix fallback (`restore-keys: turbo-v2-${{ runner.os }}-${{ github.job }}-`) while the exact key carries the commit SHA, so the exact key never hits and every run restores from some earlier commit. That makes any *future* input-set gap silently cross-branch rather than confined to one lane. Reported by the verdict-gate lane.

## Prior art

- **#667** split cache restore from save and gated the save on job success. That addressed *incomplete* entries from cancelled runs; this entry is complete and valid, and its key simply does not depend on the file that changed.
- `AGENTS.md` already documents the mechanism under "measure with `--force`". So this is not a discovery — it is an unenforced documented rule, which `AGENTS.md` itself calls out: *"A documented rule with nothing enforcing it is not a control, and filing a task is not installing one."* This is the first time it cost something.

No changeset: CI configuration and a test, nothing published changes.


---

## A naturally occurring instance, found independently

The evidence above uses a planted error. The page-builder lane hit the same
mechanism by accident while merging `main` into #854, which is worth recording
because nobody constructed it:

> The forced key moved from `ee8f6c8860611a0a` to `e2f45f80054274ba` — and the
> only reason is that the merge brought in a **top-level** `e2e/flaky-reporter.ts`,
> which `*.{ts,tsx,mts,cts}` matches. Nothing under `tests/` has ever moved that
> key.

That is the defect stated from the other direction: over the whole life of that
cache entry, the only thing that ever invalidated it was a file in the one
directory the globs happened to cover. Every change under `tests/` — 30 modules,
including the two that introduced the TS2339 this PR's sibling fixed — left it
untouched.
