### PR TITLE
ci(root): land the hash-coverage commits stranded by #858

### DIFF
--- a/scripts/turbo-inputs.test.mjs
+++ b/scripts/turbo-inputs.test.mjs
@@ -42,11 +42,22 @@ const TYPESCRIPT_EXTENSIONS = /\.(?:ts|tsx|mts|cts)$/;
  * answer accounts for `$TURBO_DEFAULT$`, negations and per-package overrides
  * that a pattern-by-pattern re-implementation here would have to model.
  */
+/**
+ * Long enough for a real compiler probe.
+ *
+ * Each case launches `tsc` synchronously, which takes seconds rather than
+ * milliseconds — and Vitest's 5s default applies per case, so the suite fails
+ * on duration while every assertion in it is correct. That failure is
+ * indistinguishable from a hash gap in the summary line, which is the reason
+ * this is a named constant rather than a number tucked into one call.
+ */
+const PROBE_TIMEOUT_MS = 180_000;
+
 function dryRun() {
   const raw = execFileSync(
     "pnpm",
     ["exec", "turbo", "run", "check-types", "--dry=json"],
-    { encoding: "utf8", maxBuffer: 64 * 1024 * 1024 }
+    { cwd: REPO_ROOT, encoding: "utf8", maxBuffer: 64 * 1024 * 1024 }
   );
   // Turbo's document is pretty-printed from column zero, while the tools around
   // it are not silent: pnpm emits config warnings and turbo a version banner,
@@ -160,12 +171,42 @@ describe("turbo hashes every TypeScript module it type-checks", () => {
 
 /** Every path git tracks, so a generated file is never mistaken for a source input. */
 function trackedPaths() {
+  // `cwd` pinned to the repository root, as everywhere else here: `git ls-files`
+  // prints paths relative to the working directory, so running this suite from
+  // `scripts/` would yield a set that shares no member with the
+  // repository-relative paths the compiler reports — and every program file
+  // would then read as untracked and be skipped as generated output. The guard
+  // would pass by checking nothing.
   return new Set(
     execFileSync("git", ["ls-files"], {
+      cwd: REPO_ROOT,
       encoding: "utf8",
       maxBuffer: 64 * 1024 * 1024,
     }).split("\n")
   );
+}
+
+/**
+ * Every tsconfig a package's `check-types` command actually compiles.
+ *
+ * Five packages here run TWO passes — `tsc --noEmit && tsc --noEmit -p
+ * tsconfig.tests.json` — because their shipping config excludes the test files.
+ * Probing only the implicit `tsconfig.json` leaves whatever is unique to the
+ * second program invisible, so an unhashed input reachable only from a test
+ * would pass this guard: the same too-narrow-population defect the guard exists
+ * to catch, one level up.
+ *
+ * Derived from the command rather than from a list of packages, so a package
+ * that gains or loses a pass is covered without anyone editing this.
+ */
+function projectConfigs(command) {
+  const configs = [];
+  for (const invocation of String(command).split("&&")) {
+    if (!/\btsc\b/.test(invocation)) continue;
+    const explicit = /(?:-p|--project)\s+(\S+)/.exec(invocation);
+    configs.push(explicit ? explicit[1] : "tsconfig.json");
+  }
+  return configs.length > 0 ? configs : ["tsconfig.json"];
 }
 
 /**
@@ -177,15 +218,19 @@ function trackedPaths() {
  * either way: the question here is which files were reached, not whether they
  * compiled.
  */
-function programFiles(directory) {
+function programFiles(directory, config) {
   let output = "";
   try {
-    output = execFileSync("pnpm", ["exec", "tsc", "--noEmit", "--listFilesOnly"], {
-      cwd: join(REPO_ROOT, directory),
-      encoding: "utf8",
-      maxBuffer: 64 * 1024 * 1024,
-      stdio: ["ignore", "pipe", "ignore"],
-    });
+    output = execFileSync(
+      "pnpm",
+      ["exec", "tsc", "--noEmit", "--listFilesOnly", "-p", config],
+      {
+        cwd: join(REPO_ROOT, directory),
+        encoding: "utf8",
+        maxBuffer: 64 * 1024 * 1024,
+        stdio: ["ignore", "pipe", "ignore"],
+      }
+    );
   } catch (error) {
     output = typeof error.stdout === "string" ? error.stdout : "";
   }
@@ -230,12 +275,19 @@ describe("every tracked file a compiler reads is covered by some hash", () => {
         .map(id => byPackage.get(id.split("#")[0])?.directory)
         .filter(Boolean);
 
-      const program = programFiles(task.directory);
+      // The UNION over every config the package's command compiles, not just
+      // the implicit one.
+      const configs = projectConfigs(task.command);
+      const program = [
+        ...new Set(
+          configs.flatMap(config => programFiles(task.directory, config))
+        ),
+      ];
       // Guards the guard: a compiler that produced no list would satisfy the
       // assertion below by having read nothing.
       expect(
         program.length,
-        `no program resolved for ${task.package} — the tsc invocation, not the package, is probably wrong`
+        `no program resolved for ${task.package} from ${configs.join(", ")} — the tsc invocation, not the package, is probably wrong`
       ).toBeGreaterThan(0);
 
       const uncovered = program.filter(file => {
@@ -256,7 +308,8 @@ describe("every tracked file a compiler reads is covered by some hash", () => {
         uncovered,
         `${task.package} compiles ${String(uncovered.length)} tracked file(s) that no hash covers, so editing one leaves its cache valid:\n  ${uncovered.slice(0, 10).join("\n  ")}`
       ).toEqual([]);
-    }
+    },
+    PROBE_TIMEOUT_MS
   );
 });
 

--- a/scripts/turbo-inputs.test.mjs
+++ b/scripts/turbo-inputs.test.mjs
@@ -285,11 +285,13 @@ describe("a package's hash covers the program it actually compiles", () => {
 });
 
 describe("the shared TypeScript config is hashed", () => {
-  // `check-types` declares `dependsOn: []`, so no package has a graph edge to
-  // `@nextlyhq/tsconfig` — yet 22 of them extend its `base.json`, which decides
-  // `strict`, `target` and `lib`. Without a global entry, changing a compiler
-  // setting leaves every hash in the repository unmoved at once, which is the
-  // same defect as above with the blast radius of the whole monorepo.
+  // 22 packages extend `@nextlyhq/tsconfig`'s `base.json`, which decides
+  // `strict`, `target` and `lib`. The `^check-types` edge gives most of them a
+  // graph edge to it, so this is no longer the only cover — it is asserted
+  // because that edge is a property of the task graph rather than of the
+  // configs, and reaches neither a task without one nor a consumer that reads
+  // these files by relative path. Without the global entry, changing a compiler
+  // setting can leave hashes unmoved across the whole repository at once.
   it("counts packages/tsconfig among the global dependencies", () => {
     const globalFiles = Object.keys(dryRun().globalCacheInputs.files);
     expect(globalFiles).toContain("packages/tsconfig/base.json");

--- a/scripts/turbo-inputs.test.mjs
+++ b/scripts/turbo-inputs.test.mjs
@@ -23,7 +23,15 @@
  * @module turbo-inputs.test
  */
 import { execFileSync } from "node:child_process";
+import { dirname, join, relative } from "node:path";
+import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
+
+/**
+ * The repository root, derived from this module rather than `process.cwd()`,
+ * which differs between a run from the root and one filtered to `scripts`.
+ */
+const REPO_ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
 
 /** Extensions the TypeScript compiler follows, so a change to one can break a build. */
 const TYPESCRIPT_EXTENSIONS = /\.(?:ts|tsx|mts|cts)$/;
@@ -145,6 +153,108 @@ describe("turbo hashes every TypeScript module it type-checks", () => {
       expect(
         unhashed,
         `${task.package} ships ${String(unhashed.length)} TypeScript module(s) that turbo does not hash, so editing one leaves the cache valid and CI replays the previous result:\n  ${unhashed.slice(0, 10).join("\n  ")}`
+      ).toEqual([]);
+    }
+  );
+});
+
+/** Every path git tracks, so a generated file is never mistaken for a source input. */
+function trackedPaths() {
+  return new Set(
+    execFileSync("git", ["ls-files"], {
+      encoding: "utf8",
+      maxBuffer: 64 * 1024 * 1024,
+    }).split("\n")
+  );
+}
+
+/**
+ * The files a package's compiler actually READS, repo-relative.
+ *
+ * `--listFilesOnly` resolves the program without type-checking it, so this is
+ * the compiler's own answer rather than a second reading of `tsconfig`. A
+ * failing invocation still prints the list it built, so its output is used
+ * either way: the question here is which files were reached, not whether they
+ * compiled.
+ */
+function programFiles(directory) {
+  let output = "";
+  try {
+    output = execFileSync("pnpm", ["exec", "tsc", "--noEmit", "--listFilesOnly"], {
+      cwd: join(REPO_ROOT, directory),
+      encoding: "utf8",
+      maxBuffer: 64 * 1024 * 1024,
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+  } catch (error) {
+    output = typeof error.stdout === "string" ? error.stdout : "";
+  }
+  return output
+    .split("\n")
+    .map(line => line.trim())
+    .filter(Boolean)
+    .map(file => relative(REPO_ROOT, file))
+    .filter(file => !file.startsWith("..") && !file.includes("node_modules"));
+}
+
+describe("every tracked file a compiler reads is covered by some hash", () => {
+  // The package-scoped check above found its gap along one axis, `^check-types`
+  // closed a second, and a root script sat outside both. Three axes, three
+  // fixes, each invisible until someone happened to look — which is the shape
+  // that says the INSTRUMENT is wrong rather than that the fixes were.
+  //
+  // So the population here is not "files under the package directory" but the
+  // program the compiler resolves, which is the thing the property is actually
+  // about. A future axis nobody has thought of fails this without anyone having
+  // to predict it.
+  const dry = dryRun();
+  const globalFiles = new Set(Object.keys(dry.globalCacheInputs.files));
+  const byPackage = new Map(dry.tasks.map(task => [task.package, task]));
+  const runnable = dry.tasks.filter(
+    task => !String(task.command).includes("NONEXISTENT")
+  );
+  const tracked = trackedPaths();
+
+  it("reads a populated task list", () => {
+    expect(runnable.length).toBeGreaterThan(15);
+    expect(runnable.map(task => task.package)).toContain("playground");
+  });
+
+  it.each(runnable.map(task => [task.package, task]))(
+    "%s: every tracked file its compiler reads moves its hash",
+    (_name, task) => {
+      const own = new Set(Object.keys(task.inputs));
+      // A dependency's files are covered transitively: `^check-types` folds its
+      // hash in, and that hash is computed from those files.
+      const dependencyDirs = (task.dependencies ?? [])
+        .map(id => byPackage.get(id.split("#")[0])?.directory)
+        .filter(Boolean);
+
+      const program = programFiles(task.directory);
+      // Guards the guard: a compiler that produced no list would satisfy the
+      // assertion below by having read nothing.
+      expect(
+        program.length,
+        `no program resolved for ${task.package} — the tsc invocation, not the package, is probably wrong`
+      ).toBeGreaterThan(0);
+
+      const uncovered = program.filter(file => {
+        // Generated output is not a source input: its content is derived from
+        // files that ARE tracked, and those are what a hash must follow.
+        if (!tracked.has(file)) return false;
+        if (globalFiles.has(file)) return false;
+        if (
+          file.startsWith(`${task.directory}/`) &&
+          own.has(file.slice(task.directory.length + 1))
+        ) {
+          return false;
+        }
+        return !dependencyDirs.some(dir => file.startsWith(`${dir}/`));
+      });
+
+      expect(
+        uncovered,
+        `${task.package} compiles ${String(uncovered.length)} tracked file(s) that no hash covers, so editing one leaves its cache valid:\n  ${uncovered.slice(0, 10).join("\n  ")}`
       ).toEqual([]);
     }
   );

--- a/turbo.jsonc
+++ b/turbo.jsonc
@@ -43,24 +43,35 @@
   "$schema": "https://v2-9-7.turborepo.dev/schema.json",
   "ui": "tui", // Terminal UI for better task visualization
 
-  // Files OUTSIDE any package that every task's result depends on.
+  // Files OUTSIDE any package that a task's result depends on.
   //
-  // A task's hash covers its own package's files and its dependencies' hashes.
-  // The shared TypeScript configs belong to neither: 22 packages extend
-  // `@nextlyhq/tsconfig`, and `check-types` declares `dependsOn: []`, so there is
-  // no edge from a package to the config that decides what its compiler does.
-  // Without this entry, editing `base.json` — turning on a strict flag, moving
-  // `target`, changing `lib` — leaves every package's hash unmoved and turbo
-  // replays greens computed under the OLD settings, across the whole repository
-  // at once. Measured before adding it: appending a newline to
-  // `packages/tsconfig/base.json` left `@nextlyhq/e2e#check-types` on the
-  // identical hash `e2f45f80054274ba`.
+  // A task's hash covers its own package's files plus, through `dependsOn`, its
+  // dependencies' hashes. Anything belonging to NEITHER is invisible to it, and
+  // a file the compiler reads but the hash cannot see is a replayed green
+  // waiting to happen. Two trees are in that position:
   //
-  // Deliberately coarse. It invalidates every task rather than only the
-  // type-aware ones, because a compiler setting reaches builds and type-aware
-  // lint rules as well, and the cost of an unnecessary re-run is minutes while
-  // the cost of a missed one is a replayed green nobody can see through.
-  "globalDependencies": ["packages/tsconfig/*.json"],
+  // - `packages/tsconfig/*.json`: 22 packages extend `@nextlyhq/tsconfig`, and
+  //   it decides `strict`, `target` and `lib`. The `^check-types` edge below
+  //   now gives most of them a graph edge to it, so this is no longer the ONLY
+  //   thing covering them — it remains because that edge is a property of the
+  //   task graph rather than of the configs, and it does not reach tasks with
+  //   no such edge or consumers that read these files by relative path.
+  // - `scripts/**`: root scripts sit in no package at all, so no edge of any
+  //   kind can reach them. `apps/playground` compiles `scripts/dev-doctor.mjs`
+  //   through a test, and before this entry, editing that file left
+  //   `playground#check-types` on the identical hash `62b43e8dbf627e65`.
+  //
+  // Both are deliberately coarse, invalidating every task rather than the
+  // type-aware ones, because a compiler setting or a shared script reaches
+  // builds and type-aware lint too. The cost of an unnecessary re-run is
+  // minutes; the cost of a missed one is a green nobody can see through.
+  //
+  // `scripts/**` is the wide answer to a narrow fact: exactly ONE tracked file
+  // needs it today. Listing that file instead would be the enumeration this
+  // task's `inputs` were changed to stop doing, and the guard in
+  // `scripts/turbo-inputs.test.mjs` reports any tracked program input that no
+  // hash covers — so a future one fails CI rather than passing quietly.
+  "globalDependencies": ["packages/tsconfig/*.json", "scripts/**"],
 
   // Runtime env vars referenced from package source (not build-time inputs).
   // Listed here so eslint-plugin-turbo's no-undeclared-env-vars rule passes.


### PR DESCRIPTION
## What this is

**#858 merged at `0bb960eb8` and stranded its last two commits.** This lands them.

The two commits fix the P1 and P2 from #858's final Codex round, which arrived after the merge was computed. Neither is on `main`.

## How it was found, and the trap in finding it

The stranded-tail screen from `.claude/rules/verifying-merged-work.md`:

```
$ git log --oneline 0bb960eb8..753636135
753636135 docs(root): state what still needs the shared-config global entry
11b815daa ci(root): derive the guard's population from the compiler's own program
```

**My first content check said `scripts/**` HAD landed, and it was wrong.** `git grep -c -F -e '"scripts/**"'` returned 1 against the merge commit — matching the phrase inside a *comment*, not the config line. The marker was not unique to the change. Reading the actual line settled it:

| | merge commit | branch tip |
| --- | --- | --- |
| `globalDependencies` | `["packages/tsconfig/*.json"]` | `["packages/tsconfig/*.json", "scripts/**"]` |
| guard derives from `--listFilesOnly` | absent | present |

That is the "marker must be unique to the commit" rule earning itself: a grep that matches prose reports a lost commit as landed.

## What `main` is missing

**1. A third hashing axis, still open.** `scripts/dev-doctor.mjs` is in `apps/playground`'s compiler program but in no package, so neither `$TURBO_DEFAULT$` (package-scoped) nor the `^check-types` edge (workspace-graph-scoped) reaches it. Measured on current `main`: editing it leaves `playground#check-types` on the identical hash `62b43e8dbf627e65`.

**2. The guard cannot see it.** The version on `main` enumerates files under the package directory — an abstraction that structurally cannot represent a cross-package or root input, which is why three separate fixes were each needed for one defect.

## What these commits do

The guard's POPULATION now comes from `tsc --listFilesOnly` — the compiler's own answer to "which files does this program read" — instead of a directory listing. Each tracked file must be covered by the package's inputs, a global entry, or a dependency's directory. **An axis nobody has predicted fails CI without anyone having to think of it.**

Run across all 22 packages it reports **exactly one** uncovered tracked file, which is why `scripts/**` goes in as a wide entry rather than naming that file — listing it would be the enumeration this work exists to remove.

Generated output is excluded deliberately: dependency `dist/*.d.ts`, `next-env.d.ts` and `.next-e2e/**` are all in these programs and none is a source input, since their content follows tracked files. Restricting to `git ls-files` is what makes the assertion meaningful rather than noisy.

## Verification

- **Stub-verified**: removing `scripts/**` fails with `playground compiles 1 tracked file(s) that no hash covers`. Restored.
- Guard: **52 tests green**. Full scripts suite: **455 green**.
- Cherry-picked onto current `main` with no conflicts; `globalDependencies` and the `--listFilesOnly` derivation both confirmed present at this tip.

No changeset: CI configuration and a test.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved build change detection so updates to shared TypeScript configuration and root-level scripts correctly trigger affected tasks to rerun.
  - Enhanced task hashing to reduce the risk of stale build results.

- **Tests**
  - Added validation that runnable tasks are available and all tracked compiler inputs are included in change tracking.
  - Expanded coverage to verify dependency and global input handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->