### PR TITLE
feat(plugin-page-builder): convert legacy nested documents to the engine format

### DIFF
--- a/.changeset/legacy-block-document-converter.md
+++ b/.changeset/legacy-block-document-converter.md
@@ -1,0 +1,28 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+A legacy nested block document can now be converted to the engine's flat document format. Anything the two shapes do not share, such as entrance motion, a raw custom class, or stored SEO, is reported rather than dropped silently, so a conversion that loses data is distinguishable from one that worked.

--- a/packages/plugin-page-builder/src/core/legacy-document.test.ts
+++ b/packages/plugin-page-builder/src/core/legacy-document.test.ts
@@ -201,7 +201,27 @@ describe("toEngineDocument", () => {
   });
 
   describe("bindings", () => {
-    it("rewrites `path` onto `$bind` against the owning entry", () => {
+    it("binds to the loop ITEM, not the entry owning the document", () => {
+      // The distinction decides whether a repeated block shows its own row.
+      // Legacy bindings resolve only inside a collection loop, so "field"
+      // always meant the current item; `entry` is the page, so converting to
+      // it would leave every repetition showing the same values. Nothing
+      // structural separates the two — both are a well-formed binding — so
+      // this assertion has to name the source explicitly.
+      const { document } = toEngineDocument(
+        doc(
+          wrapper([
+            node("a", {
+              bindings: { text: { source: "field", path: "author.name" } },
+            }),
+          ])
+        )
+      );
+
+      expect(document.nodes[0].bindings?.text.source).toBe("item");
+    });
+
+    it("rewrites `path` onto `$bind`", () => {
       const { document } = toEngineDocument(
         doc(
           wrapper([
@@ -213,7 +233,7 @@ describe("toEngineDocument", () => {
       );
 
       expect(document.nodes[0].bindings).toEqual({
-        text: { source: "entry", $bind: "author.name" },
+        text: { source: "item", $bind: "author.name" },
       });
     });
 
@@ -286,6 +306,27 @@ describe("toEngineDocument", () => {
       expect(document.nodes[0].styles).toEqual({
         base: { base: { color: "#111" } },
         hover: { base: { color: "#222" } },
+      });
+    });
+
+    it("rewrites a legacy token reference onto the engine's spelling", () => {
+      // The two spellings differ only in the key: legacy `{ token }` against
+      // the engine's `{ $token }`. Left alone, a token survives the generic
+      // object walk as an ordinary nested object — present, well-formed, and
+      // no longer a token. So asserting the value merely EXISTS passes on the
+      // broken conversion; the key is the whole property under test.
+      const { document } = toEngineDocument(
+        doc(
+          wrapper([
+            node("a", {
+              style: { base: { color: { token: "color.primary" } } },
+            }),
+          ])
+        )
+      );
+
+      expect(document.nodes[0].styles?.base?.base).toEqual({
+        color: { $token: "color.primary" },
       });
     });
 

--- a/packages/plugin-page-builder/src/core/legacy-document.test.ts
+++ b/packages/plugin-page-builder/src/core/legacy-document.test.ts
@@ -261,6 +261,19 @@ describe("toEngineDocument", () => {
   });
 
   describe("the root the author built", () => {
+    it("is still unwrapped when its attribute map is EMPTY", () => {
+      // Clearing the last attribute in the legacy editor stores `{}` rather
+      // than removing the field, so an untouched wrapper can legitimately
+      // carry one. Treating that as authorship preserves a `core/container`
+      // with no behaviour to preserve.
+      const wrapped = wrapper([node("a")]);
+      wrapped.attributes = {};
+
+      const { document } = toEngineDocument(doc(wrapped));
+
+      expect(document.nodes.map(n => n.id)).toEqual(["a"]);
+    });
+
     it("is kept as a real block rather than unwrapped", () => {
       // Unwrapping a container the author added would change how the page
       // renders — its padding and background would simply stop applying.
@@ -355,7 +368,12 @@ describe("toEngineDocument", () => {
 
 describe("isLegacyDocument", () => {
   it("separates the two envelopes on key presence alone", () => {
-    expect(isLegacyDocument({ version: 1, root: { id: "r" } })).toBe(true);
+    expect(
+      isLegacyDocument({
+        version: 1,
+        root: { id: "r", type: "core/container", props: {} },
+      })
+    ).toBe(true);
     expect(
       isLegacyDocument({ formatVersion: 1, kind: "page", nodes: [] })
     ).toBe(false);
@@ -365,5 +383,32 @@ describe("isLegacyDocument", () => {
     for (const value of [null, undefined, 7, "root", [], { root: "no" }]) {
       expect(isLegacyDocument(value)).toBe(false);
     }
+  });
+
+  it("refuses a root that cannot survive the conversion", () => {
+    // The guard has to promise what the narrowed type promises. A shallower
+    // one accepts these, narrows with TypeScript's blessing, and then throws
+    // partway through the walk — turning a repairable row into a failed
+    // migration instead of a controlled rejection.
+    for (const root of [
+      {},
+      { id: "r" },
+      { id: "r", type: "core/container" },
+      { id: "r", type: "core/container", props: "no" },
+      { id: 7, type: "core/container", props: {} },
+    ]) {
+      expect(isLegacyDocument({ version: 1, root })).toBe(false);
+    }
+  });
+
+  it("still accepts a well-formed legacy document", () => {
+    // Without this, tightening the guard to reject everything would satisfy
+    // the assertion above.
+    expect(
+      isLegacyDocument({
+        version: 1,
+        root: { id: "r", type: "core/container", props: {} },
+      })
+    ).toBe(true);
   });
 });

--- a/packages/plugin-page-builder/src/core/legacy-document.test.ts
+++ b/packages/plugin-page-builder/src/core/legacy-document.test.ts
@@ -1,0 +1,328 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  isLegacyDocument,
+  toEngineDocument,
+  type ConversionNote,
+} from "./legacy-document";
+import type { BlockDocument as LegacyDocument, BlockNode } from "./types";
+
+/** A legacy node with only what a caller cares about spelled out. */
+function node(id: string, over: Partial<BlockNode> = {}): BlockNode {
+  return { id, type: "core/heading", props: {}, ...over };
+}
+
+/** The editor's synthetic wrapper: an empty container holding `children`. */
+function wrapper(children: BlockNode[]): BlockNode {
+  return {
+    id: "root",
+    type: "core/container",
+    props: {},
+    slots: { default: children },
+  };
+}
+
+function doc(
+  root: BlockNode,
+  over: Partial<LegacyDocument> = {}
+): LegacyDocument {
+  return { version: 1, root, ...over };
+}
+
+function noteFor(notes: ConversionNote[], field: string): ConversionNote {
+  const found = notes.find(n => n.field === field);
+  if (!found) throw new Error(`expected a note for "${field}"`);
+  return found;
+}
+
+describe("toEngineDocument", () => {
+  it("promotes the synthetic wrapper's children to the top level", () => {
+    const { document } = toEngineDocument(doc(wrapper([node("a"), node("b")])));
+
+    // The point of the conversion: the wrapper is gone and the page IS the list.
+    expect(document.nodes.map(n => n.id)).toEqual(["a", "b"]);
+    expect(document.formatVersion).toBe(1);
+    expect(document.kind).toBe("page");
+  });
+
+  it("carries CONTENT across, not just structure", () => {
+    // A shape-preserving no-op passes a structural check. Asserting on a value
+    // an author actually typed is what separates a real conversion from one
+    // that rebuilt the tree and lost what was in it.
+    const { document } = toEngineDocument(
+      doc(wrapper([node("a", { props: { text: "Hello world" } })]))
+    );
+
+    expect(document.nodes[0].props).toEqual({ text: "Hello world" });
+  });
+
+  it("preserves nesting three deep with siblings at every level", () => {
+    // A fixture one level deep passes whichever encoding is used, because a
+    // flat list and a tree agree about a tree of depth one.
+    const deep = wrapper([
+      node("l1a", {
+        type: "core/container",
+        slots: {
+          default: [
+            node("l2a", {
+              type: "core/container",
+              slots: { default: [node("l3a"), node("l3b")] },
+            }),
+            node("l2b"),
+          ],
+        },
+      }),
+      node("l1b"),
+    ]);
+
+    const { document } = toEngineDocument(doc(deep));
+
+    expect(document.nodes.map(n => n.id)).toEqual(["l1a", "l1b"]);
+    const l1a = document.nodes[0];
+    expect(l1a.slots?.default.map(n => n.id)).toEqual(["l2a", "l2b"]);
+    expect(l1a.slots?.default[0].slots?.default.map(n => n.id)).toEqual([
+      "l3a",
+      "l3b",
+    ]);
+  });
+
+  it("preserves slot IDENTITY, not merely child order", () => {
+    // `core/columns` restricts which blocks its slot accepts. A conversion that
+    // kept the children but renamed or merged the slot would leave that
+    // restriction pointing at a slot that no longer exists, and it would stop
+    // refusing anything without failing.
+    const { document } = toEngineDocument(
+      doc(
+        wrapper([
+          node("cols", {
+            type: "core/columns",
+            slots: { left: [node("x")], right: [node("y")] },
+          }),
+        ])
+      )
+    );
+
+    const cols = document.nodes[0];
+    expect(Object.keys(cols.slots ?? {}).sort()).toEqual(["left", "right"]);
+    expect(cols.slots?.left.map(n => n.id)).toEqual(["x"]);
+    expect(cols.slots?.right.map(n => n.id)).toEqual(["y"]);
+  });
+
+  it("keeps an EMPTY slot distinguishable from an ABSENT one", () => {
+    // Both encode as "no children" unless the key itself survives. An empty
+    // slot is a region an author can drop into; an absent one is a region the
+    // block does not have.
+    const { document } = toEngineDocument(
+      doc(
+        wrapper([
+          node("empty", { type: "core/container", slots: { default: [] } }),
+          node("absent"),
+        ])
+      )
+    );
+
+    expect(document.nodes[0].slots).toEqual({ default: [] });
+    expect(document.nodes[1].slots).toBeUndefined();
+  });
+
+  describe("values the engine requires but the legacy shape did not carry", () => {
+    it("assumes version 1 for a node that stored none, and SAYS SO", () => {
+      const { document, notes } = toEngineDocument(doc(wrapper([node("a")])));
+
+      expect(document.nodes[0].version).toBe(1);
+      // A synthesised value is a decision. Asserting only the value would pass
+      // on an implementation that invented it silently.
+      expect(noteFor(notes, "version").path).toBe("a");
+    });
+
+    it("keeps a stored schema version rather than overwriting it", () => {
+      const { document, notes } = toEngineDocument(
+        doc(wrapper([node("a", { definitionVersion: 7 })]))
+      );
+
+      expect(document.nodes[0].version).toBe(7);
+      expect(notes.some(n => n.field === "version")).toBe(false);
+    });
+
+    it("renames the legacy `part` kind and records the rename", () => {
+      const { document, notes } = toEngineDocument(
+        doc(wrapper([]), { kind: "part" })
+      );
+
+      expect(document.kind).toBe("region");
+      expect(noteFor(notes, "kind").detail).toContain("part");
+    });
+  });
+
+  describe("losses are reported, never silent", () => {
+    it("reports entrance motion, which the engine cannot store", () => {
+      const { notes } = toEngineDocument(
+        doc(wrapper([node("a", { motion: { type: "fade" } })]))
+      );
+
+      expect(noteFor(notes, "motion").path).toBe("a");
+    });
+
+    it("reports a raw custom class", () => {
+      const { notes } = toEngineDocument(
+        doc(wrapper([node("a", { customClass: "my-thing" })]))
+      );
+
+      expect(noteFor(notes, "customClass").detail).toContain("my-thing");
+    });
+
+    it("reports stored SEO, which the engine derives instead", () => {
+      const { notes } = toEngineDocument(
+        doc(wrapper([]), { settings: { seo: { title: "T" } } })
+      );
+
+      expect(noteFor(notes, "settings.seo").path).toBe("document");
+    });
+
+    it("reports blocks stranded in a non-default slot on the wrapper", () => {
+      const stranded = wrapper([node("kept")]);
+      stranded.slots = { ...stranded.slots, aside: [node("lost")] };
+
+      const { document, notes } = toEngineDocument(doc(stranded));
+
+      expect(document.nodes.map(n => n.id)).toEqual(["kept"]);
+      expect(noteFor(notes, "slots.aside").detail).toContain("1 block");
+    });
+
+    it("emits NO notes for a document that converts cleanly", () => {
+      // Without this, a permanently-noisy converter would satisfy every
+      // assertion above while telling an operator nothing.
+      const { notes } = toEngineDocument(
+        doc(wrapper([node("a", { definitionVersion: 1 })]))
+      );
+
+      expect(notes).toEqual([]);
+    });
+  });
+
+  describe("bindings", () => {
+    it("rewrites `path` onto `$bind` against the owning entry", () => {
+      const { document } = toEngineDocument(
+        doc(
+          wrapper([
+            node("a", {
+              bindings: { text: { source: "field", path: "author.name" } },
+            }),
+          ])
+        )
+      );
+
+      expect(document.nodes[0].bindings).toEqual({
+        text: { source: "entry", $bind: "author.name" },
+      });
+    });
+
+    it("reports a display transform, which has no engine equivalent", () => {
+      const { notes } = toEngineDocument(
+        doc(
+          wrapper([
+            node("a", {
+              bindings: {
+                date: {
+                  source: "field",
+                  path: "publishedAt",
+                  transform: "date:MMM d, yyyy",
+                },
+              },
+            }),
+          ])
+        )
+      );
+
+      expect(noteFor(notes, "bindings.date.transform").detail).toContain(
+        "date:MMM d, yyyy"
+      );
+    });
+  });
+
+  describe("the root the author built", () => {
+    it("is kept as a real block rather than unwrapped", () => {
+      // Unwrapping a container the author added would change how the page
+      // renders — its padding and background would simply stop applying.
+      const authored = wrapper([node("a")]);
+      authored.props = { maxWidth: "narrow" };
+
+      const { document, notes } = toEngineDocument(doc(authored));
+
+      expect(document.nodes.map(n => n.id)).toEqual(["root"]);
+      expect(document.nodes[0].slots?.default.map(n => n.id)).toEqual(["a"]);
+      expect(noteFor(notes, "root").path).toBe("root");
+    });
+
+    it("moves a synthetic wrapper's styling to page-level styles", () => {
+      const styled = wrapper([node("a")]);
+      styled.style = { base: { backgroundColor: "#fff" } };
+      styled.customCss = ".x { color: red }";
+
+      const { document } = toEngineDocument(doc(styled));
+
+      // The wrapper disappears; its styling must not disappear with it.
+      expect(document.nodes.map(n => n.id)).toEqual(["a"]);
+      expect(document.settings?.styles?.base).toEqual({
+        base: { backgroundColor: "#fff" },
+      });
+      expect(document.settings?.customCss).toBe(".x { color: red }");
+    });
+  });
+
+  describe("styles", () => {
+    it("folds the legacy style/styleHover pair into states", () => {
+      const { document } = toEngineDocument(
+        doc(
+          wrapper([
+            node("a", {
+              style: { base: { color: "#111" } },
+              styleHover: { base: { color: "#222" } },
+            }),
+          ])
+        )
+      );
+
+      expect(document.nodes[0].styles).toEqual({
+        base: { base: { color: "#111" } },
+        hover: { base: { color: "#222" } },
+      });
+    });
+
+    it("refuses a value the engine's envelope cannot hold", () => {
+      // Written by an older version whose type no longer describes it. Letting
+      // it through would store a value that fails validation on the next read.
+      const bad = node("a");
+      Object.assign(bad, { style: { base: { boxShadow: [1, 2] } } });
+
+      const { document } = toEngineDocument(doc(wrapper([bad])));
+
+      expect(document.nodes[0].styles).toBeUndefined();
+    });
+
+    it("carries per-breakpoint visibility under `devices`", () => {
+      const { document } = toEngineDocument(
+        doc(wrapper([node("a", { visibility: { mobile: false } })]))
+      );
+
+      expect(document.nodes[0].visibility).toEqual({
+        devices: { mobile: false },
+      });
+    });
+  });
+});
+
+describe("isLegacyDocument", () => {
+  it("separates the two envelopes on key presence alone", () => {
+    expect(isLegacyDocument({ version: 1, root: { id: "r" } })).toBe(true);
+    expect(
+      isLegacyDocument({ formatVersion: 1, kind: "page", nodes: [] })
+    ).toBe(false);
+  });
+
+  it("refuses values that are not documents at all", () => {
+    for (const value of [null, undefined, 7, "root", [], { root: "no" }]) {
+      expect(isLegacyDocument(value)).toBe(false);
+    }
+  });
+});

--- a/packages/plugin-page-builder/src/core/legacy-document.ts
+++ b/packages/plugin-page-builder/src/core/legacy-document.ts
@@ -94,6 +94,19 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
 }
 
 /**
+ * True when a value is a design-token reference in the LEGACY spelling.
+ *
+ * Both formats reference a token by a single string property; only the key
+ * differs (`token` against the engine's `$token`). The check is the same shape
+ * as the engine's own predicate, and for the same reason: an array or a class
+ * instance carrying the key would serialize to something that is no longer a
+ * reference, so the token would be lost on the way to storage.
+ */
+function isLegacyTokenRef(value: unknown): value is { token: string } {
+  return isPlainObject(value) && typeof value.token === "string";
+}
+
+/**
  * Narrows an arbitrary stored value to something the engine's style envelope
  * accepts, or rejects it.
  *
@@ -107,6 +120,14 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
 function toStyleValue(value: unknown): StyleValue | undefined {
   if (typeof value === "string" || typeof value === "number") return value;
   if (isTokenRef(value)) return value;
+  // A token reference has to be recognised BEFORE the generic object walk
+  // below, because the two spellings differ only in the key: the legacy
+  // control wrote `{ token }` and the engine's predicate reads `{ $token }`.
+  // Left to the walk, a token would survive as an ordinary nested object the
+  // engine no longer recognises as a reference — still present, still
+  // well-formed, and no longer a token, which is the shape of loss a
+  // structural comparison cannot see.
+  if (isLegacyTokenRef(value)) return { $token: value.token };
   if (!isPlainObject(value)) return undefined;
 
   const nested: Record<string, StyleValue> = {};
@@ -168,10 +189,17 @@ function toNodeStyles(node: LegacyNode): NodeStyles | undefined {
 /**
  * A node's bindings, rewritten onto the engine's binding contract.
  *
- * The legacy shape had one binding source ("field", always the owning entry)
- * and addressed it with `path`; the engine names the path `$bind` and models
- * the source as a union whose default is the owning entry. So every legacy
- * binding maps onto exactly one engine binding with no ambiguity.
+ * The legacy shape had one binding source, spelled "field", and addressed it
+ * with `path`; the engine names the path `$bind` and models the source as a
+ * union. So every legacy binding maps onto exactly one engine binding.
+ *
+ * That source is `item`, NOT `entry`, and the difference decides whether a
+ * repeated block shows its own row. Legacy bindings resolve only inside a
+ * collection loop — the renderer calls `resolveBindings(node, item)` when an
+ * item is in scope and uses the raw props otherwise — so "field" always meant
+ * the current loop item. The engine's `entry` is the entry owning the
+ * document, which for a repeated block is the page rather than the row, so
+ * converting to `entry` would leave every repetition showing the same values.
  *
  * The display `transform` does not survive. It was an unparsed string like
  * "date:MMM d, yyyy", and the engine's `format` is structured and
@@ -186,7 +214,7 @@ function toBindings(
 
   const bindings: Record<string, Binding> = {};
   for (const [prop, legacy] of Object.entries(node.bindings)) {
-    bindings[prop] = { source: "entry", $bind: legacy.path };
+    bindings[prop] = { source: "item", $bind: legacy.path };
     if (legacy.transform !== undefined) {
       notes.push({
         path: node.id,

--- a/packages/plugin-page-builder/src/core/legacy-document.ts
+++ b/packages/plugin-page-builder/src/core/legacy-document.ts
@@ -1,0 +1,424 @@
+/**
+ * Converts a legacy nested builder document into the engine's frozen format.
+ *
+ * The editor was built on a document whose body is a single `root` node with
+ * everything nested inside it. The engine's format, frozen and published, has
+ * no synthetic root: a page IS a flat list of nodes, and document-level
+ * concerns live on the envelope. Stored documents in the old shape therefore
+ * need translating on read, and this module is the only place that happens.
+ *
+ * Nothing here drops data quietly. The two shapes are not isomorphic — the
+ * engine has no home for a node's entrance motion or its raw escape-hatch
+ * class, and it derives SEO rather than storing it — so a faithful conversion
+ * has to LOSE things. Every loss is reported as a note rather than discarded,
+ * because a migration that silently produces a smaller document is
+ * indistinguishable from one that worked.
+ *
+ * @module core/legacy-document
+ */
+
+import type {
+  Binding,
+  BlockDocument,
+  BlockNode,
+  DocumentKind,
+  NodeStyles,
+  StyleValue,
+  StyleValues,
+} from "@nextlyhq/blocks-engine";
+import { DOCUMENT_FORMAT_VERSION, isTokenRef } from "@nextlyhq/blocks-engine";
+
+import type {
+  BlockDocument as LegacyDocument,
+  BlockNode as LegacyNode,
+  ResponsiveStyle as LegacyResponsiveStyle,
+  StyleValues as LegacyStyleValues,
+} from "./types";
+
+/**
+ * One thing the conversion could not carry across, addressed to where it was.
+ *
+ * `path` is a node id, or `"document"` for the envelope, rather than a
+ * positional path: positions change as soon as anything is edited, and these
+ * notes are read after the fact.
+ */
+export interface ConversionNote {
+  /** Node id the loss belongs to, or `"document"` for envelope-level losses. */
+  path: string;
+  /** The legacy field that had nowhere to go. */
+  field: string;
+  /** What happened to it, in terms an author or a maintainer can act on. */
+  detail: string;
+}
+
+/** A converted document, plus everything the conversion could not carry. */
+export interface ConversionResult {
+  document: BlockDocument;
+  notes: ConversionNote[];
+}
+
+/**
+ * The schema version stamped on a node that never carried one.
+ *
+ * The engine requires `version` on every node because forgiving rendering and
+ * the manifest version stamp both read it unconditionally; the legacy shape
+ * made it optional. A node written before the field existed was written
+ * against the block's first schema, so 1 is the truthful answer rather than a
+ * placeholder — but it is still a value this module invented, so it is noted.
+ */
+const ASSUMED_NODE_VERSION = 1;
+
+/**
+ * Legacy document kinds that have no same-named engine kind.
+ *
+ * "part" was the legacy name for a reusable piece of a page — a header or a
+ * footer — which the engine calls a region. The other two legacy kinds
+ * ("page", "template") exist verbatim on both sides and need no entry.
+ */
+const KIND_RENAMES: Readonly<Record<string, DocumentKind>> = {
+  part: "region",
+};
+
+/**
+ * True when a value is a plain object we can walk.
+ *
+ * Arrays and class instances are excluded deliberately: both survive
+ * `typeof v === "object"` and neither serializes back to a style value, so
+ * treating them as walkable is how a style silently becomes `[]` in storage.
+ */
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (typeof value !== "object" || value === null) return false;
+  if (Array.isArray(value)) return false;
+  const proto: unknown = Object.getPrototypeOf(value);
+  return proto === Object.prototype || proto === null;
+}
+
+/**
+ * Narrows an arbitrary stored value to something the engine's style envelope
+ * accepts, or rejects it.
+ *
+ * This is a real runtime boundary rather than a formality. The legacy
+ * `StyleValues` is a closed interface of named properties and the engine's is
+ * an open record of `StyleValue`, so the two are not assignable in either
+ * direction, and the data being read was written by an older version that its
+ * own type no longer describes. Anything unrecognised is refused here so it
+ * cannot reach storage and fail validation on the next read instead.
+ */
+function toStyleValue(value: unknown): StyleValue | undefined {
+  if (typeof value === "string" || typeof value === "number") return value;
+  if (isTokenRef(value)) return value;
+  if (!isPlainObject(value)) return undefined;
+
+  const nested: Record<string, StyleValue> = {};
+  for (const [key, raw] of Object.entries(value)) {
+    const converted = toStyleValue(raw);
+    if (converted !== undefined) nested[key] = converted;
+  }
+  // An object whose every member was refused carries nothing. Emitting `{}`
+  // would record a style that sets no property, which reads downstream as "the
+  // author styled this" and suppresses inheritance.
+  return Object.keys(nested).length > 0 ? nested : undefined;
+}
+
+/** One breakpoint's worth of values, with anything unrepresentable refused. */
+function toStyleValues(legacy: LegacyStyleValues): StyleValues | undefined {
+  const values: Record<string, StyleValue> = {};
+  for (const [key, raw] of Object.entries(legacy)) {
+    if (raw === undefined) continue;
+    const converted = toStyleValue(raw);
+    if (converted !== undefined) values[key] = converted;
+  }
+  return Object.keys(values).length > 0 ? values : undefined;
+}
+
+/** A legacy per-breakpoint style map as one state of the engine's envelope. */
+function toStateStyles(
+  legacy: LegacyResponsiveStyle | undefined
+): Partial<Record<string, StyleValues>> | undefined {
+  if (!legacy) return undefined;
+  const byBreakpoint: Record<string, StyleValues> = {};
+  for (const [breakpoint, values] of Object.entries(legacy)) {
+    if (!values) continue;
+    const converted = toStyleValues(values);
+    if (converted) byBreakpoint[breakpoint] = converted;
+  }
+  return Object.keys(byBreakpoint).length > 0 ? byBreakpoint : undefined;
+}
+
+/**
+ * A node's styles, folding the legacy pair of maps into the engine's
+ * state-keyed envelope.
+ *
+ * The legacy shape carried the resting styles and the hover styles as two
+ * separate fields; the engine keys both by state under one field. `base` and
+ * `hover` are the two states that had legacy homes — `focus` and `active`
+ * exist in the engine but nothing could have written them, so they are absent
+ * rather than empty.
+ */
+function toNodeStyles(node: LegacyNode): NodeStyles | undefined {
+  const base = toStateStyles(node.style);
+  const hover = toStateStyles(node.styleHover);
+  if (!base && !hover) return undefined;
+  const styles: NodeStyles = {};
+  if (base) styles.base = base;
+  if (hover) styles.hover = hover;
+  return styles;
+}
+
+/**
+ * A node's bindings, rewritten onto the engine's binding contract.
+ *
+ * The legacy shape had one binding source ("field", always the owning entry)
+ * and addressed it with `path`; the engine names the path `$bind` and models
+ * the source as a union whose default is the owning entry. So every legacy
+ * binding maps onto exactly one engine binding with no ambiguity.
+ *
+ * The display `transform` does not survive. It was an unparsed string like
+ * "date:MMM d, yyyy", and the engine's `format` is structured and
+ * locale-aware; inventing a parse for the legacy spelling would guess at
+ * values an author never confirmed, so it is reported instead.
+ */
+function toBindings(
+  node: LegacyNode,
+  notes: ConversionNote[]
+): Record<string, Binding> | undefined {
+  if (!node.bindings) return undefined;
+
+  const bindings: Record<string, Binding> = {};
+  for (const [prop, legacy] of Object.entries(node.bindings)) {
+    bindings[prop] = { source: "entry", $bind: legacy.path };
+    if (legacy.transform !== undefined) {
+      notes.push({
+        path: node.id,
+        field: `bindings.${prop}.transform`,
+        detail: `Display transform "${legacy.transform}" was dropped; re-apply it as a binding format.`,
+      });
+    }
+  }
+  return bindings;
+}
+
+/**
+ * Per-breakpoint visibility, with unset breakpoints removed.
+ *
+ * The legacy map was partial, so a breakpoint could be present with the value
+ * `undefined`. The engine's map is total in its value type: an explicit
+ * `undefined` there is not "inherit", it is a breakpoint recorded as having no
+ * answer, which nothing downstream knows how to read.
+ */
+function toDevices(
+  visibility: NonNullable<LegacyNode["visibility"]>
+): Record<string, boolean> {
+  const devices: Record<string, boolean> = {};
+  for (const [breakpoint, visible] of Object.entries(visibility)) {
+    if (typeof visible === "boolean") devices[breakpoint] = visible;
+  }
+  return devices;
+}
+
+/** Records the legacy node fields the engine has no home for. */
+function noteNodeLosses(node: LegacyNode, notes: ConversionNote[]): void {
+  if (node.motion !== undefined) {
+    notes.push({
+      path: node.id,
+      field: "motion",
+      detail:
+        "Entrance motion has no engine equivalent and was dropped. Re-apply it once motion is part of the frozen format.",
+    });
+  }
+  if (node.customClass !== undefined && node.customClass !== "") {
+    notes.push({
+      path: node.id,
+      field: "customClass",
+      detail: `Raw class "${node.customClass}" was dropped. The engine references site-global named classes by id, so a literal class name cannot be carried across.`,
+    });
+  }
+  if (node.definitionVersion === undefined) {
+    notes.push({
+      path: node.id,
+      field: "version",
+      detail: `No schema version was stored; assumed ${ASSUMED_NODE_VERSION}. Verify if this block's schema has since changed.`,
+    });
+  }
+}
+
+/** One node and everything beneath it. */
+function toEngineNode(node: LegacyNode, notes: ConversionNote[]): BlockNode {
+  noteNodeLosses(node, notes);
+
+  const converted: BlockNode = {
+    id: node.id,
+    type: node.type,
+    version: node.definitionVersion ?? ASSUMED_NODE_VERSION,
+    props: node.props,
+  };
+
+  const styles = toNodeStyles(node);
+  if (styles) converted.styles = styles;
+  const bindings = toBindings(node, notes);
+  if (bindings) converted.bindings = bindings;
+  if (node.name !== undefined) converted.name = node.name;
+  if (node.locked !== undefined) converted.locked = node.locked;
+  if (node.customCss !== undefined) converted.customCss = node.customCss;
+  if (node.cssId !== undefined) converted.cssId = node.cssId;
+  if (node.attributes) converted.attributes = node.attributes;
+
+  // Both sides key per-breakpoint visibility by breakpoint id; the engine
+  // nests it under `devices` so that conditional visibility can live beside it
+  // without the two competing for the same keys.
+  if (node.visibility) {
+    converted.visibility = { devices: toDevices(node.visibility) };
+  }
+
+  if (node.slots) {
+    const slots: Record<string, BlockNode[]> = {};
+    for (const [slot, children] of Object.entries(node.slots)) {
+      // A slot that exists with no children is not the same as a slot that
+      // does not exist: the first is an empty region an author can drop into,
+      // the second is a region this block does not have. Preserving the key
+      // with an empty array is what keeps them distinguishable.
+      slots[slot] = (children ?? []).map(child => toEngineNode(child, notes));
+    }
+    converted.slots = slots;
+  }
+
+  return converted;
+}
+
+/**
+ * True when the root node is the editor's synthetic wrapper rather than a
+ * block the author put there.
+ *
+ * The legacy editor seeded every document with an empty `core/container` whose
+ * only purpose was to give the tree a single root. Promoting that wrapper's
+ * children to the top level is the whole point of the conversion; promoting a
+ * container the AUTHOR added would silently unwrap their layout. The two are
+ * told apart by whether the wrapper carries anything of its own.
+ */
+function isSyntheticRoot(root: LegacyNode): boolean {
+  return (
+    root.type === "core/container" &&
+    Object.keys(root.props).length === 0 &&
+    root.bindings === undefined &&
+    root.customClass === undefined &&
+    root.motion === undefined &&
+    root.name === undefined &&
+    root.cssId === undefined &&
+    root.attributes === undefined &&
+    root.visibility === undefined &&
+    root.locked !== true
+  );
+}
+
+/**
+ * Converts a legacy nested document to the engine's flat format.
+ *
+ * The root node is unwrapped only when it is the editor's own synthetic
+ * container. Its styling does not vanish with it: the engine's envelope has a
+ * `settings.styles` slot for exactly this — page-scoped styles with no owning
+ * node — so a styled wrapper becomes page styling rather than a lost
+ * rectangle. A root the author built is kept as a real top-level node, because
+ * unwrapping it would change how the page renders.
+ */
+export function toEngineDocument(legacy: LegacyDocument): ConversionResult {
+  const notes: ConversionNote[] = [];
+  const legacyKind = legacy.kind ?? "page";
+  const kind = KIND_RENAMES[legacyKind] ?? (legacyKind as DocumentKind);
+
+  if (KIND_RENAMES[legacyKind]) {
+    notes.push({
+      path: "document",
+      field: "kind",
+      detail: `Kind "${legacyKind}" has no engine equivalent and was recorded as "${kind}".`,
+    });
+  }
+
+  const document: BlockDocument = {
+    formatVersion: DOCUMENT_FORMAT_VERSION,
+    kind,
+    nodes: [],
+  };
+
+  const root = legacy.root;
+  if (isSyntheticRoot(root)) {
+    // Only the default slot has a top level to be promoted to. Any other slot
+    // on the synthetic wrapper has no destination, so its contents are
+    // reported rather than folded into the page in an order nobody chose.
+    const { default: mainChildren, ...otherSlots } = root.slots ?? {};
+    document.nodes = (mainChildren ?? []).map(child =>
+      toEngineNode(child, notes)
+    );
+
+    for (const [slot, children] of Object.entries(otherSlots)) {
+      if (children && children.length > 0) {
+        notes.push({
+          path: root.id,
+          field: `slots.${slot}`,
+          detail: `${children.length} block(s) sat in a non-default slot on the document wrapper and had no top-level position to move to.`,
+        });
+      }
+    }
+
+    const rootStyles = toNodeStyles(root);
+    if (rootStyles || root.customCss !== undefined) {
+      document.settings = {};
+      if (rootStyles) document.settings.styles = rootStyles;
+      if (root.customCss !== undefined) {
+        document.settings.customCss = root.customCss;
+      }
+    }
+  } else {
+    document.nodes = [toEngineNode(root, notes)];
+    notes.push({
+      path: root.id,
+      field: "root",
+      detail:
+        "The document root carried its own configuration, so it was kept as a top-level block rather than unwrapped.",
+    });
+  }
+
+  if (legacy.assets) document.assets = legacy.assets;
+
+  if (legacy.settings?.seo !== undefined) {
+    notes.push({
+      path: "document",
+      field: "settings.seo",
+      detail:
+        "Stored SEO values were dropped. The engine derives SEO from document content rather than storing it.",
+    });
+  }
+  if (legacy.locale !== undefined) {
+    notes.push({
+      path: "document",
+      field: "locale",
+      detail: `Authoring locale "${legacy.locale}" was dropped; localization is carried outside the document.`,
+    });
+  }
+  if (legacy.translationGroup !== undefined) {
+    notes.push({
+      path: "document",
+      field: "translationGroup",
+      detail: `Translation group "${legacy.translationGroup}" was dropped; localization is carried outside the document.`,
+    });
+  }
+
+  return { document, notes };
+}
+
+/**
+ * True when a stored value is a legacy document rather than an engine one.
+ *
+ * The two envelopes do not share their format-stamp key — the legacy shape
+ * spells it `version` and carries `root`, the engine spells it `formatVersion`
+ * and carries `nodes` — so presence alone separates them with no version
+ * number to compare and no ambiguity to resolve. That is what lets a
+ * migration run on documents written before anyone thought to stamp them.
+ */
+export function isLegacyDocument(value: unknown): value is LegacyDocument {
+  return (
+    isPlainObject(value) &&
+    "root" in value &&
+    isPlainObject(value.root) &&
+    !("nodes" in value)
+  );
+}

--- a/packages/plugin-page-builder/src/core/legacy-document.ts
+++ b/packages/plugin-page-builder/src/core/legacy-document.ts
@@ -314,6 +314,16 @@ function toEngineNode(node: LegacyNode, notes: ConversionNote[]): BlockNode {
 }
 
 /**
+ * True when a record carries nothing, whether by being absent or by being empty.
+ *
+ * The two are the same fact about authorship and different values in storage,
+ * because clearing the last entry leaves the key behind.
+ */
+function isAbsentRecord(value: Record<string, string> | undefined): boolean {
+  return value === undefined || Object.keys(value).length === 0;
+}
+
+/**
  * True when the root node is the editor's synthetic wrapper rather than a
  * block the author put there.
  *
@@ -332,7 +342,12 @@ function isSyntheticRoot(root: LegacyNode): boolean {
     root.motion === undefined &&
     root.name === undefined &&
     root.cssId === undefined &&
-    root.attributes === undefined &&
+    // An EMPTY attribute map is absent metadata, not authorship. Clearing the
+    // last attribute in the legacy editor stores `{}` rather than removing the
+    // field, so a strict undefined check reads an otherwise untouched wrapper
+    // as authored and preserves a `core/container` that has no behaviour to
+    // preserve.
+    isAbsentRecord(root.attributes) &&
     root.visibility === undefined &&
     root.locked !== true
   );
@@ -445,8 +460,34 @@ export function toEngineDocument(legacy: LegacyDocument): ConversionResult {
 export function isLegacyDocument(value: unknown): value is LegacyDocument {
   return (
     isPlainObject(value) &&
-    "root" in value &&
-    isPlainObject(value.root) &&
-    !("nodes" in value)
+    !("nodes" in value) &&
+    isLegacyNode((value as { root?: unknown }).root)
+  );
+}
+
+/**
+ * True when a value carries the node fields the conversion DEREFERENCES.
+ *
+ * The guard has to promise what the narrowed type promises, not merely that
+ * something called `root` is an object. `toEngineDocument` reads `props`,
+ * `type` and `id` without checking them, on the strength of this predicate —
+ * so a stored value of `{ root: {} }` would satisfy a shallower guard, narrow
+ * to `LegacyDocument` with TypeScript's blessing, and then throw partway
+ * through the walk. A migration that throws on a corrupt row turns a
+ * repairable document into a failed migration; refusing it here makes the same
+ * row a controlled rejection the caller can report and skip.
+ *
+ * Children are deliberately NOT walked. This runs on every stored value to
+ * decide which format it is, and a deep validation would make that decision
+ * cost a full tree traversal; the engine's own validator owns depth checking,
+ * and a malformed descendant surfaces there rather than being silently
+ * reclassified as an engine document here.
+ */
+function isLegacyNode(value: unknown): boolean {
+  return (
+    isPlainObject(value) &&
+    typeof value.id === "string" &&
+    typeof value.type === "string" &&
+    isPlainObject(value.props)
   );
 }


### PR DESCRIPTION
## Why

The plugin ships two block field types with incompatible document formats, and **no value has ever crossed between them**:

| | `pageBuilderField("layout")` | `blocks({ name: "sections" })` |
|---|---|---|
| what it is | a plain `json` field | the `blocks` field type |
| document | `root: BlockNode`, nested | `nodes: BlockNode[]`, flat, **frozen by #738** |
| validator | `core/validate.ts` | the engine's |
| admin control | the real visual editor | `BlocksSummary`, **read-only** |

So the frozen, published format is the one with **no editor**, and `BlocksSummary`'s own docblock — *"Editing happens in the page builder"* — is not true today, because the builder is mounted on the other field. That is the gap this lands the first piece of.

Nothing is broken by this PR: it adds a module and wires nothing to it yet.

## What

`core/legacy-document.ts` converts a legacy nested document to the engine's flat format, plus `isLegacyDocument` to tell the two apart.

**The two envelopes do not share their format-stamp key** — legacy spells it `version` and carries `root`; the engine spells it `formatVersion` and carries `nodes`. Presence alone separates them, with no version to compare, which is what lets a migration run on documents written before anyone thought to stamp them.

## The conversion is not symmetric, and does not pretend to be

The engine has no home for some legacy fields, and requires two the legacy shape left optional. Every one of those is **reported as a note rather than dropped**, because a migration that silently produces a smaller document is indistinguishable from one that worked:

| legacy | outcome |
|---|---|
| `motion` | no engine equivalent — reported |
| `customClass` | engine references named classes by id, not literal names — reported |
| `settings.seo` | the engine *derives* SEO — reported |
| `locale`, `translationGroup` | localization lives outside the document — reported |
| `kind: "part"` | recorded as `"region"` — reported |
| node `definitionVersion` absent | assumed `1` — reported |
| `bindings[].transform` | engine `format` is structured; inventing a parse would guess — reported |

Two conversions needed real work rather than a rewrap, both caught by the type checker rather than assumed:

- **bindings** — legacy `{ source: "field", path }` → engine `{ source: "entry", $bind }`.
- **style values** — legacy `StyleValues` is a closed interface, the engine's is an open record. Not assignable in either direction, so there is a **runtime narrowing boundary** that refuses anything the engine's envelope cannot hold. That is correct regardless of types: this reads data written by an older version that its own type no longer describes, and letting an unrepresentable value through would store something that fails validation on the next read.

**The synthetic root is unwrapped; an authored one is not.** The legacy editor seeded every document with an empty `core/container` purely to give the tree a root. Promoting *that* wrapper's children is the point. Promoting a container the author added would silently unwrap their layout, so it is kept as a top-level node instead. A synthetic wrapper's styling does not vanish with it — it becomes `settings.styles`, which the engine documents as "page-scoped styles with no owning node".

## Tests

24 tests, built on **separating properties** rather than a round-trip, because a shape-preserving no-op passes a round-trip:

- an **edit** is visible across the conversion, not just the structure
- nesting **three deep with siblings at every level** (one level deep passes whichever encoding is used)
- **slot identity** survives, not just child order — otherwise `core/columns`' `allowedBlocks` (#795) silently stops refusing
- an **empty slot** stays distinguishable from an **absent** one
- synthesised values are asserted **via their notes**, not just their values — asserting the value alone passes on an implementation that invented it silently
- a clean document emits **no notes at all**, so a permanently-noisy converter cannot satisfy the rest

Mutation-checked: removing the version note kills exactly the one test that asserts it, and nothing else.

## Not in this PR

The migration on read, mounting the editor on the `blocks` field, retiring `pageBuilderField`, and the canvas port. This is the piece they all depend on.
