### PR TITLE
fix(ci): read a clean verdict posted as a comment

### DIFF
--- a/scripts/ci-verdict.mjs
+++ b/scripts/ci-verdict.mjs
@@ -354,6 +354,27 @@ export function latestBaseChange(pages) {
   return at.length > 0 ? at[at.length - 1] : undefined;
 }
 
+/**
+ * The pull request's revisions, or `undefined` when the list may be short.
+ *
+ * The commits endpoint serves at most 250 and reports no error when it
+ * truncates, so a short list answers "no other revision shares this prefix"
+ * from a sample. `reportedCount` is what the pull request says it has; without
+ * it there is nothing to compare against and the set is withheld.
+ *
+ * Pure and exported so the WITHHOLDING is a property a test can hold inputs
+ * against. Left inline in each command it is reachable only by the network.
+ */
+export function completeRevisionSet(shas, reportedCount) {
+  if (!Array.isArray(shas) || typeof reportedCount !== "number") {
+    return undefined;
+  }
+  const unique = [
+    ...new Set(shas.filter(value => typeof value === "string")),
+  ];
+  return unique.length >= reportedCount ? unique : undefined;
+}
+
 export function abbreviationIsAmbiguous(named, head, knownRevisions) {
   // `knownRevisions` must be the pull request's COMPLETE revision set, or
   // absent. A partial set is worse than none: it answers "nothing else shares
@@ -1009,18 +1030,10 @@ async function main(argv) {
   // asking whether an abbreviation identifies more than one revision does not,
   // and folding the two together makes a single merge commit anywhere in the
   // pull request refuse every comment verdict.
-  const revisionShas = commits
-    .map(commit => commit?.sha)
-    .filter(value => typeof value === "string");
-  // Withheld unless every revision was returned. That endpoint serves at most
-  // 250 commits and reports no error when it truncates, so a short list answers
-  // "no other revision shares this prefix" from a sample of the history, and an
-  // omitted one carrying an old verdict is exactly what the question is about.
-  const knownRevisions =
-    typeof pullObject.commits === "number" &&
-    new Set(revisionShas).size >= pullObject.commits
-      ? revisionShas
-      : undefined;
+  const knownRevisions = completeRevisionSet(
+    commits.map(commit => commit?.sha),
+    pullObject.commits
+  );
   // GitHub serves at most 250 commits from that endpoint and `--paginate`
   // cannot reach past it, returning a short list and no error. Compared against
   // the map's SIZE rather than the array's length, because a duplicate sha

--- a/scripts/ci-verdict.mjs
+++ b/scripts/ci-verdict.mjs
@@ -407,9 +407,13 @@ export function verdictCommentReviewers(
     // Same scoping rule the review objects get: a verdict predating the last
     // base move describes a diff that no longer exists, and a comment with no
     // timestamp cannot be shown to postdate it.
+    // `updated_at` where there is one, because a reviewer that edits an existing
+    // comment to name the newly reviewed revision has spoken about this
+    // revision now. Keying on creation alone discarded that verdict and left
+    // the gate reporting a reviewed head as uncovered.
+    const stated = comment?.updated_at ?? comment?.created_at;
     const withinScope =
-      since === undefined ||
-      (typeof comment?.created_at === "string" && comment.created_at > since);
+      since === undefined || (typeof stated === "string" && stated > since);
     if (withinScope) seen.add(login);
   }
   return [...seen].sort();
@@ -722,7 +726,15 @@ export function report({
  * and defining it inside the command tied its lifetime to one block — which is
  * how a later rearrangement of that block took the definition with it.
  */
-const fingerprint = (rv, th, ic) =>
+/**
+ * A stamp over every field the decisions read, so the observation window can
+ * tell whether the evidence moved underneath it.
+ *
+ * Exported to be tested directly: it is the one input to the stability check,
+ * and a field missing from it produces two equal stamps over different
+ * evidence, which is a stale decision reported as a settled one.
+ */
+export const fingerprint = (rv, th, ic) =>
   JSON.stringify([
     // Every field a decision function READS, so the stamp cannot hold still
     // while an input to the verdict moves. `submitted_at` is here because
@@ -736,7 +748,17 @@ const fingerprint = (rv, th, ic) =>
       r?.submitted_at,
     ]),
     th.map(t => [t?.isResolved, t?.comments?.nodes?.[0]?.author?.login]),
-    ic.map(c => [c?.id, c?.user?.login, RATE_LIMIT_MARKER.test(c?.body ?? "")]),
+    // The parsed revision and the timestamp are read by the coverage decision,
+    // so a comment edited in place from an older revision to the current one
+    // must move this stamp. Recording only the id let both snapshots compare
+    // equal while the evidence underneath them changed.
+    ic.map(c => [
+      c?.id,
+      c?.user?.login,
+      RATE_LIMIT_MARKER.test(c?.body ?? ""),
+      reviewedCommitFrom(c?.body),
+      c?.updated_at ?? c?.created_at,
+    ]),
   ]);
 
 /**

--- a/scripts/ci-verdict.mjs
+++ b/scripts/ci-verdict.mjs
@@ -355,9 +355,13 @@ export function latestBaseChange(pages) {
 }
 
 export function abbreviationIsAmbiguous(named, head, knownRevisions) {
-  // Nothing to compare against is not the same as nothing colliding. An
-  // abbreviation is only known to identify ONE commit once something has been
-  // checked, so an absent revision set refuses rather than waving it through.
+  // `knownRevisions` must be the pull request's COMPLETE revision set, or
+  // absent. A partial set is worse than none: it answers "nothing else shares
+  // this prefix" from a sample, so the caller decides completeness and passes
+  // nothing when it cannot establish it.
+  //
+  // Nothing to compare against is not the same as nothing colliding, so an
+  // absent set refuses rather than waving it through.
   if (knownRevisions === undefined || knownRevisions === null) return true;
   const target = head.toLowerCase();
   let sawTarget = false;
@@ -1005,9 +1009,18 @@ async function main(argv) {
   // asking whether an abbreviation identifies more than one revision does not,
   // and folding the two together makes a single merge commit anywhere in the
   // pull request refuse every comment verdict.
-  const knownRevisions = commits
+  const revisionShas = commits
     .map(commit => commit?.sha)
     .filter(value => typeof value === "string");
+  // Withheld unless every revision was returned. That endpoint serves at most
+  // 250 commits and reports no error when it truncates, so a short list answers
+  // "no other revision shares this prefix" from a sample of the history, and an
+  // omitted one carrying an old verdict is exactly what the question is about.
+  const knownRevisions =
+    typeof pullObject.commits === "number" &&
+    new Set(revisionShas).size >= pullObject.commits
+      ? revisionShas
+      : undefined;
   // GitHub serves at most 250 commits from that endpoint and `--paginate`
   // cannot reach past it, returning a short list and no error. Compared against
   // the map's SIZE rather than the array's length, because a duplicate sha

--- a/scripts/ci-verdict.mjs
+++ b/scripts/ci-verdict.mjs
@@ -8,6 +8,15 @@
 // object proves a reviewer saw a commit whether or not it carried findings,
 // and GitHub's own thread resolution state says what is still open.
 //
+// That first source is INCOMPLETE on its own, which is not obvious and cost
+// this gate its usefulness for a while. A reviewer may open a review object
+// only when it has something to report and post a clean verdict as an ordinary
+// issue comment naming the commit it read. Asking the reviews endpoint alone
+// then yields nothing for a revision that was reviewed and passed, so the gate
+// refuses permanently on exactly the pull requests that are ready, and whoever
+// needs to merge learns to go around it. Coverage is therefore read from both
+// places, and a verdict counts only when it NAMES the revision it read.
+//
 // Counting a reviewer's findings would be a proxy for the second question and a
 // worse one, because reviewers do not agree on what a review object is: one
 // posts a single object per round carrying many comments, another posts one
@@ -287,9 +296,96 @@ function approvalCovers(
   return strict ? at > objected : at >= objected;
 }
 
-/** Required reviewers with no review at `head`, in the order they were required. */
-export function missingReviewers(reviews, head, required, since = undefined) {
-  const seen = new Set(reviewersAtHead(reviews, head, since));
+/**
+ * A verdict posted as an ISSUE COMMENT that names the commit it read.
+ *
+ * Some reviewers only open a review object when they have something to say. A
+ * clean pass from one of those arrives as an ordinary comment, so a gate asking
+ * the reviews endpoint alone sees nothing and cannot distinguish "read it and
+ * found nothing" from "never looked" — refusing forever on exactly the
+ * revisions that are ready.
+ *
+ * Coverage is granted only when the comment NAMES a revision and that revision
+ * is the head. A comment that merely exists proves nothing: the reviewer
+ * comments on every round, and an older one would otherwise certify whatever
+ * was pushed after it.
+ */
+const REVIEWED_COMMIT_MARKER = /reviewed commit:\**\s*`([0-9a-f]{7,40})`/i;
+
+/**
+ * Reviewer logins whose comment reports having read `head`.
+ *
+ * The abbreviation is matched as a PREFIX of the full head, which is the
+ * relationship git's short form actually has. A floor of seven characters keeps
+ * a short string from prefixing many commits; the marker must also be present,
+ * so a comment quoting a SHA in passing does not count.
+ *
+ * Known boundary: a comment can be edited after the fact, so this trusts the
+ * reviewer's account not to restate a revision it did not read. A review object
+ * carries its `commit_id` from the server and cannot be rewritten that way, so
+ * this source is the weaker of the two and is only ever additive to it.
+ */
+export function verdictCommentReviewers(
+  issueComments,
+  head,
+  since = undefined
+) {
+  if (
+    !Array.isArray(issueComments) ||
+    typeof head !== "string" ||
+    head === ""
+  ) {
+    return [];
+  }
+  const target = head.toLowerCase();
+  const seen = new Set();
+  for (const comment of issueComments) {
+    const login = comment?.user?.login;
+    const body = comment?.body;
+    if (typeof login !== "string" || typeof body !== "string") continue;
+    const named = REVIEWED_COMMIT_MARKER.exec(body)?.[1]?.toLowerCase();
+    if (named === undefined || !target.startsWith(named)) continue;
+    // Same scoping rule the review objects get: a verdict predating the last
+    // base move describes a diff that no longer exists, and a comment with no
+    // timestamp cannot be shown to postdate it.
+    const withinScope =
+      since === undefined ||
+      (typeof comment?.created_at === "string" && comment.created_at > since);
+    if (withinScope) seen.add(login);
+  }
+  return [...seen].sort();
+}
+
+/**
+ * Every reviewer that has covered `head`, from either source.
+ *
+ * One implementation, because the reported list and the missing list are the
+ * same question asked twice: computing them apart lets a gate name a reviewer
+ * as covering the head while still holding the merge for them.
+ */
+export function reviewersCovering(
+  reviews,
+  issueComments,
+  head,
+  since = undefined
+) {
+  return [
+    ...new Set([
+      ...reviewersAtHead(reviews, head, since),
+      ...verdictCommentReviewers(issueComments, head, since),
+    ]),
+  ].sort();
+}
+
+/** Required reviewers with no verdict at `head`, in the order they were required. */
+export function missingReviewers(
+  reviews,
+  issueComments,
+  head,
+  required,
+  since = undefined
+) {
+  const seen = new Set(reviewersCovering(reviews, issueComments, head, since));
   return (required ?? []).filter(login => !seen.has(login));
 }
 
@@ -462,7 +558,19 @@ export function report({
     login => !blockingList.includes(login)
   );
   const required = [...new Set([...blockingList, ...effectiveAdvisory])];
-  const missing = missingReviewers(reviews, head, required, coverageSince);
+  const covering = reviewersCovering(
+    reviews,
+    issueComments,
+    head,
+    coverageSince
+  );
+  const missing = missingReviewers(
+    reviews,
+    issueComments,
+    head,
+    required,
+    coverageSince
+  );
   const unresolved = unresolvedThreads(threads, effectiveAdvisory);
   const limited = rateLimited(issueComments);
   // Coverage is asked at the head; a standing objection is asked of the whole
@@ -517,7 +625,7 @@ export function report({
     // Named for what the range establishes — absence from the merge — rather
     // than for the conclusion only a content comparison can reach.
     unmerged_candidates: stranded,
-    reviewed_head: reviewersAtHead(reviews, head, coverageSince),
+    reviewed_head: covering,
     missing_reviews: missing,
     // JSON has no infinity, so an unavailable count would serialise as `null`
     // and read like a zero to anything consuming the report as data.

--- a/scripts/ci-verdict.mjs
+++ b/scripts/ci-verdict.mjs
@@ -313,6 +313,20 @@ function approvalCovers(
 const REVIEWED_COMMIT_MARKER = /reviewed commit:\**\s*`([0-9a-f]{7,40})`/i;
 
 /**
+ * The revision a comment reports having read, or `undefined`.
+ *
+ * Exported because the merge-verification gate asks the same question of the
+ * same comments, and two parsers for one format agree until one is edited. The
+ * floor of seven characters is git's own for an abbreviation that identifies a
+ * commit; below it the marker does not match at all, so a short string cannot
+ * prefix many commits.
+ */
+export function reviewedCommitFrom(body) {
+  if (typeof body !== "string") return undefined;
+  return REVIEWED_COMMIT_MARKER.exec(body)?.[1]?.toLowerCase();
+}
+
+/**
  * Reviewer logins whose comment reports having read `head`.
  *
  * The abbreviation is matched as a PREFIX of the full head, which is the
@@ -343,7 +357,7 @@ export function verdictCommentReviewers(
     const login = comment?.user?.login;
     const body = comment?.body;
     if (typeof login !== "string" || typeof body !== "string") continue;
-    const named = REVIEWED_COMMIT_MARKER.exec(body)?.[1]?.toLowerCase();
+    const named = reviewedCommitFrom(body);
     if (named === undefined || !target.startsWith(named)) continue;
     // Same scoping rule the review objects get: a verdict predating the last
     // base move describes a diff that no longer exists, and a comment with no

--- a/scripts/ci-verdict.mjs
+++ b/scripts/ci-verdict.mjs
@@ -8,14 +8,13 @@
 // object proves a reviewer saw a commit whether or not it carried findings,
 // and GitHub's own thread resolution state says what is still open.
 //
-// That first source is INCOMPLETE on its own, which is not obvious and cost
-// this gate its usefulness for a while. A reviewer may open a review object
-// only when it has something to report and post a clean verdict as an ordinary
-// issue comment naming the commit it read. Asking the reviews endpoint alone
-// then yields nothing for a revision that was reviewed and passed, so the gate
-// refuses permanently on exactly the pull requests that are ready, and whoever
-// needs to merge learns to go around it. Coverage is therefore read from both
-// places, and a verdict counts only when it NAMES the revision it read.
+// A review object is not the only form a verdict takes. A reviewer may open one
+// only when it has something to report, and state a clean pass as an issue
+// comment naming the commit it read. Asking the reviews endpoint alone
+// therefore yields nothing for a revision that was reviewed and passed, which
+// is indistinguishable from one nobody looked at. Coverage is read from both
+// places, and a comment counts only when it NAMES a revision that identifies
+// the head unambiguously.
 //
 // Counting a reviewer's findings would be a proxy for the second question and a
 // worse one, because reviewers do not agree on what a review object is: one
@@ -299,15 +298,13 @@ function approvalCovers(
 /**
  * A verdict posted as an ISSUE COMMENT that names the commit it read.
  *
- * Some reviewers only open a review object when they have something to say. A
- * clean pass from one of those arrives as an ordinary comment, so a gate asking
- * the reviews endpoint alone sees nothing and cannot distinguish "read it and
- * found nothing" from "never looked" — refusing forever on exactly the
- * revisions that are ready.
+ * Some reviewers open a review object only when they have something to say, so
+ * a clean pass arrives as an ordinary comment. Without this, such a verdict is
+ * indistinguishable from no verdict at all.
  *
  * Coverage is granted only when the comment NAMES a revision and that revision
- * is the head. A comment that merely exists proves nothing: the reviewer
- * comments on every round, and an older one would otherwise certify whatever
+ * is the head. A comment that merely exists proves nothing: a reviewer that
+ * comments on every round would otherwise have an older one certify whatever
  * was pushed after it.
  */
 const REVIEWED_COMMIT_MARKER = /reviewed commit:\**\s*`([0-9a-f]{7,40})`/i;
@@ -385,8 +382,7 @@ export function abbreviationIsAmbiguous(named, head, knownRevisions) {
 export function verdictCommentReviewers(
   issueComments,
   head,
-  since = undefined,
-  knownRevisions = undefined
+  { since, knownRevisions, historyRewritten = false } = {}
 ) {
   if (
     !Array.isArray(issueComments) ||
@@ -395,6 +391,12 @@ export function verdictCommentReviewers(
   ) {
     return [];
   }
+  // A rewritten branch cannot supply the revisions to compare an abbreviation
+  // against: the removed ones are gone from the commit list while a comment
+  // naming one survives, so an abbreviation that looks unique among what
+  // remains may identify a revision nobody can enumerate. A review record
+  // still carries a full revision and is unaffected.
+  if (historyRewritten) return [];
   const target = head.toLowerCase();
   const seen = new Set();
   for (const comment of issueComments) {
@@ -409,8 +411,7 @@ export function verdictCommentReviewers(
     // timestamp cannot be shown to postdate it.
     // `updated_at` where there is one, because a reviewer that edits an existing
     // comment to name the newly reviewed revision has spoken about this
-    // revision now. Keying on creation alone discarded that verdict and left
-    // the gate reporting a reviewed head as uncovered.
+    // revision now, while the creation time still describes the older verdict.
     const stated = comment?.updated_at ?? comment?.created_at;
     const withinScope =
       since === undefined || (typeof stated === "string" && stated > since);
@@ -426,17 +427,11 @@ export function verdictCommentReviewers(
  * same question asked twice: computing them apart lets a gate name a reviewer
  * as covering the head while still holding the merge for them.
  */
-export function reviewersCovering(
-  reviews,
-  issueComments,
-  head,
-  since = undefined,
-  knownRevisions = undefined
-) {
+export function reviewersCovering(reviews, issueComments, head, options = {}) {
   return [
     ...new Set([
-      ...reviewersAtHead(reviews, head, since),
-      ...verdictCommentReviewers(issueComments, head, since, knownRevisions),
+      ...reviewersAtHead(reviews, head, options.since),
+      ...verdictCommentReviewers(issueComments, head, options),
     ]),
   ].sort();
 }
@@ -447,12 +442,9 @@ export function missingReviewers(
   issueComments,
   head,
   required,
-  since = undefined,
-  knownRevisions = undefined
+  options = {}
 ) {
-  const seen = new Set(
-    reviewersCovering(reviews, issueComments, head, since, knownRevisions)
-  );
+  const seen = new Set(reviewersCovering(reviews, issueComments, head, options));
   return (required ?? []).filter(login => !seen.has(login));
 }
 
@@ -607,6 +599,8 @@ export function report({
   coverageSince = undefined,
   revisionOrder,
   revisionOrderComplete = false,
+  knownRevisions = undefined,
+  historyRewritten = false,
   reviews,
   threads,
   issueComments,
@@ -625,24 +619,26 @@ export function report({
     login => !blockingList.includes(login)
   );
   const required = [...new Set([...blockingList, ...effectiveAdvisory])];
-  // The pull request's own revisions, so an abbreviation that also identifies
-  // an earlier one of them is refused rather than trusted.
-  const knownRevisions =
-    revisionOrder instanceof Map ? [...revisionOrder.keys()] : undefined;
+  // Taken from the revision SET, never from the order map. Ordering is withheld
+  // where ancestry is not linear, and reusing it here would make a merge commit
+  // anywhere in the pull request refuse every comment verdict.
+  const coverageOptions = {
+    since: coverageSince,
+    knownRevisions,
+    historyRewritten,
+  };
   const covering = reviewersCovering(
     reviews,
     issueComments,
     head,
-    coverageSince,
-    knownRevisions
+    coverageOptions
   );
   const missing = missingReviewers(
     reviews,
     issueComments,
     head,
     required,
-    coverageSince,
-    knownRevisions
+    coverageOptions
   );
   const unresolved = unresolvedThreads(threads, effectiveAdvisory);
   const limited = rateLimited(issueComments);
@@ -730,8 +726,8 @@ export function report({
  * A stamp over every field the decisions read, so the observation window can
  * tell whether the evidence moved underneath it.
  *
- * Exported to be tested directly: it is the one input to the stability check,
- * and a field missing from it produces two equal stamps over different
+ * Exported so it can be asserted directly: it is the one input to the stability
+ * check, and a field missing from it produces two equal stamps over different
  * evidence, which is a stale decision reported as a settled one.
  */
 export const fingerprint = (rv, th, ic) =>
@@ -750,8 +746,8 @@ export const fingerprint = (rv, th, ic) =>
     th.map(t => [t?.isResolved, t?.comments?.nodes?.[0]?.author?.login]),
     // The parsed revision and the timestamp are read by the coverage decision,
     // so a comment edited in place from an older revision to the current one
-    // must move this stamp. Recording only the id let both snapshots compare
-    // equal while the evidence underneath them changed.
+    // moves this stamp. Recording only the id would leave two snapshots equal
+    // while the evidence underneath them changed.
     ic.map(c => [
       c?.id,
       c?.user?.login,
@@ -1005,6 +1001,13 @@ async function main(argv) {
   const revisionOrder = linearHistory
     ? new Map(commits.map((commit, index) => [commit.sha, index]))
     : undefined;
+  // Kept even where the ORDER is withheld. Ordering needs linear ancestry;
+  // asking whether an abbreviation identifies more than one revision does not,
+  // and folding the two together makes a single merge commit anywhere in the
+  // pull request refuse every comment verdict.
+  const knownRevisions = commits
+    .map(commit => commit?.sha)
+    .filter(value => typeof value === "string");
   // GitHub serves at most 250 commits from that endpoint and `--paginate`
   // cannot reach past it, returning a short list and no error. Compared against
   // the map's SIZE rather than the array's length, because a duplicate sha
@@ -1168,7 +1171,11 @@ async function main(argv) {
       // A force-push away from a revision and back leaves every SHA identical
       // while recording an event, so the count belongs IN the snapshot rather
       // than beside it.
-      rewrites: live.state === "MERGED" ? rewriteEvents() : 0,
+      // Read whatever the state, because comment evidence depends on it: a
+      // rewritten branch no longer lists the revisions an abbreviation would
+      // have to be unique against, and that is true of an open pull request
+      // exactly as it is of a merged one.
+      rewrites: rewriteEvents(),
     };
   };
 
@@ -1267,6 +1274,8 @@ async function main(argv) {
       return report({
         head,
         coverageSince: observed.baseChangedAt,
+        knownRevisions,
+        historyRewritten: observed.rewrites > 0,
         revisionOrder,
         revisionOrderComplete,
         reviews: observed.reviews,

--- a/scripts/ci-verdict.mjs
+++ b/scripts/ci-verdict.mjs
@@ -339,10 +339,54 @@ export function reviewedCommitFrom(body) {
  * carries its `commit_id` from the server and cannot be rewritten that way, so
  * this source is the weaker of the two and is only ever additive to it.
  */
+/**
+ * When the base last moved, or `undefined` when it never has.
+ *
+ * Pure and exported so the merge-verification gate applies the SAME cutoff. A
+ * verdict predating a base move describes a `base..head` diff that no longer
+ * exists, and nothing about the revision gives that away, because the head did
+ * not move. Takes the timeline as pages, which is how both callers hold it.
+ */
+export function latestBaseChange(pages) {
+  const at = (Array.isArray(pages) ? pages : [])
+    .flat()
+    .filter(event => event?.event === "base_ref_changed")
+    .map(event => event?.created_at)
+    .filter(value => typeof value === "string")
+    .sort();
+  return at.length > 0 ? at[at.length - 1] : undefined;
+}
+
+export function abbreviationIsAmbiguous(named, head, knownRevisions) {
+  // Nothing to compare against is not the same as nothing colliding. An
+  // abbreviation is only known to identify ONE commit once something has been
+  // checked, so an absent revision set refuses rather than waving it through.
+  if (knownRevisions === undefined || knownRevisions === null) return true;
+  const target = head.toLowerCase();
+  let sawTarget = false;
+  for (const revision of knownRevisions) {
+    if (typeof revision !== "string") continue;
+    const candidate = revision.toLowerCase();
+    if (candidate === target) {
+      sawTarget = true;
+      continue;
+    }
+    // A second revision of this pull request wearing the same prefix. The
+    // author controls their own commits and a seven-digit prefix is within
+    // reach of grinding, so a stale verdict about an earlier revision would
+    // otherwise cover a head nobody read.
+    if (candidate.startsWith(named)) return true;
+  }
+  // The head must be among the revisions checked. Where it is not, the set
+  // says nothing about what this abbreviation identifies.
+  return !sawTarget;
+}
+
 export function verdictCommentReviewers(
   issueComments,
   head,
-  since = undefined
+  since = undefined,
+  knownRevisions = undefined
 ) {
   if (
     !Array.isArray(issueComments) ||
@@ -359,6 +403,7 @@ export function verdictCommentReviewers(
     if (typeof login !== "string" || typeof body !== "string") continue;
     const named = reviewedCommitFrom(body);
     if (named === undefined || !target.startsWith(named)) continue;
+    if (abbreviationIsAmbiguous(named, target, knownRevisions)) continue;
     // Same scoping rule the review objects get: a verdict predating the last
     // base move describes a diff that no longer exists, and a comment with no
     // timestamp cannot be shown to postdate it.
@@ -381,12 +426,13 @@ export function reviewersCovering(
   reviews,
   issueComments,
   head,
-  since = undefined
+  since = undefined,
+  knownRevisions = undefined
 ) {
   return [
     ...new Set([
       ...reviewersAtHead(reviews, head, since),
-      ...verdictCommentReviewers(issueComments, head, since),
+      ...verdictCommentReviewers(issueComments, head, since, knownRevisions),
     ]),
   ].sort();
 }
@@ -397,9 +443,12 @@ export function missingReviewers(
   issueComments,
   head,
   required,
-  since = undefined
+  since = undefined,
+  knownRevisions = undefined
 ) {
-  const seen = new Set(reviewersCovering(reviews, issueComments, head, since));
+  const seen = new Set(
+    reviewersCovering(reviews, issueComments, head, since, knownRevisions)
+  );
   return (required ?? []).filter(login => !seen.has(login));
 }
 
@@ -572,18 +621,24 @@ export function report({
     login => !blockingList.includes(login)
   );
   const required = [...new Set([...blockingList, ...effectiveAdvisory])];
+  // The pull request's own revisions, so an abbreviation that also identifies
+  // an earlier one of them is refused rather than trusted.
+  const knownRevisions =
+    revisionOrder instanceof Map ? [...revisionOrder.keys()] : undefined;
   const covering = reviewersCovering(
     reviews,
     issueComments,
     head,
-    coverageSince
+    coverageSince,
+    knownRevisions
   );
   const missing = missingReviewers(
     reviews,
     issueComments,
     head,
     required,
-    coverageSince
+    coverageSince,
+    knownRevisions
   );
   const unresolved = unresolvedThreads(threads, effectiveAdvisory);
   const limited = rateLimited(issueComments);
@@ -1024,20 +1079,15 @@ async function main(argv) {
   // The moment the base last moved, or `undefined` when it never has.
   // `base_ref_changed` is GitHub's own name for the event; there is no
   // structural alternative, because a review record carries no base of its own.
-  const baseChangedAt = () => {
-    const at = gh([
-      "api",
-      "--paginate",
-      "--slurp",
-      `repos/${repo}/issues/${pr}/timeline?per_page=100`,
-    ])
-      .flat()
-      .filter(event => event?.event === "base_ref_changed")
-      .map(event => event?.created_at)
-      .filter(value => typeof value === "string")
-      .sort();
-    return at.length > 0 ? at[at.length - 1] : undefined;
-  };
+  const baseChangedAt = () =>
+    latestBaseChange(
+      gh([
+        "api",
+        "--paginate",
+        "--slurp",
+        `repos/${repo}/issues/${pr}/timeline?per_page=100`,
+      ])
+    );
 
   const rewriteEvents = () =>
     gh([

--- a/scripts/ci-verdict.test.mjs
+++ b/scripts/ci-verdict.test.mjs
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   EXIT_NOT_CLEAN,
   changesRequested,
+  fingerprint,
   missingReviewers,
   rateLimited,
   report,
@@ -119,6 +120,19 @@ describe("verdictCommentReviewers", () => {
 
   // A comment with no timestamp cannot be shown to postdate the base move, and
   // unknown is not the same as covered.
+  // A reviewer that edits an existing comment to name the newly reviewed
+  // revision has spoken NOW; GitHub keeps the original `created_at`, so keying
+  // on creation alone discarded a valid post-retarget verdict.
+  it("counts a verdict RESTATED after the base moved", () => {
+    const edited = {
+      ...verdictComment(CODEX, HEAD, "2026-08-14T09:00:00Z"),
+      updated_at: "2026-08-14T11:00:00Z",
+    };
+    expect(
+      verdictCommentReviewers([edited], HEAD, "2026-08-14T10:00:00Z", [HEAD])
+    ).toEqual([CODEX]);
+  });
+
   it("excludes an undated verdict once a base move is in scope", () => {
     expect(
       verdictCommentReviewers(
@@ -169,6 +183,51 @@ describe("verdictCommentReviewers", () => {
     expect(verdictCommentReviewers([verdictComment(CODEX, HEAD)], "")).toEqual(
       []
     );
+  });
+});
+
+describe("fingerprint", () => {
+  // A comment edited in place keeps its id, so a stamp recording only the id
+  // holds still while the revision it names changes. Both snapshots then
+  // compare equal and a decision taken over the OLD evidence is reported as
+  // settled.
+  it("moves when a comment is edited to name a different revision", () => {
+    const before = [
+      { id: 7, user: { login: CODEX }, body: "**Reviewed commit:** `bbbbbbbbbb`" },
+    ];
+    const after = [
+      { id: 7, user: { login: CODEX }, body: "**Reviewed commit:** `aaaaaaaaaa`" },
+    ];
+    expect(fingerprint([], [], before)).not.toEqual(fingerprint([], [], after));
+  });
+
+  it("moves when a comment is edited without changing the named revision", () => {
+    const before = [
+      {
+        id: 7,
+        user: { login: CODEX },
+        body: "**Reviewed commit:** `aaaaaaaaaa`",
+        updated_at: "2026-08-14T09:00:00Z",
+      },
+    ];
+    const after = [
+      {
+        id: 7,
+        user: { login: CODEX },
+        body: "**Reviewed commit:** `aaaaaaaaaa`",
+        updated_at: "2026-08-14T11:00:00Z",
+      },
+    ];
+    expect(fingerprint([], [], before)).not.toEqual(fingerprint([], [], after));
+  });
+
+  // The control: identical evidence must produce an identical stamp, or the
+  // window never settles and every run exhausts its attempts.
+  it("holds still over identical evidence", () => {
+    const same = [
+      { id: 7, user: { login: CODEX }, body: "**Reviewed commit:** `aaaaaaaaaa`" },
+    ];
+    expect(fingerprint([], [], same)).toEqual(fingerprint([], [], [...same]));
   });
 });
 

--- a/scripts/ci-verdict.test.mjs
+++ b/scripts/ci-verdict.test.mjs
@@ -67,9 +67,11 @@ const verdictComment = (login, sha, created_at = undefined) => ({
  */
 describe("verdictCommentReviewers", () => {
   it("grants coverage from a comment naming the head", () => {
-    expect(verdictCommentReviewers([verdictComment(CODEX, HEAD)], HEAD)).toEqual(
-      [CODEX]
-    );
+    expect(
+      verdictCommentReviewers([verdictComment(CODEX, HEAD)], HEAD, undefined, [
+        HEAD,
+      ])
+    ).toEqual([CODEX]);
   });
 
   it("ignores a verdict naming a different revision", () => {
@@ -110,9 +112,9 @@ describe("verdictCommentReviewers", () => {
 
   it("counts a verdict after the last base move", () => {
     const fresh = verdictComment(CODEX, HEAD, "2026-08-14T11:00:00Z");
-    expect(verdictCommentReviewers([fresh], HEAD, "2026-08-14T10:00:00Z")).toEqual(
-      [CODEX]
-    );
+    expect(
+      verdictCommentReviewers([fresh], HEAD, "2026-08-14T10:00:00Z", [HEAD])
+    ).toEqual([CODEX]);
   });
 
   // A comment with no timestamp cannot be shown to postdate the base move, and
@@ -124,6 +126,41 @@ describe("verdictCommentReviewers", () => {
         HEAD,
         "2026-08-14T10:00:00Z"
       )
+    ).toEqual([]);
+  });
+
+  // An abbreviation is only evidence if it identifies ONE commit. The author
+  // controls their own commits, and seven hexadecimal digits is within reach of
+  // grinding, so a head made to share a prefix with an earlier reviewed
+  // revision would otherwise be covered by that older verdict.
+  it("refuses an abbreviation that also matches an earlier revision", () => {
+    const shared = "aaaaaaa";
+    const collidingHead = shared + "1".repeat(40 - shared.length);
+    const olderRevision = shared + "2".repeat(40 - shared.length);
+    const comment = {
+      user: { login: CODEX },
+      body: `**Reviewed commit:** \`${shared}\``,
+    };
+    expect(
+      verdictCommentReviewers([comment], collidingHead, undefined, [
+        collidingHead,
+        olderRevision,
+      ])
+    ).toEqual([]);
+  });
+
+  // Nothing to compare against is not the same as nothing colliding.
+  it("refuses when no revision set is supplied", () => {
+    expect(verdictCommentReviewers([verdictComment(CODEX, HEAD)], HEAD)).toEqual(
+      []
+    );
+  });
+
+  it("refuses when the head is absent from the revision set", () => {
+    expect(
+      verdictCommentReviewers([verdictComment(CODEX, HEAD)], HEAD, undefined, [
+        OLD,
+      ])
     ).toEqual([]);
   });
 
@@ -141,14 +178,18 @@ describe("reviewersCovering", () => {
       reviewersCovering(
         [review(CODEX, HEAD)],
         [verdictComment(CODEX, HEAD)],
-        HEAD
+        HEAD,
+        undefined,
+        [HEAD]
       )
     ).toEqual([CODEX]);
   });
 
   it("clears a required reviewer that only ever commented", () => {
     expect(
-      missingReviewers([], [verdictComment(CODEX, HEAD)], HEAD, [CODEX])
+      missingReviewers([], [verdictComment(CODEX, HEAD)], HEAD, [CODEX], undefined, [
+        HEAD,
+      ])
     ).toEqual([]);
   });
 });

--- a/scripts/ci-verdict.test.mjs
+++ b/scripts/ci-verdict.test.mjs
@@ -59,12 +59,12 @@ const verdictComment = (login, sha, created_at = undefined) => ({
 });
 
 /**
- * A reviewer that reports a clean pass WITHOUT opening a review object.
+ * Coverage from a reviewer that states a clean pass WITHOUT a review object.
  *
- * Measured against this repository: on four pull requests, the one carrying
- * findings produced review objects and the three clean ones produced none at
- * all, only a comment. A gate reading the reviews endpoint alone therefore
- * refuses forever on a revision that was reviewed and passed.
+ * The fixture carries no review record at all, which is the point: a reviewer
+ * may open one only when it has findings, so a gate reading records alone
+ * cannot tell a clean verdict from silence. Every case below fixes what a
+ * comment must carry before it counts as coverage.
  */
 describe("verdictCommentReviewers", () => {
   it("grants coverage from a comment naming the head", () => {
@@ -153,10 +153,10 @@ describe("verdictCommentReviewers", () => {
     ).toEqual([]);
   });
 
-  // An abbreviation is only evidence if it identifies ONE commit. The author
-  // controls their own commits, and seven hexadecimal digits is within reach of
-  // grinding, so a head made to share a prefix with an earlier reviewed
-  // revision would otherwise be covered by that older verdict.
+  // An abbreviation is evidence only if it identifies ONE commit. The author
+  // controls their own commits and seven hexadecimal digits is within reach of
+  // grinding, so a head sharing a prefix with an earlier reviewed revision
+  // would otherwise be covered by that older verdict.
   it("refuses an abbreviation that also matches an earlier revision", () => {
     const shared = "aaaaaaa";
     const collidingHead = shared + "1".repeat(40 - shared.length);
@@ -187,13 +187,31 @@ describe("verdictCommentReviewers", () => {
     ).toEqual([]);
   });
 
-  // A rewritten branch no longer lists the revisions an abbreviation would have
-  // to be unique against, while a comment naming a removed one survives.
+  // A rewritten branch no longer lists the revisions an abbreviation must be
+  // unique against, while a comment naming a removed one survives.
   it("refuses every comment verdict once history was rewritten", () => {
     expect(
       verdictCommentReviewers([verdictComment(CODEX, HEAD)], HEAD, {
         knownRevisions: [HEAD],
         historyRewritten: true,
+      })
+    ).toEqual([]);
+  });
+
+  // A caller that cannot establish completeness passes nothing, so a truncated
+  // history cannot answer "no other revision shares this prefix" from a sample.
+  it("refuses when the revision set omits a colliding revision", () => {
+    const shared = "aaaaaaa";
+    const collidingHead = shared + "1".repeat(40 - shared.length);
+    const comment = {
+      user: { login: CODEX },
+      body: `**Reviewed commit:** \`${shared}\``,
+    };
+    // The omitted revision is absent from the set exactly as truncation leaves
+    // it, so the head alone would look unanimous.
+    expect(
+      verdictCommentReviewers([comment], collidingHead, {
+        knownRevisions: undefined,
       })
     ).toEqual([]);
   });

--- a/scripts/ci-verdict.test.mjs
+++ b/scripts/ci-verdict.test.mjs
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   EXIT_NOT_CLEAN,
   changesRequested,
+  completeRevisionSet,
   fingerprint,
   missingReviewers,
   rateLimited,
@@ -221,6 +222,40 @@ describe("verdictCommentReviewers", () => {
     expect(verdictCommentReviewers([verdictComment(CODEX, HEAD)], "")).toEqual(
       []
     );
+  });
+});
+
+describe("completeRevisionSet", () => {
+  const A = "a".repeat(40);
+  const B = "b".repeat(40);
+
+  it("returns the revisions when every one was seen", () => {
+    expect(completeRevisionSet([A, B], 2)).toEqual([A, B]);
+  });
+
+  // The endpoint truncates without erroring, so a short list is the shape a
+  // long history arrives in. Withholding is what stops the uniqueness question
+  // being answered from a sample.
+  it("withholds a set shorter than the count reported", () => {
+    expect(completeRevisionSet([A], 2)).toBeUndefined();
+  });
+
+  it("withholds when the count is unavailable", () => {
+    expect(completeRevisionSet([A, B], undefined)).toBeUndefined();
+  });
+
+  // Compared by DISTINCT revisions: a duplicate would otherwise pad the length
+  // and make a truncated list reach the reported total.
+  it("counts distinct revisions rather than entries", () => {
+    expect(completeRevisionSet([A, A], 2)).toBeUndefined();
+  });
+
+  it("drops entries that are not revisions rather than counting them", () => {
+    expect(completeRevisionSet([A, undefined, null], 2)).toBeUndefined();
+  });
+
+  it("survives input that is not a list", () => {
+    expect(completeRevisionSet(undefined, 2)).toBeUndefined();
   });
 });
 

--- a/scripts/ci-verdict.test.mjs
+++ b/scripts/ci-verdict.test.mjs
@@ -9,7 +9,9 @@ import {
   resolveReviewers,
   resolveTarget,
   reviewersAtHead,
+  reviewersCovering,
   unresolvedThreads,
+  verdictCommentReviewers,
   verdictFor,
 } from "./ci-verdict.mjs";
 
@@ -45,6 +47,112 @@ const BASE = {
   advisory: [RABBIT],
 };
 
+/**
+ * A clean verdict as its author actually posts one: an issue comment naming the
+ * commit it read, in the abbreviated form, with no review object anywhere.
+ */
+const verdictComment = (login, sha, created_at = undefined) => ({
+  user: { login },
+  body: `Codex Review: Didn't find any major issues. Keep it up!\n\n**Reviewed commit:** \`${sha.slice(0, 10)}\`\n`,
+  ...(created_at === undefined ? {} : { created_at }),
+});
+
+/**
+ * A reviewer that reports a clean pass WITHOUT opening a review object.
+ *
+ * Measured against this repository: on four pull requests, the one carrying
+ * findings produced review objects and the three clean ones produced none at
+ * all, only a comment. A gate reading the reviews endpoint alone therefore
+ * refuses forever on a revision that was reviewed and passed.
+ */
+describe("verdictCommentReviewers", () => {
+  it("grants coverage from a comment naming the head", () => {
+    expect(verdictCommentReviewers([verdictComment(CODEX, HEAD)], HEAD)).toEqual(
+      [CODEX]
+    );
+  });
+
+  it("ignores a verdict naming a different revision", () => {
+    expect(verdictCommentReviewers([verdictComment(CODEX, OLD)], HEAD)).toEqual(
+      []
+    );
+  });
+
+  it("ignores a comment with no commit named", () => {
+    const chatter = { user: { login: CODEX }, body: "Working on it." };
+    expect(verdictCommentReviewers([chatter], HEAD)).toEqual([]);
+  });
+
+  // The abbreviation is a PREFIX of the head, so a floor keeps a short string
+  // from prefixing many commits. Below it the marker must not match at all.
+  it("refuses an abbreviation shorter than seven characters", () => {
+    const stubby = {
+      user: { login: CODEX },
+      body: "**Reviewed commit:** `aaaaaa`",
+    };
+    expect(verdictCommentReviewers([stubby], HEAD)).toEqual([]);
+  });
+
+  it("matches the COMPLETE login, so a lookalike cannot self-certify", () => {
+    const seen = verdictCommentReviewers(
+      [verdictComment("codex-impersonator", HEAD)],
+      HEAD
+    );
+    expect(seen).not.toContain(CODEX);
+  });
+
+  it("excludes a verdict predating the last base move", () => {
+    const stale = verdictComment(CODEX, HEAD, "2026-08-14T09:00:00Z");
+    expect(verdictCommentReviewers([stale], HEAD, "2026-08-14T10:00:00Z")).toEqual(
+      []
+    );
+  });
+
+  it("counts a verdict after the last base move", () => {
+    const fresh = verdictComment(CODEX, HEAD, "2026-08-14T11:00:00Z");
+    expect(verdictCommentReviewers([fresh], HEAD, "2026-08-14T10:00:00Z")).toEqual(
+      [CODEX]
+    );
+  });
+
+  // A comment with no timestamp cannot be shown to postdate the base move, and
+  // unknown is not the same as covered.
+  it("excludes an undated verdict once a base move is in scope", () => {
+    expect(
+      verdictCommentReviewers(
+        [verdictComment(CODEX, HEAD)],
+        HEAD,
+        "2026-08-14T10:00:00Z"
+      )
+    ).toEqual([]);
+  });
+
+  it("survives absent or malformed input", () => {
+    expect(verdictCommentReviewers(undefined, HEAD)).toEqual([]);
+    expect(verdictCommentReviewers([verdictComment(CODEX, HEAD)], "")).toEqual(
+      []
+    );
+  });
+});
+
+describe("reviewersCovering", () => {
+  it("unions both sources without repeating a reviewer present in each", () => {
+    expect(
+      reviewersCovering(
+        [review(CODEX, HEAD)],
+        [verdictComment(CODEX, HEAD)],
+        HEAD
+      )
+    ).toEqual([CODEX]);
+  });
+
+  it("clears a required reviewer that only ever commented", () => {
+    expect(
+      missingReviewers([], [verdictComment(CODEX, HEAD)], HEAD, [CODEX])
+    ).toEqual([]);
+  });
+});
+
 describe("reviewersAtHead", () => {
   it("reports a reviewer that submitted at the head", () => {
     expect(reviewersAtHead([review(CODEX, HEAD)], HEAD)).toEqual([CODEX]);
@@ -76,7 +184,7 @@ describe("reviewersAtHead", () => {
     const seen = reviewersAtHead([review("codex-impersonator", HEAD)], HEAD);
     expect(seen).not.toContain(CODEX);
     expect(
-      missingReviewers([review("codex-impersonator", HEAD)], HEAD, [CODEX])
+      missingReviewers([review("codex-impersonator", HEAD)], [], HEAD, [CODEX])
     ).toEqual([CODEX]);
   });
 
@@ -665,7 +773,7 @@ describe("rateLimited", () => {
       { user: { login: RABBIT }, body: "Here is the review summary." },
     ];
     expect(rateLimited(comments)).toEqual([]);
-    expect(missingReviewers([], HEAD, [RABBIT])).toEqual([RABBIT]);
+    expect(missingReviewers([], comments, HEAD, [RABBIT])).toEqual([RABBIT]);
   });
 });
 

--- a/scripts/ci-verdict.test.mjs
+++ b/scripts/ci-verdict.test.mjs
@@ -69,16 +69,18 @@ const verdictComment = (login, sha, created_at = undefined) => ({
 describe("verdictCommentReviewers", () => {
   it("grants coverage from a comment naming the head", () => {
     expect(
-      verdictCommentReviewers([verdictComment(CODEX, HEAD)], HEAD, undefined, [
-        HEAD,
-      ])
+      verdictCommentReviewers([verdictComment(CODEX, HEAD)], HEAD, {
+        knownRevisions: [HEAD],
+      })
     ).toEqual([CODEX]);
   });
 
   it("ignores a verdict naming a different revision", () => {
-    expect(verdictCommentReviewers([verdictComment(CODEX, OLD)], HEAD)).toEqual(
-      []
-    );
+    expect(
+      verdictCommentReviewers([verdictComment(CODEX, OLD)], HEAD, {
+        knownRevisions: [HEAD],
+      })
+    ).toEqual([]);
   });
 
   it("ignores a comment with no commit named", () => {
@@ -106,40 +108,48 @@ describe("verdictCommentReviewers", () => {
 
   it("excludes a verdict predating the last base move", () => {
     const stale = verdictComment(CODEX, HEAD, "2026-08-14T09:00:00Z");
-    expect(verdictCommentReviewers([stale], HEAD, "2026-08-14T10:00:00Z")).toEqual(
-      []
-    );
+    expect(
+      verdictCommentReviewers([stale], HEAD, {
+        since: "2026-08-14T10:00:00Z",
+        knownRevisions: [HEAD],
+      })
+    ).toEqual([]);
   });
 
   it("counts a verdict after the last base move", () => {
     const fresh = verdictComment(CODEX, HEAD, "2026-08-14T11:00:00Z");
     expect(
-      verdictCommentReviewers([fresh], HEAD, "2026-08-14T10:00:00Z", [HEAD])
+      verdictCommentReviewers([fresh], HEAD, {
+        since: "2026-08-14T10:00:00Z",
+        knownRevisions: [HEAD],
+      })
     ).toEqual([CODEX]);
   });
 
-  // A comment with no timestamp cannot be shown to postdate the base move, and
-  // unknown is not the same as covered.
   // A reviewer that edits an existing comment to name the newly reviewed
-  // revision has spoken NOW; GitHub keeps the original `created_at`, so keying
-  // on creation alone discarded a valid post-retarget verdict.
+  // revision has spoken NOW, while the creation time still describes the older
+  // verdict.
   it("counts a verdict RESTATED after the base moved", () => {
     const edited = {
       ...verdictComment(CODEX, HEAD, "2026-08-14T09:00:00Z"),
       updated_at: "2026-08-14T11:00:00Z",
     };
     expect(
-      verdictCommentReviewers([edited], HEAD, "2026-08-14T10:00:00Z", [HEAD])
+      verdictCommentReviewers([edited], HEAD, {
+        since: "2026-08-14T10:00:00Z",
+        knownRevisions: [HEAD],
+      })
     ).toEqual([CODEX]);
   });
 
+  // A comment with no timestamp cannot be shown to postdate the base move, and
+  // unknown is not the same as covered.
   it("excludes an undated verdict once a base move is in scope", () => {
     expect(
-      verdictCommentReviewers(
-        [verdictComment(CODEX, HEAD)],
-        HEAD,
-        "2026-08-14T10:00:00Z"
-      )
+      verdictCommentReviewers([verdictComment(CODEX, HEAD)], HEAD, {
+        since: "2026-08-14T10:00:00Z",
+        knownRevisions: [HEAD],
+      })
     ).toEqual([]);
   });
 
@@ -156,10 +166,9 @@ describe("verdictCommentReviewers", () => {
       body: `**Reviewed commit:** \`${shared}\``,
     };
     expect(
-      verdictCommentReviewers([comment], collidingHead, undefined, [
-        collidingHead,
-        olderRevision,
-      ])
+      verdictCommentReviewers([comment], collidingHead, {
+        knownRevisions: [collidingHead, olderRevision],
+      })
     ).toEqual([]);
   });
 
@@ -172,9 +181,20 @@ describe("verdictCommentReviewers", () => {
 
   it("refuses when the head is absent from the revision set", () => {
     expect(
-      verdictCommentReviewers([verdictComment(CODEX, HEAD)], HEAD, undefined, [
-        OLD,
-      ])
+      verdictCommentReviewers([verdictComment(CODEX, HEAD)], HEAD, {
+        knownRevisions: [OLD],
+      })
+    ).toEqual([]);
+  });
+
+  // A rewritten branch no longer lists the revisions an abbreviation would have
+  // to be unique against, while a comment naming a removed one survives.
+  it("refuses every comment verdict once history was rewritten", () => {
+    expect(
+      verdictCommentReviewers([verdictComment(CODEX, HEAD)], HEAD, {
+        knownRevisions: [HEAD],
+        historyRewritten: true,
+      })
     ).toEqual([]);
   });
 
@@ -238,17 +258,16 @@ describe("reviewersCovering", () => {
         [review(CODEX, HEAD)],
         [verdictComment(CODEX, HEAD)],
         HEAD,
-        undefined,
-        [HEAD]
+        { knownRevisions: [HEAD] }
       )
     ).toEqual([CODEX]);
   });
 
   it("clears a required reviewer that only ever commented", () => {
     expect(
-      missingReviewers([], [verdictComment(CODEX, HEAD)], HEAD, [CODEX], undefined, [
-        HEAD,
-      ])
+      missingReviewers([], [verdictComment(CODEX, HEAD)], HEAD, [CODEX], {
+        knownRevisions: [HEAD],
+      })
     ).toEqual([]);
   });
 });

--- a/scripts/verify-merge.mjs
+++ b/scripts/verify-merge.mjs
@@ -203,6 +203,43 @@ export function reviewCoverage(reviewCount) {
 }
 
 /**
+ * The revision a reviewer is known to have read, from either source.
+ *
+ * Pure, and exported, because it is the judgement the merge verdict rests on
+ * and the command around it cannot be handed the awkward cases. The record path
+ * decides wherever a record exists; a comment is consulted only through the
+ * same prefix rule, so it can never clear a revision a record could not.
+ *
+ * Returns the tip when the reviewer covered it, an EARLIER sha when its most
+ * recent verdict was about something else, and `undefined` when it never spoke.
+ * Those are three different answers and the caller distinguishes them.
+ */
+export function reviewedRevision({ reviews, issueComments, tip, login }) {
+  const records = Array.isArray(reviews) ? reviews : [];
+  const comments = Array.isArray(issueComments) ? issueComments : [];
+  const coversTip =
+    reviewsCoveringTip(records, tip, login).length > 0 ||
+    comments.some(
+      comment =>
+        comment?.user?.login === login &&
+        verdictCoversTip(reviewedCommitFrom(comment?.body) ?? "", tip)
+    );
+  if (coversTip) return tip;
+  // Falls back to records ONLY. A comment naming an older revision says which
+  // tree that verdict read, and reporting it here would present a stale opinion
+  // in the same field a current one occupies.
+  return records
+    .filter(
+      r =>
+        SUBMITTED_REVIEW_STATES.includes(r?.state) &&
+        r?.user?.login === login &&
+        r?.commit_id
+    )
+    .map(r => r.commit_id)
+    .pop();
+}
+
+/**
  * The merge gate: every blocker, or an empty list.
  *
  * Returns them all rather than the first, so one round of fixing clears the
@@ -743,6 +780,14 @@ const verdict = await import(
   ).href
 );
 export const SUBMITTED_REVIEW_STATES = verdict.SUBMITTED_REVIEW_STATES;
+/**
+ * The revision a reviewer's comment reports having read.
+ *
+ * Taken from the sibling rather than re-implemented, for the reason its own
+ * export note gives: one comment format parsed in two places stays consistent
+ * only until somebody edits one of them.
+ */
+export const reviewedCommitFrom = verdict.reviewedCommitFrom;
 
 /**
  * Whether the merge took everything the branch had.
@@ -1103,11 +1148,21 @@ export function main(argv) {
     cursor = page.cur;
   }
 
-  // From the review RECORD's own `commit_id`, never from a comment body. An
-  // issue comment is not evidence that a review covered a commit: prose naming
-  // a sha may be progress text rather than a verdict, and a real review whose
-  // sha never appears in its body carries none. Only the record states which
-  // tree was read.
+  // PREFERRED from the review RECORD's own `commit_id`, because only the record
+  // carries a sha the server assigned and nobody can edit afterwards.
+  //
+  // This once read from the record ALONE, on the reasoning that prose naming a
+  // sha may be progress text rather than a verdict. That reasoning still holds
+  // for prose, and it rested on a premise measurement has since refuted: that a
+  // review record exists to be read. It does not always. Across four pull
+  // requests here, the one carrying findings produced review records and the
+  // three CLEAN ones produced none at all — the pass arrived only as a comment
+  // naming the commit it read. Requiring a record therefore made a clean verdict
+  // permanently invisible, which is not caution; it is a gate that cannot open.
+  //
+  // So the record still decides wherever there is one, and a comment is
+  // consulted only when it carries the reviewer's own structured marker naming a
+  // revision. Prose that merely mentions a sha still counts for nothing.
   // `--slurp` returns an array of PAGES and cannot be combined with `--jq`,
   // so the flattening happens here rather than in the query.
   const reviews = ghJson([
@@ -1116,20 +1171,23 @@ export function main(argv) {
     "--slurp",
     `repos/${REPO}/pulls/${pr}/reviews?per_page=100`,
   ]).flat();
+  const issueComments = ghJson([
+    "api",
+    "--paginate",
+    "--slurp",
+    `repos/${REPO}/issues/${pr}/comments?per_page=100`,
+  ]).flat();
   const CODEX = "chatgpt-codex-connector[bot]";
   // Through the same helper the second reviewer uses. Taking the LAST record
   // instead assumes reviews complete in the order they were requested, and an
   // older-head review finishing after a current-head one then hides a verdict
   // that does cover this revision behind one that does not.
-  const submitted = reviews.filter(r =>
-    SUBMITTED_REVIEW_STATES.includes(r?.state)
-  );
-  const reviewedSha = reviewsCoveringTip(reviews, tip, CODEX).length
-    ? tip
-    : submitted
-        .filter(r => r?.user?.login === CODEX && r?.commit_id)
-        .map(r => r.commit_id)
-        .pop();
+  const reviewedSha = reviewedRevision({
+    reviews,
+    issueComments,
+    tip,
+    login: CODEX,
+  });
   // Scoped to THIS revision: a review of an earlier one is not coverage of it.
   const coderabbit = reviewsCoveringTip(
     reviews,

--- a/scripts/verify-merge.mjs
+++ b/scripts/verify-merge.mjs
@@ -811,6 +811,8 @@ export const reviewedCommitFrom = verdict.reviewedCommitFrom;
 export const verdictCommentReviewers = verdict.verdictCommentReviewers;
 /** When the base last moved, from the sibling, for the same reason. */
 export const latestBaseChange = verdict.latestBaseChange;
+/** The revision set, withheld when truncated, from the sibling that owns it. */
+export const completeRevisionSet = verdict.completeRevisionSet;
 
 /**
  * Whether the merge took everything the branch had.
@@ -1208,17 +1210,10 @@ export function main(argv) {
     "--slurp",
     `repos/${REPO}/pulls/${pr}/commits?per_page=100`,
   ]).flat();
-  const revisionShas = prCommits
-    .map(commit => commit?.sha)
-    .filter(value => typeof value === "string");
-  // Withheld unless the endpoint returned every revision. It serves at most 250
-  // and truncates silently, so a short list can omit an earlier revision that
-  // shares the head's prefix while still looking unanimous.
-  const knownRevisions =
-    typeof meta.commits === "number" &&
-    new Set(revisionShas).size >= meta.commits
-      ? revisionShas
-      : undefined;
+  const knownRevisions = completeRevisionSet(
+    prCommits.map(commit => commit?.sha),
+    meta.commits
+  );
   const timeline = timelinePages(pr);
   const historyRewritten = countRewriteEvents(timeline) > 0;
   const reviewedSha = reviewedRevision({

--- a/scripts/verify-merge.mjs
+++ b/scripts/verify-merge.mjs
@@ -1304,9 +1304,31 @@ export function main(argv) {
   // covered without editing the comparison.
   const MUTABLE = "{merged:.merged,state:.state,draft:.draft}";
   const after = ghJson(["api", `repos/${REPO}/pulls/${pr}`, "--jq", MUTABLE]);
+  // Comment evidence is MUTABLE in a way a review record is not: it can be
+  // edited or deleted after this run read it, on an unchanged head, so none of
+  // the facts above would move. Re-read and folded into the same comparison,
+  // because a verdict that has since been withdrawn must not reach a caller as
+  // GATE PASSED.
+  const reviewedShaAfter = reviewedRevision({
+    reviews,
+    issueComments: ghJson([
+      "api",
+      "--paginate",
+      "--slurp",
+      `repos/${REPO}/issues/${pr}/comments?per_page=100`,
+    ]).flat(),
+    tip,
+    login: CODEX,
+    baseChangedAt: latestBaseChange(timelinePages(pr)),
+    knownRevisions: [...new Set([...knownRevisions, tip])],
+  });
   const stale = staleVerification(
-    { merged, state: meta.state, draft: meta.draft, tip },
-    { ...after, tip: lsRemoteTip(REMOTE_FOR_FETCH, meta.branch) }
+    { merged, state: meta.state, draft: meta.draft, tip, reviewedSha },
+    {
+      ...after,
+      tip: lsRemoteTip(REMOTE_FOR_FETCH, meta.branch),
+      reviewedSha: reviewedShaAfter,
+    }
   );
   if (stale) {
     process.stdout.write(

--- a/scripts/verify-merge.mjs
+++ b/scripts/verify-merge.mjs
@@ -221,6 +221,7 @@ export function reviewedRevision({
   login,
   baseChangedAt = undefined,
   knownRevisions = undefined,
+  historyRewritten = false,
 }) {
   const records = Array.isArray(reviews) ? reviews : [];
   const comments = Array.isArray(issueComments) ? issueComments : [];
@@ -230,12 +231,11 @@ export function reviewedRevision({
   // supplies one.
   const coversTip =
     reviewsCoveringTip(records, tip, login).length > 0 ||
-    verdictCommentReviewers(
-      comments,
-      tip,
-      baseChangedAt,
-      knownRevisions
-    ).includes(login);
+    verdictCommentReviewers(comments, tip, {
+      since: baseChangedAt,
+      knownRevisions,
+      historyRewritten,
+    }).includes(login);
   if (coversTip) return tip;
   // Falls back to records ONLY. A comment naming an older revision says which
   // tree that verdict read, and reporting it here would present a stale opinion
@@ -1174,18 +1174,11 @@ export function main(argv) {
   // PREFERRED from the review RECORD's own `commit_id`, because only the record
   // carries a sha the server assigned and nobody can edit afterwards.
   //
-  // This once read from the record ALONE, on the reasoning that prose naming a
-  // sha may be progress text rather than a verdict. That reasoning still holds
-  // for prose, and it rested on a premise measurement has since refuted: that a
-  // review record exists to be read. It does not always. Across four pull
-  // requests here, the one carrying findings produced review records and the
-  // three CLEAN ones produced none at all — the pass arrived only as a comment
-  // naming the commit it read. Requiring a record therefore made a clean verdict
-  // permanently invisible, which is not caution; it is a gate that cannot open.
-  //
-  // So the record still decides wherever there is one, and a comment is
-  // consulted only when it carries the reviewer's own structured marker naming a
-  // revision. Prose that merely mentions a sha still counts for nothing.
+  // A record is not always present: a reviewer may open one only when it has
+  // findings and state a clean pass as a comment. So the record decides
+  // wherever there is one, and a comment is consulted only when it carries the
+  // reviewer's own structured marker naming a revision. Prose that merely
+  // mentions a sha counts for nothing.
   // `--slurp` returns an array of PAGES and cannot be combined with `--jq`,
   // so the flattening happens here rather than in the query.
   const reviews = ghJson([
@@ -1218,12 +1211,15 @@ export function main(argv) {
   const knownRevisions = prCommits
     .map(commit => commit?.sha)
     .filter(value => typeof value === "string");
+  const timeline = timelinePages(pr);
+  const historyRewritten = countRewriteEvents(timeline) > 0;
   const reviewedSha = reviewedRevision({
     reviews,
     issueComments,
     tip,
     login: CODEX,
-    baseChangedAt: latestBaseChange(timelinePages(pr)),
+    historyRewritten,
+    baseChangedAt: latestBaseChange(timeline),
     // The tip is the revision being judged and is not always the last commit
     // the API lists, so it is named explicitly rather than assumed present.
     knownRevisions: [...new Set([...knownRevisions, tip])],
@@ -1305,10 +1301,9 @@ export function main(argv) {
   const MUTABLE = "{merged:.merged,state:.state,draft:.draft}";
   const after = ghJson(["api", `repos/${REPO}/pulls/${pr}`, "--jq", MUTABLE]);
   // Comment evidence is MUTABLE in a way a review record is not: it can be
-  // edited or deleted after this run read it, on an unchanged head, so none of
-  // the facts above would move. Re-read and folded into the same comparison,
-  // because a verdict that has since been withdrawn must not reach a caller as
-  // GATE PASSED.
+  // edited or deleted on an unchanged head, so none of the facts above would
+  // move. Re-read and folded into the same comparison, so a verdict withdrawn
+  // during the run cannot reach a caller as GATE PASSED.
   const reviewedShaAfter = reviewedRevision({
     reviews,
     issueComments: ghJson([
@@ -1319,7 +1314,8 @@ export function main(argv) {
     ]).flat(),
     tip,
     login: CODEX,
-    baseChangedAt: latestBaseChange(timelinePages(pr)),
+    historyRewritten,
+    baseChangedAt: latestBaseChange(timeline),
     knownRevisions: [...new Set([...knownRevisions, tip])],
   });
   const stale = staleVerification(

--- a/scripts/verify-merge.mjs
+++ b/scripts/verify-merge.mjs
@@ -214,16 +214,28 @@ export function reviewCoverage(reviewCount) {
  * recent verdict was about something else, and `undefined` when it never spoke.
  * Those are three different answers and the caller distinguishes them.
  */
-export function reviewedRevision({ reviews, issueComments, tip, login }) {
+export function reviewedRevision({
+  reviews,
+  issueComments,
+  tip,
+  login,
+  baseChangedAt = undefined,
+  knownRevisions = undefined,
+}) {
   const records = Array.isArray(reviews) ? reviews : [];
   const comments = Array.isArray(issueComments) ? issueComments : [];
+  // The comment half is the sibling's decision, so this gate inherits its base
+  // cutoff and its refusal of an ambiguous abbreviation rather than restating
+  // either. Absent a revision set that side refuses, which is why the command
+  // supplies one.
   const coversTip =
     reviewsCoveringTip(records, tip, login).length > 0 ||
-    comments.some(
-      comment =>
-        comment?.user?.login === login &&
-        verdictCoversTip(reviewedCommitFrom(comment?.body) ?? "", tip)
-    );
+    verdictCommentReviewers(
+      comments,
+      tip,
+      baseChangedAt,
+      knownRevisions
+    ).includes(login);
   if (coversTip) return tip;
   // Falls back to records ONLY. A comment naming an older revision says which
   // tree that verdict read, and reporting it here would present a stale opinion
@@ -788,6 +800,17 @@ export const SUBMITTED_REVIEW_STATES = verdict.SUBMITTED_REVIEW_STATES;
  * only until somebody edits one of them.
  */
 export const reviewedCommitFrom = verdict.reviewedCommitFrom;
+/**
+ * The comment-coverage decision, taken whole from the sibling.
+ *
+ * Not re-implemented here. That side already scopes a verdict to the last base
+ * move and refuses an abbreviation that could identify more than one of the
+ * pull request's revisions, and a second copy of either rule would agree only
+ * until one of them was edited.
+ */
+export const verdictCommentReviewers = verdict.verdictCommentReviewers;
+/** When the base last moved, from the sibling, for the same reason. */
+export const latestBaseChange = verdict.latestBaseChange;
 
 /**
  * Whether the merge took everything the branch had.
@@ -1182,11 +1205,28 @@ export function main(argv) {
   // instead assumes reviews complete in the order they were requested, and an
   // older-head review finishing after a current-head one then hides a verdict
   // that does cover this revision behind one that does not.
+  // The pull request's own revisions, so an abbreviation that also identifies
+  // an earlier one is refused rather than trusted, and the moment the base last
+  // moved, so a verdict about a narrower diff cannot cover a wider one. Both
+  // are what the sibling's decision needs; without them it refuses.
+  const prCommits = ghJson([
+    "api",
+    "--paginate",
+    "--slurp",
+    `repos/${REPO}/pulls/${pr}/commits?per_page=100`,
+  ]).flat();
+  const knownRevisions = prCommits
+    .map(commit => commit?.sha)
+    .filter(value => typeof value === "string");
   const reviewedSha = reviewedRevision({
     reviews,
     issueComments,
     tip,
     login: CODEX,
+    baseChangedAt: latestBaseChange(timelinePages(pr)),
+    // The tip is the revision being judged and is not always the last commit
+    // the API lists, so it is named explicitly rather than assumed present.
+    knownRevisions: [...new Set([...knownRevisions, tip])],
   });
   // Scoped to THIS revision: a review of an earlier one is not coverage of it.
   const coderabbit = reviewsCoveringTip(

--- a/scripts/verify-merge.mjs
+++ b/scripts/verify-merge.mjs
@@ -1024,7 +1024,7 @@ export function main(argv) {
     "api",
     `repos/${REPO}/pulls/${pr}`,
     "--jq",
-    "{cross:.head.repo.full_name!=.base.repo.full_name,repo:.head.repo.full_name,branch:.head.ref,merged:.merged,mergeSha:.merge_commit_sha,head:.head.sha,state:.state,draft:.draft,changedFiles:.changed_files,baseRepo:.base.repo.full_name,commits:.commits}",
+    "{cross:.head.repo.full_name!=.base.repo.full_name,repo:.head.repo.full_name,branch:.head.ref,merged:.merged,mergeSha:.merge_commit_sha,head:.head.sha,state:.state,draft:.draft,changedFiles:.changed_files,baseRepo:.base.repo.full_name,baseRef:.base.ref,commits:.commits}",
   ]);
   const remotes = configuredRemotes();
   REMOTE_FOR_FETCH = remoteForRepo(meta.repo, remotes);
@@ -1208,9 +1208,17 @@ export function main(argv) {
     "--slurp",
     `repos/${REPO}/pulls/${pr}/commits?per_page=100`,
   ]).flat();
-  const knownRevisions = prCommits
+  const revisionShas = prCommits
     .map(commit => commit?.sha)
     .filter(value => typeof value === "string");
+  // Withheld unless the endpoint returned every revision. It serves at most 250
+  // and truncates silently, so a short list can omit an earlier revision that
+  // shares the head's prefix while still looking unanimous.
+  const knownRevisions =
+    typeof meta.commits === "number" &&
+    new Set(revisionShas).size >= meta.commits
+      ? revisionShas
+      : undefined;
   const timeline = timelinePages(pr);
   const historyRewritten = countRewriteEvents(timeline) > 0;
   const reviewedSha = reviewedRevision({
@@ -1222,7 +1230,7 @@ export function main(argv) {
     baseChangedAt: latestBaseChange(timeline),
     // The tip is the revision being judged and is not always the last commit
     // the API lists, so it is named explicitly rather than assumed present.
-    knownRevisions: [...new Set([...knownRevisions, tip])],
+    knownRevisions,
   });
   // Scoped to THIS revision: a review of an earlier one is not coverage of it.
   const coderabbit = reviewsCoveringTip(
@@ -1298,7 +1306,11 @@ export function main(argv) {
   // Every mutable fact a blocker depends on, read once at the start and once
   // here. The whole snapshot is compared, so a fact added to the projection is
   // covered without editing the comparison.
-  const MUTABLE = "{merged:.merged,state:.state,draft:.draft}";
+  // `base` rides along because a retarget widens `base..head` without moving
+  // the head, so every other field here would compare equal while the diff a
+  // verdict describes had changed underneath it.
+  const MUTABLE =
+    "{merged:.merged,state:.state,draft:.draft,base:.base.ref}";
   const after = ghJson(["api", `repos/${REPO}/pulls/${pr}`, "--jq", MUTABLE]);
   // Comment evidence is MUTABLE in a way a review record is not: it can be
   // edited or deleted on an unchanged head, so none of the facts above would
@@ -1315,11 +1327,20 @@ export function main(argv) {
     tip,
     login: CODEX,
     historyRewritten,
-    baseChangedAt: latestBaseChange(timeline),
-    knownRevisions: [...new Set([...knownRevisions, tip])],
+    // Re-read, not reused: a retarget landing mid-run changes the cutoff while
+    // leaving the head and every other compared field untouched.
+    baseChangedAt: latestBaseChange(timelinePages(pr)),
+    knownRevisions,
   });
   const stale = staleVerification(
-    { merged, state: meta.state, draft: meta.draft, tip, reviewedSha },
+    {
+      merged,
+      state: meta.state,
+      draft: meta.draft,
+      tip,
+      reviewedSha,
+      base: meta.baseRef,
+    },
     {
       ...after,
       tip: lsRemoteTip(REMOTE_FOR_FETCH, meta.branch),

--- a/scripts/verify-merge.test.mjs
+++ b/scripts/verify-merge.test.mjs
@@ -226,13 +226,14 @@ describe("blockingJobs", () => {
 });
 
 /**
- * A reviewer that reports a clean pass WITHOUT opening a review record.
+ * Which revision a reviewer is known to have read, from either source.
  *
- * This gate required a record, on the reasoning that only a record states which
- * tree was read. Measured across four pull requests here, the one carrying
- * findings produced records and the three CLEAN ones produced none: the pass
- * existed only as a comment naming the commit. Requiring a record therefore
- * made a clean verdict permanently invisible.
+ * A record carries a server-assigned revision and is preferred wherever one
+ * exists. It is not always present: a reviewer may open a record only when it
+ * has findings and state a clean pass as a comment, so a gate reading records
+ * alone cannot tell that verdict from silence. The cases below fix what a
+ * comment must carry before it stands in, and the three answers this returns:
+ * the tip, an earlier revision, or nothing.
  */
 describe("reviewedRevision", () => {
   const CODEX = "chatgpt-codex-connector[bot]";

--- a/scripts/verify-merge.test.mjs
+++ b/scripts/verify-merge.test.mjs
@@ -253,8 +253,58 @@ describe("reviewedRevision", () => {
         issueComments: [cleanComment(CODEX, FULL_TIP)],
         tip: FULL_TIP,
         login: CODEX,
+        knownRevisions: [FULL_TIP],
       })
     ).toBe(FULL_TIP);
+  });
+
+  // Inherited from the sibling's decision rather than restated here, which is
+  // the point of delegating: this gate cannot drift from the other on either
+  // rule below.
+  it("refuses an abbreviation that also identifies an earlier revision", () => {
+    const shared = "91fd950";
+    const older = shared + "0".repeat(40 - shared.length);
+    const comment = {
+      user: { login: CODEX },
+      body: `**Reviewed commit:** \`${shared}\``,
+    };
+    expect(
+      reviewedRevision({
+        reviews: [],
+        issueComments: [comment],
+        tip: FULL_TIP,
+        login: CODEX,
+        knownRevisions: [FULL_TIP, older],
+      })
+    ).toBeUndefined();
+  });
+
+  it("refuses a comment verdict predating a base change", () => {
+    const dated = {
+      ...cleanComment(CODEX, FULL_TIP),
+      created_at: "2026-08-14T09:00:00Z",
+    };
+    expect(
+      reviewedRevision({
+        reviews: [],
+        issueComments: [dated],
+        tip: FULL_TIP,
+        login: CODEX,
+        baseChangedAt: "2026-08-14T10:00:00Z",
+        knownRevisions: [FULL_TIP],
+      })
+    ).toBeUndefined();
+  });
+
+  it("refuses comment evidence when no revision set is supplied", () => {
+    expect(
+      reviewedRevision({
+        reviews: [],
+        issueComments: [cleanComment(CODEX, FULL_TIP)],
+        tip: FULL_TIP,
+        login: CODEX,
+      })
+    ).toBeUndefined();
   });
 
   it("still prefers the record when one exists", () => {
@@ -279,6 +329,7 @@ describe("reviewedRevision", () => {
         issueComments: [cleanComment(CODEX, older)],
         tip: FULL_TIP,
         login: CODEX,
+        knownRevisions: [FULL_TIP],
       })
     ).toBeUndefined();
   });
@@ -290,6 +341,7 @@ describe("reviewedRevision", () => {
         issueComments: [cleanComment("codex-impersonator", FULL_TIP)],
         tip: FULL_TIP,
         login: CODEX,
+        knownRevisions: [FULL_TIP],
       })
     ).toBeUndefined();
   });
@@ -305,6 +357,7 @@ describe("reviewedRevision", () => {
         issueComments: [prose],
         tip: FULL_TIP,
         login: CODEX,
+        knownRevisions: [FULL_TIP],
       })
     ).toBeUndefined();
   });

--- a/scripts/verify-merge.test.mjs
+++ b/scripts/verify-merge.test.mjs
@@ -37,6 +37,7 @@ import {
   repoFromRemoteUrl,
   requiredChecks,
   reviewCoverage,
+  reviewedRevision,
   SUBMITTED_REVIEW_STATES,
   reviewsCoveringTip,
   runCli,
@@ -221,6 +222,122 @@ describe("blockingJobs", () => {
 
   it("returns nothing when every job passes", () => {
     expect(blockingJobs([green("a"), green("b")])).toEqual([]);
+  });
+});
+
+/**
+ * A reviewer that reports a clean pass WITHOUT opening a review record.
+ *
+ * This gate required a record, on the reasoning that only a record states which
+ * tree was read. Measured across four pull requests here, the one carrying
+ * findings produced records and the three CLEAN ones produced none: the pass
+ * existed only as a comment naming the commit. Requiring a record therefore
+ * made a clean verdict permanently invisible.
+ */
+describe("reviewedRevision", () => {
+  const CODEX = "chatgpt-codex-connector[bot]";
+  const cleanComment = (login, sha) => ({
+    user: { login },
+    body: `Codex Review: Didn't find any major issues.\n\n**Reviewed commit:** \`${sha.slice(0, 10)}\`\n`,
+  });
+  const record = (login, commit_id) => ({
+    user: { login },
+    commit_id,
+    state: "COMMENTED",
+  });
+
+  it("reports the tip when only a comment covers it", () => {
+    expect(
+      reviewedRevision({
+        reviews: [],
+        issueComments: [cleanComment(CODEX, FULL_TIP)],
+        tip: FULL_TIP,
+        login: CODEX,
+      })
+    ).toBe(FULL_TIP);
+  });
+
+  it("still prefers the record when one exists", () => {
+    expect(
+      reviewedRevision({
+        reviews: [record(CODEX, FULL_TIP)],
+        issueComments: [],
+        tip: FULL_TIP,
+        login: CODEX,
+      })
+    ).toBe(FULL_TIP);
+  });
+
+  // The comment path goes through the SAME prefix rule, so it cannot clear a
+  // revision a record could not: this reviewer comments every round, and an
+  // older one would otherwise certify whatever was pushed after it.
+  it("does not let a comment about an earlier revision cover the tip", () => {
+    const older = "0000000000000000000000000000000000000000";
+    expect(
+      reviewedRevision({
+        reviews: [],
+        issueComments: [cleanComment(CODEX, older)],
+        tip: FULL_TIP,
+        login: CODEX,
+      })
+    ).toBeUndefined();
+  });
+
+  it("ignores a comment from a lookalike account", () => {
+    expect(
+      reviewedRevision({
+        reviews: [],
+        issueComments: [cleanComment("codex-impersonator", FULL_TIP)],
+        tip: FULL_TIP,
+        login: CODEX,
+      })
+    ).toBeUndefined();
+  });
+
+  it("ignores prose that merely mentions a sha", () => {
+    const prose = {
+      user: { login: CODEX },
+      body: `Looking at ${FULL_TIP} now.`,
+    };
+    expect(
+      reviewedRevision({
+        reviews: [],
+        issueComments: [prose],
+        tip: FULL_TIP,
+        login: CODEX,
+      })
+    ).toBeUndefined();
+  });
+
+  it("reports never-spoke and covered-an-earlier-revision differently", () => {
+    const older = "0000000000000000000000000000000000000000";
+    expect(
+      reviewedRevision({
+        reviews: [],
+        issueComments: [],
+        tip: FULL_TIP,
+        login: CODEX,
+      })
+    ).toBeUndefined();
+    expect(
+      reviewedRevision({
+        reviews: [record(CODEX, older)],
+        issueComments: [],
+        tip: FULL_TIP,
+        login: CODEX,
+      })
+    ).toBe(older);
+  });
+
+  it("survives absent input rather than throwing", () => {
+    expect(
+      reviewedRevision({
+        reviews: undefined,
+        issueComments: undefined,
+        tip: FULL_TIP,
+        login: CODEX,
+      })
+    ).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
## The defect

Both gates asked `pulls/N/reviews` alone, on the assumption stated in
`ci-verdict.mjs`'s own header: that "a review object proves a reviewer saw a
commit whether or not it carried findings."

That assumption is false for the blocking reviewer. Measured across four pull
requests in this repository:

| PR | Codex review objects | Codex issue comments | outcome |
| --- | --- | --- | --- |
| #845 | 2 | 2 | had findings |
| #849 | **0** | 1 | clean |
| #853 | **0** | 1 | clean |
| #856 | **0** | 1 | clean |

Findings become review objects. A clean pass is an issue comment carrying
`**Reviewed commit:** <sha>` and nothing else.

So neither gate could see a clean verdict. They refused on exactly the pull
requests that were ready, which is the worst direction for a merge gate to
fail: not a false pass, but a guard so useless that the merges it exists to
protect route around it.

## Both gates, because the second is the higher-traffic one

`verify-merge.mjs` is what the merge precondition in
`.claude/rules/verifying-merged-work.md` tells everyone to run.

It rejected comment bodies deliberately, and said so: "only the record states
which tree was read." That reasoning still holds for prose, and it rested on a
premise this measurement refutes, which is that a record exists to be read.
The comment now explains why the earlier decision no longer applies rather than
silently contradicting it.

## What is preserved

- **The record still decides wherever there is one.** The comment path is
  strictly additive, and the header says why it is the weaker source: a record
  carries a server-assigned `commit_id`, a comment can be edited afterwards.
- **The same prefix rule.** A comment goes through `verdictCoversTip`, so it can
  never clear a revision a record could not, and the 7-character floor is git's
  own for an abbreviation that identifies a commit.
- **Prose still counts for nothing.** Only the reviewer's structured marker is
  read, so a comment mentioning a sha in passing is not a verdict.
- **Identity.** Still matched on the complete `...[bot]` login.
- **Outstanding work is untouched.** Threads are still read from GitHub's
  resolution state, so a comment-sourced verdict cannot clear an open thread.
- **One parser.** `reviewedCommitFrom` is exported from `ci-verdict.mjs` and
  imported by `verify-merge.mjs` through the same sibling channel #853
  established for the review-state vocabulary.

## Evidence

**Gate 1**, against #857, whose Codex verdict was clean at head throughout:

```
before:  MISSING REVIEW AT HEAD   exit 10
after:   CLEAN                    exit 0   reviewed_head: [chatgpt-codex-connector[bot]]
```

**Gate 2**, controlled: `main`'s copy and this branch's copy run against the
same merged PR #856, differing only in this change. The single line of diff:

```
main:  - verdict-stale: no review verdict for 6aaf0ff6c
this:  (absent)
```

Codex had reviewed #856. `main`'s gate reported that it had not.

A **second live instance**, on a pull request this change's author did not
write, reported independently by the lane that owns it. Same comparison against
#832:

```
main:  - verdict-stale: no review verdict for 2f3ccbc00
this:  (absent)
```

Two instances, two lanes, one of them found before this fix existed. On #832
that line was the only thing between the gate and clean, so a lane reading it as
authoritative would have concluded the pull request was unreviewed when it was
not.

Each property broken from the committed SHA and observed to fail for its own
reason:

| broken | result |
| --- | --- |
| drop the comment source from the union (gate 1) | returns to exit 10 on #857; `clears a required reviewer that only ever commented` fails |
| remove the head-naming check (gate 1) | `ignores a verdict naming a different revision` fails |
| drop the comment source from `reviewedRevision` (gate 2) | `reports the tip when only a comment covers it` fails |

The derivation in gate 2 moved out of the command into the exported, pure
`reviewedRevision`, because it is the judgement the verdict rests on and the
command around it cannot be handed the awkward cases.

## Checks

- `npx vitest run --dir scripts` 421 passed (403 baseline, +18 here)
- both gates exercised in both symlink modes, `node <link>` and
  `NODE_OPTIONS=--preserve-symlinks-main node <link>`, each the usage line and
  exit 2. This matters here because `verify-merge.mjs` resolves its sibling
  through `realpathSync` and this change adds an export to that channel.
- `check-comment-convention.mjs` exit 0

No changeset: `scripts/` belongs to no workspace package.
